### PR TITLE
fix(python): classify sse from exact media type

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -91,6 +91,12 @@ def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
     return flow_metadata.cli_agent_type(flow.metadata) == "codex"
 
 
+def _response_has_event_stream_media_type(response: http.Response) -> bool:
+    content_type = response.headers.get("content-type", "")
+    media_type = content_type.partition(";")[0].strip(_HTTP_OWS_CHARS).lower()
+    return media_type == "text/event-stream"
+
+
 def uses_model_json_fallback(flow: http.HTTPFlow) -> bool:
     """Return whether terminal model usage may parse a buffered JSON body."""
     response = flow.response
@@ -100,8 +106,7 @@ def uses_model_json_fallback(flow: http.HTTPFlow) -> bool:
         or not usage.is_model_provider_usage_observable(flow)
     ):
         return False
-    content_type = response.headers.get("content-type", "").lower()
-    if "text/event-stream" in content_type:
+    if _response_has_event_stream_media_type(response):
         return False
     return not _is_confirmed_websocket_upgrade_response(flow)
 
@@ -231,8 +236,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return _ResponseUsageStreamSetup(None, False)
     if is_observable_model_provider:
-        content_type = response.headers.get("content-type", "").lower()
-        if "text/event-stream" in content_type:
+        if _response_has_event_stream_media_type(response):
             lifecycle_observer: _AnthropicLifecycleObserver | None = None
             anthropic_accounting_events: set[str] = set()
             openai_recoverable_usage: dict = {}

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -15,6 +15,40 @@ from tests.x_flow_helpers import make_x_response_flow
 class TestResponseHeadersModelJsonParser:
     """Tests for model-provider JSON parser setup in responseheaders()."""
 
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            'application/json; profile="text/event-stream"',
+            "application/text/event-stream+json",
+        ],
+    )
+    def test_non_sse_media_type_uses_json_parser(self, real_flow, content_type):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": content_type}),
+        )
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+
+        mitm_addon.responseheaders(flow)
+
+        assert response_streaming.uses_model_json_fallback(flow)
+        assert "model_json_usage_finish" in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
+        body = b'{"model":"gpt-5.5","usage":{"input_tokens":12,"output_tokens":7}}'
+        assert response_stream(flow)(body) == body
+
+        response_streaming.finalize_model_json_usage(flow, "")
+
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
+            "model": "gpt-5.5",
+            "tokens.input": 12,
+            "tokens.output": 7,
+        }
+
     def test_brotli_model_json_skips_incremental_parser(self, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
@@ -71,7 +105,7 @@ class TestResponseHeadersSseParser:
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.response = tutils.tresp(
             status_code=200,
-            headers=header_map({"content-type": "Text/Event-Stream"}),
+            headers=header_map({"content-type": "Text/Event-Stream; Charset=UTF-8"}),
         )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
         flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -19,7 +19,7 @@ class TestResponseHeadersModelJsonParser:
         "content_type",
         [
             'application/json; profile="text/event-stream"',
-            "application/text/event-stream+json",
+            "text/event-stream+json",
         ],
     )
     def test_non_sse_media_type_uses_json_parser(self, real_flow, content_type):


### PR DESCRIPTION
## Summary

- classify model-provider SSE responses from the exact normalized media type
- share the classification between parser setup and JSON fallback eligibility
- cover misleading `Content-Type` parameters and subtypes through the real response hook and JSON usage finalization path
- preserve case-insensitive, parameterized `text/event-stream` handling

## Exclusions

- no API, schema, persisted-data, or runner protocol changes
- no general-purpose MIME parser or new flow metadata state

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_response_parser_setup.py` (18 passed)
- `uv run --no-sync python -m pytest tests/` (4957 passed)

Closes #25615
