### PR TITLE
test(guest-init): cover inherited signal dispositions

### DIFF
--- a/crates/guest-init/src/pid1.rs
+++ b/crates/guest-init/src/pid1.rs
@@ -423,6 +423,7 @@ mod tests {
 
     #[test]
     fn setup_ignores_inherited_signals_in_isolated_process() {
+        // Other PID 1 tests call waitpid(-1), so serialize ownership of this child.
         let _guard = PID1_TEST_LOCK.lock().unwrap();
         let output = Command::new(std::env::current_exe().unwrap())
             .arg("--exact")

--- a/crates/guest-init/src/pid1.rs
+++ b/crates/guest-init/src/pid1.rs
@@ -224,10 +224,12 @@ pub fn supervise(
 mod tests {
     use super::*;
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::process::Command;
     use std::sync::Mutex;
     use std::thread;
 
     static PID1_TEST_LOCK: Mutex<()> = Mutex::new(());
+    const SIGNAL_SETUP_CHILD_TEST: &str = "pid1::tests::setup_ignores_inherited_signals_child";
 
     struct ChildGuard {
         pid: libc::pid_t,
@@ -417,6 +419,57 @@ mod tests {
     fn finish_signal_test(signals: &SignalContext) {
         drain_pending_signals(signals);
         signals.restore_child_mask().unwrap();
+    }
+
+    #[test]
+    fn setup_ignores_inherited_signals_in_isolated_process() {
+        let _guard = PID1_TEST_LOCK.lock().unwrap();
+        let output = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg(SIGNAL_SETUP_CHILD_TEST)
+            .arg("--ignored")
+            .arg("--nocapture")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            stdout.contains(SIGNAL_SETUP_CHILD_TEST),
+            "isolated signal setup test did not run\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+            output.status,
+        );
+        assert!(
+            output.status.success(),
+            "isolated signal setup test failed\nstatus: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+            output.status,
+        );
+    }
+
+    #[test]
+    #[ignore = "run through the process-isolated parent test"]
+    fn setup_ignores_inherited_signals_child() {
+        let default = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());
+        for signal in [Signal::SIGTTIN, Signal::SIGTTOU, Signal::SIGPIPE] {
+            // SAFETY: the action contains SIG_DFL, so it cannot invoke an
+            // invalid function pointer.
+            unsafe {
+                sigaction(signal, &default).unwrap();
+            }
+        }
+
+        let _signals = SignalContext::setup().unwrap();
+
+        for signal in [Signal::SIGTTIN, Signal::SIGTTOU, Signal::SIGPIPE] {
+            // SAFETY: the action contains SIG_DFL, so it cannot invoke an
+            // invalid function pointer. The returned action was installed by
+            // SignalContext::setup().
+            let configured = unsafe { sigaction(signal, &default).unwrap() };
+            assert!(
+                matches!(configured.handler(), SigHandler::SigIgn),
+                "{signal:?} was not configured as SIG_IGN",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- run the real `SignalContext::setup()` path in an exact process-isolated child test
- reset `SIGTTIN`, `SIGTTOU`, and `SIGPIPE` to `SIG_DFL` before setup so the Rust runtime's ignored `SIGPIPE` cannot hide a missing production entry
- verify that the intended child test ran and that every disposition becomes `SIG_IGN`
- serialize child ownership with the existing PID 1 test lock so concurrent `waitpid(-1)` tests cannot reap the subprocess

## Scope

This is a test-only change in `crates/guest-init/src/pid1.rs`. It does not change production behavior, APIs, persisted data, protocols, dependencies, deployment ordering, or compatibility handling.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-init pid1::tests::setup_ignores_inherited_signals_in_isolated_process`
- temporarily removed each of `SIGTTIN`, `SIGTTOU`, and `SIGPIPE` from the production ignore loop; each mutation failed with the corresponding signal-specific assertion
- complete `guest-init` suite passed 20 consecutive times under the default parallel test harness
- `cargo test --manifest-path crates/Cargo.toml -p guest-init`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-init --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-init --all-features --no-deps`
- repository pre-commit and commit-message hooks

Closes #25589
