### PR TITLE
feat: add the sparse ripple thinking indicator behind a feature switch

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -357,6 +357,80 @@ body {
   }
 }
 
+/* Thinking indicator: 3x3 sparse ripple loader, behind the
+ * chatRippleThinkingIndicator switch. A wave sweeps the diagonal and each cell
+ * morphs square-to-circle as it lights, which is what makes a static grid read
+ * as soft. The delay step is wide relative to the lit window on purpose: at most
+ * one diagonal band carries the brand colour at a time, so the indicator stays
+ * quiet next to body text while never fully going dark. */
+.zero-blocks-ripple {
+  display: inline-grid;
+  grid-template-columns: repeat(3, 3.5px);
+  grid-template-rows: repeat(3, 3.5px);
+  gap: 1.5px;
+}
+.zero-blocks-ripple span {
+  border-radius: 1px;
+  background: hsl(var(--muted-foreground) / 0.3);
+  animation: zero-block-ripple 1.4s cubic-bezier(0.35, 0, 0.3, 1) infinite;
+}
+/* Delay follows each cell's diagonal distance from the top-left corner. */
+.zero-blocks-ripple span:nth-child(2),
+.zero-blocks-ripple span:nth-child(4) {
+  animation-delay: 0.26s;
+}
+.zero-blocks-ripple span:nth-child(3),
+.zero-blocks-ripple span:nth-child(5),
+.zero-blocks-ripple span:nth-child(7) {
+  animation-delay: 0.52s;
+}
+.zero-blocks-ripple span:nth-child(6),
+.zero-blocks-ripple span:nth-child(8) {
+  animation-delay: 0.78s;
+}
+.zero-blocks-ripple span:nth-child(9) {
+  animation-delay: 1.04s;
+}
+@keyframes zero-block-ripple {
+  0% {
+    transform: scale(0.84);
+    border-radius: 1px;
+    background: hsl(var(--muted-foreground) / 0.3);
+  }
+  10% {
+    transform: scale(1.08);
+    border-radius: 45%;
+    background: hsl(var(--primary) / 0.85);
+  }
+  22% {
+    transform: scale(1);
+    border-radius: 26%;
+    background: hsl(var(--primary) / 0.5);
+  }
+  36%,
+  100% {
+    transform: scale(0.84);
+    border-radius: 1px;
+    background: hsl(var(--muted-foreground) / 0.3);
+  }
+}
+/* Keep the wave legible without motion: colour still travels, nothing moves. */
+@media (prefers-reduced-motion: reduce) {
+  .zero-blocks-ripple span {
+    animation-name: zero-block-ripple-calm;
+    animation-duration: 2s;
+  }
+}
+@keyframes zero-block-ripple-calm {
+  0%,
+  100% {
+    background: hsl(var(--muted-foreground) / 0.3);
+  }
+  40% {
+    background: hsl(var(--primary) / 0.75);
+  }
+}
+
 /* Zero app: inherits global cool gray tokens; only card-specific tokens defined here */
 .zero-app {
   --zero-card-radius: 1rem;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4274,6 +4274,34 @@ function ThinkingLabel({
   );
 }
 
+function ThinkingBlocks({ blockStyle }: { blockStyle: CSSProperties }) {
+  const rippleEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatRippleThinkingIndicator] ??
+    false;
+  if (rippleEnabled) {
+    return (
+      <span className="zero-blocks-ripple shrink-0">
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+      </span>
+    );
+  }
+  return (
+    <span className="zero-blocks shrink-0" style={blockStyle}>
+      <span />
+      <span />
+      <span />
+    </span>
+  );
+}
+
 function InlineThinkingRow({
   blockStyle,
   isQueued,
@@ -4287,11 +4315,7 @@ function InlineThinkingRow({
 }) {
   return (
     <div className="flex items-center gap-2 h-5">
-      <span className="zero-blocks shrink-0" style={blockStyle}>
-        <span />
-        <span />
-        <span />
-      </span>
+      <ThinkingBlocks blockStyle={blockStyle} />
       <ThinkingLabel
         isQueued={isQueued}
         thinkingLabel={thinkingLabel}
@@ -4370,11 +4394,7 @@ function WaitingForAssistantResponse({
         <AssistantBubbleAvatar thread={thread} />
         <div className="zero-chat-bubble-assistant rounded-xl py-4 text-[0.9375rem] leading-[1.7] min-w-0 overflow-hidden">
           <div className="flex h-5 min-w-0 items-center gap-2">
-            <span className="zero-blocks shrink-0" style={blockStyle}>
-              <span />
-              <span />
-              <span />
-            </span>
+            <ThinkingBlocks blockStyle={blockStyle} />
             <ThinkingLabel
               isQueued={isQueued}
               thinkingLabel={thinkingLabel}

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -73,4 +73,5 @@ export enum FeatureSwitchKey {
   PiLoop = "piLoop",
   CjkFriendlyMarkdown = "cjkFriendlyMarkdown",
   VideoTemplateOptions = "videoTemplateOptions",
+  ChatRippleThinkingIndicator = "chatRippleThinkingIndicator",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -431,6 +431,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show the configure-permissions entry in the chat composer connector popover, opening the agent×connector firewall dialog inline.",
     enabled: false,
   },
+  [FeatureSwitchKey.ChatRippleThinkingIndicator]: {
+    maintainer: "tongx@vm0.ai",
+    description:
+      "Render the chat thinking indicator as a 3x3 sparse ripple in the brand colour instead of the 3-block loader.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## What

Adds the **C2 · Sparse ripple** thinking-indicator animation as an opt-in alternative to the current 3-block loader, gated behind a new feature switch. Nothing changes for anyone until the switch is turned on.

This is the variant the team landed on after #25607 (the fully saturated 3×3 ripple) shipped, was called too loud, and was rolled back in #25661.

## Feature switch

| | |
|---|---|
| Key | `chatRippleThinkingIndicator` |
| Maintainer | tongx@vm0.ai |
| Default | `enabled: false` + `STAFF_ORG_ID_HASHES` — staff orgs only |

Toggle it from the Lab page, or `window._vm0.featureSwitches.chatRippleThinkingIndicator = true`.

## Why "sparse"

The rolled-back version lit nearly all 9 cells in full-saturation brand orange at once. This one keeps the same choreography but widens the delay step from `0.10s` to `0.26s` and shortens each cell's lit window, so it reduces the *area* of orange rather than washing out the colour.

Measured over a cycle while tuning: at most **5 of 9** cells tinted at any instant (the previous version hit 9), and **no frame** where the whole grid goes dark — an earlier `1.9s / 0.17s` attempt had ~0.48s of full grey per cycle, which read as stalled, so it was retuned to `1.4s / 0.26s`.

## Implementation

- `.zero-blocks-ripple` is a new, separate CSS block. `.zero-blocks` and its randomized per-thread palette are untouched, so the default path is byte-for-byte the current behaviour.
- Both render sites now share a `ThinkingBlocks` component that reads the switch and renders either 9 ripple cells or the existing 3 blocks. `blockStyle` still flows to the legacy variant only.
- Colours come from `--primary` and `--muted-foreground` with alpha. No hard-coded hexes — note the vm0 primary scale inverts in dark mode, so tint tokens can't express "brighter"; the peak uses scale + alpha instead.
- Includes a `prefers-reduced-motion` variant that keeps the colour wave but removes every transform. The existing loader has no reduced-motion handling; this only covers the new path.

## Verification

Dependencies aren't installed in this container, so no local type-check or test run — relying on the PR pipeline.

The shipped CSS was extracted verbatim into a harness seeded with the real `--primary` / `--muted-foreground` / `--background` token values and rendered in both themes at true 16px inline size and 6× zoom, with the switch both off and on. Confirmed the wave direction, the square-to-circle morph, the single lit diagonal band, and that the off path still renders the pastel 3-block loader.

Needs a look on the preview with the switch flipped before anyone considers widening the rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)