### PR TITLE
feat: soften the dialog scrim and blur the backdrop

### DIFF
--- a/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
@@ -137,10 +137,7 @@ export function OnboardingDialog({
         }
       }}
     >
-      <DialogContent
-        overlayClassName="bg-black/45 backdrop-blur-sm dark:bg-black/45"
-        className="flex max-h-[calc(100dvh-32px)] w-[calc(100%-32px)] max-w-4xl flex-col gap-0 overflow-hidden rounded-lg border-border bg-background p-5 sm:p-6"
-      >
+      <DialogContent className="flex max-h-[calc(100dvh-32px)] w-[calc(100%-32px)] max-w-4xl flex-col gap-0 overflow-hidden rounded-lg border-border bg-background p-5 sm:p-6">
         <header className="shrink-0 pr-9">
           <div className="min-w-0">
             <DialogTitle className="text-lg font-semibold leading-6">

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        "zero-dialog-overlay fixed inset-0 z-50 bg-black/80 dark:bg-background/50",
+        "zero-dialog-overlay fixed inset-0 z-50 bg-black/45 backdrop-blur-sm dark:bg-black/55",
         className,
       )}
       {...props}

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        "zero-dialog-overlay fixed inset-0 z-50 bg-black/45 backdrop-blur-sm dark:bg-black/55",
+        "zero-dialog-overlay fixed inset-0 z-50 bg-overlay/45 backdrop-blur-sm dark:bg-overlay/55",
         className,
       )}
       {...props}

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -64,6 +64,7 @@
    * =================================== */
   --color-white: hsl(var(--white));
   --color-black: hsl(var(--black));
+  --color-overlay: hsl(var(--overlay));
 
   /* ===================================
    * Semantic Colors
@@ -176,6 +177,11 @@
     /* Theme-aware Colors */
     --white: 0 0% 100%; /* #FFFFFF */
     --black: 240 3% 10%; /* #19191B */
+
+    /* Dialog scrim. Deliberately NOT theme-aware: --black inverts to #FFFFFF
+       in dark, which would lighten the backdrop instead of dimming it. The
+       dark theme reuses this value and only raises the alpha. */
+    --overlay: 240 3% 10%; /* #19191B */
 
     /* ===================================
      * Semantic Colors (Light Theme)


### PR DESCRIPTION
## Why

The shared `DialogOverlay` in `packages/ui` never moved off the shadcn/ui default:

```
bg-black/80 dark:bg-background/50
```

Light mode dims the page with **80%** of the design system's ink, while dark mode uses only 50% of the near-black `--background` (`#19191B`). So the light theme reads noticeably heavier than the dark one — the opposite of the usual relationship — and 40 `<Dialog>` call sites in `apps/platform` all inherit it.

The blur was never a deliberate omission either. Three surfaces already hand-rolled it:

- `views/onboarding/onboarding-shell.tsx` — `overlayClassName="bg-black/45 backdrop-blur-sm dark:bg-black/45"`
- `views/clerk/clerk-appearance.ts` — `backdropFilter: "blur(2px)"`
- `views/zero-page/browser-session-panel.tsx` — `bg-background/50 backdrop-blur-md`

This promotes that treatment into the shared primitive.

## What

`packages/ui/src/components/ui/dialog.tsx`:

```diff
-"zero-dialog-overlay fixed inset-0 z-50 bg-black/80 dark:bg-background/50"
+"zero-dialog-overlay fixed inset-0 z-50 bg-overlay/45 backdrop-blur-sm dark:bg-overlay/55"
```

- Light drops to **45%**, matching the value onboarding already shipped.
- Dark settles on **55%**. The dark card (`240 4% 14%`) sits close in tone to the dark page background, so it needs a slightly stronger scrim than light mode to separate from it.
- `backdrop-blur-sm` is **8px** on Tailwind v4 (`tailwindcss@^4.3.3`; v4 renamed the v3 4px `sm` step to `xs`). Verified against the deployed preview: the overlay computes to `backdrop-filter: blur(8px)`.
- `onboarding-shell.tsx` drops its now-redundant `overlayClassName` and inherits the shared value.

### New `--overlay` token

`bg-black` resolves to `--color-black` → `--black`, which this design system **inverts per theme**: `240 3% 10%` (`#19191B`) in light, `0 0% 100%` in dark. A `dark:bg-black/55` scrim therefore painted a 55% *white* wash that lifted the backdrop instead of dimming it — caught on the deployed preview, not by tests.

`globals.css` gains a scrim token that deliberately does not invert:

```css
--color-overlay: hsl(var(--overlay));
/* :root only — the dark theme reuses it and only raises the alpha */
--overlay: 240 3% 10%; /* #19191B */
```

Light is unchanged by this (there `--black` already resolved to `#19191B`); dark now dims with the same ink.

## Browser support

`backdrop-filter` is Baseline widely available — Chrome 76+, Edge 79+, Firefox 103+, Safari 9+ with `-webkit-`. Windows Chrome/Edge/Firefox all support it, and the repo already ships `backdrop-blur-*` in several places, so this adds no new compatibility surface.

## Performance notes

A full-viewport `backdrop-filter` makes the compositor re-blur the backdrop while the overlay animates. Two things keep that bounded:

- The overlay's entrance is a 180ms opacity fade (`globals.css`), and `prefers-reduced-motion: reduce` already sets `animation: none` on it, so reduced-motion users get a static blur with no per-frame recomposite. No extra media query is needed — blur is not motion, and gating it on `prefers-reduced-motion` would be the wrong signal.
- 8px stays well below a large-radius blur, which matters for the dialogs whose backdrop contains a live iframe (template preview, artifact preview, browser session).

## Not in scope

`SheetOverlay` renders `fixed inset-0 z-50` with no background at all, so sheets currently have no scrim. That is a separate decision and is left untouched.

## Verification

Visual check on the deployed preview (`https://pr-25719-app.omby.ai`, Settings dialog + template picker, light and dark):

- light — backdrop dimmed and blurred, markedly lighter than the old 80% wash
- dark — backdrop dimmed, not lifted, after the `--overlay` fix

Local:

- `pnpm format` clean, `git diff --check` clean
- `pnpm turbo run lint --filter=@vm0/ui --filter=@vm0/app --concurrency=1` — 6/6 pass, 0 warnings 0 errors
- `pnpm check-types` — 12/13 pass. `@vm0/pi-agent-runtime#check-types` fails on `Cannot find module 'msw'` in `src/agent-loop.test.ts`; reproduced on a clean stashed tree, so it is a pre-existing local dependency issue unrelated to this diff.
- `pnpm -F @vm0/ui exec vitest run src/components/ui/__tests__/dialog.test.tsx` — 1 passed
- `pnpm -F @vm0/app exec vitest run` on `onboarding-flow`, `chat-composer-template-picker`, `zero-sidebar-account-menu` (the three suites that touch `.zero-dialog-overlay`) — 64 passed
- `pnpm knip --workspace packages/ui` and `--workspace apps/platform` — clean

No test asserts the overlay's colour or blur classes; per `docs/testing/testing-external-behavior.md` platform tests should not assert on CSS classes, so this visual change adds none. The inverted-token bug it would have taken to catch this is a colour-resolution issue that only the rendered page shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)