### PR TITLE
feat(api): retain raw usage events for seven days

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-compact-usage-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-compact-usage-events.test.ts
@@ -285,11 +285,17 @@ describe("usage event compaction cron", () => {
     expect(insight.body.grandTotalCredits).toBe(7);
   });
 
-  it("retains unstable hours and explicit diagnostic holds", async () => {
+  it("retains seven days of processed events and explicit diagnostic holds", async () => {
     const heldFixture = await seedFixture();
-    const currentHour = nowDate();
-    currentHour.setUTCMinutes(0, 0, 0);
-    const previousHour = new Date(currentHour.getTime() - 60 * 60 * 1000);
+    const startedHour = nowDate();
+    startedHour.setUTCMinutes(0, 0, 0);
+    const expectedCutoffAtStart = new Date(
+      startedHour.getTime() - 7 * 24 * 60 * 60 * 1000,
+    );
+    const retainedProcessedAt = new Date(
+      startedHour.getTime() - 6 * 24 * 60 * 60 * 1000,
+    );
+    const eligibleProcessedAt = new Date("0400-01-01T00:30:00.000Z");
 
     await store.set(
       insertUsageEvent$,
@@ -315,16 +321,7 @@ describe("usage event compaction cron", () => {
       {
         ...heldFixture,
         status: "processed",
-        processedAt: previousHour,
-      },
-      context.signal,
-    );
-    await store.set(
-      insertUsageEvent$,
-      {
-        ...heldFixture,
-        status: "processed",
-        processedAt: new Date(currentHour.getTime() + 1000),
+        processedAt: retainedProcessedAt,
       },
       context.signal,
     );
@@ -334,25 +331,34 @@ describe("usage event compaction cron", () => {
       {
         ...eligibleFixture,
         status: "processed",
-        processedAt: new Date("0400-01-01T00:30:00.000Z"),
+        processedAt: eligibleProcessedAt,
       },
       context.signal,
     );
     await seedZeroUsageEvents(eligibleFixture, {
-      processedAt: new Date("0400-01-01T00:30:00.000Z"),
+      processedAt: eligibleProcessedAt,
       count: RAW_SEED_LIMIT - 1,
     });
 
     const response = await compactUsage();
+    const completedHour = nowDate();
+    completedHour.setUTCMinutes(0, 0, 0);
+    const expectedCutoffAtCompletion = new Date(
+      completedHour.getTime() - 7 * 24 * 60 * 60 * 1000,
+    );
 
     expect(response.body).toMatchObject({
       rawRowsDeleted: RAW_SEED_LIMIT,
       hourlyRowsInserted: 1,
       billingErrorHeldRows: 1,
     });
+    expect([
+      expectedCutoffAtStart.toISOString(),
+      expectedCutoffAtCompletion.toISOString(),
+    ]).toContain(response.body.cutoff);
     await expect(readStorage(heldFixture)).resolves.toStrictEqual({
-      raw: 4,
-      processedRaw: 3,
+      raw: 3,
+      processedRaw: 2,
       hourly: 0,
     });
     await expect(readStorage(eligibleFixture)).resolves.toStrictEqual({

--- a/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
@@ -503,7 +503,7 @@ async function loadCompactionCutoff(db: Pick<Db, "execute">): Promise<Date> {
     sql`
       SELECT (
         date_trunc('hour', timezone('UTC', statement_timestamp()))
-        - interval '1 hour'
+        - interval '7 days'
       )::timestamp AS cutoff
     `,
     cutoffRowSchema,

--- a/turbo/packages/db/src/schema/usage-event.ts
+++ b/turbo/packages/db/src/schema/usage-event.ts
@@ -50,8 +50,8 @@ import { agentRuns } from "./agent-run";
  * Writers must keep the same UUID across retries of the same logical
  * event; the UNIQUE index blocks duplicate insertions.
  *
- * Healthy usage follows `pending -> processed -> hourly rollup`, after which
- * the source event is deleted.
+ * Healthy usage remains `processed` for at least seven days before hourly
+ * rollup replacement, after which the source event is deleted.
  */
 export const usageEvent = pgTable(
   "usage_event",


### PR DESCRIPTION
## Summary

- retain healthy processed usage events for at least seven days before hourly compaction
- keep the existing UTC-hour-aligned, strict cutoff semantics and atomic rollup/source-deletion flow
- cover retained, eligible, pending, and billing-error rows through the real cron route and PostgreSQL
- document the seven-day raw-event lifecycle in the database schema

## Behavior and exclusions

The cutoff is the start of the current UTC database hour minus seven days. Product readers already combine processed raw events with hourly rollups, so reported totals and public APIs are unchanged.

This PR does not add a migration, lifecycle status, feature switch, index, archive, or cleanup job. Account and user deletion continue to override retention, and the policy is forward-looking when old API revisions overlap or are rolled back.

Supersedes the source-cardinality approach in closed PR #25618.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-compact-usage-events.test.ts` (11 tests)
- `pnpm knip --workspace api`
- pre-commit: full Turbo Knip and type checking
- `git diff --check`

Closes #25579
