### PR TITLE
feat(api): publish atomic runner preference decisions

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -6,6 +6,7 @@ import type {
 } from "@vm0/api-contracts/contracts/realtime";
 import type {
   RunnerPreference,
+  RunnerPreferenceDecision,
   RunnerPreferenceResolution,
 } from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
@@ -401,7 +402,8 @@ export async function publishRunnerJobNotification(
     readonly reuseKey: string | null;
     readonly cliAgentSessionId: string | null;
     readonly historyGenerationRunId: string | undefined;
-    readonly runnerPreference: RunnerPreference | null;
+    readonly runnerPreferenceDecision: RunnerPreferenceDecision;
+    readonly runnerPreference?: RunnerPreference;
     readonly runnerPreferenceResolution: RunnerPreferenceResolution;
   },
 ): Promise<boolean> {
@@ -423,6 +425,7 @@ export async function publishRunnerJobNotification(
           : {}),
         ...(metadata
           ? {
+              runnerPreferenceDecision: metadata.runnerPreferenceDecision,
               runnerPreferenceResolution: metadata.runnerPreferenceResolution,
             }
           : {}),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -134,6 +134,12 @@ function runnerPreference(
   return job?.runnerPreference;
 }
 
+function runnerPreferenceDecision(
+  job: RunnerJob | null | undefined,
+): RunnerJob["runnerPreferenceDecision"] {
+  return job?.runnerPreferenceDecision;
+}
+
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_ATOMIC_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_atomic_launch",
@@ -3643,6 +3649,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(poll.body.job?.runId).toBe(resumed.runId);
     expect(poll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(poll.body.job?.reuseKey).toBeNull();
+    expect(runnerPreferenceDecision(poll.body.job)).toStrictEqual({
+      kind: "noPreference",
+      reason: "noReuseKey",
+    });
     expect(runnerPreference(poll.body.job)).toBeUndefined();
 
     const resumedClaim = await api.claimRunnerJob(resumed.runId);
@@ -3765,6 +3775,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       cliAgentSessionId,
     );
     expect(canonicalHeartbeatHolder.job?.reuseKey).toBe(reuseKey);
+    expect(
+      runnerPreferenceDecision(canonicalHeartbeatHolder.job),
+    ).toStrictEqual({
+      kind: "noPreference",
+      reason: "noViableHolder",
+    });
     expect(runnerPreference(canonicalHeartbeatHolder.job)).toBeUndefined();
     expect(canonicalHeartbeatHolder.job?.runnerPreferenceResolution).toBe(
       "no_viable_holder",
@@ -3791,6 +3807,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue with a workspace-only holder",
     );
     expect(workspaceOnlyHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
+    expect(runnerPreferenceDecision(workspaceOnlyHolder.job)).toStrictEqual({
+      kind: "preference",
+      runnerIdentity: {
+        runnerId: reuseRunnerId,
+        heartbeatGeneration: 1,
+      },
+      tier: "workspaceCache",
+      expiresAt: expect.any(String),
+    });
     expect(runnerPreference(workspaceOnlyHolder.job)).toStrictEqual({
       runnerIdentity: {
         runnerId: reuseRunnerId,
@@ -3836,13 +3861,25 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const reusableOverWorkspace = await pollFollowUp(
       "prefer a reusable holder over a capable workspace holder",
     );
-    const reusablePreference = {
+    const reusableDecision = runnerPreferenceDecision(
+      reusableOverWorkspace.job,
+    );
+    expect(reusableDecision).toStrictEqual({
+      kind: "preference",
       runnerIdentity: {
         runnerId: reusableRunnerId,
         heartbeatGeneration: 1,
       },
-      reason: "matchingReuseKey" as const,
+      tier: "reusableSandbox",
       expiresAt: expect.any(String),
+    });
+    if (reusableDecision?.kind !== "preference") {
+      throw new Error("Expected a reusable sandbox preference decision");
+    }
+    const reusablePreference = {
+      runnerIdentity: reusableDecision.runnerIdentity,
+      reason: "matchingReuseKey" as const,
+      expiresAt: reusableDecision.expiresAt,
     };
     expect(runnerPreference(reusableOverWorkspace.job)).toStrictEqual(
       reusablePreference,
@@ -3854,6 +3891,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "job",
       expect.objectContaining({
         runId: reusableOverWorkspace.run.runId,
+        runnerPreferenceDecision: {
+          kind: "preference",
+          runnerIdentity: reusablePreference.runnerIdentity,
+          tier: "reusableSandbox",
+          expiresAt: reusablePreference.expiresAt,
+        },
         runnerPreference: reusablePreference,
         runnerPreferenceResolution: "matching_reusable_sandbox",
       }),
@@ -3874,6 +3917,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const mismatchedCapableWorkspace = await pollFollowUp(
       "continue with a mismatched capable workspace",
     );
+    expect(
+      runnerPreferenceDecision(mismatchedCapableWorkspace.job),
+    ).toStrictEqual({
+      kind: "noPreference",
+      reason: "noViableHolder",
+    });
     expect(runnerPreference(mismatchedCapableWorkspace.job)).toBeUndefined();
     expect(mismatchedCapableWorkspace.job?.runnerPreferenceResolution).toBe(
       "no_viable_holder",
@@ -3889,6 +3938,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const differentGenerationHolder = await pollFollowUp(
       "continue with a different reusable generation",
     );
+    expect(
+      runnerPreferenceDecision(differentGenerationHolder.job),
+    ).toStrictEqual({
+      kind: "preference",
+      runnerIdentity: {
+        runnerId: reuseRunnerId,
+        heartbeatGeneration: 1,
+      },
+      tier: "reusableSandbox",
+      expiresAt: expect.any(String),
+    });
     expect(runnerPreference(differentGenerationHolder.job)).toStrictEqual({
       runnerIdentity: {
         runnerId: reuseRunnerId,
@@ -3911,6 +3971,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const exactGenerationHolder = await pollFollowUp(
       "continue with exact reusable generation",
     );
+    expect(runnerPreferenceDecision(exactGenerationHolder.job)).toStrictEqual({
+      kind: "preference",
+      runnerIdentity: {
+        runnerId: reuseRunnerId,
+        heartbeatGeneration: 1,
+      },
+      tier: "exactSandbox",
+      expiresAt: expect.any(String),
+    });
     expect(runnerPreference(exactGenerationHolder.job)).toStrictEqual({
       runnerIdentity: {
         runnerId: reuseRunnerId,
@@ -3923,14 +3992,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "exact_history_generation",
     );
 
-    for (const { runId, resolution } of [
+    for (const { runId, resolution, tier } of [
       {
         runId: reusableOverWorkspace.run.runId,
         resolution: "matching_reusable_sandbox",
+        tier: "reusableSandbox",
       },
       {
         runId: capableWorkspaceHolder.run.runId,
         resolution: "matching_workspace_cache",
+        tier: "workspaceCache",
       },
     ]) {
       for (const actionType of [
@@ -3942,6 +4013,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         expect(events[0]).toStrictEqual(
           expect.objectContaining({
             runner_preference_resolution: resolution,
+            runner_preference_decision_kind: "preference",
+            runner_preference_tier: tier,
             reuse_key_kind: "thread",
           }),
         );
@@ -3998,12 +4071,19 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       reason: "finalizingPredecessor" as const,
       expiresAt: new Date(sourceCompletedAt + 1500).toISOString(),
     };
+    const finalizingDecision = {
+      kind: "preference" as const,
+      runnerIdentity: sourceRunnerIdentity,
+      tier: "finalizingPredecessor" as const,
+      expiresAt: finalizingPreference.expiresAt,
+    };
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: successor.runId,
         reuseKey,
         historyGenerationRunId: first.runId,
+        runnerPreferenceDecision: finalizingDecision,
         runnerPreference: finalizingPreference,
         runnerPreferenceResolution: "finalizing_predecessor",
       }),
@@ -4022,6 +4102,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected finalizing predecessor poll to succeed");
     }
     expect(sourcePoll.body.job?.runId).toBe(successor.runId);
+    expect(runnerPreferenceDecision(sourcePoll.body.job)).toStrictEqual(
+      finalizingDecision,
+    );
     expect(runnerPreference(sourcePoll.body.job)).toStrictEqual(
       finalizingPreference,
     );
@@ -4037,6 +4120,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       ).toContainEqual(
         expect.objectContaining({
           runner_preference_resolution: "finalizing_predecessor",
+          runner_preference_decision_kind: "preference",
+          runner_preference_tier: "finalizingPredecessor",
           history_generation_run_id: first.runId,
         }),
       );
@@ -4167,10 +4252,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       reason: "exactHistoryGeneration" as const,
       expiresAt: new Date(successorCreatedAt + 1000).toISOString(),
     };
+    const exactDecision = {
+      kind: "preference" as const,
+      runnerIdentity: exactRunnerIdentity,
+      tier: "exactSandbox" as const,
+      expiresAt: exactPreference.expiresAt,
+    };
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: successor.runId,
+        runnerPreferenceDecision: exactDecision,
         runnerPreference: exactPreference,
       }),
     );
@@ -4187,6 +4279,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected exact-history poll to succeed");
     }
     expect(poll.body.job?.runId).toBe(successor.runId);
+    expect(runnerPreferenceDecision(poll.body.job)).toStrictEqual(
+      exactDecision,
+    );
     expect(runnerPreference(poll.body.job)).toStrictEqual(exactPreference);
 
     await api.requestCancelRun(actor, successor.runId, [200]);
@@ -4557,6 +4652,21 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       prompt: "continue after reuse-preference protection expires",
     });
     mockNow(now() + 60_000);
+    const expiredPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (expiredPoll.status !== 200) {
+      throw new Error("Expected expired reuse-preference poll to return 200");
+    }
+    expect(expiredPoll.body.job?.runId).toBe(expiredFollowUp.runId);
+    expect(runnerPreferenceDecision(expiredPoll.body.job)).toStrictEqual({
+      kind: "noPreference",
+      reason: "expired",
+    });
+    expect(runnerPreference(expiredPoll.body.job)).toBeUndefined();
+    expect(expiredPoll.body.job?.runnerPreferenceResolution).toBe("expired");
     const expiredClaim = await api.requestClaimRunnerJob(
       true,
       expiredFollowUp.runId,
@@ -5220,6 +5330,17 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(promotedStorageState.has_stored_storage_manifest).toBeFalsy();
     expect(promotedStorageState.canonical_mount_count).toBeGreaterThan(0);
     expect(promotedStorageState.has_run_context_storage).toBeFalsy();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: third.runId,
+        runnerPreferenceDecision: {
+          kind: "noPreference",
+          reason: "noReuseKey",
+        },
+        runnerPreferenceResolution: "no_reuse_key",
+      }),
+    );
     const decryptCountBeforeClaim = await readFakeKmsDecryptCallCount(context);
     await api.heartbeatRunner(runnerGroup);
     const thirdClaim = await api.claimRunnerJob(third.runId);
@@ -5270,6 +5391,8 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           profile: "vm0/default",
           notification_target: "broadcast",
           runner_preference_resolution: "no_reuse_key",
+          runner_preference_decision_kind: "noPreference",
+          runner_preference_no_preference_reason: "noReuseKey",
           reuse_key_kind: "none",
         }),
       );

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -20,6 +20,7 @@ import {
   type HeldSandboxState,
   type HeldWorkspaceState,
   type RunnerPreferenceClaimState,
+  type RunnerPreferenceDecision,
   type RunnerPreferenceResolution,
   type SessionHistoryDownloadSource,
   type StoredConnectorPermissionBaseline,
@@ -118,8 +119,10 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
+  runnerPreferenceDecisionTelemetryDimensions,
+  runnerPreferenceDeliveryFields,
   runnerReuseKeyTelemetryKind,
-  runnerReusePreferenceLookupError,
+  runnerReusePreferenceLookupErrorDecision,
   runnerReusePreferencePollPriority,
   resolveRunnerReusePreference,
 } from "../services/runner-reuse-preference";
@@ -551,7 +554,7 @@ function recordPollTimingMetrics(args: {
   readonly profile: string;
   readonly authType: RunnerAuthContext["type"];
   readonly pollReason: string | undefined;
-  readonly runnerPreferenceResolution: RunnerPreferenceResolution;
+  readonly runnerPreferenceDecision: RunnerPreferenceDecision;
   readonly reuseKeyKind: "thread" | "session" | "none";
   readonly historyGenerationRunId: string | undefined;
   readonly queueCreatedAtMs: number;
@@ -564,8 +567,10 @@ function recordPollTimingMetrics(args: {
     runner_group: args.runnerGroup,
     profile: args.profile,
     auth_type: args.authType,
-    runner_preference_resolution: args.runnerPreferenceResolution,
     reuse_key_kind: args.reuseKeyKind,
+    ...runnerPreferenceDecisionTelemetryDimensions(
+      args.runnerPreferenceDecision,
+    ),
   };
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
@@ -654,7 +659,7 @@ async function resolvePollRunnerReusePreference(
       });
     },
   );
-  return resolution ?? runnerReusePreferenceLookupError();
+  return resolution ?? runnerReusePreferenceLookupErrorDecision();
 }
 
 const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -732,7 +737,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!pendingJob) {
     return { status: 200 as const, body: { job: null } };
   }
-  const reusePreference = await resolvePollRunnerReusePreference(db, {
+  const runnerPreferenceDecision = await resolvePollRunnerReusePreference(db, {
     runId: pendingJob.runId,
     runnerGroup: group,
     profile: pendingJob.profile,
@@ -742,13 +747,16 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     currentDate,
   });
   signal.throwIfAborted();
+  const runnerPreferenceFields = runnerPreferenceDeliveryFields(
+    runnerPreferenceDecision,
+  );
   recordPollTimingMetrics({
     runId: pendingJob.runId,
     runnerGroup: group,
     profile: pendingJob.profile,
     authType: auth.type,
     pollReason: body.data.telemetry?.pollReason,
-    runnerPreferenceResolution: reusePreference.outcome,
+    runnerPreferenceDecision,
     reuseKeyKind: runnerReuseKeyTelemetryKind(pendingJob.reuseKey),
     historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
@@ -771,8 +779,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         cliAgentSessionId: pendingJob.cliAgentSessionId,
         reuseKey: pendingJob.reuseKey,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
-        runnerPreference: reusePreference.runnerPreference ?? undefined,
-        runnerPreferenceResolution: reusePreference.outcome,
+        ...runnerPreferenceFields,
       },
     },
   };

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -4,8 +4,10 @@ import { now } from "../../lib/time";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import {
+  runnerPreferenceDecisionTelemetryDimensions,
+  runnerPreferenceDeliveryFields,
   runnerReuseKeyTelemetryKind,
-  runnerReusePreferenceLookupError,
+  runnerReusePreferenceLookupErrorDecision,
   resolveRunnerReusePreference,
 } from "./runner-reuse-preference";
 import { tapError } from "../utils";
@@ -27,7 +29,7 @@ export async function notifyRunnerJob(
   const notificationEnteredAt = now();
   const currentDate = new Date(notificationEnteredAt);
   let preferenceLookupSucceeded = true;
-  const reusePreference =
+  const runnerPreferenceDecision =
     (await tapError(
       resolveRunnerReusePreference({
         db,
@@ -50,7 +52,10 @@ export async function notifyRunnerJob(
           },
         );
       },
-    )) ?? runnerReusePreferenceLookupError();
+    )) ?? runnerReusePreferenceLookupErrorDecision();
+  const runnerPreferenceFields = runnerPreferenceDeliveryFields(
+    runnerPreferenceDecision,
+  );
   const preferenceFinishedAt = now();
   const publishStartedAt = now();
   const published = await publishRunnerJobNotification(
@@ -61,8 +66,7 @@ export async function notifyRunnerJob(
       reuseKey: args.reuseKey,
       cliAgentSessionId: args.cliAgentSessionId,
       historyGenerationRunId: args.historyGenerationRunId,
-      runnerPreference: reusePreference.runnerPreference,
-      runnerPreferenceResolution: reusePreference.outcome,
+      ...runnerPreferenceFields,
     },
   );
   const publishFinishedAt = now();
@@ -71,8 +75,8 @@ export async function notifyRunnerJob(
     runner_group: args.runnerGroup,
     profile: args.profile,
     notification_target: "broadcast",
-    runner_preference_resolution: reusePreference.outcome,
     reuse_key_kind: runnerReuseKeyTelemetryKind(args.reuseKey),
+    ...runnerPreferenceDecisionTelemetryDimensions(runnerPreferenceDecision),
   };
   if (args.historyGenerationRunId) {
     dimensions.history_generation_run_id = args.historyGenerationRunId;

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -1,5 +1,6 @@
 import type {
   RunnerPreference,
+  RunnerPreferenceDecision,
   RunnerPreferenceResolution,
 } from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -270,15 +271,97 @@ export function runnerReusePreferencePollPriority(args: {
   END`;
 }
 
-interface RunnerReusePreferenceResolution {
-  readonly runnerPreference: RunnerPreference | null;
-  readonly outcome: RunnerPreferenceResolution;
+type PositiveRunnerPreferenceDecision = Extract<
+  RunnerPreferenceDecision,
+  { kind: "preference" }
+>;
+type NoRunnerPreferenceDecision = Extract<
+  RunnerPreferenceDecision,
+  { kind: "noPreference" }
+>;
+
+interface RunnerPreferenceDeliveryFields {
+  readonly runnerPreferenceDecision: RunnerPreferenceDecision;
+  readonly runnerPreference?: RunnerPreference;
+  readonly runnerPreferenceResolution: RunnerPreferenceResolution;
 }
 
-export function runnerReusePreferenceLookupError(): RunnerReusePreferenceResolution {
+const legacyPreferenceByTier = {
+  exactSandbox: {
+    reason: "exactHistoryGeneration",
+    resolution: "exact_history_generation",
+  },
+  finalizingPredecessor: {
+    reason: "finalizingPredecessor",
+    resolution: "finalizing_predecessor",
+  },
+  reusableSandbox: {
+    reason: "matchingReuseKey",
+    resolution: "matching_reusable_sandbox",
+  },
+  workspaceCache: {
+    reason: "matchingReuseKey",
+    resolution: "matching_workspace_cache",
+  },
+} as const satisfies Record<
+  PositiveRunnerPreferenceDecision["tier"],
+  {
+    readonly reason: RunnerPreference["reason"];
+    readonly resolution: RunnerPreferenceResolution;
+  }
+>;
+
+const legacyResolutionByNoPreferenceReason = {
+  noReuseKey: "no_reuse_key",
+  expired: "expired",
+  noViableHolder: "no_viable_holder",
+  lookupError: "lookup_error",
+} as const satisfies Record<
+  NoRunnerPreferenceDecision["reason"],
+  RunnerPreferenceResolution
+>;
+
+export function runnerReusePreferenceLookupErrorDecision(): RunnerPreferenceDecision {
   return {
-    runnerPreference: null,
-    outcome: "lookup_error",
+    kind: "noPreference",
+    reason: "lookupError",
+  };
+}
+
+export function runnerPreferenceDeliveryFields(
+  decision: RunnerPreferenceDecision,
+): RunnerPreferenceDeliveryFields {
+  if (decision.kind === "noPreference") {
+    return {
+      runnerPreferenceDecision: decision,
+      runnerPreferenceResolution:
+        legacyResolutionByNoPreferenceReason[decision.reason],
+    };
+  }
+
+  const legacy = legacyPreferenceByTier[decision.tier];
+  return {
+    runnerPreferenceDecision: decision,
+    runnerPreference: {
+      runnerIdentity: decision.runnerIdentity,
+      reason: legacy.reason,
+      expiresAt: decision.expiresAt,
+    },
+    runnerPreferenceResolution: legacy.resolution,
+  };
+}
+
+export function runnerPreferenceDecisionTelemetryDimensions(
+  decision: RunnerPreferenceDecision,
+): Record<string, string> {
+  const { runnerPreferenceResolution } =
+    runnerPreferenceDeliveryFields(decision);
+  return {
+    runner_preference_resolution: runnerPreferenceResolution,
+    runner_preference_decision_kind: decision.kind,
+    ...(decision.kind === "preference"
+      ? { runner_preference_tier: decision.tier }
+      : { runner_preference_no_preference_reason: decision.reason }),
   };
 }
 
@@ -396,11 +479,11 @@ export async function resolveRunnerReusePreference(args: {
   readonly historyGenerationRunId: string | undefined;
   readonly createdAt: Date;
   readonly currentDate: Date;
-}): Promise<RunnerReusePreferenceResolution> {
+}): Promise<RunnerPreferenceDecision> {
   if (!args.reuseKey) {
     return {
-      runnerPreference: null,
-      outcome: "no_reuse_key",
+      kind: "noPreference",
+      reason: "noReuseKey",
     };
   }
   const matchingReuseExpiresAt = new Date(
@@ -412,8 +495,8 @@ export async function resolveRunnerReusePreference(args: {
   const shouldLookUpGenericReuse = matchingReuseExpiresAt > args.currentDate;
   if (!shouldLookUpGenericReuse && !args.historyGenerationRunId) {
     return {
-      runnerPreference: null,
-      outcome: "expired",
+      kind: "noPreference",
+      reason: "expired",
     };
   }
 
@@ -437,8 +520,8 @@ export async function resolveRunnerReusePreference(args: {
 
   if (!holder) {
     return {
-      runnerPreference: null,
-      outcome: shouldLookUpGenericReuse ? "no_viable_holder" : "expired",
+      kind: "noPreference",
+      reason: shouldLookUpGenericReuse ? "noViableHolder" : "expired",
     };
   }
 
@@ -447,12 +530,10 @@ export async function resolveRunnerReusePreference(args: {
       throw new Error("Exact history preference is missing its deadline");
     }
     return {
-      runnerPreference: {
-        runnerIdentity: holder.runnerIdentity,
-        reason: "exactHistoryGeneration",
-        expiresAt: exactHistoryExpiresAt.toISOString(),
-      },
-      outcome: "exact_history_generation",
+      kind: "preference",
+      runnerIdentity: holder.runnerIdentity,
+      tier: "exactSandbox",
+      expiresAt: exactHistoryExpiresAt.toISOString(),
     };
   }
 
@@ -461,27 +542,21 @@ export async function resolveRunnerReusePreference(args: {
       throw new Error("Finalizing predecessor is missing its completion time");
     }
     return {
-      runnerPreference: {
-        runnerIdentity: holder.runnerIdentity,
-        reason: "finalizingPredecessor",
-        expiresAt: new Date(
-          holder.sourceCompletedAt.getTime() +
-            RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS,
-        ).toISOString(),
-      },
-      outcome: "finalizing_predecessor",
+      kind: "preference",
+      runnerIdentity: holder.runnerIdentity,
+      tier: "finalizingPredecessor",
+      expiresAt: new Date(
+        holder.sourceCompletedAt.getTime() +
+          RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS,
+      ).toISOString(),
     };
   }
 
   return {
-    runnerPreference: {
-      runnerIdentity: holder.runnerIdentity,
-      reason: "matchingReuseKey",
-      expiresAt: matchingReuseExpiresAt.toISOString(),
-    },
-    outcome: holder.hasReusableSandbox
-      ? "matching_reusable_sandbox"
-      : "matching_workspace_cache",
+    kind: "preference",
+    runnerIdentity: holder.runnerIdentity,
+    tier: holder.hasReusableSandbox ? "reusableSandbox" : "workspaceCache",
+    expiresAt: matchingReuseExpiresAt.toISOString(),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -286,6 +286,7 @@ interface RunnerPreferenceDeliveryFields {
   readonly runnerPreferenceResolution: RunnerPreferenceResolution;
 }
 
+// Remove this legacy projection in #25577 after old runners have drained.
 const legacyPreferenceByTier = {
   exactSandbox: {
     reason: "exactHistoryGeneration",

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -367,7 +367,7 @@ export function runnerPreferenceDecisionTelemetryDimensions(
 }
 
 interface RunnerReuseHolder {
-  readonly runnerIdentity: RunnerPreference["runnerIdentity"];
+  readonly runnerIdentity: PositiveRunnerPreferenceDecision["runnerIdentity"];
   readonly hasExactHistoryGeneration: boolean;
   readonly isFinalizingPredecessor: boolean;
   readonly hasReusableSandbox: boolean;

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -625,7 +625,7 @@ describe("runner resume session contract", () => {
     ]);
   });
 
-  it("keeps the canonical runner preference optional", () => {
+  it("keeps runner preference delivery fields optional", () => {
     const job = jobSchema.parse({
       runId: "22222222-2222-4222-8222-222222222222",
       prompt: "continue",
@@ -634,8 +634,120 @@ describe("runner resume session contract", () => {
       vars: null,
       experimentalProfile: "vm0/default",
     });
+    expect(job.runnerPreferenceDecision).toBeUndefined();
     expect(job.runnerPreference).toBeUndefined();
     expect(job.runnerPreferenceResolution).toBeUndefined();
+  });
+
+  it("accepts every strict positive runner preference decision tier", () => {
+    const runnerPreferenceDecision = {
+      kind: "preference" as const,
+      runnerIdentity: {
+        runnerId: "22222222-2222-4222-8222-222222222222",
+        heartbeatGeneration: 7,
+      },
+      expiresAt: "2026-08-03T00:00:01.000Z",
+    };
+    const jobInput = {
+      runId: "33333333-3333-4333-8333-333333333333",
+      prompt: "continue",
+      appendSystemPrompt: null,
+      agentComposeVersionId: null,
+      vars: null,
+      experimentalProfile: "vm0/default",
+    };
+
+    for (const tier of [
+      "exactSandbox",
+      "finalizingPredecessor",
+      "reusableSandbox",
+      "workspaceCache",
+    ] as const) {
+      expect(
+        jobSchema.parse({
+          ...jobInput,
+          runnerPreferenceDecision: { ...runnerPreferenceDecision, tier },
+        }).runnerPreferenceDecision,
+      ).toStrictEqual({ ...runnerPreferenceDecision, tier });
+    }
+    expect(
+      jobSchema.safeParse({
+        ...jobInput,
+        runnerPreferenceDecision: {
+          ...runnerPreferenceDecision,
+          tier: "reusableSandbox",
+          reason: "noReuseKey",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      jobSchema.safeParse({
+        ...jobInput,
+        runnerPreferenceDecision: {
+          ...runnerPreferenceDecision,
+          tier: "reusableSandbox",
+          expiresAt: undefined,
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      jobSchema.safeParse({
+        ...jobInput,
+        runnerPreferenceDecision: {
+          ...runnerPreferenceDecision,
+          runnerIdentity: {
+            ...runnerPreferenceDecision.runnerIdentity,
+            runnerId: "not-a-uuid",
+          },
+          tier: "reusableSandbox",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      jobSchema.safeParse({
+        ...jobInput,
+        runnerPreferenceDecision: {
+          ...runnerPreferenceDecision,
+          tier: "reusableSandbox",
+          expiresAt: "not-a-date",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts every strict no-preference decision reason", () => {
+    const jobInput = {
+      runId: "33333333-3333-4333-8333-333333333333",
+      prompt: "continue",
+      appendSystemPrompt: null,
+      agentComposeVersionId: null,
+      vars: null,
+      experimentalProfile: "vm0/default",
+    };
+
+    for (const reason of [
+      "noReuseKey",
+      "expired",
+      "noViableHolder",
+      "lookupError",
+    ] as const) {
+      expect(
+        jobSchema.parse({
+          ...jobInput,
+          runnerPreferenceDecision: { kind: "noPreference", reason },
+        }).runnerPreferenceDecision,
+      ).toStrictEqual({ kind: "noPreference", reason });
+    }
+    expect(
+      jobSchema.safeParse({
+        ...jobInput,
+        runnerPreferenceDecision: {
+          kind: "noPreference",
+          reason: "noReuseKey",
+          tier: "workspaceCache",
+        },
+      }).success,
+    ).toBe(false);
   });
 
   it("accepts every optional runner preference resolution beside the strict preference", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -102,8 +102,8 @@ const runnerProcessIdentitySchema = z
   .strict();
 
 /**
- * Advisory cross-runner coordination, not an exclusive assignment. A runner
- * with an equivalent compatible local resource remains eligible to claim.
+ * Legacy advisory preference retained while deployed runners migrate to the
+ * atomic decision contract.
  */
 export const runnerPreferenceSchema = z
   .object({
@@ -117,6 +117,11 @@ export const runnerPreferenceSchema = z
   })
   .strict();
 
+/**
+ * Atomic advisory decision for cross-runner reuse coordination. A preferred
+ * runner is not an exclusive assignee; another runner with a better compatible
+ * local resource remains eligible to claim.
+ */
 export const runnerPreferenceDecisionSchema = z.discriminatedUnion("kind", [
   z
     .object({

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -117,6 +117,33 @@ export const runnerPreferenceSchema = z
   })
   .strict();
 
+export const runnerPreferenceDecisionSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("preference"),
+      runnerIdentity: runnerProcessIdentitySchema,
+      tier: z.enum([
+        "exactSandbox",
+        "finalizingPredecessor",
+        "reusableSandbox",
+        "workspaceCache",
+      ]),
+      expiresAt: z.string().datetime({ offset: true }),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("noPreference"),
+      reason: z.enum([
+        "noReuseKey",
+        "expired",
+        "noViableHolder",
+        "lookupError",
+      ]),
+    })
+    .strict(),
+]);
+
 export const runnerPreferenceResolutionSchema = z.enum([
   "exact_history_generation",
   "finalizing_predecessor",
@@ -427,6 +454,7 @@ export const jobSchema = z.object({
   cliAgentSessionId: z.string().nullable().optional(),
   reuseKey: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
+  runnerPreferenceDecision: runnerPreferenceDecisionSchema.optional(),
   runnerPreference: runnerPreferenceSchema.optional(),
   runnerPreferenceResolution: runnerPreferenceResolutionSchema.optional(),
 });
@@ -1059,6 +1087,9 @@ export type RunnersHeartbeatContract = typeof runnersHeartbeatContract;
 export type RunnersBuiltinFirewallsResolveContract =
   typeof runnersBuiltinFirewallsResolveContract;
 export type Job = z.infer<typeof jobSchema>;
+export type RunnerPreferenceDecision = z.infer<
+  typeof runnerPreferenceDecisionSchema
+>;
 export type RunnerPreference = z.infer<typeof runnerPreferenceSchema>;
 export type RunnerPreferenceResolution = z.infer<
   typeof runnerPreferenceResolutionSchema


### PR DESCRIPTION
## Summary

- add a strict atomic runner preference decision covering every positive tier and normal negative outcome
- make API preference resolution decision-first and derive the legacy preference fields through one exhaustive compatibility projection
- dual-publish the canonical decision through Poll and Ably, with bounded rollout telemetry dimensions
- extend API contract and run-lifecycle integration coverage across all preference tiers and deterministic negative paths

## Compatibility

- keep the new decision optional in the shared contract
- preserve the existing `runnerPreference` and `runnerPreferenceResolution` payloads for deployed runners
- leave runner admission, claim behavior, ranking, deadlines, and persisted state unchanged

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm knip`
- pre-commit full Turbo type checks

Closes #25574

Parent: #25508
