### PR TITLE
feat: personalize pi loop system prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -36,6 +36,7 @@ const workflows = createWorkflowsBddApi(context);
 
 const MODEL = "deepseek-v4-flash";
 const COMPLETIONS_URL = "https://api.deepseek.com/chat/completions";
+const AGENT_DISPLAY_NAME = "Pi edge integration agent";
 
 function recordOf(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null
@@ -207,6 +208,7 @@ interface PiEdgeFixture {
   readonly agentId: string;
   readonly orgId: string;
   readonly runnerGroup: string;
+  readonly agentDisplayName: string;
   readonly agentInstructions: string;
   readonly workflowSkillName: string;
 }
@@ -237,7 +239,7 @@ async function piEdgeFixture(): Promise<PiEdgeFixture> {
     },
   ]);
   const agent = await bdd.createAgent(actor, {
-    displayName: "Pi edge integration agent",
+    displayName: AGENT_DISPLAY_NAME,
     description: "Exercises the in-API Pi edge turn.",
     visibility: "private",
   });
@@ -255,6 +257,7 @@ async function piEdgeFixture(): Promise<PiEdgeFixture> {
     agentId: agent.agentId,
     orgId,
     runnerGroup,
+    agentDisplayName: AGENT_DISPLAY_NAME,
     agentInstructions,
     workflowSkillName,
   };
@@ -415,6 +418,9 @@ describe("PiLoop edge turn", () => {
     );
     expect(piSystemPrompt).toContain(
       `<location>${PI_SKILLS_ROOT}/${fixture.workflowSkillName}/SKILL.md</location>`,
+    );
+    expect(piSystemPrompt).toContain(
+      `As ${fixture.agentDisplayName}, you are an excellent communicator`,
     );
     expect(piSystemPrompt).toContain(fixture.agentInstructions);
     expect(piSystemPrompt).not.toContain("/home/user/.codex/skills/");

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -117,6 +117,7 @@ import { secrets as secretsTable } from "@vm0/db/schema/secret";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { variables } from "@vm0/db/schema/variable";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import type { PersistedStorageMount } from "@vm0/db/types";
 import {
@@ -5850,11 +5851,34 @@ function storedExecutionContextWithPiResources(
   };
 }
 
+async function resolvePiAgentName(
+  db: Db,
+  resolved: Pick<ResolvedCompose, "composeId" | "agentName">,
+): Promise<string> {
+  const [agent] = await db
+    .select({
+      displayName: zeroAgents.displayName,
+      name: zeroAgents.name,
+    })
+    .from(zeroAgents)
+    .where(eq(zeroAgents.id, resolved.composeId))
+    .limit(1);
+
+  if (agent?.displayName?.trim()) {
+    return agent.displayName;
+  }
+  if (agent?.name.trim()) {
+    return agent.name;
+  }
+  return resolved.agentName?.trim() || "Pi";
+}
+
 async function preparePiLaunchResources(args: {
   readonly get: <T>(computedValue: Computed<T>) => T;
   readonly db: Db;
   readonly runId: string;
   readonly body: CreateRunBody;
+  readonly resolved: Pick<ResolvedCompose, "composeId" | "agentName">;
   readonly piEdge: PiEdgeModelConfig | undefined;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly additionalVolumeSources: AdditionalVolumeSources;
@@ -5868,10 +5892,13 @@ async function preparePiLaunchResources(args: {
     additionalVolumeSources: args.additionalVolumeSources,
     persistedStorageMounts: args.persistedStorageMounts,
   });
-  const resources = await loadPiLaunchStorageResources(args.get, args.db, {
-    snapshot,
-    persistedStorageMounts: args.persistedStorageMounts,
-  });
+  const [resources, agentName] = await Promise.all([
+    loadPiLaunchStorageResources(args.get, args.db, {
+      snapshot,
+      persistedStorageMounts: args.persistedStorageMounts,
+    }),
+    resolvePiAgentName(args.db, args.resolved),
+  ]);
   const skills = await loadPiRunSkills(resources.env, snapshot);
   if (skills.diagnostics.length > 0) {
     L.warn("Pi run Skill catalog contains diagnostics", {
@@ -5884,6 +5911,7 @@ async function preparePiLaunchResources(args: {
     modelConfig: piSandboxModelConfig(args.piEdge),
     prompt: formatPiUserPrompt(args.body.prompt, skills.skills),
     systemPrompt: renderPiSystemPrompt({
+      agentName,
       appendSystemPrompt: args.body.appendSystemPrompt,
       agentInstructions: resources.agentInstructions,
       skills: skills.skills,
@@ -5984,6 +6012,7 @@ function buildRunnerJobPayload(
       db,
       runId: args.run.id,
       body,
+      resolved: args.resolved,
       piEdge: args.piEdge,
       additionalVolumes: args.additionalVolumes,
       additionalVolumeSources: args.additionalVolumeSources,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5851,17 +5851,14 @@ function storedExecutionContextWithPiResources(
   };
 }
 
-async function resolvePiAgentName(
-  db: Db,
-  resolved: Pick<ResolvedCompose, "composeId" | "agentName">,
-): Promise<string> {
+async function resolvePiAgentName(db: Db, composeId: string): Promise<string> {
   const [agent] = await db
     .select({
       displayName: zeroAgents.displayName,
       name: zeroAgents.name,
     })
     .from(zeroAgents)
-    .where(eq(zeroAgents.id, resolved.composeId))
+    .where(eq(zeroAgents.id, composeId))
     .limit(1);
 
   if (agent?.displayName?.trim()) {
@@ -5870,7 +5867,7 @@ async function resolvePiAgentName(
   if (agent?.name.trim()) {
     return agent.name;
   }
-  return resolved.agentName?.trim() || "Pi";
+  return "Okou";
 }
 
 async function preparePiLaunchResources(args: {
@@ -5878,7 +5875,7 @@ async function preparePiLaunchResources(args: {
   readonly db: Db;
   readonly runId: string;
   readonly body: CreateRunBody;
-  readonly resolved: Pick<ResolvedCompose, "composeId" | "agentName">;
+  readonly composeId: string;
   readonly piEdge: PiEdgeModelConfig | undefined;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly additionalVolumeSources: AdditionalVolumeSources;
@@ -5897,7 +5894,7 @@ async function preparePiLaunchResources(args: {
       snapshot,
       persistedStorageMounts: args.persistedStorageMounts,
     }),
-    resolvePiAgentName(args.db, args.resolved),
+    resolvePiAgentName(args.db, args.composeId),
   ]);
   const skills = await loadPiRunSkills(resources.env, snapshot);
   if (skills.diagnostics.length > 0) {
@@ -6012,7 +6009,7 @@ function buildRunnerJobPayload(
       db,
       runId: args.run.id,
       body,
-      resolved: args.resolved,
+      composeId: args.resolved.composeId,
       piEdge: args.piEdge,
       additionalVolumes: args.additionalVolumes,
       additionalVolumeSources: args.additionalVolumeSources,

--- a/turbo/packages/pi-agent-runtime/src/runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/runtime.test.ts
@@ -66,6 +66,17 @@ describe("Pi run Skill runtime", () => {
     expect(piMessageRequiresSandbox(assistantToolCall("bash"))).toBe(true);
   });
 
+  it("falls back to Okou when the agent name is blank", () => {
+    const systemPrompt = renderPiSystemPrompt({
+      agentName: " \n ",
+      skills: [],
+    });
+    expect(systemPrompt).toContain("You are Okou, an AI agent.");
+    expect(systemPrompt).toContain(
+      "As Okou, you are an excellent communicator",
+    );
+  });
+
   it("loads only snapshot Skills and preserves prompt and read semantics", async () => {
     await mkdir(PI_SKILLS_ROOT, { recursive: true });
     const testRoot = await mkdtemp(join(PI_SKILLS_ROOT, "vm0-runtime-test-"));

--- a/turbo/packages/pi-agent-runtime/src/runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/runtime.test.ts
@@ -116,10 +116,16 @@ describe("Pi run Skill runtime", () => {
       ).toEqual(["pinned-skill"]);
 
       const systemPrompt = renderPiSystemPrompt({
+        agentName: "Test Pi Agent",
         appendSystemPrompt: "vm0 append prompt",
         agentInstructions: "Pi agent instructions",
         skills: resources.skills,
       });
+      expect(systemPrompt).toContain("You are Test Pi Agent, an AI agent.");
+      expect(systemPrompt).toContain(
+        "As Test Pi Agent, you are an excellent communicator",
+      );
+      expect(systemPrompt).not.toContain("{{agent_name}}");
       expect(systemPrompt).toContain("<name>pinned-skill</name>");
       expect(systemPrompt).toContain(
         `<location>${skillDirectory}/SKILL.md</location>`,
@@ -128,6 +134,7 @@ describe("Pi run Skill runtime", () => {
       expect(systemPrompt).not.toContain("Read references/answer.txt");
       expect(
         renderPiSystemPrompt({
+          agentName: "Test Pi Agent",
           appendSystemPrompt: "vm0 append prompt",
           agentInstructions: "Pi agent instructions",
           skills: resources.skills,

--- a/turbo/packages/pi-agent-runtime/src/runtime.ts
+++ b/turbo/packages/pi-agent-runtime/src/runtime.ts
@@ -55,7 +55,7 @@ Continue until the requested outcome is genuinely complete or you are blocked by
 Lead with the result. Be concise, mention changed files or checks when useful, and explain blockers plainly.`;
 
 function renderPiBaseSystemPrompt(agentName: string): string {
-  const normalizedAgentName = agentName.replace(/\s+/g, " ").trim() || "Pi";
+  const normalizedAgentName = agentName.replace(/\s+/g, " ").trim() || "Okou";
   return PI_BASE_SYSTEM_PROMPT_TEMPLATE.replaceAll(
     PI_AGENT_NAME_PLACEHOLDER,
     () => {
@@ -65,7 +65,7 @@ function renderPiBaseSystemPrompt(agentName: string): string {
 }
 
 /** Default base prompt used when no user-facing agent identity is available. */
-export const PI_BASE_SYSTEM_PROMPT = renderPiBaseSystemPrompt("Pi");
+export const PI_BASE_SYSTEM_PROMPT = renderPiBaseSystemPrompt("Okou");
 
 export interface PiRunSkills {
   readonly skills: readonly Skill[];

--- a/turbo/packages/pi-agent-runtime/src/runtime.ts
+++ b/turbo/packages/pi-agent-runtime/src/runtime.ts
@@ -11,9 +11,61 @@ import type {
   RunSkillSnapshotEntry,
 } from "@vm0/api-contracts/contracts/runners";
 
-export const PI_BASE_SYSTEM_PROMPT = `You are an expert coding assistant working in /home/user/workspace.
+const PI_AGENT_NAME_PLACEHOLDER = "{{agent_name}}";
 
-Follow the user's instructions and the repository's local guidance. Use the available tools to inspect the workspace, make focused changes, and verify your work. Continue until the requested task is complete, and report the result clearly.`;
+const PI_BASE_SYSTEM_PROMPT_TEMPLATE = `You are ${PI_AGENT_NAME_PLACEHOLDER}, an AI agent. You and the user share one workspace, and your job is to collaborate with them until their goal is genuinely handled.
+
+# Personality
+
+As ${PI_AGENT_NAME_PLACEHOLDER}, you are an excellent communicator with a curious, distinct personality. Match the user's tone and level of understanding so the conversation feels natural.
+
+Have judgment and a point of view. Guide users through unfamiliar tasks, anticipate likely questions and pitfalls, and set clear expectations. Communicate like a thoughtful collaborator working at the user's level.
+
+## Writing style
+
+Use the minimum formatting needed for clarity. Avoid unnecessary headings, emphasis, and long lists.
+
+Lead with the outcome. Prefer plain language over jargon, and include technical detail only when it helps the user understand or verify the result.
+
+# Working with the user
+
+Treat the user's latest request as authoritative. If a new request changes the task, follow it; if it adds to unfinished work, handle both.
+
+Make reasonable, reversible assumptions when they let you progress. Ask for clarification only when a missing choice would materially change the result or require new authority.
+
+Keep the user informed during long-running work. Your final response must stand on its own and clearly state the outcome, relevant verification, and any remaining blocker.
+
+# Rules for getting work done
+
+- Work from /home/user/workspace and follow repository-local instructions such as AGENTS.md.
+- Use the available read, bash, write, and edit tools to inspect first, make focused changes, and verify them proportionately.
+- Prefer rg and rg --files for searching. Preserve existing user changes and avoid unrelated edits.
+- Use an applicable listed Skill when the user names it or the task clearly matches it. Read its SKILL.md before acting.
+- Keep secrets and sensitive data out of commands and responses.
+- Do not take destructive or externally consequential actions unless they are clearly within the user's request. Resolve exact targets before changing or deleting data.
+
+## Autonomy and persistence
+
+For questions, explanations, reviews, or diagnosis, inspect the relevant evidence and answer without making unrequested changes. For change or build requests, carry the work through implementation and verification.
+
+Continue until the requested outcome is genuinely complete or you are blocked by a concrete need for user input or external state. Do not stop at a plan when you can safely perform the work, and do not expand the scope beyond the user's request.
+
+# Final response
+
+Lead with the result. Be concise, mention changed files or checks when useful, and explain blockers plainly.`;
+
+function renderPiBaseSystemPrompt(agentName: string): string {
+  const normalizedAgentName = agentName.replace(/\s+/g, " ").trim() || "Pi";
+  return PI_BASE_SYSTEM_PROMPT_TEMPLATE.replaceAll(
+    PI_AGENT_NAME_PLACEHOLDER,
+    () => {
+      return normalizedAgentName;
+    },
+  );
+}
+
+/** Default base prompt used when no user-facing agent identity is available. */
+export const PI_BASE_SYSTEM_PROMPT = renderPiBaseSystemPrompt("Pi");
 
 export interface PiRunSkills {
   readonly skills: readonly Skill[];
@@ -57,14 +109,15 @@ function promptParts(parts: ReadonlyArray<string | null | undefined>): string {
     .join("\n\n");
 }
 
-/** Render the one immutable system prompt shared by both Pi runtimes. */
+/** Render the system prompt shared by both Pi runtimes. */
 export function renderPiSystemPrompt(args: {
+  readonly agentName: string;
   readonly appendSystemPrompt?: string | null;
   readonly agentInstructions?: string | null;
   readonly skills: readonly Skill[];
 }): string {
   return promptParts([
-    PI_BASE_SYSTEM_PROMPT,
+    renderPiBaseSystemPrompt(args.agentName),
     args.appendSystemPrompt,
     args.agentInstructions,
     formatSkillsForSystemPrompt([...args.skills]),


### PR DESCRIPTION
## Summary

- replace the terse Pi loop base prompt with a Codex-inspired prompt adapted to Pi tools and runtime behavior
- render identity and Personality with the user-facing agent display name, falling back to the canonical agent name, then Okou
- cover dynamic name rendering, the Okou fallback, and stored Pi edge prompt assembly

## Verification

- pnpm --filter @vm0/pi-agent-runtime test
- pnpm --filter @vm0/pi-agent-runtime check-types
- pnpm --filter @vm0/pi-agent-runtime lint
- pnpm --filter api check-types:core
- pnpm --filter api check-types:tests
- targeted API Oxlint, type-aware Oxlint, and ESLint

## Not run locally

- pi-edge-loop.test.ts requires PostgreSQL; the local attempt stopped before executing tests with ECONNREFUSED on port 5432. The PR pipeline will run the integration coverage.