### PR TITLE
perf(api): isolate the stripe sdk type surface behind the gateway typecheck project

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -25,7 +25,7 @@ const gatewayModules = JSON.parse(
 // Third-party declaration surfaces that only the gateway project may resolve.
 // Add a scope here once its clients move into tsconfig.gateways.json; see
 // the ablation numbers in PR #25714.
-const isolatedDependencies = ["@aws-sdk", "@slack", "@smithy"];
+const isolatedDependencies = ["@aws-sdk", "@slack", "@smithy", "stripe"];
 
 const gatewayBoundaryOptions = {
   modules: gatewayModules,

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -17,9 +17,7 @@ import { testOverride } from "../../lib/singleton";
 /** Stripe expands a reference either to an id string or to the object. */
 export type StripeRef = string | { readonly id: string } | null;
 
-export interface StripeMetadataParam {
-  [key: string]: string | number | null;
-}
+export type StripeMetadataParam = Record<string, string | number | null>;
 
 export interface StripeProduct {
   readonly id: string;

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -2,7 +2,436 @@ import StripeSDK from "stripe";
 import { env } from "../../lib/env";
 import { testOverride } from "../../lib/singleton";
 
-interface StripeInvoice {
+/**
+ * Stripe gateway. This module is the only place `stripe` is resolved: it
+ * belongs to `tsconfig.gateways.json`, so the SDK declaration surface is parsed
+ * once in that small program instead of inside the core one, which is what sets
+ * the CI peak RSS for apps/api (same move as `@aws-sdk/*` in PR #25714).
+ *
+ * Everything exported below is a vm0-owned type; that is what keeps the emitted
+ * `.d.ts` free of Stripe types. The mirrors cover exactly the fields callers
+ * read and the params they send - widening them is fine, naming a Stripe type
+ * in an exported signature is not.
+ */
+
+/** Stripe expands a reference either to an id string or to the object. */
+export type StripeRef = string | { readonly id: string } | null;
+
+export interface StripeMetadataParam {
+  [key: string]: string | number | null;
+}
+
+export interface StripeProduct {
+  readonly id: string;
+  readonly name: string;
+  readonly metadata: Record<string, string>;
+}
+
+export interface StripeDeletedProduct {
+  readonly id: string;
+  readonly deleted: true;
+}
+
+/** Stripe returns a deleted stub instead of the product once it is removed. */
+export type StripeProductRef = string | StripeProduct | StripeDeletedProduct;
+
+export interface StripePriceRecurring {
+  readonly interval: "day" | "month" | "week" | "year";
+  readonly interval_count: number;
+}
+
+export interface StripePrice {
+  readonly id: string;
+  readonly active: boolean;
+  readonly currency?: string;
+  readonly type: "one_time" | "recurring";
+  readonly unit_amount: number | null;
+  readonly metadata?: Record<string, string> | null;
+  readonly recurring: StripePriceRecurring | null;
+  readonly product: StripeProductRef;
+}
+
+export interface StripeSubscriptionItem {
+  readonly id: string;
+  readonly price: StripePrice;
+  readonly quantity?: number;
+  readonly current_period_start: number;
+  readonly current_period_end: number;
+}
+
+export interface StripeSubscription {
+  readonly id: string;
+  readonly customer: string | { readonly id: string };
+  readonly status: string;
+  readonly metadata?: Record<string, string> | null;
+  readonly trial_end?: number | null;
+  readonly cancel_at?: number | null;
+  readonly cancel_at_period_end: boolean;
+  readonly schedule?: StripeRef;
+  readonly discounts?: readonly StripeRef[];
+  readonly default_payment_method?: StripeRef;
+  readonly latest_invoice: string | StripeInvoice | null;
+  readonly pending_update?: {
+    readonly subscription_items?: readonly StripeSubscriptionItem[] | null;
+  } | null;
+  readonly items: { readonly data: readonly StripeSubscriptionItem[] };
+}
+
+export interface StripeSubscriptionPreviousAttributes {
+  readonly trial_end?: number | null;
+  readonly cancel_at?: number | null;
+  readonly cancel_at_period_end?: boolean;
+  readonly schedule?: StripeRef;
+}
+
+export interface StripeSchedulePhase {
+  readonly start_date: number;
+  readonly end_date: number;
+}
+
+export interface StripeSubscriptionSchedule {
+  readonly id: string;
+  readonly end_behavior?: string;
+  readonly current_phase?: StripeSchedulePhase | null;
+  readonly phases: readonly StripeSchedulePhase[];
+}
+
+export interface StripeSchedulePhaseItemParam {
+  readonly price: string;
+  readonly quantity?: number;
+}
+
+export interface StripeSchedulePhaseDiscountParam {
+  readonly discount: string;
+}
+
+export interface StripeSchedulePhaseParam {
+  readonly start_date?: number;
+  readonly end_date?: number;
+  readonly duration?: StripePriceRecurring;
+  readonly items: StripeSchedulePhaseItemParam[];
+  readonly proration_behavior?: "always_invoice" | "create_prorations" | "none";
+  readonly discounts?: StripeSchedulePhaseDiscountParam[];
+}
+
+export interface StripeSubscriptionScheduleUpdateParams {
+  readonly end_behavior?: "cancel" | "none" | "release" | "renew";
+  readonly proration_behavior?: "always_invoice" | "create_prorations" | "none";
+  readonly phases?: StripeSchedulePhaseParam[];
+}
+
+export interface StripeSubscriptionUpdateParams {
+  readonly cancel_at?: number | null;
+  readonly cancel_at_period_end?: boolean;
+  readonly metadata?: StripeMetadataParam;
+}
+
+export interface StripeCustomer {
+  readonly id: string;
+  /**
+   * Mirrors Stripe's own `deleted?: void` marker so that
+   * `if (customer.deleted)` still narrows this union for callers.
+   */
+  readonly deleted?: void;
+  readonly metadata: Record<string, string>;
+  readonly discount?: {
+    readonly source: { readonly coupon: StripeRef };
+  } | null;
+  readonly invoice_settings?: {
+    readonly default_payment_method?: StripeRef;
+  } | null;
+}
+
+export interface StripeDeletedCustomer {
+  readonly id: string;
+  readonly deleted: true;
+}
+
+/** Stripe returns a deleted stub instead of the customer once it is removed. */
+export type StripeCustomerRef = StripeCustomer | StripeDeletedCustomer;
+
+export interface StripePaymentMethod {
+  readonly id: string;
+  readonly type: string;
+  readonly customer?: StripeRef;
+}
+
+export interface StripePaymentIntent {
+  readonly id: string;
+  readonly customer?: StripeRef;
+  readonly payment_method?: StripeRef;
+  readonly metadata?: Record<string, string> | null;
+}
+
+export interface StripeInvoiceLine {
+  readonly id?: string;
+  readonly amount?: number | null;
+  readonly subtotal?: number | null;
+  readonly quantity?: number | null;
+  readonly price?: { readonly id: string } | null;
+  readonly pricing?: {
+    readonly price_details?: {
+      readonly price?: StripeRef;
+    } | null;
+  } | null;
+  readonly proration?: boolean;
+  readonly period: { readonly start?: number; readonly end: number };
+  readonly parent: {
+    readonly type: "subscription_item_details" | "invoice_item_details";
+    readonly subscription_item_details?: {
+      readonly proration: boolean;
+      readonly proration_details?: {
+        readonly credited_items?: unknown;
+      } | null;
+    } | null;
+    readonly invoice_item_details?: {
+      readonly proration: boolean;
+      readonly proration_details?: {
+        readonly credited_items?: unknown;
+      } | null;
+    } | null;
+  } | null;
+}
+
+export interface StripeInvoice {
+  readonly id: string;
+  readonly hosted_invoice_url?: string | null;
+  readonly customer: StripeRef;
+  readonly metadata: Record<string, string> | null;
+  readonly subtotal?: number | null;
+  readonly lines: { readonly data: readonly StripeInvoiceLine[] };
+  readonly parent: {
+    readonly subscription_details: {
+      readonly metadata?: Record<string, string> | null;
+      readonly subscription: string | { readonly id: string };
+    } | null;
+  } | null;
+}
+
+export interface StripeCheckoutSession {
+  readonly id: string;
+  readonly url?: string | null;
+  readonly status?: string | null;
+  readonly mode?: string | null;
+  readonly invoice?: StripeRef;
+  readonly subscription: StripeRef;
+  readonly customer: StripeRef;
+  readonly metadata: Record<string, string> | null;
+  readonly setup_intent?:
+    | string
+    | {
+        readonly id: string;
+        readonly payment_method?: StripeRef;
+      }
+    | null;
+  readonly amount_subtotal?: number | null;
+  readonly amount_total?: number | null;
+  readonly payment_status?: string | null;
+}
+
+export interface StripeCoupon {
+  readonly id: string;
+  readonly valid?: boolean;
+  readonly percent_off?: number | null;
+  readonly amount_off?: number | null;
+}
+
+export interface StripeBillingPortalSession {
+  readonly id: string;
+  readonly url: string;
+}
+
+export interface StripeBillingPortalSessionCreateParams {
+  readonly customer: string;
+  readonly return_url: string;
+  readonly configuration?: string;
+  readonly flow_data?: {
+    readonly type: "subscription_update_confirm";
+    readonly after_completion?: {
+      readonly type: "redirect";
+      readonly redirect: { readonly return_url: string };
+    };
+    readonly subscription_update_confirm: {
+      readonly subscription: string;
+      readonly items: {
+        readonly id: string;
+        readonly quantity?: number;
+      }[];
+    };
+  };
+}
+
+export interface StripeList<T> {
+  readonly data: readonly T[];
+  readonly has_more: boolean;
+}
+
+export type StripeSubscriptionListStatus =
+  | "active"
+  | "all"
+  | "canceled"
+  | "ended"
+  | "incomplete"
+  | "incomplete_expired"
+  | "past_due"
+  | "paused"
+  | "trialing"
+  | "unpaid";
+
+export interface StripeSubscriptionsApi {
+  retrieve(
+    id: string,
+    params?: { expand?: string[] },
+  ): Promise<StripeSubscription>;
+  update(
+    id: string,
+    params: StripeSubscriptionUpdateParams,
+  ): Promise<StripeSubscription>;
+  list(params: {
+    customer?: string;
+    status?: StripeSubscriptionListStatus;
+    price?: string;
+    limit?: number;
+  }): Promise<StripeList<StripeSubscription>>;
+  cancel(
+    id: string,
+    params?: { invoice_now?: boolean; prorate?: boolean },
+  ): Promise<StripeSubscription>;
+}
+
+export interface StripeSubscriptionSchedulesApi {
+  retrieve(id: string): Promise<StripeSubscriptionSchedule>;
+  create(params: {
+    from_subscription: string;
+  }): Promise<StripeSubscriptionSchedule>;
+  update(
+    id: string,
+    params: StripeSubscriptionScheduleUpdateParams,
+  ): Promise<StripeSubscriptionSchedule>;
+  release(id: string): Promise<StripeSubscriptionSchedule>;
+}
+
+export interface StripeCustomersApi {
+  retrieve(id: string): Promise<StripeCustomerRef>;
+  create(params: {
+    metadata?: StripeMetadataParam;
+    email?: string;
+  }): Promise<StripeCustomer>;
+  update(
+    id: string,
+    params: {
+      metadata?: StripeMetadataParam;
+      invoice_settings?: { default_payment_method?: string };
+    },
+  ): Promise<StripeCustomer>;
+}
+
+export interface StripePricesApi {
+  retrieve(id: string, params?: { expand?: string[] }): Promise<StripePrice>;
+}
+
+export interface StripeCouponsApi {
+  retrieve(id: string): Promise<StripeCoupon>;
+}
+
+export interface StripeInvoicesApi {
+  list(params: {
+    subscription?: string;
+    customer?: string;
+    status?: "draft" | "open" | "paid" | "uncollectible" | "void";
+    limit?: number;
+  }): Promise<StripeList<StripeInvoice>>;
+  create(params: {
+    customer: string;
+    auto_advance?: boolean;
+    default_payment_method?: string;
+    metadata?: StripeMetadataParam;
+  }): Promise<StripeInvoice>;
+  finalizeInvoice(id: string): Promise<StripeInvoice>;
+  pay(id: string): Promise<StripeInvoice>;
+}
+
+export interface StripeInvoiceItemsApi {
+  create(params: {
+    invoice?: string;
+    customer: string;
+    amount: number;
+    currency: string;
+    description?: string;
+  }): Promise<{ readonly id: string }>;
+}
+
+export interface StripeCheckoutSessionCreateParams {
+  readonly mode: "payment" | "setup" | "subscription";
+  readonly customer?: string;
+  readonly currency?: string;
+  readonly line_items?: {
+    readonly price: string;
+    readonly quantity?: number;
+  }[];
+  readonly allow_promotion_codes?: boolean;
+  readonly discounts?: { readonly coupon: string }[];
+  readonly success_url?: string;
+  readonly cancel_url?: string;
+  readonly metadata?: StripeMetadataParam;
+  readonly subscription_data?: {
+    readonly metadata?: StripeMetadataParam;
+    readonly trial_period_days?: number;
+  };
+  readonly invoice_creation?: {
+    readonly enabled: boolean;
+    readonly invoice_data?: { readonly metadata?: StripeMetadataParam };
+  };
+  readonly payment_intent_data?: {
+    readonly setup_future_usage?: "off_session" | "on_session";
+    readonly metadata?: StripeMetadataParam;
+  };
+  readonly setup_intent_data?: { readonly metadata?: StripeMetadataParam };
+}
+
+export interface StripeCheckoutSessionsApi {
+  create(
+    params: StripeCheckoutSessionCreateParams,
+  ): Promise<StripeCheckoutSession>;
+  retrieve(
+    id: string,
+    params?: { expand?: string[] },
+  ): Promise<StripeCheckoutSession>;
+  expire(id: string): Promise<StripeCheckoutSession>;
+}
+
+export interface StripePaymentMethodsApi {
+  retrieve(id: string): Promise<StripePaymentMethod>;
+  list(params: {
+    customer: string;
+    /** Only card payment methods are read today; widen when that changes. */
+    type?: "card";
+    limit?: number;
+  }): Promise<StripeList<StripePaymentMethod>>;
+}
+
+export interface StripeBillingPortalApi {
+  readonly sessions: {
+    create(
+      params: StripeBillingPortalSessionCreateParams,
+    ): Promise<StripeBillingPortalSession>;
+  };
+}
+
+export interface StripeClient {
+  readonly subscriptions: StripeSubscriptionsApi;
+  readonly subscriptionSchedules: StripeSubscriptionSchedulesApi;
+  readonly customers: StripeCustomersApi;
+  readonly prices: StripePricesApi;
+  readonly coupons: StripeCouponsApi;
+  readonly invoices: StripeInvoicesApi;
+  readonly invoiceItems: StripeInvoiceItemsApi;
+  readonly checkout: { readonly sessions: StripeCheckoutSessionsApi };
+  readonly paymentMethods: StripePaymentMethodsApi;
+  readonly billingPortal: StripeBillingPortalApi;
+}
+
+interface StripeListedInvoice {
   readonly id: string;
   readonly number: string | null;
   readonly created: number;
@@ -25,7 +454,7 @@ const {
   | ((
       customerId: string,
       created?: StripeInvoiceCreatedRange,
-    ) => Promise<readonly StripeInvoice[]>)
+    ) => Promise<readonly StripeListedInvoice[]>)
   | undefined
 >(() => {
   return undefined;
@@ -34,7 +463,7 @@ const {
 export async function listStripeInvoices(
   customerId: string,
   created?: StripeInvoiceCreatedRange,
-): Promise<readonly StripeInvoice[]> {
+): Promise<readonly StripeListedInvoice[]> {
   const mocked = getMockedListInvoices();
   if (mocked) {
     return await mocked(customerId, created);
@@ -64,7 +493,7 @@ export function mockListStripeInvoices(
   fn: (
     customerId: string,
     created?: StripeInvoiceCreatedRange,
-  ) => Promise<readonly StripeInvoice[]>,
+  ) => Promise<readonly StripeListedInvoice[]>,
 ): void {
   setMockedListInvoices(fn);
 }
@@ -72,6 +501,98 @@ export function mockListStripeInvoices(
 export function clearMockListStripeInvoices(): void {
   clearMockedListInvoices();
 }
+
+const { get: getMockedStripeClient, set: setMockedStripeClient } = testOverride<
+  StripeSDK | undefined
+>(() => {
+  return undefined;
+});
+
+function stripeSdk(): StripeSDK {
+  const mocked = getMockedStripeClient();
+  if (mocked) {
+    return mocked;
+  }
+  return new StripeSDK(env("STRIPE_SECRET_KEY"));
+}
+
+/**
+ * Per-call Stripe SDK instantiation, narrowed to the vm0-owned client surface.
+ *
+ * In tests, override via `mockStripeClient(fakeSdk)` so the wrapper doesn't
+ * construct a real Stripe client. (The centralized `vi.mock("stripe")` factory
+ * in `__tests__/mocks.ts` doesn't compose with `new StripeSDK()` as a
+ * constructor - vi.fn() isn't a real constructor - so we route through this
+ * override instead.)
+ */
+export function getStripeClient(): StripeClient {
+  return stripeSdk();
+}
+
+export function mockStripeClient(fakeSdk: unknown): void {
+  setMockedStripeClient(fakeSdk as StripeSDK);
+}
+
+/**
+ * Stripe's `Event` is a wide discriminated union, and narrowing it is the only
+ * reason the webhook dispatcher would need the SDK types. The gateway does that
+ * narrowing once and hands core a vm0-owned envelope instead.
+ */
+export type StripeWebhookEvent =
+  | {
+      readonly kind: "payment_intent.succeeded";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripePaymentIntent;
+    }
+  | {
+      readonly kind: "checkout.session.paid";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripeCheckoutSession;
+    }
+  | {
+      readonly kind: "invoice.paid";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripeInvoice;
+    }
+  | {
+      readonly kind: "customer.subscription.created";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripeSubscription;
+    }
+  | {
+      readonly kind: "customer.subscription.updated";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripeSubscription;
+      readonly previousAttributes?: StripeSubscriptionPreviousAttributes;
+    }
+  | {
+      readonly kind: "customer.subscription.deleted";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripeSubscription;
+    }
+  | {
+      readonly kind: "subscription_schedule.released";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripeSubscriptionSchedule;
+    }
+  | {
+      readonly kind: "subscription_schedule.ended";
+      readonly id: string;
+      readonly type: string;
+      readonly object: StripeSubscriptionSchedule;
+    }
+  | {
+      readonly kind: "unhandled";
+      readonly id: string;
+      readonly type: string;
+    };
 
 type StripeWebhookEventConstructor = (
   rawBody: string,
@@ -86,6 +607,10 @@ const {
   return undefined;
 });
 
+/**
+ * Raw event for the workflow-events ingress, which zod-parses the payload
+ * itself rather than branching on Stripe's union.
+ */
 export function constructStripeWebhookEvent(
   rawBody: string,
   signature: string,
@@ -95,7 +620,7 @@ export function constructStripeWebhookEvent(
   if (mocked) {
     return mocked(rawBody, signature, secret);
   }
-  return getStripeClient().webhooks.constructEvent(rawBody, signature, secret);
+  return stripeSdk().webhooks.constructEvent(rawBody, signature, secret);
 }
 
 export function mockStripeWebhookEventConstructor(
@@ -104,31 +629,210 @@ export function mockStripeWebhookEventConstructor(
   setMockedStripeWebhookEventConstructor(constructor);
 }
 
-const { get: getMockedStripeClient, set: setMockedStripeClient } = testOverride<
-  StripeSDK | undefined
->(() => {
-  return undefined;
-});
+export function constructStripeBillingWebhookEvent(
+  rawBody: string,
+  signature: string,
+  secret: string,
+): StripeWebhookEvent {
+  const event = stripeSdk().webhooks.constructEvent(rawBody, signature, secret);
+  const envelope = { id: event.id, type: event.type };
 
-/**
- * Per-call Stripe SDK instantiation. Use this when a caller needs the
- * full SDK surface (e.g. auto-recharge invoice flow); for narrow
- * operations like list-invoices, prefer the wrapper helpers.
- *
- * In tests, override via `mockStripeClient(fakeSdk)` so the wrapper
- * doesn't construct a real Stripe client. (The centralized `vi.mock("stripe")`
- * factory in `__tests__/mocks.ts` doesn't compose with `new StripeSDK()`
- * as a constructor — vi.fn() isn't a real constructor — so we route
- * through this override instead.)
- */
-export function getStripeClient(): StripeSDK {
-  const mocked = getMockedStripeClient();
-  if (mocked) {
-    return mocked;
+  switch (event.type) {
+    case "payment_intent.succeeded": {
+      return {
+        kind: "payment_intent.succeeded",
+        ...envelope,
+        object: event.data.object,
+      };
+    }
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded": {
+      return {
+        kind: "checkout.session.paid",
+        ...envelope,
+        object: event.data.object,
+      };
+    }
+    case "invoice.paid": {
+      return { kind: "invoice.paid", ...envelope, object: event.data.object };
+    }
+    case "customer.subscription.created": {
+      return {
+        kind: "customer.subscription.created",
+        ...envelope,
+        object: event.data.object,
+      };
+    }
+    case "customer.subscription.updated": {
+      return {
+        kind: "customer.subscription.updated",
+        ...envelope,
+        object: event.data.object,
+        previousAttributes: event.data.previous_attributes,
+      };
+    }
+    case "customer.subscription.deleted": {
+      return {
+        kind: "customer.subscription.deleted",
+        ...envelope,
+        object: event.data.object,
+      };
+    }
+    case "subscription_schedule.released": {
+      return {
+        kind: "subscription_schedule.released",
+        ...envelope,
+        object: event.data.object,
+      };
+    }
+    case "subscription_schedule.canceled":
+    case "subscription_schedule.aborted": {
+      return {
+        kind: "subscription_schedule.ended",
+        ...envelope,
+        object: event.data.object,
+      };
+    }
+    default: {
+      return { kind: "unhandled", ...envelope };
+    }
   }
-  return new StripeSDK(env("STRIPE_SECRET_KEY"));
 }
 
-export function mockStripeClient(fakeSdk: StripeSDK): void {
-  setMockedStripeClient(fakeSdk);
+const PAYMENT_METHOD_PORTAL_CONFIGURATION_NAME = "VM0 payment methods";
+const PAYMENT_METHOD_PORTAL_CONFIGURATION_IDEMPOTENCY_KEY =
+  "vm0-payment-method-portal-v1";
+const PAYMENT_METHOD_PORTAL_METADATA = {
+  managed_by: "vm0",
+  purpose: "payment_method_management",
+} as const;
+
+function paymentMethodPortalFeatures(): StripeSDK.BillingPortal.ConfigurationCreateParams.Features {
+  return {
+    customer_update: { enabled: false },
+    invoice_history: { enabled: false },
+    payment_method_update: { enabled: true },
+    subscription_cancel: { enabled: false },
+    subscription_update: { enabled: false },
+  };
+}
+
+function isManagedPaymentMethodPortalConfiguration(
+  configuration: StripeSDK.BillingPortal.Configuration,
+): boolean {
+  return (
+    configuration.metadata?.managed_by ===
+      PAYMENT_METHOD_PORTAL_METADATA.managed_by &&
+    configuration.metadata.purpose === PAYMENT_METHOD_PORTAL_METADATA.purpose
+  );
+}
+
+function isRestrictedPaymentMethodPortalConfiguration(
+  configuration: StripeSDK.BillingPortal.Configuration,
+): boolean {
+  return (
+    configuration.active &&
+    !configuration.features.customer_update.enabled &&
+    !configuration.features.invoice_history.enabled &&
+    configuration.features.payment_method_update.enabled &&
+    !configuration.features.subscription_cancel.enabled &&
+    !configuration.features.subscription_update.enabled &&
+    !configuration.login_page.enabled
+  );
+}
+
+/**
+ * Billing portal configurations are the one caller that reads the SDK's nested
+ * feature flags, so the whole reconcile loop lives behind the boundary and
+ * hands back just the configuration id.
+ */
+export async function ensurePaymentMethodPortalConfiguration(
+  signal: AbortSignal,
+): Promise<string> {
+  const stripe = stripeSdk();
+  const configurations = await stripe.billingPortal.configurations.list({
+    limit: 100,
+  });
+  signal.throwIfAborted();
+
+  const existing = configurations.data.find(
+    isManagedPaymentMethodPortalConfiguration,
+  );
+  if (!existing) {
+    const created = await stripe.billingPortal.configurations.create(
+      {
+        name: PAYMENT_METHOD_PORTAL_CONFIGURATION_NAME,
+        features: paymentMethodPortalFeatures(),
+        login_page: { enabled: false },
+        metadata: PAYMENT_METHOD_PORTAL_METADATA,
+      },
+      { idempotencyKey: PAYMENT_METHOD_PORTAL_CONFIGURATION_IDEMPOTENCY_KEY },
+    );
+    signal.throwIfAborted();
+    return created.id;
+  }
+
+  if (isRestrictedPaymentMethodPortalConfiguration(existing)) {
+    return existing.id;
+  }
+
+  const updated = await stripe.billingPortal.configurations.update(
+    existing.id,
+    {
+      active: true,
+      name: PAYMENT_METHOD_PORTAL_CONFIGURATION_NAME,
+      features: paymentMethodPortalFeatures(),
+      login_page: { enabled: false },
+      metadata: PAYMENT_METHOD_PORTAL_METADATA,
+    },
+  );
+  signal.throwIfAborted();
+  return updated.id;
+}
+
+export interface StripeErrorInfo {
+  readonly type: string;
+  readonly code: string | null;
+  readonly message: string;
+}
+
+/** Reports Stripe API failures without exposing the SDK error classes. */
+export function stripeErrorInfo(error: unknown): StripeErrorInfo | null {
+  if (!(error instanceof StripeSDK.errors.StripeError)) {
+    return null;
+  }
+  return {
+    type: error.type,
+    code: error.code ?? null,
+    message: error.message,
+  };
+}
+
+/**
+ * Raises the same `resource_missing` failure Stripe itself would raise, so a
+ * campaign that drifted out of configuration is reported to callers exactly
+ * like a deleted Stripe resource.
+ */
+export function stripeResourceMissingError(message: string): Error {
+  return new StripeSDK.errors.StripeInvalidRequestError({
+    type: "invalid_request_error",
+    code: "resource_missing",
+    message,
+  });
+}
+
+/** `resource_missing` is the only Stripe error code callers branch on. */
+export function isStripeResourceMissingError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const candidate = error as {
+    readonly code?: unknown;
+    readonly raw?: { readonly code?: unknown };
+  };
+  return (
+    candidate.code === "resource_missing" ||
+    candidate.raw?.code === "resource_missing"
+  );
 }

--- a/turbo/apps/api/src/signals/routes/webhooks-stripe.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-stripe.ts
@@ -4,7 +4,7 @@ import { webhookStripeContract } from "@vm0/api-contracts/contracts/webhooks";
 import { optionalEnv } from "../../lib/env";
 import type { RouteEntry } from "../route-entry";
 import { request$ } from "../context/hono";
-import { getStripeClient } from "../external/stripe-client";
+import { constructStripeBillingWebhookEvent } from "../external/stripe-client";
 import { safeSync } from "../utils";
 import { handleStripeWebhookEvent$ } from "../services/webhooks-stripe.service";
 
@@ -29,11 +29,7 @@ const postStripeWebhook$ = command(
     signal.throwIfAborted();
 
     const eventResult = safeSync(() => {
-      return getStripeClient().webhooks.constructEvent(
-        body,
-        signature,
-        webhookSecret,
-      );
+      return constructStripeBillingWebhookEvent(body, signature, webhookSecret);
     });
     signal.throwIfAborted();
     if ("error" in eventResult) {

--- a/turbo/apps/api/src/signals/services/billing.service.ts
+++ b/turbo/apps/api/src/signals/services/billing.service.ts
@@ -1,4 +1,3 @@
-import type StripeSDK from "stripe";
 import { command, computed, type Computed } from "ccstate";
 import type { AutoRechargeConfig } from "@vm0/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -7,95 +6,12 @@ import { eq } from "drizzle-orm";
 
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../../lib/time";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  ensurePaymentMethodPortalConfiguration,
+  getStripeClient,
+} from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
-
-const PAYMENT_METHOD_PORTAL_CONFIGURATION_NAME = "VM0 payment methods";
-const PAYMENT_METHOD_PORTAL_CONFIGURATION_IDEMPOTENCY_KEY =
-  "vm0-payment-method-portal-v1";
-const PAYMENT_METHOD_PORTAL_METADATA = {
-  managed_by: "vm0",
-  purpose: "payment_method_management",
-} as const;
-
-function paymentMethodPortalFeatures(): StripeSDK.BillingPortal.ConfigurationCreateParams.Features {
-  return {
-    customer_update: { enabled: false },
-    invoice_history: { enabled: false },
-    payment_method_update: { enabled: true },
-    subscription_cancel: { enabled: false },
-    subscription_update: { enabled: false },
-  };
-}
-
-function isManagedPaymentMethodPortalConfiguration(
-  configuration: StripeSDK.BillingPortal.Configuration,
-): boolean {
-  return (
-    configuration.metadata?.managed_by ===
-      PAYMENT_METHOD_PORTAL_METADATA.managed_by &&
-    configuration.metadata.purpose === PAYMENT_METHOD_PORTAL_METADATA.purpose
-  );
-}
-
-function isRestrictedPaymentMethodPortalConfiguration(
-  configuration: StripeSDK.BillingPortal.Configuration,
-): boolean {
-  return (
-    configuration.active &&
-    !configuration.features.customer_update.enabled &&
-    !configuration.features.invoice_history.enabled &&
-    configuration.features.payment_method_update.enabled &&
-    !configuration.features.subscription_cancel.enabled &&
-    !configuration.features.subscription_update.enabled &&
-    !configuration.login_page.enabled
-  );
-}
-
-async function ensurePaymentMethodPortalConfiguration(
-  stripe: StripeSDK,
-  signal: AbortSignal,
-): Promise<string> {
-  const configurations = await stripe.billingPortal.configurations.list({
-    limit: 100,
-  });
-  signal.throwIfAborted();
-
-  const existing = configurations.data.find(
-    isManagedPaymentMethodPortalConfiguration,
-  );
-  if (!existing) {
-    const created = await stripe.billingPortal.configurations.create(
-      {
-        name: PAYMENT_METHOD_PORTAL_CONFIGURATION_NAME,
-        features: paymentMethodPortalFeatures(),
-        login_page: { enabled: false },
-        metadata: PAYMENT_METHOD_PORTAL_METADATA,
-      },
-      { idempotencyKey: PAYMENT_METHOD_PORTAL_CONFIGURATION_IDEMPOTENCY_KEY },
-    );
-    signal.throwIfAborted();
-    return created.id;
-  }
-
-  if (isRestrictedPaymentMethodPortalConfiguration(existing)) {
-    return existing.id;
-  }
-
-  const updated = await stripe.billingPortal.configurations.update(
-    existing.id,
-    {
-      active: true,
-      name: PAYMENT_METHOD_PORTAL_CONFIGURATION_NAME,
-      features: paymentMethodPortalFeatures(),
-      login_page: { enabled: false },
-      metadata: PAYMENT_METHOD_PORTAL_METADATA,
-    },
-  );
-  signal.throwIfAborted();
-  return updated.id;
-}
 
 export function autoRechargeConfig(
   orgId: string,
@@ -181,10 +97,8 @@ export const createBillingPortalSession$ = command(
       return session.url;
     }
 
-    const portalConfigurationId = await ensurePaymentMethodPortalConfiguration(
-      stripe,
-      signal,
-    );
+    const portalConfigurationId =
+      await ensurePaymentMethodPortalConfiguration(signal);
     signal.throwIfAborted();
 
     const session = await stripe.billingPortal.sessions.create({

--- a/turbo/apps/api/src/signals/services/stripe-subscription-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-subscription-schedules.service.ts
@@ -1,6 +1,7 @@
-import type { Stripe } from "stripe";
-
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  type StripeSubscriptionSchedule,
+} from "../external/stripe-client";
 
 interface SubscriptionScheduleRef {
   readonly schedule?: string | { readonly id: string } | null;
@@ -17,7 +18,7 @@ export function subscriptionScheduleId(
 }
 
 export function subscriptionScheduleFinalEnd(
-  schedule: Pick<Stripe.SubscriptionSchedule, "current_phase" | "phases">,
+  schedule: Pick<StripeSubscriptionSchedule, "current_phase" | "phases">,
 ): Date | null {
   const finalEnd = schedule.phases.reduce<number | null>((latest, phase) => {
     return latest === null || phase.end_date > latest ? phase.end_date : latest;

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -22,13 +22,17 @@ import {
   or,
   sql,
 } from "drizzle-orm";
-import type { Stripe } from "stripe";
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  type StripeClient,
+  type StripeMetadataParam,
+  type StripePrice,
+} from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { upsertOrgPlanEntitlement } from "./org-plan-entitlements.service";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
@@ -231,7 +235,7 @@ function positiveMetadataInteger(
 function validateUsagePackPrice(
   usagePackUsd: UsagePackUsd,
   stripePriceId: string,
-  price: Stripe.Price,
+  price: StripePrice,
   requireActive: boolean,
 ): ValidatedUsagePackPrice {
   if (price.id !== stripePriceId) {
@@ -363,8 +367,8 @@ function usagePackCheckoutMetadata(args: {
   readonly adAttribution:
     | Readonly<Record<string, string | undefined>>
     | undefined;
-}): Stripe.MetadataParam {
-  const metadata: Stripe.MetadataParam = {
+}): StripeMetadataParam {
+  const metadata: StripeMetadataParam = {
     orgId: args.orgId,
     tier: args.tier,
     priceId: args.planPriceId,
@@ -1650,7 +1654,7 @@ interface ReconcileUsagePackSubscriptionResult {
 
 async function reconcileUsagePackSubscriptionCandidate(
   db: Db,
-  stripe: Stripe,
+  stripe: StripeClient,
   candidate: UsagePackSubscriptionRow,
   signal: AbortSignal,
 ): Promise<ReconcileUsagePackSubscriptionResult> {

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -1,4 +1,3 @@
-import type { Stripe } from "stripe";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgConcurrencyEntitlements } from "@vm0/db/schema/org-concurrency-entitlement";
@@ -16,7 +15,13 @@ import { logger } from "../../lib/log";
 import { now, nowDate, timestampWithoutTimeZone } from "../../lib/time";
 import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  isStripeResourceMissingError,
+  type StripePaymentIntent,
+  type StripeSubscription,
+  type StripeWebhookEvent,
+} from "../external/stripe-client";
 import { settle } from "../utils";
 import { getCampaign } from "./one-time-products";
 import {
@@ -1003,23 +1008,22 @@ async function handleUsageAllowanceInvoicePaid(
 }
 
 function stripePreviewMetadataForEvent(
-  event: Stripe.Event,
+  event: StripeWebhookEvent,
 ): readonly (Readonly<Record<string, string>> | null | undefined)[] | null {
-  switch (event.type) {
-    case "checkout.session.completed":
-    case "checkout.session.async_payment_succeeded": {
-      return [event.data.object.metadata];
+  switch (event.kind) {
+    case "checkout.session.paid": {
+      return [event.object.metadata];
     }
     case "invoice.paid": {
       return [
-        event.data.object.metadata,
-        event.data.object.parent?.subscription_details?.metadata,
+        event.object.metadata,
+        event.object.parent?.subscription_details?.metadata,
       ];
     }
     case "customer.subscription.created":
     case "customer.subscription.updated":
     case "customer.subscription.deleted": {
-      return [event.data.object.metadata];
+      return [event.object.metadata];
     }
     default: {
       return null;
@@ -1027,7 +1031,7 @@ function stripePreviewMetadataForEvent(
   }
 }
 
-function shouldHandleStripePreviewEvent(event: Stripe.Event): boolean {
+function shouldHandleStripePreviewEvent(event: StripeWebhookEvent): boolean {
   const metadataCandidates = stripePreviewMetadataForEvent(event);
   if (metadataCandidates === null) {
     return true;
@@ -1049,7 +1053,7 @@ function stripeObjectId(value: unknown): string | null {
 
 async function paymentIntentMatchesCurrentStripePreview(
   stripe: ReturnType<typeof getStripeClient>,
-  paymentIntent: Stripe.PaymentIntent,
+  paymentIntent: StripePaymentIntent,
   customerId: string,
 ): Promise<boolean> {
   if (isCurrentStripePreviewMetadata(paymentIntent.metadata)) {
@@ -1064,7 +1068,7 @@ async function paymentIntentMatchesCurrentStripePreview(
 }
 
 async function handlePaymentIntentSucceeded(
-  paymentIntent: Stripe.PaymentIntent,
+  paymentIntent: StripePaymentIntent,
 ): Promise<void> {
   const customerId = stripeObjectId(paymentIntent.customer);
   const paymentMethodId = stripeObjectId(paymentIntent.payment_method);
@@ -2551,7 +2555,7 @@ function replacedProSubscriptionId(args: {
   return null;
 }
 
-function tierFromSubscription(subscription: Stripe.Subscription) {
+function tierFromSubscription(subscription: StripeSubscription) {
   const priceId = knownPlanPriceItem(subscription.items.data)?.price.id;
   if (!priceId) {
     return null;
@@ -2563,7 +2567,7 @@ function tierFromSubscription(subscription: Stripe.Subscription) {
 function isReplaceableProSubscription(args: {
   readonly orgId: string;
   readonly newSubscriptionId: string;
-  readonly subscription: Stripe.Subscription;
+  readonly subscription: StripeSubscription;
 }): boolean {
   const subscription = args.subscription;
   return (
@@ -2571,21 +2575,6 @@ function isReplaceableProSubscription(args: {
     subscription.metadata?.orgId === args.orgId &&
     (subscription.status === "active" || subscription.status === "trialing") &&
     tierFromSubscription(subscription) === "pro"
-  );
-}
-
-function isStripeResourceMissingError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return false;
-  }
-
-  const candidate = error as {
-    readonly code?: unknown;
-    readonly raw?: { readonly code?: unknown };
-  };
-  return (
-    candidate.code === "resource_missing" ||
-    candidate.raw?.code === "resource_missing"
   );
 }
 
@@ -2685,7 +2674,7 @@ async function cancelReplacedProSubscriptionsAfterTeamInvoice(args: {
 
 function isReplaceablePaidSubscriptionForAtomGrant(args: {
   readonly orgId: string;
-  readonly subscription: Stripe.Subscription;
+  readonly subscription: StripeSubscription;
 }): boolean {
   const subscription = args.subscription;
   return (
@@ -3943,7 +3932,7 @@ async function handleSubscriptionDeleted(
 export const handleStripeWebhookEvent$ = command(
   async (
     { get, set },
-    event: Stripe.Event,
+    event: StripeWebhookEvent,
     signal: AbortSignal,
   ): Promise<void> => {
     const db = set(writeDb$);
@@ -3962,15 +3951,14 @@ export const handleStripeWebhookEvent$ = command(
       return;
     }
 
-    switch (event.type) {
+    switch (event.kind) {
       case "payment_intent.succeeded": {
-        await handlePaymentIntentSucceeded(event.data.object);
+        await handlePaymentIntentSucceeded(event.object);
         signal.throwIfAborted();
         break;
       }
-      case "checkout.session.completed":
-      case "checkout.session.async_payment_succeeded": {
-        const result = await handleCheckoutCompleted(db, event.data.object);
+      case "checkout.session.paid": {
+        const result = await handleCheckoutCompleted(db, event.object);
         signal.throwIfAborted();
         drainOrgId = result.drainOrgId;
         addBillingChangedOrgIds(billingChangedOrgIds, result.orgIds);
@@ -3980,7 +3968,7 @@ export const handleStripeWebhookEvent$ = command(
         const paidDrainOrgId = await handleInvoicePaid(
           db,
           getClerk,
-          event.data.object,
+          event.object,
         );
         signal.throwIfAborted();
         drainOrgId = paidDrainOrgId;
@@ -3993,7 +3981,7 @@ export const handleStripeWebhookEvent$ = command(
         const orgIds = await handleSubscriptionCreated(
           db,
           getClerk,
-          event.data.object,
+          event.object,
         );
         signal.throwIfAborted();
         addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
@@ -4002,15 +3990,15 @@ export const handleStripeWebhookEvent$ = command(
       case "customer.subscription.updated": {
         const orgIds = await handleSubscriptionUpdated(
           db,
-          event.data.object,
-          event.data.previous_attributes,
+          event.object,
+          event.previousAttributes,
         );
         signal.throwIfAborted();
         addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
       }
       case "customer.subscription.deleted": {
-        const orgIds = await handleSubscriptionDeleted(db, event.data.object);
+        const orgIds = await handleSubscriptionDeleted(db, event.object);
         signal.throwIfAborted();
         addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
@@ -4018,18 +4006,14 @@ export const handleStripeWebhookEvent$ = command(
       case "subscription_schedule.released": {
         const orgIds = await handleSubscriptionScheduleReleased(
           db,
-          event.data.object,
+          event.object,
         );
         signal.throwIfAborted();
         addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;
       }
-      case "subscription_schedule.canceled":
-      case "subscription_schedule.aborted": {
-        const orgIds = await handleSubscriptionScheduleEnded(
-          db,
-          event.data.object,
-        );
+      case "subscription_schedule.ended": {
+        const orgIds = await handleSubscriptionScheduleEnded(db, event.object);
         signal.throwIfAborted();
         addBillingChangedOrgIds(billingChangedOrgIds, orgIds);
         break;

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -2,12 +2,17 @@ import { command } from "ccstate";
 import type { UsagePackUsd } from "@vm0/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { and, eq } from "drizzle-orm";
-import type { Stripe } from "stripe";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  type StripeInvoice,
+  type StripeMetadataParam,
+  type StripeSubscription,
+  type StripeSubscriptionItem,
+} from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 import {
@@ -293,7 +298,7 @@ function stripeObjectId(
   return value?.id ?? null;
 }
 
-function subscriptionWillCancel(subscription: Stripe.Subscription): boolean {
+function subscriptionWillCancel(subscription: StripeSubscription): boolean {
   return subscription.cancel_at_period_end || subscription.cancel_at !== null;
 }
 
@@ -457,7 +462,7 @@ export const createCreditCheckoutSession$ = command(
       throw new Error("Custom credit price not configured");
     }
     const unitQuantity = Math.ceil(args.credits / CREDITS_PER_DOLLAR);
-    const metadata: Stripe.MetadataParam = {
+    const metadata: StripeMetadataParam = {
       ...baseMetadata,
       creditsAmountMode: "amount_subtotal",
       requestedCreditsAmount: String(args.credits),
@@ -499,15 +504,15 @@ export const createCreditCheckoutSession$ = command(
 );
 
 function expandedLatestInvoice(
-  subscription: Stripe.Subscription,
-): Stripe.Invoice | null {
+  subscription: StripeSubscription,
+): StripeInvoice | null {
   return typeof subscription.latest_invoice === "string"
     ? null
     : subscription.latest_invoice;
 }
 
 function concurrencySubscriptionItem(
-  items: readonly Stripe.SubscriptionItem[],
+  items: readonly StripeSubscriptionItem[],
 ): {
   readonly id: string;
   readonly quantity: number;
@@ -628,7 +633,7 @@ export const startConcurrencyPurchase$ = command(
     );
     signal.throwIfAborted();
 
-    const metadata: Stripe.MetadataParam = {
+    const metadata: StripeMetadataParam = {
       purpose: CONCURRENCY_SUBSCRIPTION_PURPOSE,
       orgId: args.orgId,
       priceId: args.priceId,

--- a/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import type { Stripe } from "stripe";
 import type { OrgTier } from "@vm0/api-contracts/contracts/orgs";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { eq } from "drizzle-orm";
@@ -7,7 +6,17 @@ import { eq } from "drizzle-orm";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  type StripePrice,
+  type StripePriceRecurring,
+  type StripeSchedulePhaseDiscountParam,
+  type StripeSchedulePhaseItemParam,
+  type StripeSchedulePhaseParam,
+  type StripeSubscription,
+  type StripeSubscriptionItem,
+  type StripeSubscriptionSchedule,
+} from "../external/stripe-client";
 import {
   subscriptionScheduleFinalEnd,
   subscriptionScheduleId,
@@ -92,8 +101,8 @@ interface DowngradeContext {
 }
 
 function subscriptionPhaseRange(
-  schedule: Stripe.SubscriptionSchedule,
-  subscriptionItem: Stripe.SubscriptionItem,
+  schedule: StripeSubscriptionSchedule,
+  subscriptionItem: StripeSubscriptionItem,
 ): { readonly startDate: number; readonly endDate: number } {
   const startDate =
     schedule.current_phase?.start_date ?? subscriptionItem.current_period_start;
@@ -107,9 +116,7 @@ function subscriptionPhaseRange(
   return { startDate, endDate };
 }
 
-function phaseDuration(
-  price: Stripe.Price,
-): Stripe.SubscriptionScheduleUpdateParams.Phase.Duration {
+function phaseDuration(price: StripePrice): StripePriceRecurring {
   const recurring = price.recurring;
   if (!recurring) {
     throw new Error("Subscription price is not recurring");
@@ -124,7 +131,7 @@ function phaseDuration(
 function schedulePhaseItem(
   priceId: string,
   quantity: number | undefined,
-): Stripe.SubscriptionScheduleUpdateParams.Phase.Item {
+): StripeSchedulePhaseItemParam {
   return {
     price: priceId,
     quantity: quantity ?? 1,
@@ -141,14 +148,9 @@ function stripeObjectId(
 }
 
 function subscriptionSchedulePhaseDiscounts(
-  subscription: Stripe.Subscription,
-): Stripe.SubscriptionScheduleUpdateParams.Phase.Discount[] {
-  const discounts =
-    (
-      subscription as {
-        readonly discounts?: readonly (string | Stripe.Discount)[];
-      }
-    ).discounts ?? [];
+  subscription: StripeSubscription,
+): StripeSchedulePhaseDiscountParam[] {
+  const discounts = subscription.discounts ?? [];
   return discounts.flatMap((discount) => {
     const discountId = stripeObjectId(discount);
     return discountId ? [{ discount: discountId }] : [];
@@ -156,9 +158,9 @@ function subscriptionSchedulePhaseDiscounts(
 }
 
 function phaseWithDiscounts(
-  phase: Stripe.SubscriptionScheduleUpdateParams.Phase,
-  discounts: Stripe.SubscriptionScheduleUpdateParams.Phase.Discount[],
-): Stripe.SubscriptionScheduleUpdateParams.Phase {
+  phase: StripeSchedulePhaseParam,
+  discounts: StripeSchedulePhaseDiscountParam[],
+): StripeSchedulePhaseParam {
   if (discounts.length === 0) {
     return phase;
   }
@@ -170,8 +172,8 @@ function phaseWithDiscounts(
 }
 
 function subscriptionCurrentItem(
-  subscription: Stripe.Subscription,
-): Stripe.SubscriptionItem {
+  subscription: StripeSubscription,
+): StripeSubscriptionItem {
   const currentItem = knownPlanPriceItem(subscription.items.data);
   if (!currentItem) {
     throw new Error("Subscription has no known plan item");
@@ -180,16 +182,17 @@ function subscriptionCurrentItem(
 }
 
 function subscriptionPhaseItems(
-  subscription: Stripe.Subscription,
-): Stripe.SubscriptionScheduleUpdateParams.Phase.Item[] {
+  subscription: StripeSubscription,
+): StripeSchedulePhaseItemParam[] {
   return subscription.items.data.map((item) => {
     return schedulePhaseItem(item.price.id, item.quantity);
   });
 }
 
-function subscriptionItemPhaseRange(
-  subscriptionItem: Stripe.SubscriptionItem,
-): { readonly startDate: number; readonly endDate: number } {
+function subscriptionItemPhaseRange(subscriptionItem: StripeSubscriptionItem): {
+  readonly startDate: number;
+  readonly endDate: number;
+} {
   const startDate = subscriptionItem.current_period_start;
   const endDate = subscriptionItem.current_period_end;
 
@@ -200,7 +203,7 @@ function subscriptionItemPhaseRange(
   return { startDate, endDate };
 }
 
-function subscriptionCancelAt(subscription: Stripe.Subscription): Date | null {
+function subscriptionCancelAt(subscription: StripeSubscription): Date | null {
   return typeof subscription.cancel_at === "number"
     ? new Date(subscription.cancel_at * 1000)
     : null;
@@ -318,7 +321,7 @@ async function scheduleCancellationAtPeriodEnd(
 async function scheduleDowngradeToPro(
   context: DowngradeContext,
   currentTier: OrgTier,
-  subscription: Stripe.Subscription,
+  subscription: StripeSubscription,
 ): Promise<string> {
   const currentItem = subscriptionCurrentItem(subscription);
   const proPriceId = isUsagePackPlanPriceId(currentItem.price.id)

--- a/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
@@ -1,13 +1,17 @@
 import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
-import StripeSDK from "stripe";
 import { orgPromoRedemption } from "@vm0/db/schema/org-promo-redemption";
 import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 
 import { logger } from "../../lib/log";
 import { db$, writeDb$ } from "../external/db";
 import { nowDate } from "../../lib/time";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  isStripeResourceMissingError,
+  stripeErrorInfo,
+  stripeResourceMissingError,
+} from "../external/stripe-client";
 import { bestEffort, onRejection, settle } from "../utils";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { getCampaign } from "./one-time-products";
@@ -54,19 +58,20 @@ export const startOrResumeRedemption$ = command(
     if (outcome.ok) {
       return outcome.value;
     }
-    if (outcome.error instanceof StripeSDK.errors.StripeError) {
+    const stripeError = stripeErrorInfo(outcome.error);
+    if (stripeError) {
       log.error("redeem: stripe error", {
         orgId: args.orgId,
         campaignKey: args.campaignKey,
-        type: outcome.error.type,
-        code: outcome.error.code,
-        message: outcome.error.message,
+        type: stripeError.type,
+        code: stripeError.code,
+        message: stripeError.message,
       });
       return {
         kind: "stripe_error",
-        type: outcome.error.type,
-        code: outcome.error.code ?? null,
-        message: outcome.error.message,
+        type: stripeError.type,
+        code: stripeError.code,
+        message: stripeError.message,
       };
     }
     throw outcome.error;
@@ -230,11 +235,9 @@ const ensureCampaignStillAvailable$ = command(
       // Route already gated unknown campaigns; if we got here, env drifted
       // mid-request. Surfacing as misconfigured is fine.
       await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
-      throw new StripeSDK.errors.StripeInvalidRequestError({
-        type: "invalid_request_error",
-        code: "resource_missing",
-        message: `Campaign ${args.campaignKey} is no longer configured`,
-      });
+      throw stripeResourceMissingError(
+        `Campaign ${args.campaignKey} is no longer configured`,
+      );
     }
 
     const stripe = getStripeClient();
@@ -245,16 +248,13 @@ const ensureCampaignStillAvailable$ = command(
         stripe.prices.retrieve(campaign.priceId),
       ]),
       async (error) => {
-        if (
-          error instanceof StripeSDK.errors.StripeInvalidRequestError &&
-          error.code === "resource_missing"
-        ) {
+        if (isStripeResourceMissingError(error)) {
           log.warn("one_time_purchase stripe resource missing on resume", {
             orgId: args.orgId,
             campaignKey: args.campaignKey,
             couponId: campaign.couponId,
             priceId: campaign.priceId,
-            stripeMessage: error.message,
+            stripeMessage: stripeErrorInfo(error)?.message ?? null,
           });
           await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
         }
@@ -269,11 +269,9 @@ const ensureCampaignStillAvailable$ = command(
         couponId: campaign.couponId,
       });
       await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
-      throw new StripeSDK.errors.StripeInvalidRequestError({
-        type: "invalid_request_error",
-        code: "resource_missing",
-        message: `Coupon ${campaign.couponId} is no longer valid`,
-      });
+      throw stripeResourceMissingError(
+        `Coupon ${campaign.couponId} is no longer valid`,
+      );
     }
 
     if (!price.active) {
@@ -283,11 +281,9 @@ const ensureCampaignStillAvailable$ = command(
         priceId: campaign.priceId,
       });
       await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
-      throw new StripeSDK.errors.StripeInvalidRequestError({
-        type: "invalid_request_error",
-        code: "resource_missing",
-        message: `Price ${campaign.priceId} is no longer active`,
-      });
+      throw stripeResourceMissingError(
+        `Price ${campaign.priceId} is no longer active`,
+      );
     }
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-recharge.service.ts
@@ -1,4 +1,3 @@
-import type StripeSDK from "stripe";
 import { command } from "ccstate";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@vm0/db/schema/org-plan-entitlement";
@@ -15,7 +14,11 @@ import {
 } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  type StripeClient,
+  type StripeRef,
+} from "../external/stripe-client";
 import { nowDate } from "../../lib/time";
 import { tapError } from "../utils";
 import { logger } from "../../lib/log";
@@ -38,9 +41,7 @@ interface ClaimedRechargeState {
   readonly autoRechargePendingAt: Date | null;
 }
 
-function resolvePaymentMethodId(
-  pm: string | StripeSDK.PaymentMethod | null | undefined,
-): string | null {
+function resolvePaymentMethodId(pm: StripeRef | undefined): string | null {
   if (typeof pm === "string") {
     return pm;
   }
@@ -48,7 +49,7 @@ function resolvePaymentMethodId(
 }
 
 async function resolvePaymentMethod(
-  stripe: StripeSDK,
+  stripe: StripeClient,
   org: ClaimedRechargeState,
 ): Promise<string | null> {
   const customer = await stripe.customers.retrieve(org.stripeCustomerId);
@@ -59,7 +60,7 @@ async function resolvePaymentMethod(
     return null;
   }
   const customerPm = resolvePaymentMethodId(
-    (customer as StripeSDK.Customer).invoice_settings?.default_payment_method,
+    customer.invoice_settings?.default_payment_method,
   );
   if (customerPm) {
     return customerPm;

--- a/turbo/apps/api/tsconfig.core.json
+++ b/turbo/apps/api/tsconfig.core.json
@@ -31,6 +31,7 @@
     "src/lib/secret-kms-client.ts",
     "src/lib/singleton.ts",
     "src/signals/external/s3.ts",
+    "src/signals/external/stripe-client.ts",
     "src/signals/external/slack-block-kit.ts",
     "src/signals/external/slack-message-client.ts",
     "src/signals/external/slack-oauth-client.ts",

--- a/turbo/apps/api/tsconfig.gateways.json
+++ b/turbo/apps/api/tsconfig.gateways.json
@@ -16,6 +16,7 @@
     "src/lib/secret-kms-client.ts",
     "src/lib/singleton.ts",
     "src/signals/external/s3.ts",
+    "src/signals/external/stripe-client.ts",
     "src/signals/external/slack-block-kit.ts",
     "src/signals/external/slack-message-client.ts",
     "src/signals/external/slack-oauth-client.ts",

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -22,6 +22,7 @@
         "src/signals/context/hono.ts",
         "src/signals/context/wait-until.ts",
         "src/signals/external/clerk.ts",
+        "src/signals/external/stripe-client.ts",
         "src/signals/external/env.ts",
         "src/scripts/**/*.ts",
         "src/**/*.{test,spec}.ts"


### PR DESCRIPTION
## Why

`apps/api` `check-types` peak RSS is set by `tsconfig.core.json`, and the round-5 ablation on today's main measured `stripe` at **-236 MiB** of that peak (core head mean 2919 MiB, stub-stripe 2683 MiB) - the largest non-structural surface left after the aws (#25714), slack and clerk (#25747) boundaries.

Note the joint bound: stubbing every remaining SDK together is only -285 MiB, so stripe and clerk overlap heavily. Peak RSS is a max, not a sum.

## What

Same move as #25714: `src/signals/external/stripe-client.ts` joins `tsconfig.gateways.json`, so `stripe` is parsed once in the small gateway program instead of inside core.

The precondition is that no Stripe type may appear in an exported signature, so the module now owns its own mirror of the surface the API actually uses:

- `StripeClient` (`subscriptions`, `subscriptionSchedules`, `customers`, `prices`, `coupons`, `invoices`, `invoiceItems`, `checkout.sessions`, `paymentMethods`, `billingPortal.sessions`) plus the object and param mirrors the billing services read. `getStripeClient()` returns `StripeClient`, so every `ReturnType<typeof getStripeClient>` call site keeps working unchanged and the SDK client is checked against the mirror inside the gateway.
- `constructStripeBillingWebhookEvent()` returns a vm0-owned `StripeWebhookEvent` envelope. Narrowing Stripe's `Event` union was the only reason the 2 000-line webhook dispatcher needed the SDK types; the gateway now does that narrowing once and core switches on `event.kind` / `event.object`. The handlers already took vm0-owned input interfaces, so their bodies are untouched.
- Three pieces of logic that genuinely need SDK types moved behind the boundary rather than being mirrored: `ensurePaymentMethodPortalConfiguration()` (reads the portal configuration's nested feature flags), `stripeErrorInfo()` and `stripeResourceMissingError()` (replace `instanceof StripeSDK.errors.*` and the hand-rolled `resource_missing` check that was duplicated in `webhooks-stripe.service.ts`).
- The raw `constructStripeWebhookEvent()` used by the workflow-events ingress keeps its `unknown` return and its test override; that route zod-parses the payload itself.

`isolatedDependencies` in `eslint.config.mjs` gains `stripe`, so `api/gateway-typecheck-boundary` fails any future direct import outside the gateway (tests stay exempt: they type-check in their own smaller program).

No runtime change: the gateway still constructs the same client through the same `mockStripeClient` override, so the existing `vi.mock("stripe")` test wiring is untouched.

## Verification

- `pnpm --filter api run check-types` and `pnpm --filter api exec eslint . --max-warnings 0` green on this branch.
- The billing and webhook suites in `test-api` are the real check on the dispatcher rewrite; they run on this PR.
- Expect the CI `lint-types-apps` `[measure-memory]` peak to drop from ~3005 MiB, with the caveat above about the joint cap once #25747 also lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fallbacks

- `src/signals/external/stripe-client.ts:stripeErrorInfo` normalizes Stripe error `code` to `null` when the provider omits it. Surface: optional external Stripe error data; no vm0 deployment-version skew window. Remove if Stripe makes `code` required.
- `src/signals/services/zero-billing-downgrade.service.ts:subscriptionSchedulePhaseDiscounts` treats an omitted Stripe subscription `discounts` collection as no discounts, preserving the existing schedule behavior. Surface: optional external Stripe subscription data; no vm0 deployment-version skew window. Remove if Stripe guarantees the field or this caller stops reading discounts.
- `src/signals/services/zero-billing-redeem.service.ts:ensureCampaignStillAvailable$` records `null` when a `resource_missing`-shaped external error has no Stripe SDK message. Surface: observability for external Stripe errors; no vm0 deployment-version skew window. Remove if resource-missing classification guarantees a Stripe SDK error instance.