### PR TITLE
refactor(api): remove chat run finished import cycle

### DIFF
--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -35,6 +35,7 @@ import {
   ingestToAxiom,
 } from "./signals/external/axiom";
 import type { RouteEntry } from "./signals/route-entry";
+import { configureChatRunFinishedEventDispatcher } from "./signals/services/chat-run-finished-event-registration.service";
 import { configurePiEdgeTurnDispatcher } from "./signals/services/pi-edge-turn-registration.service";
 import {
   isAbortError,
@@ -540,6 +541,7 @@ export function createAppWithRoutes({
   routes,
   signal,
 }: CreateAppWithRoutesOptions): Hono {
+  configureChatRunFinishedEventDispatcher();
   configurePiEdgeTurnDispatcher();
   const app = new Hono();
   app.onError(handleError);

--- a/turbo/apps/api/src/signals/services/chat-run-finished-event-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-event-dispatch.service.ts
@@ -1,0 +1,42 @@
+import { command, createStore, state, type Command } from "ccstate";
+
+import type { ChatRunFinishedEvent } from "./chat-run-finished-event";
+
+type ChatRunFinishedEventCommand = Command<
+  Promise<void>,
+  [ChatRunFinishedEvent, AbortSignal]
+>;
+
+const configuredChatRunFinishedEventCommand$ = state<
+  ChatRunFinishedEventCommand | undefined
+>(undefined);
+const configurationStore = createStore();
+
+/** Configure the chat-run-finished implementation from the API composition root. */
+export function configureChatRunFinishedEventCommand(
+  commandValue: ChatRunFinishedEventCommand,
+): void {
+  const configuredCommand = configurationStore.get(
+    configuredChatRunFinishedEventCommand$,
+  );
+  if (configuredCommand !== undefined && configuredCommand !== commandValue) {
+    throw new Error("Chat run finished event command is already configured");
+  }
+  configurationStore.set(configuredChatRunFinishedEventCommand$, commandValue);
+}
+
+export const dispatchConfiguredChatRunFinishedEvent$ = command(
+  async (
+    { set },
+    event: ChatRunFinishedEvent,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const commandValue = configurationStore.get(
+      configuredChatRunFinishedEventCommand$,
+    );
+    if (commandValue === undefined) {
+      throw new Error("Chat run finished event command is not configured");
+    }
+    await set(commandValue, event, signal);
+  },
+);

--- a/turbo/apps/api/src/signals/services/chat-run-finished-event-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-event-registration.service.ts
@@ -1,0 +1,7 @@
+import { configureChatRunFinishedEventCommand } from "./chat-run-finished-event-dispatch.service";
+import { dispatchChatRunFinishedWorkflowEvents$ } from "./chat-run-finished-workflow-event.service";
+
+/** Wire the chat-run-finished implementation at the API composition root. */
+export function configureChatRunFinishedEventDispatcher(): void {
+  configureChatRunFinishedEventCommand(dispatchChatRunFinishedWorkflowEvents$);
+}

--- a/turbo/apps/api/src/signals/services/chat-run-finished-event.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-event.ts
@@ -1,0 +1,8 @@
+import type { ChatRunFinishedRunStatus } from "@vm0/api-contracts/contracts/zero-workflows";
+
+export interface ChatRunFinishedEvent {
+  readonly chatThreadId: string;
+  readonly runId: string;
+  readonly runStatus: ChatRunFinishedRunStatus;
+  readonly lastResultText: string | null;
+}

--- a/turbo/apps/api/src/signals/services/chat-run-finished-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-workflow-event.service.ts
@@ -3,7 +3,6 @@ import { v5 as uuidv5 } from "uuid";
 import {
   chatRunFinishedEventConfigSchema,
   type ChatRunFinishedEventConfig,
-  type ChatRunFinishedRunStatus,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   workflowUserAutomationThreads,
@@ -19,6 +18,7 @@ import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
 import { loadRunAutonomyBudget } from "./autonomy-budget.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import type { ChatRunFinishedEvent } from "./chat-run-finished-event";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
@@ -62,13 +62,6 @@ async function appendAutonomyBudgetError(args: {
     );
     return true;
   });
-}
-
-export interface ChatRunFinishedEvent {
-  readonly chatThreadId: string;
-  readonly runId: string;
-  readonly runStatus: ChatRunFinishedRunStatus;
-  readonly lastResultText: string | null;
 }
 
 /**

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -116,7 +116,8 @@ import {
   type CanonicalSlackThreadStatusTarget,
 } from "./canonical-slack-thread-status.service";
 import { saveRunSummary, saveRunSummary$ } from "./run-summary.service";
-import type { ChatRunFinishedEvent } from "./chat-run-finished-workflow-event.service";
+import { dispatchConfiguredChatRunFinishedEvent$ } from "./chat-run-finished-event-dispatch.service";
+import type { ChatRunFinishedEvent } from "./chat-run-finished-event";
 import {
   insertAssistantEvents,
   insertAssistantEvents$,
@@ -5109,11 +5110,9 @@ export async function handleChatInternalCallbackWithoutCcstate(
             inputSignal,
           );
         },
-        dispatchChatRunFinishedAutomations: async (event, inputSignal) => {
-          const { dispatchChatRunFinishedWorkflowEvents$ } =
-            await import("./chat-run-finished-workflow-event.service");
+        dispatchChatRunFinishedAutomations: (event, inputSignal) => {
           return createStore().set(
-            dispatchChatRunFinishedWorkflowEvents$,
+            dispatchConfiguredChatRunFinishedEvent$,
             event,
             inputSignal,
           );
@@ -5183,12 +5182,8 @@ const buildChatCallbackDependencies$ = command(
           inputSignal,
         );
       },
-      dispatchChatRunFinishedAutomations: async (event, inputSignal) => {
-        // Imported lazily: the dispatcher reaches runWorkflowAutomationNow$,
-        // whose queue-drain path imports this module back.
-        const { dispatchChatRunFinishedWorkflowEvents$ } =
-          await import("./chat-run-finished-workflow-event.service");
-        return set(dispatchChatRunFinishedWorkflowEvents$, event, inputSignal);
+      dispatchChatRunFinishedAutomations: (event, inputSignal) => {
+        return set(dispatchConfiguredChatRunFinishedEvent$, event, inputSignal);
       },
       saveRunSummary: (runId, prompt, resultText, inputSignal) => {
         return set(


### PR DESCRIPTION
## Summary

- move `ChatRunFinishedEvent` into a dependency-neutral type module
- replace both callback-service lazy imports with a fail-fast configured ccstate dispatch port
- wire the workflow-event implementation at the API composition root, removing the production TypeScript SCC without changing dispatch behavior

## Verification

- targeted Prettier check: passed
- targeted Oxlint, type-aware Oxlint, and ESLint: passed
- `pnpm -F api run check-types:boundaries`: passed
- `pnpm knip --workspace api`: passed
- production import-graph scan: 778 files, 0 multi-file SCCs
- full API typecheck not run locally because available memory was below its known peak; covered by PR CI
- targeted `chat-run-finished-automations.bdd.test.ts` was blocked before test execution because local PostgreSQL was unavailable; covered by PR CI

## Scope

- no oxlint or boundary guardrail changes
- no fallback or deployment compatibility behavior added
