### PR TITLE
fix(api): prevent indexed chat search fallback

### DIFF
--- a/turbo/apps/api/src/lib/chat-search-bigram.ts
+++ b/turbo/apps/api/src/lib/chat-search-bigram.ts
@@ -56,7 +56,7 @@ export function chatSearchIndexText(text: string): string {
  * one CJK run are chained with `<->` (adjacent-phrase, i.e. exact substring
  * semantics) and groups are combined with `&`. Returns null when the keyword
  * cannot be answered from the bigram index — a single-character CJK run or a
- * keyword with no indexable token — so the caller can fall back to ILIKE.
+ * keyword with no indexable token.
  */
 export function chatSearchBigramTsquery(keyword: string): string | null {
   const groups = tokenGroups(keyword);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2903,7 +2903,7 @@ describe("CHAT-01 chat search index", () => {
 
     const threadId = await sendNoCreditMessage(owner, {
       agentId: agent.agentId,
-      prompt: "今天天气很好 vercel 部署完成",
+      prompt: "今天天气很好，vercel 部署完成",
     });
     await sendNoCreditMessage(peer, {
       agentId: peerAgent.agentId,
@@ -2928,13 +2928,16 @@ describe("CHAT-01 chat search index", () => {
       expect(found.results).toHaveLength(1);
       expect(found.results[0]?.chatThreadId).toBe(threadId);
       expect(found.results[0]?.matchedMessage.content).toBe(
-        "今天天气很好 vercel 部署完成",
+        "今天天气很好，vercel 部署完成",
       );
     }
 
-    // A single CJK character has no bigram form and falls back to ILIKE.
+    // Unindexable keywords stay on the index path instead of falling back to
+    // ILIKE, so neither a single CJK character nor punctuation can match.
     const singleChar = await chat.searchChat(owner, "好");
-    expect(singleChar.results).toHaveLength(1);
+    expect(singleChar.results).toStrictEqual([]);
+    const punctuation = await chat.searchChat(owner, "，");
+    expect(punctuation.results).toStrictEqual([]);
 
     // Word tokens match whole words only under the index path.
     const partialWord = await chat.searchChat(owner, "verce");

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1221,9 +1221,7 @@ function chatSearchKeywordCondition(pattern: string): SQL {
 
 /**
  * Index-backed keyword condition over the chat_event_search_docs projection.
- * Returns null when the keyword has no bigram-indexable form (for example a
- * single CJK character), in which case the caller falls back to the legacy
- * ILIKE condition.
+ * Keywords without a bigram-indexable form cannot match the projection.
  */
 function chatSearchIndexCondition(
   db: ReadonlyDb,
@@ -1232,10 +1230,10 @@ function chatSearchIndexCondition(
     readonly orgId: string;
     readonly keyword: string;
   },
-): SQL | null {
+): SQL {
   const tsquery = chatSearchBigramTsquery(args.keyword);
   if (tsquery === null) {
-    return null;
+    return sql`false`;
   }
   return inArray(
     chatEvents.id,
@@ -1394,19 +1392,18 @@ export function zeroChatSearch(args: {
 > {
   return computed(async (get) => {
     const db = get(db$);
-    const pattern = `%${escapeLikePattern(args.keyword)}%`;
     const sinceDate = args.since ? new Date(args.since) : undefined;
 
-    const indexCondition = args.useSearchIndex
+    const keywordCondition = args.useSearchIndex
       ? chatSearchIndexCondition(db, args)
-      : null;
+      : chatSearchKeywordCondition(`%${escapeLikePattern(args.keyword)}%`);
     const matchConditions = [
       eq(chatThreads.userId, args.userId),
       eq(agentComposes.orgId, args.orgId),
       chatEventTextCondition(),
       visibleChatEventCondition(db),
       excludeGoalMarkerCondition(),
-      indexCondition ?? chatSearchKeywordCondition(pattern),
+      keywordCondition,
     ];
     if (sinceDate) {
       matchConditions.push(gte(chatEvents.createdAt, sinceDate));


### PR DESCRIPTION
## Summary

- keep `chatSearchIndex` requests exclusively on the `chat_event_search_docs` projection
- return no matches for keywords the bigram index cannot represent instead of scanning `chat_events` with ILIKE
- preserve the legacy ILIKE behavior when the feature switch is disabled

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `TZ=UTC DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'CHAT-01 chat search index'` (3 passed)

## Fallbacks

- Removed `zero-chat-thread.service.ts:zeroChatSearch` fallback from a non-indexable projection query to the legacy ILIKE scan. Surface: none — `chatSearchIndex` is a non-GA feature switch that remains disabled by default. Evidence: the enabled branch now produces an always-false SQL condition for non-indexable keywords, while the disabled branch explicitly selects the legacy condition. No rollout window or follow-up cleanup is required.
