### PR TITLE
test(sandbox-fc): bound cow teardown lifecycle waits

### DIFF
--- a/crates/sandbox-fc/src/cow_pool/tests.rs
+++ b/crates/sandbox-fc/src/cow_pool/tests.rs
@@ -1440,6 +1440,7 @@ async fn destroy_slot_async_starts_teardown_before_returned_future_is_polled() {
     {
         Ok(Ok(workspace)) => workspace,
         result => {
+            // A regressed waiter may own the slot, so disconnect its gate before dropping it.
             drop(release_teardown);
             drop(teardown);
             panic!(
@@ -1602,6 +1603,7 @@ async fn destroy_prepared_slot_starts_teardown_before_waiter_is_polled() {
     {
         Ok(Ok(workspace)) => workspace,
         result => {
+            // A regressed waiter may own the slot, so disconnect its gate before dropping it.
             drop(release_teardown);
             drop(teardown);
             panic!(

--- a/crates/sandbox-fc/src/cow_pool/tests.rs
+++ b/crates/sandbox-fc/src/cow_pool/tests.rs
@@ -1435,13 +1435,36 @@ async fn destroy_slot_async_starts_teardown_before_returned_future_is_polled() {
     let workspace = slot.workspace().to_owned();
 
     let teardown = destroy_slot_async(slot);
-    assert_eq!(teardown_started.await.unwrap(), workspace);
-    assert!(workspace.exists());
+    let teardown_started = match tokio::time::timeout(Duration::from_secs(1), teardown_started)
+        .await
+    {
+        Ok(Ok(workspace)) => workspace,
+        result => {
+            drop(release_teardown);
+            drop(teardown);
+            panic!(
+                "file-only slot teardown should start before returned future is polled: {result:?}"
+            );
+        }
+    };
+    let workspace_existed_after_start = workspace.exists();
 
     drop(teardown);
-    release_teardown.send(()).unwrap();
+    release_teardown
+        .send(())
+        .expect("file-only slot teardown should still be waiting on the gate");
 
-    assert_eq!(dropped.await.unwrap(), workspace);
+    let dropped = tokio::time::timeout(Duration::from_secs(1), dropped)
+        .await
+        .expect("file-only slot teardown should finish after the gate is released")
+        .expect("file-only slot teardown completion sender should remain available");
+
+    assert_eq!(teardown_started, workspace);
+    assert!(
+        workspace_existed_after_start,
+        "workspace should exist while file-only slot teardown waits on the gate"
+    );
+    assert_eq!(dropped, workspace);
     assert!(!workspace.exists());
 }
 
@@ -1574,12 +1597,35 @@ async fn destroy_prepared_slot_starts_teardown_before_waiter_is_polled() {
     let workspace = slot.workspace().to_owned();
 
     let teardown = destroy_prepared_slot_async(slot);
-    assert_eq!(teardown_started.await.unwrap(), workspace);
-    assert!(workspace.exists());
+    let teardown_started = match tokio::time::timeout(Duration::from_secs(1), teardown_started)
+        .await
+    {
+        Ok(Ok(workspace)) => workspace,
+        result => {
+            drop(release_teardown);
+            drop(teardown);
+            panic!(
+                "prepared slot teardown should start before returned waiter is polled: {result:?}"
+            );
+        }
+    };
+    let workspace_existed_after_start = workspace.exists();
 
     drop(teardown);
-    release_teardown.send(()).unwrap();
+    release_teardown
+        .send(())
+        .expect("prepared slot teardown should still be waiting on the gate");
 
-    assert_eq!(dropped.await.unwrap(), workspace);
+    let dropped = tokio::time::timeout(Duration::from_secs(1), dropped)
+        .await
+        .expect("prepared slot teardown should finish after the gate is released")
+        .expect("prepared slot teardown completion sender should remain available");
+
+    assert_eq!(teardown_started, workspace);
+    assert!(
+        workspace_existed_after_start,
+        "workspace should exist while prepared slot teardown waits on the gate"
+    );
+    assert_eq!(dropped, workspace);
     assert!(!workspace.exists());
 }


### PR DESCRIPTION
## Summary

- bound both COW teardown-eagerness start and completion notifications with local one-second timeouts
- disconnect the teardown gate before dropping a regressed slot-owning waiter on start failure
- preserve the contract that the returned waiter stays unpolled through teardown start and is dropped before normal gate release

## Scope

- test-only change in `sandbox-fc`
- production teardown helpers and the shared test gate are unchanged
- no API, data, protocol, documentation, or deployment compatibility changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sandbox-fc --lib starts_teardown_before -- --nocapture`
- temporary spawn-inside-returned-future mutation: both focused tests failed with transition-specific messages in 1.02 seconds and exited without reaching the 20-second outer bound
- `cargo test -p sandbox-fc --all-targets --all-features` (784 library tests and 1 integration test passed)
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc --no-deps --all-features`
- `git diff --check`

Closes #25588
