### PR TITLE
fix(python): revalidate auth.base authorization after auth waits

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -52,10 +52,7 @@ from firewall_auth_client import (
     FirewallAuthRequest,
     InsufficientCreditsError,
 )
-from firewall_auth_config import (
-    auth_config_injects_credentials,
-    auth_config_injects_ordinary_upstream_credentials,
-)
+from firewall_auth_config import auth_config_injects_credentials
 from logging_utils import log_proxy_entry
 from runtime_url_parsing import split_runtime_url
 from url_syntax import has_unsafe_runtime_url_syntax
@@ -77,7 +74,7 @@ class FirewallHeaderPhaseAuthResult(Enum):
     FALLBACK = "fallback"
 
 
-type OrdinaryUpstreamCredentialsGuard = Callable[[], bool]
+type CurrentFirewallAuthorizationGuard = Callable[[], bool]
 
 
 _HTTP_STATUS_INFORMATIONAL_MIN = 100
@@ -1266,14 +1263,13 @@ async def handle_firewall_request(
     allow: matching.FirewallAllow,
     vm_info: dict,
     *,
-    revalidate_ordinary_upstream_credentials: OrdinaryUpstreamCredentialsGuard,
+    revalidate_current_firewall_authorization: CurrentFirewallAuthorizationGuard,
 ) -> FirewallAuthHandlingResult:
     """Handle firewall auth and return who owns the next response lifecycle.
 
-    The required guard runs after resolution and before ordinary upstream
-    credential mutation. A rejecting caller must first create its local
-    response; this function then returns ``LOCAL_RESPONSE`` without applying
-    resolved credentials.
+    The required guard runs after resolution and before managed credential
+    application. A rejecting caller must first create its local response; this
+    function then returns ``LOCAL_RESPONSE`` without applying resolved data.
     """
     try:
         _prepare_firewall_metadata(flow, allow, vm_info)
@@ -1338,11 +1334,8 @@ async def handle_firewall_request(
         )
 
         if (
-            context.auth_request.auth_base is None
-            and auth_config_injects_ordinary_upstream_credentials(
-                context.allow.api_entry.get("auth")
-            )
-            and not revalidate_ordinary_upstream_credentials()
+            auth_config_injects_credentials(context.allow.api_entry.get("auth"))
+            and not revalidate_current_firewall_authorization()
         ):
             return _finish_firewall_auth_result(
                 flow,
@@ -1371,14 +1364,14 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
     allow: matching.FirewallAllow,
     vm_info: dict,
     *,
-    revalidate_ordinary_upstream_credentials: OrdinaryUpstreamCredentialsGuard,
+    revalidate_current_firewall_authorization: CurrentFirewallAuthorizationGuard,
 ) -> FirewallHeaderPhaseAuthResult:
     """Apply successful header/query firewall auth before request streaming.
 
     This helper intentionally falls back instead of creating local responses.
     The request hook owns auth failure semantics; requestheaders() only keeps a
     success that is safe before mitmproxy sends upstream request headers. A
-    rejected ordinary-credential guard restores the probe snapshot and falls
+    rejected current-authorization guard restores the probe snapshot and falls
     back before mutation.
     """
     auth_config = allow.api_entry.get("auth", {})
@@ -1463,7 +1456,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
         )
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
-    if injects_credentials and not revalidate_ordinary_upstream_credentials():
+    if injects_credentials and not revalidate_current_firewall_authorization():
         _restore_header_phase_probe_state(
             flow,
             metadata_snapshot=metadata_snapshot,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1016,8 +1016,8 @@ async def _try_firewall_request_stream_from_headers(
             flow,
             allow,
             vm_info,
-            revalidate_ordinary_upstream_credentials=lambda: (
-                _ordinary_upstream_credentials_are_current_for_requestheaders(
+            revalidate_current_firewall_authorization=lambda: (
+                _firewall_authorization_is_current_for_requestheaders(
                     flow,
                     allow,
                     expected_run_id=expected_run_id,
@@ -1087,7 +1087,7 @@ def _block_public_destination_denied(
     )
 
 
-def _revalidate_ordinary_upstream_credentials_for_request(
+def _revalidate_current_firewall_authorization_for_request(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     *,
@@ -1095,7 +1095,9 @@ def _revalidate_ordinary_upstream_credentials_for_request(
     admitted_server: connection.Server,
     require_connected: bool,
 ) -> bool:
-    if not _has_current_direct_connector_auth_binding(
+    if _firewall_allow_injects_ordinary_upstream_credentials(
+        allow
+    ) and not _has_current_direct_connector_auth_binding(
         flow,
         admitted_server=admitted_server,
         require_connected=require_connected,
@@ -1162,7 +1164,7 @@ def _equivalent_current_firewall_allow(
     return classification
 
 
-def _ordinary_upstream_credentials_are_current_for_requestheaders(
+def _firewall_authorization_is_current_for_requestheaders(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     *,
@@ -1256,7 +1258,7 @@ async def _prepare_codex_catalog_request_with_upstream_revalidation(
         and flow.response is None
         and _firewall_allow_injects_ordinary_upstream_credentials(allow)
     ):
-        _revalidate_ordinary_upstream_credentials_for_request(
+        _revalidate_current_firewall_authorization_for_request(
             flow,
             allow,
             expected_run_id=expected_run_id,
@@ -1405,8 +1407,8 @@ async def request(flow: http.HTTPFlow) -> None:
                 flow,
                 allow,
                 vm_info,
-                revalidate_ordinary_upstream_credentials=lambda: (
-                    _revalidate_ordinary_upstream_credentials_for_request(
+                revalidate_current_firewall_authorization=lambda: (
+                    _revalidate_current_firewall_authorization_for_request(
                         flow,
                         allow,
                         expected_run_id=expected_run_id,

--- a/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
@@ -70,7 +70,7 @@ def firewall_auth_success(
     )
 
 
-def _allow_ordinary_upstream_credentials() -> bool:
+def _allow_current_firewall_authorization() -> bool:
     return True
 
 
@@ -84,7 +84,7 @@ async def handle_firewall_request_without_upstream_admission(
         flow,
         allow,
         vm_info,
-        revalidate_ordinary_upstream_credentials=_allow_ordinary_upstream_credentials,
+        revalidate_current_firewall_authorization=_allow_current_firewall_authorization,
     )
 
 
@@ -98,7 +98,7 @@ async def apply_requestheaders_auth_without_upstream_admission(
         flow,
         allow,
         vm_info,
-        revalidate_ordinary_upstream_credentials=_allow_ordinary_upstream_credentials,
+        revalidate_current_firewall_authorization=_allow_current_firewall_authorization,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -38,8 +38,8 @@ _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success r
 _MISSING_FIELD = object()
 
 
-def _fail_if_ordinary_upstream_credentials_are_revalidated() -> bool:
-    raise AssertionError("ordinary upstream credential guard must not run")
+def _fail_if_current_firewall_authorization_is_revalidated() -> bool:
+    raise AssertionError("current firewall authorization guard must not run")
 
 
 def _allow(
@@ -289,8 +289,8 @@ class TestHandleFirewallRequest:
                 flow,
                 allow,
                 vm_info,
-                revalidate_ordinary_upstream_credentials=(
-                    _fail_if_ordinary_upstream_credentials_are_revalidated
+                revalidate_current_firewall_authorization=(
+                    _fail_if_current_firewall_authorization_is_revalidated
                 ),
             )
 

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
@@ -11,8 +11,8 @@ from tests.firewall_rewrite_helpers import make_allow, make_success_rewrite_inpu
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
 
-def _fail_if_ordinary_upstream_credentials_are_revalidated() -> bool:
-    raise AssertionError("ordinary upstream credential guard must not run")
+def _allow_current_firewall_authorization() -> bool:
+    return True
 
 
 class TestAuthBaseUrlRewriteSuccess:
@@ -81,9 +81,7 @@ class TestAuthBaseUrlRewriteSuccess:
                 flow,
                 allow,
                 vm_info,
-                revalidate_ordinary_upstream_credentials=(
-                    _fail_if_ordinary_upstream_credentials_are_revalidated
-                ),
+                revalidate_current_firewall_authorization=_allow_current_firewall_authorization,
             )
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
         assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -10,11 +10,13 @@ import pytest
 from mitmproxy import http, tls
 
 import auth
+import auth_base_forwarder
 import connector_intent
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.firewall_helpers import cancel_pending_task
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import _assert_no_request_stream, await_requestheaders_result
@@ -27,6 +29,7 @@ _CLIENT_IP = "10.200.0.5"
 _FIREWALL_NAME = "model-provider:test"
 _ORIGINAL_RUN_ID = "run-before-auth-wait"
 _RESOLVED_AUTHORIZATION = "Bearer resolved-for-old-authorization"
+_RESOLVED_AUTH_BASE = "https://webhook.example.com/deliver"
 
 
 def _registry_vm(
@@ -35,6 +38,7 @@ def _registry_vm(
     run_id: str = _ORIGINAL_RUN_ID,
     allow_repos: bool = True,
     allow_unrelated_orgs: bool = False,
+    auth_base: bool = False,
 ) -> dict[str, object]:
     allowed_permissions = ["repos-write"] if allow_repos else []
     denied_permissions = [] if allow_repos else ["repos-write"]
@@ -42,16 +46,25 @@ def _registry_vm(
         allowed_permissions.append("orgs-write")
     else:
         denied_permissions.append("orgs-write")
+    auth_config: dict[str, object]
+    api_base: str
+    if auth_base:
+        auth_config = {"base": "${{ secrets.WEBHOOK_URL }}"}
+        api_base = "https://placeholder.example.com"
+    else:
+        auth_config = {
+            "headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"},
+            "query": {"managed": "${{ secrets.GITHUB_TOKEN }}"},
+        }
+        api_base = "https://api.github.com"
+
     return _single_firewall_vm(
         tmp_path,
         run_id=run_id,
         firewall_name=_FIREWALL_NAME,
         api_entry={
-            "base": "https://api.github.com",
-            "auth": {
-                "headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"},
-                "query": {"managed": "${{ secrets.GITHUB_TOKEN }}"},
-            },
+            "base": api_base,
+            "auth": auth_config,
             "permissions": [
                 {"name": "repos-write", "rules": ["POST /repos/{path+}"]},
                 {"name": "orgs-write", "rules": ["POST /orgs/{path+}"]},
@@ -114,6 +127,8 @@ def _mutate_registry(
     registry_path: Path,
     tmp_path: Path,
     mutation: RegistryMutation,
+    *,
+    auth_base: bool = False,
 ) -> None:
     if mutation == "remove":
         _publish_registry(registry_path, vm_info=None)
@@ -121,42 +136,52 @@ def _mutate_registry(
     if mutation == "replace_run":
         _publish_registry(
             registry_path,
-            vm_info=_registry_vm(tmp_path, run_id="run-replacement-after-auth-wait"),
+            vm_info=_registry_vm(
+                tmp_path,
+                run_id="run-replacement-after-auth-wait",
+                auth_base=auth_base,
+            ),
         )
         return
     _publish_registry(
         registry_path,
-        vm_info=_registry_vm(tmp_path, allow_repos=False),
+        vm_info=_registry_vm(tmp_path, allow_repos=False, auth_base=auth_base),
     )
 
 
-def _firewall_flow(real_flow, make_tls_data) -> tuple[http.HTTPFlow, tls.ClientHelloData]:
+def _firewall_flow(
+    real_flow,
+    make_tls_data,
+    *,
+    auth_base: bool = False,
+) -> tuple[http.HTTPFlow, tls.ClientHelloData]:
+    host = "placeholder.example.com" if auth_base else "api.github.com"
     flow = real_flow(
         with_response=False,
         client_ip=_CLIENT_IP,
-        host="api.github.com",
-        sni="api.github.com",
+        host=host,
+        sni=host,
         method="POST",
         path="/repos/octocat/hello?client=visible",
         request_headers=http.Headers(
             (
-                (b"Host", b"api.github.com"),
+                (b"Host", host.encode()),
                 (b"Content-Length", str(STREAM_BUFFER_LIMIT + 1).encode()),
             )
         ),
     )
-    client_id = "client-firewall-auth-revalidation"
+    client_id = f"client-firewall-auth-revalidation-{'base' if auth_base else 'ordinary'}"
     flow.client_conn.id = client_id
     upstream_endpoint = ("172.66.0.243", 443)
     mark_connected_tls_upstream(
         flow,
-        sni="api.github.com",
+        sni=host,
         server_address=upstream_endpoint,
         peername=upstream_endpoint,
     )
     tls_data = make_tls_data(
         client_ip=_CLIENT_IP,
-        sni="api.github.com",
+        sni=host,
         client_id=client_id,
         server_address=upstream_endpoint,
         server_peername=upstream_endpoint,
@@ -166,7 +191,16 @@ def _firewall_flow(real_flow, make_tls_data) -> tuple[http.HTTPFlow, tls.ClientH
     return flow, cast(tls.ClientHelloData, tls_data)
 
 
-def _resolved_firewall_auth() -> dict[str, object]:
+def _resolved_firewall_auth(*, auth_base: bool = False) -> dict[str, object]:
+    if auth_base:
+        return {
+            "headers": {},
+            "base": _RESOLVED_AUTH_BASE,
+            "resolved_secrets": ["WEBHOOK_URL"],
+            "refreshed_connectors": [],
+            "refreshed_secrets": [],
+            "cache_hit": False,
+        }
     return {
         "headers": {"Authorization": _RESOLVED_AUTHORIZATION},
         "query": {"managed": "resolved-for-old-authorization"},
@@ -403,4 +437,140 @@ async def test_different_same_run_allow_decision_fails_closed_without_old_creden
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "firewall_authorization_changed"
     assert flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY) is None
+    assert "_usage_flow_tracked" not in flow.metadata
+
+
+@pytest.mark.parametrize(
+    "registry_mutation",
+    ["remove", "replace_run", "revoke_permission"],
+)
+async def test_auth_base_registry_change_during_auth_blocks_resolved_forward(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+    registry_mutation: RegistryMutation,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_registry_vm(tmp_path, auth_base=True),
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data, auth_base=True)
+    original_path = flow.request.path
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth(auth_base=True)
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    forward_request = AsyncMock()
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+    monkeypatch.setattr(auth, "forward_request", forward_request)
+
+    request_task: asyncio.Task[None] | None = None
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        assert mitm_addon.requestheaders(flow) is None
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            STREAM_BUFFER_LIMIT + 1,
+        )
+
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            assert flow.metadata["_usage_flow_tracked"] is True
+            _mutate_registry(
+                registry_path,
+                tmp_path,
+                registry_mutation,
+                auth_base=True,
+            )
+            release_auth_resolution.set()
+            await asyncio.gather(request_task)
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(request_task)
+
+    auth_fetch.assert_awaited_once()
+    forward_request.assert_not_awaited()
+    assert flow.request.headers["Host"] == "placeholder.example.com"
+    assert flow.request.headers.get("Authorization") is None
+    assert flow.request.path == original_path
+    for key in (
+        metadata_keys.AUTH_RESOLVED_SECRETS,
+        metadata_keys.AUTH_REFRESHED_CONNECTORS,
+        metadata_keys.AUTH_REFRESHED_SECRETS,
+        metadata_keys.AUTH_CACHE_HIT,
+        metadata_keys.AUTH_URL_REWRITE,
+    ):
+        assert key not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+    _assert_current_denial(flow, registry_mutation)
+
+
+async def test_auth_base_unrelated_policy_change_keeps_equivalent_authorization(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_registry_vm(tmp_path, auth_base=True),
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data, auth_base=True)
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth(auth_base=True)
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    request_task: asyncio.Task[None] | None = None
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        fake_forwarder_upstream(status=202, body=b"accepted") as upstream,
+    ):
+        mitm_addon.tls_clienthello(tls_data)
+        assert mitm_addon.requestheaders(flow) is None
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            _publish_registry(
+                registry_path,
+                vm_info=_registry_vm(
+                    tmp_path,
+                    allow_unrelated_orgs=True,
+                    auth_base=True,
+                ),
+            )
+            release_auth_resolution.set()
+            await asyncio.gather(request_task)
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(request_task)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 202
+        assert flow.response.content == b"accepted"
+        assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
+        assert flow.metadata[metadata_keys.VM_RUN_ID] == _ORIGINAL_RUN_ID
+        assert upstream.resolve_calls == ["webhook.example.com"]
+        assert upstream.connect_calls == [("93.184.216.34", 443)]
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+        mitm_addon.response(flow)
+
+    auth_fetch.assert_awaited_once()
     assert "_usage_flow_tracked" not in flow.metadata


### PR DESCRIPTION
## Summary

- require current canonical firewall authorization after every managed auth resolution, including `auth.base`
- preserve direct connector binding checks only for credentials that mutate the ordinary mitmproxy upstream request
- fail closed before resolved rewrite data or forwarding admission reaches `forward_request()`
- cover registry removal, run replacement, permission revocation, equivalent policy updates, and admission/usage cleanup through real addon hooks

## Scope

- no API, database, persisted state, runner protocol, registry schema, generated contract, migration, frontend, or feature-switch changes
- resolved `auth.base` destination validation and ordinary credential authorization behavior remain unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused addon suite: 146 passed
- mutation check: all three new registry-change cases fail when the old `auth.base` guard exclusion is restored
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,959 passed)
- `lefthook run pre-commit`

Closes #25611
