### PR TITLE
docs: require fallback declarations only for additions

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -222,11 +222,11 @@ Review the diff for:
 Apply `docs/fallback.md`. The default is no fallback. `docs/fallback.md` is the
 authoritative source for the rules below, including this severity table:
 
-| Rule                                                                    | Severity |
-| ----------------------------------------------------------------------- | -------- |
-| No negative tests asserting removed behavior stays removed              | P1       |
-| Every fallback in the diff must be declared in the PR summary           | P1       |
-| A rollout fallback must name its surface, window, and removal condition | P1       |
+| Rule                                                                     | Severity |
+| ------------------------------------------------------------------------ | -------- |
+| No negative tests asserting removed behavior stays removed               | P1       |
+| Every fallback introduced by the diff must be declared in the PR summary | P1       |
+| A rollout fallback must name its surface, window, and removal condition  | P1       |
 
 - Request changes for a fallback that guards a state the owning contract
   already prevents: a `??`/`||` chain on a required SDK field, Zod-required
@@ -247,23 +247,24 @@ authoritative source for the rules below, including this severity table:
   nominal gap, is a finding. For DB/API changes, check both directions defined
   in `docs/deployment-compatibility.md`: old code after migration and new code
   before migration.
-- A PR that removes a fallback must state its evidence — type/schema,
-  single-writer, production query, or closed rollback window — and must delete
-  the branch, its contract entry, and its own tests together.
+- A PR that removes a fallback must establish its evidence — type/schema,
+  single-writer, production query, or closed rollback window — through the
+  diff, tests, or linked data, and must delete the branch, its contract entry,
+  and its own tests together. It needs no `Fallbacks` section or separate
+  fallback declaration in the PR summary.
 - Flag negative tests that only assert deleted behavior is still deleted
   (retired route still 404s, legacy field still ignored). The exception is a
   fail-closed security boundary, where rejection is the product behavior.
-- The PR summary must contain a `Fallbacks` section listing **every** fallback
-  or compatibility behavior the PR introduces, keeps, or removes, or an
-  explicit `Fallbacks: none`. An undeclared fallback is a **P1** finding on its
-  own, independent of whether the fallback itself is justified. Report it under
-  High Priority (P1), require the author to add the missing entry to the PR
-  summary, and set the verdict to `Changes Requested`. Record it even when the
-  fallback is correct and stays: the finding is the missing declaration, not
-  the code.
-- The review comment must itself list every fallback found in the diff, with
-  its surface, window, removal condition, and a justified / not-justified
-  verdict. A review that stays silent about fallbacks in a PR that has one is
+- When a PR introduces a fallback or compatibility behavior, its summary must
+  contain a `Fallbacks` section listing every new one. An undeclared new
+  fallback is a **P1** finding on its own, independent of whether the fallback
+  itself is justified. Report it under High Priority (P1), require the author
+  to add the missing entry to the PR summary, and set the verdict to
+  `Changes Requested`. PRs that introduce none need neither the section nor
+  `Fallbacks: none`.
+- The review comment must itself list every fallback introduced by the diff,
+  with its surface, window, removal condition, and a justified / not-justified
+  verdict. A review that stays silent about fallbacks in a PR that adds one is
   incomplete.
 
 **Testing Coverage**
@@ -323,20 +324,24 @@ LGTM
 #### High Priority (P1)
 - <file path>: <issue description>
 
-### Fallbacks
-- <file path and symbol>: <old/new interaction it protects> — surface <DB/API up to ~102min | runner or sandbox up to 2h | web or app client ~2d | none, non-GA feature switch>, removal condition <condition and follow-up>, declared in PR summary <Yes / No — P1>, verdict <Justified / Not justified>
-- <or: None>
-
 ### Testing
 - Coverage: <Adequate / Insufficient - missing tests for: ...>
 - Conventions: <Compliant / Violations: ...>
 ```
 
-The `Fallbacks` section is mandatory in every review, including when the answer
-is `None`. List each fallback the diff introduces, keeps, or removes, and mark
-whether the PR summary declares it. Every fallback missing from the summary is
-also a P1 entry under Findings, phrased as a request to add it to the PR
-summary, and forces the `Changes Requested` verdict.
+When the diff introduces a fallback, insert this section between Findings and
+Testing:
+
+```
+### Fallbacks
+- <file path and symbol>: <old/new interaction it protects> — surface <DB/API up to ~102min | runner or sandbox up to 2h | web or app client ~2d | none, non-GA feature switch>, removal condition <condition and follow-up>, declared in PR summary <Yes / No — P1>, verdict <Justified / Not justified>
+```
+
+Do not include a `Fallbacks` section when the diff introduces none, including
+when the PR only keeps or removes an existing fallback. Every introduced
+fallback missing from the PR summary is also a P1 entry under Findings, phrased
+as a request to add it to the summary, and forces the `Changes Requested`
+verdict.
 
 Or if there are P0/P1 blockers:
 
@@ -354,21 +359,21 @@ Changes Requested
 #### High Priority (P1) - should fix before merge
 - <issue>
 
-### Fallbacks
-...
-
 ### Testing
 ...
 ```
 
+Insert the same conditional `Fallbacks` section before Testing when the PR
+introduces a fallback.
+
 **Verdict rules:**
 
 - Start with `LGTM` if there are no P0 issues, no missing tests on
-  `feat:`/`fix:` commits, and every fallback in the diff is declared in the PR
-  summary
+  `feat:`/`fix:` commits, and every fallback introduced by the diff is declared
+  in the PR summary
 - Start with `Changes Requested` if there are any P0 issues, OR missing required
-  tests, OR any fallback or compatibility behavior in the diff that the PR
-  summary does not declare
+  tests, OR any fallback or compatibility behavior introduced by the diff that
+  the PR summary does not declare
 
 If the caller asks for pr-auto marker-comment mode:
 
@@ -378,7 +383,7 @@ If the caller asks for pr-auto marker-comment mode:
 - Include the caller-provided pr-auto marker lines near the top of the same
   comment.
 - Keep the rest of the body as the detailed pr-review result, including Summary,
-  Findings, Fallbacks, and Testing.
+  Findings, Testing, and Fallbacks when the diff introduces one.
 
 ```bash
 gh pr comment <PR_NUMBER> --repo vm0-ai/vm0 --body-file "<REVIEW_BODY_FILE>"

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -204,7 +204,6 @@ How to use them:
 
   This surface also has **two independent directions**, and a fallback that
   covers one does not cover the other:
-
   - **Old code after migration** — the schema has changed while the previous
     API is still serving or draining. Every statement that API can issue must
     stay legal, including columns an ORM adds to `SELECT` or `RETURNING`.
@@ -278,27 +277,26 @@ Requirements for this pattern:
 An "old shape tolerated forever" branch with no removal condition is not a
 rollout fallback; it is section 5 slop.
 
-## 9. Declare Every Fallback in the PR Summary and the Review
+## 9. Declare New Fallbacks in the PR Summary and the Review
 
 A fallback that nobody records is a fallback that nobody removes. Declaring it
-is mandatory on both sides of the review.
+is mandatory on both sides of the review when a PR introduces it.
 
-**Every fallback belongs in the PR summary. A fallback or compatibility
-behavior present in the diff but missing from the summary is a P1 finding and
-blocks the review verdict**: the review is `Changes Requested` until the author
-adds the missing entry. This holds even when the fallback itself is correct and
-stays — the defect is the undeclared behavior, not the branch.
+**Every fallback introduced by a PR belongs in the PR summary. A fallback or
+compatibility behavior added by the diff but missing from the summary is a P1
+finding and blocks the review verdict**: the review is `Changes Requested`
+until the author adds the missing entry. This holds even when the fallback
+itself is correct — the defect is the undeclared behavior, not the branch.
 
-**Author — in the PR summary.** When a PR introduces, keeps, or removes any
-fallback, the summary must contain a `Fallbacks` section listing each one. Do
-not bury it in the diff. For each fallback give:
+**Author — in the PR summary.** When a PR introduces one or more fallbacks, the
+summary must contain a `Fallbacks` section listing each new one. Do not bury it
+in the diff. For each fallback give:
 
 - the file and symbol,
 - what old/new interaction it protects,
 - the surface and its window from section 7 (or `none — non-GA feature
 switch`),
-- the removal condition and the follow-up issue or PR,
-- for a removed fallback, the evidence from section 10.
+- the removal condition and the follow-up issue or PR.
 
 ```md
 ## Fallbacks
@@ -309,17 +307,16 @@ switch`),
   #25694.
 ```
 
-When a PR contains no fallback at all, say so explicitly: `Fallbacks: none`.
-That one line is what makes a later audit trustworthy, and it is what pr-auto
-reports as `none observed` after merge.
+PRs that do not introduce a fallback need no `Fallbacks` section. This includes
+PRs that only keep or remove existing fallbacks; do not require
+`Fallbacks: none` or a removal declaration.
 
 **Reviewer — in the review comment.** The review must list every fallback the
-diff introduces or keeps, in the same shape, and state whether each one is
-justified under section 6, correctly time-boxed under section 7, and declared
-in the PR summary. Raise each undeclared one as a P1 finding asking the author
-to record it in the summary, and request changes until it is recorded. A review
-that says nothing about fallbacks in a PR that adds one is not a completed
-review.
+diff introduces, in the same shape, and state whether each one is justified
+under section 6, correctly time-boxed under section 7, and declared in the PR
+summary. Raise each undeclared one as a P1 finding asking the author to record
+it in the summary, and request changes until it is recorded. A review that says
+nothing about fallbacks in a PR that adds one is not a completed review.
 
 ## 10. Evidence Required When Removing a Fallback
 
@@ -336,8 +333,10 @@ must show why the removed branch is unreachable:
 - **Rollout evidence** — the deploy that made the old version unreachable is
   past its rollback window.
 
-State which of these applies for each removed branch, and keep the invariant
-throw so monitoring surfaces a violation if the assumption ever breaks.
+The evidence can come from the diff, tests, or linked production or rollout
+data. Removing a fallback does not require a `Fallbacks` section or a separate
+fallback declaration in the PR summary. Keep the invariant throw so monitoring
+surfaces a violation if the assumption ever breaks.
 
 ## Review Checklist
 
@@ -352,12 +351,13 @@ throw so monitoring surfaces a violation if the assumption ever breaks.
   removal condition, and a follow-up?
 - Is the window the right one? A runner-protocol branch sized to the ~4 second
   DB window, or a client branch sized to the ~2 hour runner window, is wrong.
-- Does the PR summary contain a `Fallbacks` section, or an explicit
-  `Fallbacks: none`? Every fallback in the diff that the summary omits is a P1
-  finding and blocks the verdict: ask the author to record it there and request
-  changes.
-- Does the review comment list every fallback the diff introduces or keeps,
-  with a justified/not-justified verdict for each?
+- If the PR adds a fallback, does its summary contain a `Fallbacks` section
+  listing every new fallback? Every introduced fallback that the summary omits
+  is a P1 finding and blocks the verdict: ask the author to record it there and
+  request changes. PRs that add none need neither the section nor
+  `Fallbacks: none`.
+- Does the review comment list every fallback the diff introduces, with a
+  justified/not-justified verdict for each?
 - Does a removal PR carry type, single-writer, production, or rollout evidence?
 - Does the removal delete the branch, the contract entry, and the branch's own
   tests together?


### PR DESCRIPTION
## Summary

- require a `Fallbacks` section only when a PR introduces a fallback
- remove declaration requirements for kept or removed fallbacks and for PRs that add none
- align the repository review instructions and templates with the updated policy

## Verification

- `npx --yes prettier@3.8.1 --check REVIEW.md docs/fallback.md`
- `git diff --check`
- code tests not run (documentation-only change)

## Fallbacks

Fallbacks: none.
