### PR TITLE
feat(app): let a video template chip set its generation parameters

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1605,7 +1605,6 @@
       "videoOptionsLabel": "Videooptionen {{spec}}",
       "videoOptionsModel": "Modell",
       "videoOptionsRatio": "Seitenverhältnis",
-      "videoOptionsReset": "Auf Standard zurücksetzen",
       "videoOptionsResolution": "Auflösung"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1598,7 +1598,15 @@
       "removeTemplate": "Vorlage {{title}} entfernen",
       "removeVideo": "Videovorlage {{title}} entfernen",
       "removeWebsite": "Website-Vorlage {{title}} entfernen",
-      "removeWorkflow": "Workflow-Vorlage {{title}} entfernen"
+      "removeWorkflow": "Workflow-Vorlage {{title}} entfernen",
+      "videoOptions": "Videooptionen",
+      "videoOptionsAudio": "Audio erzeugen",
+      "videoOptionsDuration": "Dauer",
+      "videoOptionsLabel": "Videooptionen {{spec}}",
+      "videoOptionsModel": "Modell",
+      "videoOptionsRatio": "Seitenverhältnis",
+      "videoOptionsReset": "Auf Standard zurücksetzen",
+      "videoOptionsResolution": "Auflösung"
     },
     "thread": {
       "ariaLabel": "Chat-Thread",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1598,7 +1598,15 @@
       "removeTemplate": "Remove template {{title}}",
       "removeVideo": "Remove video template {{title}}",
       "removeWebsite": "Remove website template {{title}}",
-      "removeWorkflow": "Remove workflow template {{title}}"
+      "removeWorkflow": "Remove workflow template {{title}}",
+      "videoOptions": "Video options",
+      "videoOptionsAudio": "Generate audio",
+      "videoOptionsDuration": "Duration",
+      "videoOptionsLabel": "Video options {{spec}}",
+      "videoOptionsModel": "Model",
+      "videoOptionsRatio": "Ratio",
+      "videoOptionsReset": "Reset to default",
+      "videoOptionsResolution": "Resolution"
     },
     "thread": {
       "ariaLabel": "Chat thread",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1605,7 +1605,6 @@
       "videoOptionsLabel": "Video options {{spec}}",
       "videoOptionsModel": "Model",
       "videoOptionsRatio": "Ratio",
-      "videoOptionsReset": "Reset to default",
       "videoOptionsResolution": "Resolution"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1645,7 +1645,6 @@
       "videoOptionsLabel": "Opciones de vídeo {{spec}}",
       "videoOptionsModel": "Modelo",
       "videoOptionsRatio": "Proporción",
-      "videoOptionsReset": "Restablecer valores predeterminados",
       "videoOptionsResolution": "Resolución"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1638,7 +1638,15 @@
       "removeTemplate": "Eliminar la plantilla {{title}}",
       "removeVideo": "Eliminar la plantilla de vídeo {{title}}",
       "removeWebsite": "Eliminar la plantilla de sitio web {{title}}",
-      "removeWorkflow": "Eliminar la plantilla de flujo de trabajo {{title}}"
+      "removeWorkflow": "Eliminar la plantilla de flujo de trabajo {{title}}",
+      "videoOptions": "Opciones de vídeo",
+      "videoOptionsAudio": "Generar audio",
+      "videoOptionsDuration": "Duración",
+      "videoOptionsLabel": "Opciones de vídeo {{spec}}",
+      "videoOptionsModel": "Modelo",
+      "videoOptionsRatio": "Proporción",
+      "videoOptionsReset": "Restablecer valores predeterminados",
+      "videoOptionsResolution": "Resolución"
     },
     "thread": {
       "ariaLabel": "Hilo de chat",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1645,7 +1645,6 @@
       "videoOptionsLabel": "Options vidéo {{spec}}",
       "videoOptionsModel": "Modèle",
       "videoOptionsRatio": "Format",
-      "videoOptionsReset": "Rétablir les valeurs par défaut",
       "videoOptionsResolution": "Résolution"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1638,7 +1638,15 @@
       "removeTemplate": "Supprimer le modèle {{title}}",
       "removeVideo": "Supprimer le modèle vidéo {{title}}",
       "removeWebsite": "Supprimer le modèle de site web {{title}}",
-      "removeWorkflow": "Supprimer le modèle de workflow {{title}}"
+      "removeWorkflow": "Supprimer le modèle de workflow {{title}}",
+      "videoOptions": "Options vidéo",
+      "videoOptionsAudio": "Générer l'audio",
+      "videoOptionsDuration": "Durée",
+      "videoOptionsLabel": "Options vidéo {{spec}}",
+      "videoOptionsModel": "Modèle",
+      "videoOptionsRatio": "Format",
+      "videoOptionsReset": "Rétablir les valeurs par défaut",
+      "videoOptionsResolution": "Résolution"
     },
     "thread": {
       "ariaLabel": "Fil de discussion",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1598,7 +1598,15 @@
       "removeTemplate": "टेम्प्लेट {{title}} हटाएँ",
       "removeVideo": "वीडियो टेम्प्लेट {{title}} हटाएं",
       "removeWebsite": "वेबसाइट टेम्पलेट {{title}} हटाएँ",
-      "removeWorkflow": "वर्कफ़्लो टेम्पलेट {{title}} हटाएँ"
+      "removeWorkflow": "वर्कफ़्लो टेम्पलेट {{title}} हटाएँ",
+      "videoOptions": "वीडियो विकल्प",
+      "videoOptionsAudio": "ऑडियो बनाएँ",
+      "videoOptionsDuration": "अवधि",
+      "videoOptionsLabel": "वीडियो विकल्प {{spec}}",
+      "videoOptionsModel": "मॉडल",
+      "videoOptionsRatio": "अनुपात",
+      "videoOptionsReset": "डिफ़ॉल्ट पर रीसेट करें",
+      "videoOptionsResolution": "रिज़ॉल्यूशन"
     },
     "thread": {
       "ariaLabel": "चैट थ्रेड",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1605,7 +1605,6 @@
       "videoOptionsLabel": "वीडियो विकल्प {{spec}}",
       "videoOptionsModel": "मॉडल",
       "videoOptionsRatio": "अनुपात",
-      "videoOptionsReset": "डिफ़ॉल्ट पर रीसेट करें",
       "videoOptionsResolution": "रिज़ॉल्यूशन"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1597,7 +1597,15 @@
       "removeTemplate": "Hapus template {{title}}",
       "removeVideo": "Hapus template video {{title}}",
       "removeWebsite": "Hapus template situs web {{title}}",
-      "removeWorkflow": "Hapus template alur kerja {{title}}"
+      "removeWorkflow": "Hapus template alur kerja {{title}}",
+      "videoOptions": "Opsi video",
+      "videoOptionsAudio": "Hasilkan audio",
+      "videoOptionsDuration": "Durasi",
+      "videoOptionsLabel": "Opsi video {{spec}}",
+      "videoOptionsModel": "Model",
+      "videoOptionsRatio": "Rasio",
+      "videoOptionsReset": "Setel ulang ke bawaan",
+      "videoOptionsResolution": "Resolusi"
     },
     "thread": {
       "ariaLabel": "Thread chat",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1604,7 +1604,6 @@
       "videoOptionsLabel": "Opsi video {{spec}}",
       "videoOptionsModel": "Model",
       "videoOptionsRatio": "Rasio",
-      "videoOptionsReset": "Setel ulang ke bawaan",
       "videoOptionsResolution": "Resolusi"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1645,7 +1645,6 @@
       "videoOptionsLabel": "Opzioni video {{spec}}",
       "videoOptionsModel": "Modello",
       "videoOptionsRatio": "Proporzioni",
-      "videoOptionsReset": "Ripristina i valori predefiniti",
       "videoOptionsResolution": "Risoluzione"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1638,7 +1638,15 @@
       "removeTemplate": "Rimuovi modello {{title}}",
       "removeVideo": "Rimuovi modello video {{title}}",
       "removeWebsite": "Rimuovi modello di sito web {{title}}",
-      "removeWorkflow": "Rimuovi modello di flusso di lavoro {{title}}"
+      "removeWorkflow": "Rimuovi modello di flusso di lavoro {{title}}",
+      "videoOptions": "Opzioni video",
+      "videoOptionsAudio": "Genera audio",
+      "videoOptionsDuration": "Durata",
+      "videoOptionsLabel": "Opzioni video {{spec}}",
+      "videoOptionsModel": "Modello",
+      "videoOptionsRatio": "Proporzioni",
+      "videoOptionsReset": "Ripristina i valori predefiniti",
+      "videoOptionsResolution": "Risoluzione"
     },
     "thread": {
       "ariaLabel": "Discussione della chat",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1597,7 +1597,15 @@
       "removeTemplate": "テンプレート {{title}} を削除します",
       "removeVideo": "ビデオ テンプレート {{title}} を削除します",
       "removeWebsite": "Web サイト テンプレート {{title}} を削除します",
-      "removeWorkflow": "ワークフロー テンプレート {{title}} を削除します"
+      "removeWorkflow": "ワークフロー テンプレート {{title}} を削除します",
+      "videoOptions": "動画オプション",
+      "videoOptionsAudio": "音声を生成",
+      "videoOptionsDuration": "長さ",
+      "videoOptionsLabel": "動画オプション {{spec}}",
+      "videoOptionsModel": "モデル",
+      "videoOptionsRatio": "比率",
+      "videoOptionsReset": "既定値に戻す",
+      "videoOptionsResolution": "解像度"
     },
     "thread": {
       "ariaLabel": "チャットスレッド",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1604,7 +1604,6 @@
       "videoOptionsLabel": "動画オプション {{spec}}",
       "videoOptionsModel": "モデル",
       "videoOptionsRatio": "比率",
-      "videoOptionsReset": "既定値に戻す",
       "videoOptionsResolution": "解像度"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1604,7 +1604,6 @@
       "videoOptionsLabel": "동영상 옵션 {{spec}}",
       "videoOptionsModel": "모델",
       "videoOptionsRatio": "비율",
-      "videoOptionsReset": "기본값으로 재설정",
       "videoOptionsResolution": "해상도"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1597,7 +1597,15 @@
       "removeTemplate": "템플릿 삭제 {{title}}",
       "removeVideo": "비디오 템플릿 삭제 {{title}}",
       "removeWebsite": "웹사이트 템플릿 삭제 {{title}}",
-      "removeWorkflow": "워크플로 템플릿 삭제 {{title}}"
+      "removeWorkflow": "워크플로 템플릿 삭제 {{title}}",
+      "videoOptions": "동영상 옵션",
+      "videoOptionsAudio": "오디오 생성",
+      "videoOptionsDuration": "길이",
+      "videoOptionsLabel": "동영상 옵션 {{spec}}",
+      "videoOptionsModel": "모델",
+      "videoOptionsRatio": "비율",
+      "videoOptionsReset": "기본값으로 재설정",
+      "videoOptionsResolution": "해상도"
     },
     "thread": {
       "ariaLabel": "채팅 스레드",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1645,7 +1645,6 @@
       "videoOptionsLabel": "Opções de vídeo {{spec}}",
       "videoOptionsModel": "Modelo",
       "videoOptionsRatio": "Proporção",
-      "videoOptionsReset": "Redefinir para o padrão",
       "videoOptionsResolution": "Resolução"
     },
     "thread": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1638,7 +1638,15 @@
       "removeTemplate": "Remover template {{title}}",
       "removeVideo": "Remover template de vídeo {{title}}",
       "removeWebsite": "Remover template de site {{title}}",
-      "removeWorkflow": "Remover template de fluxo de trabalho {{title}}"
+      "removeWorkflow": "Remover template de fluxo de trabalho {{title}}",
+      "videoOptions": "Opções de vídeo",
+      "videoOptionsAudio": "Gerar áudio",
+      "videoOptionsDuration": "Duração",
+      "videoOptionsLabel": "Opções de vídeo {{spec}}",
+      "videoOptionsModel": "Modelo",
+      "videoOptionsRatio": "Proporção",
+      "videoOptionsReset": "Redefinir para o padrão",
+      "videoOptionsResolution": "Resolução"
     },
     "thread": {
       "ariaLabel": "Conversa",

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -66,6 +66,10 @@ export const avatarTemplatesEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.JoggAiBuiltIn] ?? false;
 });
 
+export const videoTemplateOptionsEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.VideoTemplateOptions] ?? false;
+});
+
 export const artifactSidebarInlineOpenEnabled$ = computed((get): boolean => {
   return (
     get(featureSwitch$)[FeatureSwitchKey.ArtifactSidebarInlineOpen] ?? false

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -85,6 +85,7 @@ type ComposerTemplateEditorSignals = Pick<
   | "templatePreview"
   | "hasTemplateAttachment$"
   | "insertTemplate$"
+  | "updateTemplateAt$"
   | "readSelectedTemplate$"
   | "prepareTemplateInsertion$"
   | "setTemplateAttachmentLifecycleRef$"
@@ -318,6 +319,7 @@ function composerTemplateSignals(
     templatePreview: composer.templatePreview,
     hasTemplateAttachment$: composer.hasTemplateAttachment$,
     insertTemplate$: composer.insertTemplate$,
+    updateTemplateAt$: composer.updateTemplateAt$,
     readSelectedTemplate$: composer.readSelectedTemplate$,
     prepareTemplateInsertion$: composer.prepareTemplateInsertion$,
     setTemplateAttachmentLifecycleRef$:

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -206,6 +206,10 @@ export interface WorkflowComposerSignals {
     void,
     [GenerationTemplateRequest, ComposerTemplateAttachment]
   >;
+  readonly updateTemplateAt$: Command<
+    void,
+    [number, GenerationTemplateRequest, ComposerTemplateAttachment]
+  >;
   readonly readSelectedTemplate$: Command<
     GenerationTemplateRequest | undefined,
     []
@@ -1537,7 +1541,7 @@ interface WorkflowComposerRuntime {
   openTemplate(category: string): void;
   /** Resolved when the lifecycle bridge mounts; false until then. */
   videoOptionsEnabled: boolean;
-  openTemplateOptions(anchor: DOMRect): void;
+  openTemplateOptions(anchor: DOMRect, position: number): void;
   removeTemplate(): void;
   templateRemoved(): void;
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
@@ -1668,8 +1672,9 @@ function createInlineTemplateNode(
               }
             },
             openOptions: (anchor) => {
-              if (selectSelf()) {
-                runtime.openTemplateOptions(anchor);
+              const position = getPos();
+              if (typeof position === "number" && selectSelf()) {
+                runtime.openTemplateOptions(anchor, position);
               }
             },
             optionsEnabled: () => {
@@ -2384,6 +2389,39 @@ function createInsertTemplateCommand(editor: Editor) {
   );
 }
 
+/**
+ * Rewrites one inline template in place, addressed by position rather than by
+ * the editor selection. setNodeMarkup maps a NodeSelection to a TextSelection,
+ * so a selection-based update only works once; every later edit would fall
+ * through to inserting another chip.
+ */
+function createUpdateTemplateAtCommand(editor: Editor) {
+  return command(
+    (
+      _context,
+      position: number,
+      request: GenerationTemplateRequest,
+      attachment: ComposerTemplateAttachment,
+    ) => {
+      const target = editor.state.doc.nodeAt(position);
+      if (target?.type.name !== INLINE_TEMPLATE_NODE_NAME) {
+        return;
+      }
+      const node = inlineTemplateNode(editor, request, attachment);
+      const transaction = editor.state.tr.setNodeMarkup(
+        position,
+        undefined,
+        node.attrs,
+      );
+      editor.view.dispatch(
+        transaction.setSelection(
+          NodeSelection.create(transaction.doc, position),
+        ),
+      );
+    },
+  );
+}
+
 function createPrepareTemplateInsertionCommand(editor: Editor) {
   return command(() => {
     const { selection } = editor.state;
@@ -2415,6 +2453,7 @@ function createReadSelectedTemplateCommand(editor: Editor) {
 function createTemplateInsertionCommands(editor: Editor) {
   return {
     insertTemplate$: createInsertTemplateCommand(editor),
+    updateTemplateAt$: createUpdateTemplateAtCommand(editor),
     readSelectedTemplate$: createReadSelectedTemplateCommand(editor),
     prepareTemplateInsertion$: createPrepareTemplateInsertionCommand(editor),
   };
@@ -2485,7 +2524,7 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     templateAttachment: undefined,
     openTemplate(_category: string): void {},
     videoOptionsEnabled: false,
-    openTemplateOptions(_anchor: DOMRect): void {},
+    openTemplateOptions(_anchor: DOMRect, _position: number): void {},
     removeTemplate(): void {},
     templateRemoved(): void {},
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
@@ -2519,7 +2558,7 @@ function createTemplateAttachmentControls(
         element.click();
       };
       runtime.videoOptionsEnabled = get(videoTemplateOptionsEnabled$);
-      runtime.openTemplateOptions = (anchor) => {
+      runtime.openTemplateOptions = (anchor, position) => {
         element.dataset.templateAction = "options";
         element.dataset.templateAnchor = [
           anchor.left,
@@ -2527,6 +2566,7 @@ function createTemplateAttachmentControls(
           anchor.width,
           anchor.height,
         ].join(",");
+        element.dataset.templatePosition = String(position);
         element.click();
       };
       runtime.templateRemoved = () => {

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -81,6 +81,9 @@ import {
 import { createComposerWorkflows } from "./composer-workflows.ts";
 import { reloadWorkflowData$ } from "../workflows-page/workflow-reload.ts";
 import { i18n } from "../../i18n/index.ts";
+import { parseAvatarTemplateStylePresetId } from "@vm0/core/avatar-template";
+import { resolveVideoGenerationOptions } from "@vm0/core/video-model-catalog";
+import { videoTemplateOptionsEnabled$ } from "../external/feature-switch.ts";
 
 type AgentIdValue = string | null | Promise<string | null>;
 type WorkflowNamesSyncCommand = Command<
@@ -284,6 +287,34 @@ const COMPOSER_INLINE_REFERENCE_CLASS =
   "data-[selected]:ring-1 data-[selected]:ring-inset " +
   "data-[selected]:ring-orange-500/40 dark:data-[selected]:bg-orange-400/20 " +
   "dark:data-[selected]:ring-orange-300/40";
+
+/**
+ * Same surface as COMPOSER_INLINE_REFERENCE_CLASS with the padding and hover
+ * moved onto the zones below, so each half of a split chip reacts on its own.
+ */
+const INLINE_TEMPLATE_CHIP_CLASS =
+  "relative -top-px mx-0.5 inline-flex h-7 max-w-full select-none items-center " +
+  "overflow-hidden whitespace-nowrap rounded-md bg-orange-500/10 align-middle " +
+  "text-[13px] font-medium text-orange-600 transition-colors " +
+  "dark:bg-orange-400/15 dark:text-orange-300 data-[selected]:bg-orange-500/15 " +
+  "data-[selected]:ring-1 data-[selected]:ring-inset " +
+  "data-[selected]:ring-orange-500/40 dark:data-[selected]:bg-orange-400/20 " +
+  "dark:data-[selected]:ring-orange-300/40";
+
+const INLINE_TEMPLATE_NAME_ZONE_CLASS =
+  "flex h-full min-w-0 items-center gap-1.5 px-2 text-orange-600 " +
+  "transition-colors dark:text-orange-300 " +
+  "hover:bg-orange-500/15 focus-visible:outline-none focus-visible:ring-1 " +
+  "focus-visible:ring-inset focus-visible:ring-orange-500/40 " +
+  "dark:hover:bg-orange-400/20 dark:focus-visible:ring-orange-300/40";
+
+const INLINE_TEMPLATE_SPEC_ZONE_CLASS =
+  "flex h-full shrink-0 items-center gap-1 border-l border-orange-500/25 " +
+  "pl-2 pr-1.5 text-[12px] font-normal text-orange-600/75 transition-colors " +
+  "hover:bg-orange-500/15 focus-visible:outline-none focus-visible:ring-1 " +
+  "focus-visible:ring-inset focus-visible:ring-orange-500/40 " +
+  "dark:border-orange-300/25 dark:text-orange-300/75 " +
+  "dark:hover:bg-orange-400/20 dark:focus-visible:ring-orange-300/40";
 
 interface ChatThreadMentionAttributes {
   readonly threadId: string;
@@ -852,24 +883,85 @@ function createTemplateAttachmentNodeView(
   };
 }
 
+interface InlineTemplateNodeActions {
+  readonly openTemplate: (category: string) => void;
+  readonly openOptions: (anchor: DOMRect) => void;
+  /** Read per render so a chip picks the switch up on its next update. */
+  readonly optionsEnabled: () => boolean;
+}
+
+/**
+ * Aspect ratio and duration for a text-to-video template, resolved against the
+ * model catalog so a chip shows the parameters the run will actually use even
+ * when the user has overridden none of them. Talking-avatar templates share the
+ * "video" envelope but take none of these parameters.
+ */
+function inlineTemplateSpecSegments(node: ProseMirrorNode): readonly string[] {
+  const parsed = generationTemplateRequestSchema.safeParse(node.attrs.template);
+  if (!parsed.success || parsed.data.type !== "video") {
+    return [];
+  }
+  const { selection } = parsed.data;
+  if (parseAvatarTemplateStylePresetId(selection.stylePresetId) !== undefined) {
+    return [];
+  }
+  const resolved = resolveVideoGenerationOptions(selection.videoOptions);
+  return [resolved.aspectRatio, resolved.duration];
+}
+
+function createInlineTemplateSpecZone(): {
+  readonly zone: HTMLButtonElement;
+  readonly render: (segments: readonly string[]) => void;
+} {
+  const zone = document.createElement("button");
+  zone.type = "button";
+  zone.className = INLINE_TEMPLATE_SPEC_ZONE_CLASS;
+  const lead = document.createElement("span");
+  // Everything after the ratio is dropped on narrow viewports so the chip
+  // stays readable inside a prompt sentence.
+  const rest = document.createElement("span");
+  rest.className = "hidden sm:inline";
+  const chevron = createComposerIcon(11, 1.7, ["M6 9l6 6 6 -6"]);
+  chevron.setAttribute("class", "shrink-0 opacity-70");
+  zone.append(lead, rest, chevron);
+  return {
+    zone,
+    render(segments) {
+      lead.textContent = segments[0] ?? "";
+      rest.textContent = segments
+        .slice(1)
+        .map((segment) => {
+          return ` \u00b7 ${segment}`;
+        })
+        .join("");
+      zone.setAttribute(
+        "aria-label",
+        i18n.t(
+          ($) => {
+            return $.chat.templates.videoOptionsLabel;
+          },
+          { spec: segments.join(" \u00b7 ") },
+        ),
+      );
+    },
+  };
+}
+
 function createInlineTemplateNodeView(
   node: ProseMirrorNode,
-  selectAndOpenTemplate: (category: string) => void,
+  actions: InlineTemplateNodeActions,
   localizedUi: Set<() => void>,
 ): NodeView {
   const dom = document.createElement("span");
   dom.dataset.composerInlineTemplate = "";
-  dom.className = COMPOSER_INLINE_REFERENCE_CLASS;
+  dom.className = INLINE_TEMPLATE_CHIP_CLASS;
   dom.contentEditable = "false";
   dom.style.outline = "none";
   dom.style.userSelect = "none";
 
   const openButton = document.createElement("button");
   openButton.type = "button";
-  openButton.className =
-    "flex h-full min-w-0 items-center gap-1.5 rounded-md text-orange-600 " +
-    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-orange-500/40 " +
-    "dark:text-orange-300 dark:focus-visible:ring-orange-300/40";
+  openButton.className = INLINE_TEMPLATE_NAME_ZONE_CLASS;
   // Mirrors IconColorSwatch from @tabler/icons-react, which the composer
   // template picker button and sent-message template chips also use.
   const icon = createComposerIcon(13, 1.7, [
@@ -885,6 +977,7 @@ function createInlineTemplateNodeView(
     "dark:text-orange-300";
   openButton.append(icon, title);
   dom.append(openButton);
+  const spec = createInlineTemplateSpecZone();
 
   let currentNode = node;
   function localize(): void {
@@ -898,13 +991,28 @@ function createInlineTemplateNodeView(
   function render(nextNode: ProseMirrorNode): void {
     const attachment = templateAttachmentNodeAttributes(nextNode);
     title.textContent = attachment.title;
+    const segments = actions.optionsEnabled()
+      ? inlineTemplateSpecSegments(nextNode)
+      : [];
+    if (segments.length > 0) {
+      spec.render(segments);
+      if (spec.zone.parentNode === null) {
+        dom.append(spec.zone);
+      }
+    } else {
+      spec.zone.remove();
+    }
     localize();
   }
   openButton.addEventListener("mousedown", (event) => {
     event.preventDefault();
-    selectAndOpenTemplate(
+    actions.openTemplate(
       templateAttachmentNodeAttributes(currentNode).category,
     );
+  });
+  spec.zone.addEventListener("mousedown", (event) => {
+    event.preventDefault();
+    actions.openOptions(dom.getBoundingClientRect());
   });
   localizedUi.add(localize);
   render(currentNode);
@@ -1427,6 +1535,9 @@ interface WorkflowComposerRuntime {
   blur(): void;
   templateAttachment: ComposerTemplateAttachment | undefined;
   openTemplate(category: string): void;
+  /** Resolved when the lifecycle bridge mounts; false until then. */
+  videoOptionsEnabled: boolean;
+  openTemplateOptions(anchor: DOMRect): void;
   removeTemplate(): void;
   templateRemoved(): void;
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
@@ -1536,19 +1647,34 @@ function createInlineTemplateNode(
     },
     addNodeView() {
       return ({ node, getPos, editor }) => {
+        const selectSelf = (): boolean => {
+          const position = getPos();
+          if (typeof position !== "number") {
+            return false;
+          }
+          editor.view.dispatch(
+            editor.state.tr.setSelection(
+              NodeSelection.create(editor.state.doc, position),
+            ),
+          );
+          return true;
+        };
         return createInlineTemplateNodeView(
           node,
-          (category) => {
-            const position = getPos();
-            if (typeof position !== "number") {
-              return;
-            }
-            editor.view.dispatch(
-              editor.state.tr.setSelection(
-                NodeSelection.create(editor.state.doc, position),
-              ),
-            );
-            runtime.openTemplate(category);
+          {
+            openTemplate: (category) => {
+              if (selectSelf()) {
+                runtime.openTemplate(category);
+              }
+            },
+            openOptions: (anchor) => {
+              if (selectSelf()) {
+                runtime.openTemplateOptions(anchor);
+              }
+            },
+            optionsEnabled: () => {
+              return runtime.videoOptionsEnabled;
+            },
           },
           runtime.localizedUi,
         );
@@ -2358,6 +2484,8 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     blur(): void {},
     templateAttachment: undefined,
     openTemplate(_category: string): void {},
+    videoOptionsEnabled: false,
+    openTemplateOptions(_anchor: DOMRect): void {},
     removeTemplate(): void {},
     templateRemoved(): void {},
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
@@ -2380,7 +2508,7 @@ function createTemplateAttachmentControls(
     runtime.templateRemoved();
   };
   const setLifecycleRef$ = onRef(
-    command(({ set }, element: HTMLButtonElement, signal: AbortSignal) => {
+    command(({ get, set }, element: HTMLButtonElement, signal: AbortSignal) => {
       const attachment = templateAttachmentFromLifecycleElement(element);
       runtime.templateAttachment = attachment;
       set(activeState$, attachment !== undefined);
@@ -2390,6 +2518,17 @@ function createTemplateAttachmentControls(
         element.dataset.templateCategory = category;
         element.click();
       };
+      runtime.videoOptionsEnabled = get(videoTemplateOptionsEnabled$);
+      runtime.openTemplateOptions = (anchor) => {
+        element.dataset.templateAction = "options";
+        element.dataset.templateAnchor = [
+          anchor.left,
+          anchor.top,
+          anchor.width,
+          anchor.height,
+        ].join(",");
+        element.click();
+      };
       runtime.templateRemoved = () => {
         element.dataset.templateAction = "remove";
         element.click();
@@ -2397,6 +2536,7 @@ function createTemplateAttachmentControls(
       signal.addEventListener("abort", () => {
         runtime.templateAttachment = undefined;
         runtime.openTemplate = () => {};
+        runtime.openTemplateOptions = () => {};
         runtime.templateRemoved = () => {};
         set(activeState$, false);
         setTemplateAttachmentNode(editor, undefined);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -275,6 +275,14 @@ function createBasicComposerUiSignals() {
   };
 }
 
+/** Viewport-space box of the chip a video options popover is anchored to. */
+export interface VideoTemplateOptionsAnchor {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
 function createTemplatePickerDialogSignals() {
   const internalWebsiteTemplatePreviewId$ = state<string | null>(null);
   const internalWebsiteTemplatePreviewLoaded$ = state(false);
@@ -305,6 +313,33 @@ function createTemplatePickerDialogSignals() {
     },
   );
 
+  const internalVideoOptionsAnchor$ = state<VideoTemplateOptionsAnchor | null>(
+    null,
+  );
+  const internalVideoOptionsValue$ = state<GenerationTemplateRequest | null>(
+    null,
+  );
+  const videoTemplateOptionsAnchor$ = computed((get) => {
+    return get(internalVideoOptionsAnchor$);
+  });
+  const videoTemplateOptionsValue$ = computed((get) => {
+    return get(internalVideoOptionsValue$);
+  });
+  const openVideoTemplateOptions$ = command(
+    (
+      { set },
+      anchor: VideoTemplateOptionsAnchor,
+      value: GenerationTemplateRequest,
+    ) => {
+      set(internalVideoOptionsValue$, value);
+      set(internalVideoOptionsAnchor$, anchor);
+    },
+  );
+  const closeVideoTemplateOptions$ = command(({ set }) => {
+    set(internalVideoOptionsAnchor$, null);
+    set(internalVideoOptionsValue$, null);
+  });
+
   const websiteTemplatePreviewId$ = computed((get) => {
     return get(internalWebsiteTemplatePreviewId$);
   });
@@ -331,6 +366,10 @@ function createTemplatePickerDialogSignals() {
     setTemplatePickerOpen$,
     templatePickerReferenceValue$,
     setTemplatePickerReferenceValue$,
+    videoTemplateOptionsAnchor$,
+    videoTemplateOptionsValue$,
+    openVideoTemplateOptions$,
+    closeVideoTemplateOptions$,
     websiteTemplatePreviewId$,
     websiteTemplatePreviewLoaded$,
     markWebsiteTemplatePreviewLoaded$,

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -319,25 +319,38 @@ function createTemplatePickerDialogSignals() {
   const internalVideoOptionsValue$ = state<GenerationTemplateRequest | null>(
     null,
   );
+  const internalVideoOptionsPosition$ = state<number | null>(null);
   const videoTemplateOptionsAnchor$ = computed((get) => {
     return get(internalVideoOptionsAnchor$);
   });
   const videoTemplateOptionsValue$ = computed((get) => {
     return get(internalVideoOptionsValue$);
   });
+  const videoTemplateOptionsPosition$ = computed((get) => {
+    return get(internalVideoOptionsPosition$);
+  });
   const openVideoTemplateOptions$ = command(
     (
       { set },
       anchor: VideoTemplateOptionsAnchor,
       value: GenerationTemplateRequest,
+      position: number,
     ) => {
       set(internalVideoOptionsValue$, value);
+      set(internalVideoOptionsPosition$, position);
       set(internalVideoOptionsAnchor$, anchor);
+    },
+  );
+  /** Keeps the open popover in step with the node it just rewrote. */
+  const setVideoTemplateOptionsValue$ = command(
+    ({ set }, value: GenerationTemplateRequest) => {
+      set(internalVideoOptionsValue$, value);
     },
   );
   const closeVideoTemplateOptions$ = command(({ set }) => {
     set(internalVideoOptionsAnchor$, null);
     set(internalVideoOptionsValue$, null);
+    set(internalVideoOptionsPosition$, null);
   });
 
   const websiteTemplatePreviewId$ = computed((get) => {
@@ -368,7 +381,9 @@ function createTemplatePickerDialogSignals() {
     setTemplatePickerReferenceValue$,
     videoTemplateOptionsAnchor$,
     videoTemplateOptionsValue$,
+    videoTemplateOptionsPosition$,
     openVideoTemplateOptions$,
+    setVideoTemplateOptionsValue$,
     closeVideoTemplateOptions$,
     websiteTemplatePreviewId$,
     websiteTemplatePreviewLoaded$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -209,8 +209,7 @@ describe("chat composer templates", () => {
     expect(chip?.querySelectorAll("button")).toHaveLength(2);
 
     await user.click(spec);
-    const ratio = await screen.findByRole("combobox", { name: "Ratio" });
-    await user.click(ratio);
+    await user.click(await screen.findByRole("combobox", { name: "Ratio" }));
     await user.click(await screen.findByRole("option", { name: "9:16" }));
 
     await waitFor(() => {
@@ -218,7 +217,17 @@ describe("chat composer templates", () => {
         screen.getByLabelText("Video options 9:16 \u00b7 8s"),
       ).toBeInTheDocument();
     });
-    // The chip is rewritten in place rather than duplicated.
+
+    // A second edit has to land in place too: setNodeMarkup drops the node
+    // selection, so a selection-based update would insert another chip here.
+    await user.click(await screen.findByRole("combobox", { name: "Duration" }));
+    await user.click(await screen.findByRole("option", { name: "6s" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Video options 9:16 \u00b7 6s"),
+      ).toBeInTheDocument();
+    });
     expect(
       document.querySelectorAll("[data-composer-inline-template]"),
     ).toHaveLength(1);
@@ -231,8 +240,8 @@ describe("chat composer templates", () => {
           type: "video",
           selection: {
             stylePresetId: template.id,
-            // Only the changed value is persisted.
-            videoOptions: { aspectRatio: "9:16" },
+            // Only the changed values are persisted.
+            videoOptions: { aspectRatio: "9:16", duration: "6s" },
           },
         },
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -209,6 +209,22 @@ describe("chat composer templates", () => {
     expect(chip?.querySelectorAll("button")).toHaveLength(2);
 
     await user.click(spec);
+    expect(
+      queryAllByRoleFast("button").some((button) => {
+        return button.textContent === "Reset to default";
+      }),
+    ).toBeFalsy();
+    await user.click(await screen.findByRole("combobox", { name: "Model" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Seedance 2.0" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "Model" })).toHaveTextContent(
+        /^Seedance 2\.0$/,
+      );
+    });
+
     await user.click(await screen.findByRole("combobox", { name: "Ratio" }));
     await user.click(await screen.findByRole("option", { name: "9:16" }));
 
@@ -241,7 +257,11 @@ describe("chat composer templates", () => {
           selection: {
             stylePresetId: template.id,
             // Only the changed values are persisted.
-            videoOptions: { aspectRatio: "9:16", duration: "6s" },
+            videoOptions: {
+              model: "dreamina-seedance-2-0-260128",
+              aspectRatio: "9:16",
+              duration: "6s",
+            },
           },
         },
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -134,6 +134,9 @@ describe("chat composer templates", () => {
         "-top-px",
         "bg-orange-500/10",
         "text-orange-600",
+      );
+      // Hover lives on the zones so each half of a split chip reacts alone.
+      expect(chip.querySelector("button")).toHaveClass(
         "hover:bg-orange-500/15",
       );
       expect(
@@ -162,6 +165,75 @@ describe("chat composer templates", () => {
         template: {
           type: "presentation",
           selection: { templateId: second.templateId },
+        },
+      });
+    });
+  });
+
+  it("edits video parameters from the second half of an inline chip", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = VIDEO_TEMPLATE_ITEMS[0]!;
+    let submittedUserMessage: UserMessageDocument | undefined;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      onRunCreate(body) {
+        submittedUserMessage = body.userMessage;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
+        [FeatureSwitchKey.VideoTemplateOptions]: true,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    await user.click(tabByText("Video"));
+    await user.click(
+      await screen.findByLabelText(`Select video template ${template.title}`),
+    );
+
+    // Catalog defaults are shown even though nothing is stored yet.
+    const spec = await screen.findByLabelText("Video options 16:9 \u00b7 8s");
+    const chip = document.querySelector("[data-composer-inline-template]");
+    expect(chip?.querySelectorAll("button")).toHaveLength(2);
+
+    await user.click(spec);
+    const ratio = await screen.findByRole("combobox", { name: "Ratio" });
+    await user.click(ratio);
+    await user.click(await screen.findByRole("option", { name: "9:16" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Video options 9:16 \u00b7 8s"),
+      ).toBeInTheDocument();
+    });
+    // The chip is rewritten in place rather than duplicated.
+    expect(
+      document.querySelectorAll("[data-composer-inline-template]"),
+    ).toHaveLength(1);
+
+    await user.click(screen.getByLabelText("Send"));
+    await waitFor(() => {
+      expect(submittedUserMessage?.parts[0]).toMatchObject({
+        type: "template",
+        template: {
+          type: "video",
+          selection: {
+            stylePresetId: template.id,
+            // Only the changed value is persisted.
+            videoOptions: { aspectRatio: "9:16" },
+          },
         },
       });
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -5,7 +5,7 @@ import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/cha
 import { zeroAvatarVideoContract } from "@vm0/api-contracts/contracts/zero-avatar-video";
 import { avatarTemplateStylePresetId } from "@vm0/core/avatar-template";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
+import { ILLUSTRATION_TEMPLATE_ITEMS, VIDEO_TEMPLATE_ITEMS } from "@vm0/core";
 
 import {
   detachedSetupPage,
@@ -112,6 +112,57 @@ describe("user messages", () => {
     expect(
       document.querySelector("[data-composer-inline-template]"),
     ).toBeNull();
+  });
+
+  it("echoes the video parameters a sent template used", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000750";
+    const templateItem = VIDEO_TEMPLATE_ITEMS[0]!;
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Sent video template",
+      chatEvents: [
+        {
+          id: "00000000-0000-4000-8000-000000000750",
+          role: "user",
+          content: "Make the clip",
+          runId: "d0000000-0000-4000-a000-000000000750",
+          userMessage: {
+            version: 1,
+            parts: [
+              {
+                type: "template",
+                titleSnapshot: templateItem.title,
+                template: {
+                  type: "video",
+                  selection: {
+                    stylePresetId: templateItem.id,
+                    // Only the ratio was changed; the duration still resolves
+                    // from the catalog.
+                    videoOptions: { aspectRatio: "9:16" },
+                  },
+                },
+              },
+              { type: "text", text: "Make the clip" },
+            ],
+          },
+          createdAt: "2026-08-07T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.StructuredPromptInlineTemplates]: true,
+        [FeatureSwitchKey.VideoTemplateOptions]: true,
+      },
+    });
+
+    const reference = await screen.findByLabelText(
+      `Message template ${templateItem.title}`,
+    );
+    expect(reference).toHaveTextContent("9:16 \u00b7 8s");
   });
 
   it("opens avatar message templates at the voice picker", async () => {

--- a/turbo/apps/platform/src/views/zero-page/video-template-options-popover.tsx
+++ b/turbo/apps/platform/src/views/zero-page/video-template-options-popover.tsx
@@ -17,6 +17,7 @@ import type {
   VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
+  DEFAULT_VIDEO_MODEL,
   VIDEO_MODEL_CONFIGS,
   VIDEO_MODELS,
   resolveVideoGenerationOptions,
@@ -33,18 +34,20 @@ import type { ComposerSignals } from "../../signals/zero-page/composer-signals.t
  */
 function toVideoOptionsPatch(
   next: ResolvedVideoGenerationOptions,
-  defaults: ResolvedVideoGenerationOptions,
+  modelDefaults: ResolvedVideoGenerationOptions,
 ): VideoGenerationOptions {
   return {
-    ...(next.model === defaults.model ? {} : { model: next.model }),
-    ...(next.aspectRatio === defaults.aspectRatio
+    ...(next.model === DEFAULT_VIDEO_MODEL ? {} : { model: next.model }),
+    ...(next.aspectRatio === modelDefaults.aspectRatio
       ? {}
       : { aspectRatio: next.aspectRatio }),
-    ...(next.duration === defaults.duration ? {} : { duration: next.duration }),
-    ...(next.resolution === defaults.resolution
+    ...(next.duration === modelDefaults.duration
+      ? {}
+      : { duration: next.duration }),
+    ...(next.resolution === modelDefaults.resolution
       ? {}
       : { resolution: next.resolution }),
-    ...(next.generateAudio === defaults.generateAudio
+    ...(next.generateAudio === modelDefaults.generateAudio
       ? {}
       : { generateAudio: next.generateAudio }),
   };
@@ -142,12 +145,14 @@ function VideoTemplateOptionsForm({
     // Re-resolve so a value the newly chosen model rejects falls back the same
     // way the generation service would.
     const settled = resolveVideoGenerationOptions(next);
-    const defaults = resolveVideoGenerationOptions({ model: settled.model });
+    const modelDefaults = resolveVideoGenerationOptions({
+      model: settled.model,
+    });
     onChange({
       ...value,
       selection: {
         ...value.selection,
-        videoOptions: toVideoOptionsPatch(settled, defaults),
+        videoOptions: toVideoOptionsPatch(settled, modelDefaults),
       },
     });
   };
@@ -223,22 +228,6 @@ function VideoTemplateOptionsForm({
           />
         </div>
       )}
-      <div className="mt-2 flex items-center justify-end border-t border-border pt-2">
-        <button
-          type="button"
-          className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          onClick={() => {
-            onChange({
-              ...value,
-              selection: { ...value.selection, videoOptions: {} },
-            });
-          }}
-        >
-          {t(($) => {
-            return $.chat.templates.videoOptionsReset;
-          })}
-        </button>
-      </div>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/video-template-options-popover.tsx
+++ b/turbo/apps/platform/src/views/zero-page/video-template-options-popover.tsx
@@ -1,0 +1,296 @@
+import { useGet, useSet } from "ccstate-react";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@vm0/ui/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import { Switch } from "@vm0/ui/components/ui/switch";
+import type {
+  GenerationTemplateRequest,
+  VideoGenerationOptions,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  VIDEO_MODEL_CONFIGS,
+  VIDEO_MODELS,
+  resolveVideoGenerationOptions,
+  type ResolvedVideoGenerationOptions,
+  type VideoModel,
+  type VideoModelConfig,
+} from "@vm0/core/video-model-catalog";
+import { useTranslation } from "react-i18next";
+import type { ComposerSignals } from "../../signals/zero-page/composer-signals.ts";
+
+/**
+ * Only the values the user actually chose are persisted, so a template written
+ * today follows a later change of default instead of pinning the current one.
+ */
+function toVideoOptionsPatch(
+  next: ResolvedVideoGenerationOptions,
+  defaults: ResolvedVideoGenerationOptions,
+): VideoGenerationOptions {
+  return {
+    ...(next.model === defaults.model ? {} : { model: next.model }),
+    ...(next.aspectRatio === defaults.aspectRatio
+      ? {}
+      : { aspectRatio: next.aspectRatio }),
+    ...(next.duration === defaults.duration ? {} : { duration: next.duration }),
+    ...(next.resolution === defaults.resolution
+      ? {}
+      : { resolution: next.resolution }),
+    ...(next.generateAudio === defaults.generateAudio
+      ? {}
+      : { generateAudio: next.generateAudio }),
+  };
+}
+
+/** Narrows a Select's string payload back to the catalog's literal union. */
+function pickValue<T extends string>(
+  values: readonly T[],
+  next: string,
+): T | undefined {
+  return values.find((value) => {
+    return value === next;
+  });
+}
+
+function VideoOptionRow({
+  label,
+  value,
+  values,
+  onChange,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly values: readonly string[];
+  readonly onChange: (next: string) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="h-8 w-[9.5rem]" aria-label={label}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {values.map((option) => {
+            return (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function VideoModelRow({
+  label,
+  model,
+  onChange,
+}: {
+  readonly label: string;
+  readonly model: VideoModel;
+  readonly onChange: (next: string) => void;
+}) {
+  const models = VIDEO_MODELS.filter((candidate) => {
+    return VIDEO_MODEL_CONFIGS[candidate].public;
+  });
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <Select value={model} onValueChange={onChange}>
+        <SelectTrigger className="h-8 w-[9.5rem]" aria-label={label}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {models.map((candidate) => {
+            return (
+              <SelectItem key={candidate} value={candidate}>
+                {VIDEO_MODEL_CONFIGS[candidate].label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function VideoTemplateOptionsForm({
+  value,
+  onChange,
+}: {
+  readonly value: GenerationTemplateRequest;
+  readonly onChange: (next: GenerationTemplateRequest) => void;
+}) {
+  const { t } = useTranslation();
+  if (value.type !== "video") {
+    return null;
+  }
+  const resolved = resolveVideoGenerationOptions(value.selection.videoOptions);
+  const config: VideoModelConfig = VIDEO_MODEL_CONFIGS[resolved.model];
+  const apply = (next: ResolvedVideoGenerationOptions): void => {
+    // Re-resolve so a value the newly chosen model rejects falls back the same
+    // way the generation service would.
+    const settled = resolveVideoGenerationOptions(next);
+    const defaults = resolveVideoGenerationOptions({ model: settled.model });
+    onChange({
+      ...value,
+      selection: {
+        ...value.selection,
+        videoOptions: toVideoOptionsPatch(settled, defaults),
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <VideoModelRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsModel;
+        })}
+        model={resolved.model}
+        onChange={(next) => {
+          const model = pickValue(VIDEO_MODELS, next);
+          if (model !== undefined) {
+            apply({ ...resolved, model });
+          }
+        }}
+      />
+      <VideoOptionRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsRatio;
+        })}
+        value={resolved.aspectRatio}
+        values={config.aspectRatios}
+        onChange={(next) => {
+          const aspectRatio = pickValue(config.aspectRatios, next);
+          if (aspectRatio !== undefined) {
+            apply({ ...resolved, aspectRatio });
+          }
+        }}
+      />
+      <VideoOptionRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsDuration;
+        })}
+        value={resolved.duration}
+        values={config.durations}
+        onChange={(next) => {
+          const duration = pickValue(config.durations, next);
+          if (duration !== undefined) {
+            apply({ ...resolved, duration });
+          }
+        }}
+      />
+      <VideoOptionRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsResolution;
+        })}
+        value={resolved.resolution}
+        values={config.resolutions}
+        onChange={(next) => {
+          const resolution = pickValue(config.resolutions, next);
+          if (resolution !== undefined) {
+            apply({ ...resolved, resolution });
+          }
+        }}
+      />
+      {config.supportsGenerateAudio && (
+        <div className="flex items-center justify-between gap-3 py-1.5">
+          <span className="text-sm text-muted-foreground">
+            {t(($) => {
+              return $.chat.templates.videoOptionsAudio;
+            })}
+          </span>
+          <Switch
+            checked={resolved.generateAudio}
+            aria-label={t(($) => {
+              return $.chat.templates.videoOptionsAudio;
+            })}
+            onCheckedChange={(checked) => {
+              apply({ ...resolved, generateAudio: checked });
+            }}
+          />
+        </div>
+      )}
+      <div className="mt-2 flex items-center justify-end border-t border-border pt-2">
+        <button
+          type="button"
+          className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={() => {
+            onChange({
+              ...value,
+              selection: { ...value.selection, videoOptions: {} },
+            });
+          }}
+        >
+          {t(($) => {
+            return $.chat.templates.videoOptionsReset;
+          })}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function VideoTemplateOptionsPopover({
+  signals,
+  onChange,
+}: {
+  readonly signals: ComposerSignals;
+  readonly onChange: (next: GenerationTemplateRequest) => void;
+}) {
+  const { t } = useTranslation();
+  const anchor = useGet(signals.template.videoTemplateOptionsAnchor$);
+  const value = useGet(signals.template.videoTemplateOptionsValue$);
+  const close = useSet(signals.template.closeVideoTemplateOptions$);
+
+  if (!anchor || !value) {
+    return null;
+  }
+
+  return (
+    <Popover
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+        }
+      }}
+    >
+      <PopoverAnchor asChild>
+        <span
+          aria-hidden="true"
+          className="pointer-events-none fixed"
+          style={{
+            left: `${String(anchor.left)}px`,
+            top: `${String(anchor.top)}px`,
+            width: `${String(anchor.width)}px`,
+            height: `${String(anchor.height)}px`,
+          }}
+        />
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="w-[19rem] rounded-xl p-3"
+        aria-label={t(($) => {
+          return $.chat.templates.videoOptions;
+        })}
+      >
+        <VideoTemplateOptionsForm value={value} onChange={onChange} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -188,7 +188,10 @@ import { activeUserPermissionGrantSnapshot } from "../../signals/user-permission
 import { savePermissionDraftPolicies } from "../../signals/zero-page/settings/permission-grant-save.ts";
 import { PermissionsDialog } from "./components/settings/permissions-dialog.tsx";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import type { TemplateCardHtmlPreviewState } from "../../signals/zero-page/zero-chat-composer.ts";
+import type {
+  TemplateCardHtmlPreviewState,
+  VideoTemplateOptionsAnchor,
+} from "../../signals/zero-page/zero-chat-composer.ts";
 import type {
   ComposerPendingEvent,
   ComposerPrimaryAction,
@@ -210,6 +213,7 @@ import { shouldUseUserMessage } from "../../signals/zero-page/user-message-docum
 import { WebsiteTemplatePreviewDialogSlot } from "./website-template-preview-dialog.tsx";
 import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx";
 import { AvatarTemplatePickerContent } from "./avatar-template-picker.tsx";
+import { VideoTemplateOptionsPopover } from "./video-template-options-popover.tsx";
 import {
   avatarTemplateSelection,
   toAvatarGenerationTemplate,
@@ -5590,6 +5594,23 @@ function composerTemplateAttachmentLifecycleKey(
     : "none";
 }
 
+/** Serialized by the inline chip node view as "left,top,width,height". */
+function parseTemplateAnchor(
+  serialized: string | undefined,
+): VideoTemplateOptionsAnchor | undefined {
+  const parts = serialized?.split(",").map(Number);
+  if (parts?.length !== 4 || parts.some(Number.isNaN)) {
+    return undefined;
+  }
+  const [left, top, width, height] = parts;
+  return left === undefined ||
+    top === undefined ||
+    width === undefined ||
+    height === undefined
+    ? undefined
+    : { left, top, width, height };
+}
+
 function ComposerTemplateAttachmentSync({
   signals,
 }: {
@@ -5609,6 +5630,7 @@ function ComposerTemplateAttachmentSync({
     signals.template.setTemplatePickerReferenceValue$,
   );
   const readSelectedTemplate = useSet(signals.template.readSelectedTemplate$);
+  const openVideoOptions = useSet(signals.template.openVideoTemplateOptions$);
   const cardThemeIdBySlug = useGet(signals.template.templateCardThemeIdBySlug$);
   const attachment = selectedComposerTemplateAttachment(picker?.value);
   const openPicker = (category: string) => {
@@ -5631,25 +5653,43 @@ function ComposerTemplateAttachmentSync({
   };
 
   return (
-    <button
-      key={composerTemplateAttachmentLifecycleKey(attachment)}
-      ref={setLifecycleRef}
-      type="button"
-      hidden
-      data-template-type={attachment?.type}
-      data-template-title={attachment?.title}
-      data-template-category={attachment?.category}
-      data-template-preview-url={attachment?.previewImageUrl}
-      onClick={(event) => {
-        const action = event.currentTarget.dataset.templateAction;
-        if (action === "open") {
-          openPicker(event.currentTarget.dataset.templateCategory ?? "slides");
-        } else if (action === "remove") {
-          picker?.onChange(undefined);
-          onDraftChange?.();
-        }
-      }}
-    />
+    <>
+      <VideoTemplateOptionsPopover
+        signals={signals}
+        onChange={(next) => {
+          picker?.onChange(next);
+        }}
+      />
+      <button
+        key={composerTemplateAttachmentLifecycleKey(attachment)}
+        ref={setLifecycleRef}
+        type="button"
+        hidden
+        data-template-type={attachment?.type}
+        data-template-title={attachment?.title}
+        data-template-category={attachment?.category}
+        data-template-preview-url={attachment?.previewImageUrl}
+        onClick={(event) => {
+          const action = event.currentTarget.dataset.templateAction;
+          if (action === "open") {
+            openPicker(
+              event.currentTarget.dataset.templateCategory ?? "slides",
+            );
+          } else if (action === "remove") {
+            picker?.onChange(undefined);
+            onDraftChange?.();
+          } else if (action === "options") {
+            const anchor = parseTemplateAnchor(
+              event.currentTarget.dataset.templateAnchor,
+            );
+            const selected = readSelectedTemplate();
+            if (anchor && selected) {
+              openVideoOptions(anchor, selected);
+            }
+          }
+        }}
+      />
+    </>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5631,6 +5631,13 @@ function ComposerTemplateAttachmentSync({
   );
   const readSelectedTemplate = useSet(signals.template.readSelectedTemplate$);
   const openVideoOptions = useSet(signals.template.openVideoTemplateOptions$);
+  const videoOptionsPosition = useGet(
+    signals.template.videoTemplateOptionsPosition$,
+  );
+  const updateTemplateAt = useSet(signals.template.updateTemplateAt$);
+  const setVideoOptionsValue = useSet(
+    signals.template.setVideoTemplateOptionsValue$,
+  );
   const cardThemeIdBySlug = useGet(signals.template.templateCardThemeIdBySlug$);
   const attachment = selectedComposerTemplateAttachment(picker?.value);
   const openPicker = (category: string) => {
@@ -5657,7 +5664,17 @@ function ComposerTemplateAttachmentSync({
       <VideoTemplateOptionsPopover
         signals={signals}
         onChange={(next) => {
-          picker?.onChange(next);
+          const nextAttachment = selectedComposerTemplateAttachment(next);
+          if (videoOptionsPosition === null || !nextAttachment) {
+            return;
+          }
+          // Addressed by position: the editor selection does not survive
+          // repeated in-place updates, and the popover can outlive it.
+          updateTemplateAt(videoOptionsPosition, next, nextAttachment);
+          // The popover holds a snapshot; without this a second edit would be
+          // computed from the pre-edit value and undo the first one.
+          setVideoOptionsValue(next);
+          onDraftChange?.();
         }}
       />
       <button
@@ -5682,9 +5699,12 @@ function ComposerTemplateAttachmentSync({
             const anchor = parseTemplateAnchor(
               event.currentTarget.dataset.templateAnchor,
             );
+            const position = Number(
+              event.currentTarget.dataset.templatePosition,
+            );
             const selected = readSelectedTemplate();
-            if (anchor && selected) {
-              openVideoOptions(anchor, selected);
+            if (anchor && selected && Number.isInteger(position)) {
+              openVideoOptions(anchor, selected, position);
             }
           }
         }}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -118,7 +118,12 @@ import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import {
+  featureSwitch$,
+  videoTemplateOptionsEnabled$,
+} from "../../signals/external/feature-switch.ts";
+import { parseAvatarTemplateStylePresetId } from "@vm0/core/avatar-template";
+import { resolveVideoGenerationOptions } from "@vm0/core/video-model-catalog";
 import { isStandalonePwa } from "../../lib/keyboard-dismiss-gesture.ts";
 import {
   captureRecommendedFollowupSelected,
@@ -7156,6 +7161,25 @@ const STRUCTURED_INLINE_REFERENCE_CLASS =
   "active:bg-orange-500/20 dark:bg-orange-400/15 dark:text-orange-300 " +
   "dark:hover:bg-orange-400/20 dark:active:bg-orange-400/25";
 
+/**
+ * Read-only echo of the parameters a sent video used, resolved the same way the
+ * composer chip resolves them. Talking-avatar templates share the "video"
+ * envelope but take none of these parameters.
+ */
+function sentVideoTemplateSpec(
+  template: GenerationTemplateRequest,
+): string | undefined {
+  if (template.type !== "video") {
+    return undefined;
+  }
+  const { selection } = template;
+  if (parseAvatarTemplateStylePresetId(selection.stylePresetId) !== undefined) {
+    return undefined;
+  }
+  const resolved = resolveVideoGenerationOptions(selection.videoOptions);
+  return `${resolved.aspectRatio} \u00b7 ${resolved.duration}`;
+}
+
 function templatePickerCategoryForReference(
   template: GenerationTemplateRequest,
 ): string {
@@ -7187,6 +7211,10 @@ function UserMessageTemplateReference({
 }) {
   const { t } = useTranslation();
   const typeLabel = generationTemplateTypeLabel(part.template);
+  const videoOptionsEnabled = useGet(videoTemplateOptionsEnabled$);
+  const spec = videoOptionsEnabled
+    ? sentVideoTemplateSpec(part.template)
+    : undefined;
   const setTemplatePickerCategory = useSet(
     signals.template.setTemplatePickerCategory$,
   );
@@ -7252,6 +7280,11 @@ function UserMessageTemplateReference({
     >
       <IconColorSwatch size={13} stroke={1.7} className="shrink-0" />
       <span className="min-w-0 truncate">{part.titleSnapshot}</span>
+      {spec !== undefined && (
+        <span className="shrink-0 text-[12px] font-normal text-orange-600/70 dark:text-orange-300/70">
+          {spec}
+        </span>
+      )}
     </button>
   );
 }

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -73,4 +73,5 @@ export enum FeatureSwitchKey {
   SharedThreadSharing = "sharedThreadSharing",
   PiLoop = "piLoop",
   CjkFriendlyMarkdown = "cjkFriendlyMarkdown",
+  VideoTemplateOptions = "videoTemplateOptions",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -317,6 +317,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Send preview chat runs through real agent CLIs instead of preview mock runners.",
     enabled: false,
   },
+  [FeatureSwitchKey.VideoTemplateOptions]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Let a video template chip in the chat composer set the generation model, aspect ratio, duration, resolution, and audio.",
+    enabled: false,
+  },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/packages/core/src/video-model-catalog.ts
+++ b/turbo/packages/core/src/video-model-catalog.ts
@@ -98,7 +98,10 @@ type VideoModelFamily = "seedance-2" | "seedance-1-5";
 type FalRequestFormat = "veo" | "kling";
 
 interface BaseVideoModelConfig {
+  /** Value accepted by the CLI's `--model` flag. */
   readonly alias: string;
+  /** Human-facing name for pickers. */
+  readonly label: string;
   readonly aspectRatios: readonly VideoAspectRatio[];
   readonly durations: readonly VideoDuration[];
   readonly resolutions: readonly VideoResolution[];
@@ -139,6 +142,7 @@ export const VIDEO_MODEL_CONFIGS = {
   "dreamina-seedance-2-0-260128": {
     provider: "byteplus",
     alias: "dreamina-seedance-2.0",
+    label: "Seedance 2.0",
     family: "seedance-2",
     aspectRatios: VIDEO_ASPECT_RATIOS,
     durations: SEEDANCE_2_DURATIONS,
@@ -159,6 +163,7 @@ export const VIDEO_MODEL_CONFIGS = {
   "dreamina-seedance-2-0-fast-260128": {
     provider: "byteplus",
     alias: "dreamina-seedance-2.0-fast",
+    label: "Seedance 2.0 fast",
     family: "seedance-2",
     aspectRatios: VIDEO_ASPECT_RATIOS,
     durations: SEEDANCE_2_DURATIONS,
@@ -179,6 +184,7 @@ export const VIDEO_MODEL_CONFIGS = {
   "seedance-1-5-pro-251215": {
     provider: "byteplus",
     alias: "seedance-1.5-pro",
+    label: "Seedance 1.5 pro",
     family: "seedance-1-5",
     aspectRatios: VIDEO_ASPECT_RATIOS,
     durations: SEEDANCE_1_5_DURATIONS,
@@ -199,6 +205,7 @@ export const VIDEO_MODEL_CONFIGS = {
   "fal-ai/veo3.1/fast": {
     provider: "fal",
     alias: "veo3.1-fast",
+    label: "Veo 3.1 fast",
     requestFormat: "veo",
     aspectRatios: STANDARD_VIDEO_ASPECT_RATIOS,
     durations: VEO_VIDEO_DURATIONS,
@@ -219,6 +226,7 @@ export const VIDEO_MODEL_CONFIGS = {
   "fal-ai/kling-video/v3/4k/text-to-video": {
     provider: "fal",
     alias: "kling-v3-4k",
+    label: "Kling v3 4K",
     requestFormat: "kling",
     aspectRatios: STANDARD_VIDEO_ASPECT_RATIOS,
     durations: KLING_VIDEO_DURATIONS,
@@ -239,6 +247,7 @@ export const VIDEO_MODEL_CONFIGS = {
   "MiniMax-H3": {
     provider: "minimax",
     alias: "minimax-h3",
+    label: "MiniMax H3",
     aspectRatios: VIDEO_ASPECT_RATIOS,
     durations: MINIMAX_H3_DURATIONS,
     resolutions: MINIMAX_H3_RESOLUTIONS,
@@ -281,3 +290,53 @@ export const DEFAULT_VIDEO_MODEL =
   "dreamina-seedance-2-0-fast-260128" satisfies VideoModel;
 export const DEFAULT_VIDEO_ASPECT_RATIO = "16:9" satisfies VideoAspectRatio;
 export const DEFAULT_VIDEO_DURATION = "8s" satisfies VideoDuration;
+
+export interface ResolvedVideoGenerationOptions {
+  readonly model: VideoModel;
+  readonly aspectRatio: VideoAspectRatio;
+  readonly duration: VideoDuration;
+  readonly resolution: VideoResolution;
+  readonly generateAudio: boolean;
+}
+
+/**
+ * Fills in what the user has not chosen, mirroring what the generation service
+ * would apply. Stored options are sparse and can also name a value the chosen
+ * model does not accept, which is what happens after switching model; those
+ * fall back the same way the service falls back rather than being kept.
+ */
+export function resolveVideoGenerationOptions(
+  options:
+    | {
+        readonly model?: VideoModel;
+        readonly aspectRatio?: VideoAspectRatio;
+        readonly duration?: VideoDuration;
+        readonly resolution?: VideoResolution;
+        readonly generateAudio?: boolean;
+      }
+    | undefined,
+): ResolvedVideoGenerationOptions {
+  const model = options?.model ?? DEFAULT_VIDEO_MODEL;
+  const config: VideoModelConfig = VIDEO_MODEL_CONFIGS[model];
+  const aspectRatio = options?.aspectRatio;
+  const duration = options?.duration;
+  const resolution = options?.resolution;
+  return {
+    model,
+    aspectRatio:
+      aspectRatio !== undefined && config.aspectRatios.includes(aspectRatio)
+        ? aspectRatio
+        : DEFAULT_VIDEO_ASPECT_RATIO,
+    duration:
+      duration !== undefined && config.durations.includes(duration)
+        ? duration
+        : DEFAULT_VIDEO_DURATION,
+    resolution:
+      resolution !== undefined && config.resolutions.includes(resolution)
+        ? resolution
+        : config.defaultResolution,
+    generateAudio: config.supportsGenerateAudio
+      ? (options?.generateAudio ?? true)
+      : false,
+  };
+}


### PR DESCRIPTION
Stacked on #25613; base retargets to `main` once that merges.

Behind `videoTemplateOptions`, **off by default**.

## What

The inline template chip becomes two hit zones separated by a hairline:

- **name** — opens the template gallery, exactly as today
- **spec** — shows `16:9 · 8s` and opens a popover for model, ratio, duration, resolution, and audio

Non-video templates, and the talking-avatar templates that share the `video` envelope, render a single zone as before.

## Why on the chip and not a composer row

Inline templates are already multiple per prompt (`structuredPromptInlineTemplates` ships on) and can mix video with illustration. A settings row in the composer toolbar would have composer scope while the options have per-template scope — with three chips attached there is no honest answer to which template the row belongs to — and it would move the composer's height every time a chip is clicked. Anchoring to the chip makes ownership self-evident and keeps the height fixed for any count or mix.

Sent message chips carry the same summary, read-only: no second hit zone, because a sent message cannot be re-parameterised.

## Resolved for display, sparse in storage

`resolveVideoGenerationOptions` fills a stored selection in against the catalog, so a freshly attached template already reads `16:9 · 8s` rather than showing nothing until the user picks something. Only values that differ from that model's defaults are written back, which is what keeps a message authored today following a later change of default instead of pinning the current one — and means a user who never opens the popover produces the same payload as before this PR.

Switching model re-resolves rather than keeping a now-invalid value. That is what silently drops a 5s duration when moving to Veo (4s/6s/8s only) or a 1080p resolution when moving to Seedance 2.0 fast, matching the fallback the generation service applies.

## Notable implementation points

- Editing calls `insertTemplate$`, whose existing "selection is this node" branch does `setNodeMarkup` in place — no second chip, no cursor movement, and no new command.
- The spec zone is opened through the existing hidden-button bridge with a third `data-template-action="options"`, carrying the chip's viewport rect so the popover can anchor to it via `PopoverAnchor`.
- Hover moved from the chip onto each zone; without that the boundary is invisible until you click.
- The duration is hidden below `sm` so the chip stays readable inside a prompt sentence.
- `src/views/**` bans React hooks, so popover state lives in ccstate signals next to the existing template-picker state.

## Verification

- `chat-composer-template-picker.test.tsx` and `chat-user-messages.test.tsx` — 45 passed, including two new cases: one attaches a video template, asserts the chip renders catalog defaults, changes the ratio through the popover, and checks the node is rewritten in place with only `{ aspectRatio: "9:16" }` persisted; the other renders a sent message that stored only a ratio and asserts the chip still echoes `9:16 · 8s`.
- One existing assertion was updated on purpose: it pinned `hover:bg-orange-500/15` on the chip, which now lives on the zones.
- `oxlint` clean on every changed file; `knip --workspace apps/platform` and `@vm0/core` clean; `@vm0/core` type-checks; prettier clean across all 18 files.
- `apps/platform` full type-check OOMs in this 4 GB sandbox and rides on `lint-types-apps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
