### PR TITLE
fix(runner): reject mismatched local result identities

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -708,6 +708,12 @@ impl SubmitPlan {
     fn finish_completed(&self, buf: &[u8]) -> RunnerResult<ExitCode> {
         let response: JobResponse = serde_json::from_slice(buf)
             .map_err(|e| RunnerError::Internal(format!("parse result: {e}")))?;
+        if response.run_id != self.queue.job_id {
+            return Err(RunnerError::Internal(format!(
+                "local result run_id mismatch: expected {}, actual {}",
+                self.queue.job_id, response.run_id
+            )));
+        }
 
         self.queue.cleanup_completed();
 

--- a/crates/runner/src/cmd/local/submit/tests/completed_cleanup.rs
+++ b/crates/runner/src/cmd/local/submit/tests/completed_cleanup.rs
@@ -1,9 +1,12 @@
 use std::process::ExitCode;
 
-use super::super::SubmitArgs;
-use super::support::{run_submit_and_write_result, submit_queue_entry, write_queue_job_file};
+use super::super::{SubmitArgs, run_submit_with_home};
+use super::support::{
+    TEST_SUBMIT_RENDEZVOUS_TIMEOUT, run_submit_and_write_result, submit_args_for_test,
+    submit_queue_entry, wait_for_job_and_write_result, write_queue_job_file,
+};
 use crate::ids::RunId;
-use crate::local_queue;
+use crate::local_queue::{self, JobResponse};
 use crate::paths::HomePaths;
 
 #[tokio::test]
@@ -40,6 +43,51 @@ async fn submit_returns_failure_for_nonzero_job_response() {
         !result_path.exists(),
         "completed cleanup should remove nonzero result files"
     );
+}
+
+#[tokio::test]
+async fn submit_rejects_mismatched_result_identity_before_cleanup() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let args = submit_args_for_test();
+    let group_dir = home.groups_dir().join(&args.group);
+    let actual_run_id = RunId::new_v4();
+
+    let (result, request) = tokio::time::timeout(TEST_SUBMIT_RENDEZVOUS_TIMEOUT, async {
+        tokio::join!(
+            run_submit_with_home(args, home),
+            wait_for_job_and_write_result(
+                group_dir.clone(),
+                crate::profile::DEFAULT_PROFILE.to_owned(),
+                0,
+                None,
+                Some(actual_run_id),
+            ),
+        )
+    })
+    .await
+    .expect("local submit mismatch rendezvous should not time out");
+    let error = result.expect_err("mismatched result identity should fail local submit");
+    let queue = submit_queue_entry(&group_dir, request.job_id);
+
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "internal error: local result run_id mismatch: expected {}, actual {}",
+            request.job_id, actual_run_id
+        )
+    );
+    assert!(
+        queue.job.exists(),
+        "mismatched results must not finalize the submitted job"
+    );
+    assert!(
+        queue.result.exists(),
+        "mismatched results must remain available for diagnosis"
+    );
+    let response: JobResponse =
+        serde_json::from_slice(&std::fs::read(&queue.result).unwrap()).unwrap();
+    assert_eq!(response.run_id, actual_run_id);
 }
 
 #[test]

--- a/crates/runner/src/cmd/local/submit/tests/support.rs
+++ b/crates/runner/src/cmd/local/submit/tests/support.rs
@@ -8,7 +8,7 @@ use crate::ids::RunId;
 use crate::local_queue::{self, JobRequest, JobResponse};
 use crate::paths::HomePaths;
 
-const TEST_SUBMIT_RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(5);
+pub(super) const TEST_SUBMIT_RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(5);
 const TEST_SUBMIT_QUEUE_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 pub(super) fn submit_queue_entry(group_dir: &Path, job_id: RunId) -> SubmitQueueEntry {
@@ -26,11 +26,12 @@ pub(super) fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777
 }
 
-async fn wait_for_job_and_write_result(
+pub(super) async fn wait_for_job_and_write_result(
     group_dir: std::path::PathBuf,
     profile: String,
     exit_code: i32,
     error: Option<String>,
+    response_run_id: Option<RunId>,
 ) -> JobRequest {
     let job_dir = local_queue::profile_jobs_dir(&group_dir, &profile).unwrap();
     loop {
@@ -43,7 +44,7 @@ async fn wait_for_job_and_write_result(
                 let request: JobRequest =
                     serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
                 let response = JobResponse {
-                    run_id: request.job_id,
+                    run_id: response_run_id.unwrap_or(request.job_id),
                     exit_code,
                     error: error.clone(),
                 };
@@ -91,8 +92,14 @@ async fn run_submit_and_write_result_with_timeout(
     let rendezvous = async move {
         tokio::try_join!(run_submit_with_home(args, home), async move {
             Ok::<JobRequest, crate::error::RunnerError>(
-                wait_for_job_and_write_result(watched_group_dir, watched_profile, exit_code, error)
-                    .await,
+                wait_for_job_and_write_result(
+                    watched_group_dir,
+                    watched_profile,
+                    exit_code,
+                    error,
+                    None,
+                )
+                .await,
             )
         })
     };


### PR DESCRIPTION
## Summary

- reject local result payloads whose `run_id` does not match the submitted queue identity
- fail before completed-result cleanup, stdout output, or exit-code mapping so invalid state remains diagnosable
- cover the mismatch through the real local-submit filesystem rendezvous while retaining matching success and nonzero coverage

## Compatibility

- no queue schema, payload shape, filename, writer, database, migration, or feature-switch changes
- matching results from existing runner versions retain their current behavior

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner --all-targets --all-features` (3,081 passed; 20 ignored)

Closes #25777
