### PR TITLE
refactor(platform): migrate settings icons to Lucide

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
@@ -1,12 +1,7 @@
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import {
-  IconDotsVertical,
-  IconPencil,
-  IconPlus,
-  IconTrash,
-} from "@tabler/icons-react";
+import { EllipsisVertical, Pencil, Plus, Trash } from "lucide-react";
 import {
   Button,
   Checkbox,
@@ -91,7 +86,7 @@ function AddConnectionMenu() {
           size="sm"
           className="zero-btn-morandi h-9 gap-2 rounded-lg border"
         >
-          <IconPlus size={14} />
+          <Plus size={14} />
           {t(($) => {
             return $.settings.models.gateways.add;
           })}
@@ -162,7 +157,7 @@ function ConnectionCard({
               return $.settings.models.gateways.actions;
             })}
           >
-            <IconDotsVertical size={15} />
+            <EllipsisVertical size={15} />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
@@ -171,7 +166,7 @@ function ConnectionCard({
               openEdit(connection, settingsDialogSignal);
             }}
           >
-            <IconPencil size={14} />
+            <Pencil size={14} />
             {t(($) => {
               return $.settings.shared.edit;
             })}
@@ -182,7 +177,7 @@ function ConnectionCard({
               openDelete(connection);
             }}
           >
-            <IconTrash size={14} />
+            <Trash size={14} />
             {t(($) => {
               return $.settings.shared.delete;
             })}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -5,14 +5,14 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { FeatureSwitchKey } from "@vm0/core";
 import {
-  IconExternalLink,
-  IconCrown,
-  IconArrowLeft,
-  IconChevronRight,
-  IconCoins,
-  IconMinus,
-  IconPlus,
-} from "@tabler/icons-react";
+  ExternalLink,
+  Crown,
+  ArrowLeft,
+  ChevronRight,
+  Coins,
+  Minus,
+  Plus,
+} from "lucide-react";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX,
@@ -606,7 +606,7 @@ function PlanCard({
     <div className="relative flex flex-col rounded-xl transition-transform duration-200 hover:-translate-y-0.5 zero-border px-6 py-7">
       {plan.tier === "pro" && (
         <span className="absolute top-3 right-3 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <IconCrown size={12} stroke={1.8} className="text-amber-500" />
+          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
           {i18n.t(($) => {
             return $.billing.plans.popular;
           })}
@@ -771,7 +771,7 @@ function PricingPage({
                   return $.billing.common.back;
                 })}
               >
-                <IconArrowLeft size={16} stroke={1.8} />
+                <ArrowLeft size={16} strokeWidth={1.8} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -1350,7 +1350,7 @@ function ConcurrencyQuantityControl({
             onQuantityChange(quantity - 1);
           }}
         >
-          <IconMinus size={13} stroke={2} />
+          <Minus size={13} strokeWidth={2} data-explicit-stroke-width />
         </button>
         <span className="flex h-8 w-11 items-center justify-center border-x border-border/70 text-sm font-medium tabular-nums text-foreground">
           {formatLocalizedNumber(quantity)}
@@ -1368,7 +1368,7 @@ function ConcurrencyQuantityControl({
             onQuantityChange(quantity + 1);
           }}
         >
-          <IconPlus size={13} stroke={2} />
+          <Plus size={13} strokeWidth={2} data-explicit-stroke-width />
         </button>
       </div>
     </div>
@@ -2225,7 +2225,7 @@ export function OrgBillingTab() {
                       {t(($) => {
                         return $.billing.common.manage;
                       })}
-                      <IconExternalLink size={13} stroke={1.5} />
+                      <ExternalLink size={13} strokeWidth={1.5} />
                     </Button>
                   </div>
                 </>
@@ -2242,15 +2242,15 @@ export function OrgBillingTab() {
                   {t(($) => {
                     return $.billing.plans.compareAll;
                   })}
-                  <IconCoins
+                  <Coins
                     size={14}
-                    stroke={1.5}
+                    strokeWidth={1.5}
                     className="text-foreground/40"
                   />
                 </span>
-                <IconChevronRight
+                <ChevronRight
                   size={14}
-                  stroke={1.5}
+                  strokeWidth={1.5}
                   className="shrink-0 text-muted-foreground/50"
                 />
               </button>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1350,7 +1350,7 @@ function ConcurrencyQuantityControl({
             onQuantityChange(quantity - 1);
           }}
         >
-          <Minus size={13} strokeWidth={2} data-explicit-stroke-width />
+          <Minus size={13} strokeWidth={2} data-stroke />
         </button>
         <span className="flex h-8 w-11 items-center justify-center border-x border-border/70 text-sm font-medium tabular-nums text-foreground">
           {formatLocalizedNumber(quantity)}
@@ -1368,7 +1368,7 @@ function ConcurrencyQuantityControl({
             onQuantityChange(quantity + 1);
           }}
         >
-          <Plus size={13} strokeWidth={2} data-explicit-stroke-width />
+          <Plus size={13} strokeWidth={2} data-stroke />
         </button>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -3,7 +3,7 @@
 import { useLoadable, useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import { IconUpload } from "@tabler/icons-react";
+import { Upload } from "lucide-react";
 import {
   Input,
   Button,
@@ -231,7 +231,12 @@ function ProfileSection({
               )}
               {isAdmin && (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <IconUpload size={14} stroke={2} className="text-white" />
+                  <Upload
+                    size={14}
+                    strokeWidth={2}
+                    className="text-white"
+                    data-explicit-stroke-width
+                  />
                 </div>
               )}
             </button>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -235,7 +235,7 @@ function ProfileSection({
                     size={14}
                     strokeWidth={2}
                     className="text-white"
-                    data-explicit-stroke-width
+                    data-stroke
                   />
                 </div>
               )}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -1,7 +1,7 @@
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import { IconCircleCheck, IconDownload } from "@tabler/icons-react";
+import { CircleCheck, Download } from "lucide-react";
 import {
   Button,
   cn,
@@ -219,7 +219,7 @@ function DownloadReceiptsDialog({
           className="gap-1.5"
           disabled={downloading}
         >
-          <IconDownload size={14} stroke={1.5} />
+          <Download size={14} strokeWidth={1.5} />
           {downloading
             ? t(($) => {
                 return $.billing.invoices.preparingReceipts;
@@ -368,7 +368,7 @@ export function OrgInvoicesTab() {
                   </span>
                   {inv.status && (
                     <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-                      <IconCircleCheck size={12} className="text-green-600" />
+                      <CircleCheck size={12} className="text-green-600" />
                       {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
                     </span>
                   )}
@@ -396,7 +396,7 @@ export function OrgInvoicesTab() {
                               { month: invoiceMonth },
                             )}
                           >
-                            <IconDownload size={14} stroke={1.5} />
+                            <Download size={14} strokeWidth={1.5} />
                           </a>
                         </TooltipTrigger>
                         <TooltipContent side="bottom">
@@ -413,7 +413,7 @@ export function OrgInvoicesTab() {
                     </TooltipProvider>
                   ) : (
                     <span className="flex h-7 w-7 items-center justify-center text-muted-foreground/30">
-                      <IconDownload size={14} stroke={1.5} />
+                      <Download size={14} strokeWidth={1.5} />
                     </span>
                   )}
                 </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -305,7 +305,7 @@ function InviteDialog() {
     >
       <DialogTrigger asChild>
         <Button size="sm" className="gap-1.5 rounded-lg">
-          <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
+          <Plus size={14} strokeWidth={2} data-stroke />
           {t(($) => {
             return $.settings.workspace.members.addMember;
           })}
@@ -923,7 +923,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
             return $.settings.workspace.members.membershipRequest.acceptTitle;
           })}
         >
-          <Check size={15} strokeWidth={2} data-explicit-stroke-width />
+          <Check size={15} strokeWidth={2} data-stroke />
         </button>
         <button
           className="flex h-7 w-7 items-center justify-center rounded-md text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
@@ -933,7 +933,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
             return $.settings.workspace.members.membershipRequest.rejectTitle;
           })}
         >
-          <X size={15} strokeWidth={2} data-explicit-stroke-width />
+          <X size={15} strokeWidth={2} data-stroke />
         </button>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -4,15 +4,15 @@ import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import {
-  IconSearch,
-  IconShieldCheck,
-  IconDots,
-  IconPlus,
-  IconClock,
-  IconCheck,
-  IconX,
-  IconUserPlus,
-} from "@tabler/icons-react";
+  Search,
+  ShieldCheck,
+  Ellipsis,
+  Plus,
+  Clock,
+  Check,
+  X,
+  UserPlus,
+} from "lucide-react";
 import {
   cn,
   Input,
@@ -141,9 +141,9 @@ export function OrgMembersTab() {
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-3">
         <div className="relative flex-1">
-          <IconSearch
+          <Search
             size={15}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
           />
           <Input
@@ -216,7 +216,7 @@ export function OrgMembersTab() {
           <>
             <div className="px-5 pt-3 pb-1">
               <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                <IconUserPlus size={13} stroke={1.8} />
+                <UserPlus size={13} strokeWidth={1.8} />
                 {t(($) => {
                   return $.settings.workspace.members.joinRequests;
                 })}
@@ -305,7 +305,7 @@ function InviteDialog() {
     >
       <DialogTrigger asChild>
         <Button size="sm" className="gap-1.5 rounded-lg">
-          <IconPlus size={14} stroke={2} />
+          <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
           {t(($) => {
             return $.settings.workspace.members.addMember;
           })}
@@ -464,9 +464,9 @@ function MemberRow({
       </div>
       <div>
         <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <IconShieldCheck
+          <ShieldCheck
             size={12}
-            stroke={1.8}
+            strokeWidth={1.8}
             className={
               member.role === "admin"
                 ? "text-blue-500"
@@ -524,7 +524,7 @@ function SelfDemoteAction({ email }: { email: string }) {
             )}
             className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover transition-colors"
           >
-            <IconDots size={15} stroke={1.5} />
+            <Ellipsis size={15} strokeWidth={1.5} />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -633,7 +633,7 @@ function MemberActions({ member }: { member: OrgMember }) {
             disabled={changingRole}
             className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
           >
-            <IconDots size={15} stroke={1.5} />
+            <Ellipsis size={15} strokeWidth={1.5} />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -762,7 +762,7 @@ function PendingInvitationRow({
       </div>
       <div>
         <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <IconClock size={12} stroke={1.8} className="text-amber-500" />
+          <Clock size={12} strokeWidth={1.8} className="text-amber-500" />
           {t(($) => {
             return $.settings.workspace.members.pending;
           })}
@@ -789,7 +789,7 @@ function PendingInvitationRow({
                   )}
                   className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover transition-colors"
                 >
-                  <IconDots size={15} stroke={1.5} />
+                  <Ellipsis size={15} strokeWidth={1.5} />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent
@@ -908,7 +908,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
       </div>
       <div>
         <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <IconUserPlus size={12} stroke={1.8} className="text-blue-500" />
+          <UserPlus size={12} strokeWidth={1.8} className="text-blue-500" />
           {t(($) => {
             return $.settings.workspace.members.membershipRequest.role;
           })}
@@ -923,7 +923,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
             return $.settings.workspace.members.membershipRequest.acceptTitle;
           })}
         >
-          <IconCheck size={15} stroke={2} />
+          <Check size={15} strokeWidth={2} data-explicit-stroke-width />
         </button>
         <button
           className="flex h-7 w-7 items-center justify-center rounded-md text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
@@ -933,7 +933,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
             return $.settings.workspace.members.membershipRequest.rejectTitle;
           })}
         >
-          <IconX size={15} stroke={2} />
+          <X size={15} strokeWidth={2} data-explicit-stroke-width />
         </button>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -604,7 +604,7 @@ function AddModelButton({
       disabled={disabled}
       onClick={onClick}
     >
-      <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
+      <Plus size={14} strokeWidth={2} data-stroke />
       {t(($) => {
         return $.settings.models.actions.addModel;
       })}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -10,12 +10,12 @@ import {
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import {
-  IconAlertTriangle,
-  IconDotsVertical,
-  IconPencil,
-  IconPlus,
-  IconTrash,
-} from "@tabler/icons-react";
+  AlertTriangle,
+  EllipsisVertical,
+  Pencil,
+  Plus,
+  Trash,
+} from "lucide-react";
 import {
   Button,
   DropdownMenu,
@@ -548,7 +548,7 @@ function PolicyActionsMenu({
             },
           )}
         >
-          <IconDotsVertical size={14} stroke={1.5} />
+          <EllipsisVertical size={14} strokeWidth={1.5} />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
@@ -558,7 +558,7 @@ function PolicyActionsMenu({
             onEdit(policy);
           }}
         >
-          <IconPencil size={14} stroke={1.5} />
+          <Pencil size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.settings.models.actions.editModel;
           })}
@@ -571,7 +571,7 @@ function PolicyActionsMenu({
             onDelete(policy);
           }}
         >
-          <IconTrash size={14} stroke={1.5} />
+          <Trash size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.settings.models.actions.deleteModel;
           })}
@@ -604,7 +604,7 @@ function AddModelButton({
       disabled={disabled}
       onClick={onClick}
     >
-      <IconPlus size={14} stroke={2} />
+      <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
       {t(($) => {
         return $.settings.models.actions.addModel;
       })}
@@ -661,7 +661,7 @@ function PolicyRow({
           )}
           {policy.routeStatus !== "valid" && (
             <span className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
-              <IconAlertTriangle size={12} />
+              <AlertTriangle size={12} />
               {policy.routeStatus === "missing_provider"
                 ? t(($) => {
                     return $.settings.models.policies.missingProvider;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -413,7 +413,7 @@ function CreditGrantList({ grants }: { grants: CreditGrant[] }) {
             size={13}
             strokeWidth={2}
             className="shrink-0 transition-transform group-open:rotate-90"
-            data-explicit-stroke-width
+            data-stroke
           />
           <span>
             {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import type { BillingStatusResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import type { MemberUsage } from "@vm0/api-contracts/contracts/zero-usage";
-import { IconChevronRight } from "@tabler/icons-react";
+import { ChevronRight } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -409,10 +409,11 @@ function CreditGrantList({ grants }: { grants: CreditGrant[] }) {
         className="mb-1 cursor-pointer list-none px-2"
       >
         <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-          <IconChevronRight
+          <ChevronRight
             size={13}
-            stroke={2}
+            strokeWidth={2}
             className="shrink-0 transition-transform group-open:rotate-90"
+            data-explicit-stroke-width
           />
           <span>
             {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
@@ -1,6 +1,6 @@
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { IconPencil, IconLoader2 } from "@tabler/icons-react";
+import { Pencil, Loader2 } from "lucide-react";
 import { Button } from "@vm0/ui";
 
 export function UnsavedBar({
@@ -28,9 +28,9 @@ export function UnsavedBar({
         className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
       >
         <div className="flex items-center gap-2 text-sm text-foreground">
-          <IconPencil
+          <Pencil
             size={18}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="shrink-0 text-muted-foreground"
           />
           <span>
@@ -60,9 +60,9 @@ export function UnsavedBar({
             disabled={saving || saveDisabled}
           >
             {saving ? (
-              <IconLoader2
+              <Loader2
                 size={14}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="animate-spin mr-1.5"
               />
             ) : null}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1,9 +1,4 @@
-import {
-  IconArrowLeft,
-  IconCheck,
-  IconCrown,
-  IconUser,
-} from "@tabler/icons-react";
+import { ArrowLeft, Check, Crown, User } from "lucide-react";
 import {
   Button,
   Select,
@@ -247,7 +242,7 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
             className="h-full w-full object-cover"
           />
         ) : (
-          <IconUser size={15} stroke={1.8} />
+          <User size={15} strokeWidth={1.8} />
         )}
       </span>
       <span className="min-w-0">
@@ -448,9 +443,9 @@ function PlanFeatureList({ tier }: { readonly tier: UsagePackPlanTier }) {
       {planFeatures(tier).map((feature) => {
         return (
           <li key={feature} className="flex items-center gap-2">
-            <IconCheck
+            <Check
               size={14}
-              stroke={1.8}
+              strokeWidth={1.8}
               className="shrink-0 text-muted-foreground/50"
             />
             <span className="text-[13px] text-muted-foreground">{feature}</span>
@@ -486,7 +481,7 @@ function PlanSelectionCard({
     >
       {plan.popular && (
         <span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <IconCrown size={12} stroke={1.8} className="text-amber-500" />
+          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
           {i18n.t(($) => {
             return $.billing.plans.popular;
           })}
@@ -586,7 +581,7 @@ function PricingPageHeader({
                 return $.billing.common.back;
               })}
             >
-              <IconArrowLeft size={16} stroke={1.8} />
+              <ArrowLeft size={16} strokeWidth={1.8} />
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -1,6 +1,6 @@
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { IconDotsVertical } from "@tabler/icons-react";
+import { EllipsisVertical } from "lucide-react";
 import {
   Button,
   DropdownMenu,
@@ -688,7 +688,7 @@ function OAuthCredentialRow({
                       return $.settings.shared.moreOptions;
                     })}
                   >
-                    <IconDotsVertical size={14} stroke={1.5} />
+                    <EllipsisVertical size={14} strokeWidth={1.5} />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-44">

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,16 +1,13 @@
 import type { MouseEvent } from "react";
 import { useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import {
-  IconBrandGithub,
-  IconBrandSlack,
-  IconBrandTelegram,
-  IconChevronDown,
-  IconClock,
-  IconMail,
-  IconMessageCircle,
-  IconPhone,
-  IconRobot,
-} from "@tabler/icons-react";
+  ChevronDown,
+  Clock,
+  Mail,
+  MessageCircle,
+  Phone,
+  Bot,
+} from "lucide-react";
 import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import type {
   UsageRecordKind,
@@ -27,6 +24,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  BrandGithub,
+  BrandSlack,
+  BrandTelegram,
 } from "@vm0/ui";
 import {
   Tooltip,
@@ -55,17 +55,17 @@ import {
 const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
 
 const SOURCE_ICONS = {
-  chat: IconMessageCircle,
-  automation: IconClock,
-  slack: IconBrandSlack,
-  teams: IconMessageCircle,
-  telegram: IconBrandTelegram,
-  email: IconMail,
-  agentphone: IconPhone,
-  github: IconBrandGithub,
-  agent: IconRobot,
-  other: IconRobot,
-} as const satisfies Record<UsageRecordSource, typeof IconMessageCircle>;
+  chat: MessageCircle,
+  automation: Clock,
+  slack: BrandSlack,
+  teams: MessageCircle,
+  telegram: BrandTelegram,
+  email: Mail,
+  agentphone: Phone,
+  github: BrandGithub,
+  agent: Bot,
+  other: Bot,
+} as const satisfies Record<UsageRecordSource, typeof MessageCircle>;
 
 const KIND_META = {
   model: {
@@ -270,9 +270,9 @@ export function UsageRangeSelect({
           className="zero-btn-morandi h-9 shrink-0 rounded-lg border"
         >
           {rangeLabel(value)}
-          <IconChevronDown
+          <ChevronDown
             size={14}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="ml-1.5 text-muted-foreground"
           />
         </Button>
@@ -436,7 +436,7 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
           aria-label={label}
           className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
         >
-          <Icon size={20} stroke={1.5} />
+          <Icon size={20} strokeWidth={1.5} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-h-8 min-w-0 items-center gap-3">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
@@ -1,9 +1,5 @@
 import { useLoadable } from "ccstate-react";
-import {
-  IconDeviceDesktop,
-  IconGitCommit,
-  IconPackage,
-} from "@tabler/icons-react";
+import { Monitor, GitCommit, Package } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -28,7 +24,7 @@ function BuildInfoTarget({
   readonly title: string;
   readonly version: string;
   readonly commitSha: string;
-  readonly icon: typeof IconGitCommit;
+  readonly icon: typeof GitCommit;
 }) {
   const { t } = useTranslation();
 
@@ -37,7 +33,7 @@ function BuildInfoTarget({
       <div className="flex min-w-0 items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
-            <Icon size={15} stroke={1.5} />
+            <Icon size={15} strokeWidth={1.5} />
           </span>
           <div className="truncate text-sm font-medium text-foreground">
             {title}
@@ -91,9 +87,9 @@ export function BuildInfoBlock() {
     <div className="flex items-start gap-4 rounded-xl bg-card p-4 zero-border">
       <div className="shrink-0">
         <div className="flex h-7 w-7 items-center justify-center">
-          <IconGitCommit
+          <GitCommit
             size={22}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="text-muted-foreground"
           />
         </div>
@@ -112,7 +108,7 @@ export function BuildInfoBlock() {
               })}
               version={frontendVersion}
               commitSha={frontendCommitSha}
-              icon={IconDeviceDesktop}
+              icon={Monitor}
             />
           </div>
           <div className="min-w-0 border-t border-border/60 pt-4 sm:border-l sm:border-t-0 sm:pl-5 sm:pt-0">
@@ -122,7 +118,7 @@ export function BuildInfoBlock() {
               })}
               version={backendVersion}
               commitSha={backendCommitSha}
-              icon={IconPackage}
+              icon={Package}
             />
           </div>
         </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/claude-code-device-auth-dialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { Button } from "@vm0/ui/components/ui/button";
 import { Input } from "@vm0/ui/components/ui/input";
-import { IconLoader2 } from "@tabler/icons-react";
+import { Loader2 } from "lucide-react";
 
 import {
   claudeCodeDeviceAuthDialogState$,
@@ -272,7 +272,7 @@ function ClaudeCodeDeviceAuthBody({
             disabled={submitting}
             data-testid="claude-code-device-auth-submit"
           >
-            {submitting && <IconLoader2 size={14} className="animate-spin" />}
+            {submitting && <Loader2 size={14} className="animate-spin" />}
             {submitting
               ? t(($) => {
                   return $.settings.shared.connecting;
@@ -306,7 +306,7 @@ function ClaudeCodeDeviceAuthLoadingContent() {
       role="status"
       data-testid="claude-code-device-auth-loading"
     >
-      <IconLoader2 size={16} className="animate-spin" />
+      <Loader2 size={16} className="animate-spin" />
       <span>
         {t(($) => {
           return $.settings.models.deviceAuth.claude.preparing;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/codex-device-auth-dialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { Button } from "@vm0/ui/components/ui/button";
 import { CopyButton } from "@vm0/ui/components/ui/copy-button";
-import { IconLoader2 } from "@tabler/icons-react";
+import { Loader2 } from "lucide-react";
 
 import {
   closeCodexDeviceAuthDialog$,
@@ -258,7 +258,7 @@ function CodexDeviceAuthLoadingContent() {
       role="status"
       data-testid="codex-device-auth-loading"
     >
-      <IconLoader2 size={16} className="animate-spin" />
+      <Loader2 size={16} className="animate-spin" />
       <span>
         {t(($) => {
           return $.settings.models.deviceAuth.codex.preparing;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -3,12 +3,7 @@ import type { ReactNode } from "react";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import {
-  IconAdjustmentsHorizontal,
-  IconLoader2,
-  IconSearch,
-  IconX,
-} from "@tabler/icons-react";
+import { SlidersHorizontal, Loader2, Search, X } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -96,9 +91,9 @@ function ConnectorAccessSearch({
   const { t } = useTranslation();
   return (
     <div className="relative">
-      <IconSearch
+      <Search
         size={15}
-        stroke={1.5}
+        strokeWidth={1.5}
         className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
       />
       <input
@@ -125,7 +120,7 @@ function ConnectorAccessSearch({
             return $.connectors.access.clearSearch;
           })}
         >
-          <IconX size={13} stroke={1.8} />
+          <X size={13} strokeWidth={1.8} />
         </button>
       )}
     </div>
@@ -181,7 +176,7 @@ function AgentAccessRow({
                 )}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
               >
-                <IconAdjustmentsHorizontal size={16} stroke={1.5} />
+                <SlidersHorizontal size={16} strokeWidth={1.5} />
               </button>
             </TooltipTrigger>
             <TooltipContent>
@@ -280,7 +275,7 @@ function LoadingAgents() {
   const { t } = useTranslation();
   return (
     <div className="flex min-h-[240px] flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
-      <IconLoader2 size={16} className="animate-spin" />
+      <Loader2 size={16} className="animate-spin" />
       {t(($) => {
         return $.connectors.access.loading;
       })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  IconAdjustmentsHorizontal,
-  IconCircleCheck,
-  IconDotsVertical,
-  IconLoader2,
-  IconPlus,
-} from "@tabler/icons-react";
+  SlidersHorizontal,
+  CircleCheck,
+  EllipsisVertical,
+  Loader2,
+  Plus,
+} from "lucide-react";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PlatformConnectorCatalogStatusItem } from "../../../../signals/connector-domain.ts";
 import {
@@ -157,9 +157,9 @@ function CatalogConnectorCard({
           aria-hidden="true"
         >
           {busy ? (
-            <IconLoader2 size={16} stroke={1.5} className="animate-spin" />
+            <Loader2 size={16} strokeWidth={1.5} className="animate-spin" />
           ) : (
-            <IconPlus size={14} stroke={1.5} />
+            <Plus size={14} strokeWidth={1.5} />
           )}
         </span>
       </div>
@@ -191,7 +191,7 @@ function ConnectorConnectionStatus({
   if (busy) {
     return (
       <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
+        <Loader2 size={12} strokeWidth={1.5} className="animate-spin" />
         {t(($) => {
           return $.connectors.card.connecting;
         })}
@@ -303,7 +303,7 @@ function ConnectionConnectorCard({
                   })}
                   disabled={busy}
                 >
-                  <IconDotsVertical size={14} stroke={1.5} />
+                  <EllipsisVertical size={14} strokeWidth={1.5} />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-44">
@@ -406,7 +406,7 @@ function OnboardingConnectorCard({
       </div>
       {connected ? (
         <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-primary">
-          <IconCircleCheck size={16} aria-hidden="true" />
+          <CircleCheck size={16} aria-hidden="true" />
           {t(($) => {
             return $.connectors.card.connected;
           })}
@@ -425,7 +425,7 @@ function OnboardingConnectorCard({
           }}
         >
           {busy ? (
-            <IconLoader2 className="animate-spin" aria-hidden="true" />
+            <Loader2 className="animate-spin" aria-hidden="true" />
           ) : null}
           {t(($) => {
             return $.connectors.actions.connect;
@@ -494,7 +494,7 @@ function ActionConnectorCard({
         onClick={onActivate}
         className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-state-hover disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
       >
-        {busy ? <IconLoader2 size={15} className="animate-spin" /> : null}
+        {busy ? <Loader2 size={15} className="animate-spin" /> : null}
         {actionLabel}
       </button>
     </div>
@@ -560,7 +560,7 @@ function PermissionConnectorCard({
                       { connector: connector.label },
                     )}
                   >
-                    <IconAdjustmentsHorizontal size={15} stroke={1.5} />
+                    <SlidersHorizontal size={15} strokeWidth={1.5} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -3,7 +3,7 @@ import type {
   ConnectorCatalogDiagnostics,
   ConnectorCatalogSyncFailureCode,
 } from "@vm0/api-contracts/contracts/connector-catalog-diagnostics";
-import { IconDatabase } from "@tabler/icons-react";
+import { Database } from "lucide-react";
 import { useLoadable } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -504,9 +504,9 @@ export function ConnectorCatalogDiagnosticsBlock() {
     >
       <div className="shrink-0">
         <div className="flex h-7 w-7 items-center justify-center">
-          <IconDatabase
+          <Database
             size={22}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="text-muted-foreground"
           />
         </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -1,4 +1,4 @@
-import { IconPlug } from "@tabler/icons-react";
+import { Plug } from "lucide-react";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { cn } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
@@ -20,7 +20,7 @@ function ConnectorIconFallback({
       })}
       className="inline-flex h-full w-full items-center justify-center text-muted-foreground"
     >
-      <IconPlug size={size * 0.65} stroke={1.5} aria-hidden="true" />
+      <Plug size={size * 0.65} strokeWidth={1.5} aria-hidden="true" />
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -1,6 +1,6 @@
 import type { FormEvent } from "react";
 
-import { IconChevronRight, IconPlus, IconTrash } from "@tabler/icons-react";
+import { ChevronRight, Plus, Trash } from "lucide-react";
 import type {
   CreateCustomConnectorBody,
   CustomConnectorResponse,
@@ -188,7 +188,7 @@ function ApiAuthenticationFields({
             })}
             onClick={onRemove}
           >
-            <IconTrash size={16} />
+            <Trash size={16} />
           </Button>
         )}
       </div>
@@ -365,7 +365,7 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
   return (
     <details className="group rounded-lg border border-border">
       <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-sm font-medium text-foreground">
-        <IconChevronRight
+        <ChevronRight
           size={16}
           className="shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
         />
@@ -535,7 +535,7 @@ function OAuth2AuthenticationFields({
           })}
           onClick={onRemove}
         >
-          <IconTrash size={16} />
+          <Trash size={16} />
         </Button>
       </div>
       <OAuth2EndpointFields form={form} setField={setField} />
@@ -961,7 +961,7 @@ function AuthenticationFields({
             className="self-start"
             disabled={availableAuthMethods.length === 0}
           >
-            <IconPlus size={16} />
+            <Plus size={16} />
             {t(($) => {
               return $.connectors.custom.create.addAuthentication;
             })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -4,7 +4,7 @@ import {
   useLastResolved,
   useSet,
 } from "ccstate-react";
-import { IconDotsVertical } from "@tabler/icons-react";
+import { EllipsisVertical } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { formatLocalizedNumber } from "../../../../i18n/format.ts";
@@ -299,7 +299,7 @@ function CustomConnectorRow({
                   return $.connectors.custom.moreOptions;
                 })}
               >
-                <IconDotsVertical size={14} stroke={1.5} />
+                <EllipsisVertical size={14} strokeWidth={1.5} />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-44">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -1,6 +1,6 @@
 import { useGet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { IconWorld } from "@tabler/icons-react";
+import { Globe } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   Select,
@@ -144,9 +144,9 @@ export function LanguageSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <IconWorld
+              <Globe
                 size={22}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="text-muted-foreground"
               />
             </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/morning-brief-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/morning-brief-settings.tsx
@@ -6,7 +6,7 @@ import { Button } from "@vm0/ui/components/ui/button";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { Switch } from "@vm0/ui/components/ui/switch";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import { IconSunrise } from "@tabler/icons-react";
+import { Sunrise } from "lucide-react";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   userPreferences$,
@@ -88,9 +88,9 @@ export function MorningBriefSettings() {
       <div className="flex flex-1 items-center gap-4 min-w-0">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
-            <IconSunrise
+            <Sunrise
               size={22}
-              stroke={1.5}
+              strokeWidth={1.5}
               className="text-muted-foreground"
             />
           </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
@@ -1,4 +1,4 @@
-import { IconBan, IconCheck, IconCircleHalf2 } from "@tabler/icons-react";
+import { Ban, Check, Contrast } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 type PermissionPolicyToggleValue = "allow" | "deny";
@@ -11,7 +11,7 @@ export function PermissionPolicyMixedBadge() {
   const { t } = useTranslation();
   return (
     <span className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md bg-muted/60 px-2 text-[11px] font-medium text-muted-foreground">
-      <IconCircleHalf2 size={12} className="shrink-0" />
+      <Contrast size={12} className="shrink-0" />
       <span>
         {t(($) => {
           return $.connectors.permissions.actions.mixed;
@@ -66,7 +66,7 @@ export function PermissionPolicyToggle({
           tone: "allow",
         })}
       >
-        <IconCheck size={12} stroke={2.5} />
+        <Check size={12} strokeWidth={2.5} />
         {t(($) => {
           return $.connectors.permissions.actions.allow;
         })}
@@ -83,7 +83,7 @@ export function PermissionPolicyToggle({
           tone: "deny",
         })}
       >
-        <IconBan size={12} stroke={2.5} />
+        <Ban size={12} strokeWidth={2.5} />
         {t(($) => {
           return $.connectors.permissions.actions.deny;
         })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -838,7 +838,7 @@ function PermissionGroupHeader({
           size={14}
           strokeWidth={2}
           className={`transition-transform ${expanded ? "rotate-90" : ""}`}
-          data-explicit-stroke-width
+          data-stroke
         />
         {category} ({permissions.length})
       </button>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -79,15 +79,15 @@ import {
 } from "../../../../signals/zero-page/settings/permissions-dialog.ts";
 import type { PermissionPolicy } from "../../../../signals/zero-page/settings/permissions.ts";
 import {
-  IconCheck,
-  IconBan,
-  IconChevronRight,
-  IconClock,
-  IconChevronDown,
-  IconLoader2,
-  IconSearch,
-  IconX,
-} from "@tabler/icons-react";
+  Check,
+  Ban,
+  ChevronRight,
+  Clock,
+  ChevronDown,
+  Loader2,
+  Search,
+  X,
+} from "lucide-react";
 import {
   PermissionPolicyMixedBadge,
   PermissionPolicyToggle,
@@ -335,8 +335,8 @@ function PolicyPill({
                   : "text-muted-foreground hover:text-foreground hover:bg-state-hover"
             } ${disabled ? "cursor-default" : "cursor-pointer"}`}
           >
-            {option === "allow" && <IconCheck size={12} stroke={2.5} />}
-            {option === "deny" && <IconBan size={12} stroke={2.5} />}
+            {option === "allow" && <Check size={12} strokeWidth={2.5} />}
+            {option === "deny" && <Ban size={12} strokeWidth={2.5} />}
             {option === "allow"
               ? t(($) => {
                   return $.connectors.permissions.actions.allow;
@@ -552,7 +552,7 @@ function allowDurationMenuLabel(option: UserPermissionGrantExpiresIn): string {
 
 function MenuItemCheck({ active }: { active: boolean }) {
   return active ? (
-    <IconCheck size={14} stroke={2.5} />
+    <Check size={14} strokeWidth={2.5} />
   ) : (
     <span className="h-3.5 w-3.5 shrink-0" />
   );
@@ -617,9 +617,9 @@ function PermissionAllowDurationDropdown({
               : "cursor-pointer text-muted-foreground hover:bg-state-hover hover:text-foreground"
           }`}
         >
-          <IconClock size={12} className="shrink-0" />
+          <Clock size={12} className="shrink-0" />
           <span className="max-w-[90px] truncate">{label}</span>
-          <IconChevronDown size={12} stroke={2.5} className="shrink-0" />
+          <ChevronDown size={12} strokeWidth={2.5} className="shrink-0" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -657,7 +657,7 @@ function PermissionAllowDurationDropdown({
 function PermissionAllowDurationStatic({ label }: { label: string }) {
   return (
     <span className="inline-flex h-6 max-w-[150px] shrink-0 items-center gap-1.5 rounded-md border zero-border bg-muted/40 px-2 text-[11px] font-medium text-muted-foreground">
-      <IconClock size={12} className="shrink-0" />
+      <Clock size={12} className="shrink-0" />
       <span className="truncate">{label}</span>
     </span>
   );
@@ -834,10 +834,11 @@ function PermissionGroupHeader({
         onClick={onToggle}
         className="flex items-center gap-1.5 text-xs font-medium text-foreground hover:text-foreground/80 transition-colors"
       >
-        <IconChevronRight
+        <ChevronRight
           size={14}
-          stroke={2}
+          strokeWidth={2}
           className={`transition-transform ${expanded ? "rotate-90" : ""}`}
+          data-explicit-stroke-width
         />
         {category} ({permissions.length})
       </button>
@@ -1497,9 +1498,9 @@ function LoadedPermissionsDrawerContent({
           className={`flex flex-col gap-2 pb-3 -mx-6 px-6 transition-shadow ${scrolled ? "shadow-[0_4px_8px_-4px_rgba(0,0,0,0.08)]" : ""}`}
         >
           <div className="relative w-full">
-            <IconSearch
+            <Search
               size={15}
-              stroke={1.5}
+              strokeWidth={1.5}
               className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
             />
             <input
@@ -1526,7 +1527,7 @@ function LoadedPermissionsDrawerContent({
                   return $.connectors.permissions.clearSearch;
                 })}
               >
-                <IconX size={13} stroke={1.8} />
+                <X size={13} strokeWidth={1.8} />
               </button>
             )}
           </div>
@@ -1719,7 +1720,7 @@ function PermissionsContent({
           <div className="flex flex-1 items-center justify-center">
             {loading ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <IconLoader2 size={16} className="animate-spin" />
+                <Loader2 size={16} className="animate-spin" />
                 {t(($) => {
                   return $.connectors.permissions.loading;
                 })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
@@ -1,6 +1,6 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { IconExternalLink } from "@tabler/icons-react";
+import { ExternalLink } from "lucide-react";
 import { Button } from "@vm0/ui/components/ui/button";
 import {
   clerkInstance$,
@@ -49,7 +49,7 @@ export function AccountSection() {
       </div>
       <Button asChild className="shrink-0">
         <a href={userProfileUrl} target="_blank" rel="noreferrer">
-          <IconExternalLink size={14} />
+          <ExternalLink size={14} />
           {t(($) => {
             return $.settings.preferences.account.manage;
           })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
@@ -1,7 +1,7 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import { IconBug } from "@tabler/icons-react";
+import { Bug } from "lucide-react";
 import { Switch } from "@vm0/ui/components/ui/switch";
 
 import { pageSignal$ } from "../../../../../signals/page-signal.ts";
@@ -39,7 +39,11 @@ function CaptureNetworkBodiesBlock() {
       <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
-            <IconBug size={22} stroke={1.5} className="text-muted-foreground" />
+            <Bug
+              size={22}
+              strokeWidth={1.5}
+              className="text-muted-foreground"
+            />
           </div>
         </div>
         <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
@@ -1,14 +1,7 @@
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import {
-  IconSun,
-  IconMoon,
-  IconDeviceDesktop,
-  IconKeyboard,
-  IconLoader2,
-  IconPalette,
-} from "@tabler/icons-react";
+import { Sun, Moon, Monitor, Keyboard, Loader2, Palette } from "lucide-react";
 import { cn } from "@vm0/ui";
 import type { SendMode } from "@vm0/api-contracts/contracts/zero-user-preferences";
 
@@ -32,11 +25,11 @@ import { LanguageSettings } from "../language-settings.tsx";
 
 const THEME_OPTIONS: readonly {
   value: ThemePreference;
-  icon: typeof IconSun;
+  icon: typeof Sun;
 }[] = [
-  { value: "light", icon: IconSun },
-  { value: "dark", icon: IconMoon },
-  { value: "system", icon: IconDeviceDesktop },
+  { value: "light", icon: Sun },
+  { value: "dark", icon: Moon },
+  { value: "system", icon: Monitor },
 ];
 
 function AppearanceBlock() {
@@ -52,9 +45,9 @@ function AppearanceBlock() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <IconPalette
+              <Palette
                 size={22}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="text-muted-foreground"
               />
             </div>
@@ -102,7 +95,7 @@ function AppearanceBlock() {
                     : "zero-chip text-muted-foreground hover:text-foreground",
                 )}
               >
-                <Icon size={15} stroke={1.5} />
+                <Icon size={15} strokeWidth={1.5} />
                 {label}
               </button>
             );
@@ -137,9 +130,9 @@ function EnterBlock() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <IconKeyboard
+              <Keyboard
                 size={22}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="text-muted-foreground"
               />
             </div>
@@ -191,7 +184,7 @@ function EnterBlock() {
                 )}
               >
                 {saving === value && (
-                  <IconLoader2 size={14} className="animate-spin" />
+                  <Loader2 size={14} className="animate-spin" />
                 )}
                 {label}
               </button>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -15,15 +15,15 @@ import {
   cn,
 } from "@vm0/ui";
 import {
-  IconAdjustmentsHorizontal,
-  IconBug,
-  IconBuilding,
-  IconCoins,
-  IconCpu,
-  IconCreditCard,
-  IconFileInvoice,
-  IconUsers,
-} from "@tabler/icons-react";
+  SlidersHorizontal,
+  Bug,
+  Building,
+  Coins,
+  Cpu,
+  CreditCard,
+  ReceiptText,
+  Users,
+} from "lucide-react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
@@ -172,9 +172,9 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     {
       id: "preference",
       label: sectionMeta.preference.title,
-      icon: IconAdjustmentsHorizontal,
+      icon: SlidersHorizontal,
     },
-    { id: "debug", label: sectionMeta.debug.title, icon: IconBug },
+    { id: "debug", label: sectionMeta.debug.title, icon: Bug },
   ];
   const personalGroup: SidebarGroup = {
     label: t(($) => {
@@ -192,16 +192,16 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       {
         id: "general",
         label: sectionMeta.general.title,
-        icon: IconBuilding,
+        icon: Building,
       },
-      { id: "people", label: sectionMeta.people.title, icon: IconUsers },
+      { id: "people", label: sectionMeta.people.title, icon: Users },
     ],
   };
   const modelsGroup: SidebarGroup = {
     label: t(($) => {
       return $.settings.dialog.groups.models;
     }),
-    items: [{ id: "model", label: sectionMeta.model.title, icon: IconCpu }],
+    items: [{ id: "model", label: sectionMeta.model.title, icon: Cpu }],
   };
   const billingGroup: SidebarGroup = {
     label: t(($) => {
@@ -215,19 +215,19 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
           : t(($) => {
               return $.settings.dialog.sections.usage.usageTitle;
             }),
-        icon: IconCoins,
+        icon: Coins,
       },
       ...(isAdmin
         ? [
             {
               id: "billing" as const,
               label: sectionMeta.billing.title,
-              icon: IconCreditCard,
+              icon: CreditCard,
             },
             {
               id: "invoices" as const,
               label: sectionMeta.invoices.title,
-              icon: IconFileInvoice,
+              icon: ReceiptText,
             },
           ]
         : []),

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from "@vm0/ui/components/ui/select";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import { IconClock, IconLoader2 } from "@tabler/icons-react";
+import { Clock, Loader2 } from "lucide-react";
 import {
   userPreferences$,
   updateUserPreference$,
@@ -125,9 +125,9 @@ export function TimezoneSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <IconClock
+              <Clock
                 size={22}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="text-muted-foreground"
               />
             </div>
@@ -166,7 +166,7 @@ export function TimezoneSettings() {
           </Select>
           {loading && (
             <div className="absolute inset-0 flex items-center justify-end pr-8">
-              <IconLoader2
+              <Loader2
                 size={16}
                 className="animate-spin text-muted-foreground"
               />

--- a/turbo/apps/platform/src/views/zero-page/strapi-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/strapi-settings-page.tsx
@@ -2,14 +2,14 @@ import type { FormEvent } from "react";
 
 import type { StrapiIntegration } from "@vm0/api-contracts/contracts/zero-strapi-integrations";
 import {
-  IconArrowLeft,
-  IconCircleCheck,
-  IconCopy,
-  IconLoader2,
-  IconPlus,
-  IconTrash,
-  IconWebhook,
-} from "@tabler/icons-react";
+  ArrowLeft,
+  CircleCheck,
+  Copy,
+  Loader2,
+  Plus,
+  Trash,
+  Webhook,
+} from "lucide-react";
 import { Button } from "@vm0/ui";
 import {
   Dialog,
@@ -88,7 +88,7 @@ function CopyField({
             copyValue(value, label);
           }}
         >
-          <IconCopy size={14} />
+          <Copy size={14} />
           {t(($) => {
             return $.connectors.providerSettings.strapi.actions.copy;
           })}
@@ -115,7 +115,7 @@ function StrapiIntegrationHeader({
   return (
     <div className="flex items-start gap-4 p-4">
       <div className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#4945ff]/10 text-[#4945ff]">
-        <IconWebhook size={20} />
+        <Webhook size={20} />
       </div>
       <div className="min-w-0 flex-1">
         <div className="font-medium text-foreground">{integration.name}</div>
@@ -125,7 +125,7 @@ function StrapiIntegrationHeader({
       </div>
       {integration.lastTestedAt ? (
         <span className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-border px-2 py-1 text-xs font-medium">
-          <IconCircleCheck size={14} className="text-green-600" />
+          <CircleCheck size={14} className="text-green-600" />
           {t(($) => {
             return $.connectors.providerSettings.strapi.tested;
           })}
@@ -163,7 +163,7 @@ function StrapiAdminActions({
           );
         }}
       >
-        {checking ? <IconLoader2 size={14} className="animate-spin" /> : null}
+        {checking ? <Loader2 size={14} className="animate-spin" /> : null}
         {t(($) => {
           return $.connectors.providerSettings.strapi.actions.checkTest;
         })}
@@ -171,7 +171,7 @@ function StrapiAdminActions({
       <Dialog>
         <DialogTrigger asChild>
           <Button type="button" variant="ghost" size="sm">
-            <IconTrash size={14} />
+            <Trash size={14} />
             {t(($) => {
               return $.connectors.providerSettings.strapi.actions.remove;
             })}
@@ -273,9 +273,7 @@ function StrapiIntegrationCard({
               );
             }}
           >
-            {revealing ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : null}
+            {revealing ? <Loader2 size={14} className="animate-spin" /> : null}
             {t(($) => {
               return $.connectors.providerSettings.strapi.actions
                 .revealAuthorization;
@@ -384,9 +382,9 @@ function StrapiIntegrationForm() {
       </div>
       <Button type="submit" disabled={creating}>
         {creating ? (
-          <IconLoader2 size={16} className="animate-spin" />
+          <Loader2 size={16} className="animate-spin" />
         ) : (
-          <IconPlus size={16} />
+          <Plus size={16} />
         )}
         {t(($) => {
           return $.connectors.providerSettings.strapi.actions.create;
@@ -413,7 +411,7 @@ export function ZeroStrapiSettingsPage() {
             pathname={ROUTES.works}
             className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
-            <IconArrowLeft size={16} />
+            <ArrowLeft size={16} />
             {t(($) => {
               return $.connectors.providerSettings.strapi.whereZeroWorks;
             })}

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -3,14 +3,14 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
-  IconSun,
-  IconMoon,
-  IconDeviceDesktop,
-  IconPalette,
-  IconKeyboard,
-  IconLoader2,
-  IconBug,
-} from "@tabler/icons-react";
+  Sun,
+  Moon,
+  Monitor,
+  Palette,
+  Keyboard,
+  Loader2,
+  Bug,
+} from "lucide-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Switch } from "@vm0/ui/components/ui/switch";
 import { cn } from "@vm0/ui";
@@ -41,11 +41,11 @@ import { LanguageSettings } from "./components/settings/language-settings.tsx";
 function AppearanceSettings() {
   const { t } = useTranslation();
   const THEME_OPTIONS = [
-    { value: "light" as ThemePreference, icon: IconSun },
-    { value: "dark" as ThemePreference, icon: IconMoon },
+    { value: "light" as ThemePreference, icon: Sun },
+    { value: "dark" as ThemePreference, icon: Moon },
     {
       value: "system" as ThemePreference,
-      icon: IconDeviceDesktop,
+      icon: Monitor,
     },
   ] as const;
   const prefLoadable = useLoadable(themePreference$);
@@ -64,9 +64,9 @@ function AppearanceSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <IconPalette
+              <Palette
                 size={22}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="text-muted-foreground"
               />
             </div>
@@ -113,7 +113,7 @@ function AppearanceSettings() {
                     : "zero-chip text-muted-foreground hover:text-foreground",
                 )}
               >
-                <Icon size={15} stroke={1.5} />
+                <Icon size={15} strokeWidth={1.5} />
                 {label}
               </button>
             );
@@ -150,9 +150,9 @@ function SendModeSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <IconKeyboard
+              <Keyboard
                 size={22}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="text-muted-foreground"
               />
             </div>
@@ -204,7 +204,7 @@ function SendModeSettings() {
                 )}
               >
                 {saving === value && (
-                  <IconLoader2 size={14} className="animate-spin" />
+                  <Loader2 size={14} className="animate-spin" />
                 )}
                 {label}
               </button>
@@ -247,7 +247,11 @@ function CaptureNetworkBodiesSettings() {
       <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
-            <IconBug size={22} stroke={1.5} className="text-muted-foreground" />
+            <Bug
+              size={22}
+              strokeWidth={1.5}
+              className="text-muted-foreground"
+            />
           </div>
         </div>
         <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -18,7 +18,7 @@ import {
   Switch,
   cn,
 } from "@vm0/ui";
-import { IconAlertTriangle } from "@tabler/icons-react";
+import { AlertTriangle } from "lucide-react";
 import {
   Alert,
   AlertDescription,
@@ -501,7 +501,7 @@ export function ZeroSettingsTab({
             </DialogDescription>
           </DialogHeader>
           <Alert variant="destructive">
-            <IconAlertTriangle size={16} stroke={1.5} />
+            <AlertTriangle size={16} strokeWidth={1.5} />
             <AlertTitle>
               {t(($) => {
                 return $.profile.makePrivate.warningTitle;

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -6,18 +6,18 @@ import {
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
-  IconAlertTriangle,
-  IconArrowLeft,
-  IconArrowRight,
-  IconCircleCheck,
-  IconDotsVertical,
-  IconExternalLink,
-  IconKey,
-  IconLoader2,
-  IconPlus,
-  IconRefresh,
-  IconRobot,
-} from "@tabler/icons-react";
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  CircleCheck,
+  EllipsisVertical,
+  ExternalLink,
+  Key,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Bot,
+} from "lucide-react";
 import {
   type TelegramBot,
   type TelegramBotStatus,
@@ -240,7 +240,7 @@ function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
   if (bot.tokenStatus === "invalid") {
     return (
       <span className="inline-flex items-center gap-1.5 rounded-lg border border-destructive/20 bg-destructive/10 px-2 py-1 text-xs font-medium text-destructive">
-        <IconAlertTriangle className="h-3.5 w-3.5" />
+        <AlertTriangle className="h-3.5 w-3.5" />
         {t(($) => {
           return $.connectors.providerSettings.telegram.tokenInvalid;
         })}
@@ -263,7 +263,7 @@ function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
         });
     return (
       <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-secondary-foreground">
-        <IconCircleCheck className="h-3.5 w-3.5 text-green-600" />
+        <CircleCheck className="h-3.5 w-3.5 text-green-600" />
         <span
           className="min-w-0 truncate"
           title={connectedUserLabel ?? undefined}
@@ -276,7 +276,7 @@ function TelegramStatusBadge({ bot }: { bot: TelegramBot }) {
 
   return (
     <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground">
-      <IconAlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+      <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
       {t(($) => {
         return $.connectors.providerSettings.telegram.notConnected;
       })}
@@ -290,7 +290,7 @@ function TelegramBotIconFallback({ botId }: { botId: string }) {
       className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#2AABEE]/10 text-[#2AABEE]"
       data-testid={`telegram-bot-avatar-fallback-${botId}`}
     >
-      <IconRobot className="h-5 w-5" stroke={1.75} />
+      <Bot className="h-5 w-5" strokeWidth={1.75} />
     </div>
   );
 }
@@ -457,7 +457,7 @@ function TelegramSetupStatusLine({
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
       <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
-        <IconCircleCheck className="h-4 w-4 text-green-600" />
+        <CircleCheck className="h-4 w-4 text-green-600" />
         {t(($) => {
           return $.connectors.providerSettings.telegram.token.verified;
         })}
@@ -490,7 +490,7 @@ function AddTelegramBotTokenField({
         })}
       </label>
       <div className="relative">
-        <IconKey
+        <Key
           size={16}
           className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
         />
@@ -607,7 +607,7 @@ function AddTelegramTokenStep({
             className="inline-flex items-center gap-1 font-medium text-foreground underline-offset-4 hover:underline"
           >
             {BOT_FATHER_HANDLE}
-            <IconExternalLink className="h-3.5 w-3.5" />
+            <ExternalLink className="h-3.5 w-3.5" />
           </a>
           {t(($) => {
             return $.connectors.providerSettings.telegram.token.send;
@@ -669,7 +669,7 @@ function AddTelegramDomainStep({
       </div>
       {confirmed ? (
         <div className="flex items-center gap-2 rounded-lg border border-green-600/20 bg-green-600/10 px-3 py-2 text-sm text-green-700 dark:text-green-300">
-          <IconCircleCheck className="h-4 w-4" />
+          <CircleCheck className="h-4 w-4" />
           {t(($) => {
             return $.connectors.providerSettings.telegram.domain.detected;
           })}
@@ -713,7 +713,7 @@ function AddTelegramPrivacyStep({
       </div>
       {confirmed ? (
         <div className="flex items-center gap-2 rounded-lg border border-green-600/20 bg-green-600/10 px-3 py-2 text-sm text-green-700 dark:text-green-300">
-          <IconCircleCheck className="h-4 w-4" />
+          <CircleCheck className="h-4 w-4" />
           {t(($) => {
             return $.connectors.providerSettings.telegram.privacy.off;
           })}
@@ -989,7 +989,7 @@ function AddTelegramBotDialogFrame({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
         <Button type="button" size="sm" disabled={disabled}>
-          <IconPlus size={16} />
+          <Plus size={16} />
           {t(($) => {
             return $.connectors.providerSettings.telegram.addBot;
           })}
@@ -1292,7 +1292,7 @@ function AddTelegramBotDialogFooter({
           })
         ) : (
           <span className="inline-flex items-center gap-2">
-            <IconArrowLeft size={16} />
+            <ArrowLeft size={16} />
             {t(($) => {
               return $.connectors.providerSettings.telegram.steps.back;
             })}
@@ -1307,9 +1307,9 @@ function AddTelegramBotDialogFooter({
           onClick={onAddBot}
         >
           {adding ? (
-            <IconLoader2 size={16} className="animate-spin" />
+            <Loader2 size={16} className="animate-spin" />
           ) : (
-            <IconPlus size={16} />
+            <Plus size={16} />
           )}
           {adding
             ? t(($) => {
@@ -1328,7 +1328,7 @@ function AddTelegramBotDialogFooter({
         >
           {checkingTarget ? (
             <>
-              <IconLoader2 size={16} className="animate-spin" />
+              <Loader2 size={16} className="animate-spin" />
               {t(($) => {
                 return $.connectors.providerSettings.telegram.checking;
               })}
@@ -1338,7 +1338,7 @@ function AddTelegramBotDialogFooter({
               {t(($) => {
                 return $.connectors.providerSettings.telegram.steps.next;
               })}
-              <IconArrowRight size={16} />
+              <ArrowRight size={16} />
             </>
           )}
         </Button>
@@ -1497,9 +1497,9 @@ function TelegramReinstallAction({
       }}
     >
       {reinstalling ? (
-        <IconLoader2 size={15} className="animate-spin" />
+        <Loader2 size={15} className="animate-spin" />
       ) : (
-        <IconRefresh size={15} />
+        <RefreshCw size={15} />
       )}
       {reinstalling
         ? t(($) => {
@@ -1597,7 +1597,7 @@ function TelegramMoreActions({
             { bot: botLabel },
           )}
         >
-          <IconDotsVertical size={16} stroke={1.5} />
+          <EllipsisVertical size={16} strokeWidth={1.5} />
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="flex w-40 flex-col gap-0.5 p-2">
@@ -1889,7 +1889,7 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
               })}
             </label>
             <div className="relative">
-              <IconKey
+              <Key
                 size={16}
                 className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
               />
@@ -1925,9 +1925,9 @@ function TelegramReinstallDialog({ bot }: { bot: TelegramBot | null }) {
             </Button>
             <Button type="submit" disabled={!canSubmit} className="gap-2">
               {reinstalling ? (
-                <IconLoader2 size={16} className="animate-spin" />
+                <Loader2 size={16} className="animate-spin" />
               ) : (
-                <IconRefresh size={16} />
+                <RefreshCw size={16} />
               )}
               {reinstalling
                 ? t(($) => {
@@ -2188,7 +2188,7 @@ export function ZeroTelegramSettingsPage() {
                     .backToIntegrations;
                 })}
               >
-                <IconArrowLeft size={17} stroke={1.8} />
+                <ArrowLeft size={17} strokeWidth={1.8} />
                 {t(($) => {
                   return $.connectors.providerSettings.telegram
                     .backToIntegrations;


### PR DESCRIPTION
## Summary

- migrate Tabler icons in settings, preferences, and organization management views to Lucide
- use shared UI brand icons for GitHub, Slack, and Telegram
- preserve explicit icon stroke weights while renaming `stroke` props to `strokeWidth`

## Testing

- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`
- `pnpm exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx`
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-telegram-settings-page.test.tsx`

Stacked on #25858. Part of #25458.