### PR TITLE
feat(web-chat): gate follow-up card rail to mobile devices only

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -389,7 +389,124 @@ test("chat composer keeps the Send button inside on narrow screens", async ({
   });
 });
 
-test("responsive follow-up rail aligns its edges and equalizes card heights", async ({
+// The card rail only renders on coarse-pointer text-entry devices, so this
+// group emulates touch instead of relying on the viewport width alone.
+test.describe("mobile follow-up card rail", () => {
+  test.use({ hasTouch: true });
+
+  test("responsive follow-up rail aligns its edges and equalizes card heights", async ({
+    page,
+  }) => {
+    await enableResponsiveFollowupCards(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(appUrl);
+    await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+
+    const agentId = new URL(page.url()).pathname.match(
+      /^\/agents\/([^/]+)\/chat\/?$/,
+    )?.[1];
+    if (!agentId) {
+      throw new Error("Could not resolve the active agent from the chat URL");
+    }
+    await mockResponsiveFollowupThread(page, agentId);
+    await page.goto(
+      new URL(`/chats/${responsiveFollowupThreadId}`, appUrl).href,
+    );
+
+    const rail = page.getByRole("group", { name: "Keep going" });
+    const cards = responsiveFollowupPrompts.map((prompt) => {
+      return page.getByRole("button", { name: prompt, exact: true });
+    });
+    await expect(rail).toBeVisible();
+    for (const card of cards) {
+      await expect(card).toBeVisible();
+    }
+
+    await expect
+      .poll(async () => {
+        const railBox = await rail.boundingBox();
+        const firstBox = await cards[0].boundingBox();
+        if (!railBox || !firstBox) {
+          return Number.POSITIVE_INFINITY;
+        }
+        return Math.abs(firstBox.x - railBox.x);
+      })
+      .toBeLessThan(1);
+    await expect
+      .poll(async () => {
+        const boxes = await Promise.all(
+          cards.map((card) => card.boundingBox()),
+        );
+        if (boxes.some((box) => box === null)) {
+          return Number.POSITIVE_INFINITY;
+        }
+        const heights = boxes.map((box) => box!.height);
+        return Math.max(...heights) - Math.min(...heights);
+      })
+      .toBeLessThan(1);
+
+    await cards[1].evaluate((element) => {
+      element.scrollIntoView({ block: "nearest", inline: "center" });
+    });
+    await expect
+      .poll(async () => {
+        const railBox = await rail.boundingBox();
+        const middleBox = await cards[1].boundingBox();
+        if (!railBox || !middleBox) {
+          return Number.POSITIVE_INFINITY;
+        }
+        const railCenter = railBox.x + railBox.width / 2;
+        const cardCenter = middleBox.x + middleBox.width / 2;
+        return Math.abs(cardCenter - railCenter);
+      })
+      .toBeLessThan(2);
+
+    await rail.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth;
+    });
+    await expect
+      .poll(async () => {
+        const railBox = await rail.boundingBox();
+        const lastBox = await cards[2].boundingBox();
+        if (!railBox || !lastBox) {
+          return Number.POSITIVE_INFINITY;
+        }
+        return Math.abs(
+          lastBox.x + lastBox.width - (railBox.x + railBox.width),
+        );
+      })
+      .toBeLessThan(1);
+
+    // The rail is a device decision, so a wide viewport on the same touch
+    // device keeps the cards instead of collapsing them into full-width rows.
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect
+      .poll(async () => {
+        const railBox = await rail.boundingBox();
+        const firstBox = await cards[0].boundingBox();
+        if (!railBox || !firstBox) {
+          return 0;
+        }
+        return railBox.width - firstBox.width;
+      })
+      .toBeGreaterThan(100);
+
+    await page.keyboard.press("Tab");
+    await cards[0].focus();
+    await expect
+      .poll(async () => {
+        return cards[0].evaluate((element) => {
+          return (
+            element.matches(":focus-visible") &&
+            getComputedStyle(element).boxShadow !== "none"
+          );
+        });
+      })
+      .toBe(true);
+  });
+});
+
+test("keeps the flat follow-up list in a narrow desktop window", async ({
   page,
 }) => {
   await enableResponsiveFollowupCards(page);
@@ -406,90 +523,39 @@ test("responsive follow-up rail aligns its edges and equalizes card heights", as
   await mockResponsiveFollowupThread(page, agentId);
   await page.goto(new URL(`/chats/${responsiveFollowupThreadId}`, appUrl).href);
 
-  const rail = page.getByRole("group", { name: "Keep going" });
-  const cards = responsiveFollowupPrompts.map((prompt) => {
+  const list = page.getByRole("group", { name: "Keep going" });
+  const rows = responsiveFollowupPrompts.map((prompt) => {
     return page.getByRole("button", { name: prompt, exact: true });
   });
-  await expect(rail).toBeVisible();
-  for (const card of cards) {
-    await expect(card).toBeVisible();
+  await expect(list).toBeVisible();
+  for (const row of rows) {
+    await expect(row).toBeVisible();
   }
 
+  // A fine-pointer window dragged this narrow keeps the flat vertical list:
+  // every follow-up spans the full width instead of becoming a card.
   await expect
     .poll(async () => {
-      const railBox = await rail.boundingBox();
-      const firstBox = await cards[0].boundingBox();
-      if (!railBox || !firstBox) {
+      const listBox = await list.boundingBox();
+      const boxes = await Promise.all(rows.map((row) => row.boundingBox()));
+      if (!listBox || boxes.some((box) => box === null)) {
         return Number.POSITIVE_INFINITY;
       }
-      return Math.abs(firstBox.x - railBox.x);
+      return Math.max(
+        ...boxes.map((box) => Math.abs(box!.width - listBox.width)),
+      );
     })
-    .toBeLessThan(1);
+    .toBeLessThan(2);
   await expect
     .poll(async () => {
-      const boxes = await Promise.all(cards.map((card) => card.boundingBox()));
+      const boxes = await Promise.all(rows.map((row) => row.boundingBox()));
       if (boxes.some((box) => box === null)) {
-        return Number.POSITIVE_INFINITY;
+        return 0;
       }
-      const heights = boxes.map((box) => box!.height);
-      return Math.max(...heights) - Math.min(...heights);
+      const tops = boxes.map((box) => box!.y);
+      return Math.max(...tops) - Math.min(...tops);
     })
-    .toBeLessThan(1);
-
-  await cards[1].evaluate((element) => {
-    element.scrollIntoView({ block: "nearest", inline: "center" });
-  });
-  await expect
-    .poll(async () => {
-      const railBox = await rail.boundingBox();
-      const middleBox = await cards[1].boundingBox();
-      if (!railBox || !middleBox) {
-        return Number.POSITIVE_INFINITY;
-      }
-      const railCenter = railBox.x + railBox.width / 2;
-      const cardCenter = middleBox.x + middleBox.width / 2;
-      return Math.abs(cardCenter - railCenter);
-    })
-    .toBeLessThan(2);
-
-  await rail.evaluate((element) => {
-    element.scrollLeft = element.scrollWidth;
-  });
-  await expect
-    .poll(async () => {
-      const railBox = await rail.boundingBox();
-      const lastBox = await cards[2].boundingBox();
-      if (!railBox || !lastBox) {
-        return Number.POSITIVE_INFINITY;
-      }
-      return Math.abs(lastBox.x + lastBox.width - (railBox.x + railBox.width));
-    })
-    .toBeLessThan(1);
-
-  await page.setViewportSize({ width: 1440, height: 900 });
-  await expect
-    .poll(async () => {
-      const railBox = await rail.boundingBox();
-      const firstBox = await cards[0].boundingBox();
-      if (!railBox || !firstBox) {
-        return Number.POSITIVE_INFINITY;
-      }
-      return Math.abs(firstBox.width - railBox.width);
-    })
-    .toBeLessThan(2);
-
-  await page.keyboard.press("Tab");
-  await cards[0].focus();
-  await expect
-    .poll(async () => {
-      return cards[0].evaluate((element) => {
-        return (
-          element.matches(":focus-visible") &&
-          getComputedStyle(element).boxShadow !== "none"
-        );
-      });
-    })
-    .toBe(true);
+    .toBeGreaterThan(0);
 });
 
 test("image lightbox centers and pans across the full viewer", async ({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -302,9 +302,7 @@ describe("chat lifecycle", () => {
     }
     // No horizontal card rail on desktop: the buttons stay full-width rows
     // (w-full, items-center) rather than fixed-width self-stretch cards.
-    const rows = Array.from(
-      group.querySelectorAll<HTMLElement>("button"),
-    );
+    const rows = Array.from(group.querySelectorAll<HTMLElement>("button"));
     expect(rows).toHaveLength(prompts.length);
     expect(rows[0]?.className).toContain("w-full");
     expect(rows[0]?.className).not.toContain("flex-[0_0_min");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -212,6 +212,12 @@ describe("chat lifecycle", () => {
       },
     });
 
+    // The card rail is a mobile-only surface: the same coarse-pointer
+    // heuristic that gates the composer's auto-focus device decides it.
+    context.mocks.browser.matchMedia((query) => {
+      return query === "(pointer: coarse)";
+    });
+
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
@@ -241,6 +247,67 @@ describe("chat lifecycle", () => {
       expect(composer).toHaveFocus();
     });
     expect(sentMessages).toHaveLength(0);
+  });
+
+  it("keeps the flat list on desktop even with a narrow window", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000735";
+    const prompts = ["Draft launch copy", "Generate a hero image"];
+    const completedAt = "2026-06-09T10:01:01Z";
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Narrow desktop window",
+      chatEvents: [
+        {
+          id: "msg-narrow-desktop-assistant",
+          eventType: "output.message",
+          role: "assistant",
+          content: "The launch plan is ready.",
+          runId: "run-narrow-desktop",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+        {
+          id: "msg-narrow-desktop-completed",
+          eventType: "run.completed",
+          role: "assistant",
+          content: null,
+          runId: "run-narrow-desktop",
+          runLifecycleEvent: "completed",
+          followups: prompts.map((prompt) => {
+            return { prompt, kind: "talk" as const };
+          }),
+          createdAt: completedAt,
+        },
+      ],
+    });
+
+    // Fine-pointer desktop: even a dragged-narrow window must not produce
+    // cards, matching the composer auto-focus heuristic.
+    context.mocks.browser.matchMedia((query) => {
+      return query === "(any-pointer: fine)";
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ResponsiveFollowupCards]: true,
+      },
+    });
+
+    await screen.findByText("The launch plan is ready.");
+    const group = screen.getByRole("group", { name: "Keep going" });
+    for (const prompt of prompts) {
+      expect(buttonByText(prompt)).toBeInTheDocument();
+    }
+    // No horizontal card rail on desktop: the buttons stay full-width rows
+    // (w-full, items-center) rather than fixed-width self-stretch cards.
+    const rows = Array.from(
+      group.querySelectorAll<HTMLElement>("button"),
+    );
+    expect(rows).toHaveLength(prompts.length);
+    expect(rows[0]?.className).toContain("w-full");
+    expect(rows[0]?.className).not.toContain("flex-[0_0_min");
   });
 
   it("shows recommended follow-ups after an appended follow-up event", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -116,6 +116,7 @@ import type {
 import { emptyChatImg } from "./platform-assets.ts";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { isMobileTextInputDevice } from "../../lib/visual-viewport-keyboard.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -4108,6 +4109,10 @@ function RecommendedFollowupList({
   const { t } = useTranslation();
   const responsiveFollowupCards =
     useGet(featureSwitch$)[FeatureSwitchKey.ResponsiveFollowupCards] ?? false;
+  // Card rail only on actual mobile/touch text-entry devices, mirroring the
+  // composer auto-focus heuristic. A desktop window dragged narrow must still
+  // render the flat list, so container width is not the deciding factor.
+  const showFollowupCards = responsiveFollowupCards && isMobileTextInputDevice();
   const selectOrAppendComposerText = useSet(
     thread.composer.editor.selectOrAppendText$,
   );
@@ -4136,8 +4141,8 @@ function RecommendedFollowupList({
         return $.chat.run.keepGoing;
       })}
       className={cn(
-        responsiveFollowupCards
-          ? "flex items-stretch gap-3 overflow-x-auto overscroll-x-contain snap-x snap-mandatory pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden @[900px]:-mx-2 @[900px]:block @[900px]:overflow-visible @[900px]:pb-0"
+        showFollowupCards
+          ? "-mx-2 flex items-stretch gap-3 overflow-x-auto overscroll-x-contain pb-1 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           : "-mx-2",
       )}
     >
@@ -4149,8 +4154,8 @@ function RecommendedFollowupList({
             title={followup.prompt}
             className={cn(
               "group flex text-left transition-colors",
-              responsiveFollowupCards
-                ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--zero-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 @[900px]:min-h-10 @[900px]:w-full @[900px]:items-center @[900px]:gap-2 @[900px]:rounded-lg @[900px]:border-0 @[900px]:bg-transparent @[900px]:px-2 @[900px]:py-2 @[900px]:shadow-none @[900px]:hover:bg-state-hover"
+              showFollowupCards
+                ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--zero-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 : "min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 hover:bg-state-hover",
             )}
             onClick={() => {
@@ -4160,7 +4165,7 @@ function RecommendedFollowupList({
             <span
               className={cn(
                 "shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground",
-                responsiveFollowupCards && "hidden @[900px]:block",
+                showFollowupCards && "hidden",
               )}
             >
               <RecommendedFollowupIcon followup={followup} />
@@ -4168,8 +4173,8 @@ function RecommendedFollowupList({
             <span
               className={cn(
                 "min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 group-hover:text-foreground",
-                responsiveFollowupCards
-                  ? "text-foreground @[900px]:text-muted-foreground"
+                showFollowupCards
+                  ? "text-foreground"
                   : "text-muted-foreground",
               )}
             >
@@ -4180,7 +4185,7 @@ function RecommendedFollowupList({
               stroke={1.8}
               className={cn(
                 "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100",
-                responsiveFollowupCards && "hidden @[900px]:block",
+                showFollowupCards && "hidden",
               )}
             />
           </button>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4112,7 +4112,8 @@ function RecommendedFollowupList({
   // Card rail only on actual mobile/touch text-entry devices, mirroring the
   // composer auto-focus heuristic. A desktop window dragged narrow must still
   // render the flat list, so container width is not the deciding factor.
-  const showFollowupCards = responsiveFollowupCards && isMobileTextInputDevice();
+  const showFollowupCards =
+    responsiveFollowupCards && isMobileTextInputDevice();
   const selectOrAppendComposerText = useSet(
     thread.composer.editor.selectOrAppendText$,
   );
@@ -4173,9 +4174,7 @@ function RecommendedFollowupList({
             <span
               className={cn(
                 "min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 group-hover:text-foreground",
-                showFollowupCards
-                  ? "text-foreground"
-                  : "text-muted-foreground",
+                showFollowupCards ? "text-foreground" : "text-muted-foreground",
               )}
             >
               {followup.prompt}


### PR DESCRIPTION
## Summary

The responsive follow-up **card rail** should only render on actual mobile devices — the smallest responsive tier — and must stay the flat vertical list on desktop **even when the window is dragged narrow**.

Previously the cards-only-on-small decision used a `@[900px]` **container query**, so a desktop browser resized narrower than 900px incorrectly switched to the card rail. This switches the decision to the same device heuristic the composer already uses to gate its **auto-focus** (`isMobileTextInputDevice()`): coarse-pointer touch text-entry devices get the card rail; fine-pointer desktops never do, regardless of viewport width.

## Changes

- `zero-chat-thread-page.tsx` — `RecommendedFollowupList` now computes `showFollowupCards = featureEnabled && isMobileTextInputDevice()` and applies the card-rail classes only when true. Removed the `@[900px]` container-query overrides that allowed narrow desktops to show cards.
- `chat-recommended-follow-ups.test.tsx` — the card-rail test now mocks a coarse-pointer (mobile) device so the rail renders; added a test asserting a fine-pointer desktop keeps the flat list even with the feature switch on.

## Verification

- Targeted vitest: `chat-recommended-follow-ups.test.tsx` — 10/10 pass (incl. mobile card rail + desktop flat list cases).
- `tsc -p tsconfig.production.json` and `tsconfig.tests.json` — clean.
- `oxlint` on both changed files — clean.


## E2E follow-up

- `e2e/playwright/tests/chat.spec.ts` — the existing card-rail geometry test ran in the default Desktop Chrome context, which is a fine-pointer device, so it broke once the rail became device-gated. It now runs inside a `test.describe` with `test.use({ hasTouch: true })` (Chromium touch emulation reports `(pointer: coarse)` and drops `(any-pointer: fine)`), and its final wide-viewport assertion checks that a touch device keeps the cards at 1440px instead of collapsing them into full-width rows.
- Added `keeps the flat follow-up list in a narrow desktop window`: the default fine-pointer context at 390x844 must render full-width rows stacked vertically, which is the regression this PR fixes.

## Fallbacks

Fallbacks: none. The change is a client-side layout decision behind the non-GA staff-only `FeatureSwitchKey.ResponsiveFollowupCards` switch, so no cross-version compatibility path is introduced, kept, or removed.
