### PR TITLE
refactor(runner): remove preference compatibility bridge

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -41,8 +41,7 @@ use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
 use crate::paths::short_digest;
 use crate::provider::{
-    ClaimedJob, JobCandidate, RunnerPreferenceAdmission, RunnerPreferenceReason,
-    RunnerPreferenceRemovalReason, RunnerPreferenceTier,
+    ClaimedJob, JobCandidate, RunnerPreferenceRemovalReason, RunnerPreferenceTier,
 };
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{
@@ -914,118 +913,7 @@ async fn prepare_preference_candidate(
         device_rate_limits,
         ctx,
     };
-    match preference.admission() {
-        RunnerPreferenceAdmission::Legacy(reason) => {
-            prepare_legacy_preference_candidate(request, reason).await
-        }
-        RunnerPreferenceAdmission::Ranked(tier) => {
-            prepare_ranked_preference_candidate(request, tier).await
-        }
-    }
-}
-
-async fn prepare_legacy_preference_candidate(
-    request: PreferenceCandidateRequest<'_>,
-    reason: RunnerPreferenceReason,
-) -> PreferencePreparation {
-    let PreferenceCandidateRequest {
-        candidate,
-        preference,
-        reuse_key,
-        profile_name,
-        job_vcpu,
-        job_memory,
-        device_rate_limits,
-        ctx,
-    } = request;
-    match reason {
-        RunnerPreferenceReason::ExactHistoryGeneration => {
-            let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
-                return ordinary_preparation(
-                    candidate.without_runner_preference(RunnerPreferenceRemovalReason::Cleared),
-                );
-            };
-            if let Some(reservation) = reserve_reusable_idle(
-                reuse_key,
-                profile_name,
-                device_rate_limits,
-                Some(history_generation_run_id),
-                ctx,
-            )
-            .await
-            {
-                return if reservation.guest_timezone_intent().is_usable_prediction() {
-                    exact_speculative_preparation(candidate, reservation)
-                } else {
-                    reusable_preparation(candidate, reservation)
-                };
-            }
-        }
-        RunnerPreferenceReason::MatchingReuseKey => {
-            if let Some(reservation) =
-                reserve_reusable_idle(reuse_key, profile_name, device_rate_limits, None, ctx).await
-            {
-                return reusable_preparation(candidate, reservation);
-            }
-
-            let held_workspace_states = current_local_held_workspace_states(ctx);
-            let has_capable_workspace = held_workspace_states
-                .iter()
-                .filter(|state| state.reuse_key == reuse_key)
-                .flat_map(|state| &state.workspace_caches)
-                .any(|workspace| {
-                    workspace.profile == profile_name
-                        && workspace.workspace_affinity_version == WORKSPACE_AFFINITY_VERSION
-                });
-            if has_capable_workspace
-                && let Some(lease) =
-                    ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
-            {
-                return PreferencePreparation::Ready(PreparedCandidate {
-                    candidate,
-                    resource: Some(LocalAdmissionResource::Fresh(lease)),
-                });
-            }
-        }
-        RunnerPreferenceReason::FinalizingPredecessor => {
-            let Some(history_generation_run_id) = candidate.history_generation_run_id() else {
-                return ordinary_preparation(
-                    candidate.without_runner_preference(RunnerPreferenceRemovalReason::Cleared),
-                );
-            };
-            if let Some(reservation) = reserve_reusable_idle(
-                reuse_key,
-                profile_name,
-                device_rate_limits,
-                Some(history_generation_run_id),
-                ctx,
-            )
-            .await
-            {
-                return reusable_preparation(candidate, reservation);
-            }
-
-            if preference.targets(ctx.runner_id, ctx.heartbeat_generation) {
-                if let Some(predecessor) = ctx.spawn_ctx.active_runs.finalizing_predecessor(
-                    history_generation_run_id,
-                    reuse_key,
-                    profile_name,
-                ) {
-                    return finalizing_preparation(
-                        candidate,
-                        predecessor,
-                        preference.deadline(),
-                        reuse_key,
-                        history_generation_run_id,
-                    );
-                }
-                return defer_preference_candidate(candidate, preference, reuse_key, ctx, true)
-                    .await;
-            }
-        }
-    }
-
-    defer_preference_candidate(candidate, preference, reuse_key, ctx, false).await
+    prepare_ranked_preference_candidate(request, preference.tier()).await
 }
 
 async fn prepare_ranked_preference_candidate(
@@ -1202,7 +1090,7 @@ async fn defer_preference_candidate(
         run_id = %candidate.run_id(),
         reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
         reuse_key_kind = reuse_key_kind(reuse_key),
-        preference_admission = ?preference.admission(),
+        preference_tier = ?preference.tier(),
         delay_ms = delay.as_millis(),
         retained = retain,
         "runner preference has no qualifying local resource, deferring claim"

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -11,56 +11,12 @@ use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
 use crate::provider::{
-    RunnerPreference, RunnerPreferenceAdmission, RunnerPreferenceClaimState,
-    RunnerPreferenceReason, RunnerPreferenceResolution, RunnerPreferenceTier,
+    RunnerPreference, RunnerPreferenceClaimState, RunnerPreferenceResolution, RunnerPreferenceTier,
 };
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
 
 const NON_SELECTED_RUNNER_ID: u128 = 1;
-
-fn preferred_candidate(
-    run_id: RunId,
-    reuse_key: Option<&str>,
-    reason: RunnerPreferenceReason,
-) -> crate::provider::JobCandidate {
-    preferred_candidate_until(
-        run_id,
-        reuse_key,
-        reason,
-        std::time::Instant::now() + Duration::from_secs(30),
-    )
-}
-
-fn preferred_candidate_until(
-    run_id: RunId,
-    reuse_key: Option<&str>,
-    reason: RunnerPreferenceReason,
-    deadline: std::time::Instant,
-) -> crate::provider::JobCandidate {
-    let resolution = match reason {
-        RunnerPreferenceReason::ExactHistoryGeneration => {
-            RunnerPreferenceResolution::ExactHistoryGeneration
-        }
-        RunnerPreferenceReason::MatchingReuseKey => {
-            RunnerPreferenceResolution::MatchingReusableSandbox
-        }
-        RunnerPreferenceReason::FinalizingPredecessor => {
-            RunnerPreferenceResolution::FinalizingPredecessor
-        }
-    };
-    crate::provider::JobCandidate::new(run_id, "vm0/default".into())
-        .with_reuse_key(reuse_key.map(str::to_owned))
-        .with_runner_preference_context(
-            Some(RunnerPreference::for_test(
-                uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID),
-                1,
-                reason,
-                deadline,
-            )),
-            Some(resolution),
-        )
-}
 
 fn ranked_candidate(
     run_id: RunId,
@@ -89,7 +45,7 @@ fn ranked_candidate_until(
 ) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(reuse_key.map(str::to_owned))
-        .with_atomic_runner_preference(RunnerPreference::ranked_for_test(
+        .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
             runner_id.parse().unwrap(),
             heartbeat_generation,
             tier,
@@ -98,10 +54,12 @@ fn ranked_candidate_until(
 }
 
 fn matching_preference_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
-    preferred_candidate(
+    ranked_candidate(
         run_id,
         Some(session_id),
-        RunnerPreferenceReason::MatchingReuseKey,
+        RunnerPreferenceTier::ReusableSandbox,
+        TEST_RUNNER_ID,
+        TEST_HEARTBEAT_GENERATION,
     )
 }
 
@@ -110,10 +68,12 @@ fn exact_generation_preference_candidate(
     session_id: &str,
     target_generation_run_id: RunId,
 ) -> crate::provider::JobCandidate {
-    preferred_candidate(
+    ranked_candidate(
         run_id,
         Some(session_id),
-        RunnerPreferenceReason::ExactHistoryGeneration,
+        RunnerPreferenceTier::ExactSandbox,
+        TEST_RUNNER_ID,
+        TEST_HEARTBEAT_GENERATION,
     )
     .with_history_generation_run_id(Some(target_generation_run_id))
 }
@@ -146,15 +106,12 @@ fn finalizing_candidate_until(
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(Some(reuse_key.to_owned()))
         .with_history_generation_run_id(Some(history_generation_run_id))
-        .with_runner_preference_context(
-            Some(RunnerPreference::for_test(
-                runner_id.parse().unwrap(),
-                heartbeat_generation,
-                RunnerPreferenceReason::FinalizingPredecessor,
-                deadline,
-            )),
-            Some(RunnerPreferenceResolution::FinalizingPredecessor),
-        )
+        .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
+            runner_id.parse().unwrap(),
+            heartbeat_generation,
+            RunnerPreferenceTier::FinalizingPredecessor,
+            deadline,
+        ))
 }
 
 fn context_with_reuse_key(run_id: RunId, reuse_key: &str) -> crate::types::ExecutionContext {
@@ -596,12 +553,8 @@ async fn reusable_claim_without_generation_target_reuses_sandbox() {
         .find(|candidate| candidate.run_id() == run_id)
         .expect("missing-target reusable candidate should reach claim");
     assert_eq!(
-        candidate
-            .runner_preference()
-            .map(RunnerPreference::admission),
-        Some(RunnerPreferenceAdmission::Legacy(
-            RunnerPreferenceReason::MatchingReuseKey
-        ))
+        candidate.runner_preference().map(RunnerPreference::tier),
+        Some(RunnerPreferenceTier::ReusableSandbox)
     );
 
     shutdown(&env, run_handle).await;
@@ -866,7 +819,7 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
         .expect("expired candidate should reach claim");
     let telemetry = claimed
         .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
-        .expect("atomic observation should survive expiry");
+        .expect("decision observation should survive expiry");
     assert_eq!(
         telemetry.resolution,
         RunnerPreferenceResolution::FinalizingPredecessor
@@ -1640,10 +1593,12 @@ async fn preference_without_reuse_key_uses_ordinary_admission() {
         .set_claim_result(run_id, Some(minimal_context(run_id)));
     env.handle
         .discover_tx
-        .send(preferred_candidate(
+        .send(ranked_candidate(
             run_id,
             None,
-            RunnerPreferenceReason::MatchingReuseKey,
+            RunnerPreferenceTier::ReusableSandbox,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
         ))
         .unwrap();
 
@@ -1675,15 +1630,12 @@ async fn selected_finalizing_candidate_without_reuse_key_uses_ordinary_admission
         .send(
             crate::provider::JobCandidate::new(run_id, "vm0/default".into())
                 .with_history_generation_run_id(Some(RunId::new_v4()))
-                .with_runner_preference_context(
-                    Some(RunnerPreference::for_test(
-                        TEST_RUNNER_ID.parse().unwrap(),
-                        TEST_HEARTBEAT_GENERATION,
-                        RunnerPreferenceReason::FinalizingPredecessor,
-                        std::time::Instant::now() + Duration::from_secs(30),
-                    )),
-                    Some(RunnerPreferenceResolution::FinalizingPredecessor),
-                ),
+                .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
+                    TEST_RUNNER_ID.parse().unwrap(),
+                    TEST_HEARTBEAT_GENERATION,
+                    RunnerPreferenceTier::FinalizingPredecessor,
+                    std::time::Instant::now() + Duration::from_secs(30),
+                )),
         )
         .unwrap();
 
@@ -1928,10 +1880,12 @@ async fn expired_generation_protection_preserves_local_session_claim() {
     env.handle
         .discover_tx
         .send(
-            preferred_candidate_until(
+            ranked_candidate_until(
                 run_id,
                 Some("sess-held-local"),
-                RunnerPreferenceReason::ExactHistoryGeneration,
+                RunnerPreferenceTier::ExactSandbox,
+                TEST_RUNNER_ID,
+                TEST_HEARTBEAT_GENERATION,
                 std::time::Instant::now() - Duration::from_secs(1),
             )
             .with_history_generation_run_id(Some(RunId::new_v4())),

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1,18 +1,17 @@
 use super::super::super::*;
 use super::super::support::{
-    SpeculativeIdleSeedSpec, context_with_session, mock_run_config,
-    seed_idle_pool_with_speculative_timezone, shutdown, status_idle_reuse_keys_and_active_runs,
-    test_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
-    wait_discover_entered, wait_idle_pool_len, wait_idle_pool_reuse_keys,
+    SpeculativeIdleSeedSpec, TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, context_with_session,
+    mock_run_config, seed_idle_pool_with_speculative_timezone, shutdown,
+    status_idle_reuse_keys_and_active_runs, test_profiles, wait_budget_count, wait_cancel_handle,
+    wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
+    wait_idle_pool_reuse_keys,
 };
 use std::sync::Arc;
 
 use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
-use crate::provider::{JobCandidate, RunnerPreference, RunnerPreferenceReason};
+use crate::provider::{JobCandidate, RunnerPreference, RunnerPreferenceTier};
 use crate::types::{ExecutionContext, SandboxReuseResult};
-
-const NON_SELECTED_RUNNER_ID: u128 = 1;
 
 fn exact_generation_candidate(
     run_id: RunId,
@@ -22,12 +21,12 @@ fn exact_generation_candidate(
     JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(Some(reuse_key.to_owned()))
         .with_history_generation_run_id(Some(history_generation_run_id))
-        .with_runner_preference(Some(RunnerPreference::for_test(
-            uuid::Uuid::from_u128(NON_SELECTED_RUNNER_ID),
-            1,
-            RunnerPreferenceReason::ExactHistoryGeneration,
+        .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
+            TEST_RUNNER_ID.parse().unwrap(),
+            TEST_HEARTBEAT_GENERATION,
+            RunnerPreferenceTier::ExactSandbox,
             std::time::Instant::now() + Duration::from_secs(30),
-        )))
+        ))
 }
 
 fn claimed_context(run_id: RunId, reuse_key: &str, timezone: Option<&str>) -> ExecutionContext {

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -32,7 +32,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    RunnerPreferenceClaimState, RunnerPreferenceResolution, parse_runner_preference_context,
+    RunnerPreferenceClaimState, RunnerPreferenceResolution, parse_runner_preference_decision,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -593,38 +593,25 @@ impl JobProvider for ApiProvider {
                     let run_id = job.run_id;
                     let reuse_key = job.reuse_key().map(str::to_owned);
                     let history_generation_run_id = job.history_generation_run_id;
-                    let parsed_preference = parse_runner_preference_context(
+                    let runner_preference_context = match parse_runner_preference_decision(
                         job.runner_preference_decision,
-                        job.runner_preference,
-                        job.runner_preference_resolution,
-                    );
-                    if let Some(error) = parsed_preference.decision_error {
-                        warn!(
-                            run_id = %run_id,
-                            error = %error,
-                            "poll: invalid runner preference decision, falling back to legacy preference"
-                        );
-                    }
-                    if let Some(error) = parsed_preference.legacy_preference_error {
-                        warn!(
-                            run_id = %run_id,
-                            error = %error,
-                            "poll: invalid runner preference, using ordinary admission"
-                        );
-                    }
-                    if let Some(error) = parsed_preference.legacy_resolution_error {
-                        warn!(
-                            run_id = %run_id,
-                            error = %error,
-                            "poll: invalid runner preference resolution, omitting telemetry context"
-                        );
-                    }
+                    ) {
+                        Ok(context) => context,
+                        Err(error) => {
+                            warn!(
+                                run_id = %run_id,
+                                error = %error,
+                                "poll: invalid runner preference decision, using ordinary admission"
+                            );
+                            None
+                        }
+                    };
                     let profile = job.experimental_profile;
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_reuse_key(reuse_key)
                         .with_history_generation_run_id(history_generation_run_id)
-                        .with_parsed_runner_preference_context(parsed_preference.context)
+                        .with_parsed_runner_preference_context(runner_preference_context)
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
                         .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed);
@@ -1710,10 +1697,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::http::HttpClientConfig;
-    use crate::provider::{
-        RunnerPreference, RunnerPreferenceAdmission, RunnerPreferenceReason,
-        RunnerPreferenceRemovalReason, RunnerPreferenceTier,
-    };
+    use crate::provider::{RunnerPreference, RunnerPreferenceRemovalReason, RunnerPreferenceTier};
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
         "../../../../turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json"
@@ -2306,7 +2290,6 @@ mod tests {
                 .get("runnerPreferenceTargetedSelf")
                 .is_none()
         );
-        assert!(body.get("runnerPreference").is_none());
         assert!(!body.to_string().contains("rawSizeBytes"));
         assert!(!body.to_string().contains("sessionId"));
         assert!(!body.to_string().contains("historyHash"));
@@ -2317,17 +2300,14 @@ mod tests {
 
     #[test]
     fn claim_request_body_serializes_preference_observation_at_claim_time() {
-        let active_preference = RunnerPreference::for_test(
+        let active_preference = RunnerPreference::ranked_for_test(
             TEST_RUNNER_ID.parse().unwrap(),
             TEST_HEARTBEAT_GENERATION,
-            RunnerPreferenceReason::MatchingReuseKey,
+            RunnerPreferenceTier::WorkspaceCache,
             Instant::now() + Duration::from_secs(60),
         );
         let active = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
-            .with_runner_preference_context(
-                Some(active_preference),
-                Some(RunnerPreferenceResolution::MatchingWorkspaceCache),
-            );
+            .with_runner_preference_for_test(active_preference);
         let active_body = serde_json::to_value(claim_request_body_for_test(&active)).unwrap();
         assert_eq!(
             active_body["telemetry"]["runnerPreferenceResolution"],
@@ -2342,34 +2322,28 @@ mod tests {
             true
         );
 
-        let expired_preference = RunnerPreference::for_test(
+        let expired_preference = RunnerPreference::ranked_for_test(
             TEST_RUNNER_ID.parse().unwrap(),
             TEST_HEARTBEAT_GENERATION,
-            RunnerPreferenceReason::ExactHistoryGeneration,
+            RunnerPreferenceTier::ExactSandbox,
             Instant::now() - Duration::from_secs(1),
         );
         let expired = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
-            .with_runner_preference_context(
-                Some(expired_preference),
-                Some(RunnerPreferenceResolution::ExactHistoryGeneration),
-            );
+            .with_runner_preference_for_test(expired_preference);
         let expired_body = serde_json::to_value(claim_request_body_for_test(&expired)).unwrap();
         assert_eq!(
             expired_body["telemetry"]["runnerPreferenceClaimState"],
             "expired"
         );
 
-        let cleared_preference = RunnerPreference::for_test(
+        let cleared_preference = RunnerPreference::ranked_for_test(
             Uuid::from_u128(8),
             TEST_HEARTBEAT_GENERATION,
-            RunnerPreferenceReason::FinalizingPredecessor,
+            RunnerPreferenceTier::FinalizingPredecessor,
             Instant::now() + Duration::from_secs(60),
         );
         let cleared = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
-            .with_runner_preference_context(
-                Some(cleared_preference),
-                Some(RunnerPreferenceResolution::FinalizingPredecessor),
-            )
+            .with_runner_preference_for_test(cleared_preference)
             .without_runner_preference(RunnerPreferenceRemovalReason::Cleared);
         let cleared_body = serde_json::to_value(claim_request_body_for_test(&cleared)).unwrap();
         assert_eq!(
@@ -2382,7 +2356,7 @@ mod tests {
         );
 
         let absent = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
-            .with_runner_preference_context(None, Some(RunnerPreferenceResolution::NoViableHolder));
+            .with_no_runner_preference_for_test(RunnerPreferenceResolution::NoViableHolder);
         let absent_body = serde_json::to_value(claim_request_body_for_test(&absent)).unwrap();
         assert_eq!(
             absent_body["telemetry"]["runnerPreferenceClaimState"],
@@ -2616,13 +2590,13 @@ mod tests {
                         "experimentalProfile": "vm0/large",
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
-                        "runnerPreferenceResolution": "exact_history_generation",
-                        "runnerPreference": {
+                        "runnerPreferenceDecision": {
+                            "kind": "preference",
                             "runnerIdentity": {
                                 "runnerId": "00000000-0000-0000-0000-000000000005",
                                 "heartbeatGeneration": 7
                             },
-                            "reason": "exactHistoryGeneration",
+                            "tier": "exactSandbox",
                             "expiresAt": "2999-01-01T00:00:00.000Z"
                         }
                     }
@@ -2650,10 +2624,7 @@ mod tests {
         let preference = discovered
             .runner_preference()
             .expect("canonical preference should be parsed");
-        assert_eq!(
-            preference.admission(),
-            RunnerPreferenceAdmission::Legacy(RunnerPreferenceReason::ExactHistoryGeneration)
-        );
+        assert_eq!(preference.tier(), RunnerPreferenceTier::ExactSandbox);
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
         assert_eq!(
             discovered
@@ -2674,7 +2645,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_prefers_atomic_poll_decision_over_conflicting_bridge() {
+    async fn discover_parses_positive_poll_preference_decision() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let selected_runner_id = "00000000-0000-0000-0000-000000000005";
@@ -2685,7 +2656,7 @@ mod tests {
                     "job": {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
-                        "reuseKey": "thread:atomic-poll",
+                        "reuseKey": "thread:decision-poll",
                         "runnerPreferenceDecision": {
                             "kind": "preference",
                             "runnerIdentity": {
@@ -2694,16 +2665,7 @@ mod tests {
                             },
                             "tier": "workspaceCache",
                             "expiresAt": "2999-01-01T00:00:00.000Z"
-                        },
-                        "runnerPreference": {
-                            "runnerIdentity": {
-                                "runnerId": "00000000-0000-0000-0000-000000000099",
-                                "heartbeatGeneration": 9
-                            },
-                            "reason": "exactHistoryGeneration",
-                            "expiresAt": "2999-01-01T00:00:00.000Z"
-                        },
-                        "runnerPreferenceResolution": "exact_history_generation"
+                        }
                     }
                 }));
             })
@@ -2721,12 +2683,8 @@ mod tests {
             .expect("job candidate");
 
         assert_eq!(
-            candidate
-                .runner_preference()
-                .map(RunnerPreference::admission),
-            Some(RunnerPreferenceAdmission::Ranked(
-                RunnerPreferenceTier::WorkspaceCache
-            ))
+            candidate.runner_preference().map(RunnerPreference::tier),
+            Some(RunnerPreferenceTier::WorkspaceCache)
         );
         assert_eq!(
             candidate.runner_preference_claim_telemetry(selected_runner_id, 7),
@@ -2740,7 +2698,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_atomic_negative_ignores_positive_poll_bridge() {
+    async fn discover_parses_negative_poll_preference_decision() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let mock = server
@@ -2753,16 +2711,7 @@ mod tests {
                         "runnerPreferenceDecision": {
                             "kind": "noPreference",
                             "reason": "noViableHolder"
-                        },
-                        "runnerPreference": {
-                            "runnerIdentity": {
-                                "runnerId": TEST_RUNNER_ID,
-                                "heartbeatGeneration": TEST_HEARTBEAT_GENERATION
-                            },
-                            "reason": "matchingReuseKey",
-                            "expiresAt": "2999-01-01T00:00:00.000Z"
-                        },
-                        "runnerPreferenceResolution": "matching_reusable_sandbox"
+                        }
                     }
                 }));
             })
@@ -2792,7 +2741,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_falls_back_to_poll_bridge_after_malformed_atomic_decision() {
+    async fn discover_preserves_poll_job_after_malformed_preference_decision() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let mock = server
@@ -2810,15 +2759,6 @@ mod tests {
                                 "heartbeatGeneration": 0
                             },
                             "tier": "workspaceCache",
-                            "expiresAt": "2999-01-01T00:00:00.000Z"
-                        },
-                        "runnerPreferenceResolution": "matching_workspace_cache",
-                        "runnerPreference": {
-                            "runnerIdentity": {
-                                "runnerId": TEST_RUNNER_ID,
-                                "heartbeatGeneration": TEST_HEARTBEAT_GENERATION
-                            },
-                            "reason": "matchingReuseKey",
                             "expiresAt": "2999-01-01T00:00:00.000Z"
                         }
                     }
@@ -2839,54 +2779,7 @@ mod tests {
 
         assert_eq!(candidate.run_id(), run_id);
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
-        assert_eq!(
-            candidate
-                .runner_preference()
-                .map(RunnerPreference::admission),
-            Some(RunnerPreferenceAdmission::Legacy(
-                RunnerPreferenceReason::MatchingReuseKey
-            ))
-        );
-        assert_eq!(
-            candidate.runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::MatchingWorkspaceCache,
-                state: RunnerPreferenceClaimState::Active,
-                targeted_self: Some(true),
-            })
-        );
-        mock.assert_async().await;
-    }
-
-    #[tokio::test]
-    async fn discover_preserves_poll_job_with_future_resolution() {
-        let server = MockServer::start_async().await;
-        let run_id = RunId::new_v4();
-        let mock = server
-            .mock_async(|when, then| {
-                when.method(POST).path(routes::runners::poll::POLL.path);
-                then.status(200).json_body(serde_json::json!({
-                    "job": {
-                        "runId": run_id,
-                        "experimentalProfile": "vm0/default",
-                        "runnerPreferenceResolution": "future_resolution"
-                    }
-                }));
-            })
-            .await;
-        let provider = api_provider_for_test_with_supported_profiles(
-            server.base_url(),
-            CancellationToken::new(),
-            Arc::new(PollWakeups::new(false)),
-            vec!["vm0/default".to_string()],
-        );
-
-        let candidate = tokio::time::timeout(Duration::from_secs(1), provider.discover())
-            .await
-            .expect("discover should preserve the job")
-            .expect("job candidate");
-
-        assert_eq!(candidate.run_id(), run_id);
+        assert!(candidate.runner_preference().is_none());
         assert!(
             candidate
                 .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,)

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -27,7 +27,7 @@ use super::api_direct_candidates::{
     DirectJobCandidate,
 };
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
-use super::{RunnerPreferenceContext, parse_runner_preference_context};
+use super::{RunnerPreferenceContext, parse_runner_preference_decision};
 use crate::active_input::ActiveInputNotifications;
 use crate::duration::duration_ms;
 use crate::ids::RunId;
@@ -1030,38 +1030,24 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("historyGenerationRunId")
         .and_then(|v| v.as_str())
         .and_then(|value| value.parse().ok());
-    let parsed_preference = parse_runner_preference_context(
-        msg.data.get("runnerPreferenceDecision").cloned(),
-        msg.data.get("runnerPreference").cloned(),
-        msg.data.get("runnerPreferenceResolution").cloned(),
-    );
-    if let Some(error) = parsed_preference.decision_error {
-        warn!(
-            run_id = %run_id,
-            error = %error,
-            "ably: invalid runner preference decision, falling back to legacy preference"
-        );
-    }
-    if let Some(error) = parsed_preference.legacy_preference_error {
-        warn!(
-            run_id = %run_id,
-            error = %error,
-            "ably: invalid runner preference, using ordinary admission"
-        );
-    }
-    if let Some(error) = parsed_preference.legacy_resolution_error {
-        warn!(
-            run_id = %run_id,
-            error = %error,
-            "ably: invalid runner preference resolution, omitting telemetry context"
-        );
-    }
+    let runner_preference_context =
+        match parse_runner_preference_decision(msg.data.get("runnerPreferenceDecision").cloned()) {
+            Ok(context) => context,
+            Err(error) => {
+                warn!(
+                    run_id = %run_id,
+                    error = %error,
+                    "ably: invalid runner preference decision, using ordinary admission"
+                );
+                None
+            }
+        };
     Some(JobNotification {
         run_id,
         profile,
         reuse_key,
         history_generation_run_id,
-        runner_preference_context: parsed_preference.context,
+        runner_preference_context,
     })
 }
 
@@ -1209,9 +1195,7 @@ impl AblyDisconnectState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::{
-        RunnerPreferenceAdmission, RunnerPreferenceResolution, RunnerPreferenceTier,
-    };
+    use crate::provider::{RunnerPreferenceResolution, RunnerPreferenceTier};
 
     fn make_message(name: Option<&str>, data: serde_json::Value) -> ably_subscriber::Message {
         ably_subscriber::Message {
@@ -2012,15 +1996,6 @@ mod tests {
                     },
                     "tier": "reusableSandbox",
                     "expiresAt": "2999-01-01T00:00:00.000Z"
-                },
-                "runnerPreferenceResolution": "matching_workspace_cache",
-                "runnerPreference": {
-                    "runnerIdentity": {
-                        "runnerId": "00000000-0000-0000-0000-000000000099",
-                        "heartbeatGeneration": 9
-                    },
-                    "reason": "exactHistoryGeneration",
-                    "expiresAt": "2999-01-01T00:00:00.000Z"
                 }
             }),
         );
@@ -2042,10 +2017,7 @@ mod tests {
         let preference = candidate
             .runner_preference()
             .expect("canonical preference should be parsed");
-        assert_eq!(
-            preference.admission(),
-            RunnerPreferenceAdmission::Ranked(RunnerPreferenceTier::ReusableSandbox)
-        );
+        assert_eq!(preference.tier(), RunnerPreferenceTier::ReusableSandbox);
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
         assert_eq!(
             candidate.runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,),
@@ -2060,7 +2032,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_atomic_and_bridge_preferences_preserve_direct_candidate() {
+    async fn malformed_preference_decision_preserves_direct_candidate() {
         let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
@@ -2086,15 +2058,6 @@ mod tests {
                     },
                     "tier": "workspaceCache",
                     "expiresAt": "2999-01-01T00:00:00.000Z"
-                },
-                "runnerPreferenceResolution": "future_resolution",
-                "runnerPreference": {
-                    "runnerIdentity": {
-                        "runnerId": "00000000-0000-0000-0000-000000000005",
-                        "heartbeatGeneration": 7
-                    },
-                    "reason": "futureReason",
-                    "expiresAt": "2999-01-01T00:00:00.000Z"
                 }
             }),
         );
@@ -2110,64 +2073,6 @@ mod tests {
             candidate
                 .runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,)
                 .is_none()
-        );
-        assert_no_direct_candidate(&direct_candidates).await;
-    }
-
-    #[tokio::test]
-    async fn malformed_atomic_ably_decision_falls_back_to_valid_bridge() {
-        let tokens = RunCancellationRegistry::new();
-        let wakeups = PollWakeups::new(true);
-        let direct_candidates = direct_candidate_inbox();
-        let profiles = default_profiles();
-        let _ = wakeups
-            .wait_for_poll_due(
-                &CancellationToken::new(),
-                Duration::from_secs(30),
-                Duration::from_secs(5),
-            )
-            .await;
-        let msg = make_message(
-            Some("job"),
-            serde_json::json!({
-                "runId": "00000000-0000-0000-0000-000000000012",
-                "profile": "vm0/default",
-                "reuseKey": "thread:bridge-fallback",
-                "runnerPreferenceDecision": {
-                    "kind": "futureDecision"
-                },
-                "runnerPreferenceResolution": "matching_reusable_sandbox",
-                "runnerPreference": {
-                    "runnerIdentity": {
-                        "runnerId": "00000000-0000-0000-0000-000000000005",
-                        "heartbeatGeneration": 7
-                    },
-                    "reason": "matchingReuseKey",
-                    "expiresAt": "2999-01-01T00:00:00.000Z"
-                }
-            }),
-        );
-
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
-
-        let candidate = pop_direct_candidate(&direct_candidates)
-            .await
-            .into_job_candidate();
-        assert_eq!(
-            candidate
-                .runner_preference()
-                .map(crate::provider::RunnerPreference::admission),
-            Some(RunnerPreferenceAdmission::Legacy(
-                crate::provider::RunnerPreferenceReason::MatchingReuseKey
-            ))
-        );
-        assert_eq!(
-            candidate.runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::MatchingReusableSandbox,
-                state: super::super::RunnerPreferenceClaimState::Active,
-                targeted_self: Some(true),
-            })
         );
         assert_no_direct_candidate(&direct_candidates).await;
     }

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -6,9 +6,9 @@ use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use super::{JobCandidate, JobDiscoverySource, RunnerPreferenceContext};
 #[cfg(test)]
-use super::{RunnerPreference, RunnerPreferenceResolution};
+use super::RunnerPreference;
+use super::{JobCandidate, JobDiscoverySource, RunnerPreferenceContext};
 use crate::ids::RunId;
 
 pub(super) const DIRECT_CANDIDATE_STALE_AFTER: Duration = Duration::from_secs(60);
@@ -102,20 +102,6 @@ impl DirectJobCandidate {
         self
     }
 
-    #[cfg(test)]
-    pub(super) fn with_runner_preference_resolution(
-        mut self,
-        runner_preference_resolution: Option<RunnerPreferenceResolution>,
-    ) -> Self {
-        let runner_preference = self
-            .runner_preference_context
-            .take()
-            .and_then(|context| context.preference().cloned());
-        self.runner_preference_context =
-            RunnerPreferenceContext::legacy(runner_preference, runner_preference_resolution);
-        self
-    }
-
     pub(super) fn into_job_candidate(self) -> JobCandidate {
         let dequeued_at = StdInstant::now();
         let notification_to_enqueue_elapsed = self
@@ -142,33 +128,7 @@ impl DirectJobCandidate {
             );
             return;
         }
-        if self
-            .runner_preference_context
-            .as_ref()
-            .is_some_and(RunnerPreferenceContext::is_atomic)
-        {
-            return;
-        }
-        let incoming_is_atomic = candidate
-            .runner_preference_context
-            .as_ref()
-            .is_some_and(RunnerPreferenceContext::is_atomic);
-        let preserve_existing = !incoming_is_atomic
-            && matches!(
-                (
-                    self.runner_preference_context
-                        .as_ref()
-                        .and_then(RunnerPreferenceContext::preference),
-                    candidate
-                        .runner_preference_context
-                        .as_ref()
-                        .and_then(RunnerPreferenceContext::preference),
-                ),
-                (Some(existing), Some(candidate))
-                    if existing.admission() == candidate.admission()
-                        && existing.deadline() < candidate.deadline()
-            );
-        if preserve_existing {
+        if self.runner_preference_context.is_some() {
             return;
         }
         self.reuse_key = candidate.reuse_key;
@@ -408,6 +368,7 @@ fn snapshot(depth: usize, capacity: usize) -> DirectCandidateInboxSnapshot {
 mod tests {
     use std::time::Duration;
 
+    use super::super::{RunnerPreferenceResolution, RunnerPreferenceTier};
     use super::*;
 
     fn run_id(value: u128) -> RunId {
@@ -425,29 +386,12 @@ mod tests {
         DirectCandidateInbox::new(capacity, stale_after)
     }
 
-    fn runner_preference(
-        runner_id: u128,
-        reason: super::super::RunnerPreferenceReason,
-        deadline: StdInstant,
-    ) -> RunnerPreferenceContext {
-        RunnerPreferenceContext::legacy(
-            Some(RunnerPreference::for_test(
-                uuid::Uuid::from_u128(runner_id),
-                7,
-                reason,
-                deadline,
-            )),
-            None,
-        )
-        .unwrap()
-    }
-
     fn ranked_preference_context(
         runner_id: u128,
-        tier: super::super::RunnerPreferenceTier,
+        tier: RunnerPreferenceTier,
         deadline: StdInstant,
     ) -> RunnerPreferenceContext {
-        RunnerPreferenceContext::atomic_for_test(RunnerPreference::ranked_for_test(
+        RunnerPreferenceContext::for_test(RunnerPreference::ranked_for_test(
             uuid::Uuid::from_u128(runner_id),
             7,
             tier,
@@ -466,31 +410,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn duplicate_run_id_occupies_one_slot_and_preserves_first_discovery_time() {
+    async fn duplicate_run_id_accepts_first_decision_and_preserves_first_discovery_time() {
         let inbox = direct_candidate_inbox(4);
         let first_discovered_at = StdInstant::now() - Duration::from_secs(5);
         let second_discovered_at = StdInstant::now();
         let history_generation_run_id = run_id(2);
         let run_id = run_id(1);
 
-        let first_deadline = StdInstant::now() + Duration::from_secs(5);
         let inserted = inbox
-            .push(
-                DirectJobCandidate::new_with_routing_metadata(
-                    run_id,
-                    "vm0/default".to_string(),
-                    first_discovered_at,
-                    Some("session:sess-1".to_string()),
-                    Some(runner_preference(
-                        10,
-                        super::super::RunnerPreferenceReason::MatchingReuseKey,
-                        first_deadline,
-                    )),
-                )
-                .with_runner_preference_resolution(Some(
-                    RunnerPreferenceResolution::MatchingReusableSandbox,
-                )),
-            )
+            .push(DirectJobCandidate::new_with_routing_metadata(
+                run_id,
+                "vm0/default".to_string(),
+                first_discovered_at,
+                Some("session:sess-1".to_string()),
+                None,
+            ))
             .await;
         assert_eq!(
             inserted.snapshot(),
@@ -508,15 +442,12 @@ mod tests {
                     "vm0/default".to_string(),
                     second_discovered_at,
                     Some("session:sess-2".to_string()),
-                    Some(runner_preference(
+                    Some(ranked_preference_context(
                         20,
-                        super::super::RunnerPreferenceReason::ExactHistoryGeneration,
+                        RunnerPreferenceTier::ExactSandbox,
                         exact_deadline,
                     )),
                 )
-                .with_runner_preference_resolution(Some(
-                    RunnerPreferenceResolution::ExactHistoryGeneration,
-                ))
                 .with_history_generation_run_id(Some(history_generation_run_id)),
             )
             .await;
@@ -532,22 +463,17 @@ mod tests {
         ));
 
         let renewed = inbox
-            .push(
-                DirectJobCandidate::new_with_routing_metadata(
-                    run_id,
-                    "vm0/default".to_string(),
-                    second_discovered_at,
-                    Some("session:must-not-renew".to_string()),
-                    Some(runner_preference(
-                        30,
-                        super::super::RunnerPreferenceReason::ExactHistoryGeneration,
-                        StdInstant::now() + Duration::from_secs(30),
-                    )),
-                )
-                .with_runner_preference_resolution(Some(
-                    RunnerPreferenceResolution::MatchingWorkspaceCache,
+            .push(DirectJobCandidate::new_with_routing_metadata(
+                run_id,
+                "vm0/default".to_string(),
+                second_discovered_at,
+                Some("session:must-not-renew".to_string()),
+                Some(ranked_preference_context(
+                    30,
+                    RunnerPreferenceTier::WorkspaceCache,
+                    StdInstant::now() + Duration::from_secs(30),
                 )),
-            )
+            ))
             .await;
         assert!(matches!(
             renewed,
@@ -566,12 +492,7 @@ mod tests {
         let preference = candidate
             .runner_preference()
             .expect("updated canonical preference");
-        assert_eq!(
-            preference.admission(),
-            super::super::RunnerPreferenceAdmission::Legacy(
-                super::super::RunnerPreferenceReason::ExactHistoryGeneration
-            )
-        );
+        assert_eq!(preference.tier(), RunnerPreferenceTier::ExactSandbox);
         assert_eq!(preference.deadline(), exact_deadline);
         assert!(preference.targets(&uuid::Uuid::from_u128(20).to_string(), 7));
         assert_eq!(
@@ -592,64 +513,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn duplicate_without_preference_clears_the_previous_routing_snapshot() {
-        let inbox = direct_candidate_inbox(1);
-        let candidate_run_id = run_id(3);
-        inbox
-            .push(
-                DirectJobCandidate::new_with_routing_metadata(
-                    candidate_run_id,
-                    "vm0/default".to_string(),
-                    StdInstant::now(),
-                    Some("session:stale".to_string()),
-                    Some(runner_preference(
-                        10,
-                        super::super::RunnerPreferenceReason::ExactHistoryGeneration,
-                        StdInstant::now() + Duration::from_secs(5),
-                    )),
-                )
-                .with_runner_preference_resolution(Some(
-                    RunnerPreferenceResolution::ExactHistoryGeneration,
-                ))
-                .with_history_generation_run_id(Some(run_id(4))),
-            )
-            .await;
-
-        inbox
-            .push(
-                DirectJobCandidate::new_with_routing_metadata(
-                    candidate_run_id,
-                    "vm0/default".to_string(),
-                    StdInstant::now(),
-                    None,
-                    None,
-                )
-                .with_runner_preference_resolution(Some(
-                    RunnerPreferenceResolution::NoViableHolder,
-                )),
-            )
-            .await;
-
-        let candidate = inbox
-            .try_pop()
-            .await
-            .expect("updated direct candidate")
-            .into_job_candidate();
-        assert!(candidate.reuse_key().is_none());
-        assert!(candidate.history_generation_run_id().is_none());
-        assert!(candidate.runner_preference().is_none());
-        assert_eq!(
-            candidate.runner_preference_claim_telemetry(&uuid::Uuid::from_u128(10).to_string(), 7,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::NoViableHolder,
-                state: super::super::RunnerPreferenceClaimState::Absent,
-                targeted_self: None,
-            })
-        );
-    }
-
-    #[tokio::test]
-    async fn duplicate_retains_first_atomic_routing_snapshot_and_deadline() {
+    async fn duplicate_retains_first_decision_snapshot_and_deadline() {
         let inbox = direct_candidate_inbox(1);
         let candidate_run_id = run_id(5);
         let first_history_generation = run_id(6);
@@ -660,10 +524,10 @@ mod tests {
                     candidate_run_id,
                     "vm0/default".to_string(),
                     StdInstant::now(),
-                    Some("session:first-atomic".to_string()),
+                    Some("session:first-decision".to_string()),
                     Some(ranked_preference_context(
                         10,
-                        super::super::RunnerPreferenceTier::WorkspaceCache,
+                        RunnerPreferenceTier::WorkspaceCache,
                         first_deadline,
                     )),
                 )
@@ -680,7 +544,7 @@ mod tests {
                     Some("session:must-not-replace".to_string()),
                     Some(ranked_preference_context(
                         20,
-                        super::super::RunnerPreferenceTier::ExactSandbox,
+                        RunnerPreferenceTier::ExactSandbox,
                         StdInstant::now() + Duration::from_secs(30),
                     )),
                 )
@@ -694,7 +558,7 @@ mod tests {
                 "vm0/default".to_string(),
                 StdInstant::now(),
                 None,
-                Some(RunnerPreferenceContext::atomic_negative(
+                Some(RunnerPreferenceContext::negative(
                     RunnerPreferenceResolution::NoViableHolder,
                 )),
             ))
@@ -705,18 +569,13 @@ mod tests {
             .await
             .expect("retained direct candidate")
             .into_job_candidate();
-        assert_eq!(candidate.reuse_key(), Some("session:first-atomic"));
+        assert_eq!(candidate.reuse_key(), Some("session:first-decision"));
         assert_eq!(
             candidate.history_generation_run_id(),
             Some(first_history_generation)
         );
-        let preference = candidate.runner_preference().expect("atomic preference");
-        assert_eq!(
-            preference.admission(),
-            super::super::RunnerPreferenceAdmission::Ranked(
-                super::super::RunnerPreferenceTier::WorkspaceCache
-            )
-        );
+        let preference = candidate.runner_preference().expect("runner preference");
+        assert_eq!(preference.tier(), RunnerPreferenceTier::WorkspaceCache);
         assert_eq!(preference.deadline(), first_deadline);
         assert!(preference.targets(&uuid::Uuid::from_u128(10).to_string(), 7));
         assert_eq!(
@@ -726,68 +585,6 @@ mod tests {
                 state: super::super::RunnerPreferenceClaimState::Active,
                 targeted_self: Some(true),
             })
-        );
-    }
-
-    #[tokio::test]
-    async fn first_atomic_duplicate_replaces_legacy_routing_snapshot_as_a_unit() {
-        let inbox = direct_candidate_inbox(1);
-        let candidate_run_id = run_id(8);
-        inbox
-            .push(
-                DirectJobCandidate::new_with_routing_metadata(
-                    candidate_run_id,
-                    "vm0/default".to_string(),
-                    StdInstant::now(),
-                    Some("session:legacy".to_string()),
-                    Some(runner_preference(
-                        10,
-                        super::super::RunnerPreferenceReason::MatchingReuseKey,
-                        StdInstant::now() + Duration::from_secs(5),
-                    )),
-                )
-                .with_runner_preference_resolution(Some(
-                    RunnerPreferenceResolution::MatchingReusableSandbox,
-                ))
-                .with_history_generation_run_id(Some(run_id(9))),
-            )
-            .await;
-
-        let atomic_history_generation = run_id(10);
-        inbox
-            .push(
-                DirectJobCandidate::new_with_routing_metadata(
-                    candidate_run_id,
-                    "vm0/default".to_string(),
-                    StdInstant::now(),
-                    Some("session:atomic".to_string()),
-                    Some(ranked_preference_context(
-                        20,
-                        super::super::RunnerPreferenceTier::ExactSandbox,
-                        StdInstant::now() + Duration::from_secs(8),
-                    )),
-                )
-                .with_history_generation_run_id(Some(atomic_history_generation)),
-            )
-            .await;
-
-        let candidate = inbox
-            .try_pop()
-            .await
-            .expect("updated direct candidate")
-            .into_job_candidate();
-        assert_eq!(candidate.reuse_key(), Some("session:atomic"));
-        assert_eq!(
-            candidate.history_generation_run_id(),
-            Some(atomic_history_generation)
-        );
-        assert_eq!(
-            candidate
-                .runner_preference()
-                .map(RunnerPreference::admission),
-            Some(super::super::RunnerPreferenceAdmission::Ranked(
-                super::super::RunnerPreferenceTier::ExactSandbox
-            ))
         );
     }
 

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -38,14 +38,6 @@ const JAVASCRIPT_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub(crate) enum RunnerPreferenceReason {
-    ExactHistoryGeneration,
-    MatchingReuseKey,
-    FinalizingPredecessor,
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub(crate) enum RunnerPreferenceTier {
     ExactSandbox,
     FinalizingPredecessor,
@@ -151,14 +143,6 @@ impl RunnerProcessIdentity {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct RunnerPreferencePayload {
-    runner_identity: RunnerProcessIdentity,
-    reason: RunnerPreferenceReason,
-    expires_at: DateTime<FixedOffset>,
-}
-
-#[derive(Debug, Deserialize)]
 #[serde(tag = "kind", deny_unknown_fields)]
 enum RunnerPreferenceDecisionPayload {
     #[serde(rename = "preference")]
@@ -173,22 +157,16 @@ enum RunnerPreferenceDecisionPayload {
     NoPreference { reason: RunnerNoPreferenceReason },
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RunnerPreferenceAdmission {
-    Ranked(RunnerPreferenceTier),
-    Legacy(RunnerPreferenceReason),
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RunnerPreference {
     runner_identity: RunnerProcessIdentity,
-    admission: RunnerPreferenceAdmission,
+    tier: RunnerPreferenceTier,
     deadline: Instant,
 }
 
 impl RunnerPreference {
-    pub(crate) fn admission(&self) -> RunnerPreferenceAdmission {
-        self.admission
+    pub(crate) fn tier(&self) -> RunnerPreferenceTier {
+        self.tier
     }
 
     pub(crate) fn deadline(&self) -> Instant {
@@ -209,23 +187,6 @@ impl RunnerPreference {
     }
 
     #[cfg(test)]
-    pub(crate) fn for_test(
-        runner_id: Uuid,
-        heartbeat_generation: u64,
-        reason: RunnerPreferenceReason,
-        deadline: Instant,
-    ) -> Self {
-        Self {
-            runner_identity: RunnerProcessIdentity {
-                runner_id,
-                heartbeat_generation,
-            },
-            admission: RunnerPreferenceAdmission::Legacy(reason),
-            deadline,
-        }
-    }
-
-    #[cfg(test)]
     pub(crate) fn ranked_for_test(
         runner_id: Uuid,
         heartbeat_generation: u64,
@@ -237,33 +198,10 @@ impl RunnerPreference {
                 runner_id,
                 heartbeat_generation,
             },
-            admission: RunnerPreferenceAdmission::Ranked(tier),
+            tier,
             deadline,
         }
     }
-}
-
-pub(crate) fn parse_runner_preference_resolution(
-    value: Option<serde_json::Value>,
-) -> Result<Option<RunnerPreferenceResolution>, serde_json::Error> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    serde_json::from_value(value).map(Some)
-}
-
-pub(crate) fn parse_runner_preference(
-    value: Option<serde_json::Value>,
-) -> Result<Option<RunnerPreference>, serde_json::Error> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    let payload: RunnerPreferencePayload = serde_json::from_value(value)?;
-    Ok(Some(RunnerPreference {
-        runner_identity: payload.runner_identity,
-        admission: RunnerPreferenceAdmission::Legacy(payload.reason),
-        deadline: preference_deadline(payload.expires_at)?,
-    }))
 }
 
 pub(crate) fn parse_runner_preference_decision(
@@ -278,58 +216,16 @@ pub(crate) fn parse_runner_preference_decision(
             runner_identity,
             tier,
             expires_at,
-        } => RunnerPreferenceContext::atomic_positive(
+        } => RunnerPreferenceContext::positive(
             runner_identity,
             tier,
             preference_deadline(expires_at)?,
         ),
         RunnerPreferenceDecisionPayload::NoPreference { reason } => {
-            RunnerPreferenceContext::atomic_negative(reason.resolution())
+            RunnerPreferenceContext::negative(reason.resolution())
         }
     };
     Ok(Some(context))
-}
-
-pub(crate) struct ParsedRunnerPreferenceContext {
-    pub(crate) context: Option<RunnerPreferenceContext>,
-    pub(crate) decision_error: Option<serde_json::Error>,
-    pub(crate) legacy_preference_error: Option<serde_json::Error>,
-    pub(crate) legacy_resolution_error: Option<serde_json::Error>,
-}
-
-pub(crate) fn parse_runner_preference_context(
-    decision: Option<serde_json::Value>,
-    legacy_preference: Option<serde_json::Value>,
-    legacy_resolution: Option<serde_json::Value>,
-) -> ParsedRunnerPreferenceContext {
-    let decision_error = match parse_runner_preference_decision(decision) {
-        Ok(Some(context)) => {
-            return ParsedRunnerPreferenceContext {
-                context: Some(context),
-                decision_error: None,
-                legacy_preference_error: None,
-                legacy_resolution_error: None,
-            };
-        }
-        Ok(None) => None,
-        Err(error) => Some(error),
-    };
-
-    let (preference, legacy_preference_error) = match parse_runner_preference(legacy_preference) {
-        Ok(preference) => (preference, None),
-        Err(error) => (None, Some(error)),
-    };
-    let (resolution, legacy_resolution_error) =
-        match parse_runner_preference_resolution(legacy_resolution) {
-            Ok(resolution) => (resolution, None),
-            Err(error) => (None, Some(error)),
-        };
-    ParsedRunnerPreferenceContext {
-        context: RunnerPreferenceContext::legacy(preference, resolution),
-        decision_error,
-        legacy_preference_error,
-        legacy_resolution_error,
-    }
 }
 
 fn preference_deadline(expires_at: DateTime<FixedOffset>) -> Result<Instant, serde_json::Error> {
@@ -370,7 +266,6 @@ pub(crate) enum JobDiscoverySource {
 pub(crate) struct RunnerPreferenceObservation {
     resolution: RunnerPreferenceResolution,
     runner_identity: Option<RunnerProcessIdentity>,
-    removal_reason: Option<RunnerPreferenceRemovalReason>,
 }
 
 impl RunnerPreferenceObservation {
@@ -381,111 +276,59 @@ impl RunnerPreferenceObservation {
         Self {
             resolution,
             runner_identity,
-            removal_reason: None,
         }
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum RunnerPreferenceContext {
-    Atomic {
-        preference: Option<RunnerPreference>,
-        observation: RunnerPreferenceObservation,
-    },
-    Legacy {
-        preference: Option<RunnerPreference>,
-        observation: Option<RunnerPreferenceObservation>,
-    },
+pub(crate) struct RunnerPreferenceContext {
+    preference: Option<RunnerPreference>,
+    observation: RunnerPreferenceObservation,
+    removal_reason: Option<RunnerPreferenceRemovalReason>,
 }
 
 impl RunnerPreferenceContext {
-    fn atomic_positive(
+    fn positive(
         runner_identity: RunnerProcessIdentity,
         tier: RunnerPreferenceTier,
         deadline: Instant,
     ) -> Self {
-        Self::Atomic {
+        Self {
             preference: Some(RunnerPreference {
                 runner_identity,
-                admission: RunnerPreferenceAdmission::Ranked(tier),
+                tier,
                 deadline,
             }),
             observation: RunnerPreferenceObservation::new(tier.resolution(), Some(runner_identity)),
+            removal_reason: None,
         }
     }
 
-    fn atomic_negative(resolution: RunnerPreferenceResolution) -> Self {
-        Self::Atomic {
+    fn negative(resolution: RunnerPreferenceResolution) -> Self {
+        Self {
             preference: None,
             observation: RunnerPreferenceObservation::new(resolution, None),
+            removal_reason: None,
         }
-    }
-
-    pub(crate) fn legacy(
-        preference: Option<RunnerPreference>,
-        resolution: Option<RunnerPreferenceResolution>,
-    ) -> Option<Self> {
-        if preference.is_none() && resolution.is_none() {
-            return None;
-        }
-        let runner_identity = preference
-            .as_ref()
-            .map(|preference| preference.runner_identity);
-        Some(Self::Legacy {
-            preference,
-            observation: resolution
-                .map(|resolution| RunnerPreferenceObservation::new(resolution, runner_identity)),
-        })
     }
 
     pub(crate) fn preference(&self) -> Option<&RunnerPreference> {
-        match self {
-            Self::Atomic { preference, .. } | Self::Legacy { preference, .. } => {
-                preference.as_ref()
-            }
-        }
-    }
-
-    fn preference_mut(&mut self) -> &mut Option<RunnerPreference> {
-        match self {
-            Self::Atomic { preference, .. } | Self::Legacy { preference, .. } => preference,
-        }
-    }
-
-    fn observation(&self) -> Option<RunnerPreferenceObservation> {
-        match self {
-            Self::Atomic { observation, .. } => Some(*observation),
-            Self::Legacy { observation, .. } => *observation,
-        }
-    }
-
-    fn observation_mut(&mut self) -> Option<&mut RunnerPreferenceObservation> {
-        match self {
-            Self::Atomic { observation, .. } => Some(observation),
-            Self::Legacy { observation, .. } => observation.as_mut(),
-        }
-    }
-
-    pub(crate) fn is_atomic(&self) -> bool {
-        matches!(self, Self::Atomic { .. })
+        self.preference.as_ref()
     }
 
     fn remove_preference(&mut self, removal_reason: RunnerPreferenceRemovalReason) {
-        *self.preference_mut() = None;
-        if let Some(observation) = self.observation_mut() {
-            observation.removal_reason = Some(removal_reason);
-        }
+        self.preference = None;
+        self.removal_reason = Some(removal_reason);
     }
 
     #[cfg(test)]
-    pub(crate) fn atomic_for_test(preference: RunnerPreference) -> Self {
-        let RunnerPreferenceAdmission::Ranked(tier) = preference.admission else {
-            panic!("atomic test preference must be ranked");
-        };
+    pub(crate) fn for_test(preference: RunnerPreference) -> Self {
         let runner_identity = preference.runner_identity;
-        Self::Atomic {
+        let tier = preference.tier;
+        Self {
             preference: Some(preference),
             observation: RunnerPreferenceObservation::new(tier.resolution(), Some(runner_identity)),
+            removal_reason: None,
         }
     }
 }
@@ -672,17 +515,6 @@ impl JobCandidate {
         self
     }
 
-    #[cfg(test)]
-    pub(crate) fn with_runner_preference_context(
-        mut self,
-        runner_preference: Option<RunnerPreference>,
-        resolution: Option<RunnerPreferenceResolution>,
-    ) -> Self {
-        self.runner_preference_context =
-            RunnerPreferenceContext::legacy(runner_preference, resolution);
-        self
-    }
-
     pub(crate) fn with_parsed_runner_preference_context(
         mut self,
         context: Option<RunnerPreferenceContext>,
@@ -692,17 +524,18 @@ impl JobCandidate {
     }
 
     #[cfg(test)]
-    pub(crate) fn with_atomic_runner_preference(mut self, preference: RunnerPreference) -> Self {
-        self.runner_preference_context = Some(RunnerPreferenceContext::atomic_for_test(preference));
+    pub(crate) fn with_runner_preference_for_test(mut self, preference: RunnerPreference) -> Self {
+        self.runner_preference_context = Some(RunnerPreferenceContext::for_test(preference));
         self
     }
 
     #[cfg(test)]
-    pub(crate) fn with_runner_preference(
-        self,
-        runner_preference: Option<RunnerPreference>,
+    pub(crate) fn with_no_runner_preference_for_test(
+        mut self,
+        resolution: RunnerPreferenceResolution,
     ) -> Self {
-        self.with_runner_preference_context(runner_preference, None)
+        self.runner_preference_context = Some(RunnerPreferenceContext::negative(resolution));
+        self
     }
 
     pub(crate) fn runner_preference_claim_telemetry(
@@ -711,11 +544,11 @@ impl JobCandidate {
         heartbeat_generation: u64,
     ) -> Option<RunnerPreferenceClaimTelemetry> {
         let context = self.runner_preference_context.as_ref()?;
-        let observation = context.observation()?;
+        let observation = context.observation;
         let state = match context.preference() {
             Some(preference) if preference.is_expired() => RunnerPreferenceClaimState::Expired,
             Some(_) => RunnerPreferenceClaimState::Active,
-            None => match observation.removal_reason {
+            None => match context.removal_reason {
                 Some(RunnerPreferenceRemovalReason::Expired) => RunnerPreferenceClaimState::Expired,
                 Some(RunnerPreferenceRemovalReason::Cleared) => RunnerPreferenceClaimState::Cleared,
                 None if observation.resolution.predicts_preference() => {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -40,10 +40,6 @@ pub struct Job {
     pub history_generation_run_id: Option<RunId>,
     #[serde(default)]
     pub runner_preference_decision: Option<serde_json::Value>,
-    #[serde(default)]
-    pub runner_preference: Option<serde_json::Value>,
-    #[serde(default)]
-    pub runner_preference_resolution: Option<serde_json::Value>,
 }
 
 pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
@@ -1667,13 +1663,14 @@ mod tests {
             "job": {
                 "runId": "550e8400-e29b-41d4-a716-446655440000",
                 "experimentalProfile": "browser",
-                "cliAgentSessionId": "legacy-session",
-                "runnerPreference": {
+                "cliAgentSessionId": "session-id",
+                "runnerPreferenceDecision": {
+                    "kind": "preference",
                     "runnerIdentity": {
                         "runnerId": "b85bb257-21c1-4b8f-8676-a4051f35b7b0",
                         "heartbeatGeneration": 7
                     },
-                    "reason": "matchingReuseKey",
+                    "tier": "reusableSandbox",
                     "expiresAt": "2026-08-03T12:00:00.000Z"
                 }
             }
@@ -1687,7 +1684,7 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(job.experimental_profile, "browser");
-        assert!(job.runner_preference.is_some());
+        assert!(job.runner_preference_decision.is_some());
         assert!(job.reuse_key().is_none());
     }
 

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -6,9 +6,7 @@ import type {
 } from "@vm0/api-contracts/contracts/realtime";
 import type {
   PiExecutionMode,
-  RunnerPreference,
   RunnerPreferenceDecision,
-  RunnerPreferenceResolution,
 } from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
@@ -435,14 +433,12 @@ export async function publishRunnerJobNotification(args: {
   readonly runId: string;
   readonly profile: string;
   readonly piExecutionMode?: PiExecutionMode;
+  readonly runnerPreferenceDecision: RunnerPreferenceDecision;
   readonly metadata?: {
     /** Raw key required for runner-local reuse matching; it stays on the internal runner-group channel. */
     readonly reuseKey: string | null;
     readonly cliAgentSessionId: string | null;
     readonly historyGenerationRunId: string | undefined;
-    readonly runnerPreferenceDecision: RunnerPreferenceDecision;
-    readonly runnerPreference?: RunnerPreference;
-    readonly runnerPreferenceResolution: RunnerPreferenceResolution;
   };
 }): Promise<boolean> {
   const published = await tapError(
@@ -463,16 +459,7 @@ export async function publishRunnerJobNotification(args: {
         ...(args.metadata?.historyGenerationRunId
           ? { historyGenerationRunId: args.metadata.historyGenerationRunId }
           : {}),
-        ...(args.metadata?.runnerPreference
-          ? { runnerPreference: args.metadata.runnerPreference }
-          : {}),
-        ...(args.metadata
-          ? {
-              runnerPreferenceDecision: args.metadata.runnerPreferenceDecision,
-              runnerPreferenceResolution:
-                args.metadata.runnerPreferenceResolution,
-            }
-          : {}),
+        runnerPreferenceDecision: args.runnerPreferenceDecision,
       });
       L.debug(
         `Published job ${args.runId} to runner-group:${args.group} (broadcast)`,

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -2114,18 +2114,6 @@ describe("PiLoop edge turn", () => {
     expect((await api.readRun(fixture.actor, run.runId)).status).toBe(
       "pending",
     );
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "job",
-      expect.objectContaining({
-        runId: run.runId,
-        profile: DEFAULT_PROFILE,
-        runnerPreferenceDecision: {
-          kind: "noPreference",
-          reason: "noReuseKey",
-        },
-      }),
-    );
-
     const coldPoll = await api.requestPollRunner(
       true,
       {
@@ -2147,11 +2135,14 @@ describe("PiLoop edge turn", () => {
         .slice(publishedBeforeRelease)
         .some(([topic, payload]) => {
           const job = recordOf(payload);
+          const decision = recordOf(job?.runnerPreferenceDecision);
           return (
             topic === "job" &&
             job?.runId === run.runId &&
             job.profile === fixture.runnerProfile &&
-            job.piExecutionMode === "cold-start"
+            job.piExecutionMode === "cold-start" &&
+            decision?.kind === "noPreference" &&
+            decision.reason === "noReuseKey"
           );
         }),
     ).toBeTruthy();

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -2114,6 +2114,17 @@ describe("PiLoop edge turn", () => {
     expect((await api.readRun(fixture.actor, run.runId)).status).toBe(
       "pending",
     );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: run.runId,
+        profile: DEFAULT_PROFILE,
+        runnerPreferenceDecision: {
+          kind: "noPreference",
+          reason: "noReuseKey",
+        },
+      }),
+    );
 
     const coldPoll = await api.requestPollRunner(
       true,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -131,15 +131,7 @@ const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const ASSISTANT_EVENT_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
-function runnerPreference(
-  job: RunnerJob | null | undefined,
-): RunnerJob["runnerPreference"] {
-  return job?.runnerPreference;
-}
-
-function runnerPreferenceDecision(
-  job: RunnerJob | null | undefined,
-): RunnerJob["runnerPreferenceDecision"] {
+function runnerPreferenceDecision(job: RunnerJob | null | undefined) {
   return job?.runnerPreferenceDecision;
 }
 
@@ -3650,7 +3642,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       kind: "noPreference",
       reason: "noReuseKey",
     });
-    expect(runnerPreference(poll.body.job)).toBeUndefined();
 
     const resumedClaim = await api.claimRunnerJob(resumed.runId);
     expect(resumedClaim.reuseKey).toBeNull();
@@ -3778,10 +3769,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       kind: "noPreference",
       reason: "noViableHolder",
     });
-    expect(runnerPreference(canonicalHeartbeatHolder.job)).toBeUndefined();
-    expect(canonicalHeartbeatHolder.job?.runnerPreferenceResolution).toBe(
-      "no_viable_holder",
-    );
 
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: reuseRunnerId,
@@ -3813,17 +3800,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       tier: "workspaceCache",
       expiresAt: expect.any(String),
     });
-    expect(runnerPreference(workspaceOnlyHolder.job)).toStrictEqual({
-      runnerIdentity: {
-        runnerId: reuseRunnerId,
-        heartbeatGeneration: 1,
-      },
-      reason: "matchingReuseKey",
-      expiresAt: expect.any(String),
-    });
-    expect(workspaceOnlyHolder.job?.runnerPreferenceResolution).toBe(
-      "matching_workspace_cache",
-    );
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
       workspaceCaches: [
@@ -3833,12 +3809,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const capableWorkspaceHolder = await pollFollowUp(
       "continue with a capable workspace holder",
     );
-    expect(runnerPreference(capableWorkspaceHolder.job)).toMatchObject({
-      reason: "matchingReuseKey",
+    expect(runnerPreferenceDecision(capableWorkspaceHolder.job)).toMatchObject({
+      kind: "preference",
+      tier: "workspaceCache",
     });
-    expect(capableWorkspaceHolder.job?.runnerPreferenceResolution).toBe(
-      "matching_workspace_cache",
-    );
 
     const reusableRunnerId = randomUUID();
     await api.requestHeartbeatRunner(true, [200], {
@@ -3873,29 +3847,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     if (reusableDecision?.kind !== "preference") {
       throw new Error("Expected a reusable sandbox preference decision");
     }
-    const reusablePreference = {
-      runnerIdentity: reusableDecision.runnerIdentity,
-      reason: "matchingReuseKey" as const,
-      expiresAt: reusableDecision.expiresAt,
-    };
-    expect(runnerPreference(reusableOverWorkspace.job)).toStrictEqual(
-      reusablePreference,
-    );
-    expect(reusableOverWorkspace.job?.runnerPreferenceResolution).toBe(
-      "matching_reusable_sandbox",
-    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: reusableOverWorkspace.run.runId,
         runnerPreferenceDecision: {
           kind: "preference",
-          runnerIdentity: reusablePreference.runnerIdentity,
+          runnerIdentity: reusableDecision.runnerIdentity,
           tier: "reusableSandbox",
-          expiresAt: reusablePreference.expiresAt,
+          expiresAt: reusableDecision.expiresAt,
         },
-        runnerPreference: reusablePreference,
-        runnerPreferenceResolution: "matching_reusable_sandbox",
       }),
     );
     await api.requestHeartbeatRunner(true, [200], {
@@ -3920,10 +3881,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       kind: "noPreference",
       reason: "noViableHolder",
     });
-    expect(runnerPreference(mismatchedCapableWorkspace.job)).toBeUndefined();
-    expect(mismatchedCapableWorkspace.job?.runnerPreferenceResolution).toBe(
-      "no_viable_holder",
-    );
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3946,17 +3903,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       tier: "reusableSandbox",
       expiresAt: expect.any(String),
     });
-    expect(runnerPreference(differentGenerationHolder.job)).toStrictEqual({
-      runnerIdentity: {
-        runnerId: reuseRunnerId,
-        heartbeatGeneration: 1,
-      },
-      reason: "matchingReuseKey",
-      expiresAt: expect.any(String),
-    });
-    expect(differentGenerationHolder.job?.runnerPreferenceResolution).toBe(
-      "matching_reusable_sandbox",
-    );
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -3977,17 +3923,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       tier: "exactSandbox",
       expiresAt: expect.any(String),
     });
-    expect(runnerPreference(exactGenerationHolder.job)).toStrictEqual({
-      runnerIdentity: {
-        runnerId: reuseRunnerId,
-        heartbeatGeneration: 1,
-      },
-      reason: "exactHistoryGeneration",
-      expiresAt: expect.any(String),
-    });
-    expect(exactGenerationHolder.job?.runnerPreferenceResolution).toBe(
-      "exact_history_generation",
-    );
 
     for (const { runId, resolution, tier } of [
       {
@@ -4063,16 +3998,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       threadId: first.threadId,
       prompt: "continue while the exact source is finalizing",
     });
-    const finalizingPreference = {
-      runnerIdentity: sourceRunnerIdentity,
-      reason: "finalizingPredecessor" as const,
-      expiresAt: new Date(sourceCompletedAt + 1500).toISOString(),
-    };
     const finalizingDecision = {
       kind: "preference" as const,
       runnerIdentity: sourceRunnerIdentity,
       tier: "finalizingPredecessor" as const,
-      expiresAt: finalizingPreference.expiresAt,
+      expiresAt: new Date(sourceCompletedAt + 1500).toISOString(),
     };
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
@@ -4081,8 +4011,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         reuseKey,
         historyGenerationRunId: first.runId,
         runnerPreferenceDecision: finalizingDecision,
-        runnerPreference: finalizingPreference,
-        runnerPreferenceResolution: "finalizing_predecessor",
       }),
     );
 
@@ -4101,12 +4029,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(sourcePoll.body.job?.runId).toBe(successor.runId);
     expect(runnerPreferenceDecision(sourcePoll.body.job)).toStrictEqual(
       finalizingDecision,
-    );
-    expect(runnerPreference(sourcePoll.body.job)).toStrictEqual(
-      finalizingPreference,
-    );
-    expect(sourcePoll.body.job?.runnerPreferenceResolution).toBe(
-      "finalizing_predecessor",
     );
     for (const actionType of [
       "runner_notification_affinity_lookup",
@@ -4138,17 +4060,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected generic fallback poll to succeed");
     }
     expect(genericPoll.body.job?.runId).toBe(successor.runId);
-    expect(runnerPreference(genericPoll.body.job)).toStrictEqual({
+    expect(runnerPreferenceDecision(genericPoll.body.job)).toStrictEqual({
+      kind: "preference",
       runnerIdentity: {
         runnerId: genericRunnerId,
         heartbeatGeneration: 3,
       },
-      reason: "matchingReuseKey",
+      tier: "reusableSandbox",
       expiresAt: new Date(successorCreatedAt + 2000).toISOString(),
     });
-    expect(genericPoll.body.job?.runnerPreferenceResolution).toBe(
-      "matching_reusable_sandbox",
-    );
 
     const claimed = await api.requestClaimRunnerJob(
       true,
@@ -4244,23 +4164,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       threadId: first.threadId,
       prompt: "continue with exact history already advertised",
     });
-    const exactPreference = {
-      runnerIdentity: exactRunnerIdentity,
-      reason: "exactHistoryGeneration" as const,
-      expiresAt: new Date(successorCreatedAt + 1000).toISOString(),
-    };
     const exactDecision = {
       kind: "preference" as const,
       runnerIdentity: exactRunnerIdentity,
       tier: "exactSandbox" as const,
-      expiresAt: exactPreference.expiresAt,
+      expiresAt: new Date(successorCreatedAt + 1000).toISOString(),
     };
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: successor.runId,
         runnerPreferenceDecision: exactDecision,
-        runnerPreference: exactPreference,
       }),
     );
     const poll = await api.requestPollRunner(
@@ -4279,7 +4193,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(runnerPreferenceDecision(poll.body.job)).toStrictEqual(
       exactDecision,
     );
-    expect(runnerPreference(poll.body.job)).toStrictEqual(exactPreference);
 
     await api.requestCancelRun(actor, successor.runId, [200]);
     await flushWaitUntilForTest();
@@ -4324,7 +4237,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected restarted-source poll to succeed");
     }
     expect(poll.body.job?.runId).toBe(successor.runId);
-    expect(runnerPreference(poll.body.job)).toBeUndefined();
+    expect(runnerPreferenceDecision(poll.body.job)).toStrictEqual({
+      kind: "noPreference",
+      reason: "noViableHolder",
+    });
 
     await api.requestCancelRun(actor, successor.runId, [200]);
     await flushWaitUntilForTest();
@@ -4350,7 +4266,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue while holder is starting",
     );
     expect(startingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreference(startingHolder.job)).toBeUndefined();
+    expect(runnerPreferenceDecision(startingHolder.job)).toMatchObject({
+      kind: "noPreference",
+    });
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -4360,7 +4278,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       false,
     );
     expect(unavailableHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreference(unavailableHolder.job)).toBeUndefined();
+    expect(runnerPreferenceDecision(unavailableHolder.job)).toMatchObject({
+      kind: "noPreference",
+    });
     const unavailableClaim = await api.claimRunnerJob(
       unavailableHolder.run.runId,
     );
@@ -4393,7 +4313,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue after holder heartbeat is stale",
     );
     expect(staleHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreference(staleHolder.job)).toBeUndefined();
+    expect(runnerPreferenceDecision(staleHolder.job)).toMatchObject({
+      kind: "noPreference",
+    });
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -4408,7 +4330,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(profileIncompatibleHolder.job?.cliAgentSessionId).toBe(
       cliAgentSessionId,
     );
-    expect(runnerPreference(profileIncompatibleHolder.job)).toBeUndefined();
+    expect(
+      runnerPreferenceDecision(profileIncompatibleHolder.job),
+    ).toMatchObject({
+      kind: "noPreference",
+    });
 
     await heartbeatHolder({
       admittableProfiles: [],
@@ -4422,7 +4348,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue while holder is draining",
     );
     expect(drainingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreference(drainingHolder.job)).toBeUndefined();
+    expect(runnerPreferenceDecision(drainingHolder.job)).toMatchObject({
+      kind: "noPreference",
+    });
   });
 
   it("preserves same-thread reuse-preference timing across queued admission", async () => {
@@ -4512,9 +4440,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await releaseOrgAdmissionLock(context);
     await admissionLockRequest;
     const protectedFollowUp = await protectedFollowUpRequest;
-    const exactRunnerPreference = {
+    const exactRunnerPreferenceDecision = {
+      kind: "preference" as const,
       runnerIdentity: preferredExactRunner,
-      reason: "exactHistoryGeneration" as const,
+      tier: "exactSandbox" as const,
       expiresAt: new Date(queueInsertedAt + 1000).toISOString(),
     };
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
@@ -4523,7 +4452,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runId: protectedFollowUp.runId,
         reuseKey,
         historyGenerationRunId: first.runId,
-        runnerPreference: exactRunnerPreference,
+        runnerPreferenceDecision: exactRunnerPreferenceDecision,
       }),
     );
 
@@ -4538,8 +4467,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
     expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(protectedPoll.body.job?.reuseKey).toBe(reuseKey);
-    expect(runnerPreference(protectedPoll.body.job)).toStrictEqual(
-      exactRunnerPreference,
+    expect(runnerPreferenceDecision(protectedPoll.body.job)).toStrictEqual(
+      exactRunnerPreferenceDecision,
     );
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
@@ -4635,9 +4564,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(generationExpiredPoll.body.job?.runId).toBe(
       generationExpiredRun.runId,
     );
-    expect(runnerPreference(generationExpiredPoll.body.job)).toStrictEqual({
+    expect(
+      runnerPreferenceDecision(generationExpiredPoll.body.job),
+    ).toStrictEqual({
+      kind: "preference",
       runnerIdentity: preferredExactRunner,
-      reason: "matchingReuseKey",
+      tier: "reusableSandbox",
       expiresAt: new Date(generationExpiredAt + 2000).toISOString(),
     });
     await api.requestCancelRun(actor, generationExpiredRun.runId, [200]);
@@ -4662,8 +4594,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       kind: "noPreference",
       reason: "expired",
     });
-    expect(runnerPreference(expiredPoll.body.job)).toBeUndefined();
-    expect(expiredPoll.body.job?.runnerPreferenceResolution).toBe("expired");
     const expiredClaim = await api.requestClaimRunnerJob(
       true,
       expiredFollowUp.runId,
@@ -4772,16 +4702,22 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }
       expect(poll.body.job?.runId).toBe(followUp.runId);
       if (expectedResource) {
-        expect(runnerPreference(poll.body.job)).toMatchObject({
+        expect(runnerPreferenceDecision(poll.body.job)).toMatchObject({
+          kind: "preference",
           runnerIdentity: {
             runnerId,
             heartbeatGeneration: 1,
           },
-          reason: "matchingReuseKey",
+          tier:
+            expectedResource === "reusableSandbox"
+              ? "reusableSandbox"
+              : "workspaceCache",
           expiresAt: expect.any(String),
         });
       } else {
-        expect(runnerPreference(poll.body.job)).toBeUndefined();
+        expect(runnerPreferenceDecision(poll.body.job)).toMatchObject({
+          kind: "noPreference",
+        });
       }
       await api.requestCancelRun(actor, followUp.runId, [200]);
       await flushWaitUntilForTest();
@@ -4902,12 +4838,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected reusable-holder poll to return 200");
     }
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
-    expect(runnerPreference(protectedPoll.body.job)).toMatchObject({
+    expect(runnerPreferenceDecision(protectedPoll.body.job)).toMatchObject({
+      kind: "preference",
       runnerIdentity: {
         runnerId: reuseRunnerId,
         heartbeatGeneration: 1,
       },
-      reason: "exactHistoryGeneration",
+      tier: "exactSandbox",
       expiresAt: expect.any(String),
     });
     await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
@@ -5084,12 +5021,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected workspace-priority poll to return 200");
     }
     expect(workspacePoll.body.job?.runId).toBe(newerWorkspace.runId);
-    expect(runnerPreference(workspacePoll.body.job)).toMatchObject({
+    expect(runnerPreferenceDecision(workspacePoll.body.job)).toMatchObject({
+      kind: "preference",
       runnerIdentity: {
         runnerId: workspaceRunnerId,
         heartbeatGeneration: 1,
       },
-      reason: "matchingReuseKey",
+      tier: "workspaceCache",
     });
 
     await api.requestCancelRun(actor, newerWorkspace.runId, [200]);
@@ -5335,7 +5273,6 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           kind: "noPreference",
           reason: "noReuseKey",
         },
-        runnerPreferenceResolution: "no_reuse_key",
       }),
     );
     const decryptCountBeforeClaim = await readFakeKmsDecryptCallCount(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1371,12 +1371,13 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       runId,
       cliAgentSessionId: null,
       reuseKey,
-      runnerPreference: {
+      runnerPreferenceDecision: {
+        kind: "preference",
         runnerIdentity: {
           runnerId,
           heartbeatGeneration: 1,
         },
-        reason: "matchingReuseKey",
+        tier: "reusableSandbox",
         expiresAt: expect.any(String),
       },
     });

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -121,7 +121,6 @@ import {
 } from "../services/session-history-blobs";
 import {
   runnerPreferenceDecisionTelemetryDimensions,
-  runnerPreferenceDeliveryFields,
   runnerReuseKeyTelemetryKind,
   runnerReusePreferenceLookupErrorDecision,
   runnerReusePreferencePollPriority,
@@ -756,9 +755,6 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     currentDate,
   });
   signal.throwIfAborted();
-  const runnerPreferenceFields = runnerPreferenceDeliveryFields(
-    runnerPreferenceDecision,
-  );
   recordPollTimingMetrics({
     runId: pendingJob.runId,
     runnerGroup: group,
@@ -789,7 +785,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         reuseKey: pendingJob.reuseKey,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
         ...(piExecutionMode ? { piExecutionMode } : {}),
-        ...runnerPreferenceFields,
+        runnerPreferenceDecision,
       },
     },
   };

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -324,6 +324,10 @@ async function tryReleasePiStandbyForColdStart(
       runId: input.body.runId,
       profile: requeued.profile,
       piExecutionMode: "cold-start",
+      runnerPreferenceDecision: {
+        kind: "noPreference",
+        reason: "noReuseKey",
+      },
     });
     signal.throwIfAborted();
   }
@@ -419,6 +423,10 @@ const activatePiColdStartForHandoff$ = command(
         runId: input.runId,
         profile: activation.profile,
         piExecutionMode: "cold-start",
+        runnerPreferenceDecision: {
+          kind: "noPreference",
+          reason: "noReuseKey",
+        },
       });
       signal.throwIfAborted();
     }

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -7,7 +7,6 @@ import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import {
   runnerPreferenceDecisionTelemetryDimensions,
-  runnerPreferenceDeliveryFields,
   runnerReuseKeyTelemetryKind,
   runnerReusePreferenceLookupErrorDecision,
   resolveRunnerReusePreference,
@@ -56,9 +55,6 @@ export async function notifyRunnerJob(
         );
       },
     )) ?? runnerReusePreferenceLookupErrorDecision();
-  const runnerPreferenceFields = runnerPreferenceDeliveryFields(
-    runnerPreferenceDecision,
-  );
   const preferenceFinishedAt = now();
   const publishStartedAt = now();
   const published = await publishRunnerJobNotification({
@@ -66,11 +62,11 @@ export async function notifyRunnerJob(
     runId: args.runId,
     profile: args.profile,
     piExecutionMode: args.piExecutionMode,
+    runnerPreferenceDecision,
     metadata: {
       reuseKey: args.reuseKey,
       cliAgentSessionId: args.cliAgentSessionId,
       historyGenerationRunId: args.historyGenerationRunId,
-      ...runnerPreferenceFields,
     },
   });
   const publishFinishedAt = now();

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -1,5 +1,4 @@
 import type {
-  RunnerPreference,
   RunnerPreferenceDecision,
   RunnerPreferenceResolution,
 } from "@vm0/api-contracts/contracts/runners";
@@ -280,39 +279,17 @@ type NoRunnerPreferenceDecision = Extract<
   { kind: "noPreference" }
 >;
 
-interface RunnerPreferenceDeliveryFields {
-  readonly runnerPreferenceDecision: RunnerPreferenceDecision;
-  readonly runnerPreference?: RunnerPreference;
-  readonly runnerPreferenceResolution: RunnerPreferenceResolution;
-}
-
-// Remove this legacy projection in #25577 after old runners have drained.
-const legacyPreferenceByTier = {
-  exactSandbox: {
-    reason: "exactHistoryGeneration",
-    resolution: "exact_history_generation",
-  },
-  finalizingPredecessor: {
-    reason: "finalizingPredecessor",
-    resolution: "finalizing_predecessor",
-  },
-  reusableSandbox: {
-    reason: "matchingReuseKey",
-    resolution: "matching_reusable_sandbox",
-  },
-  workspaceCache: {
-    reason: "matchingReuseKey",
-    resolution: "matching_workspace_cache",
-  },
+const preferenceResolutionByTier = {
+  exactSandbox: "exact_history_generation",
+  finalizingPredecessor: "finalizing_predecessor",
+  reusableSandbox: "matching_reusable_sandbox",
+  workspaceCache: "matching_workspace_cache",
 } as const satisfies Record<
   PositiveRunnerPreferenceDecision["tier"],
-  {
-    readonly reason: RunnerPreference["reason"];
-    readonly resolution: RunnerPreferenceResolution;
-  }
+  RunnerPreferenceResolution
 >;
 
-const legacyResolutionByNoPreferenceReason = {
+const noPreferenceResolutionByReason = {
   noReuseKey: "no_reuse_key",
   expired: "expired",
   noViableHolder: "no_viable_holder",
@@ -329,36 +306,20 @@ export function runnerReusePreferenceLookupErrorDecision(): RunnerPreferenceDeci
   };
 }
 
-export function runnerPreferenceDeliveryFields(
+function runnerPreferenceDecisionResolution(
   decision: RunnerPreferenceDecision,
-): RunnerPreferenceDeliveryFields {
+): RunnerPreferenceResolution {
   if (decision.kind === "noPreference") {
-    return {
-      runnerPreferenceDecision: decision,
-      runnerPreferenceResolution:
-        legacyResolutionByNoPreferenceReason[decision.reason],
-    };
+    return noPreferenceResolutionByReason[decision.reason];
   }
-
-  const legacy = legacyPreferenceByTier[decision.tier];
-  return {
-    runnerPreferenceDecision: decision,
-    runnerPreference: {
-      runnerIdentity: decision.runnerIdentity,
-      reason: legacy.reason,
-      expiresAt: decision.expiresAt,
-    },
-    runnerPreferenceResolution: legacy.resolution,
-  };
+  return preferenceResolutionByTier[decision.tier];
 }
 
 export function runnerPreferenceDecisionTelemetryDimensions(
   decision: RunnerPreferenceDecision,
 ): Record<string, string> {
-  const { runnerPreferenceResolution } =
-    runnerPreferenceDeliveryFields(decision);
   return {
-    runner_preference_resolution: runnerPreferenceResolution,
+    runner_preference_resolution: runnerPreferenceDecisionResolution(decision),
     runner_preference_decision_kind: decision.kind,
     ...(decision.kind === "preference"
       ? { runner_preference_tier: decision.tier }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -461,6 +461,10 @@ describe("runner poll response contract", () => {
     appendSystemPrompt: null,
     agentComposeVersionId: null,
     vars: null,
+    runnerPreferenceDecision: {
+      kind: "noPreference" as const,
+      reason: "noReuseKey" as const,
+    },
   };
 
   it.each(["vm0/default", "vm0/large"])(
@@ -717,6 +721,10 @@ describe("runner resume session contract", () => {
       vars: null,
       experimentalProfile: "vm0/default",
       historyGenerationRunId,
+      runnerPreferenceDecision: {
+        kind: "noPreference",
+        reason: "noReuseKey",
+      },
     });
     expect(job.historyGenerationRunId).toBe(historyGenerationRunId);
 
@@ -747,18 +755,26 @@ describe("runner resume session contract", () => {
     ]);
   });
 
-  it("keeps runner preference delivery fields optional", () => {
-    const job = jobSchema.parse({
+  it("requires one atomic runner preference decision", () => {
+    const jobInput = {
       runId: "22222222-2222-4222-8222-222222222222",
       prompt: "continue",
       appendSystemPrompt: null,
       agentComposeVersionId: null,
       vars: null,
       experimentalProfile: "vm0/default",
-    });
-    expect(job.runnerPreferenceDecision).toBeUndefined();
-    expect(job.runnerPreference).toBeUndefined();
-    expect(job.runnerPreferenceResolution).toBeUndefined();
+    };
+
+    expect(jobSchema.safeParse(jobInput).success).toBe(false);
+    expect(
+      jobSchema.parse({
+        ...jobInput,
+        runnerPreferenceDecision: {
+          kind: "noPreference",
+          reason: "noReuseKey",
+        },
+      }).runnerPreferenceDecision,
+    ).toStrictEqual({ kind: "noPreference", reason: "noReuseKey" });
   });
 
   it("accepts every strict positive runner preference decision tier", () => {
@@ -867,99 +883,6 @@ describe("runner resume session contract", () => {
           kind: "noPreference",
           reason: "noReuseKey",
           tier: "workspaceCache",
-        },
-      }).success,
-    ).toBe(false);
-  });
-
-  it("accepts every optional runner preference resolution beside the strict preference", () => {
-    const jobInput = {
-      runId: "33333333-3333-4333-8333-333333333333",
-      prompt: "continue",
-      appendSystemPrompt: null,
-      agentComposeVersionId: null,
-      vars: null,
-      experimentalProfile: "vm0/default",
-    };
-
-    for (const runnerPreferenceResolution of [
-      "exact_history_generation",
-      "finalizing_predecessor",
-      "matching_reusable_sandbox",
-      "matching_workspace_cache",
-      "no_reuse_key",
-      "expired",
-      "no_viable_holder",
-      "lookup_error",
-    ] as const) {
-      expect(
-        jobSchema.parse({ ...jobInput, runnerPreferenceResolution })
-          .runnerPreferenceResolution,
-      ).toBe(runnerPreferenceResolution);
-    }
-  });
-
-  it("accepts one strict optional runner preference", () => {
-    const runnerPreference = {
-      runnerIdentity: {
-        runnerId: "22222222-2222-4222-8222-222222222222",
-        heartbeatGeneration: 7,
-      },
-      expiresAt: "2026-08-03T00:00:01.000Z",
-    };
-    const jobInput = {
-      runId: "33333333-3333-4333-8333-333333333333",
-      prompt: "continue",
-      appendSystemPrompt: null,
-      agentComposeVersionId: null,
-      vars: null,
-      experimentalProfile: "vm0/default",
-    };
-
-    for (const reason of [
-      "exactHistoryGeneration",
-      "matchingReuseKey",
-      "finalizingPredecessor",
-    ] as const) {
-      const job = jobSchema.parse({
-        ...jobInput,
-        runnerPreference: { ...runnerPreference, reason },
-      });
-      expect(job.runnerPreference).toStrictEqual({
-        ...runnerPreference,
-        reason,
-      });
-    }
-    expect(
-      jobSchema.safeParse({
-        ...jobInput,
-        runnerPreference: {
-          ...runnerPreference,
-          reason: "matchingReuseKey",
-          expiresAt: undefined,
-        },
-      }).success,
-    ).toBe(false);
-    expect(
-      jobSchema.safeParse({
-        ...jobInput,
-        runnerPreference: {
-          ...runnerPreference,
-          reason: "matchingReuseKey",
-          resource: "reusableSandbox",
-        },
-      }).success,
-    ).toBe(false);
-    expect(
-      jobSchema.safeParse({
-        ...jobInput,
-        runnerPreference: {
-          ...runnerPreference,
-          reason: "matchingReuseKey",
-          runnerIdentity: {
-            ...runnerPreference.runnerIdentity,
-            resource: "reusableSandbox",
-          },
         },
       }).success,
     ).toBe(false);

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -144,6 +144,10 @@ describe("Pi execution mode contract", () => {
     agentComposeVersionId: null,
     vars: null,
     experimentalProfile: "vm0/large",
+    runnerPreferenceDecision: {
+      kind: "noPreference" as const,
+      reason: "noReuseKey" as const,
+    },
   };
 
   it.each(["standby", "cold-start"])(

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -102,22 +102,6 @@ const runnerProcessIdentitySchema = z
   .strict();
 
 /**
- * Legacy advisory preference retained while deployed runners migrate to the
- * atomic decision contract.
- */
-export const runnerPreferenceSchema = z
-  .object({
-    runnerIdentity: runnerProcessIdentitySchema,
-    reason: z.enum([
-      "exactHistoryGeneration",
-      "matchingReuseKey",
-      "finalizingPredecessor",
-    ]),
-    expiresAt: z.string().datetime({ offset: true }),
-  })
-  .strict();
-
-/**
  * Atomic advisory decision for cross-runner reuse coordination. A preferred
  * runner is not an exclusive assignee; another runner with a better compatible
  * local resource remains eligible to claim.
@@ -465,9 +449,7 @@ export const jobSchema = z.object({
   reuseKey: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
   piExecutionMode: piExecutionModeSchema.optional(),
-  runnerPreferenceDecision: runnerPreferenceDecisionSchema.optional(),
-  runnerPreference: runnerPreferenceSchema.optional(),
-  runnerPreferenceResolution: runnerPreferenceResolutionSchema.optional(),
+  runnerPreferenceDecision: runnerPreferenceDecisionSchema,
 });
 
 const heldWorkspaceCacheSchema = z.object({
@@ -1204,7 +1186,6 @@ export type Job = z.infer<typeof jobSchema>;
 export type RunnerPreferenceDecision = z.infer<
   typeof runnerPreferenceDecisionSchema
 >;
-export type RunnerPreference = z.infer<typeof runnerPreferenceSchema>;
 export type RunnerPreferenceResolution = z.infer<
   typeof runnerPreferenceResolutionSchema
 >;


### PR DESCRIPTION
## Summary

- make `runnerPreferenceDecision` the only API-to-runner preference contract for both polling and Ably delivery
- remove the legacy preference projection, parser, fallback admission path, fixtures, and dead exports
- derive claim telemetry from the accepted decision while preserving ordinary admission for missing or malformed advisory data
- keep the first accepted decision snapshot when duplicate discovery notifications arrive
- preserve the current Pi execution profile/mode contract while making every Pi job notification carry an explicit decision

## Scope

- this does not change preference ranking or claim timing
- this does not add a database migration or alter persisted runner state
- compatibility with drained runners that only understand the removed bridge fields is intentionally out of scope

## Validation

- `cargo fmt --all`
- `cargo check -p runner --tests`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`
- full runner suite before rebase (3,074 passed, 20 ignored) and focused affected runner tests after rebase
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- runner contract tests after rebase (75 passed)
- affected API route tests after rebase (188 passed)
- Pi edge-loop tests after rebase (15 passed)
- full API suite before rebase (2,760 passed)
- `pnpm knip`

Closes #25577

Parent: #25508
