### PR TITLE
fix(platform): restore abort ownership for transient retries

### DIFF
--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -18,6 +18,7 @@ import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { localStorageSignals } from "./external/local-storage.ts";
 import { retryTransientLoad } from "./utils.ts";
+import { rootSignal$ } from "./root-signal.ts";
 
 const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
 
@@ -35,9 +36,12 @@ export function agentById(id: string): Computed<Promise<ZeroAgentResponse>> {
   return computed(async (get) => {
     get(internalAgentByIdReload$);
     const client = get(zeroClient$)(zeroAgentsByIdContract);
-    const result = await retryTransientLoad(() => {
-      return accept(client.get({ params: { id } }), [200]);
-    });
+    const result = await retryTransientLoad((signal) => {
+      return accept(
+        client.get({ params: { id }, fetchOptions: { signal } }),
+        [200],
+      );
+    }, get(rootSignal$));
     return result.body;
   });
 }

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -17,6 +17,7 @@ import { agentById, currentAgentId$ } from "../agent.ts";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { retryTransientLoad } from "../utils.ts";
+import { rootSignal$ } from "../root-signal.ts";
 import { resolveActiveUserPermissionGrantPolicy } from "../user-permission-grants.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
 import { i18n } from "../../i18n/index.ts";
@@ -141,14 +142,15 @@ export function userPermissionGrantsByAgent(
   return computed(async (get) => {
     get(internalUserPermissionGrantsReload$);
     const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-    const result = await retryTransientLoad(() => {
+    const result = await retryTransientLoad((signal) => {
       return accept(
         client.list({
           query: params,
+          fetchOptions: { signal },
         }),
         [200],
       );
-    });
+    }, get(rootSignal$));
     return result.body;
   });
 }
@@ -159,14 +161,15 @@ export function userPermissionGrantsByAgentIfExists(
   return computed(async (get) => {
     get(internalUserPermissionGrantsReload$);
     const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-    const result = await retryTransientLoad(() => {
+    const result = await retryTransientLoad((signal) => {
       return accept(
         client.list({
           query: params,
+          fetchOptions: { signal },
         }),
         [200, 404],
       );
-    });
+    }, get(rootSignal$));
     return result.status === 404 ? null : result.body;
   });
 }

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -319,11 +319,21 @@ function runRetriedLoad<T>(load: () => Promise<T>): Promise<T> {
 /**
  * Retry idempotent read/lazy-load operations that can fail on transient
  * network or chunk-loading errors. Do not wrap mutations: `load` may run more
- * than once.
+ * than once. The caller must pass the lifecycle that owns both the request and
+ * its retry delay; computed reads that outlive invalidation use the app root.
  */
-export function retryTransientLoad<T>(load: () => Promise<T>): Promise<T> {
+export function retryTransientLoad<T>(
+  load: (signal: AbortSignal) => Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
   async function attemptLoad(attempt: number): Promise<T> {
-    const result = await settle(runRetriedLoad(load));
+    signal.throwIfAborted();
+    const result = await settle(
+      runRetriedLoad(() => {
+        return load(signal);
+      }),
+      signal,
+    );
     if (result.ok) {
       return result.value;
     }
@@ -331,7 +341,7 @@ export function retryTransientLoad<T>(load: () => Promise<T>): Promise<T> {
     if (delayMs === undefined || !isRetryableError(result.error)) {
       throw result.error;
     }
-    await delay(IN_VITEST ? 0 : delayMs);
+    await delay(IN_VITEST ? 0 : delayMs, { signal });
     return attemptLoad(attempt + 1);
   }
 


### PR DESCRIPTION
## Summary

- restore an explicit owner `AbortSignal` for bounded transient-load retry delays
- use the app-root lifecycle for computed reads, so invalidation still allows stale reads to finish while app teardown cancels requests, retry waits, and later attempts
- pass the same owner signal into the agent and permission-grant HTTP requests

## Violation found

`retryTransientLoad` called `signal-timers` `delay()` without `{ signal }` after computed lifecycle signals were removed. The retry was bounded, but its request and backoff no longer had lifecycle ownership.

## Behavior preserved

- computed invalidation does not cancel an in-flight stale read
- transient failures still retry with the existing delays and attempt limit
- root teardown now stops the active request, backoff, and subsequent attempts

## Verification

- Prettier on changed files
- changed-file ESLint and Oxlint, including type-aware Oxlint
- `pnpm --filter @vm0/app run check-types`
- targeted Vitest: stale permission loading survives invalidation; permission loading retries transient failure (2 passed)
- Lefthook pre-commit: Knip and full repository type checks passed
- custom-loop scan only matches the shared `setLoop` implementation
- native platform timer scan is empty

Full CI validation is delegated to the PR pipeline.

## Fallbacks

None.