### PR TITLE
refactor(api): stop writing chat event trigger source

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -125,7 +125,7 @@ describe("cron monitor chat event queue", () => {
 
     const response = await accept(
       stateClient().monitor({
-        body: { event_ids: fixture.eventIds.slice(0, 3) },
+        body: { event_ids: fixture.eventIds.slice(0, 2) },
       }),
       [200],
     );
@@ -141,7 +141,7 @@ describe("cron monitor chat event queue", () => {
     const fixture = await trackFixture(seedFixture("orphan"));
 
     const response = await accept(
-      stateClient().monitor({ body: { event_ids: fixture.eventIds.slice(3) } }),
+      stateClient().monitor({ body: { event_ids: fixture.eventIds.slice(2) } }),
       [500],
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1808,23 +1808,27 @@ describe("INT-01: Slack app deep webhook flows", () => {
         return ingress.eventId;
       }),
     ).toStrictEqual(expect.arrayContaining([eventId, stickyEventId]));
-    // Pending input events retain channel attribution alongside web messages.
-    expect(state.pending_chat_events).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          eventType: "input.prompt",
-          triggerSource: "web",
-        }),
-        expect.objectContaining({
-          eventType: "input.prompt",
-          triggerSource: "slack",
-        }),
-      ]),
+    const pendingInputEvents = state.pending_chat_events.filter((pending) => {
+      return pending.eventType === "input.prompt";
+    });
+    expect(pendingInputEvents.length).toBeGreaterThanOrEqual(2);
+    expect(
+      pendingInputEvents.every((pending) => {
+        return pending.triggerSource === null;
+      }),
+    ).toBeTruthy();
+    const pendingEventsWithContext = await Promise.all(
+      pendingInputEvents.map(async (pending) => {
+        return {
+          pending,
+          context: await readChatEventContextFixture(pending.id),
+        };
+      }),
     );
-    const queuedSlackEvents = state.pending_chat_events.filter((pending) => {
+    const queuedSlackEvents = pendingEventsWithContext.filter((candidate) => {
       return (
-        pending.chatThreadId === canonicalChatThreadId &&
-        pending.triggerSource === "slack"
+        candidate.pending.chatThreadId === canonicalChatThreadId &&
+        candidate.context?.contextType === "slack"
       );
     });
     expect(queuedSlackEvents).toHaveLength(1);
@@ -1832,9 +1836,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     if (!queuedSlackEvent) {
       throw new Error("Expected the canonical thread's pending Slack event");
     }
-    await expect(
-      readChatEventContextFixture(queuedSlackEvent.id),
-    ).resolves.toMatchObject({
+    expect(queuedSlackEvent.context).toMatchObject({
       contextType: "slack",
       contextId: expect.any(String),
       slackChannelId: channelId,
@@ -1958,14 +1960,20 @@ describe("INT-01: Slack app deep webhook flows", () => {
     }));
     expect(claim2.resumeSession?.sessionId).toBe(`bdd-slack-cli-${webRunId}`);
     state = await integrations.readSlackTestState(teamId);
-    expect(state.recent_runs).toContainEqual(
-      expect.objectContaining({
-        id: run2Id,
-        triggerSource: "slack",
-        promptPreview: expect.stringContaining(
-          "stay canonical on the same route",
-        ),
-      }),
+    expect(state.recent_runs).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: webRunId,
+          triggerSource: "web",
+        }),
+        expect.objectContaining({
+          id: run2Id,
+          triggerSource: "slack",
+          promptPreview: expect.stringContaining(
+            "stay canonical on the same route",
+          ),
+        }),
+      ]),
     );
     await completeSlackTriggeredRun({
       runId: run2Id,
@@ -2541,7 +2549,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       expect.arrayContaining([
         expect.objectContaining({
           eventType: "input.prompt",
-          triggerSource: "slack",
+          triggerSource: null,
         }),
       ]),
     );

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -48,62 +48,46 @@ const STALE_CONTEXT_FIXTURES = [
   {
     contextType: "web",
     eventType: "input.prompt",
-    triggerSource: "web",
-  },
-  {
-    contextType: "web",
-    eventType: "input.prompt",
-    triggerSource: "test",
   },
   {
     contextType: "agent_run",
     eventType: "input.prompt",
-    triggerSource: "agent",
   },
   {
     contextType: "slack",
     eventType: "input.prompt",
-    triggerSource: "slack",
   },
   {
     contextType: "feishu",
     eventType: "input.prompt",
-    triggerSource: "feishu",
   },
   {
     contextType: "teams",
     eventType: "input.prompt",
-    triggerSource: "teams",
   },
   {
     contextType: "telegram",
     eventType: "input.prompt",
-    triggerSource: "telegram",
   },
   {
     contextType: "github",
     eventType: "input.prompt",
-    triggerSource: "github",
   },
   {
     contextType: "agentphone",
     eventType: "input.prompt",
-    triggerSource: "agentphone",
   },
   {
     contextType: "automation",
     eventType: "input.automation",
-    triggerSource: "workflow-event",
   },
   {
     contextType: "goal",
     eventType: "input.goal",
-    triggerSource: null,
   },
   {
     contextType: "morning_brief",
     eventType: "input.prompt",
-    triggerSource: "workflow-schedule",
   },
 ] as const;
 
@@ -240,7 +224,6 @@ async function seedQueuedIntegrationEvent(tx: DbTransaction, threadId: string) {
       contextType: "slack",
       contextId: randomUUID(),
       eventType: "input.prompt",
-      triggerSource: "slack",
       userMessage: createUserMessageDocument({
         text: "orphan monitor fixture",
       }),
@@ -328,7 +311,6 @@ async function seedFixture(
         eventType: "input.automation",
         createdAt: new Date(0),
         automationId: randomUUID(),
-        triggerSource: "workflow-event",
         triggerBrief: null,
       });
       return [automation];
@@ -358,7 +340,6 @@ async function seedFixture(
             ...baseEvent,
             contextType: "web",
             eventType: "input.prompt",
-            triggerSource: "web",
           });
     return [event];
   });

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -356,7 +356,6 @@ async function persistCanonicalFeishuIngress(args: {
         eventType: "input.prompt",
         userMessage: feishuInboundUserMessage(args.message, chatOpenUrl),
         runId: null,
-        triggerSource: "feishu",
         feishuContext: {
           ...args.launchContext,
         },

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -355,7 +355,6 @@ async function persistCanonicalSlackMessage(
           }),
         }),
         runId: null,
-        triggerSource: "slack",
         slackContext: args.slackContext,
         createdAt: args.ingress.createdAt,
       },

--- a/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-run.service.ts
@@ -301,7 +301,6 @@ async function persistMorningBriefQueueEvent(
         },
       }),
       runId: null,
-      triggerSource: "workflow-schedule",
       morningBriefContext: {
         deliveryId: claimed.deliveryId,
         timezone: claimed.timezone,

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -153,7 +153,6 @@ async function attemptWorkflowQueueAdmission(
       workflowName: args.workflowName,
       workflowAutomationEventType: args.workflowAutomationEventType,
       workflowAutomationEventPayload: args.workflowAutomationEventPayload,
-      triggerSource: args.triggerSource,
       triggerBrief: args.triggerBrief ?? null,
     });
     if (!inserted) {
@@ -356,7 +355,6 @@ export async function rejectWorkflowQueueEvent(
       runId: null,
       error: args.reason,
       automationId: payload.automationId,
-      triggerSource: manualTriggerSource({ kind: payload.automationKind }),
       triggerBrief: payload.triggerBrief,
     });
     return rejected !== null;

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1494,7 +1494,6 @@ async function persistAgentPhoneChatMessage(args: {
           nonContentPart: createChatEventSourcePart({ kind: "agentphone" }),
         }),
         runId: null,
-        triggerSource: "agentphone",
         agentphoneContext: {
           messageText: args.prompt,
           threadContext: args.threadContext,

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -1,7 +1,6 @@
 /** Typed append-only commands for the canonical ChatEvent stream. */
 import { randomUUID } from "node:crypto";
 import { isValidChatEventRevocation } from "@vm0/api-contracts/contracts/chat-events";
-import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { ChatFeishuMessageFiles } from "@vm0/db/jsonb-contracts/chat-feishu-context";
 import type {
   ChatSlackMentionDisplayNames,
@@ -227,7 +226,6 @@ type InputPromptEvent = ChatEventIdentity &
     readonly eventType: "input.prompt";
     readonly content?: null;
     readonly contextType?: "web";
-    readonly triggerSource?: TriggerSource;
   };
 
 type InputAutomationEvent = ChatEventIdentity &
@@ -238,7 +236,6 @@ type InputAutomationEvent = ChatEventIdentity &
     readonly workflowName?: string;
     readonly workflowAutomationEventType?: WorkflowAutomationEventType;
     readonly workflowAutomationEventPayload?: WorkflowAutomationEventPayload;
-    readonly triggerSource: TriggerSource;
     readonly triggerBrief: string | null;
   };
 
@@ -265,7 +262,6 @@ type InputRejectedEvent = ChatEventIdentity &
     readonly content?: null;
     readonly error: string;
     readonly automationId?: string;
-    readonly triggerSource?: TriggerSource;
     readonly triggerBrief?: string | null;
   };
 

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -1471,7 +1471,6 @@ function appendUnassociatedUserMessage(params: {
       eventType: "input.prompt",
       userMessage: params.userMessage,
       runId: null,
-      triggerSource: params.triggerSource,
       ...(params.triggerSource === "web" ? { contextType: "web" } : {}),
       ...(params.agentRunSource
         ? {

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -67,7 +67,6 @@ import {
 } from "./autonomy-budget-schema.service";
 import type { Tx } from "../../lib/db-types";
 import { withRunModelAnnotation } from "./zero-chat-user-message.service";
-import { manualTriggerSource } from "./workflow-automation-trigger-source";
 import { chatAgentRunContextSchemaAvailable } from "./chat-agent-run-context-schema.service";
 
 type DbTransaction = Tx;
@@ -465,7 +464,6 @@ async function resolveUserQueueFirstClaimSnapshot(
       runId: args.runId,
       attachFiles: head.attachFiles ? [...head.attachFiles] : null,
       generationTemplate: head.generationTemplate,
-      triggerSource: queuedUserMessageTriggerSource(contextType),
     },
   };
 }
@@ -529,7 +527,6 @@ async function resolveWorkflowQueueFirstClaimSnapshot(
           ? head.userMessage
           : withRunModelAnnotation(head.userMessage, args.selectedModel),
       runId: args.runId,
-      triggerSource: manualTriggerSource({ kind: head.automationKind }),
     },
   };
 }
@@ -596,7 +593,6 @@ async function resolveGoalQueueFirstClaimSnapshot(
           : withRunModelAnnotation(head.userMessage, args.selectedModel),
       runId: args.runId,
       runGroupId: args.goalId,
-      triggerSource: "workflow-event",
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -1616,7 +1616,6 @@ async function persistTeamsChatMessage(args: {
           }),
         }),
         runId: null,
-        triggerSource: "teams",
         teamsContext: launchContext,
         createdAt: currentTime,
       },

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -1802,7 +1802,6 @@ async function persistTelegramChatMessage(args: {
           }),
         }),
         runId: null,
-        triggerSource: "telegram",
         telegramContext: telegramLaunchContext(args),
         createdAt: currentTime,
       },

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -260,7 +260,6 @@ export async function readChatEventContextFixture(
 const annotationProjectionInputs = [
   {
     text: "slack linked",
-    triggerSource: "slack",
     messagePermalink: "https://vm0.slack.com/archives/C123/p1753257600000100",
     context: {
       slackContext: {
@@ -280,7 +279,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "feishu linked",
-    triggerSource: "feishu",
     context: {
       feishuContext: {
         conversationHistory: "",
@@ -300,7 +298,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "teams channel linked",
-    triggerSource: "teams",
     context: {
       teamsContext: {
         tenantId: "tenant-1",
@@ -326,7 +323,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "teams personal unlinked",
-    triggerSource: "teams",
     context: {
       teamsContext: {
         tenantId: "tenant-1",
@@ -352,7 +348,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "telegram supergroup linked",
-    triggerSource: "telegram",
     context: {
       telegramContext: {
         chatId: "-1001234567890",
@@ -374,7 +369,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "telegram dm unlinked",
-    triggerSource: "telegram",
     context: {
       telegramContext: {
         chatId: "123456789",
@@ -396,7 +390,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "telegram group unlinked",
-    triggerSource: "telegram",
     context: {
       telegramContext: {
         chatId: "-123456789",
@@ -418,7 +411,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "github issue comment linked",
-    triggerSource: "github",
     context: {
       githubContext: {
         repo: "vm0-ai/vm0",
@@ -434,7 +426,6 @@ const annotationProjectionInputs = [
   },
   {
     text: "github pull request linked",
-    triggerSource: "github",
     context: {
       githubContext: {
         repo: "vm0-ai/vm0",
@@ -508,7 +499,6 @@ export async function seedChatEventAnnotationProjectionFixture(
           nonContentPart: annotationProjectionSourcePart(input),
         }),
         runId: null,
-        triggerSource: input.triggerSource,
         ...input.context,
       });
     }
@@ -528,7 +518,6 @@ export async function seedChatEventAnnotationProjectionFixture(
         }),
       }),
       runId: null,
-      triggerSource: "github",
       githubContext: {
         repo: "vm0-ai/vm0",
         subjectNumber: 24_218,
@@ -554,7 +543,6 @@ export async function seedChatEventAnnotationProjectionFixture(
         }),
       }),
       runId: randomUUID(),
-      triggerSource: "github",
     });
 
     await insertChatEvent(tx, {
@@ -571,7 +559,6 @@ export async function seedChatEventAnnotationProjectionFixture(
         }),
       }),
       runId: null,
-      triggerSource: "teams",
       teamsContext: {
         tenantId: "tenant-2",
         teamId: "team-2",
@@ -607,7 +594,6 @@ export async function seedChatEventAnnotationProjectionFixture(
       }),
       runId: null,
       error: "rejected for annotation coverage",
-      triggerSource: "teams",
     });
   });
   return { claimedPendingId, rejectedPendingId };
@@ -630,7 +616,6 @@ async function pendingTelegramEventContext(eventId: string) {
       and(
         eq(chatEvents.id, eventId),
         eq(chatEvents.contextType, "telegram"),
-        eq(chatEvents.triggerSource, "telegram"),
         isNull(chatEvents.runId),
       ),
     )
@@ -672,7 +657,7 @@ export async function findTelegramChatEventByPromptFixture(
     .where(
       and(
         eq(chatEvents.eventType, "input.prompt"),
-        eq(chatEvents.triggerSource, "telegram"),
+        eq(chatEvents.contextType, "telegram"),
       ),
     );
   const row = rows.find((candidate) => {
@@ -695,7 +680,7 @@ export async function findAgentphoneChatEventByPromptFixture(
     .where(
       and(
         eq(chatEvents.eventType, "input.prompt"),
-        eq(chatEvents.triggerSource, "agentphone"),
+        eq(chatEvents.contextType, "agentphone"),
       ),
     );
   const row = rows.find((candidate) => {
@@ -735,7 +720,6 @@ export async function insertQueuedSlackMissingContextFixture(args: {
       eventType: "input.prompt",
       userMessage: createUserMessageDocument({ text: args.content }),
       runId: null,
-      triggerSource: "slack",
       slackContext: {
         channelId: "C_MONITOR_FAILURE",
         messageTs: "1.000001",
@@ -769,7 +753,6 @@ export async function replayPendingChatInputQueueEventFixture(args: {
         userMessage: chatEvents.userMessage,
         attachFiles: chatEvents.attachFiles,
         generationTemplate: chatEvents.generationTemplate,
-        triggerSource: chatEvents.triggerSource,
       })
       .from(chatEvents)
       .where(
@@ -791,7 +774,6 @@ export async function replayPendingChatInputQueueEventFixture(args: {
       runId: null,
       attachFiles: event.attachFiles ? [...event.attachFiles] : null,
       generationTemplate: event.generationTemplate,
-      ...(event.triggerSource ? { triggerSource: event.triggerSource } : {}),
     });
     if (!replacement) {
       throw new Error("Expected the pending queue event replay to insert");

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -67,7 +67,6 @@ export async function insertQueuedWebUserMessageFixture(args: {
       eventType: "input.prompt",
       userMessage: createUserMessageDocument({ text: args.content }),
       runId: null,
-      triggerSource: "web",
       createdAt: args.createdAt,
     });
     if (!inserted) {


### PR DESCRIPTION
## Summary

- remove `triggerSource` from every `NewChatEvent` input variant and stop setting `chat_events.trigger_source` in production, test, fixture, and replacement writes
- keep the physical column unchanged so new rows use its null default while historical append-only rows remain untouched
- express the queue monitor fixture matrix solely through the 11 unique `context_type` values and keep all nine orphan-source alert groups covered
- update Slack integration coverage to assert pending web and Slack chat events leave `trigger_source` null while their runs still persist `web` and `slack`

## Monitor fixture decision

The legacy `"test"` fixture is removed instead of being remapped. `test` has no `context_type` counterpart, and remapping it to `web` would duplicate the existing web fixture without adding monitor coverage. The remaining web and `agent_run` fixtures still cover the two non-alerting source shapes, and the other nine context types still cover every grouped alert case.

## Preserved behavior

- `queuedUserMessageTriggerSource` remains in use for prior-run lookup, run creation, and admission logging
- `manualTriggerSource` remains in use for workflow run creation and Run now
- `isWebChatTriggerSource` remains in use for run-creation request handling
- `zero_runs.trigger_source`, log/activity contracts, and `chat_*_context` are unchanged
- no migration, schema, client, or contract files are changed

## Verification

- `pnpm -F api check-types`
- scoped type-aware Oxlint and ESLint for all changed files
- `pnpm knip --workspace api`
- Prettier check for all changed files
- direct `insertChatEvent`, `replaceChatEvent`, and `db.insert(chatEvents)` writer scans: no remaining `triggerSource` assignments
- database-backed focused tests are delegated to PR CI because this worktree has no `DATABASE_URL` or running PostgreSQL

Closes #25594
