### PR TITLE
fix(connectors): enforce exact custom credential readers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -47,6 +47,7 @@ import {
   downgradeCustomConnectorOAuthStorageState,
   readCustomConnectorCredentialStorageParent,
   readCustomConnectorOAuthStorageState,
+  setCustomConnectorCredentialStorageState,
 } from "./helpers/connector-credential-storage-state";
 import { zeroCustomConnectorsRoutes } from "../zero-custom-connectors";
 
@@ -1661,6 +1662,51 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connectorsApi.readAgentCustomConnectors(member, agent.agentId),
     ).resolves.toContain(created.id);
 
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: requiredOrgId(member),
+      userId: member.userId,
+      customConnectorId: created.id,
+      authMethod: "manual",
+      storageVersion: 1,
+    });
+    const authMethodMismatch = await connectorsApi.listCustomConnectors(member);
+    expect(
+      authMethodMismatch.find((connector) => {
+        return connector.id === created.id;
+      }),
+    ).toMatchObject({
+      connected: false,
+      missingRequiredFields: ["oauth"],
+    });
+    const rejectedGrant =
+      await connectorsApi.requestUpdateAgentCustomConnectors(
+        member,
+        agent.agentId,
+        [created.id],
+        [400],
+      );
+    expectApiError(rejectedGrant.body);
+    expect(rejectedGrant.body.error.message).toContain(
+      "not configured for this user",
+    );
+    await expect(
+      connectorsApi.readAgentCustomConnectors(member, agent.agentId),
+    ).resolves.toContain(created.id);
+
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: requiredOrgId(member),
+      userId: member.userId,
+      customConnectorId: created.id,
+      authMethod: "oauth",
+      storageVersion: 1,
+    });
+    const restoredConnection = await connectorsApi.listCustomConnectors(member);
+    expect(
+      restoredConnection.find((connector) => {
+        return connector.id === created.id;
+      }),
+    ).toMatchObject({ connected: true });
+
     await connectorsApi.deleteCustomConnector(admin, created.id);
     await bdd.deleteAgent(member, agent.agentId);
   });
@@ -2144,6 +2190,39 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       configuredFieldKeys: ["api_key", "subdomain"],
     });
     expectNoVisibleSecret(listed, "configured-secret");
+
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: requiredOrgId(admin),
+      userId: admin.userId,
+      customConnectorId: created.id,
+      authMethod: "manual",
+      storageVersion: 2,
+    });
+    const storageVersionMismatch =
+      await connectorsApi.listCustomConnectors(admin);
+    expect(
+      storageVersionMismatch.find((connector) => {
+        return connector.id === created.id;
+      }),
+    ).toMatchObject({
+      connected: false,
+      configuredFieldKeys: [],
+      missingRequiredFields: ["api_key", "subdomain"],
+    });
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject({
+      connected: false,
+      configuredFieldKeys: [],
+      missingRequiredFields: ["api_key", "subdomain"],
+    });
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: requiredOrgId(admin),
+      userId: admin.userId,
+      customConnectorId: created.id,
+      authMethod: "manual",
+      storageVersion: 1,
+    });
 
     await connectorsApi.deleteCustomConnectorSecret(admin, created.id);
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1806,6 +1806,25 @@ export function createConnectorBddApi(context: TestContext) {
       return response.body.connectors;
     },
 
+    async readCustomConnector(
+      actor: ApiTestUser,
+      connectorId: string,
+    ): Promise<CustomConnectorResponse> {
+      const client = setupApp({
+        context,
+        routes: zeroCustomConnectorByIdTestRoutes,
+      })(zeroCustomConnectorByIdContract);
+      const response = await accept(
+        client.get({
+          params: { id: connectorId },
+          headers: authenticate(actor),
+        }),
+        [200],
+      );
+      expectStatus(response, 200);
+      return response.body;
+    },
+
     async requestCustomConnectorPermissions(
       actor: ApiTestUser | null,
       connectorId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -156,6 +156,26 @@ export async function setConnectorCredentialStorageState(
   });
 }
 
+export async function setCustomConnectorCredentialStorageState(
+  context: TestContext,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly customConnectorId: string;
+    readonly authMethod: "manual" | "oauth";
+    readonly storageVersion: number;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "set-custom-parent-state",
+    org_id: args.orgId,
+    user_id: args.userId,
+    custom_connector_id: args.customConnectorId,
+    auth_method: args.authMethod,
+    storage_version: args.storageVersion,
+  });
+}
+
 export async function setConnectorSecretOwner(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -88,7 +88,10 @@ import {
   seedSlackEnvironmentAgent$,
   seedSlackOrgInstallation$,
 } from "./helpers/zero-integrations-slack";
-import { setConnectorCredentialStorageState } from "./helpers/connector-credential-storage-state";
+import {
+  setConnectorCredentialStorageState,
+  setCustomConnectorCredentialStorageState,
+} from "./helpers/connector-credential-storage-state";
 import {
   clearRunApiStart,
   enableFakeKms,
@@ -8473,6 +8476,57 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       state: "available",
     });
 
+    if (!actor.orgId) {
+      throw new Error("Expected a custom connector actor with an organization");
+    }
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: custom.id,
+      authMethod: "manual",
+      storageVersion: 2,
+    });
+    const [incompatibleRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    expect(incompatibleRuntime).toMatchObject({
+      target,
+      state: "absent",
+      reason: "connector-unavailable",
+    });
+    const incompatibleAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      currentAuthBody,
+      [424],
+    );
+    if (incompatibleAuth.status !== 424) {
+      throw new Error("Expected incompatible custom connector credentials");
+    }
+    expect(incompatibleAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: custom.id,
+      authMethod: "manual",
+      storageVersion: 1,
+    });
+    const [compatibleRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    expect(compatibleRuntime).toMatchObject({
+      target,
+      state: "available",
+    });
+    const compatibleAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      currentAuthBody,
+      [200],
+    );
+    expect(compatibleAuth.body).toMatchObject({
+      headers: { Authorization: "Bearer restored-custom-secret-value" },
+    });
+
     await connectors.updateCustomConnector(actor, custom.id, {
       displayName: "BDD Internal API Updated",
       prefixTemplates: ["https://*.internal.example.com/v2/"],
@@ -8695,6 +8749,19 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(claim.secretValues).not.toContain(
       "Bearer custom-oauth-initial-access-token",
     );
+    const revisionPinnedAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          Authorization: `Bearer \${{ secrets.${secretKey} }}`,
+        },
+      },
+      [200],
+    );
+    expect(revisionPinnedAuth.body).toMatchObject({
+      headers: { Authorization: "Bearer custom-oauth-initial-access-token" },
+    });
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
       targets: [{ kind: "custom", customConnectorId: custom.id }],
     });
@@ -8772,6 +8839,36 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       refreshedSecrets: [],
     });
     expect(provider.tokenBodies).toHaveLength(2);
+
+    if (!actor.orgId) {
+      throw new Error("Expected a custom connector actor with an organization");
+    }
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: custom.id,
+      authMethod: "oauth",
+      storageVersion: 2,
+    });
+    const incompatibleOAuthAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      currentAuthBody,
+      [424],
+    );
+    if (incompatibleOAuthAuth.status !== 424) {
+      throw new Error("Expected incompatible custom OAuth credentials");
+    }
+    expect(incompatibleOAuthAuth.body.error.code).toBe(
+      "CONNECTOR_NOT_CONFIGURED",
+    );
+    expect(provider.tokenBodies).toHaveLength(2);
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: custom.id,
+      authMethod: "oauth",
+      storageVersion: 1,
+    });
 
     const forceRefreshAt = firstRefreshAt + 10 * 60_000;
     mockNow(forceRefreshAt);
@@ -9402,6 +9499,76 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("omits incompatible custom credentials from initial and synced runtime", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+
+    const saved = await connectors.saveCustomConnectorProposal(actor, {
+      proposal: {
+        operation: "create",
+        displayName: "BDD Incompatible Runtime",
+        prefixTemplates: [`https://${rand}.incompatible.test/v1/`],
+        fields: [
+          {
+            key: "secret",
+            label: "API key",
+            kind: "secret",
+            required: false,
+          },
+        ],
+        headerInjections: [
+          {
+            name: "X-Connector",
+            valueTemplate: "incompatible-runtime",
+          },
+        ],
+        queryInjections: [],
+      },
+      values: [
+        {
+          key: "secret",
+          kind: "secret",
+          value: "incompatible-runtime-secret",
+        },
+      ],
+      agentId,
+    });
+    if (!actor.orgId) {
+      throw new Error("Expected a custom connector actor with an organization");
+    }
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: saved.connector.id,
+      authMethod: "manual",
+      storageVersion: 2,
+    });
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "do not use the incompatible custom connector",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const internalName = `custom_connector_${saved.connector.id.replaceAll("-", "")}`;
+    expect(findFirewallEntry(claim.firewalls, internalName)).toBeUndefined();
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty(internalName);
+
+    const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [{ kind: "custom", customConnectorId: saved.connector.id }],
+    });
+    expect(runtimeResult).toMatchObject({
+      state: "absent",
+      reason: "connector-unavailable",
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    await connectors.deleteCustomConnector(actor, saved.connector.id);
   });
 
   it("keeps legacy omission while sync preserves optional-only firewall", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8489,11 +8489,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const [incompatibleRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
     });
-    expect(incompatibleRuntime).toMatchObject({
-      target,
-      state: "absent",
-      reason: "connector-unavailable",
-    });
+    const incompatibleAvailable =
+      availableCustomConnectorRuntime(incompatibleRuntime);
+    expect(incompatibleAvailable.firewall).toStrictEqual(
+      updatedAvailable.firewall,
+    );
+    expect(incompatibleAvailable.networkPolicy).toStrictEqual(
+      updatedAvailable.networkPolicy,
+    );
     const incompatibleAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       currentAuthBody,
@@ -8503,6 +8506,38 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       throw new Error("Expected incompatible custom connector credentials");
     }
     expect(incompatibleAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: custom.id,
+      authMethod: "oauth",
+      storageVersion: 1,
+    });
+    const [incompatibleAuthMethodRuntime] = await api.syncConnectorRuntime(
+      run.runId,
+      { targets: [target] },
+    );
+    const incompatibleAuthMethodAvailable = availableCustomConnectorRuntime(
+      incompatibleAuthMethodRuntime,
+    );
+    expect(incompatibleAuthMethodAvailable.firewall).toStrictEqual(
+      updatedAvailable.firewall,
+    );
+    expect(incompatibleAuthMethodAvailable.networkPolicy).toStrictEqual(
+      updatedAvailable.networkPolicy,
+    );
+    const incompatibleAuthMethod = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      currentAuthBody,
+      [424],
+    );
+    if (incompatibleAuthMethod.status !== 424) {
+      throw new Error("Expected incompatible custom connector auth method");
+    }
+    expect(incompatibleAuthMethod.body.error.code).toBe(
+      "CONNECTOR_NOT_CONFIGURED",
+    );
 
     await setCustomConnectorCredentialStorageState(context, {
       orgId: actor.orgId,
@@ -9501,7 +9536,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("omits incompatible custom credentials from initial and synced runtime", async () => {
+  it("omits incompatible custom credentials initially while sync preserves firewall", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -9562,10 +9597,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
       targets: [{ kind: "custom", customConnectorId: saved.connector.id }],
     });
-    expect(runtimeResult).toMatchObject({
-      state: "absent",
-      reason: "connector-unavailable",
-    });
+    const availableRuntime = availableCustomConnectorRuntime(runtimeResult);
+    expect(availableRuntime.firewall.customConnectorId).toBe(
+      saved.connector.id,
+    );
+    expect(availableRuntime.networkPolicy.unknownPolicy).toBe("allow");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     await connectors.deleteCustomConnector(actor, saved.connector.id);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -56,6 +56,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   readCustomConnectorCredentialStorageParent,
   readCustomConnectorOAuthStorageState,
+  setCustomConnectorCredentialStorageState,
 } from "./helpers/connector-credential-storage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
@@ -1558,6 +1559,50 @@ describe("Feishu integration", () => {
       isConnected: true,
       connectedUserName: "Feishu User",
     });
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: requireValue(
+        admin.orgId,
+        "Expected Feishu admin to have an organization",
+      ),
+      userId: admin.userId,
+      customConnectorId: managedConnector.id,
+      authMethod: "oauth",
+      storageVersion: 2,
+    });
+    const incompatibleFeishuStatus = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(incompatibleFeishuStatus.body.isConnected).toBeFalsy();
+    const incompatibleConnectorList = await accept(
+      customConnectorClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(incompatibleConnectorList.body.connectors[0]).toMatchObject({
+      id: managedConnector.id,
+      connected: false,
+    });
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: requireValue(
+        admin.orgId,
+        "Expected Feishu admin to have an organization",
+      ),
+      userId: admin.userId,
+      customConnectorId: managedConnector.id,
+      authMethod: "oauth",
+      storageVersion: 1,
+    });
+    const restoredFeishuStatus = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(restoredFeishuStatus.body.isConnected).toBeTruthy();
     await accept(
       setupApp({ context, routes: zeroCustomConnectorSecretTestRoutes })(
         zeroCustomConnectorSecretContract,

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -319,6 +319,34 @@ async function setConnectorState(
       };
 }
 
+async function setCustomParentState(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"set-custom-parent-state">,
+  signal: AbortSignal,
+) {
+  const [updated] = await db
+    .update(connectors)
+    .set({
+      authMethod: body.auth_method,
+      storageVersion: body.storage_version,
+    })
+    .where(
+      and(
+        eq(connectors.orgId, body.org_id),
+        eq(connectors.userId, body.user_id),
+        eq(connectors.customConnectorId, body.custom_connector_id),
+      ),
+    )
+    .returning({ id: connectors.id });
+  signal.throwIfAborted();
+  return updated
+    ? actionOk({ connector_id: updated.id })
+    : {
+        status: 400 as const,
+        body: { error: "Custom connector storage test fixture was not found" },
+      };
+}
+
 async function setSecretOwner(
   db: Db,
   body: ConnectorCredentialStorageAction<"set-secret-owner">,
@@ -406,6 +434,9 @@ const mutateConnectorCredentialStorageState$ = command(
       }
       case "set-connector-state": {
         return await setConnectorState(db, body, signal);
+      }
+      case "set-custom-parent-state": {
+        return await setCustomParentState(db, body, signal);
       }
       case "set-secret-owner": {
         return await setSecretOwner(db, body, signal);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3891,7 +3891,10 @@ export async function buildCustomConnectorRuntimeContext(
   );
   const stats = new CustomConnectorRuntimeBuildStats(args.rows);
   for (const row of args.rows) {
-    if (row.credentialAccess.kind === "incompatible") {
+    if (
+      row.credentialAccess.kind === "incompatible" &&
+      !args.preserveFirewallWithoutCredentials
+    ) {
       continue;
     }
     const missingRequiredStartedAt = now();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3891,6 +3891,9 @@ export async function buildCustomConnectorRuntimeContext(
   );
   const stats = new CustomConnectorRuntimeBuildStats(args.rows);
   for (const row of args.rows) {
+    if (row.credentialAccess.kind === "incompatible") {
+      continue;
+    }
     const missingRequiredStartedAt = now();
     const valueMarkers = new Set(
       row.values.map((value) => {
@@ -4106,6 +4109,7 @@ async function loadCustomConnectorContext(
   for (const row of rows) {
     refreshedRows.push({
       connector: row.connector,
+      credentialAccess: row.credentialAccess,
       values: await refreshCustomConnectorOAuth2ValuesIfNeeded({
         db,
         orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -104,7 +104,8 @@ import {
 } from "./connector-credential-access.service";
 import {
   CustomConnectorOAuth2TokenRefreshError,
-  resolveLiveCustomConnectorOAuth2AccessToken,
+  resolveCurrentCustomConnectorOAuth2AccessToken,
+  resolveRevisionPinnedCustomConnectorOAuth2AccessToken,
 } from "./custom-connector-oauth2.service";
 import {
   CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
@@ -3058,6 +3059,18 @@ async function syncCustomConnectorRuntimeSecrets(args: {
       ),
     );
 
+  if (rows.length > 0) {
+    L.debug("Revision-pinned custom connector auth references remain in use", {
+      runId: args.runId,
+      connectorCount: new Set(
+        rows.map((row) => {
+          return row.connectorId;
+        }),
+      ).size,
+      authRefCount: rows.length,
+    });
+  }
+
   for (const row of rows) {
     if (Object.hasOwn(args.secrets, row.secretName)) {
       continue;
@@ -3065,7 +3078,7 @@ async function syncCustomConnectorRuntimeSecrets(args: {
     let encryptedValue = row.encryptedValue;
     if (row.key === CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY) {
       const accessToken = await tapError(
-        resolveLiveCustomConnectorOAuth2AccessToken({
+        resolveRevisionPinnedCustomConnectorOAuth2AccessToken({
           db: args.db,
           orgId: args.orgId,
           userId: args.userId,
@@ -4167,7 +4180,6 @@ function hasEmptyAwsSigv4Credential(
 interface CurrentCustomConnectorAuthRef {
   readonly secretName: string;
   readonly connectorId: string;
-  readonly connectorRevision: number;
   readonly key: string;
   readonly encryptedValue: string | null;
   readonly required: boolean;
@@ -4185,6 +4197,9 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     connectorIds: [args.customConnectorId],
   });
   if (!runtime) {
+    return undefined;
+  }
+  if (runtime.credentialAccess.kind === "incompatible") {
     return undefined;
   }
 
@@ -4214,7 +4229,6 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     refs.set(secretName, {
       secretName,
       connectorId: runtime.connector.id,
-      connectorRevision: runtime.connector.revision,
       key: value.key,
       encryptedValue: value.encryptedValue,
       required: field.required,
@@ -4227,7 +4241,6 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     refs.set(secretName, {
       secretName,
       connectorId: runtime.connector.id,
-      connectorRevision: runtime.connector.revision,
       key: field.key,
       encryptedValue: null,
       required: field.required,
@@ -4242,7 +4255,6 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     refs.set(secretName, {
       secretName,
       connectorId: runtime.connector.id,
-      connectorRevision: runtime.connector.revision,
       key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
       encryptedValue: null,
       required: true,
@@ -4311,12 +4323,11 @@ async function resolveCurrentCustomConnectorSecrets(args: {
       ref.key === CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY
     ) {
       const accessToken = await settle(
-        resolveLiveCustomConnectorOAuth2AccessToken({
+        resolveCurrentCustomConnectorOAuth2AccessToken({
           db: args.db,
           orgId: args.auth.orgId,
           userId: args.auth.userId,
           connectorId: ref.connectorId,
-          connectorRevision: ref.connectorRevision,
           featureContext: featureSwitchContext,
           signal: AbortSignal.timeout(firewallAuthRefreshTimeoutMs()),
           forceRefresh: args.forceRefresh,

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -148,6 +148,9 @@ async function resolveCustomTarget(args: {
       expectedStorageVersion:
         custom.row.credentialAccess.expectedStorageVersion,
       storedStorageVersion: custom.row.credentialAccess.storedStorageVersion,
+      definitionAuthMethod: custom.row.credentialAccess.definitionAuthMethod,
+      definitionStorageVersion:
+        custom.row.credentialAccess.definitionStorageVersion,
     });
     return customAbsentResult(args.target, "connector-unavailable");
   }

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -140,6 +140,7 @@ async function resolveCustomTarget(args: {
     return customAbsentResult(args.target, "connector-unavailable");
   }
   if (custom.row.credentialAccess.kind === "incompatible") {
+    // Credential compatibility gates auth resolution, not definition-owned policy.
     L.debug("Custom connector credential storage is incompatible", {
       customConnectorId: args.target.customConnectorId,
       memberConnectorId: custom.row.credentialAccess.memberConnectorId,
@@ -152,7 +153,6 @@ async function resolveCustomTarget(args: {
       definitionStorageVersion:
         custom.row.credentialAccess.definitionStorageVersion,
     });
-    return customAbsentResult(args.target, "connector-unavailable");
   }
   if (!custom.grant) {
     return customAbsentResult(args.target, "grant-unavailable");

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -7,6 +7,7 @@ import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zer
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { and, eq, inArray } from "drizzle-orm";
 
+import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import { settle } from "../utils";
 import {
@@ -22,6 +23,8 @@ import {
   CustomConnectorRuntimePrefixError,
   loadCustomConnectorRuntimeData,
 } from "./zero-custom-connector.service";
+
+const L = logger("connector-runtime-sync");
 
 interface ConnectorRuntimeScope {
   readonly orgId: string;
@@ -134,6 +137,18 @@ async function resolveCustomTarget(args: {
 }): Promise<ConnectorRuntimeResolution> {
   const custom = args.snapshot.customTargets.get(args.target.customConnectorId);
   if (!custom) {
+    return customAbsentResult(args.target, "connector-unavailable");
+  }
+  if (custom.row.credentialAccess.kind === "incompatible") {
+    L.debug("Custom connector credential storage is incompatible", {
+      customConnectorId: args.target.customConnectorId,
+      memberConnectorId: custom.row.credentialAccess.memberConnectorId,
+      expectedAuthMethod: custom.row.credentialAccess.expectedAuthMethod,
+      storedAuthMethod: custom.row.credentialAccess.storedAuthMethod,
+      expectedStorageVersion:
+        custom.row.credentialAccess.expectedStorageVersion,
+      storedStorageVersion: custom.row.credentialAccess.storedStorageVersion,
+    });
     return customAbsentResult(args.target, "connector-unavailable");
   }
   if (!custom.grant) {

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -38,6 +38,8 @@ export type CustomConnectorCredentialAccess =
       readonly storedAuthMethod: string;
       readonly expectedStorageVersion: number;
       readonly storedStorageVersion: number;
+      readonly definitionAuthMethod: OrgCustomConnectorAuthMode;
+      readonly definitionStorageVersion: number;
     };
 
 export async function loadCustomConnectorCredentialAccesses(
@@ -58,8 +60,17 @@ export async function loadCustomConnectorCredentialAccesses(
       customConnectorId: connectors.customConnectorId,
       authMethod: connectors.authMethod,
       storageVersion: connectors.storageVersion,
+      definitionAuthMethod: orgCustomConnectors.authMode,
+      definitionStorageVersion: orgCustomConnectors.storageVersion,
     })
     .from(connectors)
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, connectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, connectors.orgId),
+      ),
+    )
     .where(
       and(
         eq(connectors.orgId, args.orgId),
@@ -85,6 +96,8 @@ export async function loadCustomConnectorCredentialAccesses(
     if (!member) {
       accesses.set(definition.id, { kind: "absent" });
     } else if (
+      member.definitionAuthMethod === definition.authMode &&
+      member.definitionStorageVersion === definition.storageVersion &&
       member.authMethod === definition.authMode &&
       member.storageVersion === definition.storageVersion
     ) {
@@ -100,6 +113,8 @@ export async function loadCustomConnectorCredentialAccesses(
         storedAuthMethod: member.authMethod,
         expectedStorageVersion: definition.storageVersion,
         storedStorageVersion: member.storageVersion,
+        definitionAuthMethod: member.definitionAuthMethod,
+        definitionStorageVersion: member.definitionStorageVersion,
       });
     }
   }
@@ -117,73 +132,75 @@ export async function loadCurrentCustomConnectorValueMarkers(
   if (args.connectorIds?.length === 0) {
     return [];
   }
-  const valueRows = await db
-    .select({
-      connectorId: orgCustomConnectorValues.connectorId,
-      kind: orgCustomConnectorValues.kind,
-      key: orgCustomConnectorValues.key,
-    })
-    .from(orgCustomConnectorValues)
-    .innerJoin(
-      orgCustomConnectors,
-      and(
-        eq(orgCustomConnectors.id, orgCustomConnectorValues.connectorId),
-        eq(orgCustomConnectors.orgId, orgCustomConnectorValues.orgId),
+  const [valueRows, legacyRows] = await Promise.all([
+    db
+      .select({
+        connectorId: orgCustomConnectorValues.connectorId,
+        kind: orgCustomConnectorValues.kind,
+        key: orgCustomConnectorValues.key,
+      })
+      .from(orgCustomConnectorValues)
+      .innerJoin(
+        orgCustomConnectors,
+        and(
+          eq(orgCustomConnectors.id, orgCustomConnectorValues.connectorId),
+          eq(orgCustomConnectors.orgId, orgCustomConnectorValues.orgId),
+        ),
+      )
+      .innerJoin(
+        connectors,
+        and(
+          eq(connectors.customConnectorId, orgCustomConnectors.id),
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.authMethod, orgCustomConnectors.authMode),
+          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+        ),
+      )
+      .where(
+        and(
+          eq(orgCustomConnectorValues.orgId, args.orgId),
+          eq(orgCustomConnectorValues.userId, args.userId),
+          args.connectorIds
+            ? inArray(orgCustomConnectorValues.connectorId, [
+                ...args.connectorIds,
+              ])
+            : undefined,
+        ),
       ),
-    )
-    .innerJoin(
-      connectors,
-      and(
-        eq(connectors.customConnectorId, orgCustomConnectors.id),
-        eq(connectors.orgId, args.orgId),
-        eq(connectors.userId, args.userId),
-        eq(connectors.authMethod, orgCustomConnectors.authMode),
-        eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+    db
+      .select({ connectorId: orgCustomConnectorSecrets.connectorId })
+      .from(orgCustomConnectorSecrets)
+      .innerJoin(
+        orgCustomConnectors,
+        and(
+          eq(orgCustomConnectors.id, orgCustomConnectorSecrets.connectorId),
+          eq(orgCustomConnectors.orgId, orgCustomConnectorSecrets.orgId),
+          eq(orgCustomConnectors.authMode, "manual"),
+        ),
+      )
+      .innerJoin(
+        connectors,
+        and(
+          eq(connectors.customConnectorId, orgCustomConnectors.id),
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.authMethod, orgCustomConnectors.authMode),
+          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+        ),
+      )
+      .where(
+        and(
+          eq(orgCustomConnectorSecrets.orgId, args.orgId),
+          eq(orgCustomConnectorSecrets.userId, args.userId),
+          args.connectorIds
+            ? inArray(orgCustomConnectorSecrets.connectorId, [
+                ...args.connectorIds,
+              ])
+            : undefined,
+        ),
       ),
-    )
-    .where(
-      and(
-        eq(orgCustomConnectorValues.orgId, args.orgId),
-        eq(orgCustomConnectorValues.userId, args.userId),
-        args.connectorIds
-          ? inArray(orgCustomConnectorValues.connectorId, [
-              ...args.connectorIds,
-            ])
-          : undefined,
-      ),
-    );
-  const legacyRows = await db
-    .select({ connectorId: orgCustomConnectorSecrets.connectorId })
-    .from(orgCustomConnectorSecrets)
-    .innerJoin(
-      orgCustomConnectors,
-      and(
-        eq(orgCustomConnectors.id, orgCustomConnectorSecrets.connectorId),
-        eq(orgCustomConnectors.orgId, orgCustomConnectorSecrets.orgId),
-        eq(orgCustomConnectors.authMode, "manual"),
-      ),
-    )
-    .innerJoin(
-      connectors,
-      and(
-        eq(connectors.customConnectorId, orgCustomConnectors.id),
-        eq(connectors.orgId, args.orgId),
-        eq(connectors.userId, args.userId),
-        eq(connectors.authMethod, orgCustomConnectors.authMode),
-        eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
-      ),
-    )
-    .where(
-      and(
-        eq(orgCustomConnectorSecrets.orgId, args.orgId),
-        eq(orgCustomConnectorSecrets.userId, args.userId),
-        args.connectorIds
-          ? inArray(orgCustomConnectorSecrets.connectorId, [
-              ...args.connectorIds,
-            ])
-          : undefined,
-      ),
-    );
+  ]);
   const markers: CustomConnectorCredentialValueMarker[] = valueRows.flatMap(
     (row) => {
       return row.kind === "secret" || row.kind === "variable"

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -1,0 +1,265 @@
+import { and, eq, inArray } from "drizzle-orm";
+import {
+  orgCustomConnectors,
+  type OrgCustomConnectorAuthMode,
+} from "@vm0/db/schema/org-custom-connector";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets } from "@vm0/db/schema/secret";
+
+import type { ReadonlyDb } from "../external/db";
+
+const LEGACY_SECRET_KEY = "secret";
+const OAUTH_ACCESS_TOKEN_SECRET_NAME = "access_token";
+
+interface CustomConnectorCredentialValueMarker {
+  readonly connectorId: string;
+  readonly kind: "secret" | "variable";
+  readonly key: string;
+}
+
+interface CustomConnectorCredentialDefinition {
+  readonly id: string;
+  readonly authMode: OrgCustomConnectorAuthMode;
+  readonly storageVersion: number;
+}
+
+export type CustomConnectorCredentialAccess =
+  | { readonly kind: "absent" }
+  | {
+      readonly kind: "current";
+      readonly memberConnectorId: string;
+    }
+  | {
+      readonly kind: "incompatible";
+      readonly memberConnectorId: string;
+      readonly expectedAuthMethod: OrgCustomConnectorAuthMode;
+      readonly storedAuthMethod: string;
+      readonly expectedStorageVersion: number;
+      readonly storedStorageVersion: number;
+    };
+
+export async function loadCustomConnectorCredentialAccesses(
+  db: Pick<ReadonlyDb, "select">,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly definitions: readonly CustomConnectorCredentialDefinition[];
+  },
+): Promise<ReadonlyMap<string, CustomConnectorCredentialAccess>> {
+  if (args.definitions.length === 0) {
+    return new Map();
+  }
+
+  const rows = await db
+    .select({
+      id: connectors.id,
+      customConnectorId: connectors.customConnectorId,
+      authMethod: connectors.authMethod,
+      storageVersion: connectors.storageVersion,
+    })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        inArray(
+          connectors.customConnectorId,
+          args.definitions.map((definition) => {
+            return definition.id;
+          }),
+        ),
+      ),
+    );
+  const memberByConnectorId = new Map<string, (typeof rows)[number]>();
+  for (const row of rows) {
+    if (row.customConnectorId) {
+      memberByConnectorId.set(row.customConnectorId, row);
+    }
+  }
+
+  const accesses = new Map<string, CustomConnectorCredentialAccess>();
+  for (const definition of args.definitions) {
+    const member = memberByConnectorId.get(definition.id);
+    if (!member) {
+      accesses.set(definition.id, { kind: "absent" });
+    } else if (
+      member.authMethod === definition.authMode &&
+      member.storageVersion === definition.storageVersion
+    ) {
+      accesses.set(definition.id, {
+        kind: "current",
+        memberConnectorId: member.id,
+      });
+    } else {
+      accesses.set(definition.id, {
+        kind: "incompatible",
+        memberConnectorId: member.id,
+        expectedAuthMethod: definition.authMode,
+        storedAuthMethod: member.authMethod,
+        expectedStorageVersion: definition.storageVersion,
+        storedStorageVersion: member.storageVersion,
+      });
+    }
+  }
+  return accesses;
+}
+
+export async function loadCurrentCustomConnectorValueMarkers(
+  db: Pick<ReadonlyDb, "select">,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorIds?: readonly string[];
+  },
+): Promise<readonly CustomConnectorCredentialValueMarker[]> {
+  if (args.connectorIds?.length === 0) {
+    return [];
+  }
+  const valueRows = await db
+    .select({
+      connectorId: orgCustomConnectorValues.connectorId,
+      kind: orgCustomConnectorValues.kind,
+      key: orgCustomConnectorValues.key,
+    })
+    .from(orgCustomConnectorValues)
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, orgCustomConnectorValues.connectorId),
+        eq(orgCustomConnectors.orgId, orgCustomConnectorValues.orgId),
+      ),
+    )
+    .innerJoin(
+      connectors,
+      and(
+        eq(connectors.customConnectorId, orgCustomConnectors.id),
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.authMethod, orgCustomConnectors.authMode),
+        eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+      ),
+    )
+    .where(
+      and(
+        eq(orgCustomConnectorValues.orgId, args.orgId),
+        eq(orgCustomConnectorValues.userId, args.userId),
+        args.connectorIds
+          ? inArray(orgCustomConnectorValues.connectorId, [
+              ...args.connectorIds,
+            ])
+          : undefined,
+      ),
+    );
+  const legacyRows = await db
+    .select({ connectorId: orgCustomConnectorSecrets.connectorId })
+    .from(orgCustomConnectorSecrets)
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, orgCustomConnectorSecrets.connectorId),
+        eq(orgCustomConnectors.orgId, orgCustomConnectorSecrets.orgId),
+        eq(orgCustomConnectors.authMode, "manual"),
+      ),
+    )
+    .innerJoin(
+      connectors,
+      and(
+        eq(connectors.customConnectorId, orgCustomConnectors.id),
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.authMethod, orgCustomConnectors.authMode),
+        eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+      ),
+    )
+    .where(
+      and(
+        eq(orgCustomConnectorSecrets.orgId, args.orgId),
+        eq(orgCustomConnectorSecrets.userId, args.userId),
+        args.connectorIds
+          ? inArray(orgCustomConnectorSecrets.connectorId, [
+              ...args.connectorIds,
+            ])
+          : undefined,
+      ),
+    );
+  const markers: CustomConnectorCredentialValueMarker[] = valueRows.flatMap(
+    (row) => {
+      return row.kind === "secret" || row.kind === "variable"
+        ? [
+            {
+              connectorId: row.connectorId,
+              kind: row.kind,
+              key: row.key,
+            },
+          ]
+        : [];
+    },
+  );
+  const markerKeys = new Set(
+    markers.map((marker) => {
+      return `${marker.connectorId}:${marker.kind}:${marker.key}`;
+    }),
+  );
+  for (const row of legacyRows) {
+    const markerKey = `${row.connectorId}:secret:${LEGACY_SECRET_KEY}`;
+    if (!markerKeys.has(markerKey)) {
+      markers.push({
+        connectorId: row.connectorId,
+        kind: "secret",
+        key: LEGACY_SECRET_KEY,
+      });
+      markerKeys.add(markerKey);
+    }
+  }
+  return markers;
+}
+
+export async function loadCurrentCustomConnectorOAuthConnectionIds(
+  db: Pick<ReadonlyDb, "select">,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorIds?: readonly string[];
+  },
+): Promise<ReadonlySet<string>> {
+  if (args.connectorIds?.length === 0) {
+    return new Set();
+  }
+  const rows = await db
+    .select({ customConnectorId: connectors.customConnectorId })
+    .from(connectors)
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, connectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, connectors.orgId),
+        eq(orgCustomConnectors.authMode, "oauth"),
+        eq(connectors.authMethod, orgCustomConnectors.authMode),
+        eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+      ),
+    )
+    .innerJoin(
+      secrets,
+      and(
+        eq(secrets.connectorId, connectors.id),
+        eq(secrets.name, OAUTH_ACCESS_TOKEN_SECRET_NAME),
+      ),
+    )
+    .where(
+      and(
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.needsReconnect, false),
+        args.connectorIds
+          ? inArray(connectors.customConnectorId, [...args.connectorIds])
+          : undefined,
+      ),
+    );
+  return new Set(
+    rows.flatMap((row) => {
+      return row.customConnectorId ? [row.customConnectorId] : [];
+    }),
+  );
+}

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -838,13 +838,34 @@ async function loadConnection(args: {
   if (!connection) {
     return null;
   }
+  // Re-check the complete identity at the secret read boundary because the
+  // organization definition can change after the parent lookup.
   const tokenRows = await args.db
     .select({
       secretName: secrets.name,
       encryptedValue: secrets.encryptedValue,
     })
     .from(secrets)
-    .where(eq(secrets.connectorId, connection.id));
+    .innerJoin(connectors, eq(connectors.id, secrets.connectorId))
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, connectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, connectors.orgId),
+        eq(orgCustomConnectors.authMode, "oauth"),
+        eq(orgCustomConnectors.storageVersion, args.storageVersion),
+      ),
+    )
+    .where(
+      and(
+        eq(connectors.id, connection.id),
+        eq(connectors.customConnectorId, args.connectorId),
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.authMethod, "oauth"),
+        eq(connectors.storageVersion, args.storageVersion),
+      ),
+    );
   return {
     id: connection.id,
     tokenExpiresAt: connection.tokenExpiresAt,

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -4,7 +4,7 @@ import { isIP } from "node:net";
 import { request as httpsRequest } from "node:https";
 
 import { command } from "ccstate";
-import { and, eq, isNotNull } from "drizzle-orm";
+import { and, eq, exists, isNotNull } from "drizzle-orm";
 import { z } from "zod";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
@@ -799,6 +799,7 @@ async function loadConnection(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly connectorId: string;
+  readonly storageVersion: number;
   readonly lockRow?: boolean;
 }): Promise<StoredConnection | null> {
   const query = args.db
@@ -814,6 +815,20 @@ async function loadConnection(args: {
         eq(connectors.orgId, args.orgId),
         eq(connectors.userId, args.userId),
         eq(connectors.authMethod, "oauth"),
+        eq(connectors.storageVersion, args.storageVersion),
+        exists(
+          args.db
+            .select({ id: orgCustomConnectors.id })
+            .from(orgCustomConnectors)
+            .where(
+              and(
+                eq(orgCustomConnectors.id, args.connectorId),
+                eq(orgCustomConnectors.orgId, args.orgId),
+                eq(orgCustomConnectors.authMode, "oauth"),
+                eq(orgCustomConnectors.storageVersion, args.storageVersion),
+              ),
+            ),
+        ),
       ),
     );
   const rows = args.lockRow
@@ -946,6 +961,7 @@ async function resolveCustomConnectorOAuth2AccessToken(
     orgId: args.orgId,
     userId: args.userId,
     connectorId: args.connector.id,
+    storageVersion: args.connector.storageVersion,
   });
   args.signal.throwIfAborted();
   if (!connection) {
@@ -964,6 +980,7 @@ async function resolveCustomConnectorOAuth2AccessToken(
       orgId: args.orgId,
       userId: args.userId,
       connectorId: args.connector.id,
+      storageVersion: args.connector.storageVersion,
       lockRow: true,
     });
     args.signal.throwIfAborted();
@@ -1112,7 +1129,27 @@ async function loadLiveCustomConnector(args: {
     : null;
 }
 
-export async function resolveLiveCustomConnectorOAuth2AccessToken(args: {
+export async function resolveCurrentCustomConnectorOAuth2AccessToken(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorId: string;
+  readonly featureContext: FeatureSwitchContext;
+  readonly signal: AbortSignal;
+  readonly forceRefresh?: boolean;
+}): Promise<CustomConnectorOAuth2AccessTokenResolution> {
+  const connector = await loadLiveCustomConnector(args);
+  args.signal.throwIfAborted();
+  if (!connector || connector.authMode !== "oauth") {
+    return { kind: "unavailable" };
+  }
+  return await resolveCustomConnectorOAuth2AccessToken({
+    ...args,
+    connector,
+  });
+}
+
+export async function resolveRevisionPinnedCustomConnectorOAuth2AccessToken(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -480,6 +480,8 @@ export async function hasFeishuCustomConnectorOAuthConnection(
       and(
         eq(connectors.customConnectorId, orgCustomConnectors.id),
         eq(connectors.orgId, orgCustomConnectors.orgId),
+        eq(connectors.authMethod, orgCustomConnectors.authMode),
+        eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
       ),
     )
     .innerJoin(

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -9,11 +9,7 @@ import {
   type OrgCustomConnectorHeaderInjection,
   type OrgCustomConnectorQueryInjection,
 } from "@vm0/db/schema/org-custom-connector";
-import { connectors as connectorConnections } from "@vm0/db/schema/connector";
-import { secrets } from "@vm0/db/schema/secret";
-import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
-import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -24,6 +20,10 @@ import {
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
+import {
+  loadCurrentCustomConnectorOAuthConnectionIds,
+  loadCurrentCustomConnectorValueMarkers,
+} from "./custom-connector-credential-access.service";
 import {
   effectiveCustomConnectorPermissionBundleRef,
   FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
@@ -267,52 +267,13 @@ async function loadCustomConnectorGrantValueMarkers(
     readonly connectorIds: readonly string[];
   },
 ): Promise<ReadonlySet<string>> {
-  if (args.connectorIds.length === 0) {
-    return new Set();
-  }
-
-  const valueRows = await db
-    .select({
-      connectorId: orgCustomConnectorValues.connectorId,
-      kind: orgCustomConnectorValues.kind,
-      key: orgCustomConnectorValues.key,
-    })
-    .from(orgCustomConnectorValues)
-    .where(
-      and(
-        eq(orgCustomConnectorValues.orgId, args.orgId),
-        eq(orgCustomConnectorValues.userId, args.userId),
-        inArray(orgCustomConnectorValues.connectorId, [...args.connectorIds]),
-      ),
-    );
-  const legacyRows = await db
-    .select({ connectorId: orgCustomConnectorSecrets.connectorId })
-    .from(orgCustomConnectorSecrets)
-    .where(
-      and(
-        eq(orgCustomConnectorSecrets.orgId, args.orgId),
-        eq(orgCustomConnectorSecrets.userId, args.userId),
-        inArray(orgCustomConnectorSecrets.connectorId, [...args.connectorIds]),
-      ),
-    );
-
+  const valueMarkers = await loadCurrentCustomConnectorValueMarkers(db, args);
   const markers = new Set<string>();
-  for (const row of valueRows) {
-    if (row.kind !== "secret" && row.kind !== "variable") {
-      continue;
-    }
+  for (const row of valueMarkers) {
     markers.add(
       `${row.connectorId}:${customConnectorValueMarkerKey({
         kind: row.kind,
         key: row.key,
-      })}`,
-    );
-  }
-  for (const row of legacyRows) {
-    markers.add(
-      `${row.connectorId}:${customConnectorValueMarkerKey({
-        kind: "secret",
-        key: LEGACY_SECRET_KEY,
       })}`,
     );
   }
@@ -386,42 +347,6 @@ interface LockedCustomConnectorValidation {
   readonly unconfiguredIds: readonly string[];
   readonly revisions: ReadonlyMap<string, number>;
   readonly permissionBundleRefs: ReadonlyMap<string, string | null>;
-}
-
-async function loadCustomConnectorOAuthConnectionIds(
-  db: Pick<Db, "select">,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly connectorIds: readonly string[];
-  },
-): Promise<ReadonlySet<string>> {
-  const rows = await db
-    .select({
-      customConnectorId: connectorConnections.customConnectorId,
-    })
-    .from(connectorConnections)
-    .innerJoin(
-      secrets,
-      and(
-        eq(secrets.connectorId, connectorConnections.id),
-        eq(secrets.name, "access_token"),
-      ),
-    )
-    .where(
-      and(
-        eq(connectorConnections.orgId, args.orgId),
-        eq(connectorConnections.userId, args.userId),
-        eq(connectorConnections.authMethod, "oauth"),
-        eq(connectorConnections.needsReconnect, false),
-        inArray(connectorConnections.customConnectorId, [...args.connectorIds]),
-      ),
-    );
-  return new Set(
-    rows.flatMap((row) => {
-      return row.customConnectorId ? [row.customConnectorId] : [];
-    }),
-  );
 }
 
 function customConnectorGrantIsConfigured(args: {
@@ -556,7 +481,7 @@ async function lockCustomConnectorsForReplace(
       userId: args.userId,
       connectorIds,
     }),
-    loadCustomConnectorOAuthConnectionIds(db, {
+    loadCurrentCustomConnectorOAuthConnectionIds(db, {
       orgId: args.orgId,
       userId: args.userId,
       connectorIds,

--- a/turbo/apps/api/src/signals/services/zero-catalog-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-catalog-data.service.ts
@@ -1,11 +1,7 @@
 import { computed, type Computed } from "ccstate";
 import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
-import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
-import { connectors as connectorConnections } from "@vm0/db/schema/connector";
-import { secrets } from "@vm0/db/schema/secret";
 import { and, eq } from "drizzle-orm";
 
 import { db$ } from "../external/db";
@@ -13,10 +9,10 @@ import {
   normaliseCustomConnectorRow,
   serialiseCustomConnector,
 } from "./zero-custom-connector.service";
-
-function valueMarkerKey(args: { readonly kind: string; readonly key: string }) {
-  return `${args.kind}:${args.key}`;
-}
+import {
+  loadCurrentCustomConnectorOAuthConnectionIds,
+  loadCurrentCustomConnectorValueMarkers,
+} from "./custom-connector-credential-access.service";
 
 export function zeroCustomConnectorList(args: {
   readonly orgId: string;
@@ -24,108 +20,28 @@ export function zeroCustomConnectorList(args: {
 }): Computed<Promise<readonly CustomConnectorResponse[]>> {
   return computed(async (get): Promise<readonly CustomConnectorResponse[]> => {
     const db = get(db$);
-    const [connectorRows, valueRows, legacySecretRows, oauthRows] =
-      await Promise.all([
-        db
-          .select({
-            connector: orgCustomConnectors,
-            oauthConfig: orgCustomConnectorOauthConfigs,
-          })
-          .from(orgCustomConnectors)
-          .leftJoin(
-            orgCustomConnectorOauthConfigs,
-            and(
-              eq(
-                orgCustomConnectorOauthConfigs.connectorId,
-                orgCustomConnectors.id,
-              ),
-              eq(
-                orgCustomConnectorOauthConfigs.orgId,
-                orgCustomConnectors.orgId,
-              ),
+    const [connectorRows, markers, oauthConnected] = await Promise.all([
+      db
+        .select({
+          connector: orgCustomConnectors,
+          oauthConfig: orgCustomConnectorOauthConfigs,
+        })
+        .from(orgCustomConnectors)
+        .leftJoin(
+          orgCustomConnectorOauthConfigs,
+          and(
+            eq(
+              orgCustomConnectorOauthConfigs.connectorId,
+              orgCustomConnectors.id,
             ),
-          )
-          .where(eq(orgCustomConnectors.orgId, args.orgId))
-          .orderBy(orgCustomConnectors.displayName),
-        db
-          .select({
-            connectorId: orgCustomConnectorValues.connectorId,
-            kind: orgCustomConnectorValues.kind,
-            key: orgCustomConnectorValues.key,
-          })
-          .from(orgCustomConnectorValues)
-          .where(
-            and(
-              eq(orgCustomConnectorValues.orgId, args.orgId),
-              eq(orgCustomConnectorValues.userId, args.userId),
-            ),
+            eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
           ),
-        db
-          .select({ connectorId: orgCustomConnectorSecrets.connectorId })
-          .from(orgCustomConnectorSecrets)
-          .where(
-            and(
-              eq(orgCustomConnectorSecrets.orgId, args.orgId),
-              eq(orgCustomConnectorSecrets.userId, args.userId),
-            ),
-          ),
-        db
-          .select({
-            customConnectorId: connectorConnections.customConnectorId,
-          })
-          .from(connectorConnections)
-          .innerJoin(
-            secrets,
-            and(
-              eq(secrets.connectorId, connectorConnections.id),
-              eq(secrets.name, "access_token"),
-            ),
-          )
-          .where(
-            and(
-              eq(connectorConnections.orgId, args.orgId),
-              eq(connectorConnections.userId, args.userId),
-              eq(connectorConnections.authMethod, "oauth"),
-              eq(connectorConnections.needsReconnect, false),
-            ),
-          ),
-      ]);
-
-    const markers = valueRows
-      .filter((row) => {
-        return row.kind === "secret" || row.kind === "variable";
-      })
-      .map((row) => {
-        return {
-          connectorId: row.connectorId,
-          kind:
-            row.kind === "secret" ? ("secret" as const) : ("variable" as const),
-          key: row.key,
-        };
-      });
-    const seen = new Set(
-      markers.map((marker) => {
-        return `${marker.connectorId}:${valueMarkerKey(marker)}`;
-      }),
-    );
-    for (const row of legacySecretRows) {
-      const marker = {
-        connectorId: row.connectorId,
-        kind: "secret" as const,
-        key: "secret",
-      };
-      const key = `${marker.connectorId}:${valueMarkerKey(marker)}`;
-      if (!seen.has(key)) {
-        markers.push(marker);
-        seen.add(key);
-      }
-    }
-
-    const oauthConnected = new Set(
-      oauthRows.flatMap((row) => {
-        return row.customConnectorId ? [row.customConnectorId] : [];
-      }),
-    );
+        )
+        .where(eq(orgCustomConnectors.orgId, args.orgId))
+        .orderBy(orgCustomConnectors.displayName),
+      loadCurrentCustomConnectorValueMarkers(db, args),
+      loadCurrentCustomConnectorOAuthConnectionIds(db, args),
+    ]);
     return connectorRows.map((row) => {
       return serialiseCustomConnector({
         row: normaliseCustomConnectorRow(row.connector, row.oauthConfig),

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -2180,6 +2180,8 @@ async function loadStoredValuesForConnector(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly connectorId: string;
+  readonly authMode: CustomConnectorAuthMode;
+  readonly storageVersion: number;
 }): Promise<readonly StoredValueRow[]> {
   const [valueRows, legacyRows] = await Promise.all([
     args.db
@@ -2195,6 +2197,8 @@ async function loadStoredValuesForConnector(args: {
         and(
           eq(orgCustomConnectors.id, orgCustomConnectorValues.connectorId),
           eq(orgCustomConnectors.orgId, orgCustomConnectorValues.orgId),
+          eq(orgCustomConnectors.authMode, args.authMode),
+          eq(orgCustomConnectors.storageVersion, args.storageVersion),
         ),
       )
       .innerJoin(
@@ -2226,6 +2230,8 @@ async function loadStoredValuesForConnector(args: {
           eq(orgCustomConnectors.id, orgCustomConnectorSecrets.connectorId),
           eq(orgCustomConnectors.orgId, orgCustomConnectorSecrets.orgId),
           eq(orgCustomConnectors.authMode, "manual"),
+          eq(orgCustomConnectors.authMode, args.authMode),
+          eq(orgCustomConnectors.storageVersion, args.storageVersion),
         ),
       )
       .innerJoin(
@@ -2547,6 +2553,8 @@ export async function loadCustomConnectorRuntimeData(
                 orgId: args.orgId,
                 userId: args.userId,
                 connectorId: connector.id,
+                authMode: connector.authMode,
+                storageVersion: connector.storageVersion,
               })
             : [];
         return { connector, values, credentialAccess };

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -34,7 +34,6 @@ import {
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
-import { secrets } from "@vm0/db/schema/secret";
 
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { badRequestMessage, notFound } from "../../lib/error";
@@ -49,6 +48,12 @@ import { userFeatureSwitchContext } from "./feature-switches.service";
 import { addUserCustomConnector } from "./user-connectors.service";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
+import {
+  loadCustomConnectorCredentialAccesses,
+  loadCurrentCustomConnectorOAuthConnectionIds,
+  loadCurrentCustomConnectorValueMarkers,
+  type CustomConnectorCredentialAccess,
+} from "./custom-connector-credential-access.service";
 import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
 import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
 import type { Tx } from "../../lib/db-types";
@@ -1273,92 +1278,6 @@ async function findCustomConnectorPrefixConflict(
   return null;
 }
 
-async function loadConnectorValueMarkers(args: {
-  readonly db: ReadonlyDb;
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<readonly ValueMarker[]> {
-  const [valueRows, legacyRows] = await Promise.all([
-    args.db
-      .select({
-        connectorId: orgCustomConnectorValues.connectorId,
-        kind: orgCustomConnectorValues.kind,
-        key: orgCustomConnectorValues.key,
-      })
-      .from(orgCustomConnectorValues)
-      .where(
-        and(
-          eq(orgCustomConnectorValues.orgId, args.orgId),
-          eq(orgCustomConnectorValues.userId, args.userId),
-        ),
-      ),
-    args.db
-      .select({ connectorId: orgCustomConnectorSecrets.connectorId })
-      .from(orgCustomConnectorSecrets)
-      .where(
-        and(
-          eq(orgCustomConnectorSecrets.orgId, args.orgId),
-          eq(orgCustomConnectorSecrets.userId, args.userId),
-        ),
-      ),
-  ]);
-  const markers: ValueMarker[] = valueRows
-    .filter((row): row is ValueMarker => {
-      return row.kind === "secret" || row.kind === "variable";
-    })
-    .map((row) => {
-      return { connectorId: row.connectorId, kind: row.kind, key: row.key };
-    });
-  const existing = new Set(
-    markers.map((marker) => {
-      return `${marker.connectorId}:${customConnectorValueMarkerKey(marker)}`;
-    }),
-  );
-  for (const row of legacyRows) {
-    const marker = {
-      connectorId: row.connectorId,
-      kind: "secret" as const,
-      key: LEGACY_SECRET_KEY,
-    };
-    const key = `${marker.connectorId}:${customConnectorValueMarkerKey(marker)}`;
-    if (!existing.has(key)) {
-      markers.push(marker);
-      existing.add(key);
-    }
-  }
-  return markers;
-}
-
-async function loadConnectedOAuthConnectorIds(args: {
-  readonly db: ReadonlyDb;
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<ReadonlySet<string>> {
-  const rows = await args.db
-    .select({ customConnectorId: connectors.customConnectorId })
-    .from(connectors)
-    .innerJoin(
-      secrets,
-      and(
-        eq(secrets.connectorId, connectors.id),
-        eq(secrets.name, CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_SECRET_NAME),
-      ),
-    )
-    .where(
-      and(
-        eq(connectors.orgId, args.orgId),
-        eq(connectors.userId, args.userId),
-        eq(connectors.authMethod, "oauth"),
-        eq(connectors.needsReconnect, false),
-      ),
-    );
-  return new Set(
-    rows.flatMap((row) => {
-      return row.customConnectorId ? [row.customConnectorId] : [];
-    }),
-  );
-}
-
 export const createCustomConnector$ = command(
   async (
     { get, set },
@@ -1872,13 +1791,11 @@ export function getCustomConnectorResponse(args: {
       return null;
     }
     const [markers, oauthConnections] = await Promise.all([
-      loadConnectorValueMarkers({
-        db,
+      loadCurrentCustomConnectorValueMarkers(db, {
         orgId: args.orgId,
         userId: args.userId,
       }),
-      loadConnectedOAuthConnectorIds({
-        db,
+      loadCurrentCustomConnectorOAuthConnectionIds(db, {
         orgId: args.orgId,
         userId: args.userId,
       }),
@@ -2155,8 +2072,7 @@ export const setCustomConnectorValues$ = command(
     signal.throwIfAborted();
 
     const db = get(db$);
-    const markers = await loadConnectorValueMarkers({
-      db,
+    const markers = await loadCurrentCustomConnectorValueMarkers(db, {
       orgId: args.orgId,
       userId: args.userId,
     });
@@ -2274,6 +2190,23 @@ async function loadStoredValuesForConnector(args: {
         encryptedValue: orgCustomConnectorValues.encryptedValue,
       })
       .from(orgCustomConnectorValues)
+      .innerJoin(
+        orgCustomConnectors,
+        and(
+          eq(orgCustomConnectors.id, orgCustomConnectorValues.connectorId),
+          eq(orgCustomConnectors.orgId, orgCustomConnectorValues.orgId),
+        ),
+      )
+      .innerJoin(
+        connectors,
+        and(
+          eq(connectors.customConnectorId, orgCustomConnectors.id),
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.authMethod, orgCustomConnectors.authMode),
+          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+        ),
+      )
       .where(
         and(
           eq(orgCustomConnectorValues.orgId, args.orgId),
@@ -2287,6 +2220,24 @@ async function loadStoredValuesForConnector(args: {
         encryptedValue: orgCustomConnectorSecrets.encryptedValue,
       })
       .from(orgCustomConnectorSecrets)
+      .innerJoin(
+        orgCustomConnectors,
+        and(
+          eq(orgCustomConnectors.id, orgCustomConnectorSecrets.connectorId),
+          eq(orgCustomConnectors.orgId, orgCustomConnectorSecrets.orgId),
+          eq(orgCustomConnectors.authMode, "manual"),
+        ),
+      )
+      .innerJoin(
+        connectors,
+        and(
+          eq(connectors.customConnectorId, orgCustomConnectors.id),
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.authMethod, orgCustomConnectors.authMode),
+          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
+        ),
+      )
       .where(
         and(
           eq(orgCustomConnectorSecrets.orgId, args.orgId),
@@ -2522,6 +2473,7 @@ export async function loadCustomConnectorRuntimeData(
   readonly {
     readonly connector: CustomConnectorRow;
     readonly values: readonly StoredValueRow[];
+    readonly credentialAccess: CustomConnectorCredentialAccess;
   }[]
 > {
   const measure =
@@ -2567,19 +2519,37 @@ export async function loadCustomConnectorRuntimeData(
   }
 
   return await measure("connectorValueRows", async () => {
+    const credentialAccesses = await loadCustomConnectorCredentialAccesses(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      definitions: connectorRows.map((row) => {
+        return {
+          id: row.connector.id,
+          authMode: row.connector.authMode,
+          storageVersion: row.connector.storageVersion,
+        };
+      }),
+    });
     return await Promise.all(
       connectorRows.map(async (row) => {
         const connector = normaliseCustomConnectorRow(
           row.connector,
           row.oauthConfig,
         );
-        const values = await loadStoredValuesForConnector({
-          db,
-          orgId: args.orgId,
-          userId: args.userId,
-          connectorId: connector.id,
-        });
-        return { connector, values };
+        const credentialAccess = credentialAccesses.get(connector.id);
+        if (!credentialAccess) {
+          throw new Error("Expected custom connector credential access");
+        }
+        const values =
+          credentialAccess.kind === "current"
+            ? await loadStoredValuesForConnector({
+                db,
+                orgId: args.orgId,
+                userId: args.userId,
+                connectorId: connector.id,
+              })
+            : [];
+        return { connector, values, credentialAccess };
       }),
     );
   });

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -78,6 +78,14 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       token_expires_at: z.iso.datetime().nullable().optional(),
     }),
     z.object({
+      action: z.literal("set-custom-parent-state"),
+      org_id: z.string(),
+      user_id: z.string(),
+      custom_connector_id: z.uuid(),
+      auth_method: z.enum(["manual", "oauth"]),
+      storage_version: z.number().int().positive(),
+    }),
+    z.object({
       action: z.literal("set-secret-owner"),
       org_id: z.string(),
       user_id: z.string(),


### PR DESCRIPTION
## Summary

- centralize Custom connector credential compatibility as absent, current, or incompatible
- require exact auth-method and storage-version matches for manual values, OAuth tokens, configured markers, grants, runtime auth, runtime sync, and Feishu readiness
- keep missing credentials distinct from incompatible storage, retain frozen revision-pinned legacy auth references, and add non-secret drain diagnostics
- return the existing `connector-unavailable` runner reason for incompatible storage without changing the runner protocol

## Deployment compatibility

- reader-only preparation: no schema changes, storage-version writers, grant lifecycle changes, target pinning, or realtime mutation wake-ups
- deploy this PR and drain previous API instances before activating the writer behavior in the next child issue
- existing version-1 Custom connector behavior and legacy run auth references remain supported

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/zero-feishu-integration.test.ts --silent=passed-only` (264 passed)
- `pnpm -F api exec vitest run --maxWorkers=2 --silent=passed-only` (2764 passed)

Closes #25683

Parent delivery: #25350
