### PR TITLE
perf(api): drop the dom lib from the api type-check surface

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -29,7 +29,7 @@ type BrowserUseCdpCommandMock = Mock<
 >;
 interface RequestOptionsLike {
   readonly family?: number;
-  readonly headers?: HeadersInit;
+  readonly headers?: RequestInit["headers"];
   readonly method?: string;
   readonly lookup?: LookupFunction;
 }

--- a/turbo/apps/api/src/signals/context/route.ts
+++ b/turbo/apps/api/src/signals/context/route.ts
@@ -26,7 +26,7 @@ interface ResponseLike {
   readonly status: number;
   readonly statusText?: string;
   readonly headers: HeadersLike;
-  readonly body: BodyInit | null;
+  readonly body: ConstructorParameters<typeof Response>[0];
 }
 
 function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
@@ -60,12 +60,15 @@ function cloneHeaders(headers: HeadersLike): Headers {
 }
 
 function toResponse(response: ResponseLike): Response {
-  const init: ResponseInit = {
+  const init = {
     headers: cloneHeaders(response.headers),
     status: response.status,
   };
   if (typeof response.statusText === "string") {
-    init.statusText = response.statusText;
+    return new Response(response.body, {
+      ...init,
+      statusText: response.statusText,
+    });
   }
   return new Response(response.body, init);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -238,7 +238,9 @@ async function connectGoogleCalendar(
   );
 }
 
-async function postGoogleCalendarWebhook(headers: HeadersInit): Promise<{
+async function postGoogleCalendarWebhook(
+  headers: NonNullable<RequestInit["headers"]>,
+): Promise<{
   readonly status: number;
   readonly body: unknown;
 }> {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -45,7 +45,7 @@ function oauthStartUrl(connectorSlug: string, origin = BASE_URL): string {
   ).toString();
 }
 
-function authHeaders(): HeadersInit {
+function authHeaders(): Record<string, string> {
   return { authorization: "Bearer clerk-session" };
 }
 
@@ -104,7 +104,7 @@ async function requestOauthStart(
     readonly authMethod?: ConnectorAuthMethodId;
     readonly authenticated?: boolean;
     readonly callbackTarget?: "app";
-    readonly headers?: HeadersInit;
+    readonly headers?: RequestInit["headers"];
     readonly origin?: string;
   } = {},
 ): Promise<Response> {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -843,7 +843,7 @@ describe("Feishu integration", () => {
     const connectBody = feishuConnectBody(connectUrl);
     const statusResponse = await connectApp.request(
       `/api/zero/feishu/connect/status?${new URLSearchParams(
-        Object.entries(connectBody).map(([key, value]) => {
+        Object.entries(connectBody).map(([key, value]): [string, string] => {
           return [key, String(value)];
         }),
       )}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -261,7 +261,10 @@ function encryptPayload(payload: unknown): string {
   });
 }
 
-function signedHeaders(body: string, timestamp: number): HeadersInit {
+function signedHeaders(
+  body: string,
+  timestamp: number,
+): Record<string, string> {
   const nonce = randomUUID();
   const signature = createHash("sha256")
     .update(`${String(timestamp)}${nonce}${ENCRYPT_KEY}${body}`)

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-share-x.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-share-x.test.ts
@@ -53,7 +53,7 @@ function client() {
 
 function mockXImageShareProvider(options?: {
   readonly contentLength?: string | null;
-  readonly imageBody?: BodyInit;
+  readonly imageBody?: ReadableStream<Uint8Array> | Uint8Array;
   readonly imageBytes?: Uint8Array;
 }): {
   readonly mediaUploadBodies: unknown[];

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
@@ -28,7 +28,7 @@ async function appRequest(
   path: string,
   options: {
     readonly origin?: string;
-    readonly headers?: HeadersInit;
+    readonly headers?: RequestInit["headers"];
   } = {},
 ): Promise<Response> {
   const app = createAppWithRoutes({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -15,6 +15,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { signSandboxJwtForTests, verifyZeroToken } from "../../auth/tokens";
@@ -997,8 +998,11 @@ describe("POST /api/zero/teams/bot", () => {
         idempotencyKey: "19:thread@thread.tacv2:message:activity-1",
       },
     });
-    expect(body.connectUrl).toContain(`${APP_ORIGIN}/settings/teams`);
-    const connectUrl = new URL(String(body.connectUrl));
+    const { connectUrl: connectUrlValue } = z
+      .object({ connectUrl: z.string() })
+      .parse(body);
+    expect(connectUrlValue).toContain(`${APP_ORIGIN}/settings/teams`);
+    const connectUrl = new URL(connectUrlValue);
     expect(connectUrl.searchParams.get("tenantId")).toBe("tenant-1");
     expect(connectUrl.searchParams.get("tenantName")).toBe("Tenant One");
     expect(connectUrl.searchParams.get("teamsUserId")).toBe("29:user-1");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
@@ -86,7 +86,7 @@ function connectUrl(params: {
 
 async function requestConnect(
   url: string,
-  headers?: HeadersInit,
+  headers?: RequestInit["headers"],
 ): Promise<Response> {
   const app = createAppWithRoutes({
     signal: context.signal,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
@@ -39,7 +39,7 @@ async function appRequest(
   path: string,
   options: {
     readonly origin?: string;
-    readonly headers?: HeadersInit;
+    readonly headers?: RequestInit["headers"];
   } = {},
 ): Promise<Response> {
   const app = createAppWithRoutes({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -309,7 +309,7 @@ function expectedCredits(
 }
 
 function sttFile(
-  body: BlobPart = wavBytes(1),
+  body: Uint8Array = wavBytes(1),
   type = "audio/wav",
   name = "speech.wav",
 ): File {

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -122,7 +122,10 @@ function createAppJwt(appId: string, privateKeyPemOrBase64: string): string {
   return `${signingInput}.${signature}`;
 }
 
-function githubHeaders(appId: string, privateKey: string): HeadersInit {
+function githubHeaders(
+  appId: string,
+  privateKey: string,
+): Record<string, string> {
   return {
     Authorization: `Bearer ${createAppJwt(appId, privateKey)}`,
     Accept: "application/vnd.github+json",

--- a/turbo/apps/api/tsconfig.json
+++ b/turbo/apps/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@vm0/typescript-config/base.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022"],
     "noEmit": true,
     "incremental": true,
     "tsBuildInfoFile": "./.tsbuildinfo",

--- a/turbo/packages/connectors/src/auth-providers/connectors/cloudflare/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/cloudflare/oauth.ts
@@ -47,7 +47,7 @@ function parseScopes(scope: string | undefined): readonly string[] {
 function cloudflareTokenRequestHeaders(
   clientId: string,
   clientSecret: string,
-): HeadersInit {
+): Record<string, string> {
   return {
     Authorization: basicAuthHeader(clientId, clientSecret),
     "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
## Why

`apps/api`'s `check-types` peaks at ~3.27 GiB against a `--max-old-space-size=3072`
ceiling, so every project that lands in the `tsconfig.core.json` program is worth
auditing. `lib.dom` + `lib.dom.iterable` contribute ~2100 ambient declarations
that this process can never have: the API is a Node server, and every web global
it actually uses — `fetch`, `Response`, `Headers`, `FormData`, `File`, `Blob`,
`WebSocket`, `crypto`, `structuredClone`, `ReadableStream`, `performance` — is
already declared by `@types/node`.

A CI ablation on a scratch branch measured this at −44 MiB of peak RSS on
`tsconfig.core.json`, which is the peak of the whole `check-types` chain.
This continues the type-surface work from #25714.

## What changed

`apps/api/tsconfig.json` now sets `"lib": ["ES2022"]` (matching `apps/cli`).

Exactly three global type names in the api program resolved from `lib.dom`
alone. I enumerated them by taking the declaration names in
`lib.dom*.d.ts`, subtracting everything reachable from `lib.es2022` and
`@types/node`, and then walking every source file in the api program for free
identifiers in that set — the result was `BodyInit`, `HeadersInit` and
`BlobPart`, and after this change the same scan reports zero:

| Site | Before | After |
| --- | --- | --- |
| `signals/context/route.ts` `ResponseLike.body` | `BodyInit \| null` | `ConstructorParameters<typeof Response>[0]` |
| `signals/services/github-oauth.service.ts` `githubHeaders` | `HeadersInit` | `Record<string, string>` |
| `packages/connectors/.../cloudflare/oauth.ts` `cloudflareTokenRequestHeaders` | `HeadersInit` | `Record<string, string>` |
| 7 test helpers passing headers to `fetch`/`app.request` | `HeadersInit` | `RequestInit["headers"]` |
| `zero-image-share-x.test.ts` `imageBody` | `BodyInit` | `ReadableStream<Uint8Array> \| Uint8Array` |
| `zero-voice-io-post.test.ts` `sttFile` | `BlobPart` | `Uint8Array` |

`ConstructorParameters<typeof Response>[0]` and `RequestInit["headers"]` are the
same types the DOM spellings denoted, expressed against whichever global is in
scope, so they stay correct under either lib set. The narrower spellings
(`Record<string, string>`, `Uint8Array`) match what every call site already
passes.

Dropping `lib.dom` also swaps `ResponseInit` from the DOM declaration to
undici's, whose `statusText` is `readonly`. `toResponse` therefore builds its
init object in one expression instead of assigning `init.statusText` after the
fact. Behavior is identical: `statusText` is still only passed through when the
source response carries one.

`packages/connectors` keeps `lib.dom` in its own `tsconfig.json`; it is edited
here because `api` resolves it from source (`exports` point at `src/*.ts`) and
so type-checks it with the api lib set. `Record<string, string>` is valid under
both.

## Verification

`lint-types-apps` reports `Peak RSS (api check-types)` for the whole
`check-types` chain. Numbers from that job, all on the same runner image:

| Commit | Peak RSS |
| --- | --- |
| main `9b57e04` | 3062.6 MiB |
| main `4582020` | 3074.0 MiB |
| main `3e52c0d` | 3089.8 MiB |
| main `2110a56` | 3103.0 MiB |
| this branch `faa9014` | **3042.3 MiB** |

Main's four post-#25714 samples span 40 MiB (mean 3082.4), so the honest read is
**−40 MiB against the mean and −20 MiB against the best main sample** — in line
with the −44 MiB the isolated `tsconfig.core.json` ablation measured, but a
single branch sample cannot resolve better than the job's own noise. For
reference, the same job read 3340–3342 MiB on the four commits before #25714.

Also verified:

- The DOM-only free-identifier scan described above reports 0 remaining sites.
- No runtime code changed, only type annotations and one expression that was
  already building the same `Response`.

Two follow-on type errors surfaced in the tests program once the DOM globals
were gone, both fixed in the second commit: `Response.json()` returns
`Promise<unknown>` under undici instead of DOM's `Promise<any>` (the Teams
connect URL is now parsed with zod), and the `URLSearchParams` constructor wants
tuple entries rather than `string[][]`.

## Fallbacks

Fallbacks: none.

For completeness, the `typeof response.statusText === "string"` branch in
`toResponse` is pre-existing optional-field handling, not a compatibility
fallback, and it is preserved verbatim — the diff only moves it from a
post-hoc mutation to a branch that returns the constructed `Response`.
