### PR TITLE
test: remove follow-up rail composer alignment assertion

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -414,35 +414,13 @@ test.describe("mobile follow-up card rail", () => {
     );
 
     const rail = page.getByRole("group", { name: "Keep going" });
-    const composer = page.locator(".zero-composer");
     const cards = responsiveFollowupPrompts.map((prompt) => {
       return page.getByRole("button", { name: prompt, exact: true });
     });
     await expect(rail).toBeVisible();
-    await expect(composer).toBeVisible();
     for (const card of cards) {
       await expect(card).toBeVisible();
     }
-
-    await expect
-      .poll(async () => {
-        const [railBox, composerBox] = await Promise.all([
-          rail.boundingBox(),
-          composer.boundingBox(),
-        ]);
-        if (!railBox || !composerBox) {
-          return Number.POSITIVE_INFINITY;
-        }
-        return Math.max(
-          Math.abs(railBox.x - composerBox.x),
-          Math.abs(
-            railBox.x +
-              railBox.width -
-              (composerBox.x + composerBox.width),
-          ),
-        );
-      })
-      .toBeLessThan(1);
 
     await expect
       .poll(async () => {


### PR DESCRIPTION
## Summary

- remove the mobile follow-up rail-to-composer edge alignment regression assertion introduced by #25849
- remove the composer locator and visibility assertion that were only used by that check
- preserve the existing card rail geometry, scrolling, snap, and focus coverage
- leave the `RecommendedFollowupList` production fix unchanged

## Verification

- `pnpm dlx prettier@3.8.1 --check e2e/playwright/tests/chat.spec.ts`
- `cd e2e && corepack pnpm check-types`
- `cd e2e && VM0_API_BACKEND_URL=https://api.example.com corepack pnpm exec playwright test --config playwright/playwright.config.ts tests/chat.spec.ts --project=features --list`
- confirmed `e2e/playwright/tests/chat.spec.ts` matches its pre-#25849 blob exactly
- confirmed `turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx` matches latest `main` exactly

Fallbacks: None
