### PR TITLE
refactor(pi): remove memory path compatibility fallback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -3,7 +3,6 @@ import { gzipSync } from "node:zlib";
 
 import type { SupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import {
-  CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   DEFAULT_PROFILE,
   PI_MEMORY_ROOT,
   PI_SKILLS_ROOT,
@@ -709,18 +708,6 @@ async function enablePiLoop(fixture: PiEdgeFixture): Promise<void> {
   );
 }
 
-async function disablePiLoop(fixture: PiEdgeFixture): Promise<void> {
-  await updateFeatureSwitchesForUser(
-    context,
-    {
-      userId: fixture.switchOwner.userId,
-      orgId: fixture.orgId,
-      orgRole: fixture.switchOwner.orgRole,
-    },
-    { [FeatureSwitchKey.PiLoop]: false },
-  );
-}
-
 async function sendChatRun(
   fixture: PiEdgeFixture,
   prompt: string,
@@ -927,7 +914,7 @@ async function expectQueuedPiEdgePromotion(args: {
 }
 
 describe("PiLoop edge turn", () => {
-  it("uses the org gate, migrates legacy memory into Pi, and completes in the API", async () => {
+  it("uses the org gate, mounts Pi memory, and completes in the API", async () => {
     const fixture = await piEdgeFixture();
     const legacyPrompt = "legacy context must not enter the Pi transcript";
     const legacy = await sendChatRun(fixture, legacyPrompt);
@@ -975,7 +962,7 @@ describe("PiLoop edge turn", () => {
 
     const edgePrompt = "answer only this new message";
     const publishedBefore = context.mocks.ably.publish.mock.calls.length;
-    const edge = await sendChatRun(fixture, edgePrompt, legacy.threadId);
+    const edge = await sendChatRun(fixture, edgePrompt);
     await modelStarted.promise;
 
     const standbyPoll = await api.requestPollRunner(
@@ -1311,108 +1298,6 @@ describe("PiLoop edge turn", () => {
     expect((await api.readRun(fixture.actor, followUp.runId)).status).toBe(
       "completed",
     );
-
-    await disablePiLoop(fixture);
-    const fallback = await sendChatRun(
-      fixture,
-      "continue after disabling PiLoop",
-      edge.threadId,
-    );
-    expect((await api.readRun(fixture.actor, fallback.runId)).status).toBe(
-      "pending",
-    );
-    const fallbackPoll = await api.pollRunner(fixture.runnerGroup);
-    expect(fallbackPoll.body.job?.runId).toBe(fallback.runId);
-    const fallbackContext = await api.claimRunnerJob(fallback.runId);
-    expect(fallbackContext.storageManifest?.storageMounts).toContainEqual(
-      expect.objectContaining({
-        name: "memory",
-        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-        missingRootPolicy: "preserveParentVersion",
-      }),
-    );
-    expect(fallbackContext.storageManifest?.storageMounts).not.toContainEqual(
-      expect.objectContaining({
-        name: "memory",
-        mountPath: PI_MEMORY_ROOT,
-      }),
-    );
-    await api.requestCancelRun(fixture.actor, fallback.runId, [200]);
-  });
-
-  it("migrates a Pi-first session memory path back to Codex", async () => {
-    const fixture = await piEdgeFixture();
-    await enablePiLoop(fixture);
-    const modelStarted = createDeferredPromise<void>(context.signal);
-    const releaseModel = createDeferredPromise<void>(context.signal);
-    onTestFinished(() => {
-      if (!releaseModel.settled()) {
-        releaseModel.resolve();
-      }
-    });
-    server.use(
-      http.post(COMPLETIONS_URL, async () => {
-        modelStarted.resolve();
-        await releaseModel.promise;
-        return assistantTextStream("Pi-first answer", "Pi-first reasoning");
-      }),
-    );
-
-    const piFirst = await sendChatRun(fixture, "start this session in PiLoop");
-    await modelStarted.promise;
-    const standbyPoll = await api.requestPollRunner(
-      true,
-      {
-        group: fixture.runnerGroup,
-        supportedProfiles: [fixture.runnerProfile],
-      },
-      [200],
-    );
-    if (standbyPoll.status !== 200) {
-      throw new Error("Expected Pi standby poll to return 200");
-    }
-    expect(standbyPoll.body.job?.runId).toBe(piFirst.runId);
-    const piContext = await api.claimRunnerJob(piFirst.runId);
-    expect(piContext.storageManifest?.storageMounts).toContainEqual(
-      expect.objectContaining({
-        name: "memory",
-        mountPath: PI_MEMORY_ROOT,
-        missingRootPolicy: "preserveParentVersion",
-      }),
-    );
-
-    releaseModel.resolve();
-    await flushWaitUntilForTest();
-    expect((await api.readRun(fixture.actor, piFirst.runId)).status).toBe(
-      "completed",
-    );
-
-    await disablePiLoop(fixture);
-    const fallback = await sendChatRun(
-      fixture,
-      "continue the Pi-first session after disabling PiLoop",
-      piFirst.threadId,
-    );
-    expect((await api.readRun(fixture.actor, fallback.runId)).status).toBe(
-      "pending",
-    );
-    const fallbackPoll = await api.pollRunner(fixture.runnerGroup);
-    expect(fallbackPoll.body.job?.runId).toBe(fallback.runId);
-    const fallbackContext = await api.claimRunnerJob(fallback.runId);
-    expect(fallbackContext.storageManifest?.storageMounts).toContainEqual(
-      expect.objectContaining({
-        name: "memory",
-        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-        missingRootPolicy: "preserveParentVersion",
-      }),
-    );
-    expect(fallbackContext.storageManifest?.storageMounts).not.toContainEqual(
-      expect.objectContaining({
-        name: "memory",
-        mountPath: PI_MEMORY_ROOT,
-      }),
-    );
-    await api.requestCancelRun(fixture.actor, fallback.runId, [200]);
   });
 
   it("injects the MEMORY.md prefix and keeps the complete file readable on the edge", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1260,14 +1260,14 @@ function autoMemoryArtifact(
   });
 }
 
-function isCanonicalAutoMemoryArtifact(artifact: ContextArtifact): boolean {
-  if (artifact.name !== AUTO_MEMORY_ARTIFACT_NAME) {
-    return false;
-  }
+function isCanonicalAutoMemoryArtifact(
+  artifact: ContextArtifact,
+  framework: SupportedFramework,
+  usePiMemoryPath: boolean,
+): boolean {
   return (
-    artifact.mountPath === PI_MEMORY_ROOT ||
-    artifact.mountPath === CANONICAL_CODEX_MEMORY_MOUNT_PATH ||
-    artifact.mountPath === CANONICAL_CLAUDE_MEMORY_MOUNT_PATH
+    artifact.name === AUTO_MEMORY_ARTIFACT_NAME &&
+    artifact.mountPath === autoMemoryMountPath(framework, usePiMemoryPath)
   );
 }
 
@@ -1280,17 +1280,14 @@ function withAutoMemoryMissingRootPolicy(
   };
 }
 
-function withCanonicalAutoMemoryConfiguration(
+function withCanonicalAutoMemoryMissingRootPolicy(
   artifacts: readonly ContextArtifact[],
   framework: SupportedFramework,
   usePiMemoryPath: boolean,
 ): readonly ContextArtifact[] {
   return artifacts.map((artifact) => {
-    return isCanonicalAutoMemoryArtifact(artifact)
-      ? withAutoMemoryMissingRootPolicy({
-          ...artifact,
-          mountPath: autoMemoryMountPath(framework, usePiMemoryPath),
-        })
+    return isCanonicalAutoMemoryArtifact(artifact, framework, usePiMemoryPath)
+      ? withAutoMemoryMissingRootPolicy(artifact)
       : artifact;
   });
 }
@@ -1308,10 +1305,15 @@ function claimsAutoMemorySlot(
 
 function withoutSupersededAutoMemoryArtifacts(
   artifacts: readonly ContextArtifact[],
+  framework: SupportedFramework,
+  usePiMemoryPath: boolean,
   slotOwnerIndex: number,
 ): readonly ContextArtifact[] {
   return artifacts.filter((artifact, index) => {
-    return index >= slotOwnerIndex || !isCanonicalAutoMemoryArtifact(artifact);
+    return (
+      index >= slotOwnerIndex ||
+      !isCanonicalAutoMemoryArtifact(artifact, framework, usePiMemoryPath)
+    );
   });
 }
 
@@ -1368,17 +1370,25 @@ function artifactsForRun(args: {
   }
 
   const slotOwner = artifacts[autoMemorySlotArtifactIndex]!;
-  if (!isCanonicalAutoMemoryArtifact(slotOwner)) {
+  if (
+    !isCanonicalAutoMemoryArtifact(
+      slotOwner,
+      args.framework,
+      args.usePiMemoryPath,
+    )
+  ) {
     return {
       artifacts: withoutSupersededAutoMemoryArtifacts(
         artifacts,
+        args.framework,
+        args.usePiMemoryPath,
         autoMemorySlotArtifactIndex,
       ),
     };
   }
 
   return {
-    artifacts: withCanonicalAutoMemoryConfiguration(
+    artifacts: withCanonicalAutoMemoryMissingRootPolicy(
       artifacts,
       args.framework,
       args.usePiMemoryPath,

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -44,7 +44,7 @@ overrides:
   '@types/node': 24.3.0
   axios: '>=1.18.0'
   brace-expansion: 5.0.9
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   esbuild: 0.28.1
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
@@ -6821,8 +6821,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -17437,7 +17437,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -19575,7 +19575,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.50.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -20501,7 +20501,7 @@ snapshots:
       '@posthog/core': 1.27.5
       '@posthog/types': 1.372.1
       core-js: 3.41.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       fflate: 0.4.8
       preact: 10.29.0
       query-selector-shadow-dom: 1.0.1

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -54,7 +54,7 @@ overrides:
   "@types/node": 24.3.0
   axios: ">=1.18.0"
   brace-expansion: 5.0.9
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   esbuild: 0.28.1
   "esbuild@>=0.17.0 <0.28.1": ">=0.28.1"
   "esbuild@>=0.27.3 <0.28.1": ">=0.28.1"


### PR DESCRIPTION
## Summary

- remove the cross-runtime automatic memory mount-path translation introduced by #25687 after its five-hour rollout window
- keep Pi-first runs on `/home/user/.pi/agent/memory` and keep Codex/Claude runs on their native memory roots
- remove the fallback-only legacy-to-Pi and Pi-to-Codex test paths while retaining Pi mount, prompt-prefix, full-file-read, and continuation coverage

## Fallbacks

- Removed: `agent-run-create.service.ts` previously treated the Pi, Codex, and Claude memory roots as the same canonical automatic-memory artifact and rewrote persisted session mounts to whichever runtime was active. This bridged legacy-framework sessions into PiLoop and Pi-first sessions back to Codex/Claude. The user-selected five-hour rollout window has elapsed, and `FeatureSwitchKey.PiLoop` remains disabled by default, so the compatibility branch and its migration/rollback assertions are removed together.
- No fallback is introduced or retained by this PR.

## Testing

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL='postgresql://postgres@127.0.0.1:5432/vm0_test' pnpm --filter api exec vitest run src/signals/routes/__tests__/pi-edge-loop.test.ts` (16 tests)
