### PR TITLE
refactor(platform): migrate composer icons to lucide

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -42,6 +42,7 @@
     "idb": "~8.0.3",
     "katex": "^0.17.0",
     "lowlight": "^3.3.0",
+    "lucide-react": "1.30.0",
     "mermaid": "^11.16.1",
     "path-to-regexp": "^8.4.0",
     "posthog-js": "^1.372.1",

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -1,12 +1,12 @@
 import {
-  IconAdjustmentsHorizontal,
-  IconArrowLeft,
-  IconCheck,
-  IconLoader2,
-  IconPlayerPause,
-  IconPlayerPlay,
-  IconUser,
-} from "@tabler/icons-react";
+  ArrowLeft,
+  Check,
+  Loader2,
+  Pause,
+  Play,
+  SlidersHorizontal,
+  User,
+} from "lucide-react";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import type {
   ZeroAvatarVideoAvatar,
@@ -196,7 +196,7 @@ function CatalogFiltersPopover({
           size="sm"
           className="h-9 gap-2 rounded-full bg-background px-3 shadow-none"
         >
-          <IconAdjustmentsHorizontal size={15} stroke={1.7} />
+          <SlidersHorizontal size={15} strokeWidth={1.7} />
           {t(($) => {
             return $.artifacts.templates.filters.title;
           })}
@@ -378,7 +378,7 @@ function AvatarTemplateMedia({
             aria-hidden="true"
             className="pointer-events-none absolute inset-0 hidden items-center justify-center bg-black/15 group-data-[loading=true]/avatar-preview:flex"
           >
-            <IconLoader2 className="size-6 animate-spin text-white drop-shadow" />
+            <Loader2 className="size-6 animate-spin text-white drop-shadow" />
           </span>
         </>
       ) : previewImageUrl ? (
@@ -391,9 +391,9 @@ function AvatarTemplateMedia({
           className="h-full w-full object-cover"
         />
       ) : (
-        <IconUser
+        <User
           size={40}
-          stroke={1.4}
+          strokeWidth={1.4}
           className="text-muted-foreground"
           aria-hidden="true"
         />
@@ -431,7 +431,7 @@ function AvatarTemplateCardContent({
             className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
             aria-hidden="true"
           >
-            <IconCheck size={13} stroke={2.2} />
+            <Check size={13} strokeWidth={2.2} />
           </span>
         )}
       </div>
@@ -725,7 +725,7 @@ function CatalogLoadingSpinner() {
       role="status"
       className="flex h-14 shrink-0 items-center justify-center text-muted-foreground"
     >
-      <IconLoader2 className="size-5 animate-spin" aria-hidden="true" />
+      <Loader2 className="size-5 animate-spin" aria-hidden="true" />
       <span className="sr-only">
         {t(($) => {
           return $.settings.shared.loading;
@@ -810,14 +810,14 @@ function VoicePreviewControl({
           "group-data-[playing=true]/voice:bg-primary group-data-[playing=true]/voice:text-primary-foreground",
         )}
       >
-        <IconPlayerPlay
+        <Play
           size={17}
-          stroke={1.9}
+          strokeWidth={1.9}
           className="ml-0.5 group-data-[playing=true]/voice:hidden"
         />
-        <IconPlayerPause
+        <Pause
           size={17}
-          stroke={1.9}
+          strokeWidth={1.9}
           className="hidden group-data-[playing=true]/voice:block"
         />
       </button>
@@ -934,7 +934,7 @@ function AvatarVoiceCard({
                 className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
                 aria-hidden="true"
               >
-                <IconCheck size={13} stroke={2.2} />
+                <Check size={13} strokeWidth={2.2} />
               </span>
             )}
           </div>
@@ -1135,7 +1135,7 @@ function AvatarVoicePickerContent({
           })}
           onClick={onBack}
         >
-          <IconArrowLeft className="size-4" />
+          <ArrowLeft className="size-4" />
         </Button>
         <h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
           {t(

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -6,7 +6,7 @@ import {
   useLoadable,
   useSet,
 } from "ccstate-react";
-import { IconBolt, IconCheck, IconCpu } from "@tabler/icons-react";
+import { Bolt, Check, Cpu } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -177,7 +177,7 @@ function ResponsiveTriggerContent({
         {iconType ? (
           <ProviderIcon type={iconType} size={18} />
         ) : (
-          <IconCpu size={18} stroke={1.5} />
+          <Cpu size={18} strokeWidth={1.5} />
         )}
       </span>
       <span className="hidden min-w-0 sm:inline-flex sm:items-center sm:gap-1.5">
@@ -362,7 +362,7 @@ function ModelFirstTriggerLabel({
           </span>
           {codexServiceTier === "fast" && (
             <span className="inline-flex h-5 shrink-0 items-center gap-1 rounded bg-amber-500/10 px-1.5 text-[11px] font-medium leading-none text-amber-700 dark:text-amber-300">
-              <IconBolt size={12} stroke={1.8} />
+              <Bolt size={12} strokeWidth={1.8} />
               {t(($) => {
                 return $.settings.models.picker.fast;
               })}
@@ -464,7 +464,7 @@ function ModelFirstPolicyRowContent({
       {restricted && <ProBadge />}
       {showSelectedIndicator && (
         <span className="flex h-4 w-4 shrink-0 items-center justify-center text-foreground">
-          {selected && <IconCheck size={15} stroke={1.8} />}
+          {selected && <Check size={15} strokeWidth={1.8} />}
         </span>
       )}
     </span>
@@ -624,7 +624,7 @@ function CodexFastModeSplitPanel({
           }}
         >
           <span className="inline-flex items-center gap-1 text-xs font-medium">
-            <IconBolt size={12} stroke={1.8} />
+            <Bolt size={12} strokeWidth={1.8} />
             {t(($) => {
               return $.settings.models.picker.fast;
             })}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -10,17 +10,17 @@ import {
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
-  IconArrowsDiagonal,
-  IconArrowsDiagonalMinimize2,
-  IconChevronLeft,
-  IconChevronRight,
-  IconColumns2,
-  IconFileMusic,
-  IconPhoto,
-  IconLoader2,
-  IconZoomReset,
-  IconX,
-} from "@tabler/icons-react";
+  ChevronLeft,
+  ChevronRight,
+  Columns2,
+  FileMusic,
+  Image,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  RotateCcw,
+  X,
+} from "lucide-react";
 import type {
   ChatThreadArtifactFile,
   ChatThreadArtifactRun,
@@ -281,7 +281,7 @@ function ArtifactDialogSplitViewButton({ onClick }: { onClick: () => void }) {
       })}
       onClick={onClick}
     >
-      <IconColumns2 size={18} stroke={1.8} />
+      <Columns2 size={18} strokeWidth={1.8} />
     </DialogIconButton>
   );
 }
@@ -308,9 +308,9 @@ function ArtifactDialogFullscreenButton({
       onClick={onClick}
     >
       {fullscreen ? (
-        <IconArrowsDiagonalMinimize2 size={18} stroke={1.8} />
+        <Minimize2 size={18} strokeWidth={1.8} />
       ) : (
-        <IconArrowsDiagonal size={18} stroke={1.8} />
+        <Maximize2 size={18} strokeWidth={1.8} />
       )}
     </DialogIconButton>
   );
@@ -410,7 +410,7 @@ function artifactDialogMetadataFromItem(params: {
 function ArtifactDialogLoadingBody() {
   return (
     <div className="flex h-full items-center justify-center p-6 text-muted-foreground">
-      <IconLoader2 size={20} stroke={1.8} className="animate-spin" />
+      <Loader2 size={20} strokeWidth={1.8} className="animate-spin" />
     </div>
   );
 }
@@ -536,7 +536,7 @@ function ArtifactDialogImageZoomControls({
           return $.artifacts.actions.resetZoom;
         })}
       >
-        <IconZoomReset size={15} stroke={1.8} />
+        <RotateCcw size={15} strokeWidth={1.8} />
       </button>
     </div>
   );
@@ -567,7 +567,7 @@ function ArtifactDialogImageNavigationControls({
           data-testid="artifact-dialog-previous-image"
           className="absolute left-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <IconChevronLeft size={22} stroke={1.8} />
+          <ChevronLeft size={22} strokeWidth={1.8} />
         </button>
       )}
       {navigation.onNext && (
@@ -583,7 +583,7 @@ function ArtifactDialogImageNavigationControls({
           data-testid="artifact-dialog-next-image"
           className="absolute right-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <IconChevronRight size={22} stroke={1.8} />
+          <ChevronRight size={22} strokeWidth={1.8} />
         </button>
       )}
     </>
@@ -760,7 +760,7 @@ function ArtifactDialogImageStage({
         <div className="relative h-full min-h-0">
           {resourceUrl === null ? (
             <div className="flex h-full items-center justify-center text-muted-foreground">
-              <IconLoader2 className="animate-spin" />
+              <Loader2 className="animate-spin" />
             </div>
           ) : (
             <ZoomableArtifactImageCanvas
@@ -867,7 +867,7 @@ function ArtifactDialogBody({
       <ArtifactDialogStage centered>
         <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
           <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/70 bg-muted/50 text-muted-foreground">
-            <IconFileMusic size={28} stroke={1.6} />
+            <FileMusic size={28} strokeWidth={1.6} />
           </span>
           <p className="max-w-full truncate text-sm text-muted-foreground">
             {filename}
@@ -1249,7 +1249,7 @@ function ArtifactPreviewDialogActions({
           closeLightboxWithDialogExit(rootSignal);
         }}
       >
-        <IconX size={18} stroke={1.8} />
+        <X size={18} strokeWidth={1.8} />
       </DialogIconButton>
     </div>
   );
@@ -1591,9 +1591,9 @@ function ComposerImagePreviewButton({
         title={filename}
         className="group/image-preview relative h-9 w-9 overflow-hidden rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
       >
-        <IconPhoto
+        <Image
           size={20}
-          stroke={1.5}
+          strokeWidth={1.5}
           className="text-muted-foreground m-auto h-full"
         />
       </button>
@@ -1623,9 +1623,9 @@ function ComposerImagePreviewButton({
           className="absolute inset-0 flex items-center justify-center bg-muted/70 text-muted-foreground"
         >
           {currentImageStatus === "loading" ? (
-            <IconLoader2 size={14} stroke={1.8} className="animate-spin" />
+            <Loader2 size={14} strokeWidth={1.8} className="animate-spin" />
           ) : (
-            <IconPhoto size={16} stroke={1.5} />
+            <Image size={16} strokeWidth={1.5} />
           )}
         </span>
       )}
@@ -1647,7 +1647,7 @@ function ComposerImagePreviewButton({
         }`}
       />
       <span className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/image-preview:bg-black/30">
-        <IconPhoto
+        <Image
           size={18}
           className="text-white opacity-0 drop-shadow transition-opacity group-hover/image-preview:opacity-100"
         />
@@ -1696,10 +1696,7 @@ function AttachmentChip({
       )}
       {uploading && (
         <span className="absolute -top-1 -left-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
-          <IconLoader2
-            size={10}
-            className="animate-spin text-muted-foreground"
-          />
+          <Loader2 size={10} className="animate-spin text-muted-foreground" />
         </span>
       )}
       <button
@@ -1726,7 +1723,7 @@ function AttachmentChip({
               )
         }
       >
-        <IconX size={9} stroke={2.5} />
+        <X size={9} strokeWidth={2.5} />
       </button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -1,11 +1,5 @@
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
-import {
-  IconDownload,
-  IconEye,
-  IconFileMusic,
-  IconPlayerPlay,
-  IconVideo,
-} from "@tabler/icons-react";
+import { Download, Eye, FileMusic, Play, Video } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -231,7 +225,7 @@ function AttachmentAnchorChip({
       className="group/doc-preview inline-flex w-fit self-start align-top text-left no-underline"
     >
       <AttachmentDocumentThumbnailArtwork
-        actionIcon={<IconEye size={10} />}
+        actionIcon={<Eye size={10} />}
         actionLabel={t(($) => {
           return $.artifacts.preview.badge;
         })}
@@ -454,7 +448,7 @@ function FileThumbnailPreview({
           />
         </div>
         <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
-          <IconDownload size={10} />
+          <Download size={10} />
           {t(($) => {
             return $.artifacts.actions.download;
           })}
@@ -522,7 +516,7 @@ function AudioPreview({
           />
         </div>
         <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/doc-preview:opacity-100">
-          <IconFileMusic size={10} />
+          <FileMusic size={10} />
           {t(($) => {
             return $.artifacts.preview.badge;
           })}
@@ -599,11 +593,11 @@ function VideoThumbnailPreview({
         <div className="absolute inset-0 z-20 bg-black/15 transition-colors group-hover/video-preview:bg-black/35" />
         <span className="absolute inset-0 z-30 flex items-center justify-center">
           <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-preview:scale-105">
-            <IconPlayerPlay size={20} stroke={1.8} />
+            <Play size={20} strokeWidth={1.8} />
           </span>
         </span>
         <div className="absolute right-2 top-2 z-30 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/video-preview:opacity-100">
-          <IconVideo size={10} />
+          <Video size={10} />
           {t(($) => {
             return $.artifacts.preview.badge;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -21,33 +21,34 @@ import { equalArrays } from "../../lib/equality.ts";
 import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
 import { isMobileTextInputDevice } from "../../lib/visual-viewport-keyboard.ts";
 import {
-  IconAdjustmentsHorizontal,
-  IconAlertTriangle,
-  IconArrowUp,
-  IconBolt,
-  IconCheck,
-  IconColorSwatch,
-  IconDeviceDesktop,
-  IconDownload,
-  IconLoader2,
-  IconPresentation,
-  IconMicrophone,
-  IconPaperclip,
-  IconPalette,
-  IconPlayerPlay,
-  IconPlayerStop,
-  IconPlug,
-  IconPhoto,
-  IconPlus,
-  IconRoute,
-  IconSearch,
-  IconTarget,
-  IconTemplate,
-  IconUser,
-  IconVideo,
-  IconWorld,
-  IconX,
-} from "@tabler/icons-react";
+  AlertTriangle,
+  ArrowUp,
+  Bolt,
+  Check,
+  Download,
+  Globe,
+  Image as ImageIcon,
+  LayoutTemplate,
+  Loader2,
+  Mic,
+  Monitor,
+  Paperclip,
+  Palette,
+  Play,
+  Plug,
+  Plus,
+  Presentation,
+  Route,
+  Search,
+  SlidersHorizontal,
+  Square,
+  SwatchBook,
+  Target,
+  User,
+  Video,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -514,9 +515,9 @@ function ComposerStripRow({
             return $.chat.queue.openGoalDetails;
           })}
         >
-          <IconTarget
+          <Target
             size={16}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="shrink-0 text-emerald-800"
             aria-hidden="true"
           />
@@ -532,9 +533,9 @@ function ComposerStripRow({
                 aria-label={aboutAriaLabel}
               >
                 {isGoal ? (
-                  <IconTarget size={16} stroke={1.5} aria-hidden="true" />
+                  <Target size={16} strokeWidth={1.5} aria-hidden="true" />
                 ) : isWorkflowEvent ? (
-                  <IconBolt size={16} stroke={1.5} aria-hidden="true" />
+                  <Bolt size={16} strokeWidth={1.5} aria-hidden="true" />
                 ) : (
                   <ComposerQueueGlyph />
                 )}
@@ -567,7 +568,7 @@ function ComposerStripRow({
         }}
         aria-label={removeAriaLabel}
       >
-        <IconX size={16} stroke={1.5} />
+        <X size={16} strokeWidth={1.5} />
       </button>
     </div>
   );
@@ -1049,7 +1050,7 @@ function VideoTemplatePreview({ item }: { item: VideoTemplateItem }) {
         }}
       >
         <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-template-preview:scale-105">
-          <IconPlayerPlay size={20} stroke={1.8} />
+          <Play size={20} strokeWidth={1.8} />
         </span>
       </button>
     </div>
@@ -1111,7 +1112,7 @@ function VideoTemplateCard({
         <VideoTemplatePreview item={item} />
         {selected ? (
           <span className="pointer-events-none absolute left-[7px] top-[7px] z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-            <IconCheck size={14} stroke={2.6} />
+            <Check size={14} strokeWidth={2.6} />
           </span>
         ) : null}
         <button
@@ -1243,7 +1244,7 @@ function WebsiteTemplateCard({
         <div className={TEMPLATE_TILE_SCRIM} />
         {selected ? (
           <span className="pointer-events-none absolute left-[7px] top-[7px] z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-            <IconCheck size={14} stroke={2.6} />
+            <Check size={14} strokeWidth={2.6} />
           </span>
         ) : null}
         <button
@@ -1531,9 +1532,9 @@ function TemplateEmptyPanel() {
   return (
     <div className="flex min-h-40 flex-1 items-center justify-center rounded-[22px] border-2 border-dashed border-border bg-background px-6 py-10 text-center">
       <div className="flex max-w-xl flex-col items-center">
-        <IconSearch
+        <Search
           className="mb-4 h-8 w-8 text-muted-foreground/70"
-          stroke={1.7}
+          strokeWidth={1.7}
         />
         <p className="text-sm font-semibold text-muted-foreground">
           {t(($) => {
@@ -3647,7 +3648,7 @@ function TemplatePreviewPage({
             </h3>
             <div className="my-5 border-t border-border" />
             <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-              <IconPalette size={14} stroke={1.9} />
+              <Palette size={14} strokeWidth={1.9} />
               <span>
                 {t(($) => {
                   return $.artifacts.templates.theme;
@@ -3825,7 +3826,7 @@ function PptCard({
         <div className={TEMPLATE_TILE_SCRIM} />
         {selected ? (
           <span className="pointer-events-none absolute left-[7px] top-[7px] z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-            <IconCheck size={14} stroke={2.6} />
+            <Check size={14} strokeWidth={2.6} />
           </span>
         ) : null}
         <button
@@ -3988,7 +3989,7 @@ function IllustrationTemplateHero({
         hidden
         className="absolute inset-0 flex items-center justify-center bg-muted text-muted-foreground"
       >
-        <IconTemplate size={28} stroke={1.5} />
+        <LayoutTemplate size={28} strokeWidth={1.5} />
       </div>
     </div>
   );
@@ -4519,7 +4520,7 @@ function TemplatePickerCategoryNav({
   const categoryOptions: {
     value: string;
     label: string;
-    Icon: typeof IconPresentation;
+    Icon: LucideIcon;
   }[] = [];
   if (hasPptTab) {
     categoryOptions.push({
@@ -4527,7 +4528,7 @@ function TemplatePickerCategoryNav({
       label: t(($) => {
         return $.artifacts.kinds.presentation;
       }),
-      Icon: IconPresentation,
+      Icon: Presentation,
     });
   }
   categoryOptions.push({
@@ -4535,7 +4536,7 @@ function TemplatePickerCategoryNav({
     label: t(($) => {
       return $.artifacts.templates.website;
     }),
-    Icon: IconWorld,
+    Icon: Globe,
   });
   if (hasIllustrationTab) {
     categoryOptions.push({
@@ -4543,7 +4544,7 @@ function TemplatePickerCategoryNav({
       label: t(($) => {
         return $.artifacts.templates.illustration;
       }),
-      Icon: IconPhoto,
+      Icon: ImageIcon,
     });
   }
   if (hasVideoTab) {
@@ -4552,7 +4553,7 @@ function TemplatePickerCategoryNav({
       label: t(($) => {
         return $.artifacts.kinds.video;
       }),
-      Icon: IconVideo,
+      Icon: Video,
     });
   }
   if (hasAvatarTab) {
@@ -4561,7 +4562,7 @@ function TemplatePickerCategoryNav({
       label: t(($) => {
         return $.artifacts.templates.avatar;
       }),
-      Icon: IconUser,
+      Icon: User,
     });
   }
   if (hasWorkflowTab) {
@@ -4570,7 +4571,7 @@ function TemplatePickerCategoryNav({
       label: t(($) => {
         return $.artifacts.templates.workflow;
       }),
-      Icon: IconRoute,
+      Icon: Route,
     });
   }
 
@@ -4591,7 +4592,7 @@ function TemplatePickerCategoryNav({
               return (
                 <SelectItem key={value} value={value}>
                   <span className="flex items-center gap-2">
-                    <Icon className="h-4 w-4" stroke={1.8} />
+                    <Icon className="h-4 w-4" strokeWidth={1.8} />
                     {label}
                   </span>
                 </SelectItem>
@@ -4661,7 +4662,7 @@ function TemplatePickerCategoryNav({
                         ? "text-foreground"
                         : "text-gray-700 group-hover:text-gray-800",
                     )}
-                    stroke={1.8}
+                    strokeWidth={1.8}
                   />
                   <span className="truncate">{label}</span>
                 </button>
@@ -4698,9 +4699,9 @@ function TemplatePickerWorkflowSearch({
   return (
     <div className="relative w-56 shrink-0">
       <div className="relative">
-        <IconSearch
+        <Search
           className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-          stroke={1.8}
+          strokeWidth={1.8}
         />
         <Input
           aria-label={t(($) => {
@@ -5724,7 +5725,7 @@ function TemplatePickerButton({
                 setOpen(true);
               }}
             >
-              <IconColorSwatch size={18} stroke={1.5} aria-hidden="true" />
+              <SwatchBook size={18} strokeWidth={1.5} aria-hidden="true" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="top" className="text-xs">
@@ -5814,7 +5815,7 @@ function CreateWorkflowPromptButton({
             })}
             onClick={onCreateWorkflowPrompt}
           >
-            <IconRoute size={18} stroke={1.5} aria-hidden="true" />
+            <Route size={18} strokeWidth={1.5} aria-hidden="true" />
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
@@ -5866,7 +5867,7 @@ function ConnectorTriggerIcons({
   ].slice(0, 3);
   const hasComputerAccess = hasComputerUse || hasCloudBrowser;
   if (enabled.length === 0 && !hasComputerUse && !hasCloudBrowser) {
-    return <IconPlug size={18} stroke={1.5} />;
+    return <Plug size={18} strokeWidth={1.5} />;
   }
   return (
     <span className="flex items-center sm:-space-x-1.5">
@@ -5898,14 +5899,14 @@ function ConnectorTriggerIcons({
       {hasComputerUse && (
         <span className="relative shrink-0">
           <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-primary zero-border sm:h-7 sm:w-7">
-            <IconDeviceDesktop size={16} stroke={1.5} />
+            <Monitor size={16} strokeWidth={1.5} />
           </span>
         </span>
       )}
       {hasCloudBrowser && (
         <span className="relative shrink-0">
           <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-primary zero-border sm:h-7 sm:w-7">
-            <IconWorld size={16} stroke={1.5} />
+            <Globe size={16} strokeWidth={1.5} />
           </span>
         </span>
       )}
@@ -5966,7 +5967,7 @@ function CustomConnectorCatalogCard({
           className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 text-muted-foreground"
           aria-hidden="true"
         >
-          <IconPlus size={14} stroke={1.5} />
+          <Plus size={14} strokeWidth={1.5} />
         </span>
       </span>
       <span className="block px-5 pb-4 pt-1">
@@ -6096,7 +6097,7 @@ function ComputerUseConnectorMenuSection({
         className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-state-hover"
       >
         <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-          <IconWorld size={16} stroke={1.5} />
+          <Globe size={16} strokeWidth={1.5} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block truncate text-sm text-foreground">
@@ -6167,7 +6168,7 @@ function ComputerUseConnectorMenuSection({
                 className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-state-hover"
               >
                 <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-                  <IconDeviceDesktop size={16} stroke={1.5} />
+                  <Monitor size={16} strokeWidth={1.5} />
                 </span>
                 <span className="min-w-0 flex-1">
                   <span className="block truncate text-sm text-foreground">
@@ -6221,9 +6222,9 @@ function ComputerUseConnectorMenuSection({
         </div>
       ) : (
         <div className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground">
-          <IconDeviceDesktop
+          <Monitor
             size={16}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="shrink-0 text-muted-foreground"
           />
           {t(($) => {
@@ -6237,9 +6238,9 @@ function ComputerUseConnectorMenuSection({
           className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-state-hover"
           onClick={onOpenDownloadDialog}
         >
-          <IconPlug
+          <Plug
             size={16}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="shrink-0 text-muted-foreground"
           />
           {t(($) => {
@@ -6589,7 +6590,7 @@ function ConnectorsPopoverButton({
                             )}
                             className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
                           >
-                            <IconAdjustmentsHorizontal size={15} stroke={1.5} />
+                            <SlidersHorizontal size={15} strokeWidth={1.5} />
                           </button>
                         )}
                       <LoadingSwitch
@@ -6638,7 +6639,7 @@ function ConnectorsPopoverButton({
             }}
           >
             <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-border/60 text-muted-foreground">
-              <IconPlus size={13} stroke={1.5} />
+              <Plus size={13} strokeWidth={1.5} />
             </span>
             {t(($) => {
               return $.chat.connectors.addConnectors;
@@ -6724,7 +6725,7 @@ function ComputerUseDownloadDialog({
         <div className="px-6 pb-6 pt-4">
           {downloadSupportStatus === "unsupported-intel-mac" ? (
             <Button type="button" size="lg" className="w-full" disabled>
-              <IconAlertTriangle size={16} stroke={1.5} />
+              <AlertTriangle size={16} strokeWidth={1.5} />
               {t(($) => {
                 return $.chat.computerUse.unsupportedIntelMac;
               })}
@@ -6745,7 +6746,7 @@ function ComputerUseDownloadDialog({
                   onOpenChange(false);
                 }}
               >
-                <IconDownload size={16} stroke={1.5} />
+                <Download size={16} strokeWidth={1.5} />
                 {t(($) => {
                   return $.chat.computerUse.downloadMacos;
                 })}
@@ -6905,10 +6906,10 @@ function MicButton({ signals }: { signals: ComposerSignals }) {
                     } as CSSProperties
                   }
                 />
-                <IconMicrophone size={17} stroke={1.8} className="relative" />
+                <Mic size={17} strokeWidth={1.8} className="relative" />
               </>
             ) : (
-              <IconMicrophone size={18} stroke={1.5} />
+              <Mic size={18} strokeWidth={1.5} />
             )}
           </button>
         </TooltipTrigger>
@@ -6940,7 +6941,7 @@ function ComposerAttachButton({ signals }: { signals: ComposerSignals }) {
               fileInput?.click();
             }}
           >
-            <IconPaperclip size={18} stroke={1.5} />
+            <Paperclip size={18} strokeWidth={1.5} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
@@ -7273,7 +7274,7 @@ function ComposerSendButton({
           return $.chat.actions.stop;
         })}
       >
-        <IconPlayerStop size={16} />
+        <Square size={16} />
       </Button>
     );
   }
@@ -7287,7 +7288,7 @@ function ComposerSendButton({
         return $.chat.actions.send;
       })}
     >
-      <IconArrowUp size={18} stroke={2} />
+      <ArrowUp size={18} strokeWidth={2} />
     </Button>
   );
 }
@@ -7335,7 +7336,7 @@ function ModelConfigurationWarning({
             aria-label={`${blocker.actionLabel}: ${blocker.message}`}
             className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-amber-600 transition-colors hover:bg-amber-500/10 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
           >
-            <IconAlertTriangle size={15} stroke={1.75} />
+            <AlertTriangle size={15} strokeWidth={1.75} />
             <span className="hidden sm:inline">{blocker.actionLabel}</span>
           </button>
         </TooltipTrigger>
@@ -7488,7 +7489,7 @@ function ComposerTemporaryModelNotice({
         onClick={setAsDefault}
       >
         {updating && (
-          <IconLoader2 size={12} className="animate-spin" aria-hidden="true" />
+          <Loader2 size={12} className="animate-spin" aria-hidden="true" />
         )}
         {t(($) => {
           return $.chat.composer.setAsDefault;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7288,7 +7288,7 @@ function ComposerSendButton({
         return $.chat.actions.send;
       })}
     >
-      <ArrowUp size={18} strokeWidth={2} />
+      <ArrowUp size={18} strokeWidth={2} data-explicit-stroke-width />
     </Button>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7288,7 +7288,7 @@ function ComposerSendButton({
         return $.chat.actions.send;
       })}
     >
-      <ArrowUp size={18} strokeWidth={2} data-explicit-stroke-width />
+      <ArrowUp size={18} strokeWidth={2} data-stroke />
     </Button>
   );
 }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -592,6 +592,9 @@ importers:
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
+      lucide-react:
+        specifier: 1.30.0
+        version: 1.30.0(react@19.2.6)
       mermaid:
         specifier: ^11.16.1
         version: 11.16.1


### PR DESCRIPTION
## Summary

- migrate every Tabler icon in the composer-owned UI surface to `lucide-react`
- apply the issue mappings for renamed icons and convert `stroke` props to `strokeWidth`
- use `LucideIcon` for dynamic template category icons
- add `lucide-react@1.30.0` as a direct platform dependency while retaining Tabler for the remaining platform migration

## Scope

This is a focused stacked PR on top of #25852. It covers the composer, attachment chips and previews, avatar template picker, and composer model-provider picker. Non-composer platform files and desktop remain for follow-up batches.

Part of #25458.

## Validation

- `pnpm exec prettier --check` for all changed files
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`

## Preview verification

- verified `https://pr-25858-app.omby.ai` at 1440x900 through the real Tiptap composer path
- confirmed the resting composer and template dialog contain Lucide SVGs with zero Tabler SVGs
- confirmed computed stroke widths match the Tabler baseline, including the explicit 2px Send icon
- confirmed the tested interactions produce no current page errors or console messages