### PR TITLE
feat(platform): add stripe invoice paid automation ui

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5145,7 +5145,8 @@
         "lastEvent": "Letztes Ereignis",
         "manageConnection": "Stripe-Verbindung verwalten",
         "noDeliveries": "Noch keine Zustellungen",
-        "noMatchingEvents": "Noch keine passenden Ereignisse"
+        "noMatchingEvents": "Noch keine passenden Ereignisse",
+        "rule": "Wenn eine passende Stripe-Rechnung bezahlt wird"
       },
       "types": {
         "chat": "Chat",
@@ -5156,6 +5157,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5111,6 +5111,42 @@
         "localeSummary": "Gebietsschema {{locale}}",
         "rule": "Wenn ein passender Strapi-Eintrag veröffentlicht wird"
       },
+      "stripe": {
+        "addAction": "Stripe-Automatisierung hinzufügen",
+        "addAria": "Automatisierung für bezahlte Stripe-Rechnungen hinzufügen",
+        "addDescription": "Diesen Workflow ausführen, wenn eine passende Rechnung im verbundenen Stripe-Live-Konto bezahlt wird.",
+        "addTitle": "Stripe-Automatisierung hinzufügen",
+        "anyBillingReason": "Beliebiger Abrechnungsgrund",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "Automatische ausstehende Rechnungspositionen",
+          "manual": "Manuell",
+          "quoteAccept": "Angebot angenommen",
+          "subscription": "Abonnement",
+          "subscriptionCreate": "Abonnement erstellt",
+          "subscriptionCycle": "Abonnementzyklus",
+          "subscriptionThreshold": "Abonnementschwellenwert",
+          "subscriptionUpdate": "Abonnement aktualisiert",
+          "upcoming": "Bevorstehend"
+        },
+        "billingReasons": "Abrechnungsgründe",
+        "billingReasonsHint": "Keine Auswahl entspricht einem beliebigen Abrechnungsgrund.",
+        "bindingSummary": "Stripe-Konto {{accountId}} · Live-Modus · {{billingReasons}}",
+        "delivery": "Zustellung",
+        "deliveryStatus": {
+          "delivered": "Zugestellt",
+          "failed": "Fehlgeschlagen",
+          "pending": "Ausstehend",
+          "skipped": "Übersprungen"
+        },
+        "deliveryWarning": "Die letzte endgültige Zustellung ist fehlgeschlagen. Prüfen Sie die Workflow-Aktivität, bevor Sie es erneut versuchen.",
+        "immutableHint": "Das Stripe-Konto und die Abrechnungsgründe sind festgelegt. Löschen Sie diese Automatisierung und erstellen Sie sie neu, um sie zu ändern.",
+        "invoicePaidDescription": "Ausführen, wenn eine passende Stripe-Rechnung bezahlt wird.",
+        "invoicePaidTitle": "Stripe-Rechnung bezahlt",
+        "lastEvent": "Letztes Ereignis",
+        "manageConnection": "Stripe-Verbindung verwalten",
+        "noDeliveries": "Noch keine Zustellungen",
+        "noMatchingEvents": "Noch keine passenden Ereignisse"
+      },
       "types": {
         "chat": "Chat",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5145,7 +5145,8 @@
         "lastEvent": "Last event",
         "manageConnection": "Manage Stripe connection",
         "noDeliveries": "No deliveries yet",
-        "noMatchingEvents": "No matching events yet"
+        "noMatchingEvents": "No matching events yet",
+        "rule": "When a matching Stripe invoice is paid"
       },
       "types": {
         "chat": "Chat",
@@ -5156,6 +5157,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5111,6 +5111,42 @@
         "localeSummary": "Locale {{locale}}",
         "rule": "When a matching Strapi entry is published"
       },
+      "stripe": {
+        "addAction": "Add Stripe automation",
+        "addAria": "Add Stripe invoice paid automation",
+        "addDescription": "Run this workflow when a matching invoice is paid in the connected Stripe Live account.",
+        "addTitle": "Add Stripe automation",
+        "anyBillingReason": "Any billing reason",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "Automatic pending invoice items",
+          "manual": "Manual",
+          "quoteAccept": "Quote accepted",
+          "subscription": "Subscription",
+          "subscriptionCreate": "Subscription created",
+          "subscriptionCycle": "Subscription cycle",
+          "subscriptionThreshold": "Subscription threshold",
+          "subscriptionUpdate": "Subscription updated",
+          "upcoming": "Upcoming"
+        },
+        "billingReasons": "Billing reasons",
+        "billingReasonsHint": "Select none to match any billing reason.",
+        "bindingSummary": "Stripe account {{accountId}} · Live mode · {{billingReasons}}",
+        "delivery": "Delivery",
+        "deliveryStatus": {
+          "delivered": "Delivered",
+          "failed": "Failed",
+          "pending": "Pending",
+          "skipped": "Skipped"
+        },
+        "deliveryWarning": "The latest terminal delivery failed. Check workflow activity before trying again.",
+        "immutableHint": "The Stripe account and billing reasons are fixed. To change them, delete this automation and recreate it.",
+        "invoicePaidDescription": "Run when a matching Stripe invoice is paid.",
+        "invoicePaidTitle": "Stripe invoice paid",
+        "lastEvent": "Last event",
+        "manageConnection": "Manage Stripe connection",
+        "noDeliveries": "No deliveries yet",
+        "noMatchingEvents": "No matching events yet"
+      },
       "types": {
         "chat": "Chat",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5225,7 +5225,8 @@
         "lastEvent": "Último evento",
         "manageConnection": "Gestionar conexión de Stripe",
         "noDeliveries": "Aún no hay entregas",
-        "noMatchingEvents": "Aún no hay eventos coincidentes"
+        "noMatchingEvents": "Aún no hay eventos coincidentes",
+        "rule": "Cuando se paga una factura de Stripe que coincide"
       },
       "types": {
         "chat": "Chat",
@@ -5236,6 +5237,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5191,6 +5191,42 @@
         "localeSummary": "Configuración regional {{locale}}",
         "rule": "Cuando se publica una entrada coincidente de Strapi"
       },
+      "stripe": {
+        "addAction": "Añadir automatización de Stripe",
+        "addAria": "Añadir automatización de factura pagada de Stripe",
+        "addDescription": "Ejecuta este flujo de trabajo cuando se paga una factura coincidente en la cuenta Live de Stripe conectada.",
+        "addTitle": "Añadir automatización de Stripe",
+        "anyBillingReason": "Cualquier motivo de facturación",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "Partidas pendientes automáticas",
+          "manual": "Manual",
+          "quoteAccept": "Presupuesto aceptado",
+          "subscription": "Suscripción",
+          "subscriptionCreate": "Suscripción creada",
+          "subscriptionCycle": "Ciclo de suscripción",
+          "subscriptionThreshold": "Umbral de suscripción",
+          "subscriptionUpdate": "Suscripción actualizada",
+          "upcoming": "Próxima"
+        },
+        "billingReasons": "Motivos de facturación",
+        "billingReasonsHint": "No selecciones ninguno para aceptar cualquier motivo de facturación.",
+        "bindingSummary": "Cuenta de Stripe {{accountId}} · Modo Live · {{billingReasons}}",
+        "delivery": "Entrega",
+        "deliveryStatus": {
+          "delivered": "Entregada",
+          "failed": "Fallida",
+          "pending": "Pendiente",
+          "skipped": "Omitida"
+        },
+        "deliveryWarning": "La última entrega terminal falló. Revisa la actividad del flujo de trabajo antes de volver a intentarlo.",
+        "immutableHint": "La cuenta de Stripe y los motivos de facturación son fijos. Para cambiarlos, elimina esta automatización y vuelve a crearla.",
+        "invoicePaidDescription": "Ejecutar cuando se pague una factura coincidente de Stripe.",
+        "invoicePaidTitle": "Factura de Stripe pagada",
+        "lastEvent": "Último evento",
+        "manageConnection": "Gestionar conexión de Stripe",
+        "noDeliveries": "Aún no hay entregas",
+        "noMatchingEvents": "Aún no hay eventos coincidentes"
+      },
       "types": {
         "chat": "Chat",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5225,7 +5225,8 @@
         "lastEvent": "Dernier événement",
         "manageConnection": "Gérer la connexion Stripe",
         "noDeliveries": "Aucune livraison pour le moment",
-        "noMatchingEvents": "Aucun événement correspondant pour le moment"
+        "noMatchingEvents": "Aucun événement correspondant pour le moment",
+        "rule": "Lorsqu’une facture Stripe correspondante est payée"
       },
       "types": {
         "chat": "Chat",
@@ -5236,6 +5237,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5191,6 +5191,42 @@
         "localeSummary": "Locale {{locale}}",
         "rule": "Lorsqu'une entrée Strapi correspondante est publiée"
       },
+      "stripe": {
+        "addAction": "Ajouter l’automatisation Stripe",
+        "addAria": "Ajouter l’automatisation de facture Stripe payée",
+        "addDescription": "Exécutez ce workflow lorsqu’une facture correspondante est payée sur le compte Stripe Live connecté.",
+        "addTitle": "Ajouter une automatisation Stripe",
+        "anyBillingReason": "Tout motif de facturation",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "Éléments de facture en attente automatiques",
+          "manual": "Manuel",
+          "quoteAccept": "Devis accepté",
+          "subscription": "Abonnement",
+          "subscriptionCreate": "Abonnement créé",
+          "subscriptionCycle": "Cycle d’abonnement",
+          "subscriptionThreshold": "Seuil d’abonnement",
+          "subscriptionUpdate": "Abonnement mis à jour",
+          "upcoming": "À venir"
+        },
+        "billingReasons": "Motifs de facturation",
+        "billingReasonsHint": "Ne sélectionnez rien pour accepter tout motif de facturation.",
+        "bindingSummary": "Compte Stripe {{accountId}} · Mode Live · {{billingReasons}}",
+        "delivery": "Livraison",
+        "deliveryStatus": {
+          "delivered": "Livrée",
+          "failed": "Échouée",
+          "pending": "En attente",
+          "skipped": "Ignorée"
+        },
+        "deliveryWarning": "La dernière livraison terminale a échoué. Consultez l’activité du workflow avant de réessayer.",
+        "immutableHint": "Le compte Stripe et les motifs de facturation sont fixes. Pour les modifier, supprimez cette automatisation et recréez-la.",
+        "invoicePaidDescription": "Exécuter lorsqu’une facture Stripe correspondante est payée.",
+        "invoicePaidTitle": "Facture Stripe payée",
+        "lastEvent": "Dernier événement",
+        "manageConnection": "Gérer la connexion Stripe",
+        "noDeliveries": "Aucune livraison pour le moment",
+        "noMatchingEvents": "Aucun événement correspondant pour le moment"
+      },
       "types": {
         "chat": "Chat",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5145,7 +5145,8 @@
         "lastEvent": "पिछला इवेंट",
         "manageConnection": "Stripe कनेक्शन प्रबंधित करें",
         "noDeliveries": "अभी कोई डिलीवरी नहीं",
-        "noMatchingEvents": "अभी कोई मेल खाने वाला इवेंट नहीं"
+        "noMatchingEvents": "अभी कोई मेल खाने वाला इवेंट नहीं",
+        "rule": "जब मेल खाने वाला Stripe इनवॉइस भुगतान किया जाता है"
       },
       "types": {
         "chat": "चैट",
@@ -5156,6 +5157,7 @@
         "googleMeet": "Google मिलें",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "वेबहुक"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5111,6 +5111,42 @@
         "localeSummary": "स्थान {{locale}}",
         "rule": "जब एक मिलान Strapi प्रविष्टि प्रकाशित की जाती है"
       },
+      "stripe": {
+        "addAction": "Stripe ऑटोमेशन जोड़ें",
+        "addAria": "Stripe इनवॉइस भुगतान ऑटोमेशन जोड़ें",
+        "addDescription": "कनेक्ट किए गए Stripe Live खाते में मेल खाने वाला इनवॉइस भुगतान होने पर यह वर्कफ़्लो चलाएँ।",
+        "addTitle": "Stripe ऑटोमेशन जोड़ें",
+        "anyBillingReason": "कोई भी बिलिंग कारण",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "स्वचालित लंबित इनवॉइस आइटम",
+          "manual": "मैन्युअल",
+          "quoteAccept": "कोट स्वीकार किया गया",
+          "subscription": "सब्सक्रिप्शन",
+          "subscriptionCreate": "सब्सक्रिप्शन बनाया गया",
+          "subscriptionCycle": "सब्सक्रिप्शन चक्र",
+          "subscriptionThreshold": "सब्सक्रिप्शन सीमा",
+          "subscriptionUpdate": "सब्सक्रिप्शन अपडेट किया गया",
+          "upcoming": "आगामी"
+        },
+        "billingReasons": "बिलिंग कारण",
+        "billingReasonsHint": "किसी भी बिलिंग कारण से मिलान करने के लिए कोई विकल्प न चुनें।",
+        "bindingSummary": "Stripe खाता {{accountId}} · Live मोड · {{billingReasons}}",
+        "delivery": "डिलीवरी",
+        "deliveryStatus": {
+          "delivered": "डिलीवर किया गया",
+          "failed": "विफल",
+          "pending": "लंबित",
+          "skipped": "छोड़ा गया"
+        },
+        "deliveryWarning": "नवीनतम अंतिम डिलीवरी विफल रही। दोबारा कोशिश करने से पहले वर्कफ़्लो गतिविधि जाँचें।",
+        "immutableHint": "Stripe खाता और बिलिंग कारण तय हैं। इन्हें बदलने के लिए यह ऑटोमेशन हटाकर फिर से बनाएँ।",
+        "invoicePaidDescription": "मेल खाने वाला Stripe इनवॉइस भुगतान होने पर चलाएँ।",
+        "invoicePaidTitle": "Stripe इनवॉइस का भुगतान हुआ",
+        "lastEvent": "पिछला इवेंट",
+        "manageConnection": "Stripe कनेक्शन प्रबंधित करें",
+        "noDeliveries": "अभी कोई डिलीवरी नहीं",
+        "noMatchingEvents": "अभी कोई मेल खाने वाला इवेंट नहीं"
+      },
       "types": {
         "chat": "चैट",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5110,6 +5110,42 @@
         "localeSummary": "Locale {{locale}}",
         "rule": "Saat entri Strapi yang cocok dipublikasikan"
       },
+      "stripe": {
+        "addAction": "Tambahkan otomatisasi Stripe",
+        "addAria": "Tambahkan otomatisasi faktur Stripe dibayar",
+        "addDescription": "Jalankan alur kerja ini saat faktur yang cocok dibayar di akun Stripe Live yang terhubung.",
+        "addTitle": "Tambahkan otomatisasi Stripe",
+        "anyBillingReason": "Alasan penagihan apa pun",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "Item faktur tertunda otomatis",
+          "manual": "Manual",
+          "quoteAccept": "Penawaran diterima",
+          "subscription": "Langganan",
+          "subscriptionCreate": "Langganan dibuat",
+          "subscriptionCycle": "Siklus langganan",
+          "subscriptionThreshold": "Ambang langganan",
+          "subscriptionUpdate": "Langganan diperbarui",
+          "upcoming": "Mendatang"
+        },
+        "billingReasons": "Alasan penagihan",
+        "billingReasonsHint": "Jangan pilih apa pun untuk mencocokkan semua alasan penagihan.",
+        "bindingSummary": "Akun Stripe {{accountId}} · Mode Live · {{billingReasons}}",
+        "delivery": "Pengiriman",
+        "deliveryStatus": {
+          "delivered": "Terkirim",
+          "failed": "Gagal",
+          "pending": "Tertunda",
+          "skipped": "Dilewati"
+        },
+        "deliveryWarning": "Pengiriman terminal terbaru gagal. Periksa aktivitas alur kerja sebelum mencoba lagi.",
+        "immutableHint": "Akun Stripe dan alasan penagihan bersifat tetap. Untuk mengubahnya, hapus otomatisasi ini lalu buat ulang.",
+        "invoicePaidDescription": "Jalankan saat faktur Stripe yang cocok dibayar.",
+        "invoicePaidTitle": "Faktur Stripe dibayar",
+        "lastEvent": "Peristiwa terakhir",
+        "manageConnection": "Kelola koneksi Stripe",
+        "noDeliveries": "Belum ada pengiriman",
+        "noMatchingEvents": "Belum ada peristiwa yang cocok"
+      },
       "types": {
         "chat": "Chat",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5144,7 +5144,8 @@
         "lastEvent": "Peristiwa terakhir",
         "manageConnection": "Kelola koneksi Stripe",
         "noDeliveries": "Belum ada pengiriman",
-        "noMatchingEvents": "Belum ada peristiwa yang cocok"
+        "noMatchingEvents": "Belum ada peristiwa yang cocok",
+        "rule": "Saat faktur Stripe yang cocok dibayar"
       },
       "types": {
         "chat": "Chat",
@@ -5155,6 +5156,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5225,7 +5225,8 @@
         "lastEvent": "Ultimo evento",
         "manageConnection": "Gestisci connessione Stripe",
         "noDeliveries": "Nessuna consegna per ora",
-        "noMatchingEvents": "Nessun evento corrispondente per ora"
+        "noMatchingEvents": "Nessun evento corrispondente per ora",
+        "rule": "Quando viene pagata una fattura Stripe corrispondente"
       },
       "types": {
         "chat": "Chatta",
@@ -5236,6 +5237,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5191,6 +5191,42 @@
         "localeSummary": "Impostazioni internazionali {{locale}}",
         "rule": "Quando viene pubblicata una voce Strapi corrispondente"
       },
+      "stripe": {
+        "addAction": "Aggiungi automazione Stripe",
+        "addAria": "Aggiungi automazione per fattura Stripe pagata",
+        "addDescription": "Esegui questo workflow quando una fattura corrispondente viene pagata nell’account Stripe Live connesso.",
+        "addTitle": "Aggiungi automazione Stripe",
+        "anyBillingReason": "Qualsiasi motivo di fatturazione",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "Voci fattura in sospeso automatiche",
+          "manual": "Manuale",
+          "quoteAccept": "Preventivo accettato",
+          "subscription": "Abbonamento",
+          "subscriptionCreate": "Abbonamento creato",
+          "subscriptionCycle": "Ciclo di abbonamento",
+          "subscriptionThreshold": "Soglia di abbonamento",
+          "subscriptionUpdate": "Abbonamento aggiornato",
+          "upcoming": "In arrivo"
+        },
+        "billingReasons": "Motivi di fatturazione",
+        "billingReasonsHint": "Non selezionare nulla per accettare qualsiasi motivo di fatturazione.",
+        "bindingSummary": "Account Stripe {{accountId}} · Modalità Live · {{billingReasons}}",
+        "delivery": "Consegna",
+        "deliveryStatus": {
+          "delivered": "Consegnata",
+          "failed": "Non riuscita",
+          "pending": "In sospeso",
+          "skipped": "Ignorata"
+        },
+        "deliveryWarning": "L’ultima consegna terminale non è riuscita. Controlla l’attività del workflow prima di riprovare.",
+        "immutableHint": "L’account Stripe e i motivi di fatturazione sono fissi. Per modificarli, elimina questa automazione e ricreala.",
+        "invoicePaidDescription": "Esegui quando viene pagata una fattura Stripe corrispondente.",
+        "invoicePaidTitle": "Fattura Stripe pagata",
+        "lastEvent": "Ultimo evento",
+        "manageConnection": "Gestisci connessione Stripe",
+        "noDeliveries": "Nessuna consegna per ora",
+        "noMatchingEvents": "Nessun evento corrispondente per ora"
+      },
       "types": {
         "chat": "Chatta",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5144,7 +5144,8 @@
         "lastEvent": "最新イベント",
         "manageConnection": "Stripe 接続を管理",
         "noDeliveries": "配信はまだありません",
-        "noMatchingEvents": "一致するイベントはまだありません"
+        "noMatchingEvents": "一致するイベントはまだありません",
+        "rule": "一致する Stripe 請求書の支払いが完了したとき"
       },
       "types": {
         "chat": "チャット",
@@ -5155,6 +5156,7 @@
         "googleMeet": "Google 会う",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5110,6 +5110,42 @@
         "localeSummary": "ロケール {{locale}}",
         "rule": "一致する Strapi エントリが公開されたとき"
       },
+      "stripe": {
+        "addAction": "Stripe オートメーションを追加",
+        "addAria": "Stripe の請求書支払い済みオートメーションを追加",
+        "addDescription": "接続済みの Stripe Live アカウントで一致する請求書が支払われたときに、このワークフローを実行します。",
+        "addTitle": "Stripe オートメーションを追加",
+        "anyBillingReason": "すべての請求理由",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "保留中の請求項目の自動請求",
+          "manual": "手動",
+          "quoteAccept": "見積もり承認",
+          "subscription": "サブスクリプション",
+          "subscriptionCreate": "サブスクリプション作成",
+          "subscriptionCycle": "サブスクリプション周期",
+          "subscriptionThreshold": "サブスクリプションしきい値",
+          "subscriptionUpdate": "サブスクリプション更新",
+          "upcoming": "次回予定"
+        },
+        "billingReasons": "請求理由",
+        "billingReasonsHint": "何も選択しない場合は、すべての請求理由に一致します。",
+        "bindingSummary": "Stripe アカウント {{accountId}} · Live モード · {{billingReasons}}",
+        "delivery": "配信",
+        "deliveryStatus": {
+          "delivered": "配信済み",
+          "failed": "失敗",
+          "pending": "保留中",
+          "skipped": "スキップ"
+        },
+        "deliveryWarning": "直近の最終配信に失敗しました。再試行する前にワークフローのアクティビティを確認してください。",
+        "immutableHint": "Stripe アカウントと請求理由は固定されています。変更するには、このオートメーションを削除して再作成してください。",
+        "invoicePaidDescription": "一致する Stripe の請求書が支払われたときに実行します。",
+        "invoicePaidTitle": "Stripe 請求書の支払い完了",
+        "lastEvent": "最新イベント",
+        "manageConnection": "Stripe 接続を管理",
+        "noDeliveries": "配信はまだありません",
+        "noMatchingEvents": "一致するイベントはまだありません"
+      },
       "types": {
         "chat": "チャット",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5110,6 +5110,42 @@
         "localeSummary": "로케일 {{locale}}",
         "rule": "일치하는 Strapi 항목이 게시될 때"
       },
+      "stripe": {
+        "addAction": "Stripe 자동화 추가",
+        "addAria": "Stripe 인보이스 결제 완료 자동화 추가",
+        "addDescription": "연결된 Stripe Live 계정에서 일치하는 인보이스가 결제되면 이 워크플로를 실행합니다.",
+        "addTitle": "Stripe 자동화 추가",
+        "anyBillingReason": "모든 청구 사유",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "대기 중 인보이스 항목 자동 청구",
+          "manual": "수동",
+          "quoteAccept": "견적 승인",
+          "subscription": "구독",
+          "subscriptionCreate": "구독 생성",
+          "subscriptionCycle": "구독 주기",
+          "subscriptionThreshold": "구독 임계값",
+          "subscriptionUpdate": "구독 업데이트",
+          "upcoming": "예정"
+        },
+        "billingReasons": "청구 사유",
+        "billingReasonsHint": "아무것도 선택하지 않으면 모든 청구 사유와 일치합니다.",
+        "bindingSummary": "Stripe 계정 {{accountId}} · Live 모드 · {{billingReasons}}",
+        "delivery": "전달",
+        "deliveryStatus": {
+          "delivered": "전달됨",
+          "failed": "실패",
+          "pending": "대기 중",
+          "skipped": "건너뜀"
+        },
+        "deliveryWarning": "최근 최종 전달이 실패했습니다. 다시 시도하기 전에 워크플로 활동을 확인하세요.",
+        "immutableHint": "Stripe 계정과 청구 사유는 고정되어 있습니다. 변경하려면 이 자동화를 삭제하고 다시 만드세요.",
+        "invoicePaidDescription": "일치하는 Stripe 인보이스가 결제되면 실행합니다.",
+        "invoicePaidTitle": "Stripe 인보이스 결제 완료",
+        "lastEvent": "최근 이벤트",
+        "manageConnection": "Stripe 연결 관리",
+        "noDeliveries": "아직 전달 없음",
+        "noMatchingEvents": "아직 일치하는 이벤트 없음"
+      },
       "types": {
         "chat": "채팅",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5144,7 +5144,8 @@
         "lastEvent": "최근 이벤트",
         "manageConnection": "Stripe 연결 관리",
         "noDeliveries": "아직 전달 없음",
-        "noMatchingEvents": "아직 일치하는 이벤트 없음"
+        "noMatchingEvents": "아직 일치하는 이벤트 없음",
+        "rule": "일치하는 Stripe 인보이스가 결제될 때"
       },
       "types": {
         "chat": "채팅",
@@ -5155,6 +5156,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "웹후크"
       },
       "webhook": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5191,6 +5191,42 @@
         "localeSummary": "Localidade {{locale}}",
         "rule": "Quando uma entrada correspondente for publicada no Strapi"
       },
+      "stripe": {
+        "addAction": "Adicionar automação do Stripe",
+        "addAria": "Adicionar automação de fatura paga do Stripe",
+        "addDescription": "Execute este workflow quando uma fatura correspondente for paga na conta Stripe Live conectada.",
+        "addTitle": "Adicionar automação do Stripe",
+        "anyBillingReason": "Qualquer motivo de cobrança",
+        "billingReason": {
+          "automaticPendingInvoiceItemInvoice": "Itens de fatura pendentes automáticos",
+          "manual": "Manual",
+          "quoteAccept": "Cotação aceita",
+          "subscription": "Assinatura",
+          "subscriptionCreate": "Assinatura criada",
+          "subscriptionCycle": "Ciclo de assinatura",
+          "subscriptionThreshold": "Limite de assinatura",
+          "subscriptionUpdate": "Assinatura atualizada",
+          "upcoming": "Próxima"
+        },
+        "billingReasons": "Motivos de cobrança",
+        "billingReasonsHint": "Não selecione nenhuma opção para aceitar qualquer motivo de cobrança.",
+        "bindingSummary": "Conta Stripe {{accountId}} · Modo Live · {{billingReasons}}",
+        "delivery": "Entrega",
+        "deliveryStatus": {
+          "delivered": "Entregue",
+          "failed": "Falhou",
+          "pending": "Pendente",
+          "skipped": "Ignorada"
+        },
+        "deliveryWarning": "A entrega terminal mais recente falhou. Verifique a atividade do workflow antes de tentar novamente.",
+        "immutableHint": "A conta Stripe e os motivos de cobrança são fixos. Para alterá-los, exclua esta automação e crie-a novamente.",
+        "invoicePaidDescription": "Execute quando uma fatura correspondente do Stripe for paga.",
+        "invoicePaidTitle": "Fatura do Stripe paga",
+        "lastEvent": "Último evento",
+        "manageConnection": "Gerenciar conexão do Stripe",
+        "noDeliveries": "Nenhuma entrega ainda",
+        "noMatchingEvents": "Nenhum evento correspondente ainda"
+      },
       "types": {
         "chat": "Chat",
         "github": "GitHub",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5225,7 +5225,8 @@
         "lastEvent": "Último evento",
         "manageConnection": "Gerenciar conexão do Stripe",
         "noDeliveries": "Nenhuma entrega ainda",
-        "noMatchingEvents": "Nenhum evento correspondente ainda"
+        "noMatchingEvents": "Nenhum evento correspondente ainda",
+        "rule": "Quando uma fatura correspondente da Stripe é paga"
       },
       "types": {
         "chat": "Chat",
@@ -5236,6 +5237,7 @@
         "googleMeet": "Google Meet",
         "notion": "Notion",
         "strapi": "Strapi",
+        "stripe": "Stripe",
         "webhook": "Webhook"
       },
       "webhook": {

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -21,6 +21,7 @@ import {
   type NotionChildPageCreatedEventCreateConfig,
   type NotionDatabaseItemCreatedEventCreateConfig,
   type NotionPageContentUpdatedEventCreateConfig,
+  type StripeInvoiceBillingReason,
   type StrapiEntryPublishedEventConfig,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSchedule,
@@ -111,6 +112,7 @@ export type WorkflowAutomationCreateDialog =
   | "notion-child-page"
   | "notion-database-item"
   | "notion-page-content-updated"
+  | "stripe-invoice-paid"
   | "strapi-entry-published"
   | "webhook"
   | null;
@@ -1372,6 +1374,41 @@ export const createWorkflowStrapiEntryPublishedAutomation$ = command(
         fetchOptions: { signal },
       }),
       [201],
+    );
+    signal.throwIfAborted();
+    set(reloadWorkflows$);
+  },
+);
+
+export const createWorkflowStripeInvoicePaidAutomation$ = command(
+  async (
+    { get, set },
+    input: {
+      readonly workflowId: string;
+      readonly billingReasons: readonly StripeInvoiceBillingReason[];
+    },
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(zeroWorkflowAutomationsContract);
+    await accept(
+      client.create({
+        params: { workflowId: input.workflowId },
+        body: {
+          kind: "event",
+          eventType: "stripe-invoice-paid",
+          eventConfig: {
+            provider: "stripe",
+            event: "invoice_paid",
+            ...(input.billingReasons.length > 0
+              ? { billingReasons: [...input.billingReasons] }
+              : {}),
+          },
+        },
+        fetchOptions: { signal },
+      }),
+      [201],
+      signal,
+      { showErrorToast: false },
     );
     signal.throwIfAborted();
     set(reloadWorkflows$);

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1401,6 +1401,31 @@ describe("workflows routes", () => {
     expect(screen.getByText("Sales Research")).toBeInTheDocument();
   });
 
+  it("labels existing Stripe automations on the workspace workflows index", async () => {
+    mockWorkflowApis([
+      {
+        ...salesResearch(),
+        automations: [stripeInvoicePaidWorkflowAutomation()],
+      },
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: "/workflows",
+      featureSwitches: {
+        [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: false,
+      },
+    });
+
+    const stripePill = await waitFor(() => {
+      return buttonByText(/^Stripe$/u);
+    });
+    click(stripePill);
+    await expect(
+      screen.findByText("When a matching Stripe invoice is paid"),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("renders the workspace workflow detail", async () => {
     mockWorkflowApis([salesResearch()]);
     mockConnectedAutomationConnectors();

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -198,6 +198,10 @@ type WorkflowNotionPageContentUpdatedAutomationSummary = Extract<
   ZeroWorkflowAutomationSummary,
   { kind: "event"; eventType: "notion-page-content-updated" }
 >;
+type WorkflowStripeInvoicePaidAutomationSummary = Extract<
+  ZeroWorkflowAutomationSummary,
+  { kind: "event"; eventType: "stripe-invoice-paid" }
+>;
 
 function workflowAutomations(): ZeroWorkflowAutomationSummary[] {
   return [weekdayWorkflowAutomation()];
@@ -496,6 +500,37 @@ function webhookWorkflowAutomation(): WorkflowWebhookAutomationSummary {
       "https://api.vm0.test/api/webhooks/workflow-automations/whk_test",
     secretLastFour: "abcd",
     lastReceivedAt: null,
+  };
+}
+
+function stripeInvoicePaidWorkflowAutomation(
+  overrides: Partial<WorkflowStripeInvoicePaidAutomationSummary> = {},
+): WorkflowStripeInvoicePaidAutomationSummary {
+  return {
+    id: "workflow-automation-stripe-invoice-paid",
+    kind: "event",
+    eventType: "stripe-invoice-paid",
+    eventConfig: {
+      provider: "stripe",
+      event: "invoice_paid",
+      connectorId: "00000000-0000-4000-a000-000000000411",
+      stripeAccountId: "acct_mock_stripe_invoice_paid",
+      mode: "live",
+    },
+    schedule: null,
+    scheduleSummary: null,
+    ownerUserId: CURRENT_USER_ID,
+    enabled: true,
+    chatThreadId: "thread_stripe_invoice_paid",
+    nextRunAt: null,
+    lastRunAt: null,
+    health: {
+      lastMatchingEventReceivedAt: null,
+      lastDeliveryStatus: null,
+      lastDeliveryStatusAt: null,
+      warning: null,
+    },
+    ...overrides,
   };
 }
 
@@ -3011,6 +3046,216 @@ describe("workflow detail page", () => {
         },
       });
     });
+  });
+
+  it("keeps existing Stripe automations visible and manageable when creation is disabled", async () => {
+    const workflow = {
+      ...salesResearch(),
+      automations: [
+        stripeInvoicePaidWorkflowAutomation(),
+        stripeInvoicePaidWorkflowAutomation({
+          id: "workflow-automation-stripe-invoice-paid-failed",
+          eventConfig: {
+            provider: "stripe",
+            event: "invoice_paid",
+            billingReasons: ["manual", "subscription_cycle"],
+            connectorId: "00000000-0000-4000-a000-000000000412",
+            stripeAccountId: "acct_failed_delivery",
+            mode: "live",
+          },
+          health: {
+            lastMatchingEventReceivedAt: "2026-08-07T08:00:00.000Z",
+            lastDeliveryStatus: "failed",
+            lastDeliveryStatusAt: "2026-08-07T08:01:00.000Z",
+            warning: "delivery_failed",
+          },
+        }),
+      ],
+    };
+    mockWorkflowApis([workflow]);
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
+      [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: false,
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Stripe invoice paid")).toHaveLength(2);
+    });
+    expect(
+      screen.getByText(
+        "Stripe account acct_mock_stripe_invoice_paid · Live mode · Any billing reason",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Stripe account acct_failed_delivery · Live mode · Manual, Subscription cycle",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No matching events yet")).toBeInTheDocument();
+    expect(screen.getByText("No deliveries yet")).toBeInTheDocument();
+    expect(screen.getByText(/Failed ·/u)).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "The latest terminal delivery failed. Check workflow activity before trying again.",
+    );
+    expect(
+      screen.getAllByText(
+        "The Stripe account and billing reasons are fixed. To change them, delete this automation and recreate it.",
+      ),
+    ).toHaveLength(2);
+    expect(screen.queryByText("Webhook URL hidden")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit automation")).not.toBeInTheDocument();
+
+    click(await screen.findByText("Add automation"));
+    const picker = await screen.findByRole("dialog");
+    click(buttonByText("Integrations", picker));
+    expect(
+      within(picker).queryByText("Stripe invoice paid"),
+    ).not.toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    const stripeSwitches = screen.getAllByRole("switch", {
+      name: "Disable Stripe invoice paid",
+    });
+    const stripeSwitch = stripeSwitches[0];
+    if (!stripeSwitch) {
+      throw new Error("Stripe automation switch not found");
+    }
+    click(stripeSwitch);
+    await waitFor(() => {
+      expect(stripeSwitch).not.toBeChecked();
+    });
+    click(buttonByText("More actions"));
+    expect(menuItemByText("Delete automation")).toBeInTheDocument();
+    expect(screen.queryByText("Edit automation")).not.toBeInTheDocument();
+  });
+
+  it("creates a Stripe automation with selected billing reasons and refreshes the detail", async () => {
+    const createBodies: ZeroWorkflowAutomationCreateRequest[] = [];
+    const workflow = salesResearch();
+    mockWorkflowApis([workflow]);
+    context.mocks.api(
+      zeroWorkflowAutomationsContract.create,
+      ({ body, respond }) => {
+        createBodies.push(body);
+        if (body.kind !== "event" || body.eventType !== "stripe-invoice-paid") {
+          return respond(400, {
+            error: { code: "BAD_REQUEST", message: "Expected Stripe" },
+          });
+        }
+        const automation = stripeInvoicePaidWorkflowAutomation({
+          eventConfig: {
+            ...body.eventConfig,
+            connectorId: "00000000-0000-4000-a000-000000000411",
+            stripeAccountId: "acct_created_live",
+            mode: "live",
+          },
+        });
+        workflow.automations.push(automation);
+        return respond(201, automation);
+      },
+    );
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
+      [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
+    });
+
+    click(await screen.findByText("Add automation"));
+    await screen.findByRole("dialog");
+    pickAutomation("Integrations", /^Stripe invoice paid/u);
+    const form = await screen.findByRole("form", {
+      name: "Add Stripe invoice paid automation",
+    });
+    expect(within(form).getAllByRole("checkbox")).toHaveLength(9);
+    expect(within(form).queryByRole("combobox")).not.toBeInTheDocument();
+    expect(within(form).queryByRole("textbox")).not.toBeInTheDocument();
+    click(within(form).getByRole("checkbox", { name: "Manual" }));
+    click(within(form).getByRole("checkbox", { name: "Subscription cycle" }));
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(createBodies.at(-1)).toStrictEqual({
+        kind: "event",
+        eventType: "stripe-invoice-paid",
+        eventConfig: {
+          provider: "stripe",
+          event: "invoice_paid",
+          billingReasons: ["manual", "subscription_cycle"],
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("form", {
+          name: "Add Stripe invoice paid automation",
+        }),
+      ).not.toBeInTheDocument();
+    });
+    await expect(
+      screen.findByText(
+        "Stripe account acct_created_live · Live mode · Manual, Subscription cycle",
+      ),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it("omits billingReasons when creating a Stripe automation with no selection", async () => {
+    const createBodies: ZeroWorkflowAutomationCreateRequest[] = [];
+    mockWorkflowApis([salesResearch()]);
+    mockCreateWorkflowAutomation((body) => {
+      createBodies.push(body);
+    });
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
+      [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
+    });
+
+    click(await screen.findByText("Add automation"));
+    await screen.findByRole("dialog");
+    pickAutomation("Integrations", /^Stripe invoice paid/u);
+    const form = await screen.findByRole("form", {
+      name: "Add Stripe invoice paid automation",
+    });
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(createBodies.at(-1)).toStrictEqual({
+        kind: "event",
+        eventType: "stripe-invoice-paid",
+        eventConfig: {
+          provider: "stripe",
+          event: "invoice_paid",
+        },
+      });
+    });
+  });
+
+  it("keeps the Stripe dialog open with the accessible server readiness error", async () => {
+    const serverMessage =
+      "Stripe invoice-paid automations require Live mode; reconnect Stripe in Live mode";
+    mockWorkflowApis([salesResearch()]);
+    context.mocks.api(zeroWorkflowAutomationsContract.create, ({ respond }) => {
+      return respond(409, {
+        error: { code: "CONFLICT", message: serverMessage },
+      });
+    });
+    detachedSetupWorkflowDetailPage(workflowDetailPath("automations"), {
+      [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
+    });
+
+    click(await screen.findByText("Add automation"));
+    await screen.findByRole("dialog");
+    pickAutomation("Integrations", /^Stripe invoice paid/u);
+    const form = await screen.findByRole("form", {
+      name: "Add Stripe invoice paid automation",
+    });
+    fireEvent.submit(form);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(serverMessage);
+    expect(form).toBeInTheDocument();
+    expect(linkByText("Manage Stripe connection", alert)).toHaveAttribute(
+      "href",
+      "/connectors",
+    );
   });
 
   it("hides Strapi automation creation when the feature is disabled", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -21,6 +21,7 @@ import type {
   GithubWorkflowRunCompletedEventConfig,
   GithubWorkflowRunConclusion,
   NotionPageContentUpdatedEventCreateConfig,
+  StripeInvoiceBillingReason,
   WorkflowFileEntry,
   WorkflowFileMetadata,
   ZeroWorkflowDetailResponse,
@@ -34,6 +35,7 @@ import {
   IconAlertTriangle,
   IconBrandGithub,
   IconBrandNotion,
+  IconBrandStripe,
   IconCalendarTime,
   IconCircleCheck,
   IconChevronDown,
@@ -123,6 +125,7 @@ import {
   createGithubLabelActor$,
   createScheduleCronFields$,
   createWorkflowScheduleAutomation$,
+  createWorkflowStripeInvoicePaidAutomation$,
   createdWorkflowWebhookAutomation$,
   currentWorkflowId$,
   copyWorkflow$,
@@ -257,6 +260,26 @@ const AUTOMATION_FIELD_CLASS =
 const WORKFLOW_EDIT_TEXTAREA_CLASS =
   "min-h-24 w-full resize-y rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50";
 const AUTOMATION_TIMEZONE = "UTC";
+
+const STRIPE_INVOICE_BILLING_REASONS = [
+  "automatic_pending_invoice_item_invoice",
+  "manual",
+  "quote_accept",
+  "subscription",
+  "subscription_create",
+  "subscription_cycle",
+  "subscription_threshold",
+  "subscription_update",
+  "upcoming",
+] as const satisfies readonly StripeInvoiceBillingReason[];
+
+type WorkflowStripeInvoicePaidAutomation = Extract<
+  ZeroWorkflowAutomationSummary,
+  { readonly kind: "event"; readonly eventType: "stripe-invoice-paid" }
+>;
+type StripeDeliveryStatus = NonNullable<
+  WorkflowStripeInvoicePaidAutomation["health"]["lastDeliveryStatus"]
+>;
 
 function automationActionCopy() {
   return {
@@ -1201,6 +1224,8 @@ function AutomationCreateAction() {
     features[FeatureSwitchKey.GoogleFormsWorkflowAutomations] ?? false;
   const githubWebhookAutomationsEnabled =
     features[FeatureSwitchKey.GithubWebhookAutomations] ?? false;
+  const stripeInvoicePaidAutomationsEnabled =
+    features[FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations] ?? false;
   const strapiIntegrationEnabled =
     features[FeatureSwitchKey.StrapiIntegration] ?? false;
 
@@ -1221,6 +1246,7 @@ function AutomationCreateAction() {
       }
       googleMeetAutomationsEnabled
       notionWorkflowAutomationsEnabled={notionWorkflowAutomationsEnabled}
+      stripeInvoicePaidAutomationsEnabled={stripeInvoicePaidAutomationsEnabled}
       strapiIntegrationEnabled={strapiIntegrationEnabled}
       webhookTierEligible={webhookTierEligible}
     />
@@ -3961,6 +3987,11 @@ function workflowAutomationTitle(
       return $.workflows.automations.notion.contentUpdatedTitle;
     });
   }
+  if (automation.eventType === "stripe-invoice-paid") {
+    return i18n.t(($) => {
+      return $.workflows.automations.stripe.invoicePaidTitle;
+    });
+  }
   if (automation.eventType === "strapi-entry-published") {
     return i18n.t(($) => {
       return $.workflows.automations.strapi.entryPublishedTitle;
@@ -4186,7 +4217,7 @@ function githubWorkflowAutomationSummary(
   }
 }
 
-function meetOrChatWorkflowAutomationSummary(
+function eventWorkflowAutomationSummary(
   automation: Extract<ZeroWorkflowAutomationSummary, { kind: "event" }>,
 ): string | null {
   if (automation.eventType === "google-meet-transcript-generated") {
@@ -4197,7 +4228,82 @@ function meetOrChatWorkflowAutomationSummary(
   if (automation.eventType === "chat-run-finished") {
     return chatRunFinishedAutomationSummary(automation.eventConfig);
   }
+  if (automation.eventType === "stripe-invoice-paid") {
+    return i18n.t(
+      ($) => {
+        return $.workflows.automations.stripe.bindingSummary;
+      },
+      {
+        accountId: automation.eventConfig.stripeAccountId,
+        billingReasons: stripeBillingReasonsSummary(
+          automation.eventConfig.billingReasons,
+        ),
+      },
+    );
+  }
   return null;
+}
+
+function stripeBillingReasonLabel(reason: StripeInvoiceBillingReason): string {
+  switch (reason) {
+    case "automatic_pending_invoice_item_invoice": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason
+          .automaticPendingInvoiceItemInvoice;
+      });
+    }
+    case "manual": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason.manual;
+      });
+    }
+    case "quote_accept": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason.quoteAccept;
+      });
+    }
+    case "subscription": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason.subscription;
+      });
+    }
+    case "subscription_create": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason.subscriptionCreate;
+      });
+    }
+    case "subscription_cycle": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason.subscriptionCycle;
+      });
+    }
+    case "subscription_threshold": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason
+          .subscriptionThreshold;
+      });
+    }
+    case "subscription_update": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason.subscriptionUpdate;
+      });
+    }
+    case "upcoming": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.billingReason.upcoming;
+      });
+    }
+  }
+}
+
+function stripeBillingReasonsSummary(
+  reasons: readonly StripeInvoiceBillingReason[] | undefined,
+): string {
+  return reasons && reasons.length > 0
+    ? reasons.map(stripeBillingReasonLabel).join(", ")
+    : i18n.t(($) => {
+        return $.workflows.automations.stripe.anyBillingReason;
+      });
 }
 
 function workflowAutomationSummary(
@@ -4233,9 +4339,9 @@ function workflowAutomationSummary(
       { calendar: quote(automation.eventConfig.calendarId) },
     );
   }
-  const meetOrChatSummary = meetOrChatWorkflowAutomationSummary(automation);
-  if (meetOrChatSummary) {
-    return meetOrChatSummary;
+  const eventSummary = eventWorkflowAutomationSummary(automation);
+  if (eventSummary) {
+    return eventSummary;
   }
   if (automation.eventType === "notion-child-page-created") {
     const title = automation.eventConfig.parentPage.title;
@@ -4331,6 +4437,7 @@ type AutomationCreateDialogKind =
   | "notion-child-page"
   | "notion-database-item"
   | "notion-page-content-updated"
+  | "stripe-invoice-paid"
   | "strapi-entry-published"
   | "webhook";
 
@@ -4357,14 +4464,35 @@ type AutomationCreateCategory = {
   readonly options: readonly AutomationCreateOption[];
 };
 
+function buildStripeInvoicePaidAutomationOptions(
+  enabled: boolean,
+): AutomationCreateOption[] {
+  return enabled
+    ? [
+        {
+          kind: "stripe-invoice-paid",
+          title: i18n.t(($) => {
+            return $.workflows.automations.stripe.invoicePaidTitle;
+          }),
+          description: i18n.t(($) => {
+            return $.workflows.automations.stripe.invoicePaidDescription;
+          }),
+          icon: IconBrandStripe,
+        },
+      ]
+    : [];
+}
+
 function buildIntegrationAutomationOptions({
   githubLabelAutomationsEnabled,
   githubWebhookAutomationsEnabled,
+  stripeInvoicePaidAutomationsEnabled,
   strapiIntegrationEnabled,
   webhookTierEligible,
 }: {
   readonly githubLabelAutomationsEnabled: boolean;
   readonly githubWebhookAutomationsEnabled: boolean;
+  readonly stripeInvoicePaidAutomationsEnabled: boolean;
   readonly strapiIntegrationEnabled: boolean;
   readonly webhookTierEligible: boolean;
 }): AutomationCreateOption[] {
@@ -4446,6 +4574,11 @@ function buildIntegrationAutomationOptions({
       },
     );
   }
+  integrationOptions.push(
+    ...buildStripeInvoicePaidAutomationOptions(
+      stripeInvoicePaidAutomationsEnabled,
+    ),
+  );
   if (strapiIntegrationEnabled) {
     integrationOptions.push({
       kind: "strapi-entry-published",
@@ -4672,6 +4805,7 @@ function buildAutomationCreateCategories({
   googleFormsWorkflowAutomationsEnabled,
   googleMeetAutomationsEnabled,
   notionWorkflowAutomationsEnabled,
+  stripeInvoicePaidAutomationsEnabled,
   strapiIntegrationEnabled,
   webhookTierEligible,
 }: {
@@ -4681,6 +4815,7 @@ function buildAutomationCreateCategories({
   readonly googleFormsWorkflowAutomationsEnabled: boolean;
   readonly googleMeetAutomationsEnabled: boolean;
   readonly notionWorkflowAutomationsEnabled: boolean;
+  readonly stripeInvoicePaidAutomationsEnabled: boolean;
   readonly strapiIntegrationEnabled: boolean;
   readonly webhookTierEligible: boolean;
 }): readonly AutomationCreateCategory[] {
@@ -4694,6 +4829,7 @@ function buildAutomationCreateCategories({
   const integrationOptions = buildIntegrationAutomationOptions({
     githubLabelAutomationsEnabled,
     githubWebhookAutomationsEnabled,
+    stripeInvoicePaidAutomationsEnabled,
     strapiIntegrationEnabled,
     webhookTierEligible,
   });
@@ -4834,6 +4970,7 @@ function AutomationCreateMenu({
   googleFormsWorkflowAutomationsEnabled,
   googleMeetAutomationsEnabled,
   notionWorkflowAutomationsEnabled,
+  stripeInvoicePaidAutomationsEnabled,
   strapiIntegrationEnabled,
   webhookTierEligible,
 }: {
@@ -4844,6 +4981,7 @@ function AutomationCreateMenu({
   readonly googleFormsWorkflowAutomationsEnabled: boolean;
   readonly googleMeetAutomationsEnabled: boolean;
   readonly notionWorkflowAutomationsEnabled: boolean;
+  readonly stripeInvoicePaidAutomationsEnabled: boolean;
   readonly strapiIntegrationEnabled: boolean;
   readonly webhookTierEligible: boolean;
 }) {
@@ -4858,6 +4996,7 @@ function AutomationCreateMenu({
     googleFormsWorkflowAutomationsEnabled,
     googleMeetAutomationsEnabled,
     notionWorkflowAutomationsEnabled,
+    stripeInvoicePaidAutomationsEnabled,
     strapiIntegrationEnabled,
     webhookTierEligible,
   });
@@ -5657,6 +5796,220 @@ function StrapiAutomationForm({
   );
 }
 
+function selectedStripeBillingReasons(
+  form: FormData,
+): StripeInvoiceBillingReason[] {
+  return STRIPE_INVOICE_BILLING_REASONS.filter((reason) => {
+    return form.has(reason);
+  });
+}
+
+function StripeBillingReasonFields({
+  creating,
+}: {
+  readonly creating: boolean;
+}) {
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-sm font-medium text-foreground">
+        {i18n.t(($) => {
+          return $.workflows.automations.stripe.billingReasons;
+        })}
+      </legend>
+      <p className="text-xs text-muted-foreground">
+        {i18n.t(($) => {
+          return $.workflows.automations.stripe.billingReasonsHint;
+        })}
+      </p>
+      <div className="grid grid-cols-1 gap-2 rounded-lg border border-border/60 bg-muted/20 p-3 sm:grid-cols-2">
+        {STRIPE_INVOICE_BILLING_REASONS.map((reason) => {
+          return (
+            <label
+              key={reason}
+              className="flex min-w-0 items-start gap-2 rounded-md px-2 py-1.5 hover:bg-background"
+            >
+              <Checkbox
+                name={reason}
+                disabled={creating}
+                className="mt-0.5 shrink-0"
+              />
+              <span className="text-sm text-foreground">
+                {stripeBillingReasonLabel(reason)}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+function StripeAutomationCreateError({
+  message,
+}: {
+  readonly message: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+    >
+      <div className="flex items-start gap-2">
+        <IconAlertTriangle size={16} stroke={1.5} className="mt-0.5 shrink-0" />
+        <p>{message}</p>
+      </div>
+      <Link
+        pathname={ROUTES.connectors}
+        className="w-fit font-medium underline underline-offset-2"
+      >
+        {i18n.t(($) => {
+          return $.workflows.automations.stripe.manageConnection;
+        })}
+      </Link>
+    </div>
+  );
+}
+
+function CreateStripeInvoicePaidAutomationDialog({
+  workflowId,
+  open,
+  onOpenChange,
+}: {
+  readonly workflowId: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [createLoadable, createAutomation] = useLoadableSet(
+    createWorkflowStripeInvoicePaidAutomation$,
+  );
+  const creating = createLoadable.state === "loading";
+  const createError =
+    createLoadable.state === "hasError"
+      ? createLoadable.error instanceof Error
+        ? createLoadable.error.message
+        : i18n.t(($) => {
+            return $.global.errors.requestFailed;
+          })
+      : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {i18n.t(($) => {
+              return $.workflows.automations.stripe.addTitle;
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {i18n.t(($) => {
+              return $.workflows.automations.stripe.addDescription;
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          aria-label={i18n.t(($) => {
+            return $.workflows.automations.stripe.addAria;
+          })}
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const billingReasons = selectedStripeBillingReasons(
+              new FormData(event.currentTarget),
+            );
+            detach(
+              (async () => {
+                await createAutomation(
+                  { workflowId, billingReasons },
+                  pageSignal,
+                );
+                onOpenChange(false);
+              })(),
+              Reason.DomCallback,
+              "create Stripe invoice-paid automation",
+            );
+          }}
+        >
+          <StripeBillingReasonFields creating={creating} />
+          {createError ? (
+            <StripeAutomationCreateError message={createError} />
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={creating}
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              {i18n.t(($) => {
+                return $.workflows.automations.common.cancel;
+              })}
+            </Button>
+            <Button type="submit" disabled={creating}>
+              {creating ? (
+                <IconLoader2 size={14} className="animate-spin" />
+              ) : (
+                <IconBrandStripe size={14} />
+              )}
+              {i18n.t(($) => {
+                return $.workflows.automations.stripe.addAction;
+              })}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function IntegrationAutomationCreateDialogs({
+  workflowId,
+  createDialog,
+  setCreateDialog,
+}: {
+  readonly workflowId: string;
+  readonly createDialog: WorkflowAutomationCreateDialog;
+  readonly setCreateDialog: (dialog: WorkflowAutomationCreateDialog) => void;
+}) {
+  const features = useGet(featureSwitch$);
+  const strapiIntegrationEnabled =
+    features[FeatureSwitchKey.StrapiIntegration] ?? false;
+
+  return (
+    <>
+      {createDialog === "stripe-invoice-paid" ? (
+        <CreateStripeInvoicePaidAutomationDialog
+          workflowId={workflowId}
+          open
+          onOpenChange={(open) => {
+            setCreateDialog(open ? "stripe-invoice-paid" : null);
+          }}
+        />
+      ) : null}
+      {strapiIntegrationEnabled ? (
+        <CreateStrapiEntryPublishedAutomationDialog
+          workflowId={workflowId}
+          open={createDialog === "strapi-entry-published"}
+          onOpenChange={(open) => {
+            setCreateDialog(open ? "strapi-entry-published" : null);
+          }}
+        />
+      ) : null}
+      <CreateWebhookAutomationDialog
+        workflowId={workflowId}
+        open={createDialog === "webhook"}
+        onOpenChange={(open) => {
+          setCreateDialog(open ? "webhook" : null);
+        }}
+      />
+      <WorkflowWebhookUpgradeDialog />
+    </>
+  );
+}
+
 function WorkflowAutomationCreateDialogs({
   workflowId,
   displayTimezone,
@@ -5668,10 +6021,6 @@ function WorkflowAutomationCreateDialogs({
   readonly createDialog: WorkflowAutomationCreateDialog;
   readonly setCreateDialog: (dialog: WorkflowAutomationCreateDialog) => void;
 }) {
-  const features = useGet(featureSwitch$);
-  const strapiIntegrationEnabled =
-    features[FeatureSwitchKey.StrapiIntegration] ?? false;
-
   return (
     <>
       <CreateIntervalAutomationDialog
@@ -5766,23 +6115,11 @@ function WorkflowAutomationCreateDialogs({
           setCreateDialog(open ? "notion-page-content-updated" : null);
         }}
       />
-      {strapiIntegrationEnabled ? (
-        <CreateStrapiEntryPublishedAutomationDialog
-          workflowId={workflowId}
-          open={createDialog === "strapi-entry-published"}
-          onOpenChange={(open) => {
-            setCreateDialog(open ? "strapi-entry-published" : null);
-          }}
-        />
-      ) : null}
-      <CreateWebhookAutomationDialog
+      <IntegrationAutomationCreateDialogs
         workflowId={workflowId}
-        open={createDialog === "webhook"}
-        onOpenChange={(open) => {
-          setCreateDialog(open ? "webhook" : null);
-        }}
+        createDialog={createDialog}
+        setCreateDialog={setCreateDialog}
       />
-      <WorkflowWebhookUpgradeDialog />
     </>
   );
 }
@@ -9101,6 +9438,78 @@ function CreateWebhookAutomationView({
   );
 }
 
+function stripeDeliveryStatusLabel(status: StripeDeliveryStatus): string {
+  switch (status) {
+    case "pending": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.deliveryStatus.pending;
+      });
+    }
+    case "delivered": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.deliveryStatus.delivered;
+      });
+    }
+    case "skipped": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.deliveryStatus.skipped;
+      });
+    }
+    case "failed": {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.deliveryStatus.failed;
+      });
+    }
+  }
+}
+
+function formatStripeHealthTimestamp(
+  value: string | null,
+  displayTimezone: string,
+): string | null {
+  if (!value || !hasValidRunTimestamp(value)) {
+    return null;
+  }
+  return new Date(value).toLocaleString(currentLocale(), {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: displayTimezone,
+  });
+}
+
+function stripeLastMatchingEventLabel(
+  automation: WorkflowStripeInvoicePaidAutomation,
+  displayTimezone: string,
+): string {
+  return (
+    formatStripeHealthTimestamp(
+      automation.health.lastMatchingEventReceivedAt,
+      displayTimezone,
+    ) ??
+    i18n.t(($) => {
+      return $.workflows.automations.stripe.noMatchingEvents;
+    })
+  );
+}
+
+function stripeLastDeliveryLabel(
+  automation: WorkflowStripeInvoicePaidAutomation,
+  displayTimezone: string,
+): string {
+  const status = automation.health.lastDeliveryStatus;
+  if (!status) {
+    return i18n.t(($) => {
+      return $.workflows.automations.stripe.noDeliveries;
+    });
+  }
+  const statusLabel = stripeDeliveryStatusLabel(status);
+  const timestamp = formatStripeHealthTimestamp(
+    automation.health.lastDeliveryStatusAt,
+    displayTimezone,
+  );
+  return timestamp ? `${statusLabel} · ${timestamp}` : statusLabel;
+}
+
 function AutomationRunStat({
   icon,
   label,
@@ -9132,6 +9541,73 @@ function AutomationRunStat({
   );
 }
 
+function AutomationRowStats({
+  automation,
+  displayTimezone,
+}: {
+  readonly automation: ZeroWorkflowAutomationSummary;
+  readonly displayTimezone: string;
+}) {
+  if (
+    automation.kind === "event" &&
+    automation.eventType === "stripe-invoice-paid"
+  ) {
+    return (
+      <>
+        <AutomationRunStat
+          icon={<IconHistory size={14} stroke={1.5} />}
+          label={i18n.t(($) => {
+            return $.workflows.automations.stripe.lastEvent;
+          })}
+          value={stripeLastMatchingEventLabel(automation, displayTimezone)}
+          emphasized={hasValidRunTimestamp(
+            automation.health.lastMatchingEventReceivedAt,
+          )}
+        />
+        <AutomationRunStat
+          icon={<IconCircleCheck size={14} stroke={1.5} />}
+          label={i18n.t(($) => {
+            return $.workflows.automations.stripe.delivery;
+          })}
+          value={stripeLastDeliveryLabel(automation, displayTimezone)}
+          emphasized={automation.health.lastDeliveryStatus !== null}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <AutomationRunStat
+        icon={<IconHistory size={14} stroke={1.5} />}
+        label={i18n.t(($) => {
+          return $.workflows.automations.schedule.last;
+        })}
+        value={formatWorkflowAutomationRun(
+          automation.lastRunAt,
+          displayTimezone,
+        )}
+        emphasized={hasValidRunTimestamp(automation.lastRunAt)}
+      />
+      {automation.kind === "schedule" ? (
+        <AutomationRunStat
+          icon={<IconClock size={14} stroke={1.5} />}
+          label={i18n.t(($) => {
+            return $.workflows.automations.schedule.next;
+          })}
+          value={formatWorkflowAutomationNextRun(
+            automation.nextRunAt,
+            displayTimezone,
+          )}
+          emphasized={hasValidRunTimestamp(automation.nextRunAt)}
+        />
+      ) : (
+        <div aria-hidden="true" />
+      )}
+    </>
+  );
+}
+
 function AutomationRow({
   automation,
   canManage,
@@ -9148,16 +9624,11 @@ function AutomationRow({
   const editing = editingAutomationId === automation.id;
   const title = workflowScheduleTitle(automation, displayTimezone);
   const subtitle = workflowAutomationSubtitle(automation);
-  const hasLastRun = hasValidRunTimestamp(automation.lastRunAt);
-  const hasNextRun = hasValidRunTimestamp(automation.nextRunAt);
-  const lastRunLabel = formatWorkflowAutomationRun(
-    automation.lastRunAt,
-    displayTimezone,
-  );
-  const nextRunLabel = formatWorkflowAutomationNextRun(
-    automation.nextRunAt,
-    displayTimezone,
-  );
+  const stripeAutomation =
+    automation.kind === "event" &&
+    automation.eventType === "stripe-invoice-paid"
+      ? automation
+      : null;
 
   return (
     <>
@@ -9186,26 +9657,10 @@ function AutomationRow({
             ) : null}
           </div>
         </div>
-        <AutomationRunStat
-          icon={<IconHistory size={14} stroke={1.5} />}
-          label={i18n.t(($) => {
-            return $.workflows.automations.schedule.last;
-          })}
-          value={lastRunLabel}
-          emphasized={hasLastRun}
+        <AutomationRowStats
+          automation={automation}
+          displayTimezone={displayTimezone}
         />
-        {automation.kind === "schedule" ? (
-          <AutomationRunStat
-            icon={<IconClock size={14} stroke={1.5} />}
-            label={i18n.t(($) => {
-              return $.workflows.automations.schedule.next;
-            })}
-            value={nextRunLabel}
-            emphasized={hasNextRun}
-          />
-        ) : (
-          <div aria-hidden="true" />
-        )}
         <AutomationStatusSwitch
           automation={automation}
           title={title}
@@ -9219,6 +9674,32 @@ function AutomationRow({
         ) : (
           <div aria-hidden="true" />
         )}
+        {stripeAutomation ? (
+          <div className="flex min-w-0 flex-col gap-1 text-xs text-muted-foreground sm:col-span-5">
+            <p>
+              {i18n.t(($) => {
+                return $.workflows.automations.stripe.immutableHint;
+              })}
+            </p>
+            {stripeAutomation.health.warning === "delivery_failed" ? (
+              <div
+                role="alert"
+                className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400"
+              >
+                <IconAlertTriangle
+                  size={14}
+                  stroke={1.5}
+                  className="mt-0.5 shrink-0"
+                />
+                <p>
+                  {i18n.t(($) => {
+                    return $.workflows.automations.stripe.deliveryWarning;
+                  })}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
       {showDivider ? (
         <div className="mx-5 h-px bg-border/50" aria-hidden="true" />

--- a/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
@@ -502,6 +502,11 @@ export function humanReadableAutomationRuleLabel(
       return $.workflows.automations.strapi.rule;
     });
   }
+  if (automation.eventType === "stripe-invoice-paid") {
+    return i18n.t(($) => {
+      return $.workflows.automations.stripe.rule;
+    });
+  }
   return gmailAutomationTitle(automation);
 }
 
@@ -584,6 +589,11 @@ export function automationTypeLabel(
   if (automation.eventType === "strapi-entry-published") {
     return i18n.t(($) => {
       return $.workflows.automations.types.strapi;
+    });
+  }
+  if (automation.eventType === "stripe-invoice-paid") {
+    return i18n.t(($) => {
+      return $.workflows.automations.types.stripe;
     });
   }
   if (automation.eventType === "chat-run-finished") {

--- a/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   IconBrandGithub,
+  IconBrandStripe,
   IconCalendarTime,
   IconClock,
   IconDatabasePlus,
@@ -649,6 +650,9 @@ export function AutomationListIcon({
     if (automation.eventType === "webhook-received") {
       return IconLink;
     }
+    if (automation.eventType === "stripe-invoice-paid") {
+      return IconBrandStripe;
+    }
     if (
       automation.eventType === "github-label-applied" ||
       automation.eventType === "github-deployment-status-created" ||
@@ -684,7 +688,9 @@ export function AutomationListIcon({
       ? "bg-blue-50 text-blue-600"
       : automation.eventType === "webhook-received"
         ? "bg-amber-50 text-amber-700"
-        : "bg-emerald-50 text-emerald-700";
+        : automation.eventType === "stripe-invoice-paid"
+          ? "bg-violet-50 text-violet-700"
+          : "bg-emerald-50 text-emerald-700";
 
   const compact = size === "sm";
   return (


### PR DESCRIPTION
## Summary

- add the feature-gated Stripe invoice-paid entry to the existing workflow automation picker
- create Stripe automations with an optional nine-value billing-reason filter while leaving OAuth readiness and immutable binding to the API
- render the immutable Stripe account, Live mode, configured filter, nullable event/delivery health, and generic terminal-delivery warning
- keep existing Stripe automations visible and manageable when the creation switch is off, without adding an edit path
- add focused page-boundary coverage and complete all ten Platform locales

## Design checkpoint

- Evidence and nine focused variants: https://gist.github.com/lancy/b1aa5bd86bc98b172270291fe8c3e42f
- Approval record: https://github.com/vm0-ai/vm0/issues/25698#issuecomment-5216341405
- Selected direction: A0, combining P1 (native Integrations picker card), S1 (compact nine-checkbox billing-reason grid), and H1 (row-first immutable binding and health cells)
- Confirmation: Lancy approved this direction in the Codex task on 2026-08-07 and directed implementation to proceed, superseding the earlier Ming-only wait

## Behavior and compatibility

- `StripeInvoicePaidWorkflowAutomations` hides only the creation entry; existing Stripe automations remain visible and retain enable, disable, and delete actions
- no connector, account, mode, secret, or livemode inputs are read by the client
- no API contract, API service, database, migration, connector, CLI, webhook, worker, switch default, or rollout configuration changes
- billing reasons remain immutable in the MVP; changing them requires delete and recreate

## Validation

- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app i18n:check`
- `pnpm --filter @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx` (62 passed)
- Prettier `--check` across all 14 modified files

Closes #25698
