### PR TITLE
feat: add responsive follow-up card rail

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -4,6 +4,12 @@ import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(process.env.VM0_API_BACKEND_URL!);
 const composerConnectorSlugs = ["github", "slack", "asana"] as const;
+const responsiveFollowupThreadId = "b0000000-0000-4000-a000-000000000734";
+const responsiveFollowupPrompts = [
+  "Draft launch copy",
+  "Create a detailed presentation outline with speaker notes",
+  "Generate a hero image",
+] as const;
 
 interface ConnectorCatalogStatusItem {
   readonly slug: string;
@@ -121,6 +127,146 @@ async function mockComposerConnectorState(page: Page): Promise<void> {
       json: { enabledConnectorSlugs: composerConnectorSlugs },
     });
   });
+}
+
+async function enableResponsiveFollowupCards(page: Page): Promise<void> {
+  await page.route("**/api/zero/feature-switches", async (route) => {
+    const response = await route.fetch();
+    const body: unknown = await response.json();
+    if (!isRecord(body) || !isRecord(body.effectiveSwitches)) {
+      throw new Error("Feature switches returned an unexpected response");
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        effectiveSwitches: {
+          ...body.effectiveSwitches,
+          chatEventSnapshotRead: false,
+          responsiveFollowupCards: true,
+        },
+      },
+    });
+  });
+}
+
+async function mockResponsiveFollowupThread(
+  page: Page,
+  agentId: string,
+): Promise<void> {
+  const createdAt = "2026-06-09T10:01:01Z";
+  const runId = "run-responsive-followups";
+  const events = [
+    {
+      id: "msg-responsive-followups-assistant",
+      threadId: responsiveFollowupThreadId,
+      eventType: "output.message",
+      content: "The launch plan is ready.",
+      runId,
+      seqId: 1,
+      createdAt: "2026-06-09T10:01:00Z",
+    },
+    {
+      id: "msg-responsive-followups-completed",
+      threadId: responsiveFollowupThreadId,
+      eventType: "run.completed",
+      content: null,
+      runId,
+      runLifecycleEvent: "completed",
+      seqId: 2,
+      createdAt,
+    },
+    {
+      id: "msg-responsive-followups-followups",
+      threadId: responsiveFollowupThreadId,
+      eventType: "output.followups",
+      content: JSON.stringify({
+        version: 1,
+        followups: responsiveFollowupPrompts.map((prompt) => {
+          return { prompt, kind: "talk" };
+        }),
+      }),
+      runId,
+      seqId: 3,
+      createdAt,
+    },
+  ];
+
+  await page.route("**/api/zero/chat-threads/snapshot", async (route) => {
+    await route.fulfill({
+      json: {
+        chatThreads: [
+          {
+            id: responsiveFollowupThreadId,
+            agentId,
+            title: "Responsive follow-ups",
+            sortAt: createdAt,
+            createdAt,
+            updatedAt: createdAt,
+            pinnedAt: null,
+            renamedAt: null,
+            selectedModel: null,
+            serviceTier: null,
+            computerUseHostId: null,
+            cloudBrowserEnabled: false,
+          },
+        ],
+        latestEventId: null,
+        latestSeqId: null,
+      },
+    });
+  });
+  await page.route(
+    new RegExp(
+      `/api/zero/chat-threads/${responsiveFollowupThreadId}/events(?:\\?.*)?$`,
+    ),
+    async (route) => {
+      const requestUrl = new URL(route.request().url());
+      const isIncremental =
+        requestUrl.searchParams.has("sinceSeqId") ||
+        requestUrl.searchParams.has("beforeSeqId");
+      await route.fulfill({ json: { events: isIncremental ? [] : events } });
+    },
+  );
+  await page.route(
+    new RegExp(
+      `/api/zero/chat-threads/${responsiveFollowupThreadId}/draft(?:\\?.*)?$`,
+    ),
+    async (route) => {
+      await route.fulfill({
+        json: { draftUserMessage: null, draftAttachments: null },
+      });
+    },
+  );
+  await page.route(
+    new RegExp(
+      `/api/zero/chat-threads/${responsiveFollowupThreadId}/mark-read(?:\\?.*)?$`,
+    ),
+    async (route) => {
+      await route.fulfill({ json: { lastReadAt: createdAt, unreads: [] } });
+    },
+  );
+  await page.route(
+    new RegExp(
+      `/api/zero/chat-threads/${responsiveFollowupThreadId}/event-snapshot(?:\\?.*)?$`,
+    ),
+    async (route) => {
+      await route.fulfill({
+        status: 404,
+        json: { error: { code: "NOT_FOUND", message: "Not found" } },
+      });
+    },
+  );
+  await page.route(
+    new RegExp(
+      `/api/zero/chat-threads/${responsiveFollowupThreadId}(?:\\?.*)?$`,
+    ),
+    async (route) => {
+      await route.fulfill({
+        json: { lastReadAt: createdAt, cancellationRecoveryPending: false },
+      });
+    },
+  );
 }
 
 async function expectInside(inner: Locator, outer: Locator): Promise<void> {
@@ -241,6 +387,109 @@ test("chat composer keeps the Send button inside on narrow screens", async ({
   await waitForAgentDraftClear(page, async () => {
     await clearComposerEditor(editor);
   });
+});
+
+test("responsive follow-up rail aligns its edges and equalizes card heights", async ({
+  page,
+}) => {
+  await enableResponsiveFollowupCards(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+
+  const agentId = new URL(page.url()).pathname.match(
+    /^\/agents\/([^/]+)\/chat\/?$/,
+  )?.[1];
+  if (!agentId) {
+    throw new Error("Could not resolve the active agent from the chat URL");
+  }
+  await mockResponsiveFollowupThread(page, agentId);
+  await page.goto(new URL(`/chats/${responsiveFollowupThreadId}`, appUrl).href);
+
+  const rail = page.getByRole("group", { name: "Keep going" });
+  const cards = responsiveFollowupPrompts.map((prompt) => {
+    return page.getByRole("button", { name: prompt, exact: true });
+  });
+  await expect(rail).toBeVisible();
+  for (const card of cards) {
+    await expect(card).toBeVisible();
+  }
+
+  await expect
+    .poll(async () => {
+      const railBox = await rail.boundingBox();
+      const firstBox = await cards[0].boundingBox();
+      if (!railBox || !firstBox) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return Math.abs(firstBox.x - railBox.x);
+    })
+    .toBeLessThan(1);
+  await expect
+    .poll(async () => {
+      const boxes = await Promise.all(cards.map((card) => card.boundingBox()));
+      if (boxes.some((box) => box === null)) {
+        return Number.POSITIVE_INFINITY;
+      }
+      const heights = boxes.map((box) => box!.height);
+      return Math.max(...heights) - Math.min(...heights);
+    })
+    .toBeLessThan(1);
+
+  await cards[1].evaluate((element) => {
+    element.scrollIntoView({ block: "nearest", inline: "center" });
+  });
+  await expect
+    .poll(async () => {
+      const railBox = await rail.boundingBox();
+      const middleBox = await cards[1].boundingBox();
+      if (!railBox || !middleBox) {
+        return Number.POSITIVE_INFINITY;
+      }
+      const railCenter = railBox.x + railBox.width / 2;
+      const cardCenter = middleBox.x + middleBox.width / 2;
+      return Math.abs(cardCenter - railCenter);
+    })
+    .toBeLessThan(2);
+
+  await rail.evaluate((element) => {
+    element.scrollLeft = element.scrollWidth;
+  });
+  await expect
+    .poll(async () => {
+      const railBox = await rail.boundingBox();
+      const lastBox = await cards[2].boundingBox();
+      if (!railBox || !lastBox) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return Math.abs(lastBox.x + lastBox.width - (railBox.x + railBox.width));
+    })
+    .toBeLessThan(1);
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await expect
+    .poll(async () => {
+      const railBox = await rail.boundingBox();
+      const firstBox = await cards[0].boundingBox();
+      if (!railBox || !firstBox) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return Math.abs(firstBox.width - railBox.width);
+    })
+    .toBeLessThan(2);
+
+  await page.keyboard.press("Tab");
+  await cards[0].focus();
+  await expect
+    .poll(async () => {
+      return cards[0].evaluate((element) => {
+        return (
+          element.matches(":focus-visible") &&
+          getComputedStyle(element).boxShadow !== "none"
+        );
+      });
+    })
+    .toBe(true);
 });
 
 test("image lightbox centers and pans across the full viewer", async ({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -146,10 +146,6 @@ describe("chat lifecycle", () => {
       expect(buttonByText("Generate launch artifact")).toBeInTheDocument();
       expect(buttonByText("Draft launch copy")).toBeInTheDocument();
     });
-    expect(
-      document.querySelector("[data-responsive-followup-cards]"),
-    ).toBeNull();
-
     click(buttonByText(followupPrompt));
 
     await waitFor(() => {
@@ -169,7 +165,7 @@ describe("chat lifecycle", () => {
     expect(sentMessages).toHaveLength(0);
   });
 
-  it("renders an edge-aligned equal-height follow-up card rail when enabled", async () => {
+  it("preserves follow-up content and selection when the card rail is enabled", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000734";
     const prompts = [
       "Draft launch copy",
@@ -183,6 +179,8 @@ describe("chat lifecycle", () => {
       hour: "numeric",
       minute: "2-digit",
     });
+    const selectedPrompt = prompts[1]!;
+    const sentMessages: unknown[] = [];
 
     mockChatLifecycle(context, {
       threadId,
@@ -209,6 +207,9 @@ describe("chat lifecycle", () => {
           createdAt: completedAt,
         },
       ],
+      onRunCreate: (body) => {
+        sentMessages.push(body);
+      },
     });
 
     detachedSetupPage({
@@ -219,26 +220,27 @@ describe("chat lifecycle", () => {
       },
     });
 
+    const composer = await findWorkflowComposerEditor();
     await screen.findByText("The launch plan is ready.");
     expect(
       screen.getByText(`Keep going · ${completedAtLabel}`),
     ).toBeInTheDocument();
-    const rail = document.querySelector("[data-responsive-followup-cards]");
-    expect(rail).toHaveClass(
-      "flex",
-      "items-stretch",
-      "snap-x",
-      "@[900px]:block",
-    );
+    expect(
+      screen.getByRole("group", { name: "Keep going" }),
+    ).toBeInTheDocument();
     for (const prompt of prompts) {
       const card = buttonByText(prompt);
-      expect(card.textContent).toBe(prompt);
-      expect(card).toHaveClass(
-        "self-stretch",
-        "snap-center",
-        "@[900px]:w-full",
-      );
+      expect(card).toBeVisible();
+      expect(card).toHaveAccessibleName(prompt);
     }
+
+    click(buttonByText(selectedPrompt));
+
+    await waitFor(() => {
+      expect(composer.textContent).toBe(selectedPrompt);
+      expect(composer).toHaveFocus();
+    });
+    expect(sentMessages).toHaveLength(0);
   });
 
   it("shows recommended follow-ups after an appended follow-up event", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -169,7 +169,7 @@ describe("chat lifecycle", () => {
     expect(sentMessages).toHaveLength(0);
   });
 
-  it("renders equal-height centered follow-up cards only when enabled", async () => {
+  it("renders an edge-aligned equal-height follow-up card rail when enabled", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000734";
     const prompts = [
       "Draft launch copy",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { artifactCatalogContract } from "@vm0/api-contracts/contracts/artifact-catalog";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { click, fill } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
@@ -145,6 +146,9 @@ describe("chat lifecycle", () => {
       expect(buttonByText("Generate launch artifact")).toBeInTheDocument();
       expect(buttonByText("Draft launch copy")).toBeInTheDocument();
     });
+    expect(
+      document.querySelector("[data-responsive-followup-cards]"),
+    ).toBeNull();
 
     click(buttonByText(followupPrompt));
 
@@ -163,6 +167,78 @@ describe("chat lifecycle", () => {
     });
     expect(composer.textContent).toBe(`${existingDraft}\n${followupPrompt}`);
     expect(sentMessages).toHaveLength(0);
+  });
+
+  it("renders equal-height centered follow-up cards only when enabled", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000734";
+    const prompts = [
+      "Draft launch copy",
+      "Create a detailed presentation outline with speaker notes",
+      "Generate a hero image",
+    ];
+    const completedAt = "2026-06-09T10:01:01Z";
+    const completedAtLabel = new Date(completedAt).toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Responsive follow-ups",
+      chatEvents: [
+        {
+          id: "msg-responsive-followups-assistant",
+          eventType: "output.message",
+          role: "assistant",
+          content: "The launch plan is ready.",
+          runId: "run-responsive-followups",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+        {
+          id: "msg-responsive-followups-completed",
+          eventType: "run.completed",
+          role: "assistant",
+          content: null,
+          runId: "run-responsive-followups",
+          runLifecycleEvent: "completed",
+          followups: prompts.map((prompt) => {
+            return { prompt, kind: "talk" as const };
+          }),
+          createdAt: completedAt,
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ResponsiveFollowupCards]: true,
+      },
+    });
+
+    await screen.findByText("The launch plan is ready.");
+    expect(
+      screen.getByText(`Keep going · ${completedAtLabel}`),
+    ).toBeInTheDocument();
+    const rail = document.querySelector("[data-responsive-followup-cards]");
+    expect(rail).toHaveClass(
+      "flex",
+      "items-stretch",
+      "snap-x",
+      "@[900px]:block",
+    );
+    for (const prompt of prompts) {
+      const card = buttonByText(prompt);
+      expect(card.textContent).toBe(prompt);
+      expect(card).toHaveClass(
+        "self-stretch",
+        "snap-center",
+        "@[900px]:w-full",
+      );
+    }
   });
 
   it("shows recommended follow-ups after an appended follow-up event", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4125,7 +4125,7 @@ function RecommendedFollowupList({
       data-responsive-followup-cards={responsiveFollowupCards ? "" : undefined}
       className={cn(
         responsiveFollowupCards
-          ? "flex items-stretch gap-3 overflow-x-auto overscroll-x-contain snap-x snap-mandatory px-[max(2rem,calc((100cqw-22rem)/2))] pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden @[900px]:-mx-2 @[900px]:block @[900px]:overflow-visible @[900px]:px-0 @[900px]:pb-0"
+          ? "flex items-stretch gap-3 overflow-x-auto overscroll-x-contain snap-x snap-mandatory pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden @[900px]:-mx-2 @[900px]:block @[900px]:overflow-visible @[900px]:pb-0"
           : "-mx-2",
       )}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4097,6 +4097,8 @@ function RecommendedFollowupList({
   thread: ChatPanelSignals;
   source: RecommendedFollowupSource;
 }) {
+  const responsiveFollowupCards =
+    useGet(featureSwitch$)[FeatureSwitchKey.ResponsiveFollowupCards] ?? false;
   const selectOrAppendComposerText = useSet(
     thread.composer.editor.selectOrAppendText$,
   );
@@ -4118,28 +4120,56 @@ function RecommendedFollowupList({
   };
 
   return (
-    <div ref={handleRecommendedFollowupsRef} className="-mx-2">
+    <div
+      ref={handleRecommendedFollowupsRef}
+      data-responsive-followup-cards={responsiveFollowupCards ? "" : undefined}
+      className={cn(
+        responsiveFollowupCards
+          ? "flex items-stretch gap-3 overflow-x-auto overscroll-x-contain snap-x snap-mandatory px-[max(2rem,calc((100cqw-22rem)/2))] pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden @[900px]:-mx-2 @[900px]:block @[900px]:overflow-visible @[900px]:px-0 @[900px]:pb-0"
+          : "-mx-2",
+      )}
+    >
       {source.followups.map((followup, followupIndex) => {
         return (
           <button
             key={followup.prompt}
             type="button"
             title={followup.prompt}
-            className="group flex min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors hover:bg-state-hover"
+            className={cn(
+              "group flex text-left transition-colors",
+              responsiveFollowupCards
+                ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--zero-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 @[900px]:min-h-10 @[900px]:w-full @[900px]:items-center @[900px]:gap-2 @[900px]:rounded-lg @[900px]:border-0 @[900px]:bg-transparent @[900px]:px-2 @[900px]:py-2 @[900px]:shadow-none @[900px]:hover:bg-state-hover @[900px]:focus-visible:ring-0"
+                : "min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 hover:bg-state-hover",
+            )}
             onClick={() => {
               handleSelect(followup, followupIndex);
             }}
           >
-            <span className="shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground">
+            <span
+              className={cn(
+                "shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground",
+                responsiveFollowupCards && "hidden @[900px]:block",
+              )}
+            >
               <RecommendedFollowupIcon followup={followup} />
             </span>
-            <span className="min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 text-muted-foreground group-hover:text-foreground">
+            <span
+              className={cn(
+                "min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 group-hover:text-foreground",
+                responsiveFollowupCards
+                  ? "text-foreground @[900px]:text-muted-foreground"
+                  : "text-muted-foreground",
+              )}
+            >
               {followup.prompt}
             </span>
             <IconArrowUpRight
               size={14}
               stroke={1.8}
-              className="shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100"
+              className={cn(
+                "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100",
+                responsiveFollowupCards && "hidden @[900px]:block",
+              )}
             />
           </button>
         );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4097,6 +4097,7 @@ function RecommendedFollowupList({
   thread: ChatPanelSignals;
   source: RecommendedFollowupSource;
 }) {
+  const { t } = useTranslation();
   const responsiveFollowupCards =
     useGet(featureSwitch$)[FeatureSwitchKey.ResponsiveFollowupCards] ?? false;
   const selectOrAppendComposerText = useSet(
@@ -4122,7 +4123,10 @@ function RecommendedFollowupList({
   return (
     <div
       ref={handleRecommendedFollowupsRef}
-      data-responsive-followup-cards={responsiveFollowupCards ? "" : undefined}
+      role="group"
+      aria-label={t(($) => {
+        return $.chat.run.keepGoing;
+      })}
       className={cn(
         responsiveFollowupCards
           ? "flex items-stretch gap-3 overflow-x-auto overscroll-x-contain snap-x snap-mandatory pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden @[900px]:-mx-2 @[900px]:block @[900px]:overflow-visible @[900px]:pb-0"
@@ -4138,7 +4142,7 @@ function RecommendedFollowupList({
             className={cn(
               "group flex text-left transition-colors",
               responsiveFollowupCards
-                ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--zero-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 @[900px]:min-h-10 @[900px]:w-full @[900px]:items-center @[900px]:gap-2 @[900px]:rounded-lg @[900px]:border-0 @[900px]:bg-transparent @[900px]:px-2 @[900px]:py-2 @[900px]:shadow-none @[900px]:hover:bg-state-hover @[900px]:focus-visible:ring-0"
+                ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--zero-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 @[900px]:min-h-10 @[900px]:w-full @[900px]:items-center @[900px]:gap-2 @[900px]:rounded-lg @[900px]:border-0 @[900px]:bg-transparent @[900px]:px-2 @[900px]:py-2 @[900px]:shadow-none @[900px]:hover:bg-state-hover"
                 : "min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 hover:bg-state-hover",
             )}
             onClick={() => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -60,6 +60,7 @@ export enum FeatureSwitchKey {
   ZapierConnector = "zapierConnector",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",
+  ResponsiveFollowupCards = "responsiveFollowupCards",
   ForegroundAuthRecovery = "foregroundAuthRecovery",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   TeamsIntegration = "teamsIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -371,6 +371,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ResponsiveFollowupCards]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Render recommended follow-ups as an equal-height centered card rail in narrow chat layouts.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ForegroundAuthRecovery]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add the responsiveFollowupCards feature switch for staff rollout
- render existing follow-up prompts as a centered, equal-height card rail below 900px
- preserve the current copy and desktop follow-up list, with no swipe hint or title/body split
- cover the disabled and enabled layouts with an integration test

## Testing

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx

## Fallbacks

None.