### PR TITLE
refactor(python): clarify model token category ownership

### DIFF
--- a/crates/runner/mitm-addon/src/usage/model_tokens.py
+++ b/crates/runner/mitm-addon/src/usage/model_tokens.py
@@ -1,13 +1,23 @@
-"""Model token usage categories shared by extraction and reporting."""
+"""Normalized model token categories shared by provider extractors.
+
+Extractors write only the base categories in ``MODEL_USAGE_CATEGORIES``.
+Model-provider reporting may remap those keys to reporter-owned billing
+categories after selecting a tier, while model usage observations retain the
+base categories.
+"""
 
 MODEL_USAGE_CATEGORY_INPUT = "tokens.input"
 MODEL_USAGE_CATEGORY_OUTPUT = "tokens.output"
 MODEL_USAGE_CATEGORY_CACHE_READ = "tokens.cache_read"
 MODEL_USAGE_CATEGORY_CACHE_CREATION = "tokens.cache_creation"
-MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT = "tokens.input.long_context"
-MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT = "tokens.output.long_context"
-MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT = "tokens.cache_read.long_context"
-MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT = "tokens.cache_creation.long_context"
+
+# Canonical normalized category keys accepted from provider extractors.
+MODEL_USAGE_CATEGORIES = (
+    MODEL_USAGE_CATEGORY_INPUT,
+    MODEL_USAGE_CATEGORY_OUTPUT,
+    MODEL_USAGE_CATEGORY_CACHE_READ,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION,
+)
 
 ANTHROPIC_USAGE_FIELD_CATEGORIES = {
     "input_tokens": MODEL_USAGE_CATEGORY_INPUT,
@@ -15,5 +25,3 @@ ANTHROPIC_USAGE_FIELD_CATEGORIES = {
     "cache_read_input_tokens": MODEL_USAGE_CATEGORY_CACHE_READ,
     "cache_creation_input_tokens": MODEL_USAGE_CATEGORY_CACHE_CREATION,
 }
-
-MODEL_USAGE_CATEGORIES = tuple(ANTHROPIC_USAGE_FIELD_CATEGORIES.values())

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -37,6 +37,7 @@ from .json_selective import (
     ScalarField,
 )
 from .model_tokens import (
+    MODEL_USAGE_CATEGORIES,
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
     MODEL_USAGE_CATEGORY_CACHE_READ,
     MODEL_USAGE_CATEGORY_INPUT,
@@ -151,13 +152,6 @@ class OpenAIResponsesEvent:
     _classification: _ResponsesEventTypeClassification
 
 
-_OPENAI_RESPONSES_USAGE_CATEGORIES = (
-    MODEL_USAGE_CATEGORY_INPUT,
-    MODEL_USAGE_CATEGORY_OUTPUT,
-    MODEL_USAGE_CATEGORY_CACHE_READ,
-    MODEL_USAGE_CATEGORY_CACHE_CREATION,
-)
-
 _RESPONSES_RESPONSE_SCALAR_FIELDS = {
     ("id",): ScalarField("string", max_bytes=1024),
     ("model",): ScalarField("string", max_bytes=1024),
@@ -268,7 +262,7 @@ def _store_quantity(target: dict, category: str, value: object) -> None:
 
 
 def _has_positive_usage_quantity(values: dict) -> bool:
-    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
+    for category in MODEL_USAGE_CATEGORIES:
         value = values.get(category)
         if _is_usage_quantity(value) and value > 0:
             return True
@@ -276,10 +270,7 @@ def _has_positive_usage_quantity(values: dict) -> bool:
 
 
 def _has_usage_quantity(values: dict) -> bool:
-    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
-        if _is_usage_quantity(values.get(category)):
-            return True
-    return False
+    return any(_is_usage_quantity(values.get(category)) for category in MODEL_USAGE_CATEGORIES)
 
 
 def _partition_input_tokens(
@@ -749,7 +740,7 @@ class OpenAIResponsesJsonUsageExtractor:
         usage: dict = {}
         _store_response_values(result.values, usage)
 
-        if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
+        if not any(category in usage for category in MODEL_USAGE_CATEGORIES):
             return None, None
         return usage, None
 
@@ -848,6 +839,6 @@ def extract_openai_responses_usage_from_event(
         event_name=None,
         data_event_type=data_event_type,
     )
-    if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
+    if not any(category in usage for category in MODEL_USAGE_CATEGORIES):
         return None, None
     return usage, None

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -7,6 +7,11 @@ Flow-terminal reporters aggregate usage stored in
 response-id sources can also be buffered incrementally with their source
 idempotency keys preserved.
 
+Extractor metadata uses only the base categories in ``MODEL_USAGE_CATEGORIES``.
+Billing tier selection may remap those keys to reporter-owned
+``.long_context`` categories only while building billable usage events. Model
+usage observations retain the base categories.
+
 Model-provider usage reporting is separate from platform billing. Run contexts
 set ``flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER]`` to the canonical model
 id the proxy should report for model token usage. Billable rows go to
@@ -42,13 +47,9 @@ from ..idempotency import (
 from ..model_tokens import (
     MODEL_USAGE_CATEGORIES,
     MODEL_USAGE_CATEGORY_CACHE_CREATION,
-    MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_CACHE_READ,
-    MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_INPUT,
-    MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_OUTPUT,
-    MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT,
 )
 from ..reporting_context import UsageReportingContext, usage_reporting_context
 from ..underbilling import log_usage_underbilling
@@ -57,6 +58,10 @@ MODEL_USAGE_KIND = "model"
 type _ModelUsageTier = Literal["base", "long_context"]
 _MODEL_USAGE_TIER_BASE: _ModelUsageTier = "base"
 _MODEL_USAGE_TIER_LONG_CONTEXT: _ModelUsageTier = "long_context"
+_MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT = "tokens.input.long_context"
+_MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT = "tokens.output.long_context"
+_MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT = "tokens.cache_read.long_context"
+_MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT = "tokens.cache_creation.long_context"
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,10 +78,10 @@ _MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS = {
     "MiniMax-M3": 512_001,
 }
 _MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE = {
-    MODEL_USAGE_CATEGORY_INPUT: MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
-    MODEL_USAGE_CATEGORY_OUTPUT: MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT,
-    MODEL_USAGE_CATEGORY_CACHE_READ: MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
-    MODEL_USAGE_CATEGORY_CACHE_CREATION: MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
+    MODEL_USAGE_CATEGORY_INPUT: _MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
+    MODEL_USAGE_CATEGORY_OUTPUT: _MODEL_USAGE_CATEGORY_OUTPUT_LONG_CONTEXT,
+    MODEL_USAGE_CATEGORY_CACHE_READ: _MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION: _MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
 }
 _MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT = 100
 _MODEL_INPUT_PARTITION_CATEGORIES = frozenset(
@@ -84,9 +89,9 @@ _MODEL_INPUT_PARTITION_CATEGORIES = frozenset(
         MODEL_USAGE_CATEGORY_INPUT,
         MODEL_USAGE_CATEGORY_CACHE_READ,
         MODEL_USAGE_CATEGORY_CACHE_CREATION,
-        MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
-        MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
-        MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
+        _MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
+        _MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
+        _MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
     )
 )
 


### PR DESCRIPTION
## Summary

- define `MODEL_USAGE_CATEGORIES` directly as the canonical normalized extractor-input category set
- reuse that canonical set in the OpenAI Responses extractor instead of maintaining an identical private tuple
- keep `.long_context` category definitions private to the model-provider reporter and document the extractor, billing-event, and observation boundary

## Scope

- preserves every base and `.long_context` category string and the existing deterministic event order
- preserves tier thresholds, quantities, idempotency inputs, buffering, webhook payloads, and base-category model usage observations
- adds no API, database, migration, feature switch, configuration, or deployment protocol change
- adds no structure-only test; existing integration coverage asserts the observable contract

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_usage.py tests/test_model_provider_json_fallback.py tests/test_model_provider_sse_usage.py tests/test_model_provider_websocket_usage.py` (188 passed)
- `uv run --no-sync python -m pytest tests/` (4,955 passed)

Closes #25605
