### PR TITLE
fix(api): replay web chat history only when the session rotates

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3752,7 +3752,8 @@ describe("CHAT-02: run-level model overrides", () => {
     ).toMatch(/[0-9a-f-]{36}/);
 
     // A run-level override of another model in the same family resumes the CLI
-    // session while carrying the prior web round as context.
+    // session, which already carries the prior web round, so the prompt does
+    // not replay it.
     const second = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
@@ -3777,11 +3778,11 @@ describe("CHAT-02: run-level model overrides", () => {
     );
     const secondRun = await api.readRun(actor, second.runId);
     const appended = secondRun.appendSystemPrompt ?? "";
-    expect(appended).toContain("# Web Chat Run Context");
-    expect(appended).toContain(`- RUN_ID: ${first.runId}`);
-    expect(appended).toContain(`- LOG_COMMAND: zero logs ${first.runId} --all`);
-    expect(appended).toContain(`User: ${firstPrompt}`);
-    expect(appended).toContain("Assistant: opus answer");
+    expect(appended).not.toContain("# Web Chat Run Context");
+    expect(appended).not.toContain("Assistant: opus answer");
+    expect(appended).toContain("# This Chat Thread");
+    expect(appended).toContain(`- CHAT_THREAD_ID: ${first.threadId}`);
+    expect(appended).toContain("`zero chat messages`");
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
     expect(secondClaim.claim.resumeSession?.sessionId).toBe(
       `bdd-cli-${first.runId}`,
@@ -4494,6 +4495,83 @@ describe("CHAT-02: run-level model overrides", () => {
     const retriedClaim = await claimChatRun(runnerGroup, retried.runId);
     expect(retriedClaim.claim.resumeSession).toBeNull();
     await cancelChatRun(actor, retried.runId);
+  }, 90_000);
+
+  it("replays only each prior run's final answer when a model family rotates the session", async () => {
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const { providerId: codexProviderId } = await upsertOrgModelProvider(
+      actor,
+      {
+        type: "openai-api-key",
+        secret: "prior-round-trim-openai-key",
+      },
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-4-6",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+      {
+        model: "gpt-5.6-terra",
+        isDefault: false,
+        defaultProviderType: "openai-api-key",
+        credentialScope: "org",
+        modelProviderId: codexProviderId,
+      },
+    ]);
+
+    const firstPrompt = "plan the migration in several steps";
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: firstPrompt,
+      model: "claude-sonnet-4-6",
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "narration: reading the first file"),
+      assistantEvent(1, "narration: reading the second file"),
+      assistantEvent(2, "final answer with the migration plan"),
+    ]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders, {
+      lastEventSequence: 2,
+    });
+    await flushWaitUntilForTest();
+    await waitForThreadMessages(actor, first.threadId, (items) => {
+      return eventBackedContents(items, first.runId).some((message) => {
+        return message.content === "final answer with the migration plan";
+      });
+    });
+
+    // Switching model family rotates the CLI session, so the prior round is
+    // replayed. An agentic run emits one chat message per step; only its final
+    // answer carries information the next run needs.
+    await chat.updateThreadModelSelection(
+      actor,
+      first.threadId,
+      "gpt-5.6-terra",
+    );
+    const second = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue after the family switch",
+    });
+    const appended = (await api.readRun(actor, second.runId))
+      .appendSystemPrompt;
+    expect(appended).toContain("# Web Chat Run Context");
+    expect(appended).toContain(`- RUN_ID: ${first.runId}`);
+    expect(appended).toContain(`User: ${firstPrompt}`);
+    expect(appended).toContain(
+      "Assistant: final answer with the migration plan",
+    );
+    expect(appended).not.toContain("narration: reading the first file");
+    expect(appended).not.toContain("narration: reading the second file");
+    expect(appended).toContain(`- CHAT_THREAD_ID: ${first.threadId}`);
+    await cancelChatRun(actor, second.runId);
   }, 90_000);
 
   it("retries preparation when the canonical conversation snapshot changes", async () => {
@@ -5257,7 +5335,7 @@ describe("CHAT-02: initial thinking indicator", () => {
 });
 
 describe("CHAT-02: prior rounds and thread titles", () => {
-  it("carries prior completed rounds, generates the thread title, and accepts immutable follow-up revokes", async () => {
+  it("leaves prior completed rounds to the session, generates the thread title, and accepts immutable follow-up revokes", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     mockOptionalEnv("OPENROUTER_API_KEY", "title-key");
@@ -5359,13 +5437,11 @@ describe("CHAT-02: prior rounds and thread titles", () => {
     expect(titleRequests).toBe(1);
     const secondRun = await api.readRun(actor, second.runId);
     const appended = secondRun.appendSystemPrompt ?? "";
-    expect(appended).toContain("# Web Chat Run Context");
-    expect(appended).toContain(`- RUN_ID: ${first.runId}`);
-    expect(appended).toContain(`- LOG_COMMAND: zero logs ${first.runId} --all`);
-    expect(appended).toContain(`User: ${firstPrompt}`);
-    expect(appended).toContain("Assistant: Assistant migration answer");
-    expect(appended).toContain("- RELATIVE_INDEX: 0");
-    expect(appended).not.toContain("follow-up question");
+    // The reused CLI session already holds the completed round, so the prompt
+    // only points at the thread instead of replaying it.
+    expect(appended).not.toContain("# Web Chat Run Context");
+    expect(appended).not.toContain("Assistant: Assistant migration answer");
+    expect(appended).toContain(`- CHAT_THREAD_ID: ${first.threadId}`);
     expect(appended).not.toContain(futureFollowupContent);
     for (const followup of futureFollowups) {
       expect(appended).not.toContain(followup.prompt);
@@ -6180,7 +6256,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     const secondPrompt = (await api.readRun(actor, second.runId))
       .appendSystemPrompt;
     expect(secondPrompt).not.toContain("# Inline Templates");
-    expect(secondPrompt).toContain("# Web Chat Run Context");
+    expect(secondPrompt).toContain("# This Chat Thread");
     expect(secondPrompt).not.toContain("Selected a template");
     expect(secondPrompt).not.toContain(style.illustrationStyleId);
     await waitForRunUserMessage(

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -2850,6 +2850,7 @@ function buildCreateZeroRunArgs(params: {
     ...(prepared.thread.isNewThread
       ? {
           appendSystemPrompt: buildWebChatAppendSystemPrompt({
+            threadId: prepared.thread.threadId,
             incompleteContext: "",
             priorContext: "",
             context: webChatSessionPromptContext,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -2,17 +2,12 @@ import { PLAN_UPGRADE_CLI_HINT } from "@vm0/api-contracts/contracts/errors";
 import { CANONICAL_WORKING_DIR } from "@vm0/api-contracts/contracts/runners";
 import { zeroRunCreateBodySchema } from "@vm0/api-contracts/contracts/zero-runs";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
-import { isPiEdgeCompatibleProviderType } from "./pi-edge-config";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
-import {
-  isFeatureEnabled,
-  type FeatureSwitchContext,
-} from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import {
   agentComposeVersions,
@@ -889,10 +884,6 @@ async function resolveThreadSessionForZeroRun(
     },
   );
   const webChatSessionPromptContext = input.command.webChatSessionPromptContext;
-  const piNoLegacyHistory =
-    isFeatureEnabled(FeatureSwitchKey.PiLoop, input.featureSwitchContext) &&
-    threadSessionRoute.modelProvider !== null &&
-    isPiEdgeCompatibleProviderType(threadSessionRoute.modelProvider);
   const appendSystemPrompt = webChatSessionPromptContext
     ? await measureZeroPreCreate(
         input.timing,
@@ -903,7 +894,6 @@ async function resolveThreadSessionForZeroRun(
             threadId,
             sessionAction: resolution.action,
             context: webChatSessionPromptContext,
-            historyPolicy: piNoLegacyHistory ? "none" : "default",
           });
         },
       )

--- a/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
@@ -1,4 +1,6 @@
 import {
+  CHAT_EVENT_CONTENT_TEXT_TYPES,
+  CHAT_EVENT_USER_MESSAGE_TEXT_TYPES,
   chatEventCompatibilityRole,
   type ChatEventType,
 } from "@vm0/api-contracts/contracts/chat-events";
@@ -6,14 +8,27 @@ import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-thre
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  max,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import type { Db } from "../external/db";
 import { BEFORE_DISPATCH_CANCELLED_ERROR } from "./agent-run-create.service";
 import type { ChatThreadSessionResolutionAction } from "./chat-session-continuity.service";
 import { loadWebChatIncompleteContext } from "./zero-chat-incomplete-context.service";
 import { visibleChatEventCondition } from "./zero-chat-event-shared.service";
-import { chatEventTextCondition } from "./zero-chat-event-type.service";
+import {
+  chatEventTextCondition,
+  chatEventTypeIn,
+} from "./zero-chat-event-type.service";
 import {
   type ChatAgentRunSourceAnnotation,
   projectUserMessage,
@@ -48,6 +63,24 @@ function buildWebChatPrompt(): string {
     "# Current Integration\nYou are currently running inside: Web",
     "You are communicating with the user through the web chat UI.",
   ].join("\n\n");
+}
+
+/**
+ * Coordinates for the thread this run belongs to. The prior-round transcript is
+ * only replayed when the CLI session cannot carry it, so this block is what
+ * lets a run reach the rest of the conversation on demand instead.
+ */
+function buildCurrentThreadContext(threadId: string): string {
+  return [
+    "# This Chat Thread",
+    "",
+    `- CHAT_THREAD_ID: ${threadId}`,
+    "",
+    "Reading this thread, each through ZERO_TOKEN:",
+    "- `zero chat messages` prints this thread's user and assistant messages, oldest first (chat-event:read)",
+    "- `zero chat messages --limit <n>` prints only the most recent n messages",
+    "- `zero logs <run-id> --all` prints the full event stream of one run in this thread (agent-run:read)",
+  ].join("\n");
 }
 
 /**
@@ -94,12 +127,14 @@ function buildComputerUseSystemPrompt(displayName: string): string {
 }
 
 export function buildWebChatAppendSystemPrompt(args: {
+  readonly threadId: string;
   readonly incompleteContext: string;
   readonly priorContext: string;
   readonly context: WebChatSessionPromptContext;
 }): string {
   return [
     buildWebChatPrompt(),
+    buildCurrentThreadContext(args.threadId),
     args.context.agentRunSource
       ? buildAgentRunSourceContext(args.context.agentRunSource)
       : "",
@@ -193,6 +228,31 @@ function buildWebChatPriorRunsContext(
   ].join("\n");
 }
 
+/**
+ * Sequence id of each run's final assistant message. A single agentic run can
+ * emit dozens of intermediate assistant messages, and replaying its narration
+ * tells the next run nothing the final answer does not already say.
+ */
+function lastRunMessageSeqIds(
+  db: Pick<Db, "select">,
+  threadId: string,
+  runIds: readonly string[],
+) {
+  return db
+    .select({ seqId: max(chatEvents.seqId) })
+    .from(chatEvents)
+    .where(
+      and(
+        eq(chatEvents.chatThreadId, threadId),
+        chatEventTypeIn(CHAT_EVENT_CONTENT_TEXT_TYPES),
+        isNotNull(chatEvents.content),
+        inArray(chatEvents.runId, [...runIds]),
+        visibleChatEventCondition(db),
+      ),
+    )
+    .groupBy(chatEvents.runId);
+}
+
 async function getLatestRunsByThreadId(
   db: Db,
   threadId: string,
@@ -239,6 +299,10 @@ async function getLatestRunsByThreadId(
         chatEventTextCondition(),
         inArray(chatEvents.runId, runIds),
         visibleChatEventCondition(db),
+        or(
+          chatEventTypeIn(CHAT_EVENT_USER_MESSAGE_TEXT_TYPES),
+          inArray(chatEvents.seqId, lastRunMessageSeqIds(db, threadId, runIds)),
+        ),
       ),
     )
     .orderBy(asc(chatEvents.seqId));
@@ -268,25 +332,30 @@ async function getLatestRunsByThreadId(
   });
 }
 
+/**
+ * A rotated session starts the CLI conversation over, so the prior rounds have
+ * to be replayed in the prompt. Every other action keeps the session the runner
+ * resumes, which already carries them; replaying them there only duplicates the
+ * conversation. Rounds whose run never completed are absent from the session
+ * either way, so they keep their own block.
+ */
 export async function resolveWebChatSessionPrompt(args: {
   readonly db: Db;
   readonly threadId: string;
   readonly sessionAction: ChatThreadSessionResolutionAction;
   readonly context: WebChatSessionPromptContext;
-  readonly historyPolicy?: "default" | "none";
 }): Promise<string> {
-  const omitHistory = args.historyPolicy === "none";
-  const incompleteContext =
-    omitHistory || args.sessionAction === "rotated"
-      ? ""
-      : await loadWebChatIncompleteContext(args.db, args.threadId);
-  const priorContext =
-    omitHistory || incompleteContext.length > 0
-      ? ""
-      : buildWebChatPriorRunsContext(
-          await getLatestRunsByThreadId(args.db, args.threadId),
-        );
+  const rotated = args.sessionAction === "rotated";
+  const incompleteContext = rotated
+    ? ""
+    : await loadWebChatIncompleteContext(args.db, args.threadId);
+  const priorContext = rotated
+    ? buildWebChatPriorRunsContext(
+        await getLatestRunsByThreadId(args.db, args.threadId),
+      )
+    : "";
   return buildWebChatAppendSystemPrompt({
+    threadId: args.threadId,
     incompleteContext,
     priorContext,
     context: args.context,


### PR DESCRIPTION
## Problem

Run [`d0a3b0c5`](https://app.vm0.ai/activities/d0a3b0c5-827a-4713-855d-13f6e2d6c194) failed 1 second after start:

```
execution: Pi standby child argv/env too large:
env value too large: VM0_PI_SYSTEM_PROMPT length=216392 max=131071
```

Breaking down that 216,392-byte system prompt:

| part | bytes | share |
| --- | --- | --- |
| `# Web Chat Run Context` | 150,710 | 69.6% |
| Skill catalog (~100 skills) | ~32,800 | ~15% |
| `# Agent Tools` | 17,349 | 8.0% |
| MEMORY.md prefix (capped at 8 KiB) | ~8,700 | ~4% |
| Agent instructions | 3,212 | 1.5% |
| Pi base template | 2,655 | 1.2% |

Every other part is either capped or naturally stable. Only the replayed run
context grows with the conversation, and nothing bounded it: the per-message
cap of 4,000 chars applied, but a single prior run contributed 87,664 bytes
from 75 chat events (74 assistant messages, all of them intermediate progress
narration from one agentic run). Three chatty runs accounted for 143 KB of
the prompt.

## Change

- Prior rounds are replayed only when `sessionAction === "rotated"`. That is
  the boundary `shouldStartNewChatSession` already detects (CLI agent type,
  incompatible provider, or model family change), and it is the only case
  where the session the runner resumes cannot carry the conversation.
  `reused` / `adopted` / `initialized` sessions no longer get the block.
- Rounds whose run was cancelled, failed, or timed out are absent from the
  session either way, so `# Incomplete Rounds Context` keeps covering them
  unchanged.
- When the block is emitted, each prior run contributes its user text and its
  **final** assistant message. The last visible message per run is selected in
  SQL, so the intermediate narration is not fetched either.
- New always-present `# This Chat Thread` block carries `CHAT_THREAD_ID` and
  the `zero chat messages` / `zero logs` commands, so a run can pull the rest
  of the conversation on demand instead of receiving it up front. This mirrors
  what `buildAgentRunSourceContext` already does for cross-thread prompts.
- Removes the pi-specific `historyPolicy`. The trigger is now framework
  independent (cc / cdx / pi behave identically), and the old check compared
  `threadSessionRoute.modelProvider` (`vm0` for built-in models) against the
  Pi-capable provider table, so it never fired for built-in models even though
  those runs do take the Pi standby path.

Measured against that run's real data: the replay drops from 150,710 to
16,527 bytes when it is emitted, and to 0 when the session is reused. The
prompt would have been ~66 KB, comfortably under the 131,071-byte ceiling.

## Verification

- `prettier --check` on all touched files
- `tsc` on each changed service file
- Behavior is covered by `chat-events.bdd.test.ts`: a new case asserts that a
  model-family rotation replays only the final answer and skips the narration,
  and the same-family / follow-up cases now assert the block is absent. The
  full API suite runs in CI.

## Fallbacks

- **Removed** — `zero-runs-create.service.ts` `piNoLegacyHistory` /
  `zero-web-chat-session-prompt.service.ts` `historyPolicy`. This was a
  `FeatureSwitchKey.PiLoop`-gated branch that suppressed the legacy history
  replay for Pi runs. Evidence for removal: the trigger is now framework
  independent, so the Pi-specific escape hatch has no remaining job, and the
  predicate it used compared `threadSessionRoute.modelProvider` (`vm0` for
  built-in models) against the Pi-capable provider table, which excludes `vm0`,
  so it never fired for built-in models in the first place. The branch, its only
  caller, and its now-unused imports are deleted together; no test referenced
  `historyPolicy`.
- **Kept, pre-existing, untouched** — `buildWebChatPriorRunsContext` still
  substitutes `User: <run.prompt>` when a replayed run has no materialized user
  event, and `Assistant: [no stored assistant message]` when it has no assistant
  event. Chat materialization runs in `waitUntil`, so a completed run's events
  can legitimately lag its row; these are presentational defaults for a
  reachable state, not cross-version compatibility. Justified.
- No new cross-version rollout fallback is introduced, so no surface window or
  removal condition applies. `appendSystemPrompt` keeps its contract shape and
  only gets smaller, so neither an old runner reading a new value nor an old API
  writing an old value is affected.

## Follow-up (not in this PR)

The 128 KiB ceiling itself remains. `RunPayload.append_system_prompt` already
travels to guest-agent through `VM0_RUN_PAYLOAD_FILE` for exactly this reason,
but guest-agent still hands the merged Pi prompt to the standby child as an env
value. Splitting Pi's own system prompt (computed in `pi-agent-runtime` from an
`ExecutionEnv`) from the framework-shared append half, and reading the append
half from the payload file, removes the cliff.

