### PR TITLE
docs(vsock-host): document file-write cancellation

### DIFF
--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -402,6 +402,39 @@ impl VsockHost {
     /// truncated file at the destination.
     ///
     /// Non-sudo writes create missing parent directories on the guest.
+    ///
+    /// # Cancellation
+    ///
+    /// This contract applies to every public file-write future on [`VsockHost`]:
+    /// this method, [`write_files`](Self::write_files),
+    /// [`write_private_file`](Self::write_private_file),
+    /// [`write_file_with_write_observer`](Self::write_file_with_write_observer),
+    /// [`write_files_with_write_observer`](Self::write_files_with_write_observer),
+    /// and [`write_private_file_with_write_observer`](Self::write_private_file_with_write_observer).
+    ///
+    /// Dropping one of these futures before any request frame starts writing
+    /// sends no file-write request and leaves the connection reusable for later
+    /// normal operations. Once a frame starts writing, cancellation cannot prove
+    /// the guest-side file outcome or safe connection reuse. An interrupted frame
+    /// write poisons the connection because the guest may have received a partial
+    /// frame. If a complete frame was written but its terminal response is
+    /// abandoned, the socket may remain open while later normal operations become
+    /// unavailable. In either post-boundary case, discard the connection instead
+    /// of reusing it or returning it to a pool.
+    ///
+    /// The methods without a [`FrameWriteObserver`] do not generally reveal which
+    /// side of that boundary cancellation occurred on. Unless other
+    /// synchronization proves that no frame started writing, callers must
+    /// conservatively discard the connection after cancelling one of those
+    /// futures.
+    ///
+    /// Cancelling a large standard write after staging begins attempts
+    /// best-effort removal of its temporary file. Cleanup is not guaranteed and
+    /// does not prove the destination outcome or restore connection reuse. A
+    /// chunked private write modifies the final path directly, can leave partial
+    /// content, and has no rollback cleanup. The effects of a cancelled
+    /// [`write_files`](Self::write_files) batch are likewise unproven once its
+    /// frame starts writing.
     pub async fn write_file(&self, path: &str, content: &[u8], sudo: bool) -> io::Result<()> {
         self.write_file_with_write_observer(path, content, sudo, FrameWriteObserver::default())
             .await
@@ -415,6 +448,9 @@ impl VsockHost {
     /// that exceed the batch content limit. No public [`VsockHost`] write method
     /// exposes caller-requested append semantics. Empty batches are accepted as
     /// a no-op to match the higher-level sandbox trait default.
+    ///
+    /// Cancellation follows the
+    /// [shared file-write cancellation contract](Self::write_file).
     pub async fn write_files(&self, files: &[WriteFileEntry<'_>]) -> io::Result<()> {
         self.write_files_with_write_observer(files, FrameWriteObserver::default())
             .await
@@ -432,6 +468,9 @@ impl VsockHost {
     /// the call finishes. This does not coordinate guest processes, other
     /// connections, hard links, or aliases that depend on guest filesystem
     /// state.
+    ///
+    /// Cancellation follows the
+    /// [shared file-write cancellation contract](Self::write_file).
     pub async fn write_private_file(&self, path: &str, content: &[u8]) -> io::Result<()> {
         self.write_private_file_with_write_observer(path, content, FrameWriteObserver::default())
             .await
@@ -442,6 +481,10 @@ impl VsockHost {
     ///
     /// This uses the destination-isolation semantics documented on
     /// [`write_private_file`](Self::write_private_file).
+    ///
+    /// Cancellation follows the
+    /// [shared file-write cancellation contract](Self::write_file); the observer
+    /// reports the frame-write boundary described there.
     pub async fn write_private_file_with_write_observer(
         &self,
         path: &str,
@@ -488,6 +531,10 @@ impl VsockHost {
 
     /// Write a file on the guest and report before each helper frame is
     /// written to the guest.
+    ///
+    /// Cancellation follows the
+    /// [shared file-write cancellation contract](Self::write_file); the observer
+    /// reports the frame-write boundary described there.
     pub async fn write_file_with_write_observer(
         &self,
         path: &str,
@@ -591,6 +638,10 @@ impl VsockHost {
 
     /// Write multiple ordinary files on the guest and report before the batch
     /// frame is written.
+    ///
+    /// Cancellation follows the
+    /// [shared file-write cancellation contract](Self::write_file); the observer
+    /// reports the frame-write boundary described there.
     pub async fn write_files_with_write_observer(
         &self,
         files: &[WriteFileEntry<'_>],


### PR DESCRIPTION
## Summary

- add one canonical `VsockHost` file-write cancellation contract to `write_file`
- link `write_files`, `write_private_file`, and all three public observer variants to that contract
- document pre-write reuse, partial-frame poisoning, complete-frame response abandonment, conservative non-observer handling, staging cleanup, and private-write partial output

## Scope

This is a rustdoc-only change. It does not change runtime behavior, public signatures, the vsock protocol, schemas, persisted data, migrations, or deployment compatibility.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml -p vsock-host --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- inspected generated rustdoc links for all five delegating methods
- repository pre-commit hooks, including workspace Rust formatting, Clippy, and documentation checks

Closes #25591
