### PR TITLE
fix(runner): preserve exact reuse generation on rollback

### DIFF
--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -16,10 +16,11 @@ use guest_contracts::reuse_preparation::{
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 #[test]
-fn prepare_for_reuse_removes_only_unprotected_runtime_entries() -> TestResult {
+fn prepare_for_reuse_preserves_generation_when_candidate_runtime_is_absent() -> TestResult {
     let dir = tempfile::tempdir()?;
     let runs = dir.path().join("runtime/runs");
-    let current = runs.join("current");
+    let current = runs.join("generation");
+    let unstarted_candidate = runs.join("candidate");
     let retained = runs.join("retained");
     let stale = runs.join("stale/nested");
     let outside = dir.path().join("outside");
@@ -39,6 +40,7 @@ fn prepare_for_reuse_removes_only_unprotected_runtime_entries() -> TestResult {
     std::fs::write(runs.join("stale-file"), b"stale")?;
     std::fs::write(outside.join("keep"), b"outside")?;
     symlink(&outside, runs.join("stale-link"))?;
+    assert!(!unstarted_candidate.exists());
 
     let output = run_helper(&ReusePreparationRequest {
         current_runtime_dir: path_string(&current),
@@ -66,7 +68,31 @@ fn prepare_for_reuse_removes_only_unprotected_runtime_entries() -> TestResult {
     assert!(!runs.join("stale").exists());
     assert!(!runs.join("stale-file").exists());
     assert!(!runs.join("stale-link").exists());
+    assert!(!unstarted_candidate.exists());
     assert_eq!(std::fs::read(outside.join("keep"))?, b"outside");
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_missing_protected_generation_before_cleanup() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let runs = dir.path().join("runtime/runs");
+    let missing_generation = runs.join("missing-generation");
+    let stale = runs.join("stale");
+    std::fs::create_dir_all(&stale)?;
+    std::fs::write(stale.join("agent.jsonl"), b"stale")?;
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&missing_generation),
+        retained_runtime_dir: None,
+    })?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED)
+    );
+    assert!(!missing_generation.exists());
+    assert_eq!(std::fs::read(stale.join("agent.jsonl"))?, b"stale");
     Ok(())
 }
 

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -8,6 +8,10 @@ use super::super::support::{
 };
 use std::sync::Arc;
 
+use guest_contracts::reuse_preparation::{
+    REUSE_PREPARATION_EXIT_CLEANUP_FAILED, ReusePreparationRequest,
+};
+
 use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
 use crate::provider::{JobCandidate, RunnerPreference, RunnerPreferenceTier};
@@ -50,6 +54,24 @@ fn timezone_correction_commands(overrides: &sandbox_mock::MockSandboxOverrides) 
         .into_iter()
         .filter(|call| call.cmd.contains("/etc/timezone") && !call.cmd.contains("guest-reseed"))
         .map(|call| call.cmd)
+        .collect()
+}
+
+fn reuse_preparation_requests(
+    overrides: &sandbox_mock::MockSandboxOverrides,
+) -> Vec<ReusePreparationRequest> {
+    overrides
+        .exec_calls()
+        .into_iter()
+        .filter(|call| call.cmd.contains("guest-agent prepare-for-reuse"))
+        .map(|call| {
+            serde_json::from_slice(
+                call.stdin_bytes
+                    .as_deref()
+                    .expect("reuse preparation request should use stdin"),
+            )
+            .expect("reuse preparation request should be valid")
+        })
         .collect()
 }
 
@@ -388,7 +410,7 @@ async fn unavailable_claim_reparks_speculative_sandbox() {
     add_healthy_reuse_preparation_matcher(&overrides);
     let reuse_key = RunId::new_v4().to_string();
     let generation_run_id = RunId::new_v4();
-    seed_idle_pool_with_speculative_timezone(
+    let sandbox_id = seed_idle_pool_with_speculative_timezone(
         &env.idle_pool,
         &budget,
         &overrides,
@@ -431,10 +453,97 @@ async fn unavailable_claim_reparks_speculative_sandbox() {
 
     wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
     wait_idle_pool_reuse_keys(&env.idle_pool, &[&reuse_key], Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated(), (2, 4096, 1));
     assert_eq!(overrides.unpark_call_count(), 1);
     assert_eq!(overrides.park_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 0);
     assert!(overrides.start_process_calls().is_empty());
+    assert!(!env.start_observer.active_run_status_was_published(run_id));
+    let requests = reuse_preparation_requests(&overrides);
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].current_runtime_dir,
+        format!("/home/user/.vm0/guest-agent/runs/{generation_run_id}")
+    );
+    assert_ne!(
+        requests[0].current_runtime_dir,
+        format!("/home/user/.vm0/guest-agent/runs/{run_id}")
+    );
+
+    let followup_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        followup_run_id,
+        Some(claimed_context(followup_run_id, &reuse_key, None)),
+    );
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            followup_run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+    let completion = env
+        .handle
+        .wait_completion(followup_run_id, Duration::from_secs(30))
+        .await
+        .expect("restored speculative sandbox should serve the next exact claim");
+    assert_eq!(completion.sandbox_id, Some(sandbox_id));
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn cleanup_failure_destroys_lost_speculative_sandbox() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "prepare-for-reuse".into(),
+        exit_code: REUSE_PREPARATION_EXIT_CLEANUP_FAILED,
+        stdout: Vec::new(),
+        stderr: b"runtime cleanup failed: protected generation disappeared".to_vec(),
+    });
+    let reuse_key = RunId::new_v4().to_string();
+    let generation_run_id = RunId::new_v4();
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key: &reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: generation_run_id,
+            guest_timezone_intent: GuestTimezoneIntent::Default,
+            timing: None,
+        },
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider.set_claim_result(run_id, None);
+    env.handle
+        .discover_tx
+        .send(exact_generation_candidate(
+            run_id,
+            &reuse_key,
+            generation_run_id,
+        ))
+        .unwrap();
+
+    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.park_call_count(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_process_calls().is_empty());
+    assert!(!env.start_observer.active_run_status_was_published(run_id));
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -101,7 +101,10 @@ pub(crate) enum IdleParkFailureParts {
 }
 
 struct IdleParkTransitionInput {
-    run_id: RunId,
+    /// Run that triggered this transition and owns its diagnostics.
+    operation_run_id: RunId,
+    /// Run whose guest runtime directory must survive reuse cleanup.
+    current_runtime_run_id: RunId,
     resources: IdleSandboxResources,
     metadata: IdleSandboxMetadata,
     budget_lease: BudgetLease,
@@ -172,7 +175,8 @@ impl IdleParkRequest {
 
         park_idle_transition(
             IdleParkTransitionInput {
-                run_id,
+                operation_run_id: run_id,
+                current_runtime_run_id: run_id,
                 resources: IdleSandboxResources {
                     sandbox,
                     factory,
@@ -193,7 +197,8 @@ async fn park_idle_transition(
     observer: Option<&mut dyn SandboxFinalExecParkObserver>,
 ) -> Result<IdleParkOutcome, IdleParkFailure> {
     let IdleParkTransitionInput {
-        run_id,
+        operation_run_id,
+        current_runtime_run_id,
         resources,
         metadata,
         budget_lease,
@@ -242,24 +247,28 @@ async fn park_idle_transition(
         });
     }
 
-    let preparation =
-        match IdleReusePreparation::new(sandbox.id(), run_id, retained_runtime_dir.as_deref()) {
-            Ok(preparation) => preparation,
-            Err(error) => {
-                return Err(IdleParkFailure {
-                    ownership: IdleParkFailureOwnership::Active {
-                        resources: IdleSandboxResources {
-                            sandbox,
-                            factory,
-                            workspace_promotion,
-                        },
-                        budget_lease,
+    let preparation = match IdleReusePreparation::new(
+        sandbox.id(),
+        operation_run_id,
+        current_runtime_run_id,
+        retained_runtime_dir.as_deref(),
+    ) {
+        Ok(preparation) => preparation,
+        Err(error) => {
+            return Err(IdleParkFailure {
+                ownership: IdleParkFailureOwnership::Active {
+                    resources: IdleSandboxResources {
+                        sandbox,
+                        factory,
+                        workspace_promotion,
                     },
-                    reason: "reuse_preparation_failed",
-                    error: error.to_string(),
-                });
-            }
-        };
+                    budget_lease,
+                },
+                reason: "reuse_preparation_failed",
+                error: error.to_string(),
+            });
+        }
+    };
 
     let final_exec_and_park = {
         let request = preparation.exec_request();
@@ -335,9 +344,17 @@ async fn park_idle_transition(
 impl SpeculativeIdleSandbox {
     pub(crate) async fn repark_for_claim_rollback(
         self,
-        run_id: RunId,
+        operation_run_id: RunId,
         workspace_image_size_bytes: u64,
     ) -> SpeculativeReparkResult {
+        let Some(current_runtime_run_id) = self.entry.metadata.history_generation_run_id else {
+            const REASON: &str = "speculative_repark_missing_history_generation";
+            return SpeculativeReparkResult::Destroy {
+                destroy_job: Box::new(self.into_destroy_job(REASON)),
+                reason: REASON,
+                error: "speculative exact-reuse entry is missing a history generation".into(),
+            };
+        };
         let Self { entry } = self;
         let IdleEntry {
             resources,
@@ -350,7 +367,8 @@ impl SpeculativeIdleSandbox {
         let profile_name = metadata.profile_name.clone();
         match park_idle_transition(
             IdleParkTransitionInput {
-                run_id,
+                operation_run_id,
+                current_runtime_run_id,
                 resources,
                 metadata,
                 budget_lease,

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -298,13 +298,27 @@ async fn idle_park_request_success_preserves_reuse_metadata() {
 #[tokio::test]
 async fn speculative_repark_preserves_original_idle_age_and_metadata() {
     let overrides = Arc::new(MockSandboxOverrides::new());
+    let reuse_key = "session-speculative-repark";
+    let profile_name = "vm0/speculative";
+    let device_rate_limits = sandbox::DeviceRateLimits {
+        block: sandbox::BlockRateLimits {
+            bandwidth_bytes_per_sec: 100 * 1024 * 1024,
+            ops_per_sec: 10_000,
+        },
+        network: sandbox::NetworkRateLimits {
+            rx_bytes_per_sec: 50 * 1024 * 1024,
+            tx_bytes_per_sec: 25 * 1024 * 1024,
+        },
+    };
     let history_generation_run_id = RunId::new_v4();
     let mut request = make_idle_park_request(
         Arc::clone(&overrides),
-        "session-speculative-repark",
+        reuse_key,
         make_budget_lease(2, 2048),
     )
     .await;
+    request.parts.profile_name = profile_name.into();
+    request.parts.device_rate_limits = Some(device_rate_limits.clone());
     request.parts.history_generation_run_id = Some(history_generation_run_id);
     request.parts.guest_timezone_intent =
         crate::guest_timezone::GuestTimezoneIntent::Configured("Asia/Shanghai".into());
@@ -312,7 +326,6 @@ async fn speculative_repark_preserves_original_idle_age_and_metadata() {
         Ok(outcome) => outcome.expect_reusable(),
         Err(_) => panic!("initial park should succeed"),
     };
-    add_healthy_reuse_preparation_matcher(&overrides);
 
     let original_parked_at = Instant::now() - Duration::from_secs(120);
     let original_timeout = Duration::from_secs(300);
@@ -325,8 +338,9 @@ async fn speculative_repark_preserves_original_idle_age_and_metadata() {
     else {
         panic!("speculative unpark should succeed");
     };
+    let rollback_run_id = RunId::new_v4();
     let SpeculativeReparkResult::Reparked(restored) = speculative
-        .repark_for_claim_rollback(RunId::new_v4(), 0)
+        .repark_for_claim_rollback(rollback_run_id, 0)
         .await
     else {
         panic!("speculative repark should succeed");
@@ -334,6 +348,14 @@ async fn speculative_repark_preserves_original_idle_age_and_metadata() {
 
     assert_eq!(restored.entry.parked_at, original_parked_at);
     assert_eq!(restored.entry.idle_timeout, original_timeout);
+    assert_eq!(restored.entry.reuse_key(), reuse_key);
+    assert_eq!(restored.entry.profile_name(), profile_name);
+    assert_eq!(
+        restored.entry.device_rate_limits(),
+        &Some(device_rate_limits)
+    );
+    assert_eq!(restored.entry.budget_vcpu(), 2);
+    assert_eq!(restored.entry.budget_memory_mb(), 2048);
     assert_eq!(
         restored.entry.metadata.history_generation_run_id,
         Some(history_generation_run_id)
@@ -344,6 +366,73 @@ async fn speculative_repark_preserves_original_idle_age_and_metadata() {
     );
     assert_eq!(overrides.unpark_call_count(), 1);
     assert_eq!(overrides.park_call_count(), 2);
+    let preparation_requests: Vec<ReusePreparationRequest> = overrides
+        .exec_calls()
+        .into_iter()
+        .filter(|call| call.cmd.contains("guest-agent prepare-for-reuse"))
+        .map(|call| {
+            serde_json::from_slice(
+                call.stdin_bytes
+                    .as_deref()
+                    .expect("reuse preparation request should use stdin"),
+            )
+            .expect("reuse preparation request should be valid")
+        })
+        .collect();
+    assert_eq!(preparation_requests.len(), 2);
+    assert_eq!(
+        preparation_requests[1].current_runtime_dir,
+        format!("/home/user/.vm0/guest-agent/runs/{history_generation_run_id}")
+    );
+    assert_ne!(
+        preparation_requests[1].current_runtime_dir,
+        format!("/home/user/.vm0/guest-agent/runs/{rollback_run_id}")
+    );
+}
+
+#[tokio::test]
+async fn speculative_repark_without_history_generation_returns_owned_destroy_job() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let request = make_idle_park_request(
+        Arc::clone(&overrides),
+        "session-speculative-missing-generation",
+        make_budget_lease(2, 2048),
+    )
+    .await;
+    let candidate = match request.park_for_idle().await {
+        Ok(outcome) => outcome.expect_reusable(),
+        Err(_) => panic!("initial park should succeed"),
+    };
+    let reservation = ReservedIdleSandbox {
+        entry: candidate.into_idle_entry(Instant::now(), Duration::from_secs(300)),
+    };
+    let SpeculativeIdleUnparkResult::Ready(speculative) = reservation
+        .try_unpark_for_speculation(RunId::new_v4())
+        .await
+    else {
+        panic!("speculative unpark should succeed");
+    };
+
+    let SpeculativeReparkResult::Destroy {
+        destroy_job,
+        reason,
+        error,
+    } = speculative
+        .repark_for_claim_rollback(RunId::new_v4(), 0)
+        .await
+    else {
+        panic!("missing generation should destroy speculative ownership");
+    };
+
+    assert_eq!(reason, "speculative_repark_missing_history_generation");
+    assert_eq!(
+        error,
+        "speculative exact-reuse entry is missing a history generation"
+    );
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.park_call_count(), 1);
+    destroy_job.run().await;
+    assert_eq!(overrides.destroy_call_count(), 1);
 }
 
 #[tokio::test]

--- a/crates/runner/src/idle_reuse_preparation.rs
+++ b/crates/runner/src/idle_reuse_preparation.rs
@@ -66,7 +66,7 @@ impl std::fmt::Display for IdleReusePreparationFailure {
 }
 
 pub(crate) struct IdleReusePreparation {
-    run_id: RunId,
+    operation_run_id: RunId,
     sandbox_id: String,
     command: String,
     request_bytes: Vec<u8>,
@@ -75,17 +75,18 @@ pub(crate) struct IdleReusePreparation {
 impl IdleReusePreparation {
     pub(crate) fn new(
         sandbox_id: &str,
-        run_id: RunId,
+        operation_run_id: RunId,
+        current_runtime_run_id: RunId,
         retained_runtime_dir: Option<&str>,
     ) -> Result<Self, IdleReusePreparationFailure> {
         let current_runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(
             CANONICAL_GUEST_HOME_DIR,
-            &run_id.to_string(),
+            &current_runtime_run_id.to_string(),
         )
         .map_err(|error| {
             reject_without_exec(
                 sandbox_id,
-                run_id,
+                operation_run_id,
                 ReuseRejectionReason::InvalidRequest,
                 format!("resolve current runtime directory: {error}"),
             )
@@ -99,7 +100,7 @@ impl IdleReusePreparation {
         let request_bytes = serde_json::to_vec(&request).map_err(|error| {
             reject_without_exec(
                 sandbox_id,
-                run_id,
+                operation_run_id,
                 ReuseRejectionReason::InvalidRequest,
                 format!("serialize reuse-preparation request: {error}"),
             )
@@ -111,7 +112,7 @@ impl IdleReusePreparation {
             mount_command
         );
         Ok(Self {
-            run_id,
+            operation_run_id,
             sandbox_id: sandbox_id.to_owned(),
             command,
             request_bytes,
@@ -138,7 +139,7 @@ impl IdleReusePreparation {
             let reason = helper_failure_reason(result);
             return Err(reject_with_result(
                 &self.sandbox_id,
-                self.run_id,
+                self.operation_run_id,
                 reason,
                 result,
                 format_helper_exec_failure("reuse preparation", result),
@@ -149,7 +150,7 @@ impl IdleReusePreparation {
             serde_json::from_slice::<ReusePreparationReport>(&result.stdout).map_err(|error| {
                 reject_with_result(
                     &self.sandbox_id,
-                    self.run_id,
+                    self.operation_run_id,
                     ReuseRejectionReason::InvalidReport,
                     result,
                     format!("reuse preparation returned an invalid report: {error}"),
@@ -167,7 +168,7 @@ impl IdleReusePreparation {
             };
             log_report(
                 &self.sandbox_id,
-                self.run_id,
+                self.operation_run_id,
                 reason.as_str(),
                 result,
                 report,
@@ -181,7 +182,14 @@ impl IdleReusePreparation {
             });
         }
 
-        log_report(&self.sandbox_id, self.run_id, "ready", result, report, true);
+        log_report(
+            &self.sandbox_id,
+            self.operation_run_id,
+            "ready",
+            result,
+            report,
+            true,
+        );
         Ok(())
     }
 }
@@ -374,24 +382,30 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(captured.clone());
         let guard = tracing::subscriber::set_default(subscriber);
         tracing::callsite::rebuild_interest_cache();
-        let result = execute_preparation(sandbox, run_id, None).await;
+        let result = execute_preparation(sandbox, run_id, run_id, None).await;
         drop(guard);
         (result, captured.entries())
     }
 
     async fn execute_preparation(
         sandbox: &MockSandbox,
-        run_id: RunId,
+        operation_run_id: RunId,
+        current_runtime_run_id: RunId,
         retained_runtime_dir: Option<&str>,
     ) -> Result<(), IdleReusePreparationFailure> {
-        let preparation = IdleReusePreparation::new(sandbox.id(), run_id, retained_runtime_dir)?;
+        let preparation = IdleReusePreparation::new(
+            sandbox.id(),
+            operation_run_id,
+            current_runtime_run_id,
+            retained_runtime_dir,
+        )?;
         let result = sandbox
             .exec_with_diagnostic_label(&preparation.exec_request(), "idle-reuse-preparation")
             .await
             .map_err(|error| {
                 reject_without_exec(
                     sandbox.id(),
-                    run_id,
+                    operation_run_id,
                     ReuseRejectionReason::HelperFailed,
                     format!("reuse-preparation exec failed: {error}"),
                 )
@@ -419,12 +433,18 @@ mod tests {
             serde_json::to_vec(&healthy_reuse_preparation_report()).unwrap(),
             Vec::new(),
         )));
-        let run_id = RunId::new_v4();
+        let operation_run_id = RunId::new_v4();
+        let current_runtime_run_id = RunId::new_v4();
         let retained = "/home/user/.vm0/guest-agent/runs/previous";
 
-        execute_preparation(&sandbox, run_id, Some(retained))
-            .await
-            .expect("healthy guest should be prepared");
+        execute_preparation(
+            &sandbox,
+            operation_run_id,
+            current_runtime_run_id,
+            Some(retained),
+        )
+        .await
+        .expect("healthy guest should be prepared");
 
         let calls = sandbox.exec_calls();
         assert_eq!(calls.len(), 1);
@@ -447,7 +467,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             request.current_runtime_dir,
-            format!("/home/user/.vm0/guest-agent/runs/{run_id}")
+            format!("/home/user/.vm0/guest-agent/runs/{current_runtime_run_id}")
         );
         assert_eq!(request.retained_runtime_dir.as_deref(), Some(retained));
     }


### PR DESCRIPTION
## Summary

- separate the run that owns rollback diagnostics from the completed generation whose guest runtime directory must remain protected
- re-park a lost speculative exact sandbox against its retained history generation while preserving its original idle metadata, budget, age, and timeout
- keep missing generation metadata and guest cleanup failures fail-closed through the existing owned destroy path
- cover successful claim-loss rollback and later reuse at the runner main loop, plus real guest filesystem safety cases

## Scope

- no API, database, persistence, provider payload, frontend, or guest reuse-preparation contract changes
- no changes to claim deadlines, runner preference ranking, containment rules, or filesystem cleanup policy
- parent delivery issue #25405 remains open

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test -p runner cmd::start::tests::main_loop::exact_reuse_speculation -- --nocapture`
- `cd crates && cargo test -p runner idle_pool::park_transition_tests -- --nocapture`
- `cd crates && cargo test -p guest-agent --test reuse_preparation_helper -- --nocapture`
- `cd crates && cargo test -p runner -p guest-agent --quiet`
- `cd crates && cargo clippy -p runner -p guest-agent --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc -p runner -p guest-agent --no-deps --all-features`
- repository pre-commit Rust formatting, workspace Clippy, rustdoc, file-size, and commit-message hooks

Closes #25507
Relates to #25405
