### PR TITLE
refactor(chat): remove unread ids rollout compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -530,7 +530,7 @@ export function createChatFilesBddApi(context: TestContext) {
 
     async requestListUnreadChatThreadIds(
       actor: ApiTestUser | null,
-      statuses: readonly (200 | 401 | 404)[],
+      statuses: readonly (200 | 401)[],
     ) {
       return await accept(
         threadsClient().unreadIds({

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
@@ -151,29 +151,6 @@ describe("chat event background sync", () => {
     );
   });
 
-  it("continues active prefetch against an API without unread ids", async () => {
-    const requestedThreadIds: string[] = [];
-    context.mocks.api(chatThreadsContract.unreadIds, ({ respond }) => {
-      return respond(404, {
-        error: { message: "Not found", code: "NOT_FOUND" },
-      });
-    });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [THREAD_ID] });
-    });
-    context.mocks.api(chatThreadEventsContract.list, ({ params, respond }) => {
-      requestedThreadIds.push(params.threadId);
-      return respond(200, { events: [] });
-    });
-
-    await setupAuthenticatedBackgroundSync();
-
-    await waitFor(() => {
-      expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
-      expect(requestedThreadIds).toStrictEqual([THREAD_ID]);
-    });
-  });
-
   it("fills only messages after the cached thread end", async () => {
     mockSignedInUser();
     const appDb = await context.store.get(chatIdb$);

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -91,11 +91,8 @@ export const allUnreadThreadIds$ = computed(
   async (get): Promise<ReadonlySet<string>> => {
     get(reloadChatUnreadStateCounter$);
     const client = get(zeroClient$)(chatThreadsContract);
-    const result = await accept(client.unreadIds(), [200, 404]);
-    // A newly promoted app can briefly reach an API version from before this
-    // additive route existed. Remove after that API is outside the production
-    // rollback window.
-    return new Set(result.status === 200 ? result.body.threadIds : []);
+    const result = await accept(client.unreadIds(), [200]);
+    return new Set(result.body.threadIds);
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -890,10 +890,6 @@ export const chatThreadsContract = c.router({
         threadIds: z.array(z.string().uuid()),
       }),
       401: apiErrorSchema,
-      // A newly promoted app can briefly reach an API version from before
-      // this additive route existed. Remove after that API is outside the
-      // production rollback window.
-      404: apiErrorSchema,
     },
     summary:
       "List unread chat thread ids for the caller in the current organization.",


### PR DESCRIPTION
## Summary

- remove the temporary `404` response from the unread thread IDs contract
- require the platform unread IDs signal to receive the deployed `200` response
- remove the missing-route bootstrap test and narrow the API BDD helper status type

## Context

This is the planned follow-up to #25563 after its API/app rollout and rollback window completed.

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/api-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types:tests`
- `pnpm knip --workspace @vm0/app`
- `pnpm knip --workspace @vm0/api-contracts`
- `pnpm knip --workspace api`
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-event-background-sync.test.ts` (4 tests passed)
- Lefthook pre-commit and commit-msg hooks
