### PR TITLE
fix(python): skip usage parsers for bodyless responses

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -235,6 +235,8 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return _ResponseUsageStreamSetup(None, False)
+    if not _response_can_have_body(flow, response):
+        return _ResponseUsageStreamSetup(None, False)
     if is_observable_model_provider:
         if _response_has_event_stream_media_type(response):
             lifecycle_observer: _AnthropicLifecycleObserver | None = None

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -9,6 +9,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_streaming
 from tests.flow_helpers import header_map, response_stream
+from tests.jsonl_log_helpers import jsonl_exists_after_flush
 from tests.x_flow_helpers import make_x_response_flow
 
 
@@ -70,6 +71,77 @@ class TestResponseHeadersModelJsonParser:
             in call.args[0]
             for call in log.debug.call_args_list
         )
+
+
+class TestBodylessModelResponseParserAdmission:
+    """Tests HTTP body semantics at the shared model response parser gate."""
+
+    @pytest.mark.parametrize(
+        ("request_method", "response_status", "content_type", "content_encoding"),
+        [
+            pytest.param("GET", 103, "application/json", "", id="informational"),
+            pytest.param("GET", 204, "application/json", "", id="no-content"),
+            pytest.param("GET", 205, "application/json", "", id="reset-content"),
+            pytest.param("GET", 304, "application/json", "", id="not-modified"),
+            pytest.param("HEAD", 200, "application/json", "", id="head"),
+            pytest.param("CONNECT", 200, "application/json", "", id="successful-connect"),
+            pytest.param("GET", 204, "application/json", "gzip", id="gzip"),
+            pytest.param("GET", 204, "application/json", "deflate", id="deflate"),
+            pytest.param("GET", 204, "text/event-stream", "", id="sse"),
+        ],
+    )
+    def test_bodyless_response_skips_usage_parser_and_keeps_byte_accounting(
+        self,
+        real_flow,
+        tmp_path,
+        mitm_ctx,
+        request_method: str,
+        response_status: int,
+        content_type: str,
+        content_encoding: str,
+    ) -> None:
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method=request_method,
+        )
+        response_headers = {"content-type": content_type}
+        if content_encoding:
+            response_headers["content-encoding"] = content_encoding
+        flow.response = tutils.tresp(
+            status_code=response_status,
+            headers=header_map(response_headers),
+        )
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata.update(
+            {
+                metadata_keys.VM_PROXY_LOG_PATH: str(proxy_log_path),
+                metadata_keys.FIREWALL_NAME: "model-provider:anthropic-api-key",
+                metadata_keys.FIREWALL_BILLABLE: True,
+                metadata_keys.MODEL_USAGE_PROVIDER: "claude-sonnet-4-6",
+            }
+        )
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+            assert "model_json_usage_finish" not in flow.metadata
+            assert "model_sse_usage_finish" not in flow.metadata
+            assert "model_websocket_usage_enabled" not in flow.metadata
+            assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+
+            unexpected_wire_bytes = b"bodyless-response-wire-bytes"
+            assert response_stream(flow)(unexpected_wire_bytes) == unexpected_wire_bytes
+            assert flow.metadata[metadata_keys.RESPONSE_STREAM_STATE]["total_bytes"] == len(
+                unexpected_wire_bytes
+            )
+
+            response_streaming.finalize_model_sse_usage(flow)
+            response_streaming.finalize_model_json_usage(flow, str(proxy_log_path))
+
+        assert metadata_keys.MODEL_JSON_USAGE_FINALIZED not in flow.metadata
+        assert not jsonl_exists_after_flush(proxy_log_path)
 
 
 class TestResponseHeadersSseParser:

--- a/crates/runner/mitm-addon/tests/test_x_response_parsers.py
+++ b/crates/runner/mitm-addon/tests/test_x_response_parsers.py
@@ -18,6 +18,62 @@ from tests.x_flow_helpers import (
 _OVERSIZED_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT + 1024
 
 
+class TestBodylessXResponseParserAdmission:
+    """Tests HTTP body semantics at the shared connector response parser gate."""
+
+    @pytest.mark.parametrize(
+        ("request_method", "response_status", "content_encoding", "path"),
+        [
+            pytest.param("GET", 204, "", "/2/tweets", id="no-content"),
+            pytest.param("GET", 205, "", "/2/tweets", id="reset-content"),
+            pytest.param("HEAD", 200, "", "/2/tweets", id="head"),
+            pytest.param("CONNECT", 200, "", "/2/tweets", id="successful-connect"),
+            pytest.param("GET", 204, "gzip", "/2/tweets", id="gzip"),
+            pytest.param("GET", 204, "deflate", "/2/tweets", id="deflate"),
+            pytest.param(
+                "GET",
+                204,
+                "",
+                "/2/tweets/search/stream",
+                id="ndjson-constructor-state",
+            ),
+        ],
+    )
+    def test_bodyless_response_skips_parser_and_keeps_byte_accounting(
+        self,
+        real_flow,
+        request_method: str,
+        response_status: int,
+        content_encoding: str,
+        path: str,
+    ) -> None:
+        flow = make_x_response_flow(
+            real_flow,
+            path=path,
+            response_status=response_status,
+            content_encoding=content_encoding,
+        )
+        flow.request.method = request_method
+
+        mitm_addon.responseheaders(flow)
+
+        assert "connector_response_finish" not in flow.metadata
+        assert "connector_response_report_on_interruption" not in flow.metadata
+        assert metadata_keys.X_JSON_STATE not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
+
+        unexpected_wire_bytes = b"bodyless-response-wire-bytes"
+        assert response_stream(flow)(unexpected_wire_bytes) == unexpected_wire_bytes
+        assert flow.metadata[metadata_keys.RESPONSE_STREAM_STATE]["total_bytes"] == len(
+            unexpected_wire_bytes
+        )
+
+        response_streaming.finalize_connector_response_state(flow)
+
+        assert metadata_keys.X_JSON_STATE not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
+
+
 class TestNdjsonExtractor:
     """Tests for X NDJSON extraction through responseheaders (issue #9534)."""
 


### PR DESCRIPTION
## Summary

- make the existing HTTP body-semantics predicate gate ordinary model and connector response usage parsers
- preserve confirmed WebSocket frame usage and unconditional response streaming/byte accounting
- cover bodyless informational, `204`, `205`, `304`, `HEAD`, and successful `CONNECT` flows across model JSON/SSE and X JSON/NDJSON parser paths
- verify identity, gzip, and deflate admission without an unnecessary status-by-protocol cross-product

## Behavior

Bodyless responses no longer install model or connector response-body parser finalizers, so terminal handling cannot publish false `incomplete json` warnings or connector parse-error state. The shared response callback remains installed and continues exact byte accounting.

Confirmed Codex WebSocket upgrades remain classified before the body gate because their usage comes from WebSocket frames rather than the HTTP response body.

## Exclusions

- no API or runner queue protocol changes
- no schema, migration, or persisted-format changes
- no feature switch, rollout gate, or documentation changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused response parser, streaming, cleanup, and WebSocket suites: 170 passed
- `uv run --no-sync python -m pytest tests/`: 4981 passed

Closes #25785
