### PR TITLE
fix(connectors): align active-run auth variable semantics

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -171,6 +171,7 @@ def _build_firewall_auth_context(
     api_id = flow.metadata[metadata_keys.FIREWALL_API_ID]
     run_id = flow_metadata.run_id(flow.metadata)
     custom_connector_id = api_entry.get("customConnectorId")
+    connector_routing_variables = vm_info.get("connectorRoutingVariables", {})
     matched_firewall: dict | None = None
     if isinstance(custom_connector_id, str):
         matched_firewall = {
@@ -178,6 +179,18 @@ def _build_firewall_auth_context(
             "apiId": api_id,
             "customConnectorId": custom_connector_id,
         }
+        routing_variables = connector_routing_variables.get(f"custom:{custom_connector_id}")
+        if isinstance(routing_variables, dict):
+            matched_firewall["routingVariables"] = routing_variables
+    else:
+        routing_variables = connector_routing_variables.get(f"builtin:{allow.name}")
+        if isinstance(routing_variables, dict):
+            matched_firewall = {
+                "name": allow.name,
+                "apiId": api_id,
+                "connectorSlug": allow.name,
+                "routingVariables": routing_variables,
+            }
     auth_request = FirewallAuthRequest(
         sandbox_token=vm_info.get("sandboxToken", ""),
         encrypted_secrets=vm_info.get("encryptedSecrets") or "",

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -275,6 +275,11 @@ def _classify_registry_vms(
         except ValueError as e:
             invalid_vms[client_ip] = InvalidVmEntry("invalid_omitted_intents", str(e))
             continue
+        try:
+            _validate_connector_routing_variables(vm)
+        except (TypeError, ValueError) as e:
+            invalid_vms[client_ip] = InvalidVmEntry("invalid_connector_routing_variables", str(e))
+            continue
 
         raw_firewalls = vm.get("firewalls")
         vm_uses_builtin_catalog_dependency = isinstance(raw_firewalls, list) and any(
@@ -331,6 +336,36 @@ def _omitted_runtime_intents(vm: dict, field_name: str) -> frozenset[str]:
     if len(set(raw_values)) != len(raw_values):
         raise ValueError(f"proxy registry VM entry {field_name} must be unique")
     return frozenset(raw_values)
+
+
+def _validate_connector_routing_variables(vm: dict) -> None:
+    routing_variables = vm.get("connectorRoutingVariables", {})
+    if not isinstance(routing_variables, dict):
+        raise TypeError("proxy registry VM entry connectorRoutingVariables must be an object")
+    for identity, values in routing_variables.items():
+        if not isinstance(identity, str):
+            raise TypeError(
+                "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
+            )
+        if not identity.startswith(("builtin:", "custom:")):
+            raise ValueError(
+                "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
+            )
+        _, connector_identity = identity.split(":", 1)
+        if connector_identity == "":
+            raise ValueError(
+                "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
+            )
+        if not isinstance(values, dict) or any(
+            not isinstance(key, str) or not isinstance(value, str) for key, value in values.items()
+        ):
+            raise TypeError(
+                "proxy registry VM entry connectorRoutingVariables values must be string maps"
+            )
+        if any(key == "" for key in values):
+            raise ValueError(
+                "proxy registry VM entry connectorRoutingVariables values must be string maps"
+            )
 
 
 def _read_registry_vms(raw_bytes: bytes) -> dict:

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
@@ -158,6 +158,11 @@ async def test_custom_connector_id_is_forwarded_with_matched_firewall(
                 "ask": [],
                 "unknownPolicy": "allow",
             },
+            vm_fields={
+                "connectorRoutingVariables": {
+                    f"custom:{custom_connector_id}": {"subdomain": "münich"}
+                }
+            },
         ),
     )
     flow = real_flow(
@@ -183,8 +188,44 @@ async def test_custom_connector_id_is_forwarded_with_matched_firewall(
         "name": firewall_name,
         "apiId": api_id,
         "customConnectorId": custom_connector_id,
+        "routingVariables": {"subdomain": "münich"},
     }
     assert flow.request.headers["Authorization"] == "Bearer resolved"
+
+
+async def test_builtin_connector_routing_variables_are_forwarded_with_matched_firewall(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        vm_fields={
+            "connectorRoutingVariables": {"builtin:github": {"GITHUB_HOST": "münich.example.test"}}
+        },
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos",
+    )
+    auth_fetch = AsyncMock(return_value=_resolved_firewall_auth())
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", auth_fetch),
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    await_args = auth_fetch.await_args
+    assert await_args is not None
+    request = await_args.args[0]
+    assert request.to_body()["matchedFirewall"] == {
+        "name": "github",
+        "apiId": flow.metadata[metadata_keys.FIREWALL_API_ID],
+        "connectorSlug": "github",
+        "routingVariables": {"GITHUB_HOST": "münich.example.test"},
+    }
 
 
 async def test_custom_firewall_change_during_auth_discards_stale_credentials(

--- a/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
@@ -140,6 +140,48 @@ async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
+async def test_invalid_connector_routing_variables_block_before_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    vm_info = _single_firewall_vm(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+        vm_fields={"connectorRoutingVariables": {"github": {"HOST": "example.test"}}},
+    )
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "invalid_registry_vm",
+        "message": (
+            "proxy registry VM entry connectorRoutingVariables keys must identify a connector"
+        ),
+        "reason": "invalid_connector_routing_variables",
+    }
+    auth_fetch.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "firewalls",
     [0, 1, False, True, "", {}, {"name": "github"}, "broken"],

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1501,12 +1501,6 @@ pub(super) async fn register_proxy(
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
     let cli_agent_type = normalized_cli_agent_type(&context.cli_agent_type);
-    let connector_runtime_targets = context.connector_runtime_targets.as_ref().map(|targets| {
-        targets
-            .iter()
-            .map(crate::types::ConnectorRuntimeTargetRegistration::target)
-            .collect::<Vec<_>>()
-    });
     let registration = proxy::VmRegistration {
         run_id: &run_id_str,
         cli_agent_type,
@@ -1515,7 +1509,7 @@ pub(super) async fn register_proxy(
         proxy_log_path: &proxy_log_path,
         firewalls: context.firewalls.as_deref(),
         network_policies: context.network_policies.as_ref(),
-        connector_runtime_targets: connector_runtime_targets.as_deref(),
+        connector_runtime_targets: context.connector_runtime_targets.as_deref(),
         encrypted_secrets: context.encrypted_secrets.as_deref(),
         secret_connector_map: context.secret_connector_map.as_ref(),
         secret_connector_metadata_map: context.secret_connector_metadata_map.as_ref(),

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -951,9 +951,20 @@ impl NetworkPolicyRefreshCore {
                     },
                     state,
                 ) => {
+                    let Some(routing_variables) = self
+                        .custom_base_url_vars_for_publication(
+                            run_id,
+                            target,
+                            candidate_base_url_vars.as_ref(),
+                        )
+                        .await
+                    else {
+                        continue;
+                    };
                     let registry_state = match custom_connector_runtime_registry_state(
                         custom_connector_id,
                         state,
+                        routing_variables,
                     ) {
                         Ok(state) => state,
                         Err(error) => {
@@ -1242,6 +1253,26 @@ impl NetworkPolicyRefreshCore {
         )
     }
 
+    async fn custom_base_url_vars_for_publication(
+        &self,
+        run_id: RunId,
+        target: &ConnectorRefreshTarget,
+        candidate: Option<&HashMap<String, String>>,
+    ) -> Option<Option<HashMap<String, String>>> {
+        let active_runs = self.inner.active_runs.lock().await;
+        let active = active_runs.get(&run_id)?;
+        let connector = active.connectors.get(&target.target)?;
+        if connector.generation != target.generation {
+            return None;
+        }
+        Some(
+            connector
+                .pinned_base_url_vars
+                .clone()
+                .or_else(|| candidate.cloned()),
+        )
+    }
+
     async fn complete_successful_refresh(
         &self,
         run_id: RunId,
@@ -1511,6 +1542,7 @@ fn connector_runtime_unresolved_reason_is_valid(
 fn custom_connector_runtime_registry_state(
     custom_connector_id: &str,
     state: &ConnectorRuntimeSyncState,
+    routing_variables: Option<HashMap<String, String>>,
 ) -> Result<CustomConnectorRuntimeRegistryState, &'static str> {
     match state {
         ConnectorRuntimeSyncState::Absent { .. } => Ok(CustomConnectorRuntimeRegistryState::Absent),
@@ -1534,7 +1566,8 @@ fn custom_connector_runtime_registry_state(
                 .map_err(|_| "custom available result has an invalid inline firewall")?;
             Ok(CustomConnectorRuntimeRegistryState::Available {
                 firewall: firewall.clone(),
-                network_policy: network_policy.clone(),
+                network_policy: Box::new(network_policy.clone()),
+                routing_variables,
             })
         }
         ConnectorRuntimeSyncState::Available { network_policy, .. } => {
@@ -3007,6 +3040,13 @@ mod tests {
             Some(base_url_vars.clone())
         );
         let registry_after_available = tokio::fs::read(&registry_path).await.unwrap();
+        let registry_json: serde_json::Value =
+            serde_json::from_slice(&registry_after_available).unwrap();
+        assert_eq!(
+            registry_json["vms"]["10.200.0.2"]["connectorRoutingVariables"]
+                [format!("custom:{custom_connector_id}")],
+            json!(base_url_vars)
+        );
 
         first_sync.delete_async().await;
         let unresolved_sync = server.mock(|when, then| {

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -9,7 +9,9 @@ use tracing::info;
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::state_file::PROXY_REGISTRY_MAX_BYTES;
-use crate::types::{ConnectorRuntimeTarget, FirewallEntry, NetworkPolicy, SecretConnectorMetadata};
+use crate::types::{
+    ConnectorRuntimeTargetRegistration, FirewallEntry, NetworkPolicy, SecretConnectorMetadata,
+};
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -33,6 +35,8 @@ struct VmEntry {
     omitted_builtin_firewalls: HashSet<String>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     omitted_custom_connector_ids: HashSet<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    connector_routing_variables: HashMap<String, HashMap<String, String>>,
     encrypted_secrets: Option<String>,
     secret_connector_map: Option<HashMap<String, String>>,
     secret_connector_metadata_map: Option<HashMap<String, SecretConnectorMetadata>>,
@@ -54,7 +58,7 @@ pub struct VmRegistration<'a> {
     pub proxy_log_path: &'a std::path::Path,
     pub firewalls: Option<&'a [FirewallEntry]>,
     pub network_policies: Option<&'a HashMap<String, NetworkPolicy>>,
-    pub connector_runtime_targets: Option<&'a [ConnectorRuntimeTarget]>,
+    pub connector_runtime_targets: Option<&'a [ConnectorRuntimeTargetRegistration]>,
     pub encrypted_secrets: Option<&'a str>,
     pub secret_connector_map: Option<&'a HashMap<String, String>>,
     pub secret_connector_metadata_map: Option<&'a HashMap<String, SecretConnectorMetadata>>,
@@ -154,7 +158,8 @@ pub struct ProxyRegistryHandle {
 pub(crate) enum CustomConnectorRuntimeRegistryState {
     Available {
         firewall: FirewallEntry,
-        network_policy: NetworkPolicy,
+        network_policy: Box<NetworkPolicy>,
+        routing_variables: Option<HashMap<String, String>>,
     },
     Absent,
 }
@@ -174,6 +179,14 @@ fn custom_connector_owner(entry: &FirewallEntry) -> Option<&str> {
         } => Some(custom_connector_id),
         FirewallEntry::Builtin { .. } | FirewallEntry::Inline { .. } => None,
     }
+}
+
+fn builtin_connector_routing_key(connector_slug: &str) -> String {
+    format!("builtin:{connector_slug}")
+}
+
+fn custom_connector_routing_key(custom_connector_id: &str) -> String {
+    format!("custom:{custom_connector_id}")
 }
 
 fn validate_custom_connector_resource_ownership(firewalls: &[FirewallEntry]) -> RunnerResult<()> {
@@ -249,20 +262,65 @@ fn initial_omitted_connector_runtime_targets(
     let mut omitted_custom_connector_ids = HashSet::new();
     for target in registration.connector_runtime_targets.unwrap_or_default() {
         match target {
-            ConnectorRuntimeTarget::Builtin { connector_slug }
+            ConnectorRuntimeTargetRegistration::Builtin { connector_slug }
                 if !active_builtin_firewalls.contains(connector_slug.as_str()) =>
             {
                 omitted_builtin_firewalls.insert(connector_slug.clone());
             }
-            ConnectorRuntimeTarget::Custom {
+            ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id,
+                ..
             } if !active_custom_connector_ids.contains(custom_connector_id.as_str()) => {
                 omitted_custom_connector_ids.insert(custom_connector_id.clone());
             }
-            ConnectorRuntimeTarget::Builtin { .. } | ConnectorRuntimeTarget::Custom { .. } => {}
+            ConnectorRuntimeTargetRegistration::Builtin { .. }
+            | ConnectorRuntimeTargetRegistration::Custom { .. } => {}
         }
     }
     (omitted_builtin_firewalls, omitted_custom_connector_ids)
+}
+
+fn initial_connector_routing_variables(
+    registration: &VmRegistration<'_>,
+) -> HashMap<String, HashMap<String, String>> {
+    let mut routing_variables = HashMap::new();
+    let run_vars = registration.vars.cloned().unwrap_or_default();
+    for firewall in registration.firewalls.unwrap_or_default() {
+        if let FirewallEntry::Builtin {
+            name,
+            base_url_vars,
+        } = firewall
+        {
+            let raw_values = base_url_vars.as_ref().map_or_else(
+                || Some(HashMap::new()),
+                |resolved_values| {
+                    resolved_values
+                        .keys()
+                        .map(|key| run_vars.get(key).map(|value| (key.clone(), value.clone())))
+                        .collect::<Option<HashMap<_, _>>>()
+                },
+            );
+            // Missing raw values are the old-API compatibility shape. Omitting
+            // this identity keeps the pre-pin auth path until #25351 removes
+            // the fallback after old API instances drain.
+            if let Some(raw_values) = raw_values {
+                routing_variables.insert(builtin_connector_routing_key(name), raw_values);
+            }
+        }
+    }
+    for target in registration.connector_runtime_targets.unwrap_or_default() {
+        if let ConnectorRuntimeTargetRegistration::Custom {
+            custom_connector_id,
+            base_url_vars: Some(base_url_vars),
+        } = target
+        {
+            routing_variables.insert(
+                custom_connector_routing_key(custom_connector_id),
+                base_url_vars.clone(),
+            );
+        }
+    }
+    routing_variables
 }
 
 impl ProxyRegistryHandle {
@@ -282,6 +340,7 @@ impl ProxyRegistryHandle {
         registration: &VmRegistration<'_>,
     ) -> RunnerResult<()> {
         validate_custom_connector_resource_ownership(registration.firewalls.unwrap_or_default())?;
+        let connector_routing_variables = initial_connector_routing_variables(registration);
         let _guard = lock::acquire(self.lock_path.clone()).await?;
 
         let mut registry = read_registry(&self.registry_path).await?;
@@ -302,6 +361,7 @@ impl ProxyRegistryHandle {
                 network_policies: registration.network_policies.cloned(),
                 omitted_builtin_firewalls,
                 omitted_custom_connector_ids,
+                connector_routing_variables,
                 encrypted_secrets: registration.encrypted_secrets.map(String::from),
                 secret_connector_map: registration.secret_connector_map.cloned(),
                 secret_connector_metadata_map: registration.secret_connector_metadata_map.cloned(),
@@ -355,6 +415,7 @@ impl ProxyRegistryHandle {
             CustomConnectorRuntimeRegistryState::Available {
                 firewall,
                 network_policy,
+                routing_variables,
             } => {
                 let FirewallEntry::Inline {
                     firewall: inline_firewall,
@@ -421,7 +482,13 @@ impl ProxyRegistryHandle {
                         network_policies.remove(&firewall_name);
                     }
                 }
-                network_policies.insert(inline_firewall_name, network_policy);
+                network_policies.insert(inline_firewall_name, *network_policy);
+                if let Some(routing_variables) = routing_variables {
+                    vm.connector_routing_variables.insert(
+                        custom_connector_routing_key(custom_connector_id),
+                        routing_variables,
+                    );
+                }
                 vm.omitted_custom_connector_ids.remove(custom_connector_id);
             }
             CustomConnectorRuntimeRegistryState::Absent => {
@@ -849,6 +916,7 @@ mod tests {
                 network_policies: None,
                 omitted_builtin_firewalls: HashSet::new(),
                 omitted_custom_connector_ids: HashSet::new(),
+                connector_routing_variables: HashMap::new(),
                 encrypted_secrets: None,
                 secret_connector_map: None,
                 secret_connector_metadata_map: None,
@@ -1034,22 +1102,28 @@ mod tests {
         let firewalls = vec![
             FirewallEntry::Builtin {
                 name: "slack".to_string(),
-                base_url_vars: None,
+                base_url_vars: Some(HashMap::from([(
+                    "SLACK_HOST".to_string(),
+                    "xn--mnich-kva.example.test".to_string(),
+                )])),
             },
             custom_runtime_firewall(available_custom_id, "custom_connector_available"),
         ];
+        let vars = HashMap::from([("SLACK_HOST".to_string(), "münich.example.test".to_string())]);
         let targets = vec![
-            ConnectorRuntimeTarget::Builtin {
+            ConnectorRuntimeTargetRegistration::Builtin {
                 connector_slug: "slack".to_string(),
             },
-            ConnectorRuntimeTarget::Builtin {
+            ConnectorRuntimeTargetRegistration::Builtin {
                 connector_slug: "github".to_string(),
             },
-            ConnectorRuntimeTarget::Custom {
+            ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: available_custom_id.to_string(),
+                base_url_vars: Some(HashMap::new()),
             },
-            ConnectorRuntimeTarget::Custom {
+            ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: omitted_custom_id.to_string(),
+                base_url_vars: None,
             },
         ];
 
@@ -1060,6 +1134,7 @@ mod tests {
                 &VmRegistration {
                     firewalls: Some(&firewalls),
                     connector_runtime_targets: Some(&targets),
+                    vars: Some(&vars),
                     ..base_registration()
                 },
             )
@@ -1075,6 +1150,16 @@ mod tests {
         assert_eq!(
             vm.omitted_custom_connector_ids,
             HashSet::from([omitted_custom_id.to_string()])
+        );
+        assert_eq!(
+            vm.connector_routing_variables,
+            HashMap::from([
+                (
+                    "builtin:slack".to_string(),
+                    HashMap::from([("SLACK_HOST".to_string(), "münich.example.test".to_string(),)]),
+                ),
+                (format!("custom:{available_custom_id}"), HashMap::new(),),
+            ])
         );
     }
 
@@ -1161,7 +1246,8 @@ mod tests {
                 custom_connector_id,
                 CustomConnectorRuntimeRegistryState::Available {
                     firewall: custom_runtime_firewall(custom_connector_id, "slack"),
-                    network_policy: policy(&["custom.write"], &[], &[], "deny"),
+                    network_policy: Box::new(policy(&["custom.write"], &[], &[], "deny")),
+                    routing_variables: None,
                 },
             )
             .await
@@ -1202,6 +1288,12 @@ mod tests {
                 policy(&["chat:write"], &[], &[], "allow"),
             ),
         ]);
+        let pinned_routing_variables =
+            HashMap::from([("subdomain".to_string(), "pinned".to_string())]);
+        let runtime_targets = vec![ConnectorRuntimeTargetRegistration::Custom {
+            custom_connector_id: custom_connector_id.to_string(),
+            base_url_vars: Some(pinned_routing_variables.clone()),
+        }];
         harness
             .handle
             .register_vm(
@@ -1210,6 +1302,7 @@ mod tests {
                     run_id: "run-test",
                     firewalls: Some(&firewalls),
                     network_policies: Some(&network_policies),
+                    connector_runtime_targets: Some(&runtime_targets),
                     ..base_registration()
                 },
             )
@@ -1254,6 +1347,11 @@ mod tests {
                 .unwrap()
                 .contains_key("slack")
         );
+        assert_eq!(
+            absent_vm.connector_routing_variables
+                [&custom_connector_routing_key(custom_connector_id)],
+            pinned_routing_variables
+        );
 
         let restored_firewall = custom_runtime_firewall(custom_connector_id, restored_name);
         assert!(
@@ -1265,7 +1363,8 @@ mod tests {
                     custom_connector_id,
                     CustomConnectorRuntimeRegistryState::Available {
                         firewall: restored_firewall,
-                        network_policy: policy(&["custom.write"], &[], &[], "ask"),
+                        network_policy: Box::new(policy(&["custom.write"], &[], &[], "ask",)),
+                        routing_variables: Some(pinned_routing_variables.clone()),
                     },
                 )
                 .await
@@ -1277,6 +1376,11 @@ mod tests {
             !restored_vm
                 .omitted_custom_connector_ids
                 .contains(custom_connector_id)
+        );
+        assert_eq!(
+            restored_vm.connector_routing_variables
+                [&custom_connector_routing_key(custom_connector_id)],
+            pinned_routing_variables
         );
         assert!(
             restored_vm

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -284,7 +284,7 @@ fn initial_connector_routing_variables(
     registration: &VmRegistration<'_>,
 ) -> HashMap<String, HashMap<String, String>> {
     let mut routing_variables = HashMap::new();
-    let run_vars = registration.vars.cloned().unwrap_or_default();
+    let run_vars = registration.vars;
     let builtin_connector_slugs = registration
         .connector_runtime_targets
         .unwrap_or_default()
@@ -310,7 +310,11 @@ fn initial_connector_routing_variables(
                 |resolved_values| {
                     resolved_values
                         .keys()
-                        .map(|key| run_vars.get(key).map(|value| (key.clone(), value.clone())))
+                        .map(|key| {
+                            run_vars
+                                .and_then(|values| values.get(key))
+                                .map(|value| (key.clone(), value.clone()))
+                        })
                         .collect::<Option<HashMap<_, _>>>()
                 },
             );

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -285,12 +285,26 @@ fn initial_connector_routing_variables(
 ) -> HashMap<String, HashMap<String, String>> {
     let mut routing_variables = HashMap::new();
     let run_vars = registration.vars.cloned().unwrap_or_default();
+    let builtin_connector_slugs = registration
+        .connector_runtime_targets
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|target| match target {
+            ConnectorRuntimeTargetRegistration::Builtin { connector_slug } => {
+                Some(connector_slug.as_str())
+            }
+            ConnectorRuntimeTargetRegistration::Custom { .. } => None,
+        })
+        .collect::<HashSet<_>>();
     for firewall in registration.firewalls.unwrap_or_default() {
         if let FirewallEntry::Builtin {
             name,
             base_url_vars,
         } = firewall
         {
+            if !builtin_connector_slugs.contains(name.as_str()) {
+                continue;
+            }
             let raw_values = base_url_vars.as_ref().map_or_else(
                 || Some(HashMap::new()),
                 |resolved_values| {
@@ -1095,7 +1109,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn registration_marks_pinned_targets_without_firewalls_as_omitted() {
+    async fn registration_tracks_runtime_target_availability_and_routing_variables() {
         let harness = RegistryHarness::new().await;
         let available_custom_id = "550e8400-e29b-41d4-a716-446655440000";
         let omitted_custom_id = "550e8400-e29b-41d4-a716-446655440001";
@@ -1106,6 +1120,10 @@ mod tests {
                     "SLACK_HOST".to_string(),
                     "xn--mnich-kva.example.test".to_string(),
                 )])),
+            },
+            FirewallEntry::Builtin {
+                name: "model-provider:openai".to_string(),
+                base_url_vars: None,
             },
             custom_runtime_firewall(available_custom_id, "custom_connector_available"),
         ];
@@ -1160,6 +1178,41 @@ mod tests {
                 ),
                 (format!("custom:{available_custom_id}"), HashMap::new(),),
             ])
+        );
+    }
+
+    #[tokio::test]
+    async fn registration_omits_builtin_routing_pin_without_raw_run_values() {
+        let harness = RegistryHarness::new().await;
+        let firewalls = vec![FirewallEntry::Builtin {
+            name: "slack".to_string(),
+            base_url_vars: Some(HashMap::from([(
+                "SLACK_HOST".to_string(),
+                "resolved.example.test".to_string(),
+            )])),
+        }];
+        let targets = vec![ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "slack".to_string(),
+        }];
+
+        harness
+            .handle
+            .register_vm(
+                "10.200.0.2",
+                &VmRegistration {
+                    firewalls: Some(&firewalls),
+                    connector_runtime_targets: Some(&targets),
+                    ..base_registration()
+                },
+            )
+            .await
+            .unwrap();
+
+        let registry = read_registry(harness.registry_path()).await.unwrap();
+        assert!(
+            !registry.vms["10.200.0.2"]
+                .connector_routing_variables
+                .contains_key("builtin:slack")
         );
     }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9300,6 +9300,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
             kind: "variable",
             required: true,
           },
+          {
+            key: "scope",
+            label: "Scope",
+            kind: "variable",
+            required: true,
+          },
         ],
         headerInjections: [
           {
@@ -9312,11 +9318,16 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
             name: "tenant",
             valueTemplate: "{{variables.subdomain}}",
           },
+          {
+            name: "scope",
+            valueTemplate: "{{variables.scope}}",
+          },
         ],
       },
       values: [
         { key: "api_key", kind: "secret", value: "runtime-proposal-secret" },
         { key: "subdomain", kind: "variable", value: "münich" },
+        { key: "scope", kind: "variable", value: "initial-scope" },
       ],
       agentId,
     });
@@ -9352,32 +9363,48 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const internalName = `custom_connector_${idPart}`;
     const secretKey = `CUSTOM_${idPart}_S_API_KEY`;
     const variableKey = `CUSTOM_${idPart}_V_SUBDOMAIN`;
+    const scopeVariableKey = `CUSTOM_${idPart}_V_SCOPE`;
     const customApis = inlineFirewallApis(claim.firewalls, internalName);
-    expect(customApis[0]?.base).toBe(`https://xn--mnich-kva.${rand}.test/v1/`);
+    const customApi = customApis[0];
+    if (!customApi) {
+      throw new Error("Expected the proposed custom connector firewall API");
+    }
+    expect(customApi.base).toBe(`https://xn--mnich-kva.${rand}.test/v1/`);
     const pinnedTarget = {
       kind: "custom" as const,
       customConnectorId: saved.connector.id,
       baseUrlVars: { subdomain: "münich" },
     };
     expect(claim.connectorRuntimeTargets).toContainEqual(pinnedTarget);
-    expect(customApis[0]?.auth?.headers?.Authorization).toBe(
+    expect(customApi.auth?.headers?.Authorization).toBe(
       `Bearer \${{ secrets.${secretKey} }}`,
     );
-    expect(customApis[0]?.auth?.query?.tenant).toBe(
+    expect(customApi.auth?.query?.tenant).toBe(
       `\${{ secrets.${variableKey} }}`,
     );
+    expect(customApi.auth?.query?.scope).toBe(
+      `\${{ secrets.${scopeVariableKey} }}`,
+    );
 
+    const authBody = {
+      encryptedSecrets: fw.encryptedSecretsBody({}),
+      authHeaders: {
+        Authorization: `Bearer \${{ secrets.${secretKey} }}`,
+      },
+      authQuery: {
+        tenant: `\${{ secrets.${variableKey} }}`,
+        scope: `\${{ secrets.${scopeVariableKey} }}`,
+      },
+      matchedFirewall: {
+        name: internalName,
+        apiId: `${internalName}:0`,
+        customConnectorId: saved.connector.id,
+        routingVariables: { subdomain: "münich" },
+      },
+    };
     const resolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
-      {
-        encryptedSecrets: fw.encryptedSecretsBody({}),
-        authHeaders: {
-          Authorization: `Bearer \${{ secrets.${secretKey} }}`,
-        },
-        authQuery: {
-          tenant: `\${{ secrets.${variableKey} }}`,
-        },
-      },
+      authBody,
       [200],
     );
     if (resolved.status !== 200) {
@@ -9386,11 +9413,15 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(resolved.body.headers).toStrictEqual({
       Authorization: "Bearer runtime-proposal-secret",
     });
-    expect(resolved.body.query).toStrictEqual({ tenant: "münich" });
+    expect(resolved.body.query).toStrictEqual({
+      tenant: "münich",
+      scope: "initial-scope",
+    });
 
     context.mocks.ably.publish.mockClear();
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
       { key: "subdomain", kind: "variable", value: "later-run" },
+      { key: "scope", kind: "variable", value: "later-scope" },
     ]);
     expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
       "connector-runtime-sync",
@@ -9404,6 +9435,18 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(pinnedRuntime.firewall.firewall.apis[0]?.base).toBe(
       `https://xn--mnich-kva.${rand}.test/v1/`,
     );
+    const updatedAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      authBody,
+      [200],
+    );
+    if (updatedAuth.status !== 200) {
+      throw new Error("Expected the updated custom firewall auth to resolve");
+    }
+    expect(updatedAuth.body.query).toStrictEqual({
+      tenant: "münich",
+      scope: "later-scope",
+    });
 
     const laterRun = await api.createRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -269,6 +269,52 @@ describe("FW-2: template resolution without connector refresh", () => {
     expect(missing.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
   });
 
+  it("uses pinned routing variables and current auth-only variables for builtin connectors", async () => {
+    const fw = createFirewallApi(context);
+    const connectorsApi = createConnectorBddApi(context);
+    const { actor, headers } = await firewallRun();
+    await connectorsApi.connectManualGrant(actor, "jira", "api-token", {
+      apiToken: "current-jira-token",
+      domain: "current.atlassian.net",
+      email: "current@example.test",
+    });
+    const body = {
+      encryptedSecrets: fw.encryptedSecretsBody({}),
+      authHeaders: {
+        "X-Domain": varTemplate("JIRA_DOMAIN"),
+        "X-Email": varTemplate("JIRA_EMAIL"),
+      },
+      vars: {
+        JIRA_DOMAIN: "run-start.atlassian.net",
+        JIRA_EMAIL: "run-start@example.test",
+      },
+      matchedFirewall: {
+        name: "jira",
+        apiId: "jira:0",
+        connectorSlug: "jira" as const,
+        routingVariables: {
+          JIRA_DOMAIN: "run-start.atlassian.net",
+        },
+      },
+    };
+
+    const resolved = await fw.requestFirewallAuth(headers, body, [200]);
+    if (resolved.status !== 200) {
+      throw new Error("Expected builtin connector auth resolution to succeed");
+    }
+    expect(resolved.body.headers).toStrictEqual({
+      "X-Domain": "run-start.atlassian.net",
+      "X-Email": "current@example.test",
+    });
+
+    await connectorsApi.deleteConnectorBySlug(actor, "jira");
+    const disconnected = await fw.requestFirewallAuth(headers, body, [424]);
+    if (disconnected.status !== 424) {
+      throw new Error("Expected disconnected builtin connector auth to fail");
+    }
+    expect(disconnected.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+  });
+
   it("passes literals through query templates and keeps basic-literal templates opaque", async () => {
     const fw = createFirewallApi(context);
     const { headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -152,7 +152,9 @@ interface FirewallAuthBody {
   readonly matchedFirewall?: {
     readonly name: string;
     readonly apiId: string;
+    readonly connectorSlug?: ConnectorSlug;
     readonly customConnectorId?: string;
+    readonly routingVariables?: Record<string, string>;
   };
 }
 
@@ -3399,6 +3401,57 @@ function hasMissingUnresolvableSecrets(args: {
   });
 }
 
+function firewallAuthReferencedConnectorSlugs(args: {
+  readonly body: FirewallAuthBody;
+  readonly referencedSecretKeys: Set<string>;
+}): readonly string[] {
+  const matchedConnectorSlug = args.body.matchedFirewall?.connectorSlug;
+  return [
+    ...new Set([
+      ...referencedConnectorSlugs({
+        secretConnectorMap: args.body.secretConnectorMap,
+        secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+        referencedKeys: args.referencedSecretKeys,
+      }),
+      ...(matchedConnectorSlug === undefined ? [] : [matchedConnectorSlug]),
+    ]),
+  ];
+}
+
+function matchedBuiltinConnectorVariableAliases(args: {
+  readonly connectorSlug: ConnectorSlug | undefined;
+  readonly connectorAccessBySlug: ReadonlyMap<string, ConnectorAccessState>;
+}): ReadonlySet<string> {
+  if (args.connectorSlug === undefined) {
+    return new Set();
+  }
+  const runtimeBindings =
+    args.connectorAccessBySlug.get(args.connectorSlug)?.runtimeMetadata
+      .runtimeBindings ?? [];
+  return new Set(
+    runtimeBindings.flatMap((binding) => {
+      return binding.source.kind === "connector-variable"
+        ? [binding.envName]
+        : [];
+    }),
+  );
+}
+
+function hasMissingFirewallVariables(args: {
+  readonly vars: Readonly<Record<string, string>>;
+  readonly referencedVariableKeys: ReadonlySet<string>;
+  readonly matchedConnectorSlug: ConnectorSlug | undefined;
+  readonly connectorAccessBySlug: ReadonlyMap<string, ConnectorAccessState>;
+}): boolean {
+  const connectorVariableAliases = matchedBuiltinConnectorVariableAliases({
+    connectorSlug: args.matchedConnectorSlug,
+    connectorAccessBySlug: args.connectorAccessBySlug,
+  });
+  return [...args.referencedVariableKeys].some((key) => {
+    return !Object.hasOwn(args.vars, key) && !connectorVariableAliases.has(key);
+  });
+}
+
 async function prepareFirewallAuthResolutionContext(args: {
   readonly db: Db;
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
@@ -3429,17 +3482,23 @@ async function prepareFirewallAuthResolutionContext(args: {
   ) {
     return { ok: false, response: forbiddenModelProviderOwner() };
   }
+  const matchedConnectorSlug = args.body.matchedFirewall?.connectorSlug;
   const connectorAccessBySlug = await loadConnectorAccessStates(
     args.db,
     args.orgId,
     args.auth.userId,
-    referencedConnectorSlugs({
-      secretConnectorMap: args.body.secretConnectorMap,
-      secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
-      referencedKeys: referenced.secrets,
+    firewallAuthReferencedConnectorSlugs({
+      body: args.body,
+      referencedSecretKeys: referenced.secrets,
     }),
     args.connectorCatalogSnapshot,
   );
+  if (
+    matchedConnectorSlug !== undefined &&
+    !connectorAccessBySlug.has(matchedConnectorSlug)
+  ) {
+    return { ok: false, response: connectorNotConfigured() };
+  }
   const modelProviderRefreshable = referencedModelProviderAccessMap({
     secretConnectorMap: args.body.secretConnectorMap,
     secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
@@ -3493,7 +3552,6 @@ async function prepareFirewallAuthResolutionContext(args: {
     connectorAccessBySlug,
     featureSwitchContext: args.featureSwitchContext,
   });
-
   const hasMissingSecrets = hasMissingUnresolvableSecrets({
     secrets: args.secrets,
     referencedKeys: referenced.secrets,
@@ -3501,8 +3559,11 @@ async function prepareFirewallAuthResolutionContext(args: {
     secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
     connectorAccessBySlug,
   });
-  const hasMissingVars = [...referenced.vars].some((key) => {
-    return !Object.hasOwn(vars, key);
+  const hasMissingVars = hasMissingFirewallVariables({
+    vars,
+    referencedVariableKeys: referenced.vars,
+    matchedConnectorSlug,
+    connectorAccessBySlug,
   });
   if (hasMissingSecrets || hasMissingVars) {
     return { ok: false, response: connectorNotConfigured() };
@@ -3516,6 +3577,73 @@ async function prepareFirewallAuthResolutionContext(args: {
       connectorAccessBySlug,
     },
   };
+}
+
+async function resolveMatchedBuiltinConnectorVariables(
+  db: Db,
+  body: FirewallAuthBody,
+  context: FirewallAuthResolutionContext,
+): Promise<Record<string, string> | undefined> {
+  const connectorSlug = body.matchedFirewall?.connectorSlug;
+  if (connectorSlug === undefined) {
+    return body.vars ?? {};
+  }
+  const connectorAccess = context.connectorAccessBySlug.get(connectorSlug);
+  if (connectorAccess === undefined) {
+    return undefined;
+  }
+  const referencedBindings =
+    connectorAccess.runtimeMetadata.runtimeBindings.filter((binding) => {
+      return (
+        binding.source.kind === "connector-variable" &&
+        context.referenced.vars.has(binding.envName)
+      );
+    });
+  const storageNames = [
+    ...new Set(
+      referencedBindings.flatMap((binding) => {
+        return binding.source.kind === "connector-variable"
+          ? [binding.source.name]
+          : [];
+      }),
+    ),
+  ];
+  const rows =
+    storageNames.length === 0
+      ? []
+      : await db
+          .select({ name: variablesTable.name, value: variablesTable.value })
+          .from(variablesTable)
+          .where(
+            connectorCredentialVariableReadCondition({
+              db,
+              groups: [
+                {
+                  access: connectorAccess.access,
+                  names: storageNames,
+                },
+              ],
+            }),
+          );
+  const currentValuesByName = new Map(
+    rows.map((row) => {
+      return [row.name, row.value] as const;
+    }),
+  );
+  const vars = { ...body.vars };
+  for (const binding of referencedBindings) {
+    if (binding.source.kind !== "connector-variable") {
+      continue;
+    }
+    const currentValue = currentValuesByName.get(binding.source.name);
+    if (currentValue === undefined) {
+      return undefined;
+    }
+    const pinnedValue =
+      body.matchedFirewall?.routingVariables?.[binding.envName];
+    vars[binding.envName] = pinnedValue ?? currentValue;
+  }
+  return vars;
 }
 
 function hasMissingResolvedSecrets(
@@ -4198,6 +4326,7 @@ function hasEmptyAwsSigv4Credential(
 interface CurrentCustomConnectorAuthRef {
   readonly secretName: string;
   readonly connectorId: string;
+  readonly kind: "secret" | "variable";
   readonly key: string;
   readonly encryptedValue: string | null;
   readonly required: boolean;
@@ -4247,6 +4376,7 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     refs.set(secretName, {
       secretName,
       connectorId: runtime.connector.id,
+      kind: value.kind,
       key: value.key,
       encryptedValue: value.encryptedValue,
       required: field.required,
@@ -4259,6 +4389,7 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     refs.set(secretName, {
       secretName,
       connectorId: runtime.connector.id,
+      kind: field.kind,
       key: field.key,
       encryptedValue: null,
       required: field.required,
@@ -4273,6 +4404,7 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     refs.set(secretName, {
       secretName,
       connectorId: runtime.connector.id,
+      kind: "secret",
       key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
       encryptedValue: null,
       required: true,
@@ -4450,6 +4582,29 @@ function omitMissingOptionalCustomAuthEntries(args: {
   };
 }
 
+function applyPinnedCustomConnectorRoutingVariables(args: {
+  readonly currentSecrets: Record<string, string>;
+  readonly authRefs: readonly CurrentCustomConnectorAuthRef[];
+  readonly routingVariables: Record<string, string> | undefined;
+}): Record<string, string> {
+  if (args.routingVariables === undefined) {
+    return args.currentSecrets;
+  }
+  const secrets = { ...args.currentSecrets };
+  for (const ref of args.authRefs) {
+    const pinnedValue = args.routingVariables[ref.key];
+    if (
+      ref.kind !== "variable" ||
+      !Object.hasOwn(secrets, ref.secretName) ||
+      pinnedValue === undefined
+    ) {
+      continue;
+    }
+    secrets[ref.secretName] = pinnedValue;
+  }
+  return secrets;
+}
+
 async function resolveCurrentCustomConnectorFirewallAuth(args: {
   readonly db: Db;
   readonly auth: SandboxAuth;
@@ -4504,9 +4659,14 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
     authQuery: args.body.authQuery,
     missingOptionalSecrets: currentSecrets.missingOptionalSecrets,
   });
+  const effectiveSecrets = applyPinnedCustomConnectorRoutingVariables({
+    currentSecrets: currentSecrets.secrets,
+    authRefs,
+    routingVariables: args.body.matchedFirewall?.routingVariables,
+  });
   const resolved = resolveTemplates({
     authHeaders: availableAuth.authHeaders,
-    secrets: currentSecrets.secrets,
+    secrets: effectiveSecrets,
     vars: args.body.vars ?? {},
     authBase: args.body.authBase,
     authQuery: availableAuth.authQuery,
@@ -4578,7 +4738,7 @@ export async function resolveFirewallAuth(
   if (!prepared.ok) {
     return prepared.response;
   }
-  const { connectorAccessBySlug, referenced, vars } = prepared.context;
+  const { connectorAccessBySlug, referenced } = prepared.context;
 
   const billableCacheExpiry = await resolveBillableFirewallCacheExpiry({
     db,
@@ -4635,6 +4795,15 @@ export async function resolveFirewallAuth(
         secretConnectorMap: body.secretConnectorMap,
       }),
     );
+  }
+
+  const vars = await resolveMatchedBuiltinConnectorVariables(
+    db,
+    body,
+    prepared.context,
+  );
+  if (vars === undefined) {
+    return connectorNotConfigured();
   }
 
   const resolved = resolveTemplates({

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
+import { connectorSlugSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
 import {
   artifactMissingRootPolicySchema,
@@ -449,11 +450,24 @@ const firewallAuthResponseSchema = z.object({
   refreshedSecrets: z.array(z.string()),
 });
 
-const matchedFirewallAuthContextSchema = z.object({
-  name: z.string().min(1),
-  apiId: z.string().min(1),
-  customConnectorId: z.uuid().optional(),
-});
+const matchedFirewallAuthContextSchema = z
+  .object({
+    name: z.string().min(1),
+    apiId: z.string().min(1),
+    connectorSlug: connectorSlugSchema.optional(),
+    customConnectorId: z.uuid().optional(),
+    routingVariables: z.record(z.string(), z.string()).optional(),
+  })
+  .refine(
+    (context) => {
+      return (
+        Number(context.connectorSlug !== undefined) +
+          Number(context.customConnectorId !== undefined) ===
+        1
+      );
+    },
+    { message: "Matched firewall must identify exactly one connector" },
+  );
 
 export const webhookFirewallAuthContract = c.router({
   /**
@@ -479,8 +493,8 @@ export const webhookFirewallAuthContract = c.router({
       // alone is not enough to locate access storage.
       secretConnectorMetadataMap: secretConnectorMetadataMapSchema.optional(),
       vars: z.record(z.string(), z.string()).optional(),
-      // Stable matched-firewall identity used to resolve custom connector auth.
-      // Older addons omit this field and retain run-scoped auth-reference behavior.
+      // Stable matched-firewall identity plus run-pinned routing inputs.
+      // Older addons omit builtin context and routingVariables.
       matchedFirewall: matchedFirewallAuthContextSchema.optional(),
       // Set by mitm from billableFirewalls. Server uses this only to bound
       // auth cache lifetime by the current credit authorization lease.


### PR DESCRIPTION
## Summary

- persist the raw routing-variable values selected for each Builtin and Custom connector in the run's private proxy registry
- forward the matched connector identity and routing-variable pin from the trusted mitm addon to firewall auth
- resolve connector auth from current credential storage while overlaying only routing-used variables from the active-run pin
- preserve Custom first-admission pins across runtime firewall refreshes and fail closed on malformed registry data

## Semantics

- routing-used variables remain fixed for the lifetime of an active run
- auth-only variables and secrets use current connector storage for both Builtin and Custom connectors
- a pin cannot revive a deleted, unavailable, or storage-incompatible connector credential

## Deployment compatibility

- the webhook additions and proxy-registry field are optional during rollout
- an old runner keeps the previous auth behavior; a new runner paired with an old API omits the unavailable Builtin raw-value pin and keeps the previous auth path
- deploy the API before the runner; remove these omission paths only after both generations have drained, as tracked in #25351

## Exclusions

- no database or persisted-schema changes
- no credential revision, polling, or digest mechanism
- no compatibility cleanup in this PR

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=2 --silent=passed-only` (200 tests)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test` (546 tests)
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (3,084 tests passed; 20 ignored)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,989 tests)
- repository pre-commit hooks, including full Turbo Knip/type checking and Rust docs/Clippy

Closes #25819

Parent: #25312
