### PR TITLE
feat: offer google forms trigger in the automation picker

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4782,6 +4782,13 @@
         "second_other": "{{count}} Sekunden"
       },
       "forms": {
+        "addAction": "Google Forms-Automatisierung hinzufügen",
+        "addAria": "Automatisierung für Google Forms-Antworten hinzufügen",
+        "addDescription": "Diesen Workflow ausführen, wenn das ausgewählte Google-Formular eine neue Antwort erhält.",
+        "addTitle": "Google Forms-Automatisierung hinzufügen",
+        "formUrl": "Formularlink",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Ausführen, wenn ein Google-Formular eine neue Antwort erhält.",
         "responseSubmittedTitle": "Google Forms-Antwort eingereicht",
         "rule": "Wenn {{form}} eine Antwort erhält",
         "summary": "Formular {{form}}"
@@ -5027,6 +5034,7 @@
       "picker": {
         "calendar": "Kalender",
         "email": "E-Mail",
+        "forms": "Google Forms",
         "integrations": "Integrationen",
         "notion": "Notion",
         "schedule": "Zeitplan"

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4782,6 +4782,13 @@
         "second_other": "{{count}} seconds"
       },
       "forms": {
+        "addAction": "Add Google Forms automation",
+        "addAria": "Add Google Forms response automation",
+        "addDescription": "Run this workflow when the selected Google Form receives a new response.",
+        "addTitle": "Add Google Forms automation",
+        "formUrl": "Form link",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Run when a Google Form receives a new response.",
         "responseSubmittedTitle": "Google Forms response submitted",
         "rule": "When {{form}} receives a response",
         "summary": "Form {{form}}"
@@ -5027,6 +5034,7 @@
       "picker": {
         "calendar": "Calendar",
         "email": "Email",
+        "forms": "Google Forms",
         "integrations": "Integrations",
         "notion": "Notion",
         "schedule": "Schedule"

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4862,6 +4862,13 @@
         "second_other": "{{count}} segundos"
       },
       "forms": {
+        "addAction": "Agregar automatización de Google Forms",
+        "addAria": "Agregar automatización de respuestas de Google Forms",
+        "addDescription": "Ejecuta este flujo de trabajo cuando el formulario de Google seleccionado reciba una respuesta nueva.",
+        "addTitle": "Agregar automatización de Google Forms",
+        "formUrl": "Enlace del formulario",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Ejecutar cuando un formulario de Google reciba una respuesta nueva.",
         "responseSubmittedTitle": "Respuesta de Google Forms enviada",
         "rule": "Cuando {{form}} recibe una respuesta",
         "summary": "Formulario {{form}}"
@@ -5107,6 +5114,7 @@
       "picker": {
         "calendar": "Calendario",
         "email": "Correo electrónico",
+        "forms": "Google Forms",
         "integrations": "Integraciones",
         "notion": "Notion",
         "schedule": "Programación"

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4862,6 +4862,13 @@
         "second_other": "{{count}} secondes"
       },
       "forms": {
+        "addAction": "Ajouter une automatisation Google Forms",
+        "addAria": "Ajouter une automatisation de réponse Google Forms",
+        "addDescription": "Exécutez ce workflow lorsque le formulaire Google sélectionné reçoit une nouvelle réponse.",
+        "addTitle": "Ajouter une automatisation Google Forms",
+        "formUrl": "Lien du formulaire",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "S’exécute lorsqu’un formulaire Google reçoit une nouvelle réponse.",
         "responseSubmittedTitle": "Réponse Google Forms envoyée",
         "rule": "Lorsque {{form}} reçoit une réponse",
         "summary": "Formulaire {{form}}"
@@ -5107,6 +5114,7 @@
       "picker": {
         "calendar": "Calendrier",
         "email": "Email",
+        "forms": "Google Forms",
         "integrations": "Intégrations",
         "notion": "Notion",
         "schedule": "Planifier"

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4782,6 +4782,13 @@
         "second_other": "{{count}} सेकंड"
       },
       "forms": {
+        "addAction": "Google Forms ऑटोमेशन जोड़ें",
+        "addAria": "Google Forms जवाब ऑटोमेशन जोड़ें",
+        "addDescription": "चुने गए Google Form को नया जवाब मिलने पर यह वर्कफ़्लो चलाएँ।",
+        "addTitle": "Google Forms ऑटोमेशन जोड़ें",
+        "formUrl": "फ़ॉर्म लिंक",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "किसी Google Form को नया जवाब मिलने पर चलाएँ।",
         "responseSubmittedTitle": "Google Forms जवाब सबमिट हुआ",
         "rule": "जब {{form}} को कोई जवाब मिले",
         "summary": "फ़ॉर्म {{form}}"
@@ -5027,6 +5034,7 @@
       "picker": {
         "calendar": "कैलेंडर",
         "email": "ईमेल",
+        "forms": "Google Forms",
         "integrations": "एकीकरण",
         "notion": "Notion",
         "schedule": "अनुसूची"

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4781,6 +4781,13 @@
         "second_other": "{{count}} detik"
       },
       "forms": {
+        "addAction": "Tambahkan otomatisasi Google Forms",
+        "addAria": "Tambahkan otomatisasi respons Google Forms",
+        "addDescription": "Jalankan alur kerja ini saat Google Form yang dipilih menerima respons baru.",
+        "addTitle": "Tambahkan otomatisasi Google Forms",
+        "formUrl": "Tautan formulir",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Jalankan saat Google Form menerima respons baru.",
         "responseSubmittedTitle": "Respons Google Forms dikirim",
         "rule": "Saat {{form}} menerima respons",
         "summary": "Formulir {{form}}"
@@ -5026,6 +5033,7 @@
       "picker": {
         "calendar": "Kalender",
         "email": "Email",
+        "forms": "Google Forms",
         "integrations": "Integrasi",
         "notion": "Notion",
         "schedule": "Jadwal"

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4862,6 +4862,13 @@
         "second_other": "{{count}} secondi"
       },
       "forms": {
+        "addAction": "Aggiungi automazione Google Forms",
+        "addAria": "Aggiungi automazione per le risposte di Google Forms",
+        "addDescription": "Esegui questo flusso di lavoro quando il modulo Google selezionato riceve una nuova risposta.",
+        "addTitle": "Aggiungi automazione Google Forms",
+        "formUrl": "Link del modulo",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Esegui quando un modulo Google riceve una nuova risposta.",
         "responseSubmittedTitle": "Risposta di Google Forms inviata",
         "rule": "Quando {{form}} riceve una risposta",
         "summary": "Modulo {{form}}"
@@ -5107,6 +5114,7 @@
       "picker": {
         "calendar": "Calendario",
         "email": "E-mail",
+        "forms": "Google Forms",
         "integrations": "Integrazioni",
         "notion": "Notion",
         "schedule": "Programma"

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4781,6 +4781,13 @@
         "second_other": "{{count}} 秒"
       },
       "forms": {
+        "addAction": "Google Forms オートメーションを追加",
+        "addAria": "Google Forms 回答オートメーションを追加",
+        "addDescription": "選択した Google フォームに新しい回答が届いたときに、このワークフローを実行します。",
+        "addTitle": "Google Forms オートメーションを追加",
+        "formUrl": "フォームのリンク",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Google フォームに新しい回答が届いたときに実行します。",
         "responseSubmittedTitle": "Google Forms の回答が送信されました",
         "rule": "{{form}} に回答が送信されたとき",
         "summary": "フォーム {{form}}"
@@ -5026,6 +5033,7 @@
       "picker": {
         "calendar": "カレンダー",
         "email": "メール",
+        "forms": "Google Forms",
         "integrations": "統合",
         "notion": "Notion",
         "schedule": "スケジュール"

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4781,6 +4781,13 @@
         "second_other": "{{count}}초"
       },
       "forms": {
+        "addAction": "Google Forms 자동화 추가",
+        "addAria": "Google Forms 응답 자동화 추가",
+        "addDescription": "선택한 Google 양식에 새 응답이 제출되면 이 워크플로를 실행합니다.",
+        "addTitle": "Google Forms 자동화 추가",
+        "formUrl": "양식 링크",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Google 양식에 새 응답이 제출되면 실행합니다.",
         "responseSubmittedTitle": "Google Forms 응답이 제출됨",
         "rule": "{{form}}에 응답이 제출될 때",
         "summary": "양식 {{form}}"
@@ -5026,6 +5033,7 @@
       "picker": {
         "calendar": "캘린더",
         "email": "이메일",
+        "forms": "Google Forms",
         "integrations": "통합",
         "notion": "Notion",
         "schedule": "일정"

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4862,6 +4862,13 @@
         "second_other": "{{count}} segundos"
       },
       "forms": {
+        "addAction": "Adicionar automação do Google Forms",
+        "addAria": "Adicionar automação de respostas do Google Forms",
+        "addDescription": "Execute este fluxo de trabalho quando o formulário Google selecionado receber uma nova resposta.",
+        "addTitle": "Adicionar automação do Google Forms",
+        "formUrl": "Link do formulário",
+        "formUrlPlaceholder": "https://docs.google.com/forms/d/<form-id>/edit",
+        "responseSubmittedDescription": "Executar quando um formulário Google receber uma nova resposta.",
         "responseSubmittedTitle": "Resposta do Google Forms enviada",
         "rule": "Quando {{form}} recebe uma resposta",
         "summary": "Formulário {{form}}"
@@ -5107,6 +5114,7 @@
       "picker": {
         "calendar": "Calendário",
         "email": "E-mail",
+        "forms": "Google Forms",
         "integrations": "Integrações",
         "notion": "Notion",
         "schedule": "Agendamento"

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -10,6 +10,7 @@ import {
   type GoogleCalendarEventCancelledEventConfig,
   type GoogleCalendarEventCreatedEventConfig,
   type GoogleCalendarEventUpdatedEventConfig,
+  type GoogleFormsResponseSubmittedEventCreateConfig,
   type GoogleMeetTranscriptGeneratedEventConfig,
   type GithubDeploymentStatusCreatedEventConfig,
   type GithubIssueCommentCreatedEventConfig,
@@ -105,6 +106,7 @@ export type WorkflowAutomationCreateDialog =
   | "google-calendar-created"
   | "google-calendar-updated"
   | "google-calendar-cancelled"
+  | "google-forms"
   | "google-meet-transcript-generated"
   | "notion-child-page"
   | "notion-database-item"
@@ -117,6 +119,7 @@ type WorkflowAutomationCategoryKey =
   | "schedule"
   | "email"
   | "calendar"
+  | "forms"
   | "notion"
   | "integrations";
 type WorkflowWebhookAutomationSummary = Extract<
@@ -1171,6 +1174,41 @@ export const createWorkflowGoogleCalendarEventAutomation$ = command(
     );
     signal.throwIfAborted();
     set(reloadWorkflows$);
+  },
+);
+
+export const createWorkflowGoogleFormsResponseSubmittedAutomation$ = command(
+  async (
+    { get, set },
+    input: {
+      readonly workflowId: string;
+      readonly eventConfig: GoogleFormsResponseSubmittedEventCreateConfig;
+    },
+    signal: AbortSignal,
+  ): Promise<string | undefined> => {
+    const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
+    const result = await accept(
+      client.create({
+        params: { workflowId: input.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-forms-response-submitted",
+          eventConfig: input.eventConfig,
+        },
+        fetchOptions: { signal },
+      }),
+      [201],
+      signal,
+    );
+    signal.throwIfAborted();
+    if (
+      result.body.kind !== "event" ||
+      result.body.eventType !== "google-forms-response-submitted"
+    ) {
+      throw new Error("Expected Google Forms workflow automation summary");
+    }
+    set(reloadWorkflows$);
+    return result.body.warning;
   },
 );
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -178,6 +178,10 @@ type WorkflowGoogleCalendarEventCancelledAutomationSummary = Extract<
   ZeroWorkflowAutomationSummary,
   { kind: "event"; eventType: "google-calendar-event-cancelled" }
 >;
+type WorkflowGoogleFormsResponseSubmittedAutomationSummary = Extract<
+  ZeroWorkflowAutomationSummary,
+  { kind: "event"; eventType: "google-forms-response-submitted" }
+>;
 type WorkflowGoogleMeetTranscriptGeneratedAutomationSummary = Extract<
   ZeroWorkflowAutomationSummary,
   { kind: "event"; eventType: "google-meet-transcript-generated" }
@@ -362,6 +366,34 @@ function googleMeetTranscriptGeneratedWorkflowAutomation(): WorkflowGoogleMeetTr
     chatThreadId: "thread_google_meet_transcript_generated",
     nextRunAt: null,
     lastRunAt: null,
+  };
+}
+
+function googleFormsResponseSubmittedWorkflowAutomation(
+  warning?: string,
+): WorkflowGoogleFormsResponseSubmittedAutomationSummary {
+  return {
+    id: "workflow-automation-google-forms-response-submitted",
+    kind: "event",
+    eventType: "google-forms-response-submitted",
+    eventConfig: {
+      provider: "google-forms",
+      event: "response_submitted",
+      connectorId: "00000000-0000-4000-a000-000000000412",
+      form: {
+        id: "1FAIpQLScGoogleFormsAutomationTest",
+        title: "Customer feedback",
+        url: "https://docs.google.com/forms/d/1FAIpQLScGoogleFormsAutomationTest/edit",
+      },
+    },
+    schedule: null,
+    scheduleSummary: null,
+    ownerUserId: CURRENT_USER_ID,
+    enabled: true,
+    chatThreadId: "thread_google_forms_response_submitted",
+    nextRunAt: null,
+    lastRunAt: null,
+    ...(warning ? { warning } : {}),
   };
 }
 
@@ -2801,6 +2833,103 @@ describe("workflow detail page", () => {
         },
       });
     });
+  });
+
+  it("hides Google Forms automation creation when the feature is disabled", async () => {
+    mockWorkflowApis([salesResearch()]);
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
+      [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: false,
+    });
+
+    click(await screen.findByText("Add automation"));
+    const picker = await screen.findByRole("dialog");
+    expect(
+      queryAllByRoleFast("button", picker).some((candidate) => {
+        return textFor(candidate) === "Google Forms";
+      }),
+    ).toBeFalsy();
+    expect(
+      within(picker).queryByText("Google Forms response submitted"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("creates a Google Forms automation and shows the API warning", async () => {
+    const createBodies: ZeroWorkflowAutomationCreateRequest[] = [];
+    const warning = "This Google Form is not accepting responses yet.";
+    mockWorkflowApis([salesResearch()]);
+    context.mocks.api(
+      zeroWorkflowAutomationsContract.create,
+      ({ body, respond }) => {
+        createBodies.push(body);
+        return respond(
+          201,
+          googleFormsResponseSubmittedWorkflowAutomation(warning),
+        );
+      },
+    );
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
+      [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: true,
+    });
+
+    click(await screen.findByText("Add automation"));
+    await screen.findByRole("dialog");
+    pickAutomation("Google Forms", /^Google Forms response submitted/);
+
+    const createAutomationForm = await screen.findByRole("form", {
+      name: "Add Google Forms response automation",
+    });
+    await fill(
+      within(createAutomationForm).getByLabelText("Form link"),
+      "https://docs.google.com/forms/d/1FAIpQLScGoogleFormsAutomationTest/edit",
+    );
+    fireEvent.submit(createAutomationForm);
+
+    await waitFor(() => {
+      expect(createBodies.at(-1)).toStrictEqual({
+        kind: "event",
+        eventType: "google-forms-response-submitted",
+        eventConfig: {
+          provider: "google-forms",
+          event: "response_submitted",
+          formUrl:
+            "https://docs.google.com/forms/d/1FAIpQLScGoogleFormsAutomationTest/edit",
+        },
+      });
+    });
+    await expect(screen.findByText(warning)).resolves.toBeInTheDocument();
+  });
+
+  it("shows the Google Forms edit-page guidance returned by the API", async () => {
+    const guidance =
+      "Please open the form's edit page and copy the link from the address bar.";
+    mockWorkflowApis([salesResearch()]);
+    context.mocks.api(zeroWorkflowAutomationsContract.create, ({ respond }) => {
+      return respond(400, {
+        error: { code: "BAD_REQUEST", message: guidance },
+      });
+    });
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
+      [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: true,
+    });
+
+    click(await screen.findByText("Add automation"));
+    await screen.findByRole("dialog");
+    pickAutomation("Google Forms", /^Google Forms response submitted/);
+
+    const createAutomationForm = await screen.findByRole("form", {
+      name: "Add Google Forms response automation",
+    });
+    await fill(
+      within(createAutomationForm).getByLabelText("Form link"),
+      "https://docs.google.com/forms/d/e/responder-id/viewform",
+    );
+    fireEvent.submit(createAutomationForm);
+
+    await expect(screen.findByText(guidance)).resolves.toBeInTheDocument();
+    expect(createAutomationForm).toBeInTheDocument();
   });
 
   it("creates a Google Meet transcript-generated automation", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -110,6 +110,7 @@ import {
   createWorkflowGithubWebhookAutomation$,
   createWorkflowGithubWorkflowRunCompletedAutomation$,
   createWorkflowGoogleCalendarEventAutomation$,
+  createWorkflowGoogleFormsResponseSubmittedAutomation$,
   createWorkflowGoogleMeetTranscriptGeneratedAutomation$,
   createWorkflowGmailLabelAppliedAutomation$,
   createWorkflowGmailNewMessageAutomation$,
@@ -1196,6 +1197,8 @@ function AutomationCreateAction() {
     capabilities?.workflowWebhookAutomationAllowed ?? true;
   const notionWorkflowAutomationsEnabled =
     features[FeatureSwitchKey.NotionWorkflowAutomations] ?? false;
+  const googleFormsWorkflowAutomationsEnabled =
+    features[FeatureSwitchKey.GoogleFormsWorkflowAutomations] ?? false;
   const githubWebhookAutomationsEnabled =
     features[FeatureSwitchKey.GithubWebhookAutomations] ?? false;
   const strapiIntegrationEnabled =
@@ -1213,6 +1216,9 @@ function AutomationCreateAction() {
       githubLabelAutomationsEnabled
       githubWebhookAutomationsEnabled={githubWebhookAutomationsEnabled}
       googleCalendarAutomationsEnabled
+      googleFormsWorkflowAutomationsEnabled={
+        googleFormsWorkflowAutomationsEnabled
+      }
       googleMeetAutomationsEnabled
       notionWorkflowAutomationsEnabled={notionWorkflowAutomationsEnabled}
       strapiIntegrationEnabled={strapiIntegrationEnabled}
@@ -4320,6 +4326,7 @@ type AutomationCreateDialogKind =
   | "google-calendar-created"
   | "google-calendar-updated"
   | "google-calendar-cancelled"
+  | "google-forms"
   | "google-meet-transcript-generated"
   | "notion-child-page"
   | "notion-database-item"
@@ -4331,6 +4338,7 @@ type AutomationCategoryKey =
   | "schedule"
   | "email"
   | "calendar"
+  | "forms"
   | "notion"
   | "integrations";
 
@@ -4510,6 +4518,26 @@ function buildNotionAutomationOptions(
   ];
 }
 
+function buildGoogleFormsAutomationOptions(
+  googleFormsWorkflowAutomationsEnabled: boolean,
+): AutomationCreateOption[] {
+  if (!googleFormsWorkflowAutomationsEnabled) {
+    return [];
+  }
+  return [
+    {
+      kind: "google-forms",
+      title: i18n.t(($) => {
+        return $.workflows.automations.forms.responseSubmittedTitle;
+      }),
+      description: i18n.t(($) => {
+        return $.workflows.automations.forms.responseSubmittedDescription;
+      }),
+      icon: IconFileText,
+    },
+  ];
+}
+
 // Each category owns a single hue that colours only the card icon chip on the
 // right; the category rail stays neutral and mirrors the app sidebar.
 const AUTOMATION_CATEGORY_CHIP: Readonly<
@@ -4518,6 +4546,7 @@ const AUTOMATION_CATEGORY_CHIP: Readonly<
   schedule: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
   email: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
   calendar: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  forms: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
   notion: "bg-gray-500/10 text-gray-700 dark:text-gray-300",
   integrations: "bg-amber-500/10 text-amber-600 dark:text-amber-500",
 });
@@ -4640,6 +4669,7 @@ function buildAutomationCreateCategories({
   githubLabelAutomationsEnabled,
   githubWebhookAutomationsEnabled,
   googleCalendarAutomationsEnabled,
+  googleFormsWorkflowAutomationsEnabled,
   googleMeetAutomationsEnabled,
   notionWorkflowAutomationsEnabled,
   strapiIntegrationEnabled,
@@ -4648,6 +4678,7 @@ function buildAutomationCreateCategories({
   readonly githubLabelAutomationsEnabled: boolean;
   readonly githubWebhookAutomationsEnabled: boolean;
   readonly googleCalendarAutomationsEnabled: boolean;
+  readonly googleFormsWorkflowAutomationsEnabled: boolean;
   readonly googleMeetAutomationsEnabled: boolean;
   readonly notionWorkflowAutomationsEnabled: boolean;
   readonly strapiIntegrationEnabled: boolean;
@@ -4656,6 +4687,9 @@ function buildAutomationCreateCategories({
   const calendarOptions = buildCalendarAutomationOptions(
     googleCalendarAutomationsEnabled,
     googleMeetAutomationsEnabled,
+  );
+  const googleFormsOptions = buildGoogleFormsAutomationOptions(
+    googleFormsWorkflowAutomationsEnabled,
   );
   const integrationOptions = buildIntegrationAutomationOptions({
     githubLabelAutomationsEnabled,
@@ -4691,6 +4725,14 @@ function buildAutomationCreateCategories({
       }),
       icon: IconCalendarTime,
       options: calendarOptions,
+    },
+    {
+      key: "forms",
+      label: i18n.t(($) => {
+        return $.workflows.automations.picker.forms;
+      }),
+      icon: IconFileText,
+      options: googleFormsOptions,
     },
     {
       key: "notion",
@@ -4789,6 +4831,7 @@ function AutomationCreateMenu({
   githubLabelAutomationsEnabled,
   githubWebhookAutomationsEnabled,
   googleCalendarAutomationsEnabled,
+  googleFormsWorkflowAutomationsEnabled,
   googleMeetAutomationsEnabled,
   notionWorkflowAutomationsEnabled,
   strapiIntegrationEnabled,
@@ -4798,6 +4841,7 @@ function AutomationCreateMenu({
   readonly githubLabelAutomationsEnabled: boolean;
   readonly githubWebhookAutomationsEnabled: boolean;
   readonly googleCalendarAutomationsEnabled: boolean;
+  readonly googleFormsWorkflowAutomationsEnabled: boolean;
   readonly googleMeetAutomationsEnabled: boolean;
   readonly notionWorkflowAutomationsEnabled: boolean;
   readonly strapiIntegrationEnabled: boolean;
@@ -4811,6 +4855,7 @@ function AutomationCreateMenu({
     githubLabelAutomationsEnabled,
     githubWebhookAutomationsEnabled,
     googleCalendarAutomationsEnabled,
+    googleFormsWorkflowAutomationsEnabled,
     googleMeetAutomationsEnabled,
     notionWorkflowAutomationsEnabled,
     strapiIntegrationEnabled,
@@ -4924,6 +4969,138 @@ function GoogleCalendarAutomationDialogs({
         }}
       />
     </>
+  );
+}
+
+function CreateGoogleFormsResponseSubmittedAutomationDialog({
+  workflowId,
+  open,
+  onOpenChange,
+}: {
+  readonly workflowId: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [createLoadable, createAutomation] = useLoadableSet(
+    createWorkflowGoogleFormsResponseSubmittedAutomation$,
+  );
+  const creating = createLoadable.state === "loading";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {i18n.t(($) => {
+              return $.workflows.automations.forms.addTitle;
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {i18n.t(($) => {
+              return $.workflows.automations.forms.addDescription;
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          aria-label={i18n.t(($) => {
+            return $.workflows.automations.forms.addAria;
+          })}
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const formUrl = formTextValue(
+              new FormData(event.currentTarget),
+              "formUrl",
+            );
+            if (!formUrl) {
+              return;
+            }
+            detach(
+              (async () => {
+                const warning = await createAutomation(
+                  {
+                    workflowId,
+                    eventConfig: {
+                      provider: "google-forms",
+                      event: "response_submitted",
+                      formUrl,
+                    },
+                  },
+                  pageSignal,
+                );
+                onOpenChange(false);
+                if (warning) {
+                  toast.warning(warning);
+                }
+              })(),
+              Reason.DomCallback,
+            );
+          }}
+        >
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            {i18n.t(($) => {
+              return $.workflows.automations.forms.formUrl;
+            })}
+            <Input
+              name="formUrl"
+              aria-label={i18n.t(($) => {
+                return $.workflows.automations.forms.formUrl;
+              })}
+              required
+              disabled={creating}
+              placeholder={i18n.t(($) => {
+                return $.workflows.automations.forms.formUrlPlaceholder;
+              })}
+            />
+          </label>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={creating}
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              {i18n.t(($) => {
+                return $.workflows.automations.common.cancel;
+              })}
+            </Button>
+            <Button type="submit" disabled={creating}>
+              {creating ? (
+                <IconLoader2 size={14} className="animate-spin" />
+              ) : (
+                <IconFileText size={14} stroke={1.5} />
+              )}
+              {i18n.t(($) => {
+                return $.workflows.automations.forms.addAction;
+              })}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GoogleFormsAutomationDialogs({
+  workflowId,
+  createDialog,
+  setCreateDialog,
+}: {
+  readonly workflowId: string;
+  readonly createDialog: WorkflowAutomationCreateDialog;
+  readonly setCreateDialog: (dialog: WorkflowAutomationCreateDialog) => void;
+}) {
+  return (
+    <CreateGoogleFormsResponseSubmittedAutomationDialog
+      workflowId={workflowId}
+      open={createDialog === "google-forms"}
+      onOpenChange={(open) => {
+        setCreateDialog(open ? "google-forms" : null);
+      }}
+    />
   );
 }
 
@@ -5533,6 +5710,11 @@ function WorkflowAutomationCreateDialogs({
         onOpenChange={(open) => {
           setCreateDialog(open ? "gmail-label" : null);
         }}
+      />
+      <GoogleFormsAutomationDialogs
+        workflowId={workflowId}
+        createDialog={createDialog}
+        setCreateDialog={setCreateDialog}
       />
       <CreateGithubLabelAppliedAutomationDialog
         workflowId={workflowId}


### PR DESCRIPTION
## Summary

- add a staff-gated Google Forms category and response-submitted option to the Add automation picker
- create Google Forms automations from an edit-page link with the existing typed API contract
- surface API errors verbatim and show successful unpublished-form warnings
- add localized copy for every supported platform locale and integration coverage for the feature gate, request mapping, warning, and error paths

The picker component is in `workflow-detail-page.tsx`, while the current platform architecture keeps dialog/category state and typed API commands in `workflows-signals.ts`; the implementation updates those frontend-only definitions plus locale resources and the existing integration test file. It does not change backend behavior, API contracts, CLI behavior, feature-switch defaults, or existing automation display/edit paths.

## Validation

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx --silent=passed-only` (57 tests)

## Sequencing

#25560 is still open and conflicting as of this PR. The Forms picker reuses `IconFileText`, which #25560 maps directly to Lucide's `FileText`; this branch will be rebased if #25560 lands first.

Closes #25699
Related to #25163