### PR TITLE
test(e2e): clear composer drafts with keyboard input

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -48,6 +48,12 @@ async function waitForAgentDraftClear(
   await draftCleared;
 }
 
+async function clearComposerEditor(editor: Locator): Promise<void> {
+  await editor.press("ControlOrMeta+A");
+  await editor.press("Backspace");
+  await expect(editor).toHaveText("");
+}
+
 function isConnectorCatalogStatusResponse(
   value: unknown,
 ): value is ConnectorCatalogStatusResponse {
@@ -210,7 +216,7 @@ test("chat composer keeps the Send button inside on narrow screens", async ({
   await expectInside(sendButton, composer);
 
   await waitForAgentDraftClear(page, async () => {
-    await editor.fill("");
+    await clearComposerEditor(editor);
   });
 });
 
@@ -420,6 +426,6 @@ test("selected avatar and voice cards keep a single border", async ({
 
   await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
   await waitForAgentDraftClear(page, async () => {
-    await page.getByRole("textbox", { name: "Message" }).fill("");
+    await clearComposerEditor(page.getByRole("textbox", { name: "Message" }));
   });
 });


### PR DESCRIPTION
## Summary

- Clear TipTap chat composers through focused keyboard input instead of `Locator.fill("")`.
- Verify that the editor is empty before waiting for the successful server-side draft-clear response.
- Reuse the same synchronization boundary in the narrow-screen and avatar/voice cleanup paths.

## Root cause

The [triggering merge-group run](https://github.com/vm0-ai/vm0/actions/runs/31146488473) timed out in `waitForAgentDraftClear` while the failure snapshot still showed the original composer text. Request history for that browser session contained the successful initial non-empty draft PATCH, but no subsequent clear PATCH. This rules out a missed successful response or a draft API failure: the programmatic `fill("")` occasionally returned without producing a stable ProseMirror input transaction, so the clear request was never scheduled.

The represented change in #25502 does not modify this interaction boundary. Its earlier PR-head run passed the test, and the exact merge-group diff does not introduce draft-clear behavior, so this is a test synchronization flake rather than a deterministic regression in that PR.

The fix preserves both the narrow-screen geometry assertions and the requirement to observe a successful draft-clear response.

## Recurrence evidence

A second unrelated [merge-group run](https://github.com/vm0-ai/vm0/actions/runs/31148416916) reproduced the identical timeout in the [same Playwright test](https://github.com/vm0-ai/vm0/actions/runs/31148416916/job/92773564966). Its timeout snapshot again retained `Keep the mobile Send button contained`. The failing browser session issued one successful initial draft PATCH at `2026-08-07T04:52:20.233Z`, then no draft-clear PATCH before the timeout. The exact failing SHA still used `editor.fill("")` for cleanup.

The immediately following [merge-group Playwright job](https://github.com/vm0-ai/vm0/actions/runs/31148446534/job/92773727910), built on a base containing the prior merge-group SHA, passed all 12 tests. This recurrence reinforces the same intermittent missing editor-transaction boundary addressed here; it does not require a broader or different fix.

A third [merge-group run](https://github.com/vm0-ai/vm0/actions/runs/31148968006) on another updated base reproduced the exact response-wait timeout in the [same test](https://github.com/vm0-ai/vm0/actions/runs/31148968006/job/92774838025), while 11 other tests passed. Its snapshot again retained the original composer text, and its exact SHA still cleared with `editor.fill("")`. The [fresh #25583 merge-group run](https://github.com/vm0-ai/vm0/actions/runs/31149058186) is built directly on that failing SHA, so it validates the keyboard-input repair against the newest recurrence without rerunning the discarded failure.

## Verification

- `npx --yes prettier@3.6.2 --check e2e/playwright/tests/chat.spec.ts`
- `pnpm check-types` (from `e2e`)
- Targeted Playwright test discovery for `chat composer keeps the Send button inside on narrow screens`
- `git diff --check`
- PR Turbo `cli-e2e-02-playwright`: 5/5 normal executions passed, with 11/11 tests passing each time: [1](https://github.com/vm0-ai/vm0/actions/runs/31148024984/job/92771989223), [2](https://github.com/vm0-ai/vm0/actions/runs/31148024984/job/92772334246), [3](https://github.com/vm0-ai/vm0/actions/runs/31148024984/job/92772674881), [4](https://github.com/vm0-ai/vm0/actions/runs/31148024984/job/92773150345), [5](https://github.com/vm0-ai/vm0/actions/runs/31148024984/job/92773480165)

Trigger: https://github.com/vm0-ai/vm0/actions/runs/31146488473
Failed job: https://github.com/vm0-ai/vm0/actions/runs/31146488473/job/92767628488
