### PR TITLE
fix(api): reject saturated pi edge launches

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -1140,7 +1140,17 @@ export function createChatFilesBddApi(context: TestContext) {
     async requestSendEvent(
       actor: ApiTestUser | null,
       body: BddSendEventBody,
-      statuses: readonly (201 | 400 | 401 | 402 | 403 | 404 | 409 | 422)[],
+      statuses: readonly (
+        | 201
+        | 400
+        | 401
+        | 402
+        | 403
+        | 404
+        | 409
+        | 422
+        | 429
+      )[],
       signal?: AbortSignal,
     ) {
       const client = signal

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -29,6 +29,7 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { commitMemoryVersion } from "./helpers/zero-memory";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { webhooksAgentPiTranscriptRoutes } from "../webhooks-agent-pi-transcript";
@@ -598,6 +599,139 @@ async function outputMessages(actor: ApiTestUser, threadId: string) {
 }
 
 describe("PiLoop edge turn", () => {
+  it("rejects saturated Pi launches while ordinary launches still queue", async () => {
+    const fixture = await piEdgeFixture();
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+    const kms = useSecretKmsProbe();
+    const blocker = await sendChatRun(
+      fixture,
+      "occupy the only organization concurrency slot",
+    );
+    expect((await api.readRun(fixture.actor, blocker.runId)).status).toBe(
+      "pending",
+    );
+    const targetThread = await chat.createThread(fixture.actor, {
+      agentId: fixture.agentId,
+      model: MODEL,
+    });
+    let completionRequests = 0;
+    server.use(
+      http.post(COMPLETIONS_URL, () => {
+        completionRequests += 1;
+        return assistantTextStream("unexpected answer", "unexpected turn");
+      }),
+    );
+    const jobNotificationCount = (): number => {
+      return context.mocks.ably.publish.mock.calls.filter(([topic]) => {
+        return topic === "job";
+      }).length;
+    };
+    const baselineDataKeys = kms.generateDataKeyCalls;
+    const baselineJobNotifications = jobNotificationCount();
+    const queueBeforePi = await api.readRunQueue(fixture.actor);
+    expect(queueBeforePi.body.concurrency).toMatchObject({
+      active: 1,
+      limit: 1,
+    });
+
+    await enablePiLoop(fixture);
+    const rejectedEventId = randomUUID();
+    const rejected = await chat.requestSendEvent(
+      fixture.actor,
+      {
+        agentId: fixture.agentId,
+        threadId: targetThread.id,
+        prompt: "reject this Pi turn instead of queuing it",
+        model: MODEL,
+        clientEventId: rejectedEventId,
+      },
+      [429],
+    );
+    if (rejected.status !== 429) {
+      throw new Error("Expected the saturated Pi launch to return 429");
+    }
+    expect(rejected.body.error.code).toBe("CONCURRENT_RUN_LIMIT");
+    await flushWaitUntilForTest();
+
+    const rejectedQueue = await api.readRunQueue(fixture.actor);
+    expect(rejectedQueue.body.concurrency.active).toBe(1);
+    expect(rejectedQueue.body.queue).toStrictEqual([]);
+    expect(
+      (
+        await api.listAgentRuns(fixture.actor, {
+          status: "queued,pending,running,completed,failed,timeout,cancelled",
+          limit: 100,
+        })
+      ).runs.map((run) => {
+        return run.id;
+      }),
+    ).toStrictEqual([blocker.runId]);
+    const rejectedEvents = await chat.listThreadEvents(
+      fixture.actor,
+      targetThread.id,
+    );
+    expect(rejectedEvents.events).toContainEqual(
+      expect.objectContaining({
+        eventType: "control.revoke",
+        revokesEventId: rejectedEventId,
+      }),
+    );
+    expect(completionRequests).toBe(0);
+    expect(jobNotificationCount()).toBe(baselineJobNotifications);
+    expect(kms.generateDataKeyCalls).toBe(baselineDataKeys + 1);
+
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        userId: fixture.switchOwner.userId,
+        orgId: fixture.orgId,
+        orgRole: fixture.switchOwner.orgRole,
+      },
+      { [FeatureSwitchKey.PiLoop]: false },
+    );
+    const ordinary = await chat.requestSendEvent(
+      fixture.actor,
+      {
+        agentId: fixture.agentId,
+        threadId: targetThread.id,
+        prompt: "queue this ordinary launch behind the active run",
+        model: MODEL,
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    if (ordinary.status !== 201 || ordinary.body.runId === null) {
+      throw new Error("Expected the ordinary launch to create a queued run");
+    }
+    expect(ordinary.body.status).toBe("queued");
+    expect(kms.generateDataKeyCalls).toBe(baselineDataKeys + 3);
+    const ordinaryQueue = await api.readRunQueue(fixture.actor);
+    expect(ordinaryQueue.body.queue).toHaveLength(1);
+    expect(ordinaryQueue.body.queue[0]).toMatchObject({
+      runId: ordinary.body.runId,
+    });
+    expect(jobNotificationCount()).toBe(baselineJobNotifications);
+    expect(completionRequests).toBe(0);
+
+    await api.requestCancelRun(fixture.actor, blocker.runId, [200]);
+    await flushWaitUntilForTest();
+    const poll = await api.requestPollRunner(
+      true,
+      {
+        group: fixture.runnerGroup,
+        supportedProfiles: [DEFAULT_PROFILE],
+      },
+      [200],
+    );
+    if (poll.status !== 200) {
+      throw new Error("Expected the runner poll to return 200");
+    }
+    expect(poll.body.job?.runId).toBe(ordinary.body.runId);
+    expect(jobNotificationCount()).toBe(baselineJobNotifications + 1);
+    expect(completionRequests).toBe(0);
+    await api.requestCancelRun(fixture.actor, ordinary.body.runId, [200]);
+  });
+
   it("uses the org gate, migrates legacy memory into Pi, and completes in the API", async () => {
     const fixture = await piEdgeFixture();
     const legacyPrompt = "legacy context must not enter the Pi transcript";

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6995,6 +6995,8 @@ async function commitPreparedLaunchUnderLock(
   );
 
   if (concurrency) {
+    // Pi launch resources only live in this request and cannot be reconstructed
+    // when the durable organization queue promotes the run later.
     if (
       args.launch.piEdge !== undefined ||
       !args.createArgs.queueOnConcurrencyLimit

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6995,7 +6995,10 @@ async function commitPreparedLaunchUnderLock(
   );
 
   if (concurrency) {
-    if (!args.createArgs.queueOnConcurrencyLimit) {
+    if (
+      args.launch.piEdge !== undefined ||
+      !args.createArgs.queueOnConcurrencyLimit
+    ) {
       return concurrency;
     }
     if (!args.encryptedQueuedParams) {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1316,6 +1316,7 @@ export const chatEventsContract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
       422: apiErrorSchema,
+      429: apiErrorSchema,
     },
     summary: "Append a chat event and dispatch input when applicable",
   },


### PR DESCRIPTION
## Summary

- reject Pi edge launches with `CONCURRENT_RUN_LIMIT` when the organization is already at its run limit
- preserve the existing queue-on-concurrency behavior for ordinary Zero runs
- expose the existing 429 response through the canonical chat-event API contract
- cover rejection cleanup, KMS usage, queue state, notifications, and subsequent ordinary queue promotion in an API integration test

## Scope

- no database migration or runner protocol change
- no durable Pi queue envelope or Pi queue promotion path
- no change to ordinary run admission or queue draining

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/pi-edge-loop.test.ts --maxWorkers=1`
- `pnpm knip`

Closes #25652

Parent context: #25597
