### PR TITLE
refactor: remove aws connector feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -1,14 +1,11 @@
 /**
  * CONN-02: external-code authorization sessions through public APIs.
  *
- * Feature-switched connectors are enabled per test actor through
- * POST /api/zero/feature-switches. External provider endpoints are mocked with
- * MSW at the HTTP boundary.
+ * External provider endpoints are mocked with MSW at the HTTP boundary.
  */
 
 import { Buffer } from "node:buffer";
 
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -79,14 +76,10 @@ const NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN =
 const NINTENDO_SWITCH_PARENTAL_CONTROLS_UNLOCK_CODE =
   "bdd-switch-parental-controls-unlock-code-must-not-leak";
 
-async function awsActor(): Promise<ApiTestUser> {
+function awsActor(): ApiTestUser {
   const bdd = createBddApi(context);
-  const actor = bdd.user();
   context.mocks.ably.publish.mockResolvedValue(undefined);
-  await connectorsApi.updateFeatureSwitches(actor, {
-    [FeatureSwitchKey.AwsConnector]: true,
-  });
-  return actor;
+  return bdd.user();
 }
 
 function expectNoVisibleSecret(value: unknown, secret: string): void {
@@ -474,8 +467,6 @@ describe("CONN-02: external-code session lifecycle", () => {
         return secret.type === "connector";
       }),
     ).toStrictEqual([]);
-
-    await connectorsApi.deleteFeatureSwitches(actor);
   });
 
   it("supersedes pending sessions and restores provider-rejected sessions to pending", async () => {
@@ -532,7 +523,6 @@ describe("CONN-02: external-code session lifecycle", () => {
     expect(readBack.id).toBe(retried.connector.id);
 
     await connectorsApi.deleteConnectorBySlug(actor, "aws");
-    await connectorsApi.deleteFeatureSwitches(actor);
   });
 
   it("returns generic external-code copy when the PlayStation NPSSO token is rejected", async () => {
@@ -890,24 +880,6 @@ describe("CONN-02: external-code session lifecycle", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
-  it("completes after the AWS connector switch is disabled", async () => {
-    const provider = mockAwsExternalCodeProvider();
-    const actor = await awsActor();
-
-    const session = await connectorsApi.startExternalCode(actor, "aws", "cli");
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.AwsConnector]: false,
-    });
-
-    const completed = await connectorsApi.completeExternalCode(actor, "aws", {
-      sessionId: session.sessionId,
-      sessionToken: session.sessionToken,
-      code: awsVerificationCode(session.authorizationUrl),
-    });
-    expect(completed.status).toBe("complete");
-    expect(provider.tokenRequests).toHaveLength(1);
-  });
-
   it("keeps an in-flight completion exclusive without superseding it", async () => {
     const provider = mockAwsDeferredTokenExchange();
     const actor = await awsActor();
@@ -964,7 +936,6 @@ describe("CONN-02: external-code session lifecycle", () => {
     expect(provider.tokenRequests).toHaveLength(2);
 
     await connectorsApi.deleteConnectorBySlug(actor, "aws");
-    await connectorsApi.deleteFeatureSwitches(actor);
   });
 
   it("expires external-code sessions past their deadline, including stale completing claims", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -3523,19 +3523,12 @@ describe("connector catalog valid lifecycle", () => {
     await syncCatalog();
 
     const actor = bdd.user();
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.AwsConnector]: true,
-    });
     const cleanupConnector = createConnectorCleanup(actor, "aws");
     onTestFinished(async () => {
       await cleanupConnector();
-      await connectorsApi.deleteFeatureSwitches(actor);
     });
     const callsBeforeAction = context.mocks.s3.send.mock.calls.length;
     const session = await connectorsApi.startExternalCode(actor, "aws", "cli");
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.AwsConnector]: false,
-    });
     const completed = await connectorsApi.completeExternalCode(actor, "aws", {
       sessionId: session.sessionId,
       sessionToken: session.sessionToken,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -776,9 +776,6 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     const connectors = createConnectorBddApi(context);
     const { actor, headers } = await firewallRun();
     context.mocks.ably.publish.mockResolvedValue(undefined);
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.AwsConnector]: true,
-    });
     const oldCredentials = {
       accessKeyId: "old-aws-access-key-id",
       secretAccessKey: "old-aws-secret-access-key",
@@ -840,7 +837,6 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     });
 
     await connectors.deleteConnectorBySlug(actor, "aws");
-    await connectors.deleteFeatureSwitches(actor);
   });
 
   it("classifies invalid_grant refresh failures as reconnect-required and recovers", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -108,7 +108,8 @@ describe("GET /api/zero/connectors", () => {
       client.list({ headers: authHeaders() }),
       [200],
     );
-    expect(nonStaff.body.configuredConnectorSlugs).not.toContain("aws");
+    expect(nonStaff.body.configuredConnectorSlugs).toContain("aws");
+    expect(nonStaff.body.configuredConnectorSlugs).not.toContain("test-oauth");
     expect(nonStaff.body.configuredConnectorSlugs).toContain("nintendo-store");
     expect(nonStaff.body.configuredConnectorSlugs).toContain(
       "nintendo-switch-parental-controls",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -14,7 +14,6 @@ import { zeroConnectorsRoutes } from "../zero-connectors";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
-const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 
 interface AuthenticatedFixture {
   readonly orgId: string;
@@ -114,10 +113,6 @@ describe("GET /api/zero/connectors", () => {
     expect(nonStaff.body.configuredConnectorSlugs).toContain(
       "nintendo-switch-parental-controls",
     );
-
-    mocks.clerk.session(fixture.userId, STAFF_ORG_ID);
-    const staff = await accept(client.list({ headers: authHeaders() }), [200]);
-    expect(staff.body.configuredConnectorSlugs).toContain("aws");
   });
 
   it("returns connectors created through the connector API", async () => {

--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -12,7 +12,6 @@ const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
   Record<string, FeatureSwitchKey | undefined>
 >({
   "ahrefs\0oauth": FeatureSwitchKey.AhrefsConnector,
-  "aws\0cli": FeatureSwitchKey.AwsConnector,
   "bentoml\0api-token": FeatureSwitchKey.BentomlConnector,
   "bill\0api-token": FeatureSwitchKey.BillConnector,
   "box\0oauth": FeatureSwitchKey.BoxConnector,

--- a/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
+++ b/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
@@ -538,7 +538,6 @@ export const testConnectorCatalogDefinitions = (
           label: "Sign in with AWS",
           description:
             "Sign in with AWS and paste the authorization code. This temporary AWS connector expires after up to 12 hours.",
-          featureSwitch: FeatureSwitchKey.AwsConnector,
         }),
       ],
       permissionSummary: NO_PERMISSIONS,

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -57,7 +57,7 @@ describe("lab page", () => {
   it("lets users toggle and reset feature switches", async () => {
     let switches: Partial<Record<FeatureSwitchKey, boolean>> = {
       [FeatureSwitchKey.Lab]: true,
-      [FeatureSwitchKey.AwsConnector]: false,
+      [FeatureSwitchKey.TestOauthConnector]: false,
     };
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, { switches, effectiveSwitches: switches });
@@ -91,14 +91,16 @@ describe("lab page", () => {
       ).toBeGreaterThan(0);
     });
 
-    const awsSwitch = featureSwitchControl(FeatureSwitchKey.AwsConnector);
-    expect(awsSwitch).toHaveAttribute("aria-checked", "false");
+    const testOauthSwitch = featureSwitchControl(
+      FeatureSwitchKey.TestOauthConnector,
+    );
+    expect(testOauthSwitch).toHaveAttribute("aria-checked", "false");
 
-    click(awsSwitch);
+    click(testOauthSwitch);
 
     await waitFor(() => {
       expect(
-        featureSwitchControl(FeatureSwitchKey.AwsConnector),
+        featureSwitchControl(FeatureSwitchKey.TestOauthConnector),
       ).toHaveAttribute("aria-checked", "true");
     });
 
@@ -106,7 +108,7 @@ describe("lab page", () => {
 
     await waitFor(() => {
       expect(
-        featureSwitchControl(FeatureSwitchKey.AwsConnector),
+        featureSwitchControl(FeatureSwitchKey.TestOauthConnector),
       ).toHaveAttribute("aria-checked", "false");
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -252,7 +252,6 @@ async function setupAwsExternalCodeConnection(): Promise<{
   detachedSetupPage({
     context,
     path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.AwsConnector]: true },
   });
 
   await fill(await screen.findByPlaceholderText("Find connectors"), "aws");
@@ -1345,16 +1344,16 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.AwsConnector]: false },
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: false },
     });
 
     const searchInput = await screen.findByPlaceholderText("Find connectors");
-    await fill(searchInput, "aws");
+    await fill(searchInput, "meta");
 
     await expect(
       screen.findByText(/No connectors matching/),
     ).resolves.toBeInTheDocument();
-    expect(screen.queryByLabelText("Connect AWS")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Connect Meta Ads")).not.toBeInTheDocument();
   });
 
   it("refreshes connector catalog status when connector feature switches change", async () => {
@@ -1363,11 +1362,11 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.AwsConnector]: false },
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: false },
     });
 
     const searchInput = await screen.findByPlaceholderText("Find connectors");
-    await fill(searchInput, "aws");
+    await fill(searchInput, "meta");
 
     await expect(
       screen.findByText(/No connectors matching/),
@@ -1375,18 +1374,18 @@ describe("connectors page", () => {
 
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
-        switches: { [FeatureSwitchKey.AwsConnector]: true },
-        effectiveSwitches: { [FeatureSwitchKey.AwsConnector]: true },
+        switches: { [FeatureSwitchKey.MetaAdsConnector]: true },
+        effectiveSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
       });
     });
     await context.store.set(
       setFeatureSwitch$,
-      { [FeatureSwitchKey.AwsConnector]: true },
+      { [FeatureSwitchKey.MetaAdsConnector]: true },
       context.signal,
     );
 
     await expect(
-      screen.findByLabelText("Connect AWS"),
+      screen.findByLabelText("Connect Meta Ads"),
     ).resolves.toBeInTheDocument();
   });
 
@@ -3132,7 +3131,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.AwsConnector]: true },
     });
 
     await waitFor(() => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -30,7 +30,6 @@ export enum FeatureSwitchKey {
   CloseConnector = "closeConnector",
   MetaAdsConnector = "metaAdsConnector",
   TikTokAdsConnector = "tiktokAdsConnector",
-  AwsConnector = "awsConnector",
   PosthogConnector = "posthogConnector",
   PayPalConnector = "payPalConnector",
   RampConnector = "rampConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -169,12 +169,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the TikTok Ads Manager connector",
     enabled: false,
   },
-  [FeatureSwitchKey.AwsConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the temporary AWS remote login connector",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the PostHog analytics connector",


### PR DESCRIPTION
## Summary

Remove the `awsConnector` feature switch so the temporary AWS remote login connector is visible to all users.

## Terminal state

**Fully rolled out** — AWS becomes permanently available without the staff-org-only discovery gate. AWS IAM remains the fine-grained authorization boundary, matching the deliberate auth-only AWS firewall design in #17026 and #17043: AWS API permissions are intentionally not modeled as vm0 connector permissions because the AWS permission surface is too large.

## What changed

Removed:

- `FeatureSwitchKey.AwsConnector` and its registry entry
- The `"aws\0cli" -> AwsConnector` auth-method rollout mapping that gated AWS discovery
- The AWS `featureSwitch` field from the Platform connector-catalog fixture
- AWS switch setup and cleanup from API and Platform behavior tests
- The obsolete test that completed an AWS session after disabling a switch that no longer exists

Kept:

- The AWS auth provider, icon, catalog entry, and auth-only SigV4 firewall
- Empty vm0 permissions with AWS IAM as the authorization boundary
- AWS product behavior tests, now exercised without a switch override

Repointed existing feature-gating coverage:

- The Lab page toggle test now uses `TestOauthConnector`
- Connector catalog hiding and refresh tests now use `MetaAdsConnector`
- The configured connector list now proves AWS is visible to a non-staff organization while `test-oauth` remains gated; the obsolete staff-only follow-up assertion was removed

## Compatibility

- Old clients may still send an `awsConnector` override. The feature-switch API accepts string keys and `filterFeatureSwitchOverrides()` drops keys that are no longer registered.
- Old stored overrides are ignored on read and removed on a later feature-switch write.
- During an independently deployed frontend/backend rollout, old backends may continue gating AWS until the new API is promoted; new backends omit the AWS rollout association, which old and new frontends can both consume.

## Verification

Current head local validation:

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` — 13/13 workspaces succeeded
- `pnpm knip` — exited successfully with 44 pre-existing configuration hints
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'` — 11/11 workspaces succeeded
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-connectors-list.test.ts` — 5/5 passed
- `git diff --check`

Earlier focused validation on the submitted behavior:

- `connectors-external-code.bdd.test.ts` — 8/8 passed
- `lab-page.test.tsx` — 5/5 passed
- `zero-connectors-page.test.tsx` — 79/79 passed
- `feature-switch.test.ts` — 24/24 passed
- The AWS cases in `cron-connector-catalog.test.ts` and `webhooks-agent-firewall-auth.bdd.test.ts` passed; unrelated sandbox-only failures in those broader files were reproduced on clean `main`

The current PR head completed all GitHub checks successfully.
