### PR TITLE
perf(api): isolate the clerk sdk type surface behind the gateway typecheck project

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -25,7 +25,7 @@ const gatewayModules = JSON.parse(
 // Third-party declaration surfaces that only the gateway project may resolve.
 // Add a scope here once its clients move into tsconfig.gateways.json; see
 // the ablation numbers in PR #25714.
-const isolatedDependencies = ["@aws-sdk", "@slack", "@smithy"];
+const isolatedDependencies = ["@aws-sdk", "@clerk", "@slack", "@smithy"];
 
 const gatewayBoundaryOptions = {
   modules: gatewayModules,

--- a/turbo/apps/api/src/signals/auth/clerk-session.ts
+++ b/turbo/apps/api/src/signals/auth/clerk-session.ts
@@ -1,14 +1,8 @@
-import type { SessionAuthObject } from "@clerk/backend";
 import { computed, type Computed } from "ccstate";
 
 import { request$ } from "../context/hono";
-import { clerk$ } from "../external/clerk";
+import { authenticateClerkSession } from "../external/clerk";
 import { ApiOrgRole } from "../../types/auth";
-
-type SignedInSessionAuthObject = Extract<
-  SessionAuthObject,
-  { isAuthenticated: true }
->;
 
 type ClerkSessionAuthContext =
   | {
@@ -24,9 +18,7 @@ type ClerkSessionAuthContext =
       readonly orgRole?: undefined;
     };
 
-function mapClerkOrgRole(
-  orgRole: SignedInSessionAuthObject["orgRole"],
-): ApiOrgRole | undefined {
+function mapClerkOrgRole(orgRole: string | null): ApiOrgRole | undefined {
   if (!orgRole) {
     return undefined;
   }
@@ -36,35 +28,31 @@ function mapClerkOrgRole(
 
 const requestState$ = computed((get) => {
   const request = get(request$);
-  const clerk = get(clerk$);
-  return clerk.authenticateRequest(request.raw, {
-    acceptsToken: "session_token",
-  });
+  return authenticateClerkSession(request.raw);
 });
 
 export const clerkSessionAuth$: Computed<
   Promise<ClerkSessionAuthContext | null>
 > = computed(async (get): Promise<ClerkSessionAuthContext | null> => {
-  const requestState = await get(requestState$);
+  const identity = await get(requestState$);
 
-  if (!requestState.isAuthenticated) {
+  if (!identity) {
     return null;
   }
 
-  const auth = requestState.toAuth();
-  const orgRole = mapClerkOrgRole(auth.orgRole);
+  const orgRole = mapClerkOrgRole(identity.orgRole);
 
-  if (auth.orgId && orgRole) {
+  if (identity.orgId && orgRole) {
     return {
       tokenType: "session",
-      userId: auth.userId,
-      orgId: auth.orgId,
+      userId: identity.userId,
+      orgId: identity.orgId,
       orgRole,
     };
   }
 
   return {
     tokenType: "session",
-    userId: auth.userId,
+    userId: identity.userId,
   };
 });

--- a/turbo/apps/api/src/signals/external/clerk-organization-lists.ts
+++ b/turbo/apps/api/src/signals/external/clerk-organization-lists.ts
@@ -1,21 +1,16 @@
-import type { createClerkClient } from "@clerk/backend";
-
-type ClerkClient = ReturnType<typeof createClerkClient>;
-type ClerkOrganizations = ClerkClient["organizations"];
-type OrganizationMembership = Awaited<
-  ReturnType<ClerkOrganizations["getOrganizationMembershipList"]>
->["data"][number];
-type OrganizationInvitation = Awaited<
-  ReturnType<ClerkOrganizations["getOrganizationInvitationList"]>
->["data"][number];
+import type {
+  ClerkOrganizationInvitation,
+  ClerkOrganizationMembership,
+  ClerkOrganizationsApi,
+} from "./clerk";
 
 const ORGANIZATION_LIST_PAGE_SIZE = 100;
 
 export async function listAllOrganizationMemberships(
-  organizations: Pick<ClerkOrganizations, "getOrganizationMembershipList">,
+  organizations: Pick<ClerkOrganizationsApi, "getOrganizationMembershipList">,
   organizationId: string,
-): Promise<OrganizationMembership[]> {
-  const memberships: OrganizationMembership[] = [];
+): Promise<ClerkOrganizationMembership[]> {
+  const memberships: ClerkOrganizationMembership[] = [];
   for (let offset = 0; ; offset += ORGANIZATION_LIST_PAGE_SIZE) {
     const page = await organizations.getOrganizationMembershipList({
       organizationId,
@@ -30,10 +25,10 @@ export async function listAllOrganizationMemberships(
 }
 
 export async function listAllPendingOrganizationInvitations(
-  organizations: Pick<ClerkOrganizations, "getOrganizationInvitationList">,
+  organizations: Pick<ClerkOrganizationsApi, "getOrganizationInvitationList">,
   organizationId: string,
-): Promise<OrganizationInvitation[]> {
-  const invitations: OrganizationInvitation[] = [];
+): Promise<ClerkOrganizationInvitation[]> {
+  const invitations: ClerkOrganizationInvitation[] = [];
   for (let offset = 0; ; offset += ORGANIZATION_LIST_PAGE_SIZE) {
     const page = await organizations.getOrganizationInvitationList({
       organizationId,

--- a/turbo/apps/api/src/signals/external/clerk.ts
+++ b/turbo/apps/api/src/signals/external/clerk.ts
@@ -1,23 +1,194 @@
 import { computed, type Computed } from "ccstate";
 
 import { createClerkClient } from "@clerk/backend";
+import { verifyWebhook } from "@clerk/backend/webhooks";
 import { singleton } from "../../lib/singleton";
 import { env } from "../../lib/env";
 
-const clerk = singleton((): ReturnType<typeof createClerkClient> => {
+/**
+ * Clerk gateway. This module is the only place `@clerk/backend` is resolved:
+ * it belongs to `tsconfig.gateways.json`, so the SDK declaration surface is
+ * parsed once in that small program instead of inside the core one, which is
+ * what sets the CI peak RSS for apps/api (same move as `@aws-sdk/*` in
+ * PR #25714).
+ *
+ * Everything exported below is a vm0-owned type; that is what keeps the
+ * emitted `.d.ts` free of Clerk types. The mirrored client covers exactly the
+ * surface callers use today - widening it is fine, naming a Clerk type in an
+ * exported signature is not.
+ */
+
+export interface ClerkPaginated<T> {
+  readonly data: readonly T[];
+  readonly totalCount: number;
+}
+
+export interface ClerkEmailAddress {
+  readonly id: string;
+  readonly emailAddress: string;
+}
+
+export interface ClerkUser {
+  readonly id: string;
+  readonly emailAddresses: readonly ClerkEmailAddress[];
+  readonly primaryEmailAddressId: string | null;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+  readonly username: string | null;
+  readonly imageUrl: string;
+  readonly privateMetadata: Record<string, unknown>;
+}
+
+export interface ClerkOrganization {
+  readonly id: string;
+  readonly name: string;
+  readonly slug: string | null;
+  readonly imageUrl: string;
+  readonly hasImage: boolean;
+  readonly createdAt: number;
+}
+
+export interface ClerkOrganizationMembershipPublicUserData {
+  readonly userId: string;
+}
+
+export interface ClerkOrganizationMembership {
+  readonly id: string;
+  readonly role: string;
+  readonly createdAt: number;
+  readonly organization: ClerkOrganization;
+  readonly publicUserData?: ClerkOrganizationMembershipPublicUserData | null;
+}
+
+export interface ClerkOrganizationInvitation {
+  readonly id: string;
+  readonly emailAddress: string;
+  readonly role: string;
+  readonly createdAt: number;
+}
+
+export type ClerkOrganizationInvitationStatus =
+  | "pending"
+  | "accepted"
+  | "revoked"
+  | "expired";
+
+export interface ClerkUsersApi {
+  getUserList(params?: {
+    userId?: string[];
+    emailAddress?: string[];
+    limit?: number;
+    offset?: number;
+  }): Promise<ClerkPaginated<ClerkUser>>;
+  getOrganizationMembershipList(params: {
+    userId: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<ClerkPaginated<ClerkOrganizationMembership>>;
+  updateUserMetadata(
+    userId: string,
+    params: {
+      publicMetadata?: Record<string, unknown>;
+      privateMetadata?: Record<string, unknown>;
+    },
+  ): Promise<ClerkUser>;
+}
+
+export interface ClerkOrganizationsApi {
+  getOrganization(params: {
+    organizationId: string;
+  }): Promise<ClerkOrganization>;
+  getOrganizationMembershipList(params: {
+    organizationId: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<ClerkPaginated<ClerkOrganizationMembership>>;
+  getOrganizationInvitationList(params: {
+    organizationId: string;
+    status?: ClerkOrganizationInvitationStatus[];
+    limit?: number;
+    offset?: number;
+  }): Promise<ClerkPaginated<ClerkOrganizationInvitation>>;
+  createOrganizationInvitation(params: {
+    organizationId: string;
+    emailAddress: string;
+    inviterUserId?: string;
+    role: string;
+    redirectUrl?: string;
+  }): Promise<ClerkOrganizationInvitation>;
+  revokeOrganizationInvitation(params: {
+    organizationId: string;
+    invitationId: string;
+    requestingUserId?: string;
+  }): Promise<ClerkOrganizationInvitation>;
+  updateOrganizationMembership(params: {
+    organizationId: string;
+    userId: string;
+    role: string;
+  }): Promise<ClerkOrganizationMembership>;
+  deleteOrganizationMembership(params: {
+    organizationId: string;
+    userId: string;
+  }): Promise<ClerkOrganizationMembership>;
+  updateOrganization(
+    organizationId: string,
+    params: { name?: string },
+  ): Promise<ClerkOrganization>;
+  updateOrganizationLogo(
+    organizationId: string,
+    params: { file: Blob | File; uploaderUserId?: string },
+  ): Promise<ClerkOrganization>;
+  deleteOrganization(organizationId: string): Promise<ClerkOrganization>;
+}
+
+export interface ClerkSignInTokensApi {
+  createSignInToken(params: {
+    userId: string;
+    expiresInSeconds: number;
+  }): Promise<{ readonly token: string }>;
+}
+
+export interface ClerkMachineToMachineApi {
+  createToken(params: {
+    machineSecretKey: string;
+    secondsUntilExpiration?: number;
+    minRemainingTtlSeconds?: number;
+  }): Promise<{ readonly token?: string }>;
+}
+
+export interface ClerkClient {
+  readonly users: ClerkUsersApi;
+  readonly organizations: ClerkOrganizationsApi;
+  readonly signInTokens: ClerkSignInTokensApi;
+  readonly m2m: ClerkMachineToMachineApi;
+}
+
+/** Session identity as the API models it, independent of Clerk's auth object. */
+export interface ClerkSessionIdentity {
+  readonly userId: string;
+  readonly orgId: string | null;
+  readonly orgRole: string | null;
+}
+
+/** The only two fields the Clerk webhook route reads off an event. */
+export interface ClerkWebhookEvent {
+  readonly type: string;
+  readonly data: unknown;
+}
+
+const clerkSdk = singleton(() => {
   return createClerkClient({
     secretKey: env("CLERK_SECRET_KEY"),
     publishableKey: env("CLERK_PUBLISHABLE_KEY"),
   });
 });
 
-export const clerk$ = computed(() => {
-  return clerk();
+export const clerk$: Computed<ClerkClient> = computed((): ClerkClient => {
+  return clerkSdk();
 });
 
-export type OrganizationMembershipList = Awaited<
-  ReturnType<ReturnType<typeof clerk>["users"]["getOrganizationMembershipList"]>
->;
+export type OrganizationMembershipList =
+  ClerkPaginated<ClerkOrganizationMembership>;
 
 export function membershipsByUserId(
   userId: string,
@@ -29,4 +200,35 @@ export function membershipsByUserId(
       limit,
     });
   });
+}
+
+/**
+ * Clerk's `RequestState` is a wide union whose members disagree about what
+ * `toAuth()` returns, so it is collapsed here rather than mirrored: callers
+ * only need the signed-in identity, or nothing.
+ */
+export async function authenticateClerkSession(
+  request: Request,
+): Promise<ClerkSessionIdentity | null> {
+  const requestState = await clerkSdk().authenticateRequest(request, {
+    acceptsToken: "session_token",
+  });
+
+  if (!requestState.isAuthenticated) {
+    return null;
+  }
+
+  const auth = requestState.toAuth();
+  return {
+    userId: auth.userId,
+    orgId: auth.orgId ?? null,
+    orgRole: auth.orgRole ?? null,
+  };
+}
+
+export async function verifyClerkWebhook(
+  request: Request,
+  options: { readonly signingSecret?: string },
+): Promise<ClerkWebhookEvent> {
+  return await verifyWebhook(request, options);
 }

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -1,10 +1,10 @@
-import { verifyWebhook } from "@clerk/backend/webhooks";
 import { webhookClerkContract } from "@vm0/api-contracts/contracts/webhooks";
 import { command } from "ccstate";
 
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { request$ } from "../context/hono";
+import { verifyClerkWebhook } from "../external/clerk";
 import { waitUntil } from "../context/wait-until";
 import type { RouteEntry } from "../route-entry";
 import { tapError } from "../utils";
@@ -111,7 +111,7 @@ const postClerkWebhook$ = command(
     const signingSecret = optionalEnv("CLERK_WEBHOOK_SIGNING_SECRET");
 
     const event = await tapError(
-      verifyWebhook(request.clone(), { signingSecret }),
+      verifyClerkWebhook(request.clone(), { signingSecret }),
     );
     signal.throwIfAborted();
     if (!event) {
@@ -119,7 +119,7 @@ const postClerkWebhook$ = command(
     }
     L.debug("clerk webhook received", { type: event.type });
 
-    if ((event.type as string) === "organization.created") {
+    if (event.type === "organization.created") {
       const identity = organizationCreatedIdentity(event.data);
       if (!identity) {
         L.error("organization.created event missing org/creator user ID", {
@@ -141,7 +141,7 @@ const postClerkWebhook$ = command(
       return new Response("OK", { status: 200 });
     }
 
-    if ((event.type as string) === "organizationMembership.created") {
+    if (event.type === "organizationMembership.created") {
       const identity = organizationMembershipIdentity(event.data);
       if (!identity) {
         L.error("organizationMembership.created event missing org/user ID", {
@@ -204,8 +204,7 @@ const postClerkWebhook$ = command(
       return new Response("OK", { status: 200 });
     }
 
-    // "user.banned" is not yet in the Clerk SDK WebhookEvent type union
-    if ((event.type as string) === "user.banned") {
+    if (event.type === "user.banned") {
       const data = propertyOf(event, "data");
       const userId = eventDataId(data);
       if (!userId) {

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -1,4 +1,3 @@
-import type { createClerkClient } from "@clerk/backend";
 import { command } from "ccstate";
 import { emailOutbox } from "@vm0/db/schema/email-outbox";
 import { emailSuppressions } from "@vm0/db/schema/email-suppression";
@@ -9,7 +8,11 @@ import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
-import { clerk$ } from "../external/clerk";
+import {
+  clerk$,
+  type ClerkClient,
+  type ClerkOrganizationMembership,
+} from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
 import {
@@ -21,10 +24,7 @@ import {
   type EmailTemplate,
 } from "./zero-email-common.service";
 
-type ClerkClient = ReturnType<typeof createClerkClient>;
-type OrganizationMembership = Awaited<
-  ReturnType<ClerkClient["organizations"]["getOrganizationMembershipList"]>
->["data"][number];
+type OrganizationMembership = ClerkOrganizationMembership;
 
 export const LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS = 5000;
 

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 
-import type { createClerkClient } from "@clerk/backend";
 import { emailOutbox } from "@vm0/db/schema/email-outbox";
 import { emailSuppressions } from "@vm0/db/schema/email-suppression";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -16,10 +15,10 @@ import { z } from "zod";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
+import type { ClerkClient } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import type { Tx } from "../../lib/db-types";
 
-type ClerkClient = ReturnType<typeof createClerkClient>;
 type Transaction = Tx;
 
 interface EmailOutboxDrainContext {

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -16,10 +16,9 @@ import {
   type OrgMembersResponse,
   type OrgRole,
 } from "@vm0/api-contracts/contracts/org-members";
-import type { User } from "@clerk/backend";
 
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { clerk$ } from "../external/clerk";
+import { clerk$, type ClerkUser } from "../external/clerk";
 import {
   listAllOrganizationMemberships,
   listAllPendingOrganizationInvitations,
@@ -572,7 +571,7 @@ function requiredClerkMembershipUserId(
   return userId;
 }
 
-function userPrimaryEmail(user: User): string {
+function userPrimaryEmail(user: ClerkUser): string {
   const primary = user.emailAddresses.find((e) => {
     return e.id === user.primaryEmailAddressId;
   });

--- a/turbo/apps/api/src/signals/services/zero-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage.service.ts
@@ -12,8 +12,7 @@ import { agentSessions } from "@vm0/db/schema/agent-session";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import type { User } from "@clerk/backend";
-import { clerk$ } from "../external/clerk";
+import { clerk$, type ClerkUser } from "../external/clerk";
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { getOrgBillingPeriod$ } from "./zero-org-billing-period.service";
@@ -242,7 +241,7 @@ export const zeroUsageRuns$ = command(
 type UsageClerkClient = ReturnType<typeof clerk$.read>;
 type UsageWriteDb = ReturnType<typeof writeDb$.write>;
 
-function primaryEmail(user: User): string {
+function primaryEmail(user: ClerkUser): string {
   const primary = user.emailAddresses.find((email) => {
     return email.id === user.primaryEmailAddressId;
   });

--- a/turbo/apps/api/tsconfig.core.json
+++ b/turbo/apps/api/tsconfig.core.json
@@ -30,6 +30,7 @@
     "src/lib/log.ts",
     "src/lib/secret-kms-client.ts",
     "src/lib/singleton.ts",
+    "src/signals/external/clerk.ts",
     "src/signals/external/s3.ts",
     "src/signals/external/slack-block-kit.ts",
     "src/signals/external/slack-message-client.ts",

--- a/turbo/apps/api/tsconfig.gateways.json
+++ b/turbo/apps/api/tsconfig.gateways.json
@@ -15,6 +15,7 @@
     "src/lib/log.ts",
     "src/lib/secret-kms-client.ts",
     "src/lib/singleton.ts",
+    "src/signals/external/clerk.ts",
     "src/signals/external/s3.ts",
     "src/signals/external/slack-block-kit.ts",
     "src/signals/external/slack-message-client.ts",


### PR DESCRIPTION
## Why

`apps/api` `check-types` peak RSS is set by `tsconfig.core.json`, and the round-5 ablation on today's main measured `@clerk/*` at **-207 MiB** of that peak (core head mean 2919 MiB, stub-clerk 2712 MiB). Clerk is the second-largest non-structural surface left after the aws (#25714) and slack boundaries.

## What

Same move as #25714: `src/signals/external/clerk.ts` joins `tsconfig.gateways.json`, so `@clerk/backend` is parsed once in the small gateway program instead of inside core.

The precondition is that no Clerk type may appear in an exported signature, so the module now owns its own mirror of the surface the API actually uses:

- `ClerkClient` (`users`, `organizations`, `signInTokens`, `m2m`) plus `ClerkUser`, `ClerkOrganization`, `ClerkOrganizationMembership`, `ClerkOrganizationInvitation`. `clerk$` is pinned to `Computed<ClerkClient>`, so the SDK client is checked against the mirror inside the gateway and every `ReturnType<typeof clerk$.read>` call site keeps working unchanged.
- `authenticateClerkSession(request)` replaces raw `authenticateRequest` in `clerk-session.ts`. Clerk's `RequestState` is a wide union whose members disagree about `toAuth()`, so it is collapsed to `ClerkSessionIdentity` at the boundary instead of mirrored.
- `verifyClerkWebhook(request, { signingSecret })` replaces the direct `@clerk/backend/webhooks` import in the webhook route and returns `{ type: string; data: unknown }`, which also drops the three `event.type as string` casts the route needed for events missing from the SDK union.
- `clerk-organization-lists.ts` and the four services that imported `User` / `createClerkClient` types now use the mirrored types.

`isolatedDependencies` in `eslint.config.mjs` gains `@clerk`, so `api/gateway-typecheck-boundary` fails any future direct import outside the gateway (tests stay exempt: they type-check in their own smaller program).

No runtime change: the gateway still constructs the same client, so the existing `vi.mock("@clerk/backend")` test wiring is untouched.

## Verification

- `pnpm --filter api run check-types` and `pnpm --filter api exec eslint . --max-warnings 0` green on this branch.
- Expect the CI `lint-types-apps` `[measure-memory]` peak to drop from ~3005 MiB; the remaining SDK levers are jointly capped at about -285 MiB (stripe + clerk measured together), so stripe's own boundary will show a smaller marginal win than its -236 MiB solo number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
