### PR TITLE
fix(runner): materialize prune-eligible codex zstd history

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1196,6 +1196,26 @@ def run_codex(codex_home, *args):
     )
 
 
+def zstd_compress(history_bytes):
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            (
+                "const fs=require('node:fs');"
+                "const zlib=require('node:zlib');"
+                "process.stdout.write("
+                "zlib.zstdCompressSync(fs.readFileSync(0)));"
+            ),
+        ],
+        input=history_bytes,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr.decode(errors="replace")
+    return result.stdout
+
+
 def event_type(record):
     if record.get("type") != "event_msg":
         return None
@@ -1338,6 +1358,63 @@ def probe_current_codex(
         len(turn_completions) >= 2
         and turn_starts[-1] == turn_completions[-1]
     ), "Codex did not append a complete turn"
+
+
+def probe_zstd_materialization(
+    root,
+    candidate_relative_path,
+    candidate_bytes,
+    session_id,
+    port,
+):
+    codex_home = root / ".codex"
+    write_config(codex_home, port)
+    history_file = codex_home / "sessions" / candidate_relative_path
+    compressed_history_file = Path(f"{history_file}.zst")
+    compressed_history_file.parent.mkdir(parents=True)
+    compressed_history_file.write_bytes(zstd_compress(candidate_bytes))
+
+    requests.clear()
+    resumed = run_codex(
+        codex_home,
+        "resume",
+        session_id,
+        append_token,
+    )
+    output = resumed.stdout + resumed.stderr
+    assert (
+        f"no rollout found for thread id {session_id}" not in output.lower()
+    ), output
+    assert requests and requests[-1][0] == "/v1/responses", (
+        f"Codex did not resume the zstd rollout\n{output}"
+    )
+    assert not compressed_history_file.exists(), (
+        "Codex left the compressed rollout after append"
+    )
+    assert history_file.is_file(), (
+        "Codex did not materialize the compressed rollout as plain JSONL"
+    )
+    materialized = history_file.read_bytes()
+    assert materialized.startswith(candidate_bytes), (
+        "Codex changed the retained history while materializing zstd"
+    )
+    assert len(materialized) > len(candidate_bytes), (
+        "Codex did not append to the materialized rollout"
+    )
+
+    started = [
+        json.loads(line)
+        for line in resumed.stdout.splitlines()
+        if line.startswith("{")
+    ]
+    thread_started = [
+        event
+        for event in started
+        if event.get("type") == "thread.started"
+    ]
+    assert thread_started and thread_started[0].get("thread_id") == session_id, (
+        "Codex changed the zstd-restored thread ID"
+    )
 
 
 with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
@@ -1489,6 +1566,13 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             root / "current",
             candidate_relative_path,
             full_bytes,
+            candidate_bytes,
+            session_id,
+            port,
+        )
+        probe_zstd_materialization(
+            root / "zstd",
+            candidate_relative_path,
             candidate_bytes,
             session_id,
             port,

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
 name = "guest-session-prune"
 version = "0.3.3"
 dependencies = [
+ "guest-contracts",
  "proptest",
  "serde_json",
  "tempfile",

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -15,7 +15,9 @@ use api_contracts::generated::constants::runners::{
     SESSION_HISTORY_GZIP_MIN_BYTES,
 };
 use bytes::Bytes;
-use guest_common::telemetry::record_sandbox_op;
+use guest_common::telemetry::{
+    SandboxOpDimensions, record_sandbox_op, record_sandbox_op_with_dimensions,
+};
 use guest_common::{log_info, log_warn};
 use guest_session_prune::{
     ClaudeHistorySelection, CodexHistorySelection, select_claude_compact_generation,
@@ -30,6 +32,59 @@ use std::time::Duration;
 
 const SESSION_HISTORY_ZSTD_LEVEL: i32 = 3;
 const SESSION_HISTORY_COMPRESSION_MIN_BYTES: usize = SESSION_HISTORY_GZIP_MIN_BYTES as usize;
+
+#[derive(Clone, Copy)]
+enum SessionHistoryPruneOutcome {
+    Selected,
+    Ineligible,
+    Error,
+}
+
+impl SessionHistoryPruneOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Selected => "selected",
+            Self::Ineligible => "ineligible",
+            Self::Error => "error",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SessionHistoryPruneReason {
+    Selector(&'static str),
+    CompressedSource,
+    SelectorIo,
+}
+
+impl SessionHistoryPruneReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Selector(reason) => reason,
+            Self::CompressedSource => "compressed_source",
+            Self::SelectorIo => "selector_io",
+        }
+    }
+}
+
+fn record_session_history_prune(
+    started: std::time::Instant,
+    outcome: SessionHistoryPruneOutcome,
+    reason: Option<SessionHistoryPruneReason>,
+) {
+    let reason = reason.map(SessionHistoryPruneReason::as_str);
+    let error = matches!(outcome, SessionHistoryPruneOutcome::Error).then_some("selector_io");
+    record_sandbox_op_with_dimensions(
+        "session_history_prune",
+        started.elapsed(),
+        !matches!(outcome, SessionHistoryPruneOutcome::Error),
+        error,
+        SandboxOpDimensions {
+            outcome: Some(outcome.as_str()),
+            reason,
+        },
+    );
+}
 
 #[derive(Clone, Copy)]
 pub(super) enum CheckpointSessionHistoryLimits {
@@ -439,7 +494,11 @@ fn prepare_session_history(
                     "Selected Claude compact generation for checkpoint \
                      (source_size={source_size}, candidate_size={candidate_size})"
                 );
-                record_sandbox_op("session_history_prune", prune_start.elapsed(), true, None);
+                record_session_history_prune(
+                    prune_start,
+                    SessionHistoryPruneOutcome::Selected,
+                    None,
+                );
                 let mut prepared =
                     prepare_raw_session_history(mode, history_read_start, candidate)?;
                 prepared.live_history = PreparedLiveHistory::NativeCandidate {
@@ -454,18 +513,21 @@ fn prepare_session_history(
                     "Claude session history not eligible for pruning: {}",
                     reason.as_str()
                 );
-                record_sandbox_op("session_history_prune", prune_start.elapsed(), true, None);
+                record_session_history_prune(
+                    prune_start,
+                    SessionHistoryPruneOutcome::Ineligible,
+                    Some(SessionHistoryPruneReason::Selector(reason.as_str())),
+                );
             }
             Err(error) => {
                 log_warn!(
                     LOG_TAG,
                     "Claude session history selector failed; using ordinary checkpoint path: {error}"
                 );
-                record_sandbox_op(
-                    "session_history_prune",
-                    prune_start.elapsed(),
-                    false,
-                    Some("selector_io"),
+                record_session_history_prune(
+                    prune_start,
+                    SessionHistoryPruneOutcome::Error,
+                    Some(SessionHistoryPruneReason::SelectorIo),
                 );
             }
         }
@@ -493,10 +555,9 @@ fn prepare_session_history(
                                 "Selected Codex compact generation for checkpoint \
                              (source_size={source_size}, candidate_size={candidate_size})"
                             );
-                            record_sandbox_op(
-                                "session_history_prune",
-                                prune_start.elapsed(),
-                                true,
+                            record_session_history_prune(
+                                prune_start,
+                                SessionHistoryPruneOutcome::Selected,
                                 None,
                             );
                             let mut prepared =
@@ -513,11 +574,10 @@ fn prepare_session_history(
                                 "Codex session history not eligible for pruning: {}",
                                 reason.as_str()
                             );
-                            record_sandbox_op(
-                                "session_history_prune",
-                                prune_start.elapsed(),
-                                true,
-                                None,
+                            record_session_history_prune(
+                                prune_start,
+                                SessionHistoryPruneOutcome::Ineligible,
+                                Some(SessionHistoryPruneReason::Selector(reason.as_str())),
                             );
                         }
                         Err(error) => {
@@ -526,11 +586,10 @@ fn prepare_session_history(
                                 "Codex session history selector failed; using ordinary checkpoint \
                              path: {error}"
                             );
-                            record_sandbox_op(
-                                "session_history_prune",
-                                prune_start.elapsed(),
-                                false,
-                                Some("selector_io"),
+                            record_session_history_prune(
+                                prune_start,
+                                SessionHistoryPruneOutcome::Error,
+                                Some(SessionHistoryPruneReason::SelectorIo),
                             );
                         }
                     }
@@ -539,7 +598,11 @@ fn prepare_session_history(
                         LOG_TAG,
                         "Codex session history not eligible for pruning: compressed_source"
                     );
-                    record_sandbox_op("session_history_prune", prune_start.elapsed(), true, None);
+                    record_session_history_prune(
+                        prune_start,
+                        SessionHistoryPruneOutcome::Ineligible,
+                        Some(SessionHistoryPruneReason::CompressedSource),
+                    );
                 }
                 resolved_codex_history = Some(source);
             }
@@ -549,11 +612,10 @@ fn prepare_session_history(
                     "Codex session history selector failed; using ordinary checkpoint path: \
                      {error}"
                 );
-                record_sandbox_op(
-                    "session_history_prune",
-                    prune_start.elapsed(),
-                    false,
-                    Some("selector_io"),
+                record_session_history_prune(
+                    prune_start,
+                    SessionHistoryPruneOutcome::Error,
+                    Some(SessionHistoryPruneReason::SelectorIo),
                 );
             }
         }

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -4,7 +4,7 @@ use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
 };
 use httpmock::prelude::*;
-use serde_json::json;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 #[cfg(target_os = "linux")]
 use std::{
@@ -15,6 +15,42 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
+
+fn assert_session_history_prune_operation(
+    runtime: &guest_agent::run_context::GuestRuntime,
+    expected_outcome: &str,
+    expected_reason: Option<&str>,
+    expected_success: bool,
+) -> Result<(), String> {
+    let content = std::fs::read_to_string(runtime.paths.sandbox_ops_file())
+        .map_err(|error| format!("read checkpoint telemetry: {error}"))?;
+    let operations = content
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("parse checkpoint telemetry: {error}"))?
+        .into_iter()
+        .filter(|operation| operation["action_type"] == "session_history_prune")
+        .collect::<Vec<_>>();
+    if operations.len() != 1 {
+        return Err(format!("unexpected prune operations: {operations:?}"));
+    }
+    let Some(operation) = operations.first() else {
+        return Err("missing prune operation".into());
+    };
+    assert_eq!(operation["outcome"], expected_outcome);
+    assert_eq!(operation["success"], expected_success);
+    match expected_reason {
+        Some(reason) => assert_eq!(operation["reason"], reason),
+        None => assert!(operation.get("reason").is_none()),
+    }
+    if expected_success {
+        assert!(operation.get("error").is_none());
+    } else {
+        assert_eq!(operation["error"], "selector_io");
+    }
+    Ok(())
+}
 
 #[cfg(target_os = "linux")]
 #[tokio::test(flavor = "current_thread")]
@@ -158,6 +194,37 @@ async fn success_checkpoint_preserves_small_codex_history() {
     prepare_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
     assert_eq!(std::fs::read(&history_path).unwrap(), history);
+    assert_session_history_prune_operation(
+        &runtime,
+        "ineligible",
+        Some("source_within_guard"),
+        true,
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn checkpoint_records_codex_prune_resolution_error() {
+    let _api = SharedApiMock::new().await;
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let sessions_dir = tempfile::tempdir().unwrap();
+    let sessions_dir = sessions_dir.path().join("missing-sessions");
+    let sessions_dir = sessions_dir.to_string_lossy();
+    let marker = format!(
+        "CODEX_SEARCH:{}:{sessions_dir}:{session_id}",
+        sessions_dir.len()
+    );
+    let (session_id_file, session_history_path_file) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, session_id).unwrap();
+    guest_agent::paths::write_private(&session_history_path_file, marker).unwrap();
+
+    let error = create_bounded_checkpoint(&runtime).await.unwrap_err();
+
+    assert!(error.to_string().contains("Codex session file not found"));
+    assert_session_history_prune_operation(&runtime, "error", Some("selector_io"), false).unwrap();
 }
 
 #[tokio::test]
@@ -332,6 +399,7 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
         identity.history_marker_payload.contains(session_id),
         "Codex identity must retain the marker for the original thread"
     );
+    assert_session_history_prune_operation(&runtime, "selected", None, true).unwrap();
 }
 
 #[tokio::test]

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -156,6 +156,19 @@ struct SandboxOpEntry {
     success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+/// Optional low-cardinality dimensions for a sandbox operation.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SandboxOpDimensions<'a> {
+    /// Bounded result classification for the operation.
+    pub outcome: Option<&'a str>,
+    /// Bounded content-free explanation for the result.
+    pub reason: Option<&'a str>,
 }
 
 /// Record a sandbox operation to the telemetry log on a best-effort basis.
@@ -174,13 +187,33 @@ struct SandboxOpEntry {
 /// the secure open.
 ///
 /// Each JSONL entry contains `ts`, `action_type`, `duration_ms`, `success`, and
-/// an optional `error` field. The format is compatible with the TypeScript
-/// version for consistency.
+/// optional `error`, `outcome`, and `reason` fields. The format is compatible
+/// with the TypeScript version for consistency.
 pub fn record_sandbox_op(
     action_type: &str,
     duration: Duration,
     success: bool,
     error: Option<&str>,
+) {
+    record_sandbox_op_with_dimensions(
+        action_type,
+        duration,
+        success,
+        error,
+        SandboxOpDimensions::default(),
+    );
+}
+
+/// Record a sandbox operation with optional low-cardinality dimensions.
+///
+/// This has the same best-effort behavior as [`record_sandbox_op`]. Callers
+/// must provide only bounded, content-free values suitable for log dimensions.
+pub fn record_sandbox_op_with_dimensions(
+    action_type: &str,
+    duration: Duration,
+    success: bool,
+    error: Option<&str>,
+    dimensions: SandboxOpDimensions<'_>,
 ) {
     let Some(sink) = configured_sandbox_ops_log() else {
         return;
@@ -192,6 +225,8 @@ pub fn record_sandbox_op(
         duration_ms: duration_ms(duration),
         success,
         error: error.map(String::from),
+        outcome: dimensions.outcome.map(String::from),
+        reason: dimensions.reason.map(String::from),
     };
 
     let Ok(mut record) = serde_json::to_vec(&entry) else {
@@ -318,6 +353,32 @@ mod tests {
         }
 
         let _ = std::fs::remove_file(&log_path);
+    }
+
+    #[test]
+    fn record_sandbox_op_writes_optional_dimensions() {
+        let _guard = lock_test_state();
+        clear_sandbox_ops_log_file();
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("sandbox-ops.jsonl");
+        let _override_guard = SandboxOpsOverrideGuard::set(&log_path);
+
+        record_sandbox_op_with_dimensions(
+            "session_history_prune",
+            Duration::from_millis(5),
+            true,
+            None,
+            SandboxOpDimensions {
+                outcome: Some("ineligible"),
+                reason: Some("source_within_guard"),
+            },
+        );
+
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let entry: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(entry["outcome"], "ineligible");
+        assert_eq!(entry["reason"], "source_within_guard");
+        assert!(entry.get("error").is_none());
     }
 
     #[test]

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -15,5 +15,6 @@ pub mod exec_terminal;
 pub mod process_containment;
 pub mod reuse_preparation;
 pub mod runtime_paths;
+pub mod session_history;
 pub mod session_history_identity;
 pub mod storage_manifest;

--- a/crates/guest-contracts/src/session_history.rs
+++ b/crates/guest-contracts/src/session_history.rs
@@ -1,0 +1,7 @@
+//! Session-history limits shared by the runner and guest.
+
+/// Maximum decoded size of a Codex compact generation retained by checkpoints.
+///
+/// Restored zstd histories larger than this guard must be materialized as plain
+/// JSONL so the guest can apply the bounded native selector before checkpointing.
+pub const CODEX_COMPACT_GENERATION_MAX_BYTES: u64 = 64 * 1024 * 1024;

--- a/crates/guest-session-prune/Cargo.toml
+++ b/crates/guest-session-prune/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Bounded native session-history pruning for vm0 guest checkpoints"
 
 [dependencies]
+guest-contracts.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 

--- a/crates/guest-session-prune/src/codex.rs
+++ b/crates/guest-session-prune/src/codex.rs
@@ -1,15 +1,13 @@
 use std::fs::File;
 use std::io::{self, BufReader, Read, Seek, SeekFrom};
 
+pub use guest_contracts::session_history::CODEX_COMPACT_GENERATION_MAX_BYTES;
 use serde_json::{Map, Value};
 use uuid::Uuid;
 
 use super::{
     BoundedRecord, READ_BUFFER_BYTES, SelectionLimits, read_bounded_record, strip_jsonl_line_ending,
 };
-
-/// Maximum decoded size of an accepted Codex compact generation.
-pub const CODEX_COMPACT_GENERATION_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Maximum size of one Codex JSONL record inspected by the selector.
 pub const CODEX_JSONL_RECORD_MAX_BYTES: usize = 16 * 1024 * 1024;

--- a/crates/runner/src/executor/session_history_cpu.rs
+++ b/crates/runner/src/executor/session_history_cpu.rs
@@ -10,6 +10,7 @@ use std::sync::{Condvar, Mutex};
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use flate2::read::MultiGzDecoder;
+use guest_contracts::session_history::CODEX_COMPACT_GENERATION_MAX_BYTES;
 use sha2::{Digest, Sha256};
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
@@ -38,6 +39,8 @@ struct SessionHistoryCpuHooks {
     reader_gate: Option<SessionHistoryCpuTestGate>,
     #[cfg(test)]
     codex_timestamp_record_max_bytes: Option<usize>,
+    #[cfg(test)]
+    codex_raw_restore_threshold: Option<u64>,
 }
 
 struct CodexTimestampRecordScanner {
@@ -180,6 +183,7 @@ impl SessionHistoryCpuPool {
                 cpu_gate,
                 reader_gate,
                 codex_timestamp_record_max_bytes: None,
+                codex_raw_restore_threshold: None,
             },
         }
     }
@@ -195,6 +199,23 @@ impl SessionHistoryCpuPool {
                 cpu_gate: None,
                 reader_gate: None,
                 codex_timestamp_record_max_bytes: Some(max_record_bytes),
+                codex_raw_restore_threshold: None,
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::executor) fn with_test_codex_raw_restore_threshold(
+        capacity: usize,
+        threshold: u64,
+    ) -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(capacity.max(1))),
+            hooks: SessionHistoryCpuHooks {
+                cpu_gate: None,
+                reader_gate: None,
+                codex_timestamp_record_max_bytes: None,
+                codex_raw_restore_threshold: Some(threshold),
             },
         }
     }
@@ -308,6 +329,14 @@ impl SessionHistoryCpuHooks {
             return max_record_bytes;
         }
         CODEX_TIMESTAMP_RECORD_MAX_BYTES
+    }
+
+    fn codex_raw_restore_threshold(&self) -> u64 {
+        #[cfg(test)]
+        if let Some(threshold) = self.codex_raw_restore_threshold {
+            return threshold;
+        }
+        CODEX_COMPACT_GENERATION_MAX_BYTES
     }
 }
 
@@ -642,7 +671,7 @@ fn materialize_codex_zstd(
     let mut timings = SessionHistoryCpuTimings::default();
     let result = (|| {
         validate_compressed_raw_size(expected_raw_size, "zstd", &mut timings)?;
-        let (timestamp, prefix_outcome) = verify_codex_zstd(
+        let verified = verify_codex_zstd(
             &encoded_bytes,
             expected_raw_size,
             expected_hash,
@@ -651,13 +680,19 @@ fn materialize_codex_zstd(
             cancel,
             hooks,
         )?;
-        Ok(SessionHistoryCpuMaterialization {
-            session: MaterializedResumeSession::new_codex_zstd(
+        let session = match verified.raw_bytes {
+            Some(raw_bytes) => {
+                MaterializedResumeSession::new(cli_agent_session_id, raw_bytes, verified.timestamp)
+            }
+            None => MaterializedResumeSession::new_codex_zstd(
                 cli_agent_session_id,
                 encoded_bytes,
-                timestamp,
+                verified.timestamp,
             ),
-            prefix_outcome,
+        };
+        Ok(SessionHistoryCpuMaterialization {
+            session,
+            prefix_outcome: verified.prefix_outcome,
         })
     })();
     SessionHistoryCpuOutcome { timings, result }
@@ -887,6 +922,12 @@ fn read_compressed_history(
     Ok(bytes)
 }
 
+struct VerifiedCodexZstd {
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    prefix_outcome: Option<SessionHistoryPrefixOutcome>,
+    raw_bytes: Option<Vec<u8>>,
+}
+
 fn verify_codex_zstd(
     encoded_bytes: &[u8],
     expected_raw_size: u64,
@@ -895,10 +936,7 @@ fn verify_codex_zstd(
     timings: &mut SessionHistoryCpuTimings,
     cancel: &CancellationToken,
     hooks: &SessionHistoryCpuHooks,
-) -> RunnerResult<(
-    Option<chrono::DateTime<chrono::Utc>>,
-    Option<SessionHistoryPrefixOutcome>,
-)> {
+) -> RunnerResult<VerifiedCodexZstd> {
     let decompression_started = Instant::now();
     let input = CancellationReader::new(encoded_bytes, cancel.clone(), hooks.clone());
     let decoder = match zstd::stream::read::Decoder::new(input) {
@@ -913,6 +951,14 @@ fn verify_codex_zstd(
     let decoded = decoder.take(expected_raw_size.saturating_add(1));
     let mut output = CancellationReader::new(decoded, cancel.clone(), hooks.clone());
     let mut observer = SessionHistoryHashObserver::new(prefix_attribution);
+    let mut raw_bytes = if expected_raw_size > hooks.codex_raw_restore_threshold() {
+        let capacity = usize::try_from(expected_raw_size).map_err(|_| {
+            RunnerError::Internal("session history raw size does not fit in memory".into())
+        })?;
+        Some(Vec::with_capacity(capacity))
+    } else {
+        None
+    };
     let mut decoded_bytes = 0u64;
     let mut timestamp = None;
     let mut timestamp_scanner = Some(CodexTimestampRecordScanner::new(
@@ -949,6 +995,9 @@ fn verify_codex_zstd(
             RunnerError::Internal("invalid zstd session history read chunk length".into())
         })?;
         observer.update(chunk, cancel)?;
+        if let Some(raw_bytes) = &mut raw_bytes {
+            raw_bytes.extend_from_slice(chunk);
+        }
         if let Some(scanner) = &mut timestamp_scanner
             && let Some(discovered) = scanner.scan(chunk, cancel, hooks)?
         {
@@ -977,7 +1026,11 @@ fn verify_codex_zstd(
     let hash_result = observer.finish(expected_hash);
     timings.record_hash_verification(hash_started.elapsed(), hash_result.is_ok());
     let prefix_outcome = hash_result?;
-    Ok((timestamp, prefix_outcome))
+    Ok(VerifiedCodexZstd {
+        timestamp,
+        prefix_outcome,
+        raw_bytes,
+    })
 }
 
 impl CodexTimestampRecordScanner {
@@ -1430,6 +1483,16 @@ mod tests {
         )
     }
 
+    fn codex_zstd_job(history: &[u8]) -> SessionHistoryCpuJob {
+        SessionHistoryCpuJob::zstd(
+            "019e9154-c304-70f0-adde-36efb1be1701".into(),
+            zstd::encode_all(history, 0).expect("test history should compress"),
+            history.len() as u64,
+            hex::encode(Sha256::digest(history)),
+            EffectiveCliFramework::Codex,
+        )
+    }
+
     async fn wait_for<T>(future: impl Future<Output = T>) -> T {
         tokio::time::timeout(Duration::from_secs(5), future)
             .await
@@ -1680,6 +1743,46 @@ mod tests {
             .await
             .unwrap();
         assert!(outcome.result.unwrap().session.codex_timestamp().is_none());
+    }
+
+    #[tokio::test]
+    async fn codex_zstd_restore_materializes_raw_only_above_pruning_guard() {
+        let history =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-13T01:02:03Z\"}}\n";
+        let encoded = zstd::encode_all(history.as_slice(), 0).unwrap();
+
+        let encoded_outcome =
+            SessionHistoryCpuPool::with_test_codex_raw_restore_threshold(1, history.len() as u64)
+                .materialize(codex_zstd_job(history), &CancellationToken::new())
+                .await
+                .unwrap()
+                .result
+                .unwrap();
+        assert_eq!(encoded_outcome.session.history_bytes(), encoded);
+        assert_eq!(
+            encoded_outcome.session.codex_zstd_history(),
+            Some(encoded.as_slice())
+        );
+
+        let raw_outcome = SessionHistoryCpuPool::with_test_codex_raw_restore_threshold(
+            1,
+            history.len() as u64 - 1,
+        )
+        .materialize(codex_zstd_job(history), &CancellationToken::new())
+        .await
+        .unwrap()
+        .result
+        .unwrap();
+        assert_eq!(raw_outcome.session.history_bytes(), history);
+        assert!(raw_outcome.session.codex_zstd_history().is_none());
+        assert_eq!(
+            raw_outcome
+                .session
+                .codex_timestamp()
+                .map(|timestamp| timestamp.to_rfc3339())
+                .as_deref(),
+            Some("2026-07-13T01:02:03+00:00")
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/materialization.rs
@@ -17,7 +17,8 @@ use crate::executor::tests::support::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, minimal_context, test_executor_config, test_telemetry,
 };
 use crate::executor::{
-    SessionHistoryMaterializer, SessionHistoryRestorePlan, effective_cli_framework,
+    SessionHistoryCpuPool, SessionHistoryMaterializer, SessionHistoryRestorePlan,
+    effective_cli_framework,
 };
 use crate::telemetry::SessionHistoryTelemetrySnapshot;
 use crate::test_fixtures::session_history::OneShotSessionHistoryServer;
@@ -909,6 +910,84 @@ async fn run_in_sandbox_restores_codex_zstd_sidecar_with_session_timestamp() {
         "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl.zst"
     );
     assert_eq!(writes[0].content, compressed_history);
+    history_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_materializes_prune_eligible_codex_zstd_sidecar_as_raw() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let history =
+        b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n";
+    let compressed_history = zstd_bytes(history);
+    config.session_history_cpu =
+        SessionHistoryCpuPool::with_test_codex_raw_restore_threshold(1, history.len() as u64 - 1);
+    let sidecar_path = dir.path().join("session-history.blob");
+    tokio::fs::write(&sidecar_path, &compressed_history)
+        .await
+        .unwrap();
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(&compressed_history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                encoding: ResumeSessionHistoryEncoding::Zstd,
+                raw_size: history.len() as u64,
+                encoded_size: compressed_history.len() as u64,
+                download_source: None,
+            },
+        },
+    });
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let restore_plan = local_sidecar_restore_plan(
+        &ctx,
+        &config,
+        WorkspaceSessionHistorySidecar {
+            path: sidecar_path,
+            representation: WorkspaceSessionHistorySidecarRepresentation::CodexZstd,
+            encoded_size: compressed_history.len() as u64,
+        },
+        cancel.clone(),
+    )
+    .await;
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(cancel, None).with_session_history_restore_plan(restore_plan),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
     history_mock.assert_calls_async(0).await;
 }
 

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -31,7 +31,7 @@ use crate::executor::tests::support::{
     test_executor_config, test_telemetry,
 };
 use crate::executor::{
-    EXIT_SIGKILL, RestoredSessionIdentity, SessionHistoryMaterializer,
+    EXIT_SIGKILL, RestoredSessionIdentity, SessionHistoryCpuPool, SessionHistoryMaterializer,
     SessionHistoryRestoreFallback, SessionHistoryRestorePlan, effective_cli_framework,
 };
 use crate::restored_session_identity::{
@@ -1093,4 +1093,79 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
             .any(|op| op.0 == "session_history_identity_reuse_missing" && op.1),
         "expected identity reuse missing telemetry, got: {ops:?}"
     );
+}
+
+#[tokio::test]
+async fn reused_sandbox_fallback_materializes_prune_eligible_codex_zstd_as_raw() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let history =
+        b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n";
+    let compressed_history = zstd::encode_all(history.as_slice(), 0).unwrap();
+    config.session_history_cpu =
+        SessionHistoryCpuPool::with_test_codex_raw_restore_threshold(1, history.len() as u64 - 1);
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(&compressed_history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                encoding: ResumeSessionHistoryEncoding::Zstd,
+                raw_size: history.len() as u64,
+                encoded_size: compressed_history.len() as u64,
+                download_source: None,
+            },
+        },
+    });
+    sandbox.push_read_file_result(Ok(None));
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        &config.session_history_cpu,
+        ctx.resume_session.as_ref(),
+        effective_cli_framework(&ctx.cli_agent_type),
+        tokio_util::sync::CancellationToken::new(),
+        None,
+    );
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                materializer,
+                fallback: Some(SessionHistoryRestoreFallback::MissingIdleIdentity),
+            }),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -13075,6 +13075,14 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
             runner_startup_path: "workspace",
             sandbox_reuse_result: "poolMiss",
           },
+          {
+            ts: nowDate().toISOString(),
+            action_type: "session_history_prune",
+            duration_ms: 4,
+            success: true,
+            outcome: "ineligible",
+            reason: "source_within_guard",
+          },
         ],
       },
       sandboxHeaders,
@@ -13183,6 +13191,20 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
           success: true,
           runner_startup_path: "workspace",
           sandbox_reuse_result: "poolMiss",
+          source: "sandbox",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "session_history_prune",
+          run_id: created.runId,
+          duration_ms: 4,
+          success: true,
+          outcome: "ineligible",
+          reason: "source_within_guard",
           source: "sandbox",
         }),
       ],

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -47,6 +47,8 @@ const L = logger("webhooks:agent");
 
 interface SandboxOperationDimensionInput {
   readonly error?: string;
+  readonly outcome?: string;
+  readonly reason?: string;
   readonly runner_startup_path?: RunnerStartupPath;
   readonly sandbox_reuse_result?: SandboxReuseResult;
   readonly encoding?: string;
@@ -67,6 +69,8 @@ function sandboxOperationDimensions(
   return {
     source: "sandbox",
     ...(op.error ? { error: op.error } : {}),
+    ...(op.outcome ? { outcome: op.outcome } : {}),
+    ...(op.reason ? { reason: op.reason } : {}),
     ...(op.runner_startup_path
       ? { runner_startup_path: op.runner_startup_path }
       : {}),

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -60,6 +60,41 @@ describe("storage webhook manifest limits", () => {
 });
 
 describe("webhook telemetry contract", () => {
+  it("accepts bounded sandbox operation outcome dimensions", () => {
+    const result = webhookTelemetryContract.send.body.parse({
+      runId: "00000000-0000-4000-8000-000000000000",
+      sandboxOperations: [
+        {
+          ts: "2026-01-15T10:00:00.000Z",
+          action_type: "session_history_prune",
+          duration_ms: 10,
+          success: true,
+          outcome: "ineligible",
+          reason: "source_within_guard",
+        },
+      ],
+    });
+
+    expect(result.sandboxOperations?.[0]).toMatchObject({
+      outcome: "ineligible",
+      reason: "source_within_guard",
+    });
+    expect(
+      webhookTelemetryContract.send.body.safeParse({
+        runId: "00000000-0000-4000-8000-000000000000",
+        sandboxOperations: [
+          {
+            ts: "2026-01-15T10:00:00.000Z",
+            action_type: "session_history_prune",
+            duration_ms: 10,
+            success: true,
+            outcome: "x".repeat(65),
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts bounded startup outcomes and keeps them optional", () => {
     const startupOutcomes = [
       ["sandbox", "reused"],

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -733,6 +733,8 @@ const sandboxOperationSchema = z.object({
   duration_ms: z.number(),
   success: z.boolean(),
   error: z.string().optional(),
+  outcome: z.string().max(64).optional(),
+  reason: z.string().max(64).optional(),
   runner_startup_path: runnerStartupPathSchema.optional(),
   sandbox_reuse_result: sandboxReuseResultSchema.optional(),
   encoding: sessionHistoryEncodingSchema.optional(),


### PR DESCRIPTION
## Summary

- share the 64 MiB Codex compact-generation guard between the runner and guest selector
- retain verified decoded bytes during the runner's existing zstd verification pass and restore prune-eligible histories as canonical JSONL
- preserve compressed restore behavior at or below the guard, including Codex's own materialization-before-append behavior
- report bounded `outcome` and `reason` dimensions for session-history pruning and add coverage through the webhook ingestion path
- extend the runner behavior probe to verify that the bundled Codex resumes `.jsonl.zst`, materializes `.jsonl`, appends, and retains the thread ID

## Scope

- no database, persisted-state, queue-payload, or session-identity changes
- no feature switch or guest-side streaming zstd selector
- telemetry fields are optional for deployment compatibility

## Validation

- `cargo test -p guest-contracts -p guest-session-prune -p guest-common`
- `cargo test -p runner session_history`
- `cargo test -p guest-agent --test integration checkpoint::success::`
- `cargo test -p guest-agent --test integration recovery_checkpoint_does_not_prune_eligible_codex_history`
- `cargo clippy -p guest-contracts -p guest-session-prune -p guest-common -p guest-agent -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-contracts -p guest-session-prune -p guest-common -p guest-agent -p runner --no-deps`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "reports artifacts, volumes, model usage, and telemetry through sandbox webhooks"`
- `bash -n .github/scripts/runner-behavior-exec.sh`
- `lefthook run pre-commit`

Closes #25551
