### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -121,8 +121,8 @@ AGENT_BROWSER_VERSION="0.33.0-vm0.1"
 AGENT_BROWSER_LINUX_X64_SHA256="a9e3fbe24c537960b9ac0d1f358224a10eb70d87a619aec7bcb1175222a46a18"
 AGENT_BROWSER_LINUX_ARM64_SHA256="6a74dba04c299a69d564eae5aff67adc2ffc6fda5ddf672994ff75b73d64a9fe"
 PNPM_VERSION="11.20.0"
-CHROMIUM_VERSION="151.0.7922.71-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260731T162426Z"
+CHROMIUM_VERSION="151.0.7922.108-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260808T215433Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Chromium from 151.0.7922.71-1~deb12u1 to 151.0.7922.108-1~deb12u1.
- Update the Debian security snapshot from 20260731T162426Z to 20260808T215433Z.

## Validation

- Confirmed chromium, chromium-common, and chromium-sandbox at the new version for amd64 and arm64 in the pinned snapshot.
- `git diff --check`
- `bash -n crates/runner/scripts/build-template.sh`