### PR TITLE
refactor(platform): disallow computed lifecycle signals

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -50,6 +50,7 @@ export default [
       "ccstate/require-accept": "error",
       "ccstate/require-client-signal": "error",
       "ccstate/command-async-signal": "error",
+      "ccstate/no-computed-signal": "error",
       "ccstate/no-getter-setter-params": "error",
       "ccstate/no-accessor-escape": "error",
       "ccstate/no-store-in-params": [

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -32,15 +32,12 @@ export const defaultAgentId$ = computed(async (get) => {
 const internalAgentByIdReload$ = state(0);
 
 export function agentById(id: string): Computed<Promise<ZeroAgentResponse>> {
-  return computed(async (get, { signal }) => {
+  return computed(async (get) => {
     get(internalAgentByIdReload$);
     const client = get(zeroClient$)(zeroAgentsByIdContract);
-    const result = await retryTransientLoad((loadSignal) => {
-      return accept(
-        client.get({ params: { id }, fetchOptions: { signal: loadSignal } }),
-        [200],
-      );
-    }, signal);
+    const result = await retryTransientLoad(() => {
+      return accept(client.get({ params: { id } }), [200]);
+    });
     return result.body;
   });
 }

--- a/turbo/apps/platform/src/signals/artifacts-page/artifact-catalog-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifact-catalog-signals.ts
@@ -66,19 +66,17 @@ export function artifactDetailPreview(detail: ArtifactDetail): {
   };
 }
 
-const selectedArtifactText$ = computed(
-  async (get, { signal }): Promise<string> => {
-    const detail = await get(pageCatalog.selectedArtifactDetail$);
-    if (!detail) {
-      throw new Error("Selected artifact is unavailable");
-    }
-    const preview = artifactDetailPreview(detail);
-    if (!isTextPreviewKind(preview.kind)) {
-      throw new Error("Selected artifact is not a text preview");
-    }
-    return fetchPreviewText(preview.url, signal);
-  },
-);
+const selectedArtifactText$ = computed(async (get): Promise<string> => {
+  const detail = await get(pageCatalog.selectedArtifactDetail$);
+  if (!detail) {
+    throw new Error("Selected artifact is unavailable");
+  }
+  const preview = artifactDetailPreview(detail);
+  if (!isTextPreviewKind(preview.kind)) {
+    throw new Error("Selected artifact is not a text preview");
+  }
+  return fetchPreviewText(preview.url);
+});
 
 /**
  * Open a card. The kind entity is fetched here rather than with the list, so

--- a/turbo/apps/platform/src/signals/artifacts-page/create-artifact-catalog-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/create-artifact-catalog-signals.ts
@@ -54,26 +54,22 @@ function createCatalogPagingSignals(paging: CatalogPagingState): {
 } {
   const { chatThreadId } = paging;
 
-  const firstPage$ = computed(
-    async (get, { signal }): Promise<ArtifactCatalogPage> => {
-      get(paging.reloadVersion$);
-      const kind = get(paging.kind$);
-      const client = get(zeroClient$)(artifactCatalogContract);
-      const result = await accept(
-        client.list({
-          query: {
-            limit: ARTIFACT_CATALOG_PAGE_SIZE,
-            ...(kind ? { kind } : {}),
-            ...(chatThreadId ? { chatThreadId } : {}),
-          },
-          fetchOptions: { signal },
-        }),
-        [200],
-        signal,
-      );
-      return result.body;
-    },
-  );
+  const firstPage$ = computed(async (get): Promise<ArtifactCatalogPage> => {
+    get(paging.reloadVersion$);
+    const kind = get(paging.kind$);
+    const client = get(zeroClient$)(artifactCatalogContract);
+    const result = await accept(
+      client.list({
+        query: {
+          limit: ARTIFACT_CATALOG_PAGE_SIZE,
+          ...(kind ? { kind } : {}),
+          ...(chatThreadId ? { chatThreadId } : {}),
+        },
+      }),
+      [200],
+    );
+    return result.body;
+  });
 
   /**
    * Everything loaded so far, in server order. Reading this triggers the first
@@ -212,7 +208,7 @@ export function createArtifactCatalogSignals(
    * queries it does not render and a deleted artifact renders as unavailable.
    */
   const selectedArtifactDetail$ = computed(
-    async (get, { signal }): Promise<ArtifactDetail | null> => {
+    async (get): Promise<ArtifactDetail | null> => {
       get(internalReload$);
       const artifactId = get(internalSelectedArtifactId$);
       if (!artifactId) {
@@ -222,10 +218,8 @@ export function createArtifactCatalogSignals(
       const result = await accept(
         client.get({
           params: { artifactId },
-          fetchOptions: { signal },
         }),
         [200, 404],
-        signal,
       );
       return result.status === 404 ? null : result.body;
     },

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
@@ -114,19 +114,17 @@ export function createThreadSidebarSignals(
   const artifactCatalog = createArtifactCatalogSignals({
     chatThreadId: threadId,
   });
-  const selectedArtifactText$ = computed(
-    async (get, { signal }): Promise<string> => {
-      const detail = await get(artifactCatalog.selectedArtifactDetail$);
-      if (!detail) {
-        throw new Error("Selected artifact is unavailable");
-      }
-      const preview = artifactDetailPreview(detail);
-      if (!isTextPreviewKind(preview.kind)) {
-        throw new Error("Selected artifact is not a text preview");
-      }
-      return fetchPreviewText(preview.url, signal);
-    },
-  );
+  const selectedArtifactText$ = computed(async (get): Promise<string> => {
+    const detail = await get(artifactCatalog.selectedArtifactDetail$);
+    if (!detail) {
+      throw new Error("Selected artifact is unavailable");
+    }
+    const preview = artifactDetailPreview(detail);
+    if (!isTextPreviewKind(preview.kind)) {
+      throw new Error("Selected artifact is not a text preview");
+    }
+    return fetchPreviewText(preview.url);
+  });
 
   const open$ = command(({ get, set }, target: ThreadSidebarTarget) => {
     const current = get(internalTarget$);

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -138,18 +138,17 @@ interface UserPermissionGrantsByAgentParams {
 export function userPermissionGrantsByAgent(
   params: UserPermissionGrantsByAgentParams,
 ): Computed<Promise<readonly PlatformUserPermissionGrant[]>> {
-  return computed(async (get, { signal }) => {
+  return computed(async (get) => {
     get(internalUserPermissionGrantsReload$);
     const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-    const result = await retryTransientLoad((loadSignal) => {
+    const result = await retryTransientLoad(() => {
       return accept(
         client.list({
           query: params,
-          fetchOptions: { signal: loadSignal },
         }),
         [200],
       );
-    }, signal);
+    });
     return result.body;
   });
 }
@@ -157,18 +156,17 @@ export function userPermissionGrantsByAgent(
 export function userPermissionGrantsByAgentIfExists(
   params: UserPermissionGrantsByAgentParams,
 ): Computed<Promise<readonly PlatformUserPermissionGrant[] | null>> {
-  return computed(async (get, { signal }) => {
+  return computed(async (get) => {
     get(internalUserPermissionGrantsReload$);
     const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-    const result = await retryTransientLoad((loadSignal) => {
+    const result = await retryTransientLoad(() => {
       return accept(
         client.list({
           query: params,
-          fetchOptions: { signal: loadSignal },
         }),
         [200, 404],
       );
-    }, signal);
+    });
     return result.status === 404 ? null : result.body;
   });
 }

--- a/turbo/apps/platform/src/signals/text-preview.ts
+++ b/turbo/apps/platform/src/signals/text-preview.ts
@@ -51,13 +51,9 @@ async function readLimitedText(response: Response): Promise<string> {
   return new TextDecoder().decode(bytes);
 }
 
-export async function fetchPreviewText(
-  url: string,
-  signal?: AbortSignal,
-): Promise<string> {
+export async function fetchPreviewText(url: string): Promise<string> {
   const response = await fetch(url, {
     headers: { Range: `bytes=0-${String(TEXT_PREVIEW_MAX_BYTES - 1)}` },
-    signal,
   });
   if (!response.ok) {
     throw new Error(`HTTP ${String(response.status)}`);
@@ -66,18 +62,15 @@ export async function fetchPreviewText(
 }
 
 export function createTextPreviewComputed(url: string): TextPreviewComputed {
-  return computed((_get, { signal }) => {
-    return fetchPreviewText(url, signal);
+  return computed((_get) => {
+    return fetchPreviewText(url);
   });
 }
 
 export function createTextPreviewComputedFromBlob(
   blob: Blob,
 ): TextPreviewComputed {
-  return computed(async (_get, { signal }) => {
-    signal.throwIfAborted();
-    const text = await blob.slice(0, TEXT_PREVIEW_MAX_BYTES).text();
-    signal.throwIfAborted();
-    return text;
+  return computed((_get) => {
+    return blob.slice(0, TEXT_PREVIEW_MAX_BYTES).text();
   });
 }

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -319,18 +319,9 @@ function runRetriedLoad<T>(load: () => Promise<T>): Promise<T> {
  * network or chunk-loading errors. Do not wrap mutations: `load` may run more
  * than once.
  */
-export function retryTransientLoad<T>(
-  load: (signal: AbortSignal) => Promise<T>,
-  signal: AbortSignal,
-): Promise<T> {
+export function retryTransientLoad<T>(load: () => Promise<T>): Promise<T> {
   async function attemptLoad(attempt: number): Promise<T> {
-    signal.throwIfAborted();
-    const result = await settle(
-      runRetriedLoad(() => {
-        return load(signal);
-      }),
-      signal,
-    );
+    const result = await settle(runRetriedLoad(load));
     if (result.ok) {
       return result.value;
     }
@@ -338,7 +329,7 @@ export function retryTransientLoad<T>(
     if (delayMs === undefined || !isRetryableError(result.error)) {
       throw result.error;
     }
-    await delay(IN_VITEST ? 0 : delayMs, { signal });
+    await delay(IN_VITEST ? 0 : delayMs);
     return attemptLoad(attempt + 1);
   }
 

--- a/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
+++ b/turbo/apps/platform/src/signals/zero-page/avatar-template-picker.ts
@@ -57,7 +57,7 @@ interface OffsetCatalogPage<T> {
 
 type LoadOffsetCatalogPage<T> = (
   page: number,
-  signal: AbortSignal,
+  signal?: AbortSignal,
 ) => Promise<OffsetCatalogPage<T>>;
 
 function emptyAvatarTemplateFilters(): AvatarTemplateFilters {
@@ -254,8 +254,8 @@ function createOffsetCatalogPagingSignals<T>(
   const internalRequestedPages$ = state<ReadonlySet<number>>(new Set());
   const internalLoadingMore$ = state(false);
   const internalGeneration$ = state(0);
-  const firstPage$ = computed((get, { signal }) => {
-    return get(loadPage$)(1, signal);
+  const firstPage$ = computed((get) => {
+    return get(loadPage$)(1);
   });
   const catalog$ = computed(async (get): Promise<OffsetCatalogPage<T>> => {
     const firstPage = await get(firstPage$);
@@ -375,7 +375,7 @@ function createAvatarTemplateCatalogSignals() {
         const result = await accept(
           client.avatars({
             query: avatarCatalogQuery(filters, page),
-            fetchOptions: { signal },
+            ...(signal ? { fetchOptions: { signal } } : {}),
           }),
           [200],
           signal,
@@ -433,7 +433,7 @@ function createAvatarTemplateVoiceCatalogSignals() {
         const result = await accept(
           client.voices({
             query: voiceCatalogQuery(filters, page),
-            fetchOptions: { signal },
+            ...(signal ? { fetchOptions: { signal } } : {}),
           }),
           [200],
           signal,
@@ -457,7 +457,7 @@ function createAvatarTemplateVoiceCatalogSignals() {
     },
   );
   const avatarTemplateVoiceFilterOptions$ = computed(
-    async (get, { signal }): Promise<AvatarTemplateVoiceFilterOptions> => {
+    async (get): Promise<AvatarTemplateVoiceFilterOptions> => {
       const client = get(zeroClient$)(zeroAvatarVideoContract, {
         apiBase: "api",
       });
@@ -467,10 +467,8 @@ function createAvatarTemplateVoiceCatalogSignals() {
             page: 1,
             pageSize: AVATAR_TEMPLATE_FILTER_OPTIONS_PAGE_SIZE,
           },
-          fetchOptions: { signal },
         }),
         [200],
-        signal,
       );
       return {
         languages: result.body.filterOptions?.languages ?? [],
@@ -509,7 +507,7 @@ export function createAvatarTemplatePickerSignals() {
     return get(internalSelectedAvatar$);
   });
   const avatarTemplateRecommendedVoice$ = computed(
-    async (get, { signal }): Promise<ZeroAvatarVideoVoice | null> => {
+    async (get): Promise<ZeroAvatarVideoVoice | null> => {
       const avatar = get(internalSelectedAvatar$);
       if (!avatar) {
         return null;
@@ -528,10 +526,8 @@ export function createAvatarTemplatePickerSignals() {
             voiceFilters,
             locale,
           ),
-          fetchOptions: { signal },
         }),
         [200],
-        signal,
       );
       return recommendedVoiceFromCandidates(
         result.body.voices,

--- a/turbo/apps/platform/src/signals/zero-page/slack-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-connect-signals.ts
@@ -7,7 +7,7 @@ import { accept } from "../../lib/accept.ts";
 export type SlackConnectStatus = "idle" | "success";
 
 export const slackConnectStatus$ = computed(
-  async (get, { signal }): Promise<SlackConnectStatus> => {
+  async (get): Promise<SlackConnectStatus> => {
     const params = get(searchParams$);
     const workspaceId = params.get("w");
     const initialStatus = params.get("status");
@@ -23,14 +23,8 @@ export const slackConnectStatus$ = computed(
 
     const client = get(zeroClient$)(zeroSlackConnectContract);
     const [result] = await Promise.allSettled([
-      accept(
-        client.getStatus({
-          fetchOptions: { signal },
-        }),
-        [200],
-      ),
+      accept(client.getStatus(), [200]),
     ]);
-    signal.throwIfAborted();
 
     return result?.status === "fulfilled" && result.value.body.isConnected
       ? "success"

--- a/turbo/apps/platform/src/signals/zero-page/teams-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/teams-connect-signals.ts
@@ -13,7 +13,7 @@ export function openTeamsClient(): void {
 }
 
 export const teamsConnectStatus$ = computed(
-  async (get, { signal }): Promise<TeamsConnectPageStatus> => {
+  async (get): Promise<TeamsConnectPageStatus> => {
     const params = get(searchParams$);
     const initialStatus = params.get("status");
     const initialError = params.get("error");
@@ -28,14 +28,8 @@ export const teamsConnectStatus$ = computed(
 
     const client = get(zeroClient$)(zeroTeamsConnectContract);
     const [result] = await Promise.allSettled([
-      accept(
-        client.getStatus({
-          fetchOptions: { signal },
-        }),
-        [200],
-      ),
+      accept(client.getStatus(), [200]),
     ]);
-    signal.throwIfAborted();
 
     return result.status === "fulfilled" && result.value.body.isConnected
       ? "success"

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3008,17 +3008,18 @@ describe("chat event action cards", () => {
     );
   });
 
-  it("cancels stale permission loading when a confirmed grant reloads cards", async () => {
+  it("does not cancel stale permission loading when a confirmed grant reloads cards", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
     const requestStarted = context.mocks.deferred<void>();
-    const requestAborted = context.mocks.deferred<void>();
+    const releaseRequest = context.mocks.deferred<void>();
+    const requestFinished = context.mocks.deferred<void>();
     const threadId = "b0000000-0000-4000-a000-000000000951";
     const reloadedAgentId = "c0000000-0000-4000-a000-000000000002";
     const gmailPermissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow`;
     const youtubePermissionUrl = `https://app.vm0.ai/agents/${reloadedAgentId}/permissions?connectorSlug=youtube&permission=videos.write&action=allow`;
     let pendingRequest = true;
-    let abortObserved = false;
+    let staleRequestSignal: AbortSignal | undefined;
 
     context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
       return respond(200, {
@@ -3035,7 +3036,7 @@ describe("chat event action cards", () => {
     });
     context.mocks.api(
       zeroUserPermissionGrantsContract.list,
-      ({ query, signal, never, respond }) => {
+      async ({ query, signal, respond }) => {
         if (query.agentId !== reloadedAgentId) {
           return respond(200, []);
         }
@@ -3043,18 +3044,11 @@ describe("chat event action cards", () => {
           return respond(200, []);
         }
         pendingRequest = false;
+        staleRequestSignal = signal;
         requestStarted.resolve();
-        signal.addEventListener(
-          "abort",
-          () => {
-            if (!abortObserved) {
-              abortObserved = true;
-              requestAborted.resolve();
-            }
-          },
-          { once: true },
-        );
-        return never();
+        await releaseRequest.promise;
+        requestFinished.resolve();
+        return respond(200, []);
       },
     );
     context.mocks.api(
@@ -3104,28 +3098,35 @@ describe("chat event action cards", () => {
     });
 
     await requestStarted.promise;
-    const permissionCards = await screen.findAllByTestId(
-      "permission-action-card",
-    );
-    expect(permissionCards).toHaveLength(2);
-    const [gmailCard, youtubeCard] = permissionCards;
-    if (!gmailCard || !youtubeCard) {
-      throw new Error("Expected two permission cards");
+    try {
+      const permissionCards = await screen.findAllByTestId(
+        "permission-action-card",
+      );
+      expect(permissionCards).toHaveLength(2);
+      const [gmailCard, youtubeCard] = permissionCards;
+      if (!gmailCard || !youtubeCard) {
+        throw new Error("Expected two permission cards");
+      }
+      await waitForButtonByText("Confirm", gmailCard);
+
+      await confirmPermissionAction(user, gmailCard);
+
+      await waitFor(() => {
+        expect(
+          within(gmailCard).getByText("Permissions updated"),
+        ).toBeInTheDocument();
+        expect(
+          within(youtubeCard).getByText("Allow videos.write"),
+        ).toBeInTheDocument();
+        expect(buttonByText("Confirm", youtubeCard)).toBeEnabled();
+      });
+      expect(staleRequestSignal).toBeDefined();
+      expect(staleRequestSignal?.aborted).toBeFalsy();
+    } finally {
+      releaseRequest.resolve();
+      await requestFinished.promise;
     }
-    await waitForButtonByText("Confirm", gmailCard);
-
-    await confirmPermissionAction(user, gmailCard);
-
-    await requestAborted.promise;
-    await waitFor(() => {
-      expect(
-        within(gmailCard).getByText("Permissions updated"),
-      ).toBeInTheDocument();
-      expect(
-        within(youtubeCard).getByText("Allow videos.write"),
-      ).toBeInTheDocument();
-      expect(buttonByText("Confirm", youtubeCard)).toBeEnabled();
-    });
+    expect(staleRequestSignal?.aborted).toBeFalsy();
   });
 
   it("automatically retries permission action loading before showing an error", async () => {

--- a/turbo/packages/eslint-rules/src/ccstate/__tests__/no-computed-signal.test.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/__tests__/no-computed-signal.test.ts
@@ -1,0 +1,44 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+import rule from "../rules/no-computed-signal.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-computed-signal", rule, {
+  valid: [
+    {
+      code: "const value$ = computed((get) => get(source$));",
+    },
+    {
+      code: "const value$ = computed(async (get) => await get(source$));",
+    },
+    {
+      code: "const value$ = library.computed((get, options) => options.signal);",
+    },
+    {
+      code: "const run$ = command(async ({ get }, signal: AbortSignal) => get(source$));",
+    },
+  ],
+  invalid: [
+    {
+      code: "const value$ = computed((get, { signal }) => load(signal));",
+      errors: [{ messageId: "noComputedSignal" }],
+    },
+    {
+      code: "const value$ = computed(async (get, { signal: requestSignal }) => load(requestSignal));",
+      errors: [{ messageId: "noComputedSignal" }],
+    },
+    {
+      code: "const value$ = computed((get, options) => load(options.signal));",
+      errors: [{ messageId: "noComputedSignal" }],
+    },
+    {
+      code: "const value$ = computed(function (get, { signal }) { return load(signal); });",
+      errors: [{ messageId: "noComputedSignal" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/ccstate/index.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/index.ts
@@ -9,6 +9,7 @@
  * - no-catch-abort: Enforce throwIfAbort in catch blocks
  * - no-package-variable: Prevent mutable vars at package scope
  * - no-get-signal: Prevent getting AbortSignal from state
+ * - no-computed-signal: Prevent computed callbacks from consuming lifecycle options
  * - test-context-in-hooks: Ensure testContext() in test hooks
  * - computed-const-args-package-scope: Enforce package scope for constant functions
  * - no-store-in-params: Prevent Store type in function params
@@ -37,6 +38,7 @@ import tsxInViews from "./rules/tsx-in-views.ts";
 import noCatchAbort from "./rules/no-catch-abort.ts";
 import noPackageVariable from "./rules/no-package-variable.ts";
 import noGetSignal from "./rules/no-get-signal.ts";
+import noComputedSignal from "./rules/no-computed-signal.ts";
 import testContextInHooks from "./rules/test-context-in-hooks.ts";
 import computedConstArgsPackageScope from "./rules/computed-const-args-package-scope.ts";
 import noStoreInParams from "./rules/no-store-in-params.ts";
@@ -78,6 +80,7 @@ const plugin = {
     "no-catch-abort": noCatchAbort,
     "no-package-variable": noPackageVariable,
     "no-get-signal": noGetSignal,
+    "no-computed-signal": noComputedSignal,
     "test-context-in-hooks": testContextInHooks,
     "computed-const-args-package-scope": computedConstArgsPackageScope,
     "no-store-in-params": noStoreInParams,

--- a/turbo/packages/eslint-rules/src/ccstate/rules/no-computed-signal.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/rules/no-computed-signal.ts
@@ -1,0 +1,66 @@
+/**
+ * ESLint rule: no-computed-signal
+ *
+ * Computed callbacks must not consume ccstate's lifecycle options. Requests
+ * started by a computed are allowed to finish after the computed invalidates.
+ *
+ * Good:
+ *   computed(async (get) => load(get(id$)))
+ *
+ * Bad:
+ *   computed(async (get, { signal }) => load(get(id$), signal))
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "no-computed-signal",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow the lifecycle options parameter in computed callbacks",
+      recommended: true,
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      noComputedSignal:
+        "Computed callbacks must not accept lifecycle options. Remove the second callback parameter.",
+    },
+  },
+  create(context) {
+    function checkComputedCallback(node: TSESTree.CallExpression): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.Identifier ||
+        node.callee.name !== "computed"
+      ) {
+        return;
+      }
+
+      const callback = node.arguments[0];
+      if (
+        callback?.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+        callback?.type !== AST_NODE_TYPES.FunctionExpression
+      ) {
+        return;
+      }
+
+      const lifecycleOptions = callback.params[1];
+      if (!lifecycleOptions) {
+        return;
+      }
+
+      context.report({
+        node: lifecycleOptions,
+        messageId: "noComputedSignal",
+      });
+    }
+
+    return {
+      CallExpression: checkComputedCallback,
+    };
+  },
+});


### PR DESCRIPTION
## Summary

- remove lifecycle-option reads from every platform `computed` callback so in-flight computed requests can finish after invalidation
- preserve `AbortSignal` cancellation for command-owned avatar pagination
- add and enable `ccstate/no-computed-signal`, with regression coverage for both the rule and the non-cancelling request behavior

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- targeted Vitest coverage for the ESLint rule, artifact catalog, thread sidebar, avatar templates, Slack, Teams, permission allow, and action cards
