### PR TITLE
fix(platform): gate foreground catch-up on clerk recovery

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -9,6 +9,7 @@ type SessionTouchImpl = (options?: { intent?: "focus" }) => Promise<void>;
 
 interface MockedClerkSession {
   readonly id: string;
+  readonly lastActiveOrganizationId: string | null;
   readonly getToken: GetTokenImpl;
   readonly touch: SessionTouchImpl;
 }
@@ -259,6 +260,7 @@ const defaultBuildUserProfileUrlImpl = () => {
 interface MockedClerkLoadOptions {
   isSatellite?: boolean;
   signInUrl?: string;
+  touchSession?: boolean;
 }
 
 interface MockedSignInRedirectOptions {
@@ -349,6 +351,9 @@ export const mockedClerk = {
     }
     return {
       id: "test-session-id",
+      get lastActiveOrganizationId() {
+        return internalMockedOrganization?.id ?? null;
+      },
       getToken: sessionGetToken,
       touch: sessionTouch,
     };

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -24,7 +24,7 @@ import { vi } from "vitest";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { setMockFeatureSwitches } from "../mocks/handlers/api-feature-switches.helpers";
-import { FEATURE_SWITCH_CACHE_KEY } from "../signals/external/feature-switch";
+import { FEATURE_SWITCH_CACHE_KEY } from "../signals/external/feature-switch-state";
 import { localStorageSignals } from "../signals/external/local-storage";
 import { setDebugLoggerLocalStorage$ } from "../signals/bootstrap/loggers";
 import { detach, Reason } from "../signals/utils";

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -27,7 +27,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
-import { FEATURE_SWITCH_CACHE_KEY } from "../../signals/external/feature-switch.ts";
+import { FEATURE_SWITCH_CACHE_KEY } from "../../signals/external/feature-switch-state.ts";
 import { mockApi } from "../msw-contract.ts";
 import {
   testConnectorCatalogCategoryMetadata,

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { HttpResponse } from "msw";
+import { command } from "ccstate";
 import { CLIENT_FORCE_UPGRADE_STATUS } from "@vm0/api-contracts/contracts/client-headers";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import {
   clearMockedAuth,
@@ -19,9 +22,25 @@ import {
 import { setRootSignal$ } from "../root-signal.ts";
 import { resetSignal } from "../utils.ts";
 import { testContext } from "./test-helpers.ts";
+import { FEATURE_SWITCH_CACHE_KEY } from "../external/feature-switch.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
 
 const context = testContext();
 const resetAuthRecoverySignal$ = resetSignal();
+const { set$: setFeatureSwitchCacheLocalStorage$ } = localStorageSignals(
+  FEATURE_SWITCH_CACHE_KEY,
+);
+
+const enableForegroundAuthRecovery$ = command(({ set }) => {
+  set(
+    setFeatureSwitchCacheLocalStorage$,
+    JSON.stringify(
+      getAllFeatureStates({
+        overrides: { [FeatureSwitchKey.ForegroundAuthRecovery]: true },
+      }),
+    ),
+  );
+});
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -55,6 +74,10 @@ function mockSignedInUser(): void {
   context.signal.addEventListener("abort", () => {
     clearMockedAuth();
   });
+}
+
+function enableForegroundAuthRecovery(): void {
+  context.store.set(enableForegroundAuthRecovery$);
 }
 
 function setBrowserUrl(url: string): void {
@@ -146,6 +169,7 @@ describe("api client headers", () => {
 
   it("retries fetch$ auth recovery network failures without redirecting", async () => {
     mockSignedInUser();
+    enableForegroundAuthRecovery();
     context.store.set(setRootSignal$, context.signal);
     let requests = 0;
     let forcedTokenRefreshes = 0;
@@ -191,6 +215,7 @@ describe("api client headers", () => {
     await expect(response.json()).resolves.toStrictEqual({ recovered: true });
     expect(requests).toBe(3);
     expect(forcedTokenRefreshes).toBe(3);
+    expect(mockedClerk.sessionTouch).not.toHaveBeenCalled();
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
 
@@ -245,6 +270,7 @@ describe("api client headers", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toStrictEqual({ recovered: true });
     expect(authorizationHeaders).toStrictEqual([null, "Bearer fresh-token"]);
+    expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
 

--- a/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-headers.test.ts
@@ -22,7 +22,7 @@ import {
 import { setRootSignal$ } from "../root-signal.ts";
 import { resetSignal } from "../utils.ts";
 import { testContext } from "./test-helpers.ts";
-import { FEATURE_SWITCH_CACHE_KEY } from "../external/feature-switch.ts";
+import { FEATURE_SWITCH_CACHE_KEY } from "../external/feature-switch-state.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 
 const context = testContext();
@@ -167,7 +167,7 @@ describe("api client headers", () => {
     expect(second.requestId).not.toBe(first.requestId);
   });
 
-  it("retries fetch$ auth recovery network failures without redirecting", async () => {
+  it("recovers an enabled non-realtime 401 without a foreground task", async () => {
     mockSignedInUser();
     enableForegroundAuthRecovery();
     context.store.set(setRootSignal$, context.signal);
@@ -215,7 +215,7 @@ describe("api client headers", () => {
     await expect(response.json()).resolves.toStrictEqual({ recovered: true });
     expect(requests).toBe(3);
     expect(forcedTokenRefreshes).toBe(3);
-    expect(mockedClerk.sessionTouch).not.toHaveBeenCalled();
+    expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(3);
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
 

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -235,6 +235,7 @@ describe("platform auth redirects", () => {
       afterSignOutUrl: "https://app.vm0.ai/sign-in",
       signInUrl: "https://app.vm0.ai/sign-in",
       signUpUrl: "https://app.vm0.ai/sign-up",
+      touchSession: false,
       ui: expect.objectContaining({
         ClerkUI: expect.any(Function),
         version: "1.27.0",
@@ -270,6 +271,7 @@ describe("platform auth redirects", () => {
       satelliteAutoSync: true,
       signInUrl: "https://app.vm0.ai/sign-in",
       signUpUrl: "https://app.vm0.ai/sign-up",
+      touchSession: false,
       ui: expect.objectContaining({
         ClerkUI: expect.any(Function),
         version: "1.27.0",

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -1,4 +1,5 @@
 import { waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { detachedSetupPage, setupPage } from "../../__tests__/page-helper.ts";
@@ -211,7 +212,7 @@ describe("platform auth redirects", () => {
     });
   });
 
-  it("uses app auth for non-preview org selection", async () => {
+  it("keeps Clerk focus touch for an org outside the rollout", async () => {
     setBrowserUrl("https://app.vm0.ai/agents");
 
     detachedSetupPage({
@@ -235,11 +236,33 @@ describe("platform auth redirects", () => {
       afterSignOutUrl: "https://app.vm0.ai/sign-in",
       signInUrl: "https://app.vm0.ai/sign-in",
       signUpUrl: "https://app.vm0.ai/sign-up",
-      touchSession: false,
+      touchSession: true,
       ui: expect.objectContaining({
         ClerkUI: expect.any(Function),
         version: "1.27.0",
       }),
+    });
+  });
+
+  it("lets the foreground barrier own Clerk focus touch in the rollout", async () => {
+    setBrowserUrl("https://app.vm0.ai/agents");
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.ForegroundAuthRecovery]: true,
+      },
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_member" }],
+      },
+      path: "/agents",
+    });
+
+    await waitFor(() => {
+      expect(mockedClerkLoad).toHaveBeenCalledWith(
+        expect.objectContaining({ touchSession: false }),
+      );
     });
   });
 
@@ -271,7 +294,7 @@ describe("platform auth redirects", () => {
       satelliteAutoSync: true,
       signInUrl: "https://app.vm0.ai/sign-in",
       signUpUrl: "https://app.vm0.ai/sign-up",
-      touchSession: false,
+      touchSession: true,
       ui: expect.objectContaining({
         ClerkUI: expect.any(Function),
         version: "1.27.0",

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -212,7 +212,7 @@ describe("platform auth redirects", () => {
     });
   });
 
-  it("keeps Clerk focus touch for an org outside the rollout", async () => {
+  it("keeps foreground touch under one owner outside the rollout", async () => {
     setBrowserUrl("https://app.vm0.ai/agents");
 
     detachedSetupPage({
@@ -236,7 +236,7 @@ describe("platform auth redirects", () => {
       afterSignOutUrl: "https://app.vm0.ai/sign-in",
       signInUrl: "https://app.vm0.ai/sign-in",
       signUpUrl: "https://app.vm0.ai/sign-up",
-      touchSession: true,
+      touchSession: false,
       ui: expect.objectContaining({
         ClerkUI: expect.any(Function),
         version: "1.27.0",
@@ -244,7 +244,7 @@ describe("platform auth redirects", () => {
     });
   });
 
-  it("lets the foreground barrier own Clerk focus touch in the rollout", async () => {
+  it("keeps the same foreground touch owner inside the rollout", async () => {
     setBrowserUrl("https://app.vm0.ai/agents");
 
     detachedSetupPage({
@@ -294,7 +294,7 @@ describe("platform auth redirects", () => {
       satelliteAutoSync: true,
       signInUrl: "https://app.vm0.ai/sign-in",
       signUpUrl: "https://app.vm0.ai/sign-up",
-      touchSession: true,
+      touchSession: false,
       ui: expect.objectContaining({
         ClerkUI: expect.any(Function),
         version: "1.27.0",

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -2,11 +2,14 @@ import { command } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { waitFor } from "@testing-library/react";
 import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   clearMockedAuth,
   mockOrganization,
+  mockedClerk,
   mockUser,
 } from "../../__tests__/mock-auth.ts";
 import {
@@ -17,8 +20,24 @@ import {
 } from "../realtime.ts";
 import { subscribeChatThreadRealtime$ } from "../chat-page/chat-thread-remote-signals.ts";
 import { testContext } from "./test-helpers.ts";
+import { FEATURE_SWITCH_CACHE_KEY } from "../external/feature-switch.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
 
 const context = testContext();
+const { set$: setFeatureSwitchCacheLocalStorage$ } = localStorageSignals(
+  FEATURE_SWITCH_CACHE_KEY,
+);
+
+const enableForegroundAuthRecovery$ = command(({ set }) => {
+  set(
+    setFeatureSwitchCacheLocalStorage$,
+    JSON.stringify(
+      getAllFeatureStates({
+        overrides: { [FeatureSwitchKey.ForegroundAuthRecovery]: true },
+      }),
+    ),
+  );
+});
 
 const finishLoop$ = command((_ctx, _signal: AbortSignal) => {
   return true;
@@ -51,6 +70,10 @@ function mockSignedInUser(): void {
     activeOrg: { id: "test-org-123", name: "Test Organization" },
     memberships: [{ id: "test-org-123" }],
   });
+}
+
+function enableForegroundAuthRecovery(): void {
+  context.store.set(enableForegroundAuthRecovery$);
 }
 
 function abortError(message: string): Error {
@@ -246,10 +269,51 @@ describe("realtime signals", () => {
     await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
   });
 
-  it("reruns an active loop when the tab becomes visible", async () => {
+  it("reruns immediately when foreground auth recovery is disabled", async () => {
     mockSignedInUser();
+    const topic = "test:visibility-disabled";
+    const subscriber = new AbortController();
+    let runs = 0;
+    const loop$ = command((_ctx, _signal: AbortSignal) => {
+      runs += 1;
+      return false;
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    const loopPromise = context.store.set(
+      setAblyLoop$,
+      {
+        topic,
+        loopCommand$: loop$,
+      },
+      subscriber.signal,
+    );
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+    });
+    context.mocks.ably.trigger(topic);
+    await waitFor(() => {
+      expect(runs).toBe(1);
+    });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => {
+      expect(runs).toBe(2);
+    });
+    expect(mockedClerk.sessionTouch).not.toHaveBeenCalled();
+
+    subscriber.abort(abortError("test done"));
+    await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("waits for one foreground auth recovery before rerunning an active loop", async () => {
+    mockSignedInUser();
+    enableForegroundAuthRecovery();
     const topic = "test:visibility";
     const subscriber = new AbortController();
+    const touchCanFinish = context.mocks.deferred<void>();
+    mockedClerk.sessionTouch.mockReturnValue(touchCanFinish.promise);
     let runs = 0;
     const loop$ = command((_ctx, _signal: AbortSignal) => {
       runs += 1;
@@ -276,9 +340,67 @@ describe("realtime signals", () => {
 
     expect(document.visibilityState).toBe("visible");
     document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    });
+    expect(runs).toBe(1);
+
+    touchCanFinish.resolve();
     await waitFor(() => {
       expect(runs).toBe(2);
     });
+
+    subscriber.abort(abortError("test done"));
+    await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("retries Clerk-wrapped foreground network failures before catch-up", async () => {
+    mockSignedInUser();
+    enableForegroundAuthRecovery();
+    const topic = "test:visibility-network-retry";
+    const subscriber = new AbortController();
+    let touchAttempts = 0;
+    mockedClerk.sessionTouch.mockImplementation(() => {
+      touchAttempts += 1;
+      if (touchAttempts === 1) {
+        return Promise.reject(
+          new Error(
+            'ClerkJS: Network error at "https://clerk.example.test/touch" - TypeError: Load failed',
+          ),
+        );
+      }
+      return Promise.resolve();
+    });
+    let runs = 0;
+    const loop$ = command((_ctx, _signal: AbortSignal) => {
+      runs += 1;
+      return false;
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    const loopPromise = context.store.set(
+      setAblyLoop$,
+      {
+        topic,
+        loopCommand$: loop$,
+      },
+      subscriber.signal,
+    );
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+    });
+    context.mocks.ably.trigger(topic);
+    await waitFor(() => {
+      expect(runs).toBe(1);
+    });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => {
+      expect(runs).toBe(2);
+    });
+    expect(touchAttempts).toBe(2);
 
     subscriber.abort(abortError("test done"));
     await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import { HttpResponse } from "msw";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { waitFor } from "@testing-library/react";
 import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
@@ -18,9 +19,11 @@ import {
   setAblyMessageLoop$,
   setAblyPayloadLoop$,
 } from "../realtime.ts";
+import { fetch$ } from "../fetch.ts";
+import { setRootSignal$ } from "../root-signal.ts";
 import { subscribeChatThreadRealtime$ } from "../chat-page/chat-thread-remote-signals.ts";
 import { testContext } from "./test-helpers.ts";
-import { FEATURE_SWITCH_CACHE_KEY } from "../external/feature-switch.ts";
+import { FEATURE_SWITCH_CACHE_KEY } from "../external/feature-switch-state.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 
 const context = testContext();
@@ -353,6 +356,63 @@ describe("realtime signals", () => {
 
     subscriber.abort(abortError("test done"));
     await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("shares an in-flight foreground recovery with a concurrent 401", async () => {
+    mockSignedInUser();
+    enableForegroundAuthRecovery();
+    context.store.set(setRootSignal$, context.signal);
+    const touchCanFinish = context.mocks.deferred<void>();
+    mockedClerk.sessionTouch.mockReturnValue(touchCanFinish.promise);
+    let requests = 0;
+    let forcedTokenRefreshes = 0;
+    context.mocks.http.get("*/api/zero/foreground-auth-race-test", () => {
+      requests += 1;
+      if (requests === 1) {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "UNAUTHORIZED",
+              message: "Unauthorized",
+            },
+          },
+          { status: 401 },
+        );
+      }
+      return HttpResponse.json({ recovered: true });
+    });
+    mockedClerk.sessionGetToken.mockImplementation((options) => {
+      if (options?.skipCache) {
+        forcedTokenRefreshes += 1;
+        return Promise.resolve("fresh-token");
+      }
+      return Promise.resolve("test-token");
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    });
+
+    // eslint-disable-next-line ccstate/no-direct-fetch -- this regression verifies fetch$ joins the foreground barrier.
+    const responsePromise = context.store.get(fetch$)(
+      "/api/zero/foreground-auth-race-test",
+    );
+    await waitFor(() => {
+      expect(requests).toBe(1);
+    });
+    expect(forcedTokenRefreshes).toBe(0);
+
+    touchCanFinish.resolve();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ recovered: true });
+    expect(requests).toBe(2);
+    expect(forcedTokenRefreshes).toBe(2);
+    expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
 
   it("retries Clerk-wrapped foreground network failures before catch-up", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -1,8 +1,8 @@
 import { command } from "ccstate";
-import { HttpResponse } from "msw";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { waitFor } from "@testing-library/react";
 import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
+import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +11,7 @@ import {
   clearMockedAuth,
   mockOrganization,
   mockedClerk,
+  mockedClerkLoad,
   mockUser,
 } from "../../__tests__/mock-auth.ts";
 import {
@@ -19,26 +20,36 @@ import {
   setAblyMessageLoop$,
   setAblyPayloadLoop$,
 } from "../realtime.ts";
-import { fetch$ } from "../fetch.ts";
+import { setupClerk$ } from "../auth.ts";
 import { setRootSignal$ } from "../root-signal.ts";
 import { subscribeChatThreadRealtime$ } from "../chat-page/chat-thread-remote-signals.ts";
 import { testContext } from "./test-helpers.ts";
-import { FEATURE_SWITCH_CACHE_KEY } from "../external/feature-switch-state.ts";
-import { localStorageSignals } from "../external/local-storage.ts";
+import {
+  foregroundAuthRecoveryEnabled$,
+  setFeatureSwitchLocalStorage$,
+} from "../external/feature-switch-state.ts";
+import { reloadFeatureSwitch$ } from "../external/feature-switch.ts";
 
 const context = testContext();
-const { set$: setFeatureSwitchCacheLocalStorage$ } = localStorageSignals(
-  FEATURE_SWITCH_CACHE_KEY,
-);
 
-const enableForegroundAuthRecovery$ = command(({ set }) => {
+const setForegroundAuthRecovery$ = command(({ set }, enabled: boolean) => {
   set(
-    setFeatureSwitchCacheLocalStorage$,
+    setFeatureSwitchLocalStorage$,
     JSON.stringify(
       getAllFeatureStates({
-        overrides: { [FeatureSwitchKey.ForegroundAuthRecovery]: true },
+        overrides: { [FeatureSwitchKey.ForegroundAuthRecovery]: enabled },
       }),
     ),
+  );
+});
+
+const setMissingForegroundAuthRecovery$ = command(({ set }) => {
+  set(
+    setFeatureSwitchLocalStorage$,
+    JSON.stringify({
+      ...getAllFeatureStates({}),
+      [FeatureSwitchKey.ForegroundAuthRecovery]: undefined,
+    }),
   );
 });
 
@@ -75,8 +86,13 @@ function mockSignedInUser(): void {
   });
 }
 
-function enableForegroundAuthRecovery(): void {
-  context.store.set(enableForegroundAuthRecovery$);
+function setForegroundAuthRecovery(enabled: boolean): void {
+  context.store.set(setForegroundAuthRecovery$, enabled);
+}
+
+async function setupAuthAndRealtime(): Promise<void> {
+  await context.store.set(setupClerk$, context.signal);
+  await context.store.set(setupRealtime$, context.signal);
 }
 
 function abortError(message: string): Error {
@@ -272,17 +288,83 @@ describe("realtime signals", () => {
     await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
   });
 
-  it("reruns immediately when foreground auth recovery is disabled", async () => {
+  it("uses hydrated rollout state when the initial cache is missing the key", async () => {
     mockSignedInUser();
+    mockOrganization({
+      activeOrg: { id: "staff-org-123", name: "Staff Organization" },
+      memberships: [{ id: "staff-org-123" }],
+    });
+    context.store.set(setMissingForegroundAuthRecovery$);
     const topic = "test:visibility-disabled";
     const subscriber = new AbortController();
+    const touchCanFinish = context.mocks.deferred<void>();
+    mockedClerk.sessionTouch.mockReturnValue(touchCanFinish.promise);
     let runs = 0;
     const loop$ = command((_ctx, _signal: AbortSignal) => {
       runs += 1;
       return false;
     });
 
-    await context.store.set(setupRealtime$, context.signal);
+    await setupAuthAndRealtime();
+    expect(context.store.get(foregroundAuthRecoveryEnabled$)).toBeFalsy();
+    setForegroundAuthRecovery(true);
+    expect(context.store.get(foregroundAuthRecoveryEnabled$)).toBeTruthy();
+    const loopPromise = context.store.set(
+      setAblyLoop$,
+      {
+        topic,
+        loopCommand$: loop$,
+      },
+      subscriber.signal,
+    );
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+    });
+    context.mocks.ably.trigger(topic);
+    await waitFor(() => {
+      expect(runs).toBe(1);
+    });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    });
+    expect(runs).toBe(1);
+    expect(mockedClerkLoad).toHaveBeenCalledWith(
+      expect.objectContaining({ touchSession: false }),
+    );
+
+    touchCanFinish.resolve();
+    await waitFor(() => {
+      expect(runs).toBe(2);
+    });
+
+    subscriber.abort(abortError("test done"));
+    await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("uses refreshed external-org state after a stale staff cache loaded Clerk", async () => {
+    mockSignedInUser();
+    mockOrganization({
+      activeOrg: { id: "external-org-123", name: "External Organization" },
+      memberships: [{ id: "external-org-123" }],
+    });
+    setForegroundAuthRecovery(true);
+    const topic = "test:visibility-stale-enabled-cache";
+    const subscriber = new AbortController();
+    const touchCanFinish = context.mocks.deferred<void>();
+    mockedClerk.sessionTouch.mockReturnValue(touchCanFinish.promise);
+    let runs = 0;
+    const loop$ = command((_ctx, _signal: AbortSignal) => {
+      runs += 1;
+      return false;
+    });
+
+    await setupAuthAndRealtime();
+    expect(context.store.get(foregroundAuthRecoveryEnabled$)).toBeTruthy();
+    setForegroundAuthRecovery(false);
+    expect(context.store.get(foregroundAuthRecoveryEnabled$)).toBeFalsy();
     const loopPromise = context.store.set(
       setAblyLoop$,
       {
@@ -304,15 +386,24 @@ describe("realtime signals", () => {
     await waitFor(() => {
       expect(runs).toBe(2);
     });
-    expect(mockedClerk.sessionTouch).not.toHaveBeenCalled();
+    expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    expect(mockedClerkLoad).toHaveBeenCalledWith(
+      expect.objectContaining({ touchSession: false }),
+    );
 
+    touchCanFinish.resolve();
+    await waitFor(() => {
+      expect(mockedClerk.sessionGetToken).toHaveBeenCalledWith({
+        skipCache: true,
+      });
+    });
     subscriber.abort(abortError("test done"));
     await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
   });
 
   it("waits for one foreground auth recovery before rerunning an active loop", async () => {
     mockSignedInUser();
-    enableForegroundAuthRecovery();
+    setForegroundAuthRecovery(true);
     const topic = "test:visibility";
     const subscriber = new AbortController();
     const touchCanFinish = context.mocks.deferred<void>();
@@ -323,7 +414,7 @@ describe("realtime signals", () => {
       return false;
     });
 
-    await context.store.set(setupRealtime$, context.signal);
+    await setupAuthAndRealtime();
     const loopPromise = context.store.set(
       setAblyLoop$,
       {
@@ -360,26 +451,23 @@ describe("realtime signals", () => {
 
   it("shares an in-flight foreground recovery with a concurrent 401", async () => {
     mockSignedInUser();
-    enableForegroundAuthRecovery();
+    setForegroundAuthRecovery(true);
     context.store.set(setRootSignal$, context.signal);
     const touchCanFinish = context.mocks.deferred<void>();
     mockedClerk.sessionTouch.mockReturnValue(touchCanFinish.promise);
     let requests = 0;
     let forcedTokenRefreshes = 0;
-    context.mocks.http.get("*/api/zero/foreground-auth-race-test", () => {
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       requests += 1;
       if (requests === 1) {
-        return HttpResponse.json(
-          {
-            error: {
-              code: "UNAUTHORIZED",
-              message: "Unauthorized",
-            },
+        return respond(401, {
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Unauthorized",
           },
-          { status: 401 },
-        );
+        });
       }
-      return HttpResponse.json({ recovered: true });
+      return respond(200, { switches: {}, effectiveSwitches: {} });
     });
     mockedClerk.sessionGetToken.mockImplementation((options) => {
       if (options?.skipCache) {
@@ -389,15 +477,15 @@ describe("realtime signals", () => {
       return Promise.resolve("test-token");
     });
 
-    await context.store.set(setupRealtime$, context.signal);
+    await setupAuthAndRealtime();
     document.dispatchEvent(new Event("visibilitychange"));
     await waitFor(() => {
       expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
     });
 
-    // eslint-disable-next-line ccstate/no-direct-fetch -- this regression verifies fetch$ joins the foreground barrier.
-    const responsePromise = context.store.get(fetch$)(
-      "/api/zero/foreground-auth-race-test",
+    const responsePromise = context.store.set(
+      reloadFeatureSwitch$,
+      context.signal,
     );
     await waitFor(() => {
       expect(requests).toBe(1);
@@ -405,10 +493,7 @@ describe("realtime signals", () => {
     expect(forcedTokenRefreshes).toBe(0);
 
     touchCanFinish.resolve();
-    const response = await responsePromise;
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toStrictEqual({ recovered: true });
+    await responsePromise;
     expect(requests).toBe(2);
     expect(forcedTokenRefreshes).toBe(2);
     expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
@@ -417,7 +502,7 @@ describe("realtime signals", () => {
 
   it("retries Clerk-wrapped foreground network failures before catch-up", async () => {
     mockSignedInUser();
-    enableForegroundAuthRecovery();
+    setForegroundAuthRecovery(true);
     const topic = "test:visibility-network-retry";
     const subscriber = new AbortController();
     let touchAttempts = 0;
@@ -438,7 +523,7 @@ describe("realtime signals", () => {
       return false;
     });
 
-    await context.store.set(setupRealtime$, context.signal);
+    await setupAuthAndRealtime();
     const loopPromise = context.store.set(
       setAblyLoop$,
       {

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -24,7 +24,7 @@ interface AuthedClientOptions {
   readonly baseUrl: string;
   readonly getClerk: () => Promise<ClerkLike>;
   readonly getRootSignal: () => AbortSignal;
-  readonly shouldTouchSessionOnUnauthorized?: () => boolean;
+  readonly getForegroundAuthRecovery?: () => Promise<boolean> | null;
   readonly getUnauthorizedRedirectSuppressionUntil?: () => number;
   readonly resolvePath?: (
     path: string,
@@ -80,7 +80,7 @@ export function createAuthedContractClient<T extends AppRouter>(
         const refreshResult = await fetchFreshToken(
           clerk,
           recoverySignal,
-          options.shouldTouchSessionOnUnauthorized?.() ?? true,
+          options.getForegroundAuthRecovery?.() ?? null,
         );
         if (refreshResult.status === "refreshed") {
           response = await retryAuthRecoveryOperation(() => {

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -24,6 +24,7 @@ interface AuthedClientOptions {
   readonly baseUrl: string;
   readonly getClerk: () => Promise<ClerkLike>;
   readonly getRootSignal: () => AbortSignal;
+  readonly shouldTouchSessionOnUnauthorized?: () => boolean;
   readonly getUnauthorizedRedirectSuppressionUntil?: () => number;
   readonly resolvePath?: (
     path: string,
@@ -76,7 +77,11 @@ export function createAuthedContractClient<T extends AppRouter>(
           options.getRootSignal(),
           args.fetchOptions?.signal,
         );
-        const refreshResult = await fetchFreshToken(clerk, recoverySignal);
+        const refreshResult = await fetchFreshToken(
+          clerk,
+          recoverySignal,
+          options.shouldTouchSessionOnUnauthorized?.() ?? true,
+        );
         if (refreshResult.status === "refreshed") {
           response = await retryAuthRecoveryOperation(() => {
             return requestWithToken(refreshResult.token, recoverySignal);

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -19,6 +19,7 @@ import {
 import { createAuthedContractClient } from "./api-client-base.ts";
 import { unauthorizedRedirectSuppressionUntil$ } from "./auth-retry.ts";
 import { rootSignal$ } from "./root-signal.ts";
+import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch.ts";
 
 /**
  * Type alias for the factory function returned by `get(zeroClient$)`.
@@ -78,6 +79,9 @@ export const zeroClient$ = computed((get) => {
       },
       getRootSignal: () => {
         return get(rootSignal$);
+      },
+      shouldTouchSessionOnUnauthorized: () => {
+        return !get(foregroundAuthRecoveryEnabled$);
       },
       getUnauthorizedRedirectSuppressionUntil: () => {
         return get(unauthorizedRedirectSuppressionUntil$);

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -17,9 +17,11 @@ import {
   resolveOAuthApiBase,
 } from "./api-base.ts";
 import { createAuthedContractClient } from "./api-client-base.ts";
-import { unauthorizedRedirectSuppressionUntil$ } from "./auth-retry.ts";
+import {
+  foregroundAuthRecovery$,
+  unauthorizedRedirectSuppressionUntil$,
+} from "./auth-retry.ts";
 import { rootSignal$ } from "./root-signal.ts";
-import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch.ts";
 
 /**
  * Type alias for the factory function returned by `get(zeroClient$)`.
@@ -80,8 +82,8 @@ export const zeroClient$ = computed((get) => {
       getRootSignal: () => {
         return get(rootSignal$);
       },
-      shouldTouchSessionOnUnauthorized: () => {
-        return !get(foregroundAuthRecoveryEnabled$);
+      getForegroundAuthRecovery: () => {
+        return get(foregroundAuthRecovery$);
       },
       getUnauthorizedRedirectSuppressionUntil: () => {
         return get(unauthorizedRedirectSuppressionUntil$);

--- a/turbo/apps/platform/src/signals/auth-retry.ts
+++ b/turbo/apps/platform/src/signals/auth-retry.ts
@@ -12,20 +12,27 @@ import { command, computed, state } from "ccstate";
 import type { Clerk } from "@clerk/clerk-js";
 import { isNetworkRequestError } from "../lib/network-error.ts";
 import { now } from "../lib/time.ts";
+import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch-state.ts";
+import { logger } from "./log.ts";
 import {
   createDeferredPromise,
   detach,
+  onDomEventFn,
   Reason,
+  resetSignal,
   retryWithFibonacciBackoff,
   withCleanup,
 } from "./utils";
 
 export type ClerkLike = Pick<
   Clerk,
-  "session" | "addListener" | "redirectToSignIn"
+  "session" | "organization" | "addListener" | "redirectToSignIn"
 >;
 
 const AUTH_TRANSITION_REDIRECT_SUPPRESSION_MS = 30_000;
+const FOREGROUND_CATCH_UP_EVENT = "catch-up";
+
+const L = logger("AuthRecovery");
 
 type FreshTokenResult =
   | { readonly status: "refreshed"; readonly token: string }
@@ -33,6 +40,8 @@ type FreshTokenResult =
 
 const unauthorizedRedirectSuppressionUntilState$ = state(0);
 const internalForegroundAuthRecovery$ = state<Promise<boolean> | null>(null);
+const foregroundCatchUpTarget$ = state(new EventTarget());
+const resetForegroundRecoverySignal$ = resetSignal();
 
 export const unauthorizedRedirectSuppressionUntil$ = computed((get) => {
   return get(unauthorizedRedirectSuppressionUntilState$);
@@ -42,17 +51,137 @@ export const foregroundAuthRecovery$ = computed((get) => {
   return get(internalForegroundAuthRecovery$);
 });
 
-export const setForegroundAuthRecovery$ = command(
+const setForegroundAuthRecovery$ = command(
   ({ set }, recovery: Promise<boolean>) => {
     set(internalForegroundAuthRecovery$, recovery);
   },
 );
 
-export const clearForegroundAuthRecovery$ = command(
+const clearForegroundAuthRecovery$ = command(
   ({ get, set }, recovery: Promise<boolean>) => {
     if (get(internalForegroundAuthRecovery$) === recovery) {
       set(internalForegroundAuthRecovery$, null);
     }
+  },
+);
+
+/**
+ * Subscribe to the centralized foreground catch-up gate. While the rollout is
+ * disabled, visibility resumes are emitted immediately to preserve the legacy
+ * realtime behavior. While enabled, they are emitted only after Clerk has
+ * touched the session and refreshed the active organization's token.
+ */
+export const subscribeForegroundCatchUp$ = command(
+  ({ get }, callback: () => void, signal: AbortSignal) => {
+    get(foregroundCatchUpTarget$).addEventListener(
+      FOREGROUND_CATCH_UP_EVENT,
+      callback,
+      { signal },
+    );
+  },
+);
+
+/**
+ * Own Clerk foreground session touch for every rollout state. Clerk's load
+ * options are one-shot, while feature-switch hydration is asynchronous, so
+ * ownership cannot safely be selected in `Clerk.load()`. The switch controls
+ * only whether downstream catch-up waits for this shared recovery.
+ */
+export const setupForegroundAuthRecovery$ = command(
+  ({ get, set }, clerk: ClerkLike, signal: AbortSignal) => {
+    let foregroundRecovery: Promise<boolean> | undefined;
+    let notifyAfterRecovery = false;
+    let catchUpNotified = false;
+
+    const notifyCatchUp = (): void => {
+      if (catchUpNotified) {
+        return;
+      }
+      catchUpNotified = true;
+      get(foregroundCatchUpTarget$).dispatchEvent(
+        new Event(FOREGROUND_CATCH_UP_EVENT),
+      );
+    };
+
+    const abortForegroundRecovery = (): void => {
+      set(resetForegroundRecoverySignal$);
+      if (foregroundRecovery) {
+        set(clearForegroundAuthRecovery$, foregroundRecovery);
+      }
+      foregroundRecovery = undefined;
+      notifyAfterRecovery = false;
+      catchUpNotified = false;
+    };
+
+    const recoverForeground = (
+      waitBeforeCatchUp: boolean,
+    ): Promise<boolean> => {
+      notifyAfterRecovery ||= waitBeforeCatchUp;
+      if (foregroundRecovery) {
+        return foregroundRecovery;
+      }
+
+      catchUpNotified = false;
+      const expectedOrgId = clerk.organization?.id ?? null;
+      const recoverySignal = set(resetForegroundRecoverySignal$, signal);
+      const recovery = withCleanup(
+        (async () => {
+          const ready = await resumeClerkSession(
+            clerk,
+            expectedOrgId,
+            recoverySignal,
+          );
+          recoverySignal.throwIfAborted();
+          if (!ready) {
+            return false;
+          }
+          if (notifyAfterRecovery) {
+            L.debug("foreground auth ready, notifying catch-up subscribers");
+            notifyCatchUp();
+          }
+          return true;
+        })(),
+        () => {
+          if (foregroundRecovery === recovery) {
+            foregroundRecovery = undefined;
+            notifyAfterRecovery = false;
+            catchUpNotified = false;
+          }
+          set(clearForegroundAuthRecovery$, recovery);
+        },
+      );
+      foregroundRecovery = recovery;
+      set(setForegroundAuthRecovery$, recovery);
+      return recovery;
+    };
+
+    const recoverOnFocus = onDomEventFn(async () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      await recoverForeground(get(foregroundAuthRecoveryEnabled$));
+    });
+
+    document.addEventListener(
+      "visibilitychange",
+      onDomEventFn(async () => {
+        if (document.visibilityState !== "visible") {
+          abortForegroundRecovery();
+          return;
+        }
+
+        const waitBeforeCatchUp = get(foregroundAuthRecoveryEnabled$);
+        const recovery = recoverForeground(waitBeforeCatchUp);
+        if (!waitBeforeCatchUp) {
+          L.debug("tab visible, notifying catch-up subscribers immediately");
+          notifyCatchUp();
+        }
+        await recovery;
+      }),
+      { signal },
+    );
+    window.addEventListener("focus", recoverOnFocus, { signal });
+    signal.addEventListener("abort", abortForegroundRecovery, { once: true });
   },
 );
 
@@ -159,9 +288,9 @@ function waitForForegroundRecovery(
  * Resume Clerk's foreground session before visibility-driven data catch-up.
  * The caller owns foreground lifecycle coalescing and cancellation.
  */
-export async function resumeClerkSession(
+async function resumeClerkSession(
   clerk: ClerkLike,
-  expectedOrgId: string,
+  expectedOrgId: string | null,
   signal: AbortSignal,
 ): Promise<boolean> {
   const session = await waitForSettledClerkSession(clerk, signal);
@@ -174,7 +303,11 @@ export async function resumeClerkSession(
     signal.throwIfAborted();
     return session.getToken({ skipCache: true });
   }, signal);
-  return Boolean(token && session.lastActiveOrganizationId === expectedOrgId);
+  return Boolean(
+    token &&
+    (expectedOrgId === null ||
+      session.lastActiveOrganizationId === expectedOrgId),
+  );
 }
 
 function isClerkOfflineError(error: unknown): boolean {

--- a/turbo/apps/platform/src/signals/auth-retry.ts
+++ b/turbo/apps/platform/src/signals/auth-retry.ts
@@ -2,12 +2,11 @@
  * Auth retry helpers shared by `fetch$` (signals/fetch.ts) and
  * `zeroClient$` (signals/api-client.ts).
  *
- * On a 401 response we refresh Clerk and replay the request. During the
- * foreground-recovery rollout, the legacy arm touches the session first while
- * the enabled arm relies on the foreground barrier's completed touch.
- * Network failures during recovery or replay retry with fibonacci backoff.
- * Only an explicit 401 after recovery falls back to
- * `clerk.redirectToSignIn()`.
+ * On a 401 response we refresh Clerk and replay the request. A request that
+ * observes an active foreground recovery joins that exact task; every other
+ * request touches the session itself. Network failures during recovery or
+ * replay retry with fibonacci backoff. Only an explicit 401 after recovery
+ * falls back to `clerk.redirectToSignIn()`.
  */
 import { command, computed, state } from "ccstate";
 import type { Clerk } from "@clerk/clerk-js";
@@ -18,6 +17,7 @@ import {
   detach,
   Reason,
   retryWithFibonacciBackoff,
+  withCleanup,
 } from "./utils";
 
 export type ClerkLike = Pick<
@@ -32,10 +32,29 @@ type FreshTokenResult =
   | { readonly status: "unavailable" };
 
 const unauthorizedRedirectSuppressionUntilState$ = state(0);
+const internalForegroundAuthRecovery$ = state<Promise<boolean> | null>(null);
 
 export const unauthorizedRedirectSuppressionUntil$ = computed((get) => {
   return get(unauthorizedRedirectSuppressionUntilState$);
 });
+
+export const foregroundAuthRecovery$ = computed((get) => {
+  return get(internalForegroundAuthRecovery$);
+});
+
+export const setForegroundAuthRecovery$ = command(
+  ({ set }, recovery: Promise<boolean>) => {
+    set(internalForegroundAuthRecovery$, recovery);
+  },
+);
+
+export const clearForegroundAuthRecovery$ = command(
+  ({ get, set }, recovery: Promise<boolean>) => {
+    if (get(internalForegroundAuthRecovery$) === recovery) {
+      set(internalForegroundAuthRecovery$, null);
+    }
+  },
+);
 
 export const suppressUnauthorizedRedirectForAuthTransition$ = command(
   ({ get, set }) => {
@@ -91,20 +110,25 @@ function waitForSettledClerkSession(
 /**
  * Refresh the Clerk session token. Network failures retry until the request's
  * owning signal aborts, so a temporarily offline browser does not turn into a
- * sign-in redirect. The rollout's legacy arm also touches the session first.
+ * sign-in redirect. Only a request that joins a successful active foreground
+ * recovery can reuse its completed session touch.
  */
 export async function fetchFreshToken(
   clerk: ClerkLike,
   signal: AbortSignal,
-  touchSession: boolean,
+  foregroundRecovery: Promise<boolean> | null = null,
 ): Promise<FreshTokenResult> {
   const session = await waitForSettledClerkSession(clerk, signal);
   if (session === null) {
     return { status: "unavailable" };
   }
 
+  const foregroundReady = foregroundRecovery
+    ? await waitForForegroundRecovery(foregroundRecovery, signal)
+    : false;
+
   const token = await retryAuthRecoveryOperation(async () => {
-    if (touchSession) {
+    if (!foregroundReady) {
       await session.touch({ intent: "focus" });
       signal.throwIfAborted();
     }
@@ -114,6 +138,21 @@ export async function fetchFreshToken(
     return { status: "unavailable" };
   }
   return { status: "refreshed", token };
+}
+
+function waitForForegroundRecovery(
+  recovery: Promise<boolean>,
+  signal: AbortSignal,
+): Promise<boolean> {
+  signal.throwIfAborted();
+  const aborted = createDeferredPromise<never>(signal);
+  return withCleanup(Promise.race([recovery, aborted.promise]), () => {
+    if (!aborted.settled()) {
+      aborted.reject(
+        new DOMException("Foreground recovery settled", "AbortError"),
+      );
+    }
+  });
 }
 
 /**

--- a/turbo/apps/platform/src/signals/auth-retry.ts
+++ b/turbo/apps/platform/src/signals/auth-retry.ts
@@ -2,8 +2,10 @@
  * Auth retry helpers shared by `fetch$` (signals/fetch.ts) and
  * `zeroClient$` (signals/api-client.ts).
  *
- * On a 401 response we force-refresh the Clerk JWT and replay the request.
- * Network failures during either recovery step retry with fibonacci backoff.
+ * On a 401 response we refresh Clerk and replay the request. During the
+ * foreground-recovery rollout, the legacy arm touches the session first while
+ * the enabled arm relies on the foreground barrier's completed touch.
+ * Network failures during recovery or replay retry with fibonacci backoff.
  * Only an explicit 401 after recovery falls back to
  * `clerk.redirectToSignIn()`.
  */
@@ -87,17 +89,14 @@ function waitForSettledClerkSession(
 }
 
 /**
- * Force-refresh the Clerk session token. Network failures retry until the
- * request's owning signal aborts, so a temporarily offline browser does not
- * turn into a sign-in redirect.
- *
- * Concurrent 401s may each trigger their own refresh, but Clerk's FAPI
- * internally dedups in-flight token requests, so the extra traffic is
- * bounded and not worth adding module-level state to avoid.
+ * Refresh the Clerk session token. Network failures retry until the request's
+ * owning signal aborts, so a temporarily offline browser does not turn into a
+ * sign-in redirect. The rollout's legacy arm also touches the session first.
  */
 export async function fetchFreshToken(
   clerk: ClerkLike,
   signal: AbortSignal,
+  touchSession: boolean,
 ): Promise<FreshTokenResult> {
   const session = await waitForSettledClerkSession(clerk, signal);
   if (session === null) {
@@ -105,13 +104,38 @@ export async function fetchFreshToken(
   }
 
   const token = await retryAuthRecoveryOperation(async () => {
-    await session.touch({ intent: "focus" });
+    if (touchSession) {
+      await session.touch({ intent: "focus" });
+      signal.throwIfAborted();
+    }
     return session.getToken({ skipCache: true });
   }, signal);
   if (!token) {
     return { status: "unavailable" };
   }
   return { status: "refreshed", token };
+}
+
+/**
+ * Resume Clerk's foreground session before visibility-driven data catch-up.
+ * The caller owns foreground lifecycle coalescing and cancellation.
+ */
+export async function resumeClerkSession(
+  clerk: ClerkLike,
+  expectedOrgId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const session = await waitForSettledClerkSession(clerk, signal);
+  if (session === null) {
+    return false;
+  }
+
+  const token = await retryAuthRecoveryOperation(async () => {
+    await session.touch({ intent: "focus" });
+    signal.throwIfAborted();
+    return session.getToken({ skipCache: true });
+  }, signal);
+  return Boolean(token && session.lastActiveOrganizationId === expectedOrgId);
 }
 
 function isClerkOfflineError(error: unknown): boolean {
@@ -123,8 +147,18 @@ function isClerkOfflineError(error: unknown): boolean {
   );
 }
 
+function isClerkNetworkError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.startsWith("ClerkJS: Network error")
+  );
+}
+
 function isAuthRecoveryNetworkError(error: unknown): boolean {
-  return isClerkOfflineError(error) || isNetworkRequestError(error);
+  return (
+    isClerkOfflineError(error) ||
+    isClerkNetworkError(error) ||
+    isNetworkRequestError(error)
+  );
 }
 
 export function retryAuthRecoveryOperation<T>(

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -13,7 +13,7 @@ import {
   resolvePlatformRuntimeConfig,
 } from "../lib/platform-host.ts";
 import { bestEffort, onDomEventFn } from "./utils.ts";
-import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch-state.ts";
+import { setupForegroundAuthRecovery$ } from "./auth-retry.ts";
 
 const reload$ = state(0);
 const clerkVersion$ = state(0);
@@ -344,7 +344,7 @@ export const clerk$ = computed(async (get) => {
   const satelliteConfig = resolveClerkSatelliteConfig();
   await clerkInstance.load({
     ui,
-    touchSession: !get(foregroundAuthRecoveryEnabled$),
+    touchSession: false,
     ...(satelliteConfig
       ? {
           isSatellite: true,
@@ -368,6 +368,7 @@ export const setupClerk$ = command(
   async ({ set, get }, signal: AbortSignal) => {
     const clerk = await get(clerk$);
     signal.throwIfAborted();
+    set(setupForegroundAuthRecovery$, clerk, signal);
 
     // Set initial Sentry user context
     if (clerk.user) {

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -13,6 +13,7 @@ import {
   resolvePlatformRuntimeConfig,
 } from "../lib/platform-host.ts";
 import { bestEffort, onDomEventFn } from "./utils.ts";
+import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch-state.ts";
 
 const reload$ = state(0);
 const clerkVersion$ = state(0);
@@ -343,7 +344,7 @@ export const clerk$ = computed(async (get) => {
   const satelliteConfig = resolveClerkSatelliteConfig();
   await clerkInstance.load({
     ui,
-    touchSession: false,
+    touchSession: !get(foregroundAuthRecoveryEnabled$),
     ...(satelliteConfig
       ? {
           isSatellite: true,

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -343,6 +343,7 @@ export const clerk$ = computed(async (get) => {
   const satelliteConfig = resolveClerkSatelliteConfig();
   await clerkInstance.load({
     ui,
+    touchSession: false,
     ...(satelliteConfig
       ? {
           isSatellite: true,

--- a/turbo/apps/platform/src/signals/external/feature-switch-state.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch-state.ts
@@ -1,0 +1,28 @@
+import { computed } from "ccstate";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { localStorageSignals } from "./local-storage.ts";
+
+export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v3";
+
+const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
+  localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
+
+export { setFeatureSwitchLocalStorage$ };
+
+export const featureSwitchCacheState$ = computed((get) => {
+  const raw = get(featureSwitchCache$);
+  if (!raw) {
+    // First-ever load: identity-gated switches start disabled until
+    // `reloadFeatureSwitch$` populates the cache.
+    return getAllFeatureStates({});
+  }
+  return JSON.parse(raw) as Record<FeatureSwitchKey, boolean>;
+});
+
+export const foregroundAuthRecoveryEnabled$ = computed((get): boolean => {
+  return (
+    get(featureSwitchCacheState$)[FeatureSwitchKey.ForegroundAuthRecovery] ??
+    false
+  );
+});

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -8,12 +8,10 @@ import { resolveApiBaseForTarget } from "../api-base.ts";
 import { createAuthedContractClient } from "../api-client-base.ts";
 import { unauthorizedRedirectSuppressionUntil$ } from "../auth-retry.ts";
 import { rootSignal$ } from "../root-signal.ts";
-import { localStorageSignals } from "./local-storage.ts";
-
-export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v3";
-
-const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
-  localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
+import {
+  featureSwitchCacheState$,
+  setFeatureSwitchLocalStorage$,
+} from "./feature-switch-state.ts";
 
 // Pinned to the API backend: feature switches bootstrap before the platform API
 // client is available.
@@ -49,13 +47,7 @@ function applySwitches(
 }
 
 export const featureSwitch$ = computed((get) => {
-  const raw = get(featureSwitchCache$);
-  if (!raw) {
-    // First-ever load: identity-gated switches start disabled until
-    // `reloadFeatureSwitch$` populates the cache.
-    return getAllFeatureStates({});
-  }
-  return JSON.parse(raw) as Record<FeatureSwitchKey, boolean>;
+  return get(featureSwitchCacheState$);
 });
 
 export const imageRecognitionAvailable$ = computed((): boolean => {
@@ -72,10 +64,6 @@ export const videoTemplateOptionsEnabled$ = computed((get): boolean => {
 
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
-});
-
-export const foregroundAuthRecoveryEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.ForegroundAuthRecovery] ?? false;
 });
 
 export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -74,6 +74,10 @@ export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });
 
+export const foregroundAuthRecoveryEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.ForegroundAuthRecovery] ?? false;
+});
+
 export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
   return (
     get(featureSwitch$)[FeatureSwitchKey.ComposerConnectorPermissions] ?? false

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -6,7 +6,10 @@ import { clerk$ } from "../auth";
 import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForTarget } from "../api-base.ts";
 import { createAuthedContractClient } from "../api-client-base.ts";
-import { unauthorizedRedirectSuppressionUntil$ } from "../auth-retry.ts";
+import {
+  foregroundAuthRecovery$,
+  unauthorizedRedirectSuppressionUntil$,
+} from "../auth-retry.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import {
   featureSwitchCacheState$,
@@ -23,6 +26,9 @@ const apiFeatureSwitchClient$ = computed((get) => {
     },
     getRootSignal: () => {
       return get(rootSignal$);
+    },
+    getForegroundAuthRecovery: () => {
+      return get(foregroundAuthRecovery$);
     },
     getUnauthorizedRedirectSuppressionUntil: () => {
       return get(unauthorizedRedirectSuppressionUntil$);

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -4,6 +4,7 @@ import { clerk$ } from "./auth.ts";
 import {
   authRecoverySignal,
   fetchFreshToken,
+  foregroundAuthRecovery$,
   handleUnauthorizedRedirect,
   retryAuthRecoveryOperation,
   unauthorizedRedirectSuppressionUntil$,
@@ -12,7 +13,6 @@ import { resolveApiBase, resolveOAuthApiBase } from "./api-base.ts";
 import { addClientHeaders } from "./client-headers.ts";
 import { reportForceUpgradeResponse } from "./force-upgrade.ts";
 import { rootSignal$ } from "./root-signal.ts";
-import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch.ts";
 
 /**
  * OAuth navigation uses the direct API in preview/development so those
@@ -184,7 +184,7 @@ export const fetch$ = computed((get) => {
       const refreshResult = await fetchFreshToken(
         clerk,
         recoverySignal,
-        !get(foregroundAuthRecoveryEnabled$),
+        get(foregroundAuthRecovery$),
       );
       if (refreshResult.status === "refreshed") {
         response = await retryAuthRecoveryOperation(async () => {

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -12,6 +12,7 @@ import { resolveApiBase, resolveOAuthApiBase } from "./api-base.ts";
 import { addClientHeaders } from "./client-headers.ts";
 import { reportForceUpgradeResponse } from "./force-upgrade.ts";
 import { rootSignal$ } from "./root-signal.ts";
+import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch.ts";
 
 /**
  * OAuth navigation uses the direct API in preview/development so those
@@ -180,7 +181,11 @@ export const fetch$ = computed((get) => {
         get(rootSignal$),
         options?.signal ?? (url instanceof Request ? url.signal : undefined),
       );
-      const refreshResult = await fetchFreshToken(clerk, recoverySignal);
+      const refreshResult = await fetchFreshToken(
+        clerk,
+        recoverySignal,
+        !get(foregroundAuthRecoveryEnabled$),
+      );
       if (refreshResult.status === "refreshed") {
         response = await retryAuthRecoveryOperation(async () => {
           return await performFetch(refreshResult.token, recoverySignal);

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -5,10 +5,15 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { delay } from "signal-timers";
 import { IN_VITEST } from "../env.ts";
 import { zeroClient$ } from "./api-client.ts";
+import { resumeClerkSession, type ClerkLike } from "./auth-retry.ts";
+import { clerk$ } from "./auth.ts";
+import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch.ts";
 import { createAblyAuthCallback } from "../lib/ably-auth.ts";
 import {
   createDeferredPromise,
+  onDomEventFn,
   onRejection,
+  resetSignal,
   setLoop,
   throwIfAbort,
   withCleanup,
@@ -114,6 +119,87 @@ interface RealtimePayloadLoopIterationArgs {
   readonly catchUpCommand$?: Command<Promise<boolean> | boolean, [AbortSignal]>;
   readonly pokeLoop: () => void;
 }
+
+interface SetupForegroundRecoveryArgs {
+  readonly clerk: ClerkLike;
+  readonly expectedOrgId: string;
+  readonly subscriberPokeTarget: EventTarget;
+}
+
+const resetForegroundRecoverySignal$ = resetSignal();
+
+const setupForegroundRecovery$ = command(
+  (
+    { get, set },
+    { clerk, expectedOrgId, subscriberPokeTarget }: SetupForegroundRecoveryArgs,
+    signal: AbortSignal,
+  ) => {
+    let foregroundRecovery: Promise<void> | undefined;
+
+    const abortForegroundRecovery = (): void => {
+      set(resetForegroundRecoverySignal$);
+      foregroundRecovery = undefined;
+    };
+
+    const recoverForeground = (): Promise<void> => {
+      if (foregroundRecovery) {
+        return foregroundRecovery;
+      }
+
+      const recoverySignal = set(resetForegroundRecoverySignal$, signal);
+      const recovery = withCleanup(
+        (async () => {
+          const ready = await resumeClerkSession(
+            clerk,
+            expectedOrgId,
+            recoverySignal,
+          );
+          recoverySignal.throwIfAborted();
+          if (!ready) {
+            return;
+          }
+          L.debug("foreground auth ready, poking subscribers");
+          subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
+        })(),
+        () => {
+          if (foregroundRecovery === recovery) {
+            foregroundRecovery = undefined;
+          }
+        },
+      );
+      foregroundRecovery = recovery;
+      return recovery;
+    };
+
+    const recoverOnForeground = onDomEventFn(async () => {
+      if (
+        document.visibilityState !== "visible" ||
+        !get(foregroundAuthRecoveryEnabled$)
+      ) {
+        return;
+      }
+      await recoverForeground();
+    });
+
+    document.addEventListener(
+      "visibilitychange",
+      (event) => {
+        if (document.visibilityState !== "visible") {
+          abortForegroundRecovery();
+          return;
+        }
+        if (!get(foregroundAuthRecoveryEnabled$)) {
+          L.debug("tab visible, poking subscribers");
+          subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
+          return;
+        }
+        recoverOnForeground(event);
+      },
+      { signal },
+    );
+    window.addEventListener("focus", recoverOnForeground, { signal });
+  },
+);
 
 async function waitForTransientRetry(
   signal: AbortSignal,
@@ -446,6 +532,13 @@ const runWithChannelPayload$ = command(
  */
 export const setupRealtime$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    const organization = clerk.organization;
+    if (!organization) {
+      throw new Error("Authenticated organization is required for realtime");
+    }
+
     const createClient = get(zeroClient$);
     const client = createClient(platformRealtimeTokenContract);
 
@@ -501,16 +594,14 @@ export const setupRealtime$ = command(
       subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
     });
 
-    document.addEventListener(
-      "visibilitychange",
-      () => {
-        if (document.visibilityState !== "visible") {
-          return;
-        }
-        L.debug("tab visible, poking subscribers");
-        subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
+    set(
+      setupForegroundRecovery$,
+      {
+        clerk,
+        expectedOrgId: organization.id,
+        subscriberPokeTarget,
       },
-      { signal },
+      signal,
     );
 
     await deferred.promise;

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -5,20 +5,11 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { delay } from "signal-timers";
 import { IN_VITEST } from "../env.ts";
 import { zeroClient$ } from "./api-client.ts";
-import {
-  clearForegroundAuthRecovery$,
-  resumeClerkSession,
-  setForegroundAuthRecovery$,
-  type ClerkLike,
-} from "./auth-retry.ts";
-import { clerk$ } from "./auth.ts";
-import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch-state.ts";
+import { subscribeForegroundCatchUp$ } from "./auth-retry.ts";
 import { createAblyAuthCallback } from "../lib/ably-auth.ts";
 import {
   createDeferredPromise,
-  onDomEventFn,
   onRejection,
-  resetSignal,
   setLoop,
   throwIfAbort,
   withCleanup,
@@ -124,93 +115,6 @@ interface RealtimePayloadLoopIterationArgs {
   readonly catchUpCommand$?: Command<Promise<boolean> | boolean, [AbortSignal]>;
   readonly pokeLoop: () => void;
 }
-
-interface SetupForegroundRecoveryArgs {
-  readonly clerk: ClerkLike;
-  readonly expectedOrgId: string;
-  readonly subscriberPokeTarget: EventTarget;
-}
-
-const resetForegroundRecoverySignal$ = resetSignal();
-
-const setupForegroundRecovery$ = command(
-  (
-    { get, set },
-    { clerk, expectedOrgId, subscriberPokeTarget }: SetupForegroundRecoveryArgs,
-    signal: AbortSignal,
-  ) => {
-    let foregroundRecovery: Promise<boolean> | undefined;
-
-    const abortForegroundRecovery = (): void => {
-      set(resetForegroundRecoverySignal$);
-      if (foregroundRecovery) {
-        set(clearForegroundAuthRecovery$, foregroundRecovery);
-      }
-      foregroundRecovery = undefined;
-    };
-
-    const recoverForeground = (): Promise<boolean> => {
-      if (foregroundRecovery) {
-        return foregroundRecovery;
-      }
-
-      const recoverySignal = set(resetForegroundRecoverySignal$, signal);
-      const recovery = withCleanup(
-        (async () => {
-          const ready = await resumeClerkSession(
-            clerk,
-            expectedOrgId,
-            recoverySignal,
-          );
-          recoverySignal.throwIfAborted();
-          if (!ready) {
-            return false;
-          }
-          L.debug("foreground auth ready, poking subscribers");
-          subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
-          return true;
-        })(),
-        () => {
-          if (foregroundRecovery === recovery) {
-            foregroundRecovery = undefined;
-          }
-          set(clearForegroundAuthRecovery$, recovery);
-        },
-      );
-      foregroundRecovery = recovery;
-      set(setForegroundAuthRecovery$, recovery);
-      return recovery;
-    };
-
-    const recoverOnForeground = onDomEventFn(async () => {
-      if (
-        document.visibilityState !== "visible" ||
-        !get(foregroundAuthRecoveryEnabled$)
-      ) {
-        return;
-      }
-      await recoverForeground();
-    });
-
-    document.addEventListener(
-      "visibilitychange",
-      (event) => {
-        if (document.visibilityState !== "visible") {
-          abortForegroundRecovery();
-          return;
-        }
-        if (!get(foregroundAuthRecoveryEnabled$)) {
-          L.debug("tab visible, poking subscribers");
-          subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
-          return;
-        }
-        recoverOnForeground(event);
-      },
-      { signal },
-    );
-    window.addEventListener("focus", recoverOnForeground, { signal });
-  },
-);
 
 async function waitForTransientRetry(
   signal: AbortSignal,
@@ -543,13 +447,6 @@ const runWithChannelPayload$ = command(
  */
 export const setupRealtime$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
-    const organization = clerk.organization;
-    if (!organization) {
-      throw new Error("Authenticated organization is required for realtime");
-    }
-
     const createClient = get(zeroClient$);
     const client = createClient(platformRealtimeTokenContract);
 
@@ -606,11 +503,10 @@ export const setupRealtime$ = command(
     });
 
     set(
-      setupForegroundRecovery$,
-      {
-        clerk,
-        expectedOrgId: organization.id,
-        subscriberPokeTarget,
+      subscribeForegroundCatchUp$,
+      () => {
+        L.debug("foreground catch-up ready, poking subscribers");
+        subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
       },
       signal,
     );

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -5,9 +5,14 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { delay } from "signal-timers";
 import { IN_VITEST } from "../env.ts";
 import { zeroClient$ } from "./api-client.ts";
-import { resumeClerkSession, type ClerkLike } from "./auth-retry.ts";
+import {
+  clearForegroundAuthRecovery$,
+  resumeClerkSession,
+  setForegroundAuthRecovery$,
+  type ClerkLike,
+} from "./auth-retry.ts";
 import { clerk$ } from "./auth.ts";
-import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch.ts";
+import { foregroundAuthRecoveryEnabled$ } from "./external/feature-switch-state.ts";
 import { createAblyAuthCallback } from "../lib/ably-auth.ts";
 import {
   createDeferredPromise,
@@ -134,14 +139,17 @@ const setupForegroundRecovery$ = command(
     { clerk, expectedOrgId, subscriberPokeTarget }: SetupForegroundRecoveryArgs,
     signal: AbortSignal,
   ) => {
-    let foregroundRecovery: Promise<void> | undefined;
+    let foregroundRecovery: Promise<boolean> | undefined;
 
     const abortForegroundRecovery = (): void => {
       set(resetForegroundRecoverySignal$);
+      if (foregroundRecovery) {
+        set(clearForegroundAuthRecovery$, foregroundRecovery);
+      }
       foregroundRecovery = undefined;
     };
 
-    const recoverForeground = (): Promise<void> => {
+    const recoverForeground = (): Promise<boolean> => {
       if (foregroundRecovery) {
         return foregroundRecovery;
       }
@@ -156,18 +164,21 @@ const setupForegroundRecovery$ = command(
           );
           recoverySignal.throwIfAborted();
           if (!ready) {
-            return;
+            return false;
           }
           L.debug("foreground auth ready, poking subscribers");
           subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
+          return true;
         })(),
         () => {
           if (foregroundRecovery === recovery) {
             foregroundRecovery = undefined;
           }
+          set(clearForegroundAuthRecovery$, recovery);
         },
       );
       foregroundRecovery = recovery;
+      set(setForegroundAuthRecovery$, recovery);
       return recovery;
     };
 

--- a/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { resolvePlatformRuntimeConfig } from "../../lib/platform-host.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { locale$ } from "../../signals/locale.ts";
+import { foregroundAuthRecoveryEnabled$ } from "../../signals/external/feature-switch-state.ts";
 import {
   clerkInstance$,
   clerkUi$,
@@ -29,6 +30,7 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
   const clerkUi = useGet(clerkUi$);
   const brandName = useGet(brandName$);
   const locale = useGet(locale$);
+  const foregroundAuthRecoveryEnabled = useGet(foregroundAuthRecoveryEnabled$);
 
   const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
   const appUrl = resolveAppUrl();
@@ -46,7 +48,7 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
     signInUrl: resolveAppAuthUrl("/sign-in"),
     signUpFallbackRedirectUrl: appUrl,
     signUpUrl: resolveAppAuthUrl("/sign-up"),
-    touchSession: false,
+    touchSession: !foregroundAuthRecoveryEnabled,
     ui: clerkUi,
   };
   return satelliteConfig ? (

--- a/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from "react-i18next";
 import { resolvePlatformRuntimeConfig } from "../../lib/platform-host.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { locale$ } from "../../signals/locale.ts";
-import { foregroundAuthRecoveryEnabled$ } from "../../signals/external/feature-switch-state.ts";
 import {
   clerkInstance$,
   clerkUi$,
@@ -30,7 +29,6 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
   const clerkUi = useGet(clerkUi$);
   const brandName = useGet(brandName$);
   const locale = useGet(locale$);
-  const foregroundAuthRecoveryEnabled = useGet(foregroundAuthRecoveryEnabled$);
 
   const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
   const appUrl = resolveAppUrl();
@@ -48,7 +46,7 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
     signInUrl: resolveAppAuthUrl("/sign-in"),
     signUpFallbackRedirectUrl: appUrl,
     signUpUrl: resolveAppAuthUrl("/sign-up"),
-    touchSession: !foregroundAuthRecoveryEnabled,
+    touchSession: false,
     ui: clerkUi,
   };
   return satelliteConfig ? (

--- a/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
@@ -46,6 +46,7 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
     signInUrl: resolveAppAuthUrl("/sign-in"),
     signUpFallbackRedirectUrl: appUrl,
     signUpUrl: resolveAppAuthUrl("/sign-up"),
+    touchSession: false,
     ui: clerkUi,
   };
   return satelliteConfig ? (

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -99,6 +99,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ForegroundAuthRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
     );
@@ -117,6 +118,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ForegroundAuthRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -60,6 +60,7 @@ export enum FeatureSwitchKey {
   ZapierConnector = "zapierConnector",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",
+  ForegroundAuthRecovery = "foregroundAuthRecovery",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   TeamsIntegration = "teamsIntegration",
   FeishuIntegration = "feishuIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -365,6 +365,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ForegroundAuthRecovery]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Wait for Clerk foreground session recovery before realtime catch-up.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.SharedThreadSharing]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add the `ForegroundAuthRecovery` feature switch, default it off, and enable it for every organization in `STAFF_ORG_ID_HASHES`
- make the auth bootstrap the single owner of foreground Clerk session touch in every rollout state, with `Clerk.load()` consistently using `touchSession: false` so asynchronous feature-switch hydration cannot create duplicate owners or an ownership gap
- preserve immediate visibility catch-up while the switch is disabled; when enabled, release centralized foreground subscribers only after one shared Clerk touch, fresh token, and matching active organization
- let concurrent 401 recovery, including the bootstrap feature-switch client, join the exact in-flight foreground task while requests without one retain request-owned recovery
- cover an existing v3 cache without the new key, stale staff-to-external-org cache state, visibility/focus coalescing, Clerk network retry, and the concurrent-401 race through production setup/client boundaries

## Fallbacks

- `auth-retry.ts:setupForegroundAuthRecovery$` — while `ForegroundAuthRecovery` is disabled, the centralized owner still touches Clerk on foreground but releases visibility catch-up immediately, preserving the pre-rollout timing. Surface: none — non-GA feature switch. Removal condition: once the rollout is terminal, remove the switch, disabled branch, and disabled-arm tests together. Follow-up: terminal cleanup PR, not yet opened.
- `auth-retry.ts:fetchFreshToken` touching on a 401 with no successful active foreground task is request recovery, not a rollout fallback; it remains necessary for requests that do not coincide with a foreground recovery.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm check-types`
- `pnpm exec vitest run apps/platform/src/signals/__tests__/auth-url.test.ts apps/platform/src/signals/__tests__/realtime.test.ts apps/platform/src/signals/__tests__/api-client-headers.test.ts apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.ts` (51 tests)
- `corepack pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only` (24 tests)
- pre-commit: Prettier, Knip, typecheck, file-size check, and commitlint
