### PR TITLE
fix(ui): give icons the colour of the text they sit with

### DIFF
--- a/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
+++ b/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
@@ -115,7 +115,7 @@ function InspectEmptyState() {
         })}
       />
       <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
-        <IconUpload size={48} stroke={1} className="text-muted-foreground/40" />
+        <IconUpload size={48} stroke={1} className="" />
         <h2 className="text-lg font-semibold text-foreground">
           {t(($) => {
             return $.activity.inspect.noLog.title;

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -247,7 +247,7 @@ function ArtifactSharedConversationList({
                 size={16}
                 stroke={1.7}
                 aria-hidden
-                className="shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
+                className="shrink-0 transition-colors group-hover:text-foreground"
               />
             </button>
           </li>

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -626,14 +626,6 @@ body {
   border-color: hsl(var(--gray-400));
 }
 
-/* Lighter icons and "Recent dialogue" label; other styles unchanged */
-.zero-nav svg {
-  opacity: 0.7;
-}
-.zero-nav .zero-nav-recent-label {
-  opacity: 1;
-}
-
 @layer base {
   *,
   *::before,

--- a/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
@@ -26,7 +26,7 @@ export function EmailUnsubscribePage() {
         <VM0Logo />
         {status === "done" ? (
           <div className="flex flex-col items-center gap-2.5">
-            <IconCheck size={20} className="text-muted-foreground" />
+            <IconCheck size={20} className="" />
             <h1 className="text-lg font-medium text-foreground">
               {t(($) => {
                 return $.lifecycle.emailUnsubscribe.doneTitle;

--- a/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
@@ -59,7 +59,7 @@ export function MorningBriefUnsubscribePage() {
   if (!status) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center">
-        <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
+        <IconLoader2 size={40} className="animate-spin" />
         <span className="sr-only">
           {t(($) => {
             return $.lifecycle.morningBriefUnsubscribe.loadingLabel;

--- a/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
+++ b/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
@@ -150,20 +150,16 @@ function resolveCard(
 function CardIcon({ kind }: { kind: CardKind }): ReactNode {
   switch (kind) {
     case "ready": {
-      return <IconGift size={40} className="text-foreground opacity-80" />;
+      return <IconGift size={40} className="opacity-80" />;
     }
     case "granted": {
       return <IconCheck size={40} className="text-green-600 opacity-80" />;
     }
     case "processing": {
-      return (
-        <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
-      );
+      return <IconLoader2 size={40} className="animate-spin" />;
     }
     case "auth": {
-      return (
-        <IconLock size={40} className="text-muted-foreground opacity-70" />
-      );
+      return <IconLock size={40} className="opacity-70" />;
     }
     case "broken": {
       return <IconX size={40} className="text-destructive opacity-70" />;

--- a/turbo/apps/platform/src/views/report-error/report-error-page.tsx
+++ b/turbo/apps/platform/src/views/report-error/report-error-page.tsx
@@ -75,7 +75,7 @@ function LoadingCard() {
         role="status"
         className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12"
       >
-        <IconLoader2 size={20} className="animate-spin text-muted-foreground" />
+        <IconLoader2 size={20} className="animate-spin" />
         <span className="sr-only">
           {t(($) => {
             return $.reportError.loading;

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -2684,11 +2684,7 @@ function WorkflowFilePicker({
           className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm px-0.5 py-0.5 text-sm font-medium text-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <span className="min-w-0 truncate">{selectedLabel}</span>
-          <IconChevronDown
-            size={14}
-            stroke={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <IconChevronDown size={14} stroke={1.5} className="shrink-0" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-80">

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -841,11 +841,7 @@ function SortDropdown({
           size="sm"
           className="zero-btn-morandi h-9 shrink-0 gap-1.5 rounded-lg border"
         >
-          <IconArrowsSort
-            size={15}
-            stroke={1.8}
-            className="text-muted-foreground"
-          />
+          <IconArrowsSort size={15} stroke={1.8} className="" />
           {current?.label ??
             i18n.t(($) => {
               return $.workflows.list.sort.label;
@@ -900,11 +896,7 @@ function AgentFilterDropdown({
               size={16}
             />
           ) : (
-            <IconUser
-              size={15}
-              stroke={1.8}
-              className="text-muted-foreground"
-            />
+            <IconUser size={15} stroke={1.8} className="" />
           )}
           <span className="max-w-[8rem] truncate">
             {selected?.label ??
@@ -924,7 +916,7 @@ function AgentFilterDropdown({
             onChange(WORKFLOW_ALL_AGENTS);
           }}
         >
-          <IconUser size={15} stroke={1.8} className="text-muted-foreground" />
+          <IconUser size={15} stroke={1.8} className="" />
           {i18n.t(($) => {
             return $.workflows.list.allAgents;
           })}

--- a/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
@@ -96,7 +96,7 @@ export function BrowserSessionLoading() {
   return (
     <PanelFrame>
       <div role="status" className="flex flex-1 items-center justify-center">
-        <IconLoader2 className="animate-spin text-muted-foreground" size={20} />
+        <IconLoader2 className="animate-spin" size={20} />
         <span className="sr-only">
           {t(($) => {
             return $.browserSession.status.starting;

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -54,7 +54,7 @@ function CollapsibleSection({
           <IconChevronRight
             size={14}
             stroke={2}
-            className="transition-transform group-open:rotate-90 text-muted-foreground shrink-0"
+            className="transition-transform group-open:rotate-90 shrink-0"
           />
           <span className="text-xs font-medium text-foreground">{title}</span>
           {badge && <InlineBadge color="muted">{badge}</InlineBadge>}

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/event-group-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/event-group-card.tsx
@@ -476,7 +476,7 @@ function getTodoStatusIcon(status: string) {
       return <IconLoader className="h-4 w-4 text-yellow-500" />;
     }
     default: {
-      return <IconCircleDashed className="h-4 w-4 text-muted-foreground" />;
+      return <IconCircleDashed className="h-4 w-4" />;
     }
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -288,10 +288,7 @@ function TypeFilter({
             <IconFilter size={14} stroke={1.5} className="shrink-0" />
             {typeFilterLabel(typeFilter)}
           </span>
-          <IconChevronDown
-            size={14}
-            className="shrink-0 text-muted-foreground"
-          />
+          <IconChevronDown size={14} className="shrink-0" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-40">
@@ -1136,7 +1133,7 @@ export function NetworkContent({
       {hasMore && onLoadMore && (
         <div className="flex justify-center py-4">
           {loading ? (
-            <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <IconLoader2 className="h-5 w-5 animate-spin" />
           ) : (
             <button
               type="button"

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -2248,11 +2248,7 @@ export function OrgBillingTab() {
                     className="text-foreground/40"
                   />
                 </span>
-                <IconChevronRight
-                  size={14}
-                  stroke={1.5}
-                  className="shrink-0 text-muted-foreground/50"
-                />
+                <IconChevronRight size={14} stroke={1.5} className="shrink-0" />
               </button>
             </>
           )}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
@@ -28,11 +28,7 @@ export function UnsavedBar({
         className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
       >
         <div className="flex items-center gap-2 text-sm text-foreground">
-          <IconPencil
-            size={18}
-            stroke={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <IconPencil size={18} stroke={1.5} className="shrink-0" />
           <span>
             {t(($) => {
               return $.settings.workspace.unsaved.message;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -448,11 +448,7 @@ function PlanFeatureList({ tier }: { readonly tier: UsagePackPlanTier }) {
       {planFeatures(tier).map((feature) => {
         return (
           <li key={feature} className="flex items-center gap-2">
-            <IconCheck
-              size={14}
-              stroke={1.8}
-              className="shrink-0 text-muted-foreground/50"
-            />
+            <IconCheck size={14} stroke={1.8} className="shrink-0" />
             <span className="text-[13px] text-muted-foreground">{feature}</span>
           </li>
         );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -99,7 +99,7 @@ function ConnectorAccessSearch({
       <IconSearch
         size={15}
         stroke={1.5}
-        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
       />
       <input
         value={value}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -367,7 +367,7 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
       <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-sm font-medium text-foreground">
         <IconChevronRight
           size={16}
-          className="shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+          className="shrink-0 transition-transform group-open:rotate-90"
         />
         <span>
           {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1500,7 +1500,7 @@ function LoadedPermissionsDrawerContent({
             <IconSearch
               size={15}
               stroke={1.5}
-              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
             />
             <input
               value={search}

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -1787,7 +1787,7 @@ function FeishuSetupFaq() {
             <IconChevronRight
               size={17}
               aria-hidden="true"
-              className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+              className="mt-0.5 shrink-0 transition-transform group-open:rotate-90"
             />
             <span>
               {t(($) => {
@@ -1807,7 +1807,7 @@ function FeishuSetupFaq() {
             <IconChevronRight
               size={17}
               aria-hidden="true"
-              className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+              className="mt-0.5 shrink-0 transition-transform group-open:rotate-90"
             />
             <span>
               {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -133,9 +133,7 @@ function MailDraftCardContent({
                 })
               : statusLabel(draft.status)}
         </span>
-        {!deleted ? (
-          <IconChevronRight size={16} className="text-muted-foreground" />
-        ) : null}
+        {!deleted ? <IconChevronRight size={16} className="" /> : null}
       </span>
     </>
   );

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -277,7 +277,7 @@ function AttachmentSummary({
 }) {
   return (
     <div className="inline-flex h-7 max-w-[240px] items-center gap-1.5 rounded-md border border-foreground/15 bg-background/80 px-1.5">
-      <IconPaperclip size={14} className="shrink-0 text-muted-foreground" />
+      <IconPaperclip size={14} className="shrink-0" />
       <span className="min-w-0 truncate text-xs font-medium">
         {attachment.filename}
       </span>

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -134,9 +134,9 @@ function SessionStateIndicator({
       aria-label={t(($) => {
         return $.chat.sidebar.draft;
       })}
-      className="flex items-center justify-center text-sidebar-foreground/50"
+      className="flex items-center justify-center text-sidebar-foreground"
     >
-      <IconPencil size={16} stroke={2} />
+      <IconPencil className="opacity-35" size={16} stroke={2} />
     </span>
   );
 }
@@ -231,15 +231,19 @@ function ChatThreadMenu({
                 >
                   {usePinnedIndicatorTrigger ? (
                     <>
-                      <IconPin size={16} stroke={2} className="md:hidden" />
+                      <IconPin
+                        size={16}
+                        stroke={2}
+                        className="md:hidden opacity-70"
+                      />
                       <IconDots
                         size={16}
                         stroke={2}
-                        className="hidden md:block"
+                        className="hidden md:block opacity-70"
                       />
                     </>
                   ) : (
-                    <IconDots size={16} stroke={2} />
+                    <IconDots className="opacity-70" size={16} stroke={2} />
                   )}
                 </span>
               </TooltipTrigger>
@@ -326,9 +330,9 @@ function ChatThreadSideDecorator({
                 aria-label={t(($) => {
                   return $.chat.sidebar.pinned;
                 })}
-                className="hidden items-center justify-center text-sidebar-foreground/70 group-hover:hidden peer-data-[state=open]:hidden md:flex"
+                className="hidden items-center justify-center text-sidebar-foreground group-hover:hidden peer-data-[state=open]:hidden md:flex"
               >
-                <IconPin size={16} stroke={2} />
+                <IconPin className="opacity-50" size={16} stroke={2} />
               </span>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -663,7 +667,7 @@ function ChatThreadsListMenuTooltip() {
     <Tooltip>
       <TooltipTrigger asChild>
         <span>
-          <IconDots size={16} stroke={2} />
+          <IconDots className="opacity-70" size={16} stroke={2} />
         </span>
       </TooltipTrigger>
       <TooltipContent side="bottom">
@@ -714,13 +718,13 @@ function ChatThreadsTitle() {
         return setCollapsed(!collapsed);
       }}
     >
-      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
+      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground group-hover:text-sidebar-foreground transition-colors">
         {titleLabel}
         <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
           <IconChevronRight
+            className={`opacity-35 ${collapsed ? "" : "rotate-90"}`}
             size={12}
             stroke={2}
-            className={collapsed ? "" : "rotate-90"}
           />
         </span>
       </span>

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
@@ -70,9 +70,7 @@ function MessageMark({
   }
 
   if (state === "loading") {
-    return (
-      <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
-    );
+    return <IconLoader2 size={40} className="animate-spin" />;
   }
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1578,10 +1578,7 @@ function TemplateEmptyPanel() {
   return (
     <div className="flex min-h-40 flex-1 items-center justify-center rounded-[22px] border-2 border-dashed border-border bg-background px-6 py-10 text-center">
       <div className="flex max-w-xl flex-col items-center">
-        <IconSearch
-          className="mb-4 h-8 w-8 text-muted-foreground/70"
-          stroke={1.7}
-        />
+        <IconSearch className="mb-4 h-8 w-8" stroke={1.7} />
         <p className="text-sm font-semibold text-muted-foreground">
           {t(($) => {
             return $.artifacts.templates.noMatches;
@@ -6268,11 +6265,7 @@ function ComputerUseConnectorMenuSection({
         </div>
       ) : (
         <div className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground">
-          <IconDeviceDesktop
-            size={16}
-            stroke={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <IconDeviceDesktop size={16} stroke={1.5} className="shrink-0" />
           {t(($) => {
             return $.chat.computerUse.noOnlineComputers;
           })}
@@ -6284,11 +6277,7 @@ function ComputerUseConnectorMenuSection({
           className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
           onClick={onOpenDownloadDialog}
         >
-          <IconPlug
-            size={16}
-            stroke={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <IconPlug size={16} stroke={1.5} className="shrink-0" />
           {t(($) => {
             return $.chat.computerUse.connectMyComputer;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3393,11 +3393,7 @@ function CompletedWorkFoldRow({
         onClick={onToggle}
         className="mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-muted/50"
       >
-        <IconHourglass
-          aria-hidden
-          size={14}
-          className="shrink-0 text-muted-foreground/70"
-        />
+        <IconHourglass aria-hidden size={14} className="shrink-0" />
         <span className="text-[13px]">{label}</span>
         <IconChevronRight
           aria-hidden
@@ -3606,11 +3602,7 @@ function RunGroupFoldRow({
           embedded && "mt-1.5",
         )}
       >
-        <Icon
-          aria-hidden
-          size={14}
-          className="shrink-0 text-muted-foreground/70"
-        />
+        <Icon aria-hidden size={14} className="shrink-0" />
         <span className="min-w-0 truncate whitespace-nowrap text-[13px]">
           {label}
         </span>
@@ -4009,7 +4001,7 @@ function RecommendedFollowupList({
             <IconArrowUpRight
               size={14}
               stroke={1.8}
-              className="shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100"
+              className="shrink-0 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100"
             />
           </button>
         );

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -488,11 +488,7 @@ function ConnectorFilterDropdown({
           })}
           className="zero-btn-morandi hidden h-9 shrink-0 gap-1.5 rounded-lg border sm:inline-flex"
         >
-          <IconFilter
-            size={14}
-            stroke={1.5}
-            className="text-muted-foreground"
-          />
+          <IconFilter size={14} stroke={1.5} className="" />
           {activeAgent && (
             <AvatarFromUrl
               avatarUrl={activeAgent.avatarUrl}
@@ -502,11 +498,7 @@ function ConnectorFilterDropdown({
             />
           )}
           <span className="max-w-[140px] truncate">{triggerLabel}</span>
-          <IconChevronDown
-            size={14}
-            stroke={1.5}
-            className="text-muted-foreground"
-          />
+          <IconChevronDown size={14} stroke={1.5} className="" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -227,10 +227,7 @@ function DirectedAuthorizeCardContent({
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (
-              <IconLoader2
-                size={20}
-                className="animate-spin text-muted-foreground"
-              />
+              <IconLoader2 size={20} className="animate-spin" />
             ) : (
               <>
                 <h1 className="text-lg font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -567,10 +567,7 @@ function DirectedConnectCardContent({
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (
-              <IconLoader2
-                size={20}
-                className="animate-spin text-muted-foreground"
-              />
+              <IconLoader2 size={20} className="animate-spin" />
             ) : (
               <>
                 <h1 className="text-lg font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
@@ -73,9 +73,7 @@ function GithubMark({
   }
 
   if (state === "loading") {
-    return (
-      <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
-    );
+    return <IconLoader2 size={40} className="animate-spin" />;
   }
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -154,11 +154,7 @@ function CreateWorkspaceItem() {
         disabled={clerk === null || creatingOrg}
         className="min-w-0 gap-3 px-3 py-2.5 rounded-lg"
       >
-        <IconPlus
-          size={18}
-          stroke={1.5}
-          className="shrink-0 text-muted-foreground"
-        />
+        <IconPlus size={18} stroke={1.5} className="shrink-0" />
         <span>
           {creatingOrg
             ? t(($) => {
@@ -359,10 +355,7 @@ export function ZeroOrgSwitcher() {
             <span className="min-w-0 flex-1 text-left text-sm font-semibold leading-tight truncate">
               {orgName}
             </span>
-            <IconChevronDown
-              size={16}
-              className="ml-auto shrink-0 text-muted-foreground"
-            />
+            <IconChevronDown size={16} className="ml-auto shrink-0" />
           </button>
         </DropdownMenuTrigger>
         <OrgDropdownContent />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -412,7 +412,7 @@ function CreditBalanceItem({
       onModalSelect={onOpenCreditBalance}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <IconCoins size={18} stroke={1.5} className="text-muted-foreground" />
+      <IconCoins size={18} stroke={1.5} className="" />
       <span className="min-w-0 flex-1 truncate text-sm tabular-nums">
         {loading ? (
           <span className="block h-4 w-24 rounded bg-muted/60" />
@@ -440,11 +440,7 @@ function UnifiedSettingsGroup({
         onModalSelect={onOpenSettings}
         className="gap-3 px-3 py-2.5 rounded-lg"
       >
-        <IconSettings
-          size={18}
-          stroke={1.5}
-          className="text-muted-foreground"
-        />
+        <IconSettings size={18} stroke={1.5} className="" />
         <span>
           {t(($) => {
             return $.settings.accountMenu.settings;
@@ -458,7 +454,7 @@ function UnifiedSettingsGroup({
           }}
           className="gap-3 px-3 py-2.5 rounded-lg"
         >
-          <IconFlask size={18} stroke={1.5} className="text-muted-foreground" />
+          <IconFlask size={18} stroke={1.5} className="" />
           <span>
             {t(($) => {
               return $.settings.accountMenu.lab;
@@ -487,7 +483,7 @@ function AccountManagementGroup({
         onClick={onAddAccount}
         className="gap-3 px-3 py-2.5 rounded-lg"
       >
-        <IconPlus size={18} stroke={1.5} className="text-muted-foreground" />
+        <IconPlus size={18} stroke={1.5} className="" />
         <span>
           {t(($) => {
             return $.settings.accountMenu.addAccount;
@@ -499,21 +495,13 @@ function AccountManagementGroup({
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger className="gap-3 px-3 py-2.5 rounded-lg">
-        <IconSwitchHorizontal
-          size={18}
-          stroke={1.5}
-          className="text-muted-foreground"
-        />
+        <IconSwitchHorizontal size={18} stroke={1.5} className="" />
         <span className="flex-1">
           {t(($) => {
             return $.settings.accountMenu.switchAccount;
           })}
         </span>
-        <IconChevronRight
-          size={14}
-          stroke={1.5}
-          className="text-muted-foreground"
-        />
+        <IconChevronRight size={14} stroke={1.5} className="" />
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-[220px]">
         {others.map((account) => {
@@ -546,7 +534,7 @@ function AccountManagementGroup({
           onClick={onAddAccount}
           className="gap-3 px-3 py-2.5 rounded-lg"
         >
-          <IconPlus size={18} stroke={1.5} className="text-muted-foreground" />
+          <IconPlus size={18} stroke={1.5} className="" />
           <span>
             {t(($) => {
               return $.settings.accountMenu.addAccount;
@@ -567,11 +555,7 @@ function ExtraAccountActions() {
       }}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <IconDatabaseExport
-        size={18}
-        stroke={1.5}
-        className="text-muted-foreground"
-      />
+      <IconDatabaseExport size={18} stroke={1.5} className="" />
       <span>
         {t(($) => {
           return $.settings.accountMenu.exportData;
@@ -594,7 +578,7 @@ function SignOutItem({
       }}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <IconLogout size={18} stroke={1.5} className="text-muted-foreground" />
+      <IconLogout size={18} stroke={1.5} className="" />
       <span>
         {t(($) => {
           return $.settings.accountMenu.signOut;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -76,7 +76,7 @@ export function AgentDialogSearch({
         <IconSearch
           size={16}
           stroke={2}
-          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
         />
         <Input
           type="text"

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -289,7 +289,7 @@ export function PinnedAgentListSection({
             className="flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
           >
             <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
-              <IconPlus size={16} stroke={2} />
+              <IconPlus className="opacity-50" size={16} stroke={2} />
             </span>
             <span className="text-[11px] leading-tight">
               {t(($) => {
@@ -318,9 +318,9 @@ export function PinnedAgentListSection({
           })}
           <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
             <IconChevronRight
+              className={`opacity-35 ${collapsed ? "" : "rotate-90"}`}
               size={12}
               stroke={2}
-              className={collapsed ? "" : "rotate-90"}
             />
           </span>
         </span>
@@ -333,12 +333,12 @@ export function PinnedAgentListSection({
                   e.stopPropagation();
                   openAgentListDialog();
                 }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent-active transition-colors"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground hover:text-sidebar-foreground hover:bg-sidebar-accent-active transition-colors"
                 aria-label={t(($) => {
                   return $.sidebar.openConversation;
                 })}
               >
-                <IconPlus size={15} stroke={2.5} />
+                <IconPlus className="opacity-50" size={15} stroke={2.5} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -252,11 +252,14 @@ function CollapsedExpandButton() {
           <TooltipTrigger asChild>
             <button
               type="button"
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
               onClick={onCollapse}
               aria-label={expandLabel}
             >
-              <IconLayoutSidebarLeftCollapse size={18} className="rotate-180" />
+              <IconLayoutSidebarLeftCollapse
+                size={18}
+                className="rotate-180 opacity-50"
+              />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">
@@ -327,7 +330,7 @@ function CollapsedNavList() {
                       aria-label={label}
                     >
                       <span className="relative inline-flex">
-                        <Icon size={16} className="shrink-0" />
+                        <Icon size={16} className="shrink-0 opacity-70" />
                         {id === "works" && slackScopeMismatch && (
                           <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
                         )}
@@ -375,7 +378,7 @@ function CollapsedFooter() {
               }`}
               aria-label={insightsLabel}
             >
-              <IconSparkles size={16} className="shrink-0" />
+              <IconSparkles size={16} className="shrink-0 opacity-70" />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="right">
@@ -433,11 +436,14 @@ function ExpandedHeader() {
             <TooltipTrigger asChild>
               <button
                 type="button"
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
                 onClick={onCollapse}
                 aria-label={collapseLabel}
               >
-                <IconLayoutSidebarLeftCollapse size={18} />
+                <IconLayoutSidebarLeftCollapse
+                  className="opacity-50"
+                  size={18}
+                />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -486,9 +492,9 @@ function ExpandedManageSection() {
           })}
           <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
             <IconChevronRight
+              className={`opacity-35 ${manageCollapsed ? "" : "rotate-90"}`}
               size={12}
               stroke={2}
-              className={manageCollapsed ? "" : "rotate-90"}
             />
           </span>
         </span>
@@ -646,7 +652,7 @@ function ExpandedFooterAccountInsights() {
               }`}
               aria-label={insightsLabel}
             >
-              <IconSparkles size={16} className="shrink-0" />
+              <IconSparkles size={16} className="shrink-0 opacity-70" />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="top">
@@ -739,7 +745,7 @@ function LabeledRailLink({
             />
           </span>
         ) : (
-          <Icon size={19} className="shrink-0" />
+          <Icon size={19} className="shrink-0 opacity-70" />
         )}
         {showBadge && (
           <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-red-500" />
@@ -870,9 +876,9 @@ function ChatListColumn() {
                   openAgentList();
                 }}
                 aria-label={searchLabel}
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
               >
-                <IconSearch size={17} stroke={1.8} />
+                <IconSearch className="opacity-50" size={17} stroke={1.8} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -892,9 +898,9 @@ function ChatListColumn() {
                 }}
                 aria-label={newChatLabel}
                 aria-current={isNewChatActive ? "page" : undefined}
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 no-underline transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground no-underline transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
               >
-                <IconEdit size={17} stroke={1.8} />
+                <IconEdit className="opacity-50" size={17} stroke={1.8} />
               </Link>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -73,7 +73,7 @@ function CheckingState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
+      <IconLoader2 size={40} className="animate-spin" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -94,7 +94,7 @@ function InvalidState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconAlertCircle size={40} className="text-muted-foreground/40" />
+      <IconAlertCircle size={40} className="" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -197,7 +197,7 @@ function PageContent() {
   if (workspaceId && slackUserId) {
     return (
       <>
-        <IconBrandSlack size={40} className="text-foreground" />
+        <IconBrandSlack size={40} className="" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
             {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
@@ -113,7 +113,7 @@ function CheckingState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
+      <IconLoader2 size={40} className="animate-spin" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -134,7 +134,7 @@ function InvalidState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconAlertCircle size={40} className="text-muted-foreground/40" />
+      <IconAlertCircle size={40} className="" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -81,9 +81,7 @@ function TelegramMark({
   }
 
   if (state === "loading") {
-    return (
-      <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
-    );
+    return <IconLoader2 size={40} className="animate-spin" />;
   }
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -26,11 +26,7 @@ export function ZeroUnsavedBar({
         className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
       >
         <div className="flex items-center gap-2 text-sm text-foreground">
-          <IconPencil
-            size={18}
-            stroke={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <IconPencil size={18} stroke={1.5} className="shrink-0" />
           <span>{message}</span>
         </div>
         <div className="flex items-center gap-2 shrink-0">


### PR DESCRIPTION
Keeps the current Tabler icon set. This only fixes how icons are coloured.

Two reports, one root cause: **icons were being painted translucent.**

## The "overlay" artifact

Each path in an SVG is drawn separately, so where two strokes overlap, a semi-transparent colour composites with itself and the joint renders darker than the stroke body. Measured off the reported sidebar collapse icon:

| | stroke body | crossing | ratio |
|---|---|---|---|
| reported screenshot | `rgb(138,140,143)` | `rgb(104,106,110)` | **1.31x** |
| same icon rendered at alpha 0.7 | `rgb(136,139,142)` | `rgb(102,105,109)` | 1.30x |
| same icon rendered opaque | `rgb(89,91,95)` | `rgb(88,90,94)` | **1.01x** |

Solving the ratio back gives alpha ≈ **0.69**, and the button carries `text-sidebar-foreground/70`. Opaque removes the artifact entirely.

## Icons reading greyer than their label

`apps/platform/src/views/css/index.css` had:

```css
.zero-nav svg { opacity: 0.7; }
```

Every sidebar icon rendered 30% transparent while its label rendered at full strength. On the light theme that resolves to exactly `rgb(89,92,96)` against a `rgb(21,24,30)` label — which is what was measured off the reported screenshot.

Separately, 87 icons carried `text-muted-foreground` while the text next to them did not, so they were a lighter grey by construction.

## What changed

| | |
|---|---|
| Neutral colour utilities removed from icons | 106 |
| `opacity-50/70/80` removed from icons | 14 |
| Icon-only containers de-alpha'd | 14 |
| Redundant `hover:` colour classes removed | 11 |
| `.zero-nav svg { opacity: 0.7 }` | removed |

Removing an icon's own colour class is what makes it match its label: it then inherits from the same row the text does. Where the row is muted, both stay muted; where it isn't, both are full strength. Either way they agree.

**Untouched:** semantic status colours (`text-green-600`, `text-destructive`, `text-amber-500`, `text-primary`, ...) and the `opacity-0` / `text-muted-foreground/0` transition states. No icon is swapped, no icon library changes, no new colour token.

## Verification

- `pnpm turbo run lint` — 0 errors, warning count on `@vm0/app` unchanged from `main` (55)
- `pnpm check-types` — passes for `@vm0/ui`, `@vm0/app`, `@vm0/desktop`
- `pnpm -F @vm0/app build` — succeeds
- `@vm0/ui` tests and the CSS entrypoint test pass
- Audit: 0 neutral/alpha colour utilities left on any icon
