### PR TITLE
chore(core): open the video template options switch to staff orgs

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -322,6 +322,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Let a video template chip in the chat composer set the generation model, aspect ratio, duration, resolution, and audio.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
Follow-up to #25624.

`videoTemplateOptions` shipped with no identity scope at all — `enabled: false` and no hash list — so the only way to see the feature was to know the key and toggle it per user on the Lab page. That is fine for the author and useless for everyone else who needs to look at it.

Adds `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`, matching how the other in-development switches are scoped (`JoggAiBuiltIn`, `Banking`, `Lab`, and 17 more).

## Blast radius

Staff orgs only. For everyone else nothing changes: the composer chip keeps its single hit zone, no `videoOptions` is ever written, and generation prompts stay byte-identical.

Worth knowing when trying it: the composer reads this switch when its lifecycle bridge mounts, so an existing tab needs a refresh before the second zone appears. The suffix on sent-message chips is reactive and updates immediately.

## Verification

`@vm0/core` type-check, oxlint, and the full package test suite (190 passed) — including `feature-switch.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)