### PR TITLE
fix(mitm-addon): track decorator application exceptions

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -592,7 +592,7 @@ def _assertion_may_raise(node: ast.Assert) -> bool:
 
 
 def _function_definition_may_raise(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    return _expressions_may_raise(
+    return bool(node.decorator_list) or _expressions_may_raise(
         [
             *node.decorator_list,
             *node.args.defaults,
@@ -602,7 +602,7 @@ def _function_definition_may_raise(node: ast.FunctionDef | ast.AsyncFunctionDef)
 
 
 def _class_definition_may_raise(node: ast.ClassDef) -> bool:
-    return _expressions_may_raise(
+    return bool(node.decorator_list) or _expressions_may_raise(
         [
             *node.decorator_list,
             *node.bases,

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -561,6 +561,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._exception_alias_scopes.append(_ExceptionAliasState())
         self._visit_scoped_body(node.body, shadowed_names, metadata_defaults, body_base_aliases)
         self._exception_alias_scopes.pop()
+        if node.decorator_list:
+            self._record_implicit_exception_aliases()
         self._metadata_aliases.discard(node.name)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -618,6 +620,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             class_failure_aliases.difference_update(outer_visible_names)
             class_failure_aliases.update(class_exception_state.aliases & outer_visible_names)
             self._record_exception_aliases(class_failure_aliases)
+        if node.decorator_list:
+            self._record_implicit_exception_aliases()
         self._metadata_aliases.discard(node.name)
 
     def visit_TypeAlias(self, node: ast.AST) -> None:

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -141,11 +141,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
       a failing class body projects away class-bound names before propagating.
       Function and lambda bodies install boundaries, context managers retain paths
       they may suppress, and ``finally`` transfers normal and exceptional states.
-      Modeled implicit failures use one operation predicate, with ordered recording
-      for short-circuit, comparison, assertion, loop, and comprehension evaluation.
-      Deferred annotations, type parameters, and type-alias values retain the
-      linter's existing syntactic alias and key behavior without feeding runtime
-      exception collectors.
+      Expression-level modeled implicit failures use one operation predicate, with
+      ordered recording for short-circuit, comparison, assertion, loop, and
+      comprehension evaluation. Decorated definitions record their application-call
+      state after definition-time evaluation and before name binding. Deferred
+      annotations, type parameters, and type-alias values retain the linter's existing
+      syntactic alias and key behavior without feeding runtime exception collectors.
     * ``_class_nested_scope_alias_scopes`` holds the surrounding non-class alias
       base while a class body is active. Nested classes, function and lambda bodies,
       and implicit comprehension scopes use that base because they do not close over

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
@@ -571,3 +571,55 @@ def formatted_value_failure_before_return(flow, manager, value):
     with manager:
         return f"{value}"
     return metadata["network_log_target"]
+
+
+def function_decorator_application_preserves_prebinding_alias(flow):
+    try:
+        decorated = flow.metadata
+
+        @decorator
+        def decorated():
+            pass
+
+    except Exception:
+        pass
+    return decorated["vm_run_id"]
+
+
+def class_decorator_application_is_suppressible(flow, manager):
+    metadata = flow.metadata
+    with manager:
+
+        @decorator
+        class Decorated:
+            pass
+
+        return
+    return metadata["firewall_name"]
+
+
+def stacked_decorator_application_uses_post_evaluation_alias(flow):
+    metadata = {}
+    try:
+
+        @outer_decorator
+        @(metadata := flow.metadata)
+        def decorated():
+            pass
+
+        metadata = {}
+    except Exception:
+        pass
+    return metadata["original_url"]
+
+
+def function_decorator_application_before_return_is_suppressible(flow, manager):
+    metadata = flow.metadata
+    with manager:
+
+        @decorator
+        def decorated():
+            pass
+
+        return
+    return metadata["firewall_base"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
@@ -36,3 +36,7 @@ implicit_exception_flow.py:509: use metadata_keys.CONNECTOR_ROUTE_CANDIDATES for
 implicit_exception_flow.py:550: use metadata_keys.VM_RUN_ID for flow.metadata access
 implicit_exception_flow.py:558: use metadata_keys.FIREWALL_NAME for flow.metadata access
 implicit_exception_flow.py:573: use metadata_keys.NETWORK_LOG_TARGET for flow.metadata access
+implicit_exception_flow.py:586: use metadata_keys.VM_RUN_ID for flow.metadata access
+implicit_exception_flow.py:598: use metadata_keys.FIREWALL_NAME for flow.metadata access
+implicit_exception_flow.py:613: use metadata_keys.ORIGINAL_URL for flow.metadata access
+implicit_exception_flow.py:625: use metadata_keys.FIREWALL_BASE for flow.metadata access


### PR DESCRIPTION
## Summary

- model function, async-function, and class decorator application as a fallible definition-time operation
- preserve post-evaluation, pre-binding metadata aliases through `try` handlers and suppressing context managers
- cover plain, same-name, suppressible, and stacked decorator flows through the public linter API

## Scope

This changes repository-only Python lint tooling and its integration fixtures. It does not change mitmproxy runtime behavior, dependencies, APIs, schemas, persisted data, protocols, migrations, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py` (18 passed)
- `uv run --no-sync python scripts/check-flow-metadata-keys.py`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4965 passed)
- `lefthook run pre-commit`

Closes #25784
