### PR TITLE
docs(ably-subscriber): document messagepack decoder contract

### DIFF
--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -52,6 +52,11 @@ pub mod flags {
 // NOTE: We intentionally omit `skip_serializing_if = "Option::is_none"` on
 // these structs. rmp_serde has a long-standing bug where skipped Option fields
 // cause deserialization failures: https://github.com/3Hren/msgpack-rust/issues/86
+/// Low-level representation of an Ably MessagePack protocol message.
+///
+/// Inbound frame compatibility is defined by [`decode_msg`]. Subscription
+/// consumers observe [`crate::Event`] values; message events carry
+/// [`crate::Message`] instead of this wire representation.
 #[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ProtocolMessage {
@@ -164,6 +169,10 @@ impl fmt::Debug for AuthDetails {
 pub struct AblyMessage {
     pub id: Option<String>,
     pub name: Option<String>,
+    /// MessagePack payload normalized to JSON by [`decode_msg`].
+    ///
+    /// A missing, `nil`, or non-finite root value is `None`. See [`decode_msg`]
+    /// for the complete recursive conversion contract.
     pub data: Option<serde_json::Value>,
     pub client_id: Option<String>,
     pub timestamp: Option<i64>,
@@ -184,6 +193,50 @@ pub fn encode_msg(msg: &ProtocolMessage) -> Result<Vec<u8>, Error> {
     Ok(rmp_serde::to_vec_named(msg)?)
 }
 
+/// Decode one Ably MessagePack protocol frame.
+///
+/// This is the authoritative inbound compatibility contract for
+/// [`ProtocolMessage`] and [`AblyMessage::data`]. This module contains
+/// low-level wire types; subscription consumers observe [`crate::Event`]
+/// values, with message events carrying [`crate::Message`].
+///
+/// # Frame contract
+///
+/// The input must contain exactly one bounded-depth MessagePack value that
+/// consumes the full frame. Its root must be a map with an `action` integer
+/// representable as an `i32`. Unknown numeric actions remain valid for forward
+/// compatibility.
+///
+/// Known protocol fields, their known nested fields, and converted `params`
+/// keys use last-wins semantics when repeated. Unknown protocol fields are
+/// ignored.
+///
+/// # Message data normalization
+///
+/// A missing, `nil`, or non-finite root [`AblyMessage::data`] value becomes
+/// `None`. Other values are converted recursively to JSON:
+///
+/// - MessagePack `nil` and non-finite values nested inside data become JSON
+///   `null`.
+/// - Booleans, integers, finite floats, and valid UTF-8 strings become their
+///   corresponding JSON values.
+/// - Binary and extension payload bytes become standard-base64 JSON strings;
+///   an extension's type tag is not retained.
+/// - Invalid UTF-8 strings and map keys become empty strings.
+/// - Arrays become JSON arrays. Maps become JSON objects, with non-string keys
+///   formatted as strings and duplicate converted keys using last-wins
+///   semantics.
+///
+/// Channel delivery replaces a missing low-level data value with JSON `null`
+/// and then applies supported Ably `encoding` layers; see
+/// [`crate::Message::data`].
+///
+/// # Errors
+///
+/// Malformed MessagePack, excessive nesting, trailing bytes, an invalid root,
+/// a missing `action`, and invalid field shapes or numeric ranges return
+/// [`Error::Protocol`] with [`error_code::BAD_REQUEST`]. Diagnostic text is not
+/// part of this compatibility contract.
 pub fn decode_msg(data: &[u8]) -> Result<ProtocolMessage, Error> {
     let mut cursor = std::io::Cursor::new(data);
     let value = rmpv::decode::read_value_with_max_depth(&mut cursor, MAX_MSGPACK_DECODE_DEPTH)

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -116,10 +116,19 @@ impl fmt::Debug for TokenDetails {
 pub struct Message {
     /// Event name (e.g. "job", "events", "status").
     pub name: Option<String>,
-    /// Message payload.
+    /// Message payload after MessagePack normalization and supported Ably
+    /// `encoding` processing.
     ///
-    /// Binary payloads are exposed as base64 strings because this public API
-    /// uses `serde_json::Value`, which has no raw binary representation.
+    /// Missing, `nil`, and non-finite root wire values are exposed as JSON
+    /// `null`; those values nested inside arrays or maps are also JSON `null`.
+    /// Binary and extension payload bytes become standard-base64 strings, and
+    /// an extension's type tag is not retained. Invalid UTF-8 strings and map
+    /// keys become empty strings. Other non-string map keys are formatted as
+    /// strings, and duplicate converted keys use last-wins semantics.
+    ///
+    /// Supported `json` and `utf-8` encoding layers are processed after wire
+    /// normalization. An encoding stack containing a `base64` layer stays in
+    /// its normalized JSON form instead of being decoded to raw bytes.
     pub data: serde_json::Value,
     /// Unique message ID.
     pub id: Option<String>,

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -563,6 +563,33 @@ fn decode_msg_preserves_nested_data_maps_and_arrays() -> TestResult {
 }
 
 #[test]
+fn decode_msg_stringifies_non_string_data_map_keys_before_last_wins() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![field(
+                "data",
+                rmpv::Value::Map(vec![
+                    (rmpv::Value::from(7), str_value("integer key")),
+                    field("7", str_value("string key")),
+                ]),
+            )])]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    let message = single_message(&decoded)?;
+    assert_eq!(
+        message.data.as_ref(),
+        Some(&serde_json::json!({"7": "string key"}))
+    );
+    Ok(())
+}
+
+#[test]
 fn decode_msg_converts_msgpack_binary_data_to_base64_string() -> TestResult {
     let payload = rmpv::Value::Map(vec![
         field("action", rmpv::Value::from(action::MESSAGE)),

--- a/crates/ably-subscriber/tests/protocol_decode_properties.rs
+++ b/crates/ably-subscriber/tests/protocol_decode_properties.rs
@@ -733,7 +733,7 @@ proptest! {
     }
 
     #[test]
-    fn generated_nested_message_data_uses_documented_json_conversion(case in encoded_json_strategy()) {
+    fn generated_nested_message_data_matches_documented_decoder_conversion(case in encoded_json_strategy()) {
         let EncodedJson {
             wire,
             json,


### PR DESCRIPTION
## Summary

- document the complete inbound MessagePack frame and JSON normalization contract on the low-level `decode_msg` entry point
- link low-level protocol types to that authority while keeping the `protocol` module doc-hidden
- expand public `Message::data` Rustdoc with the consumer-visible payload representation and align the property-test name with the documented contract
- add public-boundary coverage for non-string data-map keys and last-wins collisions after key conversion

## Explicit exclusions

- no decoder, encoding, error, wire-format, API-visibility, schema, dependency, or deployment behavior changes
- no promotion of the unstable low-level `protocol` module into the supported generated API

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p ably-subscriber --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test protocol_decode` (27 passed)
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test protocol_decode_properties` (4 passed)
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber`
- `lefthook run pre-commit`

Closes #25645
