### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.140.0"
+version = "1.141.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9660cf991e512fbe6094f1041ff3d3282bc5aeeeb6184e8de437ec2de024a10"
+checksum = "d9f9420d3a2467eed22ed3635ca653653162c386a0b0f65c78189f9bd3c1379e"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4250,18 +4250,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

- Update `aws-sdk-s3` from 1.140.0 to 1.141.0.
- Update `clap` and `clap_builder` from 4.6.5 to 4.6.6.
- Update `zerocopy` and `zerocopy-derive` from 0.8.55 to 0.8.56.
- This is a lockfile-only refresh; no dependency manifests were changed.

## Dependencies not updated

- `generic-array` remains at 0.14.7 (0.14.9 is available) because `crypto-common` 0.1.7 pins it to exactly `=0.14.7`.

## Manual version bumps

- None.

## Tests

- `cargo test --workspace --exclude runner --no-fail-fast`: **3,476 passed, 17 ignored, 2 failed** across 179 targets. The two failures are both in `guest-agent --test command_output_timeout` and reproduce on current `main` in this runtime: `/proc/1` has session ID 0, causing the `rustix` 1.1.4 `Pid` debug assertion while the test helper scans `/proc`. All other 178 targets completed.
- `MALLOC_ARENA_MAX=1 RAYON_NUM_THREADS=1 cargo test -p runner --no-fail-fast`: **3,035 passed, 20 ignored, 0 failed**. The constrained profile keeps the large runner test-binary links within this 3.8 GiB runtime.
