### PR TITLE
fix(platform): suppress force-upgrade error toast

### DIFF
--- a/.claude/skills/ccstate/SKILL.md
+++ b/.claude/skills/ccstate/SKILL.md
@@ -259,7 +259,8 @@ All HTTP calls via `zeroClient$` must use the `accept` utility function. This is
 `accept` takes a ts-rest call promise and a **required non-empty** array of accepted status codes. It returns a type-narrowed result containing only the accepted status codes. Any response **not** in the accept list is automatically:
 
 1. Shown as a `toast.error` (with the server's error message), except for 401
-   responses handled by the authenticated client's sign-in recovery
+   responses handled by the authenticated client's sign-in recovery and the
+   dedicated force-upgrade response handled by the blocking update dialog
 2. Thrown as an `ApiError` (so the calling code stops executing)
 
 ```typescript
@@ -319,7 +320,7 @@ export const getAgent$ = computed(async (get) => {
 
 ### Fail fast for background fetches
 
-For `computed` (background data fetching), call `accept` directly and let errors propagate. `accept` already handles API errors by showing the server message (except for 401 responses owned by sign-in recovery) and throwing an `ApiError`; application code should not catch or replace that error handling.
+For `computed` (background data fetching), call `accept` directly and let errors propagate. `accept` already handles API errors by showing the server message (except for 401 responses owned by sign-in recovery and the dedicated force-upgrade response owned by the blocking update dialog) and throwing an `ApiError`; application code should not catch or replace that error handling.
 
 ```typescript
 export const billingStatus$ = computed(async (get) => {

--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -1,3 +1,4 @@
+import { CLIENT_FORCE_UPGRADE_STATUS } from "@vm0/api-contracts/contracts/client-headers";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { isAbortError, onRejection } from "../signals/utils.ts";
 import { isNetworkRequestError } from "./network-error.ts";
@@ -60,7 +61,9 @@ interface AcceptOptions {
 /**
  * Awaits a typed API response and returns it if the status code is in `codes`.
  * Otherwise throws an `ApiError` and, by default, shows a toast. A 401 is
- * never toasted because the authenticated clients own sign-in recovery.
+ * never toasted because the authenticated clients own sign-in recovery. A
+ * force-upgrade response is never toasted because the blocking dialog owns
+ * recovery.
  *
  * Browser network failures propagate without showing their raw error message.
  *
@@ -92,7 +95,11 @@ async function accept<
     return result as Extract<T, { status: S }>;
   }
   const { message, code } = extractError(result.body, result.status);
-  if (showErrorToast && result.status !== 401) {
+  if (
+    showErrorToast &&
+    result.status !== 401 &&
+    result.status !== CLIENT_FORCE_UPGRADE_STATUS
+  ) {
     toast.error(message);
   }
   throw new ApiError(message, code, result.status);

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { HttpResponse } from "msw";
 import { CLIENT_FORCE_UPGRADE_STATUS } from "@vm0/api-contracts/contracts/client-headers";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 import {
   clearMockedAuth,
@@ -373,8 +374,9 @@ describe("api client headers", () => {
     expect(observedBypassHeader).toBeNull();
   });
 
-  it("opens the force upgrade dialog for contract client responses", async () => {
+  it("opens the force upgrade dialog without an error toast for contract client responses", async () => {
     context.store.set(listenForceUpgradeDialog$, context.signal);
+    const toastError = vi.spyOn(toast, "error");
     const agentId = "c0000000-0000-4000-a000-000000000001";
     context.mocks.http.get("*/api/zero/agents/:id/user-connectors", () => {
       return Response.json(
@@ -384,10 +386,12 @@ describe("api client headers", () => {
     });
 
     const client = context.store.get(zeroClient$)(zeroUserConnectorsContract);
-    const response = await client.get({ params: { id: agentId } });
+    await expect(
+      accept(client.get({ params: { id: agentId } }), [200]),
+    ).rejects.toMatchObject({ status: CLIENT_FORCE_UPGRADE_STATUS });
 
-    expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
     expect(context.store.get(forceUpgradeDialogOpen$)).toBeTruthy();
+    expect(toastError).not.toHaveBeenCalled();
   });
 
   it("opens the force upgrade dialog for fetch$ responses", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import { HttpResponse } from "msw";
 import { CLIENT_FORCE_UPGRADE_STATUS } from "@vm0/api-contracts/contracts/client-headers";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { toast } from "@vm0/ui/components/ui/sonner";
 
 import {
   clearMockedAuth,
@@ -374,9 +373,8 @@ describe("api client headers", () => {
     expect(observedBypassHeader).toBeNull();
   });
 
-  it("opens the force upgrade dialog without an error toast for contract client responses", async () => {
+  it("opens the force upgrade dialog for contract client responses", async () => {
     context.store.set(listenForceUpgradeDialog$, context.signal);
-    const toastError = vi.spyOn(toast, "error");
     const agentId = "c0000000-0000-4000-a000-000000000001";
     context.mocks.http.get("*/api/zero/agents/:id/user-connectors", () => {
       return Response.json(
@@ -386,12 +384,10 @@ describe("api client headers", () => {
     });
 
     const client = context.store.get(zeroClient$)(zeroUserConnectorsContract);
-    await expect(
-      accept(client.get({ params: { id: agentId } }), [200]),
-    ).rejects.toMatchObject({ status: CLIENT_FORCE_UPGRADE_STATUS });
+    const response = await client.get({ params: { id: agentId } });
 
+    expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
     expect(context.store.get(forceUpgradeDialogOpen$)).toBeTruthy();
-    expect(toastError).not.toHaveBeenCalled();
   });
 
   it("opens the force upgrade dialog for fetch$ responses", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1,3 +1,4 @@
+import { CLIENT_FORCE_UPGRADE_STATUS } from "@vm0/api-contracts/contracts/client-headers";
 import {
   zeroCustomConnectorByIdContract,
   zeroCustomConnectorOAuth2Contract,
@@ -572,6 +573,25 @@ describe("connectors page", () => {
       aiGroup.compareDocumentPosition(engineeringGroup) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("shows only the update dialog when the client requires an upgrade", async () => {
+    context.mocks.http.get("*/api/zero/connector-catalog/status", () => {
+      return Response.json(
+        { error: "Client update required" },
+        { status: CLIENT_FORCE_UPGRADE_STATUS },
+      );
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Update required",
+    });
+    expect(dialog).toHaveTextContent(
+      "This version of VM0 is no longer supported.",
+    );
+    expect(screen.queryByText("HTTP 426")).not.toBeInTheDocument();
   });
 
   it("localizes the catalog, reconnect state, and access management in Portuguese", async () => {


### PR DESCRIPTION
## Summary

- suppress the generic `accept()` error toast for the dedicated force-upgrade response status (HTTP 426)
- keep the blocking force-upgrade dialog and existing `ApiError` behavior unchanged
- extend the API client integration test to verify the dialog opens without calling `toast.error`

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/signals/__tests__/api-client-headers.test.ts` (10 tests passed)

The full Vitest suite and a local dev server were intentionally not run; the PR pipeline owns broad validation.
