### PR TITLE
fix: restore the previous 3-block thinking indicator

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -214,6 +214,7 @@ export interface ChatPanelSignals {
   readonly resetRenderedChatGroupsIfAtBottom$: Command<void, []>;
   readonly subscribeChatThread$: Command<Promise<void>, [AbortSignal]>;
   // -- Thinking indicator ---------------------------------------------------
+  readonly blockColors$: Computed<[string, string, string]>;
   readonly thinkingPhrase$: Computed<string>;
   readonly donePhrase$: Computed<Promise<string>>;
   readonly displayedThinkingText$: Computed<Promise<string>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -220,6 +220,26 @@ function chatEventAttachFiles(
 // Thinking-indicator constants and helpers
 // ---------------------------------------------------------------------------
 
+const BLOCK_COLORS = [
+  "#e8a0b4",
+  "#c4705a",
+  "#f5b88a",
+  "#a8b560",
+  "#6bb5a0",
+  "#7baed4",
+  "#b09eda",
+  "#d4a87b",
+  "#e07878",
+  "#82c4c2",
+] as const;
+
+function shuffleBlockColors(): [string, string, string] {
+  const shuffled = [...BLOCK_COLORS].sort(() => {
+    return Math.random() - 0.5;
+  });
+  return [shuffled[0]!, shuffled[1]!, shuffled[2]!];
+}
+
 const THINKING_PHRASE_COUNT = 10;
 const DONE_PHRASE_COUNT = 8;
 
@@ -3368,6 +3388,10 @@ function createThinkingIndicatorSignals(
   thinkingText$: Computed<Promise<string | null>>,
   thinkingEventId$: Computed<Promise<string | null>>,
 ) {
+  const blockColors = shuffleBlockColors();
+  const blockColors$ = computed(() => {
+    return blockColors;
+  });
   const thinkingPhraseIndex = Math.floor(Math.random() * THINKING_PHRASE_COUNT);
   const thinkingPhrase$ = computed((get) => {
     get(locale$);
@@ -3425,6 +3449,7 @@ function createThinkingIndicatorSignals(
   );
 
   return {
+    blockColors$,
     thinkingPhrase$,
     displayedThinkingText$,
     thinkingTextFadingOut$,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -317,80 +317,43 @@ body {
   animation: zero-thinking-in 0.3s ease-out;
 }
 
-/* Thinking indicator: 3x3 ripple loader.
- * A wave of energy sweeps the grid along the diagonal; each cell morphs from
- * square to circle as it lights up, which is what makes a static grid read as
- * soft rather than mechanical. */
+/* Thinking indicator: 3-block loader */
 .zero-blocks {
   display: inline-grid;
-  grid-template-columns: repeat(3, 3.5px);
-  grid-template-rows: repeat(3, 3.5px);
+  grid-template-columns: repeat(2, 5px);
+  grid-template-rows: repeat(2, 5px);
   gap: 1.5px;
 }
 .zero-blocks span {
-  border-radius: 1px;
-  background: hsl(var(--muted-foreground) / 0.3);
-  animation: zero-block-ripple 1.25s cubic-bezier(0.4, 0, 0.3, 1) infinite;
+  border-radius: 1.5px;
 }
-/* Delay follows each cell's diagonal distance from the top-left corner, so the
- * wave travels top-left to bottom-right across five steps. */
-.zero-blocks span:nth-child(2),
-.zero-blocks span:nth-child(4) {
-  animation-delay: 0.1s;
+.zero-blocks span:nth-child(1) {
+  background: var(--zb-c1);
+  grid-column: 2;
+  grid-row: 1;
+  animation: zero-block-pop 1.4s ease-in-out infinite;
 }
-.zero-blocks span:nth-child(3),
-.zero-blocks span:nth-child(5),
-.zero-blocks span:nth-child(7) {
-  animation-delay: 0.2s;
+.zero-blocks span:nth-child(2) {
+  background: var(--zb-c2);
+  grid-column: 1;
+  grid-row: 2;
+  animation: zero-block-pop 1.4s ease-in-out 0.2s infinite;
 }
-.zero-blocks span:nth-child(6),
-.zero-blocks span:nth-child(8) {
-  animation-delay: 0.3s;
+.zero-blocks span:nth-child(3) {
+  background: var(--zb-c3);
+  grid-column: 2;
+  grid-row: 2;
+  animation: zero-block-pop 1.4s ease-in-out 0.4s infinite;
 }
-.zero-blocks span:nth-child(9) {
-  animation-delay: 0.4s;
-}
-@keyframes zero-block-ripple {
-  0% {
-    transform: scale(0.78);
-    border-radius: 1px;
-    background: hsl(var(--muted-foreground) / 0.3);
-    box-shadow: 0 0 0 hsl(var(--primary) / 0);
-  }
-  16% {
-    transform: scale(1.18);
-    border-radius: 50%;
-    background: hsl(var(--primary));
-    box-shadow: 0 0 3px hsl(var(--primary) / 0.55);
-  }
-  28% {
-    transform: scale(1);
-    border-radius: 34%;
-    background: hsl(var(--primary));
-    box-shadow: 0 0 0 hsl(var(--primary) / 0);
-  }
-  52%,
-  100% {
-    transform: scale(0.78);
-    border-radius: 1px;
-    background: hsl(var(--muted-foreground) / 0.3);
-    box-shadow: 0 0 0 hsl(var(--primary) / 0);
-  }
-}
-/* Keep the wave legible without motion: colour still travels, nothing moves. */
-@media (prefers-reduced-motion: reduce) {
-  .zero-blocks span {
-    animation-name: zero-block-ripple-calm;
-    animation-duration: 2s;
-  }
-}
-@keyframes zero-block-ripple-calm {
+@keyframes zero-block-pop {
   0%,
   100% {
-    background: hsl(var(--muted-foreground) / 0.3);
+    transform: scale(0.8);
+    opacity: 0.5;
   }
-  40% {
-    background: hsl(var(--primary) / 0.75);
+  50% {
+    transform: scale(1);
+    opacity: 1;
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,4 +1,5 @@
 import type {
+  CSSProperties,
   FormEvent,
   MouseEvent as ReactMouseEvent,
   ReactNode,
@@ -4268,34 +4269,24 @@ function ThinkingLabel({
   );
 }
 
-function ThinkingBlocks() {
-  return (
-    <span className="zero-blocks shrink-0">
-      <span />
-      <span />
-      <span />
-      <span />
-      <span />
-      <span />
-      <span />
-      <span />
-      <span />
-    </span>
-  );
-}
-
 function InlineThinkingRow({
+  blockStyle,
   isQueued,
   thinkingLabel,
   serverThinkingLabel,
 }: {
+  blockStyle: CSSProperties;
   isQueued: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
 }) {
   return (
     <div className="flex items-center gap-2 h-5">
-      <ThinkingBlocks />
+      <span className="zero-blocks shrink-0" style={blockStyle}>
+        <span />
+        <span />
+        <span />
+      </span>
       <ThinkingLabel
         isQueued={isQueued}
         thinkingLabel={thinkingLabel}
@@ -4353,11 +4344,13 @@ function FinishedRunRow({
 
 function WaitingForAssistantResponse({
   thread,
+  blockStyle,
   isQueued,
   thinkingLabel,
   serverThinkingLabel,
 }: {
   thread: ChatPanelSignals;
+  blockStyle: CSSProperties;
   isQueued: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
@@ -4372,7 +4365,11 @@ function WaitingForAssistantResponse({
         <AssistantBubbleAvatar thread={thread} />
         <div className="zero-chat-bubble-assistant rounded-xl py-4 text-[0.9375rem] leading-[1.7] min-w-0 overflow-hidden">
           <div className="flex h-5 min-w-0 items-center gap-2">
-            <ThinkingBlocks />
+            <span className="zero-blocks shrink-0" style={blockStyle}>
+              <span />
+              <span />
+              <span />
+            </span>
             <ThinkingLabel
               isQueued={isQueued}
               thinkingLabel={thinkingLabel}
@@ -4394,6 +4391,7 @@ function WaitingForAssistantResponse({
 
 function AssistantThinkingStatusRow({
   running,
+  blockStyle,
   isQueued,
   thinkingLabel,
   serverThinkingLabel,
@@ -4401,6 +4399,7 @@ function AssistantThinkingStatusRow({
   recommendedFollowupSource,
 }: {
   running: boolean;
+  blockStyle: CSSProperties;
   isQueued: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
@@ -4421,6 +4420,7 @@ function AssistantThinkingStatusRow({
       <div className="min-w-0">
         {running ? (
           <InlineThinkingRow
+            blockStyle={blockStyle}
             isQueued={isQueued}
             thinkingLabel={thinkingLabel}
             serverThinkingLabel={serverThinkingLabel}
@@ -4459,6 +4459,12 @@ function equalRecommendedFollowupSources(
 }
 
 function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
+  const [c1, c2, c3] = useGet(thread.blockColors$);
+  const blockStyle = {
+    "--zb-c1": c1,
+    "--zb-c2": c2,
+    "--zb-c3": c3,
+  } as CSSProperties;
   const mode = useLastResolved(thread.thinkingIndicatorMode$) ?? null;
   const thinkingText = useLastResolved(thread.thinkingText$);
   const recommendedFollowupSource =
@@ -4496,6 +4502,7 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
     return (
       <AssistantThinkingStatusRow
         running={running}
+        blockStyle={blockStyle}
         isQueued={isQueued}
         thinkingLabel={thinkingLabel}
         serverThinkingLabel={serverThinkingLabel}
@@ -4509,6 +4516,7 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
   return (
     <WaitingForAssistantResponse
       thread={thread}
+      blockStyle={blockStyle}
       isQueued={isQueued}
       thinkingLabel={thinkingLabel}
       serverThinkingLabel={serverThinkingLabel}


### PR DESCRIPTION
## What

Reverts #25607. The team decided the loading indicator didn't need to change, so the chat thinking indicator goes back to the 2×2 three-block loader with its randomized per-thread palette.

`BLOCK_COLORS`, `shuffleBlockColors()`, the `blockColors$` signal, the `blockStyle` prop, and the `--zb-c*` custom properties are all restored exactly as they were. Three of the four files are byte-identical to the pre-#25607 state; `zero-chat-thread-page.tsx` auto-merged cleanly around two later PRs (#25441, #25610) that touched it.

## Why `fix:` and not `revert:`

`release-please-config.json` marks `revert` as `hidden: true`, so a revert-typed commit would not bump the app version — the rollback would sit on main and never reach production. `fix:` guarantees a patch release.

## This is a user-visible rollback

#25607 shipped to production in release #25612 (app 0.700.0), so users are currently seeing the 3×3 ripple. This PR needs to go out in the next release to actually take effect.

## Unrelated: the alignment question

Tong flagged that the loader doesn't line up with the action icons above it. Measured it — **this PR does not change that behaviour**, because both loaders are anchored identically:

| | left edge, relative to the content column |
|---|---|
| icon button box | −4px (`-ml-1`) |
| **icon glyph ink** | **+2.44px** |
| old 2×2 loader | 0px |
| new 3×3 loader | 0px |

The action row uses `-ml-1` to cancel the icon button's `p-1`, which aligns the icon *box* to the column origin — but Tabler glyphs are inset 3.25 of 24 units inside their own box, so the visible ink lands 2.44px to the right. The loader has no padding and no optical inset, so it sits flush at 0, matching the message text.

So the loader is aligned with the message text; it's the **icon row** that sits ~2.4px right of everything else. That's a pre-existing optical-alignment issue in the action row, worth its own PR if we want it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)