### PR TITLE
fix(python): keep local json responses bodyless for head

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -17,6 +17,7 @@ from mitmproxy import http
 
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import http_local_responses
 import matching
 from auth_base_forwarder import (
     MAX_AUTH_BASE_REQUEST_BODY_BYTES,
@@ -309,10 +310,10 @@ def _set_matched_firewall_failure_response(
         body["connectors"] = connectors
     if failure_reason:
         body["failureReason"] = failure_reason
-    flow.response = http.Response.make(
+    flow.response = http_local_responses.make_local_json_response(
+        flow,
         status,
-        json.dumps(body).encode(),
-        {"Content-Type": "application/json"},
+        body,
     )
 
 

--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -30,6 +30,23 @@ def _diagnostic_url_without_query_or_fragment(original_url: str) -> str:
     return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
+def make_local_json_response(
+    flow: http.HTTPFlow,
+    status_code: int,
+    body: dict[str, object],
+) -> http.Response:
+    is_head_request = flow.request.method.upper() == "HEAD"
+    content = b"" if is_head_request else json.dumps(body).encode()
+    response = http.Response.make(
+        status_code,
+        content,
+        {"Content-Type": "application/json"},
+    )
+    if is_head_request:
+        del response.headers["Content-Length"]
+    return response
+
+
 def block_authority_validation_error(
     flow: http.HTTPFlow,
     error: AuthorityValidationError,
@@ -51,19 +68,17 @@ def block_authority_validation_error(
         request_port=error.request_port,
     )
 
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         403,
-        json.dumps(
-            {
-                "error": error.reason,
-                "message": error.message,
-                "sni": error.sni,
-                "request_host": error.request_host,
-                "host_header": error.host_header,
-                "request_port": error.request_port,
-            }
-        ).encode(),
-        {"Content-Type": "application/json"},
+        {
+            "error": error.reason,
+            "message": error.message,
+            "sni": error.sni,
+            "request_host": error.request_host,
+            "host_header": error.host_header,
+            "request_port": error.request_port,
+        },
     )
 
 
@@ -76,16 +91,14 @@ def block_registry_unavailable(
         "BLOCK",
         error="registry_unavailable",
     )
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         503,
-        json.dumps(
-            {
-                "error": "registry_unavailable",
-                "message": "Proxy registry is unavailable",
-                "reason": unavailable.reason,
-            }
-        ).encode(),
-        {"Content-Type": "application/json"},
+        {
+            "error": "registry_unavailable",
+            "message": "Proxy registry is unavailable",
+            "reason": unavailable.reason,
+        },
     )
 
 
@@ -98,16 +111,14 @@ def block_invalid_registry_vm(
         "BLOCK",
         error="invalid_registry_vm",
     )
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         503,
-        json.dumps(
-            {
-                "error": "invalid_registry_vm",
-                "message": invalid_vm.message,
-                "reason": invalid_vm.reason,
-            }
-        ).encode(),
-        {"Content-Type": "application/json"},
+        {
+            "error": "invalid_registry_vm",
+            "message": invalid_vm.message,
+            "reason": invalid_vm.reason,
+        },
     )
 
 
@@ -117,19 +128,16 @@ def block_stale_tls_admission(flow: http.HTTPFlow, *, reason: str) -> None:
         "BLOCK",
         error=_STALE_TLS_ADMISSION_ERROR,
     )
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         503,
-        json.dumps(
-            {
-                "error": _STALE_TLS_ADMISSION_ERROR,
-                "message": (
-                    "Request blocked: TLS admission is no longer backed by a valid "
-                    "proxy registry VM"
-                ),
-                "reason": reason,
-            }
-        ).encode(),
-        {"Content-Type": "application/json"},
+        {
+            "error": _STALE_TLS_ADMISSION_ERROR,
+            "message": (
+                "Request blocked: TLS admission is no longer backed by a valid proxy registry VM"
+            ),
+            "reason": reason,
+        },
     )
 
 
@@ -151,18 +159,15 @@ def block_firewall_authorization_changed(
         "BLOCK",
         error=_FIREWALL_AUTHORIZATION_CHANGED_ERROR,
     )
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         _HTTP_STATUS_CONFLICT,
-        json.dumps(
-            {
-                "error": _FIREWALL_AUTHORIZATION_CHANGED_ERROR,
-                "message": (
-                    "Request blocked: firewall authorization changed while credentials "
-                    "were resolving"
-                ),
-            }
-        ).encode(),
-        {"Content-Type": "application/json"},
+        {
+            "error": _FIREWALL_AUTHORIZATION_CHANGED_ERROR,
+            "message": (
+                "Request blocked: firewall authorization changed while credentials were resolving"
+            ),
+        },
     )
 
 
@@ -203,10 +208,10 @@ def block_upstream_destination_unbound(
     firewall_base = flow_metadata.firewall_base(flow.metadata)
     if firewall_base:
         body["base"] = firewall_base
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         403,
-        json.dumps(body).encode(),
-        {"Content-Type": "application/json"},
+        body,
     )
 
 
@@ -246,10 +251,10 @@ def block_builtin_host_policy_denied(
     firewall_base = flow_metadata.firewall_base(flow.metadata)
     if firewall_base:
         body["base"] = firewall_base
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         403,
-        json.dumps(body).encode(),
-        {"Content-Type": "application/json"},
+        body,
     )
 
 
@@ -280,7 +285,9 @@ def set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBl
     )
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     diagnostic_url = _diagnostic_url_without_query_or_fragment(original_url)
-    error_body = json.dumps(
+    flow.response = make_local_json_response(
+        flow,
+        403,
         {
             "error": "permission_denied",
             "message": response_message,
@@ -291,12 +298,7 @@ def set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBl
             "permissions": list(result.permissions),
             "reason": result.reason,
             "base": result.base,
-        }
-    )
-    flow.response = http.Response.make(
-        403,
-        error_body.encode(),
-        {"Content-Type": "application/json"},
+        },
     )
 
 
@@ -324,20 +326,18 @@ def set_firewall_ambiguous_response(
     flow.metadata[metadata_keys.CONNECTOR_ROUTE_CANDIDATES] = candidates
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     diagnostic_url = _diagnostic_url_without_query_or_fragment(original_url)
-    flow.response = http.Response.make(
+    flow.response = make_local_json_response(
+        flow,
         _HTTP_STATUS_CONFLICT,
-        json.dumps(
-            {
-                "error": _AMBIGUOUS_CONNECTOR_ROUTE_ERROR,
-                "message": "Request blocked: connector route requires explicit intent",
-                "reason": result.reason,
-                "method": result.method,
-                "path": result.path,
-                "url": diagnostic_url,
-                "candidates": candidates,
-            }
-        ).encode(),
-        {"Content-Type": "application/json"},
+        {
+            "error": _AMBIGUOUS_CONNECTOR_ROUTE_ERROR,
+            "message": "Request blocked: connector route requires explicit intent",
+            "reason": result.reason,
+            "method": result.method,
+            "path": result.path,
+            "url": diagnostic_url,
+            "candidates": candidates,
+        },
     )
 
 
@@ -382,20 +382,19 @@ def block_public_destination_denied(
         reason=reason,
     )
 
-    error_body = json.dumps(
-        {
-            "error": "unsafe_public_destination",
-            "message": "Request blocked: publicDestination resolved to a non-public destination",
-            "name": name,
-            "base": base,
-            "destination_host": destination_host,
-            "trusted_authority_host": trusted_authority_host,
-            "reason": reason,
-        }
-    )
     if send_response:
-        flow.response = http.Response.make(
+        flow.response = make_local_json_response(
+            flow,
             403,
-            error_body.encode(),
-            {"Content-Type": "application/json"},
+            {
+                "error": "unsafe_public_destination",
+                "message": (
+                    "Request blocked: publicDestination resolved to a non-public destination"
+                ),
+                "name": name,
+                "base": base,
+                "destination_host": destination_host,
+                "trusted_authority_host": trusted_authority_host,
+                "reason": reason,
+            },
         )

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -254,6 +254,141 @@ def _start_http1_request(
     return http_layer, request_headers_hook
 
 
+def _start_head_firewall_request(
+    addon_context: taddons.context,
+    *,
+    protocol: Literal["http1", "http2"],
+) -> tuple[connection.Client, H2Connection | None, HttpLayer, HttpRequestHeadersHook]:
+    alpn = b"h2" if protocol == "http2" else b"http/1.1"
+    client, http_layer = _start_http_layer(
+        addon_context,
+        alpn=alpn,
+        host="api.github.com",
+    )
+    http2: H2Connection | None = None
+    if protocol == "http2":
+        http2 = H2Connection(H2Configuration(client_side=True, header_encoding=None))
+        http2.initiate_connection()
+        http2.send_headers(
+            1,
+            [
+                (b":method", b"HEAD"),
+                (b":scheme", b"https"),
+                (b":authority", b"api.github.com"),
+                (b":path", b"/orgs"),
+            ],
+            end_stream=True,
+        )
+        request_bytes = http2.data_to_send()
+    else:
+        request_bytes = b"HEAD /orgs HTTP/1.1\r\nHost: api.github.com\r\n\r\n"
+
+    request_commands = list(http_layer.handle_event(events.DataReceived(client, request_bytes)))
+    request_headers_hook = next(
+        command for command in request_commands if isinstance(command, HttpRequestHeadersHook)
+    )
+    return client, http2, http_layer, request_headers_hook
+
+
+@pytest.mark.parametrize("protocol", ["http1", "http2"])
+async def test_head_firewall_block_emits_no_response_data(
+    tmp_path: Path,
+    protocol: Literal["http1", "http2"],
+) -> None:
+    registry_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "read-repos",
+                        "rules": ["GET /repos/{owner}/{repo}"],
+                    }
+                ],
+            },
+            network_policy={
+                "allow": ["read-repos"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        client, http2, http_layer, request_headers_hook = _start_head_firewall_request(
+            addon_context,
+            protocol=protocol,
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+        all_commands = list(
+            http_layer.handle_event(events.HookCompleted(request_headers_hook, None))
+        )
+
+        request_hook = next(
+            command for command in all_commands if isinstance(command, HttpRequestHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+        after_request = list(http_layer.handle_event(events.HookCompleted(request_hook, None)))
+        all_commands.extend(after_request)
+
+        response_headers_hook = next(
+            command for command in after_request if isinstance(command, HttpResponseHeadersHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, response_headers_hook)
+        after_response_headers = list(
+            http_layer.handle_event(events.HookCompleted(response_headers_hook, None))
+        )
+        all_commands.extend(after_response_headers)
+
+        response_hook = next(
+            command for command in after_response_headers if isinstance(command, HttpResponseHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, response_hook)
+        all_commands.extend(http_layer.handle_event(events.HookCompleted(response_hook, None)))
+
+    flow = request_headers_hook.flow
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert not any(isinstance(command, commands.OpenConnection) for command in all_commands)
+
+    client_bytes = b"".join(
+        command.data
+        for command in all_commands
+        if isinstance(command, commands.SendData) and command.connection is client
+    )
+    if protocol == "http1":
+        response_head, separator, response_body = client_bytes.partition(b"\r\n\r\n")
+        assert separator == b"\r\n\r\n"
+        assert response_head.startswith(b"HTTP/1.1 403 ")
+        assert b"content-length:" not in response_head.lower()
+        assert response_body == b""
+    else:
+        assert http2 is not None
+        response_events = http2.receive_data(client_bytes)
+        response_headers = next(
+            event for event in response_events if isinstance(event, h2_events.ResponseReceived)
+        )
+        assert dict(response_headers.headers)[b":status"] == b"403"
+        assert b"content-length" not in dict(response_headers.headers)
+        assert not any(isinstance(event, h2_events.DataReceived) for event in response_events)
+        assert any(isinstance(event, h2_events.StreamEnded) for event in response_events)
+
+
 async def test_http2_duplicate_host_is_rejected_before_auth_or_http1_downgrade(
     tmp_path: Path,
     fake_firewall_headers,

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
@@ -80,6 +80,61 @@ async def test_repeated_firewall_requests_reuse_snapshot_auth_identity(
     assert flows[1].request.headers["Authorization"] == "Bearer resolved"
 
 
+async def test_head_firewall_auth_failure_is_bodyless(tmp_path, real_flow, mitm_ctx, headers):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [{"name": "read-repos", "rules": ["HEAD /repos"]}],
+            },
+            network_policy={
+                "allow": ["read-repos"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="HEAD",
+        path="/repos",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=("203.0.113.10", 443),
+        peername=("203.0.113.10", 443),
+    )
+    auth_fetch = AsyncMock(side_effect=RuntimeError("auth backend unavailable"))
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", auth_fetch),
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
+    assert "Authorization" not in flow.request.headers
+    [proxy_log_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_log_entry["level"] == "error"
+    assert proxy_log_entry["type"] == "firewall"
+    assert proxy_log_entry["firewall_base"] == "https://api.github.com"
+
+
 async def test_custom_connector_id_is_forwarded_with_matched_firewall(
     tmp_path, real_flow, mitm_ctx
 ):

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -326,6 +326,70 @@ async def test_firewall_permission_blocks_unmatched(tmp_path, real_flow, mitm_ct
     assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
 
+async def test_head_firewall_permission_block_is_bodyless_and_logged(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "read-repos",
+                        "rules": ["GET /repos/{owner}/{repo}"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": ["read-repos"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="HEAD",
+        path="/orgs",
+    )
+    seed_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        host="api.github.com",
+        port=443,
+        kinds=frozenset(("connector_auth",)),
+        original_address=("api.github.com", 443),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.response.raw_content == b""
+    assert flow.response.headers["Content-Type"] == "application/json"
+    assert flow.response.headers.get_all("Content-Length") == []
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    firewall_log_entry, http_error_log_entry = read_jsonl_entries_after_flush(
+        tmp_path / "proxy.jsonl"
+    )
+    assert firewall_log_entry["type"] == "firewall_block"
+    assert firewall_log_entry["name"] == "github"
+    assert firewall_log_entry["reason"] == "unknown_endpoint"
+    assert http_error_log_entry["type"] == "http_error"
+    assert http_error_log_entry["status"] == 403
+    [network_log_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_log_entry["action"] == "DENY"
+    assert network_log_entry["status"] == 403
+    assert network_log_entry["response_size"] == 0
+
+
 @pytest.mark.parametrize(
     "unknown_policy",
     [


### PR DESCRIPTION
## Summary

- centralize local JSON response construction for shared denials and matched-firewall auth failures
- keep synthetic HEAD responses bodyless while preserving JSON Content-Type and omitting untrusted Content-Length
- cover handler behavior and pinned mitmproxy HTTP/1.1 and HTTP/2 client framing

## Scope

- non-HEAD JSON, status, metadata, and logging behavior remains unchanged
- forwarded upstream, connector diagnostic, catalog, streaming, and auth-base semantics remain unchanged
- no schema, API, protocol, persistence, migration, feature switch, or cleanup work

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`4963 passed`)

Closes #25646
