### PR TITLE
feat(platform): recommend voices for avatar templates

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -667,6 +667,7 @@
       "previewWebsite": "Vorschau der Website-Vorlage {{title}}",
       "previousHtmlPreview": "{{title}} vorherige HTML-Vorschau",
       "previousSlide": "Vorschau der vorherigen Folie",
+      "recommended": "Empfohlen",
       "searchConnector": "Vorlagen suchen",
       "searchConnectors": "Vorlagen suchen",
       "selected": "Vorlage: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -667,6 +667,7 @@
       "previewWebsite": "Preview website template {{title}}",
       "previousHtmlPreview": "{{title}} previous HTML preview",
       "previousSlide": "Preview previous slide",
+      "recommended": "Recommended",
       "searchConnector": "Search templates",
       "searchConnectors": "Search templates",
       "selected": "Template: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -684,6 +684,7 @@
       "previewWebsite": "Vista previa de la plantilla de sitio web {{title}}",
       "previousHtmlPreview": "Vista previa HTML anterior de {{title}}",
       "previousSlide": "Vista previa de la diapositiva anterior",
+      "recommended": "Recomendado",
       "searchConnector": "Buscar plantillas",
       "searchConnectors": "Buscar plantillas",
       "selected": "Plantilla: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -684,6 +684,7 @@
       "previewWebsite": "Aperçu du modèle de site Web {{title}}",
       "previousHtmlPreview": "Aperçu HTML précédent de {{title}}",
       "previousSlide": "Aperçu de la diapositive précédente",
+      "recommended": "Recommandé",
       "searchConnector": "Rechercher des modèles",
       "searchConnectors": "Rechercher des modèles",
       "selected": "Modèle : {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -667,6 +667,7 @@
       "previewWebsite": "वेबसाइट टेम्पलेट {{title}} का पूर्वावलोकन करें",
       "previousHtmlPreview": "{{title}} पिछला HTML पूर्वावलोकन",
       "previousSlide": "पिछली स्लाइड का पूर्वावलोकन करें",
+      "recommended": "अनुशंसित",
       "searchConnector": "टेम्पलेट खोजें",
       "searchConnectors": "टेम्पलेट खोजें",
       "selected": "टेम्पलेट: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -667,6 +667,7 @@
       "previewWebsite": "Pratinjau template website {{title}}",
       "previousHtmlPreview": "pratinjau HTML sebelumnya {{title}}",
       "previousSlide": "Pratinjau slide sebelumnya",
+      "recommended": "Direkomendasikan",
       "searchConnector": "Cari templat",
       "searchConnectors": "Cari templat",
       "selected": "Templat: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -684,6 +684,7 @@
       "previewWebsite": "Anteprima del modello di sito web {{title}}",
       "previousHtmlPreview": "{{title}} anteprima HTML precedente",
       "previousSlide": "Anteprima della diapositiva precedente",
+      "recommended": "Consigliato",
       "searchConnector": "Cerca modelli",
       "searchConnectors": "Cerca modelli",
       "selected": "Modello: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -667,6 +667,7 @@
       "previewWebsite": "Web サイト テンプレートのプレビュー {{title}}",
       "previousHtmlPreview": "{{title}} 前の HTML プレビュー",
       "previousSlide": "前のスライドをプレビューする",
+      "recommended": "おすすめ",
       "searchConnector": "テンプレートを検索",
       "searchConnectors": "テンプレートを検索",
       "selected": "テンプレート: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -667,6 +667,7 @@
       "previewWebsite": "웹사이트 템플릿 {{title}} 미리보기",
       "previousHtmlPreview": "{{title}} 이전 HTML 미리보기",
       "previousSlide": "이전 슬라이드 미리보기",
+      "recommended": "추천",
       "searchConnector": "템플릿 검색",
       "searchConnectors": "템플릿 검색",
       "selected": "템플릿: {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -684,6 +684,7 @@
       "previewWebsite": "Visualizar o modelo de site {{title}}",
       "previousHtmlPreview": "Visualização HTML anterior de {{title}}",
       "previousSlide": "Visualizar slide anterior",
+      "recommended": "Recomendado",
       "searchConnector": "Buscar modelos",
       "searchConnectors": "Buscar modelos",
       "selected": "Modelo: {{title}}",

--- a/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
+++ b/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
@@ -7,12 +7,15 @@ import {
   type ZeroAvatarVideoVoicesQuery,
 } from "@vm0/api-contracts/contracts/zero-avatar-video";
 
+import type { SupportedLocale } from "../../i18n/resources.ts";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { locale$ } from "../locale.ts";
 import { onRejection } from "../utils.ts";
 
 const AVATAR_TEMPLATE_PAGE_SIZE = 24;
 const AVATAR_TEMPLATE_FILTER_OPTIONS_PAGE_SIZE = 100;
+const AVATAR_TEMPLATE_RECOMMENDATION_PAGE_SIZE = 100;
 
 interface AvatarTemplateCatalogPage {
   readonly avatars: readonly ZeroAvatarVideoAvatar[];
@@ -77,6 +80,69 @@ function emptyAvatarTemplateVoiceFilters(): AvatarTemplateVoiceFilters {
   };
 }
 
+const PREFERRED_VOICE_LANGUAGE_BY_LOCALE = {
+  "de-DE": "german",
+  "en-US": "english",
+  "es-ES": "spanish",
+  "fr-FR": "french",
+  "hi-IN": "hindi",
+  "id-ID": "indonesian",
+  "it-IT": "italian",
+  "ja-JP": "japanese",
+  "ko-KR": "korean",
+  "pt-BR": "portuguese",
+} as const satisfies Record<SupportedLocale, string>;
+
+const PREFERRED_VOICE_USE_CASE_BY_AVATAR_STYLE = {
+  professional: "informative_educational",
+  social: "social_media",
+} as const satisfies Record<
+  NonNullable<ZeroAvatarVideoAvatarsQuery["style"]>,
+  string
+>;
+
+const PREFERRED_VOICE_USE_CASE_BY_AVATAR_SCENE = {
+  lifestyle: "conversational",
+  outdoors: "social_media",
+  business: "advertisement",
+  studio: "entertainment_tv",
+  health_fitness: "informative_educational",
+  education: "informative_educational",
+  news: "entertainment_tv",
+} as const satisfies Record<
+  NonNullable<ZeroAvatarVideoAvatarsQuery["scene"]>,
+  string
+>;
+
+const PREFERRED_VOICE_ACCENTS_BY_AVATAR_ETHNICITY = {
+  european: [
+    "british",
+    "irish",
+    "scottish",
+    "parisian",
+    "peninsular",
+    "moscow",
+    "russian",
+    "swedish",
+  ],
+  african: ["african", "nigerian", "south african", "african american"],
+  south_asian: ["indian", "bihari", "marathi"],
+  east_asian: [
+    "chinese",
+    "mandarin",
+    "cantonese",
+    "japanese",
+    "korean",
+    "taiwanese",
+  ],
+  middle_eastern: ["middle eastern", "arabic", "gulf", "istanbul"],
+  south_american: ["latin american", "colombian", "peruvian", "brazilian"],
+  north_american: ["american", "new york", "southern", "canadian"],
+} as const satisfies Record<
+  NonNullable<ZeroAvatarVideoAvatarsQuery["ethnicity"]>,
+  readonly string[]
+>;
+
 function voiceGenderForAvatar(
   avatarGender: string | undefined,
   fallback: AvatarTemplateVoiceFilters["gender"],
@@ -110,15 +176,74 @@ function voiceAgeForAvatar(
   }
 }
 
+function voiceUseCaseForAvatar(
+  avatarStyle: string | undefined,
+  filters: AvatarTemplateFilters,
+): AvatarTemplateVoiceFilters["useCase"] {
+  if (filters.scene) {
+    return PREFERRED_VOICE_USE_CASE_BY_AVATAR_SCENE[filters.scene];
+  }
+  const style = avatarStyle ?? filters.style;
+  if (style === "professional" || style === "social") {
+    return PREFERRED_VOICE_USE_CASE_BY_AVATAR_STYLE[style];
+  }
+  return undefined;
+}
+
+function recommendedVoiceFromCandidates(
+  voices: readonly ZeroAvatarVideoVoice[],
+  ethnicity: AvatarTemplateFilters["ethnicity"],
+): ZeroAvatarVideoVoice | null {
+  if (!ethnicity) {
+    return voices[0] ?? null;
+  }
+  const preferredAccents = new Set<string>(
+    PREFERRED_VOICE_ACCENTS_BY_AVATAR_ETHNICITY[ethnicity],
+  );
+  return (
+    voices.find((voice) => {
+      return (
+        voice.accent !== undefined &&
+        preferredAccents.has(voice.accent.toLocaleLowerCase())
+      );
+    }) ??
+    voices[0] ??
+    null
+  );
+}
+
 function voiceFiltersForAvatar(
   avatar: ZeroAvatarVideoAvatar,
   filters: AvatarTemplateFilters,
+  locale: SupportedLocale,
 ): AvatarTemplateVoiceFilters {
   return {
-    language: undefined,
+    language: PREFERRED_VOICE_LANGUAGE_BY_LOCALE[locale],
     gender: voiceGenderForAvatar(avatar.gender, filters.gender),
     age: voiceAgeForAvatar(avatar.age ?? filters.age),
-    useCase: undefined,
+    useCase: voiceUseCaseForAvatar(avatar.style, filters),
+  };
+}
+
+function recommendedVoiceQuery(
+  avatar: ZeroAvatarVideoAvatar,
+  avatarFilters: AvatarTemplateFilters,
+  voiceFilters: AvatarTemplateVoiceFilters,
+  locale: SupportedLocale,
+): ZeroAvatarVideoVoicesQuery {
+  const gender =
+    voiceFilters.gender ??
+    voiceGenderForAvatar(avatar.gender, avatarFilters.gender);
+  const age =
+    voiceFilters.age ?? voiceAgeForAvatar(avatar.age ?? avatarFilters.age);
+  return {
+    page: 1,
+    pageSize: AVATAR_TEMPLATE_RECOMMENDATION_PAGE_SIZE,
+    language:
+      voiceFilters.language ?? PREFERRED_VOICE_LANGUAGE_BY_LOCALE[locale],
+    ...(gender ? { gender } : {}),
+    ...(age ? { age } : {}),
+    ...(voiceFilters.useCase ? { useCase: voiceFilters.useCase } : {}),
   };
 }
 
@@ -336,34 +461,20 @@ function createAvatarTemplateVoiceCatalogSignals() {
       const client = get(zeroClient$)(zeroAvatarVideoContract, {
         apiBase: "api",
       });
-      const languages = new Set<string>();
-      const useCases = new Set<string>();
-      let page = 1;
-      let hasMore: boolean;
-      do {
-        const result = await accept(
-          client.voices({
-            query: {
-              page,
-              pageSize: AVATAR_TEMPLATE_FILTER_OPTIONS_PAGE_SIZE,
-            },
-            fetchOptions: { signal },
-          }),
-          [200],
-          signal,
-        );
-        for (const language of result.body.filterOptions?.languages ?? []) {
-          languages.add(language);
-        }
-        for (const useCase of result.body.filterOptions?.useCases ?? []) {
-          useCases.add(useCase);
-        }
-        hasMore = result.body.hasMore;
-        page += 1;
-      } while (hasMore);
+      const result = await accept(
+        client.voices({
+          query: {
+            page: 1,
+            pageSize: AVATAR_TEMPLATE_FILTER_OPTIONS_PAGE_SIZE,
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+        signal,
+      );
       return {
-        languages: Array.from(languages).sort(),
-        useCases: Array.from(useCases).sort(),
+        languages: result.body.filterOptions?.languages ?? [],
+        useCases: result.body.filterOptions?.useCases ?? [],
       };
     },
   );
@@ -397,12 +508,44 @@ export function createAvatarTemplatePickerSignals() {
   const selectedAvatarTemplateForVoice$ = computed((get) => {
     return get(internalSelectedAvatar$);
   });
+  const avatarTemplateRecommendedVoice$ = computed(
+    async (get, { signal }): Promise<ZeroAvatarVideoVoice | null> => {
+      const avatar = get(internalSelectedAvatar$);
+      if (!avatar) {
+        return null;
+      }
+      const avatarFilters = get(avatarCatalog.avatarTemplateFilters$);
+      const voiceFilters = get(voiceCatalog.avatarTemplateVoiceFilters$);
+      const locale = get(locale$);
+      const client = get(zeroClient$)(zeroAvatarVideoContract, {
+        apiBase: "api",
+      });
+      const result = await accept(
+        client.voices({
+          query: recommendedVoiceQuery(
+            avatar,
+            avatarFilters,
+            voiceFilters,
+            locale,
+          ),
+          fetchOptions: { signal },
+        }),
+        [200],
+        signal,
+      );
+      return recommendedVoiceFromCandidates(
+        result.body.voices,
+        avatarFilters.ethnicity,
+      );
+    },
+  );
   const selectAvatarTemplateForVoice$ = command(
     ({ get, set }, avatar: ZeroAvatarVideoAvatar) => {
       const avatarFilters = get(avatarCatalog.avatarTemplateFilters$);
+      const locale = get(locale$);
       set(
         voiceCatalog.setAvatarTemplateVoiceFilters$,
-        voiceFiltersForAvatar(avatar, avatarFilters),
+        voiceFiltersForAvatar(avatar, avatarFilters, locale),
       );
       set(internalSelectedAvatar$, avatar);
     },
@@ -416,6 +559,7 @@ export function createAvatarTemplatePickerSignals() {
     ...avatarCatalog,
     ...voiceCatalog,
     selectedAvatarTemplateForVoice$,
+    avatarTemplateRecommendedVoice$,
     selectAvatarTemplateForVoice$,
     clearAvatarTemplateVoiceSelection$,
   };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -820,9 +820,13 @@ describe("chat composer templates", () => {
         "overflow-y-auto",
         "[scrollbar-width:none]",
       );
-      expect(
-        avatarScroll.querySelector("[data-avatar-catalog-toolbar]"),
-      ).toHaveClass("sticky", "top-0");
+      expect(avatarScroll.parentElement).toHaveClass("px-6");
+      expect(avatarScroll.parentElement).not.toHaveClass("py-4");
+      const avatarToolbar = avatarScroll.querySelector(
+        "[data-avatar-catalog-toolbar]",
+      );
+      expect(avatarToolbar).toHaveClass("sticky", "top-0");
+      expect(avatarToolbar).not.toHaveClass("bg-background");
       Object.defineProperties(avatarScroll, {
         scrollHeight: { configurable: true, value: 1200 },
         clientHeight: { configurable: true, value: 500 },
@@ -864,6 +868,8 @@ describe("chat composer templates", () => {
         "[data-avatar-voice-list-scroll]",
       );
       expect(voicePicker).toHaveClass("overflow-hidden");
+      expect(voicePicker?.parentElement).toHaveClass("px-6");
+      expect(voicePicker?.parentElement).not.toHaveClass("py-4");
       expect(voiceScroll).toHaveClass(
         "overflow-y-auto",
         "[scrollbar-width:none]",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -820,13 +820,10 @@ describe("chat composer templates", () => {
         "overflow-y-auto",
         "[scrollbar-width:none]",
       );
-      expect(avatarScroll.parentElement).toHaveClass("px-6");
-      expect(avatarScroll.parentElement).not.toHaveClass("py-4");
       const avatarToolbar = avatarScroll.querySelector(
         "[data-avatar-catalog-toolbar]",
       );
       expect(avatarToolbar).toHaveClass("sticky", "top-0");
-      expect(avatarToolbar).not.toHaveClass("bg-background");
       Object.defineProperties(avatarScroll, {
         scrollHeight: { configurable: true, value: 1200 },
         clientHeight: { configurable: true, value: 500 },
@@ -868,8 +865,6 @@ describe("chat composer templates", () => {
         "[data-avatar-voice-list-scroll]",
       );
       expect(voicePicker).toHaveClass("overflow-hidden");
-      expect(voicePicker?.parentElement).toHaveClass("px-6");
-      expect(voicePicker?.parentElement).not.toHaveClass("py-4");
       expect(voiceScroll).toHaveClass(
         "overflow-y-auto",
         "[scrollbar-width:none]",
@@ -893,10 +888,7 @@ describe("chat composer templates", () => {
       );
       expect(firstVoiceCard).toHaveAttribute("data-recommended");
       expect(firstVoiceCard).toHaveAttribute("aria-pressed", "false");
-      expect(firstVoiceCard).toHaveClass(
-        "border-primary/40",
-        "bg-primary/[0.025]",
-      );
+      expect(firstVoiceCard).toHaveAccessibleDescription("Recommended");
       expect(within(firstVoiceCard).getByText("Recommended")).toBeVisible();
       const voiceFiltersButton = within(dialog).getByText("Filters", {
         selector: "button",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -616,6 +616,7 @@ describe("chat composer templates", () => {
       videoUrl: "https://example.com/ada.mp4",
       coverUrl: "https://example.com/ada.jpg",
       aspectRatio: 0,
+      style: "professional",
       gender: "male",
       age: "young_adult",
     };
@@ -625,6 +626,19 @@ describe("chat composer templates", () => {
       sampleUrl: "https://example.com/christopher.mp3",
       language: "English",
       gender: "male",
+      age: "young",
+      accent: "american",
+      useCase: "advertisement",
+    };
+    const alternateVoice = {
+      id: "es-ES-AlvaroNeural",
+      name: "Alvaro",
+      sampleUrl: "https://example.com/alvaro.mp3",
+      language: "Spanish",
+      gender: "male",
+      age: "young",
+      accent: "british",
+      useCase: "advertisement",
     };
     const secondVoice = {
       id: "en-US-AvaNeural",
@@ -632,12 +646,20 @@ describe("chat composer templates", () => {
       sampleUrl: "https://example.com/ava.mp3",
       language: "English",
       gender: "female",
+      age: "young",
+      accent: "american",
+      useCase: "advertisement",
     };
     context.mocks.api(
       zeroAvatarVideoContract.avatars,
       async ({ query, respond }) => {
         observedQueries.push(query);
-        if (query.page === 1 && query.style === "professional") {
+        if (
+          query.page === 1 &&
+          query.style === "professional" &&
+          query.scene === "business" &&
+          query.ethnicity === "north_american"
+        ) {
           await avatarFilterReady.promise;
         }
         if (query.page === 2) {
@@ -652,27 +674,46 @@ describe("chat composer templates", () => {
       zeroAvatarVideoContract.voices,
       async ({ query, respond }) => {
         observedVoiceQueries.push(query);
-        if (query.page === 1 && query.language === "english") {
+        if (
+          query.pageSize === 24 &&
+          query.page === 1 &&
+          query.language === "spanish"
+        ) {
           await voiceFilterReady.promise;
         }
         if (query.pageSize === 24 && query.page === 2) {
           await voicePageTwoReady.promise;
         }
-        const loadingFilterOptions = query.pageSize === 100;
+        const loadingFilterOptions =
+          query.pageSize === 100 &&
+          query.language === undefined &&
+          query.gender === undefined &&
+          query.age === undefined &&
+          query.useCase === undefined;
+        const loadingRecommendation =
+          query.pageSize === 100 && query.language !== undefined;
+        const voices = loadingFilterOptions
+          ? [alternateVoice, selectedVoice]
+          : loadingRecommendation
+            ? [alternateVoice, selectedVoice]
+            : query.page === 2
+              ? [secondVoice]
+              : query.language === "english"
+                ? [selectedVoice]
+                : [alternateVoice, selectedVoice];
         return respond(200, {
-          voices: query.page === 2 ? [secondVoice] : [selectedVoice],
+          voices,
           hasMore:
             query.page === 1 && (query.pageSize === 24 || loadingFilterOptions),
-          filterOptions:
-            loadingFilterOptions && query.page === 2
-              ? {
-                  languages: ["spanish"],
-                  useCases: ["social_media"],
-                }
-              : {
-                  languages: ["english"],
-                  useCases: ["narrative_story"],
-                },
+          filterOptions: loadingFilterOptions
+            ? {
+                languages: ["english", "spanish"],
+                useCases: ["advertisement", "narrative_story", "social_media"],
+              }
+            : {
+                languages: ["english"],
+                useCases: ["narrative_story"],
+              },
         });
       },
     );
@@ -715,6 +756,10 @@ describe("chat composer templates", () => {
       await user.click(within(dialog).getByText("Filters"));
       await user.click(screen.getByLabelText("Style: All"));
       await user.click(screen.getByRole("option", { name: "Professional" }));
+      await user.click(screen.getByLabelText("Scene: All"));
+      await user.click(screen.getByRole("option", { name: "Business" }));
+      await user.click(screen.getByLabelText("Ethnicity: All"));
+      await user.click(screen.getByRole("option", { name: "North american" }));
       await user.keyboard("{Escape}");
       await waitFor(() => {
         expect(
@@ -728,6 +773,8 @@ describe("chat composer templates", () => {
           pageSize: 24,
           aspectRatio: "landscape",
           style: "professional",
+          scene: "business",
+          ethnicity: "north_american",
         });
       });
       const firstCard = within(dialog).getByLabelText(
@@ -826,10 +873,25 @@ describe("chat composer templates", () => {
         expect(observedVoiceQueries).toContainEqual({
           page: 1,
           pageSize: 24,
+          language: "english",
           gender: "male",
           age: "young",
+          useCase: "advertisement",
         });
       });
+      const firstVoiceCard = await within(dialog).findByLabelText(
+        "Select voice Christopher",
+      );
+      expect(voiceScroll?.querySelector("[data-avatar-voice-card]")).toBe(
+        firstVoiceCard,
+      );
+      expect(firstVoiceCard).toHaveAttribute("data-recommended");
+      expect(firstVoiceCard).toHaveAttribute("aria-pressed", "false");
+      expect(firstVoiceCard).toHaveClass(
+        "border-primary/40",
+        "bg-primary/[0.025]",
+      );
+      expect(within(firstVoiceCard).getByText("Recommended")).toBeVisible();
       const voiceFiltersButton = within(dialog).getByText("Filters", {
         selector: "button",
       });
@@ -840,11 +902,15 @@ describe("chat composer templates", () => {
       await user.click(voiceFiltersButton);
       expect(screen.getByLabelText("Gender: Male")).toBeInTheDocument();
       expect(screen.getByLabelText("Age: Young")).toBeInTheDocument();
-      await user.click(await screen.findByLabelText("Language: All"));
+      expect(screen.getByLabelText("Language: English")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Use case: Advertisement"),
+      ).toBeInTheDocument();
+      await user.click(screen.getByLabelText("Language: English"));
       expect(
         screen.getByRole("option", { name: "Spanish" }),
       ).toBeInTheDocument();
-      await user.click(screen.getByRole("option", { name: "English" }));
+      await user.click(screen.getByRole("option", { name: "Spanish" }));
       await user.keyboard("{Escape}");
       await waitFor(() => {
         expect(
@@ -856,17 +922,18 @@ describe("chat composer templates", () => {
         expect(observedVoiceQueries).toContainEqual({
           page: 1,
           pageSize: 24,
-          language: "english",
+          language: "spanish",
           gender: "male",
           age: "young",
+          useCase: "advertisement",
         });
       });
+      const filteredFirstVoiceCard = await within(dialog).findByLabelText(
+        "Select voice Christopher",
+      );
       if (!(voiceScroll instanceof HTMLElement)) {
         throw new Error("Voice catalog scroll area not found");
       }
-      const firstVoiceCard = within(dialog).getByLabelText(
-        "Select voice Christopher",
-      );
       Object.defineProperties(voiceScroll, {
         scrollHeight: { configurable: true, value: 1200 },
         clientHeight: { configurable: true, value: 500 },
@@ -877,7 +944,7 @@ describe("chat composer templates", () => {
       voicePageTwoReady.resolve();
       await within(dialog).findByLabelText("Select voice Ava");
       expect(within(dialog).getByLabelText("Select voice Christopher")).toBe(
-        firstVoiceCard,
+        filteredFirstVoiceCard,
       );
       expect(voiceScroll.scrollTop).toBe(500);
       const voicePreview = within(dialog).getByLabelText(
@@ -918,21 +985,47 @@ describe("chat composer templates", () => {
             style: "professional",
           },
           {
+            page: 1,
+            pageSize: 24,
+            aspectRatio: "landscape",
+            style: "professional",
+            scene: "business",
+          },
+          {
+            page: 1,
+            pageSize: 24,
+            aspectRatio: "landscape",
+            style: "professional",
+            scene: "business",
+            ethnicity: "north_american",
+          },
+          {
             page: 2,
             pageSize: 24,
             aspectRatio: "landscape",
             style: "professional",
+            scene: "business",
+            ethnicity: "north_american",
           },
         ]);
         expect(observedVoiceQueries).toStrictEqual(
           expect.arrayContaining([
             { page: 1, pageSize: 100 },
-            { page: 2, pageSize: 100 },
             {
               page: 1,
-              pageSize: 24,
+              pageSize: 100,
+              language: "english",
               gender: "male",
               age: "young",
+              useCase: "advertisement",
+            },
+            {
+              page: 1,
+              pageSize: 100,
+              language: "spanish",
+              gender: "male",
+              age: "young",
+              useCase: "advertisement",
             },
             {
               page: 1,
@@ -940,16 +1033,37 @@ describe("chat composer templates", () => {
               language: "english",
               gender: "male",
               age: "young",
+              useCase: "advertisement",
+            },
+            {
+              page: 1,
+              pageSize: 24,
+              language: "spanish",
+              gender: "male",
+              age: "young",
+              useCase: "advertisement",
             },
             {
               page: 2,
               pageSize: 24,
-              language: "english",
+              language: "spanish",
               gender: "male",
               age: "young",
+              useCase: "advertisement",
             },
           ]),
         );
+        expect(
+          observedVoiceQueries.filter((query) => {
+            return (
+              query.pageSize === 100 &&
+              query.language === undefined &&
+              query.gender === undefined &&
+              query.age === undefined &&
+              query.useCase === undefined
+            );
+          }),
+        ).toStrictEqual([{ page: 1, pageSize: 100 }]);
         expect(submittedTemplate).toStrictEqual({
           type: "video",
           selection: {

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -501,7 +501,7 @@ function AvatarCatalogFilters({
   return (
     <div
       data-avatar-catalog-toolbar=""
-      className="sticky top-0 z-10 mb-5 flex flex-wrap items-center justify-between gap-3 border-b border-border/70 bg-background pb-4"
+      className="sticky top-0 z-10 mb-5 flex flex-wrap items-center justify-between gap-3 border-b border-border/70 pb-4"
     >
       <AvatarAspectRatioPicker
         value={filters.aspectRatio}

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -854,6 +854,7 @@ function AvatarVoiceCard({
   readonly onSelect: (voice: ZeroAvatarVideoVoice) => void;
 }) {
   const { t } = useTranslation();
+  const recommendedDescriptionId = `avatar-voice-recommendation-${encodeURIComponent(voice.id)}`;
   const metadata = Array.from(
     new Set(
       [voice.language, voice.gender, voice.age, voice.accent]
@@ -883,6 +884,7 @@ function AvatarVoiceCard({
         { title: voice.name },
       )}
       aria-pressed={selected}
+      aria-describedby={recommended ? recommendedDescriptionId : undefined}
       onClick={selectVoice}
       onKeyDown={(event: ReactKeyboardEvent<HTMLDivElement>) => {
         if (event.target !== event.currentTarget) {
@@ -918,7 +920,10 @@ function AvatarVoiceCard({
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {recommended && (
-              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+              <span
+                id={recommendedDescriptionId}
+                className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary"
+              >
                 {t(($) => {
                   return $.artifacts.templates.recommended;
                 })}

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -845,10 +845,12 @@ function VoicePreviewControl({
 function AvatarVoiceCard({
   voice,
   selected,
+  recommended,
   onSelect,
 }: {
   readonly voice: ZeroAvatarVideoVoice;
   readonly selected: boolean;
+  readonly recommended: boolean;
   readonly onSelect: (voice: ZeroAvatarVideoVoice) => void;
 }) {
   const { t } = useTranslation();
@@ -871,6 +873,7 @@ function AvatarVoiceCard({
     <div
       data-avatar-voice-card=""
       data-playing="false"
+      data-recommended={recommended ? "" : undefined}
       role="button"
       tabIndex={0}
       aria-label={t(
@@ -893,7 +896,11 @@ function AvatarVoiceCard({
       className={cn(
         "group/voice flex cursor-pointer items-center gap-3 rounded-xl border bg-card p-3 transition-colors duration-200 hover:border-foreground/20 hover:bg-muted/25 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         AVATAR_CARD_SHADOW,
-        selected ? "border-primary bg-primary/[0.04]" : "border-border",
+        selected
+          ? "border-primary bg-primary/[0.04]"
+          : recommended
+            ? "border-primary/40 bg-primary/[0.025]"
+            : "border-border",
       )}
     >
       <VoicePreviewControl voice={voice} />
@@ -909,14 +916,23 @@ function AvatarVoiceCard({
               </p>
             )}
           </div>
-          {selected && (
-            <span
-              className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
-              aria-hidden="true"
-            >
-              <IconCheck size={13} stroke={2.2} />
-            </span>
-          )}
+          <div className="flex shrink-0 items-center gap-2">
+            {recommended && (
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                {t(($) => {
+                  return $.artifacts.templates.recommended;
+                })}
+              </span>
+            )}
+            {selected && (
+              <span
+                className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                aria-hidden="true"
+              >
+                <IconCheck size={13} stroke={2.2} />
+              </span>
+            )}
+          </div>
         </div>
         {metadata.length > 0 && (
           <div className="mt-2 flex min-w-0 flex-wrap gap-1.5">
@@ -935,6 +951,21 @@ function AvatarVoiceCard({
       </div>
     </div>
   );
+}
+
+function recommendedVoiceFirst(
+  voices: readonly ZeroAvatarVideoVoice[],
+  recommendedVoice: ZeroAvatarVideoVoice | null,
+): readonly ZeroAvatarVideoVoice[] {
+  if (!recommendedVoice) {
+    return voices;
+  }
+  return [
+    recommendedVoice,
+    ...voices.filter((voice) => {
+      return voice.id !== recommendedVoice.id;
+    }),
+  ];
 }
 
 function SelectedAvatarCard({
@@ -975,24 +1006,19 @@ function SelectedAvatarCard({
   );
 }
 
-function AvatarVoicePickerContent({
+function AvatarVoiceCatalog({
   signals,
-  avatar,
   value,
-  onBack,
   onSelect,
 }: {
   readonly signals: ComposerSignals;
-  readonly avatar: ZeroAvatarVideoAvatar;
   readonly value: GenerationTemplateRequest | undefined;
-  readonly onBack: () => void;
-  readonly onSelect: (
-    avatar: ZeroAvatarVideoAvatar,
-    voice: ZeroAvatarVideoVoice,
-  ) => void;
+  readonly onSelect: (voice: ZeroAvatarVideoVoice) => void;
 }) {
-  const { t } = useTranslation();
   const catalog = useLoadable(signals.template.avatarTemplateVoiceCatalogPage$);
+  const recommendation = useLoadable(
+    signals.template.avatarTemplateRecommendedVoice$,
+  );
   const lastCatalog = useLastResolved(
     signals.template.avatarTemplateVoiceCatalogPage$,
   );
@@ -1010,9 +1036,16 @@ function AvatarVoicePickerContent({
   const pageSignal = useGet(pageSignal$);
   const selectedVoiceId =
     value?.type === "video" ? value.selection.voiceId : undefined;
-  const aspectRatio = useGet(
-    signals.template.avatarTemplateFilters$,
-  ).aspectRatio;
+  const recommendedVoice =
+    recommendation.state === "hasData"
+      ? (recommendation.data ?? visibleCatalog?.voices[0] ?? null)
+      : recommendation.state === "hasError"
+        ? null
+        : undefined;
+  const visibleVoices =
+    visibleCatalog && recommendedVoice !== undefined
+      ? recommendedVoiceFirst(visibleCatalog.voices, recommendedVoice)
+      : undefined;
   const handleVoiceScroll = (event: ReactUIEvent<HTMLElement>) => {
     if (catalog.state !== "hasData" || !catalog.data.hasNext) {
       return;
@@ -1025,6 +1058,61 @@ function AvatarVoicePickerContent({
     }
     detach(loadMore(pageSignal), Reason.DomCallback, "avatar voice paging");
   };
+
+  return (
+    <section className="flex min-h-0 min-w-0 flex-col">
+      <div
+        data-avatar-voice-list-scroll=""
+        className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        onScroll={handleVoiceScroll}
+      >
+        {catalog.state === "hasError" ? (
+          <AvatarTemplateEmpty error />
+        ) : visibleVoices === undefined ? (
+          <AvatarVoiceSkeletonGrid />
+        ) : visibleVoices.length > 0 ? (
+          <div className="grid grid-cols-1 gap-2.5">
+            {visibleVoices.map((voice) => {
+              return (
+                <AvatarVoiceCard
+                  key={voice.id}
+                  voice={voice}
+                  selected={voice.id === selectedVoiceId}
+                  recommended={voice.id === recommendedVoice?.id}
+                  onSelect={onSelect}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <AvatarTemplateEmpty error={false} />
+        )}
+        {loadingMore && <CatalogLoadingSpinner />}
+      </div>
+    </section>
+  );
+}
+
+function AvatarVoicePickerContent({
+  signals,
+  avatar,
+  value,
+  onBack,
+  onSelect,
+}: {
+  readonly signals: ComposerSignals;
+  readonly avatar: ZeroAvatarVideoAvatar;
+  readonly value: GenerationTemplateRequest | undefined;
+  readonly onBack: () => void;
+  readonly onSelect: (
+    avatar: ZeroAvatarVideoAvatar,
+    voice: ZeroAvatarVideoVoice,
+  ) => void;
+}) {
+  const { t } = useTranslation();
+  const aspectRatio = useGet(
+    signals.template.avatarTemplateFilters$,
+  ).aspectRatio;
 
   return (
     <div
@@ -1063,37 +1151,13 @@ function AvatarVoicePickerContent({
         >
           <SelectedAvatarCard avatar={avatar} aspectRatio={aspectRatio} />
         </div>
-        <section className="flex min-h-0 min-w-0 flex-col">
-          <div
-            data-avatar-voice-list-scroll=""
-            className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-            onScroll={handleVoiceScroll}
-          >
-            {catalog.state === "hasError" ? (
-              <AvatarTemplateEmpty error />
-            ) : visibleCatalog === undefined ? (
-              <AvatarVoiceSkeletonGrid />
-            ) : visibleCatalog.voices.length > 0 ? (
-              <div className="grid grid-cols-1 gap-2.5">
-                {visibleCatalog.voices.map((voice) => {
-                  return (
-                    <AvatarVoiceCard
-                      key={voice.id}
-                      voice={voice}
-                      selected={voice.id === selectedVoiceId}
-                      onSelect={(selectedVoice) => {
-                        onSelect(avatar, selectedVoice);
-                      }}
-                    />
-                  );
-                })}
-              </div>
-            ) : (
-              <AvatarTemplateEmpty error={false} />
-            )}
-            {loadingMore && <CatalogLoadingSpinner />}
-          </div>
-        </section>
+        <AvatarVoiceCatalog
+          signals={signals}
+          value={value}
+          onSelect={(voice) => {
+            onSelect(avatar, voice);
+          }}
+        />
       </div>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5440,7 +5440,7 @@ function TemplatePickerCategoryContent({
 
   if (selectedCategory === "avatar" && hasAvatarTab) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-6 py-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-6">
         <AvatarTemplatePickerContent
           signals={signals}
           value={value}


### PR DESCRIPTION
## Summary

- preselect voice filters from the UI locale and the selected avatar gender and age
- map avatar style and scene to JoggAI voice use cases, and prefer matching accents when an ethnicity filter is available
- fetch one bounded recommendation candidate page, pin the recommended voice, and keep manual selection explicit
- load voice filter options with one bounded request and localize the Recommended label
- remove vertical padding from both avatar and voice picker pages, and remove the avatar toolbar background fill

## Provider behavior

JoggAI does not expose a public avatar-to-voice recommendation API or a recommended voice ID on public avatars. Matching remains application-side. Scene and ethnicity are only available when the user selected those avatar filters because JoggAI does not include them in avatar responses.

## Test plan

- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx --maxWorkers=1