### PR TITLE
refactor(runner): centralize org name validation

### DIFF
--- a/crates/runner/src/group.rs
+++ b/crates/runner/src/group.rs
@@ -3,13 +3,7 @@
 //! Group names follow the `org/name` convention (e.g. `vm0/prod`,
 //! `acme/staging`). They are joined against `HomePaths::groups_dir()`
 //! to form on-disk paths, so any input containing `..`, leading `/`,
-//! or extra `/` could escape the intended directory. This module is
-//! the single source of truth for what counts as a safe group name.
-//!
-//! Mirrors the server-side Zod contract `runnerGroupSchema` in
-//! `turbo/packages/core/src/contracts/runners.ts`:
-//!   `/^[a-z0-9-]+\/[a-z0-9-]+$/`
-//! Keep the two in sync.
+//! or extra `/` could escape the intended directory.
 
 use crate::error::{RunnerError, RunnerResult};
 
@@ -18,7 +12,7 @@ use crate::error::{RunnerError, RunnerResult};
 /// name from the user (CLI flags, YAML config) so the error wording
 /// stays consistent.
 pub fn validate_or_err(name: &str) -> RunnerResult<()> {
-    if !validate_name(name) {
+    if !crate::org_name::is_valid(name) {
         return Err(RunnerError::Config(format!(
             "invalid group name: {name} (must be org/name format, lowercase alphanumeric + hyphens)"
         )));
@@ -26,57 +20,9 @@ pub fn validate_or_err(name: &str) -> RunnerResult<()> {
     Ok(())
 }
 
-/// Validate that a group name follows the `org/name` format.
-/// Each part must be non-empty lowercase alphanumeric + hyphens.
-fn validate_name(name: &str) -> bool {
-    let Some((org, group_name)) = name.split_once('/') else {
-        return false;
-    };
-    if org.is_empty() || group_name.is_empty() {
-        return false;
-    }
-    // No additional slashes
-    if group_name.contains('/') {
-        return false;
-    }
-    let valid_part = |s: &str| {
-        s.chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-    };
-    valid_part(org) && valid_part(group_name)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn validate_name_valid() {
-        assert!(validate_name("vm0/prod"));
-        assert!(validate_name("test/group"));
-        assert!(validate_name("acme/my-group-1"));
-        // Mirrors TS regex `[a-z0-9-]+/[a-z0-9-]+` — leading/trailing hyphens
-        // are accepted by the server contract, so we accept them here too.
-        assert!(validate_name("-vm0/prod"));
-        assert!(validate_name("vm0/prod-"));
-    }
-
-    #[test]
-    fn validate_name_invalid_shape() {
-        assert!(!validate_name("default")); // no org
-        assert!(!validate_name("/default")); // empty org
-        assert!(!validate_name("vm0/")); // empty name
-        assert!(!validate_name("vm0/my/nested")); // extra slash
-        assert!(!validate_name("")); // empty
-    }
-
-    #[test]
-    fn validate_name_invalid_chars() {
-        assert!(!validate_name("VM0/prod")); // uppercase
-        assert!(!validate_name("vm0/Prod")); // uppercase
-        assert!(!validate_name("vm0/pr od")); // space
-        assert!(!validate_name("vm0/prod_1")); // underscore not allowed
-    }
 
     #[test]
     fn validate_or_err_passes_for_valid_name() {
@@ -86,22 +32,9 @@ mod tests {
     #[test]
     fn validate_or_err_carries_offending_name_in_message() {
         let err = validate_or_err("/etc").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("invalid group name"), "got: {msg}");
-        assert!(msg.contains("/etc"), "got: {msg}");
-    }
-
-    #[test]
-    fn validate_name_rejects_path_traversal() {
-        // These are the security-relevant cases the validator exists to block.
-        assert!(!validate_name("..")); // bare relative
-        assert!(!validate_name("../etc")); // traversal
-        assert!(!validate_name("vm0/../etc")); // mid-traversal
-        assert!(!validate_name("/etc")); // absolute path
-        assert!(!validate_name("/etc/passwd")); // absolute, multi-segment
-        assert!(!validate_name(".")); // current dir
-        assert!(!validate_name("vm0/.")); // current-dir suffix
-        assert!(!validate_name("vm0/..")); // parent-dir suffix
-        assert!(!validate_name(r"vm0\prod")); // backslash
+        assert_eq!(
+            err.to_string(),
+            "config error: invalid group name: /etc (must be org/name format, lowercase alphanumeric + hyphens)"
+        );
     }
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -33,6 +33,7 @@ mod network_log_drain;
 mod network_log_manager;
 mod network_log_process;
 mod network_logs;
+mod org_name;
 mod paths;
 mod pi_standby;
 mod prefetch;

--- a/crates/runner/src/org_name.rs
+++ b/crates/runner/src/org_name.rs
@@ -1,0 +1,72 @@
+//! Validation for runner `org/name` identifiers.
+//!
+//! Mirrors the `/^[a-z0-9-]+\/[a-z0-9-]+$/` contracts in:
+//! - `turbo/packages/api-contracts/src/contracts/runners.ts`
+//! - `turbo/packages/api-contracts/src/contracts/composes.ts`
+//!
+//! Keep the Rust and TypeScript contracts in sync.
+
+/// Return whether `name` contains exactly two non-empty slash-separated
+/// components made of lowercase ASCII letters, digits, or hyphens.
+pub(crate) fn is_valid(name: &str) -> bool {
+    let Some((org, resource_name)) = name.split_once('/') else {
+        return false;
+    };
+    if org.is_empty() || resource_name.is_empty() || resource_name.contains('/') {
+        return false;
+    }
+
+    let valid_part = |part: &str| {
+        part.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    };
+    valid_part(org) && valid_part(resource_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_contract_language() {
+        for name in [
+            "vm0/prod",
+            "test/group",
+            "acme/my-resource-1",
+            "123/456",
+            "-vm0/prod",
+            "vm0/prod-",
+            "-/--",
+        ] {
+            assert!(is_valid(name), "expected {name:?} to be valid");
+        }
+    }
+
+    #[test]
+    fn rejects_names_outside_contract_language() {
+        for name in [
+            "",
+            "default",
+            "/default",
+            "vm0/",
+            "vm0/my/nested",
+            "VM0/prod",
+            "vm0/Prod",
+            "vm0/pr od",
+            "vm0/prod_1",
+            "vm0/pröd",
+            "组织/prod",
+            "..",
+            "../etc",
+            "vm0/../etc",
+            "/etc",
+            "/etc/passwd",
+            ".",
+            "vm0/.",
+            "vm0/..",
+            r"vm0\prod",
+        ] {
+            assert!(!is_valid(name), "expected {name:?} to be invalid");
+        }
+    }
+}

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -32,37 +32,12 @@ pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
     }
 }
 
-/// Validate that a profile name follows the `org/name` format.
-/// Each part must be non-empty lowercase alphanumeric + hyphens.
-///
-/// Mirrors the server-side Zod contract `experimental_profile` regex
-/// in `turbo/packages/core/src/contracts/composes.ts`:
-///   `/^[a-z0-9-]+\/[a-z0-9-]+$/`
-/// Keep the two in sync.
-fn validate_name(name: &str) -> bool {
-    let Some((org, profile_name)) = name.split_once('/') else {
-        return false;
-    };
-    if org.is_empty() || profile_name.is_empty() {
-        return false;
-    }
-    // No additional slashes
-    if profile_name.contains('/') {
-        return false;
-    }
-    let valid_part = |s: &str| {
-        s.chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-    };
-    valid_part(org) && valid_part(profile_name)
-}
-
 /// Validate `name` and return a `RunnerError::Config` with a uniform
 /// message if it fails. Use this at every callsite that takes a profile
 /// name from the user (CLI flags, YAML config) so the error wording
 /// stays consistent.
 pub fn validate_or_err(name: &str) -> RunnerResult<()> {
-    if !validate_name(name) {
+    if !crate::org_name::is_valid(name) {
         return Err(RunnerError::Config(format!(
             "invalid profile name: {name} (must be org/name format, lowercase alphanumeric + hyphens)"
         )));
@@ -89,32 +64,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_name_valid() {
-        assert!(validate_name("vm0/default"));
-        assert!(validate_name("my-org/data-science"));
-        assert!(validate_name("acme/my-profile-123"));
-    }
-
-    #[test]
-    fn validate_name_invalid() {
-        assert!(!validate_name("default")); // no org
-        assert!(!validate_name("/default")); // empty org
-        assert!(!validate_name("vm0/")); // empty name
-        assert!(!validate_name("vm0/my/nested")); // extra slash
-        assert!(!validate_name("VM0/default")); // uppercase
-        assert!(!validate_name("vm0/Default")); // uppercase
-        assert!(!validate_name("vm0/def ault")); // space
-    }
-
-    #[test]
-    fn validate_name_accepts_edge_hyphens() {
-        // TS contract `[a-z0-9-]+/[a-z0-9-]+` accepts leading/trailing
-        // hyphens, so we accept them too for cross-language consistency.
-        assert!(validate_name("-vm0/default"));
-        assert!(validate_name("vm0/default-"));
-    }
-
-    #[test]
     fn validate_or_err_passes_for_valid_name() {
         assert!(validate_or_err("vm0/default").is_ok());
     }
@@ -122,8 +71,9 @@ mod tests {
     #[test]
     fn validate_or_err_carries_offending_name_in_message() {
         let err = validate_or_err("/etc").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("invalid profile name"), "got: {msg}");
-        assert!(msg.contains("/etc"), "got: {msg}");
+        assert_eq!(
+            err.to_string(),
+            "config error: invalid profile name: /etc (must be org/name format, lowercase alphanumeric + hyphens)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add one runner-private `org_name` predicate for the shared group/profile format
- keep group- and profile-specific validation errors while delegating their syntax check
- consolidate ASCII, shape, edge-hyphen, Unicode, and path-traversal coverage beside the canonical predicate
- point Rust parity documentation at the current `api-contracts` files

## Scope

This is an internal Rust refactor. It does not change accepted names, error messages, APIs, persisted data, runner protocols, or rollout behavior.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- repository pre-commit and commit-message hooks

Closes #25779
