### PR TITLE
perf(rust): eliminate redundant exec-control payload copies

### DIFF
--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -128,7 +128,7 @@ async fn forward_text(
     // runner-internal and has no active-input identity or deduplication semantics.
     let correlation_id = format!("active-input:{run_id}:{delivery_sequence}");
     match control
-        .control(&correlation_id, &bytes, ACTIVE_INPUT_CONTROL_TIMEOUT)
+        .control_owned(correlation_id, bytes, ACTIVE_INPUT_CONTROL_TIMEOUT)
         .await
     {
         Ok(_) => debug!(run_id = %run_id, "forwarded active input"),

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -875,9 +875,9 @@ impl FirecrackerSandbox {
         )?;
 
         let outcome = tokio::select! {
-            result = control.control(
-                &message_id,
-                &payload,
+            result = control.control_owned(
+                message_id,
+                payload,
                 timeout,
             ) => ControlOutcome::Returned(result),
             () = wait_for_backend_crash(state_rx) => ControlOutcome::BackendCrashed,

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -491,7 +491,22 @@ impl GuestProcessControlHandle {
         payload: &[u8],
         timeout: Duration,
     ) -> std::io::Result<ProcessControlAck> {
-        (self.control)(message_id.to_owned(), payload.to_vec(), timeout).await
+        self.control_owned(message_id.to_owned(), payload.to_vec(), timeout)
+            .await
+    }
+
+    /// Send an owned opaque control payload to the live guest process.
+    ///
+    /// This has the same behavior as [`Self::control`] but transfers ownership
+    /// of `message_id` and `payload` so callers that already own large request
+    /// data do not need to clone it for the provider callback.
+    pub async fn control_owned(
+        &self,
+        message_id: String,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> std::io::Result<ProcessControlAck> {
+        (self.control)(message_id, payload, timeout).await
     }
 }
 

--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -255,6 +255,20 @@ pub(in crate::exec_operation) async fn write_frame_with_pre_write(
     Ok(())
 }
 
+pub(in crate::exec_operation) async fn write_encoded_frame_with_pre_write(
+    shared: &Arc<Shared>,
+    data: &[u8],
+    diagnostic: Option<ExecOperationFrameDiagnostic>,
+    pre_write: impl FnOnce() -> io::Result<()>,
+) -> io::Result<()> {
+    let _decision = write_encoded_frame_with_pre_write_decision(shared, data, diagnostic, || {
+        pre_write()?;
+        Ok(FrameWriteDecision::Write)
+    })
+    .await?;
+    Ok(())
+}
+
 async fn write_frame_with_pre_write_decision(
     shared: &Arc<Shared>,
     msg_type: u8,
@@ -265,6 +279,15 @@ async fn write_frame_with_pre_write_decision(
 ) -> io::Result<FrameWriteDecision> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    write_encoded_frame_with_pre_write_decision(shared, &data, diagnostic, pre_write).await
+}
+
+async fn write_encoded_frame_with_pre_write_decision(
+    shared: &Arc<Shared>,
+    data: &[u8],
+    diagnostic: Option<ExecOperationFrameDiagnostic>,
+    pre_write: impl FnOnce() -> io::Result<FrameWriteDecision>,
+) -> io::Result<FrameWriteDecision> {
     let state = Arc::new(AtomicU8::new(EXEC_OPERATION_FRAME_WRITE_NOT_STARTED));
     let guard = ExecOperationFrameWriteGuard::new(Arc::clone(shared), Arc::clone(&state));
 
@@ -277,7 +300,7 @@ async fn write_frame_with_pre_write_decision(
     }
     state.store(EXEC_OPERATION_FRAME_WRITE_STARTED, Ordering::Release);
     let write_started_at = Instant::now();
-    let result = writer.write_all(&data).await;
+    let result = writer.write_all(data).await;
     let write_elapsed_ms = write_started_at.elapsed().as_millis();
     if result.is_ok() {
         state.store(EXEC_OPERATION_FRAME_WRITE_COMPLETED, Ordering::Release);

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -5,9 +5,7 @@ use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Instant};
-use vsock_proto::{
-    ExecControlNonce, ExecControlStatus, ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
-};
+use vsock_proto::{ExecControlNonce, ExecControlStatus, ExecTermination, MSG_EXEC_CANCEL};
 
 use crate::{ConnectionState, FrameWriteObserver, Shared};
 
@@ -16,7 +14,8 @@ use super::diagnostics::ExecOperationDiagnostic;
 use super::frame::{
     ExecCancelFrameWriteOutcome, clear_exec_operation_stream_sender, exec_cancel_write_observer,
     mark_pending_exec_control_possible_guest_write,
-    send_exec_cancel_frame_for_wait_with_write_start, write_frame, write_frame_with_pre_write,
+    send_exec_cancel_frame_for_wait_with_write_start, write_encoded_frame_with_pre_write,
+    write_frame,
 };
 use super::state::{PendingExecControl, PendingExecControlGuard};
 use super::types::{
@@ -789,6 +788,27 @@ impl ExecControlHandle {
         .into_ack()
     }
 
+    /// Send an owned exec-control request and require a delivered acknowledgement.
+    ///
+    /// This has the same behavior as [`Self::control`] but transfers ownership
+    /// of `message_id` and `payload` so callers that already own large request
+    /// data do not need to clone it before frame encoding.
+    pub async fn control_owned(
+        &self,
+        message_id: String,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> io::Result<ExecControlAck> {
+        self.control_owned_with_write_observer(
+            message_id,
+            payload,
+            timeout,
+            FrameWriteObserver::default(),
+        )
+        .await?
+        .into_ack()
+    }
+
     /// Send an exec-control request and return the raw guest outcome.
     ///
     /// This has the same input, timeout, cancellation, and connection-lifecycle
@@ -799,6 +819,31 @@ impl ExecControlHandle {
         &self,
         message_id: &str,
         payload: &[u8],
+        timeout: Duration,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<ExecControlOutcome> {
+        let request_timeout_ms = duration_to_request_timeout_ms(timeout);
+        vsock_proto::validate_exec_control(
+            self.target_seq,
+            self.control_nonce,
+            message_id,
+            payload,
+            request_timeout_ms,
+        )
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+        self.control_owned_with_write_observer(
+            message_id.to_owned(),
+            payload.to_vec(),
+            timeout,
+            write_observer,
+        )
+        .await
+    }
+
+    async fn control_owned_with_write_observer(
+        &self,
+        message_id: String,
+        payload: Vec<u8>,
         timeout: Duration,
         write_observer: FrameWriteObserver,
     ) -> io::Result<ExecControlOutcome> {
@@ -927,20 +972,20 @@ pub(in crate::exec_operation) async fn exec_control_on_shared(
     shared: &Arc<Shared>,
     target_seq: u32,
     control_nonce: ExecControlNonce,
-    message_id: &str,
-    control_payload: &[u8],
+    message_id: String,
+    control_payload: Vec<u8>,
     timeout: Duration,
     write_observer: FrameWriteObserver,
 ) -> io::Result<ExecControlOutcome> {
     let request_timeout_ms = duration_to_request_timeout_ms(timeout);
-    let payload = vsock_proto::encode_exec_control(
+    vsock_proto::validate_exec_control(
         target_seq,
         control_nonce,
-        message_id,
-        control_payload,
+        &message_id,
+        &control_payload,
         request_timeout_ms,
     )
-    .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
     let request_seq = shared.next_seq();
     let normal_operation = shared.reserve_normal_operation()?;
     let (response_tx, response_rx) = oneshot::channel();
@@ -959,7 +1004,7 @@ pub(in crate::exec_operation) async fn exec_control_on_shared(
                     request_seq,
                     PendingExecControl {
                         target_seq,
-                        message_id: message_id.to_owned(),
+                        message_id: message_id.clone(),
                         control_nonce,
                         response_tx,
                         normal_operation,
@@ -969,18 +1014,25 @@ pub(in crate::exec_operation) async fn exec_control_on_shared(
         }
     }
     let _pending_guard = PendingExecControlGuard::new(Arc::clone(shared), request_seq);
-    write_frame_with_pre_write(
-        shared,
-        MSG_EXEC_CONTROL,
+    let mut frame = Vec::new();
+    vsock_proto::encode_exec_control_frame_into(
+        &mut frame,
         request_seq,
-        &payload,
-        None,
-        || {
-            mark_pending_exec_control_possible_guest_write(shared, target_seq, request_seq)?;
-            write_observer.record_write_start()
-        },
+        target_seq,
+        control_nonce,
+        &message_id,
+        &control_payload,
+        request_timeout_ms,
     )
+    .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    drop(control_payload);
+    drop(message_id);
+    write_encoded_frame_with_pre_write(shared, &frame, None, || {
+        mark_pending_exec_control_possible_guest_write(shared, target_seq, request_seq)?;
+        write_observer.record_write_start()
+    })
     .await?;
+    drop(frame);
 
     tokio::select! {
         biased;

--- a/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
@@ -33,7 +33,11 @@ async fn supervised_exec_control_uses_exec_control_messages() {
     let control_task = tokio::spawn({
         async move {
             control_handle
-                .control("message-1", b"payload", Duration::from_secs(5))
+                .control_owned(
+                    "message-1".to_owned(),
+                    b"payload".to_vec(),
+                    Duration::from_secs(5),
+                )
                 .await
         }
     });

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -167,9 +167,10 @@ pub use payloads::exec_operation::{
     ExecTermination, ExecTimeoutPolicy, MAX_EXEC_STDIN_BYTES, decode_exec_cancel,
     decode_exec_control, decode_exec_control_result, decode_exec_output, decode_exec_result,
     decode_exec_start, decode_exec_started, encode_exec_cancel, encode_exec_control,
-    encode_exec_control_result, encode_exec_output, encode_exec_output_frame_into,
-    encode_exec_result, encode_exec_result_frame_into, encode_exec_start,
-    encode_exec_start_with_expected_exit_codes, encode_exec_started,
+    encode_exec_control_frame_into, encode_exec_control_result, encode_exec_output,
+    encode_exec_output_frame_into, encode_exec_result, encode_exec_result_frame_into,
+    encode_exec_start, encode_exec_start_with_expected_exit_codes, encode_exec_started,
+    validate_exec_control,
 };
 pub use payloads::write_file::{
     WriteFileBatchEntry, decode_write_file, decode_write_file_result, decode_write_files,

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -7,7 +7,8 @@ mod started_cancel;
 pub use control::{
     DecodedExecControl, DecodedExecControlResult, EXEC_CONTROL_MAX_PAYLOAD_BYTES,
     EXEC_CONTROL_NONCE_LEN, ExecControlNonce, ExecControlStatus, decode_exec_control,
-    decode_exec_control_result, encode_exec_control, encode_exec_control_result,
+    decode_exec_control_result, encode_exec_control, encode_exec_control_frame_into,
+    encode_exec_control_result, validate_exec_control,
 };
 pub use output::{
     DecodedExecOutput, ExecOutputStream, decode_exec_output, encode_exec_output,

--- a/crates/vsock-proto/src/payloads/exec_operation/control.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/control.rs
@@ -1,8 +1,10 @@
 use crate::error::ProtocolError;
+use crate::frame::encode_into;
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
     expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
 };
+use crate::wire::MSG_EXEC_CONTROL;
 
 /// Number of bytes in an exec-control nonce.
 pub const EXEC_CONTROL_NONCE_LEN: usize = 16;
@@ -110,6 +112,15 @@ struct ControlIdentity<'a> {
     message_id: &'a str,
 }
 
+struct EncodedExecControlPayload<'a> {
+    identity: ControlIdentity<'a>,
+    request_timeout_ms: u32,
+    message_id_len: u16,
+    payload_len: u32,
+    payload: &'a [u8],
+    encoded_len: usize,
+}
+
 #[derive(Clone, Copy)]
 struct ControlIdentityErrors {
     target_seq_zero: &'static str,
@@ -212,6 +223,45 @@ fn append_control_identity_tail(
     out.extend_from_slice(identity.message_id.as_bytes());
 }
 
+fn validate_exec_control_payload<'a>(
+    target_seq: u32,
+    control_nonce: ExecControlNonce,
+    message_id: &'a str,
+    payload: &'a [u8],
+    request_timeout_ms: u32,
+) -> Result<EncodedExecControlPayload<'a>, ProtocolError> {
+    let identity = ControlIdentity {
+        target_seq,
+        control_nonce,
+        message_id,
+    };
+    validate_control_identity(identity, EXEC_CONTROL_IDENTITY_ERRORS)?;
+    if payload.len() > EXEC_CONTROL_MAX_PAYLOAD_BYTES {
+        return Err(ProtocolError::PayloadTooLarge("payload", payload.len()));
+    }
+    let message_id_len = ensure_u16_len("message_id", identity.message_id.len())?;
+    let payload_len = ensure_u32_len("payload", payload.len())?;
+    let encoded_len = encoded_control_len(message_id.len(), payload.len())?;
+    ensure_payload_fits_message(encoded_len)?;
+
+    Ok(EncodedExecControlPayload {
+        identity,
+        request_timeout_ms,
+        message_id_len,
+        payload_len,
+        payload,
+        encoded_len,
+    })
+}
+
+fn append_exec_control_payload(out: &mut Vec<u8>, encoded: &EncodedExecControlPayload<'_>) {
+    out.extend_from_slice(&encoded.identity.target_seq.to_be_bytes());
+    out.extend_from_slice(&encoded.request_timeout_ms.to_be_bytes());
+    append_control_identity_tail(out, encoded.identity, encoded.message_id_len);
+    out.extend_from_slice(&encoded.payload_len.to_be_bytes());
+    out.extend_from_slice(encoded.payload);
+}
+
 fn read_non_zero_target_seq(
     payload: &[u8],
     offset: &mut usize,
@@ -300,27 +350,65 @@ pub fn encode_exec_control(
     payload: &[u8],
     request_timeout_ms: u32,
 ) -> Result<Vec<u8>, ProtocolError> {
-    let identity = ControlIdentity {
+    let encoded = validate_exec_control_payload(
         target_seq,
         control_nonce,
         message_id,
-    };
-    validate_control_identity(identity, EXEC_CONTROL_IDENTITY_ERRORS)?;
-    if payload.len() > EXEC_CONTROL_MAX_PAYLOAD_BYTES {
-        return Err(ProtocolError::PayloadTooLarge("payload", payload.len()));
-    }
-    let message_id_len = ensure_u16_len("message_id", identity.message_id.len())?;
-    let payload_len = ensure_u32_len("payload", payload.len())?;
-    let total_len = encoded_control_len(message_id.len(), payload.len())?;
-    ensure_payload_fits_message(total_len)?;
+        payload,
+        request_timeout_ms,
+    )?;
 
-    let mut out = Vec::with_capacity(total_len);
-    out.extend_from_slice(&identity.target_seq.to_be_bytes());
-    out.extend_from_slice(&request_timeout_ms.to_be_bytes());
-    append_control_identity_tail(&mut out, identity, message_id_len);
-    out.extend_from_slice(&payload_len.to_be_bytes());
-    out.extend_from_slice(payload);
+    let mut out = Vec::with_capacity(encoded.encoded_len);
+    append_exec_control_payload(&mut out, &encoded);
+    debug_assert_eq!(out.len(), encoded.encoded_len);
     Ok(out)
+}
+
+/// Validate an exec_control payload without encoding it.
+///
+/// This applies the same input constraints documented by [`encode_exec_control`].
+pub fn validate_exec_control(
+    target_seq: u32,
+    control_nonce: ExecControlNonce,
+    message_id: &str,
+    payload: &[u8],
+    request_timeout_ms: u32,
+) -> Result<(), ProtocolError> {
+    validate_exec_control_payload(
+        target_seq,
+        control_nonce,
+        message_id,
+        payload,
+        request_timeout_ms,
+    )
+    .map(|_| ())
+}
+
+/// Encode a full exec_control frame into `frame`.
+///
+/// The resulting frame uses the same bytes as
+/// `encode(MSG_EXEC_CONTROL, seq, &encode_exec_control(...))` without allocating
+/// a separate exec-control payload vector.
+pub fn encode_exec_control_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    target_seq: u32,
+    control_nonce: ExecControlNonce,
+    message_id: &str,
+    payload: &[u8],
+    request_timeout_ms: u32,
+) -> Result<(), ProtocolError> {
+    frame.clear();
+    let encoded = validate_exec_control_payload(
+        target_seq,
+        control_nonce,
+        message_id,
+        payload,
+        request_timeout_ms,
+    )?;
+    encode_into(frame, MSG_EXEC_CONTROL, seq, encoded.encoded_len, |frame| {
+        append_exec_control_payload(frame, &encoded);
+    })
 }
 
 /// Encode an exec_control_result payload.

--- a/crates/vsock-proto/tests/exec_control_frames.rs
+++ b/crates/vsock-proto/tests/exec_control_frames.rs
@@ -1,0 +1,126 @@
+use vsock_proto::{
+    EXEC_CONTROL_MAX_PAYLOAD_BYTES, EXEC_CONTROL_NONCE_LEN, MSG_EXEC_CONTROL, ProtocolError,
+    encode, encode_exec_control, encode_exec_control_frame_into, validate_exec_control,
+};
+
+const TARGET_SEQ: u32 = 7;
+const FRAME_SEQ: u32 = 42;
+const REQUEST_TIMEOUT_MS: u32 = 5_000;
+const CONTROL_NONCE: [u8; EXEC_CONTROL_NONCE_LEN] = [0xA5; EXEC_CONTROL_NONCE_LEN];
+const MESSAGE_ID: &str = "active-input:run-id:1";
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+fn assert_frames_match(payload: &[u8]) -> TestResult {
+    let control_payload = encode_exec_control(
+        TARGET_SEQ,
+        CONTROL_NONCE,
+        MESSAGE_ID,
+        payload,
+        REQUEST_TIMEOUT_MS,
+    )?;
+    let expected = encode(MSG_EXEC_CONTROL, FRAME_SEQ, &control_payload)?;
+    let mut actual = b"stale frame bytes".to_vec();
+
+    encode_exec_control_frame_into(
+        &mut actual,
+        FRAME_SEQ,
+        TARGET_SEQ,
+        CONTROL_NONCE,
+        MESSAGE_ID,
+        payload,
+        REQUEST_TIMEOUT_MS,
+    )?;
+
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+fn assert_same_error(actual: ProtocolError, expected: &ProtocolError) {
+    assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
+    assert_eq!(actual.to_string(), expected.to_string());
+}
+
+fn assert_invalid_request_matches(
+    target_seq: u32,
+    message_id: &str,
+    payload: &[u8],
+) -> TestResult<ProtocolError> {
+    let expected = encode_exec_control(
+        target_seq,
+        CONTROL_NONCE,
+        message_id,
+        payload,
+        REQUEST_TIMEOUT_MS,
+    )
+    .err()
+    .ok_or_else(|| std::io::Error::other("invalid exec-control payload unexpectedly encoded"))?;
+    let validation = validate_exec_control(
+        target_seq,
+        CONTROL_NONCE,
+        message_id,
+        payload,
+        REQUEST_TIMEOUT_MS,
+    )
+    .err()
+    .ok_or_else(|| std::io::Error::other("invalid exec-control payload unexpectedly validated"))?;
+    assert_same_error(validation, &expected);
+
+    let mut frame = b"stale frame bytes".to_vec();
+    let direct = encode_exec_control_frame_into(
+        &mut frame,
+        FRAME_SEQ,
+        target_seq,
+        CONTROL_NONCE,
+        message_id,
+        payload,
+        REQUEST_TIMEOUT_MS,
+    )
+    .err()
+    .ok_or_else(|| {
+        std::io::Error::other("invalid exec-control payload unexpectedly encoded as a frame")
+    })?;
+    assert_same_error(direct, &expected);
+    assert!(frame.is_empty());
+
+    Ok(expected)
+}
+
+#[test]
+fn direct_exec_control_frames_match_composed_frames() -> TestResult {
+    assert_frames_match(b"")?;
+    assert_frames_match(br#"{"type":"active-input","text":"hello"}"#)?;
+    assert_frames_match(&vec![0xAB; EXEC_CONTROL_MAX_PAYLOAD_BYTES])?;
+    Ok(())
+}
+
+#[test]
+fn direct_exec_control_validation_matches_payload_encoding() -> TestResult {
+    let zero_target = assert_invalid_request_matches(0, MESSAGE_ID, b"payload")?;
+    assert!(matches!(
+        zero_target,
+        ProtocolError::InvalidPayload("exec_control target_seq must be non-zero")
+    ));
+
+    let empty_message_id = assert_invalid_request_matches(TARGET_SEQ, "", b"payload")?;
+    assert!(matches!(
+        empty_message_id,
+        ProtocolError::InvalidPayload("exec_control message_id empty")
+    ));
+
+    let long_message_id = "x".repeat(usize::from(u16::MAX) + 1);
+    let oversized_message_id =
+        assert_invalid_request_matches(TARGET_SEQ, &long_message_id, b"payload")?;
+    assert!(matches!(
+        oversized_message_id,
+        ProtocolError::PayloadTooLarge("message_id", size) if size == long_message_id.len()
+    ));
+
+    let large_payload = vec![0; EXEC_CONTROL_MAX_PAYLOAD_BYTES + 1];
+    let oversized_payload = assert_invalid_request_matches(TARGET_SEQ, MESSAGE_ID, &large_payload)?;
+    assert!(matches!(
+        oversized_payload,
+        ProtocolError::PayloadTooLarge("payload", size) if size == large_payload.len()
+    ));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- transfer already-owned active-input message IDs and payloads through the sandbox and vsock-host boundaries without cloning the large payload
- encode exec-control requests directly into the final contiguous vsock frame through shared validation and payload-appending logic
- preserve the borrowed control APIs and the existing pending-response, timeout, cancellation, observer, and connection-poisoning behavior

## Scope

- no wire-format, API-service, queue, database, schema, migration, persisted-state, or rollout changes
- small borrowed control callers continue to use the existing convenience APIs

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-proto -p vsock-host -p sandbox -p sandbox-fc -p runner --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vsock-proto -p vsock-host -p sandbox -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test -p vsock-proto --quiet`
- `cargo test -p vsock-host --quiet`
- `cargo test -p sandbox --quiet`
- `cargo test -p sandbox-fc process_control --quiet`
- `cargo test -p runner executor::tests::agent_run_tests::active_input --quiet`

Closes #25590
