### PR TITLE
test(api): enforce external behavior test boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
+import { HttpResponse, http } from "msw";
 import {
   cronCleanupSandboxesContract,
   cronCompactChatThreadSnapshotsContract,
@@ -26,13 +27,13 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { server } from "../../../mocks/server";
 import {
   seedOrgMetadata,
   seedUsagePricingRows,
 } from "../../../test-fixtures/system-config-seeds";
 import {
   holdChatEventInsertTransactionFixture,
-  insertContentFollowupsEventFixture,
   insertChatEventTransactionFixture,
   insertOutputEventWithConflictingLegacyPayloadFixture,
 } from "../../../test-fixtures/chat-events";
@@ -2953,32 +2954,57 @@ describe("CHAT-01 chat search index", () => {
   }, 60_000);
 
   it("excludes future follow-up content from indexed matches and context", async () => {
-    const orgId = `org_${randomUUID()}`;
-    const owner = bdd.user({ orgId });
-    bdd.acceptAgentStorageWrites();
-    const agent = await bdd.createAgent(owner, {
-      displayName: "Follow-up search exclusion agent",
-    });
-    await enableChatSearchIndex(owner);
-
+    const { actor, agentId, runnerGroup } = await entitledChatActor(
+      "Follow-up search exclusion agent",
+    );
+    await enableChatSearchIndex(actor);
     const visibleNeedle = `visiblemessage${randomUUID().replaceAll("-", "")}`;
     const followupOnlyNeedle = `futurefollowup${randomUUID().replaceAll("-", "")}`;
-    const threadId = await sendNoCreditMessage(owner, {
-      agentId: agent.agentId,
+    mockOptionalEnv("OPENROUTER_API_KEY", "follow-up-search-key");
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          const body = await request.text();
+          return HttpResponse.json({
+            choices: [
+              {
+                message: {
+                  content: body.includes("concise follow-up prompts")
+                    ? JSON.stringify([
+                        { prompt: followupOnlyNeedle, kind: "talk" },
+                      ])
+                    : "Follow-up search exclusion",
+                },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const run = await sendChatRun(actor, {
+      agentId,
       prompt: visibleNeedle,
     });
-    await insertContentFollowupsEventFixture({
-      threadId,
-      content: JSON.stringify({
-        version: 1,
-        followups: [{ prompt: followupOnlyNeedle, kind: "talk" }],
-      }),
+    const { sandboxHeaders } = await claimChatRun(runnerGroup, run.runId);
+    chatCallbacks.mockChatOutputEvents([
+      assistantOutputEvent(0, "Follow-up search response"),
+    ]);
+    await completeChatRunOk(run.runId, sandboxHeaders);
+    await waitForThreadMessages(actor, run.threadId, (messages) => {
+      return messages.some((message) => {
+        return (
+          message.eventType === "output.followups" &&
+          (message.content?.includes(followupOnlyNeedle) ?? false)
+        );
+      });
     });
 
     const tick = await projectChatEventSearch();
     expect(tick.success).toBeTruthy();
 
-    const visibleHit = await chat.searchChat(owner, visibleNeedle);
+    const visibleHit = await chat.searchChat(actor, visibleNeedle);
     expect(visibleHit.results).toHaveLength(1);
     const context = [
       ...(visibleHit.results[0]?.contextBefore ?? []),
@@ -2990,7 +3016,7 @@ describe("CHAT-01 chat search index", () => {
       }),
     ).toBeFalsy();
 
-    const followupHit = await chat.searchChat(owner, followupOnlyNeedle);
+    const followupHit = await chat.searchChat(actor, followupOnlyNeedle);
     expect(followupHit.results).toStrictEqual([]);
   }, 60_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
@@ -13,7 +13,6 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
-import { insertContentFollowupsEventFixture } from "../../../test-fixtures/chat-events";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { cronSnapshotChatEventsRoutes } from "../cron-snapshot-chat-events";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
@@ -263,13 +262,9 @@ describe("chat event snapshot read endpoints", () => {
     const agent = await bdd.createAgent(owner, {
       displayName: "Snapshot maintenance agent",
     });
-    const thread = await chat.createThread(owner, { agentId: agent.agentId });
-    await insertContentFollowupsEventFixture({
-      threadId: thread.id,
-      content: JSON.stringify({
-        version: 1,
-        followups: [{ prompt: "Archived follow-up", kind: "talk" }],
-      }),
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `snapshot-maintenance-${randomUUID()}`,
     });
 
     await projectChatEventSearch();
@@ -277,12 +272,12 @@ describe("chat event snapshot read endpoints", () => {
     const archived = await runSnapshotCron();
     expect(archived.corsChanged).toBeTruthy();
 
-    const head = await readChatEventSnapshotHead(context, thread.id);
+    const head = await readChatEventSnapshotHead(context, threadId);
     expect(readFakeChatEventObject(head.object_key)).toBeDefined();
 
     const future = new Date(now() + 8 * 24 * 60 * 60 * 1000);
     mockNow(future);
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD", thread.id.slice(0, 3));
+    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD", threadId.slice(0, 3));
     ageFakeChatEventObject(
       head.object_key,
       new Date(future.getTime() - 8 * 24 * 60 * 60 * 1000),
@@ -291,7 +286,7 @@ describe("chat event snapshot read endpoints", () => {
     expect(protectedHead.r2ObjectsDeleted).toBe(0);
     expect(readFakeChatEventObject(head.object_key)).toBeDefined();
 
-    const orphanKey = `chat-events/${thread.id.slice(0, 3)}-orphan.ndjson.gz`;
+    const orphanKey = `chat-events/${threadId.slice(0, 3)}-orphan.ndjson.gz`;
     writeFakeChatEventObject(orphanKey, Buffer.from("orphan"));
     ageFakeChatEventObject(
       orphanKey,
@@ -312,15 +307,16 @@ describe("chat event snapshot read endpoints", () => {
     });
     expect(readFakeChatEventObject(orphanKey)).toBeUndefined();
 
-    await insertContentFollowupsEventFixture({
-      threadId: thread.id,
-      content: JSON.stringify({ version: 1, followups: [] }),
+    await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      threadId,
+      prompt: `snapshot-replacement-${randomUUID()}`,
     });
     await projectChatEventSearch();
     const replacement = await runSnapshotCron();
     expect(replacement.r2ObjectsDeleted).toBe(1);
     expect(readFakeChatEventObject(head.object_key)).toBeUndefined();
-    const newHead = await readChatEventSnapshotHead(context, thread.id);
+    const newHead = await readChatEventSnapshotHead(context, threadId);
     expect(newHead.object_key).not.toBe(head.object_key);
     expect(readFakeChatEventObject(newHead.object_key)).toBeDefined();
   }, 120_000);

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -846,27 +846,6 @@ export async function setQueuedUserMessageCreatedAtFixture(args: {
 }
 
 /**
- * Append one canonical follow-up content event for focused BDD coverage.
- */
-export async function insertContentFollowupsEventFixture(args: {
-  readonly threadId: string;
-  readonly content: string;
-}): Promise<{ readonly id: string; readonly seqId: number }> {
-  const event = await db().transaction(async (tx) => {
-    return await insertChatEvent(tx, {
-      chatThreadId: args.threadId,
-      eventType: "output.followups",
-      content: args.content,
-      runId: null,
-    });
-  });
-  if (!event) {
-    throw new Error("Expected the content follow-up event insert");
-  }
-  return event;
-}
-
-/**
  * Complete one claimed run without dispatching its terminal callbacks. This
  * reproduces the missed-callback state that the stale queue sweep recovers.
  */


### PR DESCRIPTION
## Scan

- Timestamp: 2026-08-09 05:01 Asia/Shanghai
- Base commit: 51563fd16909f75e3b3c84c62902b80ca6ea95e2
- Full API ESLint scan: 1039 files, 0 errors, 0 warnings
- Secondary scan: 321 matches; 320 API client, HTTP mock, hash, or collection calls; 1 existing documented service-test exception
- Diff review found 3 direct DB setup calls through insertContentFollowupsEventFixture across 2 API tests

## Violations fixed

- chat-threads.bdd.test.ts now generates output.followups through the production chat send, runner claim, agent events, checkpoint, and completion endpoints. OpenRouter remains mocked at the external HTTP boundary.
- zero-chat-event-snapshot.test.ts now creates and advances snapshot state through the production chat send endpoint.
- Removed the now-unused insertContentFollowupsEventFixture DB writer.

## Remaining exception

- workflow-automation-context.test.ts remains the existing narrow lint exception for a finite event-type rendering and policy matrix. This PR does not broaden that exception.

## Verification

- pnpm --filter api exec eslint on all changed files
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types
- PostgreSQL 18 with UTC timezone and all migrations
- Vitest: chat-threads.bdd.test.ts, excludes future follow-up content from indexed matches and context
- Vitest: zero-chat-event-snapshot.test.ts, garbage-collects unreferenced snapshot objects
- git diff --check