### PR TITLE
fix(ci): build app preview from merge candidate

### DIFF
--- a/.github/scripts/tests/app-preview-ingress-workflow-test.sh
+++ b/.github/scripts/tests/app-preview-ingress-workflow-test.sh
@@ -24,6 +24,25 @@ find_step = lambda do |name|
   steps.find { |step| step["name"] == name } || raise("missing step: #{name}")
 end
 
+expected_candidate_sha = "${{ github.sha }}"
+expected_concurrency_group = "deploy-app-#{expected_candidate_sha}"
+unless deploy_app.fetch("concurrency").fetch("group") == expected_concurrency_group
+  raise "deploy-app concurrency must use the checked merge candidate"
+end
+
+checkout_step = steps.find do |step|
+  step.fetch("uses", "").start_with?("actions/checkout@")
+end
+raise "missing deploy-app checkout step" unless checkout_step
+unless checkout_step.fetch("with").fetch("ref") == expected_candidate_sha
+  raise "deploy-app must check out the merge candidate"
+end
+
+artifact_step = find_step.call("Resolve artifact commit SHA")
+unless artifact_step.fetch("run").include?("resolve-build-commit-sha.sh")
+  raise "deploy-app artifact identity must derive from the checked-out commit"
+end
+
 expected_output = "${{ steps.pages-deploy.outputs.url }}"
 unless deploy_app.fetch("outputs").fetch("deployment-url") == expected_output
   raise "deploy-app deployment-url output changed"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1148,7 +1148,7 @@ jobs:
     outputs:
       deployment-url: ${{ steps.pages-deploy.outputs.url }}
     concurrency:
-      group: deploy-app-${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      group: deploy-app-${{ github.sha }}
       cancel-in-progress: false
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
@@ -1175,7 +1175,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
 
       - name: Resolve Cloudflare Pages preview branch
         id: pages-branch


### PR DESCRIPTION
## Summary

- build pull request App previews from `github.sha`, matching the synthetic merge candidate checked out by Playwright
- key `deploy-app` concurrency by the same candidate SHA
- extend the App preview workflow integration test to pin checkout, concurrency, and checked-out-commit artifact identity

## Why

`deploy-app` previously built the PR head while Playwright tested source from GitHub's synthetic merge commit. After `main` changed a coupled App/fixture contract, one E2E run deployed the old App and exercised it with the new fixture, producing a deterministic false failure.

The R2 key, embedded App version, manifests, verification, and Pages commit hash already derive from checked-out `HEAD`, so no additional artifact logic is needed.

This does not add UI fallbacks, retries, sleeps, timeout changes, runtime API changes, schema changes, or persisted-data changes.

## Validation

- `bash -n .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `shellcheck .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `bash .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml`
- `actionlint .github/workflows/turbo.yml`
- `pnpm exec prettier --check ../.github/workflows/turbo.yml` (from `turbo`)
- all 49 `.github/scripts/tests/*.sh` scripts under `bash -euo pipefail`
- `git diff --check`

## Trade-off

A base update now creates a new App artifact even when the PR head is unchanged. That artifact represents a genuinely different merge candidate; reruns of the same candidate continue to reuse the immutable R2 artifact.

Closes #25647
