### PR TITLE
refactor: remove the template picker global search feature switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -461,9 +461,6 @@ describe("chat composer templates", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: {
-        [FeatureSwitchKey.TemplatePickerGlobalSearch]: false,
-      },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -550,80 +547,6 @@ describe("chat composer templates", () => {
         "true",
       );
     });
-  });
-
-  it("filters every non-avatar template catalogue when global search is enabled", async () => {
-    const user = userEvent.setup({ delay: null });
-    mockChatLifecycle(context, { threadId: THREAD_ID });
-
-    detachedSetupPage({
-      context,
-      featureSwitches: {
-        [FeatureSwitchKey.TemplatePickerGlobalSearch]: true,
-      },
-      path: `/chats/${THREAD_ID}`,
-    });
-
-    click(
-      await waitFor(() => {
-        return screen.getByLabelText("Template");
-      }),
-    );
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-    });
-
-    const catalogues = [
-      {
-        category: "Presentation",
-        item: PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!,
-        selectLabel: (title: string) => {
-          return `Select template ${title}`;
-        },
-      },
-      {
-        category: "Website",
-        item: WEBSITE_TEMPLATE_ITEMS[0]!,
-        selectLabel: (title: string) => {
-          return `Select website template ${title}`;
-        },
-      },
-      {
-        category: "Illustration",
-        item: ILLUSTRATION_TEMPLATE_ITEMS[0]!,
-        selectLabel: (title: string) => {
-          return `Select template ${title}`;
-        },
-      },
-      {
-        category: "Video",
-        item: VIDEO_TEMPLATE_ITEMS[0]!,
-        selectLabel: (title: string) => {
-          return `Select video template ${title}`;
-        },
-      },
-    ] as const;
-
-    for (const { category, item, selectLabel } of catalogues) {
-      await user.click(tabByText(category));
-      await waitFor(() => {
-        expect(tabByText(category)).toHaveAttribute("aria-selected", "true");
-      });
-
-      const search = screen.getByLabelText("Search templates");
-      await fill(search, "no matching template title");
-      await waitFor(() => {
-        expect(screen.getByText("No matches")).toBeInTheDocument();
-      });
-
-      await fill(search, item.title);
-      await waitFor(() => {
-        expect(screen.queryByText("No matches")).not.toBeInTheDocument();
-        expect(
-          screen.getByLabelText(selectLabel(item.title)),
-        ).toBeInTheDocument();
-      });
-    }
   });
 
   it("previews avatars and sends the selected avatar and voice", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -933,20 +933,6 @@ function selectedWorkflowTemplateItem(
   return findWorkflowTemplateItem(value.selection.workflowTemplateId);
 }
 
-// The header search spans every catalogue, so each one narrows by title.
-function filterTemplatesByTitle<T extends { readonly title: string }>(
-  items: readonly T[],
-  query: string,
-): readonly T[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return items;
-  }
-  return items.filter((item) => {
-    return item.title.toLowerCase().includes(normalizedQuery);
-  });
-}
-
 function workflowTemplateMatchesSearch(
   item: WorkflowTemplateItem,
   query: string,
@@ -4744,7 +4730,7 @@ function TemplatePickerHeader() {
   );
 }
 
-function TemplatePickerSearch({
+function TemplatePickerWorkflowSearch({
   search,
   onSearchChange,
 }: {
@@ -4882,9 +4868,6 @@ function TemplatePickerDialog({
   const setCategory = useSet(signals.template.setTemplatePickerCategory$);
   const search = useGet(signals.template.templatePickerSearch$);
   const setSearch = useSet(signals.template.setTemplatePickerSearch$);
-  const templatePickerGlobalSearchEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.TemplatePickerGlobalSearch] ??
-    false;
   const previewSlug = useGet(signals.template.templatePickerPreviewSlug$);
   const restorePresentationGridScroll = useSet(
     signals.template.restoreTemplatePickerPresentationScroll$,
@@ -4931,23 +4914,6 @@ function TemplatePickerDialog({
     skipEnterAnimation && "data-[state=open]:!animate-none",
     "flex h-[min(82vh,760px)] max-w-6xl flex-col [&>button]:right-4 [&>button]:top-4",
   );
-  const catalogueSearch = templatePickerGlobalSearchEnabled ? search : "";
-  const filteredPptItems = filterTemplatesByTitle(
-    presentationItems,
-    catalogueSearch,
-  );
-  const filteredIllustrationItems = filterTemplatesByTitle(
-    ILLUSTRATION_TEMPLATE_ITEMS,
-    catalogueSearch,
-  );
-  const filteredVideoItems = filterTemplatesByTitle(
-    VIDEO_TEMPLATE_ITEMS,
-    catalogueSearch,
-  );
-  const filteredWebsiteItems = filterTemplatesByTitle(
-    WEBSITE_TEMPLATE_ITEMS,
-    catalogueSearch,
-  );
   // A persona pill filters the grid, ideation-gallery style.
   // resolveWorkflowCatalog() keeps that logic out of this component to stay
   // under the complexity budget.
@@ -4970,9 +4936,7 @@ function TemplatePickerDialog({
     hasAvatarTab,
     hasWorkflowTab,
   });
-  const showTemplatePickerSearch =
-    selectedCategory === "workflow" ||
-    (templatePickerGlobalSearchEnabled && selectedCategory !== "avatar");
+  const showTemplatePickerSearch = selectedCategory === "workflow";
 
   const previewImageUrlsForCategory = (targetCategory: string) => {
     if (targetCategory === "slides" && hasPptTab) {
@@ -5233,7 +5197,7 @@ function TemplatePickerDialog({
                   )}
                 >
                   {showTemplatePickerSearch ? (
-                    <TemplatePickerSearch
+                    <TemplatePickerWorkflowSearch
                       search={search}
                       onSearchChange={handleSearchChange}
                     />
@@ -5246,10 +5210,10 @@ function TemplatePickerDialog({
                   hasVideoTab={hasVideoTab}
                   hasAvatarTab={hasAvatarTab}
                   hasWorkflowTab={hasWorkflowTab}
-                  filteredPptItems={filteredPptItems}
-                  filteredWebsiteItems={filteredWebsiteItems}
-                  filteredIllustrationItems={filteredIllustrationItems}
-                  filteredVideoItems={filteredVideoItems}
+                  pptItems={presentationItems}
+                  websiteItems={WEBSITE_TEMPLATE_ITEMS}
+                  illustrationItems={ILLUSTRATION_TEMPLATE_ITEMS}
+                  videoItems={VIDEO_TEMPLATE_ITEMS}
                   workflowCatalog={workflowCatalog}
                   value={value}
                   illustrationVariantIndex={illustrationVariantIndex}
@@ -5285,10 +5249,10 @@ function TemplatePickerCategoryContent({
   hasVideoTab,
   hasAvatarTab,
   hasWorkflowTab,
-  filteredPptItems,
-  filteredWebsiteItems,
-  filteredIllustrationItems,
-  filteredVideoItems,
+  pptItems,
+  websiteItems,
+  illustrationItems,
+  videoItems,
   workflowCatalog,
   value,
   illustrationVariantIndex,
@@ -5312,10 +5276,10 @@ function TemplatePickerCategoryContent({
   hasVideoTab: boolean;
   hasAvatarTab: boolean;
   hasWorkflowTab: boolean;
-  filteredPptItems: readonly PresentationTemplateItem[];
-  filteredWebsiteItems: readonly WebsiteTemplateItem[];
-  filteredIllustrationItems: readonly IllustrationTemplateItem[];
-  filteredVideoItems: readonly VideoTemplateItem[];
+  pptItems: readonly PresentationTemplateItem[];
+  websiteItems: readonly WebsiteTemplateItem[];
+  illustrationItems: readonly IllustrationTemplateItem[];
+  videoItems: readonly VideoTemplateItem[];
   workflowCatalog: ResolvedWorkflowTemplateCatalog;
   value: GenerationTemplateRequest | undefined;
   illustrationVariantIndex: Readonly<Record<string, number>>;
@@ -5353,9 +5317,9 @@ function TemplatePickerCategoryContent({
           onPresentationScroll(event.currentTarget.scrollTop);
         }}
       >
-        {filteredPptItems.length > 0 ? (
+        {pptItems.length > 0 ? (
           <PptTemplateGrid
-            items={filteredPptItems}
+            items={pptItems}
             value={value}
             onSelect={onSelectPresentation}
             onPreview={onPreviewPresentation}
@@ -5375,9 +5339,9 @@ function TemplatePickerCategoryContent({
         data-website-template-grid-scroll=""
         className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 pb-6 pt-0.5"
       >
-        {filteredWebsiteItems.length > 0 ? (
+        {websiteItems.length > 0 ? (
           <WebsiteTemplateGrid
-            items={filteredWebsiteItems}
+            items={websiteItems}
             value={value}
             onSelect={onSelectWebsite}
             onPreview={onPreviewWebsite}
@@ -5396,16 +5360,16 @@ function TemplatePickerCategoryContent({
         className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 pb-6 pt-0.5"
         onScroll={(event) => {
           prewarmIllustrationPreviewImagesNearScroll({
-            items: filteredIllustrationItems,
+            items: illustrationItems,
             runtime,
             scrollContainer: event.currentTarget,
             variantIndexBySlug: illustrationVariantIndex,
           });
         }}
       >
-        {filteredIllustrationItems.length > 0 ? (
+        {illustrationItems.length > 0 ? (
           <IllustrationTemplateGrid
-            items={filteredIllustrationItems}
+            items={illustrationItems}
             value={value}
             variantIndexBySlug={illustrationVariantIndex}
             onSelect={onSelectIllustration}
@@ -5425,9 +5389,9 @@ function TemplatePickerCategoryContent({
         data-video-template-grid-scroll=""
         className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 pb-6 pt-0.5"
       >
-        {filteredVideoItems.length > 0 ? (
+        {videoItems.length > 0 ? (
           <VideoTemplateGrid
-            items={filteredVideoItems}
+            items={videoItems}
             value={value}
             onSelect={onSelectVideo}
           />

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -55,7 +55,6 @@ export enum FeatureSwitchKey {
   NewChatDefaultModelAction = "newChatDefaultModelAction",
   ChatNextRunModelNotice = "chatNextRunModelNotice",
   RealAgentInPreview = "realAgentInPreview",
-  TemplatePickerGlobalSearch = "templatePickerGlobalSearch",
   UsagePackPlans = "usagePackPlans",
 
   ZapierConnector = "zapierConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -329,13 +329,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Run web chat runs through the in-API Pi edge loop with sandbox handoff instead of dispatching a runner job immediately.",
     enabled: false,
   },
-  [FeatureSwitchKey.TemplatePickerGlobalSearch]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Search presentation, website, illustration, and video templates from the shared template picker search field.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.UsagePackPlans]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Terminal state

`abandoned` — the global template search never ships. The template picker keeps the behaviour the switch produced when **off**: a search field only on the **Workflow** tab, and no search box on Presentation, Website, Illustration, Video or Avatar.

**Basis:** product decision by @tongx in Slack, following @bingjiez666's note that the catalogue search had already been removed once because users do not know what to search for and mostly get no results.

## Introducing commit

`09df8bf043` — `feat: restyle the template picker with a category rail and gallery tiles (#25184)`. That PR renamed `TemplatePickerWorkflowSearch` to `TemplatePickerSearch`, added `filterTemplatesByTitle`, and gated the widened search behind `FeatureSwitchKey.TemplatePickerGlobalSearch` (`enabled: false`, staff orgs only). The `templatePickerSearch$` signal itself is older (#16131, moved to signals in #24441) and belongs to the workflow search, so it stays.

## Kept

- Workflow tab search, still matching title, id, description and connector slugs via `workflowTemplateMatchesSearch`.
- `templatePickerSearch$` / `setTemplatePickerSearch$` signals and the reset on picker open/close.
- The picker restyle from #25184 (rail, header row, gallery tiles) — unrelated to the switch.
- Locale values `artifacts.templates.searchConnector(s)` = "Search templates": still accurate for a workflow search that matches more than connectors, and touching locale keys risks the `i18next-cli --ci` key-order check.

## Removed

- `FeatureSwitchKey.TemplatePickerGlobalSearch` enum member and its `FEATURE_SWITCHES` entry.
- The switch read in `TemplatePickerDialog` plus `catalogueSearch`.
- `filterTemplatesByTitle` and the four `filtered*Items` computations; the catalogues now reach `TemplatePickerCategoryContent` directly.
- Test `filters every non-avatar template catalogue when global search is enabled` (covered only the discarded behaviour) and the `featureSwitches` override in the category-navigation test.

## Renames

- `TemplatePickerSearch` → `TemplatePickerWorkflowSearch` (its pre-#25184 name, accurate again).
- `filtered{Ppt,Website,Illustration,Video}Items` props → `{ppt,website,illustration,video}Items`; nothing filters them any more.

## Commit comparison

`09df8bf043^` rendered `TemplatePickerWorkflowSearch` only on the workflow category and passed the catalogues through unfiltered. This diff restores exactly that semantics on top of the current chrome.

## Second-round search

Swept `TemplatePickerGlobalSearch`, `templatePickerGlobalSearch`, `template-picker-global-search`, `template_picker_global_search`, `filterTemplatesByTitle`, `catalogueSearch`, `TemplatePickerSearch`, `filteredPptItems`, `filteredWebsiteItems`, `filteredIllustrationItems`, `filteredVideoItems` across the repo. Remaining hits are all the retained `templatePickerSearch$` signal and `showTemplatePickerSearch`.

## Knip

`pnpm knip --workspace apps/platform` and `pnpm knip --workspace packages/core` — clean before and after; no orphans from this deletion.

## Verification

- `pnpm format` (clean), `git diff --check` (clean)
- `pnpm check-types` — 13/13 tasks pass
- `pnpm turbo run lint --filter=@vm0/app --filter=@vm0/core` — 6/6 pass (only pre-existing warnings)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx` — 28 passed
- `pnpm -F @vm0/core exec vitest run` — 190 passed

Left to the pipeline: full Vitest, e2e and deploy jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
