### PR TITLE
fix: parse google forms publish state as an object

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
@@ -128,7 +128,12 @@ function configureFormsApi(): FormsApiRecorder {
         return HttpResponse.json({
           formId: FORM_ID,
           info: { title: FORM_TITLE },
-          publishSettings: { publishState: "PUBLISHED" },
+          publishSettings: {
+            publishState: {
+              isPublished: true,
+              isAcceptingResponses: true,
+            },
+          },
         });
       },
     ),
@@ -298,6 +303,7 @@ describe("Google Forms Pub/Sub webhook", () => {
       throw new Error("Expected a Google Forms response automation");
     }
     expect(created.body.eventConfig.connectorId).toBe(connector.id);
+    expect(created.body).not.toHaveProperty("warning");
 
     const watchId = formsApi.watchIds[0];
     if (!watchId) {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -211,8 +211,13 @@ function configureGoogleFormsCreationMock(args?: {
           formId: GOOGLE_FORM_ID,
           info: { title: "Customer survey" },
           publishSettings: args?.unpublished
-            ? {}
-            : { publishState: "PUBLISHED" },
+            ? { publishState: {} }
+            : {
+                publishState: {
+                  isPublished: true,
+                  isAcceptingResponses: true,
+                },
+              },
         });
       },
     ),

--- a/turbo/apps/api/src/signals/services/google-forms-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-forms-workflow-event.service.ts
@@ -69,9 +69,13 @@ const googleFormSchema = z.object({
   info: z.object({ title: z.string() }),
   publishSettings: z
     .object({
-      publishState: z.string().optional(),
-      isPublished: z.boolean().optional(),
-      isAcceptingResponses: z.boolean().optional(),
+      publishState: z
+        .object({
+          isPublished: z.boolean().optional(),
+          isAcceptingResponses: z.boolean().optional(),
+        })
+        .passthrough()
+        .optional(),
     })
     .passthrough()
     .optional(),
@@ -432,16 +436,10 @@ async function newestGoogleFormResponseTime(args: {
 function formIsNotAcceptingResponses(
   form: z.infer<typeof googleFormSchema>,
 ): boolean {
-  if (
-    form.publishSettings?.isPublished === false ||
-    form.publishSettings?.isAcceptingResponses === false
-  ) {
-    return true;
-  }
-  if (form.publishSettings?.isPublished === true) {
-    return false;
-  }
-  return form.publishSettings?.publishState !== "PUBLISHED";
+  return (
+    form.publishSettings?.publishState?.isPublished !== true ||
+    form.publishSettings?.publishState?.isAcceptingResponses !== true
+  );
 }
 
 export async function prepareGoogleFormsResponseEventConfigForPersist(


### PR DESCRIPTION
## Summary

- model Google Forms publish settings using the nested publish state object returned by the Forms API
- classify only forms with both publication booleans set to true as accepting responses
- update API integration mocks to use real published and unpublished response shapes
- assert published forms omit the D13 warning while unpublished forms retain it

## Root cause

The Forms API returns the publication booleans under a nested publish state object. The response schema expected a string and the warning logic read the booleans from the parent object, so real forms failed response parsing and the fallback warning check would have misclassified published forms.

## Validation

- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-google-forms.test.ts src/signals/routes/__tests__/zero-workflow-automations.test.ts --maxWorkers=4 --silent=passed-only (75 passed)
- pnpm -F api lint
- pnpm -F api check-types
- targeted Prettier check for the three changed files

Closes #25663
Related to #25163