### PR TITLE
feat(platform): move default model action below composer

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1291,6 +1291,8 @@
       "selectedModelUnavailable": "Das ausgewählte Modell ist nicht verfügbar. Konfigurieren Sie es vor dem Senden.",
       "selectedModelUnavailableToast": "Das ausgewählte Modell ist nicht verfügbar",
       "selectModel": "Modell auswählen",
+      "setAsDefault": "Als Standard festlegen",
+      "temporaryModelNotice": "Vorübergehend zu {{model}} gewechselt",
       "threadSuggestions": "Chat-Threads",
       "visualAttachmentsUnsupported": "{{modelName}} kann Bilder oder Videos nicht erkennen. Wechseln Sie vor dem Anhängen zu einem visionsfähigen Modell.",
       "workflows": {
@@ -4259,9 +4261,6 @@
         "balancedUse": "Ausgewogene Nutzung",
         "builtInModel": "Einbaumodell",
         "byokHelp": "Verwendet Ihren konfigurierten Anbieter",
-        "defaultModel": "Standard",
-        "defaultModelDescription": "Standard für neue Chats und neue Automatisierungen",
-        "defaultModelUpdated": "{{model}} ist jetzt dein Standardmodell",
         "fast": "Schnell",
         "inheritDefault": "Von der Standardeinstellung der Organisation übernehmen",
         "loadError": "Modelle können nicht geladen werden.",
@@ -4283,7 +4282,6 @@
           "deepseek": "Deepseek"
         },
         "runSpeed": "Ausführungsgeschwindigkeit",
-        "setModelAsDefault": "{{model}} als Standard festlegen",
         "standard": "Standard"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1291,6 +1291,8 @@
       "selectedModelUnavailable": "The selected model is not available. Configure it before sending.",
       "selectedModelUnavailableToast": "The selected model is not available",
       "selectModel": "Select model",
+      "setAsDefault": "Set as default",
+      "temporaryModelNotice": "Temporarily switched to {{model}}",
       "threadSuggestions": "Chat threads",
       "visualAttachmentsUnsupported": "{{modelName}} cannot recognize images or videos. Switch to a vision-capable model to attach them.",
       "workflows": {
@@ -4259,9 +4261,6 @@
         "balancedUse": "Balanced use",
         "builtInModel": "Built-in model",
         "byokHelp": "Uses your configured provider",
-        "defaultModel": "Default",
-        "defaultModelDescription": "Default for new chats and new automations",
-        "defaultModelUpdated": "{{model}} is now your default model",
         "fast": "Fast",
         "inheritDefault": "Inherit from org default",
         "loadError": "Unable to load models.",
@@ -4283,7 +4282,6 @@
           "deepseek": "Deepseek"
         },
         "runSpeed": "Run speed",
-        "setModelAsDefault": "Set {{model}} as default",
         "standard": "Standard"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1317,6 +1317,8 @@
       "selectedModelUnavailable": "El modelo seleccionado no está disponible. Configúralo antes de enviar.",
       "selectedModelUnavailableToast": "El modelo seleccionado no está disponible",
       "selectModel": "Seleccionar modelo",
+      "setAsDefault": "Establecer como predeterminado",
+      "temporaryModelNotice": "Cambio temporal a {{model}}",
       "threadSuggestions": "Conversaciones",
       "visualAttachmentsUnsupported": "{{modelName}} no reconoce imágenes ni vídeos. Cambia a un modelo con capacidad visual para adjuntarlos.",
       "workflows": {
@@ -4327,9 +4329,6 @@
         "balancedUse": "Uso equilibrado",
         "builtInModel": "Modelo integrado",
         "byokHelp": "Usa el proveedor que has configurado",
-        "defaultModel": "Predeterminado",
-        "defaultModelDescription": "Predeterminado para nuevos chats y nuevas automatizaciones",
-        "defaultModelUpdated": "{{model}} ahora es tu modelo por defecto",
         "fast": "Rápido",
         "inheritDefault": "Heredar el valor predeterminado de la organización",
         "loadError": "No se pudieron cargar los modelos.",
@@ -4351,7 +4350,6 @@
           "deepseek": "Deepseek"
         },
         "runSpeed": "Velocidad de ejecución",
-        "setModelAsDefault": "Establecer {{model}} como modelo por defecto",
         "standard": "Estándar"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1317,6 +1317,8 @@
       "selectedModelUnavailable": "Le modèle sélectionné n'est pas disponible. Configurez-le avant d'envoyer.",
       "selectedModelUnavailableToast": "Le modèle sélectionné n'est pas disponible",
       "selectModel": "Sélectionner le modèle",
+      "setAsDefault": "Définir par défaut",
+      "temporaryModelNotice": "Passage temporaire à {{model}}",
       "threadSuggestions": "Conversations",
       "visualAttachmentsUnsupported": "{{modelName}} ne peut pas reconnaître les images ou les vidéos. Passez à un modèle capable de vision pour les joindre.",
       "workflows": {
@@ -4327,9 +4329,6 @@
         "balancedUse": "Utilisation équilibrée",
         "builtInModel": "Modèle intégré",
         "byokHelp": "Utilise votre fournisseur configuré",
-        "defaultModel": "Par défaut",
-        "defaultModelDescription": "Par défaut pour les nouveaux chats et les nouvelles automatisations",
-        "defaultModelUpdated": "{{model}} est désormais votre modèle par défaut",
         "fast": "Rapide",
         "inheritDefault": "Hériter des paramètres par défaut de l'organisation",
         "loadError": "Impossible de charger les modèles.",
@@ -4351,7 +4350,6 @@
           "deepseek": "Deepseek"
         },
         "runSpeed": "Vitesse d'exécution",
-        "setModelAsDefault": "Définir {{model}} par défaut",
         "standard": "Standard"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1291,6 +1291,8 @@
       "selectedModelUnavailable": "चयनित मॉडल उपलब्ध नहीं है. भेजने से पहले इसे कॉन्फ़िगर करें.",
       "selectedModelUnavailableToast": "चयनित मॉडल उपलब्ध नहीं है",
       "selectModel": "मॉडल चुनें",
+      "setAsDefault": "डिफ़ॉल्ट के रूप में सेट करें",
+      "temporaryModelNotice": "अस्थायी रूप से {{model}} पर स्विच किया गया",
       "threadSuggestions": "चैट थ्रेड",
       "visualAttachmentsUnsupported": "{{modelName}} छवियों या वीडियो को नहीं पहचान सकता। उन्हें संलग्न करने के लिए दृष्टि-सक्षम मॉडल पर स्विच करें।",
       "workflows": {
@@ -4259,9 +4261,6 @@
         "balancedUse": "संतुलित उपयोग",
         "builtInModel": "अंतर्निर्मित मॉडल",
         "byokHelp": "आपके कॉन्फ़िगर किए गए प्रोवाइडर का उपयोग करता है",
-        "defaultModel": "डिफ़ॉल्ट",
-        "defaultModelDescription": "नई चैट और नए ऑटोमेशन के लिए डिफ़ॉल्ट",
-        "defaultModelUpdated": "{{model}} अब आपका डिफ़ॉल्ट मॉडल है",
         "fast": "तेज़",
         "inheritDefault": "ऑर्ग डिफॉल्ट से इनहेरिट करें",
         "loadError": "मॉडल लोड करने में असमर्थ.",
@@ -4283,7 +4282,6 @@
           "deepseek": "गहन खोज"
         },
         "runSpeed": "भागने की गति",
-        "setModelAsDefault": "{{model}} को डिफ़ॉल्ट के रूप में सेट करें",
         "standard": "मानक"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1291,6 +1291,8 @@
       "selectedModelUnavailable": "Model yang dipilih tidak tersedia. Konfigurasikan sebelum mengirim.",
       "selectedModelUnavailableToast": "Model yang dipilih tidak tersedia",
       "selectModel": "Pilih model",
+      "setAsDefault": "Jadikan default",
+      "temporaryModelNotice": "Sementara beralih ke {{model}}",
       "threadSuggestions": "Thread chat",
       "visualAttachmentsUnsupported": "{{modelName}} tidak dapat mengenali gambar atau video. Ganti ke model yang mendukung visi untuk melampirkannya.",
       "workflows": {
@@ -4258,9 +4260,6 @@
         "balancedUse": "Penggunaan seimbang",
         "builtInModel": "Model bawaan",
         "byokHelp": "Menggunakan provider yang Anda atur",
-        "defaultModel": "Default",
-        "defaultModelDescription": "Default untuk chat baru dan otomatisasi baru",
-        "defaultModelUpdated": "{{model}} sekarang menjadi model default Anda",
         "fast": "Cepat",
         "inheritDefault": "Warisi dari default organisasi",
         "loadError": "Tidak dapat memuat model.",
@@ -4282,7 +4281,6 @@
           "deepseek": "Deepseek"
         },
         "runSpeed": "Kecepatan jalankan",
-        "setModelAsDefault": "Jadikan {{model}} sebagai default",
         "standard": "Standar"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1317,6 +1317,8 @@
       "selectedModelUnavailable": "Il modello selezionato non è disponibile. Configuralo prima dell'invio.",
       "selectedModelUnavailableToast": "Il modello selezionato non è disponibile",
       "selectModel": "Seleziona modello",
+      "setAsDefault": "Imposta come predefinito",
+      "temporaryModelNotice": "Passaggio temporaneo a {{model}}",
       "threadSuggestions": "Thread di chat",
       "visualAttachmentsUnsupported": "{{modelName}} non supporta immagini o video. Passa a un modello con capacità visive per allegarli.",
       "workflows": {
@@ -4327,9 +4329,6 @@
         "balancedUse": "Utilizzo equilibrato",
         "builtInModel": "Modello da incasso",
         "byokHelp": "Utilizza il provider configurato",
-        "defaultModel": "Predefinito",
-        "defaultModelDescription": "Predefinito per le nuove chat e le nuove automazioni",
-        "defaultModelUpdated": "{{model}} è ora il tuo modello predefinito",
         "fast": "Veloce",
         "inheritDefault": "Eredita dall'impostazione predefinita dell'organizzazione",
         "loadError": "Impossibile caricare i modelli.",
@@ -4351,7 +4350,6 @@
           "deepseek": "Ricerca profonda"
         },
         "runSpeed": "Corri velocità",
-        "setModelAsDefault": "Imposta {{model}} come predefinito",
         "standard": "Norma"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1291,6 +1291,8 @@
       "selectedModelUnavailable": "選択されたモデルは使用できません。送信する前に設定してください。",
       "selectedModelUnavailableToast": "選択したモデルは利用できません",
       "selectModel": "モデルを選択してください",
+      "setAsDefault": "デフォルトに設定",
+      "temporaryModelNotice": "一時的に {{model}} に切り替えました",
       "threadSuggestions": "チャットスレッド",
       "visualAttachmentsUnsupported": "{{modelName}} は画像またはビデオを認識できません。ビジョン対応モデルに切り替えて取り付けてください。",
       "workflows": {
@@ -4258,9 +4260,6 @@
         "balancedUse": "バランスよく使う",
         "builtInModel": "内蔵モデル",
         "byokHelp": "設定されたプロバイダーを使用します",
-        "defaultModel": "デフォルト",
-        "defaultModelDescription": "新しいチャットと新しい自動化のデフォルト",
-        "defaultModelUpdated": "{{model}} がデフォルトモデルになりました",
         "fast": "速い",
         "inheritDefault": "組織のデフォルトから継承",
         "loadError": "モデルをロードできません。",
@@ -4282,7 +4281,6 @@
           "deepseek": "ディープシーク"
         },
         "runSpeed": "走行速度",
-        "setModelAsDefault": "{{model}} をデフォルトに設定",
         "standard": "標準"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1291,6 +1291,8 @@
       "selectedModelUnavailable": "선택한 모델을 사용할 수 없습니다. 전송 전에 구성하세요.",
       "selectedModelUnavailableToast": "선택한 모델을 사용할 수 없습니다",
       "selectModel": "모델 선택",
+      "setAsDefault": "기본값으로 설정",
+      "temporaryModelNotice": "일시적으로 {{model}}(으)로 전환됨",
       "threadSuggestions": "채팅 스레드",
       "visualAttachmentsUnsupported": "{{modelName}}은 이미지나 비디오를 인식할 수 없습니다. 첨부하려면 비전 기능이 있는 모델로 전환하세요.",
       "workflows": {
@@ -4258,9 +4260,6 @@
         "balancedUse": "균형 잡힌 사용",
         "builtInModel": "내장 모델",
         "byokHelp": "구성된 공급자 사용",
-        "defaultModel": "기본값",
-        "defaultModelDescription": "새 채팅 및 새 자동화의 기본값",
-        "defaultModelUpdated": "{{model}}을(를) 기본 모델로 설정했습니다",
         "fast": "빠름",
         "inheritDefault": "조직 기본값 상속",
         "loadError": "모델을 불러올 수 없습니다.",
@@ -4282,7 +4281,6 @@
           "deepseek": "Deepseek"
         },
         "runSpeed": "실행 속도",
-        "setModelAsDefault": "{{model}}을(를) 기본값으로 설정",
         "standard": "표준"
       },
       "policies": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1317,6 +1317,8 @@
       "selectedModelUnavailable": "O modelo selecionado não está disponível. Configure-o antes de enviar.",
       "selectedModelUnavailableToast": "O modelo selecionado não está disponível",
       "selectModel": "Selecionar modelo",
+      "setAsDefault": "Definir como padrão",
+      "temporaryModelNotice": "Alternado temporariamente para {{model}}",
       "threadSuggestions": "Conversas",
       "visualAttachmentsUnsupported": "{{modelName}} não reconhece imagens nem vídeos. Troque para um modelo com visão para anexá-los.",
       "workflows": {
@@ -4327,9 +4329,6 @@
         "balancedUse": "Uso equilibrado",
         "builtInModel": "Modelo integrado",
         "byokHelp": "Usa seu provedor configurado",
-        "defaultModel": "Padrão",
-        "defaultModelDescription": "Padrão para novos chats e novas automações",
-        "defaultModelUpdated": "{{model}} agora é seu modelo padrão",
         "fast": "Rápido",
         "inheritDefault": "Herdar o padrão da organização",
         "loadError": "Não foi possível carregar os modelos.",
@@ -4351,7 +4350,6 @@
           "deepseek": "Deepseek"
         },
         "runSpeed": "Velocidade de execução",
-        "setModelAsDefault": "Definir {{model}} como padrão",
         "standard": "Padrão"
       },
       "policies": {

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -146,7 +146,7 @@ interface ComposerDraftSignals {
 }
 
 interface ComposerModelSignals extends ComposerModelUiSignals {
-  readonly explicitDefaultModelActionEnabled$: Computed<boolean>;
+  readonly temporaryModelNoticeEnabled$: Computed<boolean>;
   readonly modelSelection$: Computed<Promise<ModelProviderSelection | null>>;
   readonly runningModel$: Computed<Promise<string | null>>;
   readonly selectedModelOauthAvailable$: Computed<Promise<boolean>>;
@@ -442,7 +442,7 @@ export function createComposerSignals(
     return (await get(options.agent$)).agentId;
   });
   const feedback = createComposerFeedbackModel(options.threadId);
-  const explicitDefaultModelActionEnabled$ = computed((get): boolean => {
+  const temporaryModelNoticeEnabled$ = computed((get): boolean => {
     return (
       options.threadId === undefined &&
       (get(featureSwitch$)[FeatureSwitchKey.NewChatDefaultModelAction] ?? false)
@@ -494,7 +494,7 @@ export function createComposerSignals(
     },
     model: {
       ...ui.model,
-      explicitDefaultModelActionEnabled$,
+      temporaryModelNoticeEnabled$,
       modelSelection$: options.modelSelection$,
       runningModel$: eventSignals.runningModel$,
       selectedModelOauthAvailable$: options.selectedModelOauthAvailable$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -179,13 +179,14 @@ describe("chat composer models", () => {
     await expectComposerModel("Claude Opus 4.7");
   });
 
-  it("keeps a new-chat model choice separate from the default until the explicit action", async () => {
+  it("offers to make a temporary new-chat model choice the default below the composer", async () => {
     const user = userEvent.setup({ delay: null });
     let preference: UserModelPreferenceResponse = {
       selectedModel: "kimi-k2.7-code",
       updatedAt: "2026-03-10T00:00:00Z",
     };
     const updatedModels: UserModelPreferenceResponse["selectedModel"][] = [];
+    const preferenceUpdate = context.mocks.deferred<void>();
 
     mockOrgModelRoutes("kimi-k2.7-code");
     context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
@@ -193,8 +194,9 @@ describe("chat composer models", () => {
     });
     context.mocks.api(
       zeroUserModelPreferenceContract.update,
-      ({ body, respond }) => {
+      async ({ body, respond }) => {
         updatedModels.push(body.selectedModel);
+        await preferenceUpdate.promise;
         preference = {
           selectedModel: body.selectedModel,
           updatedAt: "2026-03-10T00:01:00Z",
@@ -224,36 +226,41 @@ describe("chat composer models", () => {
     const modelPicker = await screen.findByRole("listbox");
     expect(within(modelPicker).getByText("Models")).toBeInTheDocument();
     expect(
-      within(modelPicker).getByText(
+      within(modelPicker).queryByText(
         "Default for new chats and new automations",
       ),
-    ).toBeInTheDocument();
-    expect(
-      within(modelPicker).getByRole("option", {
-        name: /Kimi K2\.7 Code.*Default/,
-      }),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(within(modelPicker).getByText("Kimi K2.7 Code")).toBeInTheDocument();
+    expect(within(modelPicker).queryByText("Default")).not.toBeInTheDocument();
 
-    await user.click(
-      buttonContainingText("Set Claude Sonnet 4.6 as default", modelPicker),
+    await user.keyboard("{Escape}");
+    expect(
+      screen.getByText("Temporarily switched to Claude Sonnet 4.6"),
+    ).toBeInTheDocument();
+    const setDefaultButton = buttonContainingText(
+      "Set as default",
+      document.body,
     );
+
+    await user.click(setDefaultButton);
 
     await waitFor(() => {
       expect(updatedModels).toStrictEqual(["claude-sonnet-4-6"]);
+    });
+    expect(setDefaultButton).toHaveAttribute("aria-busy", "true");
+    expect(setDefaultButton.querySelector(".animate-spin")).not.toBeNull();
+
+    preferenceUpdate.resolve();
+    await waitFor(() => {
       expect(
-        queryAllByRoleFast("button", modelPicker).some((button) => {
-          return button.textContent === "Set Claude Sonnet 4.6 as default";
+        screen.queryByText("Temporarily switched to Claude Sonnet 4.6"),
+      ).not.toBeInTheDocument();
+      expect(
+        queryAllByRoleFast("button").some((button) => {
+          return button.textContent === "Set as default";
         }),
       ).toBeFalsy();
-      expect(
-        within(modelPicker).getByRole("option", {
-          name: /Claude Sonnet 4\.6.*Default/,
-        }),
-      ).toBeInTheDocument();
     });
-    await expect(
-      screen.findByText("Claude Sonnet 4.6 is now your default model"),
-    ).resolves.toBeInTheDocument();
   });
 
   it("preserves selection-as-default behavior while the feature switch is off", async () => {
@@ -290,6 +297,9 @@ describe("chat composer models", () => {
     });
     expect(
       screen.queryByText("Default for new chats and new automations"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Temporarily switched to Claude Sonnet 4.6"),
     ).not.toBeInTheDocument();
   });
 
@@ -1323,6 +1333,9 @@ describe("chat composer models", () => {
     expect(preferenceRequestStarted).toBeFalsy();
     expect(
       screen.queryByText("Default for new chats and new automations"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Temporarily switched to Claude Sonnet 4.6"),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -6,7 +6,6 @@ import {
   useLoadable,
   useSet,
 } from "ccstate-react";
-import { useLoadableSet } from "ccstate-react/experimental";
 import { IconBolt, IconCheck, IconCpu } from "@tabler/icons-react";
 import {
   Select,
@@ -23,7 +22,6 @@ import {
   TooltipTrigger,
   cn,
 } from "@vm0/ui";
-import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   getCanonicalModelDisplayName,
   getProvidersForModel,
@@ -37,10 +35,7 @@ import {
 import type { CodexServiceTier } from "@vm0/api-contracts/contracts/chat-threads";
 import { useTranslation } from "react-i18next";
 import { orgModelPolicies$ } from "../../../signals/external/org-model-policies";
-import {
-  updateUserModelPreference$,
-  userModelPreference$,
-} from "../../../signals/external/user-model-preference";
+import { userModelPreference$ } from "../../../signals/external/user-model-preference";
 import {
   DEFAULT_MODEL_PLAN_CAPABILITIES,
   modelAllowedForPlan,
@@ -102,8 +97,6 @@ interface ModelProviderPickerProps {
    * not user/workspace defaults.
    */
   resolveDefaultSelection?: boolean;
-  /** Shows the explicit personal-default action used by the new-chat composer. */
-  showDefaultModelAction?: boolean;
 }
 
 // Radix Select reserves the empty string for "no value" and throws if a
@@ -445,15 +438,12 @@ function ModelFirstPolicyRowContent({
   modelCapabilities,
   selected = false,
   showSelectedIndicator = false,
-  defaultModel,
 }: {
   policy: OrgModelPolicy;
   modelCapabilities: ModelPlanCapabilities;
   selected?: boolean;
   showSelectedIndicator?: boolean;
-  defaultModel?: string | null;
 }) {
-  const { t } = useTranslation();
   const iconType = getModelFirstIconType(policy.model);
   const builtInPriceTier =
     policy.defaultProviderType === "vm0"
@@ -472,13 +462,6 @@ function ModelFirstPolicyRowContent({
         <ByokBadge />
       )}
       {restricted && <ProBadge />}
-      {policy.model === defaultModel && (
-        <span className="shrink-0 text-[11px] text-muted-foreground/70">
-          {t(($) => {
-            return $.settings.models.picker.defaultModel;
-          })}
-        </span>
-      )}
       {showSelectedIndicator && (
         <span className="flex h-4 w-4 shrink-0 items-center justify-center text-foreground">
           {selected && <IconCheck size={15} stroke={1.8} />}
@@ -491,11 +474,9 @@ function ModelFirstPolicyRowContent({
 function ModelFirstPolicyRow({
   policy,
   modelCapabilities,
-  defaultModel,
 }: {
   policy: OrgModelPolicy;
   modelCapabilities: ModelPlanCapabilities;
-  defaultModel?: string | null;
 }) {
   return (
     <SelectItem
@@ -506,7 +487,6 @@ function ModelFirstPolicyRow({
       <ModelFirstPolicyRowContent
         policy={policy}
         modelCapabilities={modelCapabilities}
-        defaultModel={defaultModel}
       />
     </SelectItem>
   );
@@ -517,13 +497,11 @@ function ModelFirstPolicyItems({
   explicitSelectedModel,
   modelCapabilities,
   showSeparator = true,
-  defaultModel,
 }: {
   policies: OrgModelPolicy[];
   explicitSelectedModel: string | null;
   modelCapabilities: ModelPlanCapabilities;
   showSeparator?: boolean;
-  defaultModel?: string | null;
 }) {
   const { t } = useTranslation();
   const hasExplicitSelectedPolicy =
@@ -565,7 +543,6 @@ function ModelFirstPolicyItems({
                 key={policy.id}
                 policy={policy}
                 modelCapabilities={modelCapabilities}
-                defaultModel={defaultModel}
               />
             );
           })}
@@ -691,85 +668,6 @@ function CodexFastModeSelectControl({
   );
 }
 
-function NewChatDefaultModelFooter({
-  defaultModel,
-  selectedModel,
-}: {
-  defaultModel: string | null;
-  selectedModel: string | null;
-}) {
-  const { t } = useTranslation();
-  const [updateLoadable, updatePreference] = useLoadableSet(
-    updateUserModelPreference$,
-  );
-  const pageSignal = useGet(pageSignal$);
-  const selectedModelName = selectedModel
-    ? getCanonicalModelDisplayName(selectedModel)
-    : null;
-  const updating = updateLoadable.state === "loading";
-  const stopSelectDismiss = (event: SyntheticEvent) => {
-    event.stopPropagation();
-  };
-  const setSelectedModelAsDefault = (event: SyntheticEvent) => {
-    event.stopPropagation();
-    if (
-      !isSupportedRunModel(selectedModel) ||
-      selectedModel === defaultModel ||
-      updating
-    ) {
-      return;
-    }
-    const supportedSelectedModel = selectedModel;
-    detach(
-      (async () => {
-        await updatePreference(
-          { selectedModel: supportedSelectedModel },
-          pageSignal,
-        );
-        toast.success(
-          t(
-            ($) => {
-              return $.settings.models.picker.defaultModelUpdated;
-            },
-            { model: selectedModelName },
-          ),
-        );
-      })(),
-      Reason.DomCallback,
-    );
-  };
-
-  return (
-    <div
-      className="border-t border-border/60 px-2.5 py-1.5 text-[11px] leading-4 text-muted-foreground"
-      onPointerDown={stopSelectDismiss}
-    >
-      <p>
-        {t(($) => {
-          return $.settings.models.picker.defaultModelDescription;
-        })}
-      </p>
-      {isSupportedRunModel(selectedModel) &&
-        selectedModel !== defaultModel &&
-        selectedModelName && (
-          <button
-            type="button"
-            className="mt-0.5 block rounded-sm text-left text-[11px] font-medium text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline disabled:pointer-events-none disabled:opacity-50"
-            disabled={updating}
-            onClick={setSelectedModelAsDefault}
-          >
-            {t(
-              ($) => {
-                return $.settings.models.picker.setModelAsDefault;
-              },
-              { model: selectedModelName },
-            )}
-          </button>
-        )}
-    </div>
-  );
-}
-
 interface ModelFirstModelPickerContentBaseProps {
   selectValue: string;
   placeholder: string;
@@ -792,23 +690,12 @@ function ModelFirstModelPickerContentLayout({
   selectedModel,
   codexServiceTier,
   onChange,
-  newChatDefaults = false,
-  defaultModel,
-  footer,
-}: ModelFirstModelPickerContentBaseProps & {
-  newChatDefaults?: boolean;
-  defaultModel?: string | null;
-  footer?: ReactNode;
-}) {
+}: ModelFirstModelPickerContentBaseProps) {
   return (
     <SelectContent
       className={cn(
-        newChatDefaults ? "max-h-[340px]" : "max-h-[280px]",
-        codexFastModeAvailable
-          ? "min-w-[372px]"
-          : newChatDefaults
-            ? "min-w-[300px]"
-            : "min-w-[260px]",
+        "max-h-[280px]",
+        codexFastModeAvailable ? "min-w-[372px]" : "min-w-[260px]",
       )}
     >
       <div
@@ -833,7 +720,6 @@ function ModelFirstModelPickerContentLayout({
             explicitSelectedModel={selectableValue?.selectedModel ?? null}
             modelCapabilities={modelCapabilities}
             showSeparator={false}
-            defaultModel={defaultModel}
           />
         </div>
         {codexFastModeAvailable && isSupportedRunModel(selectedModel) && (
@@ -844,43 +730,8 @@ function ModelFirstModelPickerContentLayout({
           />
         )}
       </div>
-      {footer}
     </SelectContent>
   );
-}
-
-function NewChatDefaultModelPickerContent(
-  props: ModelFirstModelPickerContentBaseProps,
-) {
-  const userPreference = useLastResolved(userModelPreference$);
-  const defaultModel =
-    resolveModelFirstDefault(null, userPreference, props.policies)
-      ?.selectedModel ?? null;
-  return (
-    <ModelFirstModelPickerContentLayout
-      {...props}
-      newChatDefaults
-      defaultModel={defaultModel}
-      footer={
-        <NewChatDefaultModelFooter
-          defaultModel={defaultModel}
-          selectedModel={props.selectedModel}
-        />
-      }
-    />
-  );
-}
-
-function ModelFirstModelPickerContent({
-  showDefaultModelAction = false,
-  ...props
-}: ModelFirstModelPickerContentBaseProps & {
-  showDefaultModelAction?: boolean;
-}) {
-  if (showDefaultModelAction) {
-    return <NewChatDefaultModelPickerContent {...props} />;
-  }
-  return <ModelFirstModelPickerContentLayout {...props} />;
 }
 
 interface ModelFirstModelPickerState {
@@ -996,7 +847,7 @@ function ModelFirstSelectPicker({
       </SelectTrigger>
       {open !== false &&
         (content ?? (
-          <ModelFirstModelPickerContent
+          <ModelFirstModelPickerContentLayout
             selectValue={state.selectValue}
             placeholder={placeholder}
             policies={state.policies}
@@ -1204,13 +1055,11 @@ function SubscribedExplicitModelFirstModelPickerContent({
   placeholder,
   codexFastModeEnabled,
   onChange,
-  showDefaultModelAction,
 }: {
   value: ModelProviderSelection | null;
   placeholder: string;
   codexFastModeEnabled: boolean;
   onChange: (value: ModelProviderSelection | null) => void;
-  showDefaultModelAction: boolean;
 }) {
   const policiesLoadable = useLastLoadable(orgModelPolicies$);
   const modelCapabilities =
@@ -1241,7 +1090,7 @@ function SubscribedExplicitModelFirstModelPickerContent({
     placeholder,
   });
   return (
-    <ModelFirstModelPickerContent
+    <ModelFirstModelPickerContentLayout
       selectValue={state.selectValue}
       placeholder={placeholder}
       policies={state.policies}
@@ -1255,7 +1104,6 @@ function SubscribedExplicitModelFirstModelPickerContent({
       selectedModel={state.selectedModel}
       codexServiceTier={state.codexServiceTier}
       onChange={onChange}
-      showDefaultModelAction={showDefaultModelAction}
     />
   );
 }
@@ -1307,7 +1155,6 @@ function EnabledExplicitModelFirstModelPicker(
             placeholder={props.placeholder}
             codexFastModeEnabled={props.codexFastModeEnabled ?? false}
             onChange={props.onChange}
-            showDefaultModelAction={props.showDefaultModelAction ?? false}
           />
         ) : undefined
       }
@@ -1375,7 +1222,6 @@ export function ModelProviderPicker({
   onOpenChange,
   disabled = false,
   resolveDefaultSelection = true,
-  showDefaultModelAction = false,
 }: ModelProviderPickerProps) {
   const { t } = useTranslation();
   const resolvedPlaceholder =
@@ -1394,7 +1240,6 @@ export function ModelProviderPicker({
     open,
     onOpenChange,
     disabled,
-    showDefaultModelAction,
   };
   if (resolveDefaultSelection) {
     return <ModelFirstModelPickerWithDefaultSelection {...props} />;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -29,6 +29,7 @@ import {
   IconColorSwatch,
   IconDeviceDesktop,
   IconDownload,
+  IconLoader2,
   IconPresentation,
   IconMicrophone,
   IconPaperclip,
@@ -163,6 +164,11 @@ import { customConnectors$ } from "../../signals/zero-page/settings/custom-conne
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
+import { orgModelPolicies$ } from "../../signals/external/org-model-policies.ts";
+import {
+  updateUserModelPreference$,
+  userModelPreference$,
+} from "../../signals/external/user-model-preference.ts";
 import {
   codexFastModeEnabled$,
   composerConnectorPermissionsEnabled$,
@@ -215,6 +221,7 @@ import {
   avatarTemplateSelection,
   toAvatarGenerationTemplate,
 } from "../../signals/zero-page/avatar-template-selection.ts";
+import { resolveModelFirstUserDefaultSelection } from "../../signals/zero-page/model-default-selection.ts";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 const COMPOSER_CONTROL_FOCUS_CLASS =
@@ -7343,9 +7350,6 @@ function ModelConfigurationWarning({
 function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const { t } = useTranslation();
   const codexFastModeEnabled = useGet(codexFastModeEnabled$);
-  const explicitDefaultModelActionEnabled = useGet(
-    signals.model.explicitDefaultModelActionEnabled$,
-  );
   const modelPickerOpen = useGet(signals.model.modelPickerOpen$);
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
   const modelSelection = useLastLoadable(signals.model.modelSelection$);
@@ -7421,11 +7425,86 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
         onOpenChange={setModelPickerOpen}
         disabled={modelPicker.disabled}
         resolveDefaultSelection={false}
-        showDefaultModelAction={explicitDefaultModelActionEnabled}
       />
       <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
     </>
   );
+}
+
+function ComposerTemporaryModelNotice({
+  signals,
+}: {
+  signals: ComposerSignals;
+}) {
+  const { t } = useTranslation();
+  const selection = useLastResolved(signals.model.modelSelection$);
+  const policies = useLastResolved(orgModelPolicies$);
+  const userPreference = useLastResolved(userModelPreference$);
+  const [updateLoadable, updatePreference] = useLoadableSet(
+    updateUserModelPreference$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  const defaultSelection = resolveModelFirstUserDefaultSelection({
+    userPreference,
+    policies,
+  });
+  if (
+    !selection ||
+    !defaultSelection ||
+    selection.selectedModel === defaultSelection.selectedModel
+  ) {
+    return null;
+  }
+  const updating = updateLoadable.state === "loading";
+  const modelName = getModelDisplayName(selection.selectedModel);
+  const setAsDefault = () => {
+    if (updating) {
+      return;
+    }
+    detach(
+      updatePreference({ selectedModel: selection.selectedModel }, pageSignal),
+      Reason.DomCallback,
+    );
+  };
+  return (
+    <div
+      className="mt-1.5 flex flex-wrap items-center justify-end gap-x-1.5 gap-y-1 px-3 text-xs leading-5 text-muted-foreground sm:px-4"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <span>
+        {t(
+          ($) => {
+            return $.chat.composer.temporaryModelNotice;
+          },
+          { model: modelName },
+        )}
+      </span>
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 rounded-sm font-medium text-foreground underline-offset-2 transition-colors hover:text-foreground/70 hover:underline focus-visible:text-foreground/70 focus-visible:underline disabled:pointer-events-none disabled:opacity-70"
+        disabled={updating}
+        aria-busy={updating}
+        onClick={setAsDefault}
+      >
+        {updating && (
+          <IconLoader2 size={12} className="animate-spin" aria-hidden="true" />
+        )}
+        {t(($) => {
+          return $.chat.composer.setAsDefault;
+        })}
+      </button>
+    </div>
+  );
+}
+
+function ComposerTemporaryModelNoticeSlot({
+  signals,
+}: {
+  signals: ComposerSignals;
+}) {
+  const enabled = useGet(signals.model.temporaryModelNoticeEnabled$);
+  return enabled ? <ComposerTemporaryModelNotice signals={signals} /> : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -8004,6 +8083,7 @@ function ComposerSurface({ signals }: { signals: ComposerSignals }) {
       <div className="relative flex w-full min-w-0 flex-col">
         <PendingItemsStrip signals={signals} />
         <ComposerCard signals={signals} />
+        <ComposerTemporaryModelNoticeSlot signals={signals} />
         <ReplaceComposerDraftDialog signals={signals} />
         <WebsiteTemplatePreviewDialogSlot signals={signals} />
       </div>


### PR DESCRIPTION
## Summary

- keep the model picker visually identical regardless of the new-chat default-model feature switch
- show a temporary model notice below the new agent chat composer when its selection differs from the user default
- let users set the temporary model as default with a loadable spinner, then hide the notice after the preference updates
- cover feature-on, feature-off, existing-thread, loading, and menu presentation behavior in the composer model tests

## Testing

- `pnpm format`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for packages, platform, and API
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` (44 tests)

Browser verification was not run because the repository instructions prohibit starting a local dev server unless explicitly requested.