### PR TITLE
refactor(api): steer run time budget from a per-minute cron

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -23,6 +23,7 @@ import {
   cronRenewGoogleWorkspaceEventSubscriptionsContract,
   cronReconcileBillingEntitlementsContract,
   cronRefreshStoragePresignedUrlsContract,
+  cronSteerRunTimeBudgetContract,
   cronSyncSkillsContract,
   cronTelegramCleanupContract,
 } from "@vm0/api-contracts/contracts/cron";
@@ -138,6 +139,10 @@ const expectedVercelCrons = [
   {
     path: cronAggregateModelStatsContract.aggregate.path,
     schedule: "12 * * * *",
+  },
+  {
+    path: cronSteerRunTimeBudgetContract.steer.path,
+    schedule: "* * * * *",
   },
 ] satisfies readonly VercelCron[];
 

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -22,6 +22,7 @@ import { cronReconcileBillingEntitlementsRoutes } from "./routes/cron-reconcile-
 import { cronRefreshStoragePresignedUrlsRoutes } from "./routes/cron-refresh-storage-presigned-urls";
 import { cronComputerUseScreenshotCleanupRoutes } from "./routes/cron-computer-use-screenshot-cleanup";
 import { cronBrowserReconcileRoutes } from "./routes/cron-browser-reconcile";
+import { cronSteerRunTimeBudgetRoutes } from "./routes/cron-steer-run-time-budget";
 import { cronSyncSkillsRoutes } from "./routes/cron-sync-skills";
 import { cronTelegramCleanupRoutes } from "./routes/cron-telegram-cleanup";
 import { desktopAuthRoutes } from "./routes/desktop-auth";
@@ -244,6 +245,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronRefreshStoragePresignedUrlsRoutes,
   ...cronComputerUseScreenshotCleanupRoutes,
   ...cronBrowserReconcileRoutes,
+  ...cronSteerRunTimeBudgetRoutes,
   ...cronSyncSkillsRoutes,
   ...cronTelegramCleanupRoutes,
   ...emailMorningBriefUnsubscribeRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -23,6 +23,7 @@ import {
   type UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { isChatRunTerminalEventType } from "@vm0/api-contracts/contracts/chat-events";
+import { cronSteerRunTimeBudgetContract } from "@vm0/api-contracts/contracts/cron";
 import { ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
 import {
@@ -43,6 +44,7 @@ import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
+import { backdateRunStartedAtFixture } from "../../../test-fixtures/agent-runs";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import {
@@ -95,6 +97,7 @@ import {
   replaceBddVm0ApiKey,
   replaceThreadSessionBindingFixture,
 } from "../../../test-fixtures/chat-events";
+import { cronSteerRunTimeBudgetRoutes } from "../cron-steer-run-time-budget";
 import { zeroChatEventsRoutes } from "../zero-chat-events";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { zeroMailRoutes } from "../zero-mail";
@@ -443,6 +446,28 @@ async function claimChatRun(
     claim,
     sandboxHeaders,
   };
+}
+
+/**
+ * The time-budget sweep is global, so it can only be driven from a file that
+ * ages its own runs through `backdateRunStartedAtFixture`. Every other suite
+ * claims runs at the current time and therefore stays outside the window.
+ */
+async function runSteerRunTimeBudgetCron(): Promise<void> {
+  await accept(
+    setupApp({ context, routes: cronSteerRunTimeBudgetRoutes })(
+      cronSteerRunTimeBudgetContract,
+    ).steer({ headers: { authorization: "Bearer test-cron-secret" } }),
+    [200],
+  );
+}
+
+/** Age one claimed run to the given elapsed runtime. */
+async function ageClaimedRun(runId: string, elapsedMs: number): Promise<void> {
+  await backdateRunStartedAtFixture({
+    runId,
+    startedAt: new Date(now() - elapsedMs),
+  });
 }
 
 function claimEnvironment(claim: RunnerClaim): Record<string, string> {
@@ -1636,7 +1661,7 @@ describe("CHAT-02: queueing and recalling messages", () => {
     await cancelChatRun(actor, active.runId);
   }, 90_000);
 
-  it("steers a run once when assistant output reaches its time budget", async () => {
+  it("steers a run once when it reaches its time budget", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -1645,55 +1670,15 @@ describe("CHAT-02: queueing and recalling messages", () => {
       prompt: "run until the time budget warning",
     });
     const claimed = await claimChatRun(runnerGroup, active.runId);
-    const running = await api.readRun(actor, active.runId);
-    if (!running.startedAt) {
-      throw new Error("Expected the claimed run to have a start time");
-    }
-    const startedAt = Date.parse(running.startedAt);
-    onTestFinished(() => {
-      clearMockNow();
-    });
 
-    mockNow(startedAt + RUN_TIME_BUDGET_STEER_AT_MS - 1);
-    await webhooks.requestAgentEvents(
-      {
-        runId: active.runId,
-        events: [
-          {
-            type: "assistant",
-            sequenceNumber: 0,
-            message: {
-              content: [{ type: "text", text: "still below the threshold" }],
-            },
-          },
-        ],
-      },
-      claimed.sandboxHeaders,
-      [200],
-    );
-    await flushWaitUntilForTest();
+    await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS - 60_000);
+    await runSteerRunTimeBudgetCron();
     await expect(
       api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
     ).resolves.toStrictEqual([]);
 
-    mockNow(startedAt + RUN_TIME_BUDGET_STEER_AT_MS);
-    await webhooks.requestAgentEvents(
-      {
-        runId: active.runId,
-        events: [
-          {
-            type: "assistant",
-            sequenceNumber: 1,
-            message: {
-              content: [{ type: "text", text: "threshold reached" }],
-            },
-          },
-        ],
-      },
-      claimed.sandboxHeaders,
-      [200],
-    );
-    await flushWaitUntilForTest();
+    await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
+    await runSteerRunTimeBudgetCron();
     const budgetEventIds = await api.listRunnerActiveInputs(
       claimed.claim.sandboxToken,
       active.runId,
@@ -1724,29 +1709,11 @@ describe("CHAT-02: queueing and recalling messages", () => {
       }),
     ).toBeFalsy();
 
-    mockNow(startedAt + RUN_TIME_BUDGET_STEER_AT_MS + 1);
-    await webhooks.requestAgentEvents(
-      {
-        runId: active.runId,
-        events: [
-          {
-            type: "assistant",
-            sequenceNumber: 2,
-            message: {
-              content: [{ type: "text", text: "another assistant event" }],
-            },
-          },
-        ],
-      },
-      claimed.sandboxHeaders,
-      [200],
-    );
-    await flushWaitUntilForTest();
+    await runSteerRunTimeBudgetCron();
     await expect(
       api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
     ).resolves.toStrictEqual([]);
 
-    clearMockNow();
     await cancelChatRun(actor, active.runId);
   }, 90_000);
 
@@ -1759,36 +1726,12 @@ describe("CHAT-02: queueing and recalling messages", () => {
       prompt: "leave the budget input unclaimed",
     });
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
-    const running = await api.readRun(actor, first.runId);
-    if (!running.startedAt) {
-      throw new Error("Expected the claimed run to have a start time");
-    }
-    onTestFinished(() => {
-      clearMockNow();
-    });
-    mockNow(Date.parse(running.startedAt) + RUN_TIME_BUDGET_STEER_AT_MS);
-    await webhooks.requestAgentEvents(
-      {
-        runId: first.runId,
-        events: [
-          {
-            type: "assistant",
-            sequenceNumber: 0,
-            message: {
-              content: [{ type: "text", text: "leave this warning pending" }],
-            },
-          },
-        ],
-      },
-      firstClaim.sandboxHeaders,
-      [200],
-    );
-    await flushWaitUntilForTest();
+    await ageClaimedRun(first.runId, RUN_TIME_BUDGET_STEER_AT_MS);
+    await runSteerRunTimeBudgetCron();
     await expect(
       api.listRunnerActiveInputs(firstClaim.claim.sandboxToken, first.runId),
     ).resolves.toHaveLength(1);
 
-    clearMockNow();
     await cancelChatRun(actor, first.runId, firstClaim.sandboxHeaders);
     const second = await sendChatRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/cron-steer-run-time-budget.ts
+++ b/turbo/apps/api/src/signals/routes/cron-steer-run-time-budget.ts
@@ -1,0 +1,25 @@
+import { cronSteerRunTimeBudgetContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route-entry";
+import { steerRunsNearTimeBudget$ } from "../services/cron-steer-run-time-budget.service";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
+
+const steerRunTimeBudgetRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!get(hasValidCronSecret$)) {
+      return cronUnauthorized();
+    }
+
+    const body = await set(steerRunsNearTimeBudget$, signal);
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const cronSteerRunTimeBudgetRoutes: readonly RouteEntry[] = [
+  {
+    route: cronSteerRunTimeBudgetContract.steer,
+    handler: steerRunTimeBudgetRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -17,7 +17,6 @@ import type { SandboxAuth } from "../../types/auth";
 import { publishRunChangedForUserSafely } from "../external/realtime";
 import { refreshAgentPhoneTypingEvents$ } from "./agent-event-consumer-agentphone-typing.service";
 import { ingestAxiomEvents } from "./agent-event-consumer-axiom.service";
-import { steerRunNearTimeBudget$ } from "./agent-event-consumer-run-time-budget.service";
 import {
   materializeRunOutputEvents$,
   publishMaterializedChatProjection,
@@ -52,13 +51,6 @@ interface ReceiveAgentEventsParams {
 interface DispatchableConsumer {
   readonly name: string;
   readonly command$: ConsumerCommand;
-  readonly eventTypes?: readonly string[];
-}
-
-interface PreparedConsumer {
-  readonly name: string;
-  readonly command$: ConsumerCommand;
-  readonly events: readonly AgentEvent[];
 }
 
 interface AcceptedAgentEvents {
@@ -67,11 +59,6 @@ interface AcceptedAgentEvents {
 }
 
 const OPTIONAL_EVENT_CONSUMERS: readonly DispatchableConsumer[] = [
-  {
-    name: "run-time-budget",
-    command$: steerRunNearTimeBudget$,
-    eventTypes: ["assistant"],
-  },
   {
     name: "telegram-typing",
     command$: refreshTelegramTypingEvents$,
@@ -110,19 +97,13 @@ const runOptionalEventConsumer$ = command(
   async (
     { set },
     params: {
-      readonly consumer: PreparedConsumer;
+      readonly consumer: DispatchableConsumer;
       readonly payload: EventConsumerPayload;
     },
     signal: AbortSignal,
   ): Promise<void> => {
-    const range = eventRange(params.consumer.events);
-    set(
-      eventConsumerPayloadState$,
-      Object.freeze({
-        ...params.payload,
-        events: Object.freeze([...params.consumer.events]),
-      }),
-    );
+    const range = eventRange(params.payload.events);
+    set(eventConsumerPayloadState$, params.payload);
     const result = await tapError(
       Promise.resolve(set(params.consumer.command$, signal)),
       (error) => {
@@ -179,27 +160,7 @@ export const dispatchOptionalAgentEventConsumers$ = command(
       signal.throwIfAborted();
     }
 
-    const consumers = OPTIONAL_EVENT_CONSUMERS.map(
-      (consumer): PreparedConsumer | null => {
-        const matchingEvents = consumer.eventTypes
-          ? payload.events.filter((event) => {
-              return consumer.eventTypes?.includes(event.type) ?? false;
-            })
-          : payload.events;
-
-        return matchingEvents.length === 0
-          ? null
-          : {
-              name: consumer.name,
-              command$: consumer.command$,
-              events: matchingEvents,
-            };
-      },
-    ).filter((consumer): consumer is PreparedConsumer => {
-      return consumer !== null;
-    });
-
-    for (const consumer of consumers) {
+    for (const consumer of OPTIONAL_EVENT_CONSUMERS) {
       await set(runOptionalEventConsumer$, { consumer, payload }, signal);
     }
 

--- a/turbo/apps/api/src/signals/services/cron-steer-run-time-budget.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-steer-run-time-budget.service.ts
@@ -4,7 +4,6 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
-import { eventConsumerPayload$ } from "../../lib/event-consumer/route";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import { runTimeBudgetEventIdForRun } from "./assistant-event-id";
@@ -17,6 +16,11 @@ const RUN_TIME_BUDGET_LIMIT_MS = 120 * 60 * 1000;
 const RUN_TIME_BUDGET_REMAINING_MS = 5 * 60 * 1000;
 const RUN_TIME_BUDGET_STEER_AT_MS =
   RUN_TIME_BUDGET_LIMIT_MS - RUN_TIME_BUDGET_REMAINING_MS;
+/**
+ * A run leaves the window as soon as the runner terminates it at the hard
+ * limit, so the scan only ever sees runs inside a five-minute band.
+ */
+const RUN_TIME_BUDGET_SCAN_LIMIT = 100;
 
 const RUN_TIME_BUDGET_MESSAGE = `This runner has a hard maximum runtime of 2 hours. The current run has been active for 115 minutes, leaving approximately 5 minutes before it is terminated.
 
@@ -27,51 +31,46 @@ A normal completion provides a reliable handoff for the next run. The handoff in
 Use the remaining time to leave the task in a resumable state and finish this turn normally.`;
 
 interface RunTimeBudgetCandidate {
+  readonly runId: string;
   readonly chatThreadId: string;
 }
 
-async function loadRunTimeBudgetCandidate(
+async function loadRunTimeBudgetCandidates(
   db: Db,
-  args: {
-    readonly runId: string;
-    readonly userId: string;
-    readonly orgId: string;
-    readonly startedBefore: Date;
-  },
-): Promise<RunTimeBudgetCandidate | null> {
-  const [candidate] = await db
-    .select({ chatThreadId: zeroRuns.chatThreadId })
+  startedBefore: Date,
+): Promise<readonly RunTimeBudgetCandidate[]> {
+  return await db
+    .select({
+      runId: agentRuns.id,
+      chatThreadId: chatThreads.id,
+    })
     .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
     .innerJoin(chatThreads, eq(chatThreads.id, zeroRuns.chatThreadId))
     .where(
       and(
-        eq(agentRuns.id, args.runId),
-        eq(agentRuns.userId, args.userId),
-        eq(agentRuns.orgId, args.orgId),
         eq(agentRuns.status, "running"),
-        lte(agentRuns.startedAt, args.startedBefore),
+        lte(agentRuns.startedAt, startedBefore),
       ),
     )
-    .limit(1);
-  return candidate?.chatThreadId
-    ? { chatThreadId: candidate.chatThreadId }
-    : null;
+    .orderBy(agentRuns.startedAt)
+    .limit(RUN_TIME_BUDGET_SCAN_LIMIT);
 }
 
+/**
+ * Insert the steer once per run. The event id is derived from the run id, so a
+ * later scan of the same run conflicts on it instead of steering twice.
+ */
 async function persistRunTimeBudgetInput(
   db: Db,
   args: {
-    readonly runId: string;
-    readonly userId: string;
-    readonly orgId: string;
-    readonly chatThreadId: string;
+    readonly candidate: RunTimeBudgetCandidate;
     readonly startedBefore: Date;
     readonly createdAt: Date;
   },
 ): Promise<boolean> {
   return await db.transaction(async (tx) => {
-    if (!(await lockChatQueueThread(tx, args.chatThreadId))) {
+    if (!(await lockChatQueueThread(tx, args.candidate.chatThreadId))) {
       return false;
     }
     const [run] = await tx
@@ -84,11 +83,9 @@ async function persistRunTimeBudgetInput(
       .innerJoin(chatThreads, eq(chatThreads.id, zeroRuns.chatThreadId))
       .where(
         and(
-          eq(agentRuns.id, args.runId),
-          eq(agentRuns.userId, args.userId),
-          eq(agentRuns.orgId, args.orgId),
+          eq(agentRuns.id, args.candidate.runId),
           eq(agentRuns.status, "running"),
-          eq(zeroRuns.chatThreadId, args.chatThreadId),
+          eq(zeroRuns.chatThreadId, args.candidate.chatThreadId),
           lte(agentRuns.startedAt, args.startedBefore),
         ),
       )
@@ -98,10 +95,10 @@ async function persistRunTimeBudgetInput(
       return false;
     }
 
-    await insertChatEvent(
+    const inserted = await insertChatEvent(
       tx,
       {
-        id: runTimeBudgetEventIdForRun(args.runId),
+        id: runTimeBudgetEventIdForRun(args.candidate.runId),
         chatThreadId: run.chatThreadId,
         eventType: "input.budget",
         runId: null,
@@ -109,7 +106,7 @@ async function persistRunTimeBudgetInput(
           text: RUN_TIME_BUDGET_MESSAGE,
         }),
         agentRunContext: {
-          sourceRunId: args.runId,
+          sourceRunId: args.candidate.runId,
           sourceChatThreadId: run.chatThreadId,
           sourceAgentId: run.agentId,
         },
@@ -117,42 +114,41 @@ async function persistRunTimeBudgetInput(
       },
       "id",
     );
-    return true;
+    return inserted !== null;
   });
 }
 
-export const steerRunNearTimeBudget$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<{ status: 200 }> => {
-    const payload = get(eventConsumerPayload$);
+/**
+ * Steer every chat run that reached its time budget. A run stays a candidate
+ * until it ends, so an unclaimed steer is re-announced to the runner on the
+ * next scan.
+ */
+export const steerRunsNearTimeBudget$ = command(
+  async ({ set }, signal: AbortSignal) => {
     const db = set(writeDb$);
     const createdAt = nowDate();
     const startedBefore = new Date(
       createdAt.getTime() - RUN_TIME_BUDGET_STEER_AT_MS,
     );
-    const candidate = await loadRunTimeBudgetCandidate(db, {
-      runId: payload.runId,
-      userId: payload.context.userId,
-      orgId: payload.context.orgId,
-      startedBefore,
-    });
+    const candidates = await loadRunTimeBudgetCandidates(db, startedBefore);
     signal.throwIfAborted();
-    if (!candidate) {
-      return { status: 200 };
-    }
 
-    const persisted = await persistRunTimeBudgetInput(db, {
-      runId: payload.runId,
-      userId: payload.context.userId,
-      orgId: payload.context.orgId,
-      chatThreadId: candidate.chatThreadId,
-      startedBefore,
-      createdAt,
-    });
-    signal.throwIfAborted();
-    if (persisted) {
+    let steered = 0;
+    for (const candidate of candidates) {
+      if (
+        await persistRunTimeBudgetInput(db, {
+          candidate,
+          startedBefore,
+          createdAt,
+        })
+      ) {
+        steered += 1;
+      }
+      signal.throwIfAborted();
       await notifyRunningChatRunOfPendingInput(db, candidate.chatThreadId);
       signal.throwIfAborted();
     }
-    return { status: 200 };
+
+    return { scanned: candidates.length, steered };
   },
 );

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -8,7 +8,10 @@
  */
 import { createStore } from "ccstate";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { and, eq } from "drizzle-orm";
 
+import { db } from "../lib/db";
 import { now } from "../lib/time";
 import {
   createAgentRun$,
@@ -67,4 +70,23 @@ export async function listAgentRunsFixture(args: {
       limit: args.limit ?? 50,
     }),
   );
+}
+
+/**
+ * Age one claimed run without moving the shared test clock. Sweeps that select
+ * runs by elapsed runtime are global, so a mocked clock would also age every
+ * concurrent test file's rows in the shared database.
+ */
+export async function backdateRunStartedAtFixture(args: {
+  readonly runId: string;
+  readonly startedAt: Date;
+}): Promise<void> {
+  const updated = await db()
+    .update(agentRuns)
+    .set({ startedAt: args.startedAt })
+    .where(and(eq(agentRuns.id, args.runId), eq(agentRuns.status, "running")))
+    .returning({ id: agentRuns.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one running run to become historical");
+  }
 }

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -95,6 +95,10 @@
     {
       "path": "/api/cron/aggregate-model-stats",
       "schedule": "12 * * * *"
+    },
+    {
+      "path": "/api/cron/steer-run-time-budget",
+      "schedule": "* * * * *"
     }
   ]
 }

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -108,6 +108,11 @@ const cronMonitorChatEventQueueResponseSchema = z.object({
   orphanedMessages: z.number().int().nonnegative(),
 });
 
+const cronSteerRunTimeBudgetResponseSchema = z.object({
+  scanned: z.number().int().nonnegative(),
+  steered: z.number().int().nonnegative(),
+});
+
 const cronReconcileBillingEntitlementsResponseSchema = z.object({
   success: z.literal(true),
   downgraded: z.number(),
@@ -294,6 +299,19 @@ export const cronMonitorChatEventQueueContract = c.router({
       500: z.object({ error: z.string() }),
     },
     summary: "Monitor for orphaned queued chat messages",
+  },
+});
+
+export const cronSteerRunTimeBudgetContract = c.router({
+  steer: {
+    method: "GET",
+    path: "/api/cron/steer-run-time-budget",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronSteerRunTimeBudgetResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Steer chat runs that reached their time budget",
   },
 });
 


### PR DESCRIPTION
## Summary

The 115-minute run-time-budget steer added in #25384 was registered as an optional webhook consumer filtered to `assistant` events:

```ts
{ name: "run-time-budget", command$: steerRunNearTimeBudget$, eventTypes: ["assistant"] }
```

`type: "assistant"` is the Claude Code event shape. Codex-backed runs report assistant output as `item.completed` (see `anthropicMessageText` vs `codexAgentMessageText` in `agent-event-consumer-run-output.service.ts`), so the filter never matched and those runs were never steered. Production confirms it: since #25384 merged on 2026-08-06, `chat_events` holds `input.budget` rows for exactly one run.

Event-driven delivery is also not sufficient on a matching backend. The steer only lands if the run happens to emit another event after crossing 115 minutes, and the end of a long run is exactly when a run is most likely to sit silent inside one long tool call.

This replaces the consumer with a scheduled sweep.

- add `GET /api/cron/steer-run-time-budget`, scheduled `* * * * *`, selecting running chat runs whose `started_at` is past the threshold
- keep the deterministic `uuidv5(runId, ...)` event id, so a repeated scan conflicts on the id instead of steering twice, and count only newly inserted rows as `steered`
- re-announce a still-unclaimed steer to the runner on the next scan through the existing `notifyRunningChatRunOfPendingInput`, which no-ops once the input is claimed
- delete `agent-event-consumer-run-time-budget.service.ts` and its registration
- drop the now-unused `eventTypes` matching from the webhook dispatcher, since no remaining optional consumer filters by event type

The steer text, event type, thread-queue isolation, and claim path are unchanged, so the runner and client contracts are untouched.

## Tests

The two budget cases in `chat-events.bdd.test.ts` now drive the cron route instead of the webhook. They age their own run with a new `backdateRunStartedAtFixture` rather than `mockNow`: the sweep is global and the API suites share one database, so a mocked clock would age every concurrent test file's runs as well.

## Verification

- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types` (boundaries, gateways, core, bootstrap, tests, bootstrap-wiring)
- `pnpm -F api lint`, `pnpm -F @vm0/api-contracts lint`, `pnpm knip`
- Prettier on every changed file
- Vitest was not run locally: this sandbox has no PostgreSQL (`ECONNREFUSED :5432`), so the API suites run in the PR pipeline

## Fallbacks

None. The cron and the deleted consumer wrote the same deterministic event id, so an API instance still running the old code during the deploy overlap cannot produce a duplicate steer, and no persisted state changes shape.
