### PR TITLE
test(api): support dev-seeded pi skill archives

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -11,6 +11,9 @@ import {
 } from "@vm0/api-contracts/contracts/runners";
 import { webhookPiTranscriptContract } from "@vm0/api-contracts/contracts/webhooks";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { parseGitHubTreeUrl, resolveSkillRef } from "@vm0/core/github-url";
+import { getSkillStorageName } from "@vm0/core/storage-names";
+import { GOAL_SKILL_NAME, SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import { HttpResponse, http } from "msw";
 import { v5 as uuidv5 } from "uuid";
 import { describe, expect, it, onTestFinished } from "vitest";
@@ -51,6 +54,7 @@ import {
   createAgentComposeFixture,
   readAgentComposeByIdFixture,
 } from "../../../test-fixtures/agent-composes";
+import { readSystemStorageVersionNameByS3KeyFixture } from "../../../test-fixtures/storage";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -75,6 +79,7 @@ const CODEX_WHAM_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
 const OPENAI_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions";
 const AGENT_DISPLAY_NAME = "Pi edge integration agent";
+const STORAGE_ARCHIVE_SUFFIX = "/archive.tar.gz";
 const PI_EDGE_USAGE_OBSERVATION_IDEMPOTENCY_NAMESPACE =
   "1b7c07b8-01bc-4ae2-ac5c-ef5ca9f72683";
 
@@ -405,7 +410,44 @@ interface PiStorageObjects {
 function acceptPiStorageObjects(): PiStorageObjects {
   const objects = new Map<string, Buffer>();
   const seededObjects = new Map<string, Buffer>();
-  context.mocks.s3.send.mockImplementation((command: unknown) => {
+  const systemSkillNameByStorageName = new Map(
+    [...SEED_SKILLS, GOAL_SKILL_NAME].flatMap((skillName) => {
+      const parsed = parseGitHubTreeUrl(resolveSkillRef(skillName));
+      return parsed
+        ? [[getSkillStorageName(parsed.fullPath), skillName] as const]
+        : [];
+    }),
+  );
+  const systemSkillStorageNames = [...systemSkillNameByStorageName.keys()];
+  const resolveBody = async (
+    objectKey: string,
+    key: string,
+  ): Promise<Buffer | undefined> => {
+    const stored = objects.get(objectKey) ?? seededObjects.get(key);
+    if (stored || !key.endsWith(STORAGE_ARCHIVE_SUFFIX)) {
+      return stored;
+    }
+    const storageName = await readSystemStorageVersionNameByS3KeyFixture({
+      s3Key: key.slice(0, -STORAGE_ARCHIVE_SUFFIX.length),
+      storageNames: systemSkillStorageNames,
+    });
+    const skillName =
+      storageName === undefined
+        ? undefined
+        : systemSkillNameByStorageName.get(storageName);
+    if (skillName === undefined) {
+      return undefined;
+    }
+    const archive = createTarGz([
+      {
+        path: "SKILL.md",
+        content: `---\nname: ${skillName}\ndescription: Test fixture for the default ${skillName} Skill.\n---\n`,
+      },
+    ]);
+    seededObjects.set(key, archive);
+    return archive;
+  };
+  context.mocks.s3.send.mockImplementation(async (command: unknown) => {
     const input = commandInput(command);
     const bucket = typeof input.Bucket === "string" ? input.Bucket : "";
     const key = typeof input.Key === "string" ? input.Key : "";
@@ -413,29 +455,26 @@ function acceptPiStorageObjects(): PiStorageObjects {
     switch (commandName(command)) {
       case "PutObjectCommand": {
         objects.set(objectKey, bodyBuffer(input.Body));
-        return Promise.resolve({});
+        return {};
       }
       case "GetObjectCommand": {
-        const body = objects.get(objectKey) ?? seededObjects.get(key);
-        return Promise.resolve(
-          body
-            ? { Body: streamBody(body), ContentLength: body.byteLength }
-            : { Body: undefined },
-        );
+        const body = await resolveBody(objectKey, key);
+        return body
+          ? { Body: streamBody(body), ContentLength: body.byteLength }
+          : { Body: undefined };
       }
       case "HeadObjectCommand": {
-        const body = objects.get(objectKey) ?? seededObjects.get(key);
-        return body
-          ? Promise.resolve({ ContentLength: body.byteLength })
-          : Promise.reject(
-              Object.assign(new Error(`Missing S3 object ${objectKey}`), {
-                name: "NotFound",
-                $metadata: { httpStatusCode: 404 },
-              }),
-            );
+        const body = await resolveBody(objectKey, key);
+        if (!body) {
+          throw Object.assign(new Error(`Missing S3 object ${objectKey}`), {
+            name: "NotFound",
+            $metadata: { httpStatusCode: 404 },
+          });
+        }
+        return { ContentLength: body.byteLength };
       }
       default: {
-        return Promise.resolve({});
+        return {};
       }
     }
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -411,10 +411,10 @@ function acceptPiStorageObjects(): PiStorageObjects {
   const objects = new Map<string, Buffer>();
   const seededObjects = new Map<string, Buffer>();
   const systemSkillNameByStorageName = new Map(
-    [...SEED_SKILLS, GOAL_SKILL_NAME].flatMap((skillName) => {
-      const parsed = parseGitHubTreeUrl(resolveSkillRef(skillName));
+    [...SEED_SKILLS, GOAL_SKILL_NAME].flatMap((skillRef) => {
+      const parsed = parseGitHubTreeUrl(resolveSkillRef(skillRef));
       return parsed
-        ? [[getSkillStorageName(parsed.fullPath), skillName] as const]
+        ? [[getSkillStorageName(parsed.fullPath), parsed.skillName] as const]
         : [];
     }),
   );

--- a/turbo/apps/api/src/test-fixtures/storage.ts
+++ b/turbo/apps/api/src/test-fixtures/storage.ts
@@ -1,12 +1,13 @@
 /**
  * In-process test fixture for `storages` / `storage_versions` rows.
  *
- * Reading a storage's stored prefix is unreachable through product APIs
- * because list responses do not expose `s3_prefix`.
+ * Reading a storage's stored S3 identity is unreachable through product APIs
+ * because list responses do not expose `s3_prefix` or version `s3_key`.
  */
-import { storages } from "@vm0/db/schema/storage";
+import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { createStore } from "ccstate";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { writeDb$ } from "../signals/external/db";
 
@@ -33,4 +34,25 @@ export async function readStorageS3PrefixFixture(values: {
     );
   }
   return row.s3Prefix;
+}
+
+export async function readSystemStorageVersionNameByS3KeyFixture(values: {
+  readonly s3Key: string;
+  readonly storageNames: readonly string[];
+}): Promise<string | undefined> {
+  const db = createStore().set(writeDb$);
+  const [row] = await db
+    .select({ name: storages.name })
+    .from(storageVersions)
+    .innerJoin(storages, eq(storages.id, storageVersions.storageId))
+    .where(
+      and(
+        eq(storages.orgId, SYSTEM_ORG_ID),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        inArray(storages.name, values.storageNames),
+        eq(storageVersions.s3Key, values.s3Key),
+      ),
+    )
+    .limit(1);
+  return row?.name;
 }


### PR DESCRIPTION
## Summary

- Materialize default system Skill archives in the Pi edge S3 test mock from the exact persisted storage-version identity.
- Keep explicit test uploads authoritative and preserve missing-object behavior for unknown S3 keys.
- Add a scoped test fixture lookup for storage-version S3 keys that product APIs intentionally do not expose.

## Scope

This is test-only infrastructure. It does not change production storage behavior, database schema, migrations, or seed data.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/pi-edge-loop.test.ts --maxWorkers=1 --silent=passed-only` (15 tests, dev-seeded database)
- The same focused suite against a migration-only temporary database with no Skill rows (15 tests)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- Pre-commit hook: repository Prettier, Knip, and full Turbo typecheck

Closes #25732
