### PR TITLE
refactor(api): separate pi execution mode from runner profile

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -5,6 +5,7 @@ import type {
   ConnectorChangedPayload,
 } from "@vm0/api-contracts/contracts/realtime";
 import type {
+  PiExecutionMode,
   RunnerPreference,
   RunnerPreferenceDecision,
   RunnerPreferenceResolution,
@@ -429,11 +430,12 @@ export async function publishPiStandbyReleaseToRunnerGroupSafely(
   );
 }
 
-export async function publishRunnerJobNotification(
-  group: string,
-  runId: string,
-  profile: string,
-  metadata?: {
+export async function publishRunnerJobNotification(args: {
+  readonly group: string;
+  readonly runId: string;
+  readonly profile: string;
+  readonly piExecutionMode?: PiExecutionMode;
+  readonly metadata?: {
     /** Raw key required for runner-local reuse matching; it stays on the internal runner-group channel. */
     readonly reuseKey: string | null;
     readonly cliAgentSessionId: string | null;
@@ -441,38 +443,46 @@ export async function publishRunnerJobNotification(
     readonly runnerPreferenceDecision: RunnerPreferenceDecision;
     readonly runnerPreference?: RunnerPreference;
     readonly runnerPreferenceResolution: RunnerPreferenceResolution;
-  },
-): Promise<boolean> {
+  };
+}): Promise<boolean> {
   const published = await tapError(
     (async () => {
-      const channel = ablyClient().channels.get(`runner-group:${group}`);
+      const channel = ablyClient().channels.get(`runner-group:${args.group}`);
       await channel.publish("job", {
-        runId,
-        profile,
-        ...(metadata?.reuseKey ? { reuseKey: metadata.reuseKey } : {}),
-        ...(metadata?.cliAgentSessionId
-          ? { cliAgentSessionId: metadata.cliAgentSessionId }
+        runId: args.runId,
+        profile: args.profile,
+        ...(args.piExecutionMode
+          ? { piExecutionMode: args.piExecutionMode }
           : {}),
-        ...(metadata?.historyGenerationRunId
-          ? { historyGenerationRunId: metadata.historyGenerationRunId }
+        ...(args.metadata?.reuseKey
+          ? { reuseKey: args.metadata.reuseKey }
           : {}),
-        ...(metadata?.runnerPreference
-          ? { runnerPreference: metadata.runnerPreference }
+        ...(args.metadata?.cliAgentSessionId
+          ? { cliAgentSessionId: args.metadata.cliAgentSessionId }
           : {}),
-        ...(metadata
+        ...(args.metadata?.historyGenerationRunId
+          ? { historyGenerationRunId: args.metadata.historyGenerationRunId }
+          : {}),
+        ...(args.metadata?.runnerPreference
+          ? { runnerPreference: args.metadata.runnerPreference }
+          : {}),
+        ...(args.metadata
           ? {
-              runnerPreferenceDecision: metadata.runnerPreferenceDecision,
-              runnerPreferenceResolution: metadata.runnerPreferenceResolution,
+              runnerPreferenceDecision: args.metadata.runnerPreferenceDecision,
+              runnerPreferenceResolution:
+                args.metadata.runnerPreferenceResolution,
             }
           : {}),
       });
-      L.debug(`Published job ${runId} to runner-group:${group} (broadcast)`);
+      L.debug(
+        `Published job ${args.runId} to runner-group:${args.group} (broadcast)`,
+      );
       return true;
     })(),
     (error) => {
       L.warn("Failed to publish runner job notification", {
-        group,
-        runId,
+        group: args.group,
+        runId: args.runId,
         error,
       });
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/secret-kms-probe.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/secret-kms-probe.ts
@@ -26,6 +26,10 @@ export function generateDataKeyOutput(
   };
 }
 
+export function secretKmsPlaintext(): Uint8Array {
+  return TEST_DATA_KEY;
+}
+
 export function useSecretKmsProbe(
   overrideGenerateDataKey?: (
     request: SecretKmsGenerateDataKeyRequest,

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -7,7 +7,6 @@ import {
   DEFAULT_PROFILE,
   PI_MEMORY_ROOT,
   PI_SKILLS_ROOT,
-  PI_STANDBY_PROFILE,
   PI_STANDBY_TTL_RELEASE_EXIT_CODE,
 } from "@vm0/api-contracts/contracts/runners";
 import { webhookPiTranscriptContract } from "@vm0/api-contracts/contracts/webhooks";
@@ -37,11 +36,21 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { readModelStatsObservations } from "./helpers/model-stats-state";
-import { seedVm0ManagedModelKey } from "./helpers/runtime-state";
-import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
+import {
+  secretKmsPlaintext,
+  useSecretKmsProbe,
+} from "./helpers/secret-kms-probe";
+import {
+  mutateRunnerJobSecretValueEnvironmentKeys,
+  seedVm0ManagedModelKey,
+} from "./helpers/runtime-state";
 import { commitMemoryVersion } from "./helpers/zero-memory";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { webhooksAgentPiTranscriptRoutes } from "../webhooks-agent-pi-transcript";
+import {
+  createAgentComposeFixture,
+  readAgentComposeByIdFixture,
+} from "../../../test-fixtures/agent-composes";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -443,6 +452,7 @@ interface PiEdgeFixture {
   readonly agentId: string;
   readonly orgId: string;
   readonly runnerGroup: string;
+  readonly runnerProfile: string;
   readonly agentDisplayName: string;
   readonly agentInstructions: string;
   readonly workflowSkillName: string;
@@ -450,10 +460,55 @@ interface PiEdgeFixture {
   readonly model: SupportedRunModel;
 }
 
+async function setFixtureAgentProfile(
+  actor: ApiTestUser,
+  agentId: string,
+  profile: string,
+): Promise<void> {
+  if (!actor.orgId) {
+    throw new Error("Expected the Pi fixture actor to belong to an org");
+  }
+  const fixtureActor = { userId: actor.userId, orgId: actor.orgId };
+  const composeResponse = await readAgentComposeByIdFixture({
+    actor: fixtureActor,
+    composeId: agentId,
+  });
+  if (composeResponse.status !== 200) {
+    throw new Error("Expected the Pi fixture agent compose to be readable");
+  }
+  const content = composeResponse.body.content;
+  if (!content) {
+    throw new Error("Expected the Pi fixture agent to have compose content");
+  }
+  const entries = Object.entries(content.agents);
+  if (entries.length !== 1) {
+    throw new Error("Expected the Pi fixture compose to contain one agent");
+  }
+  const entry = entries[0];
+  if (!entry) {
+    throw new Error("Expected the Pi fixture compose agent");
+  }
+  const [agentName, agent] = entry;
+  const updated = await createAgentComposeFixture({
+    actor: fixtureActor,
+    content: {
+      ...content,
+      agents: {
+        [agentName]: { ...agent, experimental_profile: profile },
+      },
+    },
+    signal: context.signal,
+  });
+  if (updated.status !== 200 || updated.body.composeId !== agentId) {
+    throw new Error("Expected the Pi fixture compose update to preserve id");
+  }
+}
+
 async function piEdgeFixture(
   options: {
     readonly provider?: "byok" | "vm0";
     readonly model?: SupportedRunModel;
+    readonly runnerProfile?: string;
   } = {},
 ): Promise<PiEdgeFixture> {
   const providerType = options.provider ?? "byok";
@@ -497,6 +552,10 @@ async function piEdgeFixture(
   const agentInstructions =
     "# Pinned Pi instructions\nAlways preserve the run snapshot.";
   await bdd.updateAgentInstructions(actor, agent.agentId, agentInstructions);
+  const runnerProfile = options.runnerProfile ?? DEFAULT_PROFILE;
+  if (runnerProfile !== DEFAULT_PROFILE) {
+    await setFixtureAgentProfile(actor, agent.agentId, runnerProfile);
+  }
   const workflowSkillName = `pi-snapshot-${randomUUID().slice(0, 8)}`;
   await workflows.createWorkflow(actor, {
     agentId: agent.agentId,
@@ -508,6 +567,7 @@ async function piEdgeFixture(
     agentId: agent.agentId,
     orgId,
     runnerGroup,
+    runnerProfile,
     agentDisplayName: AGENT_DISPLAY_NAME,
     agentInstructions,
     workflowSkillName,
@@ -588,6 +648,7 @@ async function codexPiEdgeFixture(args?: {
     agentId: agent.agentId,
     orgId,
     runnerGroup,
+    runnerProfile: DEFAULT_PROFILE,
     agentDisplayName: AGENT_DISPLAY_NAME,
     agentInstructions,
     workflowSkillName,
@@ -855,7 +916,32 @@ describe("PiLoop edge turn", () => {
     }
     expect(poll.body.job?.runId).toBe(ordinary.body.runId);
     expect(jobNotificationCount()).toBe(baselineJobNotifications + 1);
+    const ordinaryNotification = context.mocks.ably.publish.mock.calls.find(
+      ([topic, payload]) => {
+        return (
+          topic === "job" && recordOf(payload)?.runId === ordinary.body.runId
+        );
+      },
+    );
+    const ordinaryNotificationPayload = recordOf(ordinaryNotification?.[1]);
+    if (!ordinaryNotificationPayload) {
+      throw new Error("Expected an ordinary Runner job notification");
+    }
+    expect(ordinaryNotificationPayload).not.toHaveProperty("piExecutionMode");
     expect(completionRequests).toBe(0);
+    const ordinaryContext = await api.claimRunnerJob(ordinary.body.runId);
+    expect(ordinaryContext).not.toHaveProperty("piExecutionMode");
+    const duplicateOrdinaryClaim = await api.requestClaimRunnerJob(
+      true,
+      ordinary.body.runId,
+      [404],
+    );
+    if (duplicateOrdinaryClaim.status !== 404) {
+      throw new Error("Expected the duplicate ordinary claim to return 404");
+    }
+    expect(duplicateOrdinaryClaim.body.error.message).toBe(
+      "Job not found in queue",
+    );
     await api.requestCancelRun(fixture.actor, ordinary.body.runId, [200]);
   });
 
@@ -869,6 +955,7 @@ describe("PiLoop edge turn", () => {
     );
     const legacyPoll = await api.pollRunner(fixture.runnerGroup);
     expect(legacyPoll.body.job?.runId).toBe(legacy.runId);
+    expect(legacyPoll.body.job).not.toHaveProperty("piExecutionMode");
     await api.requestCancelRun(fixture.actor, legacy.runId, [200]);
 
     await enablePiLoop(fixture);
@@ -909,13 +996,11 @@ describe("PiLoop edge turn", () => {
     const edge = await sendChatRun(fixture, edgePrompt, legacy.threadId);
     await modelStarted.promise;
 
-    const defaultPoll = await api.pollRunner(fixture.runnerGroup);
-    expect(defaultPoll.body.job).toBeNull();
     const standbyPoll = await api.requestPollRunner(
       true,
       {
         group: fixture.runnerGroup,
-        supportedProfiles: [PI_STANDBY_PROFILE],
+        supportedProfiles: [fixture.runnerProfile],
       },
       [200],
     );
@@ -924,9 +1009,33 @@ describe("PiLoop edge turn", () => {
     }
     expect(standbyPoll.body.job).toMatchObject({
       runId: edge.runId,
-      experimentalProfile: PI_STANDBY_PROFILE,
+      experimentalProfile: fixture.runnerProfile,
+      piExecutionMode: "standby",
     });
+    expect(
+      context.mocks.ably.publish.mock.calls
+        .slice(publishedBefore)
+        .some(([topic, payload]) => {
+          const job = recordOf(payload);
+          return (
+            topic === "job" &&
+            job?.runId === edge.runId &&
+            job.profile === fixture.runnerProfile &&
+            job.piExecutionMode === "standby"
+          );
+        }),
+    ).toBeTruthy();
     const standbyContext = await api.claimRunnerJob(edge.runId);
+    expect(standbyContext.piExecutionMode).toBe("standby");
+    const duplicateStandbyClaim = await api.requestClaimRunnerJob(
+      true,
+      edge.runId,
+      [404],
+    );
+    if (duplicateStandbyClaim.status !== 404) {
+      throw new Error("Expected the duplicate standby claim to return 404");
+    }
+    expect(duplicateStandbyClaim.body.error.message).toBe("Run not found");
     const skillSnapshot = standbyContext.runSkillSnapshot;
     if (skillSnapshot === undefined) {
       throw new Error("Expected Pi standby context to include Skill snapshot");
@@ -1126,6 +1235,17 @@ describe("PiLoop edge turn", () => {
     expect((await api.readRun(fixture.actor, edge.runId)).status).toBe(
       "completed",
     );
+    const settledStandbyClaim = await api.requestClaimRunnerJob(
+      true,
+      edge.runId,
+      [404],
+    );
+    if (settledStandbyClaim.status !== 404) {
+      throw new Error("Expected the settled standby claim to return 404");
+    }
+    expect(settledStandbyClaim.body.error.message).toBe(
+      "Job not found in queue",
+    );
     expect(
       context.mocks.ably.publish.mock.calls
         .slice(publishedBefore)
@@ -1262,7 +1382,7 @@ describe("PiLoop edge turn", () => {
       true,
       {
         group: fixture.runnerGroup,
-        supportedProfiles: [PI_STANDBY_PROFILE],
+        supportedProfiles: [fixture.runnerProfile],
       },
       [200],
     );
@@ -1417,7 +1537,7 @@ describe("PiLoop edge turn", () => {
       true,
       {
         group: fixture.runnerGroup,
-        supportedProfiles: [PI_STANDBY_PROFILE],
+        supportedProfiles: [fixture.runnerProfile],
       },
       [200],
     );
@@ -1426,7 +1546,8 @@ describe("PiLoop edge turn", () => {
     }
     expect(standbyPoll.body.job).toMatchObject({
       runId: run.runId,
-      experimentalProfile: PI_STANDBY_PROFILE,
+      experimentalProfile: fixture.runnerProfile,
+      piExecutionMode: "standby",
     });
     const standbyContext = await api.claimRunnerJob(run.runId);
     expect(standbyContext.piModelConfig).toStrictEqual({
@@ -1882,13 +2003,32 @@ describe("PiLoop edge turn", () => {
   });
 
   it("requeues an expired standby onto the cold-start lane without settling the run", async () => {
-    const fixture = await piEdgeFixture();
+    const fixture = await piEdgeFixture({
+      runnerProfile: "vm0/pi-lifecycle-integration",
+    });
     await enablePiLoop(fixture);
     const modelStarted = createDeferredPromise<void>(context.signal);
     const releaseModel = createDeferredPromise<void>(context.signal);
+    const claimDecryptStarted = createDeferredPromise<void>(context.signal);
+    const releaseStaleClaim = createDeferredPromise<void>(context.signal);
+    let stallNextDecrypt = false;
+    useSecretKmsProbe(undefined, () => {
+      if (!stallNextDecrypt) {
+        return undefined;
+      }
+      stallNextDecrypt = false;
+      claimDecryptStarted.resolve();
+      return (async () => {
+        await releaseStaleClaim.promise;
+        return secretKmsPlaintext();
+      })();
+    });
     onTestFinished(() => {
       if (!releaseModel.settled()) {
         releaseModel.resolve();
+      }
+      if (!releaseStaleClaim.settled()) {
+        releaseStaleClaim.resolve();
       }
     });
     server.use(
@@ -1910,15 +2050,38 @@ describe("PiLoop edge turn", () => {
       true,
       {
         group: fixture.runnerGroup,
-        supportedProfiles: [PI_STANDBY_PROFILE],
+        supportedProfiles: [fixture.runnerProfile],
       },
       [200],
     );
     if (standbyPoll.status !== 200) {
       throw new Error("Expected Pi standby poll to return 200");
     }
-    expect(standbyPoll.body.job?.runId).toBe(run.runId);
+    expect(standbyPoll.body.job).toMatchObject({
+      runId: run.runId,
+      experimentalProfile: fixture.runnerProfile,
+      piExecutionMode: "standby",
+    });
+    await mutateRunnerJobSecretValueEnvironmentKeys(
+      context,
+      run.runId,
+      "invalid",
+    );
+    stallNextDecrypt = true;
+    const staleStandbyClaim = api.claimRunnerJob(run.runId);
+    await claimDecryptStarted.promise;
     const standbyContext = await api.claimRunnerJob(run.runId);
+    expect(standbyContext.piExecutionMode).toBe("standby");
+    const duplicateStandbyClaim = await api.requestClaimRunnerJob(
+      true,
+      run.runId,
+      [404],
+    );
+    if (duplicateStandbyClaim.status !== 404) {
+      throw new Error("Expected the duplicate standby claim to return 404");
+    }
+    expect(duplicateStandbyClaim.body.error.message).toBe("Run not found");
+    const publishedBeforeRelease = context.mocks.ably.publish.mock.calls.length;
 
     const released = await webhooks.requestAgentComplete(
       {
@@ -1937,7 +2100,7 @@ describe("PiLoop edge turn", () => {
       true,
       {
         group: fixture.runnerGroup,
-        supportedProfiles: [DEFAULT_PROFILE],
+        supportedProfiles: [fixture.runnerProfile],
       },
       [200],
     );
@@ -1956,7 +2119,7 @@ describe("PiLoop edge turn", () => {
       true,
       {
         group: fixture.runnerGroup,
-        supportedProfiles: [DEFAULT_PROFILE],
+        supportedProfiles: [fixture.runnerProfile],
       },
       [200],
     );
@@ -1965,15 +2128,42 @@ describe("PiLoop edge turn", () => {
     }
     expect(coldPoll.body.job).toMatchObject({
       runId: run.runId,
-      experimentalProfile: DEFAULT_PROFILE,
+      experimentalProfile: fixture.runnerProfile,
+      piExecutionMode: "cold-start",
     });
-    const coldContext = await api.claimRunnerJob(run.runId);
+    expect(
+      context.mocks.ably.publish.mock.calls
+        .slice(publishedBeforeRelease)
+        .some(([topic, payload]) => {
+          const job = recordOf(payload);
+          return (
+            topic === "job" &&
+            job?.runId === run.runId &&
+            job.profile === fixture.runnerProfile &&
+            job.piExecutionMode === "cold-start"
+          );
+        }),
+    ).toBeTruthy();
+    releaseStaleClaim.resolve();
+    const coldContext = await staleStandbyClaim;
+    expect(coldContext.piExecutionMode).toBe("cold-start");
     expect(coldContext.piSystemPrompt).toBe(standbyContext.piSystemPrompt);
     expect(coldContext.runSkillSnapshot).toStrictEqual(
       standbyContext.runSkillSnapshot,
     );
     expect((await api.readRun(fixture.actor, run.runId)).status).toBe(
       "running",
+    );
+    const duplicateColdClaim = await api.requestClaimRunnerJob(
+      true,
+      run.runId,
+      [404],
+    );
+    if (duplicateColdClaim.status !== 404) {
+      throw new Error("Expected the duplicate cold claim to return 404");
+    }
+    expect(duplicateColdClaim.body.error.message).toBe(
+      "Job not found in queue",
     );
   });
 
@@ -2107,7 +2297,7 @@ describe("PiLoop edge turn", () => {
       true,
       {
         group: fixture.runnerGroup,
-        supportedProfiles: [PI_STANDBY_PROFILE],
+        supportedProfiles: [fixture.runnerProfile],
       },
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -5,7 +5,7 @@ import {
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   elapsedSinceApiStartMs,
   NETWORK_POLICY_REFRESH_RUN_TERMINAL_ERROR_CODE,
-  PI_STANDBY_PROFILE,
+  piExecutionModeSchema,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   runnersActiveInputsContract,
   runnersConnectorRuntimeSyncContract,
@@ -20,6 +20,7 @@ import {
   type ExecutionContext,
   type HeldSandboxState,
   type HeldWorkspaceState,
+  type PiExecutionMode,
   type RunnerPreferenceClaimState,
   type RunnerPreferenceDecision,
   type RunnerPreferenceResolution,
@@ -720,6 +721,10 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         sql`${runnerJobQueue.executionContext}->'resumeSession'->>'historyGenerationRunId'`.mapWith(
           nullableDriverValueDecoder(pgTextDecoder),
         ),
+      piExecutionMode:
+        sql`${runnerJobQueue.executionContext}->>'piExecutionMode'`.mapWith(
+          nullableDriverValueDecoder(pgTextDecoder),
+        ),
       createdAt: runnerJobQueue.createdAt,
     })
     .from(runnerJobQueue)
@@ -737,6 +742,10 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!pendingJob) {
     return { status: 200 as const, body: { job: null } };
   }
+  const piExecutionMode =
+    pendingJob.piExecutionMode === null
+      ? undefined
+      : piExecutionModeSchema.parse(pendingJob.piExecutionMode);
   const runnerPreferenceDecision = await resolvePollRunnerReusePreference(db, {
     runId: pendingJob.runId,
     runnerGroup: group,
@@ -779,6 +788,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         cliAgentSessionId: pendingJob.cliAgentSessionId,
         reuseKey: pendingJob.reuseKey,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
+        ...(piExecutionMode ? { piExecutionMode } : {}),
         ...runnerPreferenceFields,
       },
     },
@@ -938,7 +948,11 @@ function claimAuthorizationError(
 }
 
 type ClaimTransitionResult =
-  | { readonly status: "claimed"; readonly claimedAt: Date }
+  | {
+      readonly status: "claimed";
+      readonly claimedAt: Date;
+      readonly piExecutionMode: PiExecutionMode | undefined;
+    }
   | { readonly status: "job-not-found" }
   | { readonly status: "run-not-found" };
 type ClaimedTransitionResult = Extract<
@@ -965,6 +979,7 @@ const claimTransitionSqlRowSchema = z.object({
     "invariant-error",
   ]),
   claimedAtMs: z.number().nullable(),
+  piExecutionMode: piExecutionModeSchema.nullable(),
 });
 
 function decodeClaimTransitionResult(
@@ -978,7 +993,11 @@ function decodeClaimTransitionResult(
     if (row.claimedAtMs === null) {
       throw new Error("Claimed runner job is missing its transition time");
     }
-    return { status: "claimed", claimedAt: new Date(row.claimedAtMs) };
+    return {
+      status: "claimed",
+      claimedAt: new Date(row.claimedAtMs),
+      piExecutionMode: row.piExecutionMode ?? undefined,
+    };
   }
   return { status: row.status };
 }
@@ -1017,6 +1036,81 @@ async function lockRunnerJob(
   return row;
 }
 
+function piExecutionContextValidSql(): SQL {
+  return sql`
+    NOT (${runnerJobQueue.executionContext} ? 'piExecutionMode')
+    OR COALESCE(
+      (
+        ${runnerJobQueue.executionContext}->>'piExecutionMode'
+          IN ('standby', 'cold-start')
+        AND jsonb_typeof(
+          ${runnerJobQueue.executionContext}->'piSystemPrompt'
+        ) = 'string'
+        AND btrim(${runnerJobQueue.executionContext}->>'piSystemPrompt') <> ''
+        AND jsonb_typeof(
+          ${runnerJobQueue.executionContext}->'piModelConfig'
+        ) = 'object'
+        AND jsonb_typeof(
+          ${runnerJobQueue.executionContext}->'runSkillSnapshot'
+        ) = 'object'
+      ),
+      false
+    )
+  `;
+}
+
+function selectClaimTransitionResultSql(): SQL {
+  return sql`
+    SELECT
+      CASE
+        WHEN NOT EXISTS (SELECT 1 FROM locked_run)
+          THEN 'run-not-found'
+        WHEN EXISTS (
+          SELECT 1
+          FROM locked_run
+          WHERE locked_run."status" <> 'pending'
+        )
+          THEN 'run-not-found'
+        WHEN NOT EXISTS (SELECT 1 FROM locked_job)
+          OR EXISTS (
+            SELECT 1
+            FROM locked_job
+            WHERE locked_job."isExpired"
+          )
+          THEN 'job-not-found'
+        WHEN EXISTS (
+          SELECT 1
+          FROM locked_job
+          WHERE NOT locked_job."piExecutionContextValid"
+        )
+          THEN 'invariant-error'
+        WHEN EXISTS (SELECT 1 FROM updated_run)
+          AND (
+            EXISTS (SELECT 1 FROM deleted_job)
+            OR EXISTS (SELECT 1 FROM retained_pi_job)
+          )
+          THEN 'claimed'
+        ELSE 'invariant-error'
+      END AS "status",
+      (
+        SELECT
+          (
+            EXTRACT(EPOCH FROM updated_run."claimedAt") * 1000
+          )::double precision
+        FROM updated_run
+      ) AS "claimedAtMs",
+      (
+        SELECT
+          CASE
+            WHEN locked_job."piExecutionContextValid"
+              THEN locked_job."piExecutionMode"
+            ELSE NULL
+          END
+        FROM locked_job
+      ) AS "piExecutionMode"
+  `;
+}
+
 function buildClaimTransitionSql(
   runId: string,
   runnerId: string | null,
@@ -1035,7 +1129,9 @@ function buildClaimTransitionSql(
           locked_job AS MATERIALIZED (
             SELECT
               ${runnerJobQueue.runId} AS "runId",
-              ${runnerJobQueue.profile} AS "profile",
+              ${runnerJobQueue.executionContext}->>'piExecutionMode'
+                AS "piExecutionMode",
+              (${piExecutionContextValidSql()}) AS "piExecutionContextValid",
               ${lte(runnerJobQueue.expiresAt, sql`now()`)} AS "isExpired"
             FROM ${runnerJobQueue}
             INNER JOIN locked_run
@@ -1054,6 +1150,7 @@ function buildClaimTransitionSql(
             WHERE
               locked_run."status" = 'pending'
               AND NOT locked_job."isExpired"
+              AND locked_job."piExecutionContextValid"
           ),
           updated_run AS (
             UPDATE ${agentRuns}
@@ -1080,10 +1177,8 @@ function buildClaimTransitionSql(
             WHERE ${and(
               eq(runnerJobQueue.runId, sql`locked_job."runId"`),
               sql`locked_job."runId" = locked_run."id"`,
-              sql`(
-                locked_run."status" <> 'pending'
-                OR locked_job."profile" <> ${PI_STANDBY_PROFILE}
-              )`,
+              sql`locked_job."piExecutionContextValid"`,
+              sql`locked_job."piExecutionMode" IS DISTINCT FROM 'standby'`,
               sql`(
                 locked_run."status" <> 'pending'
                 OR EXISTS (
@@ -1099,45 +1194,14 @@ function buildClaimTransitionSql(
             SELECT locked_job."runId" AS "runId"
             FROM locked_job
             WHERE
-              locked_job."profile" = ${PI_STANDBY_PROFILE}
+              locked_job."piExecutionMode" = 'standby'
               AND EXISTS (
                 SELECT 1
                 FROM updated_run
                 WHERE updated_run."id" = locked_job."runId"
               )
           )
-          SELECT
-            CASE
-              WHEN NOT EXISTS (SELECT 1 FROM locked_run)
-                THEN 'run-not-found'
-              WHEN EXISTS (
-                SELECT 1
-                FROM locked_run
-                WHERE locked_run."status" <> 'pending'
-              )
-                THEN 'run-not-found'
-              WHEN NOT EXISTS (SELECT 1 FROM locked_job)
-                OR EXISTS (
-                  SELECT 1
-                  FROM locked_job
-                  WHERE locked_job."isExpired"
-                )
-                THEN 'job-not-found'
-              WHEN EXISTS (SELECT 1 FROM updated_run)
-                AND (
-                  EXISTS (SELECT 1 FROM deleted_job)
-                  OR EXISTS (SELECT 1 FROM retained_pi_job)
-                )
-                THEN 'claimed'
-              ELSE 'invariant-error'
-            END AS "status",
-            (
-              SELECT
-                (
-                  EXTRACT(EPOCH FROM updated_run."claimedAt") * 1000
-                )::double precision
-              FROM updated_run
-            ) AS "claimedAtMs"
+          ${selectClaimTransitionResultSql()}
           `;
 }
 
@@ -1871,6 +1935,7 @@ async function buildClaimResponseBody(args: {
       args.signal.throwIfAborted();
       const {
         connectorPermissionBaseline: _connectorPermissionBaseline,
+        piExecutionMode: _unlockedPiExecutionMode,
         secretValueEnvironmentKeys: _secretValueEnvironmentKeys,
         storageMounts: _storedStorageMounts,
         ...runnerStoredContext
@@ -2482,7 +2547,15 @@ const claimAuthorizedJob$ = command(
       return claimTransitionErrorResponse(claimResult);
     }
 
-    const response = { status: 200 as const, body: responseBodyResult.value };
+    const response = {
+      status: 200 as const,
+      body: {
+        ...responseBodyResult.value,
+        ...(claimResult.piExecutionMode
+          ? { piExecutionMode: claimResult.piExecutionMode }
+          : {}),
+      },
+    };
     claimRouteTiming.recordElapsed(
       "claim_route_request_to_response_ready",
       "parent",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -221,7 +221,6 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   isPiEdgeCompatibleProviderType,
   piSandboxModelConfig,
-  PI_STANDBY_PROFILE,
   resolvePiEdgeModelConfig,
   type PiEdgeModelConfig,
   type PiEdgeTurnArgs,
@@ -5903,6 +5902,7 @@ function storedExecutionContextWithPiResources(
   }
   return {
     ...context,
+    piExecutionMode: "standby",
     runSkillSnapshot: resources.snapshot,
     piSystemPrompt: resources.systemPrompt,
     piModelConfig: resources.modelConfig,
@@ -6365,9 +6365,7 @@ async function persistPendingAtomicLaunch(
       .values({
         runId: returnedCteId(context.insertedRun),
         runnerGroup: args.payload.runnerGroup,
-        profile: args.commit.launch.piEdge
-          ? PI_STANDBY_PROFILE
-          : args.payload.profile,
+        profile: args.payload.profile,
         cliAgentSessionId: args.payload.cliAgentSessionId,
         reuseKey: args.payload.reuseKey,
         executionContext: args.payload.executionContext,
@@ -8234,9 +8232,7 @@ async function committedAtomicLaunchResponse(args: {
       apiStartTime: args.createArgs.apiStartTime,
     });
   }
-  const dispatchedProfile = args.launch.piEdge
-    ? PI_STANDBY_PROFILE
-    : args.committed.runnerJobPayload.profile;
+  const dispatchedProfile = args.committed.runnerJobPayload.profile;
   await notifyRunnerJob(args.db, {
     runnerGroup: args.committed.runnerJobPayload.runnerGroup,
     runId: args.committed.run.id,
@@ -8245,6 +8241,8 @@ async function committedAtomicLaunchResponse(args: {
     cliAgentSessionId: args.committed.runnerJobPayload.cliAgentSessionId,
     historyGenerationRunId:
       args.committed.runnerJobPayload.historyGenerationRunId,
+    piExecutionMode:
+      args.committed.runnerJobPayload.executionContext.piExecutionMode,
     createdAt: args.committed.runnerJobCreatedAt,
   });
   args.timing.flush({

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -1,11 +1,7 @@
 import { command } from "ccstate";
 import type { z } from "zod";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
-import {
-  DEFAULT_PROFILE,
-  PI_STANDBY_PROFILE,
-  PI_STANDBY_TTL_RELEASE_EXIT_CODE,
-} from "@vm0/api-contracts/contracts/runners";
+import { PI_STANDBY_TTL_RELEASE_EXIT_CODE } from "@vm0/api-contracts/contracts/runners";
 import type { RunResult, RunStatus } from "@vm0/api-contracts/contracts/runs";
 import { webhookCompleteContract } from "@vm0/api-contracts/contracts/webhooks";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -22,6 +18,10 @@ import {
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
+import {
+  nullableDriverValueDecoder,
+  pgTextDecoder,
+} from "../../lib/db-structured-result";
 import type { SandboxAuth } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
@@ -172,19 +172,17 @@ async function transitionRunStatus(
   if (!updated) {
     return false;
   }
-  // Pi standby jobs stay in the queue after being claimed so a later handoff
-  // can wake the prewarmed sandbox. Nothing consumes them once the run settles,
-  // so drop them here. Every other profile is already removed by the normal
-  // claim/expiry lifecycle, and deleting those rows here would turn a stale
-  // claim's "Run not found" into "Job not found in queue".
-  await db
-    .delete(runnerJobQueue)
-    .where(
-      and(
-        eq(runnerJobQueue.runId, runId),
-        eq(runnerJobQueue.profile, PI_STANDBY_PROFILE),
-      ),
-    );
+  // Pi jobs can stay in the queue after a standby claim or while cold-start
+  // handoff data is still being persisted. Nothing consumes them once the run
+  // settles. Ordinary rows are already removed by the normal claim/expiry
+  // lifecycle, and deleting those rows here would change stale-claim errors.
+  await db.delete(runnerJobQueue).where(
+    and(
+      eq(runnerJobQueue.runId, runId),
+      sql`${runnerJobQueue.executionContext}->>'piExecutionMode'
+          IN ('standby', 'cold-start')`,
+    ),
+  );
   recordSandboxOperation({
     sandboxType: "runner",
     actionType: "run_terminal_transition_committed",
@@ -250,12 +248,16 @@ async function tryReleasePiStandbyForColdStart(
       .select({
         profile: runnerJobQueue.profile,
         runnerGroup: runnerJobQueue.runnerGroup,
+        piExecutionMode:
+          sql`${runnerJobQueue.executionContext}->>'piExecutionMode'`.mapWith(
+            nullableDriverValueDecoder(pgTextDecoder),
+          ),
       })
       .from(runnerJobQueue)
       .where(eq(runnerJobQueue.runId, input.body.runId))
       .for("update");
     signal.throwIfAborted();
-    if (!job || job.profile !== PI_STANDBY_PROFILE) {
+    if (!job || job.piExecutionMode !== "standby") {
       return null;
     }
 
@@ -267,7 +269,12 @@ async function tryReleasePiStandbyForColdStart(
     await tx
       .update(runnerJobQueue)
       .set({
-        profile: DEFAULT_PROFILE,
+        executionContext: sql`jsonb_set(
+          ${runnerJobQueue.executionContext},
+          '{piExecutionMode}',
+          to_jsonb(${"cold-start"}::text),
+          true
+        )`,
         createdAt: timestamps.createdAt,
         expiresAt: timestamps.expiresAt,
       })
@@ -286,6 +293,7 @@ async function tryReleasePiStandbyForColdStart(
     signal.throwIfAborted();
     return {
       coldStartReady,
+      profile: job.profile,
       runnerGroup: job.runnerGroup,
       userId: run.userId,
     };
@@ -311,11 +319,12 @@ async function tryReleasePiStandbyForColdStart(
       status: "pending",
     });
     signal.throwIfAborted();
-    await publishRunnerJobNotification(
-      requeued.runnerGroup,
-      input.body.runId,
-      DEFAULT_PROFILE,
-    );
+    await publishRunnerJobNotification({
+      group: requeued.runnerGroup,
+      runId: input.body.runId,
+      profile: requeued.profile,
+      piExecutionMode: "cold-start",
+    });
     signal.throwIfAborted();
   }
   return true;
@@ -347,17 +356,22 @@ const activatePiColdStartForHandoff$ = command(
         .select({
           profile: runnerJobQueue.profile,
           runnerGroup: runnerJobQueue.runnerGroup,
+          piExecutionMode:
+            sql`${runnerJobQueue.executionContext}->>'piExecutionMode'`.mapWith(
+              nullableDriverValueDecoder(pgTextDecoder),
+            ),
         })
         .from(runnerJobQueue)
         .where(eq(runnerJobQueue.runId, input.runId))
         .for("update");
       signal.throwIfAborted();
-      if (!job || job.profile !== DEFAULT_PROFILE) {
+      if (!job || job.piExecutionMode !== "cold-start") {
         return null;
       }
       if (run.status === "pending") {
         return {
           notify: false,
+          profile: job.profile,
           runnerGroup: job.runnerGroup,
           userId: run.userId,
         };
@@ -379,6 +393,7 @@ const activatePiColdStartForHandoff$ = command(
       signal.throwIfAborted();
       return {
         notify: true,
+        profile: job.profile,
         runnerGroup: job.runnerGroup,
         userId: run.userId,
       };
@@ -399,11 +414,12 @@ const activatePiColdStartForHandoff$ = command(
         status: "pending",
       });
       signal.throwIfAborted();
-      await publishRunnerJobNotification(
-        activation.runnerGroup,
-        input.runId,
-        DEFAULT_PROFILE,
-      );
+      await publishRunnerJobNotification({
+        group: activation.runnerGroup,
+        runId: input.runId,
+        profile: activation.profile,
+        piExecutionMode: "cold-start",
+      });
       signal.throwIfAborted();
     }
     return true;

--- a/turbo/apps/api/src/signals/services/pi-edge-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-edge-config.ts
@@ -1,7 +1,6 @@
-import {
-  PI_STANDBY_PROFILE,
-  type PiModelConfig,
-  type RunSkillSnapshot,
+import type {
+  PiModelConfig,
+  RunSkillSnapshot,
 } from "@vm0/api-contracts/contracts/runners";
 import {
   getModelProviderPiChatCompletionsUrl,
@@ -42,13 +41,6 @@ export interface PiEdgeTurnArgs {
   readonly runnerGroup: string;
   readonly apiStartTime: number;
 }
-
-/**
- * Runner job profile for Pi runs. Runners advertise this as a distinct queue
- * lane backed by the default Sandbox resource shape, allowing the standby job
- * to be claimed independently from ordinary agent work.
- */
-export { PI_STANDBY_PROFILE };
 
 /** Build the non-secret model config persisted for the standby Sandbox. */
 export function piSandboxModelConfig(config: PiEdgeModelConfig): PiModelConfig {

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -1,5 +1,7 @@
-import { publishRunnerJobNotification } from "../external/realtime";
+import type { PiExecutionMode } from "@vm0/api-contracts/contracts/runners";
+
 import { recordSandboxOperations } from "../external/sandbox-op-log";
+import { publishRunnerJobNotification } from "../external/realtime";
 import { now } from "../../lib/time";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
@@ -23,6 +25,7 @@ export async function notifyRunnerJob(
     readonly reuseKey: string | null;
     readonly cliAgentSessionId: string | null;
     readonly historyGenerationRunId: string | undefined;
+    readonly piExecutionMode?: PiExecutionMode;
     readonly createdAt: Date;
   },
 ): Promise<boolean> {
@@ -58,17 +61,18 @@ export async function notifyRunnerJob(
   );
   const preferenceFinishedAt = now();
   const publishStartedAt = now();
-  const published = await publishRunnerJobNotification(
-    args.runnerGroup,
-    args.runId,
-    args.profile,
-    {
+  const published = await publishRunnerJobNotification({
+    group: args.runnerGroup,
+    runId: args.runId,
+    profile: args.profile,
+    piExecutionMode: args.piExecutionMode,
+    metadata: {
       reuseKey: args.reuseKey,
       cliAgentSessionId: args.cliAgentSessionId,
       historyGenerationRunId: args.historyGenerationRunId,
       ...runnerPreferenceFields,
     },
-  );
+  });
   const publishFinishedAt = now();
 
   const dimensions: Record<string, string> = {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -112,6 +112,127 @@ describe("runner claim response contract", () => {
   });
 });
 
+describe("Pi execution mode contract", () => {
+  const storedContext = {
+    storageMounts: [],
+    environment: null,
+    secretValueEnvironmentKeys: null,
+    resumeSession: null,
+    encryptedSecrets: null,
+    cliAgentType: "claude-code",
+  };
+  const piRuntimeContext = {
+    piSystemPrompt: "Pinned Pi system prompt",
+    piModelConfig: {
+      provider: "deepseek",
+      baseUrl: "https://api.deepseek.com/",
+      model: "deepseek-v4-flash",
+      apiKeyEnv: "OPENAI_API_KEY",
+    },
+    runSkillSnapshot: {
+      schemaVersion: 1,
+      policyVersion: 1,
+      root: "/home/user/.pi/agent/skills",
+      digest: `sha256:${"a".repeat(64)}`,
+      entries: [],
+    },
+  };
+  const pollJob = {
+    runId: "22222222-2222-4222-8222-222222222222",
+    prompt: "continue",
+    appendSystemPrompt: null,
+    agentComposeVersionId: null,
+    vars: null,
+    experimentalProfile: "vm0/large",
+  };
+
+  it.each(["standby", "cold-start"])(
+    "preserves complete %s state across stored and Runner-facing contexts",
+    (piExecutionMode) => {
+      expect(
+        storedExecutionContextSchema.parse({
+          ...storedContext,
+          ...piRuntimeContext,
+          piExecutionMode,
+        }).piExecutionMode,
+      ).toBe(piExecutionMode);
+      expect(
+        compatibleStoredExecutionContextSchema.parse({
+          ...storedContext,
+          ...piRuntimeContext,
+          piExecutionMode,
+        }).piExecutionMode,
+      ).toBe(piExecutionMode);
+      expect(
+        executionContextSchema.parse({
+          ...executionContextSchema.parse(loadRunnerClaimResponseFixture()),
+          ...piRuntimeContext,
+          piExecutionMode,
+        }).piExecutionMode,
+      ).toBe(piExecutionMode);
+      expect(
+        jobSchema.parse({ ...pollJob, piExecutionMode }).piExecutionMode,
+      ).toBe(piExecutionMode);
+    },
+  );
+
+  it("rejects unknown modes on persisted and Runner-facing boundaries", () => {
+    const invalidModeContext = {
+      ...piRuntimeContext,
+      piExecutionMode: "future-mode",
+    };
+
+    expect(
+      storedExecutionContextSchema.safeParse({
+        ...storedContext,
+        ...invalidModeContext,
+      }).success,
+    ).toBe(false);
+    expect(
+      executionContextSchema.safeParse({
+        ...executionContextSchema.parse(loadRunnerClaimResponseFixture()),
+        ...invalidModeContext,
+      }).success,
+    ).toBe(false);
+    expect(
+      jobSchema.safeParse({ ...pollJob, piExecutionMode: "future-mode" })
+        .success,
+    ).toBe(false);
+  });
+
+  it.each(["piSystemPrompt", "piModelConfig", "runSkillSnapshot"])(
+    "rejects a Pi mode without %s",
+    (missingField) => {
+      const incompleteContext = { ...piRuntimeContext };
+      Reflect.deleteProperty(incompleteContext, missingField);
+
+      expect(
+        storedExecutionContextSchema.safeParse({
+          ...storedContext,
+          ...incompleteContext,
+          piExecutionMode: "standby",
+        }).success,
+      ).toBe(false);
+      expect(
+        executionContextSchema.safeParse({
+          ...executionContextSchema.parse(loadRunnerClaimResponseFixture()),
+          ...incompleteContext,
+          piExecutionMode: "cold-start",
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it("does not infer a mode from historical Pi-shaped context", () => {
+    const parsed = storedExecutionContextSchema.parse({
+      ...storedContext,
+      ...piRuntimeContext,
+    });
+
+    expect(parsed).not.toHaveProperty("piExecutionMode");
+  });
+});
+
 describe("connector runtime synchronization contract", () => {
   const customConnectorId = "00000000-0000-4000-8000-000000000001";
 
@@ -319,8 +440,9 @@ describe("stored connector permission baseline contract", () => {
   });
 
   it("allows a previous reader to ignore the new optional field", () => {
-    const previousStoredExecutionContextSchema =
-      storedExecutionContextSchema.omit({
+    const previousStoredExecutionContextSchema = z
+      .object(storedExecutionContextSchema.shape)
+      .omit({
         connectorPermissionBaseline: true,
       });
     const parsed = previousStoredExecutionContextSchema.parse({

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -424,14 +424,11 @@ const runnerBuiltinFirewallsResolveResponseSchema = z.object({
  */
 export const DEFAULT_PROFILE = "vm0/default";
 
-/**
- * Prewarmed Pi Sandbox lane. Must stay in sync with
- * `crates/runner/src/profile.rs`.
- */
-export const PI_STANDBY_PROFILE = "vm0/pi-standby";
-
 /** Non-terminal Guest/Runner exit used to request Pi cold-start fallback. */
 export const PI_STANDBY_TTL_RELEASE_EXIT_CODE = 75;
+
+export const piExecutionModeSchema = z.enum(["standby", "cold-start"]);
+export type PiExecutionMode = z.infer<typeof piExecutionModeSchema>;
 
 /**
  * Runner group format: vm0/<name> (e.g., "vm0/production")
@@ -467,6 +464,7 @@ export const jobSchema = z.object({
   cliAgentSessionId: z.string().nullable().optional(),
   reuseKey: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
+  piExecutionMode: piExecutionModeSchema.optional(),
   runnerPreferenceDecision: runnerPreferenceDecisionSchema.optional(),
   runnerPreference: runnerPreferenceSchema.optional(),
   runnerPreferenceResolution: runnerPreferenceResolutionSchema.optional(),
@@ -763,12 +761,39 @@ export const piModelConfigSchema = z
   })
   .readonly();
 
+function requireCompletePiExecutionContext(
+  context: {
+    readonly piExecutionMode?: PiExecutionMode;
+    readonly piSystemPrompt?: unknown;
+    readonly piModelConfig?: unknown;
+    readonly runSkillSnapshot?: unknown;
+  },
+  refinement: z.RefinementCtx,
+): void {
+  if (context.piExecutionMode === undefined) {
+    return;
+  }
+  for (const field of [
+    "piSystemPrompt",
+    "piModelConfig",
+    "runSkillSnapshot",
+  ] as const) {
+    if (context[field] === undefined) {
+      refinement.addIssue({
+        code: "custom",
+        path: [field],
+        message: `${field} is required for Pi execution mode`,
+      });
+    }
+  }
+}
+
 /**
  * Stored execution context (subset stored in database for late routing)
  * Contains prepared context without runtime-generated fields
  * Secrets are encrypted with AES-256-GCM before storage
  */
-export const storedExecutionContextSchema = z.object({
+const storedExecutionContextObjectSchema = z.object({
   storageMounts: z
     .array(storedStorageMountEntrySchema)
     .superRefine(uniqueStorageMountPaths),
@@ -838,10 +863,16 @@ export const storedExecutionContextSchema = z.object({
     .optional(),
   // Complete Pi prompt rendered once before the first model call and reused
   // byte-for-byte by the API loop and the standby Sandbox.
+  piExecutionMode: piExecutionModeSchema.optional(),
   piSystemPrompt: z.string().min(1).optional(),
   piModelConfig: piModelConfigSchema.optional(),
   runSkillSnapshot: runSkillSnapshotSchema.optional(),
 });
+
+export const storedExecutionContextSchema =
+  storedExecutionContextObjectSchema.superRefine(
+    requireCompletePiExecutionContext,
+  );
 
 /**
  * Tolerant reader for execution contexts already persisted in a database or
@@ -850,9 +881,11 @@ export const storedExecutionContextSchema = z.object({
  * than invalidating the complete queued execution context.
  */
 export const compatibleStoredExecutionContextSchema =
-  storedExecutionContextSchema.extend({
-    connectorPermissionBaseline: z.unknown().optional(),
-  });
+  storedExecutionContextObjectSchema
+    .extend({
+      connectorPermissionBaseline: z.unknown().optional(),
+    })
+    .superRefine(requireCompletePiExecutionContext);
 
 /**
  * Execution context returned when claiming a job.
@@ -861,7 +894,7 @@ export const compatibleStoredExecutionContextSchema =
  * tolerant consumer projection and intentionally does not mirror every field.
  * See `crates/runner/src/types.rs`.
  */
-export const executionContextSchema = z.object({
+const executionContextObjectSchema = z.object({
   runId: z.uuid(),
   reuseKey: z.string().nullable().optional(),
   prompt: z.string(),
@@ -927,10 +960,15 @@ export const executionContextSchema = z.object({
   codexRuntimeConfig: modelProviderCodexRuntimeConfigSchema
     .nullable()
     .optional(),
+  piExecutionMode: piExecutionModeSchema.optional(),
   piSystemPrompt: z.string().min(1).optional(),
   piModelConfig: piModelConfigSchema.optional(),
   runSkillSnapshot: runSkillSnapshotSchema.optional(),
 });
+
+export const executionContextSchema = executionContextObjectSchema.superRefine(
+  requireCompletePiExecutionContext,
+);
 
 /**
  * Runners job claim contract - POST /api/runners/jobs/:id/claim


### PR DESCRIPTION
## Summary

- persist strict optional `standby` / `cold-start` Pi execution mode in the existing runner job execution context
- preserve the compose-selected runner profile through persistence, discovery, claim, recovery, and cold fallback
- make the locked queue row authoritative for claim mode, retaining standby rows while consuming cold-start and ordinary rows
- expose the mode through poll, claim, and the existing runner job notification, while omitting it for ordinary jobs
- remove the TypeScript synthetic Pi standby profile and cover profile preservation, queue lifecycle, recovery readiness, and a stale-discovery claim race

## Scope

- no database schema, migration, backfill, or index
- no organization-queue Pi activation or compatibility inference for historical Pi-shaped rows
- no Runner/Rust mode consumption or static alias cleanup; that remains in #25654
- Pi remains disabled during mixed API/Runner deployment, while ordinary job payloads retain their existing shape

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- changed API files: regular and type-aware `oxlint --deny-warnings`, plus `eslint --max-warnings 0`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --maxWorkers=1 --silent=passed-only` (77 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/pi-edge-loop.test.ts --maxWorkers=1 --silent=passed-only` against a migrated temporary database (15 passed)

A full API workspace attempt with `--maxWorkers=4` passed the changed Pi integration file and 2,737 tests, but 23 unrelated tests in eight files hit their existing five-second timeout under local full-suite contention.

Closes #25653

Parent: #25597
