### PR TITLE
docs(rust): document vsock shutdown delivery uncertainty

### DIFF
--- a/crates/vsock-host/src/connection/request.rs
+++ b/crates/vsock-host/src/connection/request.rs
@@ -566,6 +566,23 @@ impl VsockHost {
 
     /// Request graceful shutdown from guest.
     ///
+    /// Once the guest receives a valid shutdown request, its connection loop
+    /// is terminal: after attempting to write `MSG_SHUTDOWN_ACK`, it stops
+    /// dispatching later frames and waits for the host to disconnect. This
+    /// remains true when the acknowledgement write fails and the host cannot
+    /// observe it.
+    ///
+    /// A transport error, timeout, or cancellation after the request may have
+    /// been written does not reveal whether the guest received it. This method
+    /// does not expose which side of that boundary a failure or cancellation
+    /// occurred on. Unless other synchronization proves that no frame started
+    /// writing, treat the guest lifecycle state as uncertain and do not attempt
+    /// later operations on this connection.
+    ///
+    /// `Ok(())` confirms that the host received a matching, valid
+    /// `MSG_SHUTDOWN_ACK`. It does not wait for or prove guest connection-loop
+    /// exit, guest-process termination, or VM termination.
+    ///
     /// The timeout covers waiting for the shared writer, writing the request,
     /// and waiting for the acknowledgement.
     ///


### PR DESCRIPTION
## Summary

- document that a delivered valid vsock shutdown is terminal for the guest connection loop, even when its acknowledgement cannot be observed
- clarify that timeout, transport failure, or cancellation after a possible write leaves request delivery and guest lifecycle state uncertain
- define `Ok(())` as receipt of a matching valid shutdown ACK, not proof of guest-process or VM termination

## Scope

- documentation-only change to `VsockHost::shutdown`
- no wire, timeout, runtime, teardown, API, schema, migration, or rollout behavior changes
- no new tests because existing host and guest integration tests already establish the documented behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p vsock-host --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host --all-features` (341 passed)
- repository pre-commit hooks: Cargo fmt, workspace Clippy, workspace rustdoc, file-size check, and commitlint

Closes #25778
