### PR TITLE
test(api): scope the threadless batch sweep assertion to its own runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -60,6 +60,8 @@ const BUCKET = "test-user-storage-bucket";
 const FIXED_NOW_MS = Date.parse("2000-01-01T00:10:00.000Z");
 const THREADLESS_FORWARD_CUTOFF_MS = Date.parse("2026-08-03T05:40:26.000Z");
 const THREADLESS_TEST_NOW_MS = Date.parse("2026-08-03T06:00:00.000Z");
+// Mirrors THREADLESS_RUN_SWEEP_LIMIT in threadless-run-cleanup.service.ts.
+const THREADLESS_SWEEP_LIMIT = 20;
 const NON_TEST_TRIGGER_SOURCES: readonly TriggerSource[] =
   triggerSourceSchema.options.filter((source) => {
     return source !== "test";
@@ -419,6 +421,49 @@ async function findRun(runId: string): Promise<{
   return row
     ? { status: stringField(row, "status"), error: nullableString(row.error) }
     : null;
+}
+
+interface ThreadlessCleanupError {
+  readonly runId: string;
+  readonly error: string;
+}
+
+/** Keeps sweep failures attributable to this test's own fixtures. */
+function ownCleanupErrors(
+  threadlessRuns: {
+    readonly errors: readonly ThreadlessCleanupError[];
+  },
+  fixtures: readonly RunFixture[],
+): readonly ThreadlessCleanupError[] {
+  const owned = new Set(
+    fixtures.map((fixture) => {
+      return fixture.runId;
+    }),
+  );
+  return threadlessRuns.errors.filter((entry) => {
+    return owned.has(entry.runId);
+  });
+}
+
+/** Returns this test's still-present runs in the fixture order. */
+async function findRemainingRunIds(
+  fixtures: readonly RunFixture[],
+): Promise<readonly string[]> {
+  const states = await Promise.all(
+    fixtures.map(async (fixture) => {
+      return {
+        runId: fixture.runId,
+        present: (await findRun(fixture.runId)) !== null,
+      };
+    }),
+  );
+  return states
+    .filter((state) => {
+      return state.present;
+    })
+    .map((state) => {
+      return state.runId;
+    });
 }
 
 async function findRunnerJob(runId: string): Promise<{
@@ -853,7 +898,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     const userId = `user-${randomUUID()}`;
     const orgId = `org-${randomUUID()}`;
     const fixtures = await Promise.all(
-      Array.from({ length: 21 }, async (_, index) => {
+      Array.from({ length: THREADLESS_SWEEP_LIMIT + 1 }, async (_, index) => {
         return await trackRun(
           insertRunFixture({
             status: "completed",
@@ -873,24 +918,40 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       apiClient().cleanup({ headers: cronHeaders() }),
       [200],
     );
-    expect(firstResponse.body.threadlessRuns).toMatchObject({
-      discovered: 20,
-      deleted: 20,
-      failed: 0,
-    });
-    await expect(findRun(fixtures[20]!.runId)).resolves.not.toBeNull();
 
-    const secondResponse = await accept(
-      apiClient().cleanup({ headers: cronHeaders() }),
-      [200],
+    // The sweep cohort is global while API test workers share one database, so
+    // a parallel file that strands its own threadless run can occupy part of
+    // this batch. The bound stays exact because these fixtures alone exceed it.
+    expect(firstResponse.body.threadlessRuns.discovered).toBe(
+      THREADLESS_SWEEP_LIMIT,
     );
     expect(
-      secondResponse.body.threadlessRuns.discovered,
-    ).toBeGreaterThanOrEqual(1);
-    expect(secondResponse.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(
-      1,
+      ownCleanupErrors(firstResponse.body.threadlessRuns, fixtures),
+    ).toStrictEqual([]);
+    const remaining = await findRemainingRunIds(fixtures);
+    // Oldest first: the pass takes a prefix of these fixtures, and the bound
+    // leaves the newest ones for a later pass.
+    expect(remaining).toStrictEqual(
+      fixtures.slice(fixtures.length - remaining.length).map((fixture) => {
+        return fixture.runId;
+      }),
     );
-    await expect(findRun(fixtures[20]!.runId)).resolves.toBeNull();
+    expect(remaining.length).toBeGreaterThanOrEqual(1);
+    expect(firstResponse.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(
+      fixtures.length - remaining.length,
+    );
+    // What the bound left behind stays untouched and eligible for a next pass.
+    await expect(
+      Promise.all(
+        remaining.map((runId) => {
+          return findRun(runId);
+        }),
+      ),
+    ).resolves.toStrictEqual(
+      remaining.map(() => {
+        return { status: "completed", error: null };
+      }),
+    );
   });
 
   it("acknowledges an event projection that loses the root-delete race", async () => {


### PR DESCRIPTION
## Summary

- keep the exact sweep bound (`discovered === 20`), which this test owns because its own 21 fixtures always saturate one pass
- attribute the rest of the batch to this test's own runs: no own errors, own survivors are the newest suffix, survivors untouched and still eligible
- leave production cleanup behaviour, the sweep limit, and every other assertion in the file unchanged

## Failure

`GET /api/cron/cleanup-sandboxes > processes only the oldest bounded batch of threadless runs`, [test-api (4) job 92872721593](https://github.com/vm0-ai/vm0/actions/runs/31180587811/job/92872721593), merge-group commit `fab38c3` for #25711.

```
AssertionError: expected { discovered: 20, cancelled: 1, …(4) } to match object { discovered: 20, deleted: 20, …(1) }
-   "deleted": 20,
+   "deleted": 19,
```

Not a regression: #25711 touches no cron, run-deletion, sandbox or DB code, the same shard was green on its head `fa109b9`, and the re-queued merge group `2110a56` passed.

## Root cause

Test isolation on a shared database, not an async-ownership or product race.

`cleanupThreadlessRuns$` scans a **global** cohort: threadless, non-`test` runs, ordered `createdAt ASC, id ASC`, `LIMIT 20`. The test seeds 21 runs back-dated to `2026-08-03T05:40:26.001Z…021Z` and asserts the whole batch is its own.

API test workers share one PostgreSQL database, and two independent facts let a parallel file's run sort **ahead** of every one of those fixtures:

1. Chat runs are stamped with the creating worker's mocked clock. `zero-browser.test.ts` — same shard — runs its entire file at `2026-07-24T10:00:00Z`.
2. `chat_thread_events.created_at` is `defaultNow()`, the real wall clock, so a deletion tombstone is always past the `2026-08-03T05:40:26Z` forward cutoff. Every thread deletion therefore admits that thread's past-clock runs into the forward cohort through the callback/tombstone branch of `loadThreadlessRunCandidates`.

Verified against a local shard-4 database: after `zero-browser.test.ts` alone, 10 threadless runs remain at `created_at = 2026-07-24 10:00:00`, and the production candidate predicate reports `tombstone_admitted = true` for all 10. Between `chat.deleteThread` and the run's cancellation being flushed, such a run is still `running`/`pending`, so the sweep takes the active branch: `discovered: 20, cancelled: 1`, and one of the test's own fixtures is pushed out of the batch — `deleted: 19`. The intermittency is exactly that window overlapping this test's sweep.

Reproduced deterministically by seeding one active threadless run at `THREADLESS_FORWARD_CUTOFF_MS` before the sweep, which reproduces the CI message byte for byte:

```
AssertionError: expected { discovered: 20, cancelled: 1, …(4) } to match object { discovered: 20, deleted: 20, …(1) }
```

The file's `withThreadlessRunCleanupTestLockFixture` serialises concurrent *sweeps*; it cannot stop another worker from putting rows into the cohort, so the lock never covered this failure mode. Extending the lock to every thread-deleting test (the approach #25468 took for past-clock export fixtures) does not close it either: the window is inherent to the real-clock tombstone, so it would only make the race rarer.

## Fix

The test now asserts what it owns:

- `discovered === THREADLESS_SWEEP_LIMIT` — still exact and now provably immune, because foreign rows can only add eligible rows while 21 own fixtures already guarantee a saturated batch. This is the assertion that proves the bound.
- sweep `errors` contain none of this test's runs.
- the own runs left behind are exactly the newest suffix of the fixture order, proving the pass took an oldest-first prefix, and at least one is left behind, proving the bound truncated the batch.
- those survivors are untouched (`completed`, no error), so they remain eligible for a later pass.

The second global pass was dropped. It asserted `discovered >= 1, deleted >= 1` and that the leftover run was gone, which has the same shared-cohort dependency and is redundant: deleting a quiescent threadless run in one pass is already covered by "waits through the quiet window and deletes at its exact boundary", "processes every non-test trigger source when the run is threadless", and "redrives expired unresolved cancellation recovery before deletion".

No retry, sleep, timeout increase, relaxed business assertion, or skipped test.

## Fallbacks

None. This change touches one test file and adds no compatibility path, no `??`/`||` default on a contract-owned field, no feature-switch-gated branch, and no negative test asserting removed behavior stays removed.

## Validation

- target file, clean database: 5 consecutive runs, 33/33 tests passed each
- target test with an injected active threadless run older than every fixture: 3 consecutive runs, passed each (the previous assertion fails on the first)
- `pnpm vitest run --project=api --shard=4/8` (the failing CI shard, 23 files): 312/312 passed
- `pnpm -F api run check-types:core`, `check-types:tests`
- `eslint --max-warnings 0` and `oxlint --type-aware` on the changed file
- `prettier --check`

## Follow-up, not in this PR

`zero-browser.test.ts` permanently strands 10 threadless runs in the shared database: 7 of its tests delete a chat thread while only 3 delete the corresponding run roots. That is real fixture leakage and adds noise to every later sweep in the shard, but it is not what makes this test flaky, so it is left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

