### PR TITLE
refactor: reduce fallback slop in stripe snapshots

### DIFF
--- a/turbo/apps/api/src/signals/services/stripe-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-workflow-event.service.ts
@@ -72,6 +72,103 @@ const stripeSupportedEventBaseSchema = z
   })
   .passthrough();
 
+const nullableIdentifierObjectSchema = z
+  .object({ id: z.string().trim().min(1).max(255) })
+  .passthrough();
+
+const stripeIdentifierValueSchema = z.union([
+  z.string(),
+  nullableIdentifierObjectSchema,
+]);
+
+function optionalStripeSnapshotField<T>(schema: z.ZodType<T>) {
+  // Optional Stripe expansions must not invalidate an otherwise usable invoice.
+  const nullableSchema = schema.nullable();
+  return z
+    .preprocess((value) => {
+      const parsed = nullableSchema.safeParse(value);
+      return parsed.success ? parsed.data : null;
+    }, nullableSchema)
+    .optional();
+}
+
+const stripeCustomerSchema = z
+  .object({
+    id: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    email: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const stripeCustomerValueSchema = z.union([z.string(), stripeCustomerSchema]);
+
+const stripeLinePriceSchema = z
+  .object({
+    id: z.string().nullable().optional(),
+    product: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+    currency: z.string().nullable().optional(),
+    unit_amount: z.number().nullable().optional(),
+    recurring: z
+      .object({ interval: z.string().nullable().optional() })
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+
+const stripeLinePricingSchema = z
+  .object({
+    type: z.string().nullable().optional(),
+    price_details: z
+      .object({
+        price: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+        product: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+      })
+      .nullable()
+      .optional(),
+    unit_amount_decimal: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const stripeInvoiceParentSchema = z
+  .object({
+    subscription_details: z
+      .object({
+        subscription: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+      })
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+
+const stripeInvoicePaymentRelationshipSchema = z
+  .object({
+    payment_intent: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+    charge: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+    payment_record: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+  })
+  .passthrough();
+
+const stripeInvoicePaymentValueSchema = z.union([
+  stripeIdentifierValueSchema,
+  stripeInvoicePaymentRelationshipSchema,
+]);
+
+const stripeInvoicePaymentsSchema = z
+  .object({
+    data: z.array(
+      z
+        .object({
+          id: z.string().trim().min(1).max(255).nullable().optional(),
+          payment: optionalStripeSnapshotField(stripeInvoicePaymentValueSchema),
+          payment_intent: optionalStripeSnapshotField(
+            stripeIdentifierValueSchema,
+          ),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+
 const stripeInvoiceLineSchema = z
   .object({
     id: z.string().nullable().optional(),
@@ -88,8 +185,8 @@ const stripeInvoiceLineSchema = z
       })
       .nullable()
       .optional(),
-    price: z.unknown().optional(),
-    pricing: z.unknown().optional(),
+    price: optionalStripeSnapshotField(stripeLinePriceSchema),
+    pricing: optionalStripeSnapshotField(stripeLinePricingSchema),
   })
   .passthrough();
 
@@ -111,11 +208,11 @@ const stripeInvoiceSchema = z
       has_more: z.boolean(),
       total_count: z.number().int().nonnegative().nullable().optional(),
     }),
-    customer: z.unknown().optional(),
-    subscription: z.unknown().optional(),
-    payment_intent: z.unknown().optional(),
-    payments: z.unknown().optional(),
-    parent: z.unknown().optional(),
+    customer: optionalStripeSnapshotField(stripeCustomerValueSchema),
+    subscription: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+    payment_intent: optionalStripeSnapshotField(stripeIdentifierValueSchema),
+    payments: optionalStripeSnapshotField(stripeInvoicePaymentsSchema),
+    parent: optionalStripeSnapshotField(stripeInvoiceParentSchema),
   })
   .passthrough();
 
@@ -140,54 +237,6 @@ const stripeDeauthorizedEventSchema = stripeDeauthorizedEventBaseSchema.extend({
   account: z.string().trim().min(1).max(255),
   livemode: z.literal(true),
 });
-
-const nullableIdentifierObjectSchema = z
-  .object({ id: z.string().trim().min(1).max(255) })
-  .passthrough();
-
-const stripeLinePriceSchema = z
-  .object({
-    id: z.string().nullable().optional(),
-    product: z.unknown().optional(),
-    currency: z.string().nullable().optional(),
-    unit_amount: z.number().nullable().optional(),
-    recurring: z
-      .object({ interval: z.string().nullable().optional() })
-      .nullable()
-      .optional(),
-  })
-  .passthrough();
-
-const stripeLinePricingSchema = z
-  .object({
-    type: z.string().nullable().optional(),
-    price_details: z
-      .object({
-        price: z.unknown().optional(),
-        product: z.unknown().optional(),
-      })
-      .nullable()
-      .optional(),
-    unit_amount_decimal: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-const stripeInvoiceParentSchema = z
-  .object({
-    subscription_details: z
-      .object({ subscription: z.unknown().optional() })
-      .nullable()
-      .optional(),
-  })
-  .passthrough();
-
-const stripeInvoicePaymentRelationshipSchema = z
-  .object({
-    payment_intent: z.unknown().optional(),
-    charge: z.unknown().optional(),
-    payment_record: z.unknown().optional(),
-  })
-  .passthrough();
 
 type StripeWorkflowDeliveryRow = typeof stripeWorkflowDeliveries.$inferSelect;
 type StripeWorkflowTransaction = Tx;
@@ -299,14 +348,7 @@ function normalizeCustomer(
   if (typeof value === "string") {
     return { id: value, name: null, email: null };
   }
-  const customer = z
-    .object({
-      id: z.string().nullable().optional(),
-      name: z.string().nullable().optional(),
-      email: z.string().nullable().optional(),
-    })
-    .passthrough()
-    .safeParse(value);
+  const customer = stripeCustomerSchema.safeParse(value);
   return customer.success
     ? {
         id: customer.data.id ?? null,
@@ -322,20 +364,7 @@ function normalizePayments(value: unknown): {
   readonly chargeIds: readonly string[];
   readonly paymentRecordIds: readonly string[];
 } {
-  const payments = z
-    .object({
-      data: z.array(
-        z
-          .object({
-            id: z.string().trim().min(1).max(255).nullable().optional(),
-            payment: z.unknown().optional(),
-            payment_intent: z.unknown().optional(),
-          })
-          .passthrough(),
-      ),
-    })
-    .passthrough()
-    .safeParse(value);
+  const payments = stripeInvoicePaymentsSchema.safeParse(value);
   if (!payments.success) {
     return {
       paymentIds: [],


### PR DESCRIPTION
## Summary

- replace 16 loose optional Stripe invoice snapshot fields with structural Zod schemas
- share typed schemas for expandable identifiers, customers, line pricing, invoice parents, and payment relationships
- preserve tolerant webhook ingestion by normalizing malformed optional expansions to `null` instead of rejecting an otherwise usable invoice

## Why this was slop

The 16 `z.unknown().optional()` fields accepted every value and deferred their real contracts to scattered downstream `safeParse` calls. That erased useful inferred types, duplicated customer/payment structures, and made the ingress schema look less precise than the snapshot normalization it already enforced.

## Why this is safe

- The new schemas mirror the exact customer, identifier, price, pricing, parent, and payment shapes already parsed by the downstream normalizers.
- Missing and explicit `null` values remain supported.
- Invalid optional expansions still normalize to `null`, matching the previous snapshot result rather than turning them into a whole-invoice validation failure.
- Current and legacy Stripe relationship representations remain covered by the existing route test fixtures.

## Fallbacks

- `turbo/apps/api/src/signals/services/stripe-workflow-event.service.ts:optionalStripeSnapshotField` preserves the existing tolerance for invalid optional Stripe expansion values by normalizing them to `null` rather than rejecting the invoice. Surface: external Stripe webhook to API; there is no vm0 deployment-version skew window. This is justified external-data tolerance and remains while these provider fields are optional or expandable; no rollout cleanup is planned.

## Scan evidence

- Scanner base: `f1d1772a418362f62288b4cfc0add31400ac8d38`
- Initial scan: `2026-08-07T20:01:47.289Z`, 3,990 tracked source files
- Initial high-confidence production candidates: 249
- Required cleanup floor: 13 (`ceil(249 * 5%)`)
- Fixed: 16 loose optional Zod candidates (6.42%)
- Remaining high-confidence production candidates: 233
- Remaining high-confidence candidates in the target service: 0
- Total scanner-actionable matches: 4,521 -> 4,505

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/stripe-workflow-event.service.ts`
- targeted Oxlint, type-aware Oxlint, and ESLint for the changed file
- `pnpm --filter api run check-types`
- Lefthook: Prettier, Knip, all 14 Turbo type tasks, file-size check, and commitlint
- `pnpm exec vitest run src/signals/routes/__tests__/stripe-workflow-events.test.ts` could not initialize because no local PostgreSQL was listening on port 5432; all 11 tests were skipped before assertions
