### PR TITLE
fix(runner): skip reuse refresh for non-reusable runs

### DIFF
--- a/crates/runner/src/cmd/start/active_runs.rs
+++ b/crates/runner/src/cmd/start/active_runs.rs
@@ -168,7 +168,9 @@ impl ActiveRunGuard {
         lock_entries(&self.active_runs.entries).remove(&run_id);
         self.phase.send_replace(ActiveRunPhase::Released);
         bump_changes(&self.active_runs.changes);
-        self.active_runs.reuse_state_notify.notify_one();
+        if self.has_reuse_key {
+            self.active_runs.reuse_state_notify.notify_one();
+        }
         self.has_reuse_key
     }
 }


### PR DESCRIPTION
## Summary

- notify reusable-state observers only when a released active run has a reuse key
- avoid redundant immediate heartbeats after ordinary run completions
- restore deterministic coverage of the deferred startup heartbeat tick

## Root cause

The active-run registry notified `reuse_state_notify` for every release, including runs without a reuse key. Depending on scheduler order, the main loop could send that immediate heartbeat before the startup interval regression test inspected the provider, even though the interval itself was still correctly deferred.

## Exclusions

- no heartbeat interval or cadence changes
- no runner protocol, persisted-state, or deployment compatibility changes

## Validation

- reproduced the failure on iteration 50 before the fix
- repeated `heartbeat_tick_defers_past_first_select_poll` 200 times after the fix
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features --quiet`
