### PR TITLE
feat(platform): move avatar catalog filters into the dialog header row

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -157,25 +157,6 @@ async function cardEdgeAppearance(locator: Locator) {
   });
 }
 
-async function toolbarSurfaceAppearance(locator: Locator) {
-  return locator.evaluate((element) => {
-    const style = getComputedStyle(element);
-    const canvas = document.createElement("canvas");
-    canvas.width = 1;
-    canvas.height = 1;
-    const context = canvas.getContext("2d");
-    if (!context) {
-      throw new Error("Canvas context unavailable");
-    }
-    context.fillStyle = style.backgroundColor;
-    context.fillRect(0, 0, 1, 1);
-    return {
-      backgroundAlpha: context.getImageData(0, 0, 1, 1).data[3],
-      borderBottomWidth: style.borderBottomWidth,
-    };
-  });
-}
-
 test("chat page displays tagline after onboarding", async ({ page }) => {
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
@@ -436,8 +417,13 @@ test("avatar catalog surfaces stay stable while scrolling and selecting", async 
   await page.getByRole("tab", { name: "Avatar" }).click();
   const dialog = page.getByRole("dialog");
   const avatarScroll = dialog.locator("[data-avatar-template-grid-scroll]");
-  const avatarToolbar = avatarScroll.locator("[data-avatar-catalog-toolbar]");
+  const avatarToolbar = dialog.locator("[data-avatar-catalog-toolbar]");
   await expect(avatarToolbar).toBeVisible();
+  // The toolbar shares the dialog header row with the close button, so catalog
+  // cards can never scroll underneath it.
+  await expect(
+    avatarScroll.locator("[data-avatar-catalog-toolbar]"),
+  ).toHaveCount(0);
   await avatarScroll.evaluate((element) => {
     element.scrollTop = element.scrollHeight;
     element.dispatchEvent(new Event("scroll"));
@@ -450,11 +436,6 @@ test("avatar catalog surfaces stay stable while scrolling and selecting", async 
     })
     .toBeGreaterThan(0);
   await expect(avatarToolbar).toBeInViewport();
-  await expect
-    .poll(async () => {
-      return toolbarSurfaceAppearance(avatarToolbar);
-    })
-    .toEqual({ backgroundAlpha: 255, borderBottomWidth: "0px" });
 
   await page.getByRole("button", { name: "Select template Ada" }).click();
   await page.getByRole("button", { name: "Select voice Christopher" }).click();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -783,10 +783,14 @@ describe("chat composer templates", () => {
         "overflow-y-auto",
         "[scrollbar-width:none]",
       );
-      const avatarToolbar = avatarScroll.querySelector(
-        "[data-avatar-catalog-toolbar]",
-      );
-      expect(avatarToolbar).toHaveClass("sticky", "top-0");
+      // The toolbar lives in the dialog header row next to the close button,
+      // so it must not sit inside the scrolling catalog area.
+      expect(
+        avatarScroll.querySelector("[data-avatar-catalog-toolbar]"),
+      ).toBeNull();
+      expect(
+        dialog.querySelector("[data-avatar-catalog-toolbar]"),
+      ).not.toBeNull();
       Object.defineProperties(avatarScroll, {
         scrollHeight: { configurable: true, value: 1200 },
         clientHeight: { configurable: true, value: 500 },

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -501,7 +501,7 @@ function AvatarCatalogFilters({
   return (
     <div
       data-avatar-catalog-toolbar=""
-      className="sticky top-0 z-10 mb-5 flex flex-wrap items-center justify-between gap-3 bg-card pb-4"
+      className="flex w-full flex-wrap items-center justify-between gap-3"
     >
       <AvatarAspectRatioPicker
         value={filters.aspectRatio}
@@ -1211,7 +1211,6 @@ function AvatarCatalogPickerContent({
       className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       onScroll={handleAvatarScroll}
     >
-      <AvatarCatalogFilters signals={signals} />
       {catalog.state === "hasError" ? (
         <AvatarTemplateEmpty error />
       ) : visibleCatalog === undefined ? (
@@ -1247,6 +1246,25 @@ function AvatarCatalogPickerContent({
       {loadingMore && <CatalogLoadingSpinner />}
     </div>
   );
+}
+
+/**
+ * Avatar catalog filters, rendered by the template dialog into the header row
+ * that already reserves space for the close button. Returns null on the voice
+ * step, which carries its own back/title/filters row.
+ */
+export function AvatarTemplatePickerToolbar({
+  signals,
+}: {
+  readonly signals: ComposerSignals;
+}) {
+  const selectedAvatar = useGet(
+    signals.template.selectedAvatarTemplateForVoice$,
+  );
+  if (selectedAvatar) {
+    return null;
+  }
+  return <AvatarCatalogFilters signals={signals} />;
 }
 
 export function AvatarTemplatePickerContent({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -208,7 +208,10 @@ import { readChatMessageFromClipboard } from "../../signals/zero-page/clipboard.
 import { shouldUseUserMessage } from "../../signals/zero-page/user-message-document-codec.ts";
 import { WebsiteTemplatePreviewDialogSlot } from "./website-template-preview-dialog.tsx";
 import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx";
-import { AvatarTemplatePickerContent } from "./avatar-template-picker.tsx";
+import {
+  AvatarTemplatePickerContent,
+  AvatarTemplatePickerToolbar,
+} from "./avatar-template-picker.tsx";
 import { VideoTemplateOptionsPopover } from "./video-template-options-popover.tsx";
 import {
   avatarTemplateSelection,
@@ -4936,6 +4939,7 @@ function TemplatePickerDialog({
     hasWorkflowTab,
   });
   const showTemplatePickerSearch = selectedCategory === "workflow";
+  const showAvatarPickerToolbar = selectedCategory === "avatar" && hasAvatarTab;
 
   const previewImageUrlsForCategory = (targetCategory: string) => {
     if (targetCategory === "slides" && hasPptTab) {
@@ -5192,7 +5196,9 @@ function TemplatePickerDialog({
                 <div
                   className={cn(
                     "relative h-[68px] shrink-0 items-center px-6 pr-14",
-                    showTemplatePickerSearch ? "flex" : "hidden sm:flex",
+                    showTemplatePickerSearch || showAvatarPickerToolbar
+                      ? "flex"
+                      : "hidden sm:flex",
                   )}
                 >
                   {showTemplatePickerSearch ? (
@@ -5200,6 +5206,9 @@ function TemplatePickerDialog({
                       search={search}
                       onSearchChange={handleSearchChange}
                     />
+                  ) : null}
+                  {showAvatarPickerToolbar ? (
+                    <AvatarTemplatePickerToolbar signals={signals} />
                   ) : null}
                 </div>
                 <TemplatePickerCategoryContent


### PR DESCRIPTION
## Why

On the avatar tab the template dialog reserved a `h-[68px]` header row for the close button and left it **empty**, then rendered the aspect-ratio picker and the Filters button as a *sticky toolbar inside the scrolling catalog* just below it. With the toolbar's own `mb-5` + `pb-4`, the first row of avatars started **140px** down.

## What

The filters now render into that existing header row, sharing the line with the close button. The catalog starts **68px** down — 72px reclaimed, no new chrome.

- `AvatarCatalogFilters` loses `sticky top-0 z-10 mb-5 bg-card pb-4` and becomes a plain full-width flex row
- new `AvatarTemplatePickerToolbar` export keeps the catalog/voice step logic inside the avatar module — it returns `null` on the voice step, which carries its own back/title/filters row
- the header row already had `pr-14` to clear the close button, and now also renders on mobile for the avatar tab (previously `hidden sm:flex` when there was no workflow search)

## Note on #25667

That PR gave the toolbar an opaque background so catalog cards would not show through while scrolling under it. Now that the toolbar sits outside the scroll container, that can't happen structurally. The e2e assertion on background alpha is replaced by a check that the toolbar is **not** a descendant of `[data-avatar-template-grid-scroll]`, and the now-unused `toolbarSurfaceAppearance` helper is removed.

## Test plan

- `pnpm format`, `turbo run lint`, `turbo run check-types` for `@vm0/app` — clean
- `chat-composer-template-picker.test.tsx` — 28 passed; its toolbar assertion now checks placement instead of stickiness
- `e2e/playwright/tests/chat.spec.ts` updated for the new location; runs in the PR pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
