### PR TITLE
refactor(api): source goal runs from thread goals

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -20,10 +20,7 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import {
-  appendGoalMarkerFixture,
-  readGoalQueueStateFixture,
-} from "../../../test-fixtures/goal-queue";
+import { readGoalQueueStateFixture } from "../../../test-fixtures/goal-queue";
 import {
   holdCheckpointReadsFixture,
   holdChatEventInsertTransactionFixture,
@@ -1738,7 +1735,7 @@ describe("CHAT-02: completed chat callback", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("sources the goal system prompt from thread goals and ignores later UI markers", async () => {
+  it("sources the goal system prompt from thread goals", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     await enableGoalWorkflows(actor);
@@ -1757,19 +1754,6 @@ ${noisySeparator}
 
 Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-42](https://acme.example.com/treasury) before marking done.`;
     await createGoalForRun(actor, first.runId, goalObjective);
-    const goalRunPreparationStarted = createDeferredPromise<void>(
-      context.signal,
-    );
-    const releaseGoalRunPreparation = deferredGate();
-    useSecretKmsProbe((command) => {
-      if (!goalRunPreparationStarted.settled()) {
-        goalRunPreparationStarted.resolve(undefined);
-      }
-      return releaseGoalRunPreparation.wait().then(() => {
-        return generateDataKeyOutput(command);
-      });
-    });
-
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "completed before goal continuation"),
     ]);
@@ -1778,12 +1762,6 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await completeChatRunOk(first.runId, sandboxHeaders, {
       lastEventSequence: 0,
     });
-    await goalRunPreparationStarted.promise;
-    await appendGoalMarkerFixture({
-      threadId: first.threadId,
-      objectiveBrief: "Display-only marker must not invalidate this run",
-    });
-    releaseGoalRunPreparation.release();
 
     const messages = await waitForThreadMessages(
       actor,
@@ -1839,9 +1817,6 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     expect(appendSystemPrompt).toContain(goalBrief);
     expect(appendSystemPrompt).toContain("Autonomy budget: 9");
     expect(appendSystemPrompt).toContain("# How to operate");
-    expect(appendSystemPrompt).not.toContain(
-      "Display-only marker must not invalidate this run",
-    );
     expect(goalContext.body.sessionId).toBe(
       cliAgentSessionIdForChatRun(first.runId),
     );
@@ -1857,7 +1832,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await flushWaitUntilForTest();
   }, 90_000);
 
-  it("rebuilds a preparing goal run from the latest thread goal row", async () => {
+  it("rebuilds a preparing goal run from the latest row despite its UI marker", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -20,7 +20,10 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { readGoalQueueStateFixture } from "../../../test-fixtures/goal-queue";
+import {
+  appendGoalMarkerFixture,
+  readGoalQueueStateFixture,
+} from "../../../test-fixtures/goal-queue";
 import {
   holdCheckpointReadsFixture,
   holdChatEventInsertTransactionFixture,
@@ -1735,7 +1738,7 @@ describe("CHAT-02: completed chat callback", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("continues an active goal with the full objective in the run prompt and the brief in the user message snapshot", async () => {
+  it("sources the goal system prompt from thread goals and ignores later UI markers", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     await enableGoalWorkflows(actor);
@@ -1754,6 +1757,18 @@ ${noisySeparator}
 
 Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-42](https://acme.example.com/treasury) before marking done.`;
     await createGoalForRun(actor, first.runId, goalObjective);
+    const goalRunPreparationStarted = createDeferredPromise<void>(
+      context.signal,
+    );
+    const releaseGoalRunPreparation = deferredGate();
+    useSecretKmsProbe((command) => {
+      if (!goalRunPreparationStarted.settled()) {
+        goalRunPreparationStarted.resolve(undefined);
+      }
+      return releaseGoalRunPreparation.wait().then(() => {
+        return generateDataKeyOutput(command);
+      });
+    });
 
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "completed before goal continuation"),
@@ -1763,6 +1778,12 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await completeChatRunOk(first.runId, sandboxHeaders, {
       lastEventSequence: 0,
     });
+    await goalRunPreparationStarted.promise;
+    await appendGoalMarkerFixture({
+      threadId: first.threadId,
+      objectiveBrief: "Display-only marker must not invalidate this run",
+    });
+    releaseGoalRunPreparation.release();
 
     const messages = await waitForThreadMessages(
       actor,
@@ -1808,13 +1829,18 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       ],
     });
     const goalContext = await waitForRunContext(actor, goalContinuation.runId);
-    expect(goalContext.body.prompt).toContain("# Active thread goal");
-    expect(goalContext.body.prompt).toContain(goalObjective);
-    expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
-      "# Active thread goal",
-    );
-    expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
-      "# How to operate",
+    expect(goalContext.body.prompt).toBe("Continue the active thread goal.");
+    expect(goalContext.body.prompt).not.toContain(goalBrief);
+    expect(goalContext.body.prompt).not.toContain(goalObjective);
+    const appendSystemPrompt = goalContext.body.appendSystemPrompt ?? "";
+    expect(appendSystemPrompt).toContain("# Active thread goal");
+    expect(appendSystemPrompt).toContain(goalObjective);
+    expect(appendSystemPrompt).toContain("# User-visible objective brief");
+    expect(appendSystemPrompt).toContain(goalBrief);
+    expect(appendSystemPrompt).toContain("Autonomy budget: 9");
+    expect(appendSystemPrompt).toContain("# How to operate");
+    expect(appendSystemPrompt).not.toContain(
+      "Display-only marker must not invalidate this run",
     );
     expect(goalContext.body.sessionId).toBe(
       cliAgentSessionIdForChatRun(first.runId),
@@ -1831,7 +1857,87 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await flushWaitUntilForTest();
   }, 90_000);
 
-  it("revokes a goal invalidated during run preparation without creating a run", async () => {
+  it("rebuilds a preparing goal run from the latest thread goal row", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before the goal objective is updated",
+    });
+    const initialObjective = "Continue the original goal target";
+    const updatedObjective = "Continue the updated goal target";
+    await createGoalForRun(actor, first.runId, initialObjective);
+
+    const goalRunPreparationStarted = createDeferredPromise<void>(
+      context.signal,
+    );
+    const releaseGoalRunPreparation = deferredGate();
+    useSecretKmsProbe((command) => {
+      if (!goalRunPreparationStarted.settled()) {
+        goalRunPreparationStarted.resolve(undefined);
+      }
+      return releaseGoalRunPreparation.wait().then(() => {
+        return generateDataKeyOutput(command);
+      });
+    });
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before the goal objective changed"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await goalRunPreparationStarted.promise;
+
+    const edited = await accept(
+      goalsClient().edit({
+        headers: zeroGoalHeaders(actor, first.runId),
+        body: { objective: updatedObjective },
+      }),
+      [200],
+    );
+    expect(edited.body).toMatchObject({
+      objective: updatedObjective,
+      objectiveBrief: updatedObjective,
+      status: "active",
+    });
+    releaseGoalRunPreparation.release();
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return isGoalContinuationUserMessage(message, updatedObjective);
+        });
+      },
+    );
+    const continuation = userMessages(messages.events).find((message) => {
+      return isGoalContinuationUserMessage(message, updatedObjective);
+    });
+    if (!continuation?.runId) {
+      throw new Error("Expected the updated goal continuation run");
+    }
+    await expect(goalRunIds(first.threadId)).resolves.toStrictEqual([
+      continuation.runId,
+    ]);
+
+    const goalContext = await waitForRunContext(actor, continuation.runId);
+    expect(goalContext.body.prompt).toBe("Continue the active thread goal.");
+    expect(goalContext.body.prompt).not.toContain(initialObjective);
+    expect(goalContext.body.prompt).not.toContain(updatedObjective);
+    expect(goalContext.body.appendSystemPrompt).toContain(updatedObjective);
+    expect(goalContext.body.appendSystemPrompt).not.toContain(initialObjective);
+
+    await api.requestCancelRun(actor, continuation.runId, [200]);
+    await waitForRunStatus(actor, continuation.runId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
+  it("revokes a goal deleted during run preparation without creating a run", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -1847,7 +1953,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     useSecretKmsProbe((command) => {
       // The terminal callback drain and the goal enqueue drain may both prepare
       // this queued run. Hold every preparation so neither can win the final
-      // claim before the goal is paused.
+      // claim before the goal is deleted.
       if (!runPreparationStarted.settled()) {
         runPreparationStarted.resolve(undefined);
       }
@@ -1865,13 +1971,13 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     });
     await runPreparationStarted.promise;
 
-    const paused = await accept(
-      goalsClient().pause({
+    const cleared = await accept(
+      goalsClient().clear({
         headers: zeroGoalHeaders(actor, first.runId),
       }),
       [200],
     );
-    expect(paused.body.status).toBe("paused");
+    expect(cleared.body).toStrictEqual({ cleared: true });
     const [goalEventId] = await goalQueueEventIds(first.threadId);
     expect(goalEventId).toBeDefined();
     if (!goalEventId) {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6474,9 +6474,6 @@ async function resolveQueueFirstAdmissionForLaunch(args: {
   if (association.threadId !== args.createArgs.chatThreadId) {
     throw new Error("Queue-first association must match the run chat thread");
   }
-  if (association.kind === "goal_event") {
-    await lockGoalQueueFirstRunSource(args.tx, association);
-  }
   return await resolveQueueFirstRunAdmission(args.tx, {
     admissionTime:
       association.kind === "user_message"
@@ -6487,6 +6484,16 @@ async function resolveQueueFirstAdmissionForLaunch(args: {
     timing: args.timing,
     ...(args.threadAlreadyLocked ? { threadAlreadyLocked: true } : {}),
   });
+}
+
+async function lockQueueFirstRunSourceForLaunch(args: {
+  readonly tx: DbTransaction;
+  readonly createArgs: CreateAgentRunArgs;
+}): Promise<void> {
+  const association = args.createArgs.queueFirstAssociation;
+  if (association?.kind === "goal_event") {
+    await lockGoalQueueFirstRunSource(args.tx, association);
+  }
 }
 
 async function claimQueueFirstAssociationForLaunch(args: {
@@ -6527,6 +6534,10 @@ async function commitFailedLaunch(args: {
   const message = runFailureMessage(args.error);
   const committed = await args.db.transaction(
     async (tx): Promise<FailedLaunchCommitResult> => {
+      await lockQueueFirstRunSourceForLaunch({
+        tx,
+        createArgs: args.createArgs,
+      });
       const queueFirstAdmission = await resolveQueueFirstAdmissionForLaunch({
         tx,
         createArgs: args.createArgs,
@@ -7006,6 +7017,10 @@ async function commitPreparedLaunch(
       },
     );
     const admissionLockHeldStartedAt = now();
+    await lockQueueFirstRunSourceForLaunch({
+      tx,
+      createArgs: args.createArgs,
+    });
     return {
       result: await commitPreparedLaunchUnderLock(tx, args, payload),
       admissionLockHeldStartedAt,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -260,6 +260,7 @@ import type {
 } from "./chat-session-continuity.service";
 import {
   claimQueueFirstRunAssociation,
+  lockGoalQueueFirstRunSource,
   recordQueueFirstClaimedRun,
   recordQueueFirstFailedRun,
   resolveQueueFirstRunAdmission,
@@ -6472,6 +6473,9 @@ async function resolveQueueFirstAdmissionForLaunch(args: {
   }
   if (association.threadId !== args.createArgs.chatThreadId) {
     throw new Error("Queue-first association must match the run chat thread");
+  }
+  if (association.kind === "goal_event") {
+    await lockGoalQueueFirstRunSource(args.tx, association);
   }
   return await resolveQueueFirstRunAdmission(args.tx, {
     admissionTime:

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -2,7 +2,7 @@ import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, eq, gt, isNull, notExists } from "drizzle-orm";
+import { and, eq, isNull, notExists } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import { nowDate } from "../../lib/time";
@@ -31,7 +31,6 @@ import {
 import { lockGoalThread } from "./zero-goal-lock.service";
 
 const goalEventRevoker = alias(chatEvents, "goal_event_revoker");
-const laterGoalChange = alias(chatEvents, "later_goal_change");
 
 export type GoalQueueAdmission =
   | { readonly kind: "inserted"; readonly eventId: string }
@@ -55,11 +54,13 @@ export interface GoalQueueTarget {
   readonly objective: string;
   readonly objectiveBrief: string;
   readonly autonomyBudget: number;
+  readonly updatedAt: Date;
 }
 
 type FailedGoalQueueSettlement =
   | { readonly kind: "not_pending" }
   | { readonly kind: "revoked" }
+  | { readonly kind: "stale" }
   | { readonly kind: "rejected"; readonly goalId: string };
 
 async function pendingGoalEventExists(
@@ -122,21 +123,6 @@ export async function admitGoalQueueEvent(
     }
     return { kind: "inserted", eventId: inserted.id };
   });
-}
-
-export function noGoalChangeAfterQueueEvent(db: Pick<Db, "select">) {
-  return notExists(
-    db
-      .select({ id: laterGoalChange.id })
-      .from(laterGoalChange)
-      .where(
-        and(
-          eq(laterGoalChange.chatThreadId, chatEvents.chatThreadId),
-          eq(laterGoalChange.eventType, "goal.changed"),
-          gt(laterGoalChange.seqId, chatEvents.seqId),
-        ),
-      ),
-  );
 }
 
 /** Load the next runnable goal trigger. */
@@ -205,6 +191,7 @@ export async function loadGoalQueueTarget(
         threadGoals.autonomyBudget,
       ),
       status: threadGoals.status,
+      updatedAt: threadGoals.updatedAt,
     })
     .from(threadGoals)
     .innerJoin(
@@ -220,7 +207,6 @@ export async function loadGoalQueueTarget(
         eq(threadGoals.chatThreadId, event.chatThreadId),
         eq(threadGoals.orgId, event.orgId),
         eq(threadGoals.ownerUserId, event.userId),
-        noGoalChangeAfterQueueEvent(db),
       ),
     )
     .limit(1);
@@ -236,6 +222,7 @@ export async function loadGoalQueueTarget(
     objective: goal.objective,
     objectiveBrief: goal.objectiveBrief,
     autonomyBudget: goal.autonomyBudget,
+    updatedAt: goal.updatedAt,
   };
 }
 
@@ -245,6 +232,25 @@ async function pendingGoalEventStillExists(
 ): Promise<boolean> {
   const pending = await loadPendingChatQueueEvent(db, args);
   return pending?.eventType === "input.goal";
+}
+
+async function lockGoalQueueTarget(
+  db: Db,
+  event: PendingGoalQueueEvent,
+): Promise<void> {
+  await db
+    .select({ id: threadGoals.id })
+    .from(threadGoals)
+    .where(
+      and(
+        eq(threadGoals.id, event.goalId),
+        eq(threadGoals.chatThreadId, event.chatThreadId),
+        eq(threadGoals.orgId, event.orgId),
+        eq(threadGoals.ownerUserId, event.userId),
+      ),
+    )
+    .for("update")
+    .limit(1);
 }
 
 /** Remove a goal trigger invalidated by a normal goal lifecycle change. */
@@ -273,19 +279,21 @@ export async function revokeGoalQueueEvent(
 
 /**
  * Settle a failed launch against the final goal state. Goal lifecycle writers
- * take the advisory lock before appending their queue marker, so this keeps
- * validity, event transition, and the exact-goal pause in one serialization
- * order and one transaction.
+ * take the advisory lock before changing the goal row. Lock the exact source
+ * row before the chat queue row so validity, event transition, and the
+ * exact-goal pause share the same serialization order as final run claim.
  */
 export async function settleFailedGoalQueueEvent(
   db: Db,
   args: {
     readonly event: PendingGoalQueueEvent;
+    readonly expectedGoalUpdatedAt: Date;
     readonly reason: string;
   },
 ): Promise<FailedGoalQueueSettlement> {
   return await db.transaction(async (tx) => {
     await lockGoalThread(tx, args.event.chatThreadId);
+    await lockGoalQueueTarget(tx, args.event);
     if (!(await lockChatQueueThread(tx, args.event.chatThreadId))) {
       return { kind: "not_pending" };
     }
@@ -306,6 +314,9 @@ export async function settleFailedGoalQueueEvent(
         runId: null,
       });
       return revoked ? { kind: "revoked" } : { kind: "not_pending" };
+    }
+    if (goal.updatedAt.getTime() !== args.expectedGoalUpdatedAt.getTime()) {
+      return { kind: "stale" };
     }
 
     const [payload] = await tx

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -2,9 +2,10 @@ import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, eq, isNull, notExists } from "drizzle-orm";
+import { and, eq, isNull, notExists, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
@@ -54,7 +55,7 @@ export interface GoalQueueTarget {
   readonly objective: string;
   readonly objectiveBrief: string;
   readonly autonomyBudget: number;
-  readonly updatedAt: Date;
+  readonly stateRevision: string;
 }
 
 type FailedGoalQueueSettlement =
@@ -191,7 +192,8 @@ export async function loadGoalQueueTarget(
         threadGoals.autonomyBudget,
       ),
       status: threadGoals.status,
-      updatedAt: threadGoals.updatedAt,
+      // A Date decoder drops PostgreSQL microseconds needed by the final CAS.
+      stateRevision: sql`${threadGoals.updatedAt}::text`.mapWith(pgTextDecoder),
     })
     .from(threadGoals)
     .innerJoin(
@@ -222,7 +224,7 @@ export async function loadGoalQueueTarget(
     objective: goal.objective,
     objectiveBrief: goal.objectiveBrief,
     autonomyBudget: goal.autonomyBudget,
-    updatedAt: goal.updatedAt,
+    stateRevision: goal.stateRevision,
   };
 }
 
@@ -287,7 +289,7 @@ export async function settleFailedGoalQueueEvent(
   db: Db,
   args: {
     readonly event: PendingGoalQueueEvent;
-    readonly expectedGoalUpdatedAt: Date;
+    readonly expectedGoalStateRevision: string;
     readonly reason: string;
   },
 ): Promise<FailedGoalQueueSettlement> {
@@ -315,7 +317,7 @@ export async function settleFailedGoalQueueEvent(
       });
       return revoked ? { kind: "revoked" } : { kind: "not_pending" };
     }
-    if (goal.updatedAt.getTime() !== args.expectedGoalUpdatedAt.getTime()) {
+    if (goal.stateRevision !== args.expectedGoalStateRevision) {
       return { kind: "stale" };
     }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -195,7 +195,7 @@ export type QueueFirstRunAssociation =
       readonly prompt: string;
       readonly goalId: string;
       readonly goalObjectiveBrief: string;
-      readonly goalUpdatedAt: Date;
+      readonly goalStateRevision: string;
       readonly orgId: string;
       readonly userId: string;
     };
@@ -571,7 +571,8 @@ async function resolveGoalQueueFirstClaimSnapshot(
         eq(threadGoals.orgId, args.orgId),
         eq(threadGoals.ownerUserId, args.userId),
         eq(chatEvents.runGroupId, threadGoals.id),
-        eq(threadGoals.updatedAt, args.goalUpdatedAt),
+        // Match the lossless revision captured before run preparation.
+        eq(sql`${threadGoals.updatedAt}::text`, args.goalStateRevision),
       ),
     )
     .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -29,10 +29,7 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
-import {
-  pgBooleanDecoder,
-  pgNullDecoder,
-} from "../../lib/db-structured-result";
+import { pgNullDecoder } from "../../lib/db-structured-result";
 import { db$, type Db } from "../external/db";
 import {
   chatQueueEventPriority,
@@ -53,7 +50,6 @@ import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
 import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
-import { noGoalChangeAfterQueueEvent } from "./chat-goal-queue.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
 import { attachCanonicalWebInputAssetsToEvent } from "./canonical-asset.service";
 import {
@@ -66,7 +62,10 @@ import {
   rolloutCompatibleAutonomyBudgetColumn,
 } from "./autonomy-budget-schema.service";
 import type { Tx } from "../../lib/db-types";
-import { withRunModelAnnotation } from "./zero-chat-user-message.service";
+import {
+  createUserMessageDocument,
+  withRunModelAnnotation,
+} from "./zero-chat-user-message.service";
 import { chatAgentRunContextSchemaAvailable } from "./chat-agent-run-context-schema.service";
 
 type DbTransaction = Tx;
@@ -195,6 +194,8 @@ export type QueueFirstRunAssociation =
       readonly eventId: string;
       readonly prompt: string;
       readonly goalId: string;
+      readonly goalObjectiveBrief: string;
+      readonly goalUpdatedAt: Date;
       readonly orgId: string;
       readonly userId: string;
     };
@@ -217,9 +218,29 @@ export type QueueFirstRunSessionSnapshotState =
   | "session_changed"
   | "unvalidated";
 
+/** Keep the exact goal source row stable through the later chat queue claim. */
+export async function lockGoalQueueFirstRunSource(
+  db: DbTransaction,
+  args: Extract<QueueFirstRunAssociation, { readonly kind: "goal_event" }>,
+): Promise<void> {
+  await db
+    .select({ id: threadGoals.id })
+    .from(threadGoals)
+    .where(
+      and(
+        eq(threadGoals.id, args.goalId),
+        eq(threadGoals.chatThreadId, args.threadId),
+        eq(threadGoals.orgId, args.orgId),
+        eq(threadGoals.ownerUserId, args.userId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+}
+
 /**
- * Establish the thread-first lock order shared by every event-backed queue
- * claim, rejection, and revocation.
+ * Establish the shared thread lock for every event-backed queue claim,
+ * rejection, and revocation. Goal claims stabilize their source row first.
  */
 export async function lockUserMessageQueueThread(
   db: Db,
@@ -540,9 +561,6 @@ async function resolveGoalQueueFirstClaimSnapshot(
       ...queueFirstReplacementTargetFields,
       goalId: threadGoals.id,
       goalStatus: threadGoals.status,
-      goalSnapshotCurrent:
-        noGoalChangeAfterQueueEvent(db).mapWith(pgBooleanDecoder),
-      userMessage: chatEvents.userMessage,
     })
     .from(chatEvents)
     .leftJoin(
@@ -553,6 +571,7 @@ async function resolveGoalQueueFirstClaimSnapshot(
         eq(threadGoals.orgId, args.orgId),
         eq(threadGoals.ownerUserId, args.userId),
         eq(chatEvents.runGroupId, threadGoals.id),
+        eq(threadGoals.updatedAt, args.goalUpdatedAt),
       ),
     )
     .where(
@@ -573,14 +592,17 @@ async function resolveGoalQueueFirstClaimSnapshot(
     head.eventType !== "input.goal" ||
     head.id !== args.eventId ||
     head.goalId !== args.goalId ||
-    head.goalStatus !== "active" ||
-    !head.goalSnapshotCurrent
+    head.goalStatus !== "active"
   ) {
     return null;
   }
-  if (!head.userMessage) {
-    throw new Error("Goal queue event is missing its user message");
-  }
+  const userMessage = createUserMessageDocument({
+    text: null,
+    nonContentPart: {
+      type: "goal",
+      goalBrief: args.goalObjectiveBrief,
+    },
+  });
   return {
     target: replacementTargetFromQueueHead(head),
     routingContextType: "goal",
@@ -589,8 +611,8 @@ async function resolveGoalQueueFirstClaimSnapshot(
       eventType: "input.prompt",
       userMessage:
         args.selectedModel === null
-          ? head.userMessage
-          : withRunModelAnnotation(head.userMessage, args.selectedModel),
+          ? userMessage
+          : withRunModelAnnotation(userMessage, args.selectedModel),
       runId: args.runId,
       runGroupId: args.goalId,
     },

--- a/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
@@ -193,7 +193,7 @@ function buildQueueFirstGoalRunInput(args: {
       prompt,
       goalId: normalizedGoal.goalId,
       goalObjectiveBrief: normalizedGoal.objectiveBrief,
-      goalUpdatedAt: normalizedGoal.updatedAt,
+      goalStateRevision: normalizedGoal.stateRevision,
       orgId: normalizedGoal.orgId,
       userId: normalizedGoal.userId,
     },
@@ -458,7 +458,7 @@ export const drainGoalQueueForThread$ = command(
           await revokeGoalEvent(db, event, signal);
           return;
         }
-        if (stillValid.updatedAt.getTime() !== goal.updatedAt.getTime()) {
+        if (stillValid.stateRevision !== goal.stateRevision) {
           continue;
         }
         return;
@@ -466,7 +466,7 @@ export const drainGoalQueueForThread$ = command(
 
       const settlement = await settleFailedGoalQueueEvent(db, {
         event,
-        expectedGoalUpdatedAt: goal.updatedAt,
+        expectedGoalStateRevision: goal.stateRevision,
         reason: result.response.body.error.message,
       });
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
@@ -28,6 +28,7 @@ import { createQueueFirstZeroRun$ } from "./zero-runs-create.service";
 
 const log = logger("api:zero-goal-queue-drain");
 const MAX_DRAIN_ATTEMPTS = 5;
+const GOAL_CONTINUATION_PROMPT = "Continue the active thread goal.";
 
 type GoalDrainAttempt = "initial" | "retry";
 type GoalDrainTimingRole = "waiting" | "phase" | "aggregate";
@@ -80,9 +81,10 @@ type ModelContext =
       readonly failure: Extract<RunGoalResult, { readonly kind: "run_error" }>;
     };
 
-function buildGoalContinuationPrompt(goal: {
+function buildGoalAppendSystemPrompt(goal: {
   readonly objective: string;
   readonly objectiveBrief: string;
+  readonly autonomyBudget: number;
 }): string {
   const lines = [
     "# Current context",
@@ -96,6 +98,7 @@ function buildGoalContinuationPrompt(goal: {
   if (goal.objectiveBrief !== goal.objective) {
     lines.push("", "# User-visible objective brief", "", goal.objectiveBrief);
   }
+  lines.push("", `Autonomy budget: ${goal.autonomyBudget}`);
   lines.push(
     "",
     "# How to operate",
@@ -142,7 +145,8 @@ function buildQueueFirstGoalRunInput(args: {
       objectiveBrief: args.goal.objectiveBrief,
     }),
   };
-  const prompt = buildGoalContinuationPrompt(normalizedGoal);
+  const prompt = GOAL_CONTINUATION_PROMPT;
+  const appendSystemPrompt = buildGoalAppendSystemPrompt(normalizedGoal);
   const { modelPin, effectiveModelProvider, cliAgentType, codexServiceTier } =
     args.modelContext;
   return {
@@ -161,6 +165,7 @@ function buildQueueFirstGoalRunInput(args: {
     },
     apiStartTime: args.apiStartTime,
     triggerSource: "workflow-event",
+    appendSystemPrompt,
     chatThreadId: normalizedGoal.threadId,
     modelProviderId: modelPin.modelProviderId ?? undefined,
     modelProviderCredentialScope:
@@ -187,6 +192,8 @@ function buildQueueFirstGoalRunInput(args: {
       eventId: args.event.id,
       prompt,
       goalId: normalizedGoal.goalId,
+      goalObjectiveBrief: normalizedGoal.objectiveBrief,
+      goalUpdatedAt: normalizedGoal.updatedAt,
       orgId: normalizedGoal.orgId,
       userId: normalizedGoal.userId,
     },
@@ -449,15 +456,23 @@ export const drainGoalQueueForThread$ = command(
         signal.throwIfAborted();
         if (!stillValid) {
           await revokeGoalEvent(db, event, signal);
+          return;
+        }
+        if (stillValid.updatedAt.getTime() !== goal.updatedAt.getTime()) {
+          continue;
         }
         return;
       }
 
       const settlement = await settleFailedGoalQueueEvent(db, {
         event,
+        expectedGoalUpdatedAt: goal.updatedAt,
         reason: result.response.body.error.message,
       });
       signal.throwIfAborted();
+      if (settlement.kind === "stale") {
+        continue;
+      }
       if (settlement.kind !== "not_pending") {
         await publishGoalQueueChanged(event, signal);
       }

--- a/turbo/apps/api/src/test-fixtures/goal-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-queue.ts
@@ -11,6 +11,10 @@ import {
   type GoalQueueAdmission,
 } from "../signals/services/chat-goal-queue.service";
 import { drainChatThreadQueueForThread$ } from "../signals/services/chat-thread-queue-drain.service";
+import {
+  activeGoalEvent,
+  appendGoalEventMarker,
+} from "../signals/services/zero-chat-goal-marker.service";
 
 interface GoalQueueAdmissionFixtureArgs {
   readonly threadId: string;
@@ -92,6 +96,19 @@ export async function pauseGoalQueueTargetFixture(
   if (!goal) {
     throw new Error("Expected the goal queue target fixture");
   }
+}
+
+/** Append a display-only goal marker without changing the goal source row. */
+export async function appendGoalMarkerFixture(args: {
+  readonly threadId: string;
+  readonly objectiveBrief: string;
+}): Promise<void> {
+  await db().transaction(async (tx) => {
+    await appendGoalEventMarker(tx, {
+      chatThreadId: args.threadId,
+      event: activeGoalEvent(args.objectiveBrief),
+    });
+  });
 }
 
 /**

--- a/turbo/apps/api/src/test-fixtures/goal-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-queue.ts
@@ -11,10 +11,6 @@ import {
   type GoalQueueAdmission,
 } from "../signals/services/chat-goal-queue.service";
 import { drainChatThreadQueueForThread$ } from "../signals/services/chat-thread-queue-drain.service";
-import {
-  activeGoalEvent,
-  appendGoalEventMarker,
-} from "../signals/services/zero-chat-goal-marker.service";
 
 interface GoalQueueAdmissionFixtureArgs {
   readonly threadId: string;
@@ -96,19 +92,6 @@ export async function pauseGoalQueueTargetFixture(
   if (!goal) {
     throw new Error("Expected the goal queue target fixture");
   }
-}
-
-/** Append a display-only goal marker without changing the goal source row. */
-export async function appendGoalMarkerFixture(args: {
-  readonly threadId: string;
-  readonly objectiveBrief: string;
-}): Promise<void> {
-  await db().transaction(async (tx) => {
-    await appendGoalEventMarker(tx, {
-      chatThreadId: args.threadId,
-      event: activeGoalEvent(args.objectiveBrief),
-    });
-  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Source every queued goal run from the current `thread_goals` row instead of goal lifecycle marker ordering.
- Put the full objective, objective brief, autonomy budget, and operating policy in `appendSystemPrompt`; keep the user prompt as a minimal continuation trigger.
- Lock and revalidate the exact goal row at the final queue-first claim boundary with a lossless PostgreSQL state revision. Updated goals are rebuilt from the latest row, while inactive, deleted, or replaced goals lose the claim safely.
- Preserve ordinary queued messages, active input, workflow runs, and non-goal run behavior.

## Production behavior

Goal continuations now use `thread_goals` as their runtime source of truth. Display-only `goal.changed` markers no longer make a queued goal stale, and a lifecycle change cannot launch an old objective after final claim validation.

## Validation

- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- ESLint, Oxlint, and Prettier checks for all changed API files
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t "goal"` (10 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts` (25 passed)
- `git diff --check`

Full local Vitest was intentionally not run; the PR pipeline remains the final broad verification.

## Compatibility and fallback audit

- No new runtime fallback was added.
- Existing autonomy-budget schema rollout compatibility and chat agent-run context compatibility remain unchanged.
- Public chat-event types, goal marker UI events, legacy columns, IndexedDB, and unrelated payload fields remain intact for later cleanup stages.
