### PR TITLE
feat(api): force app.vm0.ai clients to upgrade to v0.707.0

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -985,7 +985,7 @@ describe("createApp", () => {
   });
 
   describe("web client compatibility", () => {
-    it("rejects pre-content-event-reader app clients before route handlers run", async () => {
+    it("rejects pre-canonical-chat-event app clients before route handlers run", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
@@ -994,7 +994,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.706.2",
+          [CLIENT_VERSION_HEADER]: "0.706.4",
         },
       });
 
@@ -1050,7 +1050,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.706.4",
+          [CLIENT_VERSION_HEADER]: "0.707.1",
         },
       });
 

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.706.3"
+  "minimumSupportedVersion": "0.707.0"
 }


### PR DESCRIPTION
## Summary

- raise the `app.vm0.ai` web-client compatibility floor from `0.706.3` to `0.707.0`
- force every older App bundle to refresh before Stage 7 removes the temporary old-API insert bridge and remaining legacy chat-event columns
- update the directly coupled API compatibility coverage for the last pre-Stage-5 build and a newer supported build

## Target resolution

- `window._vm0.getBuildVersion()` on live `https://app.vm0.ai` returned `0.707.0`
- `window._vm0.getBuildCommitSha()` returned `819745bf596ab5bd7cf6b7c5bce20d3748711cc9`
- Git ancestry confirms that live commit contains Stage 5 PR #25768 merge commit `057d1eb82aa00207347b5bbe1ec27fc817b90cbd`
- the Stage 5 merge commit still declared App `0.706.4`; release PR #25765 commit `819745bf596ab5bd7cf6b7c5bce20d3748711cc9` first declared and tagged stable App `0.707.0`
- production release-please run [31236989577](https://github.com/vm0-ai/vm0/actions/runs/31236989577) completed successfully at that release commit, including `validate-db-release-coupling`, `build-api-production`, `promote-api-production`, `promote-app-production`, `deploy-api-schema`, `deploy-host-worker-production`, and `queue-production-deploy`

Therefore `0.707.0` is the first live stable production App version containing the Stage 5 canonical chat-event contract, and the selected target equals rather than exceeds production.

## User-visible impact

App clients below `0.707.0` receive the existing compatibility rejection on their next API request and must refresh to load a supported build. Version `0.707.0` and newer clients remain supported.

## Files changed

- `turbo/apps/api/src/lib/web-client-compatibility.json`
- `turbo/apps/api/src/__tests__/app-factory.test.ts`

The test now proves that App `0.706.4` receives the existing `426` rejection before route matching, while the configured target and `0.707.1` remain supported. No ChatEvent contract, reader, writer, goal/followup behavior, user-message parts, database data, migration, IndexedDB, event type, textual consumer, or Stage 5 physical compatibility surface changed.

## Fallbacks

- `turbo/apps/api/src/lib/web-client-compatibility.json:minimumSupportedVersion` — advances the existing permanent force-upgrade boundary to `0.707.0`; it does not add a new legacy code path. Surface: old web/App clients, with the observed maximum version-skew window of approximately two days; a handled API request ends the skew earlier by requiring a refresh. Future floor increases still require independent live-production verification.
- `turbo/packages/db/src/migrations/0861_chat_event_contract_cutover.sql:is_supported_legacy_followups_0861`, `canonicalize_legacy_chat_event_insert_0861`, and its trigger — retained unchanged as the temporary Stage 5 DB-before-API insert bridge. Surface: old API pods during the observed DB/API overlap of up to approximately 102 minutes. Removal condition: Stage 7, only after this Stage 6 floor is released and both the full API drain and client drain are independently proven.
- `turbo/packages/db/src/schema/chat-event.ts` physical columns `goal_event`, `attach_files`, `generation_template`, `recommended_followups`, and `active_input_sequence` (including the latter's partial unique index) — retained unchanged so the draining old API's ORM reads, returns, and exact legacy inserts remain legal. The first four are opaque to the canonical application contract; Stage 7 owns their physical deletion together with `active_input_sequence` after the same drains.
- The existing physical event-type allowances for `browser.started` and `browser.stopped` remain unchanged and out of scope. This PR adds no reader, writer, or fallback for them and does not alter any event type.

No new legacy fallback is introduced. Stage 5's application readers and writers remain canonical-only.

## Verification

- read the live production build version and commit through `window._vm0`
- verified the live commit and Stage 5 merge commit are contained in `origin/main`
- parsed the compatibility JSON and asserted `minimumSupportedVersion === "0.707.0"`
- `pnpm exec prettier --check apps/api/src/lib/web-client-compatibility.json apps/api/src/__tests__/app-factory.test.ts`
- `pnpm --dir apps/api exec vitest run src/__tests__/app-factory.test.ts -t 'web client compatibility'` (5 passed, 40 skipped by the targeted filter)
- `git diff --check`

No full Vitest suite or local development server was run. Full repository checks are intentionally left to the PR pipeline.
