### PR TITLE
fix: make sent template chips static in chat history

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1582,7 +1582,6 @@
         "website": "Webseite",
         "workflow": "Workflow"
       },
-      "messageTemplate": "Nachrichtenvorlage {{title}}",
       "previewTemplate": "Vorschauvorlage {{title}}",
       "previewVideo": "Vorschau der Videovorlage {{title}}",
       "previewWebsite": "Vorschau der Website-Vorlage {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1582,7 +1582,6 @@
         "website": "Website",
         "workflow": "Workflow"
       },
-      "messageTemplate": "Message template {{title}}",
       "previewTemplate": "Preview template {{title}}",
       "previewVideo": "Preview video template {{title}}",
       "previewWebsite": "Preview website template {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1622,7 +1622,6 @@
         "website": "Sitio web",
         "workflow": "Flujo de trabajo"
       },
-      "messageTemplate": "Plantilla de mensaje {{title}}",
       "previewTemplate": "Plantilla de vista previa {{title}}",
       "previewVideo": "Vista previa de la plantilla de vídeo {{title}}",
       "previewWebsite": "Vista previa de la plantilla de sitio web {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1622,7 +1622,6 @@
         "website": "Site web",
         "workflow": "Workflow"
       },
-      "messageTemplate": "Modèle de message {{title}}",
       "previewTemplate": "Aperçu du modèle {{title}}",
       "previewVideo": "Aperçu du modèle vidéo {{title}}",
       "previewWebsite": "Aperçu du modèle de site web {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1582,7 +1582,6 @@
         "website": "वेबसाइट",
         "workflow": "वर्कफ़्लो"
       },
-      "messageTemplate": "संदेश टेम्पलेट {{title}}",
       "previewTemplate": "पूर्वावलोकन टेम्पलेट {{title}}",
       "previewVideo": "पूर्वावलोकन वीडियो टेम्पलेट {{title}}",
       "previewWebsite": "वेबसाइट टेम्पलेट {{title}} का पूर्वावलोकन करें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1581,7 +1581,6 @@
         "website": "Situs web",
         "workflow": "Alur kerja"
       },
-      "messageTemplate": "Template pesan {{title}}",
       "previewTemplate": "Pratinjau template {{title}}",
       "previewVideo": "Pratinjau template video {{title}}",
       "previewWebsite": "Pratinjau template situs web {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1622,7 +1622,6 @@
         "website": "Sito web",
         "workflow": "Flusso di lavoro"
       },
-      "messageTemplate": "Modello messaggio {{title}}",
       "previewTemplate": "Modello di anteprima {{title}}",
       "previewVideo": "Anteprima modello video {{title}}",
       "previewWebsite": "Anteprima del modello di sito web {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1581,7 +1581,6 @@
         "website": "ウェブサイト",
         "workflow": "ワークフロー"
       },
-      "messageTemplate": "メッセージ テンプレート {{title}}",
       "previewTemplate": "プレビュー テンプレート {{title}}",
       "previewVideo": "プレビュービデオテンプレート {{title}}",
       "previewWebsite": "Web サイト テンプレートのプレビュー {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1581,7 +1581,6 @@
         "website": "웹사이트",
         "workflow": "워크플로"
       },
-      "messageTemplate": "메시지 템플릿 {{title}}",
       "previewTemplate": "템플릿 미리보기 {{title}}",
       "previewVideo": "비디오 템플릿 미리보기 {{title}}",
       "previewWebsite": "웹사이트 템플릿 미리보기 {{title}}",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1622,7 +1622,6 @@
         "website": "Site",
         "workflow": "Fluxo de trabalho"
       },
-      "messageTemplate": "Template da mensagem: {{title}}",
       "previewTemplate": "Visualizar template {{title}}",
       "previewVideo": "Visualizar template de vídeo {{title}}",
       "previewWebsite": "Visualizar template de site {{title}}",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -1,22 +1,27 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
-import { zeroAvatarVideoContract } from "@vm0/api-contracts/contracts/zero-avatar-video";
-import { avatarTemplateStylePresetId } from "@vm0/core/avatar-template";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { ILLUSTRATION_TEMPLATE_ITEMS, VIDEO_TEMPLATE_ITEMS } from "@vm0/core";
 
 import {
   detachedSetupPage,
-  fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { findComposerEditor } from "./chat-composer-test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const context = testContext();
+
+// Sent templates are static text, so they carry no role or accessible name to
+// query by.
+function sentTemplateReferences(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      "[data-structured-template-reference]",
+    ),
+  );
+}
 
 describe("user messages", () => {
   it("renders templates inline in message and feedback-note order", async () => {
@@ -77,17 +82,13 @@ describe("user messages", () => {
       expect(element).toBeInstanceOf(HTMLElement);
       return element as HTMLElement;
     });
-    const references = screen.getAllByLabelText(
-      `Message template ${templateItem.title}`,
-    );
+    const references = sentTemplateReferences();
     expect(references).toHaveLength(2);
     for (const reference of references) {
-      expect(reference.tagName).toBe("BUTTON");
-      expect(reference).toHaveAttribute("aria-haspopup", "dialog");
-      expect(reference).toHaveAttribute(
-        "data-structured-template-reference",
-        "",
-      );
+      // A sent template is a record, not a control: it must not read or behave
+      // as a button.
+      expect(reference.tagName).toBe("SPAN");
+      expect(reference).not.toHaveAttribute("aria-haspopup");
       expect(reference.textContent).toBe(templateItem.title);
     }
     const feedback = document.querySelector("[data-structured-feedback-group]");
@@ -100,18 +101,7 @@ describe("user messages", () => {
 
     await user.click(references[0]!);
 
-    const dialog = await screen.findByRole("dialog");
-    expect(dialog).toBeInTheDocument();
-    const illustrationTab = queryAllByRoleFast("tab").find((tab) => {
-      return tab.textContent === "Illustration";
-    });
-    expect(illustrationTab).toHaveAttribute("aria-selected", "true");
-    expect(
-      screen.getByLabelText(`Select template ${templateItem.title}`),
-    ).toHaveAttribute("aria-pressed", "true");
-    expect(
-      document.querySelector("[data-composer-inline-template]"),
-    ).toBeNull();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("echoes the video parameters a sent template used", async () => {
@@ -158,126 +148,8 @@ describe("user messages", () => {
       },
     });
 
-    const reference = await screen.findByLabelText(
-      `Message template ${templateItem.title}`,
-    );
-    expect(reference).toHaveTextContent("9:16 \u00b7 8s");
-  });
-
-  it("opens avatar message templates at the voice picker", async () => {
-    const user = userEvent.setup({ delay: null });
-    const threadId = "b0000000-0000-4000-a000-000000000749";
-    const avatar = {
-      id: 81,
-      name: "Ada",
-      coverUrl: "https://example.com/ada.jpg",
-    };
-    const voice = {
-      id: "en-US-ChristopherNeural",
-      name: "Christopher",
-      sampleUrl: "https://example.com/christopher.mp3",
-      language: "English",
-      gender: "male",
-    };
-    const avatarOptions = {
-      titleSnapshot: avatar.name,
-      previewUrl: avatar.coverUrl,
-      voiceId: voice.id,
-      aspectRatio: "landscape" as const,
-    };
-    // The stored message predates avatarOptions, so it carries only the flat
-    // fields; reopening it must still resolve the avatar and its voice.
-    const template = {
-      type: "video" as const,
-      selection: {
-        stylePresetId: avatarTemplateStylePresetId(avatar.id),
-        ...avatarOptions,
-      },
-    };
-    context.mocks.api(zeroAvatarVideoContract.voices, ({ respond }) => {
-      return respond(200, {
-        voices: [voice],
-        hasMore: false,
-        filterOptions: { languages: ["english"], useCases: [] },
-      });
-    });
-    let submittedTemplate: GenerationTemplateRequest | undefined;
-    mockChatLifecycle(context, {
-      threadId,
-      threadTitle: "Avatar template reference",
-      onRunCreate(body) {
-        const templatePart = body.userMessage?.parts.find((part) => {
-          return part.type === "template";
-        });
-        submittedTemplate =
-          templatePart?.type === "template" ? templatePart.template : undefined;
-      },
-      chatEvents: [
-        {
-          id: "00000000-0000-4000-8000-000000000749",
-          role: "user",
-          content: "Create an avatar video",
-          runId: "d0000000-0000-4000-a000-000000000749",
-          userMessage: {
-            version: 1,
-            parts: [
-              {
-                type: "template",
-                titleSnapshot: avatar.name,
-                template,
-              },
-              { type: "text", text: "Create an avatar video" },
-            ],
-          },
-          createdAt: "2026-08-05T10:00:00Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${threadId}`,
-      featureSwitches: {
-        [FeatureSwitchKey.JoggAiBuiltIn]: true,
-      },
-    });
-
-    await screen.findByLabelText("Template");
-    const editor = await findComposerEditor();
-    await fill(editor, "Reuse this avatar template");
-    await user.click(
-      await screen.findByLabelText(`Message template ${avatar.name}`),
-    );
-
-    const dialog = await screen.findByRole("dialog");
-    await expect(
-      within(dialog).findByText(`Choose a voice for ${avatar.name}`),
-    ).resolves.toBeInTheDocument();
-    expect(
-      within(dialog).getByLabelText(`Select voice ${voice.name}`),
-    ).toHaveAttribute("aria-pressed", "true");
-    expect(
-      within(dialog).queryByLabelText(`Select template ${avatar.name}`),
-    ).not.toBeInTheDocument();
-
-    await user.click(
-      within(dialog).getByLabelText(`Select voice ${voice.name}`),
-    );
     await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-      expect(
-        screen.getByLabelText(`Preview template ${avatar.name}`),
-      ).toBeInTheDocument();
-    });
-    await user.click(screen.getByLabelText("Send"));
-
-    // Re-selecting the voice rewrites the selection, which now nests the
-    // options and mirrors them flat.
-    await waitFor(() => {
-      expect(submittedTemplate).toStrictEqual({
-        ...template,
-        selection: { ...template.selection, avatarOptions },
-      });
+      expect(sentTemplateReferences()[0]).toHaveTextContent("9:16 \u00b7 8s");
     });
   });
 
@@ -401,7 +273,7 @@ describe("user messages", () => {
       'a[aria-label="Open chat Archived source"]',
     );
     expect(threadLink).toHaveAttribute("href", `/chats/${referencedThreadId}`);
-    const template = screen.getByLabelText("Message template Archived deck");
+    const template = sentTemplateReferences()[0];
     const image = screen.getByLabelText("Preview reference.png");
     expect(image).toBeInTheDocument();
     // Templates render inline at their position in the message, so the chip

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -13,16 +13,6 @@ import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
-// Sent templates are static text, so they carry no role or accessible name to
-// query by.
-function sentTemplateReferences(): HTMLElement[] {
-  return Array.from(
-    document.querySelectorAll<HTMLElement>(
-      "[data-structured-template-reference]",
-    ),
-  );
-}
-
 describe("user messages", () => {
   it("renders templates inline in message and feedback-note order", async () => {
     const user = userEvent.setup({ delay: null });
@@ -82,14 +72,15 @@ describe("user messages", () => {
       expect(element).toBeInstanceOf(HTMLElement);
       return element as HTMLElement;
     });
-    const references = sentTemplateReferences();
+    const references = screen.getAllByTitle(
+      `Illustration · ${templateItem.title}`,
+    );
     expect(references).toHaveLength(2);
+    const buttons = queryAllByRoleFast("button");
     for (const reference of references) {
-      // A sent template is a record, not a control: it must not read or behave
-      // as a button.
-      expect(reference.tagName).toBe("SPAN");
-      expect(reference).not.toHaveAttribute("aria-haspopup");
       expect(reference.textContent).toBe(templateItem.title);
+      // A sent template is a record, not a control, so it exposes no button.
+      expect(buttons).not.toContain(reference);
     }
     const feedback = document.querySelector("[data-structured-feedback-group]");
     expect(feedback).toBeInstanceOf(HTMLElement);
@@ -148,9 +139,10 @@ describe("user messages", () => {
       },
     });
 
-    await waitFor(() => {
-      expect(sentTemplateReferences()[0]).toHaveTextContent("9:16 \u00b7 8s");
-    });
+    const reference = await screen.findByTitle(
+      `Video \u00b7 ${templateItem.title}`,
+    );
+    expect(reference).toHaveTextContent("9:16 \u00b7 8s");
   });
 
   it("renders ordered snapshots with literal Markdown text", async () => {
@@ -273,7 +265,7 @@ describe("user messages", () => {
       'a[aria-label="Open chat Archived source"]',
     );
     expect(threadLink).toHaveAttribute("href", `/chats/${referencedThreadId}`);
-    const template = sentTemplateReferences()[0];
+    const template = screen.getByTitle("Presentation · Archived deck");
     const image = screen.getByLabelText("Preview reference.png");
     expect(image).toBeInTheDocument();
     // Templates render inline at their position in the message, so the chip

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -17,7 +17,11 @@ import {
   createMockWorkflowAutomation,
   setMockWorkflowAutomations,
 } from "../../../mocks/handlers/workflow-automations-store.ts";
-import { click, fill } from "../../../__tests__/page-helper.ts";
+import {
+  click,
+  fill,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import {
   expectQueuedMessages,
   mockChatLifecycle,
@@ -1579,7 +1583,7 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       expect(illustrationChip).toHaveTextContent(illustrationTemplate.title);
       expect(websiteChip).toHaveTextContent(websiteTemplate.title);
       // Sent templates are a record of the run, so they stay static text.
-      expect(videoChip).not.toHaveAttribute("aria-haspopup");
+      expect(queryAllByRoleFast("button")).not.toContain(videoChip);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1564,45 +1564,22 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     });
 
     await waitFor(() => {
-      const presentationTemplateLabel = screen.getByLabelText(
-        `Message template ${presentationTemplate.title}`,
-      );
-      const videoTemplateLabel = screen.getByLabelText(
-        `Message template ${videoTemplate.title}`,
-      );
-      const illustrationTemplateLabel = screen.getByLabelText(
-        `Message template ${illustrationTemplate.title}`,
-      );
-      const websiteTemplateLabel = screen.getByLabelText(
-        `Message template ${websiteTemplate.title}`,
-      );
-      expect(presentationTemplateLabel).toHaveTextContent(
-        presentationTemplate.title,
-      );
-      expect(presentationTemplateLabel).toHaveAttribute(
-        "title",
+      const presentationChip = screen.getByTitle(
         `Presentation · ${presentationTemplate.title}`,
       );
-      expect(videoTemplateLabel).toHaveTextContent(videoTemplate.title);
-      expect(videoTemplateLabel).toHaveAttribute(
-        "title",
-        `Video · ${videoTemplate.title}`,
-      );
-      expect(illustrationTemplateLabel).toHaveTextContent(
-        illustrationTemplate.title,
-      );
-      expect(illustrationTemplateLabel).toHaveAttribute(
-        "title",
+      const videoChip = screen.getByTitle(`Video · ${videoTemplate.title}`);
+      const illustrationChip = screen.getByTitle(
         `Illustration · ${illustrationTemplate.title}`,
       );
-      expect(websiteTemplateLabel).toHaveTextContent(websiteTemplate.title);
-      expect(websiteTemplateLabel).toHaveAttribute(
-        "title",
+      const websiteChip = screen.getByTitle(
         `Website · ${websiteTemplate.title}`,
       );
-      expect(
-        screen.getByLabelText(`Message template ${videoTemplate.title}`),
-      ).toHaveAttribute("aria-haspopup", "dialog");
+      expect(presentationChip).toHaveTextContent(presentationTemplate.title);
+      expect(videoChip).toHaveTextContent(videoTemplate.title);
+      expect(illustrationChip).toHaveTextContent(illustrationTemplate.title);
+      expect(websiteChip).toHaveTextContent(websiteTemplate.title);
+      // Sent templates are a record of the run, so they stay static text.
+      expect(videoChip).not.toHaveAttribute("aria-haspopup");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -105,10 +105,7 @@ import type {
   ChatThreadWorkflowAutomation,
   ZeroWorkflowSchedule,
 } from "@vm0/api-contracts/contracts/zero-workflows";
-import {
-  PRESENTATION_TEMPLATE_PICKER_ITEMS,
-  r2ImageTransformUrl,
-} from "@vm0/core";
+import { r2ImageTransformUrl } from "@vm0/core";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type {
   PlatformConnectorPermissionMetadata,
@@ -262,7 +259,6 @@ import type {
   RecommendedFollowupSource,
   ThinkingIndicatorMode,
 } from "../../signals/chat-page/chat-panel-signals.ts";
-import type { ComposerSignals } from "../../signals/zero-page/composer-signals.ts";
 import {
   applyChatThreadEmoji,
   removeChatThreadEmoji,
@@ -7164,9 +7160,11 @@ const INLINE_FILE_REFERENCE_SPACING_CLASS = "mx-1";
 const STRUCTURED_INLINE_REFERENCE_CLASS =
   "relative -top-px mx-0.5 inline-flex h-7 max-w-[240px] items-center " +
   "gap-1.5 rounded-md bg-orange-500/10 px-2 align-middle text-[13px] " +
-  "font-medium text-orange-600 transition-colors hover:bg-orange-500/15 " +
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500/30 " +
-  "active:bg-orange-500/20 dark:bg-orange-400/15 dark:text-orange-300 " +
+  "font-medium text-orange-600 dark:bg-orange-400/15 dark:text-orange-300";
+const STRUCTURED_INLINE_LINK_REFERENCE_CLASS =
+  `${STRUCTURED_INLINE_REFERENCE_CLASS} transition-colors ` +
+  "hover:bg-orange-500/15 focus-visible:outline-none focus-visible:ring-2 " +
+  "focus-visible:ring-orange-500/30 active:bg-orange-500/20 " +
   "dark:hover:bg-orange-400/20 dark:active:bg-orange-400/25";
 
 /**
@@ -7188,103 +7186,25 @@ function sentVideoTemplateSpec(
   return `${resolved.aspectRatio} \u00b7 ${resolved.duration}`;
 }
 
-function templatePickerCategoryForReference(
-  template: GenerationTemplateRequest,
-): string {
-  if (avatarTemplateSelection(template)) {
-    return "avatar";
-  }
-  return template.type === "presentation" ? "slides" : template.type;
-}
-
-function presentationTemplatePreviewSlug(
-  template: GenerationTemplateRequest,
-): string | null {
-  if (template.type !== "presentation") {
-    return null;
-  }
-  return (
-    PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
-      return item.templateId === template.selection.templateId;
-    })?.slug ?? null
-  );
-}
-
+/**
+ * A sent template is a record of what the message used, not a control. It
+ * renders as static text so the history stays read-only.
+ */
 function UserMessageTemplateReference({
   part,
-  signals,
 }: {
   part: Extract<UserMessagePart, { type: "template" }>;
-  signals: ComposerSignals;
 }) {
-  const { t } = useTranslation();
   const typeLabel = generationTemplateTypeLabel(part.template);
   const videoOptionsEnabled = useGet(videoTemplateOptionsEnabled$);
   const spec = videoOptionsEnabled
     ? sentVideoTemplateSpec(part.template)
     : undefined;
-  const setTemplatePickerCategory = useSet(
-    signals.template.setTemplatePickerCategory$,
-  );
-  const setTemplatePickerOpen = useSet(signals.template.setTemplatePickerOpen$);
-  const setTemplatePickerPreviewSlug = useSet(
-    signals.template.setTemplatePickerPreviewSlug$,
-  );
-  const setTemplatePickerReferenceValue = useSet(
-    signals.template.setTemplatePickerReferenceValue$,
-  );
-  const setTemplatePickerSearch = useSet(
-    signals.template.setTemplatePickerSearch$,
-  );
-  const selectAvatarTemplateForVoice = useSet(
-    signals.template.selectAvatarTemplateForVoice$,
-  );
-  const setAvatarTemplateFilters = useSet(
-    signals.template.setAvatarTemplateFilters$,
-  );
   return (
-    <button
-      type="button"
+    <span
       data-structured-template-reference=""
-      aria-label={t(
-        ($) => {
-          return $.chat.templates.messageTemplate;
-        },
-        {
-          title: part.titleSnapshot,
-        },
-      )}
-      aria-haspopup="dialog"
       className={STRUCTURED_INLINE_REFERENCE_CLASS}
       title={`${typeLabel ?? part.template.type} · ${part.titleSnapshot}`}
-      onClick={() => {
-        const avatar = avatarTemplateSelection(part.template);
-        if (avatar) {
-          setAvatarTemplateFilters({
-            aspectRatio:
-              avatar.aspectRatio === "landscape" ? "landscape" : "portrait",
-            style: undefined,
-            gender: undefined,
-            age: undefined,
-            scene: undefined,
-            ethnicity: undefined,
-          });
-          selectAvatarTemplateForVoice({
-            id: avatar.avatarId,
-            name: avatar.title,
-            coverUrl: avatar.previewUrl,
-          });
-        }
-        setTemplatePickerCategory(
-          templatePickerCategoryForReference(part.template),
-        );
-        setTemplatePickerSearch("");
-        setTemplatePickerPreviewSlug(
-          presentationTemplatePreviewSlug(part.template),
-        );
-        setTemplatePickerReferenceValue(part.template);
-        setTemplatePickerOpen(true);
-      }}
     >
       <IconColorSwatch size={13} stroke={1.7} className="shrink-0" />
       <span className="min-w-0 truncate">{part.titleSnapshot}</span>
@@ -7293,7 +7213,7 @@ function UserMessageTemplateReference({
           {spec}
         </span>
       )}
-    </button>
+    </span>
   );
 }
 
@@ -7427,7 +7347,7 @@ function UserMessageChatThreadReference({
         },
         { title },
       )}
-      className={STRUCTURED_INLINE_REFERENCE_CLASS}
+      className={STRUCTURED_INLINE_LINK_REFERENCE_CLASS}
       title={title}
     >
       <IconMessageCircle size={13} stroke={1.7} className="shrink-0" />
@@ -7457,7 +7377,7 @@ function UserMessageAgentReference({
         },
         { name },
       )}
-      className={STRUCTURED_INLINE_REFERENCE_CLASS}
+      className={STRUCTURED_INLINE_LINK_REFERENCE_CLASS}
       title={name}
     >
       <AvatarFromUrl
@@ -7474,11 +7394,9 @@ function UserMessageAgentReference({
 function UserMessageFeedbackNote({
   note,
   agentReferenceSignalsForId,
-  composerSignals,
 }: {
   note: readonly FeedbackNotePart[];
   agentReferenceSignalsForId: ChatPanelSignals["agentReferenceSignalsForId"];
-  composerSignals: ComposerSignals;
 }) {
   const partOccurrences = new Map<string, number>();
   return (
@@ -7508,13 +7426,7 @@ function UserMessageFeedbackNote({
           );
         }
         if (part.type === "template") {
-          return (
-            <UserMessageTemplateReference
-              key={key}
-              part={part}
-              signals={composerSignals}
-            />
-          );
+          return <UserMessageTemplateReference key={key} part={part} />;
         }
         return <span key={key}>{part.text}</span>;
       })}
@@ -7606,11 +7518,9 @@ function userMessageFeedbackHeading(
 function UserMessageFeedbackGroup({
   parts,
   agentReferenceSignalsForId,
-  composerSignals,
 }: {
   parts: readonly UserMessageFeedbackPart[];
   agentReferenceSignalsForId: ChatPanelSignals["agentReferenceSignalsForId"];
-  composerSignals: ComposerSignals;
 }) {
   const partOccurrences = new Map<string, number>();
   let firstPart = true;
@@ -7640,7 +7550,6 @@ function UserMessageFeedbackGroup({
             <UserMessageFeedbackNote
               note={part.note}
               agentReferenceSignalsForId={agentReferenceSignalsForId}
-              composerSignals={composerSignals}
             />
           </div>
         );
@@ -7664,12 +7573,10 @@ function UserMessagePartView({
   part,
   attachments,
   agentReferenceSignalsForId,
-  composerSignals,
 }: {
   part: UserMessageStandalonePart;
   attachments: readonly ResolvedAttachFile[];
   agentReferenceSignalsForId: ChatPanelSignals["agentReferenceSignalsForId"];
-  composerSignals: ComposerSignals;
 }): ReactNode {
   if (part.type === "text") {
     return <span>{part.text}</span>;
@@ -7692,9 +7599,7 @@ function UserMessagePartView({
     );
   }
   if (part.type === "template") {
-    return (
-      <UserMessageTemplateReference part={part} signals={composerSignals} />
-    );
+    return <UserMessageTemplateReference part={part} />;
   }
   if (part.type === "file") {
     const attachment = attachments.find((candidate) => {
@@ -7711,13 +7616,11 @@ function UserMessageView({
   attachments,
   elevatedFileIds,
   agentReferenceSignalsForId,
-  composerSignals,
 }: {
   document: UserMessageDocument;
   attachments: readonly ResolvedAttachFile[];
   elevatedFileIds: ReadonlySet<string>;
   agentReferenceSignalsForId: ChatPanelSignals["agentReferenceSignalsForId"];
-  composerSignals: ComposerSignals;
 }) {
   const partOccurrences = new Map<string, number>();
   const bodyParts = document.parts.filter(
@@ -7757,7 +7660,6 @@ function UserMessageView({
           key={`feedback:${String(index)}`}
           parts={feedbackParts}
           agentReferenceSignalsForId={agentReferenceSignalsForId}
-          composerSignals={composerSignals}
         />,
       );
       index = nextIndex;
@@ -7772,7 +7674,6 @@ function UserMessageView({
         part={part}
         attachments={attachments}
         agentReferenceSignalsForId={agentReferenceSignalsForId}
-        composerSignals={composerSignals}
       />,
     );
     index += 1;
@@ -7797,14 +7698,12 @@ function UserMessageContent({
   referenceAttachments,
   onImageClick,
   agentReferenceSignalsForId,
-  composerSignals,
 }: {
   document: UserMessageDocument;
   attachments: ReturnType<typeof resolveAttachments>;
   referenceAttachments: readonly ResolvedAttachFile[];
   onImageClick: (url: string) => void;
   agentReferenceSignalsForId: ChatPanelSignals["agentReferenceSignalsForId"];
-  composerSignals: ComposerSignals;
 }) {
   // Attachments read as their own object, so they all sit above the bubble
   // instead of interrupting the sentence they were dropped into. Attachments
@@ -7838,7 +7737,6 @@ function UserMessageContent({
               attachments={referenceAttachments}
               elevatedFileIds={elevatedFileIds}
               agentReferenceSignalsForId={agentReferenceSignalsForId}
-              composerSignals={composerSignals}
             />
           </div>
         </div>
@@ -8097,7 +7995,6 @@ function PagedUserMessage({
               referenceAttachments={attachFiles ?? []}
               onImageClick={openLightbox}
               agentReferenceSignalsForId={thread.agentReferenceSignalsForId}
-              composerSignals={thread.composer}
             />
           ) : (
             <>


### PR DESCRIPTION
## Problem

In chat history, a template chip inside an already-sent user message was a `<button>`. Clicking it reopened the template picker dialog and rewrote composer picker state (category, search, preview slug, reference value, avatar filters/voice selection).

Sent messages are a record of what a run used, not a control surface, so this dialog should not be reachable from history.

## Change

`UserMessageTemplateReference` now renders static text:

- `<button aria-haspopup="dialog">` → `<span>`; no click handler, no picker state writes
- Dropped the now-dead `aria-label` (`chat.templates.messageTemplate`) — the chip's visible title already names it; the `title` tooltip (`<Type> · <Title>`) is unchanged
- Interactive hover/focus/active styles moved to `STRUCTURED_INLINE_LINK_REFERENCE_CLASS`, still used by the chat-thread and agent link chips; the static chip keeps only the base orange styling
- `composerSignals` was threaded through five user-message components solely for this handler, so it is removed along with the `PRESENTATION_TEMPLATE_PICKER_ITEMS` / `ComposerSignals` imports and the two helpers that fed the picker

The composer's own inline template chip and its picker are untouched.

## Tests

- `chat-user-messages`: sent chips are located by their visible `title` tooltip; the regression assertion is that clicking one opens no dialog, and that the chip exposes no button role
- Deleted "opens avatar message templates at the voice picker" — its entry point is gone; the `avatarOptions` submission it also covered is already asserted in `chat-composer-template-picker`
- `chat-workflows-and-goals`: template chips are queried by their `title`, and the video chip is asserted to expose no button role

## Fallbacks

Fallbacks: none. This PR removes a click handler and its prop threading; it introduces no compatibility branch, tolerance path, or defaulting logic, and touches no API contract, persisted shape, or runner protocol.

Related, unchanged: `readAvatarTemplateOptions` (`turbo/packages/core/src/avatar-template.ts`) keeps reading the flat avatar fields for messages persisted before the nested `avatarOptions` split. This PR does not modify that fallback. It does delete the platform test that happened to exercise the flat-only shape, because that test reached it through the interaction being removed; the fallback stays covered by `turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`. Removal condition and follow-up remain as documented there: https://github.com/vm0-ai/vm0/issues/25620.

Verified locally: `prettier`, `pnpm -F @vm0/app lint`, `check-types`, `knip --workspace apps/platform`, and vitest on `chat-user-messages`, `chat-workflows-and-goals`, `chat-composer-template-picker`, `chat-inline-feedback` (86 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
