### PR TITLE
fix(runner): consume explicit pi execution mode

### DIFF
--- a/crates/runner/src/cmd/start/factory_lifecycle.rs
+++ b/crates/runner/src/cmd/start/factory_lifecycle.rs
@@ -22,10 +22,6 @@ pub(super) type SharedFactory = Arc<Box<dyn SandboxFactory>>;
 
 /// Build one sandbox factory per configured profile.
 ///
-/// Profiles that alias another profile's factory (see
-/// [`crate::profile::canonical_factory_profile`]) are skipped here; job
-/// dispatch resolves them to the canonical factory instead.
-///
 /// On failure, already-created factories are stopped, but shared runtime
 /// resources remain owned by the caller so dependent services can stop before
 /// the runtime removes their network isolation.
@@ -38,9 +34,6 @@ pub(super) async fn start_factories(
 ) -> RunnerResult<BTreeMap<String, (SharedFactory, bool)>> {
     let mut factories: BTreeMap<String, (Box<dyn SandboxFactory>, bool)> = BTreeMap::new();
     for (profile_name, profile_config) in profiles {
-        if crate::profile::canonical_factory_profile(profile_name) != profile_name.as_str() {
-            continue;
-        }
         let factory_config = config::RunnerConfig::build_factory_config(
             firecracker,
             base_dir,
@@ -258,7 +251,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_factories_skips_alias_profiles() {
+    async fn start_factories_creates_each_configured_profile() {
         let temp = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(temp.path().join("home"));
         let base_dir = temp.path().join("base");
@@ -271,20 +264,20 @@ mod tests {
             crate::profile::DEFAULT_PROFILE.into(),
             profile("rootfs-1", "snapshot-1"),
         );
-        profiles.insert(
-            crate::profile::PI_STANDBY_PROFILE.into(),
-            profile("rootfs-1", "snapshot-1"),
-        );
+        profiles.insert("vm0/large".into(), profile("rootfs-2", "snapshot-2"));
         let mut runtime = RecordingRuntime::new(usize::MAX);
 
         let factories = start_factories(&profiles, &firecracker, &base_dir, &home, &mut runtime)
             .await
             .unwrap();
 
-        assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.create_calls.load(Ordering::SeqCst), 2);
         assert_eq!(
             factories.keys().cloned().collect::<Vec<_>>(),
-            vec![crate::profile::DEFAULT_PROFILE.to_string()]
+            vec![
+                crate::profile::DEFAULT_PROFILE.to_string(),
+                "vm0/large".to_string()
+            ]
         );
     }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -233,10 +233,7 @@ pub(super) async fn handle_discovered_job(
     let job_memory = profile_config.memory_mb;
     let job_workspace_disk_mb = profile_config.workspace_disk_mb;
     let device_rate_limits = ctx.spawn_ctx.device_rate_limits.clone();
-    // Look up factory for this profile. Alias profiles share the factory of
-    // the profile they are backed by.
-    let factory_profile = crate::profile::canonical_factory_profile(&profile_name);
-    let Some((factory, restore_guest_state)) = ctx.factories.get(factory_profile) else {
+    let Some((factory, restore_guest_state)) = ctx.factories.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
         return DiscoveredJobResult::completed(false);
     };

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -320,7 +320,6 @@ async fn run_start_with_home(
         .map_err(|e| RunnerError::Internal(format!("register signal handlers: {e}")))?;
 
     let mut runner_config = config::load_for_start(&args.config, args.api_url.as_deref()).await?;
-    config::install_internal_profile_aliases(&mut runner_config.profiles);
     let registry_config_path = tokio::fs::canonicalize(&args.config).await.map_err(|e| {
         RunnerError::Config(format!(
             "canonicalize config path {} for live runner registry: {e}",

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -130,21 +130,6 @@ pub struct ProfileConfig {
     pub workspace_disk_mb: u32,
 }
 
-/// Add runtime-only profile aliases backed by an already validated image.
-///
-/// Runner configuration files do not need to duplicate the default image
-/// hashes for Pi standby. Keeping the alias in the runtime map makes provider
-/// advertisement, factory creation, resource accounting, and job admission
-/// all observe the same profile set.
-pub(crate) fn install_internal_profile_aliases(profiles: &mut BTreeMap<String, ProfileConfig>) {
-    let Some(default_profile) = profiles.get(crate::profile::DEFAULT_PROFILE).cloned() else {
-        return;
-    };
-    profiles
-        .entry(crate::profile::PI_STANDBY_PROFILE.to_string())
-        .or_insert(default_profile);
-}
-
 /// Sandbox-level knobs for concurrency and the idle-VM pool.
 ///
 /// All fields accept defaults via `#[serde(default)]`, so the whole

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -158,34 +158,6 @@ fn default_profile_config() -> ProfileConfig {
     }
 }
 
-#[test]
-fn runtime_profiles_install_pi_standby_from_default_image() {
-    let mut profiles = make_profiles();
-    let default_profile = profiles[crate::profile::DEFAULT_PROFILE].clone();
-
-    install_internal_profile_aliases(&mut profiles);
-
-    assert_eq!(
-        profiles[crate::profile::PI_STANDBY_PROFILE],
-        default_profile
-    );
-}
-
-#[test]
-fn runtime_profiles_preserve_an_explicit_pi_standby_image() {
-    let mut profiles = make_profiles();
-    let explicit = ProfileConfig {
-        rootfs_hash: "explicit-rootfs".into(),
-        snapshot_hash: "explicit-snapshot".into(),
-        ..default_profile_config()
-    };
-    profiles.insert(crate::profile::PI_STANDBY_PROFILE.into(), explicit.clone());
-
-    install_internal_profile_aliases(&mut profiles);
-
-    assert_eq!(profiles[crate::profile::PI_STANDBY_PROFILE], explicit);
-}
-
 #[cfg(unix)]
 fn mode_of(path: &std::path::Path) -> u32 {
     use std::os::unix::fs::PermissionsExt;

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -13,7 +13,6 @@ pub struct ProfileDef {
 }
 
 pub const DEFAULT_PROFILE: &str = "vm0/default";
-pub const PI_STANDBY_PROFILE: &str = "vm0/pi-standby";
 
 /// Return the profile definition for a given profile name.
 pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
@@ -24,24 +23,12 @@ pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
         workspace_disk_mb: 16384,
     };
 
-    match name {
-        DEFAULT_PROFILE | PI_STANDBY_PROFILE => Ok(&DEFAULT),
-        _ => Err(RunnerError::Config(format!(
-            "unknown profile: {name}. available profiles: {DEFAULT_PROFILE}, {PI_STANDBY_PROFILE}"
-        ))),
-    }
-}
-
-/// Return the profile whose sandbox factory backs `name`.
-///
-/// Pi standby reuses the default image and resource shape, so it must not
-/// start a second factory: a factory owns a CoW pool that warms up from the
-/// same base image, and duplicating it would double runner startup work and
-/// idle-pool footprint for no behavioral gain.
-pub fn canonical_factory_profile(name: &str) -> &str {
-    match name {
-        PI_STANDBY_PROFILE => DEFAULT_PROFILE,
-        _ => name,
+    if name == DEFAULT_PROFILE {
+        Ok(&DEFAULT)
+    } else {
+        Err(RunnerError::Config(format!(
+            "unknown profile: {name}. available profiles: {DEFAULT_PROFILE}"
+        )))
     }
 }
 
@@ -94,17 +81,6 @@ mod tests {
         assert_eq!(def.memory_mb, 4096);
         assert_eq!(def.rootfs_disk_mb, 8192);
         assert_eq!(def.workspace_disk_mb, 16384);
-    }
-
-    #[test]
-    fn pi_standby_uses_default_resource_shape() {
-        let standby = get(PI_STANDBY_PROFILE).unwrap();
-        let default = get(DEFAULT_PROFILE).unwrap();
-
-        assert_eq!(standby.vcpu, default.vcpu);
-        assert_eq!(standby.memory_mb, default.memory_mb);
-        assert_eq!(standby.rootfs_disk_mb, default.rootfs_disk_mb);
-        assert_eq!(standby.workspace_disk_mb, default.workspace_disk_mb);
     }
 
     #[test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -43,7 +43,8 @@ use crate::pi_standby::PiStandbyNotifications;
 use crate::run_cancellation::RunCancellationRegistry;
 use crate::types::{
     CompleteRequest, ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeTarget, ExecutionContext,
-    HeartbeatState, Job, NetworkPolicyRefreshBatchResponse, PollResponse, SandboxReuseResult,
+    HeartbeatState, Job, NetworkPolicyRefreshBatchResponse, PiExecutionMode, PollResponse,
+    SandboxReuseResult,
 };
 use sandbox::SandboxId;
 
@@ -593,6 +594,7 @@ impl JobProvider for ApiProvider {
                     let run_id = job.run_id;
                     let reuse_key = job.reuse_key().map(str::to_owned);
                     let history_generation_run_id = job.history_generation_run_id;
+                    let pi_execution_mode = job.pi_execution_mode;
                     let runner_preference_context = match parse_runner_preference_decision(
                         job.runner_preference_decision,
                     ) {
@@ -611,6 +613,7 @@ impl JobProvider for ApiProvider {
                     let mut candidate = JobCandidate::new(run_id, profile)
                         .with_reuse_key(reuse_key)
                         .with_history_generation_run_id(history_generation_run_id)
+                        .with_pi_execution_mode(pi_execution_mode)
                         .with_parsed_runner_preference_context(runner_preference_context)
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
@@ -651,29 +654,50 @@ impl JobProvider for ApiProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
-        let is_pi_standby = candidate.profile_name() == crate::profile::PI_STANDBY_PROFILE;
+        let discovery_pi_execution_mode = candidate.pi_execution_mode();
         match self
             .api
             .claim(&candidate, &self.runner_id, self.heartbeat_generation)
             .await
         {
-            Ok(Some(ctx)) => {
-                let has_pi_runtime = ctx.pi_system_prompt.is_some()
-                    && ctx.pi_model_config.is_some()
-                    && ctx.run_skill_snapshot.is_some();
-                let pi_standby_source = (is_pi_standby || has_pi_runtime).then(|| {
+            Ok(Some(mut ctx)) => {
+                let pi_execution_mode = ctx.pi_execution_mode;
+                if pi_execution_mode.is_some()
+                    && (ctx.pi_system_prompt.is_none()
+                        || ctx.pi_model_config.is_none()
+                        || ctx.run_skill_snapshot.is_none())
+                {
+                    self.record_claim_failure(
+                        run_id,
+                        ClaimFailureDecision {
+                            class: ClaimFailureClass::ResponseInvariant,
+                            cooldown: CLAIM_DETERMINISTIC_COOLDOWN,
+                            status: None,
+                            transport_kind: None,
+                            response_run_id: Some(ctx.run_id),
+                        },
+                    )
+                    .await;
+                    return None;
+                }
+                if pi_execution_mode.is_none() {
+                    ctx.pi_system_prompt = None;
+                    ctx.pi_model_config = None;
+                    ctx.run_skill_snapshot = None;
+                }
+                let pi_standby_source = pi_execution_mode.map(|mode| {
                     let source = self.pi_standby_notifications.subscribe(run_id);
-                    if !is_pi_standby {
+                    if mode == PiExecutionMode::ColdStart {
                         // A standby failure/TTL requeues the exact context on
-                        // the default lane. Cold-started Pi must resume
-                        // immediately because the original Ably handoff may
-                        // predate this replacement subscription.
+                        // its real profile. Cold-started Pi must resume immediately
+                        // because the original Ably handoff may predate this
+                        // replacement subscription.
                         self.pi_standby_notifications
                             .notify(run_id, crate::pi_standby::PiStandbySignal::Handoff);
                     }
                     source
                 });
-                let active_input_source = (!has_pi_runtime
+                let active_input_source = (pi_execution_mode.is_none()
                     && supports_thread_active_input(ctx.reuse_key.as_deref()))
                 .then(|| {
                     ActiveInputSource::api(
@@ -711,6 +735,8 @@ impl JobProvider for ApiProvider {
                     run_id = %run_id,
                     runner_id = %self.runner_id,
                     heartbeat_generation = self.heartbeat_generation,
+                    discovery_pi_execution_mode = ?discovery_pi_execution_mode,
+                    claim_pi_execution_mode = ?pi_execution_mode,
                     "job claimed"
                 );
                 Some(claimed)
@@ -1684,7 +1710,10 @@ fn sanitized_json_error_detail(error: &serde_json::Error) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::task::Poll;
+
     use super::*;
+    use futures_util::poll;
     use httpmock::Method::POST;
     use httpmock::MockServer;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1704,6 +1733,37 @@ mod tests {
     );
     const RUNNER_CLAIM_RESPONSE_FIXTURE_RUN_ID: &str = "00000000-0000-4000-8000-000000020985";
     const TEST_RUNNER_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    fn pi_claim_response(run_id: RunId, mode: Option<&str>) -> serde_json::Value {
+        let mut response = serde_json::json!({
+            "runId": run_id,
+            "prompt": "resume Pi",
+            "sandboxToken": "pi-sandbox-token",
+            "cliAgentType": "codex",
+            "billableFirewalls": [],
+            "piSystemPrompt": "fixed Pi system prompt",
+            "piModelConfig": {
+                "provider": "deepseek",
+                "baseUrl": "https://api.deepseek.com/",
+                "model": "deepseek-chat",
+                "apiKeyEnv": "OPENAI_API_KEY"
+            },
+            "runSkillSnapshot": {
+                "schemaVersion": 1,
+                "policyVersion": 1,
+                "root": "/home/user/.pi/agent/skills",
+                "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                "entries": []
+            }
+        });
+        if let Some(mode) = mode {
+            response
+                .as_object_mut()
+                .expect("Pi claim response should be an object")
+                .insert("piExecutionMode".to_string(), serde_json::json!(mode));
+        }
+        response
+    }
     const TEST_HEARTBEAT_GENERATION: u64 = 7;
 
     fn claim_request_body_for_test(candidate: &JobCandidate) -> ClaimRequestBody<'_> {
@@ -2590,6 +2650,7 @@ mod tests {
                         "experimentalProfile": "vm0/large",
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
+                        "piExecutionMode": "standby",
                         "runnerPreferenceDecision": {
                             "kind": "preference",
                             "runnerIdentity": {
@@ -2617,6 +2678,10 @@ mod tests {
 
         assert_eq!(discovered.run_id(), run_id);
         assert_eq!(discovered.profile_name(), "vm0/large");
+        assert_eq!(
+            discovered.pi_execution_mode(),
+            Some(PiExecutionMode::Standby)
+        );
         assert_eq!(
             discovered.history_generation_run_id(),
             Some(history_generation_run_id)
@@ -4290,34 +4355,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cold_start_pi_claim_receives_immediate_handoff() {
+    async fn cold_start_claim_mode_overrides_stale_standby_discovery() {
         let server = MockServer::start_async().await;
         let run_id = RunId::nil();
         let claim_path = format!("/api/runners/jobs/{run_id}/claim");
         let claim_mock = server
             .mock_async(|when, then| {
                 when.method(POST).path(claim_path.as_str());
-                then.status(200).json_body(serde_json::json!({
-                    "runId": run_id,
-                    "prompt": "resume Pi",
-                    "sandboxToken": "pi-cold-sandbox-token",
-                    "cliAgentType": "codex",
-                    "billableFirewalls": [],
-                    "piSystemPrompt": "fixed Pi system prompt",
-                    "piModelConfig": {
-                        "provider": "deepseek",
-                        "baseUrl": "https://api.deepseek.com/",
-                        "model": "deepseek-chat",
-                        "apiKeyEnv": "OPENAI_API_KEY"
-                    },
-                    "runSkillSnapshot": {
-                        "schemaVersion": 1,
-                        "policyVersion": 1,
-                        "root": "/home/user/.pi/agent/skills",
-                        "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-                        "entries": []
-                    }
-                }));
+                then.status(200)
+                    .json_body(pi_claim_response(run_id, Some("cold-start")));
             })
             .await;
         let provider = api_provider_for_test(
@@ -4326,7 +4372,8 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
+        let candidate = JobCandidate::new(run_id, "vm0/large".to_string())
+            .with_pi_execution_mode(Some(PiExecutionMode::Standby));
         let claimed = provider
             .claim(candidate)
             .await
@@ -4342,6 +4389,154 @@ mod tests {
         .expect("cold Pi claim should not wait for another Ably handoff");
 
         assert_eq!(signal, crate::pi_standby::PiStandbySignal::Handoff);
+        claim_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn standby_claim_waits_for_its_run_notification() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(200)
+                    .json_body(pi_claim_response(run_id, Some("standby")));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("standby claim should succeed");
+        let (_, _, _, pi_standby_source) = claimed.into_run_parts();
+        let wait = pi_standby_source
+            .expect("standby claim should install control")
+            .wait();
+        tokio::pin!(wait);
+        assert!(matches!(poll!(&mut wait), Poll::Pending));
+
+        provider
+            .pi_standby_notifications
+            .notify(run_id, crate::pi_standby::PiStandbySignal::Handoff);
+
+        assert_eq!(wait.await, crate::pi_standby::PiStandbySignal::Handoff);
+        claim_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn missing_mode_sanitizes_legacy_pi_resources_as_ordinary_work() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let mut response = pi_claim_response(run_id, None);
+        response
+            .as_object_mut()
+            .expect("Pi claim response should be an object")
+            .insert(
+                "reuseKey".to_string(),
+                serde_json::json!("thread:legacy-pi"),
+            );
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(200).json_body(response);
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let claimed = provider
+            .claim(JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .expect("legacy claim should follow the ordinary path");
+        let (context, _, active_input_source, pi_standby_source) = claimed.into_run_parts();
+
+        assert!(context.pi_execution_mode.is_none());
+        assert!(context.pi_system_prompt.is_none());
+        assert!(context.pi_model_config.is_none());
+        assert!(context.run_skill_snapshot.is_none());
+        assert!(active_input_source.is_some());
+        assert!(pi_standby_source.is_none());
+        claim_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_incomplete_pi_execution_context() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let mut response = pi_claim_response(run_id, Some("standby"));
+        response
+            .as_object_mut()
+            .expect("Pi claim response should be an object")
+            .remove("runSkillSnapshot");
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(200).json_body(response);
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
+            run_id,
+            crate::profile::DEFAULT_PROFILE.to_string(),
+        )))
+        .await;
+
+        assert!(claimed.is_none());
+        let event = captured_event(&events, "claim failed, candidate cooling down");
+        assert_eq!(event_field(event, "failure_class"), "response_invariant");
+        assert_eq!(event_field(event, "response_run_id"), run_id.to_string());
+        claim_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_unknown_pi_execution_mode() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(200)
+                    .json_body(pi_claim_response(run_id, Some("future-mode")));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+
+        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
+            run_id,
+            crate::profile::DEFAULT_PROFILE.to_string(),
+        )))
+        .await;
+
+        assert!(claimed.is_none());
+        let event = captured_event(&events, "claim failed, candidate cooling down");
+        assert_eq!(event_field(event, "failure_class"), "response_decode");
         claim_mock.assert_calls_async(1).await;
     }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -660,13 +660,19 @@ impl JobProvider for ApiProvider {
             .claim(&candidate, &self.runner_id, self.heartbeat_generation)
             .await
         {
-            Ok(Some(mut ctx)) => {
+            Ok(Some(ctx)) => {
                 let pi_execution_mode = ctx.pi_execution_mode;
-                if pi_execution_mode.is_some()
-                    && (ctx.pi_system_prompt.is_none()
-                        || ctx.pi_model_config.is_none()
-                        || ctx.run_skill_snapshot.is_none())
-                {
+                let pi_resource_presence = [
+                    ctx.pi_system_prompt.is_some(),
+                    ctx.pi_model_config.is_some(),
+                    ctx.run_skill_snapshot.is_some(),
+                ];
+                let pi_execution_context_valid = if pi_execution_mode.is_some() {
+                    pi_resource_presence.iter().all(|present| *present)
+                } else {
+                    pi_resource_presence.iter().all(|present| !present)
+                };
+                if !pi_execution_context_valid {
                     self.record_claim_failure(
                         run_id,
                         ClaimFailureDecision {
@@ -679,11 +685,6 @@ impl JobProvider for ApiProvider {
                     )
                     .await;
                     return None;
-                }
-                if pi_execution_mode.is_none() {
-                    ctx.pi_system_prompt = None;
-                    ctx.pi_model_config = None;
-                    ctx.run_skill_snapshot = None;
                 }
                 let pi_standby_source = pi_execution_mode.map(|mode| {
                     let source = self.pi_standby_notifications.subscribe(run_id);
@@ -4433,7 +4434,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_mode_sanitizes_legacy_pi_resources_as_ordinary_work() {
+    async fn claim_rejects_pi_resources_without_execution_mode() {
         let server = MockServer::start_async().await;
         let run_id = RunId::nil();
         let claim_path = format!("/api/runners/jobs/{run_id}/claim");
@@ -4457,21 +4458,16 @@ mod tests {
             Arc::new(PollWakeups::new(false)),
         );
 
-        let claimed = provider
-            .claim(JobCandidate::new(
-                run_id,
-                crate::profile::DEFAULT_PROFILE.to_string(),
-            ))
-            .await
-            .expect("legacy claim should follow the ordinary path");
-        let (context, _, active_input_source, pi_standby_source) = claimed.into_run_parts();
+        let (claimed, events) = capture_api_provider_events(provider.claim(JobCandidate::new(
+            run_id,
+            crate::profile::DEFAULT_PROFILE.to_string(),
+        )))
+        .await;
 
-        assert!(context.pi_execution_mode.is_none());
-        assert!(context.pi_system_prompt.is_none());
-        assert!(context.pi_model_config.is_none());
-        assert!(context.run_skill_snapshot.is_none());
-        assert!(active_input_source.is_some());
-        assert!(pi_standby_source.is_none());
+        assert!(claimed.is_none());
+        let event = captured_event(&events, "claim failed, candidate cooling down");
+        assert_eq!(event_field(event, "failure_class"), "response_invariant");
+        assert_eq!(event_field(event, "response_run_id"), run_id.to_string());
         claim_mock.assert_calls_async(1).await;
     }
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -34,7 +34,7 @@ use crate::ids::RunId;
 use crate::pi_standby::{PiStandbyNotifications, PiStandbySignal};
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::RunCancellationRegistry;
-use crate::types::ConnectorRuntimeTarget;
+use crate::types::{ConnectorRuntimeTarget, PiExecutionMode};
 
 const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
 const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
@@ -738,7 +738,8 @@ async fn handle_ably_message_with_network_policy_refresh(
                         notif.reuse_key.map(str::to_owned),
                         notif.runner_preference_context,
                     )
-                    .with_history_generation_run_id(notif.history_generation_run_id),
+                    .with_history_generation_run_id(notif.history_generation_run_id)
+                    .with_pi_execution_mode(notif.pi_execution_mode),
                 ))
             } else {
                 info!(
@@ -779,6 +780,7 @@ struct JobNotification<'a> {
     profile: Option<&'a str>,
     reuse_key: Option<&'a str>,
     history_generation_run_id: Option<RunId>,
+    pi_execution_mode: Option<PiExecutionMode>,
     runner_preference_context: Option<RunnerPreferenceContext>,
 }
 
@@ -1030,6 +1032,21 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("historyGenerationRunId")
         .and_then(|v| v.as_str())
         .and_then(|value| value.parse().ok());
+    let pi_execution_mode = match msg.data.get("piExecutionMode") {
+        Some(value) => match serde_json::from_value(value.clone()) {
+            Ok(mode) => Some(mode),
+            Err(error) => {
+                warn!(
+                    run_id = %run_id,
+                    value = %value,
+                    error = %error,
+                    "ably: invalid Pi execution mode"
+                );
+                return None;
+            }
+        },
+        None => None,
+    };
     let runner_preference_context =
         match parse_runner_preference_decision(msg.data.get("runnerPreferenceDecision").cloned()) {
             Ok(context) => context,
@@ -1047,6 +1064,7 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         profile,
         reuse_key,
         history_generation_run_id,
+        pi_execution_mode,
         runner_preference_context,
     })
 }
@@ -1988,6 +2006,7 @@ mod tests {
                 "profile": "vm0/default",
                 "reuseKey": "thread:chat-thread",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
+                "piExecutionMode": "standby",
                 "runnerPreferenceDecision": {
                     "kind": "preference",
                     "runnerIdentity": {
@@ -2009,6 +2028,10 @@ mod tests {
         );
         assert_eq!(candidate.profile_name(), "vm0/default");
         let candidate = candidate.into_job_candidate();
+        assert_eq!(
+            candidate.pi_execution_mode(),
+            Some(PiExecutionMode::Standby)
+        );
         assert_eq!(candidate.reuse_key(), Some("thread:chat-thread"));
         assert_eq!(
             candidate.history_generation_run_id(),
@@ -2027,6 +2050,34 @@ mod tests {
                 targeted_self: Some(true),
             })
         );
+        assert_no_direct_candidate(&direct_candidates).await;
+        assert!(!wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn job_notification_with_unknown_pi_execution_mode_is_ignored() {
+        let tokens = RunCancellationRegistry::new();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default",
+                "piExecutionMode": "future-mode"
+            }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
     }

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -10,6 +10,7 @@ use tracing::warn;
 use super::RunnerPreference;
 use super::{JobCandidate, JobDiscoverySource, RunnerPreferenceContext};
 use crate::ids::RunId;
+use crate::types::PiExecutionMode;
 
 pub(super) const DIRECT_CANDIDATE_STALE_AFTER: Duration = Duration::from_secs(60);
 
@@ -21,6 +22,7 @@ pub(super) struct DirectJobCandidate {
     enqueued_at: Option<StdInstant>,
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
+    pi_execution_mode: Option<PiExecutionMode>,
     runner_preference_context: Option<RunnerPreferenceContext>,
 }
 
@@ -66,6 +68,7 @@ impl DirectJobCandidate {
             enqueued_at: None,
             reuse_key,
             history_generation_run_id: None,
+            pi_execution_mode: None,
             runner_preference_context,
         }
     }
@@ -102,6 +105,14 @@ impl DirectJobCandidate {
         self
     }
 
+    pub(super) fn with_pi_execution_mode(
+        mut self,
+        pi_execution_mode: Option<PiExecutionMode>,
+    ) -> Self {
+        self.pi_execution_mode = pi_execution_mode;
+        self
+    }
+
     pub(super) fn into_job_candidate(self) -> JobCandidate {
         let dequeued_at = StdInstant::now();
         let notification_to_enqueue_elapsed = self
@@ -113,6 +124,7 @@ impl DirectJobCandidate {
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
             .with_reuse_key(self.reuse_key)
             .with_history_generation_run_id(self.history_generation_run_id)
+            .with_pi_execution_mode(self.pi_execution_mode)
             .with_parsed_runner_preference_context(self.runner_preference_context)
             .with_discovery_source(JobDiscoverySource::Ably)
             .with_direct_candidate_timing(notification_to_enqueue_elapsed, inbox_wait_elapsed)
@@ -128,6 +140,7 @@ impl DirectJobCandidate {
             );
             return;
         }
+        self.pi_execution_mode = candidate.pi_execution_mode;
         if self.runner_preference_context.is_some() {
             return;
         }
@@ -531,7 +544,8 @@ mod tests {
                         first_deadline,
                     )),
                 )
-                .with_history_generation_run_id(Some(first_history_generation)),
+                .with_history_generation_run_id(Some(first_history_generation))
+                .with_pi_execution_mode(Some(PiExecutionMode::Standby)),
             )
             .await;
 
@@ -548,20 +562,24 @@ mod tests {
                         StdInstant::now() + Duration::from_secs(30),
                     )),
                 )
-                .with_history_generation_run_id(Some(run_id(7))),
+                .with_history_generation_run_id(Some(run_id(7)))
+                .with_pi_execution_mode(Some(PiExecutionMode::ColdStart)),
             )
             .await;
 
         inbox
-            .push(DirectJobCandidate::new_with_routing_metadata(
-                candidate_run_id,
-                "vm0/default".to_string(),
-                StdInstant::now(),
-                None,
-                Some(RunnerPreferenceContext::negative(
-                    RunnerPreferenceResolution::NoViableHolder,
-                )),
-            ))
+            .push(
+                DirectJobCandidate::new_with_routing_metadata(
+                    candidate_run_id,
+                    "vm0/default".to_string(),
+                    StdInstant::now(),
+                    None,
+                    Some(RunnerPreferenceContext::negative(
+                        RunnerPreferenceResolution::NoViableHolder,
+                    )),
+                )
+                .with_pi_execution_mode(Some(PiExecutionMode::ColdStart)),
+            )
             .await;
 
         let candidate = inbox
@@ -570,6 +588,10 @@ mod tests {
             .expect("retained direct candidate")
             .into_job_candidate();
         assert_eq!(candidate.reuse_key(), Some("session:first-decision"));
+        assert_eq!(
+            candidate.pi_execution_mode(),
+            Some(PiExecutionMode::ColdStart)
+        );
         assert_eq!(
             candidate.history_generation_run_id(),
             Some(first_history_generation)

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -198,6 +198,7 @@ impl JobProvider for LocalProvider {
             billable_firewalls: vec![],
             model_usage_provider: None,
             codex_runtime_config: None,
+            pi_execution_mode: None,
             pi_system_prompt: None,
             pi_model_config: None,
             run_skill_snapshot: None,

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -32,7 +32,7 @@ use crate::active_input::ActiveInputSource;
 use crate::error::RunnerResult;
 use crate::ids::RunId;
 use crate::pi_standby::PiStandbySubscription;
-use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
+use crate::types::{ExecutionContext, HeartbeatState, PiExecutionMode, SandboxReuseResult};
 
 const JAVASCRIPT_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
@@ -369,6 +369,7 @@ pub struct JobCandidate {
     poll_http_request_elapsed: Option<Duration>,
     reuse_key: Option<String>,
     history_generation_run_id: Option<RunId>,
+    pi_execution_mode: Option<PiExecutionMode>,
     runner_preference_context: Option<RunnerPreferenceContext>,
 }
 
@@ -400,6 +401,7 @@ impl JobCandidate {
             poll_http_request_elapsed: None,
             reuse_key: None,
             history_generation_run_id: None,
+            pi_execution_mode: None,
             runner_preference_context: None,
         }
     }
@@ -494,6 +496,10 @@ impl JobCandidate {
         self.history_generation_run_id
     }
 
+    pub(crate) fn pi_execution_mode(&self) -> Option<PiExecutionMode> {
+        self.pi_execution_mode
+    }
+
     pub(crate) fn runner_preference(&self) -> Option<&RunnerPreference> {
         self.runner_preference_context
             .as_ref()
@@ -571,6 +577,14 @@ impl JobCandidate {
         history_generation_run_id: Option<RunId>,
     ) -> Self {
         self.history_generation_run_id = history_generation_run_id;
+        self
+    }
+
+    pub(crate) fn with_pi_execution_mode(
+        mut self,
+        pi_execution_mode: Option<PiExecutionMode>,
+    ) -> Self {
+        self.pi_execution_mode = pi_execution_mode;
         self
     }
 

--- a/crates/runner/src/test_fixtures/execution_context.rs
+++ b/crates/runner/src/test_fixtures/execution_context.rs
@@ -33,6 +33,7 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
         billable_firewalls: vec![],
         model_usage_provider: None,
         codex_runtime_config: None,
+        pi_execution_mode: None,
         pi_system_prompt: None,
         pi_model_config: None,
         run_skill_snapshot: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -29,6 +29,13 @@ pub struct PollResponse {
     pub job: Option<Job>,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum PiExecutionMode {
+    Standby,
+    ColdStart,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Job {
@@ -38,6 +45,8 @@ pub struct Job {
     pub reuse_key: Option<String>,
     #[serde(default)]
     pub history_generation_run_id: Option<RunId>,
+    #[serde(default)]
+    pub pi_execution_mode: Option<PiExecutionMode>,
     #[serde(default)]
     pub runner_preference_decision: Option<serde_json::Value>,
 }
@@ -138,6 +147,9 @@ pub struct ExecutionContext {
     pub model_usage_provider: Option<String>,
     #[serde(default)]
     pub codex_runtime_config: Option<CodexRuntimeConfig>,
+    /// Claim-authoritative Pi lifecycle mode. Absence means ordinary execution.
+    #[serde(default)]
+    pub pi_execution_mode: Option<PiExecutionMode>,
     /// Complete Pi system prompt rendered once by the API for this run.
     #[serde(default)]
     pub pi_system_prompt: Option<String>,
@@ -1664,6 +1676,7 @@ mod tests {
                 "runId": "550e8400-e29b-41d4-a716-446655440000",
                 "experimentalProfile": "browser",
                 "cliAgentSessionId": "session-id",
+                "piExecutionMode": "standby",
                 "runnerPreferenceDecision": {
                     "kind": "preference",
                     "runnerIdentity": {
@@ -1684,8 +1697,35 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(job.experimental_profile, "browser");
+        assert_eq!(job.pi_execution_mode, Some(PiExecutionMode::Standby));
         assert!(job.runner_preference_decision.is_some());
         assert!(job.reuse_key().is_none());
+    }
+
+    #[test]
+    fn poll_response_without_pi_execution_mode_is_ordinary() {
+        let response: PollResponse = serde_json::from_value(json!({
+            "job": {
+                "runId": "550e8400-e29b-41d4-a716-446655440000",
+                "experimentalProfile": "vm0/default"
+            }
+        }))
+        .unwrap();
+
+        assert!(response.job.unwrap().pi_execution_mode.is_none());
+    }
+
+    #[test]
+    fn poll_response_rejects_unknown_pi_execution_mode() {
+        let result = serde_json::from_value::<PollResponse>(json!({
+            "job": {
+                "runId": "550e8400-e29b-41d4-a716-446655440000",
+                "experimentalProfile": "vm0/default",
+                "piExecutionMode": "future-mode"
+            }
+        }));
+
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1710,6 +1750,7 @@ mod tests {
             "prompt": "hello",
             "sandboxToken": "tok",
             "cliAgentType": "codex",
+            "piExecutionMode": "cold-start",
             "piSystemPrompt": "fixed Pi prompt",
             "piModelConfig": {
                 "provider": "deepseek",
@@ -1736,6 +1777,7 @@ mod tests {
 
         let context: ExecutionContext = serde_json::from_value(json).unwrap();
 
+        assert_eq!(context.pi_execution_mode, Some(PiExecutionMode::ColdStart));
         assert_eq!(context.pi_system_prompt.as_deref(), Some("fixed Pi prompt"));
         assert_eq!(
             context

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1034,7 +1034,13 @@ async function lockRunnerJob(
 
 function piExecutionContextValidSql(): SQL {
   return sql`
-    NOT (${runnerJobQueue.executionContext} ? 'piExecutionMode')
+    (
+      NOT (${runnerJobQueue.executionContext} ? 'piExecutionMode')
+      AND NOT (
+        ${runnerJobQueue.executionContext}
+          ?| ARRAY['piSystemPrompt', 'piModelConfig', 'runSkillSnapshot']
+      )
+    )
     OR COALESCE(
       (
         ${runnerJobQueue.executionContext}->>'piExecutionMode'

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -227,14 +227,30 @@ describe("Pi execution mode contract", () => {
     },
   );
 
-  it("does not infer a mode from historical Pi-shaped context", () => {
-    const parsed = storedExecutionContextSchema.parse({
-      ...storedContext,
-      ...piRuntimeContext,
-    });
+  it.each(["piSystemPrompt", "piModelConfig", "runSkillSnapshot"] as const)(
+    "rejects %s without Pi execution mode",
+    (field) => {
+      const invalidStoredContext = {
+        ...storedContext,
+        [field]: piRuntimeContext[field],
+      };
+      const invalidRunnerContext = {
+        ...executionContextSchema.parse(loadRunnerClaimResponseFixture()),
+        [field]: piRuntimeContext[field],
+      };
 
-    expect(parsed).not.toHaveProperty("piExecutionMode");
-  });
+      expect(
+        storedExecutionContextSchema.safeParse(invalidStoredContext).success,
+      ).toBe(false);
+      expect(
+        compatibleStoredExecutionContextSchema.safeParse(invalidStoredContext)
+          .success,
+      ).toBe(false);
+      expect(
+        executionContextSchema.safeParse(invalidRunnerContext).success,
+      ).toBe(false);
+    },
+  );
 });
 
 describe("connector runtime synchronization contract", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -743,7 +743,7 @@ export const piModelConfigSchema = z
   })
   .readonly();
 
-function requireCompletePiExecutionContext(
+function requireValidPiExecutionContext(
   context: {
     readonly piExecutionMode?: PiExecutionMode;
     readonly piSystemPrompt?: unknown;
@@ -752,15 +752,19 @@ function requireCompletePiExecutionContext(
   },
   refinement: z.RefinementCtx,
 ): void {
-  if (context.piExecutionMode === undefined) {
-    return;
-  }
   for (const field of [
     "piSystemPrompt",
     "piModelConfig",
     "runSkillSnapshot",
   ] as const) {
-    if (context[field] === undefined) {
+    const fieldPresent = context[field] !== undefined;
+    if (context.piExecutionMode === undefined && fieldPresent) {
+      refinement.addIssue({
+        code: "custom",
+        path: [field],
+        message: `${field} requires Pi execution mode`,
+      });
+    } else if (context.piExecutionMode !== undefined && !fieldPresent) {
       refinement.addIssue({
         code: "custom",
         path: [field],
@@ -853,7 +857,7 @@ const storedExecutionContextObjectSchema = z.object({
 
 export const storedExecutionContextSchema =
   storedExecutionContextObjectSchema.superRefine(
-    requireCompletePiExecutionContext,
+    requireValidPiExecutionContext,
   );
 
 /**
@@ -867,7 +871,7 @@ export const compatibleStoredExecutionContextSchema =
     .extend({
       connectorPermissionBaseline: z.unknown().optional(),
     })
-    .superRefine(requireCompletePiExecutionContext);
+    .superRefine(requireValidPiExecutionContext);
 
 /**
  * Execution context returned when claiming a job.
@@ -949,7 +953,7 @@ const executionContextObjectSchema = z.object({
 });
 
 export const executionContextSchema = executionContextObjectSchema.superRefine(
-  requireCompletePiExecutionContext,
+  requireValidPiExecutionContext,
 );
 
 /**


### PR DESCRIPTION
## Summary

- decode the optional `piExecutionMode` contract from poll, Ably discovery, and claim responses
- make the successful claim response authoritative for standby, cold-start, and ordinary execution
- remove the synthetic `vm0/pi-standby` profile alias and use the compose-selected profile for factories and resource accounting
- enforce the Pi mode/resource invariant in API contracts, API job locking, and Runner claims so invalid contexts are rejected instead of downgraded to ordinary work

## Scope

- no database schema, migration, or API producer changes
- no guest protocol, V1 event/path, or reuse-key changes
- no compatibility path for experimental Pi contexts that contain resources without an explicit execution mode
- Pi remains disabled until this Runner version is deployed

## Fallbacks

Fallbacks: none.

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm knip --workspace @vm0/api-contracts --workspace api`
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --maxWorkers=1 --silent=passed-only` (77 passed)
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/pi-edge-loop.test.ts --maxWorkers=1 --silent=passed-only` (17 passed)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3078 passed, 20 ignored)
- `cargo test --manifest-path crates/Cargo.toml -p runner claim_rejects_pi_resources_without_execution_mode`

Closes #25654

Parent: #25597
