### PR TITLE
refactor(chat): stop writing web chat_event_asset_refs rows

### DIFF
--- a/turbo/apps/api/src/signals/services/canonical-asset.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-asset.service.ts
@@ -691,24 +691,27 @@ export async function attachCanonicalAssetsToEvent(
     .onConflictDoNothing();
 }
 
-export async function attachCanonicalWebInputAssetsToEvent(
+/**
+ * Registers web chat input files as canonical assets.
+ *
+ * Web input events carry their own ordered attachment list in
+ * `chat_events.user_message` (`type: "file"` parts with fileId, filename, and
+ * content type), and the only reader of `chat_event_asset_refs` is the Slack
+ * queued-launch loader, which `active-input-prompt` and
+ * `internal-chat-run-callback` reach only on the `contextType === "slack"`
+ * branch. Web ref rows were therefore write-only, so this path registers the
+ * canonical asset rows without also writing the join table.
+ */
+export async function registerCanonicalWebInputAssets(
   db: Db,
   args: {
-    readonly eventId: string;
     readonly chatThreadId: string;
     readonly userId: string;
     readonly orgId: string;
     readonly files: readonly ChatEventAttachFileMetadata[];
-    readonly replaceExisting?: boolean;
   },
 ): Promise<void> {
-  if (args.replaceExisting) {
-    await db
-      .delete(chatEventAssetRefs)
-      .where(eq(chatEventAssetRefs.chatEventId, args.eventId));
-  }
-  const assets: { readonly assetId: string; readonly position: number }[] = [];
-  for (const [position, file] of args.files.entries()) {
+  for (const file of args.files) {
     const [inserted] = await db
       .insert(runUploadedFiles)
       .values({
@@ -743,9 +746,7 @@ export async function attachCanonicalWebInputAssetsToEvent(
     if (!asset) {
       throw new Error("Canonical web input asset conflict is missing");
     }
-    assets.push({ assetId: asset.id, position });
   }
-  await attachCanonicalAssetsToEvent(db, args.eventId, assets);
 }
 
 interface PrepareCanonicalPublishedAssetArgs {

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -102,7 +102,7 @@ import {
   chatThreadServiceTierFromCodex,
 } from "./zero-chat-thread-event.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { attachCanonicalWebInputAssetsToEvent } from "./canonical-asset.service";
+import { registerCanonicalWebInputAssets } from "./canonical-asset.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
@@ -1436,8 +1436,7 @@ function appendUnassociatedUserMessage(params: {
         })
       : await insertChatEvent(tx, event, "id");
     if (inserted) {
-      await attachCanonicalWebInputAssetsToEvent(tx, {
-        eventId: inserted.id,
+      await registerCanonicalWebInputAssets(tx, {
         chatThreadId: params.threadId,
         userId: params.userId,
         orgId: params.orgId,
@@ -1554,8 +1553,7 @@ async function appendAssociatedUserMessage(params: {
         })
       : await insertChatEvent(tx, event, "id");
     if (inserted) {
-      await attachCanonicalWebInputAssetsToEvent(tx, {
-        eventId: inserted.id,
+      await registerCanonicalWebInputAssets(tx, {
         chatThreadId: params.threadId,
         userId: params.userId,
         orgId: params.orgId,
@@ -2703,13 +2701,11 @@ async function appendInsufficientCreditsEvents(params: {
 
     const createdAt = userMessage?.createdAt ?? userCreatedAt;
     if (userMessage) {
-      await attachCanonicalWebInputAssetsToEvent(tx, {
-        eventId: userMessage.id,
+      await registerCanonicalWebInputAssets(tx, {
         chatThreadId: params.prepared.thread.threadId,
         userId: params.userId,
         orgId: params.orgId,
         files: fileMetadata ?? [],
-        replaceExisting: params.body.revokesEventId !== undefined,
       });
     }
     if (userMessage && params.touchThreadSort) {


### PR DESCRIPTION
Web chat input events already carry their own ordered attachment list inside `chat_events.user_message` — `type: "file"` parts with `fileId`, `filenameSnapshot`, and `contentType`. The parallel `chat_event_asset_refs` rows written on the same web path were never read back, so this stops writing them.

## Why the web rows are unread

The only reader of `chat_event_asset_refs` is `loadSlackPromptAssets` in `slack-queued-launch-context.service.ts`, reachable exclusively through `loadSlackQueuedLaunchMaterial`. Both of its callers dispatch on the event's `contextType` and route web traffic elsewhere:

- `active-input-prompt.service.ts` — `switch (event.contextType)`, only `case "slack"` calls the Slack loader.
- `internal-chat-run-callback.service.ts` — `switch (contextType)`, `web` and `agent_run` go to `loadWebQueuedLaunchMaterial`.

A repo-wide search finds no other consumer: outside the schema and the baseline migration, `chat_event_asset_refs` appears only in `canonical-asset.service.ts` (write), `slack-queued-launch-context.service.ts` (the Slack read), `zero-chat-event.service.ts` (copy-on-claim), and the test-runtime-state fixture route. Nothing queries the `chat_event_asset_refs_asset_idx` reverse direction.

Slack is untouched: `attachCanonicalAssetsToEvent` and the `preserveAssetRefs` copy in `replaceChatEvent` both stay.

## What is kept

`registerCanonicalWebInputAssets` (renamed from `attachCanonicalWebInputAssetsToEvent`) still upserts the canonical `run_uploaded_files` rows with `chat_thread_id`, `classification: "input"`, and the `web-input` idempotency key. That column is what the artifact catalog's thread filter resolves through, so dropping it would have been a real regression. The rename drops the now-unused `eventId` and `replaceExisting` arguments, since the function no longer touches the event.

## Fallbacks

None. This removes a write, not a compatibility path.

Removal evidence per `docs/fallback.md` §10:

- **Type/code evidence** — the single reader sits behind a `contextType === "slack"` branch in both call paths, so no web-origin ref row is reachable.
- **Single-writer evidence** — web ref rows were written only by the function changed here.
- **Cross-version safety** — during rollout, an older API instance still writing web ref rows is harmless (nothing reads them), and Slack ref rows keep being written and read by both versions. Pre-existing rows are left in place; a separate cleanup can drop them once the table's remaining Slack-only role is settled.

## Testing

No new test. Asserting "web writes no ref rows" would be a tombstone under `docs/fallback.md` §1; the meaningful coverage is that the retained behavior still works, which existing suites already pin:

- `chat-files.bdd.test.ts` + `zero-integrations-slack-upload-complete.test.ts` — 22 passed. The Slack suite still asserts `readChatEventAssetRefIds` on the Slack path, proving the reader and its writer are intact.
- `artifact-catalog.bdd.test.ts` + `chat-events.bdd.test.ts` — 92 passed, covering the thread-scoped artifact resolution that depends on `run_uploaded_files.chat_thread_id`.
- `chat-threads.bdd.test.ts` + `chat-callbacks.bdd.test.ts` + `artifacts.bdd.test.ts` — 86 passed.

`pnpm -F api check-types`, targeted ESLint, and `pnpm knip --workspace apps/api` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
