### PR TITLE
ci: align staging playwright runner dispatch

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -19,5 +19,12 @@ grep -Fq -- "--config \${RUNNER_DIR}/runner.yaml" "$WORKFLOW" ||
 if grep -Fq -- "--runner-dirname \${RUNNER_SERVICE_REF}" "$WORKFLOW"; then
   fail "runner service identity must not select the manifest config directory"
 fi
+grep -Fq "RUNNER_SERVICE_REF: \${{ needs.prepare.outputs.job-ref }}" "$WORKFLOW" ||
+  fail "runner service identity must follow the deployed API job ref"
+grep -Fq "RUNNER_GROUP: \${{ format('vm0/development-{0}', needs.prepare.outputs.job-ref) }}" "$WORKFLOW" ||
+  fail "runner group must match the deployed API default group"
+if grep -Fq 'playwright-staging' "$WORKFLOW"; then
+  fail "main Playwright runs must not use a group outside the staging API default"
+fi
 
 echo "turbo-playwright-runner-workflow-test: ok"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2234,8 +2234,8 @@ jobs:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          RUNNER_SERVICE_REF: ${{ github.event_name == 'push' && 'playwright-staging' || needs.prepare.outputs.job-ref }}
-          RUNNER_GROUP: ${{ github.event_name == 'push' && 'vm0/playwright-staging' || format('vm0/development-{0}', needs.prepare.outputs.job-ref) }}
+          RUNNER_SERVICE_REF: ${{ needs.prepare.outputs.job-ref }}
+          RUNNER_GROUP: ${{ format('vm0/development-{0}', needs.prepare.outputs.job-ref) }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
           ROOTFS_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.rootfs-hash-map }}


### PR DESCRIPTION
## Summary

- deploy the CI-managed main runner under the staging service identity and API default runner group
- add a workflow regression guard that rejects a separate Playwright-only staging group
- keep the product onboarding and chat path intact without restoring test-only routes, retries, sleeps, or timeout increases

## Root cause

Product-created agents do not set an explicit experimental runner group, so staging dispatch falls back to RUNNER_DEFAULT_GROUP=vm0/development-staging. Turbo instead deployed the main Playwright runner in vm0/playwright-staging under a separate service identity. The submitted chat run therefore remained pending outside the group owned by the current pipeline.

PR #24268 originally paired the dedicated group with an E2E compose override. PR #25550 removed that override together with the deployed test routes but left the dedicated runner group behind. PR previews still passed because both sides used vm0/development-pr-N; main pushes failed because only staging diverged.

This change makes service identity and group derive from the deployed API job ref for every event. On main, the pipeline now replaces the staging service and registers it in vm0/development-staging, matching product dispatch. PR and merge-group behavior remains vm0/development-pr-N.

## Evidence

- Trigger: https://github.com/vm0-ai/vm0/actions/runs/31149407955
- Recurrence: https://github.com/vm0-ai/vm0/actions/runs/31149787994
- Third consecutive main recurrence: https://github.com/vm0-ai/vm0/actions/runs/31150059735
- Same-SHA merge-group pass: https://github.com/vm0-ai/vm0/actions/runs/31148909793
- Historical isolated-runner fix: https://github.com/vm0-ai/vm0/pull/24268
- Regression introduction: https://github.com/vm0-ai/vm0/pull/25550

All three main failures reached the product chat running state but timed out waiting for the unique PRODUCT_CHAT_E2E assistant marker. Eleven other tests passed in each shard.

## Validation

- .github/scripts/tests/turbo-playwright-runner-workflow-test.sh, 5 consecutive runs after the final rebase
- .github/scripts/tests/runner-image-context-test.sh
- bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh
- ShellCheck 0.11.0 on the changed shell test
- actionlint 1.7.12 on .github/workflows/turbo.yml
- Prettier 3.8.1 check on .github/workflows/turbo.yml
- git diff --check

The main-push deployed-runner path cannot be exercised from a PR or local checkout; the workflow regression assertion covers the event mapping, while the first post-merge staging run provides the deployed-path verification.