### PR TITLE
fix(browser): emit open events only for viewer actions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -1415,14 +1415,16 @@ describe("zero browser route", () => {
 
     // The viewer can restore a reclaimed browser without a live run.
     context.mocks.ably.publish.mockClear();
+    const resumedEventId = randomUUID();
     const resumed = await accept(
       client().open({
         headers: { authorization: "Bearer clerk-session" },
         params: { threadId },
-        body: { eventId: randomUUID() },
+        body: { eventId: resumedEventId },
       }),
       [200],
     );
+    expect(resumed.body.lifecycleEventId).toBe(resumedEventId);
     expect(resumed.body.browser).toMatchObject({
       threadId: threadId,
       status: "active",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -2310,7 +2310,7 @@ describe("zero browser route", () => {
     await deleteAgentRunRootFixture(first.runId);
   }, 120_000);
 
-  it("records browser close events for UI actions and automatic reclamation", async () => {
+  it("records browser lifecycle events only for UI actions and automatic reclamation", async () => {
     const { routeMocks, runs, chat, actor, agent } =
       await setupBrowserScenario();
     const first = await createClaimedChatRun(
@@ -2367,6 +2367,7 @@ describe("zero browser route", () => {
       client().use({ headers: first.claim.browserHeaders, body: {} }),
       [200],
     );
+    expect(firstStart.body.lifecycleEventId).toBeNull();
 
     routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const beforeReclaimCloseEventId = randomUUID();
@@ -2397,19 +2398,20 @@ describe("zero browser route", () => {
       threadId: firstStart.body.browser.threadId,
       status: "active",
     });
+    expect(resumed.body.lifecycleEventId).toBeNull();
     expect(providerCreates).toBe(2);
 
-    const noOpEventId = randomUUID();
+    const openEventId = randomUUID();
     const alreadyActive = await accept(
       client().open({
         headers: { authorization: "Bearer clerk-session" },
         params: { threadId: first.threadId },
-        body: { eventId: noOpEventId },
+        body: { eventId: openEventId },
       }),
       [200],
     );
     expect(alreadyActive.body).toMatchObject({
-      lifecycleEventId: null,
+      lifecycleEventId: openEventId,
       browser: { threadId: first.threadId, status: "active" },
     });
 
@@ -2459,11 +2461,6 @@ describe("zero browser route", () => {
       }),
     ).toStrictEqual([
       {
-        id: firstStart.body.lifecycleEventId,
-        eventType: "browser.open",
-        content: null,
-      },
-      {
         id: beforeReclaimCloseEventId,
         eventType: "browser.close",
         content: null,
@@ -2474,7 +2471,7 @@ describe("zero browser route", () => {
         content: null,
       },
       {
-        id: resumed.body.lifecycleEventId,
+        id: openEventId,
         eventType: "browser.open",
         content: null,
       },
@@ -2484,11 +2481,6 @@ describe("zero browser route", () => {
         content: null,
       },
     ]);
-    expect(
-      events.body.events.some((event) => {
-        return event.id === noOpEventId;
-      }),
-    ).toBeFalsy();
 
     const collided = await createApp({
       signal: context.signal,

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -108,8 +108,6 @@ type BrowserThreadProfileRow = typeof browserThreadProfiles.$inferSelect;
 type DbTransaction = Tx;
 type InactiveBrowserStatus = (typeof INACTIVE_BROWSER_STATUSES)[number];
 
-class BrowserOpenEventIdConflictError extends Error {}
-
 export interface BrowserServiceError {
   readonly kind: "error";
   readonly status: 400 | 403 | 404 | 409 | 502 | 503;
@@ -1427,7 +1425,6 @@ async function claimStartedProviderInstance(
     readonly browser: BrowserSessionRow;
     readonly context: BrowserRunContext;
     readonly provider: BrowserUseSession;
-    readonly lifecycleEventId?: string;
     readonly screenHeight: number;
   },
 ) {
@@ -1488,42 +1485,17 @@ async function claimStartedProviderInstance(
     if (!browser) {
       throw new Error("Failed to activate managed browser");
     }
-    const lifecycleEvent = args.lifecycleEventId
-      ? await insertChatEvent(
-          tx,
-          {
-            id: args.lifecycleEventId,
-            chatThreadId: current.chatThreadId,
-            eventType: "browser.open",
-            content: null,
-          },
-          "id",
-        )
-      : null;
-    if (args.lifecycleEventId && !lifecycleEvent) {
-      throw new BrowserOpenEventIdConflictError(
-        "Managed browser open event ID is already in use",
-      );
-    }
     return {
       kind: "active" as const,
       browser,
       instance,
       screen,
-      lifecycleEvent,
     };
   });
   if (claimed.kind === "cleanup" || claimed.kind === "active") {
     await publishBrowserSessionChangedSafely(args.browser.userId, {
       threadId: args.browser.chatThreadId,
     });
-  }
-  if (claimed.kind === "active" && claimed.lifecycleEvent) {
-    await publishChatThreadMessageCreatedSafely(
-      args.browser.userId,
-      args.browser.chatThreadId,
-      claimed.lifecycleEvent.seqId,
-    );
   }
   return claimed;
 }
@@ -1534,7 +1506,6 @@ async function createAndClaimProviderInstance(
     readonly browser: BrowserSessionRow;
     readonly profile: Pick<BrowserThreadProfileRow, "providerProfileId">;
     readonly context: BrowserRunContext;
-    readonly lifecycleEventId?: string;
     readonly screenHeight: number;
   },
 ) {
@@ -1581,7 +1552,6 @@ async function createAndClaimProviderInstance(
       browser: args.browser,
       context: args.context,
       provider: provider.value,
-      lifecycleEventId: args.lifecycleEventId,
       screenHeight: args.screenHeight,
     }),
   );
@@ -1589,12 +1559,6 @@ async function createAndClaimProviderInstance(
     // Provider creation is irreversible. Any failed claim must reclaim the
     // provider because the transaction rolls back every durable owner row.
     stopProviderSessionLater(provider.value.id);
-    if (claimResult.error instanceof BrowserOpenEventIdConflictError) {
-      return conflict(
-        "The managed browser lifecycle event ID is already in use",
-        "BROWSER_EVENT_ID_CONFLICT",
-      );
-    }
     throw claimResult.error;
   }
   const claimed = claimResult.value;
@@ -1613,7 +1577,6 @@ const startProviderInstance$ = command(
     args: {
       readonly browser: BrowserSessionRow;
       readonly context: BrowserRunContext;
-      readonly lifecycleEventId?: string;
     },
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<BrowserConnection>> => {
@@ -1639,7 +1602,6 @@ const startProviderInstance$ = command(
       browser: args.browser,
       profile,
       context: args.context,
-      lifecycleEventId: args.lifecycleEventId,
       screenHeight,
     });
     signal.throwIfAborted();
@@ -1689,7 +1651,7 @@ const startProviderInstance$ = command(
           claimed.screen,
         ),
         cdpUrl: started.cdpUrl,
-        lifecycleEventId: claimed.lifecycleEvent?.id ?? null,
+        lifecycleEventId: null,
       },
     };
   },
@@ -1759,7 +1721,6 @@ const createBrowserForContext$ = command(
     args: {
       readonly context: BrowserRunContext;
       readonly input: BrowserCreateInput;
-      readonly lifecycleEventId?: string;
     },
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<BrowserConnection>> => {
@@ -1785,7 +1746,6 @@ const createBrowserForContext$ = command(
       {
         browser: claimed.value,
         context: args.context,
-        lifecycleEventId: args.lifecycleEventId,
       },
       AbortSignal.timeout(PROVIDER_START_LIFECYCLE_TIMEOUT_MS),
     );
@@ -2070,7 +2030,6 @@ const resumeSuspendedBrowser$ = command(
     args: {
       readonly context: BrowserRunContext;
       readonly current: BrowserSessionRow;
-      readonly lifecycleEventId?: string;
     },
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<BrowserConnection>> => {
@@ -2107,7 +2066,6 @@ const resumeSuspendedBrowser$ = command(
       {
         browser: claim.browser,
         context,
-        lifecycleEventId: args.lifecycleEventId,
       },
       AbortSignal.timeout(PROVIDER_START_LIFECYCLE_TIMEOUT_MS),
     );
@@ -2138,7 +2096,6 @@ const openBrowserForContext$ = command(
     { set },
     args: {
       readonly context: BrowserRunContext;
-      readonly lifecycleEventId?: string;
       readonly input?: BrowserCreateInput;
     },
     signal: AbortSignal,
@@ -2157,7 +2114,6 @@ const openBrowserForContext$ = command(
             name: "browser",
             proxyCountryCode: null,
           },
-          lifecycleEventId: args.lifecycleEventId,
         },
         signal,
       );
@@ -2176,7 +2132,6 @@ const openBrowserForContext$ = command(
           {
             context,
             current: reused.browser,
-            lifecycleEventId: args.lifecycleEventId,
           },
           signal,
         );
@@ -2221,7 +2176,6 @@ export const openZeroBrowserForThread$ = command(
       openBrowserForContext$,
       {
         context: context.value,
-        lifecycleEventId: args.lifecycleEventId,
       },
       signal,
     );
@@ -2231,15 +2185,6 @@ export const openZeroBrowserForThread$ = command(
     }
     // The viewer runs in the user's browser, so it only ever learns the live
     // view; the CDP endpoint stays inside the agent runtime.
-    if (connection.value.lifecycleEventId) {
-      return {
-        kind: "ok",
-        value: {
-          browser: connection.value.browser,
-          lifecycleEventId: connection.value.lifecycleEventId,
-        },
-      };
-    }
     const event = await db.transaction(async (tx) => {
       return await insertChatEvent(
         tx,

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -1427,7 +1427,7 @@ async function claimStartedProviderInstance(
     readonly browser: BrowserSessionRow;
     readonly context: BrowserRunContext;
     readonly provider: BrowserUseSession;
-    readonly lifecycleEventId: string;
+    readonly lifecycleEventId?: string;
     readonly screenHeight: number;
   },
 ) {
@@ -1488,17 +1488,19 @@ async function claimStartedProviderInstance(
     if (!browser) {
       throw new Error("Failed to activate managed browser");
     }
-    const event = await insertChatEvent(
-      tx,
-      {
-        id: args.lifecycleEventId,
-        chatThreadId: current.chatThreadId,
-        eventType: "browser.open",
-        content: null,
-      },
-      "id",
-    );
-    if (!event) {
+    const lifecycleEvent = args.lifecycleEventId
+      ? await insertChatEvent(
+          tx,
+          {
+            id: args.lifecycleEventId,
+            chatThreadId: current.chatThreadId,
+            eventType: "browser.open",
+            content: null,
+          },
+          "id",
+        )
+      : null;
+    if (args.lifecycleEventId && !lifecycleEvent) {
       throw new BrowserOpenEventIdConflictError(
         "Managed browser open event ID is already in use",
       );
@@ -1508,7 +1510,7 @@ async function claimStartedProviderInstance(
       browser,
       instance,
       screen,
-      lifecycleEvent: event,
+      lifecycleEvent,
     };
   });
   if (claimed.kind === "cleanup" || claimed.kind === "active") {
@@ -1516,7 +1518,7 @@ async function claimStartedProviderInstance(
       threadId: args.browser.chatThreadId,
     });
   }
-  if (claimed.kind === "active") {
+  if (claimed.kind === "active" && claimed.lifecycleEvent) {
     await publishChatThreadMessageCreatedSafely(
       args.browser.userId,
       args.browser.chatThreadId,
@@ -1532,7 +1534,7 @@ async function createAndClaimProviderInstance(
     readonly browser: BrowserSessionRow;
     readonly profile: Pick<BrowserThreadProfileRow, "providerProfileId">;
     readonly context: BrowserRunContext;
-    readonly lifecycleEventId: string;
+    readonly lifecycleEventId?: string;
     readonly screenHeight: number;
   },
 ) {
@@ -1611,7 +1613,7 @@ const startProviderInstance$ = command(
     args: {
       readonly browser: BrowserSessionRow;
       readonly context: BrowserRunContext;
-      readonly lifecycleEventId: string;
+      readonly lifecycleEventId?: string;
     },
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<BrowserConnection>> => {
@@ -1687,7 +1689,7 @@ const startProviderInstance$ = command(
           claimed.screen,
         ),
         cdpUrl: started.cdpUrl,
-        lifecycleEventId: claimed.lifecycleEvent.id,
+        lifecycleEventId: claimed.lifecycleEvent?.id ?? null,
       },
     };
   },
@@ -1757,7 +1759,7 @@ const createBrowserForContext$ = command(
     args: {
       readonly context: BrowserRunContext;
       readonly input: BrowserCreateInput;
-      readonly lifecycleEventId: string;
+      readonly lifecycleEventId?: string;
     },
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<BrowserConnection>> => {
@@ -1825,7 +1827,6 @@ export const createZeroBrowser$ = command(
       {
         context: context.value,
         input: args.input,
-        lifecycleEventId: randomUUID(),
       },
       signal,
     );
@@ -2069,7 +2070,7 @@ const resumeSuspendedBrowser$ = command(
     args: {
       readonly context: BrowserRunContext;
       readonly current: BrowserSessionRow;
-      readonly lifecycleEventId: string;
+      readonly lifecycleEventId?: string;
     },
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<BrowserConnection>> => {
@@ -2137,7 +2138,7 @@ const openBrowserForContext$ = command(
     { set },
     args: {
       readonly context: BrowserRunContext;
-      readonly lifecycleEventId: string;
+      readonly lifecycleEventId?: string;
       readonly input?: BrowserCreateInput;
     },
     signal: AbortSignal,
@@ -2198,7 +2199,6 @@ export const useZeroBrowser$ = command(
       openBrowserForContext$,
       {
         context: context.value,
-        lifecycleEventId: randomUUID(),
       },
       signal,
     );
@@ -2225,17 +2225,53 @@ export const openZeroBrowserForThread$ = command(
       },
       signal,
     );
+    signal.throwIfAborted();
+    if (connection.kind === "error") {
+      return connection;
+    }
     // The viewer runs in the user's browser, so it only ever learns the live
     // view; the CDP endpoint stays inside the agent runtime.
-    return connection.kind === "error"
-      ? connection
-      : {
-          kind: "ok",
-          value: {
-            browser: connection.value.browser,
-            lifecycleEventId: connection.value.lifecycleEventId,
-          },
-        };
+    if (connection.value.lifecycleEventId) {
+      return {
+        kind: "ok",
+        value: {
+          browser: connection.value.browser,
+          lifecycleEventId: connection.value.lifecycleEventId,
+        },
+      };
+    }
+    const event = await db.transaction(async (tx) => {
+      return await insertChatEvent(
+        tx,
+        {
+          id: args.lifecycleEventId,
+          chatThreadId: context.value.chatThreadId,
+          eventType: "browser.open",
+          content: null,
+        },
+        "id",
+      );
+    });
+    signal.throwIfAborted();
+    if (!event) {
+      return conflict(
+        "The managed browser open event ID is already in use",
+        "BROWSER_EVENT_ID_CONFLICT",
+      );
+    }
+    await publishChatThreadMessageCreatedSafely(
+      context.value.userId,
+      context.value.chatThreadId,
+      event.seqId,
+    );
+    signal.throwIfAborted();
+    return {
+      kind: "ok",
+      value: {
+        browser: connection.value.browser,
+        lifecycleEventId: event.id,
+      },
+    };
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3864,6 +3864,15 @@ describe("chat event action cards", () => {
       browserRequests += 1;
       return respond(200, { browser });
     });
+    const browserOpenEventIds: string[] = [];
+    context.mocks.api(zeroBrowserContract.open, ({ body, params, respond }) => {
+      expect(params.threadId).toBe(threadId);
+      browserOpenEventIds.push(body.eventId);
+      return respond(200, {
+        browser,
+        lifecycleEventId: body.eventId,
+      });
+    });
     let leaseRequests = 0;
     context.mocks.api(zeroBrowserContract.leaseByThread, ({ respond }) => {
       leaseRequests += 1;
@@ -3920,6 +3929,7 @@ describe("chat event action cards", () => {
     expect(
       document.querySelector('iframe[title="Live browser: booking"]'),
     ).toBeNull();
+    expect(browserOpenEventIds).toHaveLength(0);
 
     const firstCard = cards.at(0);
     if (!firstCard) {
@@ -3928,6 +3938,10 @@ describe("chat event action cards", () => {
     await user.click(firstCard);
 
     const frame = await screen.findByTitle("Live browser: booking");
+    await waitFor(() => {
+      expect(browserOpenEventIds).toHaveLength(1);
+      expect(browserOpenEventIds[0]).toBeTypeOf("string");
+    });
     expect(frame).toHaveAttribute("src", liveUrl);
     expect(frame).toHaveAttribute("referrerpolicy", "no-referrer");
     expect(frame.closest("[data-browser-session-sidebar]")).not.toBeNull();

--- a/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
@@ -8,6 +8,8 @@ import {
   activeSidebarBrowserThreadId$,
   openThreadBrowserSession$,
 } from "../../signals/chat-page/thread-sidebar-coordinator.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { ArtifactThumbnailImage } from "./zero-artifact-thumbnail.tsx";
 
 interface BrowserSessionCardProps {
@@ -141,7 +143,9 @@ export function BrowserSessionCard({ signals }: BrowserSessionCardProps) {
   const { t } = useTranslation();
   const sessionLoadable = useLastLoadable(signals.session$);
   const selectedBrowserThreadId = useGet(activeSidebarBrowserThreadId$);
+  const pageSignal = useGet(pageSignal$);
   const openSidebar = useSet(openThreadBrowserSession$);
+  const start = useSet(signals.start$);
 
   if (sessionLoadable.state === "loading") {
     return <BrowserSessionCardSkeleton />;
@@ -168,6 +172,9 @@ export function BrowserSessionCard({ signals }: BrowserSessionCardProps) {
         { name: session.name },
       )}
       onClick={() => {
+        if (live && !selected) {
+          detach(start(pageSignal), Reason.DomCallback);
+        }
         openSidebar(signals.threadId);
       }}
       className={cn(


### PR DESCRIPTION
## Summary

- stop agent browser create/use operations from emitting `browser.open` chat events
- emit `browser.open` only for explicit viewer actions, including Browser Start and live browser card clicks
- keep chat-event persistence outside the provider lifecycle, so a lost event does not roll back a successful browser open

## Fallbacks

Fallbacks: none.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts` (13 tests)
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx` (37 tests)
