### PR TITLE
fix(runner): isolate pi standby notifications by run

### DIFF
--- a/crates/runner/src/executor/pi_standby.rs
+++ b/crates/runner/src/executor/pi_standby.rs
@@ -24,7 +24,7 @@ impl PiStandbyForwarder {
         control: Option<GuestProcessControlHandle>,
         job_cancel: CancellationToken,
     ) -> Option<Self> {
-        let (Some(mut source), Some(control)) = (source, control) else {
+        let (Some(source), Some(control)) = (source, control) else {
             return None;
         };
         let stop = CancellationToken::new();
@@ -35,6 +35,9 @@ impl PiStandbyForwarder {
                 () = task_stop.cancelled() => return,
                 () = job_cancel.cancelled() => return,
                 signal = source.wait() => signal,
+            };
+            let Some(signal) = signal else {
+                return;
             };
             let payload = match signal {
                 PiStandbySignal::Handoff => br#"{"type":"pi-handoff"}"#.as_slice(),

--- a/crates/runner/src/executor/pi_standby.rs
+++ b/crates/runner/src/executor/pi_standby.rs
@@ -70,3 +70,41 @@ impl PiStandbyForwarder {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use sandbox::ProcessControlAck;
+
+    use super::*;
+    use crate::pi_standby::PiStandbyNotifications;
+
+    #[tokio::test]
+    async fn superseded_source_does_not_send_guest_control() {
+        let notifications = PiStandbyNotifications::new();
+        let run_id = RunId::new_v4();
+        let source = notifications.subscribe(run_id);
+        let _replacement = notifications.subscribe(run_id);
+        let control_called = Arc::new(AtomicBool::new(false));
+        let task_control_called = Arc::clone(&control_called);
+        let control = GuestProcessControlHandle::new(move |message_id, _, _| {
+            task_control_called.store(true, Ordering::SeqCst);
+            Box::pin(async move { Ok(ProcessControlAck { message_id }) })
+        });
+        let forwarder = PiStandbyForwarder::start(
+            run_id,
+            Some(source),
+            Some(control),
+            CancellationToken::new(),
+        )
+        .expect("complete Pi standby controls should start a forwarder");
+        let PiStandbyForwarder { task, .. } = forwarder;
+
+        task.await
+            .expect("Pi standby forwarder should exit cleanly");
+
+        assert!(!control_called.load(Ordering::SeqCst));
+    }
+}

--- a/crates/runner/src/pi_standby.rs
+++ b/crates/runner/src/pi_standby.rs
@@ -153,6 +153,7 @@ impl PiStandbyNotifications {
 }
 
 impl PiStandbySubscription {
+    /// Returns `None` when a newer subscription replaces this registration.
     pub(crate) async fn wait(mut self) -> Option<PiStandbySignal> {
         let result = (&mut self.receiver).await;
         match result {

--- a/crates/runner/src/pi_standby.rs
+++ b/crates/runner/src/pi_standby.rs
@@ -298,6 +298,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn closed_receiver_returns_failed_delivery_to_pending() {
+        let notifications = PiStandbyNotifications::new();
+        let run_id = RunId::new_v4();
+        let mut subscription = notifications.subscribe(run_id);
+        subscription.receiver.close();
+
+        notifications.notify(run_id, PiStandbySignal::Release);
+        drop(subscription);
+
+        assert_eq!(
+            notifications.subscribe(run_id).wait().await,
+            Some(PiStandbySignal::Release)
+        );
+    }
+
+    #[tokio::test]
     async fn superseded_subscription_finishes_without_signal() {
         let notifications = PiStandbyNotifications::new();
         let run_id = RunId::new_v4();

--- a/crates/runner/src/pi_standby.rs
+++ b/crates/runner/src/pi_standby.rs
@@ -1,11 +1,11 @@
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
-use tokio::sync::broadcast;
+use tokio::sync::oneshot;
 
 use crate::ids::RunId;
 
-const PI_STANDBY_NOTIFICATION_CAPACITY: usize = 256;
+const PI_STANDBY_PENDING_CAPACITY: usize = 256;
 
 /// Control actions for a claimed Pi standby run. Release is intentionally
 /// distinct from cancellation: it retires unused prewarm capacity without
@@ -16,22 +16,33 @@ pub(crate) enum PiStandbySignal {
     Release,
 }
 
-#[derive(Clone, Copy, Debug)]
-struct PiStandbyNotification {
-    run_id: RunId,
-    signal: PiStandbySignal,
+enum PiStandbyDelivery {
+    Signal(PiStandbySignal),
+    Superseded,
 }
 
 #[derive(Clone)]
 pub(crate) struct PiStandbyNotifications {
-    sender: broadcast::Sender<PiStandbyNotification>,
-    pending: Arc<Mutex<PendingPiStandbyNotifications>>,
+    state: Arc<Mutex<PiStandbyNotificationState>>,
 }
 
 pub(crate) struct PiStandbySubscription {
     run_id: RunId,
-    receiver: broadcast::Receiver<PiStandbyNotification>,
-    pending: Arc<Mutex<PendingPiStandbyNotifications>>,
+    registration_id: u64,
+    receiver: oneshot::Receiver<PiStandbyDelivery>,
+    state: Weak<Mutex<PiStandbyNotificationState>>,
+}
+
+#[derive(Default)]
+struct PiStandbyNotificationState {
+    active_waiters: HashMap<RunId, ActivePiStandbyWaiter>,
+    pending: PendingPiStandbyNotifications,
+    next_registration_id: u64,
+}
+
+struct ActivePiStandbyWaiter {
+    registration_id: u64,
+    sender: oneshot::Sender<PiStandbyDelivery>,
 }
 
 #[derive(Default)]
@@ -46,7 +57,7 @@ impl PendingPiStandbyNotifications {
             self.order.push_back(run_id);
         }
         self.signals.insert(run_id, signal);
-        while self.signals.len() > PI_STANDBY_NOTIFICATION_CAPACITY {
+        while self.signals.len() > PI_STANDBY_PENDING_CAPACITY {
             let Some(expired_run_id) = self.order.pop_front() else {
                 break;
             };
@@ -63,60 +74,115 @@ impl PendingPiStandbyNotifications {
     }
 }
 
+impl PiStandbyNotificationState {
+    fn next_registration_id(&mut self) -> u64 {
+        self.next_registration_id += 1;
+        self.next_registration_id
+    }
+
+    fn deliver_or_cache(&mut self, run_id: RunId, signal: PiStandbySignal) {
+        let Some(waiter) = self.active_waiters.remove(&run_id) else {
+            self.pending.insert(run_id, signal);
+            return;
+        };
+        if waiter
+            .sender
+            .send(PiStandbyDelivery::Signal(signal))
+            .is_err()
+        {
+            self.pending.insert(run_id, signal);
+        }
+    }
+
+    fn remove_waiter(&mut self, run_id: RunId, registration_id: u64) {
+        if self
+            .active_waiters
+            .get(&run_id)
+            .is_some_and(|waiter| waiter.registration_id == registration_id)
+        {
+            self.active_waiters.remove(&run_id);
+        }
+    }
+}
+
 impl PiStandbyNotifications {
     pub(crate) fn new() -> Self {
-        let (sender, receiver) = broadcast::channel(PI_STANDBY_NOTIFICATION_CAPACITY);
-        drop(receiver);
         Self {
-            sender,
-            pending: Arc::new(Mutex::new(PendingPiStandbyNotifications::default())),
+            state: Arc::new(Mutex::new(PiStandbyNotificationState::default())),
         }
     }
 
     pub(crate) fn subscribe(&self, run_id: RunId) -> PiStandbySubscription {
+        let (sender, receiver) = oneshot::channel();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let registration_id = state.next_registration_id();
+        let superseded = if let Some(signal) = state.pending.take(run_id) {
+            let _ = sender.send(PiStandbyDelivery::Signal(signal));
+            None
+        } else {
+            state.active_waiters.insert(
+                run_id,
+                ActivePiStandbyWaiter {
+                    registration_id,
+                    sender,
+                },
+            )
+        };
+        drop(state);
+        if let Some(waiter) = superseded {
+            let _ = waiter.sender.send(PiStandbyDelivery::Superseded);
+        }
+
         PiStandbySubscription {
             run_id,
-            receiver: self.sender.subscribe(),
-            pending: Arc::clone(&self.pending),
+            registration_id,
+            receiver,
+            state: Arc::downgrade(&self.state),
         }
     }
 
     pub(crate) fn notify(&self, run_id: RunId, signal: PiStandbySignal) {
-        self.pending
+        self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(run_id, signal);
-        let _ = self.sender.send(PiStandbyNotification { run_id, signal });
+            .deliver_or_cache(run_id, signal);
     }
 }
 
 impl PiStandbySubscription {
-    fn take_pending(&self) -> Option<PiStandbySignal> {
-        self.pending
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take(self.run_id)
-    }
-
-    pub(crate) async fn wait(&mut self) -> PiStandbySignal {
-        if let Some(signal) = self.take_pending() {
-            return signal;
+    pub(crate) async fn wait(mut self) -> Option<PiStandbySignal> {
+        let result = (&mut self.receiver).await;
+        match result {
+            Ok(PiStandbyDelivery::Signal(signal)) => Some(signal),
+            Ok(PiStandbyDelivery::Superseded) => None,
+            // Subscriptions hold a weak state reference, so closure means the
+            // final notification owner has gone away.
+            Err(_) => Some(PiStandbySignal::Release),
         }
-        loop {
-            match self.receiver.recv().await {
-                Ok(notification) if notification.run_id == self.run_id => {
-                    return self.take_pending().unwrap_or(notification.signal);
-                }
-                Ok(_) => {}
-                // A lagged standby must re-read the durable transcript. Treat
-                // the wakeup as handoff; the zero agent decides from API state
-                // whether a pending tool batch actually exists.
-                Err(broadcast::error::RecvError::Lagged(_)) => {
-                    return self.take_pending().unwrap_or(PiStandbySignal::Handoff);
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    return self.take_pending().unwrap_or(PiStandbySignal::Release);
-                }
+    }
+}
+
+impl Drop for PiStandbySubscription {
+    fn drop(&mut self) {
+        // Close before locking so a concurrent sender either fails and caches
+        // the signal or leaves it here for this subscription to recover.
+        self.receiver.close();
+        let delivery = self.receiver.try_recv().ok();
+        let Some(state) = self.state.upgrade() else {
+            return;
+        };
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match delivery {
+            Some(PiStandbyDelivery::Signal(signal)) => {
+                state.deliver_or_cache(self.run_id, signal);
+            }
+            Some(PiStandbyDelivery::Superseded) | None => {
+                state.remove_waiter(self.run_id, self.registration_id);
             }
         }
     }
@@ -124,18 +190,47 @@ impl PiStandbySubscription {
 
 #[cfg(test)]
 mod tests {
+    use std::task::Poll;
+
+    use futures_util::poll;
+
     use super::*;
 
     #[tokio::test]
-    async fn subscription_filters_other_runs_and_preserves_release_semantics() {
-        let notifications = PiStandbyNotifications::new();
-        let run_id = RunId::new_v4();
-        let mut subscription = notifications.subscribe(run_id);
+    async fn unrelated_notifications_do_not_resolve_subscription() {
+        for signal in [PiStandbySignal::Handoff, PiStandbySignal::Release] {
+            let notifications = PiStandbyNotifications::new();
+            let run_id = RunId::new_v4();
+            let subscription = notifications.subscribe(run_id);
 
-        notifications.notify(RunId::new_v4(), PiStandbySignal::Handoff);
-        notifications.notify(run_id, PiStandbySignal::Release);
+            for _ in 0..=PI_STANDBY_PENDING_CAPACITY {
+                notifications.notify(RunId::new_v4(), PiStandbySignal::Handoff);
+            }
 
-        assert_eq!(subscription.wait().await, PiStandbySignal::Release);
+            let wait = subscription.wait();
+            tokio::pin!(wait);
+            assert!(matches!(poll!(&mut wait), Poll::Pending));
+
+            notifications.notify(run_id, signal);
+
+            assert_eq!(wait.await, Some(signal));
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribed_signals_survive_unrelated_notifications() {
+        for signal in [PiStandbySignal::Handoff, PiStandbySignal::Release] {
+            let notifications = PiStandbyNotifications::new();
+            let run_id = RunId::new_v4();
+            let subscription = notifications.subscribe(run_id);
+
+            notifications.notify(run_id, signal);
+            for _ in 0..=PI_STANDBY_PENDING_CAPACITY {
+                notifications.notify(RunId::new_v4(), PiStandbySignal::Handoff);
+            }
+
+            assert_eq!(subscription.wait().await, Some(signal));
+        }
     }
 
     #[tokio::test]
@@ -144,9 +239,79 @@ mod tests {
         let run_id = RunId::new_v4();
         notifications.notify(run_id, PiStandbySignal::Handoff);
 
-        let mut subscription = notifications.subscribe(run_id);
+        let subscription = notifications.subscribe(run_id);
 
-        assert_eq!(subscription.wait().await, PiStandbySignal::Handoff);
-        assert!(subscription.take_pending().is_none());
+        assert_eq!(subscription.wait().await, Some(PiStandbySignal::Handoff));
+
+        let next_subscription = notifications.subscribe(run_id);
+        let wait = next_subscription.wait();
+        tokio::pin!(wait);
+        assert!(matches!(poll!(&mut wait), Poll::Pending));
+
+        notifications.notify(run_id, PiStandbySignal::Release);
+
+        assert_eq!(wait.await, Some(PiStandbySignal::Release));
+    }
+
+    #[tokio::test]
+    async fn dropped_subscription_returns_later_notification_to_pending() {
+        let notifications = PiStandbyNotifications::new();
+        let run_id = RunId::new_v4();
+        let subscription = notifications.subscribe(run_id);
+        drop(subscription);
+
+        notifications.notify(run_id, PiStandbySignal::Handoff);
+
+        assert_eq!(
+            notifications.subscribe(run_id).wait().await,
+            Some(PiStandbySignal::Handoff)
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_superseded_subscription_preserves_replacement() {
+        let notifications = PiStandbyNotifications::new();
+        let run_id = RunId::new_v4();
+        let subscription = notifications.subscribe(run_id);
+        let replacement = notifications.subscribe(run_id);
+        drop(subscription);
+
+        notifications.notify(run_id, PiStandbySignal::Release);
+
+        assert_eq!(replacement.wait().await, Some(PiStandbySignal::Release));
+    }
+
+    #[tokio::test]
+    async fn delivered_signal_is_recovered_when_subscription_drops() {
+        let notifications = PiStandbyNotifications::new();
+        let run_id = RunId::new_v4();
+        let subscription = notifications.subscribe(run_id);
+
+        notifications.notify(run_id, PiStandbySignal::Release);
+        drop(subscription);
+
+        assert_eq!(
+            notifications.subscribe(run_id).wait().await,
+            Some(PiStandbySignal::Release)
+        );
+    }
+
+    #[tokio::test]
+    async fn superseded_subscription_finishes_without_signal() {
+        let notifications = PiStandbyNotifications::new();
+        let run_id = RunId::new_v4();
+        let subscription = notifications.subscribe(run_id);
+        let _replacement = notifications.subscribe(run_id);
+
+        assert_eq!(subscription.wait().await, None);
+    }
+
+    #[tokio::test]
+    async fn final_notification_owner_drop_releases_subscription() {
+        let notifications = PiStandbyNotifications::new();
+        let subscription = notifications.subscribe(RunId::new_v4());
+        drop(notifications);
+
+        assert_eq!(subscription.wait().await, Some(PiStandbySignal::Release));
     }
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -4305,16 +4305,16 @@ mod tests {
             .claim(candidate)
             .await
             .expect("cold Pi claim should succeed");
-        let (_, _, _, mut pi_standby_source) = claimed.into_run_parts();
+        let (_, _, _, pi_standby_source) = claimed.into_run_parts();
         let signal = tokio::time::timeout(
             Duration::from_millis(100),
             pi_standby_source
-                .as_mut()
                 .expect("Pi context should install standby control")
                 .wait(),
         )
         .await
-        .expect("cold Pi claim should not wait for another Ably handoff");
+        .expect("cold Pi claim should not wait for another Ably handoff")
+        .expect("cold Pi standby source should not be superseded");
 
         assert_eq!(signal, crate::pi_standby::PiStandbySignal::Handoff);
         claim_mock.assert_calls_async(1).await;


### PR DESCRIPTION
## Summary

- replace the process-wide Pi standby broadcast stream with run-keyed one-shot waiters
- retain bounded pending storage only for signals that arrive without an active waiter
- make same-run replacement and cancellation cleanup registration-safe while preserving exact handoff/release signals
- add deterministic coverage for unrelated overflow, delivered-signal retention, pending consumption, replacement, cancellation, failed one-shot delivery, and final-owner shutdown

## Scope

This is Runner-local. It does not change API or Ably contracts, guest control payloads, persisted data, database schema, or sandbox images. Durable recovery after Runner restart or arbitrary realtime loss remains tracked by #25617.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner pi_standby` (15 passed)
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner` (3056 passed, 20 ignored)

Closes #25593

Parent context: #25596
