### PR TITLE
refactor(runner): migrate to canonical runner preference contract

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -189,7 +189,7 @@ struct ClaimAdmissionRequest<'a> {
 
 struct PreferenceCandidateRequest<'a> {
     candidate: JobCandidate,
-    preference: &'a crate::provider::RunnerPreference,
+    preference: &'a crate::provider::ActiveRunnerPreference,
     reuse_key: &'a str,
     profile_name: &'a str,
     job_vcpu: u32,
@@ -1072,7 +1072,7 @@ fn finalizing_preparation(
 
 async fn defer_preference_candidate(
     candidate: JobCandidate,
-    preference: &crate::provider::RunnerPreference,
+    preference: &crate::provider::ActiveRunnerPreference,
     reuse_key: &str,
     ctx: &DiscoveredJobContext<'_>,
     retain: bool,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1635,7 +1635,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         let pending_finalizing_deadline = pending_finalizing_candidate
             .as_ref()
             .and_then(JobCandidate::runner_preference)
-            .map(crate::provider::RunnerPreference::deadline);
+            .map(crate::provider::ActiveRunnerPreference::deadline);
         tokio::select! {
             // Job discovery via provider (Ably wakeups + HTTP poll).
             // The future is pinned outside the loop so heartbeat/cleanup

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
 use crate::provider::{
-    RunnerPreference, RunnerPreferenceClaimState, RunnerPreferenceResolution, RunnerPreferenceTier,
+    ActiveRunnerPreference, RunnerPreference, RunnerPreferenceClaimState, RunnerPreferenceTier,
 };
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
@@ -45,7 +45,7 @@ fn ranked_candidate_until(
 ) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(reuse_key.map(str::to_owned))
-        .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
+        .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
             runner_id.parse().unwrap(),
             heartbeat_generation,
             tier,
@@ -106,7 +106,7 @@ fn finalizing_candidate_until(
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(Some(reuse_key.to_owned()))
         .with_history_generation_run_id(Some(history_generation_run_id))
-        .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
+        .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
             runner_id.parse().unwrap(),
             heartbeat_generation,
             RunnerPreferenceTier::FinalizingPredecessor,
@@ -553,7 +553,9 @@ async fn reusable_claim_without_generation_target_reuses_sandbox() {
         .find(|candidate| candidate.run_id() == run_id)
         .expect("missing-target reusable candidate should reach claim");
     assert_eq!(
-        candidate.runner_preference().map(RunnerPreference::tier),
+        candidate
+            .runner_preference()
+            .map(ActiveRunnerPreference::tier),
         Some(RunnerPreferenceTier::ReusableSandbox)
     );
 
@@ -749,17 +751,19 @@ async fn selected_finalizing_candidate_claims_while_predecessor_is_running() {
         .find(|candidate| candidate.run_id() == pending_run_id)
         .expect("finalizing candidate should already be claimed");
     let preference_telemetry = claimed
-        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .runner_preference_claim_telemetry()
         .expect("finalizing observation should be recorded at claim");
-    assert_eq!(
-        preference_telemetry.resolution,
-        RunnerPreferenceResolution::FinalizingPredecessor
-    );
+    assert!(matches!(
+        preference_telemetry.runner_preference,
+        RunnerPreference::Preference {
+            tier: RunnerPreferenceTier::FinalizingPredecessor,
+            ..
+        }
+    ));
     assert_eq!(
         preference_telemetry.state,
-        RunnerPreferenceClaimState::Active
+        Some(RunnerPreferenceClaimState::Active)
     );
-    assert_eq!(preference_telemetry.targeted_self, Some(true));
 
     shutdown(&env, run_handle).await;
 }
@@ -818,14 +822,16 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
         .find(|candidate| candidate.run_id() == run_id)
         .expect("expired candidate should reach claim");
     let telemetry = claimed
-        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .runner_preference_claim_telemetry()
         .expect("decision observation should survive expiry");
-    assert_eq!(
-        telemetry.resolution,
-        RunnerPreferenceResolution::FinalizingPredecessor
-    );
-    assert_eq!(telemetry.state, RunnerPreferenceClaimState::Active);
-    assert_eq!(telemetry.targeted_self, Some(true));
+    assert!(matches!(
+        telemetry.runner_preference,
+        RunnerPreference::Preference {
+            tier: RunnerPreferenceTier::FinalizingPredecessor,
+            ..
+        }
+    ));
+    assert_eq!(telemetry.state, Some(RunnerPreferenceClaimState::Active));
 
     drop(predecessor_guard);
     shutdown(&env, run_handle).await;
@@ -1424,17 +1430,19 @@ async fn same_run_duplicate_does_not_renew_claimed_finalizing_deadline() {
         .find(|candidate| candidate.run_id() == run_id)
         .expect("expired pending candidate should reach claim");
     let preference_telemetry = claimed
-        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .runner_preference_claim_telemetry()
         .expect("finalizing observation should survive expiry");
-    assert_eq!(
-        preference_telemetry.resolution,
-        RunnerPreferenceResolution::FinalizingPredecessor
-    );
+    assert!(matches!(
+        preference_telemetry.runner_preference,
+        RunnerPreference::Preference {
+            tier: RunnerPreferenceTier::FinalizingPredecessor,
+            ..
+        }
+    ));
     assert_eq!(
         preference_telemetry.state,
-        RunnerPreferenceClaimState::Active
+        Some(RunnerPreferenceClaimState::Active)
     );
-    assert_eq!(preference_telemetry.targeted_self, Some(true));
 
     drop(predecessor_guard);
     shutdown(&env, run_handle).await;
@@ -1630,7 +1638,7 @@ async fn selected_finalizing_candidate_without_reuse_key_uses_ordinary_admission
         .send(
             crate::provider::JobCandidate::new(run_id, "vm0/default".into())
                 .with_history_generation_run_id(Some(RunId::new_v4()))
-                .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
+                .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
                     TEST_RUNNER_ID.parse().unwrap(),
                     TEST_HEARTBEAT_GENERATION,
                     RunnerPreferenceTier::FinalizingPredecessor,
@@ -1658,17 +1666,19 @@ async fn selected_finalizing_candidate_without_reuse_key_uses_ordinary_admission
         "ordinary admission should clear the incomplete advisory preference"
     );
     let preference_telemetry = claimed
-        .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+        .runner_preference_claim_telemetry()
         .expect("incomplete finalizing metadata should preserve its observation");
-    assert_eq!(
-        preference_telemetry.resolution,
-        RunnerPreferenceResolution::FinalizingPredecessor
-    );
+    assert!(matches!(
+        preference_telemetry.runner_preference,
+        RunnerPreference::Preference {
+            tier: RunnerPreferenceTier::FinalizingPredecessor,
+            ..
+        }
+    ));
     assert_eq!(
         preference_telemetry.state,
-        RunnerPreferenceClaimState::Cleared
+        Some(RunnerPreferenceClaimState::Cleared)
     );
-    assert_eq!(preference_telemetry.targeted_self, Some(true));
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
-use crate::provider::{JobCandidate, RunnerPreference, RunnerPreferenceTier};
+use crate::provider::{ActiveRunnerPreference, JobCandidate, RunnerPreferenceTier};
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
 fn exact_generation_candidate(
@@ -21,7 +21,7 @@ fn exact_generation_candidate(
     JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(Some(reuse_key.to_owned()))
         .with_history_generation_run_id(Some(history_generation_run_id))
-        .with_runner_preference_for_test(RunnerPreference::ranked_for_test(
+        .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
             TEST_RUNNER_ID.parse().unwrap(),
             TEST_HEARTBEAT_GENERATION,
             RunnerPreferenceTier::ExactSandbox,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -32,7 +32,7 @@ use super::builtin_firewall_catalog::{
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    RunnerPreferenceClaimState, RunnerPreferenceResolution, parse_runner_preference_decision,
+    RunnerPreference, RunnerPreferenceClaimState, parse_runner_preference,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -89,11 +89,9 @@ struct ClaimRequestTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     poll_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    runner_preference_resolution: Option<RunnerPreferenceResolution>,
+    runner_preference: Option<RunnerPreference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     runner_preference_claim_state: Option<RunnerPreferenceClaimState>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    runner_preference_targeted_self: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -205,7 +203,7 @@ const NETWORK_POLICY_REFRESH_TIMEOUT: Duration = Duration::from_secs(3);
 const BUILTIN_FIREWALL_CATALOG_RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
 
 enum DiscoveryWakeup {
-    Direct(DirectJobCandidate),
+    Direct(Box<DirectJobCandidate>),
     Poll(PollDue),
 }
 
@@ -450,7 +448,7 @@ impl ApiProvider {
     async fn wait_for_discovery_wakeup(&self) -> Option<DiscoveryWakeup> {
         loop {
             if let Some(candidate) = self.try_recv_direct_candidate().await {
-                return Some(DiscoveryWakeup::Direct(candidate));
+                return Some(DiscoveryWakeup::Direct(Box::new(candidate)));
             }
 
             tokio::select! {
@@ -460,7 +458,7 @@ impl ApiProvider {
                 }
                 candidate = self.wait_for_direct_candidate() => {
                     if let Some(candidate) = candidate {
-                        return Some(DiscoveryWakeup::Direct(candidate));
+                        return Some(DiscoveryWakeup::Direct(Box::new(candidate)));
                     }
                 }
                 due = self.poll_wakeups.wait_for_poll_due(&self.cancel, POLL_SLOW, POLL_FAST) => {
@@ -595,17 +593,38 @@ impl JobProvider for ApiProvider {
                     let reuse_key = job.reuse_key().map(str::to_owned);
                     let history_generation_run_id = job.history_generation_run_id;
                     let pi_execution_mode = job.pi_execution_mode;
-                    let runner_preference_context = match parse_runner_preference_decision(
-                        job.runner_preference_decision,
+                    let runner_preference_context = match parse_runner_preference(
+                        job.runner_preference,
                     ) {
-                        Ok(context) => context,
+                        Ok(Some(context)) => Some(context),
+                        Ok(None) => match parse_runner_preference(job.runner_preference_decision) {
+                            Ok(context) => context,
+                            Err(error) => {
+                                warn!(
+                                    run_id = %run_id,
+                                    error = %error,
+                                    "poll: invalid compatibility runner preference, using ordinary admission"
+                                );
+                                None
+                            }
+                        },
                         Err(error) => {
                             warn!(
                                 run_id = %run_id,
                                 error = %error,
-                                "poll: invalid runner preference decision, using ordinary admission"
+                                "poll: invalid canonical runner preference, trying compatibility field"
                             );
-                            None
+                            match parse_runner_preference(job.runner_preference_decision) {
+                                Ok(context) => context,
+                                Err(error) => {
+                                    warn!(
+                                        run_id = %run_id,
+                                        error = %error,
+                                        "poll: invalid compatibility runner preference, using ordinary admission"
+                                    );
+                                    None
+                                }
+                            }
                         }
                     };
                     let profile = job.experimental_profile;
@@ -1330,8 +1349,7 @@ fn claim_request_body<'a>(
     runner_id: &'a str,
     heartbeat_generation: u64,
 ) -> ClaimRequestBody<'a> {
-    let runner_preference_telemetry =
-        candidate.runner_preference_claim_telemetry(runner_id, heartbeat_generation);
+    let runner_preference_telemetry = candidate.runner_preference_claim_telemetry();
     let is_ably_candidate = candidate.discovery_source() == Some(JobDiscoverySource::Ably);
     let (
         direct_candidate_notification_to_enqueue_ms,
@@ -1381,12 +1399,11 @@ fn claim_request_body<'a>(
                 .poll_http_request_elapsed()
                 .map(claim_telemetry_duration_ms),
             poll_reason: candidate.poll_reason().map(String::from),
-            runner_preference_resolution: runner_preference_telemetry
-                .map(|telemetry| telemetry.resolution),
+            runner_preference: runner_preference_telemetry
+                .as_ref()
+                .map(|telemetry| telemetry.runner_preference.clone()),
             runner_preference_claim_state: runner_preference_telemetry
-                .map(|telemetry| telemetry.state),
-            runner_preference_targeted_self: runner_preference_telemetry
-                .and_then(|telemetry| telemetry.targeted_self),
+                .and_then(|telemetry| telemetry.state),
         },
     }
 }
@@ -1727,7 +1744,10 @@ mod tests {
     use uuid::Uuid;
 
     use crate::http::HttpClientConfig;
-    use crate::provider::{RunnerPreference, RunnerPreferenceRemovalReason, RunnerPreferenceTier};
+    use crate::provider::{
+        ActiveRunnerPreference, RunnerNoPreferenceReason, RunnerPreference,
+        RunnerPreferenceRemovalReason, RunnerPreferenceTier,
+    };
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
         "../../../../turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json"
@@ -2336,6 +2356,7 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
+        assert!(body["telemetry"].get("runnerPreference").is_none());
         assert!(
             body["telemetry"]
                 .get("runnerPreferenceResolution")
@@ -2360,8 +2381,8 @@ mod tests {
     }
 
     #[test]
-    fn claim_request_body_serializes_preference_observation_at_claim_time() {
-        let active_preference = RunnerPreference::ranked_for_test(
+    fn claim_request_body_serializes_canonical_preference_at_claim_time() {
+        let active_preference = ActiveRunnerPreference::ranked_for_test(
             TEST_RUNNER_ID.parse().unwrap(),
             TEST_HEARTBEAT_GENERATION,
             RunnerPreferenceTier::WorkspaceCache,
@@ -2371,19 +2392,33 @@ mod tests {
             .with_runner_preference_for_test(active_preference);
         let active_body = serde_json::to_value(claim_request_body_for_test(&active)).unwrap();
         assert_eq!(
-            active_body["telemetry"]["runnerPreferenceResolution"],
-            "matching_workspace_cache"
+            active_body["telemetry"]["runnerPreference"]["kind"],
+            "preference"
+        );
+        assert_eq!(
+            active_body["telemetry"]["runnerPreference"]["tier"],
+            "workspaceCache"
+        );
+        assert_eq!(
+            active_body["telemetry"]["runnerPreference"]["runnerIdentity"]["runnerId"],
+            TEST_RUNNER_ID
         );
         assert_eq!(
             active_body["telemetry"]["runnerPreferenceClaimState"],
             "active"
         );
-        assert_eq!(
-            active_body["telemetry"]["runnerPreferenceTargetedSelf"],
-            true
+        assert!(
+            active_body["telemetry"]
+                .get("runnerPreferenceResolution")
+                .is_none()
+        );
+        assert!(
+            active_body["telemetry"]
+                .get("runnerPreferenceTargetedSelf")
+                .is_none()
         );
 
-        let expired_preference = RunnerPreference::ranked_for_test(
+        let expired_preference = ActiveRunnerPreference::ranked_for_test(
             TEST_RUNNER_ID.parse().unwrap(),
             TEST_HEARTBEAT_GENERATION,
             RunnerPreferenceTier::ExactSandbox,
@@ -2397,7 +2432,7 @@ mod tests {
             "expired"
         );
 
-        let cleared_preference = RunnerPreference::ranked_for_test(
+        let cleared_preference = ActiveRunnerPreference::ranked_for_test(
             Uuid::from_u128(8),
             TEST_HEARTBEAT_GENERATION,
             RunnerPreferenceTier::FinalizingPredecessor,
@@ -2411,21 +2446,20 @@ mod tests {
             cleared_body["telemetry"]["runnerPreferenceClaimState"],
             "cleared"
         );
-        assert_eq!(
-            cleared_body["telemetry"]["runnerPreferenceTargetedSelf"],
-            false
-        );
-
         let absent = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
-            .with_no_runner_preference_for_test(RunnerPreferenceResolution::NoViableHolder);
+            .with_no_runner_preference_for_test(RunnerNoPreferenceReason::NoViableHolder);
         let absent_body = serde_json::to_value(claim_request_body_for_test(&absent)).unwrap();
         assert_eq!(
-            absent_body["telemetry"]["runnerPreferenceClaimState"],
-            "absent"
+            absent_body["telemetry"]["runnerPreference"]["kind"],
+            "noPreference"
+        );
+        assert_eq!(
+            absent_body["telemetry"]["runnerPreference"]["reason"],
+            "noViableHolder"
         );
         assert!(
             absent_body["telemetry"]
-                .get("runnerPreferenceTargetedSelf")
+                .get("runnerPreferenceClaimState")
                 .is_none()
         );
     }
@@ -2652,7 +2686,7 @@ mod tests {
                         "cliAgentSessionId": "sess-poll",
                         "historyGenerationRunId": history_generation_run_id,
                         "piExecutionMode": "standby",
-                        "runnerPreferenceDecision": {
+                        "runnerPreference": {
                             "kind": "preference",
                             "runnerIdentity": {
                                 "runnerId": "00000000-0000-0000-0000-000000000005",
@@ -2660,6 +2694,10 @@ mod tests {
                             },
                             "tier": "exactSandbox",
                             "expiresAt": "2999-01-01T00:00:00.000Z"
+                        },
+                        "runnerPreferenceDecision": {
+                            "kind": "noPreference",
+                            "reason": "noReuseKey"
                         }
                     }
                 }));
@@ -2692,15 +2730,17 @@ mod tests {
             .expect("canonical preference should be parsed");
         assert_eq!(preference.tier(), RunnerPreferenceTier::ExactSandbox);
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
-        assert_eq!(
-            discovered
-                .runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::ExactHistoryGeneration,
-                state: RunnerPreferenceClaimState::Active,
-                targeted_self: Some(true),
-            })
-        );
+        let telemetry = discovered
+            .runner_preference_claim_telemetry()
+            .expect("canonical preference telemetry");
+        assert!(matches!(
+            telemetry.runner_preference,
+            RunnerPreference::Preference {
+                tier: RunnerPreferenceTier::ExactSandbox,
+                ..
+            }
+        ));
+        assert_eq!(telemetry.state, Some(RunnerPreferenceClaimState::Active));
         assert_eq!(
             discovered.discovery_source(),
             Some(JobDiscoverySource::Poll)
@@ -2711,7 +2751,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_parses_positive_poll_preference_decision() {
+    async fn discover_falls_back_to_compatibility_poll_preference() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let selected_runner_id = "00000000-0000-0000-0000-000000000005";
@@ -2723,6 +2763,9 @@ mod tests {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
                         "reuseKey": "thread:decision-poll",
+                        "runnerPreference": {
+                            "kind": "futurePreference"
+                        },
                         "runnerPreferenceDecision": {
                             "kind": "preference",
                             "runnerIdentity": {
@@ -2749,22 +2792,27 @@ mod tests {
             .expect("job candidate");
 
         assert_eq!(
-            candidate.runner_preference().map(RunnerPreference::tier),
+            candidate
+                .runner_preference()
+                .map(ActiveRunnerPreference::tier),
             Some(RunnerPreferenceTier::WorkspaceCache)
         );
-        assert_eq!(
-            candidate.runner_preference_claim_telemetry(selected_runner_id, 7),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::MatchingWorkspaceCache,
-                state: RunnerPreferenceClaimState::Active,
-                targeted_self: Some(true),
-            })
-        );
+        let telemetry = candidate
+            .runner_preference_claim_telemetry()
+            .expect("compatibility preference telemetry");
+        assert!(matches!(
+            telemetry.runner_preference,
+            RunnerPreference::Preference {
+                tier: RunnerPreferenceTier::WorkspaceCache,
+                ..
+            }
+        ));
+        assert_eq!(telemetry.state, Some(RunnerPreferenceClaimState::Active));
         mock.assert_async().await;
     }
 
     #[tokio::test]
-    async fn discover_parses_negative_poll_preference_decision() {
+    async fn discover_parses_negative_compatibility_poll_preference() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let mock = server
@@ -2795,19 +2843,21 @@ mod tests {
             .expect("job candidate");
 
         assert!(candidate.runner_preference().is_none());
-        assert_eq!(
-            candidate.runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::NoViableHolder,
-                state: RunnerPreferenceClaimState::Absent,
-                targeted_self: None,
-            })
-        );
+        let telemetry = candidate
+            .runner_preference_claim_telemetry()
+            .expect("negative compatibility preference telemetry");
+        assert!(matches!(
+            telemetry.runner_preference,
+            RunnerPreference::NoPreference {
+                reason: RunnerNoPreferenceReason::NoViableHolder
+            }
+        ));
+        assert_eq!(telemetry.state, None);
         mock.assert_async().await;
     }
 
     #[tokio::test]
-    async fn discover_preserves_poll_job_after_malformed_preference_decision() {
+    async fn discover_preserves_poll_job_after_malformed_compatibility_preference() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let mock = server
@@ -2846,11 +2896,7 @@ mod tests {
         assert_eq!(candidate.run_id(), run_id);
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
         assert!(candidate.runner_preference().is_none());
-        assert!(
-            candidate
-                .runner_preference_claim_telemetry(TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION,)
-                .is_none()
-        );
+        assert!(candidate.runner_preference_claim_telemetry().is_none());
         mock.assert_async().await;
     }
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -27,7 +27,7 @@ use super::api_direct_candidates::{
     DirectJobCandidate,
 };
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
-use super::{RunnerPreferenceContext, parse_runner_preference_decision};
+use super::{RunnerPreferenceContext, parse_runner_preference};
 use crate::active_input::ActiveInputNotifications;
 use crate::duration::duration_ms;
 use crate::ids::RunId;
@@ -1047,18 +1047,42 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         },
         None => None,
     };
-    let runner_preference_context =
-        match parse_runner_preference_decision(msg.data.get("runnerPreferenceDecision").cloned()) {
-            Ok(context) => context,
-            Err(error) => {
-                warn!(
-                    run_id = %run_id,
-                    error = %error,
-                    "ably: invalid runner preference decision, using ordinary admission"
-                );
-                None
+    let runner_preference_context = match parse_runner_preference(
+        msg.data.get("runnerPreference").cloned(),
+    ) {
+        Ok(Some(context)) => Some(context),
+        Ok(None) => {
+            match parse_runner_preference(msg.data.get("runnerPreferenceDecision").cloned()) {
+                Ok(context) => context,
+                Err(error) => {
+                    warn!(
+                        run_id = %run_id,
+                        error = %error,
+                        "ably: invalid compatibility runner preference, using ordinary admission"
+                    );
+                    None
+                }
             }
-        };
+        }
+        Err(error) => {
+            warn!(
+                run_id = %run_id,
+                error = %error,
+                "ably: invalid canonical runner preference, trying compatibility field"
+            );
+            match parse_runner_preference(msg.data.get("runnerPreferenceDecision").cloned()) {
+                Ok(context) => context,
+                Err(error) => {
+                    warn!(
+                        run_id = %run_id,
+                        error = %error,
+                        "ably: invalid compatibility runner preference, using ordinary admission"
+                    );
+                    None
+                }
+            }
+        }
+    };
     Some(JobNotification {
         run_id,
         profile,
@@ -1213,7 +1237,7 @@ impl AblyDisconnectState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::{RunnerPreferenceResolution, RunnerPreferenceTier};
+    use crate::provider::{RunnerPreference, RunnerPreferenceTier};
 
     fn make_message(name: Option<&str>, data: serde_json::Value) -> ably_subscriber::Message {
         ably_subscriber::Message {
@@ -2007,7 +2031,7 @@ mod tests {
                 "reuseKey": "thread:chat-thread",
                 "historyGenerationRunId": "00000000-0000-0000-0000-000000000098",
                 "piExecutionMode": "standby",
-                "runnerPreferenceDecision": {
+                "runnerPreference": {
                     "kind": "preference",
                     "runnerIdentity": {
                         "runnerId": "00000000-0000-0000-0000-000000000005",
@@ -2015,6 +2039,10 @@ mod tests {
                     },
                     "tier": "reusableSandbox",
                     "expiresAt": "2999-01-01T00:00:00.000Z"
+                },
+                "runnerPreferenceDecision": {
+                    "kind": "noPreference",
+                    "reason": "noReuseKey"
                 }
             }),
         );
@@ -2042,13 +2070,19 @@ mod tests {
             .expect("canonical preference should be parsed");
         assert_eq!(preference.tier(), RunnerPreferenceTier::ReusableSandbox);
         assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
+        let telemetry = candidate
+            .runner_preference_claim_telemetry()
+            .expect("canonical preference telemetry");
+        assert!(matches!(
+            telemetry.runner_preference,
+            RunnerPreference::Preference {
+                tier: RunnerPreferenceTier::ReusableSandbox,
+                ..
+            }
+        ));
         assert_eq!(
-            candidate.runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::MatchingReusableSandbox,
-                state: super::super::RunnerPreferenceClaimState::Active,
-                targeted_self: Some(true),
-            })
+            telemetry.state,
+            Some(super::super::RunnerPreferenceClaimState::Active)
         );
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
@@ -2083,7 +2117,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_preference_decision_preserves_direct_candidate() {
+    async fn malformed_canonical_preference_uses_compatibility_value() {
         let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
@@ -2101,7 +2135,7 @@ mod tests {
                 "runId": "00000000-0000-0000-0000-000000000011",
                 "profile": "vm0/default",
                 "reuseKey": "thread:malformed-preference",
-                "runnerPreferenceDecision": {
+                "runnerPreference": {
                     "kind": "preference",
                     "runnerIdentity": {
                         "runnerId": "00000000-0000-0000-0000-000000000005",
@@ -2109,6 +2143,10 @@ mod tests {
                     },
                     "tier": "workspaceCache",
                     "expiresAt": "2999-01-01T00:00:00.000Z"
+                },
+                "runnerPreferenceDecision": {
+                    "kind": "noPreference",
+                    "reason": "noViableHolder"
                 }
             }),
         );
@@ -2120,11 +2158,14 @@ mod tests {
             .into_job_candidate();
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
         assert!(candidate.runner_preference().is_none());
-        assert!(
-            candidate
-                .runner_preference_claim_telemetry("00000000-0000-0000-0000-000000000005", 7,)
-                .is_none()
-        );
+        let telemetry = candidate
+            .runner_preference_claim_telemetry()
+            .expect("compatibility preference telemetry");
+        assert!(matches!(
+            telemetry.runner_preference,
+            RunnerPreference::NoPreference { .. }
+        ));
+        assert_eq!(telemetry.state, None);
         assert_no_direct_candidate(&direct_candidates).await;
     }
 

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 #[cfg(test)]
-use super::RunnerPreference;
+use super::ActiveRunnerPreference;
 use super::{JobCandidate, JobDiscoverySource, RunnerPreferenceContext};
 use crate::ids::RunId;
 use crate::types::PiExecutionMode;
@@ -381,7 +381,7 @@ fn snapshot(depth: usize, capacity: usize) -> DirectCandidateInboxSnapshot {
 mod tests {
     use std::time::Duration;
 
-    use super::super::{RunnerPreferenceResolution, RunnerPreferenceTier};
+    use super::super::{RunnerNoPreferenceReason, RunnerPreference, RunnerPreferenceTier};
     use super::*;
 
     fn run_id(value: u128) -> RunId {
@@ -404,7 +404,7 @@ mod tests {
         tier: RunnerPreferenceTier,
         deadline: StdInstant,
     ) -> RunnerPreferenceContext {
-        RunnerPreferenceContext::for_test(RunnerPreference::ranked_for_test(
+        RunnerPreferenceContext::for_test(ActiveRunnerPreference::ranked_for_test(
             uuid::Uuid::from_u128(runner_id),
             7,
             tier,
@@ -508,13 +508,19 @@ mod tests {
         assert_eq!(preference.tier(), RunnerPreferenceTier::ExactSandbox);
         assert_eq!(preference.deadline(), exact_deadline);
         assert!(preference.targets(&uuid::Uuid::from_u128(20).to_string(), 7));
+        let telemetry = candidate
+            .runner_preference_claim_telemetry()
+            .expect("canonical preference telemetry");
+        assert!(matches!(
+            telemetry.runner_preference,
+            RunnerPreference::Preference {
+                tier: RunnerPreferenceTier::ExactSandbox,
+                ..
+            }
+        ));
         assert_eq!(
-            candidate.runner_preference_claim_telemetry(&uuid::Uuid::from_u128(20).to_string(), 7,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::ExactHistoryGeneration,
-                state: super::super::RunnerPreferenceClaimState::Active,
-                targeted_self: Some(true),
-            })
+            telemetry.state,
+            Some(super::super::RunnerPreferenceClaimState::Active)
         );
         assert!(
             candidate
@@ -574,8 +580,8 @@ mod tests {
                     "vm0/default".to_string(),
                     StdInstant::now(),
                     None,
-                    Some(RunnerPreferenceContext::negative(
-                        RunnerPreferenceResolution::NoViableHolder,
+                    Some(RunnerPreferenceContext::no_preference_for_test(
+                        RunnerNoPreferenceReason::NoViableHolder,
                     )),
                 )
                 .with_pi_execution_mode(Some(PiExecutionMode::ColdStart)),
@@ -600,13 +606,19 @@ mod tests {
         assert_eq!(preference.tier(), RunnerPreferenceTier::WorkspaceCache);
         assert_eq!(preference.deadline(), first_deadline);
         assert!(preference.targets(&uuid::Uuid::from_u128(10).to_string(), 7));
+        let telemetry = candidate
+            .runner_preference_claim_telemetry()
+            .expect("retained canonical preference telemetry");
+        assert!(matches!(
+            telemetry.runner_preference,
+            RunnerPreference::Preference {
+                tier: RunnerPreferenceTier::WorkspaceCache,
+                ..
+            }
+        ));
         assert_eq!(
-            candidate.runner_preference_claim_telemetry(&uuid::Uuid::from_u128(10).to_string(), 7,),
-            Some(super::super::RunnerPreferenceClaimTelemetry {
-                resolution: RunnerPreferenceResolution::MatchingWorkspaceCache,
-                state: super::super::RunnerPreferenceClaimState::Active,
-                targeted_self: Some(true),
-            })
+            telemetry.state,
+            Some(super::super::RunnerPreferenceClaimState::Active)
         );
     }
 

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -36,7 +36,7 @@ use crate::types::{ExecutionContext, HeartbeatState, PiExecutionMode, SandboxReu
 
 const JAVASCRIPT_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum RunnerPreferenceTier {
     ExactSandbox,
@@ -54,60 +54,15 @@ impl RunnerPreferenceTier {
             Self::ExactSandbox => 4,
         }
     }
-
-    fn resolution(self) -> RunnerPreferenceResolution {
-        match self {
-            Self::ExactSandbox => RunnerPreferenceResolution::ExactHistoryGeneration,
-            Self::FinalizingPredecessor => RunnerPreferenceResolution::FinalizingPredecessor,
-            Self::ReusableSandbox => RunnerPreferenceResolution::MatchingReusableSandbox,
-            Self::WorkspaceCache => RunnerPreferenceResolution::MatchingWorkspaceCache,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-enum RunnerNoPreferenceReason {
-    NoReuseKey,
-    Expired,
-    NoViableHolder,
-    LookupError,
-}
-
-impl RunnerNoPreferenceReason {
-    fn resolution(self) -> RunnerPreferenceResolution {
-        match self {
-            Self::NoReuseKey => RunnerPreferenceResolution::NoReuseKey,
-            Self::Expired => RunnerPreferenceResolution::Expired,
-            Self::NoViableHolder => RunnerPreferenceResolution::NoViableHolder,
-            Self::LookupError => RunnerPreferenceResolution::LookupError,
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum RunnerPreferenceResolution {
-    ExactHistoryGeneration,
-    FinalizingPredecessor,
-    MatchingReusableSandbox,
-    MatchingWorkspaceCache,
+#[serde(rename_all = "camelCase")]
+pub(crate) enum RunnerNoPreferenceReason {
     NoReuseKey,
     Expired,
     NoViableHolder,
     LookupError,
-}
-
-impl RunnerPreferenceResolution {
-    fn predicts_preference(self) -> bool {
-        matches!(
-            self,
-            Self::ExactHistoryGeneration
-                | Self::FinalizingPredecessor
-                | Self::MatchingReusableSandbox
-                | Self::MatchingWorkspaceCache
-        )
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -116,7 +71,6 @@ pub(crate) enum RunnerPreferenceClaimState {
     Active,
     Expired,
     Cleared,
-    Absent,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -125,7 +79,7 @@ pub(crate) enum RunnerPreferenceRemovalReason {
     Cleared,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct RunnerProcessIdentity {
     runner_id: Uuid,
@@ -142,9 +96,9 @@ impl RunnerProcessIdentity {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "kind", deny_unknown_fields)]
-enum RunnerPreferenceDecisionPayload {
+pub(crate) enum RunnerPreference {
     #[serde(rename = "preference")]
     Preference {
         #[serde(rename = "runnerIdentity")]
@@ -158,13 +112,13 @@ enum RunnerPreferenceDecisionPayload {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct RunnerPreference {
+pub(crate) struct ActiveRunnerPreference {
     runner_identity: RunnerProcessIdentity,
     tier: RunnerPreferenceTier,
     deadline: Instant,
 }
 
-impl RunnerPreference {
+impl ActiveRunnerPreference {
     pub(crate) fn tier(&self) -> RunnerPreferenceTier {
         self.tier
     }
@@ -204,28 +158,30 @@ impl RunnerPreference {
     }
 }
 
-pub(crate) fn parse_runner_preference_decision(
+pub(crate) fn parse_runner_preference(
     value: Option<serde_json::Value>,
 ) -> Result<Option<RunnerPreferenceContext>, serde_json::Error> {
     let Some(value) = value else {
         return Ok(None);
     };
-    let payload: RunnerPreferenceDecisionPayload = serde_json::from_value(value)?;
-    let context = match payload {
-        RunnerPreferenceDecisionPayload::Preference {
+    let runner_preference: RunnerPreference = serde_json::from_value(value)?;
+    let active_preference = match &runner_preference {
+        RunnerPreference::Preference {
             runner_identity,
             tier,
             expires_at,
-        } => RunnerPreferenceContext::positive(
-            runner_identity,
-            tier,
-            preference_deadline(expires_at)?,
-        ),
-        RunnerPreferenceDecisionPayload::NoPreference { reason } => {
-            RunnerPreferenceContext::negative(reason.resolution())
-        }
+        } => Some(ActiveRunnerPreference {
+            runner_identity: *runner_identity,
+            tier: *tier,
+            deadline: preference_deadline(*expires_at)?,
+        }),
+        RunnerPreference::NoPreference { .. } => None,
     };
-    Ok(Some(context))
+    Ok(Some(RunnerPreferenceContext {
+        runner_preference,
+        active_preference,
+        removal_reason: None,
+    }))
 }
 
 fn preference_deadline(expires_at: DateTime<FixedOffset>) -> Result<Instant, serde_json::Error> {
@@ -257,87 +213,56 @@ pub(crate) enum JobDiscoverySource {
     Poll,
 }
 
-/// Immutable API decision context used only for claim telemetry.
-///
-/// The live preference may be removed as admission progresses, but this
-/// observation must continue to follow the selected candidate and must never
-/// influence admission itself.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct RunnerPreferenceObservation {
-    resolution: RunnerPreferenceResolution,
-    runner_identity: Option<RunnerProcessIdentity>,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RunnerPreferenceContext {
+    runner_preference: RunnerPreference,
+    active_preference: Option<ActiveRunnerPreference>,
+    removal_reason: Option<RunnerPreferenceRemovalReason>,
 }
 
-impl RunnerPreferenceObservation {
-    fn new(
-        resolution: RunnerPreferenceResolution,
-        runner_identity: Option<RunnerProcessIdentity>,
-    ) -> Self {
+impl RunnerPreferenceContext {
+    pub(crate) fn preference(&self) -> Option<&ActiveRunnerPreference> {
+        self.active_preference.as_ref()
+    }
+
+    fn remove_preference(&mut self, removal_reason: RunnerPreferenceRemovalReason) {
+        self.active_preference = None;
+        self.removal_reason = Some(removal_reason);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(preference: ActiveRunnerPreference) -> Self {
+        let runner_identity = preference.runner_identity;
+        let tier = preference.tier;
+        let expires_at = (Utc::now()
+            + chrono::Duration::from_std(preference.remaining())
+                .expect("test runner preference deadline"))
+        .fixed_offset();
         Self {
-            resolution,
-            runner_identity,
+            runner_preference: RunnerPreference::Preference {
+                runner_identity,
+                tier,
+                expires_at,
+            },
+            active_preference: Some(preference),
+            removal_reason: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn no_preference_for_test(reason: RunnerNoPreferenceReason) -> Self {
+        Self {
+            runner_preference: RunnerPreference::NoPreference { reason },
+            active_preference: None,
+            removal_reason: None,
         }
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct RunnerPreferenceContext {
-    preference: Option<RunnerPreference>,
-    observation: RunnerPreferenceObservation,
-    removal_reason: Option<RunnerPreferenceRemovalReason>,
-}
-
-impl RunnerPreferenceContext {
-    fn positive(
-        runner_identity: RunnerProcessIdentity,
-        tier: RunnerPreferenceTier,
-        deadline: Instant,
-    ) -> Self {
-        Self {
-            preference: Some(RunnerPreference {
-                runner_identity,
-                tier,
-                deadline,
-            }),
-            observation: RunnerPreferenceObservation::new(tier.resolution(), Some(runner_identity)),
-            removal_reason: None,
-        }
-    }
-
-    fn negative(resolution: RunnerPreferenceResolution) -> Self {
-        Self {
-            preference: None,
-            observation: RunnerPreferenceObservation::new(resolution, None),
-            removal_reason: None,
-        }
-    }
-
-    pub(crate) fn preference(&self) -> Option<&RunnerPreference> {
-        self.preference.as_ref()
-    }
-
-    fn remove_preference(&mut self, removal_reason: RunnerPreferenceRemovalReason) {
-        self.preference = None;
-        self.removal_reason = Some(removal_reason);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn for_test(preference: RunnerPreference) -> Self {
-        let runner_identity = preference.runner_identity;
-        let tier = preference.tier;
-        Self {
-            preference: Some(preference),
-            observation: RunnerPreferenceObservation::new(tier.resolution(), Some(runner_identity)),
-            removal_reason: None,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RunnerPreferenceClaimTelemetry {
-    pub(crate) resolution: RunnerPreferenceResolution,
-    pub(crate) state: RunnerPreferenceClaimState,
-    pub(crate) targeted_self: Option<bool>,
+    pub(crate) runner_preference: RunnerPreference,
+    pub(crate) state: Option<RunnerPreferenceClaimState>,
 }
 
 impl JobDiscoverySource {
@@ -500,7 +425,7 @@ impl JobCandidate {
         self.pi_execution_mode
     }
 
-    pub(crate) fn runner_preference(&self) -> Option<&RunnerPreference> {
+    pub(crate) fn runner_preference(&self) -> Option<&ActiveRunnerPreference> {
         self.runner_preference_context
             .as_ref()
             .and_then(RunnerPreferenceContext::preference)
@@ -530,7 +455,10 @@ impl JobCandidate {
     }
 
     #[cfg(test)]
-    pub(crate) fn with_runner_preference_for_test(mut self, preference: RunnerPreference) -> Self {
+    pub(crate) fn with_runner_preference_for_test(
+        mut self,
+        preference: ActiveRunnerPreference,
+    ) -> Self {
         self.runner_preference_context = Some(RunnerPreferenceContext::for_test(preference));
         self
     }
@@ -538,37 +466,35 @@ impl JobCandidate {
     #[cfg(test)]
     pub(crate) fn with_no_runner_preference_for_test(
         mut self,
-        resolution: RunnerPreferenceResolution,
+        reason: RunnerNoPreferenceReason,
     ) -> Self {
-        self.runner_preference_context = Some(RunnerPreferenceContext::negative(resolution));
+        self.runner_preference_context =
+            Some(RunnerPreferenceContext::no_preference_for_test(reason));
         self
     }
 
     pub(crate) fn runner_preference_claim_telemetry(
         &self,
-        runner_id: &str,
-        heartbeat_generation: u64,
     ) -> Option<RunnerPreferenceClaimTelemetry> {
         let context = self.runner_preference_context.as_ref()?;
-        let observation = context.observation;
-        let state = match context.preference() {
-            Some(preference) if preference.is_expired() => RunnerPreferenceClaimState::Expired,
-            Some(_) => RunnerPreferenceClaimState::Active,
-            None => match context.removal_reason {
-                Some(RunnerPreferenceRemovalReason::Expired) => RunnerPreferenceClaimState::Expired,
-                Some(RunnerPreferenceRemovalReason::Cleared) => RunnerPreferenceClaimState::Cleared,
-                None if observation.resolution.predicts_preference() => {
-                    RunnerPreferenceClaimState::Cleared
-                }
-                None => RunnerPreferenceClaimState::Absent,
-            },
+        let state = match &context.runner_preference {
+            RunnerPreference::NoPreference { .. } => None,
+            RunnerPreference::Preference { .. } => Some(match context.preference() {
+                Some(preference) if preference.is_expired() => RunnerPreferenceClaimState::Expired,
+                Some(_) => RunnerPreferenceClaimState::Active,
+                None => match context.removal_reason {
+                    Some(RunnerPreferenceRemovalReason::Expired) => {
+                        RunnerPreferenceClaimState::Expired
+                    }
+                    Some(RunnerPreferenceRemovalReason::Cleared) | None => {
+                        RunnerPreferenceClaimState::Cleared
+                    }
+                },
+            }),
         };
         Some(RunnerPreferenceClaimTelemetry {
-            resolution: observation.resolution,
+            runner_preference: context.runner_preference.clone(),
             state,
-            targeted_self: observation
-                .runner_identity
-                .map(|identity| identity.targets(runner_id, heartbeat_generation)),
         })
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -48,6 +48,8 @@ pub struct Job {
     #[serde(default)]
     pub pi_execution_mode: Option<PiExecutionMode>,
     #[serde(default)]
+    pub runner_preference: Option<serde_json::Value>,
+    #[serde(default)]
     pub runner_preference_decision: Option<serde_json::Value>,
 }
 
@@ -1677,7 +1679,7 @@ mod tests {
                 "experimentalProfile": "browser",
                 "cliAgentSessionId": "session-id",
                 "piExecutionMode": "standby",
-                "runnerPreferenceDecision": {
+                "runnerPreference": {
                     "kind": "preference",
                     "runnerIdentity": {
                         "runnerId": "b85bb257-21c1-4b8f-8676-a4051f35b7b0",
@@ -1685,6 +1687,10 @@ mod tests {
                     },
                     "tier": "reusableSandbox",
                     "expiresAt": "2026-08-03T12:00:00.000Z"
+                },
+                "runnerPreferenceDecision": {
+                    "kind": "noPreference",
+                    "reason": "noReuseKey"
                 }
             }
         });
@@ -1698,6 +1704,7 @@ mod tests {
         );
         assert_eq!(job.experimental_profile, "browser");
         assert_eq!(job.pi_execution_mode, Some(PiExecutionMode::Standby));
+        assert!(job.runner_preference.is_some());
         assert!(job.runner_preference_decision.is_some());
         assert!(job.reuse_key().is_none());
     }

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -6,7 +6,7 @@ import type {
 } from "@vm0/api-contracts/contracts/realtime";
 import type {
   PiExecutionMode,
-  RunnerPreferenceDecision,
+  RunnerPreference,
 } from "@vm0/api-contracts/contracts/runners";
 import type { ZeroBuiltInGenerationRealtimeSubscription } from "@vm0/api-contracts/contracts/zero-built-in-generation";
 
@@ -433,7 +433,7 @@ export async function publishRunnerJobNotification(args: {
   readonly runId: string;
   readonly profile: string;
   readonly piExecutionMode?: PiExecutionMode;
-  readonly runnerPreferenceDecision: RunnerPreferenceDecision;
+  readonly runnerPreference: RunnerPreference;
   readonly metadata?: {
     /** Raw key required for runner-local reuse matching; it stays on the internal runner-group channel. */
     readonly reuseKey: string | null;
@@ -459,7 +459,8 @@ export async function publishRunnerJobNotification(args: {
         ...(args.metadata?.historyGenerationRunId
           ? { historyGenerationRunId: args.metadata.historyGenerationRunId }
           : {}),
-        runnerPreferenceDecision: args.runnerPreferenceDecision,
+        runnerPreference: args.runnerPreference,
+        runnerPreferenceDecision: args.runnerPreference,
       });
       L.debug(
         `Published job ${args.runId} to runner-group:${args.group} (broadcast)`,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -138,6 +138,10 @@ function runnerPreferenceDecision(job: RunnerJob | null | undefined) {
   return job?.runnerPreferenceDecision;
 }
 
+function runnerPreference(job: RunnerJob | null | undefined) {
+  return job?.runnerPreference;
+}
+
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_ATOMIC_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_atomic_launch",
@@ -3850,10 +3854,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     if (reusableDecision?.kind !== "preference") {
       throw new Error("Expected a reusable sandbox preference decision");
     }
+    expect(runnerPreference(reusableOverWorkspace.job)).toStrictEqual(
+      reusableDecision,
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: reusableOverWorkspace.run.runId,
+        runnerPreference: reusableDecision,
         runnerPreferenceDecision: {
           kind: "preference",
           runnerIdentity: reusableDecision.runnerIdentity,
@@ -4013,6 +4021,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runId: successor.runId,
         reuseKey,
         historyGenerationRunId: first.runId,
+        runnerPreference: finalizingDecision,
         runnerPreferenceDecision: finalizingDecision,
       }),
     );
@@ -4081,9 +4090,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runnerIdentity: sourceRunnerIdentity,
         telemetry: {
           discoverySource: "ably",
-          runnerPreferenceResolution: "finalizing_predecessor",
+          runnerPreference: finalizingDecision,
+          runnerPreferenceResolution: "no_reuse_key",
           runnerPreferenceClaimState: "expired",
-          runnerPreferenceTargetedSelf: true,
+          runnerPreferenceTargetedSelf: false,
         },
       },
     );
@@ -4177,6 +4187,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "job",
       expect.objectContaining({
         runId: successor.runId,
+        runnerPreference: exactDecision,
         runnerPreferenceDecision: exactDecision,
       }),
     );
@@ -4443,7 +4454,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await releaseOrgAdmissionLock(context);
     await admissionLockRequest;
     const protectedFollowUp = await protectedFollowUpRequest;
-    const exactRunnerPreferenceDecision = {
+    const exactRunnerPreference = {
       kind: "preference" as const,
       runnerIdentity: preferredExactRunner,
       tier: "exactSandbox" as const,
@@ -4455,7 +4466,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runId: protectedFollowUp.runId,
         reuseKey,
         historyGenerationRunId: first.runId,
-        runnerPreferenceDecision: exactRunnerPreferenceDecision,
+        runnerPreference: exactRunnerPreference,
+        runnerPreferenceDecision: exactRunnerPreference,
       }),
     );
 
@@ -4471,7 +4483,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(protectedPoll.body.job?.reuseKey).toBe(reuseKey);
     expect(runnerPreferenceDecision(protectedPoll.body.job)).toStrictEqual(
-      exactRunnerPreferenceDecision,
+      exactRunnerPreference,
     );
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
@@ -4593,14 +4605,29 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected expired reuse-preference poll to return 200");
     }
     expect(expiredPoll.body.job?.runId).toBe(expiredFollowUp.runId);
-    expect(runnerPreferenceDecision(expiredPoll.body.job)).toStrictEqual({
+    const expiredPreference = {
       kind: "noPreference",
       reason: "expired",
-    });
+    } as const;
+    expect(runnerPreference(expiredPoll.body.job)).toStrictEqual(
+      expiredPreference,
+    );
+    expect(runnerPreferenceDecision(expiredPoll.body.job)).toStrictEqual(
+      expiredPreference,
+    );
     const expiredClaim = await api.requestClaimRunnerJob(
       true,
       expiredFollowUp.runId,
       [200],
+      {
+        runnerIdentity: preferredExactRunner,
+        telemetry: {
+          runnerPreference: expiredPreference,
+          runnerPreferenceResolution: "no_reuse_key",
+          runnerPreferenceClaimState: "active",
+          runnerPreferenceTargetedSelf: true,
+        },
+      },
     );
     if (expiredClaim.status !== 200) {
       throw new Error("Expected expired reuse-preference claim to succeed");
@@ -4608,6 +4635,23 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(expiredClaim.body.prompt).toBe(
       "continue after reuse-preference protection expires",
     );
+    expect(
+      sandboxOperationEventsForRunByAction(
+        expiredFollowUp.runId,
+        "claim_request_to_running",
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        runner_preference_resolution: "expired",
+        runner_preference_claim_state: "absent",
+      }),
+    );
+    expect(
+      sandboxOperationEventsForRunByAction(
+        expiredFollowUp.runId,
+        "claim_request_to_running",
+      )[0],
+    ).not.toHaveProperty("runner_preference_targeted_self");
     await api.requestCancelRun(actor, expiredFollowUp.runId, [200]);
   });
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -21,8 +21,8 @@ import {
   type HeldSandboxState,
   type HeldWorkspaceState,
   type PiExecutionMode,
+  type RunnerPreference,
   type RunnerPreferenceClaimState,
-  type RunnerPreferenceDecision,
   type RunnerPreferenceResolution,
   type SessionHistoryDownloadSource,
   type StoredConnectorPermissionBaseline,
@@ -120,9 +120,10 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
-  runnerPreferenceDecisionTelemetryDimensions,
+  runnerPreferenceResolution,
+  runnerPreferenceTelemetryDimensions,
   runnerReuseKeyTelemetryKind,
-  runnerReusePreferenceLookupErrorDecision,
+  runnerReusePreferenceLookupError,
   runnerReusePreferencePollPriority,
   resolveRunnerReusePreference,
 } from "../services/runner-reuse-preference";
@@ -554,7 +555,7 @@ function recordPollTimingMetrics(args: {
   readonly profile: string;
   readonly authType: RunnerAuthContext["type"];
   readonly pollReason: string | undefined;
-  readonly runnerPreferenceDecision: RunnerPreferenceDecision;
+  readonly runnerPreference: RunnerPreference;
   readonly reuseKeyKind: "thread" | "session" | "none";
   readonly historyGenerationRunId: string | undefined;
   readonly queueCreatedAtMs: number;
@@ -568,9 +569,7 @@ function recordPollTimingMetrics(args: {
     profile: args.profile,
     auth_type: args.authType,
     reuse_key_kind: args.reuseKeyKind,
-    ...runnerPreferenceDecisionTelemetryDimensions(
-      args.runnerPreferenceDecision,
-    ),
+    ...runnerPreferenceTelemetryDimensions(args.runnerPreference),
   };
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
@@ -659,7 +658,7 @@ async function resolvePollRunnerReusePreference(
       });
     },
   );
-  return resolution ?? runnerReusePreferenceLookupErrorDecision();
+  return resolution ?? runnerReusePreferenceLookupError();
 }
 
 const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -745,7 +744,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     pendingJob.piExecutionMode === null
       ? undefined
       : piExecutionModeSchema.parse(pendingJob.piExecutionMode);
-  const runnerPreferenceDecision = await resolvePollRunnerReusePreference(db, {
+  const runnerPreference = await resolvePollRunnerReusePreference(db, {
     runId: pendingJob.runId,
     runnerGroup: group,
     profile: pendingJob.profile,
@@ -761,7 +760,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     profile: pendingJob.profile,
     authType: auth.type,
     pollReason: body.data.telemetry?.pollReason,
-    runnerPreferenceDecision,
+    runnerPreference,
     reuseKeyKind: runnerReuseKeyTelemetryKind(pendingJob.reuseKey),
     historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
     queueCreatedAtMs: pendingJob.createdAt.getTime(),
@@ -785,7 +784,8 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         reuseKey: pendingJob.reuseKey,
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
         ...(piExecutionMode ? { piExecutionMode } : {}),
-        runnerPreferenceDecision,
+        runnerPreference,
+        runnerPreferenceDecision: runnerPreference,
       },
     },
   };
@@ -2030,9 +2030,50 @@ interface ClaimTimingTelemetry {
   readonly pollDueToJobDiscoveredMs?: number;
   readonly pollHttpRequestMs?: number;
   readonly pollReason?: string;
+  readonly runnerPreference?: RunnerPreference;
   readonly runnerPreferenceResolution?: RunnerPreferenceResolution;
   readonly runnerPreferenceClaimState?: RunnerPreferenceClaimState;
   readonly runnerPreferenceTargetedSelf?: boolean;
+}
+
+interface SuccessfulClaimPreferenceTelemetry {
+  readonly resolution: RunnerPreferenceResolution | undefined;
+  readonly claimState: RunnerPreferenceClaimState | undefined;
+  readonly targetedSelf: boolean | undefined;
+}
+
+function successfulClaimPreferenceTelemetry(args: {
+  readonly telemetry: ClaimTimingTelemetry | undefined;
+  readonly runnerIdentity: RunnerClaimIdentity | undefined;
+}): SuccessfulClaimPreferenceTelemetry {
+  const preference = args.telemetry?.runnerPreference;
+  if (!preference) {
+    return {
+      resolution: args.telemetry?.runnerPreferenceResolution,
+      claimState: args.telemetry?.runnerPreferenceClaimState,
+      targetedSelf: args.telemetry?.runnerPreferenceTargetedSelf,
+    };
+  }
+
+  if (preference.kind === "noPreference") {
+    return {
+      resolution: runnerPreferenceResolution(preference),
+      claimState: "absent",
+      targetedSelf: undefined,
+    };
+  }
+
+  const claimState = args.telemetry?.runnerPreferenceClaimState;
+  return {
+    resolution: runnerPreferenceResolution(preference),
+    claimState: claimState === "absent" ? undefined : claimState,
+    targetedSelf: args.runnerIdentity
+      ? preference.runnerIdentity.runnerId.toLowerCase() ===
+          args.runnerIdentity.runnerId.toLowerCase() &&
+        preference.runnerIdentity.heartbeatGeneration ===
+          args.runnerIdentity.heartbeatGeneration
+      : undefined,
+  };
 }
 
 function scheduleSuccessfulClaimSideEffects(args: {
@@ -2042,10 +2083,15 @@ function scheduleSuccessfulClaimSideEffects(args: {
   readonly claimRequestStartedAtMs: number;
   readonly claimResult: ClaimedTransitionResult;
   readonly telemetry: ClaimTimingTelemetry | undefined;
+  readonly runnerIdentity: RunnerClaimIdentity | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): void {
   const { job, run } = args.jobWithRun;
   const queueCreatedAtMs = job.createdAt.getTime();
+  const preferenceTelemetry = successfulClaimPreferenceTelemetry({
+    telemetry: args.telemetry,
+    runnerIdentity: args.runnerIdentity,
+  });
   scheduleClaimSucceededSideEffects({
     runId: run.id,
     userId: run.userId,
@@ -2088,9 +2134,9 @@ function scheduleSuccessfulClaimSideEffects(args: {
     pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
     pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
     pollReason: args.telemetry?.pollReason,
-    runnerPreferenceResolution: args.telemetry?.runnerPreferenceResolution,
-    runnerPreferenceClaimState: args.telemetry?.runnerPreferenceClaimState,
-    runnerPreferenceTargetedSelf: args.telemetry?.runnerPreferenceTargetedSelf,
+    runnerPreferenceResolution: preferenceTelemetry.resolution,
+    runnerPreferenceClaimState: preferenceTelemetry.claimState,
+    runnerPreferenceTargetedSelf: preferenceTelemetry.targetedSelf,
     historyGenerationRunId: historyGenerationRunIdForStoredExecutionContext(
       args.storedContext,
     ),
@@ -2570,6 +2616,7 @@ const claimAuthorizedJob$ = command(
       claimRequestStartedAtMs: args.claimRequestStartedAtMs,
       claimResult,
       telemetry: args.telemetry,
+      runnerIdentity: args.runnerIdentity,
       claimRouteTiming,
     });
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -324,7 +324,7 @@ async function tryReleasePiStandbyForColdStart(
       runId: input.body.runId,
       profile: requeued.profile,
       piExecutionMode: "cold-start",
-      runnerPreferenceDecision: {
+      runnerPreference: {
         kind: "noPreference",
         reason: "noReuseKey",
       },
@@ -423,7 +423,7 @@ const activatePiColdStartForHandoff$ = command(
         runId: input.runId,
         profile: activation.profile,
         piExecutionMode: "cold-start",
-        runnerPreferenceDecision: {
+        runnerPreference: {
           kind: "noPreference",
           reason: "noReuseKey",
         },

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -6,9 +6,9 @@ import { now } from "../../lib/time";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import {
-  runnerPreferenceDecisionTelemetryDimensions,
+  runnerPreferenceTelemetryDimensions,
   runnerReuseKeyTelemetryKind,
-  runnerReusePreferenceLookupErrorDecision,
+  runnerReusePreferenceLookupError,
   resolveRunnerReusePreference,
 } from "./runner-reuse-preference";
 import { tapError } from "../utils";
@@ -33,7 +33,7 @@ export async function notifyRunnerJob(
   const notificationEnteredAt = now();
   const currentDate = new Date(notificationEnteredAt);
   let preferenceLookupSucceeded = true;
-  const runnerPreferenceDecision =
+  const runnerPreference =
     (await tapError(
       resolveRunnerReusePreference({
         db,
@@ -56,7 +56,7 @@ export async function notifyRunnerJob(
           },
         );
       },
-    )) ?? runnerReusePreferenceLookupErrorDecision();
+    )) ?? runnerReusePreferenceLookupError();
   const preferenceFinishedAt = now();
   const publishStartedAt = now();
   const published = await publishRunnerJobNotification({
@@ -64,7 +64,7 @@ export async function notifyRunnerJob(
     runId: args.runId,
     profile: args.profile,
     piExecutionMode: args.piExecutionMode,
-    runnerPreferenceDecision,
+    runnerPreference,
     metadata: {
       reuseKey: args.reuseKey,
       cliAgentSessionId: args.cliAgentSessionId,
@@ -78,7 +78,7 @@ export async function notifyRunnerJob(
     profile: args.profile,
     notification_target: "broadcast",
     reuse_key_kind: runnerReuseKeyTelemetryKind(args.reuseKey),
-    ...runnerPreferenceDecisionTelemetryDimensions(runnerPreferenceDecision),
+    ...runnerPreferenceTelemetryDimensions(runnerPreference),
   };
   if (args.historyGenerationRunId) {
     dimensions.history_generation_run_id = args.historyGenerationRunId;

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -1,5 +1,5 @@
 import type {
-  RunnerPreferenceDecision,
+  RunnerPreference,
   RunnerPreferenceResolution,
 } from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -270,14 +270,11 @@ export function runnerReusePreferencePollPriority(args: {
   END`;
 }
 
-type PositiveRunnerPreferenceDecision = Extract<
-  RunnerPreferenceDecision,
+type PositiveRunnerPreference = Extract<
+  RunnerPreference,
   { kind: "preference" }
 >;
-type NoRunnerPreferenceDecision = Extract<
-  RunnerPreferenceDecision,
-  { kind: "noPreference" }
->;
+type NoRunnerPreference = Extract<RunnerPreference, { kind: "noPreference" }>;
 
 const preferenceResolutionByTier = {
   exactSandbox: "exact_history_generation",
@@ -285,7 +282,7 @@ const preferenceResolutionByTier = {
   reusableSandbox: "matching_reusable_sandbox",
   workspaceCache: "matching_workspace_cache",
 } as const satisfies Record<
-  PositiveRunnerPreferenceDecision["tier"],
+  PositiveRunnerPreference["tier"],
   RunnerPreferenceResolution
 >;
 
@@ -295,40 +292,40 @@ const noPreferenceResolutionByReason = {
   noViableHolder: "no_viable_holder",
   lookupError: "lookup_error",
 } as const satisfies Record<
-  NoRunnerPreferenceDecision["reason"],
+  NoRunnerPreference["reason"],
   RunnerPreferenceResolution
 >;
 
-export function runnerReusePreferenceLookupErrorDecision(): RunnerPreferenceDecision {
+export function runnerReusePreferenceLookupError(): RunnerPreference {
   return {
     kind: "noPreference",
     reason: "lookupError",
   };
 }
 
-function runnerPreferenceDecisionResolution(
-  decision: RunnerPreferenceDecision,
+export function runnerPreferenceResolution(
+  preference: RunnerPreference,
 ): RunnerPreferenceResolution {
-  if (decision.kind === "noPreference") {
-    return noPreferenceResolutionByReason[decision.reason];
+  if (preference.kind === "noPreference") {
+    return noPreferenceResolutionByReason[preference.reason];
   }
-  return preferenceResolutionByTier[decision.tier];
+  return preferenceResolutionByTier[preference.tier];
 }
 
-export function runnerPreferenceDecisionTelemetryDimensions(
-  decision: RunnerPreferenceDecision,
+export function runnerPreferenceTelemetryDimensions(
+  preference: RunnerPreference,
 ): Record<string, string> {
   return {
-    runner_preference_resolution: runnerPreferenceDecisionResolution(decision),
-    runner_preference_decision_kind: decision.kind,
-    ...(decision.kind === "preference"
-      ? { runner_preference_tier: decision.tier }
-      : { runner_preference_no_preference_reason: decision.reason }),
+    runner_preference_resolution: runnerPreferenceResolution(preference),
+    runner_preference_decision_kind: preference.kind,
+    ...(preference.kind === "preference"
+      ? { runner_preference_tier: preference.tier }
+      : { runner_preference_no_preference_reason: preference.reason }),
   };
 }
 
 interface RunnerReuseHolder {
-  readonly runnerIdentity: PositiveRunnerPreferenceDecision["runnerIdentity"];
+  readonly runnerIdentity: PositiveRunnerPreference["runnerIdentity"];
   readonly hasExactHistoryGeneration: boolean;
   readonly isFinalizingPredecessor: boolean;
   readonly hasReusableSandbox: boolean;
@@ -441,7 +438,7 @@ export async function resolveRunnerReusePreference(args: {
   readonly historyGenerationRunId: string | undefined;
   readonly createdAt: Date;
   readonly currentDate: Date;
-}): Promise<RunnerPreferenceDecision> {
+}): Promise<RunnerPreference> {
   if (!args.reuseKey) {
     return {
       kind: "noPreference",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -144,6 +144,10 @@ describe("Pi execution mode contract", () => {
     agentComposeVersionId: null,
     vars: null,
     experimentalProfile: "vm0/large",
+    runnerPreference: {
+      kind: "noPreference" as const,
+      reason: "noReuseKey" as const,
+    },
     runnerPreferenceDecision: {
       kind: "noPreference" as const,
       reason: "noReuseKey" as const,
@@ -481,6 +485,10 @@ describe("runner poll response contract", () => {
     appendSystemPrompt: null,
     agentComposeVersionId: null,
     vars: null,
+    runnerPreference: {
+      kind: "noPreference" as const,
+      reason: "noReuseKey" as const,
+    },
     runnerPreferenceDecision: {
       kind: "noPreference" as const,
       reason: "noReuseKey" as const,
@@ -741,6 +749,10 @@ describe("runner resume session contract", () => {
       vars: null,
       experimentalProfile: "vm0/default",
       historyGenerationRunId,
+      runnerPreference: {
+        kind: "noPreference",
+        reason: "noReuseKey",
+      },
       runnerPreferenceDecision: {
         kind: "noPreference",
         reason: "noReuseKey",
@@ -775,7 +787,7 @@ describe("runner resume session contract", () => {
     ]);
   });
 
-  it("requires one atomic runner preference decision", () => {
+  it("requires canonical and compatibility runner preferences", () => {
     const jobInput = {
       runId: "22222222-2222-4222-8222-222222222222",
       prompt: "continue",
@@ -786,19 +798,24 @@ describe("runner resume session contract", () => {
     };
 
     expect(jobSchema.safeParse(jobInput).success).toBe(false);
+    const runnerPreference = {
+      kind: "noPreference" as const,
+      reason: "noReuseKey" as const,
+    };
     expect(
       jobSchema.parse({
         ...jobInput,
-        runnerPreferenceDecision: {
-          kind: "noPreference",
-          reason: "noReuseKey",
-        },
-      }).runnerPreferenceDecision,
-    ).toStrictEqual({ kind: "noPreference", reason: "noReuseKey" });
+        runnerPreference,
+        runnerPreferenceDecision: runnerPreference,
+      }),
+    ).toMatchObject({
+      runnerPreference,
+      runnerPreferenceDecision: runnerPreference,
+    });
   });
 
-  it("accepts every strict positive runner preference decision tier", () => {
-    const runnerPreferenceDecision = {
+  it("accepts every strict positive runner preference tier", () => {
+    const runnerPreference = {
       kind: "preference" as const,
       runnerIdentity: {
         runnerId: "22222222-2222-4222-8222-222222222222",
@@ -813,6 +830,10 @@ describe("runner resume session contract", () => {
       agentComposeVersionId: null,
       vars: null,
       experimentalProfile: "vm0/default",
+      runnerPreferenceDecision: {
+        ...runnerPreference,
+        tier: "reusableSandbox" as const,
+      },
     };
 
     for (const tier of [
@@ -824,15 +845,15 @@ describe("runner resume session contract", () => {
       expect(
         jobSchema.parse({
           ...jobInput,
-          runnerPreferenceDecision: { ...runnerPreferenceDecision, tier },
-        }).runnerPreferenceDecision,
-      ).toStrictEqual({ ...runnerPreferenceDecision, tier });
+          runnerPreference: { ...runnerPreference, tier },
+        }).runnerPreference,
+      ).toStrictEqual({ ...runnerPreference, tier });
     }
     expect(
       jobSchema.safeParse({
         ...jobInput,
-        runnerPreferenceDecision: {
-          ...runnerPreferenceDecision,
+        runnerPreference: {
+          ...runnerPreference,
           tier: "reusableSandbox",
           reason: "noReuseKey",
         },
@@ -841,8 +862,8 @@ describe("runner resume session contract", () => {
     expect(
       jobSchema.safeParse({
         ...jobInput,
-        runnerPreferenceDecision: {
-          ...runnerPreferenceDecision,
+        runnerPreference: {
+          ...runnerPreference,
           tier: "reusableSandbox",
           expiresAt: undefined,
         },
@@ -851,10 +872,10 @@ describe("runner resume session contract", () => {
     expect(
       jobSchema.safeParse({
         ...jobInput,
-        runnerPreferenceDecision: {
-          ...runnerPreferenceDecision,
+        runnerPreference: {
+          ...runnerPreference,
           runnerIdentity: {
-            ...runnerPreferenceDecision.runnerIdentity,
+            ...runnerPreference.runnerIdentity,
             runnerId: "not-a-uuid",
           },
           tier: "reusableSandbox",
@@ -864,8 +885,8 @@ describe("runner resume session contract", () => {
     expect(
       jobSchema.safeParse({
         ...jobInput,
-        runnerPreferenceDecision: {
-          ...runnerPreferenceDecision,
+        runnerPreference: {
+          ...runnerPreference,
           tier: "reusableSandbox",
           expiresAt: "not-a-date",
         },
@@ -873,7 +894,7 @@ describe("runner resume session contract", () => {
     ).toBe(false);
   });
 
-  it("accepts every strict no-preference decision reason", () => {
+  it("accepts every strict no-preference reason", () => {
     const jobInput = {
       runId: "33333333-3333-4333-8333-333333333333",
       prompt: "continue",
@@ -881,6 +902,10 @@ describe("runner resume session contract", () => {
       agentComposeVersionId: null,
       vars: null,
       experimentalProfile: "vm0/default",
+      runnerPreferenceDecision: {
+        kind: "noPreference" as const,
+        reason: "noReuseKey" as const,
+      },
     };
 
     for (const reason of [
@@ -892,14 +917,14 @@ describe("runner resume session contract", () => {
       expect(
         jobSchema.parse({
           ...jobInput,
-          runnerPreferenceDecision: { kind: "noPreference", reason },
-        }).runnerPreferenceDecision,
+          runnerPreference: { kind: "noPreference", reason },
+        }).runnerPreference,
       ).toStrictEqual({ kind: "noPreference", reason });
     }
     expect(
       jobSchema.safeParse({
         ...jobInput,
-        runnerPreferenceDecision: {
+        runnerPreference: {
           kind: "noPreference",
           reason: "noReuseKey",
           tier: "workspaceCache",
@@ -1332,6 +1357,46 @@ describe("runner claim request contract", () => {
         runnerPreferenceTargetedSelf: false,
       });
     }
+  });
+
+  it("accepts canonical runner preference claim telemetry", () => {
+    const runnerPreference = {
+      kind: "preference" as const,
+      runnerIdentity: {
+        runnerId: "22222222-2222-4222-8222-222222222222",
+        heartbeatGeneration: 7,
+      },
+      tier: "workspaceCache" as const,
+      expiresAt: "2026-08-03T00:00:01.000Z",
+    };
+
+    expect(
+      runnersJobClaimContract.claim.body.parse({
+        telemetry: {
+          runnerPreference,
+          runnerPreferenceClaimState: "active",
+        },
+      }).telemetry,
+    ).toStrictEqual({
+      runnerPreference,
+      runnerPreferenceClaimState: "active",
+    });
+  });
+
+  it("keeps valid legacy claim telemetry when canonical preference is malformed", () => {
+    expect(
+      runnersJobClaimContract.claim.body.parse({
+        telemetry: {
+          runnerPreference: { kind: "futurePreference" },
+          runnerPreferenceResolution: "no_viable_holder",
+          runnerPreferenceClaimState: "absent",
+        },
+      }).telemetry,
+    ).toStrictEqual({
+      runnerPreference: undefined,
+      runnerPreferenceResolution: "no_viable_holder",
+      runnerPreferenceClaimState: "absent",
+    });
   });
 
   it("discards malformed diagnostic telemetry", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -106,7 +106,7 @@ const runnerProcessIdentitySchema = z
  * runner is not an exclusive assignee; another runner with a better compatible
  * local resource remains eligible to claim.
  */
-export const runnerPreferenceDecisionSchema = z.discriminatedUnion("kind", [
+export const runnerPreferenceSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("preference"),
@@ -168,6 +168,7 @@ const runnerClaimTelemetrySchema = z
     pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
     pollHttpRequestMs: z.number().int().nonnegative().optional(),
     pollReason: runnerClaimPollReasonSchema.optional(),
+    runnerPreference: runnerPreferenceSchema.optional().catch(undefined),
     runnerPreferenceResolution: runnerPreferenceResolutionSchema.optional(),
     runnerPreferenceClaimState: runnerPreferenceClaimStateSchema.optional(),
     runnerPreferenceTargetedSelf: z.boolean().optional(),
@@ -449,7 +450,10 @@ export const jobSchema = z.object({
   reuseKey: z.string().nullable().optional(),
   historyGenerationRunId: z.uuid().optional(),
   piExecutionMode: piExecutionModeSchema.optional(),
-  runnerPreferenceDecision: runnerPreferenceDecisionSchema,
+  runnerPreference: runnerPreferenceSchema,
+  // Keep the compatibility field until every pre-migration runner is unable
+  // to claim. Cleanup is tracked by #25751.
+  runnerPreferenceDecision: runnerPreferenceSchema,
 });
 
 const heldWorkspaceCacheSchema = z.object({
@@ -1187,9 +1191,7 @@ export type RunnersHeartbeatContract = typeof runnersHeartbeatContract;
 export type RunnersBuiltinFirewallsResolveContract =
   typeof runnersBuiltinFirewallsResolveContract;
 export type Job = z.infer<typeof jobSchema>;
-export type RunnerPreferenceDecision = z.infer<
-  typeof runnerPreferenceDecisionSchema
->;
+export type RunnerPreference = z.infer<typeof runnerPreferenceSchema>;
 export type RunnerPreferenceResolution = z.infer<
   typeof runnerPreferenceResolutionSchema
 >;


### PR DESCRIPTION
## Summary

- make `RunnerPreference` the canonical TypeScript and Rust preference contract
- dual-deliver the canonical value through Poll and Ably while old runners remain active
- return the accepted canonical preference on claim and derive legacy resolution and targeted-self telemetry in the API
- separate immutable accepted preference data from mutable runner admission state

## Compatibility

- current runners continue to consume `runnerPreferenceDecision` and submit legacy claim telemetry
- migrated runners prefer `runnerPreference`, fall back to the compatibility field, and preserve jobs with malformed advisory metadata
- canonical claim telemetry takes precedence over conflicting legacy fields without affecting authorization or claim CAS

## Exclusions

- compatibility delivery, fallback parsing, and legacy claim telemetry acceptance remain until the rollout gate in #25751 is complete
- no persistence, decision identifier, high-cardinality dimensions, or new per-run event is added

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/pi-edge-loop.test.ts src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts --silent=passed-only`
- `pnpm knip`
- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features`

Closes #25750

Parent: #25741
