### PR TITLE
test(api): flush queue drain between model override turns

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3735,6 +3735,7 @@ describe("CHAT-02: run-level model overrides", () => {
     await completeChatRunOk(first.runId, firstClaim.sandboxHeaders, {
       lastEventSequence: 0,
     });
+    await flushWaitUntilForTest();
     await waitForThreadMessages(actor, first.threadId, (items) => {
       return eventBackedContents(items, first.runId).some((message) => {
         return message.content === "opus answer";
@@ -3794,6 +3795,7 @@ describe("CHAT-02: run-level model overrides", () => {
     );
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(second.runId, secondClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
 
     // Follow-ups without a send model override go back to the thread's stored
     // model. Both models remain in the Claude family, so session continuity is


### PR DESCRIPTION
## Summary

- flush tracked terminal waitUntil work after each completed turn before the next model-override send
- preserve the API dispatch telemetry, stored-model, and same-family session assertions unchanged

## Root cause

The completion route commits terminal run state before its terminal callback and queue drain finish in waitUntil. This test observed the committed messages and run result, then immediately sent the next turn while that drain was still owned by the prior completion.

The drain and the foreground send can both attempt the same queue-first claim. When the drain wins, the foreground collector flushes its early pre-create spans under the losing provisional run ID, while sendChatRun resolves and returns the winning run ID. The business run remains valid, but telemetry lookup for the returned run ID has no foreground load-snapshot span. Scheduler ordering at that ownership boundary made the assertion intermittent.

The failed merge-group SHA and current main have identical relevant API test and dispatch code. PR #25794 only changed platform authentication behavior. The other test-api cancellations occurred during Codecov upload, and ci-gate-turbo was only the aggregate failure.

## Fix

Wait for the test harness tracked waitUntil work after the first and second completions. This closes the prior-turn queue-drain ownership before the next foreground send without retries, sleeps, timeout changes, skipped checks, or weakened assertions.

## Verification

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- git diff --check

The focused Vitest file requires PostgreSQL. Per the repair constraints, no local database or development service was started; the PR test-api shard provides the isolated database validation.

## Preview applicability

Not applicable. This changes only integration-test synchronization around mocked Axiom ingestion and waitUntil queue ownership. The invariant is not observable through a deployed app, API, or browser preview, so staging-browser cannot validate it.

## Trigger

- Workflow run: https://github.com/vm0-ai/vm0/actions/runs/31249412723
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/31249412723/job/93083298204
- Failed SHA: b35cc52851c5ee751be466a3737c24ddb08676f2
- Test: CHAT-02: run-level model overrides > uses send model overrides without mutating the thread model while preserving same-family sessions

## Fallbacks

None.