### PR TITLE
feat(runner): pin custom connector routing inputs

### DIFF
--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1501,6 +1501,12 @@ pub(super) async fn register_proxy(
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
     let cli_agent_type = normalized_cli_agent_type(&context.cli_agent_type);
+    let connector_runtime_targets = context.connector_runtime_targets.as_ref().map(|targets| {
+        targets
+            .iter()
+            .map(crate::types::ConnectorRuntimeTargetRegistration::target)
+            .collect::<Vec<_>>()
+    });
     let registration = proxy::VmRegistration {
         run_id: &run_id_str,
         cli_agent_type,
@@ -1509,7 +1515,7 @@ pub(super) async fn register_proxy(
         proxy_log_path: &proxy_log_path,
         firewalls: context.firewalls.as_deref(),
         network_policies: context.network_policies.as_ref(),
-        connector_runtime_targets: context.connector_runtime_targets.as_deref(),
+        connector_runtime_targets: connector_runtime_targets.as_deref(),
         encrypted_secrets: context.encrypted_secrets.as_deref(),
         secret_connector_map: context.secret_connector_map.as_ref(),
         secret_connector_metadata_map: context.secret_connector_metadata_map.as_ref(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -42,9 +42,9 @@ use crate::ids::RunId;
 use crate::pi_standby::PiStandbyNotifications;
 use crate::run_cancellation::RunCancellationRegistry;
 use crate::types::{
-    CompleteRequest, ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeTarget, ExecutionContext,
-    HeartbeatState, Job, NetworkPolicyRefreshBatchResponse, PiExecutionMode, PollResponse,
-    SandboxReuseResult,
+    CompleteRequest, ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeTargetRegistration,
+    ExecutionContext, HeartbeatState, Job, NetworkPolicyRefreshBatchResponse, PiExecutionMode,
+    PollResponse, SandboxReuseResult,
 };
 use sandbox::SandboxId;
 
@@ -1254,7 +1254,7 @@ impl ApiClient {
     pub(super) async fn sync_connector_runtime(
         &self,
         run_id: RunId,
-        targets: &[ConnectorRuntimeTarget],
+        targets: &[ConnectorRuntimeTargetRegistration],
     ) -> RunnerResult<ConnectorRuntimeSyncOutcome> {
         let run_id = run_id.to_string();
         let resp = send_api(
@@ -1285,7 +1285,7 @@ impl ApiClient {
     fn connector_runtime_sync_request(
         &self,
         run_id: &str,
-        targets: &[ConnectorRuntimeTarget],
+        targets: &[ConnectorRuntimeTargetRegistration],
     ) -> ApiRequestBuilder {
         self.http
             .request_resolved_route(

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -876,6 +876,8 @@ impl NetworkPolicyRefreshCore {
             let Some(snapshot) = self.active_snapshot_for_target(run_id, target).await else {
                 continue;
             };
+            // Missing metadata is the old-API compatibility shape. #25351
+            // removes this acceptance after the producer and old APIs drain.
             if let Some(candidate) = &candidate_base_url_vars {
                 let Some(matches_pinned_values) = self
                     .custom_base_url_vars_match(run_id, target, candidate)

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -50,7 +50,7 @@ use crate::ids::RunId;
 use crate::proxy::{CustomConnectorRuntimeRegistryState, ProxyRegistryHandle};
 use crate::types::{
     ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeSyncState, ConnectorRuntimeTarget,
-    FirewallEntry, NetworkPolicy, NetworkPolicyRefresh,
+    ConnectorRuntimeTargetRegistration, FirewallEntry, NetworkPolicy, NetworkPolicyRefresh,
 };
 
 const REFRESH_REQUEST_QUEUE_CAPACITY: usize = 256;
@@ -99,6 +99,8 @@ struct ActiveRunNetworkPolicyState {
 struct ActiveConnectorRefreshState {
     generation: u64,
     consecutive_failures: u32,
+    // Custom-only routing inputs pinned for this run. They are not target identity.
+    pinned_base_url_vars: Option<HashMap<String, String>>,
 }
 
 struct ScheduledRefreshTask {
@@ -119,7 +121,7 @@ pub(crate) struct NetworkPolicyRefreshRegistration<'a> {
     pub(crate) source_ip: &'a str,
     pub(crate) registry: ProxyRegistryHandle,
     pub(crate) connector_slugs: HashSet<String>,
-    pub(crate) targets: Option<&'a [ConnectorRuntimeTarget]>,
+    pub(crate) targets: Option<&'a [ConnectorRuntimeTargetRegistration]>,
     pub(crate) refreshes: Option<&'a HashMap<String, NetworkPolicyRefresh>>,
 }
 
@@ -266,7 +268,9 @@ impl NetworkPolicyRefreshCore {
                 .connector_slugs
                 .iter()
                 .cloned()
-                .map(|connector_slug| ConnectorRuntimeTarget::Builtin { connector_slug })
+                .map(
+                    |connector_slug| ConnectorRuntimeTargetRegistration::Builtin { connector_slug },
+                )
                 .collect(),
         };
         if runtime_targets.is_empty() {
@@ -287,13 +291,13 @@ impl NetworkPolicyRefreshCore {
 
             let connectors = runtime_targets
                 .iter()
-                .cloned()
-                .map(|target| {
+                .map(|registration| {
                     (
-                        target,
+                        registration.target(),
                         ActiveConnectorRefreshState {
                             generation: 0,
                             consecutive_failures: 0,
+                            pinned_base_url_vars: registration.custom_base_url_vars().cloned(),
                         },
                     )
                 })
@@ -316,12 +320,13 @@ impl NetworkPolicyRefreshCore {
         if tagged {
             for target in runtime_targets
                 .iter()
+                .map(ConnectorRuntimeTargetRegistration::target)
                 .filter(|target| matches!(target, ConnectorRuntimeTarget::Custom { .. }))
             {
                 self.replace_schedule_deadline_if_current(
                     registration.run_id,
                     &ConnectorRefreshTarget {
-                        target: target.clone(),
+                        target,
                         generation: 0,
                     },
                     Some(tokio::time::Instant::now()),
@@ -666,7 +671,7 @@ impl NetworkPolicyRefreshCore {
             {
                 Ok(true) => {
                     if self
-                        .complete_successful_refresh(run_id, target, deadline)
+                        .complete_successful_refresh(run_id, target, deadline, None)
                         .await
                     {
                         info!(
@@ -709,10 +714,12 @@ impl NetworkPolicyRefreshCore {
         run_id: RunId,
         active_targets: &[ConnectorRefreshTarget],
     ) -> bool {
-        let requested_targets = active_targets
-            .iter()
-            .map(|target| target.target.clone())
-            .collect::<Vec<_>>();
+        let Some(requested_targets) = self
+            .connector_runtime_sync_registrations(run_id, active_targets)
+            .await
+        else {
+            return true;
+        };
         let mut transport_retry_attempted = false;
         let response = loop {
             let response = self
@@ -833,16 +840,28 @@ impl NetworkPolicyRefreshCore {
                 retry_targets.push(target.clone());
                 continue;
             };
-            if let (
-                ConnectorRuntimeTarget::Builtin { .. },
-                ConnectorRuntimeSyncState::Unresolved { reason },
-            ) = (&target.target, &result.state)
-            {
+            let candidate_base_url_vars = match (&target.target, &result.state) {
+                (
+                    ConnectorRuntimeTarget::Custom { .. },
+                    ConnectorRuntimeSyncState::Available { .. },
+                ) => result.base_url_vars.clone(),
+                _ if result.base_url_vars.is_some() => {
+                    warn!(
+                        run_id = %run_id,
+                        target = %target.target.log_identity(),
+                        "connector runtime sync returned base URL variables for an invalid target state"
+                    );
+                    retry_targets.push(target.clone());
+                    continue;
+                }
+                _ => None,
+            };
+            if let ConnectorRuntimeSyncState::Unresolved { reason } = &result.state {
                 warn!(
                     run_id = %run_id,
                     target = %target.target.log_identity(),
                     reason = ?reason,
-                    "builtin connector runtime sync is unresolved; retaining last-known-good policy"
+                    "connector runtime sync is unresolved; retaining last-known-good state"
                 );
                 retry_targets.push(target.clone());
                 continue;
@@ -857,6 +876,20 @@ impl NetworkPolicyRefreshCore {
             let Some(snapshot) = self.active_snapshot_for_target(run_id, target).await else {
                 continue;
             };
+            if candidate_base_url_vars.is_some()
+                && !self
+                    .custom_base_url_vars_match(run_id, target, candidate_base_url_vars.as_ref())
+                    .await
+                    .unwrap_or(true)
+            {
+                warn!(
+                    run_id = %run_id,
+                    target = %target.target.log_identity(),
+                    "connector runtime sync tried to replace run-pinned base URL variables"
+                );
+                retry_targets.push(target.clone());
+                continue;
+            }
             let publication = match (&target.target, &result.state) {
                 (
                     ConnectorRuntimeTarget::Builtin { connector_slug },
@@ -967,7 +1000,12 @@ impl NetworkPolicyRefreshCore {
             match published {
                 true => {
                     if self
-                        .complete_successful_refresh(run_id, target, deadline)
+                        .complete_successful_refresh(
+                            run_id,
+                            target,
+                            deadline,
+                            candidate_base_url_vars.as_ref(),
+                        )
                         .await
                     {
                         info!(
@@ -1106,6 +1144,37 @@ impl NetworkPolicyRefreshCore {
             .collect()
     }
 
+    async fn connector_runtime_sync_registrations(
+        &self,
+        run_id: RunId,
+        targets: &[ConnectorRefreshTarget],
+    ) -> Option<Vec<ConnectorRuntimeTargetRegistration>> {
+        let active_runs = self.inner.active_runs.lock().await;
+        let active = active_runs.get(&run_id)?;
+        targets
+            .iter()
+            .map(|target| {
+                let connector = active.connectors.get(&target.target)?;
+                if connector.generation != target.generation {
+                    return None;
+                }
+                Some(match &target.target {
+                    ConnectorRuntimeTarget::Builtin { connector_slug } => {
+                        ConnectorRuntimeTargetRegistration::Builtin {
+                            connector_slug: connector_slug.clone(),
+                        }
+                    }
+                    ConnectorRuntimeTarget::Custom {
+                        custom_connector_id,
+                    } => ConnectorRuntimeTargetRegistration::Custom {
+                        custom_connector_id: custom_connector_id.clone(),
+                        base_url_vars: connector.pinned_base_url_vars.clone(),
+                    },
+                })
+            })
+            .collect()
+    }
+
     async fn run_is_tagged(&self, run_id: RunId) -> bool {
         self.inner
             .active_runs
@@ -1135,11 +1204,27 @@ impl NetworkPolicyRefreshCore {
         })
     }
 
+    async fn custom_base_url_vars_match(
+        &self,
+        run_id: RunId,
+        target: &ConnectorRefreshTarget,
+        candidate: Option<&HashMap<String, String>>,
+    ) -> Option<bool> {
+        let active_runs = self.inner.active_runs.lock().await;
+        let active = active_runs.get(&run_id)?;
+        let connector = active.connectors.get(&target.target)?;
+        Some(match (&connector.pinned_base_url_vars, candidate) {
+            (Some(pinned), Some(candidate)) => pinned == candidate,
+            _ => true,
+        })
+    }
+
     async fn complete_successful_refresh(
         &self,
         run_id: RunId,
         target: &ConnectorRefreshTarget,
         deadline: Option<tokio::time::Instant>,
+        candidate_base_url_vars: Option<&HashMap<String, String>>,
     ) -> bool {
         let mut active_runs = self.inner.active_runs.lock().await;
         let Some(active) = active_runs.get_mut(&run_id) else {
@@ -1148,6 +1233,13 @@ impl NetworkPolicyRefreshCore {
         let Some(connector) = active.connectors.get_mut(&target.target) else {
             return false;
         };
+        if let Some(candidate) = candidate_base_url_vars {
+            match &connector.pinned_base_url_vars {
+                Some(pinned) if pinned != candidate => return false,
+                Some(_) => {}
+                None => connector.pinned_base_url_vars = Some(candidate.clone()),
+            }
+        }
         if connector.generation != target.generation {
             return false;
         }
@@ -1400,6 +1492,7 @@ fn custom_connector_runtime_registry_state(
                         custom_connector_id: Some(entry_connector_id),
                     },
                 ),
+            ..
         } => {
             validate_connector_runtime_network_policy(network_policy)?;
             if entry_connector_id != custom_connector_id {
@@ -1418,7 +1511,7 @@ fn custom_connector_runtime_registry_state(
             Err("custom available result must include an inline firewall")
         }
         ConnectorRuntimeSyncState::Unresolved { .. } => {
-            Err("custom connector runtime result cannot be unresolved")
+            Err("unresolved custom runtime result reached registry publication")
         }
     }
 }
@@ -1532,6 +1625,12 @@ mod tests {
         ConnectorRuntimeTarget::Custom {
             custom_connector_id: custom_connector_id.to_string(),
         }
+    }
+
+    fn runtime_target_registration(
+        target: &ConnectorRuntimeTarget,
+    ) -> ConnectorRuntimeTargetRegistration {
+        target.clone().into()
     }
 
     fn custom_runtime_firewall(custom_connector_id: &str) -> FirewallEntry {
@@ -1918,6 +2017,7 @@ mod tests {
                         ActiveConnectorRefreshState {
                             generation: 0,
                             consecutive_failures: 0,
+                            pinned_base_url_vars: None,
                         },
                     )
                 })
@@ -2395,7 +2495,7 @@ mod tests {
             source_ip: "10.200.0.2",
             registry,
             connector_slugs: HashSet::from(["slack".to_string()]),
-            targets: Some(std::slice::from_ref(&target)),
+            targets: Some(std::slice::from_ref(&runtime_target_registration(&target))),
             refreshes: Some(&refreshes),
         })
         .await;
@@ -2575,12 +2675,15 @@ mod tests {
         let (_dir, registry, registry_path) =
             registered_runtime_registry(run_id, &firewalls, &policies).await;
 
+        let registrations = targets
+            .clone()
+            .map(ConnectorRuntimeTargetRegistration::from);
         core.register_run(NetworkPolicyRefreshRegistration {
             run_id,
             source_ip: "10.200.0.2",
             registry,
             connector_slugs: connector_slugs.map(ToOwned::to_owned).into(),
-            targets: Some(&targets),
+            targets: Some(&registrations),
             refreshes: None,
         })
         .await;
@@ -2657,7 +2760,7 @@ mod tests {
             source_ip: "10.200.0.2",
             registry,
             connector_slugs: HashSet::new(),
-            targets: Some(std::slice::from_ref(&target)),
+            targets: Some(std::slice::from_ref(&runtime_target_registration(&target))),
             refreshes: None,
         })
         .await;
@@ -2741,6 +2844,199 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tagged_custom_target_pins_first_routing_values_and_forwards_them_after_wakeup() {
+        let server = MockServer::start();
+        let (core, mut requests) = core_without_worker(&server);
+        let run_id = RunId::nil();
+        let custom_connector_id = "550e8400-e29b-41d4-a716-446655440000";
+        let target = custom_target(custom_connector_id);
+        let registration = runtime_target_registration(&target);
+        let firewall = custom_runtime_firewall(custom_connector_id);
+        let base_url_vars = HashMap::from([("subdomain".to_string(), "acme".to_string())]);
+        let first_sync = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
+                .json_body(json!({ "targets": [target.clone()] }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": [{
+                        "target": target.clone(),
+                        "state": "available",
+                        "firewall": firewall,
+                        "networkPolicy": {
+                            "allow": ["custom.read"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                        "baseUrlVars": base_url_vars,
+                    }],
+                }));
+        });
+        let empty_firewalls = Vec::new();
+        let empty_policies = HashMap::new();
+        let (_dir, registry, registry_path) =
+            registered_runtime_registry(run_id, &empty_firewalls, &empty_policies).await;
+
+        core.register_run(NetworkPolicyRefreshRegistration {
+            run_id,
+            source_ip: "10.200.0.2",
+            registry,
+            connector_slugs: HashSet::new(),
+            targets: Some(std::slice::from_ref(&registration)),
+            refreshes: None,
+        })
+        .await;
+        let request = recv_refresh_request(&mut requests).await;
+        assert!(
+            core.sync_connector_runtime_batch_now(run_id, &request.targets)
+                .await
+        );
+
+        first_sync.assert_calls(1);
+        assert_eq!(
+            core.inner.active_runs.lock().await[&run_id].connectors[&target].pinned_base_url_vars,
+            Some(base_url_vars.clone())
+        );
+        let registry_after_available = tokio::fs::read(&registry_path).await.unwrap();
+
+        first_sync.delete_async().await;
+        let unresolved_sync = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
+                .json_body(json!({
+                    "targets": [{
+                        "kind": "custom",
+                        "customConnectorId": custom_connector_id,
+                        "baseUrlVars": base_url_vars,
+                    }],
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": [{
+                        "target": target.clone(),
+                        "state": "unresolved",
+                        "reason": "runtime-configuration-unavailable",
+                    }],
+                }));
+        });
+        core.notify_connector_runtime_sync(run_id, target.clone())
+            .await;
+        let request = recv_refresh_request(&mut requests).await;
+        assert!(
+            core.sync_connector_runtime_batch_now(run_id, &request.targets)
+                .await
+        );
+
+        unresolved_sync.assert_calls(1);
+        assert_eq!(
+            tokio::fs::read(&registry_path).await.unwrap(),
+            registry_after_available
+        );
+        let active_runs = core.inner.active_runs.lock().await;
+        let active = &active_runs[&run_id];
+        assert_eq!(
+            active.connectors[&target].pinned_base_url_vars,
+            Some(base_url_vars)
+        );
+        assert_eq!(active.connectors[&target].consecutive_failures, 1);
+        assert!(active.refresh_tasks.contains_key(&target));
+        drop(active_runs);
+        core.unregister_run(run_id).await;
+    }
+
+    #[tokio::test]
+    async fn tagged_custom_target_rejects_routing_value_replacement() {
+        let server = MockServer::start();
+        let (core, mut requests) = core_without_worker(&server);
+        let run_id = RunId::nil();
+        let custom_connector_id = "550e8400-e29b-41d4-a716-446655440000";
+        let target = custom_target(custom_connector_id);
+        let pinned_base_url_vars = HashMap::from([("subdomain".to_string(), "acme".to_string())]);
+        let replacement_base_url_vars =
+            HashMap::from([("subdomain".to_string(), "other".to_string())]);
+        let registration = ConnectorRuntimeTargetRegistration::Custom {
+            custom_connector_id: custom_connector_id.to_string(),
+            base_url_vars: Some(pinned_base_url_vars.clone()),
+        };
+        let firewall = custom_runtime_firewall(custom_connector_id);
+        server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
+                .json_body(json!({
+                    "targets": [{
+                        "kind": "custom",
+                        "customConnectorId": custom_connector_id,
+                        "baseUrlVars": pinned_base_url_vars,
+                    }],
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": [{
+                        "target": target.clone(),
+                        "state": "available",
+                        "firewall": firewall,
+                        "networkPolicy": {
+                            "allow": ["custom.write"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "allow",
+                        },
+                        "baseUrlVars": replacement_base_url_vars,
+                    }],
+                }));
+        });
+        let initial_firewall = custom_runtime_firewall(custom_connector_id);
+        let initial_name = format!("custom_connector_{}", custom_connector_id.replace('-', ""));
+        let initial_policies = HashMap::from([(
+            initial_name,
+            NetworkPolicy {
+                allow: vec!["custom.read".to_string()],
+                deny: vec![],
+                ask: vec![],
+                unknown_policy: "deny".to_string(),
+            },
+        )]);
+        let firewalls = vec![initial_firewall];
+        let (_dir, registry, registry_path) =
+            registered_runtime_registry(run_id, &firewalls, &initial_policies).await;
+        let registry_before = tokio::fs::read(&registry_path).await.unwrap();
+
+        core.register_run(NetworkPolicyRefreshRegistration {
+            run_id,
+            source_ip: "10.200.0.2",
+            registry,
+            connector_slugs: HashSet::new(),
+            targets: Some(std::slice::from_ref(&registration)),
+            refreshes: None,
+        })
+        .await;
+        let request = recv_refresh_request(&mut requests).await;
+        assert!(
+            core.sync_connector_runtime_batch_now(run_id, &request.targets)
+                .await
+        );
+
+        assert_eq!(
+            tokio::fs::read(&registry_path).await.unwrap(),
+            registry_before
+        );
+        let active_runs = core.inner.active_runs.lock().await;
+        let active = &active_runs[&run_id];
+        assert_eq!(
+            active.connectors[&target].pinned_base_url_vars,
+            Some(pinned_base_url_vars)
+        );
+        assert_eq!(active.connectors[&target].consecutive_failures, 1);
+        assert!(active.refresh_tasks.contains_key(&target));
+        drop(active_runs);
+        core.unregister_run(run_id).await;
+    }
+
+    #[tokio::test]
     async fn invalid_tagged_custom_response_retains_last_known_good_and_retries() {
         let server = MockServer::start();
         let (core, mut requests) = core_without_worker(&server);
@@ -2788,7 +3084,7 @@ mod tests {
             source_ip: "10.200.0.2",
             registry,
             connector_slugs: HashSet::new(),
-            targets: Some(std::slice::from_ref(&target)),
+            targets: Some(std::slice::from_ref(&runtime_target_registration(&target))),
             refreshes: None,
         })
         .await;
@@ -2862,7 +3158,7 @@ mod tests {
             source_ip: "10.200.0.2",
             registry,
             connector_slugs: HashSet::from(["slack".to_string()]),
-            targets: Some(std::slice::from_ref(&target)),
+            targets: Some(std::slice::from_ref(&runtime_target_registration(&target))),
             refreshes: None,
         })
         .await;
@@ -2924,7 +3220,7 @@ mod tests {
             source_ip: "10.200.0.2",
             registry,
             connector_slugs: HashSet::new(),
-            targets: Some(std::slice::from_ref(&target)),
+            targets: Some(std::slice::from_ref(&runtime_target_registration(&target))),
             refreshes: None,
         })
         .await;
@@ -2984,7 +3280,7 @@ mod tests {
             source_ip: "10.200.0.2",
             registry,
             connector_slugs: HashSet::from(["slack".to_string()]),
-            targets: Some(std::slice::from_ref(&target)),
+            targets: Some(std::slice::from_ref(&runtime_target_registration(&target))),
             refreshes: None,
         })
         .await;

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -50,7 +50,8 @@ use crate::ids::RunId;
 use crate::proxy::{CustomConnectorRuntimeRegistryState, ProxyRegistryHandle};
 use crate::types::{
     ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeSyncState, ConnectorRuntimeTarget,
-    ConnectorRuntimeTargetRegistration, FirewallEntry, NetworkPolicy, NetworkPolicyRefresh,
+    ConnectorRuntimeTargetRegistration, ConnectorRuntimeUnresolvedReason, FirewallEntry,
+    NetworkPolicy, NetworkPolicyRefresh,
 };
 
 const REFRESH_REQUEST_QUEUE_CAPACITY: usize = 256;
@@ -714,12 +715,14 @@ impl NetworkPolicyRefreshCore {
         run_id: RunId,
         active_targets: &[ConnectorRefreshTarget],
     ) -> bool {
-        let Some(requested_targets) = self
-            .connector_runtime_sync_registrations(run_id, active_targets)
-            .await
-        else {
+        let current_targets = self
+            .current_connector_runtime_sync_targets(run_id, active_targets)
+            .await;
+        if current_targets.is_empty() {
             return true;
-        };
+        }
+        let (active_targets, requested_targets): (Vec<_>, Vec<_>) =
+            current_targets.into_iter().unzip();
         let mut transport_retry_attempted = false;
         let response = loop {
             let response = self
@@ -731,7 +734,7 @@ impl NetworkPolicyRefreshCore {
                 transport_retry_attempted = true;
                 warn!(
                     run_id = %run_id,
-                    targets = ?target_identities(active_targets),
+                    targets = ?target_identities(&active_targets),
                     error = %error,
                     attempt = 1,
                     max_attempts = 2,
@@ -778,18 +781,18 @@ impl NetworkPolicyRefreshCore {
             Err(error) => {
                 warn!(
                     run_id = %run_id,
-                    targets = ?target_identities(active_targets),
+                    targets = ?target_identities(&active_targets),
                     error = %error,
                     transport_retry_attempted,
                     "connector runtime sync failed; retaining last-known-good state"
                 );
-                self.schedule_refresh_retries(run_id, active_targets, "api_error")
+                self.schedule_refresh_retries(run_id, &active_targets, "api_error")
                     .await;
                 return true;
             }
         };
 
-        self.publish_connector_runtime_response(run_id, active_targets, response)
+        self.publish_connector_runtime_response(run_id, &active_targets, response)
             .await
     }
 
@@ -857,6 +860,16 @@ impl NetworkPolicyRefreshCore {
                 _ => None,
             };
             if let ConnectorRuntimeSyncState::Unresolved { reason } = &result.state {
+                if !connector_runtime_unresolved_reason_is_valid(&target.target, reason) {
+                    warn!(
+                        run_id = %run_id,
+                        target = %target.target.log_identity(),
+                        reason = ?reason,
+                        "invalid connector runtime sync result; retaining last-known-good state"
+                    );
+                    retry_targets.push(target.clone());
+                    continue;
+                }
                 warn!(
                     run_id = %run_id,
                     target = %target.target.log_identity(),
@@ -1149,21 +1162,23 @@ impl NetworkPolicyRefreshCore {
             .collect()
     }
 
-    async fn connector_runtime_sync_registrations(
+    async fn current_connector_runtime_sync_targets(
         &self,
         run_id: RunId,
         targets: &[ConnectorRefreshTarget],
-    ) -> Option<Vec<ConnectorRuntimeTargetRegistration>> {
+    ) -> Vec<(ConnectorRefreshTarget, ConnectorRuntimeTargetRegistration)> {
         let active_runs = self.inner.active_runs.lock().await;
-        let active = active_runs.get(&run_id)?;
+        let Some(active) = active_runs.get(&run_id) else {
+            return Vec::new();
+        };
         targets
             .iter()
-            .map(|target| {
+            .filter_map(|target| {
                 let connector = active.connectors.get(&target.target)?;
                 if connector.generation != target.generation {
                     return None;
                 }
-                Some(match &target.target {
+                let registration = match &target.target {
                     ConnectorRuntimeTarget::Builtin { connector_slug } => {
                         ConnectorRuntimeTargetRegistration::Builtin {
                             connector_slug: connector_slug.clone(),
@@ -1175,7 +1190,8 @@ impl NetworkPolicyRefreshCore {
                         custom_connector_id: custom_connector_id.clone(),
                         base_url_vars: connector.pinned_base_url_vars.clone(),
                     },
-                })
+                };
+                Some((target.clone(), registration))
             })
             .collect()
     }
@@ -1240,15 +1256,15 @@ impl NetworkPolicyRefreshCore {
         let Some(connector) = active.connectors.get_mut(&target.target) else {
             return false;
         };
+        if connector.generation != target.generation {
+            return false;
+        }
         if let Some(candidate) = candidate_base_url_vars {
             match &connector.pinned_base_url_vars {
                 Some(pinned) if pinned != candidate => return false,
                 Some(_) => {}
                 None => connector.pinned_base_url_vars = Some(candidate.clone()),
             }
-        }
-        if connector.generation != target.generation {
-            return false;
         }
         connector.consecutive_failures = 0;
         self.replace_schedule_locked(active, run_id, target, deadline)
@@ -1482,6 +1498,14 @@ async fn patch_network_policy(
             policy,
         )
         .await
+}
+
+fn connector_runtime_unresolved_reason_is_valid(
+    target: &ConnectorRuntimeTarget,
+    reason: &ConnectorRuntimeUnresolvedReason,
+) -> bool {
+    matches!(target, ConnectorRuntimeTarget::Custom { .. })
+        || matches!(reason, ConnectorRuntimeUnresolvedReason::Connector)
 }
 
 fn custom_connector_runtime_registry_state(
@@ -2168,6 +2192,61 @@ mod tests {
         (dir, registry, registry_path)
     }
 
+    async fn register_tagged_builtin_runtime(
+        core: &NetworkPolicyRefreshCore,
+        run_id: RunId,
+        connector_slugs: &[&str],
+    ) -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        Vec<ConnectorRuntimeTarget>,
+    ) {
+        let targets = connector_slugs
+            .iter()
+            .map(|connector_slug| builtin_target(connector_slug))
+            .collect::<Vec<_>>();
+        let registrations = targets
+            .iter()
+            .map(runtime_target_registration)
+            .collect::<Vec<_>>();
+        let firewalls = connector_slugs
+            .iter()
+            .map(|connector_slug| FirewallEntry::Builtin {
+                name: (*connector_slug).to_string(),
+                base_url_vars: None,
+            })
+            .collect::<Vec<_>>();
+        let policies = connector_slugs
+            .iter()
+            .map(|connector_slug| {
+                (
+                    (*connector_slug).to_string(),
+                    NetworkPolicy {
+                        allow: vec!["last-known-good".to_string()],
+                        deny: vec![],
+                        ask: vec![],
+                        unknown_policy: "allow".to_string(),
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        let (dir, registry, registry_path) =
+            registered_runtime_registry(run_id, &firewalls, &policies).await;
+        core.register_run(NetworkPolicyRefreshRegistration {
+            run_id,
+            source_ip: "10.200.0.2",
+            registry,
+            connector_slugs: connector_slugs
+                .iter()
+                .map(|connector_slug| (*connector_slug).to_string())
+                .collect(),
+            targets: Some(&registrations),
+            refreshes: None,
+        })
+        .await;
+        (dir, registry_path, targets)
+    }
+
     async fn wait_until_slack_policy(
         registry_path: &std::path::Path,
         predicate: impl Fn(&serde_json::Value) -> bool,
@@ -2603,8 +2682,8 @@ mod tests {
         let server = MockServer::start();
         let (core, _requests) = core_without_worker(&server);
         let run_id = RunId::nil();
-        let connector_slugs = ["slack", "github", "linear"];
-        let targets = connector_slugs.map(builtin_target);
+        let (_dir, registry_path, targets) =
+            register_tagged_builtin_runtime(&core, run_id, &["slack", "github", "linear"]).await;
         let unexpected_target = builtin_target("notion");
         let runtime_sync = server.mock(|when, then| {
             when.method(POST)
@@ -2658,42 +2737,6 @@ mod tests {
                     ],
                 }));
         });
-        let firewalls = connector_slugs
-            .iter()
-            .map(|connector_slug| FirewallEntry::Builtin {
-                name: (*connector_slug).to_string(),
-                base_url_vars: None,
-            })
-            .collect::<Vec<_>>();
-        let policies = connector_slugs
-            .iter()
-            .map(|connector_slug| {
-                (
-                    (*connector_slug).to_string(),
-                    NetworkPolicy {
-                        allow: vec!["last-known-good".to_string()],
-                        deny: vec![],
-                        ask: vec![],
-                        unknown_policy: "allow".to_string(),
-                    },
-                )
-            })
-            .collect::<HashMap<_, _>>();
-        let (_dir, registry, registry_path) =
-            registered_runtime_registry(run_id, &firewalls, &policies).await;
-
-        let registrations = targets
-            .clone()
-            .map(ConnectorRuntimeTargetRegistration::from);
-        core.register_run(NetworkPolicyRefreshRegistration {
-            run_id,
-            source_ip: "10.200.0.2",
-            registry,
-            connector_slugs: connector_slugs.map(ToOwned::to_owned).into(),
-            targets: Some(&registrations),
-            refreshes: None,
-        })
-        .await;
         let active_targets = targets
             .iter()
             .cloned()
@@ -2732,6 +2775,63 @@ mod tests {
         assert!(active.refresh_tasks.contains_key(&targets[1]));
         assert!(active.refresh_tasks.contains_key(&targets[2]));
         drop(active_runs);
+        core.unregister_run(run_id).await;
+    }
+
+    #[tokio::test]
+    async fn tagged_batch_keeps_current_target_when_another_generation_is_superseded() {
+        let server = MockServer::start();
+        let (core, _requests) = core_without_worker(&server);
+        let run_id = RunId::nil();
+        let (_dir, registry_path, targets) =
+            register_tagged_builtin_runtime(&core, run_id, &["slack", "github"]).await;
+        let stale_batch = targets
+            .iter()
+            .cloned()
+            .map(|target| ConnectorRefreshTarget {
+                target,
+                generation: 0,
+            })
+            .collect::<Vec<_>>();
+        let github_target = targets[1].clone();
+        let runtime_sync = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
+                .json_body(json!({ "targets": [github_target.clone()] }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": [{
+                        "target": github_target,
+                        "state": "available",
+                        "networkPolicy": {
+                            "allow": ["issues:write"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    }],
+                }));
+        });
+
+        core.notify_connector_runtime_sync(run_id, targets[0].clone())
+            .await;
+        assert!(
+            core.sync_connector_runtime_batch_now(run_id, &stale_batch)
+                .await
+        );
+
+        runtime_sync.assert_calls(1);
+        let registry_json: serde_json::Value = serde_json::from_str(
+            &tokio::fs::read_to_string(registry_path)
+                .await
+                .expect("registry should be readable"),
+        )
+        .expect("registry should be valid JSON");
+        assert_eq!(
+            registry_json["vms"]["10.200.0.2"]["networkPolicies"]["github"]["allow"],
+            json!(["issues:write"])
+        );
         core.unregister_run(run_id).await;
     }
 

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -876,19 +876,22 @@ impl NetworkPolicyRefreshCore {
             let Some(snapshot) = self.active_snapshot_for_target(run_id, target).await else {
                 continue;
             };
-            if candidate_base_url_vars.is_some()
-                && !self
-                    .custom_base_url_vars_match(run_id, target, candidate_base_url_vars.as_ref())
+            if let Some(candidate) = &candidate_base_url_vars {
+                let Some(matches_pinned_values) = self
+                    .custom_base_url_vars_match(run_id, target, candidate)
                     .await
-                    .unwrap_or(true)
-            {
-                warn!(
-                    run_id = %run_id,
-                    target = %target.target.log_identity(),
-                    "connector runtime sync tried to replace run-pinned base URL variables"
-                );
-                retry_targets.push(target.clone());
-                continue;
+                else {
+                    continue;
+                };
+                if !matches_pinned_values {
+                    warn!(
+                        run_id = %run_id,
+                        target = %target.target.log_identity(),
+                        "connector runtime sync tried to replace run-pinned base URL variables"
+                    );
+                    retry_targets.push(target.clone());
+                    continue;
+                }
             }
             let publication = match (&target.target, &result.state) {
                 (
@@ -1208,15 +1211,17 @@ impl NetworkPolicyRefreshCore {
         &self,
         run_id: RunId,
         target: &ConnectorRefreshTarget,
-        candidate: Option<&HashMap<String, String>>,
+        candidate: &HashMap<String, String>,
     ) -> Option<bool> {
         let active_runs = self.inner.active_runs.lock().await;
         let active = active_runs.get(&run_id)?;
         let connector = active.connectors.get(&target.target)?;
-        Some(match (&connector.pinned_base_url_vars, candidate) {
-            (Some(pinned), Some(candidate)) => pinned == candidate,
-            _ => true,
-        })
+        Some(
+            connector
+                .pinned_base_url_vars
+                .as_ref()
+                .is_none_or(|pinned| pinned == candidate),
+        )
     }
 
     async fn complete_successful_refresh(
@@ -2943,6 +2948,93 @@ mod tests {
         );
         assert_eq!(active.connectors[&target].consecutive_failures, 1);
         assert!(active.refresh_tasks.contains_key(&target));
+        drop(active_runs);
+        core.unregister_run(run_id).await;
+    }
+
+    #[tokio::test]
+    async fn tagged_custom_target_accepts_old_api_result_without_routing_metadata() {
+        let server = MockServer::start();
+        let (core, mut requests) = core_without_worker(&server);
+        let run_id = RunId::nil();
+        let custom_connector_id = "550e8400-e29b-41d4-a716-446655440000";
+        let target = custom_target(custom_connector_id);
+        let pinned_base_url_vars = HashMap::from([("subdomain".to_string(), "acme".to_string())]);
+        let registration = ConnectorRuntimeTargetRegistration::Custom {
+            custom_connector_id: custom_connector_id.to_string(),
+            base_url_vars: Some(pinned_base_url_vars.clone()),
+        };
+        let firewall = custom_runtime_firewall(custom_connector_id);
+        server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
+                .json_body(json!({
+                    "targets": [{
+                        "kind": "custom",
+                        "customConnectorId": custom_connector_id,
+                        "baseUrlVars": pinned_base_url_vars,
+                    }],
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": [{
+                        "target": target.clone(),
+                        "state": "available",
+                        "firewall": firewall,
+                        "networkPolicy": {
+                            "allow": ["custom.write"],
+                            "deny": [],
+                            "ask": [],
+                            "unknownPolicy": "deny",
+                        },
+                    }],
+                }));
+        });
+        let initial_firewall = custom_runtime_firewall(custom_connector_id);
+        let firewall_name = format!("custom_connector_{}", custom_connector_id.replace('-', ""));
+        let initial_policies = HashMap::from([(
+            firewall_name.clone(),
+            NetworkPolicy {
+                allow: vec!["custom.read".to_string()],
+                deny: vec![],
+                ask: vec![],
+                unknown_policy: "deny".to_string(),
+            },
+        )]);
+        let firewalls = vec![initial_firewall];
+        let (_dir, registry, registry_path) =
+            registered_runtime_registry(run_id, &firewalls, &initial_policies).await;
+
+        core.register_run(NetworkPolicyRefreshRegistration {
+            run_id,
+            source_ip: "10.200.0.2",
+            registry,
+            connector_slugs: HashSet::new(),
+            targets: Some(std::slice::from_ref(&registration)),
+            refreshes: None,
+        })
+        .await;
+        let request = recv_refresh_request(&mut requests).await;
+        assert!(
+            core.sync_connector_runtime_batch_now(run_id, &request.targets)
+                .await
+        );
+
+        let registry_json: serde_json::Value =
+            serde_json::from_str(&tokio::fs::read_to_string(registry_path).await.unwrap()).unwrap();
+        assert_eq!(
+            registry_json["vms"]["10.200.0.2"]["networkPolicies"][firewall_name]["allow"],
+            json!(["custom.write"])
+        );
+        let active_runs = core.inner.active_runs.lock().await;
+        let active = &active_runs[&run_id];
+        assert_eq!(
+            active.connectors[&target].pinned_base_url_vars,
+            Some(pinned_base_url_vars)
+        );
+        assert_eq!(active.connectors[&target].consecutive_failures, 0);
+        assert!(!active.refresh_tasks.contains_key(&target));
         drop(active_runs);
         core.unregister_run(run_id).await;
     }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -131,7 +131,7 @@ pub struct ExecutionContext {
     #[serde(default)]
     pub network_policy_refreshes: Option<std::collections::HashMap<String, NetworkPolicyRefresh>>,
     #[serde(default)]
-    pub connector_runtime_targets: Option<Vec<ConnectorRuntimeTarget>>,
+    pub connector_runtime_targets: Option<Vec<ConnectorRuntimeTargetRegistration>>,
     #[serde(default)]
     pub disallowed_tools: Option<Vec<String>>,
     #[serde(default)]
@@ -1268,6 +1268,59 @@ pub enum ConnectorRuntimeTarget {
     Custom { custom_connector_id: String },
 }
 
+/// Stable connector identity plus run-pinned metadata used at registration and
+/// in runtime synchronization requests. Metadata never participates in target
+/// equality, result correlation, or realtime notification routing.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum ConnectorRuntimeTargetRegistration {
+    #[serde(rename_all = "camelCase")]
+    Builtin { connector_slug: String },
+    #[serde(rename_all = "camelCase")]
+    Custom {
+        custom_connector_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url_vars: Option<HashMap<String, String>>,
+    },
+}
+
+impl ConnectorRuntimeTargetRegistration {
+    pub(crate) fn target(&self) -> ConnectorRuntimeTarget {
+        match self {
+            Self::Builtin { connector_slug } => ConnectorRuntimeTarget::Builtin {
+                connector_slug: connector_slug.clone(),
+            },
+            Self::Custom {
+                custom_connector_id,
+                ..
+            } => ConnectorRuntimeTarget::Custom {
+                custom_connector_id: custom_connector_id.clone(),
+            },
+        }
+    }
+
+    pub(crate) fn custom_base_url_vars(&self) -> Option<&HashMap<String, String>> {
+        match self {
+            Self::Custom { base_url_vars, .. } => base_url_vars.as_ref(),
+            Self::Builtin { .. } => None,
+        }
+    }
+}
+
+impl From<ConnectorRuntimeTarget> for ConnectorRuntimeTargetRegistration {
+    fn from(target: ConnectorRuntimeTarget) -> Self {
+        match target {
+            ConnectorRuntimeTarget::Builtin { connector_slug } => Self::Builtin { connector_slug },
+            ConnectorRuntimeTarget::Custom {
+                custom_connector_id,
+            } => Self::Custom {
+                custom_connector_id,
+                base_url_vars: None,
+            },
+        }
+    }
+}
+
 impl ConnectorRuntimeTarget {
     pub(crate) fn log_identity(&self) -> String {
         match self {
@@ -1291,6 +1344,10 @@ impl ConnectorRuntimeTarget {
 pub struct ConnectorRuntimeSyncResult {
     pub target: ConnectorRuntimeTarget,
     pub next_sync_at: Option<String>,
+    /// First-admission Custom routing inputs. The scheduler pins these only
+    /// after the accompanying executable state publishes successfully.
+    #[serde(default)]
+    pub base_url_vars: Option<HashMap<String, String>>,
     #[serde(flatten)]
     pub state: ConnectorRuntimeSyncState,
 }
@@ -1319,6 +1376,12 @@ pub enum ConnectorRuntimeSyncState {
 pub enum ConnectorRuntimeUnresolvedReason {
     #[serde(rename = "connector-unavailable")]
     Connector,
+    #[serde(rename = "grant-unavailable")]
+    Grant,
+    #[serde(rename = "permission-bundle-unavailable")]
+    PermissionBundle,
+    #[serde(rename = "runtime-configuration-unavailable")]
+    RuntimeConfiguration,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8289,12 +8289,21 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       Authorization: "Bearer custom-secret-value",
     });
 
-    const target = { kind: "custom" as const, customConnectorId: custom.id };
+    const targetIdentity = {
+      kind: "custom" as const,
+      customConnectorId: custom.id,
+    };
+    const target = {
+      ...targetIdentity,
+      baseUrlVars: { subdomain: "pinned-routing-value" },
+    };
     const [initialRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
     });
     const initialAvailable = availableCustomConnectorRuntime(initialRuntime);
     expect(initialAvailable.nextSyncAt).toBeUndefined();
+    expect(initialAvailable.target).toStrictEqual(targetIdentity);
+    expect(initialAvailable.baseUrlVars).toBeUndefined();
     const { api: initialApi, body: currentAuthBody } =
       customConnectorRuntimeAuthBody(
         initialAvailable,
@@ -8398,7 +8407,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       throw new Error("Expected an absent custom connector runtime result");
     }
     expect(absentRuntime).toMatchObject({
-      target,
+      target: targetIdentity,
       state: "absent",
       reason: "grant-unavailable",
     });
@@ -8409,7 +8418,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       targets: [target],
     });
     expect(restoredRuntime).toMatchObject({
-      target,
+      target: targetIdentity,
       state: "available",
     });
 
@@ -8487,7 +8496,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       targets: [target],
     });
     expect(compatibleRuntime).toMatchObject({
-      target,
+      target: targetIdentity,
       state: "available",
     });
     const compatibleAuth = await fw.requestFirewallAuth(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -16,7 +16,7 @@ import {
   runnersPollContract,
   storedConnectorPermissionBaselineSchema,
   type CompatibleStoredExecutionContext,
-  type ConnectorRuntimeTarget,
+  type ConnectorRuntimeTargetRegistration,
   type ExecutionContext,
   type HeldSandboxState,
   type HeldWorkspaceState,
@@ -1427,7 +1427,7 @@ function connectorPermissionBaselineMatchesStoredContext(
 
 function connectorRuntimeTargetsForClaim(
   storedContext: StoredExecutionContext,
-): ConnectorRuntimeTarget[] | undefined {
+): ConnectorRuntimeTargetRegistration[] | undefined {
   if (storedContext.connectorRuntimeTargets !== undefined) {
     return storedContext.connectorRuntimeTargets;
   }

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -2,6 +2,7 @@ import type {
   ConnectorRuntimeCustomAbsentReason,
   ConnectorRuntimeSyncResult,
   ConnectorRuntimeTarget,
+  ConnectorRuntimeTargetRegistration,
 } from "@vm0/api-contracts/contracts/runners";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
@@ -39,6 +40,20 @@ interface CustomTargetSnapshot {
 
 interface ConnectorRuntimeResolution {
   readonly result: ConnectorRuntimeSyncResult;
+}
+
+function connectorRuntimeTargetIdentity(
+  registration: ConnectorRuntimeTargetRegistration,
+): ConnectorRuntimeTarget {
+  return registration.kind === "builtin"
+    ? {
+        kind: "builtin",
+        connectorSlug: registration.connectorSlug,
+      }
+    : {
+        kind: "custom",
+        customConnectorId: registration.customConnectorId,
+      };
 }
 
 function customAbsentResult(
@@ -211,7 +226,7 @@ async function resolveCustomTarget(args: {
 export async function resolveConnectorRuntimeTargets(args: {
   readonly db: Db;
   readonly scope: ConnectorRuntimeScope;
-  readonly targets: readonly ConnectorRuntimeTarget[];
+  readonly targets: readonly ConnectorRuntimeTargetRegistration[];
 }): Promise<readonly ConnectorRuntimeResolution[]> {
   const builtinConnectorSlugs = args.targets.flatMap((target) => {
     return target.kind === "builtin" ? [target.connectorSlug] : [];
@@ -240,7 +255,8 @@ export async function resolveConnectorRuntimeTargets(args: {
   );
 
   const results: ConnectorRuntimeResolution[] = [];
-  for (const target of args.targets) {
+  for (const registration of args.targets) {
+    const target = connectorRuntimeTargetIdentity(registration);
     if (target.kind === "custom") {
       if (!customSnapshot) {
         throw new Error("Custom connector runtime snapshot is unavailable");

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -1,5 +1,5 @@
 import type {
-  ConnectorRuntimeCustomAbsentReason,
+  ConnectorRuntimeCustomUnavailableReason,
   ConnectorRuntimeSyncResult,
   ConnectorRuntimeTarget,
   ConnectorRuntimeTargetRegistration,
@@ -58,7 +58,7 @@ function connectorRuntimeTargetIdentity(
 
 function customAbsentResult(
   target: Extract<ConnectorRuntimeTarget, { readonly kind: "custom" }>,
-  reason: ConnectorRuntimeCustomAbsentReason,
+  reason: ConnectorRuntimeCustomUnavailableReason,
 ): ConnectorRuntimeResolution {
   return {
     result: {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -284,16 +284,48 @@ describe("connector runtime synchronization contract", () => {
   });
 
   it("requires unique tagged targets", () => {
-    const target = {
+    const firstTarget = {
       kind: "custom" as const,
       customConnectorId,
+      baseUrlVars: { subdomain: "first" },
+    };
+    const secondTarget = {
+      ...firstTarget,
+      baseUrlVars: { subdomain: "second" },
     };
 
     expect(
       runnersConnectorRuntimeSyncContract.sync.body.safeParse({
-        targets: [target, target],
+        targets: [firstTarget, secondTarget],
       }).success,
     ).toBe(false);
+  });
+
+  it("preserves optional custom routing values in target registrations", () => {
+    const fixture = executionContextSchema.parse(
+      loadRunnerClaimResponseFixture(),
+    );
+    const target = {
+      kind: "custom" as const,
+      customConnectorId,
+      baseUrlVars: { subdomain: "acme" },
+    };
+
+    const execution = executionContextSchema.parse({
+      ...fixture,
+      connectorRuntimeTargets: [target],
+    });
+    const request = runnersConnectorRuntimeSyncContract.sync.body.parse({
+      targets: [target],
+    });
+
+    expect(execution.connectorRuntimeTargets).toEqual([target]);
+    expect(request.targets).toEqual([target]);
+    expect(
+      runnersConnectorRuntimeSyncContract.sync.body.safeParse({
+        targets: [{ kind: "custom", customConnectorId }],
+      }).success,
+    ).toBe(true);
   });
 
   it("requires stable API identities on available custom firewalls", () => {
@@ -320,6 +352,7 @@ describe("connector runtime synchronization contract", () => {
         ask: [],
         unknownPolicy: "allow" as const,
       },
+      baseUrlVars: { subdomain: "acme" },
     };
 
     expect(connectorRuntimeSyncResultSchema.safeParse(result).success).toBe(
@@ -341,7 +374,7 @@ describe("connector runtime synchronization contract", () => {
     ).toBe(false);
   });
 
-  it("keeps builtin retry states distinct from custom authoritative absence", () => {
+  it("keeps target-specific retry and authoritative absence states distinct", () => {
     const builtinTarget = {
       kind: "builtin" as const,
       connectorSlug: "slack",
@@ -373,7 +406,14 @@ describe("connector runtime synchronization contract", () => {
       connectorRuntimeSyncResultSchema.safeParse({
         target: customTarget,
         state: "unresolved",
-        reason: "connector-unavailable",
+        reason: "runtime-configuration-unavailable",
+      }).success,
+    ).toBe(true);
+    expect(
+      connectorRuntimeSyncResultSchema.safeParse({
+        target: builtinTarget,
+        state: "unresolved",
+        reason: "runtime-configuration-unavailable",
       }).success,
     ).toBe(false);
   });

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -665,7 +665,7 @@ export {
   type RunSkillSnapshotEntry,
   type NetworkPolicyRefresh,
   type ConnectorRuntimeTarget,
-  type ConnectorRuntimeCustomAbsentReason,
+  type ConnectorRuntimeCustomUnavailableReason,
   type ConnectorRuntimeSyncResult,
   type SecretConnectorMetadata,
   type CanonicalStorageManifest,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -665,6 +665,7 @@ export {
   type RunSkillSnapshotEntry,
   type NetworkPolicyRefresh,
   type ConnectorRuntimeTarget,
+  type ConnectorRuntimeTargetRegistration,
   type ConnectorRuntimeCustomUnavailableReason,
   type ConnectorRuntimeSyncResult,
   type SecretConnectorMetadata,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -256,7 +256,7 @@ const connectorRuntimeSyncTargetsSchema = connectorRuntimeTargetsSchema
   .min(1)
   .max(CONNECTOR_RUNTIME_SYNC_TARGETS_MAX);
 
-export const connectorRuntimeCustomAbsentReasonSchema = z.enum([
+export const connectorRuntimeCustomUnavailableReasonSchema = z.enum([
   "connector-unavailable",
   "grant-unavailable",
   "permission-bundle-unavailable",
@@ -303,14 +303,14 @@ export const connectorRuntimeCustomUnresolvedResultSchema =
   connectorRuntimeResultBaseSchema.extend({
     target: connectorRuntimeCustomTargetSchema,
     state: z.literal("unresolved"),
-    reason: connectorRuntimeCustomAbsentReasonSchema,
+    reason: connectorRuntimeCustomUnavailableReasonSchema,
   });
 
 export const connectorRuntimeCustomAbsentResultSchema =
   connectorRuntimeResultBaseSchema.extend({
     target: connectorRuntimeCustomTargetSchema,
     state: z.literal("absent"),
-    reason: connectorRuntimeCustomAbsentReasonSchema,
+    reason: connectorRuntimeCustomUnavailableReasonSchema,
   });
 
 export const connectorRuntimeSyncResultSchema = z.union([
@@ -1240,8 +1240,8 @@ export type ConnectorRuntimeTarget = z.infer<
 export type ConnectorRuntimeTargetRegistration = z.infer<
   typeof connectorRuntimeTargetRegistrationSchema
 >;
-export type ConnectorRuntimeCustomAbsentReason = z.infer<
-  typeof connectorRuntimeCustomAbsentReasonSchema
+export type ConnectorRuntimeCustomUnavailableReason = z.infer<
+  typeof connectorRuntimeCustomUnavailableReasonSchema
 >;
 export type ConnectorRuntimeSyncResult = z.infer<
   typeof connectorRuntimeSyncResultSchema

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -208,8 +208,21 @@ export const connectorRuntimeTargetSchema = z.discriminatedUnion("kind", [
   connectorRuntimeCustomTargetSchema,
 ]);
 
+export const connectorRuntimeCustomTargetRegistrationSchema =
+  connectorRuntimeCustomTargetSchema.extend({
+    baseUrlVars: z.record(z.string(), z.string()).optional(),
+  });
+
+export const connectorRuntimeTargetRegistrationSchema = z.discriminatedUnion(
+  "kind",
+  [
+    connectorRuntimeBuiltinTargetSchema,
+    connectorRuntimeCustomTargetRegistrationSchema,
+  ],
+);
+
 function connectorRuntimeTargetKey(
-  target: z.infer<typeof connectorRuntimeTargetSchema>,
+  target: z.infer<typeof connectorRuntimeTargetRegistrationSchema>,
 ): string {
   return target.kind === "builtin"
     ? `builtin:${target.connectorSlug}`
@@ -217,7 +230,7 @@ function connectorRuntimeTargetKey(
 }
 
 function uniqueConnectorRuntimeTargets(
-  targets: readonly z.infer<typeof connectorRuntimeTargetSchema>[],
+  targets: readonly z.infer<typeof connectorRuntimeTargetRegistrationSchema>[],
   context: z.RefinementCtx,
 ): void {
   const seen = new Set<string>();
@@ -236,7 +249,7 @@ function uniqueConnectorRuntimeTargets(
 }
 
 const connectorRuntimeTargetsSchema = z
-  .array(connectorRuntimeTargetSchema)
+  .array(connectorRuntimeTargetRegistrationSchema)
   .superRefine(uniqueConnectorRuntimeTargets);
 
 const connectorRuntimeSyncTargetsSchema = connectorRuntimeTargetsSchema
@@ -283,6 +296,14 @@ export const connectorRuntimeCustomAvailableResultSchema =
       }),
     }),
     networkPolicy: networkPolicySchema,
+    baseUrlVars: z.record(z.string(), z.string()).optional(),
+  });
+
+export const connectorRuntimeCustomUnresolvedResultSchema =
+  connectorRuntimeResultBaseSchema.extend({
+    target: connectorRuntimeCustomTargetSchema,
+    state: z.literal("unresolved"),
+    reason: connectorRuntimeCustomAbsentReasonSchema,
   });
 
 export const connectorRuntimeCustomAbsentResultSchema =
@@ -296,6 +317,7 @@ export const connectorRuntimeSyncResultSchema = z.union([
   connectorRuntimeBuiltinAvailableResultSchema,
   connectorRuntimeBuiltinUnresolvedResultSchema,
   connectorRuntimeCustomAvailableResultSchema,
+  connectorRuntimeCustomUnresolvedResultSchema,
   connectorRuntimeCustomAbsentResultSchema,
 ]);
 const connectorPermissionNameListSchema = z
@@ -1214,6 +1236,9 @@ export type StoredConnectorPermissionBaseline = z.infer<
 export type NetworkPolicyRefresh = z.infer<typeof networkPolicyRefreshSchema>;
 export type ConnectorRuntimeTarget = z.infer<
   typeof connectorRuntimeTargetSchema
+>;
+export type ConnectorRuntimeTargetRegistration = z.infer<
+  typeof connectorRuntimeTargetRegistrationSchema
 >;
 export type ConnectorRuntimeCustomAbsentReason = z.infer<
   typeof connectorRuntimeCustomAbsentReasonSchema


### PR DESCRIPTION
## Summary

- keep connector runtime target identity separate from run-pinned Custom routing inputs
- carry pinned Custom `baseUrlVars` through registration, retries, coalescing, and ID-only realtime wake-ups
- retain last-known-good Custom firewall and policy for unresolved or routing-mismatch responses
- allow a valid first Custom result to establish routing inputs only after its executable firewall and policy publish successfully
- validate the active generation before mutating the first-admission routing pin
- process coalesced runtime sync work per target so one superseded generation does not drop unrelated Builtin or Custom work
- reject target-invalid unresolved reasons without weakening the existing Builtin protocol
- keep API results normalized to pure target identities and expose the registration type consistently through claim handling and the contracts barrel

## Behavior and compatibility

Builtin routing behavior is unchanged. Custom routing now has the consumer-side protocol needed to match Builtin run-scoped routing: a running run does not accept replacement routing values merely because current storage changed.

This is a consumer-first change. The current API resolver accepts the additive request shape but does not author or depend on routing metadata yet. #25684 owns producer activation and must wait until this runner has deployed and previous runner generations have drained.

Complete old-API Custom results without routing metadata remain accepted during the rollout window. This compatibility path is covered explicitly and is tracked for removal by #25351 after producer activation and old API/runner drain.

There is no database migration, Python addon change, credential-cache protocol, or production producer cutover in this PR.

## Validation

- `pnpm format`
- API contract runner tests: 78 passed
- targeted API run-lifecycle integration test passed
- API contracts and API lint/type checks passed
- full Turbo type checking passed in the pre-commit hook
- Knip passed
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- runner rustdoc with warnings denied
- connector runtime scheduler module: 42 passed
- proxy registry tests: 22 passed
- full runner binary suite: 3082 passed, 20 ignored
- commitlint passed

Closes #25743
Relates to #25350
