### PR TITLE
fix: inject quickbooks oauth config into deployments

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -329,6 +329,7 @@ runs:
           TODOIST
           ASANA
           POSTHOG
+          QUICKBOOKS
           GUMROAD
           MERCURY
           SPOTIFY

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -159,6 +159,8 @@ assert_env_value "$success_env_file" GH_OAUTH_CLIENT_ID "doppler-GH_OAUTH_CLIENT
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_SECRET "doppler-GH_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_SECRET "doppler-SLACK_OAUTH_CLIENT_SECRET"
+assert_env_value "$success_env_file" QUICKBOOKS_OAUTH_CLIENT_ID "doppler-QUICKBOOKS_OAUTH_CLIENT_ID"
+assert_env_value "$success_env_file" QUICKBOOKS_OAUTH_CLIENT_SECRET "doppler-QUICKBOOKS_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" MICROSOFT_TEAMS_BOT_APP_ID "github-teams-bot-app-id"
 assert_env_value "$success_env_file" MICROSOFT_TEAMS_BOT_APP_PASSWORD "github-teams-bot-app-password"
 assert_env_value "$success_env_file" MICROSOFT_TEAMS_APP_TENANT_ID "github-teams-app-tenant-id"


### PR DESCRIPTION
## Summary

- Include QUICKBOOKS in the shared OAuth client config prefix list used by Web and API deployments.
- Cover the rendered QuickBooks OAuth client ID and secret in the deployment action regression test.

## Context

The QuickBooks auth provider requires QUICKBOOKS_OAUTH_CLIENT_ID and QUICKBOOKS_OAUTH_CLIENT_SECRET. Doppler supplies both values, but the deployment action did not render them. Connector catalog compatibility therefore removed quickbooks/oauth before the quickbooksConnector feature switch could expose it.

## Verification

- bash -n .github/scripts/tests/web-api-env-action-test.sh
- bash .github/scripts/tests/web-api-env-action-test.sh