### PR TITLE
docs: add fallback rules and route pr review to them

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -231,14 +231,25 @@ Apply `docs/fallback.md`. The default is no fallback.
   rollback handling for it, and do not treat a transient error during its
   cutover as a blocker. Request removal when such a PR adds that fallback.
 - A new cross-version rollout fallback must carry a comment naming the
-  condition that makes it removable and a follow-up issue or PR. An
-  open-ended "tolerate the old shape" branch is a finding.
+  affected surface, its rollout window, the condition that makes it removable,
+  and a follow-up issue or PR. An open-ended "tolerate the old shape" branch is
+  a finding. Check the window against the production version-skew facts:
+  DB ahead of API for about 4 seconds, existing runner or sandbox instances old
+  for up to 2 hours, old web or app clients in use for about 2 days. A branch
+  sized to the wrong surface's window is a finding.
 - A PR that removes a fallback must state its evidence — type/schema,
   single-writer, production query, or closed rollback window — and must delete
   the branch, its contract entry, and its own tests together.
 - Flag negative tests that only assert deleted behavior is still deleted
   (retired route still 404s, legacy field still ignored). The exception is a
   fail-closed security boundary, where rejection is the product behavior.
+- The PR summary must contain a `Fallbacks` section listing every fallback the
+  PR introduces, keeps, or removes, or an explicit `Fallbacks: none`. A
+  fallback present in the diff but absent from the summary is a finding.
+- The review comment must itself list every fallback found in the diff, with
+  its surface, window, removal condition, and a justified / not-justified
+  verdict. A review that stays silent about fallbacks in a PR that has one is
+  incomplete.
 
 **Testing Coverage**
 
@@ -297,10 +308,18 @@ LGTM
 #### High Priority (P1)
 - <file path>: <issue description>
 
+### Fallbacks
+- <file path and symbol>: <old/new interaction it protects> — surface <DB/API ~4s | runner or sandbox up to 2h | web or app client ~2d | none, non-GA feature switch>, removal condition <condition and follow-up>, verdict <Justified / Not justified>
+- <or: None>
+
 ### Testing
 - Coverage: <Adequate / Insufficient - missing tests for: ...>
 - Conventions: <Compliant / Violations: ...>
 ```
+
+The `Fallbacks` section is mandatory in every review, including when the answer
+is `None`. List each fallback the diff introduces, keeps, or removes, and flag
+any that the PR summary failed to declare.
 
 Or if there are P0/P1 blockers:
 
@@ -317,6 +336,9 @@ Changes Requested
 
 #### High Priority (P1) - should fix before merge
 - <issue>
+
+### Fallbacks
+...
 
 ### Testing
 ...
@@ -335,7 +357,7 @@ If the caller asks for pr-auto marker-comment mode:
 - Include the caller-provided pr-auto marker lines near the top of the same
   comment.
 - Keep the rest of the body as the detailed pr-review result, including Summary,
-  Findings, and Testing.
+  Findings, Fallbacks, and Testing.
 
 ```bash
 gh pr comment <PR_NUMBER> --repo vm0-ai/vm0 --body-file "<REVIEW_BODY_FILE>"

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -176,7 +176,6 @@ Use the testing docs as the authoritative source for testing conventions. Key st
 | Test behavior not mocks — no `expect(mock).toHaveBeenCalled()` as sole assertion | P1       |
 | Mock cleanup — `vi.clearAllMocks()` in `beforeEach` when mocks are used          | P1       |
 | New user-facing features must be gated behind a `FeatureSwitchKey`               | P1       |
-| No negative tests asserting removed behavior stays removed                       | P1       |
 
 ### Step 5: Code Review Analysis
 
@@ -220,7 +219,14 @@ Review the diff for:
 
 **Fallback Discipline**
 
-Apply `docs/fallback.md`. The default is no fallback.
+Apply `docs/fallback.md`. The default is no fallback. `docs/fallback.md` is the
+authoritative source for the rules below, including this severity table:
+
+| Rule                                                                    | Severity |
+| ----------------------------------------------------------------------- | -------- |
+| No negative tests asserting removed behavior stays removed              | P1       |
+| Every fallback in the diff must be declared in the PR summary           | P1       |
+| A rollout fallback must name its surface, window, and removal condition | P1       |
 
 - Request changes for a fallback that guards a state the owning contract
   already prevents: a `??`/`||` chain on a required SDK field, Zod-required
@@ -233,10 +239,14 @@ Apply `docs/fallback.md`. The default is no fallback.
 - A new cross-version rollout fallback must carry a comment naming the
   affected surface, its rollout window, the condition that makes it removable,
   and a follow-up issue or PR. An open-ended "tolerate the old shape" branch is
-  a finding. Check the window against the production version-skew facts:
-  DB ahead of API for about 4 seconds, existing runner or sandbox instances old
-  for up to 2 hours, old web or app clients in use for about 2 days. A branch
-  sized to the wrong surface's window is a finding.
+  a finding. Size the window by the observed maximum exposure, not the nominal
+  deploy gap: DB/API skew has reached about 102 minutes in recorded incidents
+  even though the pipeline promotes within seconds, existing runner or sandbox
+  instances stay old for up to 2 hours, and old web or app clients stay in use
+  for about 2 days. A branch sized to the wrong surface's window, or to a
+  nominal gap, is a finding. For DB/API changes, check both directions defined
+  in `docs/deployment-compatibility.md`: old code after migration and new code
+  before migration.
 - A PR that removes a fallback must state its evidence — type/schema,
   single-writer, production query, or closed rollback window — and must delete
   the branch, its contract entry, and its own tests together.
@@ -314,7 +324,7 @@ LGTM
 - <file path>: <issue description>
 
 ### Fallbacks
-- <file path and symbol>: <old/new interaction it protects> — surface <DB/API ~4s | runner or sandbox up to 2h | web or app client ~2d | none, non-GA feature switch>, removal condition <condition and follow-up>, declared in PR summary <Yes / No — P1>, verdict <Justified / Not justified>
+- <file path and symbol>: <old/new interaction it protects> — surface <DB/API up to ~102min | runner or sandbox up to 2h | web or app client ~2d | none, non-GA feature switch>, removal condition <condition and follow-up>, declared in PR summary <Yes / No — P1>, verdict <Justified / Not justified>
 - <or: None>
 
 ### Testing

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -66,6 +66,15 @@ gh api repos/vm0-ai/vm0/contents/docs/bad-smell.md --jq '.content' | base64 -d
 gh api repos/vm0-ai/vm0/contents/docs/testing.md --jq '.content' | base64 -d
 ```
 
+Fetch the fallback rules when the PR adds, keeps, or removes a fallback path:
+`??`/`||` defaults on contract-owned fields, compatibility branches for old
+clients, runners, routes, or persisted shapes, behavior gated by a feature
+switch, or tests that assert removed behavior stays removed:
+
+```bash
+gh api repos/vm0-ai/vm0/contents/docs/fallback.md --jq '.content' | base64 -d
+```
+
 #### Surface-Specific Practice Documents
 
 Fetch the event-sourcing rules when the PR changes persistent or optimistic
@@ -167,6 +176,7 @@ Use the testing docs as the authoritative source for testing conventions. Key st
 | Test behavior not mocks — no `expect(mock).toHaveBeenCalled()` as sole assertion | P1       |
 | Mock cleanup — `vi.clearAllMocks()` in `beforeEach` when mocks are used          | P1       |
 | New user-facing features must be gated behind a `FeatureSwitchKey`               | P1       |
+| No negative tests asserting removed behavior stays removed                       | P1       |
 
 ### Step 5: Code Review Analysis
 
@@ -207,6 +217,28 @@ Review the diff for:
 - Do not require failure-path rollback, removal, timeout cleanup, or other
   fallback cleanup for optimistic events. A rare transient mismatch is recovered
   by refreshing the page and reloading persistent state.
+
+**Fallback Discipline**
+
+Apply `docs/fallback.md`. The default is no fallback.
+
+- Request changes for a fallback that guards a state the owning contract
+  already prevents: a `??`/`||` chain on a required SDK field, Zod-required
+  property, or `NOT NULL` column; a fabricated default for a corrupted row; a
+  reader for a producer that no longer exists.
+- A feature still gated by a non-GA `FeatureSwitchKey` has no external users.
+  Do not request compatibility code, dual-read/dual-write, migrations, or
+  rollback handling for it, and do not treat a transient error during its
+  cutover as a blocker. Request removal when such a PR adds that fallback.
+- A new cross-version rollout fallback must carry a comment naming the
+  condition that makes it removable and a follow-up issue or PR. An
+  open-ended "tolerate the old shape" branch is a finding.
+- A PR that removes a fallback must state its evidence — type/schema,
+  single-writer, production query, or closed rollback window — and must delete
+  the branch, its contract entry, and its own tests together.
+- Flag negative tests that only assert deleted behavior is still deleted
+  (retired route still 404s, legacy field still ignored). The exception is a
+  fail-closed security boundary, where rejection is the product behavior.
 
 **Testing Coverage**
 
@@ -344,6 +376,7 @@ Review posted: https://github.com/vm0-ai/vm0/pull/<number>#pullrequestreview-<re
 
 - Documentation index: https://github.com/vm0-ai/vm0/blob/main/docs/docs.md
 - Production-code quality: https://github.com/vm0-ai/vm0/blob/main/docs/bad-smell.md
+- Fallbacks to avoid: https://github.com/vm0-ai/vm0/blob/main/docs/fallback.md
 - Event sourcing and optimistic events: https://github.com/vm0-ai/vm0/blob/main/docs/event-sourcing.md
 - Testing standards: https://github.com/vm0-ai/vm0/blob/main/docs/testing.md
 - React effects and ccstate commands: https://github.com/vm0-ai/vm0/blob/main/docs/effect.md

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -243,9 +243,13 @@ Apply `docs/fallback.md`. The default is no fallback.
 - Flag negative tests that only assert deleted behavior is still deleted
   (retired route still 404s, legacy field still ignored). The exception is a
   fail-closed security boundary, where rejection is the product behavior.
-- The PR summary must contain a `Fallbacks` section listing every fallback the
-  PR introduces, keeps, or removes, or an explicit `Fallbacks: none`. A
-  fallback present in the diff but absent from the summary is a finding.
+- The PR summary must contain a `Fallbacks` section listing **every** fallback
+  or compatibility behavior the PR introduces, keeps, or removes, or an
+  explicit `Fallbacks: none`. An undeclared fallback is a **P1** finding on its
+  own, independent of whether the fallback itself is justified. Report it under
+  High Priority (P1) and require the author to add the missing entry to the PR
+  summary. Record it even when the fallback is correct and stays: the finding
+  is the missing declaration, not the code.
 - The review comment must itself list every fallback found in the diff, with
   its surface, window, removal condition, and a justified / not-justified
   verdict. A review that stays silent about fallbacks in a PR that has one is
@@ -309,7 +313,7 @@ LGTM
 - <file path>: <issue description>
 
 ### Fallbacks
-- <file path and symbol>: <old/new interaction it protects> — surface <DB/API ~4s | runner or sandbox up to 2h | web or app client ~2d | none, non-GA feature switch>, removal condition <condition and follow-up>, verdict <Justified / Not justified>
+- <file path and symbol>: <old/new interaction it protects> — surface <DB/API ~4s | runner or sandbox up to 2h | web or app client ~2d | none, non-GA feature switch>, removal condition <condition and follow-up>, declared in PR summary <Yes / No — P1>, verdict <Justified / Not justified>
 - <or: None>
 
 ### Testing
@@ -318,8 +322,10 @@ LGTM
 ```
 
 The `Fallbacks` section is mandatory in every review, including when the answer
-is `None`. List each fallback the diff introduces, keeps, or removes, and flag
-any that the PR summary failed to declare.
+is `None`. List each fallback the diff introduces, keeps, or removes, and mark
+whether the PR summary declares it. Every fallback missing from the summary is
+also a P1 entry under Findings, phrased as a request to add it to the PR
+summary.
 
 Or if there are P0/P1 blockers:
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -247,9 +247,10 @@ Apply `docs/fallback.md`. The default is no fallback.
   or compatibility behavior the PR introduces, keeps, or removes, or an
   explicit `Fallbacks: none`. An undeclared fallback is a **P1** finding on its
   own, independent of whether the fallback itself is justified. Report it under
-  High Priority (P1) and require the author to add the missing entry to the PR
-  summary. Record it even when the fallback is correct and stays: the finding
-  is the missing declaration, not the code.
+  High Priority (P1), require the author to add the missing entry to the PR
+  summary, and set the verdict to `Changes Requested`. Record it even when the
+  fallback is correct and stays: the finding is the missing declaration, not
+  the code.
 - The review comment must itself list every fallback found in the diff, with
   its surface, window, removal condition, and a justified / not-justified
   verdict. A review that stays silent about fallbacks in a PR that has one is
@@ -325,7 +326,7 @@ The `Fallbacks` section is mandatory in every review, including when the answer
 is `None`. List each fallback the diff introduces, keeps, or removes, and mark
 whether the PR summary declares it. Every fallback missing from the summary is
 also a P1 entry under Findings, phrased as a request to add it to the PR
-summary.
+summary, and forces the `Changes Requested` verdict.
 
 Or if there are P0/P1 blockers:
 
@@ -352,8 +353,12 @@ Changes Requested
 
 **Verdict rules:**
 
-- Start with `LGTM` if there are no P0 issues and no missing tests on `feat:`/`fix:` commits
-- Start with `Changes Requested` if there are any P0 issues OR missing required tests
+- Start with `LGTM` if there are no P0 issues, no missing tests on
+  `feat:`/`fix:` commits, and every fallback in the diff is declared in the PR
+  summary
+- Start with `Changes Requested` if there are any P0 issues, OR missing required
+  tests, OR any fallback or compatibility behavior in the diff that the PR
+  summary does not declare
 
 If the caller asks for pr-auto marker-comment mode:
 

--- a/docs/bad-smell.md
+++ b/docs/bad-smell.md
@@ -31,6 +31,7 @@ const data: UserData = fetchData();
 **PROHIBITION**: Zero tolerance for suppression comments.
 
 **Prohibited comments**:
+
 - `// eslint-disable` or `/* eslint-disable */`
 - `// oxlint-disable` or `/* oxlint-disable */`
 - `// @ts-ignore`
@@ -39,9 +40,11 @@ const data: UserData = fetchData();
 - `// prettier-ignore`
 
 **Prohibited plugins**:
+
 - `eslint-plugin-only-warn`
 
 **Always fix the root cause**:
+
 ```typescript
 // ❌ Bad: Suppressing the warning
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -71,11 +74,13 @@ if (isValidData(data)) {
 **PROHIBITION**: Zero tolerance for dynamic `import()` in production code - use static imports only.
 
 **Prohibited patterns:**
+
 - `await import("module")` - Use static `import` at file top instead
 - `import("module").then(...)` - Use static `import` at file top instead
 - Conditional imports like `if (condition) { await import(...) }` - Restructure code to use static imports
 
 **Why dynamic imports are harmful:**
+
 - Break tree-shaking and bundle optimization
 - Add unnecessary async complexity to synchronous operations
 - Make dependency analysis harder for tools
@@ -83,6 +88,7 @@ if (isValidData(data)) {
 - Hide import errors until runtime instead of catching at build time
 
 **Always use static imports:**
+
 ```typescript
 // ❌ Bad: Dynamic import adds unnecessary async
 async function generateToken() {
@@ -112,6 +118,7 @@ async function handleClick() {
 ```
 
 **Rare exceptions (must be justified):**
+
 - Truly optional dependencies that may not exist (e.g., dev-only tools)
 - Route-based code splitting in Next.js (handled by framework automatically)
 - Testing utilities that need to be mocked (prefer static imports with mocking instead)
@@ -144,14 +151,15 @@ if (!process.env.API_URL) {
 
 **PROHIBITION**: No fallback/recovery logic - errors should fail immediately and visibly.
 
+See `docs/fallback.md` for the full rules on compatibility fallbacks, feature-switched features, and negative tests against removed code.
+
 - Fallback patterns increase complexity and hide configuration problems
 - When critical dependencies are missing, throw errors instead of falling back
 
 ```typescript
 // ❌ Bad: Fallback to another secret
-const jwtSecret = process.env.JWT_SECRET ||
-                  process.env.SOME_OTHER_SECRET ||
-                  "default-secret";
+const jwtSecret =
+  process.env.JWT_SECRET || process.env.SOME_OTHER_SECRET || "default-secret";
 
 // ❌ Bad: Silent fallback behavior
 if (!config) {
@@ -166,6 +174,7 @@ if (!jwtSecret) {
 ```
 
 **Rationale:**
+
 - Fallbacks make debugging harder - you don't know which path was taken
 - Configuration errors should be caught during deployment, not hidden
 - Explicit failures are easier to fix than subtle wrong behavior

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -7,6 +7,9 @@ surface; the index does not replace their detailed rules.
 ## Code Review
 
 - [Bad code smells](./bad-smell.md): production-code quality rules.
+- [Fallbacks to avoid](./fallback.md): fallback slop, negative tests against
+  removed code, feature-switched features that need no compatibility, and the
+  narrow cases where a time-boxed fallback is required.
 - [Event sourcing and optimistic events](./event-sourcing.md): authoritative
   persistent events, optimistic projections, reconciliation, and failure
   semantics.

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -253,10 +253,10 @@ A fallback that nobody records is a fallback that nobody removes. Declaring it
 is mandatory on both sides of the review.
 
 **Every fallback belongs in the PR summary. A fallback or compatibility
-behavior present in the diff but missing from the summary is a P1 finding**,
-and the requested fix is to add the missing entry to the summary. This holds
-even when the fallback itself is correct and stays: the defect is the
-undeclared behavior, not the branch.
+behavior present in the diff but missing from the summary is a P1 finding and
+blocks the review verdict**: the review is `Changes Requested` until the author
+adds the missing entry. This holds even when the fallback itself is correct and
+stays — the defect is the undeclared behavior, not the branch.
 
 **Author — in the PR summary.** When a PR introduces, keeps, or removes any
 fallback, the summary must contain a `Fallbacks` section listing each one. Do
@@ -286,8 +286,9 @@ reports as `none observed` after merge.
 diff introduces or keeps, in the same shape, and state whether each one is
 justified under section 6, correctly time-boxed under section 7, and declared
 in the PR summary. Raise each undeclared one as a P1 finding asking the author
-to record it in the summary. A review that says nothing about fallbacks in a PR
-that adds one is not a completed review.
+to record it in the summary, and request changes until it is recorded. A review
+that says nothing about fallbacks in a PR that adds one is not a completed
+review.
 
 ## 10. Evidence Required When Removing a Fallback
 
@@ -322,7 +323,8 @@ throw so monitoring surfaces a violation if the assumption ever breaks.
   DB window, or a client branch sized to the ~2 hour runner window, is wrong.
 - Does the PR summary contain a `Fallbacks` section, or an explicit
   `Fallbacks: none`? Every fallback in the diff that the summary omits is a P1
-  finding: ask the author to record it there.
+  finding and blocks the verdict: ask the author to record it there and request
+  changes.
 - Does the review comment list every fallback the diff introduces or keeps,
   with a justified/not-justified verdict for each?
 - Does a removal PR carry type, single-writer, production, or rollout evidence?

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -48,8 +48,9 @@ it("does not read legacy vm0 preview bypass query params", () => {
 
 **Delete the old test together with the old code.** When a behavior is
 replaced, update the existing test to the new behavior instead of keeping the
-old assertion alongside it. PR #22573 removed roughly forty such tombstones in
-one pass; that entire class of test should never have been written.
+old assertion alongside it. PR #22573 removed dozens of retired-behavior tests
+in one pass, many of them tombstones; that class of test should never have been
+written.
 
 **The narrow exception** is a fail-closed security boundary, where the
 assertion is that an attacker-supplied legacy credential, token prefix, or
@@ -172,35 +173,65 @@ Everything else is slop.
 ## 7. Rolling Update Windows
 
 A rollout fallback is only justified for the duration that an old version can
-still be live. These are the production version-skew windows pr-auto uses when
-it audits a merged PR for retained version-migration fallbacks. Use the same
-numbers when you write, size, or remove a compatibility branch.
+still be live. Size every compatibility branch against the surface it protects.
 
-| Surface                   | Maximum skew  | What resolves it                                            |
-| ------------------------- | ------------- | ----------------------------------------------------------- |
-| DB vs API                 | ~4 seconds    | DB deploys ahead of API; after that the API matches the DB. |
-| Existing runner / sandbox | up to 2 hours | Old instances drain; newly created ones match immediately.  |
-| Old web / app clients     | ~2 days       | A refresh loads the current version.                        |
+Two different numbers matter, and confusing them is how compatibility code gets
+deleted too early:
+
+- the **nominal deploy gap**, how far apart the pipeline intends to promote two
+  surfaces, and
+- the **observed maximum exposure**, how long the two versions have actually
+  overlapped in production, including promotion drift, rollback, and draining
+  instances.
+
+Only the second number bounds a fallback.
+
+| Surface                   | Nominal deploy gap | Observed maximum exposure | What resolves it                                                                    |
+| ------------------------- | ------------------ | ------------------------- | ----------------------------------------------------------------------------------- |
+| DB vs API                 | ~4 seconds         | ~102 minutes              | API and DB converge only after promotion completes without drift or rollback.       |
+| Existing runner / sandbox | none               | up to 2 hours             | Old instances drain; newly created ones match immediately.                          |
+| Old web / app clients     | none               | ~2 days                   | A refresh loads the current version; a `426` response can force the prompt earlier. |
 
 How to use them:
 
-- **DB ahead of API (~4s).** A migration is live while the previous API is
-  still serving or draining. This window is short but real, which is why
-  migrations must be additive and destructive steps split into a later PR. It
-  does not justify a permanent tolerant reader.
+- **DB vs API.** `docs/deployment-compatibility.md` is the source of truth for
+  this surface; treat the numbers above as a summary of it, not a replacement.
+  The pipeline promotes migrations before API traffic, nominally within a few
+  seconds, but intended ordering is not compatibility. Recorded incidents ran
+  far longer: migration `0697` exposed new readers for **102 minutes**, `0723`
+  for **12 minutes**, `0700` for **10 minutes**, and `0722` for **2 minutes**.
+  Never size a DB/API compatibility branch by the nominal gap.
+
+  This surface also has **two independent directions**, and a fallback that
+  covers one does not cover the other:
+
+  - **Old code after migration** — the schema has changed while the previous
+    API is still serving or draining. Every statement that API can issue must
+    stay legal, including columns an ORM adds to `SELECT` or `RETURNING`.
+  - **New code before migration** — the new API is serving before the migration
+    is visible to it. This is the direction that produced `42703`, `22P02`, and
+    `42P01` in production. New readers and writers must not require the new
+    column, enum value, relation, or constraint until the migration lands.
+
 - **Old runner or sandbox (up to 2h).** The backend must accept the old runner
-  protocol for the full drain. Runner-facing endpoints, payload variants, and
+  protocol for the full drain. The bound is the guest runtime budget,
+  `JOB_TIMEOUT = Duration::from_secs(7200)` in
+  `crates/runner/src/executor/mod.rs`: a draining runner can still be finishing
+  a claimed run for that long. Runner-facing endpoints, payload variants, and
   event shapes cannot be deleted in the same PR that stops emitting them; the
   removal is a follow-up after the window closes. Newly created runners and
   sandboxes are already on the new version, so no fallback is needed for them.
 - **Old web or app clients (~2 days).** Frontend-to-API compatibility branches
   are sized by this window. It is the longest one, so a client-facing rollout
   fallback is the one most worth writing — and the one most often left behind.
+  A raised client-version floor can end it earlier by returning `426 Upgrade
+Required`, but only once an open page makes a handled API request; an idle
+  page never discovers it.
 
-State the applicable window in the code comment and in the PR summary, so the
-removal condition is a date-bounded fact rather than a judgment call. If a
-fallback protects more than one surface, state every relevant window; the
-removal waits for the longest one.
+State the applicable surface and its observed maximum exposure in the code
+comment and in the PR summary, so the removal condition is a bounded fact rather
+than a judgment call. If a fallback protects more than one surface, state every
+relevant window; the removal waits for the longest one.
 
 These windows apply only to GA behavior. A feature still behind a non-GA
 feature switch has no old external client to protect, so none of these windows

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -1,0 +1,241 @@
+# Fallbacks to Avoid
+
+A fallback is any extra code path that handles a state the current system is
+not supposed to produce: a `??` chain on a field the contract makes required,
+a branch for a retired protocol, a default that hides a corrupted row, or a
+test that asserts deleted behavior is still deleted.
+
+The default in this repository is **no fallback**. `docs/bad-smell.md` states
+the fail-fast rule for configuration; this document extends it to protocols,
+persisted state, feature rollout, and tests, and lists the narrow cases where
+a fallback is required.
+
+Every fallback costs the same three things: an extra code path that nobody
+executes on purpose, an extra state that every future reader must reason
+about, and a silent failure mode that turns a loud bug into wrong behavior.
+A fallback is worth that cost only when a real, currently-reachable state
+needs it.
+
+## 1. Do Not Write Negative Tests Against Old Code
+
+A negative test asserts that removed behavior stays removed: the retired route
+still 404s, the legacy field is still ignored, the old parser still rejects the
+old shape. These are tombstones. They do not protect a user-visible behavior;
+they pin the absence of code that no longer exists.
+
+```typescript
+// ❌ Bad: tombstone tests for behavior that was deleted
+it("returns 404 for retired BB0, API key, and public v1 routes", async () => {
+  /* ... */
+});
+it("does not expose the legacy computer-use command approval route", async () => {
+  /* ... */
+});
+it("does not read legacy vm0 preview bypass query params", () => {
+  /* ... */
+});
+```
+
+**Why they are harmful:**
+
+- They never fail for a real reason. The route table and the type system
+  already prove the code is gone; the test only re-states the deletion.
+- They accumulate. Every cleanup adds another tombstone, and the suite grows
+  in the one direction that produces no coverage.
+- They block the next change. Reusing a path, a field name, or an error code
+  now requires deleting a test that looks like a deliberate guard.
+- They cost CI time on every run, forever.
+
+**Delete the old test together with the old code.** When a behavior is
+replaced, update the existing test to the new behavior instead of keeping the
+old assertion alongside it. PR #22573 removed roughly forty such tombstones in
+one pass; that entire class of test should never have been written.
+
+**The narrow exception** is a fail-closed security boundary, where the
+assertion is that an attacker-supplied legacy credential, token prefix, or
+signature format is rejected. There the negative outcome _is_ the product
+behavior, and the test stays. "Old code is gone" is not a security boundary.
+
+## 2. Features Behind a Feature Switch Need No Fallback
+
+A feature that has not reached full rollout has no external users. While it is
+gated by a `FeatureSwitchKey` that is off by default or staff-only, do not
+write compatibility code for it:
+
+- no dual-read or dual-write between the old and new shape,
+- no tolerance branch for data written by the previous iteration of the
+  feature,
+- no client-side handling for an API response the deployed API no longer
+  returns,
+- no migration or backfill for rows only staff produced.
+
+**A temporary 500 or a broken screen during the cutover is acceptable.** The
+blast radius is the staff org that opted in, and the recovery is a refresh or
+a redeploy. Paying for a fallback here buys nothing and slows every subsequent
+iteration, because each iteration then has to carry, test, and later remove
+that fallback.
+
+```typescript
+// ❌ Bad: compatibility branch for a pre-GA feature's own earlier shape
+const layout = parseLayout(row.layout) ?? parseLegacyStaffLayout(row.layout);
+
+// ✅ Good: one shape, fail loudly if a stale staff row shows up
+const layout = parseLayout(row.layout);
+```
+
+**Where this stops applying:** once the switch is `enabled: true` for everyone,
+the feature is GA and the normal rules in `docs/deployment-compatibility.md`
+apply in full. The boundary is the rollout state of the switch, not the age of
+the code.
+
+Removing the switch itself is a separate cleanup: when a switch is terminal,
+delete the switch, the disabled branch, and the tests for the disabled branch
+together.
+
+## 3. Do Not Fall Back On States the Contract Cannot Produce
+
+Most fallback slop is a `??` or `||` chain guarding a value that the owning
+contract already guarantees. The chain does not add safety; it invents an
+identity that no caller ever asked for.
+
+```typescript
+// ❌ Bad: `name` is required by the SDK type; the chain silently changes the
+// cached identity to an unrelated field
+const displayName = org.name ?? org.slug ?? org.id;
+
+// ✅ Good: use the field the contract guarantees
+const displayName = org.name;
+```
+
+The same rule covers:
+
+- `?? 0` on a metric that is initialized and updated as a required number,
+- a final `?? null` on a value derived from a `NOT NULL` column,
+- a fabricated React key for a state the component never constructs,
+- `as unknown as` bridges that reconnect types the fallback broke.
+
+Before deleting one, confirm the state is genuinely unreachable under the
+owning contract — the SDK type, the Zod schema, the DB nullability, or the
+single writer that produces the row. Record that evidence in the PR.
+
+## 4. Do Not Fabricate Data For Corrupted Persisted State
+
+When a required column is null but the only writer always sets it, the row is
+corrupted. Deriving a plausible value from an ID or a filename hides an
+impossible database state and produces a wrong answer instead of an alert.
+
+```typescript
+// ❌ Bad: rebuild metadata from the asset ID when the row is incomplete
+const contentType = row.contentType ?? guessMimeFromUuid(row.id);
+const status = row.status ?? "failed";
+
+// ✅ Good: throw a precise invariant error
+if (!row.contentType) {
+  throw new Error(`slack-input asset ${row.id} is missing contentType`);
+}
+```
+
+Genuinely optional columns keep their documented default. The test is whether
+the writer can legitimately leave the field unset, not whether the type happens
+to be nullable.
+
+## 5. Do Not Keep Fallbacks For Retired Protocols and Layouts
+
+Once a producer is gone, its reader is dead weight. Delete the reader in the
+same PR that retires the producer, or in an explicit follow-up PR that names
+the rollout window it waited for.
+
+This includes retired runner event shapes, superseded API routes, old storage
+prefixes, previous OAuth callback metadata, obsolete IndexedDB cache versions,
+and unordered heartbeat senders that no live runner can still emit. When old
+rows in the retired shape still exist, delete or migrate them rather than
+teaching the reader to accept both.
+
+## 6. Fallbacks That Are Required
+
+Keep a fallback only when it belongs to one of these:
+
+1. **Time-boxed cross-version rollout compatibility.** Frontend, backend, and
+   runner deploy independently, so a briefly-mixed fleet is a real reachable
+   state. See `docs/deployment-compatibility.md`. This fallback must be
+   time-boxed (see section 7).
+2. **Genuinely optional external data.** Third-party API fields that the
+   provider documents as optional, or that runtime inspection proves absent
+   despite the TypeScript declaration.
+3. **Genuinely nullable persisted columns**, where a legitimate writer leaves
+   the field unset.
+4. **Presentational defaults** with no identity meaning — placeholder artwork
+   for an unavailable preview, an empty-state label.
+
+Everything else is slop.
+
+## 7. Writing a Time-Boxed Rollout Fallback
+
+A legitimate rollout fallback is introduced with its removal already planned.
+
+**Step 1 — ship the tolerant version with a comment stating the removal
+condition.** PR #25563 added an additive route and let the app accept the old
+API's `404`:
+
+```typescript
+const result = await accept(client.unreadIds(), [200, 404]);
+// A newly promoted app can briefly reach an API version from before this
+// additive route existed. Remove after that API is outside the production
+// rollback window.
+return new Set(result.status === 200 ? result.body.threadIds : []);
+```
+
+**Step 2 — after the rollback window closes, remove the fallback, the contract
+entry, and its test.** PR #25694 did exactly that:
+
+```typescript
+const result = await accept(client.unreadIds(), [200]);
+return new Set(result.body.threadIds);
+```
+
+The follow-up PR removed the `404` from the contract, narrowed the BDD helper's
+status type, and deleted the test that exercised the missing route. Note that
+the deleted test is not a regression loss: it covered the temporary fallback,
+so it dies with the fallback rather than becoming a tombstone.
+
+Requirements for this pattern:
+
+- a comment naming the condition that makes the branch removable,
+- a follow-up issue or PR that removes it,
+- the removal deletes the tolerant branch, the contract entry, the helper
+  types, and the fallback's tests together.
+
+An "old shape tolerated forever" branch with no removal condition is not a
+rollout fallback; it is section 5 slop.
+
+## 8. Evidence Required When Removing a Fallback
+
+Removing a fallback is a behavior change until proven otherwise. A cleanup PR
+must show why the removed branch is unreachable:
+
+- **Type or schema evidence** — the field is required by the SDK type, the Zod
+  schema, or a `NOT NULL` column.
+- **Single-writer evidence** — the only code path that creates the row always
+  sets the field.
+- **Production evidence** — a read-only query against the masked production
+  branch showing zero rows in the old shape. PR #24888 removed an unreachable
+  claim-time fallback only after confirming `pending_automation = 0`.
+- **Rollout evidence** — the deploy that made the old version unreachable is
+  past its rollback window.
+
+State which of these applies for each removed branch, and keep the invariant
+throw so monitoring surfaces a violation if the assumption ever breaks.
+
+## Review Checklist
+
+- Does the PR add a fallback for a state the contract, schema, or single
+  writer already prevents? Request removal.
+- Is the feature still behind a non-GA feature switch? Then no compatibility
+  code, no migration, no dual-read is required, and a transient error during
+  cutover is acceptable.
+- Does the PR add a test that asserts removed behavior stays removed? Request
+  removal unless it is a fail-closed security boundary.
+- Does a new rollout fallback carry a removal condition and a follow-up?
+- Does a removal PR carry type, single-writer, production, or rollout evidence?
+- Does the removal delete the branch, the contract entry, and the branch's own
+  tests together?

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -252,6 +252,12 @@ rollout fallback; it is section 5 slop.
 A fallback that nobody records is a fallback that nobody removes. Declaring it
 is mandatory on both sides of the review.
 
+**Every fallback belongs in the PR summary. A fallback or compatibility
+behavior present in the diff but missing from the summary is a P1 finding**,
+and the requested fix is to add the missing entry to the summary. This holds
+even when the fallback itself is correct and stays: the defect is the
+undeclared behavior, not the branch.
+
 **Author — in the PR summary.** When a PR introduces, keeps, or removes any
 fallback, the summary must contain a `Fallbacks` section listing each one. Do
 not bury it in the diff. For each fallback give:
@@ -278,9 +284,10 @@ reports as `none observed` after merge.
 
 **Reviewer — in the review comment.** The review must list every fallback the
 diff introduces or keeps, in the same shape, and state whether each one is
-justified under section 6 and correctly time-boxed under section 7. A fallback
-the author did not declare is itself a finding. A review that says nothing
-about fallbacks in a PR that adds one is not a completed review.
+justified under section 6, correctly time-boxed under section 7, and declared
+in the PR summary. Raise each undeclared one as a P1 finding asking the author
+to record it in the summary. A review that says nothing about fallbacks in a PR
+that adds one is not a completed review.
 
 ## 10. Evidence Required When Removing a Fallback
 
@@ -314,7 +321,8 @@ throw so monitoring surfaces a violation if the assumption ever breaks.
 - Is the window the right one? A runner-protocol branch sized to the ~4 second
   DB window, or a client branch sized to the ~2 hour runner window, is wrong.
 - Does the PR summary contain a `Fallbacks` section, or an explicit
-  `Fallbacks: none`?
+  `Fallbacks: none`? Every fallback in the diff that the summary omits is a P1
+  finding: ask the author to record it there.
 - Does the review comment list every fallback the diff introduces or keeps,
   with a justified/not-justified verdict for each?
 - Does a removal PR carry type, single-writer, production, or rollout evidence?

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -158,7 +158,7 @@ Keep a fallback only when it belongs to one of these:
 1. **Time-boxed cross-version rollout compatibility.** Frontend, backend, and
    runner deploy independently, so a briefly-mixed fleet is a real reachable
    state. See `docs/deployment-compatibility.md`. This fallback must be
-   time-boxed (see section 7).
+   time-boxed to a known rollout window (see sections 7 and 8).
 2. **Genuinely optional external data.** Third-party API fields that the
    provider documents as optional, or that runtime inspection proves absent
    despite the TypeScript declaration.
@@ -169,7 +169,44 @@ Keep a fallback only when it belongs to one of these:
 
 Everything else is slop.
 
-## 7. Writing a Time-Boxed Rollout Fallback
+## 7. Rolling Update Windows
+
+A rollout fallback is only justified for the duration that an old version can
+still be live. These are the production version-skew windows pr-auto uses when
+it audits a merged PR for retained version-migration fallbacks. Use the same
+numbers when you write, size, or remove a compatibility branch.
+
+| Surface                   | Maximum skew  | What resolves it                                            |
+| ------------------------- | ------------- | ----------------------------------------------------------- |
+| DB vs API                 | ~4 seconds    | DB deploys ahead of API; after that the API matches the DB. |
+| Existing runner / sandbox | up to 2 hours | Old instances drain; newly created ones match immediately.  |
+| Old web / app clients     | ~2 days       | A refresh loads the current version.                        |
+
+How to use them:
+
+- **DB ahead of API (~4s).** A migration is live while the previous API is
+  still serving or draining. This window is short but real, which is why
+  migrations must be additive and destructive steps split into a later PR. It
+  does not justify a permanent tolerant reader.
+- **Old runner or sandbox (up to 2h).** The backend must accept the old runner
+  protocol for the full drain. Runner-facing endpoints, payload variants, and
+  event shapes cannot be deleted in the same PR that stops emitting them; the
+  removal is a follow-up after the window closes. Newly created runners and
+  sandboxes are already on the new version, so no fallback is needed for them.
+- **Old web or app clients (~2 days).** Frontend-to-API compatibility branches
+  are sized by this window. It is the longest one, so a client-facing rollout
+  fallback is the one most worth writing — and the one most often left behind.
+
+State the applicable window in the code comment and in the PR summary, so the
+removal condition is a date-bounded fact rather than a judgment call. If a
+fallback protects more than one surface, state every relevant window; the
+removal waits for the longest one.
+
+These windows apply only to GA behavior. A feature still behind a non-GA
+feature switch has no old external client to protect, so none of these windows
+create an obligation (see section 2).
+
+## 8. Writing a Time-Boxed Rollout Fallback
 
 A legitimate rollout fallback is introduced with its removal already planned.
 
@@ -200,7 +237,9 @@ so it dies with the fallback rather than becoming a tombstone.
 
 Requirements for this pattern:
 
-- a comment naming the condition that makes the branch removable,
+- a comment naming the surface, its window from section 7, and the condition
+  that makes the branch removable,
+- an entry in the PR summary (see section 9),
 - a follow-up issue or PR that removes it,
 - the removal deletes the tolerant branch, the contract entry, the helper
   types, and the fallback's tests together.
@@ -208,7 +247,42 @@ Requirements for this pattern:
 An "old shape tolerated forever" branch with no removal condition is not a
 rollout fallback; it is section 5 slop.
 
-## 8. Evidence Required When Removing a Fallback
+## 9. Declare Every Fallback in the PR Summary and the Review
+
+A fallback that nobody records is a fallback that nobody removes. Declaring it
+is mandatory on both sides of the review.
+
+**Author — in the PR summary.** When a PR introduces, keeps, or removes any
+fallback, the summary must contain a `Fallbacks` section listing each one. Do
+not bury it in the diff. For each fallback give:
+
+- the file and symbol,
+- what old/new interaction it protects,
+- the surface and its window from section 7 (or `none — non-GA feature
+switch`),
+- the removal condition and the follow-up issue or PR,
+- for a removed fallback, the evidence from section 10.
+
+```md
+## Fallbacks
+
+- `sidebar-unread-threads.ts:allUnreadThreadIds$` — accepts `404` from an API
+  that predates the additive `unreadIds` route. Surface: old app clients,
+  ~2 days. Remove after the API is outside the rollback window; follow-up
+  #25694.
+```
+
+When a PR contains no fallback at all, say so explicitly: `Fallbacks: none`.
+That one line is what makes a later audit trustworthy, and it is what pr-auto
+reports as `none observed` after merge.
+
+**Reviewer — in the review comment.** The review must list every fallback the
+diff introduces or keeps, in the same shape, and state whether each one is
+justified under section 6 and correctly time-boxed under section 7. A fallback
+the author did not declare is itself a finding. A review that says nothing
+about fallbacks in a PR that adds one is not a completed review.
+
+## 10. Evidence Required When Removing a Fallback
 
 Removing a fallback is a behavior change until proven otherwise. A cleanup PR
 must show why the removed branch is unreachable:
@@ -235,7 +309,14 @@ throw so monitoring surfaces a violation if the assumption ever breaks.
   cutover is acceptable.
 - Does the PR add a test that asserts removed behavior stays removed? Request
   removal unless it is a fail-closed security boundary.
-- Does a new rollout fallback carry a removal condition and a follow-up?
+- Does a new rollout fallback name its surface, its window from section 7, a
+  removal condition, and a follow-up?
+- Is the window the right one? A runner-protocol branch sized to the ~4 second
+  DB window, or a client branch sized to the ~2 hour runner window, is wrong.
+- Does the PR summary contain a `Fallbacks` section, or an explicit
+  `Fallbacks: none`?
+- Does the review comment list every fallback the diff introduces or keeps,
+  with a justified/not-justified verdict for each?
 - Does a removal PR carry type, single-writer, production, or rollout evidence?
 - Does the removal delete the branch, the contract entry, and the branch's own
   tests together?


### PR DESCRIPTION
## Summary

Adds `docs/fallback.md`, a dedicated practice document for the fallback classes we have been cleaning up over the past weeks, and routes PR review to it.

The two rules that drove this doc:

1. **No negative tests against old code.** Tests that assert removed behavior stays removed (retired route still 404s, legacy field still ignored) are tombstones. They never fail for a real reason, they accumulate with every cleanup, and they block the next change. #22573 alone removed roughly forty of them. The only exception is a fail-closed security boundary, where rejection is the product behavior.
2. **Features behind a non-GA feature switch need no fallback.** No dual-read/dual-write, no migration, no rollback handling. A transient 500 or broken screen during cutover is acceptable because the blast radius is the staff org that opted in, and skipping the fallback lets us iterate faster. The boundary is the rollout state of the switch, not the age of the code.

The doc also covers the classes the daily cleanup keeps finding: `??`/`||` chains on states the owning contract cannot produce (#25314), fabricated metadata for corrupted rows (#25531), and readers for retired producers (#25511, #22573).

## Rolling update windows

Section 7 records the production version-skew windows so authors and reviewers size a compatibility branch against the same numbers. It separates two figures that are easy to confuse, because conflating them is how compatibility code gets deleted too early:

| Surface | Nominal deploy gap | Observed maximum exposure | What resolves it |
| --- | --- | --- | --- |
| DB vs API | ~4 seconds | ~102 minutes | API and DB converge only after promotion completes without drift or rollback |
| Existing runner / sandbox | none | up to 2 hours | Old instances drain; newly created ones match immediately |
| Old web / app clients | none | ~2 days | A refresh loads the current version; a `426` response can force the prompt earlier |

Only the observed maximum bounds a fallback. `docs/deployment-compatibility.md` stays the source of truth for the DB/API surface, including its two independent directions — old code after migration, and new code before migration, the direction that produced `42703`, `22P02`, and `42P01` in production. The 2 hour runner window is `JOB_TIMEOUT = Duration::from_secs(7200)` in `crates/runner/src/executor/mod.rs`.

A rollout fallback must name its surface and observed window in the code comment, which turns "remove after the rollback window" into a bounded fact. A branch sized to the wrong surface's window, or to a nominal deploy gap, is a review finding.

## Declaring fallbacks

Every PR summary must carry a `Fallbacks` section listing each fallback it introduces, keeps, or removes — file and symbol, the old/new interaction protected, the surface and window, the removal condition and follow-up — or an explicit `Fallbacks: none`.

**A fallback or compatibility behavior present in the diff but missing from the summary is a P1 finding and a verdict rule**: the review is `Changes Requested` until the author records it, independent of whether the fallback itself is justified. The review comment must list every fallback with its surface, window, removal condition, whether the summary declares it, and a justified / not-justified verdict. `REVIEW.md` gets a mandatory `Fallbacks` section in both review body templates.

The doc closes with the time-boxed rollout pattern from #25563 to #25694, and the type / single-writer / production-query / rollback-window evidence a removal PR must carry (#24888).

## Changes

- `docs/fallback.md` — new practice document
- `REVIEW.md` — fetch routing for the new doc, a Fallback Discipline review section including the skew windows, a mandatory `Fallbacks` section in both review templates, and a P1 testing-standards row for negative tests
- `docs/docs.md` — index entry
- `docs/bad-smell.md` — cross-reference from the existing fail-fast section (the rest of its diff is Prettier normalizing pre-existing list spacing)

## Fallbacks

None. Documentation-only change.

## Verification

- `prettier --check` on all four files
