### PR TITLE
fix: align follow-up card rail with the composer edges

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -414,13 +414,35 @@ test.describe("mobile follow-up card rail", () => {
     );
 
     const rail = page.getByRole("group", { name: "Keep going" });
+    const composer = page.locator(".zero-composer");
     const cards = responsiveFollowupPrompts.map((prompt) => {
       return page.getByRole("button", { name: prompt, exact: true });
     });
     await expect(rail).toBeVisible();
+    await expect(composer).toBeVisible();
     for (const card of cards) {
       await expect(card).toBeVisible();
     }
+
+    await expect
+      .poll(async () => {
+        const [railBox, composerBox] = await Promise.all([
+          rail.boundingBox(),
+          composer.boundingBox(),
+        ]);
+        if (!railBox || !composerBox) {
+          return Number.POSITIVE_INFINITY;
+        }
+        return Math.max(
+          Math.abs(railBox.x - composerBox.x),
+          Math.abs(
+            railBox.x +
+              railBox.width -
+              (composerBox.x + composerBox.width),
+          ),
+        );
+      })
+      .toBeLessThan(1);
 
     await expect
       .poll(async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -231,9 +231,11 @@ describe("chat lifecycle", () => {
     expect(
       screen.getByText(`Keep going · ${completedAtLabel}`),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("group", { name: "Keep going" }),
-    ).toBeInTheDocument();
+    const rail = screen.getByRole("group", { name: "Keep going" });
+    expect(rail).toBeInTheDocument();
+    // Cards have no inner px-2 to cancel out, so the rail must not carry the
+    // flat list's negative margin or it overhangs the composer on both edges.
+    expect(rail.className).not.toContain("-mx-2");
     for (const prompt of prompts) {
       const card = buttonByText(prompt);
       expect(card).toBeVisible();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx
@@ -231,11 +231,9 @@ describe("chat lifecycle", () => {
     expect(
       screen.getByText(`Keep going · ${completedAtLabel}`),
     ).toBeInTheDocument();
-    const rail = screen.getByRole("group", { name: "Keep going" });
-    expect(rail).toBeInTheDocument();
-    // Cards have no inner px-2 to cancel out, so the rail must not carry the
-    // flat list's negative margin or it overhangs the composer on both edges.
-    expect(rail.className).not.toContain("-mx-2");
+    expect(
+      screen.getByRole("group", { name: "Keep going" }),
+    ).toBeInTheDocument();
     for (const prompt of prompts) {
       const card = buttonByText(prompt);
       expect(card).toBeVisible();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4142,8 +4142,11 @@ function RecommendedFollowupList({
         return $.chat.run.keepGoing;
       })}
       className={cn(
+        // The flat list pulls out by the row buttons' own px-2 so its text
+        // aligns with the message column. Cards carry no such inner offset,
+        // so the rail must stay flush with the column and the composer.
         showFollowupCards
-          ? "-mx-2 flex items-stretch gap-3 overflow-x-auto overscroll-x-contain pb-1 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          ? "flex items-stretch gap-3 overflow-x-auto overscroll-x-contain pb-1 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           : "-mx-2",
       )}
     >


### PR DESCRIPTION
## Problem

On mobile, the recommended follow-up card rail does not line up with the composer. The first card's left border sits 8px to the left of the composer's left border, and the last card's right border sits 8px to the right of the composer's right border.

Measured from the reported screenshots (iPhone, DPR 3): composer border at x=48/1156 device px, card border at x=24/1180 device px, i.e. exactly 8 CSS px of overhang on each side.

## Cause

`RecommendedFollowupList` applies `-mx-2` to the container in both modes. That negative margin exists only for the flat list, where it cancels the row buttons' own `px-2` so their text aligns with the message column. Cards use `p-4` and carry no matching inner offset, so on the card rail the `-mx-2` is an uncompensated bleed on both edges.

## Fix

Keep `-mx-2` on the flat list only; the card rail stays flush with the message column, which is the same column the composer occupies.

The card width formula (`min(22rem, calc(100cqw - 4rem))`) is unchanged, so the next-card peek shrinks from 80px to 52px — still clearly visible as a scroll affordance.

## Fallbacks

None.

## Test

Extended the existing Playwright card-rail geometry test to assert that both rail edges align with the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
