### PR TITLE
feat: show model changes in chat history

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1467,7 +1467,6 @@
       "loadingGoal": "Ziel wird geladen...",
       "message_one": "{{count}} Nachricht",
       "message_other": "{{count}} Nachrichten",
-      "modelChangeAppliesNextRun": "Ihr ausgewähltes Modell wird bei Ihrer nächsten Ausführung verwendet.",
       "openGoalDetails": "Zieldetails öffnen",
       "pendingAutomationEvent": "Ausstehendes Automatisierungsereignis",
       "queuedMessage": "Nachricht in der Warteschlange",
@@ -1516,7 +1515,9 @@
       "justNow": "soeben",
       "keepGoing": "Fortsetzen",
       "keepGoingAt": "Fortsetzen · {{timestamp}}",
+      "modelChangedTo": "Modell wurde auf {{model}} geändert",
       "queueEllipsis": "In Warteschlange...",
+      "selectedModelAppliesAfterCurrentRun": "Ihr ausgewähltes {{model}}-Modell wird nach dieser Ausführung wirksam",
       "thinking": {
         "assembling": "Teile werden zusammengesetzt...",
         "brewing": "Eine Antwort wird vorbereitet...",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1467,7 +1467,6 @@
       "loadingGoal": "Loading goal...",
       "message_one": "{{count}} message",
       "message_other": "{{count}} messages",
-      "modelChangeAppliesNextRun": "Your selected model will take effect on your next run.",
       "openGoalDetails": "Open goal details",
       "pendingAutomationEvent": "Pending automation event",
       "queuedMessage": "Queued message",
@@ -1516,7 +1515,9 @@
       "justNow": "just now",
       "keepGoing": "Keep going",
       "keepGoingAt": "Keep going · {{timestamp}}",
+      "modelChangedTo": "Model changed to {{model}}",
       "queueEllipsis": "queue...",
+      "selectedModelAppliesAfterCurrentRun": "Your selected {{model}} model will take effect after this run",
       "thinking": {
         "assembling": "Assembling the pieces...",
         "brewing": "Brewing up a response...",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1500,7 +1500,6 @@
       "message_one": "{{count}} mensaje",
       "message_many": "{{count}} mensajes",
       "message_other": "{{count}} mensajes",
-      "modelChangeAppliesNextRun": "El modelo seleccionado se aplicará en tu próxima ejecución.",
       "openGoalDetails": "Abrir detalles del objetivo",
       "pendingAutomationEvent": "Evento de automatización pendiente",
       "queuedMessage": "Mensaje en cola",
@@ -1555,7 +1554,9 @@
       "justNow": "Justo ahora",
       "keepGoing": "Sigue",
       "keepGoingAt": "Sigue adelante · {{timestamp}}",
+      "modelChangedTo": "Modelo cambiado a {{model}}",
       "queueEllipsis": "cola...",
+      "selectedModelAppliesAfterCurrentRun": "Tu modelo seleccionado {{model}} entrará en vigor después de esta ejecución",
       "thinking": {
         "assembling": "Ensamblando las piezas...",
         "brewing": "Preparando una respuesta...",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1500,7 +1500,6 @@
       "message_one": "{{count}} message",
       "message_many": "{{count}} messages",
       "message_other": "{{count}} messages",
-      "modelChangeAppliesNextRun": "Votre modèle sélectionné sera appliqué à votre prochaine exécution.",
       "openGoalDetails": "Ouvrir les détails de l'objectif",
       "pendingAutomationEvent": "Événement d'automatisation en attente",
       "queuedMessage": "Message en file d'attente",
@@ -1555,7 +1554,9 @@
       "justNow": "à l'instant",
       "keepGoing": "Continuez",
       "keepGoingAt": "Continuez · {{timestamp}}",
+      "modelChangedTo": "Le modèle a été changé en {{model}}",
       "queueEllipsis": "en file d'attente...",
+      "selectedModelAppliesAfterCurrentRun": "Votre modèle sélectionné {{model}} entrera en vigueur après cette exécution",
       "thinking": {
         "assembling": "Assemblage des pièces...",
         "brewing": "Préparation d'une réponse...",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1467,7 +1467,6 @@
       "loadingGoal": "लक्ष्य लोड हो रहा है...",
       "message_one": "{{count}} संदेश",
       "message_other": "{{count}} संदेश",
-      "modelChangeAppliesNextRun": "आपका चुना हुआ मॉडल आपके अगले रन से लागू होगा।",
       "openGoalDetails": "लक्ष्य विवरण खोलें",
       "pendingAutomationEvent": "लंबित ऑटोमेशन कार्यक्रम",
       "queuedMessage": "पंक्तिबद्ध संदेश",
@@ -1516,7 +1515,9 @@
       "justNow": "बस अब",
       "keepGoing": "जारी रखें",
       "keepGoingAt": "चलते रहें · {{timestamp}}",
+      "modelChangedTo": "मॉडल को {{model}} में बदल दिया गया है",
       "queueEllipsis": "कतार...",
+      "selectedModelAppliesAfterCurrentRun": "आपका चुना हुआ {{model}} मॉडल इस रन के बाद लागू होगा",
       "thinking": {
         "assembling": "टुकड़ों को जोड़ना...",
         "brewing": "एक प्रतिक्रिया तैयार की जा रही है...",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1467,7 +1467,6 @@
       "loadingGoal": "Memuat tujuan...",
       "message_one": "{{count}} pesan",
       "message_other": "{{count}} pesan",
-      "modelChangeAppliesNextRun": "Model yang Anda pilih akan diterapkan pada eksekusi berikutnya.",
       "openGoalDetails": "Buka detail tujuan",
       "pendingAutomationEvent": "Peristiwa otomatisasi tertunda",
       "queuedMessage": "Pesan dalam antrean",
@@ -1516,7 +1515,9 @@
       "justNow": "baru saja",
       "keepGoing": "Lanjutkan",
       "keepGoingAt": "Lanjutkan · {{timestamp}}",
+      "modelChangedTo": "Model diganti menjadi {{model}}",
       "queueEllipsis": "antrean...",
+      "selectedModelAppliesAfterCurrentRun": "Model {{model}} yang Anda pilih akan berlaku setelah eksekusi ini",
       "thinking": {
         "assembling": "Menyusun bagian-bagiannya...",
         "brewing": "Meracik respons...",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1500,7 +1500,6 @@
       "message_one": "{{count}} messaggio",
       "message_many": "{{count}} messaggi",
       "message_other": "{{count}} messaggi",
-      "modelChangeAppliesNextRun": "Il modello selezionato verrà applicato alla prossima esecuzione.",
       "openGoalDetails": "Apri i dettagli dell'obiettivo",
       "pendingAutomationEvent": "Evento di automazione in sospeso",
       "queuedMessage": "Messaggio in coda",
@@ -1555,7 +1554,9 @@
       "justNow": "proprio adesso",
       "keepGoing": "Continua così",
       "keepGoingAt": "Continua · {{timestamp}}",
+      "modelChangedTo": "Modello cambiato in {{model}}",
       "queueEllipsis": "in coda...",
+      "selectedModelAppliesAfterCurrentRun": "Il modello {{model}} selezionato entrerà in vigore dopo questa esecuzione",
       "thinking": {
         "assembling": "Assemblando i pezzi...",
         "brewing": "Sto preparando una risposta...",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1467,7 +1467,6 @@
       "loadingGoal": "目標を読み込んでいます...",
       "message_one": "{{count}} メッセージ",
       "message_other": "{{count}} メッセージ",
-      "modelChangeAppliesNextRun": "選択したモデルは次回の実行から適用されます。",
       "openGoalDetails": "目標の詳細を開く",
       "pendingAutomationEvent": "保留中のオートメーションイベント",
       "queuedMessage": "キューに入れられたメッセージ",
@@ -1516,7 +1515,9 @@
       "justNow": "たった今",
       "keepGoing": "続ける",
       "keepGoingAt": "続ける · {{timestamp}}",
+      "modelChangedTo": "モデルを{{model}}に変更しました",
       "queueEllipsis": "行列...",
+      "selectedModelAppliesAfterCurrentRun": "選択した{{model}}モデルはこの実行後に適用されます",
       "thinking": {
         "assembling": "部品を組み立て中...",
         "brewing": "返答を作成中...",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1467,7 +1467,6 @@
       "loadingGoal": "목표 불러오는 중...",
       "message_one": "{{count}}개 메시지",
       "message_other": "{{count}}개 메시지",
-      "modelChangeAppliesNextRun": "선택한 모델은 다음 실행부터 적용됩니다.",
       "openGoalDetails": "목표 세부 정보 열기",
       "pendingAutomationEvent": "대기 중인 자동화 이벤트",
       "queuedMessage": "대기 중인 메시지",
@@ -1516,7 +1515,9 @@
       "justNow": "방금",
       "keepGoing": "계속 진행",
       "keepGoingAt": "계속 진행 · {{timestamp}}",
+      "modelChangedTo": "모델을 {{model}}로 변경했습니다",
       "queueEllipsis": "대기 중...",
+      "selectedModelAppliesAfterCurrentRun": "선택한 {{model}} 모델은 이번 실행 후에 적용됩니다",
       "thinking": {
         "assembling": "조립 중...",
         "brewing": "응답 준비 중...",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1500,7 +1500,6 @@
       "message_one": "{{count}} mensagem",
       "message_many": "{{count}} mensagens",
       "message_other": "{{count}} mensagens",
-      "modelChangeAppliesNextRun": "O modelo selecionado será aplicado na próxima execução.",
       "openGoalDetails": "Abrir detalhes do objetivo",
       "pendingAutomationEvent": "Evento de automação pendente",
       "queuedMessage": "Mensagem na fila",
@@ -1555,7 +1554,9 @@
       "justNow": "agora mesmo",
       "keepGoing": "Continuar",
       "keepGoingAt": "Continuar · {{timestamp}}",
+      "modelChangedTo": "Modelo alterado para {{model}}",
       "queueEllipsis": "fila...",
+      "selectedModelAppliesAfterCurrentRun": "O modelo {{model}} selecionado entrará em vigor após esta execução",
       "thinking": {
         "assembling": "Juntando as peças...",
         "brewing": "Preparando uma resposta...",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -36,7 +36,8 @@ const AGENT_CHAT_PATH = `/agents/${AGENT_ID}/chat`;
 const CANCELLATION_RECOVERY_COPY =
   "Finalizing the cancelled run before queued work continues.";
 const NEXT_RUN_MODEL_COPY =
-  "Your selected model will take effect on your next run.";
+  "Your selected Claude Opus 4.8 model will take effect after this run";
+const MODEL_CHANGED_COPY = "Model changed to Claude Sonnet 4.6";
 
 afterEach(async () => {
   await i18n.changeLanguage("en-US");
@@ -92,6 +93,21 @@ function buildProvider(
     createdAt: "2026-07-14T00:00:00.000Z",
     updatedAt: "2026-07-14T00:00:00.000Z",
     ...overrides,
+  };
+}
+
+function modelAnnotatedMessage(
+  text: string,
+  selectedModel: string | undefined,
+): UserMessageDocument {
+  return {
+    version: 1,
+    parts: [
+      { type: "text", text },
+      ...(selectedModel === undefined
+        ? []
+        : [{ type: "model" as const, selectedModel }]),
+    ],
   };
 }
 
@@ -206,6 +222,50 @@ function mockActiveRunModelChange(): void {
         },
         runId: undefined,
         createdAt: "2026-08-06T10:00:02Z",
+      },
+    ],
+  });
+}
+
+function mockCompletedRunModelHistory({
+  previousModel,
+  nextModel,
+}: {
+  previousModel: string | undefined;
+  nextModel: string | undefined;
+}): void {
+  mockChatLifecycle(context, {
+    threadId: THREAD_ID,
+    chatEvents: [
+      {
+        id: `${THREAD_ID}-previous-user`,
+        role: "user",
+        content: "First prompt",
+        userMessage: modelAnnotatedMessage("First prompt", previousModel),
+        runId: "run-previous",
+        createdAt: "2026-08-06T09:00:00Z",
+      },
+      {
+        id: `${THREAD_ID}-previous-assistant`,
+        role: "assistant",
+        content: "First answer",
+        runId: "run-previous",
+        createdAt: "2026-08-06T09:00:01Z",
+      },
+      {
+        id: `${THREAD_ID}-next-user`,
+        role: "user",
+        content: "Second prompt",
+        userMessage: modelAnnotatedMessage("Second prompt", nextModel),
+        runId: "run-next",
+        createdAt: "2026-08-06T09:01:00Z",
+      },
+      {
+        id: `${THREAD_ID}-next-assistant`,
+        role: "assistant",
+        content: "Second answer",
+        runId: "run-next",
+        createdAt: "2026-08-06T09:01:01Z",
       },
     ],
   });
@@ -358,7 +418,7 @@ describe("chat run queue", () => {
     expectTextBefore("Working on the first request.", "Steer this follow-up");
   });
 
-  it("shows a selected model change above queued work", async () => {
+  it("shows a selected model change at the bottom of the message area", async () => {
     mockActiveRunModelChange();
 
     detachedSetupPage({
@@ -367,9 +427,11 @@ describe("chat run queue", () => {
       path: CHAT_PATH,
     });
 
-    const notice = await screen.findByText(NEXT_RUN_MODEL_COPY);
-    expect(notice).toHaveAttribute("role", "status");
+    const label = await screen.findByText(NEXT_RUN_MODEL_COPY);
+    const notice = label.closest('[role="status"]');
     expect(notice).toHaveAttribute("aria-live", "polite");
+    expect(label.closest("[data-message-container]")).toBeInTheDocument();
+    expectTextBefore("Start the active run", NEXT_RUN_MODEL_COPY);
     expectTextBefore(NEXT_RUN_MODEL_COPY, "1 message waiting");
     expectTextBefore(NEXT_RUN_MODEL_COPY, "Follow up after the active run");
   });
@@ -387,6 +449,56 @@ describe("chat run queue", () => {
       screen.findByText("Follow up after the active run"),
     ).resolves.toBeInTheDocument();
     expect(screen.queryByText(NEXT_RUN_MODEL_COPY)).not.toBeInTheDocument();
+  });
+
+  it("inserts a model change divider between adjacent runs", async () => {
+    mockCompletedRunModelHistory({
+      previousModel: "gpt-5.5",
+      nextModel: "claude-sonnet-4-6",
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
+      path: CHAT_PATH,
+    });
+
+    await expect(
+      screen.findByText(MODEL_CHANGED_COPY),
+    ).resolves.toBeInTheDocument();
+    expectTextBefore("First answer", MODEL_CHANGED_COPY);
+    expectTextBefore(MODEL_CHANGED_COPY, "Second prompt");
+  });
+
+  it.each([
+    {
+      name: "the models match",
+      previousModel: "claude-sonnet-4-6",
+      nextModel: "claude-sonnet-4-6",
+    },
+    {
+      name: "the previous run has no model",
+      previousModel: undefined,
+      nextModel: "claude-sonnet-4-6",
+    },
+    {
+      name: "the next run has no model",
+      previousModel: "gpt-5.5",
+      nextModel: undefined,
+    },
+  ])("does not insert a model change divider when $name", async (models) => {
+    mockCompletedRunModelHistory(models);
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
+      path: CHAT_PATH,
+    });
+
+    await expect(
+      screen.findByText("Second prompt"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText(MODEL_CHANGED_COPY)).not.toBeInTheDocument();
   });
 
   it("keeps an optimistic steer prompt at the bottom until persistence", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1191,8 +1191,7 @@ describe("chat lifecycle", () => {
     expect(followupButton).not.toHaveClass("border", "bg-background");
 
     const finishedLabel = screen.getByText(`Keep going · ${completedAtLabel}`);
-    const finishedLabelRow = finishedLabel.parentElement;
-    const finishedDivider = finishedLabelRow!.parentElement;
+    const finishedDivider = finishedLabel.parentElement;
     const finishedRunRow = finishedDivider!.parentElement;
     expect(finishedRunRow).toHaveClass("flex", "flex-col", "gap-2");
     expect(finishedRunRow).not.toHaveClass(
@@ -1201,18 +1200,23 @@ describe("chat lifecycle", () => {
       "p-3",
     );
     expect(followupList!.parentElement).toBe(finishedRunRow);
-    expect(finishedDivider!.firstElementChild).toHaveClass(
-      "h-px",
-      "w-full",
-      "bg-border/40",
+    expect(finishedDivider).toHaveClass(
+      "flex",
+      "min-h-5",
+      "items-center",
+      "gap-2",
     );
-    expect(finishedDivider!.firstElementChild).not.toHaveClass("hidden");
-    expect(finishedLabelRow!.lastElementChild).toHaveClass(
+    expect(finishedDivider).toHaveTextContent(
+      `Keep going · ${completedAtLabel}`,
+    );
+    expect(finishedDivider!.children).toHaveLength(2);
+    expect(finishedDivider!.firstElementChild).toBe(finishedLabel);
+    expect(finishedDivider!.lastElementChild).toHaveClass(
       "h-px",
       "flex-1",
       "bg-border/40",
     );
-    expect(finishedLabelRow!.lastElementChild).not.toHaveClass("hidden");
+    expect(finishedDivider!.querySelector(".w-full")).toBeNull();
   });
 
   it.each([

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -168,9 +168,7 @@ import {
   composerConnectorPermissionsEnabled$,
   avatarTemplatesEnabled$,
   imageRecognitionAvailable$,
-  featureSwitch$,
 } from "../../signals/external/feature-switch.ts";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   computerUseHosts$,
   selectedComputerUseHostId,
@@ -570,37 +568,15 @@ function ComposerStripRow({
 
 function PendingItemsStripHeader({
   label,
-  modelChangeAppliesNextRun,
   cancellationRecoveryPending,
 }: {
   label: string | null;
-  modelChangeAppliesNextRun: boolean;
   cancellationRecoveryPending: boolean;
 }) {
   const { t } = useTranslation();
   return (
     <div className="px-5 pt-3 pb-2">
-      {modelChangeAppliesNextRun ? (
-        <p
-          role="status"
-          aria-live="polite"
-          className="text-sm text-muted-foreground"
-        >
-          {t(($) => {
-            return $.chat.queue.modelChangeAppliesNextRun;
-          })}
-        </p>
-      ) : null}
-      {label ? (
-        <p
-          className={cn(
-            "text-sm text-muted-foreground",
-            modelChangeAppliesNextRun && "mt-1",
-          )}
-        >
-          {label}
-        </p>
-      ) : null}
+      {label ? <p className="text-sm text-muted-foreground">{label}</p> : null}
       {cancellationRecoveryPending ? (
         <p
           role="status"
@@ -616,42 +592,13 @@ function PendingItemsStripHeader({
   );
 }
 
-function shouldShowNextRunModelNotice({
-  enabled,
-  selectedModel,
-  runningModel,
-}: {
-  enabled: boolean;
-  selectedModel: string | undefined;
-  runningModel: string | null | undefined;
-}): boolean {
-  return (
-    enabled &&
-    selectedModel !== undefined &&
-    runningModel !== undefined &&
-    runningModel !== null &&
-    selectedModel !== runningModel
-  );
-}
-
 function PendingItemsStrip({ signals }: { signals: ComposerSignals }) {
   const { t } = useTranslation();
-  const nextRunModelNoticeEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatNextRunModelNotice] ?? false;
   const pendingEvents =
     useLastResolved(signals.queue.pendingEvents$) ??
     ([] satisfies readonly ComposerPendingEvent[]);
   const cancellationRecoveryPending =
     useLastResolved(signals.queue.cancellationRecoveryPending$) ?? false;
-  const selectedModel = useLastResolved(
-    signals.model.modelSelection$,
-  )?.selectedModel;
-  const runningModel = useLastResolved(signals.model.runningModel$);
-  const modelChangeAppliesNextRun = shouldShowNextRunModelNotice({
-    enabled: nextRunModelNoticeEnabled,
-    selectedModel,
-    runningModel,
-  });
   const activeGoalObjective = useLastResolved(
     signals.goal.activeGoalObjective$,
   );
@@ -712,15 +659,14 @@ function PendingItemsStrip({ signals }: { signals: ComposerSignals }) {
             items: queued.length > 0 ? messageLabel : eventLabel,
           },
         );
-  if (count === 0 && !activeGoal && !modelChangeAppliesNextRun) {
+  if (count === 0 && !activeGoal) {
     return null;
   }
   return (
     <div className="relative z-0 mx-5 -mb-6 overflow-hidden rounded-xl bg-gray-50 dark:bg-gray-100">
-      {count > 0 || modelChangeAppliesNextRun ? (
+      {count > 0 ? (
         <PendingItemsStripHeader
-          label={count > 0 ? label : null}
-          modelChangeAppliesNextRun={modelChangeAppliesNextRun}
+          label={label}
           cancellationRecoveryPending={cancellationRecoveryPending}
         />
       ) : null}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -106,6 +106,7 @@ import type {
   ZeroWorkflowSchedule,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { r2ImageTransformUrl } from "@vm0/core";
+import { getModelDisplayName } from "@vm0/core/model-display-name";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type {
   PlatformConnectorPermissionMetadata,
@@ -364,6 +365,52 @@ function visibleUserMessage(
   inputEvent: ChatInputEvent | undefined,
 ): UserMessageDocument | undefined {
   return inputEvent?.userMessage;
+}
+
+function selectedModelFromUserMessage(
+  document: UserMessageDocument | undefined,
+): string | undefined {
+  const modelPart = document?.parts.find((part) => {
+    return part.type === "model";
+  });
+  return modelPart?.type === "model" ? modelPart.selectedModel : undefined;
+}
+
+function modelChangesByEventId(
+  groups: readonly ChatEventGroup[],
+): ReadonlyMap<string, string> {
+  const changes = new Map<string, string>();
+  let previousRunId: string | undefined;
+  let previousModel: string | undefined;
+  let hasPreviousRun = false;
+
+  for (const group of groups) {
+    for (const event of group.events) {
+      const inputEvent = asInputChatEvent(event);
+      if (
+        inputEvent?.runId === undefined ||
+        inputEvent.runId === previousRunId
+      ) {
+        continue;
+      }
+      const selectedModel = selectedModelFromUserMessage(
+        inputEvent.userMessage,
+      );
+      if (
+        hasPreviousRun &&
+        previousModel !== undefined &&
+        selectedModel !== undefined &&
+        selectedModel !== previousModel
+      ) {
+        changes.set(event.id, selectedModel);
+      }
+      previousRunId = inputEvent.runId;
+      previousModel = selectedModel;
+      hasPreviousRun = true;
+    }
+  }
+
+  return changes;
 }
 
 function userMessageNonContentPart(
@@ -2644,6 +2691,11 @@ function ChatThreadRenderedEventGroups({
     }) ?? [];
   const { activeGroups: renderedActiveGroups } =
     splitQueuedEventsForThinkingIndicator(renderedGroups);
+  const chatModelNoticesEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatNextRunModelNotice] ?? false;
+  const modelChanges = chatModelNoticesEnabled
+    ? modelChangesByEventId(renderedActiveGroups)
+    : new Map<string, string>();
   const scrollTargetEventId =
     useGet(thread.threadScrollPosition$)?.targetEventId ?? null;
   const runGroupExpansionOverrides = useGet(runGroupExpansionOverrides$);
@@ -2671,6 +2723,7 @@ function ChatThreadRenderedEventGroups({
     <ChatThreadEventGroups
       thread={thread}
       groups={visibleGroups}
+      modelChanges={modelChanges}
       runGroupFolding={runGroupFolding}
       onToggleRunGroup={toggleRunGroupExpanded}
       completedWorkFolding={completedWorkFolding}
@@ -2747,6 +2800,7 @@ function ChatThreadEventsMain({ thread }: { thread: ChatPanelSignals }) {
         <ChatHistoryBackfillSkeleton thread={thread} />
         <ChatThreadRenderedEventGroups thread={thread} />
         <ChatThreadThinkingIndicator thread={thread} />
+        <ChatThreadNextRunModelNotice thread={thread} />
       </div>
     </main>
   );
@@ -2756,9 +2810,41 @@ function ChatThreadThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
   return <ThinkingIndicator thread={thread} />;
 }
 
+function ChatThreadNextRunModelNotice({
+  thread,
+}: {
+  thread: ChatPanelSignals;
+}) {
+  const { t } = useTranslation();
+  const enabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatNextRunModelNotice] ?? false;
+  const selectedModel = useLastResolved(
+    thread.composer.model.modelSelection$,
+  )?.selectedModel;
+  const runningModel = useLastResolved(thread.composer.model.runningModel$);
+  if (
+    !enabled ||
+    selectedModel === undefined ||
+    runningModel === undefined ||
+    runningModel === null ||
+    selectedModel === runningModel
+  ) {
+    return null;
+  }
+
+  const label = t(
+    ($) => {
+      return $.chat.run.selectedModelAppliesAfterCurrentRun;
+    },
+    { model: getModelDisplayName(selectedModel) },
+  );
+  return <RunSectionDividerRow label={label} announce />;
+}
+
 function ChatThreadEventGroups({
   thread,
   groups,
+  modelChanges,
   runGroupFolding,
   onToggleRunGroup,
   completedWorkFolding,
@@ -2767,6 +2853,7 @@ function ChatThreadEventGroups({
 }: {
   thread: ChatPanelSignals;
   groups: readonly ChatEventGroup[];
+  modelChanges: ReadonlyMap<string, string>;
   runGroupFolding: RunGroupFolding | null;
   onToggleRunGroup: (key: string, expanded: boolean) => void;
   completedWorkFolding: CompletedWorkFolding | null;
@@ -2807,6 +2894,7 @@ function ChatThreadEventGroups({
             <SelectablePagedGroupRow
               group={group}
               thread={thread}
+              modelChanges={modelChanges}
               runGroupFolds={embeddedFolds}
               completedWorkFold={
                 completedWorkFold !== null
@@ -3363,7 +3451,51 @@ function completedWorkLabel(groups: readonly ChatEventGroup[]): string {
 }
 
 const RUN_SECTION_LABEL_CLASS =
-  "shrink-0 font-serif text-[13px] italic text-muted-foreground/50";
+  "min-w-0 max-w-full shrink-0 break-words font-serif text-[13px] italic text-muted-foreground/50";
+
+function RunSectionDivider({ label }: { label: string }) {
+  return (
+    <div className="flex min-h-5 flex-col justify-center gap-1.5">
+      <div className="h-px w-full bg-border/40" />
+      <div className="flex items-center gap-2">
+        <p className={RUN_SECTION_LABEL_CLASS}>{label}</p>
+        <div className="h-px flex-1 bg-border/40" />
+      </div>
+    </div>
+  );
+}
+
+function RunSectionDividerRow({
+  label,
+  announce = false,
+}: {
+  label: string;
+  announce?: boolean;
+}) {
+  return (
+    <div
+      role={announce ? "status" : undefined}
+      aria-live={announce ? "polite" : undefined}
+      className="@[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start"
+    >
+      <div className="hidden @[900px]:block" />
+      <div className="min-w-0">
+        <RunSectionDivider label={label} />
+      </div>
+    </div>
+  );
+}
+
+function ModelChangeDividerRow({ selectedModel }: { selectedModel: string }) {
+  const { t } = useTranslation();
+  const label = t(
+    ($) => {
+      return $.chat.run.modelChangedTo;
+    },
+    { model: getModelDisplayName(selectedModel) },
+  );
+  return <RunSectionDividerRow label={label} />;
+}
 
 function CompletedWorkFoldRow({
   groups,
@@ -4353,13 +4485,7 @@ function FinishedRunRow({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex h-5 flex-col justify-center gap-1.5">
-        <div className="h-px w-full bg-border/40" />
-        <div className="flex items-center gap-2">
-          <p className={RUN_SECTION_LABEL_CLASS}>{label}</p>
-          <div className="h-px flex-1 bg-border/40" />
-        </div>
-      </div>
+      <RunSectionDivider label={label} />
       {source ? (
         <RecommendedFollowupList thread={thread} source={source} />
       ) : null}
@@ -6380,11 +6506,13 @@ function AssistantBubbleAvatar({ thread }: { thread: ChatPanelSignals }) {
 function PagedGroupRow({
   group,
   thread,
+  modelChanges,
   runGroupFolds,
   completedWorkFold,
 }: {
   group: ChatEventGroup;
   thread: ChatPanelSignals;
+  modelChanges: ReadonlyMap<string, string>;
   runGroupFolds?: readonly RunGroupFoldControl[];
   completedWorkFold?: {
     groups: readonly ChatEventGroup[];
@@ -6398,6 +6526,7 @@ function PagedGroupRow({
       <PagedUserGroup
         group={group}
         thread={thread}
+        modelChanges={modelChanges}
         runGroupFolds={runGroupFolds}
       />
     );
@@ -6456,6 +6585,7 @@ function clickTargetsExistingInteraction(target: EventTarget | null): boolean {
 function SelectablePagedGroupRow({
   group,
   thread,
+  modelChanges,
   runGroupFolds,
   completedWorkFold,
 }: Parameters<typeof PagedGroupRow>[0]) {
@@ -6472,6 +6602,7 @@ function SelectablePagedGroupRow({
       <PagedGroupRow
         group={group}
         thread={thread}
+        modelChanges={modelChanges}
         runGroupFolds={runGroupFolds}
         completedWorkFold={completedWorkFold}
       />
@@ -6514,6 +6645,7 @@ function SelectablePagedGroupRow({
       <PagedGroupRow
         group={group}
         thread={thread}
+        modelChanges={modelChanges}
         runGroupFolds={runGroupFolds}
         completedWorkFold={completedWorkFold}
       />
@@ -6538,17 +6670,25 @@ function SelectablePagedGroupRow({
 function PagedUserGroup({
   group,
   thread,
+  modelChanges,
   runGroupFolds,
 }: {
   group: ChatEventGroup;
   thread: ChatPanelSignals;
+  modelChanges: ReadonlyMap<string, string>;
   runGroupFolds?: readonly RunGroupFoldControl[];
 }) {
   return (
     <>
       {group.events.map((event) => {
+        const changedModel = modelChanges.get(event.id);
         return (
-          <PagedUserMessage key={event.id} event={event} thread={thread} />
+          <div key={event.id} className="contents">
+            {changedModel === undefined ? null : (
+              <ModelChangeDividerRow selectedModel={changedModel} />
+            )}
+            <PagedUserMessage event={event} thread={thread} />
+          </div>
         );
       })}
       {runGroupFolds?.map((fold) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3457,12 +3457,9 @@ const RUN_SECTION_ROW_CLASS =
 
 function RunSectionDivider({ label }: { label: string }) {
   return (
-    <div className="flex min-h-5 flex-col justify-center gap-1.5">
-      <div className="h-px w-full bg-border/40" />
-      <div className="flex items-center gap-2">
-        <p className={RUN_SECTION_LABEL_CLASS}>{label}</p>
-        <div className="h-px flex-1 bg-border/40" />
-      </div>
+    <div className="flex min-h-5 items-center gap-2">
+      <p className={RUN_SECTION_LABEL_CLASS}>{label}</p>
+      <div className="h-px flex-1 bg-border/40" />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3452,6 +3452,8 @@ function completedWorkLabel(groups: readonly ChatEventGroup[]): string {
 
 const RUN_SECTION_LABEL_CLASS =
   "min-w-0 max-w-full shrink-0 break-words font-serif text-[13px] italic text-muted-foreground/50";
+const RUN_SECTION_ROW_CLASS =
+  "-mt-5 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
 function RunSectionDivider({ label }: { label: string }) {
   return (
@@ -3476,7 +3478,7 @@ function RunSectionDividerRow({
     <div
       role={announce ? "status" : undefined}
       aria-live={announce ? "polite" : undefined}
-      className="@[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start"
+      className={RUN_SECTION_ROW_CLASS}
     >
       <div className="hidden @[900px]:block" />
       <div className="min-w-0">
@@ -4565,7 +4567,7 @@ function AssistantThinkingStatusRow({
     <div
       {...thinkingIndicatorProps}
       data-role="assistant-thinking"
-      className="-mt-5 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start"
+      className={RUN_SECTION_ROW_CLASS}
     >
       <div className="hidden @[900px]:block" />
       <div className="min-w-0">


### PR DESCRIPTION
## Summary

- move the selected-model notice from the Composer strip to the bottom of the chat message stream and include the selected model name
- insert run-style model change dividers before later user messages when adjacent runs both record different models
- reuse the finished-run divider visual, localize both notices, and keep the existing feature switch boundary

## Test plan

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-queue.test.tsx --maxWorkers=2 --silent=passed-only` (23 tests)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- Prettier 3.8.1 check on all changed files

## Notes

- no local dev server or full Vitest suite was run; the PR pipeline will cover the broader checks
