### PR TITLE
feat(ui): lighten sidebar hover and active states

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -204,8 +204,8 @@ function ChatThreadMenu({
               showMobileTrigger ? "visible" : "invisible"
             } md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
               isHighlighted
-                ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
-                : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
+                ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-accent-strong"
+                : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-accent-active"
             }`}
             aria-label={t(($) => {
               return $.chat.sidebar.openChatMenu;
@@ -379,7 +379,7 @@ function ChatThreadItemLink({
       }}
       className={`flex h-8 items-center gap-2 rounded-lg py-2 pl-2 pr-8 text-left text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
         isHighlighted
-          ? "bg-gray-200 text-gray-900 font-medium"
+          ? "bg-sidebar-accent-active text-sidebar-foreground font-medium"
           : isUnread
             ? "text-sidebar-foreground font-medium hover:bg-sidebar-accent"
             : "text-sidebar-foreground hover:bg-sidebar-accent"
@@ -733,7 +733,7 @@ function ChatThreadsTitle() {
                 onClick={(e) => {
                   e.stopPropagation();
                 }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent-active transition-colors"
                 aria-label={t(($) => {
                   return $.chat.sidebar.openListMenu;
                 })}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -258,7 +258,7 @@ export function PinnedAgentListSection({
                   data-testid="pinned-agent-card"
                   className={`group flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 no-underline transition-colors duration-200 ${
                     isPrimarySelected
-                      ? "bg-gray-200 text-foreground"
+                      ? "bg-sidebar-accent-active text-sidebar-foreground"
                       : "text-sidebar-foreground hover:bg-sidebar-accent"
                   }`}
                 >
@@ -333,7 +333,7 @@ export function PinnedAgentListSection({
                   e.stopPropagation();
                   openAgentListDialog();
                 }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent-active transition-colors"
                 aria-label={t(($) => {
                   return $.sidebar.openConversation;
                 })}
@@ -393,9 +393,9 @@ export function PinnedAgentListSection({
                       hasSideActions ? "pl-2 pr-8" : "px-2"
                     } ${
                       isPrimarySelected
-                        ? "bg-gray-200 text-foreground font-medium"
+                        ? "bg-sidebar-accent-active text-sidebar-foreground font-medium"
                         : isFromChat
-                          ? "border-l-2 border-[hsl(var(--gray-400))] bg-sidebar-accent/50"
+                          ? "border-l-2 border-[hsl(var(--gray-400))] bg-sidebar-accent text-sidebar-foreground hover:bg-sidebar-accent-active"
                           : "text-sidebar-foreground hover:bg-sidebar-accent"
                     }`}
                   >

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -252,7 +252,7 @@ function CollapsedExpandButton() {
           <TooltipTrigger asChild>
             <button
               type="button"
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
               onClick={onCollapse}
               aria-label={expandLabel}
             >
@@ -321,7 +321,7 @@ function CollapsedNavList() {
                       }}
                       className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
                         isActive
-                          ? "bg-gray-200 text-gray-900"
+                          ? "bg-sidebar-accent-active text-sidebar-foreground"
                           : "text-sidebar-foreground hover:bg-sidebar-accent"
                       }`}
                       aria-label={label}
@@ -370,7 +370,7 @@ function CollapsedFooter() {
               }}
               className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
                 activeId === "insights"
-                  ? "bg-gray-200 text-gray-900"
+                  ? "bg-sidebar-accent-active text-sidebar-foreground"
                   : "text-sidebar-foreground hover:bg-sidebar-accent"
               }`}
               aria-label={insightsLabel}
@@ -433,7 +433,7 @@ function ExpandedHeader() {
             <TooltipTrigger asChild>
               <button
                 type="button"
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
                 onClick={onCollapse}
                 aria-label={collapseLabel}
               >
@@ -514,7 +514,7 @@ function ExpandedManageSection() {
                   aria-current={isActive ? "page" : undefined}
                   className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
                     isActive
-                      ? "bg-gray-200 text-gray-900 font-medium"
+                      ? "bg-sidebar-accent-active text-sidebar-foreground font-medium"
                       : "text-sidebar-foreground hover:bg-sidebar-accent"
                   }`}
                 >
@@ -580,7 +580,7 @@ function ExpandedFooter() {
                 }}
                 className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
                   isActive
-                    ? "bg-gray-200 text-gray-900 font-medium"
+                    ? "bg-sidebar-accent-active text-sidebar-foreground font-medium"
                     : "text-sidebar-foreground hover:bg-sidebar-accent"
                 }`}
               >
@@ -641,7 +641,7 @@ function ExpandedFooterAccountInsights() {
               }}
               className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
                 activeId === "insights"
-                  ? "bg-gray-200 text-gray-900"
+                  ? "bg-sidebar-accent-active text-sidebar-foreground"
                   : "text-sidebar-foreground hover:bg-sidebar-accent"
               }`}
               aria-label={insightsLabel}
@@ -724,7 +724,7 @@ function LabeledRailLink({
       <span
         className={`relative inline-flex h-9 w-10 items-center justify-center rounded-xl transition-colors duration-200 ${
           isActive
-            ? "bg-gray-200 text-gray-900"
+            ? "bg-sidebar-accent-active text-sidebar-foreground"
             : "text-sidebar-foreground group-hover:bg-sidebar-accent"
         }`}
       >

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -92,6 +92,8 @@
   --color-sidebar-primary: hsl(var(--sidebar-primary));
   --color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
   --color-sidebar-accent: hsl(var(--sidebar-accent));
+  --color-sidebar-accent-active: hsl(var(--sidebar-accent-active));
+  --color-sidebar-accent-strong: hsl(var(--sidebar-accent-strong));
   --color-semantic-foreground: hsl(var(--semantic-foreground));
   --color-on-filled: hsl(var(--on-filled));
   --color-background-50: hsl(var(--background-50));
@@ -217,7 +219,9 @@
     --sidebar-foreground: var(--gray-950); /* gray-950 */
     --sidebar-primary: var(--primary-800); /* primary-800 */
     --sidebar-primary-foreground: var(--gray-50); /* gray-50 */
-    --sidebar-accent: var(--gray-100); /* gray-100 */
+    --sidebar-accent: 215 25% 94.6%; /* sidebar row hover - one step above sidebar surface */
+    --sidebar-accent-active: 214 23% 92.2%; /* sidebar row selected - always heavier than hover */
+    --sidebar-accent-strong: 213 22% 89.8%; /* controls layered on an already-hovered/selected row */
 
     --semantic-foreground: var(--gray-0); /* gray-0 */
 
@@ -321,9 +325,9 @@
     --sidebar-foreground: var(--gray-950); /* gray-950 */
     --sidebar-primary: var(--primary-800); /* primary-800 */
     --sidebar-primary-foreground: var(--gray-50); /* gray-50 */
-    --sidebar-accent: var(
-      --gray-300
-    ); /* gray-300 - visible hover against sidebar */
+    --sidebar-accent: 240 3% 17.5%; /* sidebar row hover - one step above sidebar surface */
+    --sidebar-accent-active: 240 3% 20%; /* sidebar row selected - always heavier than hover */
+    --sidebar-accent-strong: 240 3% 22.5%; /* controls layered on an already-hovered/selected row */
 
     --tooltip-bg: hsl(
       var(--gray-300)

--- a/turbo/packages/ui/tailwind.config.ts
+++ b/turbo/packages/ui/tailwind.config.ts
@@ -79,6 +79,8 @@ const config: Config = {
           primary: "hsl(var(--sidebar-primary))",
           "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
           accent: "hsl(var(--sidebar-accent))",
+          "accent-active": "hsl(var(--sidebar-accent-active))",
+          "accent-strong": "hsl(var(--sidebar-accent-strong))",
         },
         "semantic-foreground": "hsl(var(--semantic-foreground))",
         "on-filled": "hsl(var(--on-filled))",


### PR DESCRIPTION
## Why

The sidebar's interaction states read too heavy. Looking into it turned up two more problems in dark mode:

1. **hover outweighed active.** `--sidebar-accent` maps to `gray-300` in dark, `bg-gray-200` was the selected state — so hovering an unselected row made it *more* prominent than the currently selected one.
2. **the selected row's text was the dimmest in the list.** Selected rows used `text-gray-900` (`#C3C5CB`) while every other row uses `sidebar-foreground` = `gray-950` (`#E9EAEC`).

The values were also uncentralised: hover came from `--sidebar-accent`, but the selected state was `bg-gray-200` hardcoded in 9 places, and the row-level control chips used one-off `hover:bg-[hsl(var(--gray-200))]` / `--gray-300` values.

## What

Three dedicated sidebar state tokens on an even 2.5pt lightness ladder above the sidebar surface:

| token | light | dark | used for |
|---|---|---|---|
| `--sidebar-accent` | `#EEF1F5` | `#2B2B2E` | row hover |
| `--sidebar-accent-active` | `#E7EBF0` | `#313135` | row selected |
| `--sidebar-accent-strong` | `#DFE4EB` | `#38383B` | controls layered on an already-hovered/selected row |

Ladder: light `96 → 94.6 → 92.2 → 89.8`, dark `15 → 17.5 → 20 → 22.5`. Active is now always heavier than hover in both themes.

Call sites:
- 9 × `bg-gray-200` selected states → `bg-sidebar-accent-active`
- `text-gray-900` / `text-foreground` on selected rows → `text-sidebar-foreground`
- row menu-trigger chips → `hover:bg-sidebar-accent-active`, or `-strong` when the row underneath is already selected
- the two sidebar collapse buttons sit on the bare surface, so they now use plain `hover:bg-sidebar-accent` like a row
- pinned `bg-sidebar-accent/50` would have gone nearly invisible against the lighter surface — now a solid `bg-sidebar-accent` plus a `hover:bg-sidebar-accent-active` it was previously missing

Tuning the sidebar's feel from here is a two-line change in `globals.css`.

## Test plan

- `pnpm format`, `turbo run lint`, `turbo run check-types` for `@vm0/ui` + `@vm0/app` — clean
- No test asserts on the replaced class names
- Visual check in light and dark, all four states

🤖 Generated with [Claude Code](https://claude.com/claude-code)
