### PR TITLE
feat(cli): support stripe invoice-paid automations

### DIFF
--- a/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
@@ -16,30 +16,9 @@ import { join } from "node:path";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../../mocks/server";
 import { zeroWorkflowCommand } from "../../index";
-import { automationCommand } from "../index";
+import { automationCommand, createAutomationAddCommand } from "../index";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import chalk from "chalk";
-
-const stripeFeatureSwitch = vi.hoisted(() => {
-  return { enabled: false };
-});
-
-// The production rollout intentionally has no enabled identity yet. Control
-// only that configuration boundary so both gated command paths can run here.
-vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@vm0/core/feature-switch")>();
-  return {
-    ...actual,
-    isFeatureEnabled: (
-      ...args: Parameters<typeof actual.isFeatureEnabled>
-    ): boolean => {
-      if (args[0] === "stripeInvoicePaidWorkflowAutomations") {
-        return stripeFeatureSwitch.enabled;
-      }
-      return actual.isFeatureEnabled(...args);
-    },
-  };
-});
 
 const AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const WORKFLOW_ID = "22222222-2222-4222-8222-222222222222";
@@ -393,7 +372,6 @@ describe("zero workflow automation commands", () => {
   });
 
   afterEach(() => {
-    stripeFeatureSwitch.enabled = false;
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
@@ -426,6 +404,15 @@ describe("zero workflow automation commands", () => {
       ),
     );
     return captured;
+  }
+
+  async function runStripeEnabledAdd(...args: string[]): Promise<void> {
+    vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+    await createAutomationAddCommand({
+      featureSwitchOverrides: {
+        [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
+      },
+    }).parseAsync(["node", "cli", ...args]);
   }
 
   function mockWorkflowList() {
@@ -958,8 +945,6 @@ describe("zero workflow automation commands", () => {
     });
 
     it("should add a Stripe invoice-paid automation without a billing filter", async () => {
-      stripeFeatureSwitch.enabled = true;
-      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
       const response = {
         ...stripeInvoicePaidAutomation,
         eventConfig: {
@@ -978,13 +963,7 @@ describe("zero workflow automation commands", () => {
       };
       const captured = captureCreateAutomation(response);
 
-      await automationCommand.parseAsync([
-        "node",
-        "cli",
-        "add",
-        WORKFLOW_ID,
-        "stripe-invoice-paid",
-      ]);
+      await runStripeEnabledAdd(WORKFLOW_ID, "stripe-invoice-paid");
 
       expect(captured.body).toEqual({
         kind: "event",
@@ -1006,6 +985,10 @@ describe("zero workflow automation commands", () => {
       expect(output).toContain("Delivery at:");
       expect(output).toContain("delete and recreate");
       expect(output).not.toContain("zero workflow automation update --help");
+      expect(output).toContain(
+        `zero workflow automation add ${WORKFLOW_ID} stripe-invoice-paid`,
+      );
+      expect(output).not.toContain("--billing-reason");
       expect(mockConsoleWarn.mock.calls.flat().join("\n")).toContain(
         "The latest Stripe workflow delivery failed.",
       );
@@ -1019,19 +1002,14 @@ describe("zero workflow automation commands", () => {
     });
 
     it("should add a Stripe invoice-paid automation with one billing reason", async () => {
-      stripeFeatureSwitch.enabled = true;
-      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
       const captured = captureCreateAutomation(stripeInvoicePaidAutomation);
 
-      await automationCommand.parseAsync([
-        "node",
-        "cli",
-        "add",
+      await runStripeEnabledAdd(
         WORKFLOW_ID,
         "stripe-invoice-paid",
         "--billing-reason",
         "subscription_cycle",
-      ]);
+      );
 
       expect(captured.body).toEqual({
         kind: "event",
@@ -1045,8 +1023,6 @@ describe("zero workflow automation commands", () => {
     });
 
     it("should trim and stably deduplicate Stripe billing reasons", async () => {
-      stripeFeatureSwitch.enabled = true;
-      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
       const response = {
         ...stripeInvoicePaidAutomation,
         eventConfig: {
@@ -1056,15 +1032,12 @@ describe("zero workflow automation commands", () => {
       };
       const captured = captureCreateAutomation(response);
 
-      await automationCommand.parseAsync([
-        "node",
-        "cli",
-        "add",
+      await runStripeEnabledAdd(
         WORKFLOW_ID,
         "stripe-invoice-paid",
         "--billing-reason",
         " subscription_cycle, subscription_create,subscription_cycle ",
-      ]);
+      );
 
       expect(captured.body).toEqual({
         kind: "event",
@@ -1077,6 +1050,9 @@ describe("zero workflow automation commands", () => {
       });
       expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
         "subscription_cycle, subscription_create",
+      );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        `zero workflow automation add ${WORKFLOW_ID} stripe-invoice-paid --billing-reason subscription_cycle,subscription_create`,
       );
     });
 
@@ -1092,19 +1068,13 @@ describe("zero workflow automation commands", () => {
     ])(
       "should reject invalid Stripe billing reasons in %j",
       async (billingReason, expectedMessage) => {
-        stripeFeatureSwitch.enabled = true;
-        vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
-
         await expect(async () => {
-          await automationCommand.parseAsync([
-            "node",
-            "cli",
-            "add",
+          await runStripeEnabledAdd(
             WORKFLOW_ID,
             "stripe-invoice-paid",
             "--billing-reason",
             billingReason,
-          ]);
+          );
         }).rejects.toThrow("process.exit called");
 
         expect(mockConsoleError).toHaveBeenCalledWith(
@@ -1117,20 +1087,15 @@ describe("zero workflow automation commands", () => {
     it.each(["--connector-id", "--stripe-account-id", "--mode"])(
       "should not accept server-owned Stripe binding option %s",
       async (option) => {
-        stripeFeatureSwitch.enabled = true;
-        vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
         const captured = captureCreateAutomation(stripeInvoicePaidAutomation);
 
         await expect(async () => {
-          await automationCommand.parseAsync([
-            "node",
-            "cli",
-            "add",
+          await runStripeEnabledAdd(
             WORKFLOW_ID,
             "stripe-invoice-paid",
             option,
             "server-owned-value",
-          ]);
+          );
         }).rejects.toThrow("process.exit called");
 
         expect(captured.body).toBeUndefined();
@@ -1168,8 +1133,6 @@ describe("zero workflow automation commands", () => {
       "Stripe invoice-paid automations require Live mode; reconnect Stripe in Live mode",
       "Reconnect Stripe with OAuth before using Stripe invoice-paid automations",
     ])("should surface Stripe readiness failure: %s", async (message) => {
-      stripeFeatureSwitch.enabled = true;
-      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
       server.use(
         http.post(
           "http://localhost:3000/api/zero/workflows/:workflowId/automations",
@@ -1183,13 +1146,7 @@ describe("zero workflow automation commands", () => {
       );
 
       await expect(async () => {
-        await automationCommand.parseAsync([
-          "node",
-          "cli",
-          "add",
-          WORKFLOW_ID,
-          "stripe-invoice-paid",
-        ]);
+        await runStripeEnabledAdd(WORKFLOW_ID, "stripe-invoice-paid");
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -1237,17 +1194,12 @@ describe("zero workflow automation commands", () => {
     });
 
     it("should show Stripe creation in help when the feature is enabled", async () => {
-      stripeFeatureSwitch.enabled = true;
       vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
-      vi.resetModules();
-      const { automationCommand: enabledAutomationCommand } =
-        await import("../index");
-      const addCommand = enabledAutomationCommand.commands.find((command) => {
-        return command.name() === "add";
+      const addCommand = createAutomationAddCommand({
+        featureSwitchOverrides: {
+          [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
+        },
       });
-      if (!addCommand) {
-        throw new Error("add command not found");
-      }
       let helpOutput = "";
       addCommand.configureOutput({
         writeOut: (value) => {
@@ -2517,8 +2469,9 @@ describe("zero workflow automation commands", () => {
           `zero workflow automation rm ${AUTOMATION_ID}`,
         );
         expect(output).toContain(
-          `zero workflow automation add ${WORKFLOW_ID} stripe-invoice-paid --billing-reason <billing-reasons>`,
+          `zero workflow automation add ${WORKFLOW_ID} stripe-invoice-paid`,
         );
+        expect(output).not.toContain("--billing-reason");
         expect(output).not.toContain("zero workflow automation update --help");
         expect(output).not.toContain("private Stripe delivery failure details");
         const warningOutput = mockConsoleWarn.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
@@ -19,6 +19,28 @@ import { zeroWorkflowCommand } from "../../index";
 import { automationCommand } from "../index";
 import chalk from "chalk";
 
+const stripeFeatureSwitch = vi.hoisted(() => {
+  return { enabled: false };
+});
+
+// The production rollout intentionally has no enabled identity yet. Control
+// only that configuration boundary so both gated command paths can run here.
+vi.mock("@vm0/core/feature-switch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@vm0/core/feature-switch")>();
+  return {
+    ...actual,
+    isFeatureEnabled: (
+      ...args: Parameters<typeof actual.isFeatureEnabled>
+    ): boolean => {
+      if (args[0] === "stripeInvoicePaidWorkflowAutomations") {
+        return stripeFeatureSwitch.enabled;
+      }
+      return actual.isFeatureEnabled(...args);
+    },
+  };
+});
+
 const AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const WORKFLOW_ID = "22222222-2222-4222-8222-222222222222";
 const AUTOMATION_ID = "33333333-3333-4333-8333-333333333333";
@@ -333,6 +355,12 @@ const stripeInvoicePaidAutomation = {
   schedule: null,
   scheduleSummary: null,
   nextRunAt: null,
+  health: {
+    lastMatchingEventReceivedAt: "2026-08-07T08:00:00.000Z",
+    lastDeliveryStatus: "delivered",
+    lastDeliveryStatusAt: "2026-08-07T08:01:00.000Z",
+    warning: null,
+  },
 };
 
 describe("zero workflow automation commands", () => {
@@ -365,6 +393,7 @@ describe("zero workflow automation commands", () => {
   });
 
   afterEach(() => {
+    stripeFeatureSwitch.enabled = false;
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
@@ -926,6 +955,313 @@ describe("zero workflow automation commands", () => {
       expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
         "Strapi entry published: api::article.article, en",
       );
+    });
+
+    it("should add a Stripe invoice-paid automation without a billing filter", async () => {
+      stripeFeatureSwitch.enabled = true;
+      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+      const response = {
+        ...stripeInvoicePaidAutomation,
+        eventConfig: {
+          provider: "stripe",
+          event: "invoice_paid",
+          connectorId: "00000000-0000-4000-a000-000000000411",
+          stripeAccountId: "acct_cli_stripe_invoice_paid",
+          mode: "live",
+        },
+        health: {
+          ...stripeInvoicePaidAutomation.health,
+          lastDeliveryStatus: "failed",
+          warning: "delivery_failed",
+          internalError: "private create delivery failure details",
+        },
+      };
+      const captured = captureCreateAutomation(response);
+
+      await automationCommand.parseAsync([
+        "node",
+        "cli",
+        "add",
+        WORKFLOW_ID,
+        "stripe-invoice-paid",
+      ]);
+
+      expect(captured.body).toEqual({
+        kind: "event",
+        eventType: "stripe-invoice-paid",
+        eventConfig: {
+          provider: "stripe",
+          event: "invoice_paid",
+        },
+      });
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("Stripe invoice paid");
+      expect(output).toContain(
+        "Stripe account ID:  acct_cli_stripe_invoice_paid",
+      );
+      expect(output).toContain("Mode:               live");
+      expect(output).toContain("Billing reasons:    any");
+      expect(output).toContain("Last matched:");
+      expect(output).toContain("Delivery:           failed");
+      expect(output).toContain("Delivery at:");
+      expect(output).toContain("delete and recreate");
+      expect(output).not.toContain("zero workflow automation update --help");
+      expect(mockConsoleWarn.mock.calls.flat().join("\n")).toContain(
+        "The latest Stripe workflow delivery failed.",
+      );
+      expect(output).not.toContain("private create delivery failure details");
+      expect(mockConsoleWarn.mock.calls.flat().join("\n")).not.toContain(
+        "private create delivery failure details",
+      );
+      expect(JSON.stringify(captured.body)).not.toContain("connectorId");
+      expect(JSON.stringify(captured.body)).not.toContain("stripeAccountId");
+      expect(JSON.stringify(captured.body)).not.toContain('"mode"');
+    });
+
+    it("should add a Stripe invoice-paid automation with one billing reason", async () => {
+      stripeFeatureSwitch.enabled = true;
+      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+      const captured = captureCreateAutomation(stripeInvoicePaidAutomation);
+
+      await automationCommand.parseAsync([
+        "node",
+        "cli",
+        "add",
+        WORKFLOW_ID,
+        "stripe-invoice-paid",
+        "--billing-reason",
+        "subscription_cycle",
+      ]);
+
+      expect(captured.body).toEqual({
+        kind: "event",
+        eventType: "stripe-invoice-paid",
+        eventConfig: {
+          provider: "stripe",
+          event: "invoice_paid",
+          billingReasons: ["subscription_cycle"],
+        },
+      });
+    });
+
+    it("should trim and stably deduplicate Stripe billing reasons", async () => {
+      stripeFeatureSwitch.enabled = true;
+      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+      const response = {
+        ...stripeInvoicePaidAutomation,
+        eventConfig: {
+          ...stripeInvoicePaidAutomation.eventConfig,
+          billingReasons: ["subscription_cycle", "subscription_create"],
+        },
+      };
+      const captured = captureCreateAutomation(response);
+
+      await automationCommand.parseAsync([
+        "node",
+        "cli",
+        "add",
+        WORKFLOW_ID,
+        "stripe-invoice-paid",
+        "--billing-reason",
+        " subscription_cycle, subscription_create,subscription_cycle ",
+      ]);
+
+      expect(captured.body).toEqual({
+        kind: "event",
+        eventType: "stripe-invoice-paid",
+        eventConfig: {
+          provider: "stripe",
+          event: "invoice_paid",
+          billingReasons: ["subscription_cycle", "subscription_create"],
+        },
+      });
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        "subscription_cycle, subscription_create",
+      );
+    });
+
+    it.each([
+      ["", "cannot contain empty values"],
+      [",manual", "cannot contain empty values"],
+      ["manual,", "cannot contain empty values"],
+      ["subscription_cycle,,manual", "cannot contain empty values"],
+      [
+        "subscription_cycle,unknown",
+        'Invalid --billing-reason value "unknown"',
+      ],
+    ])(
+      "should reject invalid Stripe billing reasons in %j",
+      async (billingReason, expectedMessage) => {
+        stripeFeatureSwitch.enabled = true;
+        vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+
+        await expect(async () => {
+          await automationCommand.parseAsync([
+            "node",
+            "cli",
+            "add",
+            WORKFLOW_ID,
+            "stripe-invoice-paid",
+            "--billing-reason",
+            billingReason,
+          ]);
+        }).rejects.toThrow("process.exit called");
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+          expect.stringContaining(expectedMessage),
+        );
+        expect(mockExit).toHaveBeenCalledWith(1);
+      },
+    );
+
+    it.each(["--connector-id", "--stripe-account-id", "--mode"])(
+      "should not accept server-owned Stripe binding option %s",
+      async (option) => {
+        stripeFeatureSwitch.enabled = true;
+        vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+        const captured = captureCreateAutomation(stripeInvoicePaidAutomation);
+
+        await expect(async () => {
+          await automationCommand.parseAsync([
+            "node",
+            "cli",
+            "add",
+            WORKFLOW_ID,
+            "stripe-invoice-paid",
+            option,
+            "server-owned-value",
+          ]);
+        }).rejects.toThrow("process.exit called");
+
+        expect(captured.body).toBeUndefined();
+        expect(mockExit).toHaveBeenCalledWith(1);
+      },
+    );
+
+    it.each(["cron", "gmail-new-message"])(
+      "should reject --billing-reason for %s automations",
+      async (kind) => {
+        await expect(async () => {
+          await automationCommand.parseAsync([
+            "node",
+            "cli",
+            "add",
+            WORKFLOW_ID,
+            kind,
+            "--billing-reason",
+            "subscription_cycle",
+          ]);
+        }).rejects.toThrow("process.exit called");
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "--billing-reason only applies to stripe-invoice-paid automations",
+          ),
+        );
+        expect(mockExit).toHaveBeenCalledWith(1);
+      },
+    );
+
+    it.each([
+      "Connect Stripe with OAuth in Live mode before adding a Stripe invoice-paid automation",
+      "Stripe invoice-paid automations require OAuth; reconnect Stripe using OAuth",
+      "Stripe invoice-paid automations require Live mode; reconnect Stripe in Live mode",
+      "Reconnect Stripe with OAuth before using Stripe invoice-paid automations",
+    ])("should surface Stripe readiness failure: %s", async (message) => {
+      stripeFeatureSwitch.enabled = true;
+      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/workflows/:workflowId/automations",
+          () => {
+            return HttpResponse.json(
+              { error: { code: "BAD_REQUEST", message } },
+              { status: 400 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          "add",
+          WORKFLOW_ID,
+          "stripe-invoice-paid",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(message),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should hide disabled Stripe creation and reject a directly typed kind", async () => {
+      const addCommand = automationCommand.commands.find((command) => {
+        return command.name() === "add";
+      });
+      if (!addCommand) {
+        throw new Error("add command not found");
+      }
+      let helpOutput = "";
+      addCommand.configureOutput({
+        writeOut: (value) => {
+          helpOutput += value;
+        },
+        writeErr: (value) => {
+          helpOutput += value;
+        },
+      });
+      addCommand.outputHelp();
+
+      expect(helpOutput).not.toContain("stripe-invoice-paid");
+      expect(helpOutput).not.toContain("--billing-reason");
+
+      await expect(async () => {
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          "add",
+          WORKFLOW_ID,
+          "stripe-invoice-paid",
+        ]);
+      }).rejects.toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Stripe invoice-paid workflow automations are not enabled for this workspace",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should show Stripe creation in help when the feature is enabled", async () => {
+      stripeFeatureSwitch.enabled = true;
+      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+      vi.resetModules();
+      const { automationCommand: enabledAutomationCommand } =
+        await import("../index");
+      const addCommand = enabledAutomationCommand.commands.find((command) => {
+        return command.name() === "add";
+      });
+      if (!addCommand) {
+        throw new Error("add command not found");
+      }
+      let helpOutput = "";
+      addCommand.configureOutput({
+        writeOut: (value) => {
+          helpOutput += value;
+        },
+        writeErr: (value) => {
+          helpOutput += value;
+        },
+      });
+
+      addCommand.outputHelp();
+
+      expect(helpOutput).toContain("stripe-invoice-paid");
+      expect(helpOutput).toContain("--billing-reason <reasons>");
     });
 
     it("should add a Google Calendar event-created automation", async () => {
@@ -1583,6 +1919,44 @@ describe("zero workflow automation commands", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
+    it("should reject Stripe updates with delete-and-recreate guidance and no Stripe flags", async () => {
+      mockExistingAutomation(stripeInvoicePaidAutomation);
+      const updateCommand = automationCommand.commands.find((command) => {
+        return command.name() === "update";
+      });
+      if (!updateCommand) {
+        throw new Error("update command not found");
+      }
+      let helpOutput = "";
+      updateCommand.configureOutput({
+        writeOut: (value) => {
+          helpOutput += value;
+        },
+        writeErr: (value) => {
+          helpOutput += value;
+        },
+      });
+      updateCommand.outputHelp();
+
+      expect(helpOutput).not.toContain("--billing-reason");
+
+      await expect(async () => {
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          "update",
+          AUTOMATION_ID,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Stripe billing reasons cannot be updated; delete and recreate the automation",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should switch to a cron schedule", async () => {
       const captured = captureUpdateAutomation(cronAutomation);
 
@@ -1934,6 +2308,54 @@ describe("zero workflow automation commands", () => {
         "Strapi entry published: api::article.article, en",
       );
       expect(logCalls).toContain("Stripe invoice paid");
+      expect(logCalls).toContain("acct_cli_stripe_invoice_paid (live)");
+      expect(logCalls).toContain("billing reasons: subscription_cycle");
+      expect(logCalls).toContain("last matched:");
+      expect(logCalls).toContain("delivery: delivered at");
+    });
+
+    it("should display nullable Stripe health and a generic delivery warning while creation is disabled", async () => {
+      const lastMatchedAt = new Date(
+        Date.now() - 2 * 60 * 60 * 1000,
+      ).toISOString();
+      const failedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const failedAutomation = {
+        ...stripeInvoicePaidAutomation,
+        eventConfig: {
+          ...stripeInvoicePaidAutomation.eventConfig,
+          billingReasons: [],
+        },
+        health: {
+          lastMatchingEventReceivedAt: lastMatchedAt,
+          lastDeliveryStatus: "failed",
+          lastDeliveryStatusAt: failedAt,
+          warning: "delivery_failed",
+          internalError: "do not expose this delivery error",
+        },
+      };
+      server.use(
+        http.get(
+          "http://localhost:3000/api/zero/workflows/:workflowId/automations",
+          () => {
+            return HttpResponse.json([failedAutomation]);
+          },
+        ),
+      );
+
+      await automationCommand.parseAsync(["node", "cli", "list", WORKFLOW_ID]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("acct_cli_stripe_invoice_paid (live)");
+      expect(output).toContain("any billing reason");
+      expect(output).toContain("last matched: 2h ago");
+      expect(output).toContain("delivery: failed at 1h ago");
+      expect(mockConsoleWarn.mock.calls.flat().join("\n")).toContain(
+        "The latest Stripe workflow delivery failed.",
+      );
+      expect(output).not.toContain("do not expose this delivery error");
+      expect(mockConsoleWarn.mock.calls.flat().join("\n")).not.toContain(
+        "do not expose this delivery error",
+      );
     });
 
     it("should display an empty state with an add hint", async () => {
@@ -2024,6 +2446,96 @@ describe("zero workflow automation commands", () => {
       expect(logCalls).not.toContain("Manage with Zero CLI:");
       expect(mockExit).not.toHaveBeenCalled();
     });
+
+    it.each([
+      ["pending", null],
+      ["delivered", null],
+      ["skipped", null],
+      ["failed", "delivery_failed"],
+      [null, null],
+    ] as const)(
+      "should display Stripe delivery status %s and immutable recreate guidance while creation is disabled",
+      async (deliveryStatus, warning) => {
+        const hasDelivery = deliveryStatus !== null;
+        const automation = {
+          ...stripeInvoicePaidAutomation,
+          eventConfig: {
+            ...stripeInvoicePaidAutomation.eventConfig,
+            billingReasons: undefined,
+          },
+          health: {
+            lastMatchingEventReceivedAt: hasDelivery
+              ? new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString()
+              : null,
+            lastDeliveryStatus: deliveryStatus,
+            lastDeliveryStatusAt: hasDelivery
+              ? new Date(Date.now() - 60 * 60 * 1000).toISOString()
+              : null,
+            warning,
+            internalError: "private Stripe delivery failure details",
+          },
+        };
+        server.use(
+          http.get(
+            "http://localhost:3000/api/zero/workflow-automations/:id",
+            () => {
+              return HttpResponse.json(automation);
+            },
+          ),
+          http.get(
+            "http://localhost:3000/api/zero/workflow-automations",
+            () => {
+              return HttpResponse.json([
+                { workflow: workflowSummary, automation },
+              ]);
+            },
+          ),
+        );
+
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          "show",
+          AUTOMATION_ID,
+        ]);
+
+        const output = mockConsoleLog.mock.calls.flat().join("\n");
+        expect(output).toContain(
+          "Stripe account ID:  acct_cli_stripe_invoice_paid",
+        );
+        expect(output).toContain("Mode:               live");
+        expect(output).toContain("Billing reasons:    any");
+        expect(output).toContain(
+          `Delivery:           ${deliveryStatus ?? "-"}`,
+        );
+        expect(output).toContain("Last matched:");
+        expect(output).toContain("Delivery at:");
+        expect(output).toContain(
+          "Change billing reasons (delete and recreate)",
+        );
+        expect(output).toContain(
+          `zero workflow automation rm ${AUTOMATION_ID}`,
+        );
+        expect(output).toContain(
+          `zero workflow automation add ${WORKFLOW_ID} stripe-invoice-paid --billing-reason <billing-reasons>`,
+        );
+        expect(output).not.toContain("zero workflow automation update --help");
+        expect(output).not.toContain("private Stripe delivery failure details");
+        const warningOutput = mockConsoleWarn.mock.calls.flat().join("\n");
+        if (warning === "delivery_failed") {
+          expect(warningOutput).toContain(
+            "The latest Stripe workflow delivery failed.",
+          );
+        } else {
+          expect(warningOutput).not.toContain(
+            "The latest Stripe workflow delivery failed.",
+          );
+        }
+        expect(warningOutput).not.toContain(
+          "private Stripe delivery failure details",
+        );
+      },
+    );
   });
 
   describe("rm", () => {
@@ -2049,6 +2561,87 @@ describe("zero workflow automation commands", () => {
   });
 
   describe("enable / disable", () => {
+    it("should keep existing Stripe automations manageable while creation is disabled", async () => {
+      const actions: string[] = [];
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/workflow-automations/:id/enable",
+          () => {
+            actions.push("enable");
+            return HttpResponse.json(stripeInvoicePaidAutomation);
+          },
+        ),
+        http.post(
+          "http://localhost:3000/api/zero/workflow-automations/:id/disable",
+          () => {
+            actions.push("disable");
+            return HttpResponse.json({
+              ...stripeInvoicePaidAutomation,
+              enabled: false,
+            });
+          },
+        ),
+        http.delete(
+          "http://localhost:3000/api/zero/workflow-automations/:id",
+          () => {
+            actions.push("delete");
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await automationCommand.parseAsync([
+        "node",
+        "cli",
+        "enable",
+        AUTOMATION_ID,
+      ]);
+      await automationCommand.parseAsync([
+        "node",
+        "cli",
+        "disable",
+        AUTOMATION_ID,
+      ]);
+      await automationCommand.parseAsync(["node", "cli", "rm", AUTOMATION_ID]);
+
+      expect(actions).toEqual(["enable", "disable", "delete"]);
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(`Automation ${AUTOMATION_ID} enabled`);
+      expect(output).toContain(`Automation ${AUTOMATION_ID} disabled`);
+      expect(output).toContain(`Automation ${AUTOMATION_ID} removed`);
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it("should surface a Stripe binding-mismatch readiness failure on enable", async () => {
+      const message =
+        "The Stripe connection no longer matches this automation; delete and recreate the automation to bind the current Live-mode Stripe account";
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/workflow-automations/:id/enable",
+          () => {
+            return HttpResponse.json(
+              { error: { code: "BAD_REQUEST", message } },
+              { status: 400 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          "enable",
+          AUTOMATION_ID,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(message),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should enable a workflow automation", async () => {
       server.use(
         http.post(

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/display.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/display.ts
@@ -19,6 +19,10 @@ interface WorkflowAutomationDetailsOptions {
   readonly threadModel?: WorkflowAutomationThreadModel;
 }
 
+interface WorkflowAutomationsTableOptions {
+  readonly showStripeDetails?: boolean;
+}
+
 const GMAIL_TEXT_FIELDS: readonly GmailTextField[] = [
   "from",
   "subject",
@@ -339,6 +343,7 @@ function formatGoogleAutomationEntry(
 
 function formatWorkflowAutomationEntry(
   automation: ZeroWorkflowAutomationSummary,
+  options: WorkflowAutomationsTableOptions = {},
 ): string {
   if (
     automation.kind === "event" &&
@@ -367,7 +372,7 @@ function formatWorkflowAutomationEntry(
   if (isWebhookAutomation(automation)) {
     return formatWebhookAutomationEntry(automation);
   }
-  if (isStripeInvoicePaidAutomation(automation)) {
+  if (options.showStripeDetails && isStripeInvoicePaidAutomation(automation)) {
     return formatStripeInvoicePaidAutomationEntry(automation);
   }
 
@@ -473,6 +478,7 @@ function signedCurlExample(
 
 export function printWorkflowAutomationsTable(
   automations: readonly ZeroWorkflowAutomationSummary[],
+  options: WorkflowAutomationsTableOptions = {},
 ): void {
   const idWidth = Math.max(
     2,
@@ -483,7 +489,7 @@ export function printWorkflowAutomationsTable(
   const scheduleWidth = Math.max(
     7,
     ...automations.map((automation) => {
-      return formatWorkflowAutomationEntry(automation).length;
+      return formatWorkflowAutomationEntry(automation, options).length;
     }),
   );
 
@@ -506,10 +512,15 @@ export function printWorkflowAutomationsTable(
       [
         automation.id.padEnd(idWidth),
         status.padEnd(8 + (automation.enabled ? 0 : 2)),
-        formatWorkflowAutomationEntry(automation).padEnd(scheduleWidth),
+        formatWorkflowAutomationEntry(automation, options).padEnd(
+          scheduleWidth,
+        ),
         formatRunTime(automation.nextRunAt),
       ].join("  "),
     );
+  }
+  if (!options.showStripeDetails) {
+    return;
   }
   for (const automation of automations) {
     if (
@@ -605,6 +616,18 @@ function printCommand(lines: readonly string[]): void {
   }
 }
 
+function stripeRecreateCommand(
+  automation: WorkflowStripeInvoicePaidAutomationSummary,
+  workflowId: string,
+): string {
+  const billingReasons = automation.eventConfig.billingReasons;
+  const billingReasonOption =
+    billingReasons && billingReasons.length > 0
+      ? ` --billing-reason ${billingReasons.join(",")}`
+      : "";
+  return `zero workflow automation add ${workflowId} stripe-invoice-paid${billingReasonOption}`;
+}
+
 function automationUpdateGuidance(
   automation: ZeroWorkflowAutomationSummary,
   workflowId: string,
@@ -617,7 +640,7 @@ function automationUpdateGuidance(
       label: "Change billing reasons (delete and recreate)",
       command: [
         `zero workflow automation rm ${automation.id}`,
-        `zero workflow automation add ${workflowId} stripe-invoice-paid --billing-reason <billing-reasons>`,
+        stripeRecreateCommand(automation, workflowId),
       ],
     };
   }

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/display.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/display.ts
@@ -65,6 +65,10 @@ type WorkflowStrapiAutomationSummary = Extract<
   ZeroWorkflowAutomationSummary,
   { readonly kind: "event"; readonly eventType: "strapi-entry-published" }
 >;
+type WorkflowStripeInvoicePaidAutomationSummary = Extract<
+  ZeroWorkflowAutomationSummary,
+  { readonly kind: "event"; readonly eventType: "stripe-invoice-paid" }
+>;
 type WorkflowGoogleFormsAutomationSummary = Extract<
   ZeroWorkflowAutomationSummary,
   {
@@ -144,6 +148,76 @@ function isGoogleFormsAutomation(
     automation.kind === "event" &&
     automation.eventType === "google-forms-response-submitted"
   );
+}
+
+function isStripeInvoicePaidAutomation(
+  automation: ZeroWorkflowAutomationSummary,
+): automation is WorkflowStripeInvoicePaidAutomationSummary {
+  return (
+    automation.kind === "event" &&
+    automation.eventType === "stripe-invoice-paid"
+  );
+}
+
+function stripeBillingReasons(
+  automation: WorkflowStripeInvoicePaidAutomationSummary,
+): string {
+  const billingReasons = automation.eventConfig.billingReasons;
+  return billingReasons && billingReasons.length > 0
+    ? billingReasons.join(", ")
+    : "any";
+}
+
+const STRIPE_DELIVERY_FAILURE_WARNING =
+  "The latest Stripe workflow delivery failed.";
+
+function formatStripeInvoicePaidAutomationEntry(
+  automation: WorkflowStripeInvoicePaidAutomationSummary,
+): string {
+  const billingReasons = stripeBillingReasons(automation);
+  const billingReasonSummary =
+    billingReasons === "any"
+      ? "any billing reason"
+      : `billing reasons: ${billingReasons}`;
+  return [
+    `Stripe invoice paid: ${automation.eventConfig.stripeAccountId} (${automation.eventConfig.mode})`,
+    billingReasonSummary,
+    `last matched: ${formatRelativeTime(automation.health.lastMatchingEventReceivedAt)}`,
+    `delivery: ${automation.health.lastDeliveryStatus ?? "-"} at ${formatRelativeTime(automation.health.lastDeliveryStatusAt)}`,
+  ].join("; ");
+}
+
+function printStripeDeliveryWarning(
+  automation: WorkflowStripeInvoicePaidAutomationSummary,
+): void {
+  if (automation.health.warning === "delivery_failed") {
+    console.warn(chalk.yellow(STRIPE_DELIVERY_FAILURE_WARNING));
+  }
+}
+
+function printStripeInvoicePaidAutomationDetails(
+  automation: ZeroWorkflowAutomationSummary,
+): void {
+  if (!isStripeInvoicePaidAutomation(automation)) {
+    return;
+  }
+  console.log(
+    `${"Stripe account ID:".padEnd(20)}${automation.eventConfig.stripeAccountId}`,
+  );
+  console.log(`${"Mode:".padEnd(20)}${automation.eventConfig.mode}`);
+  console.log(
+    `${"Billing reasons:".padEnd(20)}${stripeBillingReasons(automation)}`,
+  );
+  console.log(
+    `${"Last matched:".padEnd(20)}${formatRunTime(automation.health.lastMatchingEventReceivedAt)}`,
+  );
+  console.log(
+    `${"Delivery:".padEnd(20)}${automation.health.lastDeliveryStatus ?? chalk.dim("-")}`,
+  );
+  console.log(
+    `${"Delivery at:".padEnd(20)}${formatRunTime(automation.health.lastDeliveryStatusAt)}`,
+  );
+  printStripeDeliveryWarning(automation);
 }
 
 function quote(value: string): string {
@@ -293,6 +367,9 @@ function formatWorkflowAutomationEntry(
   if (isWebhookAutomation(automation)) {
     return formatWebhookAutomationEntry(automation);
   }
+  if (isStripeInvoicePaidAutomation(automation)) {
+    return formatStripeInvoicePaidAutomationEntry(automation);
+  }
 
   if (automation.kind !== "schedule") {
     return workflowAutomationKindLabel(automation);
@@ -434,6 +511,18 @@ export function printWorkflowAutomationsTable(
       ].join("  "),
     );
   }
+  for (const automation of automations) {
+    if (
+      isStripeInvoicePaidAutomation(automation) &&
+      automation.health.warning === "delivery_failed"
+    ) {
+      console.warn(
+        chalk.yellow(
+          `Warning for automation ${automation.id}: ${STRIPE_DELIVERY_FAILURE_WARNING}`,
+        ),
+      );
+    }
+  }
 }
 
 function printGithubFilters(automation: ZeroWorkflowAutomationSummary): void {
@@ -516,10 +605,22 @@ function printCommand(lines: readonly string[]): void {
   }
 }
 
-function automationUpdateGuidance(automation: ZeroWorkflowAutomationSummary): {
+function automationUpdateGuidance(
+  automation: ZeroWorkflowAutomationSummary,
+  workflowId: string,
+): {
   readonly label: string;
   readonly command: readonly string[];
 } {
+  if (isStripeInvoicePaidAutomation(automation)) {
+    return {
+      label: "Change billing reasons (delete and recreate)",
+      command: [
+        `zero workflow automation rm ${automation.id}`,
+        `zero workflow automation add ${workflowId} stripe-invoice-paid --billing-reason <billing-reasons>`,
+      ],
+    };
+  }
   if (automation.kind !== "schedule") {
     return {
       label: "Edit automation",
@@ -566,7 +667,7 @@ function printManagementCommands(
     return;
   }
 
-  const update = automationUpdateGuidance(automation);
+  const update = automationUpdateGuidance(automation, options.workflowId);
   const statusAction = automation.enabled
     ? {
         label: "Pause automation",
@@ -752,6 +853,7 @@ export function printWorkflowAutomationDetails(
       console.log(signedCurlExample(automation));
     }
   }
+  printStripeInvoicePaidAutomationDetails(automation);
   console.log(`${"Owner:".padEnd(14)}${automation.ownerUserId}`);
   console.log(
     `${"Chat thread:".padEnd(14)}${automation.chatThreadId ?? chalk.dim("-")}`,

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
@@ -10,7 +10,10 @@ import type {
   ZeroWorkflowSchedule,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   type ZeroWorkflowAutomationCreateRequest,
@@ -175,26 +178,29 @@ function strapiIntegrationEnabled(): boolean {
   });
 }
 
-function stripeInvoicePaidWorkflowAutomationsEnabled(): boolean {
+function stripeInvoicePaidWorkflowAutomationsEnabled(
+  overrides?: FeatureSwitchContext["overrides"],
+): boolean {
   const payload = decodeZeroTokenPayload();
   return isFeatureEnabled(
     FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations,
     {
       userId: payload?.userId,
       orgId: payload?.orgId,
+      overrides,
     },
   );
 }
 
-function automationKinds(): readonly string[] {
+function automationKinds(
+  stripeInvoicePaidEnabled = stripeInvoicePaidWorkflowAutomationsEnabled(),
+): readonly string[] {
   return [
     ...SCHEDULE_KINDS,
     ...EVENT_KINDS,
     ...(githubWebhookAutomationsEnabled() ? GITHUB_WEBHOOK_EVENT_KINDS : []),
     ...(strapiIntegrationEnabled() ? STRAPI_EVENT_KINDS : []),
-    ...(stripeInvoicePaidWorkflowAutomationsEnabled()
-      ? STRIPE_EVENT_KINDS
-      : []),
+    ...(stripeInvoicePaidEnabled ? STRIPE_EVENT_KINDS : []),
   ];
 }
 
@@ -2096,82 +2102,98 @@ function buildUpdate(
   return buildScheduleUpdate(options);
 }
 
-function stripeBillingReasonOption(): Option {
+function stripeBillingReasonOption(stripeInvoicePaidEnabled: boolean): Option {
   const option = new Option(
     "--billing-reason <reasons>",
     "Comma-separated Stripe invoice billing reasons (default: any)",
   );
-  if (!stripeInvoicePaidWorkflowAutomationsEnabled()) {
+  if (!stripeInvoicePaidEnabled) {
     option.hideHelp();
   }
   return option;
 }
 
-const addCommand = addGithubAutomationOptions(
-  addGmailAutomationOptions(
-    new Command()
-      .name("add")
-      .description("Add an automation to a workflow")
-      .argument("<workflow>", "Workflow ID or name")
-      .argument("<kind>", `Automation type: ${automationKinds().join(" | ")}`)
-      .option("--expr <expression>", 'Cron expression for kind "cron"')
-      .option("--at <iso-time>", 'Fire time for kind "once"')
-      .option(
-        "--every <duration>",
-        'Interval for kind "loop" (e.g. 15m, 1h, 90s)',
-      )
-      .option(
-        "-z, --timezone <tz>",
-        "IANA timezone for cron/once (default: UTC)",
-      ),
-  ),
-)
-  .option(
-    "--calendar-id <id>",
-    "Google Calendar ID for Google Calendar event automations (default: primary)",
+export function createAutomationAddCommand(
+  commandOptions: {
+    readonly featureSwitchOverrides?: FeatureSwitchContext["overrides"];
+  } = {},
+): Command {
+  const stripeInvoicePaidEnabledForHelp =
+    stripeInvoicePaidWorkflowAutomationsEnabled(
+      commandOptions.featureSwitchOverrides,
+    );
+  const stripeExample = stripeInvoicePaidEnabledForHelp
+    ? "  zero workflow automation add invoice-follow-up --agent <agent-id> stripe-invoice-paid --billing-reason subscription_create,subscription_cycle\n"
+    : "";
+
+  return addGithubAutomationOptions(
+    addGmailAutomationOptions(
+      new Command()
+        .name("add")
+        .description("Add an automation to a workflow")
+        .argument("<workflow>", "Workflow ID or name")
+        .argument(
+          "<kind>",
+          `Automation type: ${automationKinds(stripeInvoicePaidEnabledForHelp).join(" | ")}`,
+        )
+        .option("--expr <expression>", 'Cron expression for kind "cron"')
+        .option("--at <iso-time>", 'Fire time for kind "once"')
+        .option(
+          "--every <duration>",
+          'Interval for kind "loop" (e.g. 15m, 1h, 90s)',
+        )
+        .option(
+          "-z, --timezone <tz>",
+          "IANA timezone for cron/once (default: UTC)",
+        ),
+    ),
   )
-  .option(
-    "--form-url <url>",
-    "Google Form edit-page URL or bare form ID for response automations",
-  )
-  .option(
-    "--page-url <url>",
-    "Notion page URL for notion-page-content-updated automations",
-  )
-  .option(
-    "--parent-page-url <url>",
-    "Parent Notion page URL for notion-child-page-created automations",
-  )
-  .option(
-    "--database-url <url>",
-    "Notion database URL for notion-database-item-created or notion-page-content-updated automations",
-  )
-  .option(
-    "--integration-id <uuid>",
-    "Strapi integration ID for Strapi event automations",
-  )
-  .option(
-    "--content-type-uid <uid>",
-    "Optional Strapi content type UID, for example api::article.article",
-  )
-  .option("--locale <locale>", "Optional Strapi locale filter")
-  .option(
-    "--chat-thread-id <uuid>",
-    "Watched chat thread ID for chat-run-finished automations",
-  )
-  .option(
-    "--run-status <statuses>",
-    "Comma-separated finish statuses for chat-run-finished automations: completed, failed, cancelled (default: all)",
-  )
-  .option(
-    "--output-pattern <pattern>",
-    "Optional * wildcard matched against the finished run's final assistant text",
-  )
-  .addOption(stripeBillingReasonOption())
-  .option("--agent <id>", "Agent ID for resolving a workflow name")
-  .addHelpText(
-    "after",
-    `
+    .option(
+      "--calendar-id <id>",
+      "Google Calendar ID for Google Calendar event automations (default: primary)",
+    )
+    .option(
+      "--form-url <url>",
+      "Google Form edit-page URL or bare form ID for response automations",
+    )
+    .option(
+      "--page-url <url>",
+      "Notion page URL for notion-page-content-updated automations",
+    )
+    .option(
+      "--parent-page-url <url>",
+      "Parent Notion page URL for notion-child-page-created automations",
+    )
+    .option(
+      "--database-url <url>",
+      "Notion database URL for notion-database-item-created or notion-page-content-updated automations",
+    )
+    .option(
+      "--integration-id <uuid>",
+      "Strapi integration ID for Strapi event automations",
+    )
+    .option(
+      "--content-type-uid <uid>",
+      "Optional Strapi content type UID, for example api::article.article",
+    )
+    .option("--locale <locale>", "Optional Strapi locale filter")
+    .option(
+      "--chat-thread-id <uuid>",
+      "Watched chat thread ID for chat-run-finished automations",
+    )
+    .option(
+      "--run-status <statuses>",
+      "Comma-separated finish statuses for chat-run-finished automations: completed, failed, cancelled (default: all)",
+    )
+    .option(
+      "--output-pattern <pattern>",
+      "Optional * wildcard matched against the finished run's final assistant text",
+    )
+    .addOption(stripeBillingReasonOption(stripeInvoicePaidEnabledForHelp))
+    .option("--agent <id>", "Agent ID for resolving a workflow name")
+    .addHelpText(
+      "after",
+      `
 Examples:
   zero workflow automation add tell-a-joke --agent <agent-id> cron --expr "0 9 * * *" -z Asia/Shanghai
   zero workflow automation add tell-a-joke --agent <agent-id> once --at "2026-06-10T09:00" -z Asia/Shanghai
@@ -2191,11 +2213,7 @@ Examples:
   zero workflow automation add research-notes --agent <agent-id> notion-page-content-updated --page-url "https://www.notion.so/workspace/Page-title-1234567890abcdef1234567890abcdef"
   zero workflow automation add research-notes --agent <agent-id> notion-page-content-updated --database-url "https://www.notion.so/1234567890abcdef1234567890abcdef?v=abcdef1234567890abcdef1234567890"
   zero workflow automation add deploy-blog --agent <agent-id> strapi-entry-published --integration-id <uuid> --content-type-uid api::article.article
-  ${
-    stripeInvoicePaidWorkflowAutomationsEnabled()
-      ? "zero workflow automation add invoice-follow-up --agent <agent-id> stripe-invoice-paid --billing-reason subscription_create,subscription_cycle\n  "
-      : ""
-  }zero workflow automation add triage --agent <agent-id> webhook
+${stripeExample}  zero workflow automation add triage --agent <agent-id> webhook
   zero workflow automation add follow-up --agent <agent-id> chat-run-finished --chat-thread-id <thread-uuid> --run-status completed,failed --output-pattern "*deploy failed*"
 
 Notes:
@@ -2206,58 +2224,66 @@ Notes:
   - Google Meet automations run only when a meeting you organize generates a transcript
   - Webhook automations print the signing secret only once after creation
   - Use the workflow ID when a name is ambiguous`,
-  )
-  .action(
-    withErrorHandler(
-      async (workflowRef: string, kind: string, options: AddOptions) => {
-        if (
-          githubWebhookEventKind(kind) &&
-          !githubWebhookAutomationsEnabled()
-        ) {
-          throw new Error(
-            "GitHub webhook automations are not enabled for this workspace",
-          );
-        }
-        if (kind === "strapi-entry-published" && !strapiIntegrationEnabled()) {
-          throw new Error(
-            "Strapi workflow automations are not enabled for this workspace",
-          );
-        }
-        if (
-          kind === "stripe-invoice-paid" &&
-          !stripeInvoicePaidWorkflowAutomationsEnabled()
-        ) {
-          throw new Error(
-            "Stripe invoice-paid workflow automations are not enabled for this workspace",
-          );
-        }
-        if (
-          options.timezone &&
-          kind !== "cron" &&
-          kind !== "once" &&
-          kind !== "gmail-new-message"
-        ) {
-          throw new Error(
-            "--timezone only applies to cron and once automations",
-          );
-        }
-        const workflowId = await resolveWorkflowRef(workflowRef, options);
-        const body = buildCreateRequest(kind, options);
-        const automation = await createWorkflowAutomation(workflowId, body);
+    )
+    .action(
+      withErrorHandler(
+        async (workflowRef: string, kind: string, options: AddOptions) => {
+          if (
+            githubWebhookEventKind(kind) &&
+            !githubWebhookAutomationsEnabled()
+          ) {
+            throw new Error(
+              "GitHub webhook automations are not enabled for this workspace",
+            );
+          }
+          if (
+            kind === "strapi-entry-published" &&
+            !strapiIntegrationEnabled()
+          ) {
+            throw new Error(
+              "Strapi workflow automations are not enabled for this workspace",
+            );
+          }
+          if (
+            kind === "stripe-invoice-paid" &&
+            !stripeInvoicePaidWorkflowAutomationsEnabled(
+              commandOptions.featureSwitchOverrides,
+            )
+          ) {
+            throw new Error(
+              "Stripe invoice-paid workflow automations are not enabled for this workspace",
+            );
+          }
+          if (
+            options.timezone &&
+            kind !== "cron" &&
+            kind !== "once" &&
+            kind !== "gmail-new-message"
+          ) {
+            throw new Error(
+              "--timezone only applies to cron and once automations",
+            );
+          }
+          const workflowId = await resolveWorkflowRef(workflowRef, options);
+          const body = buildCreateRequest(kind, options);
+          const automation = await createWorkflowAutomation(workflowId, body);
 
-        console.log(
-          chalk.green(`✓ Automation added to workflow "${workflowRef}"`),
-        );
-        const threadModel =
-          await tryLoadWorkflowAutomationThreadModel(automation);
-        printWorkflowAutomationDetails(automation, {
-          workflowRef,
-          workflowId,
-          threadModel,
-        });
-      },
-    ),
-  );
+          console.log(
+            chalk.green(`✓ Automation added to workflow "${workflowRef}"`),
+          );
+          const threadModel =
+            await tryLoadWorkflowAutomationThreadModel(automation);
+          printWorkflowAutomationDetails(automation, {
+            workflowRef,
+            workflowId,
+            threadModel,
+          });
+        },
+      ),
+    );
+}
+
+const addCommand = createAutomationAddCommand();
 
 const updateCommand = addGithubAutomationOptions(
   addGmailAutomationOptions(
@@ -2329,7 +2355,9 @@ Examples:
           return;
         }
 
-        printWorkflowAutomationsTable(automations);
+        printWorkflowAutomationsTable(automations, {
+          showStripeDetails: true,
+        });
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import chalk from "chalk";
 import type {
   ChatRunFinishedRunStatus,
@@ -6,6 +6,7 @@ import type {
   GithubLabelAppliedSubjectFilter,
   GithubPullRequestReviewState,
   GithubWorkflowRunConclusion,
+  StripeInvoiceBillingReason,
   ZeroWorkflowSchedule,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -85,6 +86,7 @@ interface AddOptions extends GmailAutomationOptions {
   readonly chatThreadId?: string;
   readonly runStatus?: string;
   readonly outputPattern?: string;
+  readonly billingReason?: string;
 }
 
 interface UpdateOptions extends GmailAutomationOptions {
@@ -139,11 +141,23 @@ const GITHUB_WEBHOOK_EVENT_KINDS = [
   "github-issue-comment-created",
 ] as const;
 const STRAPI_EVENT_KINDS = ["strapi-entry-published"] as const;
+const STRIPE_EVENT_KINDS = ["stripe-invoice-paid"] as const;
 const CHAT_RUN_FINISHED_STATUSES = [
   "completed",
   "failed",
   "cancelled",
 ] as const;
+const STRIPE_INVOICE_BILLING_REASONS: readonly StripeInvoiceBillingReason[] = [
+  "automatic_pending_invoice_item_invoice",
+  "manual",
+  "quote_accept",
+  "subscription",
+  "subscription_create",
+  "subscription_cycle",
+  "subscription_threshold",
+  "subscription_update",
+  "upcoming",
+];
 
 function githubWebhookAutomationsEnabled(): boolean {
   const payload = decodeZeroTokenPayload();
@@ -161,12 +175,26 @@ function strapiIntegrationEnabled(): boolean {
   });
 }
 
+function stripeInvoicePaidWorkflowAutomationsEnabled(): boolean {
+  const payload = decodeZeroTokenPayload();
+  return isFeatureEnabled(
+    FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations,
+    {
+      userId: payload?.userId,
+      orgId: payload?.orgId,
+    },
+  );
+}
+
 function automationKinds(): readonly string[] {
   return [
     ...SCHEDULE_KINDS,
     ...EVENT_KINDS,
     ...(githubWebhookAutomationsEnabled() ? GITHUB_WEBHOOK_EVENT_KINDS : []),
     ...(strapiIntegrationEnabled() ? STRAPI_EVENT_KINDS : []),
+    ...(stripeInvoicePaidWorkflowAutomationsEnabled()
+      ? STRIPE_EVENT_KINDS
+      : []),
   ];
 }
 
@@ -1673,6 +1701,61 @@ function buildStrapiEntryPublishedCreateRequest(
   };
 }
 
+function parseStripeInvoiceBillingReasons(
+  value: string,
+): StripeInvoiceBillingReason[] {
+  const values = value.split(",").map((billingReason) => {
+    return billingReason.trim();
+  });
+  if (
+    values.some((billingReason) => {
+      return billingReason.length === 0;
+    })
+  ) {
+    throw new Error("--billing-reason cannot contain empty values");
+  }
+
+  const billingReasons: StripeInvoiceBillingReason[] = [];
+  for (const value of values) {
+    const billingReason = STRIPE_INVOICE_BILLING_REASONS.find((candidate) => {
+      return candidate === value;
+    });
+    if (!billingReason) {
+      throw new Error(
+        `Invalid --billing-reason value "${value}"; expected one of: ${STRIPE_INVOICE_BILLING_REASONS.join(", ")}`,
+      );
+    }
+    if (!billingReasons.includes(billingReason)) {
+      billingReasons.push(billingReason);
+    }
+  }
+  return billingReasons;
+}
+
+function buildStripeInvoicePaidCreateRequest(
+  options: AddOptions,
+): ZeroWorkflowAutomationCreateRequest {
+  assertNoScheduleAddOptions(options);
+  if (hasEventAddOptions(options)) {
+    throw new Error(
+      "Only --billing-reason applies to stripe-invoice-paid automations",
+    );
+  }
+  const billingReasons =
+    options.billingReason === undefined
+      ? undefined
+      : parseStripeInvoiceBillingReasons(options.billingReason);
+  return {
+    kind: "event",
+    eventType: "stripe-invoice-paid",
+    eventConfig: {
+      provider: "stripe",
+      event: "invoice_paid",
+      ...(billingReasons ? { billingReasons } : {}),
+    },
+  };
+}
+
 function buildScheduleCreateRequest(
   kind: string,
   options: AddOptions,
@@ -1683,7 +1766,7 @@ function buildScheduleCreateRequest(
   return { schedule: buildSchedule(kind, options) };
 }
 
-function buildCreateRequest(
+function buildNonStripeCreateRequest(
   kind: string,
   options: AddOptions,
 ): ZeroWorkflowAutomationCreateRequest {
@@ -1729,6 +1812,21 @@ function buildCreateRequest(
     default:
       return buildScheduleCreateRequest(kind, options);
   }
+}
+
+function buildCreateRequest(
+  kind: string,
+  options: AddOptions,
+): ZeroWorkflowAutomationCreateRequest {
+  if (kind === "stripe-invoice-paid") {
+    return buildStripeInvoicePaidCreateRequest(options);
+  }
+  if (options.billingReason !== undefined) {
+    throw new Error(
+      "--billing-reason only applies to stripe-invoice-paid automations",
+    );
+  }
+  return buildNonStripeCreateRequest(kind, options);
 }
 
 function buildGithubWorkflowEventUpdate(
@@ -1880,6 +1978,12 @@ function buildEventUpdate(
     );
   }
 
+  if (existing.eventType === "stripe-invoice-paid") {
+    throw new Error(
+      "Stripe billing reasons cannot be updated; delete and recreate the automation",
+    );
+  }
+
   if (existing.eventType === "github-label-applied") {
     if (hasGmailOptions) {
       throw new Error(
@@ -1992,6 +2096,17 @@ function buildUpdate(
   return buildScheduleUpdate(options);
 }
 
+function stripeBillingReasonOption(): Option {
+  const option = new Option(
+    "--billing-reason <reasons>",
+    "Comma-separated Stripe invoice billing reasons (default: any)",
+  );
+  if (!stripeInvoicePaidWorkflowAutomationsEnabled()) {
+    option.hideHelp();
+  }
+  return option;
+}
+
 const addCommand = addGithubAutomationOptions(
   addGmailAutomationOptions(
     new Command()
@@ -2052,6 +2167,7 @@ const addCommand = addGithubAutomationOptions(
     "--output-pattern <pattern>",
     "Optional * wildcard matched against the finished run's final assistant text",
   )
+  .addOption(stripeBillingReasonOption())
   .option("--agent <id>", "Agent ID for resolving a workflow name")
   .addHelpText(
     "after",
@@ -2075,7 +2191,11 @@ Examples:
   zero workflow automation add research-notes --agent <agent-id> notion-page-content-updated --page-url "https://www.notion.so/workspace/Page-title-1234567890abcdef1234567890abcdef"
   zero workflow automation add research-notes --agent <agent-id> notion-page-content-updated --database-url "https://www.notion.so/1234567890abcdef1234567890abcdef?v=abcdef1234567890abcdef1234567890"
   zero workflow automation add deploy-blog --agent <agent-id> strapi-entry-published --integration-id <uuid> --content-type-uid api::article.article
-  zero workflow automation add triage --agent <agent-id> webhook
+  ${
+    stripeInvoicePaidWorkflowAutomationsEnabled()
+      ? "zero workflow automation add invoice-follow-up --agent <agent-id> stripe-invoice-paid --billing-reason subscription_create,subscription_cycle\n  "
+      : ""
+  }zero workflow automation add triage --agent <agent-id> webhook
   zero workflow automation add follow-up --agent <agent-id> chat-run-finished --chat-thread-id <thread-uuid> --run-status completed,failed --output-pattern "*deploy failed*"
 
 Notes:
@@ -2101,6 +2221,14 @@ Notes:
         if (kind === "strapi-entry-published" && !strapiIntegrationEnabled()) {
           throw new Error(
             "Strapi workflow automations are not enabled for this workspace",
+          );
+        }
+        if (
+          kind === "stripe-invoice-paid" &&
+          !stripeInvoicePaidWorkflowAutomationsEnabled()
+        ) {
+          throw new Error(
+            "Stripe invoice-paid workflow automations are not enabled for this workspace",
           );
         }
         if (


### PR DESCRIPTION
## Summary

- add feature-gated `stripe-invoice-paid` creation to Zero CLI
- parse optional comma-separated billing reasons with validation and stable deduplication
- render immutable Stripe binding, filters, delivery health, and generic failure warnings
- keep Stripe billing reasons immutable with delete-and-recreate guidance

## Scope

This PR is confined to the Zero CLI workflow automation command, renderer, and command-boundary tests. It does not change the API contract, API service, database, migrations, connectors, Platform, webhook delivery, workers, rollout configuration, or feature-switch defaults.

## Validation

- `pnpm --filter @vm0/zero-cli check-types`
- `pnpm --filter @vm0/zero-cli lint`
- `pnpm --filter @vm0/zero-cli exec vitest run src/commands/zero/workflow/automation/__tests__/automation.test.ts` (86 tests)
- `pnpm --filter @vm0/zero-cli exec vitest run src/commands/zero/workflow/__tests__/copy.test.ts` (3 caller regression tests)
- `pnpm exec prettier --check apps/cli/src/commands/zero/workflow/automation/index.ts apps/cli/src/commands/zero/workflow/automation/display.ts apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts`
- `pnpm knip --workspace @vm0/zero-cli`

## Review

- completed two self-review rounds against #25697, `REVIEW.md`, bad-smell rules, CLI testing guidance, and deployment compatibility
- verified the final rebased diff and shared `workflow copy` caller
- checked all 28 open PRs before Ready; no overlapping automation files

Closes #25697