### PR TITLE
refactor(runner): remove runner preference migration bridge

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -2404,19 +2404,21 @@ mod tests {
             cleared_body["telemetry"]["runnerPreferenceClaimState"],
             "cleared"
         );
-        let absent = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
-            .with_no_runner_preference_for_test(RunnerNoPreferenceReason::NoViableHolder);
-        let absent_body = serde_json::to_value(claim_request_body_for_test(&absent)).unwrap();
+        let no_preference =
+            JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
+                .with_no_runner_preference_for_test(RunnerNoPreferenceReason::NoViableHolder);
+        let no_preference_body =
+            serde_json::to_value(claim_request_body_for_test(&no_preference)).unwrap();
         assert_eq!(
-            absent_body["telemetry"]["runnerPreference"]["kind"],
+            no_preference_body["telemetry"]["runnerPreference"]["kind"],
             "noPreference"
         );
         assert_eq!(
-            absent_body["telemetry"]["runnerPreference"]["reason"],
+            no_preference_body["telemetry"]["runnerPreference"]["reason"],
             "noViableHolder"
         );
         assert!(
-            absent_body["telemetry"]
+            no_preference_body["telemetry"]
                 .get("runnerPreferenceClaimState")
                 .is_none()
         );

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -593,40 +593,18 @@ impl JobProvider for ApiProvider {
                     let reuse_key = job.reuse_key().map(str::to_owned);
                     let history_generation_run_id = job.history_generation_run_id;
                     let pi_execution_mode = job.pi_execution_mode;
-                    let runner_preference_context = match parse_runner_preference(
-                        job.runner_preference,
-                    ) {
-                        Ok(Some(context)) => Some(context),
-                        Ok(None) => match parse_runner_preference(job.runner_preference_decision) {
+                    let runner_preference_context =
+                        match parse_runner_preference(job.runner_preference) {
                             Ok(context) => context,
                             Err(error) => {
                                 warn!(
                                     run_id = %run_id,
                                     error = %error,
-                                    "poll: invalid compatibility runner preference, using ordinary admission"
+                                    "poll: invalid runner preference, using ordinary admission"
                                 );
                                 None
                             }
-                        },
-                        Err(error) => {
-                            warn!(
-                                run_id = %run_id,
-                                error = %error,
-                                "poll: invalid canonical runner preference, trying compatibility field"
-                            );
-                            match parse_runner_preference(job.runner_preference_decision) {
-                                Ok(context) => context,
-                                Err(error) => {
-                                    warn!(
-                                        run_id = %run_id,
-                                        error = %error,
-                                        "poll: invalid compatibility runner preference, using ordinary admission"
-                                    );
-                                    None
-                                }
-                            }
-                        }
-                    };
+                        };
                     let profile = job.experimental_profile;
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
@@ -2359,17 +2337,7 @@ mod tests {
         assert!(body["telemetry"].get("runnerPreference").is_none());
         assert!(
             body["telemetry"]
-                .get("runnerPreferenceResolution")
-                .is_none()
-        );
-        assert!(
-            body["telemetry"]
                 .get("runnerPreferenceClaimState")
-                .is_none()
-        );
-        assert!(
-            body["telemetry"]
-                .get("runnerPreferenceTargetedSelf")
                 .is_none()
         );
         assert!(!body.to_string().contains("rawSizeBytes"));
@@ -2406,16 +2374,6 @@ mod tests {
         assert_eq!(
             active_body["telemetry"]["runnerPreferenceClaimState"],
             "active"
-        );
-        assert!(
-            active_body["telemetry"]
-                .get("runnerPreferenceResolution")
-                .is_none()
-        );
-        assert!(
-            active_body["telemetry"]
-                .get("runnerPreferenceTargetedSelf")
-                .is_none()
         );
 
         let expired_preference = ActiveRunnerPreference::ranked_for_test(
@@ -2694,10 +2652,6 @@ mod tests {
                             },
                             "tier": "exactSandbox",
                             "expiresAt": "2999-01-01T00:00:00.000Z"
-                        },
-                        "runnerPreferenceDecision": {
-                            "kind": "noPreference",
-                            "reason": "noReuseKey"
                         }
                     }
                 }));
@@ -2751,10 +2705,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_falls_back_to_compatibility_poll_preference() {
+    async fn discover_parses_canonical_no_preference() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
-        let selected_runner_id = "00000000-0000-0000-0000-000000000005";
         let mock = server
             .mock_async(|when, then| {
                 when.method(POST).path(routes::runners::poll::POLL.path);
@@ -2762,67 +2715,7 @@ mod tests {
                     "job": {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
-                        "reuseKey": "thread:decision-poll",
                         "runnerPreference": {
-                            "kind": "futurePreference"
-                        },
-                        "runnerPreferenceDecision": {
-                            "kind": "preference",
-                            "runnerIdentity": {
-                                "runnerId": selected_runner_id,
-                                "heartbeatGeneration": 7
-                            },
-                            "tier": "workspaceCache",
-                            "expiresAt": "2999-01-01T00:00:00.000Z"
-                        }
-                    }
-                }));
-            })
-            .await;
-        let provider = api_provider_for_test_with_supported_profiles(
-            server.base_url(),
-            CancellationToken::new(),
-            Arc::new(PollWakeups::new(false)),
-            vec!["vm0/default".to_string()],
-        );
-
-        let candidate = tokio::time::timeout(Duration::from_secs(1), provider.discover())
-            .await
-            .expect("discover should poll after wakeup")
-            .expect("job candidate");
-
-        assert_eq!(
-            candidate
-                .runner_preference()
-                .map(ActiveRunnerPreference::tier),
-            Some(RunnerPreferenceTier::WorkspaceCache)
-        );
-        let telemetry = candidate
-            .runner_preference_claim_telemetry()
-            .expect("compatibility preference telemetry");
-        assert!(matches!(
-            telemetry.runner_preference,
-            RunnerPreference::Preference {
-                tier: RunnerPreferenceTier::WorkspaceCache,
-                ..
-            }
-        ));
-        assert_eq!(telemetry.state, Some(RunnerPreferenceClaimState::Active));
-        mock.assert_async().await;
-    }
-
-    #[tokio::test]
-    async fn discover_parses_negative_compatibility_poll_preference() {
-        let server = MockServer::start_async().await;
-        let run_id = RunId::new_v4();
-        let mock = server
-            .mock_async(|when, then| {
-                when.method(POST).path(routes::runners::poll::POLL.path);
-                then.status(200).json_body(serde_json::json!({
-                    "job": {
-                        "runId": run_id,
-                        "experimentalProfile": "vm0/default",
-                        "runnerPreferenceDecision": {
                             "kind": "noPreference",
                             "reason": "noViableHolder"
                         }
@@ -2845,7 +2738,7 @@ mod tests {
         assert!(candidate.runner_preference().is_none());
         let telemetry = candidate
             .runner_preference_claim_telemetry()
-            .expect("negative compatibility preference telemetry");
+            .expect("no-preference telemetry");
         assert!(matches!(
             telemetry.runner_preference,
             RunnerPreference::NoPreference {
@@ -2857,7 +2750,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_preserves_poll_job_after_malformed_compatibility_preference() {
+    async fn discover_preserves_poll_job_after_malformed_preference() {
         let server = MockServer::start_async().await;
         let run_id = RunId::new_v4();
         let mock = server
@@ -2868,7 +2761,7 @@ mod tests {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
                         "reuseKey": "thread:malformed-preference",
-                        "runnerPreferenceDecision": {
+                        "runnerPreference": {
                             "kind": "preference",
                             "runnerIdentity": {
                                 "runnerId": TEST_RUNNER_ID,
@@ -2895,6 +2788,41 @@ mod tests {
 
         assert_eq!(candidate.run_id(), run_id);
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
+        assert!(candidate.runner_preference().is_none());
+        assert!(candidate.runner_preference_claim_telemetry().is_none());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_preserves_poll_job_without_preference() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::new_v4();
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": run_id,
+                        "experimentalProfile": "vm0/default",
+                        "reuseKey": "thread:missing-preference"
+                    }
+                }));
+            })
+            .await;
+        let provider = api_provider_for_test_with_supported_profiles(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+            vec!["vm0/default".to_string()],
+        );
+
+        let candidate = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should preserve the job")
+            .expect("job candidate");
+
+        assert_eq!(candidate.run_id(), run_id);
+        assert_eq!(candidate.reuse_key(), Some("thread:missing-preference"));
         assert!(candidate.runner_preference().is_none());
         assert!(candidate.runner_preference_claim_telemetry().is_none());
         mock.assert_async().await;

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1047,42 +1047,18 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         },
         None => None,
     };
-    let runner_preference_context = match parse_runner_preference(
-        msg.data.get("runnerPreference").cloned(),
-    ) {
-        Ok(Some(context)) => Some(context),
-        Ok(None) => {
-            match parse_runner_preference(msg.data.get("runnerPreferenceDecision").cloned()) {
-                Ok(context) => context,
-                Err(error) => {
-                    warn!(
-                        run_id = %run_id,
-                        error = %error,
-                        "ably: invalid compatibility runner preference, using ordinary admission"
-                    );
-                    None
-                }
+    let runner_preference_context =
+        match parse_runner_preference(msg.data.get("runnerPreference").cloned()) {
+            Ok(context) => context,
+            Err(error) => {
+                warn!(
+                    run_id = %run_id,
+                    error = %error,
+                    "ably: invalid runner preference, using ordinary admission"
+                );
+                None
             }
-        }
-        Err(error) => {
-            warn!(
-                run_id = %run_id,
-                error = %error,
-                "ably: invalid canonical runner preference, trying compatibility field"
-            );
-            match parse_runner_preference(msg.data.get("runnerPreferenceDecision").cloned()) {
-                Ok(context) => context,
-                Err(error) => {
-                    warn!(
-                        run_id = %run_id,
-                        error = %error,
-                        "ably: invalid compatibility runner preference, using ordinary admission"
-                    );
-                    None
-                }
-            }
-        }
-    };
+        };
     Some(JobNotification {
         run_id,
         profile,
@@ -2039,10 +2015,6 @@ mod tests {
                     },
                     "tier": "reusableSandbox",
                     "expiresAt": "2999-01-01T00:00:00.000Z"
-                },
-                "runnerPreferenceDecision": {
-                    "kind": "noPreference",
-                    "reason": "noReuseKey"
                 }
             }),
         );
@@ -2117,7 +2089,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn malformed_canonical_preference_uses_compatibility_value() {
+    async fn malformed_preference_preserves_direct_candidate() {
         let tokens = RunCancellationRegistry::new();
         let wakeups = PollWakeups::new(true);
         let direct_candidates = direct_candidate_inbox();
@@ -2143,10 +2115,6 @@ mod tests {
                     },
                     "tier": "workspaceCache",
                     "expiresAt": "2999-01-01T00:00:00.000Z"
-                },
-                "runnerPreferenceDecision": {
-                    "kind": "noPreference",
-                    "reason": "noViableHolder"
                 }
             }),
         );
@@ -2158,14 +2126,40 @@ mod tests {
             .into_job_candidate();
         assert_eq!(candidate.reuse_key(), Some("thread:malformed-preference"));
         assert!(candidate.runner_preference().is_none());
-        let telemetry = candidate
-            .runner_preference_claim_telemetry()
-            .expect("compatibility preference telemetry");
-        assert!(matches!(
-            telemetry.runner_preference,
-            RunnerPreference::NoPreference { .. }
-        ));
-        assert_eq!(telemetry.state, None);
+        assert!(candidate.runner_preference_claim_telemetry().is_none());
+        assert_no_direct_candidate(&direct_candidates).await;
+    }
+
+    #[tokio::test]
+    async fn missing_preference_preserves_direct_candidate() {
+        let tokens = RunCancellationRegistry::new();
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000012",
+                "profile": "vm0/default",
+                "reuseKey": "thread:missing-preference"
+            }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        let candidate = pop_direct_candidate(&direct_candidates)
+            .await
+            .into_job_candidate();
+        assert_eq!(candidate.reuse_key(), Some("thread:missing-preference"));
+        assert!(candidate.runner_preference().is_none());
+        assert!(candidate.runner_preference_claim_telemetry().is_none());
         assert_no_direct_candidate(&direct_candidates).await;
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -49,8 +49,6 @@ pub struct Job {
     pub pi_execution_mode: Option<PiExecutionMode>,
     #[serde(default)]
     pub runner_preference: Option<serde_json::Value>,
-    #[serde(default)]
-    pub runner_preference_decision: Option<serde_json::Value>,
 }
 
 pub(crate) fn reuse_key_kind(reuse_key: &str) -> &'static str {
@@ -1687,10 +1685,6 @@ mod tests {
                     },
                     "tier": "reusableSandbox",
                     "expiresAt": "2026-08-03T12:00:00.000Z"
-                },
-                "runnerPreferenceDecision": {
-                    "kind": "noPreference",
-                    "reason": "noReuseKey"
                 }
             }
         });
@@ -1705,7 +1699,6 @@ mod tests {
         assert_eq!(job.experimental_profile, "browser");
         assert_eq!(job.pi_execution_mode, Some(PiExecutionMode::Standby));
         assert!(job.runner_preference.is_some());
-        assert!(job.runner_preference_decision.is_some());
         assert!(job.reuse_key().is_none());
     }
 

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -460,7 +460,6 @@ export async function publishRunnerJobNotification(args: {
           ? { historyGenerationRunId: args.metadata.historyGenerationRunId }
           : {}),
         runnerPreference: args.runnerPreference,
-        runnerPreferenceDecision: args.runnerPreference,
       });
       L.debug(
         `Published job ${args.runId} to runner-group:${args.group} (broadcast)`,

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -2109,14 +2109,14 @@ describe("PiLoop edge turn", () => {
         .slice(publishedBeforeRelease)
         .some(([topic, payload]) => {
           const job = recordOf(payload);
-          const decision = recordOf(job?.runnerPreferenceDecision);
+          const preference = recordOf(job?.runnerPreference);
           return (
             topic === "job" &&
             job?.runId === run.runId &&
             job.profile === fixture.runnerProfile &&
             job.piExecutionMode === "cold-start" &&
-            decision?.kind === "noPreference" &&
-            decision.reason === "noReuseKey"
+            preference?.kind === "noPreference" &&
+            preference.reason === "noReuseKey"
           );
         }),
     ).toBeTruthy();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11581,19 +11581,6 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect(serialized).not.toContain(apiKey.token);
     }
     const timingEvents = sandboxOperationEventsForRun(first.runId);
-    const oldRunnerClaimEvent = singleSandboxOperationEvent(
-      timingEvents,
-      "claim_request_to_running",
-    );
-    expect(oldRunnerClaimEvent).not.toHaveProperty(
-      "runner_preference_resolution",
-    );
-    expect(oldRunnerClaimEvent).not.toHaveProperty(
-      "runner_preference_claim_state",
-    );
-    expect(oldRunnerClaimEvent).not.toHaveProperty(
-      "runner_preference_targeted_self",
-    );
     expect(
       timingEvents.find((event) => {
         return event.op_type === "job_discovered_to_claim_request";

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -134,10 +134,6 @@ const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const ASSISTANT_EVENT_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
-function runnerPreferenceDecision(job: RunnerJob | null | undefined) {
-  return job?.runnerPreferenceDecision;
-}
-
 function runnerPreference(job: RunnerJob | null | undefined) {
   return job?.runnerPreference;
 }
@@ -3645,7 +3641,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(poll.body.job?.runId).toBe(resumed.runId);
     expect(poll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(poll.body.job?.reuseKey).toBeNull();
-    expect(runnerPreferenceDecision(poll.body.job)).toStrictEqual({
+    expect(runnerPreference(poll.body.job)).toStrictEqual({
       kind: "noPreference",
       reason: "noReuseKey",
     });
@@ -3770,9 +3766,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       cliAgentSessionId,
     );
     expect(canonicalHeartbeatHolder.job?.reuseKey).toBe(reuseKey);
-    expect(
-      runnerPreferenceDecision(canonicalHeartbeatHolder.job),
-    ).toStrictEqual({
+    expect(runnerPreference(canonicalHeartbeatHolder.job)).toStrictEqual({
       kind: "noPreference",
       reason: "noViableHolder",
     });
@@ -3798,7 +3792,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue with a workspace-only holder",
     );
     expect(workspaceOnlyHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreferenceDecision(workspaceOnlyHolder.job)).toStrictEqual({
+    expect(runnerPreference(workspaceOnlyHolder.job)).toStrictEqual({
       kind: "preference",
       runnerIdentity: {
         runnerId: reuseRunnerId,
@@ -3816,7 +3810,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const capableWorkspaceHolder = await pollFollowUp(
       "continue with a capable workspace holder",
     );
-    expect(runnerPreferenceDecision(capableWorkspaceHolder.job)).toMatchObject({
+    expect(runnerPreference(capableWorkspaceHolder.job)).toMatchObject({
       kind: "preference",
       tier: "workspaceCache",
     });
@@ -3839,10 +3833,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const reusableOverWorkspace = await pollFollowUp(
       "prefer a reusable holder over a capable workspace holder",
     );
-    const reusableDecision = runnerPreferenceDecision(
-      reusableOverWorkspace.job,
-    );
-    expect(reusableDecision).toStrictEqual({
+    const reusablePreference = runnerPreference(reusableOverWorkspace.job);
+    expect(reusablePreference).toStrictEqual({
       kind: "preference",
       runnerIdentity: {
         runnerId: reusableRunnerId,
@@ -3851,23 +3843,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       tier: "reusableSandbox",
       expiresAt: expect.any(String),
     });
-    if (reusableDecision?.kind !== "preference") {
-      throw new Error("Expected a reusable sandbox preference decision");
+    if (reusablePreference?.kind !== "preference") {
+      throw new Error("Expected a reusable sandbox preference");
     }
     expect(runnerPreference(reusableOverWorkspace.job)).toStrictEqual(
-      reusableDecision,
+      reusablePreference,
     );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "job",
       expect.objectContaining({
         runId: reusableOverWorkspace.run.runId,
-        runnerPreference: reusableDecision,
-        runnerPreferenceDecision: {
-          kind: "preference",
-          runnerIdentity: reusableDecision.runnerIdentity,
-          tier: "reusableSandbox",
-          expiresAt: reusableDecision.expiresAt,
-        },
+        runnerPreference: reusablePreference,
       }),
     );
     await api.requestHeartbeatRunner(true, [200], {
@@ -3886,9 +3872,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const mismatchedCapableWorkspace = await pollFollowUp(
       "continue with a mismatched capable workspace",
     );
-    expect(
-      runnerPreferenceDecision(mismatchedCapableWorkspace.job),
-    ).toStrictEqual({
+    expect(runnerPreference(mismatchedCapableWorkspace.job)).toStrictEqual({
       kind: "noPreference",
       reason: "noViableHolder",
     });
@@ -3903,9 +3887,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const differentGenerationHolder = await pollFollowUp(
       "continue with a different reusable generation",
     );
-    expect(
-      runnerPreferenceDecision(differentGenerationHolder.job),
-    ).toStrictEqual({
+    expect(runnerPreference(differentGenerationHolder.job)).toStrictEqual({
       kind: "preference",
       runnerIdentity: {
         runnerId: reuseRunnerId,
@@ -3925,7 +3907,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const exactGenerationHolder = await pollFollowUp(
       "continue with exact reusable generation",
     );
-    expect(runnerPreferenceDecision(exactGenerationHolder.job)).toStrictEqual({
+    expect(runnerPreference(exactGenerationHolder.job)).toStrictEqual({
       kind: "preference",
       runnerIdentity: {
         runnerId: reuseRunnerId,
@@ -4009,7 +3991,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       threadId: first.threadId,
       prompt: "continue while the exact source is finalizing",
     });
-    const finalizingDecision = {
+    const finalizingPreference = {
       kind: "preference" as const,
       runnerIdentity: sourceRunnerIdentity,
       tier: "finalizingPredecessor" as const,
@@ -4021,8 +4003,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runId: successor.runId,
         reuseKey,
         historyGenerationRunId: first.runId,
-        runnerPreference: finalizingDecision,
-        runnerPreferenceDecision: finalizingDecision,
+        runnerPreference: finalizingPreference,
       }),
     );
 
@@ -4039,8 +4020,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected finalizing predecessor poll to succeed");
     }
     expect(sourcePoll.body.job?.runId).toBe(successor.runId);
-    expect(runnerPreferenceDecision(sourcePoll.body.job)).toStrictEqual(
-      finalizingDecision,
+    expect(runnerPreference(sourcePoll.body.job)).toStrictEqual(
+      finalizingPreference,
     );
     for (const actionType of [
       "runner_notification_affinity_lookup",
@@ -4072,7 +4053,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected generic fallback poll to succeed");
     }
     expect(genericPoll.body.job?.runId).toBe(successor.runId);
-    expect(runnerPreferenceDecision(genericPoll.body.job)).toStrictEqual({
+    expect(runnerPreference(genericPoll.body.job)).toStrictEqual({
       kind: "preference",
       runnerIdentity: {
         runnerId: genericRunnerId,
@@ -4090,10 +4071,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runnerIdentity: sourceRunnerIdentity,
         telemetry: {
           discoverySource: "ably",
-          runnerPreference: finalizingDecision,
-          runnerPreferenceResolution: "no_reuse_key",
+          runnerPreference: finalizingPreference,
           runnerPreferenceClaimState: "expired",
-          runnerPreferenceTargetedSelf: false,
         },
       },
     );
@@ -4177,7 +4156,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       threadId: first.threadId,
       prompt: "continue with exact history already advertised",
     });
-    const exactDecision = {
+    const exactPreference = {
       kind: "preference" as const,
       runnerIdentity: exactRunnerIdentity,
       tier: "exactSandbox" as const,
@@ -4187,8 +4166,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "job",
       expect.objectContaining({
         runId: successor.runId,
-        runnerPreference: exactDecision,
-        runnerPreferenceDecision: exactDecision,
+        runnerPreference: exactPreference,
       }),
     );
     const poll = await api.requestPollRunner(
@@ -4204,9 +4182,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected exact-history poll to succeed");
     }
     expect(poll.body.job?.runId).toBe(successor.runId);
-    expect(runnerPreferenceDecision(poll.body.job)).toStrictEqual(
-      exactDecision,
-    );
+    expect(runnerPreference(poll.body.job)).toStrictEqual(exactPreference);
 
     await api.requestCancelRun(actor, successor.runId, [200]);
     await flushWaitUntilForTest();
@@ -4251,7 +4227,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected restarted-source poll to succeed");
     }
     expect(poll.body.job?.runId).toBe(successor.runId);
-    expect(runnerPreferenceDecision(poll.body.job)).toStrictEqual({
+    expect(runnerPreference(poll.body.job)).toStrictEqual({
       kind: "noPreference",
       reason: "noViableHolder",
     });
@@ -4280,7 +4256,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue while holder is starting",
     );
     expect(startingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreferenceDecision(startingHolder.job)).toMatchObject({
+    expect(runnerPreference(startingHolder.job)).toMatchObject({
       kind: "noPreference",
     });
 
@@ -4292,7 +4268,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       false,
     );
     expect(unavailableHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreferenceDecision(unavailableHolder.job)).toMatchObject({
+    expect(runnerPreference(unavailableHolder.job)).toMatchObject({
       kind: "noPreference",
     });
     const unavailableClaim = await api.claimRunnerJob(
@@ -4327,7 +4303,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue after holder heartbeat is stale",
     );
     expect(staleHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreferenceDecision(staleHolder.job)).toMatchObject({
+    expect(runnerPreference(staleHolder.job)).toMatchObject({
       kind: "noPreference",
     });
 
@@ -4344,9 +4320,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(profileIncompatibleHolder.job?.cliAgentSessionId).toBe(
       cliAgentSessionId,
     );
-    expect(
-      runnerPreferenceDecision(profileIncompatibleHolder.job),
-    ).toMatchObject({
+    expect(runnerPreference(profileIncompatibleHolder.job)).toMatchObject({
       kind: "noPreference",
     });
 
@@ -4362,7 +4336,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue while holder is draining",
     );
     expect(drainingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(runnerPreferenceDecision(drainingHolder.job)).toMatchObject({
+    expect(runnerPreference(drainingHolder.job)).toMatchObject({
       kind: "noPreference",
     });
   });
@@ -4467,7 +4441,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         reuseKey,
         historyGenerationRunId: first.runId,
         runnerPreference: exactRunnerPreference,
-        runnerPreferenceDecision: exactRunnerPreference,
       }),
     );
 
@@ -4482,7 +4455,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
     expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(protectedPoll.body.job?.reuseKey).toBe(reuseKey);
-    expect(runnerPreferenceDecision(protectedPoll.body.job)).toStrictEqual(
+    expect(runnerPreference(protectedPoll.body.job)).toStrictEqual(
       exactRunnerPreference,
     );
 
@@ -4579,9 +4552,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(generationExpiredPoll.body.job?.runId).toBe(
       generationExpiredRun.runId,
     );
-    expect(
-      runnerPreferenceDecision(generationExpiredPoll.body.job),
-    ).toStrictEqual({
+    expect(runnerPreference(generationExpiredPoll.body.job)).toStrictEqual({
       kind: "preference",
       runnerIdentity: preferredExactRunner,
       tier: "reusableSandbox",
@@ -4612,9 +4583,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(runnerPreference(expiredPoll.body.job)).toStrictEqual(
       expiredPreference,
     );
-    expect(runnerPreferenceDecision(expiredPoll.body.job)).toStrictEqual(
-      expiredPreference,
-    );
     const expiredClaim = await api.requestClaimRunnerJob(
       true,
       expiredFollowUp.runId,
@@ -4623,9 +4591,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         runnerIdentity: preferredExactRunner,
         telemetry: {
           runnerPreference: expiredPreference,
-          runnerPreferenceResolution: "no_reuse_key",
-          runnerPreferenceClaimState: "active",
-          runnerPreferenceTargetedSelf: true,
         },
       },
     );
@@ -4749,7 +4714,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }
       expect(poll.body.job?.runId).toBe(followUp.runId);
       if (expectedResource) {
-        expect(runnerPreferenceDecision(poll.body.job)).toMatchObject({
+        expect(runnerPreference(poll.body.job)).toMatchObject({
           kind: "preference",
           runnerIdentity: {
             runnerId,
@@ -4762,7 +4727,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           expiresAt: expect.any(String),
         });
       } else {
-        expect(runnerPreferenceDecision(poll.body.job)).toMatchObject({
+        expect(runnerPreference(poll.body.job)).toMatchObject({
           kind: "noPreference",
         });
       }
@@ -4885,7 +4850,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected reusable-holder poll to return 200");
     }
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
-    expect(runnerPreferenceDecision(protectedPoll.body.job)).toMatchObject({
+    expect(runnerPreference(protectedPoll.body.job)).toMatchObject({
       kind: "preference",
       runnerIdentity: {
         runnerId: reuseRunnerId,
@@ -5068,7 +5033,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected workspace-priority poll to return 200");
     }
     expect(workspacePoll.body.job?.runId).toBe(newerWorkspace.runId);
-    expect(runnerPreferenceDecision(workspacePoll.body.job)).toMatchObject({
+    expect(runnerPreference(workspacePoll.body.job)).toMatchObject({
       kind: "preference",
       runnerIdentity: {
         runnerId: workspaceRunnerId,
@@ -5316,7 +5281,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       "job",
       expect.objectContaining({
         runId: third.runId,
-        runnerPreferenceDecision: {
+        runnerPreference: {
           kind: "noPreference",
           reason: "noReuseKey",
         },
@@ -11789,9 +11754,16 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           directCandidateInboxWaitMs: 34,
           providerDiscoveryToMainLoopMs: 45,
           mainLoopToLocalAdmissionMs: 67,
-          runnerPreferenceResolution: "matching_workspace_cache",
+          runnerPreference: {
+            kind: "preference",
+            runnerIdentity: {
+              runnerId: randomUUID(),
+              heartbeatGeneration: 1,
+            },
+            tier: "workspaceCache",
+            expiresAt: "2999-01-01T00:00:00.000Z",
+          },
           runnerPreferenceClaimState: "active",
-          runnerPreferenceTargetedSelf: false,
         },
       },
     );
@@ -11820,9 +11792,14 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect.objectContaining({
         runner_preference_resolution: "matching_workspace_cache",
         runner_preference_claim_state: "active",
-        runner_preference_targeted_self: "false",
       }),
     );
+    expect(
+      singleSandboxOperationEvent(
+        directClaimEvents,
+        "claim_request_to_running",
+      ),
+    ).not.toHaveProperty("runner_preference_targeted_self");
 
     const tokenRequest = {
       keyName: "bdd-key",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1371,7 +1371,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       runId,
       cliAgentSessionId: null,
       reuseKey,
-      runnerPreferenceDecision: {
+      runnerPreference: {
         kind: "preference",
         runnerIdentity: {
           runnerId,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -23,7 +23,6 @@ import {
   type PiExecutionMode,
   type RunnerPreference,
   type RunnerPreferenceClaimState,
-  type RunnerPreferenceResolution,
   type SessionHistoryDownloadSource,
   type StoredConnectorPermissionBaseline,
   type StoredExecutionContext,
@@ -120,12 +119,13 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
-  runnerPreferenceResolution,
+  runnerPreferenceTelemetryResolution,
   runnerPreferenceTelemetryDimensions,
   runnerReuseKeyTelemetryKind,
   runnerReusePreferenceLookupError,
   runnerReusePreferencePollPriority,
   resolveRunnerReusePreference,
+  type RunnerPreferenceTelemetryResolution,
 } from "../services/runner-reuse-preference";
 import type { RouteEntry } from "../route-entry";
 import { settle, tapError } from "../utils";
@@ -785,7 +785,6 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         historyGenerationRunId: pendingJob.historyGenerationRunId ?? undefined,
         ...(piExecutionMode ? { piExecutionMode } : {}),
         runnerPreference,
-        runnerPreferenceDecision: runnerPreference,
       },
     },
   };
@@ -2035,14 +2034,14 @@ interface ClaimTimingTelemetry {
   readonly pollHttpRequestMs?: number;
   readonly pollReason?: string;
   readonly runnerPreference?: RunnerPreference;
-  readonly runnerPreferenceResolution?: RunnerPreferenceResolution;
   readonly runnerPreferenceClaimState?: RunnerPreferenceClaimState;
-  readonly runnerPreferenceTargetedSelf?: boolean;
 }
 
+type RunnerPreferenceTelemetryState = RunnerPreferenceClaimState | "absent";
+
 interface SuccessfulClaimPreferenceTelemetry {
-  readonly resolution: RunnerPreferenceResolution | undefined;
-  readonly claimState: RunnerPreferenceClaimState | undefined;
+  readonly resolution: RunnerPreferenceTelemetryResolution | undefined;
+  readonly claimState: RunnerPreferenceTelemetryState | undefined;
   readonly targetedSelf: boolean | undefined;
 }
 
@@ -2053,15 +2052,15 @@ function successfulClaimPreferenceTelemetry(args: {
   const preference = args.telemetry?.runnerPreference;
   if (!preference) {
     return {
-      resolution: args.telemetry?.runnerPreferenceResolution,
-      claimState: args.telemetry?.runnerPreferenceClaimState,
-      targetedSelf: args.telemetry?.runnerPreferenceTargetedSelf,
+      resolution: undefined,
+      claimState: undefined,
+      targetedSelf: undefined,
     };
   }
 
   if (preference.kind === "noPreference") {
     return {
-      resolution: runnerPreferenceResolution(preference),
+      resolution: runnerPreferenceTelemetryResolution(preference),
       claimState: "absent",
       targetedSelf: undefined,
     };
@@ -2069,8 +2068,8 @@ function successfulClaimPreferenceTelemetry(args: {
 
   const claimState = args.telemetry?.runnerPreferenceClaimState;
   return {
-    resolution: runnerPreferenceResolution(preference),
-    claimState: claimState === "absent" ? undefined : claimState,
+    resolution: runnerPreferenceTelemetryResolution(preference),
+    claimState,
     targetedSelf: args.runnerIdentity
       ? preference.runnerIdentity.runnerId.toLowerCase() ===
           args.runnerIdentity.runnerId.toLowerCase() &&
@@ -2138,9 +2137,9 @@ function scheduleSuccessfulClaimSideEffects(args: {
     pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
     pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
     pollReason: args.telemetry?.pollReason,
-    runnerPreferenceResolution: preferenceTelemetry.resolution,
-    runnerPreferenceClaimState: preferenceTelemetry.claimState,
-    runnerPreferenceTargetedSelf: preferenceTelemetry.targetedSelf,
+    preferenceResolution: preferenceTelemetry.resolution,
+    preferenceClaimState: preferenceTelemetry.claimState,
+    preferenceTargetedSelf: preferenceTelemetry.targetedSelf,
     historyGenerationRunId: historyGenerationRunIdForStoredExecutionContext(
       args.storedContext,
     ),
@@ -2169,9 +2168,11 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
-  readonly runnerPreferenceResolution: RunnerPreferenceResolution | undefined;
-  readonly runnerPreferenceClaimState: RunnerPreferenceClaimState | undefined;
-  readonly runnerPreferenceTargetedSelf: boolean | undefined;
+  readonly preferenceResolution:
+    | RunnerPreferenceTelemetryResolution
+    | undefined;
+  readonly preferenceClaimState: RunnerPreferenceTelemetryState | undefined;
+  readonly preferenceTargetedSelf: boolean | undefined;
   readonly historyGenerationRunId: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): void {
@@ -2208,9 +2209,11 @@ interface ClaimTimingMetricArgs {
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
-  readonly runnerPreferenceResolution: RunnerPreferenceResolution | undefined;
-  readonly runnerPreferenceClaimState: RunnerPreferenceClaimState | undefined;
-  readonly runnerPreferenceTargetedSelf: boolean | undefined;
+  readonly preferenceResolution:
+    | RunnerPreferenceTelemetryResolution
+    | undefined;
+  readonly preferenceClaimState: RunnerPreferenceTelemetryState | undefined;
+  readonly preferenceTargetedSelf: boolean | undefined;
   readonly historyGenerationRunId: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }
@@ -2339,28 +2342,26 @@ function claimSuccessfulPreferenceDimensions(
   dimensions: Record<string, string>,
 ): Record<string, string> {
   if (
-    args.runnerPreferenceResolution === undefined &&
-    args.runnerPreferenceClaimState === undefined &&
-    args.runnerPreferenceTargetedSelf === undefined
+    args.preferenceResolution === undefined &&
+    args.preferenceClaimState === undefined &&
+    args.preferenceTargetedSelf === undefined
   ) {
     return dimensions;
   }
 
   return {
     ...dimensions,
-    ...(args.runnerPreferenceResolution
+    ...(args.preferenceResolution
       ? {
-          runner_preference_resolution: args.runnerPreferenceResolution,
+          runner_preference_resolution: args.preferenceResolution,
         }
       : {}),
-    ...(args.runnerPreferenceClaimState
-      ? { runner_preference_claim_state: args.runnerPreferenceClaimState }
+    ...(args.preferenceClaimState
+      ? { runner_preference_claim_state: args.preferenceClaimState }
       : {}),
-    ...(args.runnerPreferenceTargetedSelf !== undefined
+    ...(args.preferenceTargetedSelf !== undefined
       ? {
-          runner_preference_targeted_self: String(
-            args.runnerPreferenceTargetedSelf,
-          ),
+          runner_preference_targeted_self: String(args.preferenceTargetedSelf),
         }
       : {}),
   };

--- a/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
+++ b/turbo/apps/api/src/signals/services/runner-reuse-preference.ts
@@ -1,7 +1,4 @@
-import type {
-  RunnerPreference,
-  RunnerPreferenceResolution,
-} from "@vm0/api-contracts/contracts/runners";
+import type { RunnerPreference } from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
@@ -281,20 +278,18 @@ const preferenceResolutionByTier = {
   finalizingPredecessor: "finalizing_predecessor",
   reusableSandbox: "matching_reusable_sandbox",
   workspaceCache: "matching_workspace_cache",
-} as const satisfies Record<
-  PositiveRunnerPreference["tier"],
-  RunnerPreferenceResolution
->;
+} as const satisfies Record<PositiveRunnerPreference["tier"], string>;
 
 const noPreferenceResolutionByReason = {
   noReuseKey: "no_reuse_key",
   expired: "expired",
   noViableHolder: "no_viable_holder",
   lookupError: "lookup_error",
-} as const satisfies Record<
-  NoRunnerPreference["reason"],
-  RunnerPreferenceResolution
->;
+} as const satisfies Record<NoRunnerPreference["reason"], string>;
+
+export type RunnerPreferenceTelemetryResolution =
+  | (typeof preferenceResolutionByTier)[keyof typeof preferenceResolutionByTier]
+  | (typeof noPreferenceResolutionByReason)[keyof typeof noPreferenceResolutionByReason];
 
 export function runnerReusePreferenceLookupError(): RunnerPreference {
   return {
@@ -303,9 +298,9 @@ export function runnerReusePreferenceLookupError(): RunnerPreference {
   };
 }
 
-export function runnerPreferenceResolution(
+export function runnerPreferenceTelemetryResolution(
   preference: RunnerPreference,
-): RunnerPreferenceResolution {
+): RunnerPreferenceTelemetryResolution {
   if (preference.kind === "noPreference") {
     return noPreferenceResolutionByReason[preference.reason];
   }
@@ -316,7 +311,8 @@ export function runnerPreferenceTelemetryDimensions(
   preference: RunnerPreference,
 ): Record<string, string> {
   return {
-    runner_preference_resolution: runnerPreferenceResolution(preference),
+    runner_preference_resolution:
+      runnerPreferenceTelemetryResolution(preference),
     runner_preference_decision_kind: preference.kind,
     ...(preference.kind === "preference"
       ? { runner_preference_tier: preference.tier }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -148,10 +148,6 @@ describe("Pi execution mode contract", () => {
       kind: "noPreference" as const,
       reason: "noReuseKey" as const,
     },
-    runnerPreferenceDecision: {
-      kind: "noPreference" as const,
-      reason: "noReuseKey" as const,
-    },
   };
 
   it.each(["standby", "cold-start"])(
@@ -489,10 +485,6 @@ describe("runner poll response contract", () => {
       kind: "noPreference" as const,
       reason: "noReuseKey" as const,
     },
-    runnerPreferenceDecision: {
-      kind: "noPreference" as const,
-      reason: "noReuseKey" as const,
-    },
   };
 
   it.each(["vm0/default", "vm0/large"])(
@@ -753,10 +745,6 @@ describe("runner resume session contract", () => {
         kind: "noPreference",
         reason: "noReuseKey",
       },
-      runnerPreferenceDecision: {
-        kind: "noPreference",
-        reason: "noReuseKey",
-      },
     });
     expect(job.historyGenerationRunId).toBe(historyGenerationRunId);
 
@@ -787,7 +775,7 @@ describe("runner resume session contract", () => {
     ]);
   });
 
-  it("requires canonical and compatibility runner preferences", () => {
+  it("requires a canonical runner preference", () => {
     const jobInput = {
       runId: "22222222-2222-4222-8222-222222222222",
       prompt: "continue",
@@ -806,11 +794,9 @@ describe("runner resume session contract", () => {
       jobSchema.parse({
         ...jobInput,
         runnerPreference,
-        runnerPreferenceDecision: runnerPreference,
       }),
     ).toMatchObject({
       runnerPreference,
-      runnerPreferenceDecision: runnerPreference,
     });
   });
 
@@ -830,10 +816,6 @@ describe("runner resume session contract", () => {
       agentComposeVersionId: null,
       vars: null,
       experimentalProfile: "vm0/default",
-      runnerPreferenceDecision: {
-        ...runnerPreference,
-        tier: "reusableSandbox" as const,
-      },
     };
 
     for (const tier of [
@@ -902,10 +884,6 @@ describe("runner resume session contract", () => {
       agentComposeVersionId: null,
       vars: null,
       experimentalProfile: "vm0/default",
-      runnerPreferenceDecision: {
-        kind: "noPreference" as const,
-        reason: "noReuseKey" as const,
-      },
     };
 
     for (const reason of [
@@ -1336,30 +1314,7 @@ describe("runner claim request contract", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts optional bounded runner preference claim telemetry", () => {
-    for (const runnerPreferenceClaimState of [
-      "active",
-      "expired",
-      "cleared",
-      "absent",
-    ] as const) {
-      expect(
-        runnersJobClaimContract.claim.body.parse({
-          telemetry: {
-            runnerPreferenceResolution: "matching_workspace_cache",
-            runnerPreferenceClaimState,
-            runnerPreferenceTargetedSelf: false,
-          },
-        }).telemetry,
-      ).toStrictEqual({
-        runnerPreferenceResolution: "matching_workspace_cache",
-        runnerPreferenceClaimState,
-        runnerPreferenceTargetedSelf: false,
-      });
-    }
-  });
-
-  it("accepts canonical runner preference claim telemetry", () => {
+  it("accepts every positive runner preference claim state", () => {
     const runnerPreference = {
       kind: "preference" as const,
       runnerIdentity: {
@@ -1370,32 +1325,55 @@ describe("runner claim request contract", () => {
       expiresAt: "2026-08-03T00:00:01.000Z",
     };
 
+    for (const runnerPreferenceClaimState of [
+      "active",
+      "expired",
+      "cleared",
+    ] as const) {
+      expect(
+        runnersJobClaimContract.claim.body.parse({
+          telemetry: {
+            runnerPreference,
+            runnerPreferenceClaimState,
+          },
+        }).telemetry,
+      ).toStrictEqual({
+        runnerPreference,
+        runnerPreferenceClaimState,
+      });
+    }
+  });
+
+  it("accepts canonical no-preference claim telemetry", () => {
+    const runnerPreference = {
+      kind: "noPreference" as const,
+      reason: "noViableHolder" as const,
+    };
+
     expect(
       runnersJobClaimContract.claim.body.parse({
         telemetry: {
           runnerPreference,
-          runnerPreferenceClaimState: "active",
         },
       }).telemetry,
     ).toStrictEqual({
       runnerPreference,
-      runnerPreferenceClaimState: "active",
     });
   });
 
-  it("keeps valid legacy claim telemetry when canonical preference is malformed", () => {
+  it("keeps other claim telemetry when canonical preference is malformed", () => {
     expect(
       runnersJobClaimContract.claim.body.parse({
         telemetry: {
+          discoverySource: "poll",
           runnerPreference: { kind: "futurePreference" },
-          runnerPreferenceResolution: "no_viable_holder",
-          runnerPreferenceClaimState: "absent",
+          runnerPreferenceClaimState: "active",
         },
       }).telemetry,
     ).toStrictEqual({
+      discoverySource: "poll",
       runnerPreference: undefined,
-      runnerPreferenceResolution: "no_viable_holder",
-      runnerPreferenceClaimState: "absent",
+      runnerPreferenceClaimState: "active",
     });
   });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -133,22 +133,10 @@ export const runnerPreferenceSchema = z.discriminatedUnion("kind", [
     .strict(),
 ]);
 
-export const runnerPreferenceResolutionSchema = z.enum([
-  "exact_history_generation",
-  "finalizing_predecessor",
-  "matching_reusable_sandbox",
-  "matching_workspace_cache",
-  "no_reuse_key",
-  "expired",
-  "no_viable_holder",
-  "lookup_error",
-]);
-
 export const runnerPreferenceClaimStateSchema = z.enum([
   "active",
   "expired",
   "cleared",
-  "absent",
 ]);
 
 const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
@@ -169,9 +157,7 @@ const runnerClaimTelemetrySchema = z
     pollHttpRequestMs: z.number().int().nonnegative().optional(),
     pollReason: runnerClaimPollReasonSchema.optional(),
     runnerPreference: runnerPreferenceSchema.optional().catch(undefined),
-    runnerPreferenceResolution: runnerPreferenceResolutionSchema.optional(),
     runnerPreferenceClaimState: runnerPreferenceClaimStateSchema.optional(),
-    runnerPreferenceTargetedSelf: z.boolean().optional(),
   })
   .catch({});
 
@@ -451,9 +437,6 @@ export const jobSchema = z.object({
   historyGenerationRunId: z.uuid().optional(),
   piExecutionMode: piExecutionModeSchema.optional(),
   runnerPreference: runnerPreferenceSchema,
-  // Keep the compatibility field until every pre-migration runner is unable
-  // to claim. Cleanup is tracked by #25751.
-  runnerPreferenceDecision: runnerPreferenceSchema,
 });
 
 const heldWorkspaceCacheSchema = z.object({
@@ -1192,9 +1175,6 @@ export type RunnersBuiltinFirewallsResolveContract =
   typeof runnersBuiltinFirewallsResolveContract;
 export type Job = z.infer<typeof jobSchema>;
 export type RunnerPreference = z.infer<typeof runnerPreferenceSchema>;
-export type RunnerPreferenceResolution = z.infer<
-  typeof runnerPreferenceResolutionSchema
->;
 export type RunnerPreferenceClaimState = z.infer<
   typeof runnerPreferenceClaimStateSchema
 >;


### PR DESCRIPTION
## Summary

- make `RunnerPreference` the only preference value delivered through Poll and Ably
- remove legacy claim resolution and targeted-self inputs, deriving those dimensions in the API
- remove runner fallback parsing and compatibility-only fixtures while preserving missing and malformed advisory behavior

## Compatibility

- #25750 is deployed to the current production API and runner fleet, and the pre-migration runner has drained and stopped
- API-first and runner-first promotion remain compatible with the already migrated counterpart
- pre-migration runner rollback is intentionally outside the final contract
- ranking, admission, deadlines, claim CAS, resource selection, persistence, and lifecycle behavior are unchanged
- canonical Poll and Ably production telemetry remains the pre-merge operational gate tracked by #25751

## Fallbacks

- Removed `api.rs:ApiProvider::discover` and `api_ably_supervisor.rs:parse_job_notification` fallback parsing of `runnerPreferenceDecision`. It protected pre-migration runners from an API/runner rollout mismatch. Surface: runner/backend, normally up to the two-hour runner drain window. Removal evidence: #25750 is promoted, runner v0.160.9 consumes canonical `runnerPreference` on every production host, and pre-migration v0.160.8 has stopped and cannot claim new work. This PR and #25751 are the planned removal; no later follow-up remains.
- Removed `runners.ts:successfulClaimPreferenceTelemetry` fallback and precedence for runner-supplied resolution and targeted-self fields. It protected claims from pre-migration runners. Surface: runner/backend claim path, normally up to the two-hour runner drain window. Removal evidence: the migrated runner sends canonical preference plus positive local state, and the pre-migration service has stopped, so it cannot reach the claim path. This PR and #25751 are the planned removal; no later follow-up remains.
- Remaining compatibility fallbacks: none. Missing or malformed canonical claim metadata is optional, untrusted telemetry, and missing or malformed Poll/Ably preference metadata has defined ordinary-admission semantics; neither path reads a retired protocol or fabricates a replacement value.

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/pi-edge-loop.test.ts src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts --silent=passed-only`
- `cd turbo && pnpm knip`
- `cd crates && cargo fmt --all --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner --all-features`

Closes #25751

Parent: #25741
