### PR TITLE
perf(runner): enforce rank-aware resource admission

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -40,7 +40,8 @@ use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
 use crate::paths::short_digest;
 use crate::provider::{
-    ClaimedJob, JobCandidate, RunnerPreferenceReason, RunnerPreferenceRemovalReason,
+    ClaimedJob, JobCandidate, RunnerPreferenceAdmission, RunnerPreferenceReason,
+    RunnerPreferenceRemovalReason, RunnerPreferenceTier,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{
@@ -169,6 +170,17 @@ struct ClaimAdmissionRequest<'a> {
     job_memory: u32,
     workspace_disk_mb: u32,
     device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
+}
+
+struct PreferenceCandidateRequest<'a> {
+    candidate: JobCandidate,
+    preference: &'a crate::provider::RunnerPreference,
+    reuse_key: &'a str,
+    profile_name: &'a str,
+    job_vcpu: u32,
+    job_memory: u32,
+    device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
+    ctx: &'a DiscoveredJobContext<'a>,
 }
 
 struct ReservedActivationRequest<'a> {
@@ -776,7 +788,41 @@ async fn prepare_preference_candidate(
         );
     };
 
-    match preference.reason() {
+    let request = PreferenceCandidateRequest {
+        candidate,
+        preference: &preference,
+        reuse_key: &reuse_key,
+        profile_name,
+        job_vcpu,
+        job_memory,
+        device_rate_limits,
+        ctx,
+    };
+    match preference.admission() {
+        RunnerPreferenceAdmission::Legacy(reason) => {
+            prepare_legacy_preference_candidate(request, reason).await
+        }
+        RunnerPreferenceAdmission::Ranked(tier) => {
+            prepare_ranked_preference_candidate(request, tier).await
+        }
+    }
+}
+
+async fn prepare_legacy_preference_candidate(
+    request: PreferenceCandidateRequest<'_>,
+    reason: RunnerPreferenceReason,
+) -> PreferencePreparation {
+    let PreferenceCandidateRequest {
+        candidate,
+        preference,
+        reuse_key,
+        profile_name,
+        job_vcpu,
+        job_memory,
+        device_rate_limits,
+        ctx,
+    } = request;
+    match reason {
         RunnerPreferenceReason::ExactHistoryGeneration => {
             let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
                 return ordinary_preparation(
@@ -784,7 +830,7 @@ async fn prepare_preference_candidate(
                 );
             };
             if let Some(reservation) = reserve_reusable_idle(
-                &reuse_key,
+                reuse_key,
                 profile_name,
                 device_rate_limits,
                 Some(history_generation_run_id),
@@ -801,7 +847,7 @@ async fn prepare_preference_candidate(
         }
         RunnerPreferenceReason::MatchingReuseKey => {
             if let Some(reservation) =
-                reserve_reusable_idle(&reuse_key, profile_name, device_rate_limits, None, ctx).await
+                reserve_reusable_idle(reuse_key, profile_name, device_rate_limits, None, ctx).await
             {
                 return reusable_preparation(candidate, reservation);
             }
@@ -832,7 +878,7 @@ async fn prepare_preference_candidate(
                 );
             };
             if let Some(reservation) = reserve_reusable_idle(
-                &reuse_key,
+                reuse_key,
                 profile_name,
                 device_rate_limits,
                 Some(history_generation_run_id),
@@ -844,18 +890,113 @@ async fn prepare_preference_candidate(
             }
 
             if preference.targets(ctx.runner_id, ctx.heartbeat_generation) {
-                if !contains_active_reuse_key(&ctx.spawn_ctx.active_reuse_keys, &reuse_key) {
+                if !contains_active_reuse_key(&ctx.spawn_ctx.active_reuse_keys, reuse_key) {
                     return ordinary_preparation(
                         candidate.without_runner_preference(RunnerPreferenceRemovalReason::Cleared),
                     );
                 }
-                return defer_preference_candidate(candidate, &preference, &reuse_key, ctx, true)
+                return defer_preference_candidate(candidate, preference, reuse_key, ctx, true)
                     .await;
             }
         }
     }
 
-    defer_preference_candidate(candidate, &preference, &reuse_key, ctx, false).await
+    defer_preference_candidate(candidate, preference, reuse_key, ctx, false).await
+}
+
+async fn prepare_ranked_preference_candidate(
+    request: PreferenceCandidateRequest<'_>,
+    advertised_tier: RunnerPreferenceTier,
+) -> PreferencePreparation {
+    let PreferenceCandidateRequest {
+        candidate,
+        preference,
+        reuse_key,
+        profile_name,
+        job_vcpu,
+        job_memory,
+        device_rate_limits,
+        ctx,
+    } = request;
+    let selected = preference.targets(ctx.runner_id, ctx.heartbeat_generation);
+    let history_generation_run_id = candidate.history_generation_run_id();
+
+    if ranked_preference_allows(
+        advertised_tier,
+        RunnerPreferenceTier::ExactSandbox,
+        selected,
+    ) && let Some(history_generation_run_id) = history_generation_run_id
+        && let Some(reservation) = reserve_reusable_idle(
+            reuse_key,
+            profile_name,
+            device_rate_limits,
+            Some(history_generation_run_id),
+            ctx,
+        )
+        .await
+    {
+        return if reservation.guest_timezone_intent().is_usable_prediction() {
+            exact_speculative_preparation(candidate, reservation)
+        } else {
+            reusable_preparation(candidate, reservation)
+        };
+    }
+
+    if advertised_tier == RunnerPreferenceTier::FinalizingPredecessor && selected {
+        return defer_preference_candidate(candidate, preference, reuse_key, ctx, true).await;
+    }
+
+    if ranked_preference_allows(
+        advertised_tier,
+        RunnerPreferenceTier::ReusableSandbox,
+        selected,
+    ) && let Some(reservation) =
+        reserve_reusable_idle(reuse_key, profile_name, device_rate_limits, None, ctx).await
+    {
+        return reusable_preparation(candidate, reservation);
+    }
+
+    if ranked_preference_allows(
+        advertised_tier,
+        RunnerPreferenceTier::WorkspaceCache,
+        selected,
+    ) && has_compatible_workspace(reuse_key, profile_name, ctx)
+        && let Some(lease) = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
+    {
+        return PreferencePreparation::Ready(PreparedCandidate {
+            candidate,
+            resource: Some(LocalAdmissionResource::Fresh(lease)),
+        });
+    }
+
+    defer_preference_candidate(candidate, preference, reuse_key, ctx, false).await
+}
+
+fn ranked_preference_allows(
+    advertised_tier: RunnerPreferenceTier,
+    local_tier: RunnerPreferenceTier,
+    selected: bool,
+) -> bool {
+    if selected {
+        local_tier.rank() >= advertised_tier.rank()
+    } else {
+        local_tier.rank() > advertised_tier.rank()
+    }
+}
+
+fn has_compatible_workspace(
+    reuse_key: &str,
+    profile_name: &str,
+    ctx: &DiscoveredJobContext<'_>,
+) -> bool {
+    current_local_held_workspace_states(ctx)
+        .iter()
+        .filter(|state| state.reuse_key == reuse_key)
+        .flat_map(|state| &state.workspace_caches)
+        .any(|workspace| {
+            workspace.profile == profile_name
+                && workspace.workspace_affinity_version == WORKSPACE_AFFINITY_VERSION
+        })
 }
 
 fn ordinary_preparation(candidate: JobCandidate) -> PreferencePreparation {
@@ -904,7 +1045,7 @@ async fn defer_preference_candidate(
         run_id = %candidate.run_id(),
         reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
         reuse_key_kind = reuse_key_kind(reuse_key),
-        preference_reason = ?preference.reason(),
+        preference_admission = ?preference.admission(),
         delay_ms = delay.as_millis(),
         retained = retain,
         "runner preference has no qualifying local resource, deferring claim"
@@ -1854,6 +1995,51 @@ mod tests {
                 reuse_key: "sess-removed-from-pool".into(),
                 sandbox_id: SandboxId::new_v4(),
             }],
+        }
+    }
+
+    #[test]
+    fn ranked_preference_admission_matrix() {
+        use RunnerPreferenceTier::{
+            ExactSandbox, FinalizingPredecessor, ReusableSandbox, WorkspaceCache,
+        };
+
+        let tiers = [
+            WorkspaceCache,
+            ReusableSandbox,
+            FinalizingPredecessor,
+            ExactSandbox,
+        ];
+        let selected = [
+            [true, true, true, true],
+            [false, true, true, true],
+            [false, false, true, true],
+            [false, false, false, true],
+        ];
+        let unselected = [
+            [false, true, true, true],
+            [false, false, true, true],
+            [false, false, false, true],
+            [false, false, false, false],
+        ];
+
+        for ((advertised_tier, selected_row), unselected_row) in
+            tiers.into_iter().zip(selected).zip(unselected)
+        {
+            for ((local_tier, selected_expected), unselected_expected) in
+                tiers.into_iter().zip(selected_row).zip(unselected_row)
+            {
+                assert_eq!(
+                    ranked_preference_allows(advertised_tier, local_tier, true),
+                    selected_expected,
+                    "selected runner: advertised={advertised_tier:?}, local={local_tier:?}"
+                );
+                assert_eq!(
+                    ranked_preference_allows(advertised_tier, local_tier, false),
+                    unselected_expected,
+                    "unselected runner: advertised={advertised_tier:?}, local={local_tier:?}"
+                );
+            }
         }
     }
 

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use super::super::super::active_reuse_keys::ActiveReuseKeyGuard;
 use crate::paths::RunnerPaths;
 use crate::provider::{
-    RunnerPreference, RunnerPreferenceClaimState, RunnerPreferenceReason,
-    RunnerPreferenceResolution,
+    RunnerPreference, RunnerPreferenceAdmission, RunnerPreferenceClaimState,
+    RunnerPreferenceReason, RunnerPreferenceResolution, RunnerPreferenceTier,
 };
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
@@ -60,6 +60,41 @@ fn preferred_candidate_until(
             )),
             Some(resolution),
         )
+}
+
+fn ranked_candidate(
+    run_id: RunId,
+    reuse_key: Option<&str>,
+    tier: RunnerPreferenceTier,
+    runner_id: &str,
+    heartbeat_generation: u64,
+) -> crate::provider::JobCandidate {
+    ranked_candidate_until(
+        run_id,
+        reuse_key,
+        tier,
+        runner_id,
+        heartbeat_generation,
+        std::time::Instant::now() + Duration::from_secs(30),
+    )
+}
+
+fn ranked_candidate_until(
+    run_id: RunId,
+    reuse_key: Option<&str>,
+    tier: RunnerPreferenceTier,
+    runner_id: &str,
+    heartbeat_generation: u64,
+    deadline: std::time::Instant,
+) -> crate::provider::JobCandidate {
+    crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+        .with_reuse_key(reuse_key.map(str::to_owned))
+        .with_atomic_runner_preference(RunnerPreference::ranked_for_test(
+            runner_id.parse().unwrap(),
+            heartbeat_generation,
+            tier,
+            deadline,
+        ))
 }
 
 fn matching_preference_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
@@ -359,11 +394,16 @@ async fn exact_idle_reservation_is_restored_after_claim_conflict() {
     env.provider.set_claim_result(conflict_run_id, None);
     env.handle
         .discover_tx
-        .send(exact_generation_preference_candidate(
-            conflict_run_id,
-            session_id,
-            reserved_generation_run_id,
-        ))
+        .send(
+            ranked_candidate(
+                conflict_run_id,
+                Some(session_id),
+                RunnerPreferenceTier::ExactSandbox,
+                TEST_RUNNER_ID,
+                TEST_HEARTBEAT_GENERATION,
+            )
+            .with_history_generation_run_id(Some(reserved_generation_run_id)),
+        )
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;
@@ -448,6 +488,75 @@ async fn matching_preference_reservation_is_restored_after_claim_conflict() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn unselected_reusable_sandbox_preempts_workspace_preference() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = "thread:reusable-preempts-workspace";
+    seed_idle_pool(&env.idle_pool, &budget, reuse_key, "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(ranked_candidate(
+            run_id,
+            Some(reuse_key),
+            RunnerPreferenceTier::WorkspaceCache,
+            &uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID).to_string(),
+            1,
+        ))
+        .unwrap();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("strictly better reusable sandbox should preempt workspace preference");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert!(env.handle.deferred_poll_deadlines().is_empty());
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn equal_unselected_reusable_sandbox_defers() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = "thread:equal-reusable-defers";
+    seed_idle_pool(&env.idle_pool, &budget, reuse_key, "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(ranked_candidate(
+            run_id,
+            Some(reuse_key),
+            RunnerPreferenceTier::ReusableSandbox,
+            &uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID).to_string(),
+            1,
+        ))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(env.handle.claim_candidates().is_empty());
+    assert_eq!(env.handle.deferred_poll_deadlines().len(), 1);
+    assert_eq!(
+        env.idle_pool.lock().await.held_reuse_keys(),
+        vec![reuse_key.to_string()],
+        "equal-tier unselected admission must not reserve the sandbox"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn reusable_claim_without_generation_target_reuses_sandbox() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
@@ -487,8 +596,12 @@ async fn reusable_claim_without_generation_target_reuses_sandbox() {
         .find(|candidate| candidate.run_id() == run_id)
         .expect("missing-target reusable candidate should reach claim");
     assert_eq!(
-        candidate.runner_preference().map(RunnerPreference::reason),
-        Some(RunnerPreferenceReason::MatchingReuseKey)
+        candidate
+            .runner_preference()
+            .map(RunnerPreference::admission),
+        Some(RunnerPreferenceAdmission::Legacy(
+            RunnerPreferenceReason::MatchingReuseKey
+        ))
     );
 
     shutdown(&env, run_handle).await;
@@ -666,6 +779,73 @@ async fn selected_finalizing_candidate_keeps_reactor_live_and_claims_after_key_r
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn selected_ranked_finalizing_candidate_does_not_downgrade_after_key_release() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let reuse_key = "thread:ranked-finalizing-retained";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = ActiveReuseKeyGuard::new(
+        env.active_reuse_keys.clone(),
+        Arc::clone(&env.reuse_state_notify),
+        Some(reuse_key.to_owned()),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    let deadline = std::time::Instant::now() + Duration::from_millis(100);
+    env.handle
+        .discover_tx
+        .send(
+            ranked_candidate_until(
+                run_id,
+                Some(reuse_key),
+                RunnerPreferenceTier::FinalizingPredecessor,
+                TEST_RUNNER_ID,
+                TEST_HEARTBEAT_GENERATION,
+                deadline,
+            )
+            .with_history_generation_run_id(Some(history_generation_run_id)),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    assert!(env.handle.claim_candidates().is_empty());
+
+    drop(predecessor_guard);
+    tokio::task::yield_now().await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "canonical finalizing selection must not downgrade when the active key disappears"
+    );
+
+    tokio::time::advance(Duration::from_millis(101)).await;
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("expired finalizing preference should enter ordinary admission");
+    assert_ne!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    let claimed = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("expired candidate should reach claim");
+    let telemetry = claimed
+        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .expect("atomic observation should survive expiry");
+    assert_eq!(
+        telemetry.resolution,
+        RunnerPreferenceResolution::FinalizingPredecessor
+    );
+    assert_eq!(telemetry.state, RunnerPreferenceClaimState::Expired);
+    assert_eq!(telemetry.targeted_self, Some(true));
+
+    shutdown(&env, run_handle).await;
+}
+
 #[tokio::test]
 async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wakeup() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
@@ -685,13 +865,16 @@ async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wake
         .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
     env.handle
         .discover_tx
-        .send(finalizing_candidate(
-            run_id,
-            reuse_key,
-            history_generation_run_id,
-            TEST_RUNNER_ID,
-            TEST_HEARTBEAT_GENERATION,
-        ))
+        .send(
+            ranked_candidate(
+                run_id,
+                Some(reuse_key),
+                RunnerPreferenceTier::FinalizingPredecessor,
+                TEST_RUNNER_ID,
+                TEST_HEARTBEAT_GENERATION,
+            )
+            .with_history_generation_run_id(Some(history_generation_run_id)),
+        )
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(5)).await;
 
@@ -714,6 +897,53 @@ async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wake
         .expect("exact resource state should wake the retained candidate");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
     drop(predecessor_guard);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn unselected_exact_sandbox_preempts_finalizing_preference() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = "thread:exact-preempts-finalizing";
+    let history_generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_history_generation(
+        &env.idle_pool,
+        &budget,
+        reuse_key,
+        "vm0/default",
+        2,
+        4096,
+        history_generation_run_id,
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(
+            ranked_candidate(
+                run_id,
+                Some(reuse_key),
+                RunnerPreferenceTier::FinalizingPredecessor,
+                &uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID).to_string(),
+                1,
+            )
+            .with_history_generation_run_id(Some(history_generation_run_id)),
+        )
+        .unwrap();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("strictly better exact sandbox should preempt finalizing preference");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert!(env.handle.deferred_poll_deadlines().is_empty());
 
     shutdown(&env, run_handle).await;
 }
@@ -1337,7 +1567,7 @@ async fn expired_generation_protection_preserves_local_session_claim() {
 }
 
 #[tokio::test]
-async fn exact_preference_defers_for_cache_then_matching_preference_claims_it() {
+async fn selected_reusable_defers_for_cache_then_selected_workspace_claims_it() {
     let reuse_key = "thread:cache-local";
     let provider_session_id = "provider-session-cache-local";
     let image_size_bytes = 1024 * 1024;
@@ -1365,23 +1595,25 @@ async fn exact_preference_defers_for_cache_then_matching_preference_claims_it() 
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
-    let exact_run_id = RunId::new_v4();
-    let mut exact_context = context_with_session(exact_run_id, provider_session_id);
-    exact_context.reuse_key = Some(reuse_key.into());
+    let reusable_run_id = RunId::new_v4();
+    let mut reusable_context = context_with_session(reusable_run_id, provider_session_id);
+    reusable_context.reuse_key = Some(reuse_key.into());
     env.provider
-        .set_claim_result(exact_run_id, Some(exact_context));
+        .set_claim_result(reusable_run_id, Some(reusable_context));
     env.handle
         .discover_tx
-        .send(exact_generation_preference_candidate(
-            exact_run_id,
-            reuse_key,
-            RunId::new_v4(),
+        .send(ranked_candidate(
+            reusable_run_id,
+            Some(reuse_key),
+            RunnerPreferenceTier::ReusableSandbox,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
         ))
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     assert!(
         env.handle.claim_candidates().is_empty(),
-        "workspace-cache state must not impersonate an exact reusable generation"
+        "workspace-cache state must not satisfy a selected reusable preference"
     );
     assert_eq!(env.handle.deferred_poll_deadlines().len(), 1);
 
@@ -1392,7 +1624,13 @@ async fn exact_preference_defers_for_cache_then_matching_preference_claims_it() 
         .set_claim_result(run_id, Some(workspace_context));
     env.handle
         .discover_tx
-        .send(matching_preference_candidate(run_id, reuse_key))
+        .send(ranked_candidate(
+            run_id,
+            Some(reuse_key),
+            RunnerPreferenceTier::WorkspaceCache,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
         .unwrap();
 
     let completion = env
@@ -1459,7 +1697,13 @@ async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
     env.provider.set_claim_result(run_id, Some(context));
     env.handle
         .discover_tx
-        .send(matching_preference_candidate(run_id, reuse_key))
+        .send(ranked_candidate(
+            run_id,
+            Some(reuse_key),
+            RunnerPreferenceTier::WorkspaceCache,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
         .unwrap();
 
     wait_discover_entered(&env, Duration::from_secs(5)).await;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -32,8 +32,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    RunnerPreferenceClaimState, RunnerPreferenceResolution, parse_runner_preference,
-    parse_runner_preference_resolution,
+    RunnerPreferenceClaimState, RunnerPreferenceResolution, parse_runner_preference_context,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -594,39 +593,38 @@ impl JobProvider for ApiProvider {
                     let run_id = job.run_id;
                     let reuse_key = job.reuse_key().map(str::to_owned);
                     let history_generation_run_id = job.history_generation_run_id;
-                    let runner_preference = match parse_runner_preference(job.runner_preference) {
-                        Ok(runner_preference) => runner_preference,
-                        Err(error) => {
-                            warn!(
-                                run_id = %run_id,
-                                error = %error,
-                                "poll: invalid runner preference, using ordinary admission"
-                            );
-                            None
-                        }
-                    };
-                    let runner_preference_resolution = match parse_runner_preference_resolution(
+                    let parsed_preference = parse_runner_preference_context(
+                        job.runner_preference_decision,
+                        job.runner_preference,
                         job.runner_preference_resolution,
-                    ) {
-                        Ok(resolution) => resolution,
-                        Err(error) => {
-                            warn!(
-                                run_id = %run_id,
-                                error = %error,
-                                "poll: invalid runner preference resolution, omitting telemetry context"
-                            );
-                            None
-                        }
-                    };
+                    );
+                    if let Some(error) = parsed_preference.decision_error {
+                        warn!(
+                            run_id = %run_id,
+                            error = %error,
+                            "poll: invalid runner preference decision, falling back to legacy preference"
+                        );
+                    }
+                    if let Some(error) = parsed_preference.legacy_preference_error {
+                        warn!(
+                            run_id = %run_id,
+                            error = %error,
+                            "poll: invalid runner preference, using ordinary admission"
+                        );
+                    }
+                    if let Some(error) = parsed_preference.legacy_resolution_error {
+                        warn!(
+                            run_id = %run_id,
+                            error = %error,
+                            "poll: invalid runner preference resolution, omitting telemetry context"
+                        );
+                    }
                     let profile = job.experimental_profile;
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_reuse_key(reuse_key)
                         .with_history_generation_run_id(history_generation_run_id)
-                        .with_runner_preference_context(
-                            runner_preference,
-                            runner_preference_resolution,
-                        )
+                        .with_parsed_runner_preference_context(parsed_preference.context)
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
                         .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed);
@@ -1713,7 +1711,8 @@ mod tests {
 
     use crate::http::HttpClientConfig;
     use crate::provider::{
-        RunnerPreference, RunnerPreferenceReason, RunnerPreferenceRemovalReason,
+        RunnerPreference, RunnerPreferenceAdmission, RunnerPreferenceReason,
+        RunnerPreferenceRemovalReason, RunnerPreferenceTier,
     };
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
@@ -2652,8 +2651,8 @@ mod tests {
             .runner_preference()
             .expect("canonical preference should be parsed");
         assert_eq!(
-            preference.reason(),
-            RunnerPreferenceReason::ExactHistoryGeneration
+            preference.admission(),
+            RunnerPreferenceAdmission::Legacy(RunnerPreferenceReason::ExactHistoryGeneration)
         );
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
         assert_eq!(
@@ -2675,7 +2674,125 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_preserves_poll_job_with_malformed_optional_preference() {
+    async fn discover_prefers_atomic_poll_decision_over_conflicting_bridge() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::new_v4();
+        let selected_runner_id = "00000000-0000-0000-0000-000000000005";
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": run_id,
+                        "experimentalProfile": "vm0/default",
+                        "reuseKey": "thread:atomic-poll",
+                        "runnerPreferenceDecision": {
+                            "kind": "preference",
+                            "runnerIdentity": {
+                                "runnerId": selected_runner_id,
+                                "heartbeatGeneration": 7
+                            },
+                            "tier": "workspaceCache",
+                            "expiresAt": "2999-01-01T00:00:00.000Z"
+                        },
+                        "runnerPreference": {
+                            "runnerIdentity": {
+                                "runnerId": "00000000-0000-0000-0000-000000000099",
+                                "heartbeatGeneration": 9
+                            },
+                            "reason": "exactHistoryGeneration",
+                            "expiresAt": "2999-01-01T00:00:00.000Z"
+                        },
+                        "runnerPreferenceResolution": "exact_history_generation"
+                    }
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test_with_supported_profiles(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+            vec!["vm0/default".to_string()],
+        );
+
+        let candidate = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should poll after wakeup")
+            .expect("job candidate");
+
+        assert_eq!(
+            candidate
+                .runner_preference()
+                .map(RunnerPreference::admission),
+            Some(RunnerPreferenceAdmission::Ranked(
+                RunnerPreferenceTier::WorkspaceCache
+            ))
+        );
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry(selected_runner_id, 7),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::MatchingWorkspaceCache,
+                state: RunnerPreferenceClaimState::Active,
+                targeted_self: Some(true),
+            })
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_atomic_negative_ignores_positive_poll_bridge() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::new_v4();
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": run_id,
+                        "experimentalProfile": "vm0/default",
+                        "runnerPreferenceDecision": {
+                            "kind": "noPreference",
+                            "reason": "noViableHolder"
+                        },
+                        "runnerPreference": {
+                            "runnerIdentity": {
+                                "runnerId": TEST_RUNNER_ID,
+                                "heartbeatGeneration": TEST_HEARTBEAT_GENERATION
+                            },
+                            "reason": "matchingReuseKey",
+                            "expiresAt": "2999-01-01T00:00:00.000Z"
+                        },
+                        "runnerPreferenceResolution": "matching_reusable_sandbox"
+                    }
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test_with_supported_profiles(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+            vec!["vm0/default".to_string()],
+        );
+
+        let candidate = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should preserve the job")
+            .expect("job candidate");
+
+        assert!(candidate.runner_preference().is_none());
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::NoViableHolder,
+                state: RunnerPreferenceClaimState::Absent,
+                targeted_self: None,
+            })
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_falls_back_to_poll_bridge_after_malformed_atomic_decision() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let mock = server
@@ -2686,11 +2803,20 @@ mod tests {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
                         "reuseKey": "thread:malformed-preference",
+                        "runnerPreferenceDecision": {
+                            "kind": "preference",
+                            "runnerIdentity": {
+                                "runnerId": TEST_RUNNER_ID,
+                                "heartbeatGeneration": 0
+                            },
+                            "tier": "workspaceCache",
+                            "expiresAt": "2999-01-01T00:00:00.000Z"
+                        },
                         "runnerPreferenceResolution": "matching_workspace_cache",
                         "runnerPreference": {
                             "runnerIdentity": {
                                 "runnerId": TEST_RUNNER_ID,
-                                "heartbeatGeneration": 0
+                                "heartbeatGeneration": TEST_HEARTBEAT_GENERATION
                             },
                             "reason": "matchingReuseKey",
                             "expiresAt": "2999-01-01T00:00:00.000Z"
@@ -2713,13 +2839,20 @@ mod tests {
 
         assert_eq!(candidate.run_id(), run_id);
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
-        assert!(candidate.runner_preference().is_none());
+        assert_eq!(
+            candidate
+                .runner_preference()
+                .map(RunnerPreference::admission),
+            Some(RunnerPreferenceAdmission::Legacy(
+                RunnerPreferenceReason::MatchingReuseKey
+            ))
+        );
         assert_eq!(
             candidate.runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,),
             Some(super::super::RunnerPreferenceClaimTelemetry {
                 resolution: RunnerPreferenceResolution::MatchingWorkspaceCache,
-                state: RunnerPreferenceClaimState::Cleared,
-                targeted_self: None,
+                state: RunnerPreferenceClaimState::Active,
+                targeted_self: Some(true),
             })
         );
         mock.assert_async().await;

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -27,10 +27,7 @@ use super::api_direct_candidates::{
     DirectJobCandidate,
 };
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
-use super::{
-    RunnerPreference, RunnerPreferenceResolution, parse_runner_preference,
-    parse_runner_preference_resolution,
-};
+use super::{RunnerPreferenceContext, parse_runner_preference_context};
 use crate::active_input::ActiveInputNotifications;
 use crate::duration::duration_ms;
 use crate::ids::RunId;
@@ -733,17 +730,16 @@ async fn handle_ably_message_with_network_policy_refresh(
                     profile = %profile,
                     "ably: job notification, queueing direct candidate"
                 );
-                JobNotificationAction::Direct(
+                JobNotificationAction::Direct(Box::new(
                     DirectJobCandidate::new_with_routing_metadata(
                         notif.run_id,
                         profile.to_owned(),
                         notification_received_at,
                         notif.reuse_key.map(str::to_owned),
-                        notif.runner_preference,
+                        notif.runner_preference_context,
                     )
-                    .with_runner_preference_resolution(notif.runner_preference_resolution)
                     .with_history_generation_run_id(notif.history_generation_run_id),
-                )
+                ))
             } else {
                 info!(
                     run_id = %notif.run_id,
@@ -766,14 +762,14 @@ async fn handle_ably_message_with_network_policy_refresh(
             poll_wakeups.request_immediate_poll().await;
         }
         JobNotificationAction::Direct(candidate) => {
-            enqueue_direct_candidate(candidate, direct_candidates, poll_wakeups).await;
+            enqueue_direct_candidate(*candidate, direct_candidates, poll_wakeups).await;
         }
         JobNotificationAction::Ignore => {}
     }
 }
 
 enum JobNotificationAction {
-    Direct(DirectJobCandidate),
+    Direct(Box<DirectJobCandidate>),
     Ignore,
     WakeNow,
 }
@@ -783,8 +779,7 @@ struct JobNotification<'a> {
     profile: Option<&'a str>,
     reuse_key: Option<&'a str>,
     history_generation_run_id: Option<RunId>,
-    runner_preference: Option<RunnerPreference>,
-    runner_preference_resolution: Option<RunnerPreferenceResolution>,
+    runner_preference_context: Option<RunnerPreferenceContext>,
 }
 
 struct NetworkPolicyRefreshNotification {
@@ -1035,38 +1030,38 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("historyGenerationRunId")
         .and_then(|v| v.as_str())
         .and_then(|value| value.parse().ok());
-    let runner_preference = match parse_runner_preference(msg.data.get("runnerPreference").cloned())
-    {
-        Ok(runner_preference) => runner_preference,
-        Err(error) => {
-            warn!(
-                run_id = %run_id,
-                error = %error,
-                "ably: invalid runner preference, using ordinary admission"
-            );
-            None
-        }
-    };
-    let runner_preference_resolution = match parse_runner_preference_resolution(
+    let parsed_preference = parse_runner_preference_context(
+        msg.data.get("runnerPreferenceDecision").cloned(),
+        msg.data.get("runnerPreference").cloned(),
         msg.data.get("runnerPreferenceResolution").cloned(),
-    ) {
-        Ok(resolution) => resolution,
-        Err(error) => {
-            warn!(
-                run_id = %run_id,
-                error = %error,
-                "ably: invalid runner preference resolution, omitting telemetry context"
-            );
-            None
-        }
-    };
+    );
+    if let Some(error) = parsed_preference.decision_error {
+        warn!(
+            run_id = %run_id,
+            error = %error,
+            "ably: invalid runner preference decision, falling back to legacy preference"
+        );
+    }
+    if let Some(error) = parsed_preference.legacy_preference_error {
+        warn!(
+            run_id = %run_id,
+            error = %error,
+            "ably: invalid runner preference, using ordinary admission"
+        );
+    }
+    if let Some(error) = parsed_preference.legacy_resolution_error {
+        warn!(
+            run_id = %run_id,
+            error = %error,
+            "ably: invalid runner preference resolution, omitting telemetry context"
+        );
+    }
     Some(JobNotification {
         run_id,
         profile,
         reuse_key,
         history_generation_run_id,
-        runner_preference,
-        runner_preference_resolution,
+        runner_preference_context: parsed_preference.context,
     })
 }
 
@@ -1214,7 +1209,9 @@ impl AblyDisconnectState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::RunnerPreferenceReason;
+    use crate::provider::{
+        RunnerPreferenceAdmission, RunnerPreferenceResolution, RunnerPreferenceTier,
+    };
 
     fn make_message(name: Option<&str>, data: serde_json::Value) -> ably_subscriber::Message {
         ably_subscriber::Message {
@@ -2007,13 +2004,22 @@ mod tests {
                 "profile": "vm0/default",
                 "reuseKey": "thread:chat-thread",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
-                "runnerPreferenceResolution": "matching_reusable_sandbox",
-                "runnerPreference": {
+                "runnerPreferenceDecision": {
+                    "kind": "preference",
                     "runnerIdentity": {
                         "runnerId": "00000000-0000-0000-0000-000000000005",
                         "heartbeatGeneration": 7
                     },
-                    "reason": "matchingReuseKey",
+                    "tier": "reusableSandbox",
+                    "expiresAt": "2999-01-01T00:00:00.000Z"
+                },
+                "runnerPreferenceResolution": "matching_workspace_cache",
+                "runnerPreference": {
+                    "runnerIdentity": {
+                        "runnerId": "00000000-0000-0000-0000-000000000099",
+                        "heartbeatGeneration": 9
+                    },
+                    "reason": "exactHistoryGeneration",
                     "expiresAt": "2999-01-01T00:00:00.000Z"
                 }
             }),
@@ -2037,8 +2043,8 @@ mod tests {
             .runner_preference()
             .expect("canonical preference should be parsed");
         assert_eq!(
-            preference.reason(),
-            RunnerPreferenceReason::MatchingReuseKey
+            preference.admission(),
+            RunnerPreferenceAdmission::Ranked(RunnerPreferenceTier::ReusableSandbox)
         );
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
         assert_eq!(
@@ -2054,7 +2060,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_optional_preference_preserves_direct_candidate() {
+    async fn malformed_atomic_and_bridge_preferences_preserve_direct_candidate() {
         let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
@@ -2072,6 +2078,15 @@ mod tests {
                 "runId": "00000000-0000-0000-0000-000000000011",
                 "profile": "vm0/default",
                 "reuseKey": "thread:malformed-preference",
+                "runnerPreferenceDecision": {
+                    "kind": "preference",
+                    "runnerIdentity": {
+                        "runnerId": "00000000-0000-0000-0000-000000000005",
+                        "heartbeatGeneration": 0
+                    },
+                    "tier": "workspaceCache",
+                    "expiresAt": "2999-01-01T00:00:00.000Z"
+                },
                 "runnerPreferenceResolution": "future_resolution",
                 "runnerPreference": {
                     "runnerIdentity": {
@@ -2095,6 +2110,64 @@ mod tests {
             candidate
                 .runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,)
                 .is_none()
+        );
+        assert_no_direct_candidate(&direct_candidates).await;
+    }
+
+    #[tokio::test]
+    async fn malformed_atomic_ably_decision_falls_back_to_valid_bridge() {
+        let tokens = RunCancellationRegistry::new();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000012",
+                "profile": "vm0/default",
+                "reuseKey": "thread:bridge-fallback",
+                "runnerPreferenceDecision": {
+                    "kind": "futureDecision"
+                },
+                "runnerPreferenceResolution": "matching_reusable_sandbox",
+                "runnerPreference": {
+                    "runnerIdentity": {
+                        "runnerId": "00000000-0000-0000-0000-000000000005",
+                        "heartbeatGeneration": 7
+                    },
+                    "reason": "matchingReuseKey",
+                    "expiresAt": "2999-01-01T00:00:00.000Z"
+                }
+            }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        let candidate = pop_direct_candidate(&direct_candidates)
+            .await
+            .into_job_candidate();
+        assert_eq!(
+            candidate
+                .runner_preference()
+                .map(crate::provider::RunnerPreference::admission),
+            Some(RunnerPreferenceAdmission::Legacy(
+                crate::provider::RunnerPreferenceReason::MatchingReuseKey
+            ))
+        );
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::MatchingReusableSandbox,
+                state: super::super::RunnerPreferenceClaimState::Active,
+                targeted_self: Some(true),
+            })
         );
         assert_no_direct_candidate(&direct_candidates).await;
     }

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -6,7 +6,9 @@ use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use super::{JobCandidate, JobDiscoverySource, RunnerPreference, RunnerPreferenceResolution};
+use super::{JobCandidate, JobDiscoverySource, RunnerPreferenceContext};
+#[cfg(test)]
+use super::{RunnerPreference, RunnerPreferenceResolution};
 use crate::ids::RunId;
 
 pub(super) const DIRECT_CANDIDATE_STALE_AFTER: Duration = Duration::from_secs(60);
@@ -19,8 +21,7 @@ pub(super) struct DirectJobCandidate {
     enqueued_at: Option<StdInstant>,
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
-    runner_preference: Option<RunnerPreference>,
-    runner_preference_resolution: Option<RunnerPreferenceResolution>,
+    runner_preference_context: Option<RunnerPreferenceContext>,
 }
 
 impl DirectJobCandidate {
@@ -56,7 +57,7 @@ impl DirectJobCandidate {
         profile_name: String,
         discovered_at: StdInstant,
         reuse_key: Option<String>,
-        runner_preference: Option<RunnerPreference>,
+        runner_preference_context: Option<RunnerPreferenceContext>,
     ) -> Self {
         Self {
             run_id,
@@ -65,8 +66,7 @@ impl DirectJobCandidate {
             enqueued_at: None,
             reuse_key,
             history_generation_run_id: None,
-            runner_preference,
-            runner_preference_resolution: None,
+            runner_preference_context,
         }
     }
 
@@ -102,11 +102,17 @@ impl DirectJobCandidate {
         self
     }
 
+    #[cfg(test)]
     pub(super) fn with_runner_preference_resolution(
         mut self,
         runner_preference_resolution: Option<RunnerPreferenceResolution>,
     ) -> Self {
-        self.runner_preference_resolution = runner_preference_resolution;
+        let runner_preference = self
+            .runner_preference_context
+            .take()
+            .and_then(|context| context.preference().cloned());
+        self.runner_preference_context =
+            RunnerPreferenceContext::legacy(runner_preference, runner_preference_resolution);
         self
     }
 
@@ -121,10 +127,7 @@ impl DirectJobCandidate {
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
             .with_reuse_key(self.reuse_key)
             .with_history_generation_run_id(self.history_generation_run_id)
-            .with_runner_preference_context(
-                self.runner_preference,
-                self.runner_preference_resolution,
-            )
+            .with_parsed_runner_preference_context(self.runner_preference_context)
             .with_discovery_source(JobDiscoverySource::Ably)
             .with_direct_candidate_timing(notification_to_enqueue_elapsed, inbox_wait_elapsed)
     }
@@ -139,19 +142,38 @@ impl DirectJobCandidate {
             );
             return;
         }
-        let preserve_existing = matches!(
-            (&self.runner_preference, &candidate.runner_preference),
-            (Some(existing), Some(candidate))
-                if existing.reason() == candidate.reason()
-                    && existing.deadline() < candidate.deadline()
-        );
+        if self
+            .runner_preference_context
+            .as_ref()
+            .is_some_and(RunnerPreferenceContext::is_atomic)
+        {
+            return;
+        }
+        let incoming_is_atomic = candidate
+            .runner_preference_context
+            .as_ref()
+            .is_some_and(RunnerPreferenceContext::is_atomic);
+        let preserve_existing = !incoming_is_atomic
+            && matches!(
+                (
+                    self.runner_preference_context
+                        .as_ref()
+                        .and_then(RunnerPreferenceContext::preference),
+                    candidate
+                        .runner_preference_context
+                        .as_ref()
+                        .and_then(RunnerPreferenceContext::preference),
+                ),
+                (Some(existing), Some(candidate))
+                    if existing.admission() == candidate.admission()
+                        && existing.deadline() < candidate.deadline()
+            );
         if preserve_existing {
             return;
         }
         self.reuse_key = candidate.reuse_key;
         self.history_generation_run_id = candidate.history_generation_run_id;
-        self.runner_preference = candidate.runner_preference;
-        self.runner_preference_resolution = candidate.runner_preference_resolution;
+        self.runner_preference_context = candidate.runner_preference_context;
     }
 }
 
@@ -407,8 +429,30 @@ mod tests {
         runner_id: u128,
         reason: super::super::RunnerPreferenceReason,
         deadline: StdInstant,
-    ) -> RunnerPreference {
-        RunnerPreference::for_test(uuid::Uuid::from_u128(runner_id), 7, reason, deadline)
+    ) -> RunnerPreferenceContext {
+        RunnerPreferenceContext::legacy(
+            Some(RunnerPreference::for_test(
+                uuid::Uuid::from_u128(runner_id),
+                7,
+                reason,
+                deadline,
+            )),
+            None,
+        )
+        .unwrap()
+    }
+
+    fn ranked_preference_context(
+        runner_id: u128,
+        tier: super::super::RunnerPreferenceTier,
+        deadline: StdInstant,
+    ) -> RunnerPreferenceContext {
+        RunnerPreferenceContext::atomic_for_test(RunnerPreference::ranked_for_test(
+            uuid::Uuid::from_u128(runner_id),
+            7,
+            tier,
+            deadline,
+        ))
     }
 
     fn candidate_with_enqueued_at(run_id: RunId, enqueued_at: StdInstant) -> DirectJobCandidate {
@@ -523,8 +567,10 @@ mod tests {
             .runner_preference()
             .expect("updated canonical preference");
         assert_eq!(
-            preference.reason(),
-            super::super::RunnerPreferenceReason::ExactHistoryGeneration
+            preference.admission(),
+            super::super::RunnerPreferenceAdmission::Legacy(
+                super::super::RunnerPreferenceReason::ExactHistoryGeneration
+            )
         );
         assert_eq!(preference.deadline(), exact_deadline);
         assert!(preference.targets(&uuid::Uuid::from_u128(20).to_string(), 7));
@@ -599,6 +645,149 @@ mod tests {
                 state: super::super::RunnerPreferenceClaimState::Absent,
                 targeted_self: None,
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_retains_first_atomic_routing_snapshot_and_deadline() {
+        let inbox = direct_candidate_inbox(1);
+        let candidate_run_id = run_id(5);
+        let first_history_generation = run_id(6);
+        let first_deadline = StdInstant::now() + Duration::from_secs(5);
+        inbox
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    candidate_run_id,
+                    "vm0/default".to_string(),
+                    StdInstant::now(),
+                    Some("session:first-atomic".to_string()),
+                    Some(ranked_preference_context(
+                        10,
+                        super::super::RunnerPreferenceTier::WorkspaceCache,
+                        first_deadline,
+                    )),
+                )
+                .with_history_generation_run_id(Some(first_history_generation)),
+            )
+            .await;
+
+        inbox
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    candidate_run_id,
+                    "vm0/default".to_string(),
+                    StdInstant::now(),
+                    Some("session:must-not-replace".to_string()),
+                    Some(ranked_preference_context(
+                        20,
+                        super::super::RunnerPreferenceTier::ExactSandbox,
+                        StdInstant::now() + Duration::from_secs(30),
+                    )),
+                )
+                .with_history_generation_run_id(Some(run_id(7))),
+            )
+            .await;
+
+        inbox
+            .push(DirectJobCandidate::new_with_routing_metadata(
+                candidate_run_id,
+                "vm0/default".to_string(),
+                StdInstant::now(),
+                None,
+                Some(RunnerPreferenceContext::atomic_negative(
+                    RunnerPreferenceResolution::NoViableHolder,
+                )),
+            ))
+            .await;
+
+        let candidate = inbox
+            .try_pop()
+            .await
+            .expect("retained direct candidate")
+            .into_job_candidate();
+        assert_eq!(candidate.reuse_key(), Some("session:first-atomic"));
+        assert_eq!(
+            candidate.history_generation_run_id(),
+            Some(first_history_generation)
+        );
+        let preference = candidate.runner_preference().expect("atomic preference");
+        assert_eq!(
+            preference.admission(),
+            super::super::RunnerPreferenceAdmission::Ranked(
+                super::super::RunnerPreferenceTier::WorkspaceCache
+            )
+        );
+        assert_eq!(preference.deadline(), first_deadline);
+        assert!(preference.targets(&uuid::Uuid::from_u128(10).to_string(), 7));
+        assert_eq!(
+            candidate.runner_preference_claim_telemetry(&uuid::Uuid::from_u128(10).to_string(), 7,),
+            Some(super::super::RunnerPreferenceClaimTelemetry {
+                resolution: RunnerPreferenceResolution::MatchingWorkspaceCache,
+                state: super::super::RunnerPreferenceClaimState::Active,
+                targeted_self: Some(true),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn first_atomic_duplicate_replaces_legacy_routing_snapshot_as_a_unit() {
+        let inbox = direct_candidate_inbox(1);
+        let candidate_run_id = run_id(8);
+        inbox
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    candidate_run_id,
+                    "vm0/default".to_string(),
+                    StdInstant::now(),
+                    Some("session:legacy".to_string()),
+                    Some(runner_preference(
+                        10,
+                        super::super::RunnerPreferenceReason::MatchingReuseKey,
+                        StdInstant::now() + Duration::from_secs(5),
+                    )),
+                )
+                .with_runner_preference_resolution(Some(
+                    RunnerPreferenceResolution::MatchingReusableSandbox,
+                ))
+                .with_history_generation_run_id(Some(run_id(9))),
+            )
+            .await;
+
+        let atomic_history_generation = run_id(10);
+        inbox
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    candidate_run_id,
+                    "vm0/default".to_string(),
+                    StdInstant::now(),
+                    Some("session:atomic".to_string()),
+                    Some(ranked_preference_context(
+                        20,
+                        super::super::RunnerPreferenceTier::ExactSandbox,
+                        StdInstant::now() + Duration::from_secs(8),
+                    )),
+                )
+                .with_history_generation_run_id(Some(atomic_history_generation)),
+            )
+            .await;
+
+        let candidate = inbox
+            .try_pop()
+            .await
+            .expect("updated direct candidate")
+            .into_job_candidate();
+        assert_eq!(candidate.reuse_key(), Some("session:atomic"));
+        assert_eq!(
+            candidate.history_generation_run_id(),
+            Some(atomic_history_generation)
+        );
+        assert_eq!(
+            candidate
+                .runner_preference()
+                .map(RunnerPreference::admission),
+            Some(super::super::RunnerPreferenceAdmission::Ranked(
+                super::super::RunnerPreferenceTier::ExactSandbox
+            ))
         );
     }
 

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -44,6 +44,55 @@ pub(crate) enum RunnerPreferenceReason {
     FinalizingPredecessor,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum RunnerPreferenceTier {
+    ExactSandbox,
+    FinalizingPredecessor,
+    ReusableSandbox,
+    WorkspaceCache,
+}
+
+impl RunnerPreferenceTier {
+    pub(crate) fn rank(self) -> u8 {
+        match self {
+            Self::WorkspaceCache => 1,
+            Self::ReusableSandbox => 2,
+            Self::FinalizingPredecessor => 3,
+            Self::ExactSandbox => 4,
+        }
+    }
+
+    fn resolution(self) -> RunnerPreferenceResolution {
+        match self {
+            Self::ExactSandbox => RunnerPreferenceResolution::ExactHistoryGeneration,
+            Self::FinalizingPredecessor => RunnerPreferenceResolution::FinalizingPredecessor,
+            Self::ReusableSandbox => RunnerPreferenceResolution::MatchingReusableSandbox,
+            Self::WorkspaceCache => RunnerPreferenceResolution::MatchingWorkspaceCache,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum RunnerNoPreferenceReason {
+    NoReuseKey,
+    Expired,
+    NoViableHolder,
+    LookupError,
+}
+
+impl RunnerNoPreferenceReason {
+    fn resolution(self) -> RunnerPreferenceResolution {
+        match self {
+            Self::NoReuseKey => RunnerPreferenceResolution::NoReuseKey,
+            Self::Expired => RunnerPreferenceResolution::Expired,
+            Self::NoViableHolder => RunnerPreferenceResolution::NoViableHolder,
+            Self::LookupError => RunnerPreferenceResolution::LookupError,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum RunnerPreferenceResolution {
@@ -109,16 +158,37 @@ struct RunnerPreferencePayload {
     expires_at: DateTime<FixedOffset>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", deny_unknown_fields)]
+enum RunnerPreferenceDecisionPayload {
+    #[serde(rename = "preference")]
+    Preference {
+        #[serde(rename = "runnerIdentity")]
+        runner_identity: RunnerProcessIdentity,
+        tier: RunnerPreferenceTier,
+        #[serde(rename = "expiresAt")]
+        expires_at: DateTime<FixedOffset>,
+    },
+    #[serde(rename = "noPreference")]
+    NoPreference { reason: RunnerNoPreferenceReason },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RunnerPreferenceAdmission {
+    Ranked(RunnerPreferenceTier),
+    Legacy(RunnerPreferenceReason),
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RunnerPreference {
     runner_identity: RunnerProcessIdentity,
-    reason: RunnerPreferenceReason,
+    admission: RunnerPreferenceAdmission,
     deadline: Instant,
 }
 
 impl RunnerPreference {
-    pub(crate) fn reason(&self) -> RunnerPreferenceReason {
-        self.reason
+    pub(crate) fn admission(&self) -> RunnerPreferenceAdmission {
+        self.admission
     }
 
     pub(crate) fn deadline(&self) -> Instant {
@@ -150,7 +220,24 @@ impl RunnerPreference {
                 runner_id,
                 heartbeat_generation,
             },
-            reason,
+            admission: RunnerPreferenceAdmission::Legacy(reason),
+            deadline,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ranked_for_test(
+        runner_id: Uuid,
+        heartbeat_generation: u64,
+        tier: RunnerPreferenceTier,
+        deadline: Instant,
+    ) -> Self {
+        Self {
+            runner_identity: RunnerProcessIdentity {
+                runner_id,
+                heartbeat_generation,
+            },
+            admission: RunnerPreferenceAdmission::Ranked(tier),
             deadline,
         }
     }
@@ -172,18 +259,86 @@ pub(crate) fn parse_runner_preference(
         return Ok(None);
     };
     let payload: RunnerPreferencePayload = serde_json::from_value(value)?;
-    let now = Instant::now();
-    let remaining = (payload.expires_at.with_timezone(&Utc) - Utc::now())
-        .to_std()
-        .unwrap_or_default();
-    let deadline = now
-        .checked_add(remaining)
-        .ok_or_else(|| serde_json::Error::custom("runner preference expiry is out of range"))?;
     Ok(Some(RunnerPreference {
         runner_identity: payload.runner_identity,
-        reason: payload.reason,
-        deadline,
+        admission: RunnerPreferenceAdmission::Legacy(payload.reason),
+        deadline: preference_deadline(payload.expires_at)?,
     }))
+}
+
+pub(crate) fn parse_runner_preference_decision(
+    value: Option<serde_json::Value>,
+) -> Result<Option<RunnerPreferenceContext>, serde_json::Error> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let payload: RunnerPreferenceDecisionPayload = serde_json::from_value(value)?;
+    let context = match payload {
+        RunnerPreferenceDecisionPayload::Preference {
+            runner_identity,
+            tier,
+            expires_at,
+        } => RunnerPreferenceContext::atomic_positive(
+            runner_identity,
+            tier,
+            preference_deadline(expires_at)?,
+        ),
+        RunnerPreferenceDecisionPayload::NoPreference { reason } => {
+            RunnerPreferenceContext::atomic_negative(reason.resolution())
+        }
+    };
+    Ok(Some(context))
+}
+
+pub(crate) struct ParsedRunnerPreferenceContext {
+    pub(crate) context: Option<RunnerPreferenceContext>,
+    pub(crate) decision_error: Option<serde_json::Error>,
+    pub(crate) legacy_preference_error: Option<serde_json::Error>,
+    pub(crate) legacy_resolution_error: Option<serde_json::Error>,
+}
+
+pub(crate) fn parse_runner_preference_context(
+    decision: Option<serde_json::Value>,
+    legacy_preference: Option<serde_json::Value>,
+    legacy_resolution: Option<serde_json::Value>,
+) -> ParsedRunnerPreferenceContext {
+    let decision_error = match parse_runner_preference_decision(decision) {
+        Ok(Some(context)) => {
+            return ParsedRunnerPreferenceContext {
+                context: Some(context),
+                decision_error: None,
+                legacy_preference_error: None,
+                legacy_resolution_error: None,
+            };
+        }
+        Ok(None) => None,
+        Err(error) => Some(error),
+    };
+
+    let (preference, legacy_preference_error) = match parse_runner_preference(legacy_preference) {
+        Ok(preference) => (preference, None),
+        Err(error) => (None, Some(error)),
+    };
+    let (resolution, legacy_resolution_error) =
+        match parse_runner_preference_resolution(legacy_resolution) {
+            Ok(resolution) => (resolution, None),
+            Err(error) => (None, Some(error)),
+        };
+    ParsedRunnerPreferenceContext {
+        context: RunnerPreferenceContext::legacy(preference, resolution),
+        decision_error,
+        legacy_preference_error,
+        legacy_resolution_error,
+    }
+}
+
+fn preference_deadline(expires_at: DateTime<FixedOffset>) -> Result<Instant, serde_json::Error> {
+    let now = Instant::now();
+    let remaining = (expires_at.with_timezone(&Utc) - Utc::now())
+        .to_std()
+        .unwrap_or_default();
+    now.checked_add(remaining)
+        .ok_or_else(|| serde_json::Error::custom("runner preference expiry is out of range"))
 }
 
 fn deserialize_heartbeat_generation<'de, D>(deserializer: D) -> Result<u64, D::Error>
@@ -212,7 +367,7 @@ pub(crate) enum JobDiscoverySource {
 /// observation must continue to follow the selected candidate and must never
 /// influence admission itself.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct RunnerPreferenceObservation {
+pub(crate) struct RunnerPreferenceObservation {
     resolution: RunnerPreferenceResolution,
     runner_identity: Option<RunnerProcessIdentity>,
     removal_reason: Option<RunnerPreferenceRemovalReason>,
@@ -221,12 +376,116 @@ struct RunnerPreferenceObservation {
 impl RunnerPreferenceObservation {
     fn new(
         resolution: RunnerPreferenceResolution,
-        runner_preference: Option<&RunnerPreference>,
+        runner_identity: Option<RunnerProcessIdentity>,
     ) -> Self {
         Self {
             resolution,
-            runner_identity: runner_preference.map(|preference| preference.runner_identity),
+            runner_identity,
             removal_reason: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RunnerPreferenceContext {
+    Atomic {
+        preference: Option<RunnerPreference>,
+        observation: RunnerPreferenceObservation,
+    },
+    Legacy {
+        preference: Option<RunnerPreference>,
+        observation: Option<RunnerPreferenceObservation>,
+    },
+}
+
+impl RunnerPreferenceContext {
+    fn atomic_positive(
+        runner_identity: RunnerProcessIdentity,
+        tier: RunnerPreferenceTier,
+        deadline: Instant,
+    ) -> Self {
+        Self::Atomic {
+            preference: Some(RunnerPreference {
+                runner_identity,
+                admission: RunnerPreferenceAdmission::Ranked(tier),
+                deadline,
+            }),
+            observation: RunnerPreferenceObservation::new(tier.resolution(), Some(runner_identity)),
+        }
+    }
+
+    fn atomic_negative(resolution: RunnerPreferenceResolution) -> Self {
+        Self::Atomic {
+            preference: None,
+            observation: RunnerPreferenceObservation::new(resolution, None),
+        }
+    }
+
+    pub(crate) fn legacy(
+        preference: Option<RunnerPreference>,
+        resolution: Option<RunnerPreferenceResolution>,
+    ) -> Option<Self> {
+        if preference.is_none() && resolution.is_none() {
+            return None;
+        }
+        let runner_identity = preference
+            .as_ref()
+            .map(|preference| preference.runner_identity);
+        Some(Self::Legacy {
+            preference,
+            observation: resolution
+                .map(|resolution| RunnerPreferenceObservation::new(resolution, runner_identity)),
+        })
+    }
+
+    pub(crate) fn preference(&self) -> Option<&RunnerPreference> {
+        match self {
+            Self::Atomic { preference, .. } | Self::Legacy { preference, .. } => {
+                preference.as_ref()
+            }
+        }
+    }
+
+    fn preference_mut(&mut self) -> &mut Option<RunnerPreference> {
+        match self {
+            Self::Atomic { preference, .. } | Self::Legacy { preference, .. } => preference,
+        }
+    }
+
+    fn observation(&self) -> Option<RunnerPreferenceObservation> {
+        match self {
+            Self::Atomic { observation, .. } => Some(*observation),
+            Self::Legacy { observation, .. } => *observation,
+        }
+    }
+
+    fn observation_mut(&mut self) -> Option<&mut RunnerPreferenceObservation> {
+        match self {
+            Self::Atomic { observation, .. } => Some(observation),
+            Self::Legacy { observation, .. } => observation.as_mut(),
+        }
+    }
+
+    pub(crate) fn is_atomic(&self) -> bool {
+        matches!(self, Self::Atomic { .. })
+    }
+
+    fn remove_preference(&mut self, removal_reason: RunnerPreferenceRemovalReason) {
+        *self.preference_mut() = None;
+        if let Some(observation) = self.observation_mut() {
+            observation.removal_reason = Some(removal_reason);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn atomic_for_test(preference: RunnerPreference) -> Self {
+        let RunnerPreferenceAdmission::Ranked(tier) = preference.admission else {
+            panic!("atomic test preference must be ranked");
+        };
+        let runner_identity = preference.runner_identity;
+        Self::Atomic {
+            preference: Some(preference),
+            observation: RunnerPreferenceObservation::new(tier.resolution(), Some(runner_identity)),
         }
     }
 }
@@ -267,8 +526,7 @@ pub struct JobCandidate {
     poll_http_request_elapsed: Option<Duration>,
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
-    runner_preference: Option<RunnerPreference>,
-    runner_preference_observation: Option<RunnerPreferenceObservation>,
+    runner_preference_context: Option<RunnerPreferenceContext>,
 }
 
 impl JobCandidate {
@@ -299,8 +557,7 @@ impl JobCandidate {
             poll_http_request_elapsed: None,
             reuse_key: None,
             history_generation_run_id: None,
-            runner_preference: None,
-            runner_preference_observation: None,
+            runner_preference_context: None,
         }
     }
 
@@ -395,16 +652,17 @@ impl JobCandidate {
     }
 
     pub(crate) fn runner_preference(&self) -> Option<&RunnerPreference> {
-        self.runner_preference.as_ref()
+        self.runner_preference_context
+            .as_ref()
+            .and_then(RunnerPreferenceContext::preference)
     }
 
     pub(crate) fn without_runner_preference(
         mut self,
         removal_reason: RunnerPreferenceRemovalReason,
     ) -> Self {
-        self.runner_preference = None;
-        if let Some(observation) = &mut self.runner_preference_observation {
-            observation.removal_reason = Some(removal_reason);
+        if let Some(context) = &mut self.runner_preference_context {
+            context.remove_preference(removal_reason);
         }
         self
     }
@@ -414,15 +672,28 @@ impl JobCandidate {
         self
     }
 
+    #[cfg(test)]
     pub(crate) fn with_runner_preference_context(
         mut self,
         runner_preference: Option<RunnerPreference>,
         resolution: Option<RunnerPreferenceResolution>,
     ) -> Self {
-        self.runner_preference_observation = resolution.map(|resolution| {
-            RunnerPreferenceObservation::new(resolution, runner_preference.as_ref())
-        });
-        self.runner_preference = runner_preference;
+        self.runner_preference_context =
+            RunnerPreferenceContext::legacy(runner_preference, resolution);
+        self
+    }
+
+    pub(crate) fn with_parsed_runner_preference_context(
+        mut self,
+        context: Option<RunnerPreferenceContext>,
+    ) -> Self {
+        self.runner_preference_context = context;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_atomic_runner_preference(mut self, preference: RunnerPreference) -> Self {
+        self.runner_preference_context = Some(RunnerPreferenceContext::atomic_for_test(preference));
         self
     }
 
@@ -439,8 +710,9 @@ impl JobCandidate {
         runner_id: &str,
         heartbeat_generation: u64,
     ) -> Option<RunnerPreferenceClaimTelemetry> {
-        let observation = self.runner_preference_observation?;
-        let state = match &self.runner_preference {
+        let context = self.runner_preference_context.as_ref()?;
+        let observation = context.observation()?;
+        let state = match context.preference() {
             Some(preference) if preference.is_expired() => RunnerPreferenceClaimState::Expired,
             Some(_) => RunnerPreferenceClaimState::Active,
             None => match observation.removal_reason {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -39,6 +39,8 @@ pub struct Job {
     #[serde(default)]
     pub history_generation_run_id: Option<RunId>,
     #[serde(default)]
+    pub runner_preference_decision: Option<serde_json::Value>,
+    #[serde(default)]
     pub runner_preference: Option<serde_json::Value>,
     #[serde(default)]
     pub runner_preference_resolution: Option<serde_json::Value>,


### PR DESCRIPTION
## Summary

- consume the atomic runner preference decision through both Poll and Ably, with legacy bridge fallback during mixed-version deployment
- enforce selected equal-or-better and unselected strictly-better admission using real sandbox reservations or compatible workspace state plus fresh budget
- retain one immutable atomic routing snapshot across duplicate Ably delivery and preserve the current unclaimed finalizing behavior

## Scope

- leaves the claim API unchanged
- defers claimed waiting for finalizing predecessors to #25576
- leaves production conversion and latency validation on parent #25508

## Validation

- `cargo test -p runner --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`

Closes #25575

Parent: #25508
