### PR TITLE
fix(platform): wait for chat thread metadata before setup

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1621,6 +1621,7 @@
       "icon": "Chat-Thread-Symbol",
       "loadingEarlier": "Frühere Nachrichten werden geladen",
       "noEmojiFound": "Kein Emoji gefunden",
+      "notFound": "Chat-Thread nicht gefunden",
       "openArtifacts": "Artefakte öffnen",
       "openBrowser": "Browser öffnen",
       "openNamedAgent": "Agent {{name}} öffnen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1621,6 +1621,7 @@
       "icon": "Chat thread icon",
       "loadingEarlier": "Loading earlier messages",
       "noEmojiFound": "No emoji found",
+      "notFound": "Chat thread not found",
       "openArtifacts": "Open artifacts",
       "openBrowser": "Open browser",
       "openNamedAgent": "Open agent {{name}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1661,6 +1661,7 @@
       "icon": "Icono del hilo de chat",
       "loadingEarlier": "Cargando mensajes anteriores",
       "noEmojiFound": "No se ha encontrado ningún emoji",
+      "notFound": "Hilo de chat no encontrado",
       "openArtifacts": "Abrir artefactos",
       "openBrowser": "Abrir navegador",
       "openNamedAgent": "Abrir agente {{name}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1661,6 +1661,7 @@
       "icon": "Icône de fil de discussion",
       "loadingEarlier": "Chargement des messages précédents",
       "noEmojiFound": "Aucun emoji trouvé",
+      "notFound": "Fil de discussion introuvable",
       "openArtifacts": "Ouvrir les artéfacts",
       "openBrowser": "Ouvrir le navigateur",
       "openNamedAgent": "Ouvrir l'agent {{name}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1621,6 +1621,7 @@
       "icon": "चैट थ्रेड आइकन",
       "loadingEarlier": "पहले के संदेश लोड हो रहे हैं",
       "noEmojiFound": "कोई इमोजी नहीं मिला",
+      "notFound": "चैट थ्रेड नहीं मिला",
       "openArtifacts": "आर्टिफ़ैक्ट खोलें",
       "openBrowser": "खुला ब्राउज़र",
       "openNamedAgent": "ओपन एजेंट {{name}}",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1620,6 +1620,7 @@
       "icon": "Ikon thread chat",
       "loadingEarlier": "Memuat pesan sebelumnya",
       "noEmojiFound": "Emoji tidak ditemukan",
+      "notFound": "Utas chat tidak ditemukan",
       "openArtifacts": "Buka artefak",
       "openBrowser": "Buka browser",
       "openNamedAgent": "Buka agen {{name}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1661,6 +1661,7 @@
       "icon": "Icona del thread di chat",
       "loadingEarlier": "Caricamento dei messaggi precedenti",
       "noEmojiFound": "Nessuna emoji trovata",
+      "notFound": "Conversazione non trovata",
       "openArtifacts": "Artefatti aperti",
       "openBrowser": "Apri il browser",
       "openNamedAgent": "Apri agente {{name}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1620,6 +1620,7 @@
       "icon": "チャットスレッドアイコン",
       "loadingEarlier": "以前のメッセージを読み込んでいます",
       "noEmojiFound": "絵文字が見つかりませんでした",
+      "notFound": "チャットスレッドが見つかりません",
       "openArtifacts": "オープンアーティファクト",
       "openBrowser": "ブラウザを開く",
       "openNamedAgent": "エージェント {{name}} を開く",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1620,6 +1620,7 @@
       "icon": "채팅 스레드 아이콘",
       "loadingEarlier": "이전 메시지 불러오는 중",
       "noEmojiFound": "이모지가 없습니다",
+      "notFound": "채팅 스레드를 찾을 수 없습니다",
       "openArtifacts": "아티팩트 열기",
       "openBrowser": "브라우저 열기",
       "openNamedAgent": "에이전트 {{name}} 열기",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1661,6 +1661,7 @@
       "icon": "Ícone da conversa",
       "loadingEarlier": "Carregando mensagens anteriores",
       "noEmojiFound": "Nenhum emoji encontrado",
+      "notFound": "Conversa não encontrada",
       "openArtifacts": "Abrir artefatos",
       "openBrowser": "Abrir navegador",
       "openNamedAgent": "Abrir agente {{name}}",

--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -4,7 +4,6 @@ import { ZeroChatThreadPage } from "../../views/zero-page/zero-chat-thread-page.
 import { updatePage$ } from "../react-router.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { searchParams$ } from "../route.ts";
 import {
   SIDEBAR_PARAM,
@@ -46,7 +45,6 @@ export const setupChatPage$ = command(async ({ set }, signal: AbortSignal) => {
   await Promise.all([
     set(onboardGuard$, signal),
     set(internalSetupChatPage$, signal),
-    set(hideAppSkeleton$, signal),
   ]);
   signal.throwIfAborted();
 });

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -19,8 +19,9 @@ import { chatIdb$ } from "../external/chat-idb-store.ts";
 import { logger } from "../log.ts";
 import { reloadChatActiveRunIdsCounter$ } from "../chat-thread-list-reload.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { rootSignal$ } from "../root-signal.ts";
 import { pathParams$ } from "../route.ts";
-import { bestEffort } from "../utils.ts";
+import { bestEffort, createDeferredPromise } from "../utils.ts";
 import { i18n } from "../../i18n/index.ts";
 import type {
   ChatThreadEventView,
@@ -87,6 +88,22 @@ const chatThreadEventState$ = state<ChatThreadEventState>({
   events: [],
   latestEventId: null,
   latestSeqId: null,
+});
+
+const initialLocalChatThreadEventsLoadedDeferred$ = computed((get) => {
+  return createDeferredPromise<void>(get(rootSignal$));
+});
+
+const initialRemoteChatThreadEventsSyncedDeferred$ = computed((get) => {
+  return createDeferredPromise<void>(get(rootSignal$));
+});
+
+export const initialLocalChatThreadEventsLoaded$ = computed((get) => {
+  return get(initialLocalChatThreadEventsLoadedDeferred$).promise;
+});
+
+export const initialRemoteChatThreadEventsSynced$ = computed((get) => {
+  return get(initialRemoteChatThreadEventsSyncedDeferred$).promise;
 });
 
 const optimisticChatThreadCreateIds$ = computed((get): ReadonlySet<string> => {
@@ -302,6 +319,10 @@ const initializeChatThreadEventState$ = command(
       events: state.events,
     });
     set(syncCurrentChatThreadDocumentTitle$, signal);
+    const loaded = get(initialLocalChatThreadEventsLoadedDeferred$);
+    if (!loaded.settled()) {
+      loaded.resolve();
+    }
   },
 );
 
@@ -322,33 +343,43 @@ const syncChatThreadEvents$ = command(
       signal,
     );
     signal.throwIfAborted();
+    let result: ChatThreadEventSyncResult;
     if (!update) {
-      return {
+      result = {
         eventCount: state.events.length,
         snapshotReplaced: false,
       };
+    } else {
+      const persistableNewEvents = update.newEvents;
+      if (update.replacementSnapshot) {
+        await store.writeStore.replaceFromSnapshot(
+          update.replacementSnapshot,
+          persistableNewEvents,
+          signal,
+        );
+      } else {
+        await store.writeStore.upsertEvents(persistableNewEvents, signal);
+      }
+      signal.throwIfAborted();
+      set(chatThreadEventState$, update.state);
+      set(reconcileOptimisticChatThreadEvents$, {
+        snapshot: update.state.snapshot?.chatThreads ?? [],
+        events: update.state.events,
+      });
+      set(syncCurrentChatThreadDocumentTitle$, signal);
+      result = {
+        eventCount: update.state.events.length,
+        snapshotReplaced: update.replacementSnapshot !== null,
+      };
     }
 
-    const persistableNewEvents = update.newEvents;
-    if (update.replacementSnapshot) {
-      await store.writeStore.replaceFromSnapshot(
-        update.replacementSnapshot,
-        persistableNewEvents,
-        signal,
-      );
-    } else {
-      await store.writeStore.upsertEvents(persistableNewEvents, signal);
+    if (mode === "incremental") {
+      const synced = get(initialRemoteChatThreadEventsSyncedDeferred$);
+      if (!synced.settled()) {
+        synced.resolve();
+      }
     }
-    set(chatThreadEventState$, update.state);
-    set(reconcileOptimisticChatThreadEvents$, {
-      snapshot: update.state.snapshot?.chatThreads ?? [],
-      events: update.state.events,
-    });
-    set(syncCurrentChatThreadDocumentTitle$, signal);
-    return {
-      eventCount: update.state.events.length,
-      snapshotReplaced: update.replacementSnapshot !== null,
-    };
+    return result;
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -5,6 +5,7 @@ import type {
   UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { currentChatThreadId$ } from "../agent-chat.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { logger } from "../log.ts";
 import {
   detachedNavigateTo$,
@@ -21,6 +22,11 @@ import {
 import { createCachedChatPanelSignals$ } from "./create-chat-thread.ts";
 import { createChatEventSignals } from "./chat-event-signals.ts";
 import type { ChatPanelSignals } from "./chat-panel-signals.ts";
+import {
+  initialLocalChatThreadEventsLoaded$,
+  initialRemoteChatThreadEventsSynced$,
+  threadMeta,
+} from "./chat-thread-event-sourcing.ts";
 import {
   currentLeftThread$,
   currentRightThread$,
@@ -64,6 +70,7 @@ export const unloadRightThread$ = command(({ get, set }) => {
 interface PaneSpec {
   setPaneThread$: Command<void, [ChatPanelSignals | null]>;
   resetSetupSignal$: ReturnType<typeof resetSignal>;
+  onReady$?: Command<void, [AbortSignal]>;
 }
 
 interface RestoredDraftState {
@@ -171,9 +178,23 @@ const resolvePaneThread$ = command(
   },
 );
 
+const waitForThreadMetaResolution$ = command(
+  async ({ get }, threadId: string, signal: AbortSignal): Promise<void> => {
+    await get(initialLocalChatThreadEventsLoaded$);
+    signal.throwIfAborted();
+
+    if (get(threadMeta(threadId))) {
+      return;
+    }
+
+    await get(initialRemoteChatThreadEventsSynced$);
+    signal.throwIfAborted();
+  },
+);
+
 const setupPaneThread$ = command(
   async (
-    { set },
+    { get, set },
     spec: PaneSpec,
     threadId: string,
     parentSignal: AbortSignal,
@@ -181,6 +202,8 @@ const setupPaneThread$ = command(
     const signal = set(spec.resetSetupSignal$, parentSignal);
 
     L.debug("setupPaneThread$ start", { threadId });
+    await set(waitForThreadMetaResolution$, threadId, signal);
+    signal.throwIfAborted();
 
     const chatEvents = createChatEventSignals(threadId);
     const { thread, isNew } = set(
@@ -189,6 +212,13 @@ const setupPaneThread$ = command(
       signal,
     );
     set(spec.setPaneThread$, thread);
+    if (spec.onReady$) {
+      set(spec.onReady$, signal);
+    }
+
+    if (!get(thread.threadMeta$)) {
+      return;
+    }
 
     await set(
       resolvePaneThread$,
@@ -207,6 +237,9 @@ export const setupLeftThread$ = command(
     threadId: string,
     parentSignal: AbortSignal,
   ): Promise<void> => {
+    await set(waitForThreadMetaResolution$, threadId, parentSignal);
+    parentSignal.throwIfAborted();
+
     await Promise.all([
       set(syncPrimaryThread$, threadId, parentSignal),
       set(
@@ -214,6 +247,7 @@ export const setupLeftThread$ = command(
         {
           setPaneThread$: setCurrentLeftThread$,
           resetSetupSignal$: resetLeftSetupSignal$,
+          onReady$: hideAppSkeleton$,
         },
         threadId,
         parentSignal,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -180,6 +180,10 @@ const resolvePaneThread$ = command(
 
 const waitForThreadMetaResolution$ = command(
   async ({ get }, threadId: string, signal: AbortSignal): Promise<void> => {
+    if (get(threadMeta(threadId))) {
+      return;
+    }
+
     await get(initialLocalChatThreadEventsLoaded$);
     signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -16,8 +16,41 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { Markdown } from "../markdown.tsx";
 
 const context = testContext();
+const THREAD_ID = "eb000000-0000-4000-a000-000000000001";
 
-function mockThread(content: string): void {
+function threadSnapshot(id: string, title: string) {
+  return {
+    id,
+    agentId: "c0000000-0000-4000-a000-000000000001",
+    title,
+    sortAt: "2026-01-01T00:00:00Z",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    pinnedAt: null,
+    renamedAt: null,
+    selectedModel: null,
+    serviceTier: null,
+    computerUseHostId: null,
+  };
+}
+
+function mockThread(
+  content: string,
+  additionalThreads: ReturnType<typeof threadSnapshot>[] = [],
+): void {
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: [
+        threadSnapshot(THREAD_ID, "Markdown thread"),
+        ...additionalThreads,
+      ],
+      latestEventId: null,
+      latestSeqId: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+    return respond(200, { events: [], hasMore: false });
+  });
   context.mocks.api(
     chatThreadEventsContract.list,
     ({ params, query, respond }) => {
@@ -129,7 +162,10 @@ describe("assistant markdown", () => {
   it("renders formatted text and follows theme changes", async () => {
     mockThread("**bold text**");
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
 
     await waitFor(() => {
       expect(
@@ -159,7 +195,10 @@ describe("assistant markdown", () => {
   it("shows a raw style block as text instead of styling the page", async () => {
     mockThread("<style>\n.zero-injected { color: red }\n</style>");
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
 
     await waitFor(() => {
       expect(document.querySelector(".wmde-markdown")?.textContent).toContain(
@@ -178,7 +217,10 @@ describe("assistant markdown", () => {
   it("keeps allowlisted html blocks rendering as elements", async () => {
     mockThread("<div><strong>kept markup</strong></div>");
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
 
     const kept = await screen.findByText("kept markup", { selector: "strong" });
     expect(kept).toBeInTheDocument();
@@ -189,7 +231,10 @@ describe("assistant markdown", () => {
     const videoSrc = "https://example.com/clip.mp4";
     mockThread(`[cat](${imageSrc})\n\n[clip](${videoSrc})`);
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
 
     await waitFor(() => {
       const img = document.querySelector(`img[src="${imageSrc}"]`);
@@ -209,7 +254,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     // The diagram is shown by an <img>, so the SVG itself never reaches the
@@ -239,7 +284,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     // Copies share one result entry. Mounting the second must not reset that
@@ -262,7 +307,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     const settingsDialog = await openSettingsDialog();
@@ -297,7 +342,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     const inlineDiagram = await screen.findByAltText("Diagram");
@@ -347,7 +392,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     const artifactsButton = await waitFor(() => {
@@ -395,35 +440,13 @@ describe("assistant markdown", () => {
   it("revokes a mermaid object URL when its chat panel signal aborts", async () => {
     const objectUrls = context.mocks.browser.blobDownload();
     const replacementThreadId = "c0000000-0000-4000-a000-000000000002";
-    mockThread("```mermaid\nflowchart TD\n  A --> B\n```");
-    context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
-      return respond(200, {
-        chatThreads: [
-          {
-            id: replacementThreadId,
-            agentId: "c0000000-0000-4000-a000-000000000001",
-            title: "Replacement thread",
-            sortAt: "2026-01-01T00:00:01Z",
-            createdAt: "2026-01-01T00:00:01Z",
-            updatedAt: "2026-01-01T00:00:01Z",
-            pinnedAt: null,
-            renamedAt: null,
-            selectedModel: null,
-            serviceTier: null,
-            computerUseHostId: null,
-          },
-        ],
-        latestEventId: null,
-        latestSeqId: null,
-      });
-    });
-    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
-      return respond(200, { events: [], hasMore: false });
-    });
+    mockThread("```mermaid\nflowchart TD\n  A --> B\n```", [
+      threadSnapshot(replacementThreadId, "Replacement thread"),
+    ]);
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     const diagram = await screen.findByAltText("Diagram");
@@ -454,7 +477,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     await waitFor(() => {
@@ -471,7 +494,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     const diagram = await screen.findByAltText("Diagram");
@@ -485,7 +508,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     await waitFor(() => {
@@ -506,7 +529,10 @@ describe("assistant markdown", () => {
   it("keeps external links safe", async () => {
     mockThread("[example](https://example.com)");
 
-    detachedSetupPage({ context, path: "/chats/thread-markdown" });
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
 
     await waitFor(() => {
       const link = queryAllByRoleFast("link").find((el) => {
@@ -535,7 +561,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     await waitFor(() => {
@@ -561,7 +587,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     await waitFor(() => {
@@ -586,7 +612,7 @@ describe("assistant markdown", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-markdown",
+      path: `/chats/${THREAD_ID}`,
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import {
   chatThreadByIdContract,
   chatThreadEventsContract,
+  chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   zeroBillingConcurrencyCheckoutContract,
@@ -21,7 +22,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
-const THREAD_ID = "thread-queue";
+const THREAD_ID = "ea000000-0000-4000-a000-000000000001";
 
 function queuedEntry(): QueueEntry {
   return {
@@ -84,6 +85,30 @@ function mockConcurrencyCapability(canBuyConcurrency: boolean): void {
 }
 
 function mockQueuedThread(): void {
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: [
+        {
+          id: THREAD_ID,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          title: "Queued thread",
+          sortAt: "2026-01-01T00:00:02Z",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:02Z",
+          pinnedAt: null,
+          renamedAt: null,
+          selectedModel: null,
+          serviceTier: null,
+          computerUseHostId: null,
+        },
+      ],
+      latestEventId: null,
+      latestSeqId: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+    return respond(200, { events: [], hasMore: false });
+  });
   context.mocks.api(chatThreadEventsContract.list, ({ query, respond }) => {
     if (query.sinceSeqId !== undefined || query.beforeSeqId !== undefined) {
       return respond(200, { events: [] });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
@@ -36,7 +36,7 @@ import {
 
 describe("chat lifecycle", () => {
   it("shows billing recovery guidance when credits are depleted", async () => {
-    const threadId = "failed-guidance-credits";
+    const threadId = "e1000000-0000-4000-a000-000000000001";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
     context.mocks.api(
       zeroBillingCheckoutContract.create,
@@ -66,7 +66,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows Pro upgrade guidance when built-in video requires Pro", async () => {
-    const threadId = "failed-guidance-video-pro";
+    const threadId = "e1000000-0000-4000-a000-000000000002";
     mockFailedAssistantThread({ threadId, error: "pro_required" });
     context.mocks.api(
       zeroBillingCheckoutContract.create,
@@ -96,7 +96,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows Pro upgrade guidance for limited-free-1 even with credits", async () => {
-    const threadId = "failed-guidance-limited-free";
+    const threadId = "e1000000-0000-4000-a000-000000000003";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
     context.mocks.data.org({
       id: "org_1",
@@ -153,7 +153,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows admin-only billing guidance when a member runs out of credits", async () => {
-    const threadId = "failed-guidance-member-credits";
+    const threadId = "e1000000-0000-4000-a000-000000000004";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
     context.mocks.data.org({
       id: "org_1",
@@ -177,7 +177,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows that chat can continue when credits become available", async () => {
-    const threadId = "failed-guidance-restored-credits";
+    const threadId = "e1000000-0000-4000-a000-000000000005";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
     context.mocks.data.org({
       id: "org_1",
@@ -220,7 +220,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows paid credit top-ups when a paid workspace runs out of credits", async () => {
-    const threadId = "failed-guidance-paid-credits";
+    const threadId = "e1000000-0000-4000-a000-000000000006";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
     context.mocks.data.org({
       id: "org_1",
@@ -289,7 +289,7 @@ describe("chat lifecycle", () => {
   });
 
   it("uses the plan capability when a paid tier cannot buy credits", async () => {
-    const threadId = "failed-guidance-capability-blocked-credits";
+    const threadId = "e1000000-0000-4000-a000-000000000007";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
     context.mocks.data.org({
       id: "org_1",
@@ -331,7 +331,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows credit top-ups when a Custom workspace runs out of credits", async () => {
-    const threadId = "failed-guidance-custom-credits";
+    const threadId = "e1000000-0000-4000-a000-000000000008";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
     context.mocks.data.org({
       id: "org_1",
@@ -390,7 +390,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows model-provider setup guidance from failed assistant messages", async () => {
-    const threadId = "failed-guidance-provider";
+    const threadId = "e1000000-0000-4000-a000-000000000009";
     mockFailedAssistantThread({
       threadId,
       error: "No model provider configured",
@@ -409,7 +409,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows restart guidance for incompatible provider sessions", async () => {
-    const threadId = "failed-guidance-incompatible";
+    const threadId = "e1000000-0000-4000-a000-000000000010";
     mockFailedAssistantThread({
       threadId,
       error: "Cannot continue session with the selected provider",
@@ -426,7 +426,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows restart guidance for deleted provider sessions", async () => {
-    const threadId = "failed-guidance-deleted";
+    const threadId = "e1000000-0000-4000-a000-000000000011";
     mockFailedAssistantThread({
       threadId,
       error: "Model provider unavailable",
@@ -445,7 +445,7 @@ describe("chat lifecycle", () => {
   });
 
   it("renders generic assistant failures as markdown", async () => {
-    const threadId = "failed-guidance-generic";
+    const threadId = "e1000000-0000-4000-a000-000000000012";
     mockFailedAssistantThread({
       threadId,
       error: "Unexpected **tool** failure",
@@ -620,7 +620,7 @@ describe("chat lifecycle", () => {
 });
 describe("initial thinking indicator", () => {
   it("renders the latest run thinking marker inside the thinking indicator", async () => {
-    const threadId = "thread-initial-thinking";
+    const threadId = "e1000000-0000-4000-a000-000000000013";
     mockChatLifecycle(context, {
       threadId,
       chatEvents: [
@@ -656,7 +656,7 @@ describe("initial thinking indicator", () => {
   });
 
   it("renders the thinking marker before thread detail resolves", async () => {
-    const threadId = "thread-initial-thinking-thread-detail-gated";
+    const threadId = "e1000000-0000-4000-a000-000000000014";
     const threadGate = context.mocks.deferred<void>();
     mockChatLifecycle(context, {
       threadId,
@@ -693,7 +693,7 @@ describe("initial thinking indicator", () => {
   });
 
   it("restarts on every follow-up line instead of sliding a short tail", async () => {
-    const threadId = "thread-initial-thinking-rollover";
+    const threadId = "e1000000-0000-4000-a000-000000000015";
     const thinking = "ABCDEFG";
     mockThinkingTypewriterLayout({
       text: thinking,
@@ -775,7 +775,7 @@ describe("initial thinking indicator", () => {
   });
 
   it("shows every explicit thinking line in sequence", async () => {
-    const threadId = "thread-initial-thinking-multiline";
+    const threadId = "e1000000-0000-4000-a000-000000000016";
     const thinking = "ONE\nTWO\nTHREE";
     mockThinkingTypewriterLayout({
       text: thinking,
@@ -857,7 +857,7 @@ describe("initial thinking indicator", () => {
   });
 
   it("keeps the thinking marker visible while a later Morning Brief is queued", async () => {
-    const threadId = "thread-initial-thinking-with-queue";
+    const threadId = "e1000000-0000-4000-a000-000000000017";
     mockChatLifecycle(context, {
       threadId,
       chatEvents: [
@@ -909,7 +909,7 @@ describe("initial thinking indicator", () => {
   });
 
   it("hides the thinking marker when the same run has assistant text", async () => {
-    const threadId = "thread-initial-thinking-answer";
+    const threadId = "e1000000-0000-4000-a000-000000000018";
     mockChatLifecycle(context, {
       threadId,
       chatEvents: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -2488,8 +2488,10 @@ describe("chat composer models", () => {
       path: `/chats/${THREAD_ID}?sidebar=${OTHER_AGENT_THREAD_ID}`,
     });
 
-    const threadRegions = await screen.findAllByLabelText("Chat thread");
-    expect(threadRegions).toHaveLength(2);
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Chat thread")).toHaveLength(2);
+    });
+    const threadRegions = screen.getAllByLabelText("Chat thread");
     await waitFor(() => {
       expect(authorizationRequestCount).toBe(1);
     });
@@ -2603,8 +2605,10 @@ describe("chat composer models", () => {
       },
     });
 
-    const threadRegions = await screen.findAllByLabelText("Chat thread");
-    expect(threadRegions).toHaveLength(2);
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Chat thread")).toHaveLength(2);
+    });
+    const threadRegions = screen.getAllByLabelText("Chat thread");
     const sideThread = threadRegions[1];
     if (!sideThread) {
       throw new Error("Side chat thread not found");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -458,7 +458,7 @@ describe("chat lifecycle", () => {
 
   it("opens the Computer Use download dialog from the chat composer", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "computer-use-download";
+    const threadId = "e2000000-0000-4000-a000-000000000001";
     mockChatLifecycle(context, { threadId });
     context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
       return respond(200, { hosts: [] });
@@ -501,7 +501,7 @@ describe("chat lifecycle", () => {
   it("blocks the Computer Use download dialog on Intel Macs", async () => {
     mockMacUserAgentData("x86");
     const user = userEvent.setup({ delay: null });
-    const threadId = "computer-use-download-intel";
+    const threadId = "e2000000-0000-4000-a000-000000000002";
     mockChatLifecycle(context, { threadId });
     context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
       return respond(200, { hosts: [] });
@@ -532,7 +532,7 @@ describe("chat lifecycle", () => {
 
   it("does not auto-select the only online Computer Use host", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "computer-use-manual-selection";
+    const threadId = "e2000000-0000-4000-a000-000000000003";
     let sentComputerUseHostId: string | null | undefined;
     mockChatLifecycle(context, {
       threadId,
@@ -586,7 +586,7 @@ describe("chat lifecycle", () => {
 
   it("refreshes computers when the computer-use hosts Ably event arrives", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "computer-use-refresh";
+    const threadId = "e2000000-0000-4000-a000-000000000004";
     let hostOnline = true;
     let requestCount = 0;
     mockChatLifecycle(context, { threadId });
@@ -852,7 +852,7 @@ describe("chat lifecycle", () => {
 
   it("shows a computer use empty state when host listing is unavailable", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "computer-use-forbidden";
+    const threadId = "e2000000-0000-4000-a000-000000000005";
     mockChatLifecycle(context, { threadId });
     context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
       return respond(403, {
@@ -881,7 +881,7 @@ describe("chat lifecycle", () => {
 
   it("transcribes voice input into the composer", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "voice-input-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000006";
     const draftPatches: unknown[] = [];
     const toastError = vi.spyOn(toast, "error");
     context.mocks.browser.voiceInput({ rms: 0.1 });
@@ -1070,7 +1070,7 @@ describe("chat lifecycle", () => {
 
   it("transcribes a voice input segment after silence while recording", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "voice-input-segment-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000007";
     const draftPatches: unknown[] = [];
     const uploadedAudio: string[] = [];
     const transcriptionRequested = context.mocks.deferred<void>();
@@ -1138,7 +1138,7 @@ describe("chat lifecycle", () => {
 
   it("uploads voice input segments one at a time", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "voice-input-serialized-segments-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000008";
     const firstRequestStarted = context.mocks.deferred<void>();
     const releaseFirstRequest = context.mocks.deferred<void>();
     const speechResumed = context.mocks.deferred<void>();
@@ -1221,7 +1221,7 @@ describe("chat lifecycle", () => {
 
   it("automatically stops voice input after extended silence", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "voice-input-auto-stop-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000009";
     let transcriptionCalls = 0;
     context.mocks.browser.voiceInput({ rms: [0.1, 0.1, 0, 0, 0] });
     mockChatLifecycle(context, { threadId });
@@ -1255,7 +1255,7 @@ describe("chat lifecycle", () => {
 
   it("appends a delayed voice input segment to the current composer text", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "voice-input-append-current-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000010";
     const transcriptionReady = context.mocks.deferred<void>();
     const transcriptionRequested = context.mocks.deferred<void>();
     context.mocks.browser.voiceInput({ rms: [0.1, 0.1, 0, 0, 0] });
@@ -1293,7 +1293,7 @@ describe("chat lifecycle", () => {
 
   it("shows voice input starting state while the browser opens the microphone", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "voice-input-starting-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000011";
     const micReady = context.mocks.deferred<void>();
     context.mocks.browser.voiceInput({
       getUserMediaReady: micReady.promise,
@@ -1323,7 +1323,7 @@ describe("chat lifecycle", () => {
 
   it("starts recording before the voice activity monitor is ready", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "voice-input-monitor-pending-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000012";
     const audioReady = context.mocks.deferred<void>();
     context.mocks.browser.voiceInput({
       audioContextReady: audioReady.promise,
@@ -1364,7 +1364,7 @@ describe("chat lifecycle", () => {
 
   it("cancels silent voice input without calling transcription", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "silent-voice-input-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000013";
     context.mocks.browser.voiceInput({ rms: 0 });
     mockChatLifecycle(context, { threadId });
     let transcriptionCalled = false;
@@ -1399,7 +1399,7 @@ describe("chat lifecycle", () => {
   it("opens billing recovery when voice input quota is depleted", async () => {
     const user = userEvent.setup({ delay: null });
     const toastError = vi.spyOn(toast, "error");
-    const threadId = "voice-input-quota-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000014";
     context.mocks.browser.voiceInput({ rms: 0.1 });
     mockChatLifecycle(context, { threadId });
     context.mocks.http.post("*/api/zero/voice-io/stt", () => {
@@ -1454,7 +1454,7 @@ describe("chat lifecycle", () => {
   it("opens billing recovery before recording when voice input quota is already depleted", async () => {
     const user = userEvent.setup({ delay: null });
     const toastError = vi.spyOn(toast, "error");
-    const threadId = "voice-input-preflight-quota-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000015";
     let transcriptionCalls = 0;
     context.mocks.browser.voiceInput({ rms: 0.1 });
     mockChatLifecycle(context, { threadId });
@@ -1495,7 +1495,7 @@ describe("chat lifecycle", () => {
   it("opens billing recovery when voice input daily request limit is reached", async () => {
     const user = userEvent.setup({ delay: null });
     const toastError = vi.spyOn(toast, "error");
-    const threadId = "voice-input-daily-rate-thread";
+    const threadId = "e2000000-0000-4000-a000-000000000016";
     context.mocks.browser.voiceInput({ rms: 0.1 });
     mockChatLifecycle(context, { threadId });
     context.mocks.http.post("*/api/zero/voice-io/stt", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -614,7 +614,7 @@ describe("chat drafts", () => {
       });
     });
 
-    detachedSetupPage({ context, path: "/chats/thread-server-draft" });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ONE_ID}` });
 
     await waitFor(() => {
       expect(textarea()).toHaveTextContent("Review the saved launch brief");
@@ -1448,15 +1448,16 @@ describe("chat drafts", () => {
 
   it("keeps pasted plain text inline at the caret", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "thread-plain-text-paste";
+    const threadId = "e3000000-0000-4000-a000-000000000001";
 
     mockChatLifecycle(context, { threadId });
 
     detachedSetupPage({ context, path: `/chats/${threadId}` });
 
-    const editor = await findComposerEditor();
+    let editor = await findComposerEditor();
+    await fillComposer(editor, "Before after");
+    editor = await findComposerEditor();
     await user.click(editor);
-    await user.keyboard("Before after");
     await user.keyboard(
       "{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}",
     );
@@ -1483,15 +1484,16 @@ describe("chat drafts", () => {
 
   it("joins multiline prompt items only at the paste boundaries", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "thread-multiline-paste";
+    const threadId = "e3000000-0000-4000-a000-000000000002";
 
     mockChatLifecycle(context, { threadId });
 
     detachedSetupPage({ context, path: `/chats/${threadId}` });
 
-    const editor = await findComposerEditor();
+    let editor = await findComposerEditor();
+    await fillComposer(editor, "Before after");
+    editor = await findComposerEditor();
     await user.click(editor);
-    await user.keyboard("Before after");
     await user.keyboard(
       "{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}",
     );
@@ -1525,7 +1527,7 @@ describe("chat drafts", () => {
 
   it("restores copied chat text and attachments from the clipboard", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "thread-copied-attachment";
+    const threadId = "e3000000-0000-4000-a000-000000000003";
     const pastedText = "Please use the copied brief";
     const filename = "product-brief.md";
 
@@ -1569,7 +1571,7 @@ describe("chat drafts", () => {
 
   it("falls back to plain text when copied chat html only carries attachments", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "thread-copied-attachment-plain-fallback";
+    const threadId = "e3000000-0000-4000-a000-000000000004";
     const pastedText = "123";
     const filename = "image.png";
     const url =
@@ -1623,7 +1625,7 @@ describe("chat drafts", () => {
 
   it("preserves multiline copied chat text when attachments prevent default paste", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "thread-copied-attachment-slash-composer";
+    const threadId = "e3000000-0000-4000-a000-000000000005";
     const pastedText = `first\n[Thread 1](/chats/${THREAD_ONE_ID})\nlast `;
     const filename = "image.png";
     const url =
@@ -1639,9 +1641,10 @@ describe("chat drafts", () => {
       path: `/chats/${threadId}`,
     });
 
-    const editor = await findComposerEditor();
+    let editor = await findComposerEditor();
+    await fillComposer(editor, "Before after");
+    editor = await findComposerEditor();
     await user.click(editor);
-    await user.keyboard("Before after");
     await user.keyboard(
       "{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}",
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -45,7 +45,7 @@ import { PLACEHOLDER, mockChatLifecycle } from "./chat-test-helpers.ts";
 const context = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
-const THREAD_ID = "thread-action-cards";
+const THREAD_ID = "e4000000-0000-4000-a000-000000000001";
 
 function catalogPermissionDetail(
   overrides: Partial<PublicConnectorCatalogPermissionDetail> &
@@ -308,7 +308,7 @@ function selectMailText(element: HTMLElement): void {
 
 describe("chat event action cards", () => {
   it("keeps connector action card height stable while catalog metadata loads", async () => {
-    const threadId = `${THREAD_ID}-connector-loading-height`;
+    const threadId = "e4000000-0000-4000-a000-000000000002";
     const connectorUrl = `${window.location.origin}/connectors/slack/authorize?agentId=${AGENT_ID}`;
     let catalogRequestStarted = false;
     let resolveCatalog = (): void => {
@@ -367,7 +367,7 @@ describe("chat event action cards", () => {
 
   it("keeps sent mail card height stable without exposing follow-up", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = `${THREAD_ID}-mail-loading-height`;
+    const threadId = "e4000000-0000-4000-a000-000000000003";
     const mailDraftId = "c0000000-0000-4000-a000-000000000091";
     const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
     const createdAt = "2026-07-30T10:00:00.000Z";
@@ -891,7 +891,7 @@ describe("chat event action cards", () => {
 
   it("renders canonical user text literally and assistant actions on alternate origins", async () => {
     const previousUrl = window.location.href;
-    const threadId = `${THREAD_ID}-alternate-production-origin`;
+    const threadId = "e4000000-0000-4000-a000-000000000004";
     window.location.href = `https://app.okou.ai/chats/${threadId}`;
     context.signal.addEventListener(
       "abort",
@@ -990,11 +990,27 @@ describe("chat event action cards", () => {
         },
       });
     });
-    mockChatLifecycle(context, {
+    const lifecycle = mockChatLifecycle(context, {
       threadId: leftThreadId,
       threadTitle: "Left chat",
       chatEvents: [],
     });
+    lifecycle.setThreadList([
+      {
+        id: leftThreadId,
+        title: "Left chat",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt,
+        updatedAt: createdAt,
+      },
+      {
+        id: rightThreadId,
+        title: "Right chat",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt,
+        updatedAt: createdAt,
+      },
+    ]);
     context.mocks.api(
       chatThreadEventsContract.list,
       ({ params, query, respond }) => {
@@ -1159,7 +1175,7 @@ describe("chat event action cards", () => {
 
   it("preserves assistant copy and reconnects an expired connector", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = `${THREAD_ID}-reconnect`;
+    const threadId = "e4000000-0000-4000-a000-000000000005";
     const callbackPrompt = "Retry the Gmail draft after reconnecting";
     const connectorUrl = `${window.location.origin}/connectors/gmail/connect?agentId=${AGENT_ID}&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
     const assistantCopy = `Gmail needs to be reconnected. [Reconnect Gmail](${connectorUrl}) to continue creating the draft.`;
@@ -1287,7 +1303,7 @@ describe("chat event action cards", () => {
 
   it("connects a single OAuth connector directly and resumes the chat", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = `${THREAD_ID}-direct-oauth`;
+    const threadId = "e4000000-0000-4000-a000-000000000006";
     const callbackPrompt = "Re-check GitHub access, then continue";
     const connectorUrl = `${window.location.origin}/connectors/github/authorize?agentId=${AGENT_ID}&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
     const sentPrompts: string[] = [];
@@ -1405,7 +1421,7 @@ describe("chat event action cards", () => {
 
   it("enables a single no-auth connector directly", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = `${THREAD_ID}-direct-no-auth`;
+    const threadId = "e4000000-0000-4000-a000-000000000007";
     const connectorUrl = `${window.location.origin}/connectors/stripe/authorize?agentId=${AGENT_ID}`;
     let connected = false;
     let authorized = false;
@@ -2032,7 +2048,7 @@ describe("chat event action cards", () => {
       },
     );
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-multiple-permissions`,
+      threadId: "e4000000-0000-4000-a000-000000000008",
       threadTitle: "Multiple permission cards",
       chatEvents: [
         {
@@ -2054,7 +2070,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-multiple-permissions`,
+      path: "/chats/e4000000-0000-4000-a000-000000000008",
     });
 
     const permissionCards = await screen.findAllByTestId(
@@ -2124,7 +2140,7 @@ describe("chat event action cards", () => {
   it("runs a permission callback prompt after the grant is confirmed", async () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
-    const threadId = `${THREAD_ID}-single-permission`;
+    const threadId = "e4000000-0000-4000-a000-000000000009";
     const callbackPrompt = "Re-check Slack access, then continue";
     const permissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=slack&permission=channels.read&action=allow&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
     const sentPrompts: {
@@ -2222,7 +2238,7 @@ describe("chat event action cards", () => {
 
   it("runs a connector callback prompt after authorization", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = `${THREAD_ID}-single-connector`;
+    const threadId = "e4000000-0000-4000-a000-000000000010";
     const callbackPrompt = "Re-check GitHub access, then continue";
     const connectorUrl = `${window.location.origin}/connectors/github/authorize?agentId=${AGENT_ID}&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
     const sentPrompts: string[] = [];
@@ -2298,7 +2314,7 @@ describe("chat event action cards", () => {
       }),
     ]);
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-hidden-connector-metadata`,
+      threadId: "e4000000-0000-4000-a000-000000000011",
       threadTitle: "Hidden connector metadata",
       chatEvents: [
         {
@@ -2320,7 +2336,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-hidden-connector-metadata`,
+      path: "/chats/e4000000-0000-4000-a000-000000000011",
     });
 
     const userMessage = await screen.findByText(
@@ -2399,7 +2415,7 @@ describe("chat event action cards", () => {
       },
     );
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-future-connector`,
+      threadId: "e4000000-0000-4000-a000-000000000012",
       threadTitle: "Future connector",
       chatEvents: [
         {
@@ -2421,7 +2437,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-future-connector`,
+      path: "/chats/e4000000-0000-4000-a000-000000000012",
     });
 
     const connectorCard = await screen.findByTestId("connector-action-card");
@@ -2468,7 +2484,7 @@ describe("chat event action cards", () => {
       },
     );
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-hidden-permission-metadata`,
+      threadId: "e4000000-0000-4000-a000-000000000013",
       threadTitle: "Hidden permission metadata",
       chatEvents: [
         {
@@ -2490,7 +2506,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-hidden-permission-metadata`,
+      path: "/chats/e4000000-0000-4000-a000-000000000013",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -2530,7 +2546,7 @@ describe("chat event action cards", () => {
       return respond(200, []);
     });
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-already-allowed-permission`,
+      threadId: "e4000000-0000-4000-a000-000000000014",
       threadTitle: "Permission already allowed",
       chatEvents: [
         {
@@ -2552,7 +2568,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-already-allowed-permission`,
+      path: "/chats/e4000000-0000-4000-a000-000000000014",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -2605,7 +2621,7 @@ describe("chat event action cards", () => {
       ]);
     });
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-expired-allowed-permission`,
+      threadId: "e4000000-0000-4000-a000-000000000015",
       threadTitle: "Expired permission allow",
       chatEvents: [
         {
@@ -2627,7 +2643,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-expired-allowed-permission`,
+      path: "/chats/e4000000-0000-4000-a000-000000000015",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -2672,7 +2688,7 @@ describe("chat event action cards", () => {
       return respond(200, []);
     });
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-already-denied-permission`,
+      threadId: "e4000000-0000-4000-a000-000000000016",
       threadTitle: "Permission already denied",
       chatEvents: [
         {
@@ -2694,7 +2710,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-already-denied-permission`,
+      path: "/chats/e4000000-0000-4000-a000-000000000016",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -2735,7 +2751,7 @@ describe("chat event action cards", () => {
       );
     });
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-permission-updated-event`,
+      threadId: "e4000000-0000-4000-a000-000000000017",
       threadTitle: "Permission updated event",
       chatEvents: [
         {
@@ -2757,7 +2773,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-permission-updated-event`,
+      path: "/chats/e4000000-0000-4000-a000-000000000017",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -2825,7 +2841,7 @@ describe("chat event action cards", () => {
     );
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-custom-connector`,
+      threadId: "e4000000-0000-4000-a000-000000000018",
       threadTitle: "Custom connector card",
       chatEvents: [
         {
@@ -2847,7 +2863,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-custom-connector`,
+      path: "/chats/e4000000-0000-4000-a000-000000000018",
     });
 
     const card = await screen.findByTestId("connector-action-card");
@@ -2874,7 +2890,7 @@ describe("chat event action cards", () => {
   it("leaves legacy custom connector proposal links as markdown", async () => {
     const proposalUrl = `${window.location.origin}/connectors/custom/proposal?p=legacy`;
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-custom-connector-proposal`,
+      threadId: "e4000000-0000-4000-a000-000000000019",
       threadTitle: "Legacy custom connector proposal",
       chatEvents: [
         {
@@ -2889,7 +2905,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-custom-connector-proposal`,
+      path: "/chats/e4000000-0000-4000-a000-000000000019",
     });
 
     const legacyProposal = await screen.findByText("Legacy proposal");
@@ -2902,7 +2918,7 @@ describe("chat event action cards", () => {
       "https://app.vm0.ai/computer-use/authorize/vm0_computer_use_authorization_request_test";
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-computer-use-authorization`,
+      threadId: "e4000000-0000-4000-a000-000000000020",
       threadTitle: "Computer Use authorization card",
       chatEvents: [
         {
@@ -2924,7 +2940,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-computer-use-authorization`,
+      path: "/chats/e4000000-0000-4000-a000-000000000020",
     });
 
     const card = await screen.findByTestId("computer-use-authorization-card");
@@ -2954,7 +2970,7 @@ describe("chat event action cards", () => {
     const creditUrl = "/?settings=billing&billingView=credits";
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-plan-upgrade`,
+      threadId: "e4000000-0000-4000-a000-000000000021",
       threadTitle: "Plan upgrade cards",
       chatEvents: [
         {
@@ -2981,7 +2997,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-plan-upgrade`,
+      path: "/chats/e4000000-0000-4000-a000-000000000021",
     });
 
     const cards = await screen.findAllByTestId("plan-upgrade-card");
@@ -3164,7 +3180,7 @@ describe("chat event action cards", () => {
       },
     );
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-permission-load-retry`,
+      threadId: "e4000000-0000-4000-a000-000000000022",
       threadTitle: "Permission load retry",
       chatEvents: [
         {
@@ -3186,7 +3202,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-permission-load-retry`,
+      path: "/chats/e4000000-0000-4000-a000-000000000022",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -3244,7 +3260,7 @@ describe("chat event action cards", () => {
     );
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-permission-status-loading`,
+      threadId: "e4000000-0000-4000-a000-000000000023",
       threadTitle: "Permission status loading",
       chatEvents: [
         {
@@ -3266,7 +3282,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-permission-status-loading`,
+      path: "/chats/e4000000-0000-4000-a000-000000000023",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -3306,7 +3322,7 @@ describe("chat event action cards", () => {
     });
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-permission-load-forbidden`,
+      threadId: "e4000000-0000-4000-a000-000000000024",
       threadTitle: "Permission load forbidden",
       chatEvents: [
         {
@@ -3328,7 +3344,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-permission-load-forbidden`,
+      path: "/chats/e4000000-0000-4000-a000-000000000024",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -3366,7 +3382,7 @@ describe("chat event action cards", () => {
     });
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-permission-save-error`,
+      threadId: "e4000000-0000-4000-a000-000000000025",
       threadTitle: "Permission save error",
       chatEvents: [
         {
@@ -3388,7 +3404,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-permission-save-error`,
+      path: "/chats/e4000000-0000-4000-a000-000000000025",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -3592,7 +3608,7 @@ describe("chat event action cards", () => {
       },
     );
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-duration`,
+      threadId: "e4000000-0000-4000-a000-000000000026",
       threadTitle: "Permission duration",
       chatEvents: [
         {
@@ -3614,7 +3630,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-duration`,
+      path: "/chats/e4000000-0000-4000-a000-000000000026",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -3679,7 +3695,7 @@ describe("chat event action cards", () => {
       },
     );
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-unknown-permission`,
+      threadId: "e4000000-0000-4000-a000-000000000027",
       threadTitle: "Unknown permission",
       chatEvents: [
         {
@@ -3701,7 +3717,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-unknown-permission`,
+      path: "/chats/e4000000-0000-4000-a000-000000000027",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
@@ -3775,7 +3791,7 @@ describe("chat event action cards", () => {
     );
 
     mockChatLifecycle(context, {
-      threadId: `${THREAD_ID}-deny`,
+      threadId: "e4000000-0000-4000-a000-000000000028",
       threadTitle: "Permission action",
       chatEvents: [
         {
@@ -3797,7 +3813,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: `/chats/${THREAD_ID}-deny`,
+      path: "/chats/e4000000-0000-4000-a000-000000000028",
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -785,7 +785,7 @@ describe("chat lifecycle", () => {
   it("renders the latest chat groups first and prepends older in-memory groups near the top", async () => {
     mockResizeObserver();
     let markReadCalls = 0;
-    const threadId = "render-window-thread";
+    const threadId = "e5000000-0000-4000-a000-000000000001";
     const chatEvents: ChatEvent[] = Array.from({ length: 24 }, (_, index) => {
       return {
         id: `render-window-message-${index}`,
@@ -848,7 +848,7 @@ describe("chat lifecycle", () => {
   });
 
   it("counts a folded tail run group as one item in the initial chat window", async () => {
-    const threadId = "render-window-tail-run-group";
+    const threadId = "e5000000-0000-4000-a000-000000000002";
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Tail run group window",
@@ -884,7 +884,7 @@ describe("chat lifecycle", () => {
   });
 
   it("labels folded runs from their userMessage projection", async () => {
-    const threadId = "structured-run-group-label";
+    const threadId = "e5000000-0000-4000-a000-000000000003";
     const messages = makeRunGroupMessages({
       label: "legacy run label",
       count: 2,
@@ -933,7 +933,7 @@ describe("chat lifecycle", () => {
   });
 
   it("keeps the item before a folded middle run group in the initial chat window", async () => {
-    const threadId = "render-window-middle-run-group";
+    const threadId = "e5000000-0000-4000-a000-000000000004";
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Middle run group window",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -116,7 +116,7 @@ async function setupKeyboardGestureChat({
 
 describe("chat lifecycle", () => {
   it("links Slack-origin user messages back to the original message", async () => {
-    const threadId = "thread-slack-message-origin";
+    const threadId = "e6000000-0000-4000-a000-000000000001";
     const permalink =
       "https://vm0.slack.com/archives/C12345678/p1753257600000100";
     mockChatLifecycle(context, {
@@ -181,7 +181,7 @@ describe("chat lifecycle", () => {
   });
 
   it("links Feishu-origin user messages back to the original chat", async () => {
-    const threadId = "thread-feishu-message-origin";
+    const threadId = "e6000000-0000-4000-a000-000000000002";
     const chatOpenUrl =
       "https://applink.feishu.cn/client/chat/open?openChatId=oc_feishu_chat";
     mockChatLifecycle(context, {
@@ -244,7 +244,7 @@ describe("chat lifecycle", () => {
   });
 
   it("renders generic source annotations with precise link behavior", async () => {
-    const threadId = "thread-generic-message-annotations";
+    const threadId = "e6000000-0000-4000-a000-000000000003";
     const teamsHref =
       "https://teams.microsoft.com/l/message/19%3Achannel%40thread.tacv2/activity-1?tenantId=tenant-1";
     const githubHref =
@@ -942,7 +942,7 @@ describe("chat lifecycle", () => {
   });
 
   it("renders user html-like text literally", async () => {
-    const threadId = "thread-user-html-like-text";
+    const threadId = "e6000000-0000-4000-a000-000000000004";
     mockChatLifecycle(context, {
       threadId,
       chatEvents: [
@@ -970,7 +970,7 @@ describe("chat lifecycle", () => {
 
   it("ignores usage-only pages for rendering and thinking state", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-usage-only",
+      threadId: "e6000000-0000-4000-a000-000000000005",
       chatEvents: [
         {
           id: "msg-usage-only",
@@ -996,7 +996,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-usage-only",
+      path: "/chats/e6000000-0000-4000-a000-000000000005",
     });
 
     await waitFor(() => {
@@ -1007,7 +1007,7 @@ describe("chat lifecycle", () => {
 
   it("shows thinking for an assistant run even without active run ids", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-message-list-thinking",
+      threadId: "e6000000-0000-4000-a000-000000000006",
       activeRunIds: [],
       chatEvents: [
         {
@@ -1023,7 +1023,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-message-list-thinking",
+      path: "/chats/e6000000-0000-4000-a000-000000000006",
     });
 
     await waitFor(() => {
@@ -1037,7 +1037,7 @@ describe("chat lifecycle", () => {
   it("shows thinking from loaded messages before thread metadata resolves", async () => {
     const threadGate = context.mocks.deferred<void>();
     mockChatLifecycle(context, {
-      threadId: "thread-message-list-thinking-pending-metadata",
+      threadId: "e6000000-0000-4000-a000-000000000007",
       activeRunIds: ["run-message-list-thinking-pending-metadata"],
       threadGate: threadGate.promise,
       chatEvents: [
@@ -1054,7 +1054,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-message-list-thinking-pending-metadata",
+      path: "/chats/e6000000-0000-4000-a000-000000000007",
     });
 
     await screen.findByText("I am still working on this.");
@@ -1069,7 +1069,7 @@ describe("chat lifecycle", () => {
 
   it("clears thinking when the same run completes even with stale active run ids", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-message-list-completed",
+      threadId: "e6000000-0000-4000-a000-000000000008",
       activeRunIds: ["run-message-list-completed"],
       chatEvents: [
         {
@@ -1092,7 +1092,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-message-list-completed",
+      path: "/chats/e6000000-0000-4000-a000-000000000008",
     });
 
     await waitFor(() => {
@@ -1104,7 +1104,7 @@ describe("chat lifecycle", () => {
 
   it("clears thinking for a completed latest run with an older terminated run", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-stale-run-before-completed-latest-run",
+      threadId: "e6000000-0000-4000-a000-000000000009",
       activeRunIds: [],
       chatEvents: [
         {
@@ -1158,7 +1158,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-stale-run-before-completed-latest-run",
+      path: "/chats/e6000000-0000-4000-a000-000000000009",
     });
 
     await waitFor(() => {
@@ -1172,7 +1172,7 @@ describe("chat lifecycle", () => {
 
   it("ignores active run ids when loaded messages end at a completed run", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-stale-lifecycle-thinking",
+      threadId: "e6000000-0000-4000-a000-000000000010",
       activeRunIds: ["run-r2"],
       chatEvents: [
         {
@@ -1229,7 +1229,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-stale-lifecycle-thinking",
+      path: "/chats/e6000000-0000-4000-a000-000000000010",
     });
 
     await waitFor(() => {
@@ -1242,7 +1242,7 @@ describe("chat lifecycle", () => {
 
   it("keeps thinking when the message stream shows later run activity", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-stale-lifecycle-thinking-active-later",
+      threadId: "e6000000-0000-4000-a000-000000000011",
       activeRunIds: ["run-r2"],
       chatEvents: [
         {
@@ -1307,7 +1307,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-stale-lifecycle-thinking-active-later",
+      path: "/chats/e6000000-0000-4000-a000-000000000011",
     });
 
     await waitFor(() => {
@@ -1374,7 +1374,7 @@ describe("chat lifecycle", () => {
   });
 
   it("keeps completion when the loaded window does not include either run start", async () => {
-    const threadId = "thread-run-starts-outside-loaded-window";
+    const threadId = "e6000000-0000-4000-a000-000000000012";
     mockChatLifecycle(context, {
       threadId,
       activeRunIds: ["run-window-older-active"],
@@ -1422,7 +1422,7 @@ describe("chat lifecycle", () => {
 
   it("does not use active run ids to revive an older run after a newer run completes", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-concurrent-run-completed-later",
+      threadId: "e6000000-0000-4000-a000-000000000013",
       activeRunIds: ["run-concurrent-active"],
       chatEvents: [
         {
@@ -1468,7 +1468,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-concurrent-run-completed-later",
+      path: "/chats/e6000000-0000-4000-a000-000000000013",
     });
 
     await waitFor(() => {
@@ -1482,7 +1482,7 @@ describe("chat lifecycle", () => {
 
   it("keeps thinking for an active run when the message stream shows later activity", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-concurrent-run-active-later",
+      threadId: "e6000000-0000-4000-a000-000000000014",
       activeRunIds: ["run-concurrent-active"],
       chatEvents: [
         {
@@ -1536,7 +1536,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-concurrent-run-active-later",
+      path: "/chats/e6000000-0000-4000-a000-000000000014",
     });
 
     await waitFor(() => {
@@ -1552,7 +1552,7 @@ describe("chat lifecycle", () => {
 
   it("does not use active run ids when active messages are outside the loaded window", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-active-run-outside-loaded-window",
+      threadId: "e6000000-0000-4000-a000-000000000015",
       activeRunIds: ["run-active-outside-window"],
       chatEvents: [
         {
@@ -1568,7 +1568,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-active-run-outside-loaded-window",
+      path: "/chats/e6000000-0000-4000-a000-000000000015",
     });
 
     await waitFor(() => {
@@ -1579,7 +1579,7 @@ describe("chat lifecycle", () => {
 
   it("keeps interleaved run messages grouped by run turn", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-interleaved-run-turns",
+      threadId: "e6000000-0000-4000-a000-000000000016",
       chatEvents: [
         {
           id: "msg-run-a-user",
@@ -1637,7 +1637,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-interleaved-run-turns",
+      path: "/chats/e6000000-0000-4000-a000-000000000016",
     });
 
     await waitFor(() => {
@@ -1655,7 +1655,7 @@ describe("chat lifecycle", () => {
 
   it("shows thinking when the latest message is a user message", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-message-list-latest-user",
+      threadId: "e6000000-0000-4000-a000-000000000017",
       activeRunIds: [],
       chatEvents: [
         {
@@ -1670,7 +1670,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-message-list-latest-user",
+      path: "/chats/e6000000-0000-4000-a000-000000000017",
     });
 
     await waitFor(() => {
@@ -1683,7 +1683,7 @@ describe("chat lifecycle", () => {
 
   it("clears thinking when a run is cancelled", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-message-list-cancelled",
+      threadId: "e6000000-0000-4000-a000-000000000018",
       activeRunIds: ["run-message-list-cancelled"],
       chatEvents: [
         {
@@ -1707,7 +1707,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-message-list-cancelled",
+      path: "/chats/e6000000-0000-4000-a000-000000000018",
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -37,7 +37,7 @@ afterEach(async () => {
 describe("chat lifecycle", () => {
   it("keeps budget inputs out of the visible transcript", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-budget-input-visibility",
+      threadId: "e7000000-0000-4000-a000-000000000001",
       chatEvents: [
         {
           id: "msg-budget-input-user",
@@ -68,7 +68,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-budget-input-visibility",
+      path: "/chats/e7000000-0000-4000-a000-000000000001",
     });
 
     await expect(
@@ -84,7 +84,7 @@ describe("chat lifecycle", () => {
 
   it("shows run credit usage with friendly popover details", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-usage-chip",
+      threadId: "e7000000-0000-4000-a000-000000000002",
       chatEvents: [
         {
           id: "msg-usage-chip-user",
@@ -134,7 +134,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-usage-chip",
+      path: "/chats/e7000000-0000-4000-a000-000000000002",
     });
 
     const credit = await waitFor(() => {
@@ -194,7 +194,7 @@ describe("chat lifecycle", () => {
       );
     });
     mockChatLifecycle(context, {
-      threadId: "thread-limited-free-usage-chip",
+      threadId: "e7000000-0000-4000-a000-000000000003",
       chatEvents: [
         {
           id: "msg-limited-free-usage-user",
@@ -239,7 +239,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-limited-free-usage-chip",
+      path: "/chats/e7000000-0000-4000-a000-000000000003",
     });
 
     click(await screen.findByLabelText("Credit usage 330"));
@@ -256,7 +256,7 @@ describe("chat lifecycle", () => {
 
   it("shows generation usage with model names only", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-generation-usage-model-names",
+      threadId: "e7000000-0000-4000-a000-000000000004",
       chatEvents: [
         {
           id: "msg-generation-usage-user",
@@ -306,7 +306,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-generation-usage-model-names",
+      path: "/chats/e7000000-0000-4000-a000-000000000004",
     });
 
     const credit = await screen.findByLabelText("Credit usage 1,976");
@@ -331,7 +331,7 @@ describe("chat lifecycle", () => {
 
   it("shows the latest immutable run usage settlement", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-usage-chip-settlements",
+      threadId: "e7000000-0000-4000-a000-000000000005",
       chatEvents: [
         {
           id: "msg-usage-settlement-user",
@@ -395,7 +395,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-usage-chip-settlements",
+      path: "/chats/e7000000-0000-4000-a000-000000000005",
     });
 
     await expect(
@@ -408,7 +408,7 @@ describe("chat lifecycle", () => {
     document.documentElement.lang = "pt-BR";
     await initializeI18n("pt-BR");
     mockChatLifecycle(context, {
-      threadId: "thread-usage-chip-folded-managed-api",
+      threadId: "e7000000-0000-4000-a000-000000000006",
       chatEvents: [
         {
           id: "msg-usage-folded-user",
@@ -488,7 +488,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-usage-chip-folded-managed-api",
+      path: "/chats/e7000000-0000-4000-a000-000000000006",
     });
 
     await expect(
@@ -521,7 +521,7 @@ describe("chat lifecycle", () => {
 
   it("keeps connector usage attached to consecutive assistant runs", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-usage-chip-consecutive-runs",
+      threadId: "e7000000-0000-4000-a000-000000000007",
       chatEvents: [
         {
           id: "msg-usage-consecutive-user",
@@ -603,7 +603,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-usage-chip-consecutive-runs",
+      path: "/chats/e7000000-0000-4000-a000-000000000007",
     });
 
     await expect(
@@ -721,7 +721,7 @@ describe("chat lifecycle", () => {
 
   it("keeps chat work visible while the run is active", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-running",
+      threadId: "e7000000-0000-4000-a000-000000000008",
       activeRunIds: ["run-work-folding-running"],
       chatEvents: [
         {
@@ -741,7 +741,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-running",
+      path: "/chats/e7000000-0000-4000-a000-000000000008",
     });
 
     await waitFor(() => {
@@ -757,7 +757,7 @@ describe("chat lifecycle", () => {
 
   it("keeps completed chat work folded while a later run is active", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-completed-before-active",
+      threadId: "e7000000-0000-4000-a000-000000000009",
       activeRunIds: ["run-work-folding-active-later"],
       chatEvents: [
         {
@@ -796,7 +796,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-completed-before-active",
+      path: "/chats/e7000000-0000-4000-a000-000000000009",
     });
 
     const expandButtons = await screen.findAllByLabelText(
@@ -821,7 +821,7 @@ describe("chat lifecycle", () => {
 
   it("folds completed chat work and toggles the hidden history", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-completed",
+      threadId: "e7000000-0000-4000-a000-000000000010",
       chatEvents: [
         {
           role: "user",
@@ -847,7 +847,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-completed",
+      path: "/chats/e7000000-0000-4000-a000-000000000010",
     });
 
     const expandButton = await screen.findByLabelText("Expand work history");
@@ -912,6 +912,7 @@ describe("chat lifecycle", () => {
     {
       name: "splits one completed run into folds at user boundaries",
       caseId: "two-folds",
+      threadId: "e7000000-0000-4000-a000-000000000023",
       sequence: ["U1", "A2", "A3", "A4", "U2", "A5", "A6", "A7", "A8"],
       visibleOrder: [
         "U1",
@@ -938,6 +939,7 @@ describe("chat lifecycle", () => {
     {
       name: "keeps one assistant before a trailing user unfolded",
       caseId: "single-assistant-before-user",
+      threadId: "e7000000-0000-4000-a000-000000000024",
       sequence: ["U1", "A2", "U2"],
       visibleOrder: ["U1", "A2", "U2"],
       usageAssistant: "A2",
@@ -946,6 +948,7 @@ describe("chat lifecycle", () => {
     {
       name: "folds earlier assistant work before a trailing user",
       caseId: "fold-before-user",
+      threadId: "e7000000-0000-4000-a000-000000000025",
       sequence: ["U1", "A2", "A3", "U2"],
       visibleOrder: ["U1", "Worked for 20s", "A3", "U2"],
       usageAssistant: "A3",
@@ -960,6 +963,7 @@ describe("chat lifecycle", () => {
     {
       name: "keeps one assistant in each user phase unfolded",
       caseId: "single-assistant-per-phase",
+      threadId: "e7000000-0000-4000-a000-000000000026",
       sequence: ["U1", "A2", "U2", "A3"],
       visibleOrder: ["U1", "A2", "U2", "A3"],
       usageAssistant: "A3",
@@ -967,8 +971,14 @@ describe("chat lifecycle", () => {
     },
   ])(
     "$name",
-    async ({ caseId, sequence, visibleOrder, usageAssistant, folds }) => {
-      const threadId = `thread-work-folding-${caseId}`;
+    async ({
+      caseId,
+      threadId,
+      sequence,
+      visibleOrder,
+      usageAssistant,
+      folds,
+    }) => {
       const runId = `run-work-folding-${caseId}`;
       const chatEvents: MockChatEventInput[] = sequence.map(
         (content, index) => {
@@ -1086,7 +1096,7 @@ describe("chat lifecycle", () => {
     });
 
     mockChatLifecycle(context, {
-      threadId: "thread-completed-run-layout",
+      threadId: "e7000000-0000-4000-a000-000000000011",
       chatEvents: [
         {
           role: "user",
@@ -1131,7 +1141,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-completed-run-layout",
+      path: "/chats/e7000000-0000-4000-a000-000000000011",
     });
 
     const expandButton = await screen.findByLabelText("Expand work history");
@@ -1232,7 +1242,7 @@ describe("chat lifecycle", () => {
       });
       context.mocks.data.userPreferences({ locale });
       mockChatLifecycle(context, {
-        threadId: "thread-localized-completed-run",
+        threadId: "e7000000-0000-4000-a000-000000000012",
         chatEvents: [
           {
             role: "user",
@@ -1271,7 +1281,7 @@ describe("chat lifecycle", () => {
 
       detachedSetupPage({
         context,
-        path: "/chats/thread-localized-completed-run",
+        path: "/chats/e7000000-0000-4000-a000-000000000012",
       });
 
       await expect(
@@ -1294,7 +1304,7 @@ describe("chat lifecycle", () => {
       supportedLocales: ["en-US", "ja-JP"],
     });
     mockChatLifecycle(context, {
-      threadId: "thread-japanese-completed-run",
+      threadId: "e7000000-0000-4000-a000-000000000013",
       chatEvents: [
         {
           role: "user",
@@ -1333,7 +1343,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-japanese-completed-run",
+      path: "/chats/e7000000-0000-4000-a000-000000000013",
     });
 
     await expect(
@@ -1352,7 +1362,7 @@ describe("chat lifecycle", () => {
     });
     context.mocks.data.userPreferences({ locale: "es-ES" });
     mockChatLifecycle(context, {
-      threadId: "thread-spanish-completed-run",
+      threadId: "e7000000-0000-4000-a000-000000000014",
       chatEvents: [
         {
           role: "user",
@@ -1391,7 +1401,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-spanish-completed-run",
+      path: "/chats/e7000000-0000-4000-a000-000000000014",
     });
 
     await expect(
@@ -1402,7 +1412,7 @@ describe("chat lifecycle", () => {
 
   it("folds each completed run independently", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-each-run",
+      threadId: "e7000000-0000-4000-a000-000000000015",
       chatEvents: [
         {
           role: "user",
@@ -1447,7 +1457,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-each-run",
+      path: "/chats/e7000000-0000-4000-a000-000000000015",
     });
 
     const expandButtons = await screen.findAllByLabelText(
@@ -1508,7 +1518,7 @@ describe("chat lifecycle", () => {
 
   it("keeps chat work visible when the run was cancelled", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-cancelled",
+      threadId: "e7000000-0000-4000-a000-000000000016",
       chatEvents: [
         {
           role: "user",
@@ -1535,7 +1545,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-cancelled",
+      path: "/chats/e7000000-0000-4000-a000-000000000016",
     });
 
     await waitFor(() => {
@@ -1549,7 +1559,7 @@ describe("chat lifecycle", () => {
 
   it("does not fold a completed run with only a user message and final reply", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-user-final-only",
+      threadId: "e7000000-0000-4000-a000-000000000017",
       chatEvents: [
         {
           role: "user",
@@ -1569,7 +1579,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-user-final-only",
+      path: "/chats/e7000000-0000-4000-a000-000000000017",
     });
 
     await waitFor(() => {
@@ -1581,7 +1591,7 @@ describe("chat lifecycle", () => {
 
   it("does not fold a completed run when the only prior assistant message is thinking", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-thinking-only",
+      threadId: "e7000000-0000-4000-a000-000000000018",
       chatEvents: [
         {
           role: "user",
@@ -1608,7 +1618,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-thinking-only",
+      path: "/chats/e7000000-0000-4000-a000-000000000018",
     });
 
     await waitFor(() => {
@@ -1623,7 +1633,7 @@ describe("chat lifecycle", () => {
 
   it("does not fold a completed run with a single message", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-work-folding-single-message",
+      threadId: "e7000000-0000-4000-a000-000000000019",
       chatEvents: [
         {
           role: "assistant",
@@ -1637,7 +1647,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-work-folding-single-message",
+      path: "/chats/e7000000-0000-4000-a000-000000000019",
     });
 
     await waitFor(() => {
@@ -1648,7 +1658,7 @@ describe("chat lifecycle", () => {
 
   it("renders a server-corrected assistant message without the stale answer", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-corrected-answer",
+      threadId: "e7000000-0000-4000-a000-000000000020",
       threadTitle: "Corrected answer",
       chatEvents: [
         {
@@ -1678,7 +1688,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-corrected-answer",
+      path: "/chats/e7000000-0000-4000-a000-000000000020",
     });
 
     await waitFor(() => {
@@ -1693,7 +1703,7 @@ describe("chat lifecycle", () => {
 
   it("restores an interrupted run without duplicate cancellation rows", async () => {
     mockChatLifecycle(context, {
-      threadId: "thread-restored-interrupt",
+      threadId: "e7000000-0000-4000-a000-000000000021",
       threadTitle: "Restored interrupt",
       chatEvents: [
         {
@@ -1731,7 +1741,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/thread-restored-interrupt",
+      path: "/chats/e7000000-0000-4000-a000-000000000021",
     });
 
     await waitFor(() => {
@@ -1841,66 +1851,75 @@ describe("chat lifecycle", () => {
   it.each([
     {
       name: "Codex usage limit",
+      threadId: "e7000000-0000-4000-a000-000000000027",
       error:
         "You've hit your usage limit. Try again at 5:00 PM (Asia/Shanghai).",
       title: "Codex limit reached",
     },
     {
       name: "Claude Code session limit",
+      threadId: "e7000000-0000-4000-a000-000000000028",
       error: "You've hit your session limit · resets 5:00 PM (Asia/Shanghai)",
       title: "Claude Code limit reached",
     },
     {
       name: "Claude usage limit",
+      threadId: "e7000000-0000-4000-a000-000000000029",
       error:
         "Claude usage limit reached. Visit https://claude.ai/settings/usage or try again at 6:17 AM.",
       title: "Claude Code limit reached",
     },
     {
       name: "Codex model capacity",
+      threadId: "e7000000-0000-4000-a000-000000000030",
       error: "Selected model is at capacity. Please try a different model.",
       title: "Codex model is busy",
     },
     {
       name: "Claude Code model capacity",
+      threadId: "e7000000-0000-4000-a000-000000000031",
       error:
         "Claude Sonnet 4.6 is overloaded. Please wait a few minutes and try again, or switch to another model.",
       title: "Claude Code model is busy",
     },
-  ])("recognizes the latest $name error", async ({ name, error, title }) => {
-    const threadId = `thread-recovery-${name.replaceAll(" ", "-")}`;
-    mockChatLifecycle(context, {
-      threadId,
-      chatEvents: [
-        {
-          id: `${threadId}-user`,
-          role: "user",
-          content: "Continue",
-          runId: `${threadId}-run`,
-          createdAt: "2026-07-30T09:00:00Z",
-        },
-        {
-          id: `${threadId}-failure`,
-          role: "assistant",
-          content: null,
-          error,
-          runId: `${threadId}-run`,
-          runLifecycleEvent: "failed",
-          createdAt: "2026-07-30T09:00:01Z",
-        },
-      ],
-    });
+  ])(
+    "recognizes the latest $name error",
+    async ({ threadId, error, title }) => {
+      mockChatLifecycle(context, {
+        threadId,
+        chatEvents: [
+          {
+            id: `${threadId}-user`,
+            role: "user",
+            content: "Continue",
+            runId: `${threadId}-run`,
+            createdAt: "2026-07-30T09:00:00Z",
+          },
+          {
+            id: `${threadId}-failure`,
+            role: "assistant",
+            content: null,
+            error,
+            runId: `${threadId}-run`,
+            runLifecycleEvent: "failed",
+            createdAt: "2026-07-30T09:00:01Z",
+          },
+        ],
+      });
 
-    detachedSetupPage({
-      context,
-      featureSwitches: { [FeatureSwitchKey.ChatErrorRecovery]: true },
-      path: `/chats/${threadId}`,
-    });
+      detachedSetupPage({
+        context,
+        featureSwitches: { [FeatureSwitchKey.ChatErrorRecovery]: true },
+        path: `/chats/${threadId}`,
+      });
 
-    const recoveryTitle = await screen.findByText(title);
-    expect(recoveryTitle).toBeInTheDocument();
-    expect(screen.getByTestId("assistant-error-recovery")).toBeInTheDocument();
-  });
+      const recoveryTitle = await screen.findByText(title);
+      expect(recoveryTitle).toBeInTheDocument();
+      expect(
+        screen.getByTestId("assistant-error-recovery"),
+      ).toBeInTheDocument();
+    },
+  );
 
   it("shows limited-free recovery models with Pro gating", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000789";
@@ -2215,7 +2234,7 @@ describe("chat lifecycle", () => {
   });
 
   it("keeps the provider error unchanged when recovery is disabled", async () => {
-    const threadId = "thread-recovery-disabled";
+    const threadId = "e7000000-0000-4000-a000-000000000022";
     const error =
       "You've hit your usage limit. Try again at 5:00 PM (Asia/Shanghai).";
     mockChatLifecycle(context, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -1240,7 +1240,7 @@ describe("chat scroll position", () => {
   });
 
   it("preserves the visible anchor when older in-memory groups are prepended", async () => {
-    const threadId = "scroll-prepend-anchor";
+    const threadId = "e8000000-0000-4000-a000-000000000001";
     const chatEvents: ChatEvent[] = Array.from({ length: 24 }, (_, index) => {
       return {
         id: `prepend-anchor-${index}`,
@@ -1606,7 +1606,7 @@ describe("chat scroll position", () => {
   });
 
   it("preserves its visible anchor when composer or viewport resize changes layout", async () => {
-    const threadId = "scroll-resize-preserve";
+    const threadId = "e8000000-0000-4000-a000-000000000002";
     const events = simpleUserEvents(threadId, "resize-preserve", 8);
     let clientHeight = 300;
     let scrollHeight = 1000;
@@ -1675,7 +1675,7 @@ describe("chat scroll position", () => {
   });
 
   it("keeps following the tail when composer or viewport resize shortens it", async () => {
-    const threadId = "scroll-resize-follow";
+    const threadId = "e8000000-0000-4000-a000-000000000003";
     const events = simpleUserEvents(threadId, "resize-follow", 8);
     let clientHeight = 300;
     const resizeObserver = installResizeObserver();
@@ -1724,7 +1724,7 @@ describe("chat scroll position", () => {
 
   it("restores the visible anchor after entering and exiting sharing", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "scroll-sharing-transition";
+    const threadId = "e8000000-0000-4000-a000-000000000004";
     const events = simpleUserEvents(threadId, "sharing-transition", 8);
     const sharingActive = () => {
       return (

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -69,7 +69,31 @@ function modelSelectionFromBody(body: {
   return body.model === null ? null : modelFirstSelection(body.model);
 }
 
-export function mockSubagentThread(context: TestContext, _threadId: string) {
+export function mockSubagentThread(context: TestContext, threadId: string) {
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: [
+        {
+          id: threadId,
+          agentId: DEFAULT_AGENT_ID,
+          title: "Subagent thread",
+          sortAt: "2026-03-10T00:00:00Z",
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          pinnedAt: null,
+          renamedAt: null,
+          selectedModel: null,
+          serviceTier: null,
+          computerUseHostId: null,
+        },
+      ],
+      latestEventId: null,
+      latestSeqId: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+    return respond(200, { events: [], hasMore: false });
+  });
   context.mocks.data.team([
     {
       id: DEFAULT_AGENT_ID,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-indicator.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { context, detachedSetupPage } from "./chat-lifecycle-test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
-const THREAD_ID = "thread-thinking-indicator-chunks";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000210";
 const RUN_ID = "run-thinking-indicator-chunks";
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -48,7 +48,7 @@ import {
 
 describe("chat lifecycle", () => {
   it("does not render a rejected goal continuation after an assistant response", async () => {
-    const threadId = "thread-rejected-goal-artifact";
+    const threadId = "e9000000-0000-4000-a000-000000000001";
     const objectiveBrief = "Keep the launch moving";
     const machineReason = "internal provider credential id abc123 is invalid";
     const assistantResponse = "The active goal has been stopped.";
@@ -89,7 +89,7 @@ describe("chat lifecycle", () => {
 
   it("opens run logs from assistant message actions", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "message-run-logs-thread";
+    const threadId = "e9000000-0000-4000-a000-000000000002";
     const runId = "a0000000-0000-4000-a000-000000000001";
     const assistantReply = "The launch summary is ready to share.";
 
@@ -130,7 +130,7 @@ describe("chat lifecycle", () => {
 
   it("copies an assistant response from chat history", async () => {
     const clipboard = context.mocks.browser.clipboardWriteText();
-    const threadId = "assistant-copy-thread";
+    const threadId = "e9000000-0000-4000-a000-000000000003";
     const assistantReply = "The launch summary is ready to share.";
 
     mockChatLifecycle(context, {
@@ -175,7 +175,7 @@ describe("chat lifecycle", () => {
 
   it("starts a workflow prompt from the composer when the composer is empty", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "assistant-message-create-workflow-empty";
+    const threadId = "e9000000-0000-4000-a000-000000000004";
     const assistantReply = "We can turn this into a workflow.";
     mockWorkflowComposerWorkflows();
     mockChatLifecycle(context, {
@@ -240,7 +240,7 @@ describe("chat lifecycle", () => {
   });
 
   it("confirms before replacing an existing composer draft with a workflow prompt", async () => {
-    const threadId = "assistant-message-create-workflow-draft";
+    const threadId = "e9000000-0000-4000-a000-000000000005";
     const assistantReply = "This is a good workflow candidate.";
     const draft = "Keep this draft";
     mockWorkflowComposerWorkflows();
@@ -724,7 +724,7 @@ describe("chat lifecycle", () => {
 
   it("opens an active goal objective dialog from the goal row", async () => {
     const user = userEvent.setup({ delay: null });
-    const threadId = "thread-goal-dialog";
+    const threadId = "e9000000-0000-4000-a000-000000000006";
     mockChatLifecycle(context, {
       threadId,
       chatEvents: [
@@ -784,7 +784,7 @@ describe("chat lifecycle", () => {
   });
 
   it("hides the goal row once a completion marker folds in", async () => {
-    const threadId = "thread-goal-complete";
+    const threadId = "e9000000-0000-4000-a000-000000000007";
     mockChatLifecycle(context, {
       threadId,
       chatEvents: [
@@ -821,7 +821,7 @@ describe("chat lifecycle", () => {
   });
 
   it("folds non-goal runs that share a run group id", async () => {
-    const threadId = "thread-non-goal-run-group-folding";
+    const threadId = "e9000000-0000-4000-a000-000000000008";
     const runGroupId = "f0000001-0000-4000-a000-00000000071b";
 
     mockChatLifecycle(context, {
@@ -890,7 +890,7 @@ describe("chat lifecycle", () => {
   });
 
   it("surfaces archived goal history in the latest assistant row", async () => {
-    const threadId = "thread-goal-run-group-folding";
+    const threadId = "e9000000-0000-4000-a000-000000000009";
     const runGroupId = "f0000001-0000-4000-a000-00000000072b";
     const goalBrief = "Keep the release moving";
     const goalPrompt = `${goalBrief}
@@ -1006,7 +1006,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("keeps archived goal history below a running goal without assistant text", async () => {
-    const threadId = "thread-goal-run-group-folding-active";
+    const threadId = "e9000000-0000-4000-a000-000000000010";
     const runGroupId = "f0000001-0000-4000-a000-00000000082b";
     const goalBrief = "Migrate legacy automations";
     const goalPrompt = `${goalBrief}
@@ -1091,7 +1091,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("does not treat workflow run groups as goals", async () => {
-    const threadId = "thread-workflow-run-group-folding";
+    const threadId = "e9000000-0000-4000-a000-000000000011";
     const runGroupId = "f0000001-0000-4000-a000-00000000073b";
     const workflowPrompt = "/daily-workflow";
     const workflowUserMessage = {
@@ -1165,7 +1165,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("keeps a paused latest workflow run group collapsed by default", async () => {
-    const threadId = "thread-paused-workflow-run-group";
+    const threadId = "e9000000-0000-4000-a000-000000000012";
     const runGroupId = "f0000001-0000-4000-a000-00000000074b";
     const workflowPrompt = "/daily-workflow";
     const workflowUserMessage = {
@@ -1254,7 +1254,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("keeps rendering legacy workflow automation briefs without text", async () => {
-    const threadId = "thread-workflow-user-message-marker";
+    const threadId = "e9000000-0000-4000-a000-000000000013";
     const workflowPrompt = "/daily-workflow";
 
     mockChatLifecycle(context, {
@@ -1307,7 +1307,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("renders the persisted workflow prompt instead of its brief", async () => {
-    const threadId = "thread-workflow-user-message-prompt";
+    const threadId = "e9000000-0000-4000-a000-000000000014";
     const workflowPrompt =
       '/daily-workflow\nTrigger: Gmail applied label "todo" to message msg-123.';
 
@@ -1353,7 +1353,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("renders persisted workflow prompts without a trigger brief", async () => {
-    const threadId = "thread-workflow-user-message-no-brief";
+    const threadId = "e9000000-0000-4000-a000-000000000015";
     const workflowPrompt =
       '/turbo-flaky-test-repair\nTrigger: GitHub Actions workflow "Turbo" completed with conclusion "failure".';
 
@@ -1398,7 +1398,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("renders a pending automation only as an automation event", async () => {
-    const threadId = "thread-pending-automation-event";
+    const threadId = "e9000000-0000-4000-a000-000000000016";
 
     mockChatLifecycle(context, {
       threadId,
@@ -1457,7 +1457,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
   });
 
   it("shows template labels on historical user messages", async () => {
-    const threadId = "template-message-history";
+    const threadId = "e9000000-0000-4000-a000-000000000017";
     const presentationTemplate = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
     const videoTemplate = VIDEO_TEMPLATE_ITEMS[0]!;
     const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
@@ -1589,7 +1589,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
 
   it("copies a canonical user message with rich attachments from chat history", async () => {
     const clipboard = context.mocks.browser.clipboardWrite();
-    const threadId = "rich-attachment-copy";
+    const threadId = "e9000000-0000-4000-a000-000000000018";
     const messageText = "Review the launch assets";
     const imageUrl = "/f/test-user/attachment-chart/chart.png";
     const videoUrl = "/f/test-user/attachment-demo/demo.mp4";
@@ -1699,14 +1699,14 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
 
   it("copies text and links for a user message with image attachments from chat history", async () => {
     const clipboard = context.mocks.browser.clipboardWrite();
-    const threadId = "image-attachment-copy";
+    const threadId = "e9000000-0000-4000-a000-000000000019";
     const messageText = "Review this image";
     const imageUrl = "https://cdn.vm7.io/artifacts/test/photo/photo.png";
     mockChatLifecycle(context, {
       threadId,
       chatEvents: [
         {
-          id: "msg-image-attachment-copy",
+          id: "msg-e9000000-0000-4000-a000-000000000019",
           role: "user",
           content: messageText,
           attachFiles: [
@@ -1769,7 +1769,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
 
   it("copies the structured message snapshot instead of stale legacy fields", async () => {
     const clipboard = context.mocks.browser.clipboardWrite();
-    const threadId = "structured-message-copy";
+    const threadId = "e9000000-0000-4000-a000-000000000020";
     const referencedThreadId = "b0000000-0000-4000-a000-000000000799";
     const style = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
     const firstAttachment = {
@@ -1867,7 +1867,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
 
   it("restores a copied structured template when pasting into the composer", async () => {
     const clipboard = context.mocks.browser.clipboardWrite();
-    const threadId = "structured-template-copy-paste";
+    const threadId = "e9000000-0000-4000-a000-000000000021";
     const style = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
     const generationTemplate = {
       type: "illustration" as const,
@@ -1898,7 +1898,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       threadId,
       chatEvents: [
         {
-          id: "msg-structured-template-copy-paste",
+          id: "msg-e9000000-0000-4000-a000-000000000021",
           role: "user",
           content: "invalidate",
           userMessage,
@@ -1951,7 +1951,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       new DOMException("Clipboard blocked", "NotAllowedError"),
     );
     const fallbackClipboard = context.mocks.browser.clipboardExecCommand();
-    const threadId = "structured-feedback-copy-fallback";
+    const threadId = "e9000000-0000-4000-a000-000000000022";
     const userMessage = {
       version: 1 as const,
       parts: [
@@ -1971,7 +1971,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       threadId,
       chatEvents: [
         {
-          id: "msg-structured-feedback-copy-fallback",
+          id: "msg-e9000000-0000-4000-a000-000000000022",
           role: "user",
           content: "stale legacy feedback",
           userMessage,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1691,10 +1691,32 @@ describe("zero attachment chips", () => {
         return respond(200, { runs: [] });
       },
     );
-    mockChatLifecycle(context, {
+    const lifecycle = mockChatLifecycle(context, {
       threadId: leftThreadId,
       threadTitle: "Left image thread",
     });
+    lifecycle.setThreadList([
+      {
+        id: leftThreadId,
+        title: "Left image thread",
+        agent: {
+          id: "c0000000-0000-4000-a000-000000000001",
+          avatarUrl: null,
+        },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+      {
+        id: rightThreadId,
+        title: "Right image thread",
+        agent: {
+          id: "c0000000-0000-4000-a000-000000000001",
+          avatarUrl: null,
+        },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+    ]);
     context.mocks.api(
       chatThreadEventsContract.list,
       ({ params, query, respond }) => {
@@ -1734,8 +1756,11 @@ describe("zero attachment chips", () => {
       path: `/chats/${leftThreadId}?sidebar=${rightThreadId}`,
     });
 
-    const threadRegions = await screen.findAllByLabelText("Chat thread");
-    expect(threadRegions).toHaveLength(2);
+    const threadRegions = await waitFor(() => {
+      const regions = screen.getAllByLabelText("Chat thread");
+      expect(regions).toHaveLength(2);
+      return regions;
+    });
     const leftThread = threadRegions[0];
     const rightThread = threadRegions[1];
     if (!leftThread || !rightThread) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -22,6 +22,7 @@ import {
   chatIdb$,
   openChatIdb,
 } from "../../../signals/external/chat-idb-store.ts";
+import { setLogErrorHandler } from "../../../signals/log.ts";
 import { CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY } from "../../../signals/chat-page/chat-thread-sidebar-layout.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 
@@ -181,39 +182,53 @@ function mockCurrentThreadDetail(): void {
   });
 }
 
-function mockSidebarThread(): void {
-  const thread = {
-    id: THREAD_ID,
-    title: THREAD_TITLE,
-    agent: { id: AGENT_ID, avatarUrl: null },
-    createdAt: "2026-03-10T00:00:00Z",
-    updatedAt: "2026-03-10T00:00:02Z",
-    pinnedAt: null,
+function currentThreadSnapshot() {
+  return {
+    chatThreads: [
+      {
+        id: THREAD_ID,
+        agentId: AGENT_ID,
+        title: THREAD_TITLE,
+        sortAt: "2026-03-10T00:00:02Z",
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:02Z",
+        pinnedAt: null,
+        renamedAt: null,
+        selectedModel: null,
+        serviceTier: null,
+        computerUseHostId: null,
+      },
+    ],
+    latestEventId: null,
+    latestSeqId: null,
   };
+}
+
+function mockSidebarThread(): void {
   context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
-    return respond(200, {
-      chatThreads: [
-        {
-          id: thread.id,
-          agentId: thread.agent.id,
-          title: thread.title,
-          sortAt: thread.updatedAt,
-          createdAt: thread.createdAt,
-          updatedAt: thread.updatedAt,
-          pinnedAt: thread.pinnedAt,
-          renamedAt: null,
-          selectedModel: null,
-          serviceTier: null,
-          computerUseHostId: null,
-        },
-      ],
-      latestEventId: null,
-      latestSeqId: null,
-    });
+    return respond(200, currentThreadSnapshot());
   });
   context.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
   });
+}
+
+function trackActiveAgentError(): () => boolean {
+  let logged = false;
+  setLogErrorHandler((loggerName, args) => {
+    const [message, error] = args;
+    if (
+      loggerName === "Promise" &&
+      message === "Detached promise rejected [dom_callback]" &&
+      error instanceof Error &&
+      error.message === "Chat thread requires an active agent"
+    ) {
+      logged = true;
+    }
+  });
+  return () => {
+    return logged;
+  };
 }
 
 describe("zero chat thread IndexedDB fallback", () => {
@@ -223,6 +238,146 @@ describe("zero chat thread IndexedDB fallback", () => {
 
   afterEach(async () => {
     await clearCachedChatData();
+  });
+
+  it("keeps the app skeleton visible until uncached thread metadata syncs", async () => {
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    context.mocks.api(zeroBrowserContract.get, ({ respond }) => {
+      return respond(404, {
+        error: {
+          code: "BROWSER_NOT_FOUND",
+          message: "Managed browser not found",
+        },
+      });
+    });
+    const runtimeDb = await primeRuntimeChatDb();
+    const snapshotRequested = context.mocks.deferred<void>();
+    const releaseSnapshot = context.mocks.deferred<void>();
+    const activeAgentErrorLogged = trackActiveAgentError();
+    context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
+      if (!snapshotRequested.settled()) {
+        snapshotRequested.resolve();
+      }
+      await releaseSnapshot.promise;
+      return respond(200, currentThreadSnapshot());
+    });
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    try {
+      setupChatPage();
+      await snapshotRequested.promise;
+
+      const appSkeleton = await screen.findByTestId("app-skeleton");
+      expect(appSkeleton).not.toHaveAttribute("aria-hidden");
+      expect(
+        screen.queryByPlaceholderText(PLACEHOLDER),
+      ).not.toBeInTheDocument();
+      expect(activeAgentErrorLogged()).toBeFalsy();
+
+      releaseSnapshot.resolve();
+
+      await expect(
+        screen.findByPlaceholderText(PLACEHOLDER),
+      ).resolves.toBeInTheDocument();
+      await waitFor(() => {
+        expect(appSkeleton).toHaveAttribute("aria-hidden", "true");
+      });
+      expect(activeAgentErrorLogged()).toBeFalsy();
+    } finally {
+      if (!releaseSnapshot.settled()) {
+        releaseSnapshot.resolve();
+      }
+      runtimeDb.close();
+    }
+  });
+
+  it("shows chat thread not found after remote metadata sync confirms a miss", async () => {
+    const runtimeDb = await primeRuntimeChatDb();
+    const snapshotRequested = context.mocks.deferred<void>();
+    const releaseSnapshot = context.mocks.deferred<void>();
+    const activeAgentErrorLogged = trackActiveAgentError();
+    context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
+      snapshotRequested.resolve();
+      await releaseSnapshot.promise;
+      return respond(200, {
+        chatThreads: [],
+        latestEventId: null,
+        latestSeqId: null,
+      });
+    });
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    try {
+      setupChatPage();
+      await snapshotRequested.promise;
+
+      const appSkeleton = await screen.findByTestId("app-skeleton");
+      expect(appSkeleton).not.toHaveAttribute("aria-hidden");
+      expect(
+        screen.queryByRole("heading", { name: "Chat thread not found" }),
+      ).not.toBeInTheDocument();
+
+      releaseSnapshot.resolve();
+
+      await expect(
+        screen.findByRole("heading", { name: "Chat thread not found" }),
+      ).resolves.toBeInTheDocument();
+      expect(appSkeleton).toHaveAttribute("aria-hidden", "true");
+      expect(
+        screen.queryByPlaceholderText(PLACEHOLDER),
+      ).not.toBeInTheDocument();
+      expect(activeAgentErrorLogged()).toBeFalsy();
+    } finally {
+      if (!releaseSnapshot.settled()) {
+        releaseSnapshot.resolve();
+      }
+      runtimeDb.close();
+    }
+  });
+
+  it("renders from cached thread metadata without waiting for remote sync", async () => {
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    const runtimeDb = await primeRuntimeChatDb();
+    await runtimeDb.put(CHAT_THREAD_SNAPSHOT_STORE, {
+      id: "current",
+      ...currentThreadSnapshot(),
+      latestEventId: "00000000-0000-4000-8000-000000000001",
+      latestSeqId: 1,
+    });
+    const remoteEventsRequested = context.mocks.deferred<void>();
+    const releaseRemoteEvents = context.mocks.deferred<void>();
+    const activeAgentErrorLogged = trackActiveAgentError();
+    context.mocks.api(chatThreadsContract.events, async ({ respond }) => {
+      remoteEventsRequested.resolve();
+      await releaseRemoteEvents.promise;
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    try {
+      setupChatPage();
+      await remoteEventsRequested.promise;
+
+      await expect(
+        screen.findByPlaceholderText(PLACEHOLDER),
+      ).resolves.toBeInTheDocument();
+      expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+      expect(releaseRemoteEvents.settled()).toBeFalsy();
+      expect(activeAgentErrorLogged()).toBeFalsy();
+    } finally {
+      if (!releaseRemoteEvents.settled()) {
+        releaseRemoteEvents.resolve();
+      }
+      runtimeDb.close();
+    }
   });
 
   it("shows cached messages without auto-opening their artifact before remote catch-up", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3708,7 +3708,28 @@ function ChatHistoryBackfillSkeleton({ thread }: { thread: ChatPanelSignals }) {
   );
 }
 
+function ChatThreadNotFound() {
+  const { t } = useTranslation();
+  return (
+    <main
+      data-chat-thread-not-found
+      className="flex min-h-0 flex-1 items-center justify-center px-6 py-16 text-center"
+    >
+      <h1 className="text-lg font-semibold text-foreground">
+        {t(($) => {
+          return $.chat.thread.notFound;
+        })}
+      </h1>
+    </main>
+  );
+}
+
 function ChatThreadContent({ thread }: { thread: ChatPanelSignals }) {
+  const threadMeta = useGet(thread.threadMeta$);
+  if (!threadMeta) {
+    return <ChatThreadNotFound />;
+  }
+
   return (
     <>
       <ChatThreadHeader thread={thread} />


### PR DESCRIPTION
## Summary

- add explicit local IndexedDB load and initial remote sync barriers for event-sourced chat thread metadata
- delay chat pane publication and global skeleton hiding until the requested thread is resolved
- render a localized chat-thread-not-found state when remote sync confirms the thread is missing
- preserve local-first rendering when cached metadata exists and prevent composer initialization from reading a temporarily missing agent

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx --silent=passed-only` (11 tests passed)
- `pnpm -F @vm0/app check-types`
- targeted Oxlint, type-aware Oxlint, and ESLint checks
- `pnpm -F @vm0/app i18n:check`
- Prettier check for all changed files

## Fallbacks

None.
