### PR TITLE
feat: replace agent thinking indicator with 3x3 ripple loader

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -214,7 +214,6 @@ export interface ChatPanelSignals {
   readonly resetRenderedChatGroupsIfAtBottom$: Command<void, []>;
   readonly subscribeChatThread$: Command<Promise<void>, [AbortSignal]>;
   // -- Thinking indicator ---------------------------------------------------
-  readonly blockColors$: Computed<[string, string, string]>;
   readonly thinkingPhrase$: Computed<string>;
   readonly donePhrase$: Computed<Promise<string>>;
   readonly displayedThinkingText$: Computed<Promise<string>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -219,26 +219,6 @@ function chatEventAttachFiles(
 // Thinking-indicator constants and helpers
 // ---------------------------------------------------------------------------
 
-const BLOCK_COLORS = [
-  "#e8a0b4",
-  "#c4705a",
-  "#f5b88a",
-  "#a8b560",
-  "#6bb5a0",
-  "#7baed4",
-  "#b09eda",
-  "#d4a87b",
-  "#e07878",
-  "#82c4c2",
-] as const;
-
-function shuffleBlockColors(): [string, string, string] {
-  const shuffled = [...BLOCK_COLORS].sort(() => {
-    return Math.random() - 0.5;
-  });
-  return [shuffled[0]!, shuffled[1]!, shuffled[2]!];
-}
-
 const THINKING_PHRASE_COUNT = 10;
 const DONE_PHRASE_COUNT = 8;
 
@@ -3387,10 +3367,6 @@ function createThinkingIndicatorSignals(
   thinkingText$: Computed<Promise<string | null>>,
   thinkingEventId$: Computed<Promise<string | null>>,
 ) {
-  const blockColors = shuffleBlockColors();
-  const blockColors$ = computed(() => {
-    return blockColors;
-  });
   const thinkingPhraseIndex = Math.floor(Math.random() * THINKING_PHRASE_COUNT);
   const thinkingPhrase$ = computed((get) => {
     get(locale$);
@@ -3448,7 +3424,6 @@ function createThinkingIndicatorSignals(
   );
 
   return {
-    blockColors$,
     thinkingPhrase$,
     displayedThinkingText$,
     thinkingTextFadingOut$,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -317,43 +317,80 @@ body {
   animation: zero-thinking-in 0.3s ease-out;
 }
 
-/* Thinking indicator: 3-block loader */
+/* Thinking indicator: 3x3 ripple loader.
+ * A wave of energy sweeps the grid along the diagonal; each cell morphs from
+ * square to circle as it lights up, which is what makes a static grid read as
+ * soft rather than mechanical. */
 .zero-blocks {
   display: inline-grid;
-  grid-template-columns: repeat(2, 5px);
-  grid-template-rows: repeat(2, 5px);
+  grid-template-columns: repeat(3, 3.5px);
+  grid-template-rows: repeat(3, 3.5px);
   gap: 1.5px;
 }
 .zero-blocks span {
-  border-radius: 1.5px;
+  border-radius: 1px;
+  background: hsl(var(--muted-foreground) / 0.3);
+  animation: zero-block-ripple 1.25s cubic-bezier(0.4, 0, 0.3, 1) infinite;
 }
-.zero-blocks span:nth-child(1) {
-  background: var(--zb-c1);
-  grid-column: 2;
-  grid-row: 1;
-  animation: zero-block-pop 1.4s ease-in-out infinite;
+/* Delay follows each cell's diagonal distance from the top-left corner, so the
+ * wave travels top-left to bottom-right across five steps. */
+.zero-blocks span:nth-child(2),
+.zero-blocks span:nth-child(4) {
+  animation-delay: 0.1s;
 }
-.zero-blocks span:nth-child(2) {
-  background: var(--zb-c2);
-  grid-column: 1;
-  grid-row: 2;
-  animation: zero-block-pop 1.4s ease-in-out 0.2s infinite;
+.zero-blocks span:nth-child(3),
+.zero-blocks span:nth-child(5),
+.zero-blocks span:nth-child(7) {
+  animation-delay: 0.2s;
 }
-.zero-blocks span:nth-child(3) {
-  background: var(--zb-c3);
-  grid-column: 2;
-  grid-row: 2;
-  animation: zero-block-pop 1.4s ease-in-out 0.4s infinite;
+.zero-blocks span:nth-child(6),
+.zero-blocks span:nth-child(8) {
+  animation-delay: 0.3s;
 }
-@keyframes zero-block-pop {
+.zero-blocks span:nth-child(9) {
+  animation-delay: 0.4s;
+}
+@keyframes zero-block-ripple {
+  0% {
+    transform: scale(0.78);
+    border-radius: 1px;
+    background: hsl(var(--muted-foreground) / 0.3);
+    box-shadow: 0 0 0 hsl(var(--primary) / 0);
+  }
+  16% {
+    transform: scale(1.18);
+    border-radius: 50%;
+    background: hsl(var(--primary));
+    box-shadow: 0 0 3px hsl(var(--primary) / 0.55);
+  }
+  28% {
+    transform: scale(1);
+    border-radius: 34%;
+    background: hsl(var(--primary));
+    box-shadow: 0 0 0 hsl(var(--primary) / 0);
+  }
+  52%,
+  100% {
+    transform: scale(0.78);
+    border-radius: 1px;
+    background: hsl(var(--muted-foreground) / 0.3);
+    box-shadow: 0 0 0 hsl(var(--primary) / 0);
+  }
+}
+/* Keep the wave legible without motion: colour still travels, nothing moves. */
+@media (prefers-reduced-motion: reduce) {
+  .zero-blocks span {
+    animation-name: zero-block-ripple-calm;
+    animation-duration: 2s;
+  }
+}
+@keyframes zero-block-ripple-calm {
   0%,
   100% {
-    transform: scale(0.8);
-    opacity: 0.5;
+    background: hsl(var(--muted-foreground) / 0.3);
   }
-  50% {
-    transform: scale(1);
-    opacity: 1;
+  40% {
+    background: hsl(var(--primary) / 0.75);
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,5 +1,4 @@
 import type {
-  CSSProperties,
   FormEvent,
   MouseEvent as ReactMouseEvent,
   ReactNode,
@@ -4269,24 +4268,34 @@ function ThinkingLabel({
   );
 }
 
+function ThinkingBlocks() {
+  return (
+    <span className="zero-blocks shrink-0">
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+    </span>
+  );
+}
+
 function InlineThinkingRow({
-  blockStyle,
   isQueued,
   thinkingLabel,
   serverThinkingLabel,
 }: {
-  blockStyle: CSSProperties;
   isQueued: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
 }) {
   return (
     <div className="flex items-center gap-2 h-5">
-      <span className="zero-blocks shrink-0" style={blockStyle}>
-        <span />
-        <span />
-        <span />
-      </span>
+      <ThinkingBlocks />
       <ThinkingLabel
         isQueued={isQueued}
         thinkingLabel={thinkingLabel}
@@ -4344,13 +4353,11 @@ function FinishedRunRow({
 
 function WaitingForAssistantResponse({
   thread,
-  blockStyle,
   isQueued,
   thinkingLabel,
   serverThinkingLabel,
 }: {
   thread: ChatPanelSignals;
-  blockStyle: CSSProperties;
   isQueued: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
@@ -4365,11 +4372,7 @@ function WaitingForAssistantResponse({
         <AssistantBubbleAvatar thread={thread} />
         <div className="zero-chat-bubble-assistant rounded-xl py-4 text-[0.9375rem] leading-[1.7] min-w-0 overflow-hidden">
           <div className="flex h-5 min-w-0 items-center gap-2">
-            <span className="zero-blocks shrink-0" style={blockStyle}>
-              <span />
-              <span />
-              <span />
-            </span>
+            <ThinkingBlocks />
             <ThinkingLabel
               isQueued={isQueued}
               thinkingLabel={thinkingLabel}
@@ -4391,7 +4394,6 @@ function WaitingForAssistantResponse({
 
 function AssistantThinkingStatusRow({
   running,
-  blockStyle,
   isQueued,
   thinkingLabel,
   serverThinkingLabel,
@@ -4399,7 +4401,6 @@ function AssistantThinkingStatusRow({
   recommendedFollowupSource,
 }: {
   running: boolean;
-  blockStyle: CSSProperties;
   isQueued: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
@@ -4420,7 +4421,6 @@ function AssistantThinkingStatusRow({
       <div className="min-w-0">
         {running ? (
           <InlineThinkingRow
-            blockStyle={blockStyle}
             isQueued={isQueued}
             thinkingLabel={thinkingLabel}
             serverThinkingLabel={serverThinkingLabel}
@@ -4459,12 +4459,6 @@ function equalRecommendedFollowupSources(
 }
 
 function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
-  const [c1, c2, c3] = useGet(thread.blockColors$);
-  const blockStyle = {
-    "--zb-c1": c1,
-    "--zb-c2": c2,
-    "--zb-c3": c3,
-  } as CSSProperties;
   const mode = useLastResolved(thread.thinkingIndicatorMode$) ?? null;
   const thinkingText = useLastResolved(thread.thinkingText$);
   const recommendedFollowupSource =
@@ -4502,7 +4496,6 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
     return (
       <AssistantThinkingStatusRow
         running={running}
-        blockStyle={blockStyle}
         isQueued={isQueued}
         thinkingLabel={thinkingLabel}
         serverThinkingLabel={serverThinkingLabel}
@@ -4516,7 +4509,6 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
   return (
     <WaitingForAssistantResponse
       thread={thread}
-      blockStyle={blockStyle}
       isQueued={isQueued}
       thinkingLabel={thinkingLabel}
       serverThinkingLabel={serverThinkingLabel}


### PR DESCRIPTION
## What

Replaces the chat thinking indicator (`.zero-blocks`) with the **Ripple** 3×3 loader — the direction picked out of a set of differentiated concepts explored against Manus and Claude's loaders.

| | Before | After |
|---|---|---|
| Grid | 2×2 with 3 cells (L-shape) | 3×3, nine cells |
| Motion | each cell scales/fades on its own | a wave sweeps the diagonal, five delay steps |
| Shape | fixed 1.5px radius | morphs square → circle as a cell lights up |
| Colour | one of 10 pastels, shuffled per thread | `--primary` (brand orange) over `--muted-foreground / 0.3` |

The square↔circle morph is the point of the design: it's what makes a static grid read as soft rather than mechanical.

## Why the randomized palette goes away

The approved design is a single brand accent, so the per-thread pastel identity no longer has anywhere to live. `BLOCK_COLORS`, `shuffleBlockColors()`, the `blockColors$` signal, the `blockStyle` prop threaded through three components, and the `--zb-c*` custom properties are all removed rather than left as dead plumbing.

If per-thread colour variety turns out to be worth keeping, that's a follow-up — say the word and I'll bring it back as a hue rotation on the primary token instead of a separate palette.

## Notes

- Both render sites now share one `ThinkingBlocks` component instead of repeating the markup.
- Sizing: 3.5px cells with the existing 1.5px gap → 13.5px total, which still sits inside the `h-5` row without layout jump.
- Colours come entirely from existing tokens. The demo's `#FFD9A0` peak highlight was **not** ported: the primary scale inverts in dark mode, so a lighter tint token would read darker there. The overshoot is carried by scale + a `box-shadow` glow instead, which brightens correctly in both themes.
- Adds a `prefers-reduced-motion` variant — the colour wave still travels, nothing moves. The old loader had no reduced-motion handling.

## Verification

Dependencies aren't installed in this container, so no local type-check or test run — relying on the PR pipeline for those.

The shipped CSS was extracted verbatim into a harness seeded with the real `--primary` / `--muted-foreground` token values and rendered in both themes at true 16px inline size plus 6× zoom, confirming the wave direction, the morph, the resting grey, and the row fit. Needs a look on the preview before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)