### PR TITLE
refactor(platform): migrate Zero icons to Lucide

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -957,13 +957,13 @@ function createInlineTemplateNodeView(
   const openButton = document.createElement("button");
   openButton.type = "button";
   openButton.className = INLINE_TEMPLATE_NAME_ZONE_CLASS;
-  // Mirrors IconColorSwatch from @tabler/icons-react, which the composer
-  // template picker button and sent-message template chips also use.
+  // Mirrors Lucide's SwatchBook, which the composer template picker button and
+  // sent-message template chips also use.
   const icon = createComposerIcon(13, 1.7, [
-    "M19 3h-4a2 2 0 0 0 -2 2v12a4 4 0 0 0 8 0v-12a2 2 0 0 0 -2 -2",
-    "M13 7.35l-2 -2a2 2 0 0 0 -2.828 0l-2.828 2.828a2 2 0 0 0 0 2.828l9 9",
-    "M7.3 13h-2.3a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h12",
-    "M17 17l0 .01",
+    "M11 17a4 4 0 0 1-8 0V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2Z",
+    "M16.7 13H19a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H7",
+    "M 7 17h.01",
+    "m11 8 2.3-2.3a2.4 2.4 0 0 1 3.404.004L18.6 7.6a2.4 2.4 0 0 1 .026 3.434L9.9 19.8",
   ]);
   icon.setAttribute("class", "shrink-0");
   const title = document.createElement("span");

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
-import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
+import { ArrowUpRight, Pin, UserPlus } from "lucide-react";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import {
@@ -264,7 +264,7 @@ function InviteButton() {
       tabIndex={isAdmin ? undefined : -1}
       data-testid="invite-button"
     >
-      <IconUserPlus size={14} stroke={1.5} />
+      <UserPlus size={14} strokeWidth={1.5} />
       {t(($) => {
         return $.chat.agentPage.invitePeople;
       })}
@@ -304,7 +304,7 @@ function PinPill() {
               return $.sidebar.pin;
             })}
           >
-            <IconPin size={12} stroke={2} />
+            <Pin size={12} strokeWidth={2} data-explicit-stroke-width />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -399,10 +399,11 @@ function SuggestedPromptButton({
         onSelectPrompt(item.prompt);
       }}
     >
-      <IconArrowUpRight
+      <ArrowUpRight
         size={14}
-        stroke={2}
+        strokeWidth={2}
         className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
+        data-explicit-stroke-width
       />
       <p className="text-sm font-semibold text-foreground pr-5">{item.title}</p>
       <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
@@ -446,10 +447,11 @@ function IdeasUseCasesButton() {
       className="zero-card cursor-pointer p-4 text-left flex flex-col relative group hover:bg-state-hover transition-colors"
       onClick={handleClick}
     >
-      <IconArrowUpRight
+      <ArrowUpRight
         size={14}
-        stroke={2}
+        strokeWidth={2}
         className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
+        data-explicit-stroke-width
       />
       <p className="text-sm font-semibold text-foreground pr-5">
         {t(($) => {
@@ -467,7 +469,7 @@ function IdeasUseCasesButton() {
             return $.ideation.entry.viewAll;
           })}
         </span>
-        <IconArrowUpRight size={14} stroke={2} />
+        <ArrowUpRight size={14} strokeWidth={2} data-explicit-stroke-width />
       </div>
     </button>
   );

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -304,7 +304,7 @@ function PinPill() {
               return $.sidebar.pin;
             })}
           >
-            <Pin size={12} strokeWidth={2} data-explicit-stroke-width />
+            <Pin size={12} strokeWidth={2} data-stroke />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -403,7 +403,7 @@ function SuggestedPromptButton({
         size={14}
         strokeWidth={2}
         className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-        data-explicit-stroke-width
+        data-stroke
       />
       <p className="text-sm font-semibold text-foreground pr-5">{item.title}</p>
       <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
@@ -451,7 +451,7 @@ function IdeasUseCasesButton() {
         size={14}
         strokeWidth={2}
         className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-        data-explicit-stroke-width
+        data-stroke
       />
       <p className="text-sm font-semibold text-foreground pr-5">
         {t(($) => {
@@ -469,7 +469,7 @@ function IdeasUseCasesButton() {
             return $.ideation.entry.viewAll;
           })}
         </span>
-        <ArrowUpRight size={14} strokeWidth={2} data-explicit-stroke-width />
+        <ArrowUpRight size={14} strokeWidth={2} data-stroke />
       </div>
     </button>
   );

--- a/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
@@ -6,12 +6,7 @@ import {
   useSet,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import {
-  IconCircleCheck,
-  IconCopy,
-  IconDotsVertical,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { CircleCheck, Copy, EllipsisVertical, Loader2 } from "lucide-react";
 import { Button } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
@@ -110,7 +105,7 @@ function PhoneNumberCopyButton({
       }}
     >
       {formatted}
-      <IconCopy size={13} className="shrink-0 text-muted-foreground" />
+      <Copy size={13} className="shrink-0 text-muted-foreground" />
     </button>
   );
 }
@@ -134,9 +129,9 @@ function AgentPhoneVerificationStatus({
     >
       <span className="flex items-center gap-2">
         {connecting ? (
-          <IconLoader2 size={14} className="shrink-0 animate-spin" />
+          <Loader2 size={14} className="shrink-0 animate-spin" />
         ) : (
-          <IconCircleCheck size={14} className="shrink-0 text-green-600" />
+          <CircleCheck size={14} className="shrink-0 text-green-600" />
         )}
         <span>
           {t(
@@ -183,7 +178,7 @@ function AgentPhoneConnectActions({
         type="submit"
         disabled={!normalizedPhone || Boolean(phoneError) || busy}
       >
-        {busy ? <IconLoader2 size={14} className="animate-spin" /> : null}
+        {busy ? <Loader2 size={14} className="animate-spin" /> : null}
         {starting
           ? t(($) => {
               return $.connectors.providerSettings.agentphone.sending;
@@ -368,7 +363,7 @@ function AgentPhoneCardActions() {
                 data-testid="agentphone-connected-indicator"
                 className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
               >
-                <IconCircleCheck className="h-3 w-3 text-green-600" />
+                <CircleCheck className="h-3 w-3 text-green-600" />
                 <span className="min-w-0 truncate">
                   {connectedPhone ??
                     t(($) => {
@@ -414,7 +409,7 @@ function AgentPhoneCardActions() {
                 return $.connectors.providerSettings.agentphone.options;
               })}
             >
-              <IconDotsVertical size={16} stroke={1.5} />
+              <EllipsisVertical size={16} strokeWidth={1.5} />
             </button>
           </PopoverTrigger>
           <PopoverContent

--- a/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
@@ -13,12 +13,7 @@ import {
   TooltipTrigger,
   cn,
 } from "@vm0/ui";
-import {
-  IconWand,
-  IconChevronLeft,
-  IconChevronRight,
-  IconDice,
-} from "@tabler/icons-react";
+import { Wand, ChevronLeft, ChevronRight, Dices } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AvatarSvgConfig } from "./avatar-svg-utils.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
@@ -247,9 +242,9 @@ function AvatarPreviewWithShuffle() {
                 return $.avatar.randomize;
               })}
             >
-              <IconDice
+              <Dices
                 size={14}
-                stroke={1.5}
+                strokeWidth={1.5}
                 style={
                   shuffling
                     ? { animation: "avatar-dice-spin 0.6s ease-out" }
@@ -330,7 +325,7 @@ function StepNavigator() {
             return $.avatar.previousStep;
           })}
         >
-          <IconChevronLeft size={14} />
+          <ChevronLeft size={14} />
         </button>
         <p
           className="min-w-[3rem] text-center text-xs font-semibold text-foreground"
@@ -350,7 +345,7 @@ function StepNavigator() {
             return $.avatar.nextStep;
           })}
         >
-          <IconChevronRight size={14} />
+          <ChevronRight size={14} />
         </button>
       </div>
     </>
@@ -506,7 +501,7 @@ export function AvatarMaker({ onConfirm, trigger }: AvatarMakerProps) {
                   return $.avatar.create;
                 })}
               >
-                <IconWand size={16} stroke={1.5} />
+                <Wand size={16} strokeWidth={1.5} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
@@ -1,4 +1,4 @@
-import { IconBrowser } from "@tabler/icons-react";
+import { AppWindow } from "lucide-react";
 import { cn } from "@vm0/ui";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
@@ -52,7 +52,7 @@ function BrowserSessionStatus({ live }: { readonly live: boolean }) {
 function BrowserSessionPreviewPlaceholder() {
   return (
     <span className="absolute inset-0 flex items-center justify-center bg-muted/30 text-muted-foreground/60">
-      <IconBrowser size={30} stroke={1.5} />
+      <AppWindow size={30} strokeWidth={1.5} />
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react";
 import {
-  IconAspectRatio,
-  IconBrowser,
-  IconBrowserOff,
-  IconLoader2,
-  IconPlayerPlay,
-} from "@tabler/icons-react";
+  RectangleHorizontal,
+  AppWindow,
+  AppWindowMac,
+  Loader2,
+  Play,
+} from "lucide-react";
 import {
   ZERO_BROWSER_INITIAL_SCREEN_HEIGHT,
   ZERO_BROWSER_SCREEN_WIDTH,
@@ -82,7 +82,7 @@ export function BrowserSessionNotFound() {
   return (
     <PanelFrame>
       <PanelMessage
-        icon={<IconBrowserOff size={26} className="text-muted-foreground" />}
+        icon={<AppWindowMac size={26} className="text-muted-foreground" />}
         title={t(($) => {
           return $.browserSession.notFound;
         })}
@@ -96,7 +96,7 @@ export function BrowserSessionLoading() {
   return (
     <PanelFrame>
       <div role="status" className="flex flex-1 items-center justify-center">
-        <IconLoader2 className="animate-spin text-muted-foreground" size={20} />
+        <Loader2 className="animate-spin text-muted-foreground" size={20} />
         <span className="sr-only">
           {t(($) => {
             return $.browserSession.status.starting;
@@ -112,7 +112,7 @@ export function BrowserSessionUnavailable() {
   return (
     <PanelFrame>
       <PanelMessage
-        icon={<IconBrowserOff size={26} className="text-muted-foreground" />}
+        icon={<AppWindowMac size={26} className="text-muted-foreground" />}
         title={t(($) => {
           return $.browserSession.unavailable.title;
         })}
@@ -210,9 +210,9 @@ function ContainedLiveBrowserViewport({
           className="pointer-events-auto rounded-full border-border/70 bg-background/90 px-3 text-xs text-foreground backdrop-blur-sm hover:bg-state-hover"
         >
           {fittingWindow ? (
-            <IconLoader2 className="animate-spin" size={14} />
+            <Loader2 className="animate-spin" size={14} />
           ) : (
-            <IconAspectRatio size={14} />
+            <RectangleHorizontal size={14} />
           )}
           {t(($) => {
             return $.browserSession.fitAction;
@@ -238,7 +238,7 @@ function PausedBrowserSession({
   const showScreenshot = containLiveFrame && screenshotUrl;
   const pausedMessage = (
     <PanelMessage
-      icon={<IconBrowser size={26} className="text-muted-foreground" />}
+      icon={<AppWindow size={26} className="text-muted-foreground" />}
       title={t(($) => {
         return $.browserSession.panel.notLive;
       })}
@@ -254,9 +254,9 @@ function PausedBrowserSession({
           className="mt-1 inline-flex items-center gap-1.5 rounded-lg border border-border/70 bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-wait disabled:opacity-70"
         >
           {starting ? (
-            <IconLoader2 className="animate-spin" size={14} />
+            <Loader2 className="animate-spin" size={14} />
           ) : (
-            <IconPlayerPlay size={14} />
+            <Play size={14} />
           )}
           {starting
             ? t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/browser-session-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-sidebar.tsx
@@ -1,4 +1,4 @@
-import { IconArrowsDiagonal, IconX } from "@tabler/icons-react";
+import { Maximize2, X } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 
@@ -42,7 +42,7 @@ export function BrowserSessionSidebar({
           })}
           className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
         >
-          <IconArrowsDiagonal size={16} />
+          <Maximize2 size={16} />
         </a>
         <button
           type="button"
@@ -59,7 +59,7 @@ export function BrowserSessionSidebar({
           })}
           className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
         >
-          <IconX size={16} />
+          <X size={16} />
         </button>
       </div>
       <div className="min-h-0 flex-1">

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -55,7 +55,7 @@ function CollapsibleSection({
             size={14}
             strokeWidth={2}
             className="transition-transform group-open:rotate-90 text-muted-foreground shrink-0"
-            data-explicit-stroke-width
+            data-stroke
           />
           <span className="text-xs font-medium text-foreground">{title}</span>
           {badge && <InlineBadge color="muted">{badge}</InlineBadge>}

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight } from "@tabler/icons-react";
+import { ChevronRight } from "lucide-react";
 import { CopyButton } from "@vm0/ui";
 import type { NetworkLogEntry } from "@vm0/api-contracts/contracts/runs";
 import { useTranslation } from "react-i18next";
@@ -51,10 +51,11 @@ function CollapsibleSection({
     <details className="group">
       <summary className="cursor-pointer list-none w-full text-left">
         <div className="flex items-center gap-2">
-          <IconChevronRight
+          <ChevronRight
             size={14}
-            stroke={2}
+            strokeWidth={2}
             className="transition-transform group-open:rotate-90 text-muted-foreground shrink-0"
+            data-explicit-stroke-width
           />
           <span className="text-xs font-medium text-foreground">{title}</span>
           {badge && <InlineBadge color="muted">{badge}</InlineBadge>}

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/event-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/event-card.tsx
@@ -1,10 +1,4 @@
-import {
-  IconClock,
-  IconRepeat,
-  IconTool,
-  IconRobot,
-  IconTerminal,
-} from "@tabler/icons-react";
+import { Clock, Repeat, Wrench, Bot, Terminal } from "lucide-react";
 import { Markdown } from "../../../components/markdown.tsx";
 import { Popover, PopoverContent, PopoverTrigger } from "@vm0/ui";
 import {
@@ -44,7 +38,7 @@ function CategoryPopover({
   count,
   items,
 }: {
-  icon: typeof IconTool;
+  icon: typeof Wrench;
   label: string;
   count: number;
   items: string[];
@@ -153,7 +147,7 @@ export function SystemInitContent({ eventData }: { eventData: unknown }) {
     <div className="flex flex-wrap gap-2">
       {tools.length > 0 && (
         <CategoryPopover
-          icon={IconTool}
+          icon={Wrench}
           label={t(
             ($) => {
               return $.activity.events.tools;
@@ -166,7 +160,7 @@ export function SystemInitContent({ eventData }: { eventData: unknown }) {
       )}
       {agents.length > 0 && (
         <CategoryPopover
-          icon={IconRobot}
+          icon={Bot}
           label={t(
             ($) => {
               return $.activity.events.agents;
@@ -179,7 +173,7 @@ export function SystemInitContent({ eventData }: { eventData: unknown }) {
       )}
       {slashCommands.length > 0 && (
         <CategoryPopover
-          icon={IconTerminal}
+          icon={Terminal}
           label={t(
             ($) => {
               return $.activity.events.commands;
@@ -211,7 +205,7 @@ function ModelUsagePopover({ modelUsage }: { modelUsage: ModelUsage }) {
   return (
     <Popover>
       <PopoverTrigger className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
-        <IconTool className="h-3 w-3" />
+        <Wrench className="h-3 w-3" />
         <span>
           {t(
             ($) => {
@@ -283,13 +277,13 @@ export function ResultEventContent({ eventData }: { eventData: unknown }) {
       <div className="flex flex-wrap gap-2">
         {durationMs !== null && durationMs !== undefined && (
           <div className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-            <IconClock className="h-3 w-3" />
+            <Clock className="h-3 w-3" />
             <span>{formatDuration(durationMs)}</span>
           </div>
         )}
         {numTurns !== null && numTurns !== undefined && (
           <div className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-            <IconRepeat className="h-3 w-3" />
+            <Repeat className="h-3 w-3" />
             <span>
               {t(
                 ($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/event-group-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/event-group-card.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconCircleDashed, IconLoader } from "@tabler/icons-react";
+import { Check, CircleDashed, Loader } from "lucide-react";
 import { Markdown } from "../../../components/markdown.tsx";
 import {
   eventGroupKey,
@@ -266,7 +266,7 @@ function TaskEventGroupCard({
         )}
         <div className="flex gap-2 items-center relative">
           {isRunning ? (
-            <IconLoader className="h-3 w-3 text-yellow-600 animate-spin shrink-0" />
+            <Loader className="h-3 w-3 text-yellow-600 animate-spin shrink-0" />
           ) : (
             <StatusDot variant={isFailed ? "error" : "success"} />
           )}
@@ -304,7 +304,7 @@ function TaskEventGroupCard({
         <summary className="cursor-pointer list-none relative py-2">
           <div className="flex gap-2 items-center">
             {isRunning ? (
-              <IconLoader className="h-3 w-3 text-yellow-600 animate-spin shrink-0" />
+              <Loader className="h-3 w-3 text-yellow-600 animate-spin shrink-0" />
             ) : (
               <StatusDot variant={isFailed ? "error" : "success"} />
             )}
@@ -470,13 +470,13 @@ function ResultEventGroupCard({
 function getTodoStatusIcon(status: string) {
   switch (status) {
     case "completed": {
-      return <IconCheck className="h-4 w-4 text-green-600" />;
+      return <Check className="h-4 w-4 text-green-600" />;
     }
     case "in_progress": {
-      return <IconLoader className="h-4 w-4 text-yellow-500" />;
+      return <Loader className="h-4 w-4 text-yellow-500" />;
     }
     default: {
-      return <IconCircleDashed className="h-4 w-4 text-muted-foreground" />;
+      return <CircleDashed className="h-4 w-4 text-muted-foreground" />;
     }
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight, IconClock, IconLoader2 } from "@tabler/icons-react";
+import { ChevronRight, Clock, Loader2 } from "lucide-react";
 import { cn } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import {
@@ -103,9 +103,9 @@ function LogRow({
               className="inline-flex items-center gap-1"
               data-testid="duration-running"
             >
-              <IconLoader2
+              <Loader2
                 size={12}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="animate-spin"
                 aria-label={t(($) => {
                   return $.activity.statuses.running;
@@ -117,7 +117,7 @@ function LogRow({
             </span>
           ) : (
             <span className="inline-flex items-center gap-0.5">
-              <IconClock size={12} stroke={1.5} />
+              <Clock size={12} strokeWidth={1.5} />
               {formatDuration(entry.startedAt, entry.completedAt) ?? "\u2014"}
             </span>
           )}
@@ -127,7 +127,7 @@ function LogRow({
             className="rounded p-1 text-muted-foreground hover:bg-state-hover hover:text-foreground transition-colors inline-flex"
             aria-hidden="true"
           >
-            <IconChevronRight size={14} stroke={1.5} />
+            <ChevronRight size={14} strokeWidth={1.5} />
           </span>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/status-badge.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/status-badge.tsx
@@ -1,17 +1,17 @@
 import {
-  IconCircleCheck,
-  IconClock,
-  IconPlayerPlay,
-  IconCircleX,
-  IconClockExclamation,
-  IconBan,
-} from "@tabler/icons-react";
+  CircleCheck,
+  Clock,
+  Play,
+  CircleX,
+  ClockAlert,
+  Ban,
+} from "lucide-react";
 import type { LogStatus } from "../../../../signals/zero-page/log-types.ts";
 import { i18n } from "../../../../i18n/index.ts";
 
 interface StatusBadgeConfig {
   label: string;
-  icon: typeof IconCircleCheck;
+  icon: typeof CircleCheck;
   iconClassName: string;
 }
 
@@ -105,37 +105,37 @@ function getStatusConfig(): Record<LogStatus, StatusBadgeConfig> {
   return {
     queued: {
       label: getStatusLabel("queued"),
-      icon: IconClock,
+      icon: Clock,
       iconClassName: "text-gray-400",
     },
     pending: {
       label: getStatusLabel("pending"),
-      icon: IconClock,
+      icon: Clock,
       iconClassName: "text-yellow-600",
     },
     running: {
       label: getStatusLabel("running"),
-      icon: IconPlayerPlay,
+      icon: Play,
       iconClassName: "text-sky-600",
     },
     completed: {
       label: getStatusLabel("completed"),
-      icon: IconCircleCheck,
+      icon: CircleCheck,
       iconClassName: "text-green-600",
     },
     failed: {
       label: getStatusLabel("failed"),
-      icon: IconCircleX,
+      icon: CircleX,
       iconClassName: "text-red-600",
     },
     timeout: {
       label: getStatusLabel("timeout"),
-      icon: IconClockExclamation,
+      icon: ClockAlert,
       iconClassName: "text-orange-600",
     },
     cancelled: {
       label: getStatusLabel("cancelled"),
-      icon: IconBan,
+      icon: Ban,
       iconClassName: "text-gray-600",
     },
   };

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -1,9 +1,4 @@
-import {
-  IconCheck,
-  IconChevronDown,
-  IconFilter,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { Check, ChevronDown, Filter, Loader2 } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import {
   DropdownMenu,
@@ -285,13 +280,10 @@ function TypeFilter({
           className="flex h-8 min-w-[140px] items-center justify-between gap-1.5 rounded-md border border-border bg-input px-3 text-xs text-foreground outline-none transition-colors hover:bg-input-hover focus:border-primary focus:ring-[3px] focus:ring-primary/10"
         >
           <span className="flex items-center gap-1.5">
-            <IconFilter size={14} stroke={1.5} className="shrink-0" />
+            <Filter size={14} strokeWidth={1.5} className="shrink-0" />
             {typeFilterLabel(typeFilter)}
           </span>
-          <IconChevronDown
-            size={14}
-            className="shrink-0 text-muted-foreground"
-          />
+          <ChevronDown size={14} className="shrink-0 text-muted-foreground" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-40">
@@ -304,7 +296,7 @@ function TypeFilter({
           }}
         >
           <span className="flex h-4 w-4 items-center justify-center">
-            {typeFilter.mode === "all" && <IconCheck size={14} />}
+            {typeFilter.mode === "all" && <Check size={14} />}
           </span>
           {t(($) => {
             return $.activity.network.filter.allTypes;
@@ -323,7 +315,7 @@ function TypeFilter({
               }}
             >
               <span className="flex h-4 w-4 items-center justify-center">
-                {selected && <IconCheck size={14} />}
+                {selected && <Check size={14} />}
               </span>
               {type}
             </DropdownMenuItem>
@@ -1136,7 +1128,7 @@ export function NetworkContent({
       {hasMore && onLoadMore && (
         <div className="flex justify-center py-4">
           {loading ? (
-            <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           ) : (
             <button
               type="button"

--- a/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
@@ -18,7 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@vm0/ui";
-import { IconAlertTriangle, IconTrash } from "@tabler/icons-react";
+import { AlertTriangle, Trash } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { pageSignal$ } from "../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
@@ -50,9 +50,9 @@ function DeleteDangerHeader({ agentName }: { agentName: string }) {
     <>
       <DialogHeader className="space-y-0 text-left">
         <div className="flex items-center gap-2">
-          <IconAlertTriangle
+          <AlertTriangle
             size={20}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="shrink-0 text-destructive"
           />
           <DialogTitle>
@@ -360,7 +360,7 @@ export function AgentDeleteDialog({
                   size="sm"
                   className="h-9 gap-2 rounded-lg border-destructive/40 px-4 text-destructive hover:bg-destructive/10 hover:text-destructive"
                 >
-                  <IconTrash size={14} stroke={1.5} />
+                  <Trash size={14} strokeWidth={1.5} />
                   {t(($) => {
                     return $.actions.delete;
                   })}

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -2,16 +2,16 @@ import type { FormEvent } from "react";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
-  IconArrowLeft,
-  IconArrowRight,
-  IconChevronRight,
-  IconCircleCheck,
-  IconCopy,
-  IconDotsVertical,
-  IconLoader2,
-  IconPlus,
-  IconSettings,
-} from "@tabler/icons-react";
+  ArrowLeft,
+  ArrowRight,
+  ChevronRight,
+  CircleCheck,
+  Copy,
+  EllipsisVertical,
+  Loader2,
+  Plus,
+  Settings,
+} from "lucide-react";
 import { FEISHU_OAUTH_SCOPES } from "@vm0/api-contracts/contracts/zero-feishu-connect";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { Button } from "@vm0/ui";
@@ -145,7 +145,7 @@ function CopyButton({ value, label }: { value: string; label: string }) {
   };
   return (
     <Button type="button" variant="outline" size="sm" onClick={copy}>
-      <IconCopy size={14} />
+      <Copy size={14} />
       {t(($) => {
         return $.connectors.providerSettings.feishu.copy;
       })}
@@ -163,7 +163,7 @@ function SetupStatus({
   return (
     <span className="inline-flex items-center gap-1.5 text-xs font-medium text-secondary-foreground">
       {complete ? (
-        <IconCircleCheck className="h-4 w-4 text-green-600" />
+        <CircleCheck className="h-4 w-4 text-green-600" />
       ) : (
         <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />
       )}
@@ -1222,7 +1222,7 @@ function FeishuSetupWizardFooter({
           firstStepLabel
         ) : (
           <span className="inline-flex items-center gap-2">
-            <IconArrowLeft size={16} />
+            <ArrowLeft size={16} />
             {t(($) => {
               return $.connectors.providerSettings.feishu.steps.back;
             })}
@@ -1234,10 +1234,10 @@ function FeishuSetupWizardFooter({
         disabled={!canContinue}
         onClick={step === "tokens" && !readOnly ? undefined : onContinue}
       >
-        {saving ? <IconLoader2 size={16} className="animate-spin" /> : null}
+        {saving ? <Loader2 size={16} className="animate-spin" /> : null}
         {continueLabel}
         {(step !== "tokens" || readOnly) && step !== "publish" ? (
-          <IconArrowRight size={16} />
+          <ArrowRight size={16} />
         ) : null}
       </Button>
     </DialogFooter>
@@ -1385,7 +1385,7 @@ export function FeishuCard() {
           </div>
         </div>
         <span className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
-          <IconSettings size={14} stroke={1.5} />
+          <Settings size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.connectors.providerSettings.feishu.manage;
           })}
@@ -1400,7 +1400,7 @@ function FeishuStatusBadge({ bot }: { bot: FeishuBotInstallation }) {
   if (bot.isConnected) {
     return (
       <span className="inline-flex min-w-0 max-w-52 items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-secondary-foreground">
-        <IconCircleCheck className="h-3.5 w-3.5 text-green-600" />
+        <CircleCheck className="h-3.5 w-3.5 text-green-600" />
         <span className="min-w-0 truncate" title={bot.connectedUserName ?? ""}>
           {bot.connectedUserName
             ? t(
@@ -1512,7 +1512,7 @@ function FeishuBotMenu({
             { bot: title },
           )}
         >
-          <IconDotsVertical size={16} stroke={1.5} />
+          <EllipsisVertical size={16} strokeWidth={1.5} />
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="flex w-40 flex-col gap-0.5 p-2">
@@ -1747,7 +1747,7 @@ function FeishuBotsCard({
             disabled={agentsLoading}
             onClick={onAdd}
           >
-            <IconPlus size={16} />
+            <Plus size={16} />
             {t(($) => {
               return $.connectors.providerSettings.feishu.addBot;
             })}
@@ -1784,7 +1784,7 @@ function FeishuSetupFaq() {
       <div className="divide-y divide-border/50">
         <details className="group px-4 py-4 sm:px-5">
           <summary className="flex cursor-pointer list-none items-start gap-2 text-sm font-medium text-foreground">
-            <IconChevronRight
+            <ChevronRight
               size={17}
               aria-hidden="true"
               className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
@@ -1804,7 +1804,7 @@ function FeishuSetupFaq() {
         </details>
         <details className="group px-4 py-4 sm:px-5">
           <summary className="flex cursor-pointer list-none items-start gap-2 text-sm font-medium text-foreground">
-            <IconChevronRight
+            <ChevronRight
               size={17}
               aria-hidden="true"
               className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
@@ -2177,7 +2177,7 @@ export function ZeroFeishuSettingsPage() {
                   return $.connectors.catalog.title;
                 })}
               >
-                <IconArrowLeft size={17} stroke={1.8} />
+                <ArrowLeft size={17} strokeWidth={1.8} />
                 {t(($) => {
                   return $.connectors.providerSettings.feishu
                     .backToIntegrations;

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight, IconLoader2 } from "@tabler/icons-react";
+import { ChevronRight, Loader2 } from "lucide-react";
 import type {
   ZeroMailDraft,
   ZeroMailDraftStatus,
@@ -53,7 +53,7 @@ function MailDraftCardSkeleton() {
       )}
     >
       <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted/60">
-        <IconLoader2 className="animate-spin text-muted-foreground" size={16} />
+        <Loader2 className="animate-spin text-muted-foreground" size={16} />
       </span>
       <div className="min-w-0 flex-1 space-y-2">
         <div className="h-4 w-2/3 rounded bg-muted/70" />
@@ -134,7 +134,7 @@ function MailDraftCardContent({
               : statusLabel(draft.status)}
         </span>
         {!deleted ? (
-          <IconChevronRight size={16} className="text-muted-foreground" />
+          <ChevronRight size={16} className="text-muted-foreground" />
         ) : null}
       </span>
     </>

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -1,14 +1,14 @@
 import {
-  IconCircleCheck,
-  IconExternalLink,
-  IconLoader2,
-  IconPaperclip,
-  IconPencil,
-  IconPlayerPlay,
-  IconSend,
-  IconTrash,
-  IconX,
-} from "@tabler/icons-react";
+  CircleCheck,
+  ExternalLink,
+  Loader2,
+  Paperclip,
+  Pencil,
+  Play,
+  Send,
+  Trash,
+  X,
+} from "lucide-react";
 import type {
   ZeroMailAttachment,
   ZeroMailDraft,
@@ -56,7 +56,7 @@ function SidebarCloseButton({ close }: { readonly close: () => void }) {
       })}
       className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
     >
-      <IconX size={16} />
+      <X size={16} />
     </button>
   );
 }
@@ -153,7 +153,7 @@ function GmailReconnectButton({
       disabled={reconnectDisabled}
       onClick={reconnect}
     >
-      {reconnecting ? <IconLoader2 size={15} className="animate-spin" /> : null}
+      {reconnecting ? <Loader2 size={15} className="animate-spin" /> : null}
       {reconnecting
         ? t(($) => {
             return $.chat.mail.reconnecting;
@@ -194,9 +194,13 @@ function MailMessageHeader({
             }
           >
             {active ? (
-              <IconPencil size={11} stroke={2} />
+              <Pencil size={11} strokeWidth={2} data-explicit-stroke-width />
             ) : (
-              <IconCircleCheck size={11} stroke={2} />
+              <CircleCheck
+                size={11}
+                strokeWidth={2}
+                data-explicit-stroke-width
+              />
             )}
             {active
               ? t(($) => {
@@ -277,7 +281,7 @@ function AttachmentSummary({
 }) {
   return (
     <div className="inline-flex h-7 max-w-[240px] items-center gap-1.5 rounded-md border border-foreground/15 bg-background/80 px-1.5">
-      <IconPaperclip size={14} className="shrink-0 text-muted-foreground" />
+      <Paperclip size={14} className="shrink-0 text-muted-foreground" />
       <span className="min-w-0 truncate text-xs font-medium">
         {attachment.filename}
       </span>
@@ -409,7 +413,7 @@ function MailMediaAttachmentPreview({
             className="h-full w-full object-contain"
           />
           <span className="absolute inset-0 flex items-center justify-center bg-black/10 text-white transition-colors group-hover:bg-black/30">
-            <IconPlayerPlay size={16} stroke={1.8} />
+            <Play size={16} strokeWidth={1.8} />
           </span>
         </>
       )}
@@ -1101,9 +1105,9 @@ function MailDraftDetail({
             onClick={onDelete}
           >
             {deleteLoadable.state === "loading" ? (
-              <IconLoader2 size={15} className="animate-spin" />
+              <Loader2 size={15} className="animate-spin" />
             ) : (
-              <IconTrash size={15} />
+              <Trash size={15} />
             )}
             {t(($) => {
               return $.chat.actions.delete;
@@ -1115,7 +1119,7 @@ function MailDraftDetail({
         <div className="flex items-center gap-2">
           <Button asChild variant="outline" size="sm">
             <a href={openInGmail} target="_blank" rel="noreferrer">
-              <IconExternalLink size={15} />
+              <ExternalLink size={15} />
               {t(($) => {
                 return $.chat.mail.openInGmail;
               })}
@@ -1124,9 +1128,9 @@ function MailDraftDetail({
           {active ? (
             <Button type="button" size="sm" disabled={pending} onClick={onSend}>
               {sendLoadable.state === "loading" ? (
-                <IconLoader2 size={15} className="animate-spin" />
+                <Loader2 size={15} className="animate-spin" />
               ) : (
-                <IconSend size={15} />
+                <Send size={15} />
               )}
               {t(($) => {
                 return $.chat.actions.send;

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -194,13 +194,9 @@ function MailMessageHeader({
             }
           >
             {active ? (
-              <Pencil size={11} strokeWidth={2} data-explicit-stroke-width />
+              <Pencil size={11} strokeWidth={2} data-stroke />
             ) : (
-              <CircleCheck
-                size={11}
-                strokeWidth={2}
-                data-explicit-stroke-width
-              />
+              <CircleCheck size={11} strokeWidth={2} data-stroke />
             )}
             {active
               ? t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -6,12 +6,7 @@ import {
   useLastResolved,
 } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import {
-  IconMenu2,
-  IconPackage,
-  IconShare3,
-  IconUserPlus,
-} from "@tabler/icons-react";
+import { Menu, Package, Share2, UserPlus } from "lucide-react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { RouteKey } from "../../signals/route-paths.ts";
 import { Button, cn } from "@vm0/ui";
@@ -84,7 +79,7 @@ function InviteButtonLeaf() {
       }}
       className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-state-hover transition-colors shrink-0"
     >
-      <IconUserPlus size={14} stroke={1.5} />
+      <UserPlus size={14} strokeWidth={1.5} />
       {t(($) => {
         return $.appShell.sidebar.mobile.invite;
       })}
@@ -117,7 +112,7 @@ function MobileArtifactsButtonInner({ thread }: { thread: ChatPanelSignals }) {
       })}
       aria-pressed={open}
     >
-      <IconPackage size={16} stroke={1.5} />
+      <Package size={16} strokeWidth={1.5} />
     </button>
   );
 }
@@ -179,7 +174,7 @@ function MobileShareButtonInner({ thread }: { thread: ChatPanelSignals }) {
         return $.chat.sharing.start;
       })}
     >
-      <IconShare3 size={16} stroke={1.5} />
+      <Share2 size={16} strokeWidth={1.5} />
     </button>
   );
 }
@@ -272,7 +267,7 @@ function MobileTopBar() {
           return $.appShell.sidebar.mobile.openMenu;
         })}
       >
-        <IconMenu2 size={18} stroke={1.8} />
+        <Menu size={18} strokeWidth={1.8} />
       </button>
       {breadcrumb && (
         <div className="flex-1 min-w-0 flex items-center gap-2 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -8,15 +8,15 @@ import {
 } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import {
-  IconPlus,
-  IconCheck,
-  IconChevronRight,
-  IconTrash,
-  IconPencil,
-  IconDots,
-  IconPin,
-  IconPinnedOff,
-} from "@tabler/icons-react";
+  Plus,
+  Check,
+  ChevronRight,
+  Trash,
+  Pencil,
+  Ellipsis,
+  Pin,
+  PinOff,
+} from "lucide-react";
 import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";
 import {
   Tooltip,
@@ -136,7 +136,7 @@ function SessionStateIndicator({
       })}
       className="flex items-center justify-center text-sidebar-foreground/50"
     >
-      <IconPencil size={16} stroke={2} />
+      <Pencil size={16} strokeWidth={2} data-explicit-stroke-width />
     </span>
   );
 }
@@ -226,15 +226,25 @@ function ChatThreadMenu({
                 >
                   {usePinnedIndicatorTrigger ? (
                     <>
-                      <IconPin size={16} stroke={2} className="md:hidden" />
-                      <IconDots
+                      <Pin
                         size={16}
-                        stroke={2}
+                        strokeWidth={2}
+                        className="md:hidden"
+                        data-explicit-stroke-width
+                      />
+                      <Ellipsis
+                        size={16}
+                        strokeWidth={2}
                         className="hidden md:block"
+                        data-explicit-stroke-width
                       />
                     </>
                   ) : (
-                    <IconDots size={16} stroke={2} />
+                    <Ellipsis
+                      size={16}
+                      strokeWidth={2}
+                      data-explicit-stroke-width
+                    />
                   )}
                 </span>
               </TooltipTrigger>
@@ -252,14 +262,24 @@ function ChatThreadMenu({
           <DropdownMenuItem onSelect={handleTogglePin}>
             {isPinned ? (
               <>
-                <IconPinnedOff size={16} stroke={2} className="mr-2" />
+                <PinOff
+                  size={16}
+                  strokeWidth={2}
+                  className="mr-2"
+                  data-explicit-stroke-width
+                />
                 {t(($) => {
                   return $.chat.sidebar.unpin;
                 })}
               </>
             ) : (
               <>
-                <IconPin size={16} stroke={2} className="mr-2" />
+                <Pin
+                  size={16}
+                  strokeWidth={2}
+                  className="mr-2"
+                  data-explicit-stroke-width
+                />
                 {t(($) => {
                   return $.chat.sidebar.pin;
                 })}
@@ -267,7 +287,12 @@ function ChatThreadMenu({
             )}
           </DropdownMenuItem>
           <DropdownMenuModalItem onModalSelect={openRenameDialog}>
-            <IconPencil size={16} stroke={2} className="mr-2" />
+            <Pencil
+              size={16}
+              strokeWidth={2}
+              className="mr-2"
+              data-explicit-stroke-width
+            />
             {t(($) => {
               return $.chat.sidebar.rename;
             })}
@@ -278,7 +303,12 @@ function ChatThreadMenu({
             }}
             className="text-destructive focus:text-destructive"
           >
-            <IconTrash size={16} stroke={2} className="mr-2" />
+            <Trash
+              size={16}
+              strokeWidth={2}
+              className="mr-2"
+              data-explicit-stroke-width
+            />
             {t(($) => {
               return $.chat.sidebar.delete;
             })}
@@ -323,7 +353,7 @@ function ChatThreadSideDecorator({
                 })}
                 className="hidden items-center justify-center text-sidebar-foreground/70 group-hover:hidden peer-data-[state=open]:hidden md:flex"
               >
-                <IconPin size={16} stroke={2} />
+                <Pin size={16} strokeWidth={2} data-explicit-stroke-width />
               </span>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -658,7 +688,7 @@ function ChatThreadsListMenuTooltip() {
     <Tooltip>
       <TooltipTrigger asChild>
         <span>
-          <IconDots size={16} stroke={2} />
+          <Ellipsis size={16} strokeWidth={2} data-explicit-stroke-width />
         </span>
       </TooltipTrigger>
       <TooltipContent side="bottom">
@@ -712,10 +742,11 @@ function ChatThreadsTitle() {
       <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
         {titleLabel}
         <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-          <IconChevronRight
+          <ChevronRight
             size={12}
-            stroke={2}
+            strokeWidth={2}
             className={collapsed ? "" : "rotate-90"}
+            data-explicit-stroke-width
           />
         </span>
       </span>
@@ -749,7 +780,12 @@ function ChatThreadsTitle() {
                 }}
                 disabled={!currentChatAgentId || newChatDisabled}
               >
-                <IconPlus size={16} stroke={2} className="mr-2" />
+                <Plus
+                  size={16}
+                  strokeWidth={2}
+                  className="mr-2"
+                  data-explicit-stroke-width
+                />
                 {t(($) => {
                   return $.chat.newChat;
                 })}
@@ -760,10 +796,11 @@ function ChatThreadsTitle() {
                   toggleUnreadOnly(false);
                 }}
               >
-                <IconCheck
+                <Check
                   size={16}
-                  stroke={2}
+                  strokeWidth={2}
                   className={`mr-2 ${unreadOnly ? "invisible" : ""}`}
+                  data-explicit-stroke-width
                 />
                 {t(($) => {
                   return $.chat.sidebar.allChats;
@@ -774,10 +811,11 @@ function ChatThreadsTitle() {
                   toggleUnreadOnly(true);
                 }}
               >
-                <IconCheck
+                <Check
                   size={16}
-                  stroke={2}
+                  strokeWidth={2}
                   className={`mr-2 ${unreadOnly ? "" : "invisible"}`}
+                  data-explicit-stroke-width
                 />
                 {t(($) => {
                   return $.chat.sidebar.unreadOnly;

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -136,7 +136,7 @@ function SessionStateIndicator({
       })}
       className="flex items-center justify-center text-sidebar-foreground/50"
     >
-      <Pencil size={16} strokeWidth={2} data-explicit-stroke-width />
+      <Pencil size={16} strokeWidth={2} data-stroke />
     </span>
   );
 }
@@ -230,21 +230,17 @@ function ChatThreadMenu({
                         size={16}
                         strokeWidth={2}
                         className="md:hidden"
-                        data-explicit-stroke-width
+                        data-stroke
                       />
                       <Ellipsis
                         size={16}
                         strokeWidth={2}
                         className="hidden md:block"
-                        data-explicit-stroke-width
+                        data-stroke
                       />
                     </>
                   ) : (
-                    <Ellipsis
-                      size={16}
-                      strokeWidth={2}
-                      data-explicit-stroke-width
-                    />
+                    <Ellipsis size={16} strokeWidth={2} data-stroke />
                   )}
                 </span>
               </TooltipTrigger>
@@ -266,7 +262,7 @@ function ChatThreadMenu({
                   size={16}
                   strokeWidth={2}
                   className="mr-2"
-                  data-explicit-stroke-width
+                  data-stroke
                 />
                 {t(($) => {
                   return $.chat.sidebar.unpin;
@@ -274,12 +270,7 @@ function ChatThreadMenu({
               </>
             ) : (
               <>
-                <Pin
-                  size={16}
-                  strokeWidth={2}
-                  className="mr-2"
-                  data-explicit-stroke-width
-                />
+                <Pin size={16} strokeWidth={2} className="mr-2" data-stroke />
                 {t(($) => {
                   return $.chat.sidebar.pin;
                 })}
@@ -287,12 +278,7 @@ function ChatThreadMenu({
             )}
           </DropdownMenuItem>
           <DropdownMenuModalItem onModalSelect={openRenameDialog}>
-            <Pencil
-              size={16}
-              strokeWidth={2}
-              className="mr-2"
-              data-explicit-stroke-width
-            />
+            <Pencil size={16} strokeWidth={2} className="mr-2" data-stroke />
             {t(($) => {
               return $.chat.sidebar.rename;
             })}
@@ -303,12 +289,7 @@ function ChatThreadMenu({
             }}
             className="text-destructive focus:text-destructive"
           >
-            <Trash
-              size={16}
-              strokeWidth={2}
-              className="mr-2"
-              data-explicit-stroke-width
-            />
+            <Trash size={16} strokeWidth={2} className="mr-2" data-stroke />
             {t(($) => {
               return $.chat.sidebar.delete;
             })}
@@ -353,7 +334,7 @@ function ChatThreadSideDecorator({
                 })}
                 className="hidden items-center justify-center text-sidebar-foreground/70 group-hover:hidden peer-data-[state=open]:hidden md:flex"
               >
-                <Pin size={16} strokeWidth={2} data-explicit-stroke-width />
+                <Pin size={16} strokeWidth={2} data-stroke />
               </span>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -688,7 +669,7 @@ function ChatThreadsListMenuTooltip() {
     <Tooltip>
       <TooltipTrigger asChild>
         <span>
-          <Ellipsis size={16} strokeWidth={2} data-explicit-stroke-width />
+          <Ellipsis size={16} strokeWidth={2} data-stroke />
         </span>
       </TooltipTrigger>
       <TooltipContent side="bottom">
@@ -746,7 +727,7 @@ function ChatThreadsTitle() {
             size={12}
             strokeWidth={2}
             className={collapsed ? "" : "rotate-90"}
-            data-explicit-stroke-width
+            data-stroke
           />
         </span>
       </span>
@@ -780,12 +761,7 @@ function ChatThreadsTitle() {
                 }}
                 disabled={!currentChatAgentId || newChatDisabled}
               >
-                <Plus
-                  size={16}
-                  strokeWidth={2}
-                  className="mr-2"
-                  data-explicit-stroke-width
-                />
+                <Plus size={16} strokeWidth={2} className="mr-2" data-stroke />
                 {t(($) => {
                   return $.chat.newChat;
                 })}
@@ -800,7 +776,7 @@ function ChatThreadsTitle() {
                   size={16}
                   strokeWidth={2}
                   className={`mr-2 ${unreadOnly ? "invisible" : ""}`}
-                  data-explicit-stroke-width
+                  data-stroke
                 />
                 {t(($) => {
                   return $.chat.sidebar.allChats;
@@ -815,7 +791,7 @@ function ChatThreadsTitle() {
                   size={16}
                   strokeWidth={2}
                   className={`mr-2 ${unreadOnly ? "" : "invisible"}`}
-                  data-explicit-stroke-width
+                  data-stroke
                 />
                 {t(($) => {
                   return $.chat.sidebar.unreadOnly;

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -1,7 +1,7 @@
 // Slash-workflow domain helpers and the suggestion menu, shared by the chat
 // composer. Kept in its own module so the textarea composer and the TipTap
 // workflow composer can both reuse them without an import cycle.
-import { IconChevronRight, IconFileText } from "@tabler/icons-react";
+import { ChevronRight, FileText } from "lucide-react";
 import { cn, PopoverContent } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { ROUTES } from "../../signals/route-paths.ts";
@@ -155,9 +155,9 @@ export function SlashWorkflowMenu({
             className="flex h-8 w-full items-center justify-between rounded px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-state-hover"
           >
             <span className="flex min-w-0 items-center gap-2">
-              <IconFileText
+              <FileText
                 size={16}
-                stroke={1.8}
+                strokeWidth={1.8}
                 className="shrink-0 text-muted-foreground"
               />
               <span className="truncate">
@@ -166,9 +166,9 @@ export function SlashWorkflowMenu({
                 })}
               </span>
             </span>
-            <IconChevronRight
+            <ChevronRight
               size={16}
-              stroke={1.8}
+              strokeWidth={1.8}
               className="shrink-0 text-muted-foreground"
             />
           </Link>

--- a/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
@@ -1,12 +1,6 @@
 import type { UIEvent as ReactUIEvent } from "react";
 import { createPortal } from "react-dom";
-import {
-  IconArrowLeft,
-  IconExternalLink,
-  IconMaximize,
-  IconMinimize,
-  IconX,
-} from "@tabler/icons-react";
+import { ArrowLeft, ExternalLink, Maximize, Minimize, X } from "lucide-react";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { cn } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
@@ -90,7 +84,7 @@ function ThreadSidebarHeader({
           })}
           className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
         >
-          <IconArrowLeft size={16} />
+          <ArrowLeft size={16} />
         </button>
       ) : null}
       <span className="min-w-0 flex-1 truncate text-sm font-medium">
@@ -112,7 +106,7 @@ function ThreadSidebarHeader({
           data-testid="thread-sidebar-fullscreen-toggle"
           className="hidden xl:inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
         >
-          {fullscreen ? <IconMinimize size={16} /> : <IconMaximize size={16} />}
+          {fullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
         </button>
       ) : null}
       <button
@@ -130,7 +124,7 @@ function ThreadSidebarHeader({
         )}
         className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
       >
-        <IconX size={16} />
+        <X size={16} />
       </button>
     </div>
   );
@@ -344,7 +338,7 @@ function ThreadArtifactDetail({
             rel="noreferrer"
             className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary-hover"
           >
-            <IconExternalLink size={16} stroke={1.7} />
+            <ExternalLink size={16} strokeWidth={1.7} />
             {t(($) => {
               return $.artifacts.sidebar.openSharedConversation;
             })}

--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -10,17 +10,17 @@ import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { Markdown } from "@tiptap/markdown";
 import { common, createLowlight } from "lowlight";
 import {
-  IconBold,
-  IconItalic,
-  IconStrikethrough,
-  IconH1,
-  IconH2,
-  IconH3,
-  IconList,
-  IconListNumbers,
-  IconBlockquote,
-  IconCode,
-} from "@tabler/icons-react";
+  Bold,
+  Italic,
+  Strikethrough,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  Quote,
+  Code,
+} from "lucide-react";
 import { cn } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import "highlight.js/styles/github.css";
@@ -310,7 +310,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.bold}
           >
-            <IconBold size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Bold size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -320,7 +320,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.italic}
           >
-            <IconItalic size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Italic size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -330,7 +330,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.strikethrough}
           >
-            <IconStrikethrough size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Strikethrough size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -340,7 +340,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.inlineCode}
           >
-            <IconCode size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Code size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
 
           <ToolbarDivider />
@@ -353,7 +353,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.heading1}
           >
-            <IconH1 size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Heading1 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -363,7 +363,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.heading2}
           >
-            <IconH2 size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Heading2 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -373,7 +373,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.heading3}
           >
-            <IconH3 size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Heading3 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
 
           <ToolbarDivider />
@@ -386,7 +386,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.bulletList}
           >
-            <IconList size={ICON_SIZE} stroke={ICON_STROKE} />
+            <List size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -396,7 +396,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.orderedList}
           >
-            <IconListNumbers size={ICON_SIZE} stroke={ICON_STROKE} />
+            <ListOrdered size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -406,7 +406,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.blockquote}
           >
-            <IconBlockquote size={ICON_SIZE} stroke={ICON_STROKE} />
+            <Quote size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </ToolbarButton>
         </BubbleMenu>
       )}

--- a/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
@@ -11,21 +11,19 @@ import type {
   ZeroWorkflowAutomationSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
-  IconBrandGithub,
-  IconBrandStripe,
-  IconCalendarTime,
-  IconClock,
-  IconDatabasePlus,
-  IconFilePencil,
-  IconFilePlus,
-  IconLink,
-  IconMail,
-  IconMessageCircle,
-  IconRepeat,
-  IconTag,
-  IconVideo,
-} from "@tabler/icons-react";
-import { Button, Switch, cn } from "@vm0/ui";
+  CalendarClock,
+  Clock,
+  DatabasePlus,
+  FilePen,
+  FilePlus,
+  Link,
+  Mail,
+  MessageCircle,
+  Repeat,
+  Tag,
+  Video,
+} from "lucide-react";
+import { Button, Switch, cn, BrandGithub, BrandStripe } from "@vm0/ui";
 import {
   Dialog,
   DialogContent,
@@ -650,18 +648,18 @@ export function AutomationListIcon({
   const Icon = (() => {
     if (automation.kind === "schedule") {
       if (automation.schedule.type === "loop") {
-        return IconRepeat;
+        return Repeat;
       }
       if (automation.schedule.type === "once") {
-        return IconClock;
+        return Clock;
       }
-      return IconCalendarTime;
+      return CalendarClock;
     }
     if (automation.eventType === "webhook-received") {
-      return IconLink;
+      return Link;
     }
     if (automation.eventType === "stripe-invoice-paid") {
-      return IconBrandStripe;
+      return BrandStripe;
     }
     if (
       automation.eventType === "github-label-applied" ||
@@ -671,27 +669,27 @@ export function AutomationListIcon({
       automation.eventType === "github-workflow-job-completed" ||
       automation.eventType === "github-workflow-run-completed"
     ) {
-      return IconBrandGithub;
+      return BrandGithub;
     }
     if (automation.eventType === "google-meet-transcript-generated") {
-      return IconVideo;
+      return Video;
     }
     if (automation.eventType === "notion-child-page-created") {
-      return IconFilePlus;
+      return FilePlus;
     }
     if (automation.eventType === "notion-database-item-created") {
-      return IconDatabasePlus;
+      return DatabasePlus;
     }
     if (automation.eventType === "notion-page-content-updated") {
-      return IconFilePencil;
+      return FilePen;
     }
     if (automation.eventType === "gmail-label-applied") {
-      return IconTag;
+      return Tag;
     }
     if (automation.eventType === "chat-run-finished") {
-      return IconMessageCircle;
+      return MessageCircle;
     }
-    return IconMail;
+    return Mail;
   })();
   const tone =
     automation.kind === "schedule"
@@ -714,7 +712,7 @@ export function AutomationListIcon({
       )}
       aria-hidden="true"
     >
-      <Icon size={compact ? 16 : 28} stroke={1.6} />
+      <Icon size={compact ? 16 : 28} strokeWidth={1.6} />
     </span>
   );
 }
@@ -809,7 +807,7 @@ function WorkflowSelectionStep({
         onClick={onCreateWorkflow}
       >
         <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-muted-foreground">
-          <IconMessageCircle size={16} stroke={1.6} />
+          <MessageCircle size={16} strokeWidth={1.6} />
         </span>
         <span className="min-w-0">
           <span className="block text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -6,12 +6,7 @@ import {
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
-import {
-  IconSearch,
-  IconLoader2,
-  IconDownload,
-  IconChartLine,
-} from "@tabler/icons-react";
+import { Search, Loader2, Download, ChartLine } from "lucide-react";
 import {
   Button,
   Input,
@@ -224,7 +219,7 @@ function ActivityBreadcrumbLink() {
       pathname="/activities"
       className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-state-hover hover:text-foreground transition-colors no-underline text-inherit"
     >
-      <IconChartLine size={14} stroke={1.5} className="shrink-0" />
+      <ChartLine size={14} strokeWidth={1.5} className="shrink-0" />
       {t(($) => {
         return $.activity.detail.activity;
       })}
@@ -435,7 +430,7 @@ export function ActivityHeaderCard({
                         }
                       }}
                     >
-                      <IconDownload size={14} stroke={1.5} />
+                      <Download size={14} strokeWidth={1.5} />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="left">
@@ -554,7 +549,7 @@ function ActivityStepsContent({
         </div>
         <div className="flex items-center gap-2 sm:gap-3">
           <div className="relative flex-1 sm:flex-none sm:w-44">
-            <IconSearch className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
               placeholder={t(($) => {
                 return $.activity.detail.steps.search;
@@ -1107,9 +1102,9 @@ export function StepsList({
       )}
       {isLoading ? (
         <div className="flex justify-center py-8">
-          <IconLoader2
+          <Loader2
             size={20}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="animate-spin text-muted-foreground"
           />
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -2,11 +2,7 @@
 // oxlint-disable max-lines-per-function
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import {
-  IconUsers,
-  IconCircleDot,
-  IconPlugConnected,
-} from "@tabler/icons-react";
+import { Users, CircleDot, PlugZap } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -153,7 +149,7 @@ export function ZeroActivityPage() {
                   })}
                   className="zero-btn-morandi h-9 w-auto gap-1.5 rounded-lg px-3.5 text-sm font-medium"
                 >
-                  <IconUsers size={14} stroke={1.5} className="shrink-0" />
+                  <Users size={14} strokeWidth={1.5} className="shrink-0" />
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -178,7 +174,7 @@ export function ZeroActivityPage() {
                   })}
                   className="zero-btn-morandi h-9 w-auto gap-1.5 rounded-lg px-3.5 text-sm font-medium"
                 >
-                  <IconCircleDot size={14} stroke={1.5} className="shrink-0" />
+                  <CircleDot size={14} strokeWidth={1.5} className="shrink-0" />
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -203,11 +199,7 @@ export function ZeroActivityPage() {
                   })}
                   className="zero-btn-morandi h-9 w-auto gap-1.5 rounded-lg px-3.5 text-sm font-medium"
                 >
-                  <IconPlugConnected
-                    size={14}
-                    stroke={1.5}
-                    className="shrink-0"
-                  />
+                  <PlugZap size={14} strokeWidth={1.5} className="shrink-0" />
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
@@ -1,12 +1,7 @@
 import { useGet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { JSX, ReactNode } from "react";
-import {
-  IconAlertCircle,
-  IconArrowLeft,
-  IconCircleCheck,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { AlertCircle, ArrowLeft, CircleCheck, Loader2 } from "lucide-react";
 import { Button } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
@@ -33,7 +28,7 @@ function BackLink() {
       pathname="/works"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
-      <IconArrowLeft size={14} />
+      <ArrowLeft size={14} />
       {t(
         ($) => {
           return $.connectors.providerConnect.agentphone.back;
@@ -62,17 +57,15 @@ function MessageMark({
   state?: "idle" | "success" | "error" | "loading";
 }) {
   if (state === "success") {
-    return <IconCircleCheck size={40} className="text-emerald-500" />;
+    return <CircleCheck size={40} className="text-emerald-500" />;
   }
 
   if (state === "error") {
-    return <IconAlertCircle size={40} className="text-destructive" />;
+    return <AlertCircle size={40} className="text-destructive" />;
   }
 
   if (state === "loading") {
-    return (
-      <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
-    );
+    return <Loader2 size={40} className="animate-spin text-muted-foreground" />;
   }
 
   return (
@@ -223,9 +216,7 @@ export function ZeroAgentPhoneConnectPage(): JSX.Element {
             detach(connectAgentPhone(pageSignal), Reason.DomCallback);
           }}
         >
-          {connecting ? (
-            <IconLoader2 size={16} className="animate-spin" />
-          ) : null}
+          {connecting ? <Loader2 size={16} className="animate-spin" /> : null}
           {connecting
             ? t(($) => {
                 return $.connectors.actions.connecting;

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,10 +1,5 @@
 import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from "react";
-import {
-  IconBrandGoogleDrive,
-  IconDownload,
-  IconLoader2,
-  IconShare,
-} from "@tabler/icons-react";
+import { Download, Loader2, Share } from "lucide-react";
 import {
   cn,
   Popover,
@@ -15,6 +10,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  BrandGoogleDrive,
 } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { isConnectorAppOauthCallbackEnabled } from "@vm0/connectors/app-oauth-callback";
@@ -332,7 +328,7 @@ export function ArtifactShareButton({
         title={publicAttachmentUrl(url)}
         className={iconButtonClassName(className)}
       >
-        <IconShare size={iconSize} stroke={1.5} />
+        <Share size={iconSize} strokeWidth={1.5} />
       </a>
     </ArtifactActionTooltip>
   );
@@ -438,7 +434,7 @@ function GoogleDriveDisabledMenuItem({
       className={muted ? "text-muted-foreground" : ""}
       disabled
     >
-      <IconBrandGoogleDrive size={14} stroke={1.5} />
+      <BrandGoogleDrive size={14} strokeWidth={1.5} />
       {text}
     </ArtifactDownloadMenuItem>
   );
@@ -535,7 +531,7 @@ function GoogleDriveMenuItem({
   if (googleDriveReady) {
     return (
       <ArtifactDownloadMenuItem onClick={syncOrConnect}>
-        <IconBrandGoogleDrive size={14} stroke={1.5} />
+        <BrandGoogleDrive size={14} strokeWidth={1.5} />
         {t(($) => {
           return $.artifacts.googleDrive.upload;
         })}
@@ -554,7 +550,7 @@ function GoogleDriveMenuItem({
             }
             onClick={syncOrConnect}
           >
-            <IconBrandGoogleDrive size={14} stroke={1.5} />
+            <BrandGoogleDrive size={14} strokeWidth={1.5} />
             {t(($) => {
               return $.artifacts.googleDrive.connect;
             })}
@@ -612,9 +608,9 @@ function ArtifactDownloadTrigger({
       )}
     >
       {downloadPending ? (
-        <IconLoader2 size={iconSize} stroke={1.5} className="animate-spin" />
+        <Loader2 size={iconSize} strokeWidth={1.5} className="animate-spin" />
       ) : (
-        <IconDownload size={iconSize} stroke={1.5} />
+        <Download size={iconSize} strokeWidth={1.5} />
       )}
     </button>
   );
@@ -741,7 +737,7 @@ export function ArtifactDownloadMenu({
             });
           }}
         >
-          <IconDownload size={14} stroke={1.5} />
+          <Download size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.artifacts.actions.download;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1,16 +1,16 @@
 import type { ReactNode } from "react";
 import {
-  IconArrowLeft,
-  IconArrowsDiagonal,
-  IconArrowsDiagonalMinimize2,
-  IconChevronLeft,
-  IconChevronRight,
-  IconDots,
-  IconExternalLink,
-  IconLoader2,
-  IconZoomReset,
-  IconX,
-} from "@tabler/icons-react";
+  ArrowLeft,
+  Maximize2,
+  Minimize2,
+  ChevronLeft,
+  ChevronRight,
+  Ellipsis,
+  ExternalLink,
+  Loader2,
+  RotateCcw,
+  X,
+} from "lucide-react";
 import {
   useGet,
   useLastLoadable,
@@ -567,7 +567,7 @@ function ArtifactSidebarHeader({
             })}
             className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
           >
-            <IconArrowLeft size={16} />
+            <ArrowLeft size={16} />
           </button>
         </ArtifactActionTooltip>
       )}
@@ -705,7 +705,7 @@ function ArtifactOpenExternalAction({ url }: { url: string }) {
         data-testid="artifact-sidebar-open-external"
         className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
       >
-        <IconExternalLink size={16} />
+        <ExternalLink size={16} />
       </a>
     </ArtifactActionTooltip>
   );
@@ -735,11 +735,7 @@ function ArtifactFullscreenAction({
         data-testid="artifact-sidebar-fullscreen-toggle"
         className="hidden xl:inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
       >
-        {fullscreen ? (
-          <IconArrowsDiagonalMinimize2 size={16} />
-        ) : (
-          <IconArrowsDiagonal size={16} />
-        )}
+        {fullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
       </button>
     </ArtifactActionTooltip>
   );
@@ -762,7 +758,7 @@ function ArtifactMoreActions({ onClose }: { onClose: () => void }) {
             })}
             className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
           >
-            <IconDots size={16} />
+            <Ellipsis size={16} />
           </button>
         </DropdownMenuTrigger>
       </ArtifactActionTooltip>
@@ -794,7 +790,7 @@ function ArtifactCloseAction({ onClose }: { onClose: () => void }) {
         data-testid="artifact-sidebar-close"
         className="inline-flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground hover:bg-state-hover hover:text-foreground"
       >
-        <IconX size={16} />
+        <X size={16} />
       </button>
     </ArtifactActionTooltip>
   );
@@ -884,7 +880,7 @@ function ArtifactBody({
 function ArtifactSpinner() {
   return (
     <div className="flex h-full items-center justify-center text-muted-foreground">
-      <IconLoader2 size={20} className="animate-spin" />
+      <Loader2 size={20} className="animate-spin" />
     </div>
   );
 }
@@ -1213,7 +1209,7 @@ function ArtifactImageNavigationControls({
           data-testid="artifact-sidebar-previous-image"
           className="absolute left-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <IconChevronLeft size={22} stroke={1.8} />
+          <ChevronLeft size={22} strokeWidth={1.8} />
         </button>
       )}
       {navigation.onNext && (
@@ -1229,7 +1225,7 @@ function ArtifactImageNavigationControls({
           data-testid="artifact-sidebar-next-image"
           className="absolute right-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <IconChevronRight size={22} stroke={1.8} />
+          <ChevronRight size={22} strokeWidth={1.8} />
         </button>
       )}
     </>
@@ -1295,7 +1291,7 @@ function ArtifactImageZoomControls({
         })}
         data-testid="artifact-sidebar-image-reset-zoom"
       >
-        <IconZoomReset size={15} stroke={1.8} />
+        <RotateCcw size={15} strokeWidth={1.8} />
       </button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { IconCopy, IconMessageCircle } from "@tabler/icons-react";
+import { Copy, MessageCircle } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import {
@@ -71,7 +71,7 @@ function FeedbackToolbar({
           aria-keyshortcuts="c"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
         >
-          <IconCopy size={14} stroke={2} />
+          <Copy size={14} strokeWidth={2} data-explicit-stroke-width />
           {t(($) => {
             return $.chat.actions.copy;
           })}
@@ -84,7 +84,7 @@ function FeedbackToolbar({
           aria-keyshortcuts="f"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
         >
-          <IconMessageCircle size={14} stroke={2} />
+          <MessageCircle size={14} strokeWidth={2} data-explicit-stroke-width />
           {t(($) => {
             return $.chat.feedback.provide;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -71,7 +71,7 @@ function FeedbackToolbar({
           aria-keyshortcuts="c"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
         >
-          <Copy size={14} strokeWidth={2} data-explicit-stroke-width />
+          <Copy size={14} strokeWidth={2} data-stroke />
           {t(($) => {
             return $.chat.actions.copy;
           })}
@@ -84,7 +84,7 @@ function FeedbackToolbar({
           aria-keyshortcuts="f"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
         >
-          <MessageCircle size={14} strokeWidth={2} data-explicit-stroke-width />
+          <MessageCircle size={14} strokeWidth={2} data-stroke />
           {t(($) => {
             return $.chat.feedback.provide;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -24,36 +24,35 @@ import {
   setRunUsagePopoverOpenRunId$,
 } from "../../signals/chat-page/run-usage-popover.ts";
 import {
-  IconAlertCircle,
-  IconHandStop,
-  IconPhoto,
-  IconChartLine,
-  IconWorld,
-  IconPlayerPlay,
-  IconVideo,
-  IconCopy,
-  IconDeviceDesktop,
-  IconCheck,
-  IconColorSwatch,
-  IconArrowDown,
-  IconArrowUpRight,
-  IconChevronRight,
-  IconLink,
-  IconLoader2,
-  IconMessageCircle,
-  IconMoodPlus,
-  IconPackage,
-  IconRoute,
-  IconSearch,
-  IconSunrise,
-  IconTarget,
-  IconX,
-  IconClock,
-  IconCoins,
-  IconHourglass,
-  IconBrandSlack,
-  IconShare3,
-} from "@tabler/icons-react";
+  AlertCircle,
+  Hand,
+  Image,
+  ChartLine,
+  Globe,
+  Play,
+  Video,
+  Copy,
+  Monitor,
+  Check,
+  SwatchBook,
+  ArrowDown,
+  ArrowUpRight,
+  ChevronRight,
+  Link as LinkIcon,
+  Loader2,
+  MessageCircle,
+  SmilePlus,
+  Package,
+  Route,
+  Search,
+  Sunrise,
+  Target,
+  X,
+  Clock,
+  Coins,
+  Hourglass,
+  Share2,
+} from "lucide-react";
 import {
   cn,
   getShortcutLabel,
@@ -80,6 +79,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  BrandSlack,
 } from "@vm0/ui";
 import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
 import type {
@@ -477,7 +477,7 @@ function ArtifactsButtonInner({ thread }: { thread: ChatPanelSignals }) {
             })}
             aria-pressed={open}
           >
-            <IconPackage size={17} stroke={1.5} />
+            <Package size={17} strokeWidth={1.5} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -541,7 +541,7 @@ export function AutomationMenuButton({
               openAutomationSidebar(thread);
             }}
           >
-            <IconClock size={18} />
+            <Clock size={18} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -580,7 +580,7 @@ function BrowserMenuButton({ thread }: { thread: ChatPanelSignals }) {
               openBrowserSidebar(thread.threadId);
             }}
           >
-            <IconWorld size={18} stroke={1.5} />
+            <Globe size={18} strokeWidth={1.5} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -686,7 +686,7 @@ function ChatThreadHeader({ thread }: { thread: ChatPanelSignals }) {
                     return $.chat.sharing.start;
                   })}
                 >
-                  <IconShare3 size={18} stroke={1.5} />
+                  <Share2 size={18} strokeWidth={1.5} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom">
@@ -821,7 +821,7 @@ function ChatThreadEmojiMenuButton({
                     {emoji}
                   </span>
                 ) : (
-                  <IconMoodPlus size={18} stroke={1.75} aria-hidden="true" />
+                  <SmilePlus size={18} strokeWidth={1.75} aria-hidden="true" />
                 )}
               </button>
             </PopoverTrigger>
@@ -909,7 +909,7 @@ function ChatThreadEmojiPicker({
     <div className="flex flex-col">
       <div className="flex items-center gap-2 p-2">
         <div className="relative flex-1">
-          <IconSearch
+          <Search
             size={15}
             className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
             aria-hidden="true"
@@ -1183,9 +1183,9 @@ function ChatImagePreviewLink({
           )}
         >
           {imageStatus === "loading" ? (
-            <IconLoader2 size={18} stroke={1.8} className="animate-spin" />
+            <Loader2 size={18} strokeWidth={1.8} className="animate-spin" />
           ) : (
-            <IconPhoto size={18} stroke={1.5} />
+            <Image size={18} strokeWidth={1.5} />
           )}
         </span>
       )}
@@ -1284,7 +1284,7 @@ function ChatVideoPreviewButton({
       )}
       <span className="absolute inset-0 flex items-center justify-center bg-black/10 transition-colors group-hover/video-preview:bg-black/35">
         <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-preview:scale-105">
-          <IconPlayerPlay size={17} stroke={1.8} />
+          <Play size={17} strokeWidth={1.8} />
         </span>
       </span>
     </button>
@@ -1851,7 +1851,7 @@ function HeaderWorkflowAutomationCard({
           {t(($) => {
             return $.chat.actions.view;
           })}
-          <IconArrowUpRight size={12} stroke={1.5} />
+          <ArrowUpRight size={12} strokeWidth={1.5} />
         </Link>
       </div>
       <WorkflowAutomationCard
@@ -1890,9 +1890,9 @@ function HeaderWorkflowAutomationCard({
               }}
             >
               {running ? (
-                <IconLoader2 size={13} className="animate-spin" />
+                <Loader2 size={13} className="animate-spin" />
               ) : (
-                <IconPlayerPlay size={13} stroke={1.5} />
+                <Play size={13} strokeWidth={1.5} />
               )}
               {running
                 ? t(($) => {
@@ -2153,7 +2153,7 @@ function HeaderScheduleAutomationEditForm({
           })}
         </Button>
         <Button type="submit" disabled={saving}>
-          {saving ? <IconLoader2 size={14} className="animate-spin" /> : null}
+          {saving ? <Loader2 size={14} className="animate-spin" /> : null}
           {t(($) => {
             return $.chat.automations.save;
           })}
@@ -2399,7 +2399,7 @@ function HeaderGmailNewMessageAutomationEditForm({
           })}
         </Button>
         <Button type="submit" disabled={saving}>
-          {saving ? <IconLoader2 size={14} className="animate-spin" /> : null}
+          {saving ? <Loader2 size={14} className="animate-spin" /> : null}
           {t(($) => {
             return $.chat.automations.save;
           })}
@@ -2481,7 +2481,7 @@ function HeaderGmailLabelAutomationEditForm({
           })}
         </Button>
         <Button type="submit" disabled={saving}>
-          {saving ? <IconLoader2 size={14} className="animate-spin" /> : null}
+          {saving ? <Loader2 size={14} className="animate-spin" /> : null}
           {t(($) => {
             return $.chat.automations.save;
           })}
@@ -2532,7 +2532,7 @@ function HeaderAutomationSidebar({
           })}
           className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground"
         >
-          <IconX size={16} />
+          <X size={16} />
         </button>
       </div>
 
@@ -2752,7 +2752,7 @@ function ChatThreadSessionError({ thread }: { thread: ChatPanelSignals }) {
   return (
     <div className="flex-1 flex items-center justify-center py-16">
       <div className="flex items-center gap-2 text-destructive">
-        <IconAlertCircle size={16} />
+        <AlertCircle size={16} />
         <p className="text-sm">{sessionError}</p>
       </div>
     </div>
@@ -3550,13 +3550,13 @@ function CompletedWorkFoldRow({
         onClick={onToggle}
         className="mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover"
       >
-        <IconHourglass
+        <Hourglass
           aria-hidden
           size={14}
           className="shrink-0 text-muted-foreground/70"
         />
         <span className="text-[13px]">{label}</span>
-        <IconChevronRight
+        <ChevronRight
           aria-hidden
           size={14}
           className={cn(
@@ -3739,7 +3739,7 @@ function RunGroupFoldRow({
   const { fold, expanded, onToggle } = control;
   const label = runGroupFoldLabel(fold);
   const isGoal = isGoalGroupFold(fold);
-  const Icon = isGoal ? IconTarget : IconPackage;
+  const Icon = isGoal ? Target : Package;
   return (
     <div
       data-chat-run-group-fold
@@ -3771,7 +3771,7 @@ function RunGroupFoldRow({
         <span className="min-w-0 truncate whitespace-nowrap text-[13px]">
           {label}
         </span>
-        <IconChevronRight
+        <ChevronRight
           aria-hidden
           size={14}
           className={cn(
@@ -3964,7 +3964,7 @@ function ChatThreadBottomBar({ thread }: { thread: ChatPanelSignals }) {
                   );
                 }}
               >
-                <IconCopy size={16} stroke={1.7} />
+                <Copy size={16} strokeWidth={1.7} />
                 {t(($) => {
                   return $.chat.sharing.copyLink;
                 })}
@@ -4015,9 +4015,9 @@ function ChatThreadBottomBar({ thread }: { thread: ChatPanelSignals }) {
               }}
             >
               {creating ? (
-                <IconLoader2 size={16} stroke={1.7} className="animate-spin" />
+                <Loader2 size={16} strokeWidth={1.7} className="animate-spin" />
               ) : (
-                <IconShare3 size={16} stroke={1.7} />
+                <Share2 size={16} strokeWidth={1.7} />
               )}
               {t(($) => {
                 return $.chat.sharing.create;
@@ -4056,7 +4056,7 @@ function ScrollToBottomButton({ thread }: { thread: ChatPanelSignals }) {
       }}
       className="absolute bottom-4 left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-md transition-colors hover:bg-state-hover hover:text-foreground"
     >
-      <IconArrowDown size={18} />
+      <ArrowDown size={18} />
     </button>
   );
 }
@@ -4067,22 +4067,22 @@ function RecommendedFollowupIcon({
   followup: RecommendedFollowup;
 }) {
   if (followup.kind !== "generate") {
-    return <IconMessageCircle size={14} stroke={1.8} />;
+    return <MessageCircle size={14} strokeWidth={1.8} />;
   }
 
   if (followup.generationType === "image") {
-    return <IconPhoto size={14} stroke={1.8} />;
+    return <Image size={14} strokeWidth={1.8} />;
   }
   if (followup.generationType === "video") {
-    return <IconVideo size={14} stroke={1.8} />;
+    return <Video size={14} strokeWidth={1.8} />;
   }
   if (followup.generationType === "presentation") {
-    return <IconChartLine size={14} stroke={1.8} />;
+    return <ChartLine size={14} strokeWidth={1.8} />;
   }
   if (followup.generationType === "website") {
-    return <IconLink size={14} stroke={1.8} />;
+    return <LinkIcon size={14} strokeWidth={1.8} />;
   }
-  return <IconPackage size={14} stroke={1.8} />;
+  return <Package size={14} strokeWidth={1.8} />;
 }
 
 function recommendedFollowupShownKey(
@@ -4200,9 +4200,9 @@ function RecommendedFollowupList({
             >
               {followup.prompt}
             </span>
-            <IconArrowUpRight
+            <ArrowUpRight
               size={14}
-              stroke={1.8}
+              strokeWidth={1.8}
               className={cn(
                 "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100",
                 showFollowupCards && "hidden",
@@ -4301,9 +4301,9 @@ function ActiveGoalObjectiveDialog({ threadId }: { threadId: string }) {
         <div className="max-h-[min(60vh,520px)] overflow-y-auto rounded-lg bg-muted/40 px-3 py-3 text-sm text-foreground sm:px-4">
           {goalLoadable.state === "loading" ? (
             <div className="flex min-h-28 items-center justify-center gap-2 text-muted-foreground">
-              <IconLoader2
+              <Loader2
                 size={16}
-                stroke={1.7}
+                strokeWidth={1.7}
                 className="animate-spin"
                 aria-hidden="true"
               />
@@ -5067,7 +5067,7 @@ function ComputerUseAuthorizationCard({
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          <IconDeviceDesktop size={22} />
+          <Monitor size={22} />
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
@@ -5091,7 +5091,7 @@ function ComputerUseAuthorizationCard({
         {t(($) => {
           return $.chat.actions.authorize;
         })}
-        <IconArrowUpRight size={15} />
+        <ArrowUpRight size={15} />
       </a>
     </div>
   );
@@ -5106,7 +5106,7 @@ function PlanUpgradeCard({ signals }: { signals: PlanUpgradeSignals }) {
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          <IconCoins size={22} />
+          <Coins size={22} />
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
@@ -5130,7 +5130,7 @@ function PlanUpgradeCard({ signals }: { signals: PlanUpgradeSignals }) {
         {t(($) => {
           return $.chat.billing.comparePlans;
         })}
-        <IconArrowUpRight size={15} />
+        <ArrowUpRight size={15} />
       </a>
     </div>
   );
@@ -5243,7 +5243,7 @@ function PermissionActionButton({
       onClick={onClick}
       className="inline-flex h-9 w-full min-w-0 flex-1 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-state-hover sm:w-auto sm:flex-none"
     >
-      {saving && <IconLoader2 size={15} className="animate-spin" />}
+      {saving && <Loader2 size={15} className="animate-spin" />}
       {saving
         ? t(($) => {
             return $.chat.actions.saving;
@@ -5283,7 +5283,7 @@ function PermissionActionInlineStatus({
     case "loading": {
       return (
         <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-          <IconLoader2 size={13} className="animate-spin" />
+          <Loader2 size={13} className="animate-spin" />
           <span>
             {t(($) => {
               return $.chat.permissions.checking;
@@ -5295,7 +5295,7 @@ function PermissionActionInlineStatus({
     case "load-error": {
       return (
         <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
-          <IconAlertCircle size={13} />
+          <AlertCircle size={13} />
           <span>
             {t(($) => {
               return $.chat.permissions.loadFailed;
@@ -5307,7 +5307,7 @@ function PermissionActionInlineStatus({
     case "save-error": {
       return (
         <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
-          <IconAlertCircle size={13} />
+          <AlertCircle size={13} />
           <span>
             {t(($) => {
               return $.chat.permissions.updateFailed;
@@ -5319,7 +5319,7 @@ function PermissionActionInlineStatus({
     case "missing-target": {
       return (
         <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
-          <IconAlertCircle size={13} />
+          <AlertCircle size={13} />
           <span>
             {t(($) => {
               return $.chat.permissions.agentNotFound;
@@ -5331,7 +5331,7 @@ function PermissionActionInlineStatus({
     case "missing-permission": {
       return (
         <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
-          <IconAlertCircle size={13} />
+          <AlertCircle size={13} />
           <span>
             {t(($) => {
               return $.chat.permissions.unknown;
@@ -6219,7 +6219,7 @@ function assistantRecoveryResetText(
 
 function AssistantRecoveryActionSpinner({ loading }: { loading: boolean }) {
   return loading ? (
-    <IconLoader2 size={14} stroke={1.75} className="animate-spin" />
+    <Loader2 size={14} strokeWidth={1.75} className="animate-spin" />
   ) : null;
 }
 
@@ -6321,9 +6321,9 @@ function AssistantErrorRecoveryCard({
       <div className="flex items-start gap-3">
         <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400">
           {recovery.kind === "usage-limit" ? (
-            <IconClock size={17} stroke={1.75} />
+            <Clock size={17} strokeWidth={1.75} />
           ) : (
-            <IconAlertCircle size={17} stroke={1.75} />
+            <AlertCircle size={17} strokeWidth={1.75} />
           )}
         </div>
         <div className="min-w-0 flex-1">
@@ -6353,9 +6353,9 @@ function AssistantErrorRecoveryCard({
           </p>
           {resetText && (
             <div className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
-              <IconClock
+              <Clock
                 size={14}
-                stroke={1.75}
+                strokeWidth={1.75}
                 className="text-muted-foreground"
               />
               {resetText}
@@ -6386,7 +6386,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
           borderRadius: "12px",
         }}
       >
-        <IconHandStop size={14} stroke={1.75} className="shrink-0" />
+        <Hand size={14} strokeWidth={1.75} className="shrink-0" />
         <span>
           {t(($) => {
             return $.chat.errors.runCancelled;
@@ -6404,10 +6404,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
   if (isNoModelProvider) {
     return (
       <div className="flex items-start gap-2 text-foreground">
-        <IconAlertCircle
-          size={16}
-          className="shrink-0 mt-[3px] text-amber-500"
-        />
+        <AlertCircle size={16} className="shrink-0 mt-[3px] text-amber-500" />
         <span>
           {t(($) => {
             return $.chat.errors.noModelProviderPrefix;
@@ -6441,10 +6438,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
   if (isProviderIncompatible) {
     return (
       <div className="flex items-start gap-2 text-foreground">
-        <IconAlertCircle
-          size={16}
-          className="shrink-0 mt-[3px] text-amber-500"
-        />
+        <AlertCircle size={16} className="shrink-0 mt-[3px] text-amber-500" />
         <span>
           {t(($) => {
             return $.chat.errors.providerIncompatiblePrefix;
@@ -6471,10 +6465,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
   if (isProviderDeleted) {
     return (
       <div className="flex items-start gap-2 text-foreground">
-        <IconAlertCircle
-          size={16}
-          className="shrink-0 mt-[3px] text-amber-500"
-        />
+        <AlertCircle size={16} className="shrink-0 mt-[3px] text-amber-500" />
         <span>
           {t(($) => {
             return $.chat.errors.providerDeletedPrefix;
@@ -6497,7 +6488,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
 
   return (
     <div className="flex items-start gap-2 text-destructive">
-      <IconAlertCircle size={16} className="shrink-0 mt-[3px]" />
+      <AlertCircle size={16} className="shrink-0 mt-[3px]" />
       <Markdown
         source={error}
         style={{ fontSize: "inherit", lineHeight: "inherit" }}
@@ -6996,9 +6987,9 @@ function UserMessageActions({
         })}
       >
         {copied ? (
-          <IconCheck size={18} stroke={1.5} />
+          <Check size={18} strokeWidth={1.5} />
         ) : (
-          <IconCopy size={18} stroke={1.5} />
+          <Copy size={18} strokeWidth={1.5} />
         )}
       </button>
     </div>
@@ -7074,7 +7065,7 @@ function MessageAnnotation({
         className={className}
         title={part.workflowName}
       >
-        <IconRoute size={15} stroke={1.8} className="shrink-0" />
+        <Route size={15} strokeWidth={1.8} className="shrink-0" />
         <span className="min-w-0 truncate">{part.workflowName}</span>
       </div>
     );
@@ -7087,7 +7078,7 @@ function MessageAnnotation({
         })}
         className={className}
       >
-        <IconTarget size={15} stroke={1.8} className="shrink-0" />
+        <Target size={15} strokeWidth={1.8} className="shrink-0" />
         <span>
           {t(($) => {
             return $.chat.queue.goal;
@@ -7104,7 +7095,7 @@ function MessageAnnotation({
         })}
         className={className}
       >
-        <IconSunrise size={15} stroke={1.8} className="shrink-0" />
+        <Sunrise size={15} strokeWidth={1.8} className="shrink-0" />
         <span>
           {t(($) => {
             return $.settings.preferences.morningBrief.title;
@@ -7201,7 +7192,7 @@ function SourceMessageAnnotation({
   const content = (
     <>
       {part.kind === "slack" ? (
-        <IconBrandSlack size={15} stroke={1.8} className="shrink-0" />
+        <BrandSlack size={15} strokeWidth={1.8} className="shrink-0" />
       ) : (
         <img
           src={annotationIconImgs[part.kind]}
@@ -7214,7 +7205,7 @@ function SourceMessageAnnotation({
         <>
           <span className="shrink-0">·</span>
           <span className="min-w-0 truncate">{openLabel}</span>
-          <IconArrowUpRight size={12} stroke={1.5} className="shrink-0" />
+          <ArrowUpRight size={12} strokeWidth={1.5} className="shrink-0" />
         </>
       ) : null}
     </>
@@ -7332,7 +7323,7 @@ function UserMessageTemplateReference({
       className={STRUCTURED_INLINE_REFERENCE_CLASS}
       title={`${typeLabel ?? part.template.type} · ${part.titleSnapshot}`}
     >
-      <IconColorSwatch size={13} stroke={1.7} className="shrink-0" />
+      <SwatchBook size={13} strokeWidth={1.7} className="shrink-0" />
       <span className="min-w-0 truncate">{part.titleSnapshot}</span>
       {spec !== null && <SentVideoTemplateSpec spec={spec} />}
     </span>
@@ -7466,7 +7457,7 @@ function UserMessageChatThreadReference({
       className={STRUCTURED_INLINE_LINK_REFERENCE_CLASS}
       title={title}
     >
-      <IconMessageCircle size={13} stroke={1.7} className="shrink-0" />
+      <MessageCircle size={13} strokeWidth={1.7} className="shrink-0" />
       <span className="min-w-0 truncate">{title}</span>
     </Link>
   );
@@ -8380,7 +8371,7 @@ function UsageChip({
           className="inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground/70 hover:bg-state-hover hover:text-foreground transition-colors duration-150"
           aria-label={`${ariaLabel} ${total}`}
         >
-          <IconCoins size={17} stroke={1.5} />
+          <Coins size={17} strokeWidth={1.5} />
           <span>{total}</span>
         </button>
       </PopoverTrigger>
@@ -8469,7 +8460,7 @@ function PagedGroupPrimaryActions({
                   return $.chat.run.viewLogs;
                 })}
               >
-                <IconChartLine size={18} stroke={1.5} />
+                <ChartLine size={18} strokeWidth={1.5} />
               </Link>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -8493,9 +8484,9 @@ function PagedGroupPrimaryActions({
                 })}
               >
                 {copied ? (
-                  <IconCheck size={18} stroke={1.5} />
+                  <Check size={18} strokeWidth={1.5} />
                 ) : (
-                  <IconCopy size={18} stroke={1.5} />
+                  <Copy size={18} strokeWidth={1.5} />
                 )}
               </button>
             </TooltipTrigger>

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,4 +1,4 @@
-import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
+import { AlertCircle, Check, Loader2 } from "lucide-react";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
 import { useTranslation } from "react-i18next";
@@ -78,7 +78,7 @@ export function ZeroConnectorCallbackPage({
     >
       {status === "loading" ? (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <IconLoader2 size={16} className="animate-spin" aria-hidden="true" />
+          <Loader2 size={16} className="animate-spin" aria-hidden="true" />
           <span>
             {t(($) => {
               return $.connectors.callback.finishing;
@@ -95,9 +95,9 @@ export function ZeroConnectorCallbackPage({
             }
           >
             {status === "success" ? (
-              <IconCheck size={16} aria-hidden="true" />
+              <Check size={16} aria-hidden="true" />
             ) : (
-              <IconAlertCircle size={16} aria-hidden="true" />
+              <AlertCircle size={16} aria-hidden="true" />
             )}
             <span>
               {status === "success"

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -1,8 +1,4 @@
-import {
-  IconAlertCircle,
-  IconArrowLeft,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
 import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { Button } from "@vm0/ui/components/ui/button";
 import { useGet } from "ccstate-react";
@@ -67,7 +63,7 @@ export function ZeroConnectorRedirectingPage({
       <div className="flex flex-col items-center gap-4">
         {hasError ? (
           <div className="flex items-center gap-2 text-sm text-destructive">
-            <IconAlertCircle size={16} aria-hidden="true" />
+            <AlertCircle size={16} aria-hidden="true" />
             <span>
               {t(($) => {
                 return $.connectors.redirect.errorStatus;
@@ -76,11 +72,7 @@ export function ZeroConnectorRedirectingPage({
           </div>
         ) : (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <IconLoader2
-              size={16}
-              className="animate-spin"
-              aria-hidden="true"
-            />
+            <Loader2 size={16} className="animate-spin" aria-hidden="true" />
             <span>
               {t(($) => {
                 return $.connectors.redirect.preparing;
@@ -100,7 +92,7 @@ export function ZeroConnectorRedirectingPage({
         )}
         <Button variant="outline" asChild>
           <Link pathname={ROUTES.home}>
-            <IconArrowLeft size={16} aria-hidden="true" />
+            <ArrowLeft size={16} aria-hidden="true" />
             {t(
               ($) => {
                 return $.connectors.redirect.back;

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -438,7 +438,7 @@ function ConnectorFilterOption({
           size={15}
           strokeWidth={2}
           className="shrink-0 text-foreground"
-          data-explicit-stroke-width
+          data-stroke
         />
       )}
     </DropdownMenuItem>
@@ -640,7 +640,7 @@ function ConnectorsToolbarActions({
           className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
           onClick={onCreateCustom}
         >
-          <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
+          <Plus size={14} strokeWidth={2} data-stroke />
           {t(($) => {
             return $.connectors.catalog.newConnector;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -9,13 +9,7 @@ import {
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import {
-  IconSearch,
-  IconPlus,
-  IconFilter,
-  IconChevronDown,
-  IconCheck,
-} from "@tabler/icons-react";
+import { Search, Plus, Filter, ChevronDown, Check } from "lucide-react";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogCategoryMetadata } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
@@ -440,7 +434,12 @@ function ConnectorFilterOption({
     <DropdownMenuItem className="justify-between gap-2" onClick={onSelect}>
       <span className="flex min-w-0 items-center gap-2">{children}</span>
       {active && (
-        <IconCheck size={15} stroke={2} className="shrink-0 text-foreground" />
+        <Check
+          size={15}
+          strokeWidth={2}
+          className="shrink-0 text-foreground"
+          data-explicit-stroke-width
+        />
       )}
     </DropdownMenuItem>
   );
@@ -488,9 +487,9 @@ function ConnectorFilterDropdown({
           })}
           className="zero-btn-morandi hidden h-9 shrink-0 gap-1.5 rounded-lg border sm:inline-flex"
         >
-          <IconFilter
+          <Filter
             size={14}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="text-muted-foreground"
           />
           {activeAgent && (
@@ -502,9 +501,9 @@ function ConnectorFilterDropdown({
             />
           )}
           <span className="max-w-[140px] truncate">{triggerLabel}</span>
-          <IconChevronDown
+          <ChevronDown
             size={14}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="text-muted-foreground"
           />
         </Button>
@@ -609,9 +608,9 @@ function ConnectorsToolbarActions({
     <div className="flex items-center gap-2">
       {activeTab === "builtin" && (
         <div className="relative w-40 sm:w-52">
-          <IconSearch
+          <Search
             size={15}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
           />
           <input
@@ -641,7 +640,7 @@ function ConnectorsToolbarActions({
           className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
           onClick={onCreateCustom}
         >
-          <IconPlus size={14} stroke={2} />
+          <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
           {t(($) => {
             return $.connectors.catalog.newConnector;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -36,7 +36,7 @@ import {
 } from "../../signals/chat-page/action-callback.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../../signals/zero-page/agent-connector-authorizations.ts";
-import { IconCheck, IconLoader2 } from "@tabler/icons-react";
+import { Check, Loader2 } from "lucide-react";
 import { Vm0LogoLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { useTranslation } from "react-i18next";
@@ -62,7 +62,7 @@ function AuthorizeAction({
   if (isAuthorized) {
     return (
       <div className="inline-flex h-9 w-[140px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
-        <IconCheck size={16} />
+        <Check size={16} />
         {t(($) => {
           return $.connectors.card.authorized;
         })}
@@ -76,7 +76,7 @@ function AuthorizeAction({
       onClick={onAuthorize}
       className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] px-4 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:opacity-60"
     >
-      {isConnecting && <IconLoader2 size={14} className="animate-spin" />}
+      {isConnecting && <Loader2 size={14} className="animate-spin" />}
       {isConnecting
         ? t(($) => {
             return $.connectors.actions.connecting;
@@ -227,7 +227,7 @@ function DirectedAuthorizeCardContent({
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (
-              <IconLoader2
+              <Loader2
                 size={20}
                 className="animate-spin text-muted-foreground"
               />

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -60,7 +60,7 @@ import {
   setDirectedConnectCustomDialogKey$,
 } from "../../signals/connectors-page/directed-connect-slug.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { IconCheck, IconLoader2 } from "@tabler/icons-react";
+import { Check, Loader2 } from "lucide-react";
 import { Vm0LogoLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import type { FormEvent, ReactNode } from "react";
@@ -283,7 +283,7 @@ function ManualGrantForm({
         disabled={!allFilled || submitting}
         className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:opacity-60"
       >
-        {submitting && <IconLoader2 size={14} className="animate-spin" />}
+        {submitting && <Loader2 size={14} className="animate-spin" />}
         {submitting
           ? t(($) => {
               return $.connectors.actions.saving;
@@ -358,7 +358,7 @@ function ConnectActions({
     return (
       <>
         <div className="inline-flex h-9 w-[100px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
-          <IconCheck size={16} />
+          <Check size={16} />
           {t(($) => {
             return $.connectors.card.connected;
           })}
@@ -369,7 +369,7 @@ function ConnectActions({
           onClick={onConnect}
           className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60 inline-flex items-center gap-1.5"
         >
-          {isConnecting && <IconLoader2 size={12} className="animate-spin" />}
+          {isConnecting && <Loader2 size={12} className="animate-spin" />}
           {isConnecting
             ? t(($) => {
                 return $.connectors.directed.reconnecting;
@@ -388,7 +388,7 @@ function ConnectActions({
       onClick={onConnect}
       className="inline-flex h-9 w-[100px] items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:opacity-60"
     >
-      {isConnecting && <IconLoader2 size={14} className="animate-spin" />}
+      {isConnecting && <Loader2 size={14} className="animate-spin" />}
       {isConnecting
         ? t(($) => {
             return $.connectors.actions.connecting;
@@ -567,7 +567,7 @@ function DirectedConnectCardContent({
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (
-              <IconLoader2
+              <Loader2
                 size={20}
                 className="animate-spin text-muted-foreground"
               />

--- a/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
@@ -1,12 +1,7 @@
 import { useGet, useLastLoadable, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { JSX, ReactNode } from "react";
-import {
-  IconAlertCircle,
-  IconArrowLeft,
-  IconCircleCheck,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { AlertCircle, ArrowLeft, CircleCheck, Loader2 } from "lucide-react";
 import { Button } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
@@ -39,7 +34,7 @@ function BackLink() {
       pathname="/workflows"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
-      <IconArrowLeft size={14} />
+      <ArrowLeft size={14} />
       {t(($) => {
         return $.connectors.providerConnect.github.back;
       })}
@@ -65,17 +60,15 @@ function GithubMark({
   state?: "idle" | "success" | "error" | "loading";
 }) {
   if (state === "success") {
-    return <IconCircleCheck size={40} className="text-emerald-500" />;
+    return <CircleCheck size={40} className="text-emerald-500" />;
   }
 
   if (state === "error") {
-    return <IconAlertCircle size={40} className="text-destructive" />;
+    return <AlertCircle size={40} className="text-destructive" />;
   }
 
   if (state === "loading") {
-    return (
-      <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
-    );
+    return <Loader2 size={40} className="animate-spin text-muted-foreground" />;
   }
 
   return (
@@ -256,9 +249,7 @@ function ConnectState({
       ) : null}
       <div className="flex w-full flex-col gap-4">
         <Button className="w-full" disabled={connecting} onClick={onConnect}>
-          {connecting ? (
-            <IconLoader2 size={16} className="animate-spin" />
-          ) : null}
+          {connecting ? <Loader2 size={16} className="animate-spin" /> : null}
           {connecting
             ? t(($) => {
                 return $.connectors.actions.connecting;

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -256,7 +256,7 @@ export function ZeroIdeationPage() {
                                   size={14}
                                   strokeWidth={2}
                                   className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-                                  data-explicit-stroke-width
+                                  data-stroke
                                 />
                                 <p className="text-sm font-semibold text-foreground pr-5">
                                   {useCase.title}

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -1,11 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useGet, useLoadable, useLastResolved, useSet } from "ccstate-react";
-import {
-  IconArrowUpRight,
-  IconMessageCircle,
-  IconSearch,
-} from "@tabler/icons-react";
+import { ArrowUpRight, MessageCircle, Search } from "lucide-react";
 import { Card, CardContent, cn, Input } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
@@ -126,7 +122,7 @@ export function ZeroIdeationPage() {
           onClick={handleBack}
           className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-state-hover hover:text-foreground transition-colors cursor-pointer"
         >
-          <IconMessageCircle size={14} stroke={1.5} className="shrink-0" />
+          <MessageCircle size={14} strokeWidth={1.5} className="shrink-0" />
           {t(($) => {
             return $.ideation.chat;
           })}
@@ -195,9 +191,9 @@ export function ZeroIdeationPage() {
                   })}
                 </div>
                 <div className="relative w-full min-w-0 sm:max-w-[240px] sm:flex-1 sm:min-w-[12rem]">
-                  <IconSearch
+                  <Search
                     className="pointer-events-none absolute left-3 top-1/2 z-10 size-[14px] -translate-y-1/2 text-muted-foreground"
-                    stroke={1.5}
+                    strokeWidth={1.5}
                     aria-hidden
                   />
                   <Input
@@ -256,10 +252,11 @@ export function ZeroIdeationPage() {
                               }}
                             >
                               <CardContent className="p-4 group relative">
-                                <IconArrowUpRight
+                                <ArrowUpRight
                                   size={14}
-                                  stroke={2}
+                                  strokeWidth={2}
                                   className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
+                                  data-explicit-stroke-width
                                 />
                                 <p className="text-sm font-semibold text-foreground pr-5">
                                   {useCase.title}

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@vm0/ui";
-import { IconChevronDown, IconPlus, IconMail } from "@tabler/icons-react";
+import { ChevronDown, Plus, Mail } from "lucide-react";
 import { clerk$, currentOrgInfo$ } from "../../signals/auth.ts";
 import {
   bestEffort,
@@ -111,7 +111,7 @@ function InvitationRow({
         onClick={handleAccept}
         className="shrink-0 flex items-center gap-1 px-2 h-7 rounded-md text-xs font-medium text-muted-foreground border border-border hover:text-foreground hover:bg-state-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
       >
-        <IconMail size={13} />
+        <Mail size={13} />
         {isAccepting
           ? t(($) => {
               return $.appShell.sidebar.workspaceSwitcher.joining;
@@ -154,9 +154,9 @@ function CreateWorkspaceItem() {
         disabled={clerk === null || creatingOrg}
         className="min-w-0 gap-3 px-3 py-2.5 rounded-lg"
       >
-        <IconPlus
+        <Plus
           size={18}
-          stroke={1.5}
+          strokeWidth={1.5}
           className="shrink-0 text-muted-foreground"
         />
         <span>
@@ -359,7 +359,7 @@ export function ZeroOrgSwitcher() {
             <span className="min-w-0 flex-1 text-left text-sm font-semibold leading-tight truncate">
               {orgName}
             </span>
-            <IconChevronDown
+            <ChevronDown
               size={16}
               className="ml-auto shrink-0 text-muted-foreground"
             />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -9,15 +9,15 @@ import {
 } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import {
-  IconLogout,
-  IconPlus,
-  IconChevronRight,
-  IconSettings,
-  IconSwitchHorizontal,
-  IconDatabaseExport,
-  IconFlask,
-  IconCoins,
-} from "@tabler/icons-react";
+  LogOut,
+  Plus,
+  ChevronRight,
+  Settings,
+  ArrowRightLeft,
+  DatabaseBackup,
+  FlaskConical,
+  Coins,
+} from "lucide-react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   DropdownMenu,
@@ -412,7 +412,7 @@ function CreditBalanceItem({
       onModalSelect={onOpenCreditBalance}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <IconCoins size={18} stroke={1.5} className="text-muted-foreground" />
+      <Coins size={18} strokeWidth={1.5} className="text-muted-foreground" />
       <span className="min-w-0 flex-1 truncate text-sm tabular-nums">
         {loading ? (
           <span className="block h-4 w-24 rounded bg-muted/60" />
@@ -440,9 +440,9 @@ function UnifiedSettingsGroup({
         onModalSelect={onOpenSettings}
         className="gap-3 px-3 py-2.5 rounded-lg"
       >
-        <IconSettings
+        <Settings
           size={18}
-          stroke={1.5}
+          strokeWidth={1.5}
           className="text-muted-foreground"
         />
         <span>
@@ -458,7 +458,11 @@ function UnifiedSettingsGroup({
           }}
           className="gap-3 px-3 py-2.5 rounded-lg"
         >
-          <IconFlask size={18} stroke={1.5} className="text-muted-foreground" />
+          <FlaskConical
+            size={18}
+            strokeWidth={1.5}
+            className="text-muted-foreground"
+          />
           <span>
             {t(($) => {
               return $.settings.accountMenu.lab;
@@ -487,7 +491,7 @@ function AccountManagementGroup({
         onClick={onAddAccount}
         className="gap-3 px-3 py-2.5 rounded-lg"
       >
-        <IconPlus size={18} stroke={1.5} className="text-muted-foreground" />
+        <Plus size={18} strokeWidth={1.5} className="text-muted-foreground" />
         <span>
           {t(($) => {
             return $.settings.accountMenu.addAccount;
@@ -499,9 +503,9 @@ function AccountManagementGroup({
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger className="gap-3 px-3 py-2.5 rounded-lg">
-        <IconSwitchHorizontal
+        <ArrowRightLeft
           size={18}
-          stroke={1.5}
+          strokeWidth={1.5}
           className="text-muted-foreground"
         />
         <span className="flex-1">
@@ -509,9 +513,9 @@ function AccountManagementGroup({
             return $.settings.accountMenu.switchAccount;
           })}
         </span>
-        <IconChevronRight
+        <ChevronRight
           size={14}
-          stroke={1.5}
+          strokeWidth={1.5}
           className="text-muted-foreground"
         />
       </DropdownMenuSubTrigger>
@@ -546,7 +550,7 @@ function AccountManagementGroup({
           onClick={onAddAccount}
           className="gap-3 px-3 py-2.5 rounded-lg"
         >
-          <IconPlus size={18} stroke={1.5} className="text-muted-foreground" />
+          <Plus size={18} strokeWidth={1.5} className="text-muted-foreground" />
           <span>
             {t(($) => {
               return $.settings.accountMenu.addAccount;
@@ -567,9 +571,9 @@ function ExtraAccountActions() {
       }}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <IconDatabaseExport
+      <DatabaseBackup
         size={18}
-        stroke={1.5}
+        strokeWidth={1.5}
         className="text-muted-foreground"
       />
       <span>
@@ -594,7 +598,7 @@ function SignOutItem({
       }}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <IconLogout size={18} stroke={1.5} className="text-muted-foreground" />
+      <LogOut size={18} strokeWidth={1.5} className="text-muted-foreground" />
       <span>
         {t(($) => {
           return $.settings.accountMenu.signOut;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, MouseEvent, ReactNode } from "react";
-import { IconDots } from "@tabler/icons-react";
+import { Ellipsis } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -220,7 +220,11 @@ export function AgentRowSideActions({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex h-full w-full items-center justify-center">
-                      <IconDots size={16} stroke={2} />
+                      <Ellipsis
+                        size={16}
+                        strokeWidth={2}
+                        data-explicit-stroke-width
+                      />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
@@ -220,11 +220,7 @@ export function AgentRowSideActions({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex h-full w-full items-center justify-center">
-                      <Ellipsis
-                        size={16}
-                        strokeWidth={2}
-                        data-explicit-stroke-width
-                      />
+                      <Ellipsis size={16} strokeWidth={2} data-stroke />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -77,7 +77,7 @@ export function AgentDialogSearch({
           size={16}
           strokeWidth={2}
           className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-          data-explicit-stroke-width
+          data-stroke
         />
         <Input
           type="text"
@@ -101,7 +101,7 @@ export function AgentDialogSearch({
               return $.sidebar.clearSearch;
             })}
           >
-            <X size={14} strokeWidth={2} data-explicit-stroke-width />
+            <X size={14} strokeWidth={2} data-stroke />
           </button>
         )}
       </div>
@@ -196,7 +196,7 @@ function AgentCommandSearch({
               return $.sidebar.clearSearch;
             })}
           >
-            <X size={14} strokeWidth={2} data-explicit-stroke-width />
+            <X size={14} strokeWidth={2} data-stroke />
           </button>
         )}
       </div>
@@ -382,9 +382,7 @@ function PinnedAgentCommandItem({
                 return $.sidebar.unpin;
               }),
               disabled,
-              icon: (
-                <PinOff size={16} strokeWidth={2} data-explicit-stroke-width />
-              ),
+              icon: <PinOff size={16} strokeWidth={2} data-stroke />,
               onSelect: onUnpin,
             }}
           />
@@ -536,9 +534,7 @@ function UnpinnedAgentsCommandSection({
                     return $.sidebar.pin;
                   }),
                   disabled,
-                  icon: (
-                    <Pin size={16} strokeWidth={2} data-explicit-stroke-width />
-                  ),
+                  icon: <Pin size={16} strokeWidth={2} data-stroke />,
                   onSelect: () => {
                     return onTogglePin(agent.id);
                   },

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode, SyntheticEvent } from "react";
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { IconSearch, IconX, IconPin, IconPinnedOff } from "@tabler/icons-react";
+import { Search, X, Pin, PinOff } from "lucide-react";
 import {
   CommandDialog,
   CommandGroup,
@@ -73,10 +73,11 @@ export function AgentDialogSearch({
   return (
     <div className="px-5 pb-3">
       <div className="relative w-full">
-        <IconSearch
+        <Search
           size={16}
-          stroke={2}
+          strokeWidth={2}
           className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          data-explicit-stroke-width
         />
         <Input
           type="text"
@@ -100,7 +101,7 @@ export function AgentDialogSearch({
               return $.sidebar.clearSearch;
             })}
           >
-            <IconX size={14} stroke={2} />
+            <X size={14} strokeWidth={2} data-explicit-stroke-width />
           </button>
         )}
       </div>
@@ -195,7 +196,7 @@ function AgentCommandSearch({
               return $.sidebar.clearSearch;
             })}
           >
-            <IconX size={14} stroke={2} />
+            <X size={14} strokeWidth={2} data-explicit-stroke-width />
           </button>
         )}
       </div>
@@ -381,7 +382,9 @@ function PinnedAgentCommandItem({
                 return $.sidebar.unpin;
               }),
               disabled,
-              icon: <IconPinnedOff size={16} stroke={2} />,
+              icon: (
+                <PinOff size={16} strokeWidth={2} data-explicit-stroke-width />
+              ),
               onSelect: onUnpin,
             }}
           />
@@ -533,7 +536,9 @@ function UnpinnedAgentsCommandSection({
                     return $.sidebar.pin;
                   }),
                   disabled,
-                  icon: <IconPin size={16} stroke={2} />,
+                  icon: (
+                    <Pin size={16} strokeWidth={2} data-explicit-stroke-width />
+                  ),
                   onSelect: () => {
                     return onTogglePin(agent.id);
                   },

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -103,13 +103,7 @@ function PinnedAgentSideDecorator({
               return $.sidebar.markAllRead;
             }),
             disabled: markingRead,
-            icon: (
-              <CheckCheck
-                size={16}
-                strokeWidth={2}
-                data-explicit-stroke-width
-              />
-            ),
+            icon: <CheckCheck size={16} strokeWidth={2} data-stroke />,
             onSelect: markAllRead,
           },
         ]
@@ -122,13 +116,7 @@ function PinnedAgentSideDecorator({
                   return $.sidebar.unpin;
                 }),
                 disabled: savingPinned,
-                icon: (
-                  <PinOff
-                    size={16}
-                    strokeWidth={2}
-                    data-explicit-stroke-width
-                  />
-                ),
+                icon: <PinOff size={16} strokeWidth={2} data-stroke />,
                 onSelect: unpinAgent,
               }
             : {
@@ -136,9 +124,7 @@ function PinnedAgentSideDecorator({
                   return $.sidebar.pin;
                 }),
                 disabled: savingPinned,
-                icon: (
-                  <Pin size={16} strokeWidth={2} data-explicit-stroke-width />
-                ),
+                icon: <Pin size={16} strokeWidth={2} data-stroke />,
                 onSelect: pinAgent,
               },
         ]
@@ -297,7 +283,7 @@ export function PinnedAgentListSection({
             className="flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground/70 transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
           >
             <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
-              <Plus size={16} strokeWidth={2} data-explicit-stroke-width />
+              <Plus size={16} strokeWidth={2} data-stroke />
             </span>
             <span className="text-[11px] leading-tight">
               {t(($) => {
@@ -329,7 +315,7 @@ export function PinnedAgentListSection({
               size={12}
               strokeWidth={2}
               className={collapsed ? "" : "rotate-90"}
-              data-explicit-stroke-width
+              data-stroke
             />
           </span>
         </span>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -7,13 +7,7 @@ import {
   useLastLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import {
-  IconPlus,
-  IconChevronRight,
-  IconPin,
-  IconPinnedOff,
-  IconChecks,
-} from "@tabler/icons-react";
+import { Plus, ChevronRight, Pin, PinOff, CheckCheck } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -109,7 +103,13 @@ function PinnedAgentSideDecorator({
               return $.sidebar.markAllRead;
             }),
             disabled: markingRead,
-            icon: <IconChecks size={16} stroke={2} />,
+            icon: (
+              <CheckCheck
+                size={16}
+                strokeWidth={2}
+                data-explicit-stroke-width
+              />
+            ),
             onSelect: markAllRead,
           },
         ]
@@ -122,7 +122,13 @@ function PinnedAgentSideDecorator({
                   return $.sidebar.unpin;
                 }),
                 disabled: savingPinned,
-                icon: <IconPinnedOff size={16} stroke={2} />,
+                icon: (
+                  <PinOff
+                    size={16}
+                    strokeWidth={2}
+                    data-explicit-stroke-width
+                  />
+                ),
                 onSelect: unpinAgent,
               }
             : {
@@ -130,7 +136,9 @@ function PinnedAgentSideDecorator({
                   return $.sidebar.pin;
                 }),
                 disabled: savingPinned,
-                icon: <IconPin size={16} stroke={2} />,
+                icon: (
+                  <Pin size={16} strokeWidth={2} data-explicit-stroke-width />
+                ),
                 onSelect: pinAgent,
               },
         ]
@@ -289,7 +297,7 @@ export function PinnedAgentListSection({
             className="flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground/70 transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
           >
             <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
-              <IconPlus size={16} stroke={2} />
+              <Plus size={16} strokeWidth={2} data-explicit-stroke-width />
             </span>
             <span className="text-[11px] leading-tight">
               {t(($) => {
@@ -317,10 +325,11 @@ export function PinnedAgentListSection({
             return $.sidebar.pinned;
           })}
           <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-            <IconChevronRight
+            <ChevronRight
               size={12}
-              stroke={2}
+              strokeWidth={2}
               className={collapsed ? "" : "rotate-90"}
+              data-explicit-stroke-width
             />
           </span>
         </span>
@@ -338,7 +347,7 @@ export function PinnedAgentListSection({
                   return $.sidebar.openConversation;
                 })}
               >
-                <IconPlus size={15} stroke={2.5} />
+                <Plus size={15} strokeWidth={2.5} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -2,18 +2,18 @@ import type { ReactNode } from "react";
 import { useLastResolved, useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import {
-  IconChartLine,
-  IconLayoutGrid,
-  IconPackage,
-  IconRoute,
-  IconUsers,
-  IconEdit,
-  IconChevronRight,
-  IconLayoutSidebarLeftCollapse,
-  IconPlug,
-  IconSparkles,
-  IconSearch,
-} from "@tabler/icons-react";
+  ChartLine,
+  LayoutGrid,
+  Package,
+  Route,
+  Users,
+  Edit,
+  ChevronRight,
+  PanelLeftClose,
+  Plug,
+  Sparkles,
+  Search,
+} from "lucide-react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   Tooltip,
@@ -77,7 +77,7 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     id: "agents",
     activeKeys: ["agents", "agentDetail", "agentPermissions"],
     pathname: "/agents",
-    icon: IconUsers as NavIcon,
+    icon: Users as NavIcon,
   },
   {
     id: "workflows",
@@ -89,25 +89,25 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
       "workflowDetailInfo",
     ],
     pathname: "/workflows",
-    icon: IconRoute as NavIcon,
+    icon: Route as NavIcon,
   },
   {
     id: "connectors",
     activeKeys: ["connectors"],
     pathname: "/connectors",
-    icon: IconPlug as NavIcon,
+    icon: Plug as NavIcon,
   },
   {
     id: "artifacts",
     activeKeys: ["artifacts"],
     pathname: "/artifacts",
-    icon: IconPackage as NavIcon,
+    icon: Package as NavIcon,
   },
   {
     id: "activities",
     activeKeys: ["activities", "activityDetail", "activityInspect"],
     pathname: "/activities",
-    icon: IconChartLine as NavIcon,
+    icon: ChartLine as NavIcon,
     featureGate: FeatureSwitchKey.ZeroDebug,
   },
 ];
@@ -125,7 +125,7 @@ const FOOTER_NAV = [
     id: "works",
     activeKeys: ["works"],
     pathname: "/works",
-    icon: IconLayoutGrid as NavIcon,
+    icon: LayoutGrid as NavIcon,
     iconImg: slackIcon,
   },
 ] as const satisfies readonly FooterNavItem[];
@@ -256,7 +256,7 @@ function CollapsedExpandButton() {
               onClick={onCollapse}
               aria-label={expandLabel}
             >
-              <IconLayoutSidebarLeftCollapse size={18} className="rotate-180" />
+              <PanelLeftClose size={18} className="rotate-180" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">
@@ -285,7 +285,7 @@ function CollapsedNavList() {
       label: t(($) => {
         return $.appShell.sidebar.navigation.newChat;
       }),
-      icon: IconEdit as NavIcon,
+      icon: Edit as NavIcon,
     },
     ...footerNav.map(({ id, activeKeys, pathname: p, label, icon }) => {
       return { id, activeKeys, pathname: p, label, icon };
@@ -375,7 +375,7 @@ function CollapsedFooter() {
               }`}
               aria-label={insightsLabel}
             >
-              <IconSparkles size={16} className="shrink-0" />
+              <Sparkles size={16} className="shrink-0" />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="right">
@@ -437,7 +437,7 @@ function ExpandedHeader() {
                 onClick={onCollapse}
                 aria-label={collapseLabel}
               >
-                <IconLayoutSidebarLeftCollapse size={18} />
+                <PanelLeftClose size={18} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -485,10 +485,11 @@ function ExpandedManageSection() {
             return $.appShell.sidebar.manage;
           })}
           <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-            <IconChevronRight
+            <ChevronRight
               size={12}
-              stroke={2}
+              strokeWidth={2}
               className={manageCollapsed ? "" : "rotate-90"}
+              data-explicit-stroke-width
             />
           </span>
         </span>
@@ -646,7 +647,7 @@ function ExpandedFooterAccountInsights() {
               }`}
               aria-label={insightsLabel}
             >
-              <IconSparkles size={16} className="shrink-0" />
+              <Sparkles size={16} className="shrink-0" />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="top">
@@ -779,7 +780,7 @@ function LabeledNavRail() {
       label: t(($) => {
         return $.appShell.sidebar.navigation.newChat;
       }),
-      icon: IconEdit as NavIcon,
+      icon: Edit as NavIcon,
     },
     ...manageNav,
     ...footerNav,
@@ -824,7 +825,7 @@ function LabeledNavRail() {
           label={t(($) => {
             return $.appShell.sidebar.navigation.insights;
           })}
-          icon={IconSparkles as NavIcon}
+          icon={Sparkles as NavIcon}
           isActive={activeId === "insights"}
           onSelect={onSelect}
         />
@@ -872,7 +873,7 @@ function ChatListColumn() {
                 aria-label={searchLabel}
                 className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
               >
-                <IconSearch size={17} stroke={1.8} />
+                <Search size={17} strokeWidth={1.8} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -894,7 +895,7 @@ function ChatListColumn() {
                 aria-current={isNewChatActive ? "page" : undefined}
                 className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 no-underline transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
               >
-                <IconEdit size={17} stroke={1.8} />
+                <Edit size={17} strokeWidth={1.8} />
               </Link>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -489,7 +489,7 @@ function ExpandedManageSection() {
               size={12}
               strokeWidth={2}
               className={manageCollapsed ? "" : "rotate-90"}
-              data-explicit-stroke-width
+              data-stroke
             />
           </span>
         </span>

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -1,14 +1,8 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import {
-  IconBrandSlack,
-  IconLoader2,
-  IconAlertCircle,
-  IconCircleCheck,
-  IconArrowLeft,
-} from "@tabler/icons-react";
-import { Button } from "@vm0/ui";
+import { Loader2, AlertCircle, CircleCheck, ArrowLeft } from "lucide-react";
+import { Button, BrandSlack } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
@@ -29,7 +23,7 @@ function BackLink() {
       pathname="/works"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
-      <IconArrowLeft size={14} />
+      <ArrowLeft size={14} />
       {t(($) => {
         return $.connectors.providerConnect.common.backToSettings;
       })}
@@ -53,7 +47,7 @@ function ErrorState({ message }: { message: string }) {
   const { t } = useTranslation();
   return (
     <>
-      <IconAlertCircle size={40} className="text-destructive" />
+      <AlertCircle size={40} className="text-destructive" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -73,7 +67,7 @@ function CheckingState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
+      <Loader2 size={40} className="text-muted-foreground animate-spin" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -94,7 +88,7 @@ function InvalidState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconAlertCircle size={40} className="text-muted-foreground/40" />
+      <AlertCircle size={40} className="text-muted-foreground/40" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -146,7 +140,7 @@ function PageContent() {
   if (status === "success") {
     return (
       <>
-        <IconCircleCheck size={40} className="text-emerald-500" />
+        <CircleCheck size={40} className="text-emerald-500" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
             {t(($) => {
@@ -175,7 +169,7 @@ function PageContent() {
               window.location.href = "slack://open";
             }}
           >
-            <IconBrandSlack size={16} />
+            <BrandSlack size={16} />
             {t(($) => {
               return $.connectors.providerConnect.slack.open;
             })}
@@ -197,7 +191,7 @@ function PageContent() {
   if (workspaceId && slackUserId) {
     return (
       <>
-        <IconBrandSlack size={40} className="text-foreground" />
+        <BrandSlack size={40} className="text-foreground" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
             {t(($) => {
@@ -217,7 +211,7 @@ function PageContent() {
           disabled={connectLoading}
         >
           {connectLoading ? (
-            <IconLoader2 size={16} className="animate-spin mr-2" />
+            <Loader2 size={16} className="animate-spin mr-2" />
           ) : null}
           {connectLoading
             ? t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
@@ -1,11 +1,6 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import {
-  IconAlertCircle,
-  IconArrowLeft,
-  IconCircleCheck,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { AlertCircle, ArrowLeft, CircleCheck, Loader2 } from "lucide-react";
 import { Button } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
@@ -32,7 +27,7 @@ function BackLink() {
       pathname="/works"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
-      <IconArrowLeft size={14} />
+      <ArrowLeft size={14} />
       {t(($) => {
         return $.connectors.providerConnect.common.backToSettings;
       })}
@@ -93,7 +88,7 @@ function ErrorState({ message }: { message: string }) {
   const { t } = useTranslation();
   return (
     <>
-      <IconAlertCircle size={40} className="text-destructive" />
+      <AlertCircle size={40} className="text-destructive" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -113,7 +108,7 @@ function CheckingState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
+      <Loader2 size={40} className="text-muted-foreground animate-spin" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -134,7 +129,7 @@ function InvalidState() {
   const { t } = useTranslation();
   return (
     <>
-      <IconAlertCircle size={40} className="text-muted-foreground/40" />
+      <AlertCircle size={40} className="text-muted-foreground/40" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -186,7 +181,7 @@ function PageContent() {
     const label = connectedLabel(params);
     return (
       <>
-        <IconCircleCheck size={40} className="text-emerald-500" />
+        <CircleCheck size={40} className="text-emerald-500" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
             {t(($) => {
@@ -258,7 +253,7 @@ function PageContent() {
           disabled={connectLoading}
         >
           {connectLoading ? (
-            <IconLoader2 size={16} className="animate-spin mr-2" />
+            <Loader2 size={16} className="animate-spin mr-2" />
           ) : null}
           {connectLoading
             ? t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -1,12 +1,7 @@
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { JSX, ReactNode } from "react";
-import {
-  IconAlertCircle,
-  IconArrowLeft,
-  IconCircleCheck,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { AlertCircle, ArrowLeft, CircleCheck, Loader2 } from "lucide-react";
 import { Button, CopyButton } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
@@ -43,7 +38,7 @@ function BackLink() {
       pathname="/settings/telegram"
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >
-      <IconArrowLeft size={14} />
+      <ArrowLeft size={14} />
       {t(($) => {
         return $.connectors.providerConnect.telegram.back;
       })}
@@ -69,21 +64,19 @@ function TelegramMark({
   state?: "idle" | "success" | "error" | "loading" | "warning";
 }) {
   if (state === "success") {
-    return <IconCircleCheck size={40} className="text-emerald-500" />;
+    return <CircleCheck size={40} className="text-emerald-500" />;
   }
 
   if (state === "warning") {
-    return <IconAlertCircle size={40} className="text-amber-500" />;
+    return <AlertCircle size={40} className="text-amber-500" />;
   }
 
   if (state === "error") {
-    return <IconAlertCircle size={40} className="text-destructive" />;
+    return <AlertCircle size={40} className="text-destructive" />;
   }
 
   if (state === "loading") {
-    return (
-      <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
-    );
+    return <Loader2 size={40} className="animate-spin text-muted-foreground" />;
   }
 
   return (
@@ -239,7 +232,7 @@ function DomainStatusPolling() {
     <>
       <span ref={domainStatusPollerRef} hidden />
       <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
-        <IconLoader2 size={13} className="animate-spin" />
+        <Loader2 size={13} className="animate-spin" />
         {t(($) => {
           return $.connectors.providerConnect.telegram.checkingDomain;
         })}
@@ -355,9 +348,7 @@ function ConnectActions({
     return (
       <div className="flex w-full flex-col gap-3">
         <Button className="w-full" disabled={connecting} onClick={onConnect}>
-          {connecting ? (
-            <IconLoader2 size={16} className="animate-spin" />
-          ) : null}
+          {connecting ? <Loader2 size={16} className="animate-spin" /> : null}
           {connecting
             ? t(($) => {
                 return $.connectors.actions.connecting;
@@ -372,7 +363,7 @@ function ConnectActions({
 
   return (
     <Button className="w-full" disabled={connecting} onClick={onConnect}>
-      {connecting ? <IconLoader2 size={16} className="animate-spin" /> : null}
+      {connecting ? <Loader2 size={16} className="animate-spin" /> : null}
       {connecting
         ? t(($) => {
             return $.connectors.actions.connecting;

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { IconPencil, IconLoader2 } from "@tabler/icons-react";
+import { Pencil, Loader2 } from "lucide-react";
 import { Button } from "@vm0/ui";
 
 interface ZeroUnsavedBarProps {
@@ -26,9 +26,9 @@ export function ZeroUnsavedBar({
         className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
       >
         <div className="flex items-center gap-2 text-sm text-foreground">
-          <IconPencil
+          <Pencil
             size={18}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="shrink-0 text-muted-foreground"
           />
           <span>{message}</span>
@@ -52,10 +52,10 @@ export function ZeroUnsavedBar({
             disabled={saving}
           >
             {saving ? (
-              <IconLoader2
+              <Loader2
                 data-testid="save-spinner"
                 size={14}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="animate-spin mr-1.5"
               />
             ) : null}

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -3,13 +3,13 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import type { TeamsConnectStatus } from "@vm0/api-contracts/contracts/zero-teams-connect";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
-  IconAlertTriangle,
-  IconCircleCheck,
-  IconDotsVertical,
-  IconDownload,
-  IconSettings,
-  IconWebhook,
-} from "@tabler/icons-react";
+  AlertTriangle,
+  CircleCheck,
+  EllipsisVertical,
+  Download,
+  Settings,
+  Webhook,
+} from "lucide-react";
 import { Button } from "@vm0/ui";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
@@ -87,7 +87,7 @@ function ConnectedIndicator({
       data-testid={testId}
       className="inline-flex min-w-0 max-w-52 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
     >
-      <IconCircleCheck className="h-3 w-3 text-green-600" />
+      <CircleCheck className="h-3 w-3 text-green-600" />
       <span className="min-w-0 truncate" title={connectedDetail ?? ""}>
         {connectedDetail
           ? t(
@@ -144,7 +144,7 @@ function SlackCardActions({
             return openFreshOAuth(installUrl);
           }}
         >
-          <IconDownload size={14} stroke={1.5} />
+          <Download size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.works.slack.install;
           })}
@@ -174,7 +174,7 @@ function SlackCardActions({
                 return $.works.actions.moreOptions;
               })}
             >
-              <IconDotsVertical size={16} stroke={1.5} />
+              <EllipsisVertical size={16} strokeWidth={1.5} />
             </button>
           </PopoverTrigger>
           <PopoverContent
@@ -233,7 +233,7 @@ function SlackPermissionWarning({
 
   return (
     <div className="flex items-center gap-3 border-t border-border/50 px-4 py-3">
-      <IconAlertTriangle size={16} className="shrink-0 text-amber-500" />
+      <AlertTriangle size={16} className="shrink-0 text-amber-500" />
       <span className="flex-1 text-sm text-amber-600 dark:text-amber-400">
         {t(($) => {
           return $.works.slack.permissionsUpdated;
@@ -437,7 +437,7 @@ function TeamsCardActions({
             return openFreshOAuth(installActionUrl);
           }}
         >
-          <IconDownload size={14} stroke={1.5} />
+          <Download size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.works.teams.install;
           })}
@@ -468,7 +468,7 @@ function TeamsCardActions({
                 return $.works.teams.moreOptions;
               })}
             >
-              <IconDotsVertical size={16} stroke={1.5} />
+              <EllipsisVertical size={16} strokeWidth={1.5} />
             </button>
           </PopoverTrigger>
           <PopoverContent
@@ -538,7 +538,7 @@ function TeamsPermissionWarning({
 
   return (
     <div className="flex items-center gap-3 border-t border-border/50 px-4 py-3">
-      <IconAlertTriangle size={16} className="shrink-0 text-amber-500" />
+      <AlertTriangle size={16} className="shrink-0 text-amber-500" />
       <span className="flex-1 text-sm text-amber-600 dark:text-amber-400">
         {t(($) => {
           return $.works.teams.permissionsUpdated;
@@ -783,7 +783,7 @@ function GithubCard() {
               target="_blank"
               rel="noreferrer"
             >
-              <IconDownload size={14} stroke={1.5} />
+              <Download size={14} strokeWidth={1.5} />
               {t(($) => {
                 return $.works.github.install;
               })}
@@ -844,7 +844,7 @@ function TelegramCard() {
           </div>
         </div>
         <span className="shrink-0 inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
-          <IconSettings size={14} stroke={1.5} />
+          <Settings size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.works.actions.manage;
           })}
@@ -863,7 +863,7 @@ function StrapiCard() {
     >
       <div className="flex items-center gap-4 p-4">
         <div className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#4945ff]/10 text-[#4945ff]">
-          <IconWebhook size={18} />
+          <Webhook size={18} />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="truncate text-sm font-medium text-foreground">
@@ -878,7 +878,7 @@ function StrapiCard() {
           </div>
         </div>
         <span className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
-          <IconSettings size={14} stroke={1.5} />
+          <Settings size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.works.actions.manage;
           })}


### PR DESCRIPTION
## Summary

- migrate Tabler icons across Zero chat, sidebar, connector, artifact, and activity views to Lucide
- route GitHub, Google Drive, Slack, and Stripe marks through shared UI brand icons
- replace the raw composer template swatch geometry with Lucide SwatchBook paths
- preserve explicit icon stroke weights while renaming `stroke` props to `strokeWidth`

## Testing

- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx`
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx`

Stacked on #25870. Part of #25458.