### PR TITLE
test(api): scope shared-database test lookups to their own resources

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -320,8 +320,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     });
     await waitForTyping(sends, [conversationId]);
 
-    const admitted =
-      await findAgentphoneChatEventByPromptFixture("summarize my inbox");
+    const admitted = await findAgentphoneChatEventByPromptFixture({
+      userId: actor.userId,
+      prompt: "summarize my inbox",
+    });
     expect(admitted).toMatchObject({ eventId: expect.any(String) });
     if (!admitted) {
       throw new Error("Expected admitted AgentPhone input event");
@@ -524,8 +526,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       from: phone,
       body: "start on my phone",
     });
-    const admittedSms =
-      await findAgentphoneChatEventByPromptFixture("start on my phone");
+    const admittedSms = await findAgentphoneChatEventByPromptFixture({
+      userId: actor.userId,
+      prompt: "start on my phone",
+    });
     if (!admittedSms) {
       throw new Error("Expected admitted AgentPhone SMS input event");
     }
@@ -656,9 +660,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       from: phone,
       body: "second queued prompt",
     });
-    const secondEvent = await findAgentphoneChatEventByPromptFixture(
-      "second queued prompt",
-    );
+    const secondEvent = await findAgentphoneChatEventByPromptFixture({
+      userId: actor.userId,
+      prompt: "second queued prompt",
+    });
     if (!secondEvent) {
       throw new Error("Expected pending AgentPhone queue item");
     }
@@ -917,9 +922,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
         },
       ],
     });
-    const admittedGroup = await findAgentphoneChatEventByPromptFixture(
-      "summarize this thread",
-    );
+    const admittedGroup = await findAgentphoneChatEventByPromptFixture({
+      userId: actor.userId,
+      prompt: "summarize this thread",
+    });
     expect(admittedGroup).toMatchObject({ eventId: expect.any(String) });
     if (!admittedGroup) {
       throw new Error("Expected admitted AgentPhone group input event");

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -646,8 +646,10 @@ describe("Teams chat callbacks", () => {
       activityId: "activity-queue-params-second",
       text: queuedPrompt,
     });
-    const queuedParams =
-      await findPendingChatEventByPromptFixture(queuedPrompt);
+    const queuedParams = await findPendingChatEventByPromptFixture({
+      userId: teams.actor.userId,
+      prompt: queuedPrompt,
+    });
     expect(queuedParams).toMatchObject({
       eventId: expect.any(String),
     });
@@ -731,7 +733,10 @@ describe("Teams chat callbacks", () => {
       text: queuedPrompt,
     });
     await expect(
-      findPendingChatEventByPromptFixture(queuedPrompt),
+      findPendingChatEventByPromptFixture({
+        userId: teams.actor.userId,
+        prompt: queuedPrompt,
+      }),
     ).resolves.toMatchObject({ eventId: expect.any(String) });
 
     await seedOrgMetadata({
@@ -795,8 +800,10 @@ describe("Teams chat callbacks", () => {
       text: queuedPrompt,
       omitRecipient: true,
     });
-    const queuedParams =
-      await findPendingChatEventByPromptFixture(queuedPrompt);
+    const queuedParams = await findPendingChatEventByPromptFixture({
+      userId: teams.actor.userId,
+      prompt: queuedPrompt,
+    });
     if (!queuedParams) {
       throw new Error("Expected queued Teams bot fallback event");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -496,9 +496,15 @@ describe("zero browser route", () => {
     acceptBrowserUseCdpSessions(providerIds);
     const providerCreateBodies: unknown[] = [];
     const deletedProfiles: string[] = [];
+    const stoppedProviderIds: string[] = [];
     let profileCreates = 0;
     let providerCreates = 0;
-    let providerStops = 0;
+    // The reconcile route is global, so count only this test's own instances.
+    const providerStops = () => {
+      return stoppedProviderIds.filter((stopped) => {
+        return (providerIds as readonly string[]).includes(stopped);
+      }).length;
+    };
     server.use(
       http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
         expect(request.headers.get("x-browser-use-api-key")).toBe(
@@ -557,7 +563,7 @@ describe("zero browser route", () => {
           await expect(request.json()).resolves.toStrictEqual({
             action: "stop",
           });
-          providerStops += 1;
+          stoppedProviderIds.push(String(params.id));
           return HttpResponse.json(
             providerBrowser(String(params.id), { status: "stopped" }),
           );
@@ -827,7 +833,7 @@ describe("zero browser route", () => {
       [200],
     );
     await flushWaitUntilForTest();
-    expect(providerStops).toBe(0);
+    expect(providerStops()).toBe(0);
     const stillLive = await accept(
       client().get({
         headers: first.claim.browserHeaders,
@@ -846,7 +852,7 @@ describe("zero browser route", () => {
     await chat.deleteThread(actor, first.threadId);
     await chat.deleteThread(actor, other.threadId);
     await flushWaitUntilForTest();
-    expect(providerStops).toBe(2);
+    expect(providerStops()).toBe(2);
     expect(
       deletedProfiles.filter((profileId) => {
         return profileId === profileIds[0];
@@ -864,12 +870,10 @@ describe("zero browser route", () => {
     // is covered by the cleanup route integration tests.
     await deleteAgentRunRootFixture(first.runId);
     await deleteAgentRunRootFixture(other.runId);
-    const reconciled = await reconcileBrowsers();
-    expect(reconciled.body).toMatchObject({
-      checked: 1,
-      stopped: 1,
-      errors: 0,
-    });
+    // The reconcile route scans every active browser in the shared database,
+    // so this test's own provider instances and profiles carry the assertion.
+    await reconcileBrowsers();
+    expect(providerStops()).toBe(3);
     expect(
       deletedProfiles.filter((profileId) => {
         return profileId === profileIds[0];
@@ -880,12 +884,13 @@ describe("zero browser route", () => {
         return profileId === profileIds[1];
       }),
     ).toHaveLength(1);
-    const fullyRetired = await reconcileBrowsers();
-    expect(fullyRetired.body).toMatchObject({
-      checked: 0,
-      stopped: 0,
-      errors: 0,
-    });
+    await reconcileBrowsers();
+    expect(providerStops()).toBe(3);
+    expect(
+      deletedProfiles.filter((profileId) => {
+        return profileId === profileIds[0];
+      }),
+    ).toHaveLength(2);
   }, 120_000);
 
   it("fails browser start when its initial size cannot be applied", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -3234,7 +3234,10 @@ describe("Feishu integration", () => {
     });
     await postEvent(callbackUrl, queuedPayload, { encrypted: true });
     await flushWaitUntilForTest();
-    const queuedEvent = await findPendingChatEventByPromptFixture(queuedPrompt);
+    const queuedEvent = await findPendingChatEventByPromptFixture({
+      userId: fixture.actor.userId,
+      prompt: queuedPrompt,
+    });
     if (!queuedEvent) {
       throw new Error("Expected the queued Feishu input event");
     }
@@ -3425,8 +3428,10 @@ describe("Feishu integration", () => {
       { encrypted: true },
     );
     await flushWaitUntilForTest();
-    const failedDeliveryEvent =
-      await findPendingChatEventByPromptFixture(failedDeliveryPrompt);
+    const failedDeliveryEvent = await findPendingChatEventByPromptFixture({
+      userId: fixture.actor.userId,
+      prompt: failedDeliveryPrompt,
+    });
     if (!failedDeliveryEvent) {
       throw new Error("Expected the failed-delivery Feishu input event");
     }
@@ -3601,8 +3606,10 @@ describe("Feishu integration", () => {
         },
       ),
     ).toBeFalsy();
-    const queuedFeishuParams =
-      await findPendingChatEventByPromptFixture(secondPrompt);
+    const queuedFeishuParams = await findPendingChatEventByPromptFixture({
+      userId: secondActor.userId,
+      prompt: secondPrompt,
+    });
     expect(queuedFeishuParams).toMatchObject({
       eventId: expect.any(String),
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1207,9 +1207,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
         "Root message ID: dm",
       ].join("\n"),
     );
-    const admitted = await findTelegramChatEventByPromptFixture(
-      "hello from telegram",
-    );
+    const admitted = await findTelegramChatEventByPromptFixture({
+      userId: fixture.userId,
+      prompt: "hello from telegram",
+    });
     expect(admitted).toMatchObject({ eventId: expect.any(String) });
     if (!admitted) {
       throw new Error("Expected admitted Telegram input event");
@@ -1456,8 +1457,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       ).status,
     ).toBe(200);
     await flushWaitUntilForTest();
-    const queuedParams =
-      await findPendingChatEventByPromptFixture(queuedPrompt);
+    const queuedParams = await findPendingChatEventByPromptFixture({
+      userId: fixture.userId,
+      prompt: queuedPrompt,
+    });
     expect(queuedParams).toMatchObject({
       eventId: expect.any(String),
     });
@@ -1716,8 +1719,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
 
     const firstState = await telegramPostRunState(fixture, firstPrompt);
     expect(firstState.zeroRun?.chatThreadId).toStrictEqual(expect.any(String));
-    const admittedForum =
-      await findTelegramChatEventByPromptFixture(firstPrompt);
+    const admittedForum = await findTelegramChatEventByPromptFixture({
+      userId: fixture.userId,
+      prompt: firstPrompt,
+    });
     expect(admittedForum).toMatchObject({ eventId: expect.any(String) });
     if (!admittedForum) {
       throw new Error("Expected admitted Telegram forum input event");
@@ -1826,8 +1831,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       "",
       followUpPrompt,
     ].join("\n");
-    const admittedFollowUp =
-      await findTelegramChatEventByPromptFixture(followUpAgentPrompt);
+    const admittedFollowUp = await findTelegramChatEventByPromptFixture({
+      userId: fixture.userId,
+      prompt: followUpAgentPrompt,
+    });
     expect(admittedFollowUp).toMatchObject({ eventId: expect.any(String) });
     if (!admittedFollowUp) {
       throw new Error("Expected admitted Telegram forum follow-up event");
@@ -2082,9 +2089,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
         "Message ID: 101",
       ].join("\n"),
     );
-    const admitted = await findTelegramChatEventByPromptFixture(
-      "summarize this thread",
-    );
+    const admitted = await findTelegramChatEventByPromptFixture({
+      userId: fixture.userId,
+      prompt: "summarize this thread",
+    });
     expect(admitted).toMatchObject({ eventId: expect.any(String) });
     if (!admitted) {
       throw new Error("Expected admitted Telegram supergroup input event");
@@ -2152,9 +2160,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
         "Root message ID: dm",
       ].join("\n"),
     );
-    const admitted = await findTelegramChatEventByPromptFixture(
-      "run through official bot",
-    );
+    const admitted = await findTelegramChatEventByPromptFixture({
+      userId: fixture.userId,
+      prompt: "run through official bot",
+    });
     expect(admitted).toMatchObject({ eventId: expect.any(String) });
     if (!admitted) {
       throw new Error("Expected admitted official Telegram input event");

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -23,7 +23,7 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
-import { and, count, eq, isNull, like, or, sql } from "drizzle-orm";
+import { and, count, eq, isNull, like, or, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
@@ -645,68 +645,69 @@ interface TelegramChatEventByPromptFixture {
   readonly eventId: string;
 }
 
-export async function findTelegramChatEventByPromptFixture(
-  prompt: string,
-): Promise<TelegramChatEventByPromptFixture | null> {
+/**
+ * Chat events live in a database shared by every parallel test worker, so a
+ * prompt lookup must be scoped to the caller's own user. Matching on prompt
+ * text alone reads whichever worker's row happens to be there.
+ */
+async function findOwnedChatEventByPrompt(args: {
+  readonly userId: string;
+  readonly prompt: string;
+  readonly filter: SQL | undefined;
+}): Promise<{ readonly eventId: string } | null> {
   const rows = await db()
     .select({
       eventId: chatEvents.id,
       userMessage: chatEvents.userMessage,
     })
     .from(chatEvents)
-    .where(
-      and(
-        eq(chatEvents.eventType, "input.prompt"),
-        eq(chatEvents.contextType, "telegram"),
-      ),
-    );
+    .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
+    .where(and(eq(chatThreads.userId, args.userId), args.filter));
   const row = rows.find((candidate) => {
     return candidate.userMessage?.parts.some((part) => {
-      return part.type === "text" && part.text === prompt;
+      return part.type === "text" && part.text === args.prompt;
     });
   });
   return row ?? null;
 }
 
-export async function findAgentphoneChatEventByPromptFixture(
-  prompt: string,
-): Promise<AgentphoneChatEventByPromptFixture | null> {
-  const rows = await db()
-    .select({
-      eventId: chatEvents.id,
-      userMessage: chatEvents.userMessage,
-    })
-    .from(chatEvents)
-    .where(
-      and(
-        eq(chatEvents.eventType, "input.prompt"),
-        eq(chatEvents.contextType, "agentphone"),
-      ),
-    );
-  const row = rows.find((candidate) => {
-    return candidate.userMessage?.parts.some((part) => {
-      return part.type === "text" && part.text === prompt;
-    });
+export async function findTelegramChatEventByPromptFixture(args: {
+  readonly userId: string;
+  readonly prompt: string;
+}): Promise<TelegramChatEventByPromptFixture | null> {
+  return await findOwnedChatEventByPrompt({
+    userId: args.userId,
+    prompt: args.prompt,
+    filter: and(
+      eq(chatEvents.eventType, "input.prompt"),
+      eq(chatEvents.contextType, "telegram"),
+    ),
   });
-  return row ?? null;
 }
 
-export async function findPendingChatEventByPromptFixture(
-  prompt: string,
-): Promise<{ readonly eventId: string } | null> {
-  const rows = await db()
-    .select({
-      eventId: chatEvents.id,
-      userMessage: chatEvents.userMessage,
-    })
-    .from(chatEvents)
-    .where(isNull(chatEvents.runId));
-  const row = rows.find((candidate) => {
-    return candidate.userMessage?.parts.some((part) => {
-      return part.type === "text" && part.text === prompt;
-    });
+export async function findAgentphoneChatEventByPromptFixture(args: {
+  readonly userId: string;
+  readonly prompt: string;
+}): Promise<AgentphoneChatEventByPromptFixture | null> {
+  return await findOwnedChatEventByPrompt({
+    userId: args.userId,
+    prompt: args.prompt,
+    filter: and(
+      eq(chatEvents.eventType, "input.prompt"),
+      eq(chatEvents.contextType, "agentphone"),
+    ),
   });
-  return row ?? null;
+}
+
+export async function findPendingChatEventByPromptFixture(args: {
+  readonly userId: string;
+  readonly prompt: string;
+}): Promise<{ readonly eventId: string } | null> {
+  return await findOwnedChatEventByPrompt({
+    userId: args.userId,
+    prompt: args.prompt,
+    filter: isNull(chatEvents.runId),
+  });
 }
 
 /** Inserts a pending Slack event, then removes the context its claim requires. */


### PR DESCRIPTION
## Summary

- scope the three chat-event prompt fixtures to the caller's own user instead of scanning the whole table
- assert the browser reconcile outcome through this test's own provider instances instead of the route's global counters
- leave production code, test coverage, and every business assertion unchanged

## Why

Follow-up to the review comment on #25727: tests must isolate through their own random user/org resources, not through the assumption that a previous test cleaned up after itself. API test workers share one database, so any lookup or count that is not scoped to the caller's own rows reads whatever another worker left behind.

Reproduction, before this change — run the same shard twice against one database:

```
pnpm vitest run --project=api --shard=4/8   # pass 1: 23 files, 312 tests, green
pnpm vitest run --project=api --shard=4/8   # pass 2: 4 tests fail in 2 files
```

```
agentphone.bdd > shares one canonical session across AgentPhone and web messages on the same thread
  AssertionError: expected { …(88) } to match object { contextType: 'agentphone', …(12) }
-   "agentphoneFromNumber": "+15558957596",
+   "agentphoneFromNumber": "+15557980211",

zero-browser > isolates profiles across concurrent thread browser sessions
  AssertionError: expected { checked: 9, stopped: 9, …(2) } to match object { checked: 1, stopped: 1, errors: +0 }
```

CI gives every shard a fresh database, so these four are not flaky in CI today. They break the documented local workflow (`pnpm -F api exec vitest` against a dev database) on the second run, and they become CI-flaky as soon as another file in the same shard writes the same kind of row — shard composition changes every time a test file is added.

## What was unscoped

**`test-fixtures/chat-events.ts`** — three exported lookups selected across the entire `chat_events` table and picked the first row whose prompt text matched, with no ownership predicate:

- `findTelegramChatEventByPromptFixture`
- `findAgentphoneChatEventByPromptFixture`
- `findPendingChatEventByPromptFixture` (only `runId IS NULL`, not even a context type)

Used by 5 test files across 14 call sites. Some callers already worked around it by embedding a tenant id or `randomUUID()` in the prompt text; others pass plain literals, and two files already use the same literal `"summarize this thread"` for different contexts. The fixtures now take `{ userId, prompt }` and join `chat_threads` to filter on the caller's own user, so a text collision can no longer cross actors.

Scoping also surfaced a latent gap: the Feishu group test read a queued event that belongs to its `secondActor`, not to the fixture owner. The global lookup silently returned it; the scoped lookup made the intended owner explicit.

**`zero-browser.test.ts`** — the `isolates profiles across concurrent thread browser sessions` test asserted `checked: 1, stopped: 1` and then `checked: 0, stopped: 0` from `/api/cron/browsers/reconcile`, which scans every active browser session instance in the database. It also counted provider stop calls with a mock handler that matched any browser id, so instances belonging to other rows inflated the count too. The test now records the stopped provider ids and asserts against its own `providerIds`, keeping the same numbers and the same idempotence claim.

## Validation

- `--shard=4/8` twice against one database: 317/317 passed on both passes (previously 4 failures on the second)
- `agentphone.bdd` + `zero-integrations-telegram-post` + `internal-callbacks-teams` + `zero-feishu-integration` twice against one database: 85/85 passed on both passes
- `zero-browser.test.ts` three consecutive times against one database: 13/13 passed each
- `pnpm -F api run check-types:gateways`, `check-types:core`, `check-types:tests`
- `eslint --max-warnings 0` on all six changed files, `oxlint --type-aware`, `prettier --check`

## Not in this PR

`zero-browser.test.ts` has about twenty more assertions on the same global reconcile counters (`checked`/`stopped`/`errors`). Only the one above is reachable today, because the tests that follow it create their instances after it runs. Converting the rest is a mechanical but large change to that file and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
