### PR TITLE
perf(runner): avoid rewalking unchanged storage cache entries

### DIFF
--- a/crates/runner/src/cmd/gc/filesystem.rs
+++ b/crates/runner/src/cmd/gc/filesystem.rs
@@ -115,15 +115,37 @@ pub(super) async fn gc_entry_is_real_dir(entry: &tokio::fs::DirEntry) -> std::io
 /// Last-used time comes from the root directory's own mtime, which `touch_mtime`
 /// updates on every cache hit and `runner start`.
 pub(super) async fn dir_stats(dir: &Path) -> (u64, SystemTime) {
+    let stats = collect_dir_stats(dir).await;
+    (stats.size, stats.mtime)
+}
+
+pub(super) struct DirStats {
+    pub(super) size: u64,
+    pub(super) mtime: SystemTime,
+    pub(super) root_metadata: Option<std::fs::Metadata>,
+}
+
+/// Compute directory stats while retaining the root metadata fetched for the walk.
+pub(super) async fn collect_dir_stats(dir: &Path) -> DirStats {
     const BYTES_PER_BLOCK: u64 = 512;
 
     let root_meta = match tokio::fs::symlink_metadata(dir).await {
         Ok(meta) => meta,
-        Err(_) => return (0, SystemTime::UNIX_EPOCH),
+        Err(_) => {
+            return DirStats {
+                size: 0,
+                mtime: SystemTime::UNIX_EPOCH,
+                root_metadata: None,
+            };
+        }
     };
     let mtime = root_meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
     if !root_meta.file_type().is_dir() {
-        return (root_meta.blocks() * BYTES_PER_BLOCK, mtime);
+        return DirStats {
+            size: root_meta.blocks() * BYTES_PER_BLOCK,
+            mtime,
+            root_metadata: Some(root_meta),
+        };
     }
 
     let mut total_bytes = 0u64;
@@ -157,7 +179,11 @@ pub(super) async fn dir_stats(dir: &Path) -> (u64, SystemTime) {
         }
     }
 
-    (total_bytes, mtime)
+    DirStats {
+        size: total_bytes,
+        mtime,
+        root_metadata: Some(root_meta),
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/cmd/gc/filesystem.rs
+++ b/crates/runner/src/cmd/gc/filesystem.rs
@@ -122,11 +122,20 @@ pub(super) async fn dir_stats(dir: &Path) -> (u64, SystemTime) {
 pub(super) struct DirStats {
     pub(super) size: u64,
     pub(super) mtime: SystemTime,
+    /// Present only when the full directory walk completed.
     pub(super) root_metadata: Option<std::fs::Metadata>,
 }
 
 /// Compute directory stats while retaining the root metadata fetched for the walk.
 pub(super) async fn collect_dir_stats(dir: &Path) -> DirStats {
+    let mut entry_reader = GcDirEntryReader::new();
+    collect_dir_stats_with_reader(dir, &mut entry_reader).await
+}
+
+async fn collect_dir_stats_with_reader(
+    dir: &Path,
+    entry_reader: &mut GcDirEntryReader,
+) -> DirStats {
     const BYTES_PER_BLOCK: u64 = 512;
 
     let root_meta = match tokio::fs::symlink_metadata(dir).await {
@@ -149,13 +158,19 @@ pub(super) async fn collect_dir_stats(dir: &Path) -> DirStats {
     }
 
     let mut total_bytes = 0u64;
+    let mut complete = true;
     let mut stack = vec![dir.to_path_buf()];
     while let Some(current) = stack.pop() {
-        let Ok(current_meta) = tokio::fs::symlink_metadata(&current).await else {
-            tracing::debug!("dir_stats: cannot stat {}", current.display());
-            continue;
+        let current_meta = match tokio::fs::symlink_metadata(&current).await {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                tracing::debug!("dir_stats: cannot stat {}", current.display());
+                complete = false;
+                continue;
+            }
         };
         if !current_meta.file_type().is_dir() {
+            complete = false;
             continue;
         }
 
@@ -163,14 +178,30 @@ pub(super) async fn collect_dir_stats(dir: &Path) -> DirStats {
             Ok(rd) => rd,
             Err(e) => {
                 tracing::debug!("dir_stats: cannot read {}: {e}", current.display());
+                complete = false;
                 continue;
             }
         };
-        while let Some(entry) = next_entry_warn_or_stop(&mut entries, "dir_stats", &current).await {
+        loop {
+            let entry = match entry_reader
+                .next_entry_warn(&mut entries, "dir_stats", &current)
+                .await
+            {
+                Ok(Some(entry)) => entry,
+                Ok(None) => break,
+                Err(_) => {
+                    complete = false;
+                    break;
+                }
+            };
             let path = entry.path();
-            let Ok(meta) = tokio::fs::symlink_metadata(&path).await else {
-                tracing::debug!("dir_stats: cannot stat {}", entry.path().display());
-                continue;
+            let meta = match tokio::fs::symlink_metadata(&path).await {
+                Ok(metadata) => metadata,
+                Err(_) => {
+                    tracing::debug!("dir_stats: cannot stat {}", entry.path().display());
+                    complete = false;
+                    continue;
+                }
             };
             total_bytes += meta.blocks() * BYTES_PER_BLOCK;
             if meta.file_type().is_dir() {
@@ -182,7 +213,7 @@ pub(super) async fn collect_dir_stats(dir: &Path) -> DirStats {
     DirStats {
         size: total_bytes,
         mtime,
-        root_metadata: Some(root_meta),
+        root_metadata: complete.then_some(root_meta),
     }
 }
 
@@ -215,5 +246,18 @@ mod tests {
             without_symlink + symlink_bytes,
             "dir_stats should count the symlink itself but not recurse into its target"
         );
+    }
+
+    #[tokio::test]
+    async fn collect_dir_stats_withholds_root_metadata_after_incomplete_walk() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("archive.tar.gz"), vec![1u8; 4096]).unwrap();
+        let mut entry_reader = GcDirEntryReader::failing_after(0);
+
+        let stats = collect_dir_stats_with_reader(&root, &mut entry_reader).await;
+
+        assert!(stats.root_metadata.is_none());
     }
 }

--- a/crates/runner/src/cmd/gc/storage.rs
+++ b/crates/runner/src/cmd/gc/storage.rs
@@ -10,8 +10,8 @@ use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
 use super::filesystem::{
-    GcDirStatus, dir_stats, gc_entry_is_real_dir, gc_path_dir_status, next_entry_warn_or_stop,
-    read_dir_or_missing,
+    GcDirStatus, collect_dir_stats, dir_stats, gc_entry_is_real_dir, gc_path_dir_status,
+    next_entry_warn_or_stop, read_dir_or_missing,
 };
 use super::lock_file::{LockProbe, probe_lock};
 use super::report::{GcReport, human_bytes};
@@ -26,14 +26,30 @@ const STORAGE_CACHE_MAX_ENTRIES: u64 = 5_000;
 
 /// Eligible `<version>` directory discovered during the scan phase.
 ///
-/// The scan-time size and mtime are advisory: deletion reacquires the
-/// per-version lock and revalidates both before removing the directory.
+/// The scan-time size is reused only when deletion reacquires the per-version
+/// lock and finds the same directory identity and mtime.
 struct StorageCandidate {
     path: PathBuf,
     name: String,
     version: String,
     size: u64,
     mtime: SystemTime,
+    identity: Option<StorageDirectoryIdentity>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct StorageDirectoryIdentity {
+    device: u64,
+    inode: u64,
+}
+
+impl From<&std::fs::Metadata> for StorageDirectoryIdentity {
+    fn from(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }
+    }
 }
 
 struct StorageEvictionResult {
@@ -197,7 +213,13 @@ async fn gc_storage_cache_with_limits_report(
                 }
             };
 
-            let (size, mtime) = dir_stats(&version_path).await;
+            let stats = collect_dir_stats(&version_path).await;
+            let size = stats.size;
+            let mtime = stats.mtime;
+            let identity = stats
+                .root_metadata
+                .as_ref()
+                .map(StorageDirectoryIdentity::from);
             let age = now.duration_since(mtime).unwrap_or_default();
             total_size = total_size.saturating_add(size);
             drop(lock);
@@ -215,6 +237,7 @@ async fn gc_storage_cache_with_limits_report(
                 version,
                 size,
                 mtime,
+                identity,
             });
         }
     }
@@ -292,8 +315,8 @@ async fn evict_storage_candidate(
         }
     };
 
-    match gc_path_dir_status(&candidate.path).await {
-        Ok(GcDirStatus::RealDir(_)) => {}
+    let metadata = match gc_path_dir_status(&candidate.path).await {
+        Ok(GcDirStatus::RealDir(metadata)) => metadata,
         Ok(GcDirStatus::NotDirectory) => {
             info!(
                 "storages/{}/{}: no longer a directory, skipping",
@@ -326,9 +349,16 @@ async fn evict_storage_candidate(
                 evicted: false,
             };
         }
-    }
+    };
 
-    let (size, mtime) = dir_stats(&candidate.path).await;
+    let current_mtime = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    let current_identity = StorageDirectoryIdentity::from(&metadata);
+    let (size, mtime) =
+        if candidate.identity == Some(current_identity) && candidate.mtime == current_mtime {
+            (candidate.size, current_mtime)
+        } else {
+            dir_stats(&candidate.path).await
+        };
     let age = now.duration_since(mtime).unwrap_or_default();
     if age < GC_MIN_AGE {
         info!(

--- a/crates/runner/src/cmd/gc/storage/tests.rs
+++ b/crates/runner/src/cmd/gc/storage/tests.rs
@@ -778,7 +778,7 @@ async fn gc_storage_cache_delete_recheck_treats_symlink_candidate_as_removed() {
 }
 
 #[tokio::test]
-async fn gc_storage_cache_delete_recheck_reuses_unchanged_candidate_size() {
+async fn gc_storage_cache_delete_recheck_reuses_only_identified_candidate_size() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
     std::fs::create_dir_all(home.locks_dir()).unwrap();
@@ -795,6 +795,13 @@ async fn gc_storage_cache_delete_recheck_reuses_unchanged_candidate_size() {
     assert!(!result.remaining_entry);
     assert!(result.evicted);
     assert!(entry.exists(), "dry-run must keep the unchanged candidate");
+
+    candidate.identity = None;
+    let result = evict_storage_candidate(&home, &candidate, SystemTime::now(), true).await;
+    let fresh_size = dir_stats(&entry).await.0;
+
+    assert_eq!(result.freed, fresh_size);
+    assert_ne!(result.freed, scan_size);
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/gc/storage/tests.rs
+++ b/crates/runner/src/cmd/gc/storage/tests.rs
@@ -86,13 +86,17 @@ async fn storage_candidate_for(path: PathBuf) -> StorageCandidate {
         .and_then(|name| name.to_str())
         .unwrap()
         .to_owned();
-    let (size, mtime) = dir_stats(&path).await;
+    let stats = collect_dir_stats(&path).await;
     StorageCandidate {
         path,
         name,
         version,
-        size,
-        mtime,
+        size: stats.size,
+        mtime: stats.mtime,
+        identity: stats
+            .root_metadata
+            .as_ref()
+            .map(StorageDirectoryIdentity::from),
     }
 }
 
@@ -774,6 +778,59 @@ async fn gc_storage_cache_delete_recheck_treats_symlink_candidate_as_removed() {
 }
 
 #[tokio::test]
+async fn gc_storage_cache_delete_recheck_reuses_unchanged_candidate_size() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let entry = make_storage_entry(&home, "foo", "v1", &[0u8; 256], old_gc_time());
+    let mut candidate = storage_candidate_for(entry.clone()).await;
+    let scan_size = candidate.size.saturating_add(1);
+    candidate.size = scan_size;
+
+    let result = evict_storage_candidate(&home, &candidate, SystemTime::now(), true).await;
+
+    assert_eq!(result.freed, scan_size);
+    assert_eq!(result.remaining_size, None);
+    assert!(!result.remaining_entry);
+    assert!(result.evicted);
+    assert!(entry.exists(), "dry-run must keep the unchanged candidate");
+}
+
+#[tokio::test]
+async fn gc_storage_cache_delete_recheck_reaccounts_replaced_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home(dir.path());
+    std::fs::create_dir_all(home.locks_dir()).unwrap();
+
+    let old = old_gc_time();
+    let entry = make_storage_entry(&home, "foo", "v1", &[0u8; 256], old);
+    let candidate = storage_candidate_for(entry.clone()).await;
+
+    let replacement = make_storage_entry_at(
+        dir.path().join("replacement-version"),
+        &[0u8; 128 * 1024],
+        old,
+    );
+    let replacement_size = dir_stats(&replacement).await.0;
+    assert_ne!(replacement_size, candidate.size);
+    assert_ne!(
+        std::fs::symlink_metadata(&replacement).unwrap().ino(),
+        candidate.identity.unwrap().inode
+    );
+    std::fs::remove_dir_all(&entry).unwrap();
+    std::fs::rename(&replacement, &entry).unwrap();
+
+    let result = evict_storage_candidate(&home, &candidate, SystemTime::now(), true).await;
+
+    assert_eq!(result.freed, replacement_size);
+    assert_eq!(result.remaining_size, None);
+    assert!(!result.remaining_entry);
+    assert!(result.evicted);
+    assert!(entry.exists(), "dry-run must keep the replacement");
+}
+
+#[tokio::test]
 async fn gc_storage_cache_delete_recheck_keeps_candidate_that_became_recent() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home(dir.path());
@@ -782,7 +839,9 @@ async fn gc_storage_cache_delete_recheck_keeps_candidate_that_became_recent() {
     let old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
     let entry = make_storage_entry(&home, "foo", "v1", &[0u8; 256], old);
     let candidate = storage_candidate_for(entry.clone()).await;
+    let scanned_size = candidate.size;
 
+    std::fs::write(entry.join("archive.tar.gz"), vec![0u8; 128 * 1024]).unwrap();
     std::fs::File::open(&entry)
         .unwrap()
         .set_times(std::fs::FileTimes::new().set_modified(SystemTime::now()))
@@ -791,6 +850,7 @@ async fn gc_storage_cache_delete_recheck_keeps_candidate_that_became_recent() {
     let result = evict_storage_candidate(&home, &candidate, SystemTime::now(), false).await;
     let (fresh_size, _) = dir_stats(&entry).await;
 
+    assert_ne!(fresh_size, scanned_size);
     assert_eq!(result.freed, 0);
     assert_eq!(result.remaining_size, Some(fresh_size));
     assert!(result.remaining_entry);


### PR DESCRIPTION
## Summary

- retain the root metadata already fetched during storage cache inventory
- reuse scan-time allocated bytes when the eviction lock sees the same device, inode, and mtime
- fall back to fresh recursive accounting for replaced, modified, or unidentifiable candidates
- cover unchanged reuse, real-directory replacement, and newly recent accounting with real filesystem tests

## Scope

This is a runner-local storage GC optimization. It does not change cache layout, admission policy, configuration, persisted state, APIs, or runner protocols. Other GC domains are unchanged.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::storage::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- repository pre-commit hooks for staged Rust files

Closes #25641
