### PR TITLE
fix: stop clipping the video template spec on sent messages

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -139,8 +139,11 @@ describe("user messages", () => {
       },
     });
 
+    // The hover title repeats the spec because narrow viewports hide the
+    // inline echo.
     const reference = await screen.findByTitle(
-      `Video \u00b7 ${templateItem.title}`,
+      `Video \u00b7 ${templateItem.title} \u00b7 ` +
+        "Seedance 2.0 fast \u00b7 9:16 \u00b7 8s \u00b7 720p \u00b7 Audio",
     );
     // Every parameter is echoed, not only the one the user changed.
     expect(reference).toHaveTextContent(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -125,6 +125,7 @@ import {
 } from "../../signals/external/feature-switch.ts";
 import {
   videoTemplateSpec,
+  videoTemplateSpecText,
   type VideoTemplateSpec,
 } from "../../signals/zero-page/video-template-spec.ts";
 import { isStandalonePwa } from "../../lib/keyboard-dismiss-gesture.ts";
@@ -7283,10 +7284,11 @@ const STRUCTURED_REFERENCE_CHIP_CLASS =
 // File chips carry their own border, so they need more breathing room from the
 // surrounding sentence than a borderless inline mention does.
 const INLINE_FILE_REFERENCE_SPACING_CLASS = "mx-1";
-const STRUCTURED_INLINE_REFERENCE_CLASS =
-  "relative -top-px mx-0.5 inline-flex h-7 max-w-[240px] items-center " +
+const STRUCTURED_INLINE_REFERENCE_BASE_CLASS =
+  "relative -top-px mx-0.5 inline-flex h-7 items-center " +
   "gap-1.5 rounded-md bg-orange-500/10 px-2 align-middle text-[13px] " +
   "font-medium text-orange-600 dark:bg-orange-400/15 dark:text-orange-300";
+const STRUCTURED_INLINE_REFERENCE_CLASS = `${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} max-w-[240px]`;
 const STRUCTURED_INLINE_LINK_REFERENCE_CLASS =
   `${STRUCTURED_INLINE_REFERENCE_CLASS} transition-colors ` +
   "hover:bg-orange-500/15 focus-visible:outline-none focus-visible:ring-2 " +
@@ -7294,22 +7296,15 @@ const STRUCTURED_INLINE_LINK_REFERENCE_CLASS =
   "dark:hover:bg-orange-400/20 dark:active:bg-orange-400/25";
 
 /**
- * Read-only echo of the parameters a sent video used. Like the composer chip,
- * it drops the model name and the trailing parameters on narrow viewports so
- * the template title keeps the room it needs.
+ * Read-only echo of the parameters a sent video used. Narrow viewports hide
+ * the spec entirely — the chip's hover title still carries it — so the
+ * template title keeps the room it needs; wide viewports show every
+ * parameter in full.
  */
 function SentVideoTemplateSpec({ spec }: { readonly spec: VideoTemplateSpec }) {
   return (
-    <span className="shrink-0 text-[12px] font-normal text-orange-600/70 dark:text-orange-300/70">
-      <span className="hidden sm:inline">{`${spec.model} · `}</span>
-      {spec.core.join(" · ")}
-      <span className="hidden sm:inline">
-        {spec.rest
-          .map((segment) => {
-            return ` · ${segment}`;
-          })
-          .join("")}
-      </span>
+    <span className="hidden shrink-0 text-[12px] font-normal text-orange-600/70 dark:text-orange-300/70 sm:inline">
+      {videoTemplateSpecText(spec)}
     </span>
   );
 }
@@ -7326,11 +7321,20 @@ function UserMessageTemplateReference({
   const typeLabel = generationTemplateTypeLabel(part.template);
   const videoOptionsEnabled = useGet(videoTemplateOptionsEnabled$);
   const spec = videoOptionsEnabled ? videoTemplateSpec(part.template) : null;
+  const label = `${typeLabel ?? part.template.type} · ${part.titleSnapshot}`;
   return (
     <span
       data-structured-template-reference=""
-      className={STRUCTURED_INLINE_REFERENCE_CLASS}
-      title={`${typeLabel ?? part.template.type} · ${part.titleSnapshot}`}
+      // The spec is as wide as the chip's old fixed cap on its own, so a
+      // spec-bearing chip trades the cap for the full message width.
+      className={
+        spec === null
+          ? STRUCTURED_INLINE_REFERENCE_CLASS
+          : `${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} max-w-full`
+      }
+      title={
+        spec === null ? label : `${label} · ${videoTemplateSpecText(spec)}`
+      }
     >
       <IconColorSwatch size={13} stroke={1.7} className="shrink-0" />
       <span className="min-w-0 truncate">{part.titleSnapshot}</span>


### PR DESCRIPTION
## Problem

A sent video template chip in chat history clipped its parameter echo. The chip reuses the structured-reference `max-w-[240px]` cap that predates the video spec, while the spec span is `shrink-0`. On `sm+` viewports the full spec ("Seedance 2.0 fast · 4:3 · 8s · 720p · Audio") alone exceeds the cap, so:

- the template title collapsed to zero width and disappeared, and
- the message bubble's `overflow-hidden` hard-clipped the spec mid-word with no ellipsis.

## Change

- **Wide viewports (`sm+`)** — a spec-bearing chip drops the 240px cap (`max-w-full`, matching the composer chip) and shows every parameter in full.
- **Narrow viewports** — the spec is hidden entirely instead of showing a truncated prefix, so the chip shows just the template title.
- **Hover** — the chip's `title` tooltip now appends the full spec text, so the parameters stay reachable when the inline echo is hidden.

Chips without a video spec (image/presentation templates, agent/thread references) keep the existing 240px cap.

## Testing

- `pnpm --filter @vm0/app run lint` ✅
- `pnpm --filter @vm0/app run check-types` ✅
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-user-messages.test.tsx` — 7/7 ✅ (title assertion updated to cover the tooltip spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)