### PR TITLE
fix(platform): shorten next-run model notice

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1517,7 +1517,7 @@
       "keepGoingAt": "Keep going · {{timestamp}}",
       "modelChangedTo": "Model changed to {{model}}",
       "queueEllipsis": "queue...",
-      "selectedModelAppliesAfterCurrentRun": "Your selected {{model}} model will take effect after this run",
+      "selectedModelAppliesAfterCurrentRun": "Next run will use {{model}}",
       "thinking": {
         "assembling": "Assembling the pieces...",
         "brewing": "Brewing up a response...",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -35,8 +35,7 @@ const CHAT_PATH = `/chats/${THREAD_ID}`;
 const AGENT_CHAT_PATH = `/agents/${AGENT_ID}/chat`;
 const CANCELLATION_RECOVERY_COPY =
   "Finalizing the cancelled run before queued work continues.";
-const NEXT_RUN_MODEL_COPY =
-  "Your selected Claude Opus 4.8 model will take effect after this run";
+const NEXT_RUN_MODEL_COPY = "Next run will use Claude Opus 4.8";
 const MODEL_CHANGED_COPY = "Model changed to Claude Sonnet 4.6";
 
 afterEach(async () => {


### PR DESCRIPTION
## Summary

- shorten the active-run model change notice to `Next run will use {{model}}`
- update the existing chat queue behavior test expectation

## Verification

- `corepack pnpm prettier --check apps/platform/src/i18n/locales/en-US/common.json apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx`
- `corepack pnpm -F @vm0/app i18n:check`
- `corepack pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-queue.test.tsx --maxWorkers=1 --silent=passed-only` (23 tests passed)
- `corepack pnpm -F @vm0/app exec oxlint src/views/zero-page/__tests__/chat-run-queue.test.tsx`
- `corepack pnpm -F @vm0/app exec eslint src/views/zero-page/__tests__/chat-run-queue.test.tsx --max-warnings 0`

Browser verification was not run because this is a copy-only change and the repository workflow defers browser/dev-server checks unless explicitly requested.
