### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -685,9 +685,6 @@ test("avatar catalog surfaces stay stable while scrolling and selecting", async 
       json: {
         switches: {},
         effectiveSwitches: { joggAiBuiltIn: true },
-        supportsCustomConnectorOAuth2: true,
-        supportsImageRecognition: true,
-        supportsAvatarTemplates: true,
       },
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feature-switches.test.ts
@@ -16,29 +16,6 @@ function client() {
 }
 
 describe("/api/zero/feature-switches", () => {
-  it("keeps the capability handshakes the previous Platform bundle reads", async () => {
-    createZeroRouteMocks(context).clerk.session(
-      "user_capability_handshake_test",
-      "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-      "org:member",
-    );
-    const response = await accept(
-      client().get({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    // The pre-cleanup Platform bundle disables inline templates, image
-    // recognition, and avatar templates when these fields are absent, so they
-    // must survive until that frontend release has drained.
-    expect(response.body).toMatchObject({
-      supportsStructuredInlineTemplates: true,
-      supportsImageRecognition: true,
-      supportsAvatarTemplates: true,
-    });
-  });
-
   it("persists and activates a user override for a non-staff org", async () => {
     createZeroRouteMocks(context).clerk.session(
       "user_nonstaff_feature_switch_test",

--- a/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feature-switches.ts
@@ -30,13 +30,6 @@ function featureSwitchResponseBody(params: {
   return {
     switches: params.switches,
     effectiveSwitches: registeredEffectiveSwitches,
-    // Web/app clients can remain open for about two days. The Platform bundle
-    // deployed 2026-08-07 14:02 Asia/Shanghai gates these features on the
-    // handshakes. Remove them after 2026-08-09 14:02, once that client window
-    // drains; follow-up issue: #25762.
-    supportsStructuredInlineTemplates: true,
-    supportsImageRecognition: true,
-    supportsAvatarTemplates: true,
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
@@ -7,15 +7,6 @@ const c = initContract();
 export const featureSwitchesResponseSchema = z.object({
   switches: z.record(z.string(), z.boolean()),
   effectiveSwitches: z.record(z.string(), z.boolean()),
-  /**
-   * The Platform bundle deployed 2026-08-07 14:02 Asia/Shanghai reads these
-   * capability handshakes and old web/app clients can remain open for about two
-   * days. Current clients ignore them. Remove all three after 2026-08-09 14:02,
-   * once that client window drains; follow-up issue: #25762.
-   */
-  supportsStructuredInlineTemplates: z.boolean().optional(),
-  supportsImageRecognition: z.boolean().optional(),
-  supportsAvatarTemplates: z.boolean().optional(),
 });
 
 export type FeatureSwitchesResponse = z.infer<


### PR DESCRIPTION
## Summary

- remove the drained `supportsStructuredInlineTemplates`, `supportsImageRecognition`, and `supportsAvatarTemplates` fields from the feature-switch API response and contract
- remove the compatibility regression test and stale Playwright response fields, including the already-retired `supportsCustomConnectorOAuth2` fixture value
- leave the canonical `switches` and `effectiveSwitches` response unchanged

Closes #25762

## Compatibility cohort

### App capability handshakes

- Old boundary: an already-open Platform bundle gated inline templates, image recognition, and avatar templates on three top-level capability booleans.
- New boundary: current Platform bundles use the canonical feature-switch maps and ignore these booleans.
- Replacement rollout: app `0.701.0` completed production promotion at `2026-08-07T08:59:07Z`.
- Policy window: the 24-hour App compatibility window expired at `2026-08-08T08:59:07Z`; this workflow fired at `2026-08-08T21:01:33Z`, 12h 2m after expiry.
- Stronger production floor: API `minimumSupportedVersion` is `0.708.2`, and that floor completed production promotion at `2026-08-08T19:16:22Z`. Although the source comment retained a more conservative open-tab deadline, older bundles can no longer receive a successful API response.

Observed Axiom evidence from `vm0-request-log-prod`, range `2026-08-08T19:16:22Z` through `2026-08-08T21:01:33Z`:

- 14,544 App requests, all with a client version
- 2,785 requests from unsupported versions returned `426`; no unsupported version received a successful response
- 21 successful `/api/zero/feature-switches` requests, all from app `0.711.0` or `0.711.1`

MaskDB is not applicable to this response-only cohort: it changes no database schema, persisted payload, migration, or historical-data reader.

## Fallbacks

None. This removes a drained response shim and adds no fallback. There is no persisted-data fallback associated with these fields.

## Verification

- `pnpm format`
- `pnpm exec prettier --write ../e2e/playwright/tests/chat.spec.ts`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts`
- repository-wide reference search confirms all four retired capability names are gone
