### PR TITLE
test(e2e): wait for avatar card shadow transitions

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -143,7 +143,12 @@ async function expectInside(inner: Locator, outer: Locator): Promise<void> {
 }
 
 async function cardEdgeAppearance(locator: Locator) {
-  return locator.evaluate((element) => {
+  return locator.evaluate(async (element) => {
+    await Promise.all(
+      element.getAnimations().map((animation) => {
+        return animation.finished;
+      }),
+    );
     const style = getComputedStyle(element);
     return {
       borderWidths: [


### PR DESCRIPTION
## Summary

- wait for active CSS animations on avatar cards before reading their computed edge appearance
- keep the exact selected-versus-unselected border and box-shadow equality assertions
- synchronize on the browser animation lifecycle without retries, sleeps, timeout changes, or product-style changes

## Root cause

The test moves the pointer away from an avatar card and immediately samples `getComputedStyle()`. The card uses `transition-all duration-200 hover:shadow-md`, while the already-satisfied `aria-pressed` checks do not wait for that hover-exit transition. CI therefore occasionally captures an interpolated box shadow instead of the stable resting shadow.

Evidence:

- [Triggering main run 31169921432](https://github.com/vm0-ai/vm0/actions/runs/31169921432) captured fractional shadow offsets such as `2.03488px`; [the same SHA passed in merge-group run 31169597128](https://github.com/vm0-ai/vm0/actions/runs/31169597128).
- [Recurrence on the next main SHA in run 31170359844](https://github.com/vm0-ai/vm0/actions/runs/31170359844) captured the same assertion and a nearby `2.03467px` interpolation frame; [the same SHA passed in merge-group run 31169924276](https://github.com/vm0-ai/vm0/actions/runs/31169924276).
- The recurrence contained no Clerk FAPI warning, separating the visual race from the earlier non-causal request noise.

## Validation

Non-service checks:

- `cd e2e && pnpm check-types`
- `npx --yes prettier@3.6.2 --check e2e/playwright/tests/chat.spec.ts`
- `git diff --check`

PR preview:

- App: https://pr-25701-app.omby.ai
- API: https://pr-25701-api.vm6.ai
- Used a fresh test user and the browser-context onboarding completion endpoint because onboarding is outside this test's scope; the endpoint returned 200.
- Enabled `joggAiBuiltIn` through the preview Lab page, selected Zoe with Irvin as the unselected comparison, and repeated the narrow selected/unselected surface check five times: **5/5 PASS**.
- Every check retained `aria-pressed=true/false`, four `1px` borders, and the exact resting shadow `0 2px 12px` plus `0 0 0 0.5px` on both cards.
- The staging-browser ARM session reports `hover:none`, so those five repetitions validate the stable rendered invariant rather than the transition timing itself. The PR's native Desktop Chrome Playwright job exercises the exact patched test and passed: [cli-e2e-02-playwright](https://github.com/vm0-ai/vm0/actions/runs/31170970812/job/92843019781). The [Turbo gate](https://github.com/vm0-ai/vm0/actions/runs/31170970812/job/92843335804) also passed.

![Avatar catalog preview with Zoe selected and Irvin unselected](https://cdn.vm0.io/artifacts/0ka5cbt5mx.png)
