### PR TITLE
feat(api): force app.vm0.ai clients to upgrade to v0.706.3

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -985,7 +985,7 @@ describe("createApp", () => {
   });
 
   describe("web client compatibility", () => {
-    it("rejects pre-run-model-annotation app clients before route handlers run", async () => {
+    it("rejects pre-content-event-reader app clients before route handlers run", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
@@ -994,7 +994,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.695.0",
+          [CLIENT_VERSION_HEADER]: "0.706.2",
         },
       });
 
@@ -1035,6 +1035,22 @@ describe("createApp", () => {
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
           [CLIENT_VERSION_HEADER]: MINIMUM_WEB_CLIENT_VERSION,
+        },
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("allows newer app clients", async () => {
+      const app = createApp({
+        signal: context.signal,
+        routes: TEST_APP_ROUTES,
+      });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: {
+          [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
+          [CLIENT_VERSION_HEADER]: "0.706.4",
         },
       });
 

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.696.0"
+  "minimumSupportedVersion": "0.706.3"
 }


### PR DESCRIPTION
## Summary

- raise the `app.vm0.ai` web-client compatibility floor from `0.696.0` to `0.706.3`
- force every older App bundle to refresh before Stage 5 begins writing `goal.open`, `goal.close`, and `output.followups.content`
- update the directly coupled API compatibility coverage for the last pre-Stage-3 build and a newer supported build

## Target resolution

- `window._vm0.getBuildVersion()` on live `https://app.vm0.ai` returned `0.706.3`
- `window._vm0.getBuildCommitSha()` returned `c877a75a0e33cde95b920cc025faf875e63e5c9c`
- Git ancestry confirms that live commit contains Stage 3 PR #25748 merge commit `aa5fd7b5da87a3fe21f45e54bae1d1fea9d56ab2`
- the Stage 3 merge commit still declared App `0.706.2`; release PR #25749 commit `c877a75a0e33cde95b920cc025faf875e63e5c9c` first declared stable App `0.706.3`
- production release-please run [31202386818](https://github.com/vm0-ai/vm0/actions/runs/31202386818) completed successfully at that release commit, including `build-api-production`, `promote-api-production`, `deploy-api-schema`, and `promote-app-production`

Therefore `0.706.3` is the first live stable production App version containing the Stage 3 content-based event readers, and it is not newer than production.

## User-visible impact

App clients below `0.706.3` receive the existing compatibility rejection on their next API request and must refresh to load a supported build. Version `0.706.3` and newer clients remain supported.

## Files changed

- `turbo/apps/api/src/lib/web-client-compatibility.json`
- `turbo/apps/api/src/__tests__/app-factory.test.ts`

The legacy `goal.changed` and `recommendedFollowups` dual-read paths remain intact for the Stage 5 cutover. No chat-event types, readers, writers, persistence, migrations, IndexedDB behavior, API response fields, or legacy dual-read fallback code was changed.

## Fallbacks

- `turbo/apps/api/src/lib/web-client-compatibility.json:minimumSupportedVersion` — advances the existing force-upgrade boundary so App clients older than `0.706.3` receive `426` before Stage 5 writes the new event content. Surface: old web/App clients, with an observed maximum version-skew window of approximately two days; a handled API request ends the skew earlier by requiring a refresh. The target build is already live, so this PR is the cleanup boundary. The floor remains as the permanent supported-client gate and can only be advanced again after a newer target is independently verified in production.
- `turbo/packages/api-contracts/src/contracts/chat-events.ts:legacyGoalChangedObjective` and `turbo/packages/api-contracts/src/contracts/chat-threads.ts:resolveChatEventRecommendedFollowups` — retain the Stage 3 dual readers for legacy `goal.changed + goalEvent` and `recommendedFollowups` alongside the new content-based shapes. Surface: old web/App clients and rows written during the rollout, with the same approximately two-day client window shortened by the `426` gate. Removal condition: Stage 5, after this Stage 4 floor is active and the content-marker/content-followups writers cut over.
- `turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts:appendGoalEventMarker` and the existing follow-up writer — continue emitting the legacy fields in this PR. Surface: API-to-old-web/App compatibility during the same client window. Removal condition: the Stage 5 writer cutover; this PR intentionally does not start that cutover.

## Verification

- parsed the compatibility JSON and asserted `minimumSupportedVersion === "0.706.3"`
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed)
- `pnpm check-types` (14/14 tasks passed)
- `pnpm exec vitest run src/__tests__/app-factory.test.ts -t 'web client compatibility'` from `turbo/apps/api` (5 passed, 40 skipped by the targeted filter)
- `git diff origin/main...HEAD --check`

No full Vitest suite or local development server was run.
