### PR TITLE
test(app): synchronize indexeddb fallback assertion

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -576,7 +576,9 @@ describe("zero chat thread IndexedDB fallback", () => {
       createdAt: "2026-03-10T00:00:01Z",
     });
 
+    const messageListRequested = context.mocks.deferred<void>();
     context.mocks.api(chatThreadEventsContract.list, ({ respond }) => {
+      messageListRequested.resolve();
       return respond(200, {
         events: [
           {
@@ -605,6 +607,7 @@ describe("zero chat thread IndexedDB fallback", () => {
 
     try {
       setupChatPage();
+      await messageListRequested.promise;
 
       await expect(
         screen.findByText(USER_MESSAGE),


### PR DESCRIPTION
## Summary

- synchronize the unknown-event IndexedDB fallback test with the first remote event-list request
- preserve the production contract that an unrecognized cached event invalidates the snapshot and canonical remote user and assistant events render
- avoid retries, sleeps, timeout increases, weakened assertions, or forced state

## Failure analysis

Turbo run [31150564577](https://github.com/vm0-ai/vm0/actions/runs/31150564577) failed in `test-app (4)` while `findByText(USER_MESSAGE)` was still waiting for the remote fallback message. The cached unknown event is intentionally rejected by the strict event schema and converted into an IndexedDB cache miss. The remote list request starts only after chat setup, IndexedDB initialization, and realtime subscription ownership settle.

The test called `setupChatPage()` and immediately started the default Testing Library text search, so that search's time budget also covered the detached bootstrap path. Instrumented targeted execution showed the intended sequence completing: IndexedDB read returned the fallback snapshot, the remote API returned two canonical events, and the storage signals merged them. This makes the missing request boundary the first causal nondeterminism rather than a stable product-state error.

The repeated realtime HTTP 500 warnings also occurred in passing comparison tests and are fixture behavior. The aggregate `ci-gate-turbo` failure is downstream fallout. Neither is used as causal evidence.

The repair resolves a deferred marker when the remote list handler is reached and awaits that marker before asserting the rendered messages. It observes the actual fallback handoff without changing application state or timing policy.

## Verification

- targeted failing test: 5 independent runs, 5 passed
- `zero-chat-thread-idb.test.tsx`: 8/8 passed before and after rebasing onto current `origin/main`
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

## Comparisons and duplicate guards

- the represented API change did not modify the App IndexedDB fallback path
- the PR-head and merge-group base runs both passed the same shard; this supports intermittency but is not treated as proof by itself
- open PR and merge-queue searches found no repair touching this test or its relevant synchronization boundary
