### PR TITLE
fix(platform): make avatar filter toolbar opaque

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -157,6 +157,25 @@ async function cardEdgeAppearance(locator: Locator) {
   });
 }
 
+async function toolbarSurfaceAppearance(locator: Locator) {
+  return locator.evaluate((element) => {
+    const style = getComputedStyle(element);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Canvas context unavailable");
+    }
+    context.fillStyle = style.backgroundColor;
+    context.fillRect(0, 0, 1, 1);
+    return {
+      backgroundAlpha: context.getImageData(0, 0, 1, 1).data[3],
+      borderBottomWidth: style.borderBottomWidth,
+    };
+  });
+}
+
 test("chat page displays tagline after onboarding", async ({ page }) => {
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
@@ -357,7 +376,7 @@ test("image lightbox centers and pans across the full viewer", async ({
   });
 });
 
-test("selected avatar and voice cards keep a single border", async ({
+test("avatar catalog surfaces stay stable while scrolling and selecting", async ({
   page,
 }) => {
   await page.route("**/api/zero/feature-switches", async (route) => {
@@ -377,6 +396,13 @@ test("selected avatar and voice cards keep a single border", async ({
         avatars: [
           { id: 81, name: "Ada", aspectRatio: 0 },
           { id: 82, name: "Alex", aspectRatio: 0 },
+          ...Array.from({ length: 16 }, (_, index) => {
+            return {
+              id: index + 83,
+              name: `Avatar ${String(index + 3)}`,
+              aspectRatio: 0,
+            };
+          }),
         ],
       },
     });
@@ -408,6 +434,28 @@ test("selected avatar and voice cards keep a single border", async ({
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
   await page.getByRole("button", { name: "Template" }).click();
   await page.getByRole("tab", { name: "Avatar" }).click();
+  const dialog = page.getByRole("dialog");
+  const avatarScroll = dialog.locator("[data-avatar-template-grid-scroll]");
+  const avatarToolbar = avatarScroll.locator("[data-avatar-catalog-toolbar]");
+  await expect(avatarToolbar).toBeVisible();
+  await avatarScroll.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect
+    .poll(async () => {
+      return avatarScroll.evaluate((element) => {
+        return element.scrollTop;
+      });
+    })
+    .toBeGreaterThan(0);
+  await expect(avatarToolbar).toBeInViewport();
+  await expect
+    .poll(async () => {
+      return toolbarSurfaceAppearance(avatarToolbar);
+    })
+    .toEqual({ backgroundAlpha: 255, borderBottomWidth: "0px" });
+
   await page.getByRole("button", { name: "Select template Ada" }).click();
   await page.getByRole("button", { name: "Select voice Christopher" }).click();
 
@@ -441,7 +489,7 @@ test("selected avatar and voice cards keep a single border", async ({
   expect(selectedVoiceEdge.borderWidths).toEqual(["1px", "1px", "1px", "1px"]);
   expect(selectedVoiceEdge).toEqual(unselectedVoiceEdge);
 
-  await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+  await dialog.getByRole("button", { name: "Close" }).click();
   await waitForAgentDraftClear(page, async () => {
     await clearComposerEditor(page.getByRole("textbox", { name: "Message" }));
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -763,7 +763,8 @@ describe("chat composer templates", () => {
       const avatarToolbar = avatarScroll.querySelector(
         "[data-avatar-catalog-toolbar]",
       );
-      expect(avatarToolbar).toHaveClass("sticky", "top-0");
+      expect(avatarToolbar).toHaveClass("sticky", "top-0", "bg-card");
+      expect(avatarToolbar).not.toHaveClass("border-b");
       Object.defineProperties(avatarScroll, {
         scrollHeight: { configurable: true, value: 1200 },
         clientHeight: { configurable: true, value: 500 },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -763,8 +763,7 @@ describe("chat composer templates", () => {
       const avatarToolbar = avatarScroll.querySelector(
         "[data-avatar-catalog-toolbar]",
       );
-      expect(avatarToolbar).toHaveClass("sticky", "top-0", "bg-card");
-      expect(avatarToolbar).not.toHaveClass("border-b");
+      expect(avatarToolbar).toHaveClass("sticky", "top-0");
       Object.defineProperties(avatarScroll, {
         scrollHeight: { configurable: true, value: 1200 },
         clientHeight: { configurable: true, value: 500 },

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -501,7 +501,7 @@ function AvatarCatalogFilters({
   return (
     <div
       data-avatar-catalog-toolbar=""
-      className="sticky top-0 z-10 mb-5 flex flex-wrap items-center justify-between gap-3 border-b border-border/70 pb-4"
+      className="sticky top-0 z-10 mb-5 flex flex-wrap items-center justify-between gap-3 bg-card pb-4"
     >
       <AvatarAspectRatioPicker
         value={filters.aspectRatio}


### PR DESCRIPTION
## Summary

- remove the divider below the avatar catalog filters
- give the sticky avatar filter toolbar an opaque card background while templates scroll underneath
- add regression coverage for the toolbar surface styling

## Test plan

- pnpm exec prettier --check on the two changed files
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx --maxWorkers=4 --silent=passed-only