### PR TITLE
refactor(api): stop writing chat_event_asset_refs rows

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -405,36 +405,6 @@ export async function readRunUploadedFileSources(
   return response.uploaded_file_sources ?? [];
 }
 
-export async function readChatEventAssetRefIds(
-  context: TestContext,
-  eventId: string,
-): Promise<readonly string[]> {
-  const response = await postAction(context, {
-    action: "read-chat-event-asset-refs",
-    event_id: eventId,
-  });
-  if (response.chat_event_asset_ref_ids === undefined) {
-    throw new Error("readChatEventAssetRefIds missing asset ref ids");
-  }
-  return response.chat_event_asset_ref_ids;
-}
-
-export async function insertChatEventAssetRefFixture(
-  context: TestContext,
-  args: {
-    readonly eventId: string;
-    readonly assetId: string;
-    readonly position: number;
-  },
-): Promise<void> {
-  await postAction(context, {
-    action: "insert-chat-event-asset-ref",
-    event_id: args.eventId,
-    asset_id: args.assetId,
-    position: args.position,
-  });
-}
-
 export async function setChatEventSnapshotHeadVersion(
   context: TestContext,
   threadId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -27,7 +27,6 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import {
-  readChatEventAssetRefIds,
   setChatSlackContextAsPreviousApi,
   readThreadSessionBinding,
 } from "./helpers/runtime-state";
@@ -1584,10 +1583,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     }
     // The Slack context row is the complete launch snapshot: the bot user ID
     // the system prompt renders and the canonical asset the agent prompt
-    // renders both live here, so no ref row is written any more.
-    await expect(
-      readChatEventAssetRefIds(context, canonicalInputMessage.id),
-    ).resolves.toStrictEqual([]);
+    // renders both live here.
     await expect(
       readChatEventContextFixture(canonicalInputMessage.id),
     ).resolves.toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-upload-complete.test.ts
@@ -34,10 +34,6 @@ import {
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import {
-  insertChatEventAssetRefFixture,
-  readChatEventAssetRefIds,
-} from "./helpers/runtime-state";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import {
   deleteSlackIntegrationFixture$,
@@ -720,32 +716,6 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     expect(lifecycleMarker).toBeDefined();
     expect(lifecycleMarker?.content).toBeNull();
     expect(lifecycleMarker).not.toHaveProperty("attachFiles");
-    if (!lifecycleMarker) {
-      throw new Error("Expected a completed lifecycle marker");
-    }
-
-    // Completion-to-output refs have no production write API after this
-    // change. The test-only state boundary verifies the writer stopped, then
-    // simulates one pre-cutover row while the assertion stays on the public API.
-    await expect(
-      readChatEventAssetRefIds(context, lifecycleMarker.id),
-    ).resolves.toStrictEqual([]);
-    await insertChatEventAssetRefFixture(context, {
-      eventId: lifecycleMarker.id,
-      assetId: canonicalAssetId,
-      position: 0,
-    });
-    const eventsWithHistoricalRef = await chatApi.listThreadEvents(
-      actorFor({ orgId, userId }),
-      threadId,
-    );
-    const historicalLifecycleMarker = eventsWithHistoricalRef.events.find(
-      (message) => {
-        return message.id === lifecycleMarker.id;
-      },
-    );
-    expect(historicalLifecycleMarker).toBeDefined();
-    expect(historicalLifecycleMarker).not.toHaveProperty("attachFiles");
   }, 20_000);
 
   it("keeps an attachment-only output out of the event stream", async () => {

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -22,10 +22,7 @@ import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { hostedSites } from "@vm0/db/schema/hosted-site";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import {
-  chatEventAssetRefs,
-  runUploadedFiles,
-} from "@vm0/db/schema/run-uploaded-file";
+import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
@@ -1159,11 +1156,6 @@ type PreviousApiRunnerJobContextProfileAction = Extract<
   { action: "set-runner-job-context-profile-as-previous-api" }
 >;
 
-type ChatEventAssetRefFixtureAction = Extract<
-  TestRuntimeStateActionBody,
-  { action: "read-chat-event-asset-refs" | "insert-chat-event-asset-ref" }
->;
-
 type PreviousApiBrowserTabSnapshotAction = Extract<
   TestRuntimeStateActionBody,
   { action: "set-browser-tab-snapshot-as-previous-api" }
@@ -1242,7 +1234,6 @@ type CompatibilityFixtureAction =
   | PreviousApiChatSlackContextAction
   | PreviousApiBrowserTabSnapshotAction
   | PreviousApiRunnerJobContextProfileAction
-  | ChatEventAssetRefFixtureAction
   | ConnectorPermissionBaselineMutationAction;
 
 type ChatEventSnapshotFixtureAction = Extract<
@@ -1367,32 +1358,6 @@ async function compatibilityFixtureActionResponse(
     }
     case "set-runner-job-context-profile-as-previous-api": {
       return await setRunnerJobContextProfileAsPreviousApi(db, body, signal);
-    }
-    case "read-chat-event-asset-refs": {
-      const rows = await db
-        .select({ assetId: chatEventAssetRefs.assetId })
-        .from(chatEventAssetRefs)
-        .where(eq(chatEventAssetRefs.chatEventId, body.event_id))
-        .orderBy(chatEventAssetRefs.position);
-      signal.throwIfAborted();
-      return {
-        status: 200 as const,
-        body: {
-          ok: true as const,
-          chat_event_asset_ref_ids: rows.map((row) => {
-            return row.assetId;
-          }),
-        },
-      };
-    }
-    case "insert-chat-event-asset-ref": {
-      await db.insert(chatEventAssetRefs).values({
-        chatEventId: body.event_id,
-        assetId: body.asset_id,
-        position: body.position,
-      });
-      signal.throwIfAborted();
-      return { status: 200 as const, body: { ok: true as const } };
     }
     case "mutate-runner-job-connector-permission-baseline": {
       await mutateRunnerJobConnectorPermissionBaseline(db, body, signal);

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -1323,8 +1323,6 @@ function isCompatibilityFixtureAction(
     "set-chat-slack-context-as-previous-api",
     "set-browser-tab-snapshot-as-previous-api",
     "set-runner-job-context-profile-as-previous-api",
-    "read-chat-event-asset-refs",
-    "insert-chat-event-asset-ref",
     "mutate-runner-job-connector-permission-baseline",
   ].includes(body.action);
 }

--- a/turbo/apps/api/src/signals/services/canonical-asset.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-asset.service.ts
@@ -3,7 +3,6 @@ import { command } from "ccstate";
 import {
   CANONICAL_ASSET_VERSION,
   canonicalAssetDeliveries,
-  chatEventAssetRefs,
   runUploadedFiles,
   type CanonicalAssetMaterializationStatus,
   type RunUploadedFileSource,
@@ -665,41 +664,12 @@ export const materializeCanonicalSlackInputAssets$ = command(
   },
 );
 
-async function attachCanonicalAssetsToEvent(
-  db: Db,
-  eventId: string,
-  assets: readonly {
-    readonly assetId: string;
-    readonly position: number;
-  }[],
-): Promise<void> {
-  if (assets.length === 0) {
-    return;
-  }
-  await db
-    .insert(chatEventAssetRefs)
-    .values(
-      assets.map((asset) => {
-        return {
-          chatEventId: eventId,
-          assetId: asset.assetId,
-          position: asset.position,
-        };
-      }),
-    )
-    .onConflictDoNothing();
-}
-
 /**
  * Registers web chat input files as canonical assets.
  *
  * Web input events carry their own ordered attachment list in
  * `chat_events.user_message` (`type: "file"` parts with fileId, filename, and
- * content type), and the only reader of `chat_event_asset_refs` is the Slack
- * queued-launch loader, which `active-input-prompt` and
- * `internal-chat-run-callback` reach only on the `contextType === "slack"`
- * branch. Web ref rows were therefore write-only, so this path registers the
- * canonical asset rows without also writing the join table.
+ * content type), so this path only needs the canonical asset rows.
  */
 export async function registerCanonicalWebInputAssets(
   db: Db,

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -22,7 +22,6 @@ import { chatSlackContext } from "@vm0/db/schema/chat-slack-context";
 import { chatTeamsContext } from "@vm0/db/schema/chat-teams-context";
 import { chatTelegramContext } from "@vm0/db/schema/chat-telegram-context";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { chatEventAssetRefs } from "@vm0/db/schema/run-uploaded-file";
 import { eq, sql } from "drizzle-orm";
 import { nowDate } from "../../lib/time";
 import type {
@@ -1131,7 +1130,6 @@ export async function replaceChatEvent(
   tx: ChatEventWriteTransaction,
   eventId: string,
   replacement: NewChatEvent,
-  options?: { readonly preserveAssetRefs?: boolean },
 ): Promise<ChatEventCommandResult | null> {
   const [target] = await tx
     .select({
@@ -1148,7 +1146,7 @@ export async function replaceChatEvent(
   if (!target) {
     throw new Error("Cannot revoke a missing chat event");
   }
-  return await replaceLoadedChatEvent(tx, target, replacement, options);
+  return await replaceLoadedChatEvent(tx, target, replacement);
 }
 
 /** Append a replacement for a target already loaded by an authoritative read. */
@@ -1156,7 +1154,6 @@ export async function replaceLoadedChatEvent(
   tx: ChatEventWriteTransaction,
   target: LoadedChatEventReplacementTarget,
   replacement: NewChatEvent,
-  options?: { readonly preserveAssetRefs?: boolean },
 ): Promise<ChatEventCommandResult | null> {
   if (target.chatThreadId !== replacement.chatThreadId) {
     throw new Error("Cannot revoke a chat event from another thread");
@@ -1209,26 +1206,6 @@ export async function replaceLoadedChatEvent(
 
   if (displayContext) {
     await insertDisplayContext(tx, displayContext, inserted.createdAt);
-  }
-  if (options?.preserveAssetRefs !== false) {
-    await tx
-      .insert(chatEventAssetRefs)
-      .select(
-        tx
-          .select({
-            chatEventId: sql`${inserted.id}`
-              .mapWith(chatEventAssetRefs.chatEventId)
-              .as("chat_event_id"),
-            assetId: chatEventAssetRefs.assetId,
-            position: chatEventAssetRefs.position,
-            createdAt: sql`now()`
-              .mapWith(chatEventAssetRefs.createdAt)
-              .as("created_at"),
-          })
-          .from(chatEventAssetRefs)
-          .where(eq(chatEventAssetRefs.chatEventId, target.id)),
-      )
-      .onConflictDoNothing();
   }
   return inserted;
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -1431,9 +1431,7 @@ function appendUnassociatedUserMessage(params: {
         : {}),
     };
     const inserted = params.revokesEventId
-      ? await replaceChatEvent(tx, params.revokesEventId, event, {
-          preserveAssetRefs: false,
-        })
+      ? await replaceChatEvent(tx, params.revokesEventId, event)
       : await insertChatEvent(tx, event, "id");
     if (inserted) {
       await registerCanonicalWebInputAssets(tx, {
@@ -1548,9 +1546,7 @@ async function appendAssociatedUserMessage(params: {
       ...(params.triggerSource === "web" ? { contextType: "web" } : {}),
     };
     const inserted = params.revokesEventId
-      ? await replaceChatEvent(tx, params.revokesEventId, event, {
-          preserveAssetRefs: false,
-        })
+      ? await replaceChatEvent(tx, params.revokesEventId, event)
       : await insertChatEvent(tx, event, "id");
     if (inserted) {
       await registerCanonicalWebInputAssets(tx, {
@@ -2694,9 +2690,7 @@ async function appendInsufficientCreditsEvents(params: {
       createdAt: userCreatedAt,
     };
     const userMessage = params.body.revokesEventId
-      ? await replaceChatEvent(tx, params.body.revokesEventId, userValues, {
-          preserveAssetRefs: false,
-        })
+      ? await replaceChatEvent(tx, params.body.revokesEventId, userValues)
       : await insertChatEvent(tx, userValues, "id");
 
     const createdAt = userMessage?.createdAt ?? userCreatedAt;

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -119,16 +119,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     run_id: z.uuid(),
   }),
   z.object({
-    action: z.literal("read-chat-event-asset-refs"),
-    event_id: z.uuid(),
-  }),
-  z.object({
-    action: z.literal("insert-chat-event-asset-ref"),
-    event_id: z.uuid(),
-    asset_id: z.uuid(),
-    position: z.int().nonnegative(),
-  }),
-  z.object({
     action: z.literal("read-chat-event-snapshot-head"),
     thread_id: z.uuid(),
   }),
@@ -220,7 +210,6 @@ export const testRuntimeStateActionResponseSchema = z.object({
   admission_lock_held: z.boolean().optional(),
   admission_lock_waiting: z.boolean().optional(),
   uploaded_file_sources: z.array(z.string()).optional(),
-  chat_event_asset_ref_ids: z.array(z.uuid()).optional(),
   chat_event_snapshot_head: z
     .object({
       archive_schema_version: z.int().positive(),


### PR DESCRIPTION
## Summary

Removes the last `chat_event_asset_refs` writers so the physical table can be dropped in the next release. No schema or migration change here.

- `canonical-asset.service.ts` — delete the private `attachCanonicalAssetsToEvent` helper, which lost its last caller when #25822 stopped writing web input ref rows, and trim the now-stale comment on `registerCanonicalWebInputAssets`
- `zero-chat-event.service.ts` — delete the revoke/replace ref-copy `INSERT ... SELECT` and the `preserveAssetRefs` option on `replaceChatEvent` / `replaceLoadedChatEvent`
- `zero-chat-events.command.ts` — drop the three `preserveAssetRefs: false` call sites, which now match the default behavior
- delete the test-only fixture actions `read-chat-event-asset-refs` and `insert-chat-event-asset-ref`, their `test-runtime-state` contract entries and `chat_event_asset_ref_ids` response field, the `readChatEventAssetRefIds` / `insertChatEventAssetRefFixture` helpers, and their two usages

## Evidence that nothing remains

- **Reader:** the Slack queued-launch loader was the only reader. #25824 (`d5f5388`) made `chat_slack_context` the complete launch snapshot via `bot_user_id` and `message_assets`, so that read is gone. A repo-wide search for `chat_event_asset_refs` / `chatEventAssetRefs` on current `main` finds no other reader in any app, package, or crate.
- **Writer:** #25822 (`8a7fb5a`) removed the web input write. What remained were the dead private helper, the revoke/replace copy, and the test fixture. The copy only propagated rows that no live path produces, into a table nothing reads.
- Removing the two test assertions is not a coverage loss: they existed to observe the join table itself, and #25824 already reduced the Slack one to an assertion that no row is written. Per `docs/fallback.md` §1 they die with the code rather than becoming tombstones.

## Why this is split from the drop

`docs/deployment-compatibility.md` requires a migration to be backward compatible with the backend that is still serving traffic. The currently deployed API issues `INSERT INTO chat_event_asset_refs ... SELECT ... FROM chat_event_asset_refs` on every revoke/replace outside the three web-input call sites — `runners.ts`, the queue-marker, queued-event, goal-queue, and workflow-queue services all take the default path. Dropping the table in the same release would give the draining previous API `42P01` on those hot paths for the full DB-vs-API window (observed maximum exposure ~102 minutes, `docs/fallback.md` §7), which is the same failure mode recorded for migration `0722`.

This is therefore the first release of a two-release contract, matching the gating used for the `chat_goal_context` drop in #25046. The drop follows in 25834.

## Fallbacks

Fallbacks: none.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db check-types`
- `pnpm knip`

Test suites are left to the PR pipeline.