### PR TITLE
fix(platform): show model change before run reconciliation

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
@@ -29,7 +29,6 @@ function userMessage(params: {
     createdAt: "2026-06-24T00:00:00.000Z",
     blocks: [],
     isQueued: false,
-    isOptimisticRun: false,
   };
 }
 
@@ -49,7 +48,6 @@ function assistantEvent(params: {
     createdAt: "2026-06-24T00:00:00.000Z",
     blocks: [],
     isQueued: false,
-    isOptimisticRun: false,
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
@@ -100,10 +100,10 @@ function createSendInputChatEvent({
       const clientEventId = crypto.randomUUID();
       const createdAt = nowDate().toISOString();
       const chatThreadSortEventId = crypto.randomUUID();
-      const userMessage = withSelectedModelAnnotation(
-        input.userMessage,
-        input.selectedModel,
-      );
+      const userMessage =
+        input.delivery === "run"
+          ? withSelectedModelAnnotation(input.userMessage, input.selectedModel)
+          : input.userMessage;
       L.debug("send input prepared", {
         traceTime: chatEventTraceTime(),
         threadId,

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-state.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-state.ts
@@ -89,7 +89,6 @@ export function isInterruptedAssistantCancellation(
 export interface SemanticChatEventState {
   readonly event: ChatEvent;
   readonly isQueued: boolean;
-  readonly isOptimisticRun: boolean;
 }
 
 type QueuedChatEvent = Extract<
@@ -173,7 +172,6 @@ export function semanticChatEventsFromChatEvents(
             event.interruptsRunId,
           ),
           isQueued: false,
-          isOptimisticRun: false,
         },
       ];
     }
@@ -182,15 +180,13 @@ export function semanticChatEventsFromChatEvents(
       chatEventCompatibilityRole(event.eventType) === "user" &&
       event.runId === undefined;
     const optimisticAssociation = event.optimisticUserMessageAssociation;
-    const isOptimisticRun =
-      isUnassociatedUser && optimisticAssociation === "run";
     const isQueued =
       isUnassociatedUser &&
       optimisticAssociation !== "run" &&
       (event.eventType === "input.automation" ||
         (event.eventType === "input.prompt" &&
           isTemporarilyQueuedMorningBrief(event)));
-    return [{ event, isQueued, isOptimisticRun }];
+    return [{ event, isQueued }];
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-event.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event.ts
@@ -22,7 +22,6 @@ import type { OptimisticChatThreadEvent } from "./chat-thread-event-types.ts";
 export type EnrichedChatEvent = ChatEvent & {
   blocks: BodyRenderBlock[];
   isQueued: boolean;
-  isOptimisticRun: boolean;
 };
 
 /** A group of consecutive events with the same role. */

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1214,21 +1214,11 @@ function createTranscriptEventsComputed(
   return computed((get): Promise<EnrichedChatEvent[]> => {
     return Promise.resolve(
       get(semanticEvents$).map((entry) => {
-        const { event, isQueued, isOptimisticRun } = entry;
-        const role = chatEventCompatibilityRole(event.eventType);
-        if (role !== "assistant") {
-          return {
-            ...event,
-            blocks: entry.blocks,
-            isQueued,
-            isOptimisticRun,
-          };
-        }
+        const { event, isQueued } = entry;
         return {
           ...event,
           blocks: entry.blocks,
           isQueued,
-          isOptimisticRun: false,
         };
       }),
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished } from "vitest";
 import {
   chatThreadByIdContract,
+  chatThreadsContract,
   type ChatRunOptionsRequest,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -13,6 +14,7 @@ import type {
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { i18n } from "../../../i18n/index.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { optimisticChatThreadCreateUnsettled } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import { triggerAblyEvent, triggerAblyReconnect } from "../../../mocks/ably.ts";
 import {
   click,
@@ -36,6 +38,7 @@ const AGENT_CHAT_PATH = `/agents/${AGENT_ID}/chat`;
 const CANCELLATION_RECOVERY_COPY =
   "Finalizing the cancelled run before queued work continues.";
 const NEXT_RUN_MODEL_COPY = "Next run will use Claude Opus 4.8";
+const NEXT_RUN_SONNET_MODEL_COPY = "Next run will use Claude Sonnet 4.6";
 const MODEL_CHANGED_COPY = "Model changed to Claude Sonnet 4.6";
 
 afterEach(async () => {
@@ -466,6 +469,305 @@ describe("chat run queue", () => {
     ).resolves.toBeInTheDocument();
     expectTextBefore("First answer", MODEL_CHANGED_COPY);
     expectTextBefore(MODEL_CHANGED_COPY, "Second prompt");
+  });
+
+  it("inserts a model change divider before an optimistic run reconciles", async () => {
+    const user = userEvent.setup({ delay: null });
+    const secondSendGate = context.mocks.deferred<void>();
+    let sendCount = 0;
+    let clientThreadId: string | undefined;
+    let threadCreateEventId: string | undefined;
+    let secondUserMessage: UserMessageDocument | undefined;
+    onTestFinished(() => {
+      if (!secondSendGate.settled()) {
+        secondSendGate.resolve();
+      }
+    });
+    context.mocks.data.userModelPreference({
+      selectedModel: "gpt-5.5",
+      updatedAt: "2026-08-06T09:00:00Z",
+    });
+    context.mocks.data.orgModelPolicies([
+      buildModelPolicy({
+        model: "gpt-5.5",
+        modelLabel: "GPT 5.5",
+      }),
+      buildModelPolicy({
+        model: "claude-sonnet-4-6",
+        modelLabel: "Claude Sonnet 4.6",
+        isDefault: false,
+      }),
+    ]);
+    const lifecycle = mockChatLifecycle(context, {
+      sendGate: () => {
+        sendCount++;
+        return sendCount === 2
+          ? secondSendGate.promise
+          : Promise.resolve(undefined);
+      },
+      onSendRequest: ({ prompt, userMessage }) => {
+        if (prompt === "Second prompt") {
+          secondUserMessage = userMessage;
+        }
+      },
+      onThreadCreate: (body) => {
+        clientThreadId = body.clientThreadId;
+        threadCreateEventId = body.eventId;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
+      path: AGENT_CHAT_PATH,
+    });
+
+    await sendMessageInUI(
+      user,
+      (await screen.findByPlaceholderText(PLACEHOLDER)) as HTMLTextAreaElement,
+      "First prompt",
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+    const settledThreadId = clientThreadId;
+    const settledThreadCreateEventId = threadCreateEventId;
+    if (
+      settledThreadId === undefined ||
+      settledThreadCreateEventId === undefined
+    ) {
+      throw new Error("Expected the optimistic thread create identifiers");
+    }
+
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, {
+        events: [
+          {
+            id: settledThreadCreateEventId,
+            seqId: 1,
+            kind: "created",
+            chatThreadId: settledThreadId,
+            agentId: AGENT_ID,
+            title: null,
+            selectedModel: "gpt-5.5",
+            serviceTier: null,
+            computerUseHostId: null,
+            cloudBrowserEnabled: true,
+            createdAt: "2026-08-06T09:00:00Z",
+          },
+        ],
+        hasMore: false,
+      });
+    });
+    triggerAblyEvent("threadListChanged");
+    await waitFor(() => {
+      expect(
+        context.store.get(optimisticChatThreadCreateUnsettled(settledThreadId)),
+      ).toBeFalsy();
+    });
+
+    lifecycle.completeRun("First answer");
+    await waitFor(() => {
+      expect(screen.getByText("First answer")).toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+    });
+
+    await user.click(await screen.findByRole("combobox", { name: "GPT 5.5" }));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: "Claude Sonnet 4.6" }),
+      ).toBeInTheDocument();
+    });
+
+    await fill(
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Second prompt",
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send")).toBeEnabled();
+    });
+    await user.click(screen.getByLabelText("Send"));
+
+    await expect(
+      screen.findByText("Second prompt"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(secondUserMessage?.parts).toContainEqual({
+        type: "model",
+        selectedModel: "claude-sonnet-4-6",
+      });
+    });
+    expect(secondSendGate.settled()).toBeFalsy();
+    expect(screen.getByText(MODEL_CHANGED_COPY)).toBeInTheDocument();
+    expectTextBefore("First answer", MODEL_CHANGED_COPY);
+    expectTextBefore(MODEL_CHANGED_COPY, "Second prompt");
+  });
+
+  it("keeps a model change pending through a steer before showing the next run divider optimistically", async () => {
+    const user = userEvent.setup({ delay: null });
+    const nextRunSendGate = context.mocks.deferred<void>();
+    const steerMessages: QueuedMessageCapture[] = [];
+    let runCreateCount = 0;
+    let nextRunUserMessage: UserMessageDocument | undefined;
+    onTestFinished(() => {
+      if (!nextRunSendGate.settled()) {
+        nextRunSendGate.resolve();
+      }
+    });
+    context.mocks.data.userModelPreference({
+      selectedModel: "gpt-5.5",
+      updatedAt: "2026-08-06T09:00:00Z",
+    });
+    context.mocks.data.orgModelPolicies([
+      buildModelPolicy({
+        model: "gpt-5.5",
+        modelLabel: "GPT 5.5",
+      }),
+      buildModelPolicy({
+        model: "claude-sonnet-4-6",
+        modelLabel: "Claude Sonnet 4.6",
+        isDefault: false,
+      }),
+    ]);
+    const lifecycle = mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      selectedModel: "gpt-5.5",
+      sendGate: () => {
+        runCreateCount++;
+        return runCreateCount === 2
+          ? nextRunSendGate.promise
+          : Promise.resolve(undefined);
+      },
+      onQueuedEventAppend: (body) => {
+        steerMessages.push(body);
+      },
+      onSendRequest: ({ prompt, userMessage }) => {
+        if (prompt === "Start the model B run") {
+          nextRunUserMessage = userMessage;
+        }
+      },
+    });
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
+      path: CHAT_PATH,
+    });
+
+    await sendMessageInUI(
+      user,
+      (await screen.findByPlaceholderText(PLACEHOLDER)) as HTMLTextAreaElement,
+      "Start the model A run",
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+    lifecycle.setRunOutput("Working with model A.");
+    await waitFor(() => {
+      expect(screen.getByText("Working with model A.")).toBeInTheDocument();
+    });
+
+    await user.click(await screen.findByRole("combobox", { name: "GPT 5.5" }));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+    await expect(
+      screen.findByText(NEXT_RUN_SONNET_MODEL_COPY),
+    ).resolves.toBeInTheDocument();
+
+    await sendQueuedMessage(user, "Steer the model A run");
+    await expect(
+      screen.findByText("Steer the model A run"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(steerMessages).toHaveLength(1);
+    });
+    expect(
+      steerMessages[0]?.userMessage?.parts.find((part) => {
+        return part.type === "model";
+      }),
+    ).toBeUndefined();
+    expect(screen.getByText(NEXT_RUN_SONNET_MODEL_COPY)).toBeInTheDocument();
+    expect(screen.queryByText(MODEL_CHANGED_COPY)).not.toBeInTheDocument();
+
+    lifecycle.completeRun("Model A finished.");
+    await waitFor(() => {
+      expect(screen.getByText("Model A finished.")).toBeInTheDocument();
+      expect(
+        screen.queryByText(NEXT_RUN_SONNET_MODEL_COPY),
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+    });
+
+    await fill(
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Start the model B run",
+    );
+    await user.click(screen.getByLabelText("Send"));
+
+    await expect(
+      screen.findByText("Start the model B run"),
+    ).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(nextRunUserMessage?.parts).toContainEqual({
+        type: "model",
+        selectedModel: "claude-sonnet-4-6",
+      });
+    });
+    expect(nextRunSendGate.settled()).toBeFalsy();
+    expect(screen.getByText(MODEL_CHANGED_COPY)).toBeInTheDocument();
+    expectTextBefore("Model A finished.", MODEL_CHANGED_COPY);
+    expectTextBefore(MODEL_CHANGED_COPY, "Start the model B run");
+  });
+
+  it("does not mistake a persisted steer model annotation for a new run", async () => {
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: `${THREAD_ID}-active-user`,
+          role: "user",
+          content: "Start the model A run",
+          userMessage: modelAnnotatedMessage(
+            "Start the model A run",
+            "gpt-5.5",
+          ),
+          runId: "run-active",
+          createdAt: "2026-08-06T09:00:00Z",
+        },
+        {
+          id: `${THREAD_ID}-active-assistant`,
+          role: "assistant",
+          content: "Model A finished.",
+          runId: "run-active",
+          createdAt: "2026-08-06T09:00:01Z",
+        },
+        {
+          id: `${THREAD_ID}-persisted-steer`,
+          role: "user",
+          content: "Legacy persisted steer",
+          userMessage: modelAnnotatedMessage(
+            "Legacy persisted steer",
+            "claude-sonnet-4-6",
+          ),
+          runId: undefined,
+          createdAt: "2026-08-06T09:00:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
+      path: CHAT_PATH,
+    });
+
+    await expect(
+      screen.findByText("Legacy persisted steer"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText(MODEL_CHANGED_COPY)).not.toBeInTheDocument();
   });
 
   it.each([
@@ -1106,7 +1408,6 @@ describe("chat run queue", () => {
               filenameSnapshot: "queued.mp4",
               contentType: "video/mp4",
             },
-            { type: "model", selectedModel: "glm-5.1" },
           ],
         },
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -14,7 +14,6 @@ import type {
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { i18n } from "../../../i18n/index.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { optimisticChatThreadCreateUnsettled } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import { triggerAblyEvent, triggerAblyReconnect } from "../../../mocks/ably.ts";
 import {
   click,
@@ -40,6 +39,7 @@ const CANCELLATION_RECOVERY_COPY =
 const NEXT_RUN_MODEL_COPY = "Next run will use Claude Opus 4.8";
 const NEXT_RUN_SONNET_MODEL_COPY = "Next run will use Claude Sonnet 4.6";
 const MODEL_CHANGED_COPY = "Model changed to Claude Sonnet 4.6";
+const RECONCILED_THREAD_TITLE = "Reconciled thread";
 
 afterEach(async () => {
   await i18n.changeLanguage("en-US");
@@ -548,7 +548,7 @@ describe("chat run queue", () => {
             kind: "created",
             chatThreadId: settledThreadId,
             agentId: AGENT_ID,
-            title: null,
+            title: RECONCILED_THREAD_TITLE,
             selectedModel: "gpt-5.5",
             serviceTier: null,
             computerUseHostId: null,
@@ -561,9 +561,7 @@ describe("chat run queue", () => {
     });
     triggerAblyEvent("threadListChanged");
     await waitFor(() => {
-      expect(
-        context.store.get(optimisticChatThreadCreateUnsettled(settledThreadId)),
-      ).toBeFalsy();
+      expect(document.title).toBe(`${RECONCILED_THREAD_TITLE} | VM0`);
     });
 
     lifecycle.completeRun("First answer");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -304,6 +304,7 @@ interface MockLifecycleControl {
   setRunStatus: (status: RunStatus) => void;
   setQueuePosition: (n: number) => void;
   setEvents: (e: AgentEvent[]) => void;
+  setRunOutput: (content: string) => void;
   setThreadList: (list: ThreadListItem[]) => void;
   setCodexServiceTier: (tier: CodexServiceTier | null) => void;
   completeRun: (content?: string) => void;
@@ -475,10 +476,10 @@ export function mockChatLifecycle(
      */
     appendGate?: Promise<void>;
     /**
-     * Promise the initial send handler awaits before responding. Lets tests
-     * keep the new-thread optimistic view mounted while interacting with it.
+     * Gate or per-send gate factory awaited before the initial send responds.
+     * Lets tests keep an optimistic run mounted while interacting with it.
      */
-    sendGate?: Promise<void>;
+    sendGate?: Promise<void> | (() => Promise<void>);
     /**
      * Promise the paged history handler awaits before responding to beforeSeqId.
      * Lets tests prove the latest-event view renders before silent backfill.
@@ -515,6 +516,7 @@ export function mockChatLifecycle(
     }) => void;
     onThreadCreate?: (body: {
       clientThreadId?: string;
+      eventId?: string;
       model?: string;
       modelSelection: ModelSelectionRequest;
     }) => void;
@@ -769,7 +771,9 @@ export function mockChatLifecycle(
     cloudBrowserEnabled?: boolean;
     revokesEventId?: string;
   }) => {
-    if (options?.sendGate) {
+    if (typeof options?.sendGate === "function") {
+      await options.sendGate();
+    } else if (options?.sendGate) {
       await options.sendGate;
     }
     if (body.prompt) {
@@ -945,6 +949,7 @@ export function mockChatLifecycle(
     selectedModel = modelSelection.selectedModel;
     options?.onThreadCreate?.({
       clientThreadId: body.clientThreadId,
+      eventId: body.eventId,
       model: body.model,
       modelSelection,
     });
@@ -1048,6 +1053,11 @@ export function mockChatLifecycle(
     },
     setEvents: (e) => {
       events = e;
+    },
+    setRunOutput: (content) => {
+      resultContent = content;
+      assistantVersion++;
+      createChatEvent(threadId);
     },
     setThreadList: (list) => {
       threadListOverride = list;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -383,6 +383,10 @@ function modelChangeRunKey(
   if (inputEvent.runId !== undefined) {
     return `run:${inputEvent.runId}`;
   }
+  // Old web/app clients can persist model annotations on steer inputs for up
+  // to about two days. Keep persisted events from looking like run starts
+  // until their stored rows and snapshots are migrated; remove the seqId
+  // check after #25879 confirms no runless model annotations remain.
   if (inputEvent.seqId === undefined && selectedModel !== undefined) {
     return `event:${inputEvent.id}`;
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -376,26 +376,40 @@ function selectedModelFromUserMessage(
   return modelPart?.type === "model" ? modelPart.selectedModel : undefined;
 }
 
+function modelChangeRunKey(
+  inputEvent: ChatInputEvent,
+  selectedModel: string | undefined,
+): string | undefined {
+  if (inputEvent.runId !== undefined) {
+    return `run:${inputEvent.runId}`;
+  }
+  if (inputEvent.seqId === undefined && selectedModel !== undefined) {
+    return `event:${inputEvent.id}`;
+  }
+  return undefined;
+}
+
 function modelChangesByEventId(
   groups: readonly ChatEventGroup[],
 ): ReadonlyMap<string, string> {
   const changes = new Map<string, string>();
-  let previousRunId: string | undefined;
+  let previousRunKey: string | undefined;
   let previousModel: string | undefined;
   let hasPreviousRun = false;
 
   for (const group of groups) {
     for (const event of group.events) {
       const inputEvent = asInputChatEvent(event);
-      if (
-        inputEvent?.runId === undefined ||
-        inputEvent.runId === previousRunId
-      ) {
+      if (inputEvent === undefined) {
         continue;
       }
       const selectedModel = selectedModelFromUserMessage(
         inputEvent.userMessage,
       );
+      const runKey = modelChangeRunKey(inputEvent, selectedModel);
+      if (runKey === undefined || runKey === previousRunKey) {
+        continue;
+      }
       if (
         hasPreviousRun &&
         previousModel !== undefined &&
@@ -404,7 +418,7 @@ function modelChangesByEventId(
       ) {
         changes.set(event.id, selectedModel);
       }
-      previousRunId = inputEvent.runId;
+      previousRunKey = runKey;
       previousModel = selectedModel;
       hasPreviousRun = true;
     }


### PR DESCRIPTION
## Summary

- annotate the selected model only on inputs that start a run, leaving active-run steer messages model-free
- derive model-change dividers from a pending run input model annotation until the server assigns its run ID
- remove the unused `isOptimisticRun` projection and ignore legacy persisted steers that already contain model annotations

## Fallbacks

- `turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx:modelChangeRunKey` ignores model annotations on persisted runless inputs written by older web/app clients so a steer is not rendered as a new model-change boundary. Surface: old web/app clients, approximately 2 days, plus persisted chat-event history until migration. Remove the `seqId` guard and its legacy-shape test after the client window closes and #25879 backfills stored rows and snapshot heads and confirms through production evidence that no runless model annotations remain.

## Test plan

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-queue.test.tsx --maxWorkers=1` (26 passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "includes the selected model" --maxWorkers=1` (1 passed)
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/run-group-folding.test.ts --maxWorkers=1` (8 passed)
