### PR TITLE
feat: include selected models in client chat messages

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -20,6 +20,7 @@ import {
   type ChatThreadEvent,
   type GenerationTemplateRequest,
   type ChatEvent,
+  type UserMessageDocument,
   type UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { isChatRunTerminalEventType } from "@vm0/api-contracts/contracts/chat-events";
@@ -7082,7 +7083,7 @@ describe("CHAT-02: shared user message queue", () => {
 
     const messageId = randomUUID();
     const referencedThreadId = randomUUID();
-    const userMessage: UserMessageInputDocument = {
+    const userMessage: UserMessageDocument = {
       version: 1,
       parts: [
         { type: "text", text: "queue-first " },
@@ -7091,6 +7092,7 @@ describe("CHAT-02: shared user message queue", () => {
           threadId: referencedThreadId,
           titleSnapshot: "direct dispatch",
         },
+        { type: "model", selectedModel: "gpt-5.6-sol" },
       ],
     };
     const sent = await chat.requestSendEvent(
@@ -7131,7 +7133,9 @@ describe("CHAT-02: shared user message queue", () => {
       userMessage: {
         version: 1,
         parts: [
-          ...userMessage.parts,
+          ...userMessage.parts.filter((part) => {
+            return part.type !== "model";
+          }),
           {
             type: "model",
             selectedModel: "claude-sonnet-4-6",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -23,6 +23,7 @@ import {
   type ChatRunOptionsRequest,
   type CodexServiceTier,
   type PersistedAttachment,
+  type UserMessageDocument,
   type UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
@@ -97,7 +98,7 @@ type BddSendEventBody =
       readonly clientThreadId?: string;
       readonly model?: SupportedRunModel;
       readonly runOptions?: ChatRunOptionsRequest;
-      readonly userMessage?: UserMessageInputDocument;
+      readonly userMessage?: UserMessageDocument;
       readonly hasTextContent?: boolean;
       readonly computerUseHostId?: string | null;
       readonly cloudBrowserEnabled?: boolean;

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -8,7 +8,6 @@ import {
   type CodexServiceTier,
   type GenerationTemplateRequest,
   type UserMessageDocument,
-  type UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { SupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -136,7 +135,7 @@ interface NormalSendBody {
   readonly runOptions?: {
     readonly codexServiceTier?: CodexServiceTier;
   };
-  readonly userMessage: UserMessageInputDocument;
+  readonly userMessage: UserMessageDocument;
   readonly hasTextContent: boolean;
   readonly computerUseHostId?: string | null;
   readonly cloudBrowserEnabled?: boolean;

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
@@ -34,6 +34,7 @@ import {
   chatEventDebugSummaries,
   chatEventTraceTime,
 } from "./chat-event-debug.ts";
+import { withSelectedModelAnnotation } from "./model-selection-request.ts";
 
 const L = logger("ChatEventSignals");
 
@@ -44,6 +45,7 @@ export interface SendInputChatEvent {
   readonly prompt: string;
   readonly hasTextContent: boolean;
   readonly userMessage: UserMessageInputDocument;
+  readonly selectedModel?: string | null;
   readonly runOptions?: ChatRunOptionsRequest;
   readonly realAgentInPreview?: boolean;
   readonly computerUseHostId?: string | null;
@@ -98,6 +100,10 @@ function createSendInputChatEvent({
       const clientEventId = crypto.randomUUID();
       const createdAt = nowDate().toISOString();
       const chatThreadSortEventId = crypto.randomUUID();
+      const userMessage = withSelectedModelAnnotation(
+        input.userMessage,
+        input.selectedModel,
+      );
       L.debug("send input prepared", {
         traceTime: chatEventTraceTime(),
         threadId,
@@ -121,7 +127,7 @@ function createSendInputChatEvent({
             threadId,
             eventType: "input.prompt",
             content: null,
-            userMessage: input.userMessage,
+            userMessage,
             ...(input.revokesEventId === undefined
               ? {}
               : { revokesEventId: input.revokesEventId }),
@@ -151,7 +157,7 @@ function createSendInputChatEvent({
           ...(input.realAgentInPreview === true
             ? { realAgentInPreview: true }
             : {}),
-          userMessage: input.userMessage,
+          userMessage,
           ...(input.computerUseHostId === undefined
             ? {}
             : { computerUseHostId: input.computerUseHostId }),

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2568,6 +2568,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
             prompt: result.prompt,
             hasTextContent: result.hasTextContent,
             userMessage,
+            selectedModel: request.modelSelection?.selectedModel ?? null,
             ...(runOptions === undefined ? {} : { runOptions }),
             ...(realAgentInPreviewEnabled ? { realAgentInPreview: true } : {}),
             ...(request.options && "computerUseHostId" in request.options
@@ -2719,6 +2720,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
             prompt: result.prompt,
             hasTextContent: result.hasTextContent,
             userMessage,
+            selectedModel: modelSelection?.selectedModel ?? null,
             ...(runOptions === undefined ? {} : { runOptions }),
             ...(realAgentInPreviewEnabled ? { realAgentInPreview: true } : {}),
             ...(options.computerUseHostId === undefined

--- a/turbo/apps/platform/src/signals/chat-page/model-selection-request.ts
+++ b/turbo/apps/platform/src/signals/chat-page/model-selection-request.ts
@@ -1,8 +1,28 @@
 import type {
   ChatRunOptionsRequest,
   CodexServiceTier,
+  UserMessageDocument,
+  UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
+
+/**
+ * Mirror the server-owned run-model annotation in the client projection and
+ * send document. The separate model request field remains authoritative; the
+ * server replaces this annotation with the model resolved for the run.
+ */
+export function withSelectedModelAnnotation(
+  document: UserMessageInputDocument,
+  selectedModel: string | null | undefined,
+): UserMessageDocument {
+  if (selectedModel === null || selectedModel === undefined) {
+    return document;
+  }
+  return {
+    version: 1,
+    parts: [...document.parts, { type: "model", selectedModel }],
+  };
+}
 
 export function runOptionsFromModelProviderSelection(
   value: ModelProviderSelection | null,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -5,6 +5,7 @@ import {
   chatThreadsContract,
   type GenerationTemplateRequest,
   type ResolvedAttachFile,
+  type UserMessageDocument,
   type UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { OrgModelPoliciesResponse } from "@vm0/api-contracts/contracts/model-providers";
@@ -41,7 +42,10 @@ import {
 } from "../external/feature-switch.ts";
 import { codexFastModeLocalDefault$ } from "../zero-page/codex-fast-local-default.ts";
 import { logger } from "../log.ts";
-import { runOptionsFromModelProviderSelection } from "./model-selection-request.ts";
+import {
+  runOptionsFromModelProviderSelection,
+  withSelectedModelAnnotation,
+} from "./model-selection-request.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
 import { chatPageModelSelection$ } from "../zero-page/zero-chat-page.ts";
@@ -127,7 +131,7 @@ function createNewThreadOptimisticEventEntry({
 }: {
   threadId: string;
   clientEventId: string;
-  userMessage: UserMessageInputDocument;
+  userMessage: UserMessageDocument;
 }): OptimisticChatEventInput {
   return {
     threadId,
@@ -162,7 +166,7 @@ function newThreadSendBody({
   modelSelection: ModelProviderSelection;
   codexFastModeEnabled: boolean;
   realAgentInPreviewEnabled: boolean;
-  userMessage: UserMessageInputDocument;
+  userMessage: UserMessageDocument;
   computerUseHostId?: string | null;
   cloudBrowserEnabled?: boolean;
 }) {
@@ -509,6 +513,10 @@ const sendNewThreadMessage$ = command(
     }
     const features = get(featureSwitch$);
     const userMessage = userMessageForNewThread(request, prepared);
+    const annotatedUserMessage = withSelectedModelAnnotation(
+      userMessage,
+      resolvedModelSelection.selectedModel,
+    );
     const threadId = crypto.randomUUID();
     const clientEventId = crypto.randomUUID();
     const chatThreadEventId = crypto.randomUUID();
@@ -518,7 +526,7 @@ const sendNewThreadMessage$ = command(
         createNewThreadOptimisticEventEntry({
           threadId,
           clientEventId,
-          userMessage,
+          userMessage: annotatedUserMessage,
         }),
       ),
     );
@@ -566,7 +574,7 @@ const sendNewThreadMessage$ = command(
       codexFastModeEnabled: codexFastModeSwitchEnabled(features),
       realAgentInPreviewEnabled:
         features[FeatureSwitchKey.RealAgentInPreview] ?? false,
-      userMessage,
+      userMessage: annotatedUserMessage,
       computerUseHostId,
       cloudBrowserEnabled,
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -24,6 +24,9 @@ import {
   linkByText,
   chatScrollContainer,
   chatComposerTextarea,
+  parseChatClipboardPayload,
+  readClipboardItemText,
+  readSingleRichClipboardWrite,
 } from "./chat-lifecycle-test-helpers.ts";
 import { normalizeMockChatEvents } from "./chat-event-test-helpers.ts";
 
@@ -656,9 +659,11 @@ describe("chat lifecycle", () => {
 
   it("projects the first-run model from the optimistic created event", async () => {
     const user = userEvent.setup({ delay: null });
+    const clipboard = context.mocks.browser.clipboardWrite();
     const prompt = "Start with my preferred model";
     const sendGate = context.mocks.deferred<void>();
     let clientThreadId: string | undefined;
+    let sentUserMessage: UserMessageDocument | undefined;
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
       updatedAt: "2026-03-10T00:00:00Z",
@@ -684,6 +689,9 @@ describe("chat lifecycle", () => {
         clientThreadId = body.clientThreadId;
         expect(body.modelSelection.selectedModel).toBe("claude-sonnet-4-6");
       },
+      onSendRequest: ({ userMessage }) => {
+        sentUserMessage = userMessage;
+      },
     });
 
     detachedSetupPage({ context, path: AGENT_CHAT_PATH });
@@ -704,6 +712,81 @@ describe("chat lifecycle", () => {
       context.store.get(eventDrivenChatThread(clientThreadId)),
     ).toMatchObject({
       selectedModel: "claude-sonnet-4-6",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(prompt)).toBeInTheDocument();
+      expect(screen.getByLabelText("Copy message")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Copy message"));
+    const item = await readSingleRichClipboardWrite(clipboard);
+    const html = await readClipboardItemText(item, "text/html");
+    expect(parseChatClipboardPayload(html).userMessage).toStrictEqual({
+      version: 1,
+      parts: [
+        { type: "text", text: prompt },
+        { type: "model", selectedModel: "claude-sonnet-4-6" },
+      ],
+    });
+    expect(sentUserMessage).toStrictEqual({
+      version: 1,
+      parts: [
+        { type: "text", text: prompt },
+        { type: "model", selectedModel: "claude-sonnet-4-6" },
+      ],
+    });
+  });
+
+  it("includes the selected model in optimistic and sent user messages", async () => {
+    const user = userEvent.setup({ delay: null });
+    const clipboard = context.mocks.browser.clipboardWrite();
+    const sendGate = context.mocks.deferred<void>();
+    onTestFinished(() => {
+      if (!sendGate.settled()) {
+        sendGate.resolve();
+      }
+    });
+    const threadId = "b0000000-0000-4000-a000-000000000993";
+    const prompt = "Keep the model visible while sending";
+    const selectedModel = "claude-sonnet-4-6";
+    let sentUserMessage: UserMessageDocument | undefined;
+    mockChatLifecycle(context, {
+      threadId,
+      selectedModel,
+      sendGate: sendGate.promise,
+      onSendRequest: ({ userMessage }) => {
+        sentUserMessage = userMessage;
+      },
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await sendMessageInUI(user, textarea, prompt);
+
+    await waitFor(() => {
+      expect(screen.getByText(prompt)).toBeInTheDocument();
+      expect(screen.getByLabelText("Copy message")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Copy message"));
+
+    const item = await readSingleRichClipboardWrite(clipboard);
+    const html = await readClipboardItemText(item, "text/html");
+    expect(parseChatClipboardPayload(html).userMessage).toStrictEqual({
+      version: 1,
+      parts: [
+        { type: "text", text: prompt },
+        { type: "model", selectedModel },
+      ],
+    });
+    expect(sentUserMessage).toStrictEqual({
+      version: 1,
+      parts: [
+        { type: "text", text: prompt },
+        { type: "model", selectedModel },
+      ],
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -1106,6 +1106,7 @@ describe("chat run queue", () => {
               filenameSnapshot: "queued.mp4",
               contentType: "video/mp4",
             },
+            { type: "model", selectedModel: "glm-5.1" },
           ],
         },
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-message-writing.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-message-writing.test.tsx
@@ -75,6 +75,7 @@ describe("user-message writes", () => {
               contentType: "text/plain",
             },
             { type: "text", text: "Review the launch brief" },
+            { type: "model", selectedModel: "deepseek-v4-flash" },
           ],
         },
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -97,7 +97,10 @@ describe("prompt query parameter injection", () => {
       expect(runPrompt).toBe("Build a launch recap");
       expect(userMessage).toStrictEqual({
         version: 1,
-        parts: [{ type: "text", text: "Build a launch recap" }],
+        parts: [
+          { type: "text", text: "Build a launch recap" },
+          { type: "model", selectedModel: "deepseek-v4-flash" },
+        ],
       });
       expect(createdThreadModel).toBe("deepseek-v4-flash");
     });
@@ -221,6 +224,7 @@ describe("prompt query parameter injection", () => {
             },
           },
           { type: "text", text: "Make a launch deck" },
+          { type: "model", selectedModel: "deepseek-v4-flash" },
         ],
       });
     });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -312,7 +312,7 @@ describe("chat thread generation template contract", () => {
     ).toMatchObject({ success: true });
   });
 
-  it("accepts one server-owned model annotation but rejects it upstream", () => {
+  it("accepts one model annotation in sends but rejects it in draft input", () => {
     const userMessage = {
       version: 1,
       parts: [
@@ -323,6 +323,15 @@ describe("chat thread generation template contract", () => {
     expect(userMessageDocumentSchema.safeParse(userMessage)).toMatchObject({
       success: true,
     });
+    expect(
+      chatEventsContract.send.body.safeParse({
+        agentId: "agent-1",
+        prompt: "Run with this model",
+        hasTextContent: true,
+        model: "claude-sonnet-4-6",
+        userMessage,
+      }),
+    ).toMatchObject({ success: true });
     expect(
       userMessageDocumentSchema.safeParse({
         version: 1,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -855,7 +855,7 @@ const chatNormalSendBodyShape = {
    */
   model: selectedModelRequestSchema.optional(),
   runOptions: chatRunOptionsRequestSchema.optional(),
-  userMessage: userMessageInputDocumentSchema,
+  userMessage: userMessageDocumentSchema,
   computerUseHostId: z.string().uuid().nullable().optional(),
   cloudBrowserEnabled: z.boolean().optional(),
   hasTextContent: z.boolean(),


### PR DESCRIPTION
## Summary

- Add the selected model annotation to optimistic user-message projections and outbound API `userMessage` documents for existing and new chat threads.
- Keep the separate model selection authoritative; the server replaces any client annotation with the model resolved for the run.
- Accept model annotations only on chat send bodies while keeping draft input documents model-free.
- Cover the client request/projection paths, send contract, and authoritative server replacement behavior.

## Fallbacks

Fallbacks: none

## Verification

- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F api check-types:core`
- `pnpm -F api check-types:tests`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/chat-threads.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --maxWorkers=1 --silent=passed-only`
- Targeted Prettier, Oxlint, and ESLint checks for all changed files

The targeted API BDD case requires PostgreSQL and is left to the PR pipeline; its test project type-check passes locally.
