### PR TITLE
fix(platform): make the shared thread page scrollable

### DIFF
--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -50,4 +50,30 @@ describe("shared thread page", () => {
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
   });
+
+  it("owns its scrolling because the app shell clips overflow", async () => {
+    context.mocks.api(sharedThreadsContract.get, ({ respond }) => {
+      return respond(200, {
+        id: SHARED_THREAD_ID,
+        title: "Long thread",
+        messages: [
+          {
+            messageIndex: 0,
+            role: "user",
+            content: "First question",
+            runIndex: 0,
+          },
+        ],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/share/threads/${SHARED_THREAD_ID}`,
+      user: null,
+    });
+
+    const scroller = await screen.findByTestId("shared-thread-scroll");
+    expect(scroller).toHaveClass("h-full", "overflow-y-auto");
+  });
 });

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -125,7 +125,10 @@ export function SharedThreadPage({
   const { t } = useTranslation();
   const groups = sharedThread ? groupSharedMessages(sharedThread.messages) : [];
   return (
-    <main className="flex min-h-full flex-col bg-background text-foreground">
+    <main
+      className="flex h-full flex-col overflow-y-auto bg-background text-foreground"
+      data-testid="shared-thread-scroll"
+    >
       <header className="sticky top-0 z-20 border-b border-border/70 bg-background/95 backdrop-blur">
         <div className="mx-auto flex h-14 w-full max-w-[948px] items-center justify-between px-4 sm:px-6">
           <a


### PR DESCRIPTION
## Problem

The public shared-thread page (`/share/threads/:id`) cannot be scrolled at all. Any conversation taller than one viewport is clipped, and the reader has no way to reach the rest of it — the wheel, a touch drag, and keyboard paging all do nothing.

Reproduced on production against https://app.okou.ai/share/threads/a4600006-e303-4be1-848e-04fda84bd1bd:

| element | `overflow-y` | `clientHeight` | `scrollHeight` |
| --- | --- | --- | --- |
| `html` / `body` | `hidden` | 633 | 633 |
| `#root` | `hidden` | 633 | **3120** |
| `main` | `visible` | 3120 | 3120 |

`window.scrollY` and `#root.scrollTop` both stay at `0` after a wheel scroll. About 80% of that thread is unreachable.

## Root cause

`index.css` pins the app shell to the viewport:

```css
html, body, #root {
  height: var(--zero-viewport-height);
  overflow: hidden;
}
```

That is deliberate — the chat UI wants inner panes to own their scrolling, and it is what keeps iOS from rubber-banding the shell. The consequence is that every route rendered with the `none` page layout must supply its own scroll container.

`SharedThreadPage` did not. Its `<main>` used `min-h-full`, which lets the element *grow* past the shell rather than scroll inside it, so the overflow was simply clipped by `#root`.

## Fix

Make `<main>` the scroll container:

```diff
-<main className="flex min-h-full flex-col bg-background text-foreground">
+<main className="flex h-full flex-col overflow-y-auto bg-background text-foreground">
```

`h-full` resolves against `#root`'s definite height, so the element is exactly one viewport tall and scrolls internally. This matches the pattern already used by the other `none`-layout routes (`auth-layout.tsx` uses `h-full min-h-0 overflow-y-auto`).

The `sticky top-0` header keeps working — it now sticks to the scrolling `<main>` instead of the document.

## Verification

Applied the class change against the live production page and confirmed `main` becomes `clientHeight: 633` / `scrollHeight: 3120` with a working `scrollTop` range of `0–2487`, and that the header stays pinned while scrolling.

## Tests

Added a regression test asserting the shared-thread page renders its own scroll container, so a future refactor cannot silently drop it back to a clipped `min-h-full`.

- `pnpm -F @vm0/app exec vitest run src/views/shared-thread-page` — 2 passed
- `pnpm -F @vm0/app lint` — clean
- `pnpm -F @vm0/app check-types` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
