### PR TITLE
perf(api): raise chat event snapshot batch to 500 for backfill

### DIFF
--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -36,7 +36,14 @@ interface SnapshotCandidate {
  */
 const ARCHIVE_SCHEMA_VERSION = 1;
 const ARCHIVE_CONTENT_TYPE = "application/gzip";
-const DEFAULT_THREAD_BATCH_SIZE = 25;
+/**
+ * Sized for the initial backfill: ~130k candidate threads at 48 runs/day
+ * clear in about 5 days, and the first production run measured ~0.19s per
+ * thread, so a full batch stays far below the platform function timeout.
+ * After catch-up this is only a cap; steady state re-archives ~700 active
+ * threads per day.
+ */
+const DEFAULT_THREAD_BATCH_SIZE = 500;
 const EVENT_PAGE_SIZE = 1000;
 const OBJECT_KEY_CONTENT_SHA256 = /-([0-9a-f]{64})\.ndjson\.gz$/;
 


### PR DESCRIPTION
## Summary

Raises the chat-event snapshot cron's default thread batch from 25 to 500 so the initial backfill catches up in days instead of months.

Production numbers behind the sizing (measured 2026-08-08 after #25770 went live):

- Backlog: ~130.3k candidate threads (`chat_event_search_watermarks` rows) vs 25 archived on the first tick.
- At 25/tick × 48 ticks/day = 1,200/day the backlog takes ~109 days; at 500/tick it clears in ~5.5 days.
- The first production tick archived 25 threads in 4.83s (~0.19s/thread including cold start), so a 500-thread pass stays around ~2 minutes, far below the platform function timeout. If a pass is ever cut off, each thread commits independently and the next tick resumes from the watermark, so oversizing is safe.
- Steady state only needs ~714 re-archives/day (threads active in the last 24h); 500 then acts as a cap, not a target.

The `CHAT_EVENT_SNAPSHOT_BATCH_SIZE` env override stays as-is (tests use it); production intentionally runs the new default with no env configuration.

## Fallbacks

None. One constant change; no compatibility path between deployed versions.

## Testing

- `cron-snapshot-chat-events.test.ts` (3 route integration tests) passes; the suite pins batch size via the env override, so no assertions depend on the default.
- Prettier, eslint, and `check-types` clean on the touched workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
