### PR TITLE
refactor(platform): finish Lucide icon migration

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -327,6 +327,23 @@ export default [
     ],
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@tabler/icons-react",
+              message:
+                "Use lucide-react or a shared @vm0/ui brand icon instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // react/jsx-uses-vars marked JSX identifiers as "used" for ESLint's no-unused-vars.
   // Both no-unused-vars and @typescript-eslint/no-unused-vars are now handled by
   // oxlint, so this rule is no longer needed.

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -23,7 +23,6 @@
     "@sentry/react": "^10.38.0",
     "@sentry/vite-plugin": "^4.9.0",
     "@solana/web3.js": "^1.98.4",
-    "@tabler/icons-react": "3.44.0",
     "@tiptap/core": "3.21.0",
     "@tiptap/markdown": "3.23.1",
     "@tiptap/pm": "3.21.0",

--- a/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
+++ b/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { IconSearch, IconChartLine, IconUpload } from "@tabler/icons-react";
+import { Search, ChartLine, Upload } from "lucide-react";
 import { Button, Input, Tabs, TabsList, TabsTrigger } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -88,7 +88,7 @@ function InspectBreadcrumb({ title }: { title: string }) {
         pathname="/activities"
         className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-state-hover hover:text-foreground transition-colors no-underline text-inherit"
       >
-        <IconChartLine size={14} stroke={1.5} className="shrink-0" />
+        <ChartLine size={14} strokeWidth={1.5} className="shrink-0" />
         {t(($) => {
           return $.activity.detail.activity;
         })}
@@ -115,7 +115,11 @@ function InspectEmptyState() {
         })}
       />
       <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
-        <IconUpload size={48} stroke={1} className="text-muted-foreground/40" />
+        <Upload
+          size={48}
+          strokeWidth={1}
+          className="text-muted-foreground/40"
+        />
         <h2 className="text-lg font-semibold text-foreground">
           {t(($) => {
             return $.activity.inspect.noLog.title;
@@ -133,7 +137,7 @@ function InspectEmptyState() {
         )}
         <Button variant="outline" asChild>
           <label className="cursor-pointer">
-            <IconUpload size={16} stroke={1.5} />
+            <Upload size={16} strokeWidth={1.5} />
             {t(($) => {
               return $.activity.inspect.noLog.upload;
             })}
@@ -235,7 +239,7 @@ function StepsTab({
         </div>
         <div className="flex items-center gap-2 sm:gap-3">
           <div className="relative flex-1 sm:flex-none sm:w-44">
-            <IconSearch className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
               placeholder={t(($) => {
                 return $.activity.detail.steps.search;

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -241,7 +241,7 @@ function AgentTabsView({
             return onCreate(activeTab);
           }}
         >
-          <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
+          <Plus size={14} strokeWidth={2} data-stroke />
           {t(($) => {
             return $.list.actions.new;
           })}

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -2,7 +2,7 @@ import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { IconLoader2, IconPlus, IconWand } from "@tabler/icons-react";
+import { Loader2, Plus, Wand } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -241,7 +241,7 @@ function AgentTabsView({
             return onCreate(activeTab);
           }}
         >
-          <IconPlus size={14} stroke={2} />
+          <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
           {t(($) => {
             return $.list.actions.new;
           })}
@@ -422,7 +422,7 @@ function CreateAgentAvatarPreview() {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="absolute -right-0.5 -bottom-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border">
-                      <IconWand size={10} stroke={1.5} />
+                      <Wand size={10} strokeWidth={1.5} />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
@@ -619,7 +619,7 @@ function CreateTeammateDialogContent({
         >
           {creating ? (
             <span className="inline-flex items-center gap-1.5">
-              <IconLoader2 size={14} className="animate-spin" />
+              <Loader2 size={14} className="animate-spin" />
               {t(($) => {
                 return $.list.create.creating;
               })}

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -4,16 +4,16 @@ import type {
   ArtifactSummary,
 } from "@vm0/api-contracts/contracts/artifact-catalog";
 import {
-  IconAlertTriangle,
-  IconChevronRight,
-  IconFile,
-  IconPhoto,
-  IconPresentationAnalytics,
-  IconMessages,
-  IconUser,
-  IconVideo,
-  IconWorld,
-} from "@tabler/icons-react";
+  AlertTriangle,
+  ChevronRight,
+  File,
+  Image,
+  Presentation,
+  MessagesSquare,
+  User,
+  Video,
+  Globe,
+} from "lucide-react";
 import { r2ImageTransformUrl } from "@vm0/core";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { useGet, useLoadable, useSet } from "ccstate-react";
@@ -60,19 +60,19 @@ function ArtifactKindIcon({ kind }: { readonly kind: ArtifactCatalogKind }) {
   const { t } = useTranslation();
   const icon =
     kind === "presentation" ? (
-      <IconPresentationAnalytics size={16} stroke={1.7} />
+      <Presentation size={16} strokeWidth={1.7} />
     ) : kind === "hosted-site" ? (
-      <IconWorld size={16} stroke={1.7} />
+      <Globe size={16} strokeWidth={1.7} />
     ) : kind === "image" ? (
-      <IconPhoto size={16} stroke={1.7} />
+      <Image size={16} strokeWidth={1.7} />
     ) : kind === "video" ? (
-      <IconVideo size={16} stroke={1.7} />
+      <Video size={16} strokeWidth={1.7} />
     ) : kind === "avatar" ? (
-      <IconUser size={16} stroke={1.7} />
+      <User size={16} strokeWidth={1.7} />
     ) : kind === "shared-thread" ? (
-      <IconMessages size={16} stroke={1.7} />
+      <MessagesSquare size={16} strokeWidth={1.7} />
     ) : (
-      <IconFile size={16} stroke={1.7} />
+      <File size={16} strokeWidth={1.7} />
     );
   const kindLabel =
     kind === "presentation"
@@ -235,7 +235,7 @@ function ArtifactSharedConversationList({
               className="group flex w-full items-center gap-3 px-4 py-3 text-left outline-none transition-colors hover:bg-state-hover focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
             >
               <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-muted-foreground transition-colors group-hover:text-foreground">
-                <IconMessages size={16} stroke={1.7} aria-hidden />
+                <MessagesSquare size={16} strokeWidth={1.7} aria-hidden />
               </span>
               <span
                 title={artifact.title}
@@ -243,9 +243,9 @@ function ArtifactSharedConversationList({
               >
                 {artifact.title}
               </span>
-              <IconChevronRight
+              <ChevronRight
                 size={16}
-                stroke={1.7}
+                strokeWidth={1.7}
                 aria-hidden
                 className="shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
               />
@@ -340,7 +340,7 @@ export function ArtifactCatalogError() {
   const { t } = useTranslation();
   return (
     <Alert variant="destructive">
-      <IconAlertTriangle size={16} stroke={1.5} aria-hidden />
+      <AlertTriangle size={16} strokeWidth={1.5} aria-hidden />
       <AlertDescription>
         {t(($) => {
           return $.artifacts.catalog.error;

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -389,9 +389,9 @@ export function AuthLayout({ children }: AuthLayoutProps) {
           })}
         >
           {theme === "dark" ? (
-            <Sun size={16} strokeWidth={2} data-explicit-stroke-width />
+            <Sun size={16} strokeWidth={2} data-stroke />
           ) : (
-            <Moon size={16} strokeWidth={2} data-explicit-stroke-width />
+            <Moon size={16} strokeWidth={2} data-stroke />
           )}
         </button>
 

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -1,4 +1,4 @@
-import { IconMoon, IconSun } from "@tabler/icons-react";
+import { Moon, Sun } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -389,9 +389,9 @@ export function AuthLayout({ children }: AuthLayoutProps) {
           })}
         >
           {theme === "dark" ? (
-            <IconSun size={16} stroke={2} />
+            <Sun size={16} strokeWidth={2} data-explicit-stroke-width />
           ) : (
-            <IconMoon size={16} stroke={2} />
+            <Moon size={16} strokeWidth={2} data-explicit-stroke-width />
           )}
         </button>
 

--- a/turbo/apps/platform/src/views/auth/auth-page.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-page.tsx
@@ -1,5 +1,5 @@
 import { GoogleOneTap, SignIn, SignUp } from "@clerk/react";
-import { IconLoader2 } from "@tabler/icons-react";
+import { Loader2 } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { activeRoute$ } from "../../signals/active-route.ts";
@@ -27,7 +27,7 @@ function AuthLoadingFallback() {
       data-testid="clerk-auth-loading"
       role="status"
     >
-      <IconLoader2 className="animate-spin" size={20} aria-hidden="true" />
+      <Loader2 className="animate-spin" size={20} aria-hidden="true" />
       <span className="sr-only">
         {t(($) => {
           return $.auth.loading;

--- a/turbo/apps/platform/src/views/browser-authorization/browser-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/browser-authorization/browser-authorization-page.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconLoader2, IconWorld } from "@tabler/icons-react";
+import { Check, Loader2, Globe } from "lucide-react";
 import { useGet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
@@ -57,7 +57,7 @@ export function BrowserAuthorizationPage() {
   if (requestLoadable.state === "loading") {
     return (
       <div className="fixed inset-0 z-10 flex items-center justify-center">
-        <IconLoader2 size={22} className="animate-spin text-muted-foreground" />
+        <Loader2 size={22} className="animate-spin text-muted-foreground" />
       </div>
     );
   }
@@ -77,7 +77,7 @@ export function BrowserAuthorizationPage() {
         <div className="flex flex-col items-center gap-5 text-center">
           <Vm0LogoLink />
           <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-muted">
-            <IconWorld size={22} />
+            <Globe size={22} />
           </div>
           <div className="flex flex-col gap-2">
             <h1 className="text-lg font-medium text-foreground">
@@ -102,11 +102,11 @@ export function BrowserAuthorizationPage() {
           className="h-10 w-full"
         >
           {applying ? (
-            <IconLoader2 size={16} className="animate-spin" />
+            <Loader2 size={16} className="animate-spin" />
           ) : enabled ? (
-            <IconCheck size={16} />
+            <Check size={16} />
           ) : (
-            <IconWorld size={16} />
+            <Globe size={16} />
           )}
           {enabled
             ? t(($) => {

--- a/turbo/apps/platform/src/views/components/loading-switch.tsx
+++ b/turbo/apps/platform/src/views/components/loading-switch.tsx
@@ -1,4 +1,4 @@
-import { IconLoader2 } from "@tabler/icons-react";
+import { Loader2 } from "lucide-react";
 import { Switch, cn } from "@vm0/ui";
 
 /** Track/thumb sizing shared with plain `Switch` when toggles must align (e.g. settings rows). */
@@ -38,9 +38,9 @@ export function LoadingSwitch({
         className={size === "default" ? compactSwitchClassName : undefined}
       />
       {loading && (
-        <IconLoader2
+        <Loader2
           size={10}
-          stroke={2.5}
+          strokeWidth={2.5}
           className={cn(
             "absolute top-1/2 -translate-x-1/2 -translate-y-1/2 animate-spin text-muted-foreground/70",
             checked ? "left-1/4" : "left-3/4",

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -1,7 +1,7 @@
 import MarkdownPreview, {
   type MarkdownPreviewProps,
 } from "@uiw/react-markdown-preview/common";
-import { IconLoader2, IconPhoto } from "@tabler/icons-react";
+import { Loader2, Image } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { openImageLightbox$ } from "../../signals/zero-page/zero-attachment-chips.ts";
@@ -277,9 +277,9 @@ function MediaImage({ src, alt }: { src: string; alt: string }) {
           className="absolute inset-0 flex h-full w-full items-center justify-center bg-muted/70 text-muted-foreground"
         >
           {imageStatus === "loading" ? (
-            <IconLoader2 size={18} stroke={1.8} className="animate-spin" />
+            <Loader2 size={18} strokeWidth={1.8} className="animate-spin" />
           ) : (
-            <IconPhoto size={18} stroke={1.5} />
+            <Image size={18} strokeWidth={1.5} />
           )}
         </span>
       )}

--- a/turbo/apps/platform/src/views/components/mermaid-diagram.tsx
+++ b/turbo/apps/platform/src/views/components/mermaid-diagram.tsx
@@ -1,4 +1,4 @@
-import { IconLoader2 } from "@tabler/icons-react";
+import { Loader2 } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import {
@@ -78,7 +78,7 @@ export function MermaidDiagram({
           />
         ) : (
           <span className="mermaid-diagram-pending" aria-hidden="true">
-            <IconLoader2 size={18} stroke={1.8} className="animate-spin" />
+            <Loader2 size={18} strokeWidth={1.8} className="animate-spin" />
           </span>
         )}
       </button>

--- a/turbo/apps/platform/src/views/components/pagination.tsx
+++ b/turbo/apps/platform/src/views/components/pagination.tsx
@@ -1,9 +1,9 @@
 import {
-  IconChevronLeft,
-  IconChevronRight,
-  IconChevronsLeft,
-  IconChevronsRight,
-} from "@tabler/icons-react";
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
 import {
   Button,
   Select,
@@ -73,7 +73,7 @@ function PaginationNavigation({
         onClick={onBackTwoPages}
         disabled={!canGoBackTwo}
       >
-        <IconChevronsLeft className="size-4" />
+        <ChevronsLeft className="size-4" />
       </Button>
       <Button
         aria-label={t(($) => {
@@ -85,7 +85,7 @@ function PaginationNavigation({
         onClick={onPrevPage}
         disabled={!hasPrev}
       >
-        <IconChevronLeft className="size-4" />
+        <ChevronLeft className="size-4" />
       </Button>
       <Button
         aria-label={t(($) => {
@@ -97,7 +97,7 @@ function PaginationNavigation({
         onClick={onNextPage}
         disabled={!hasNext || isLoading}
       >
-        <IconChevronRight className="size-4" />
+        <ChevronRight className="size-4" />
       </Button>
       <Button
         aria-label={t(($) => {
@@ -109,7 +109,7 @@ function PaginationNavigation({
         onClick={onForwardTwoPages}
         disabled={!hasNext || isLoading}
       >
-        <IconChevronsRight className="size-4" />
+        <ChevronsRight className="size-4" />
       </Button>
     </div>
   );

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -1,12 +1,6 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import {
-  IconAlertTriangle,
-  IconCheck,
-  IconDeviceDesktop,
-  IconDownload,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { AlertTriangle, Check, Monitor, Download, Loader2 } from "lucide-react";
 import type {
   ComputerUseAuthorizationSource,
   ComputerUseHost,
@@ -75,7 +69,7 @@ function HostOption({
     <div className="flex w-full flex-col gap-3 rounded-lg border border-border bg-background px-3 py-3 text-left sm:flex-row sm:items-center sm:justify-between">
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
-          <IconDeviceDesktop size={18} />
+          <Monitor size={18} />
         </div>
         <div className="min-w-0">
           <div className="truncate text-sm font-medium text-foreground">
@@ -98,10 +92,10 @@ function HostOption({
         onClick={onAuthorize}
         className="h-9 w-full shrink-0 sm:w-auto"
       >
-        {applying && <IconLoader2 size={16} className="animate-spin" />}
+        {applying && <Loader2 size={16} className="animate-spin" />}
         {applied ? (
           <>
-            <IconCheck size={16} />
+            <Check size={16} />
             {t(($) => {
               return $.authorization.computerUse.authorized;
             })}
@@ -154,7 +148,7 @@ function EmptyHosts() {
       </div>
       {downloadSupportStatus === "unsupported-intel-mac" ? (
         <Button type="button" variant="outline" disabled className="h-9">
-          <IconAlertTriangle size={16} />
+          <AlertTriangle size={16} />
           {t(($) => {
             return $.authorization.computerUse.unsupportedIntelMac;
           })}
@@ -172,7 +166,7 @@ function EmptyHosts() {
           rel="noreferrer"
           className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-state-hover"
         >
-          <IconDownload size={16} />
+          <Download size={16} />
           {t(($) => {
             return $.authorization.computerUse.downloadMac;
           })}
@@ -225,7 +219,7 @@ export function ComputerUseAuthorizationPage() {
   if (requestLoadable.state === "loading") {
     return (
       <div className="fixed inset-0 z-10 flex items-center justify-center">
-        <IconLoader2 size={22} className="animate-spin text-muted-foreground" />
+        <Loader2 size={22} className="animate-spin text-muted-foreground" />
       </div>
     );
   }
@@ -244,7 +238,7 @@ export function ComputerUseAuthorizationPage() {
         <div className="flex flex-col items-center gap-5 text-center">
           <Vm0LogoLink />
           <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-muted">
-            <IconDeviceDesktop size={22} />
+            <Monitor size={22} />
           </div>
           <div className="flex flex-col gap-2">
             <h1 className="text-lg font-medium text-foreground">

--- a/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@vm0/ui";
-import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
+import { AlertCircle, Check, Loader2 } from "lucide-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import {
@@ -26,7 +26,7 @@ export function EmailUnsubscribePage() {
         <VM0Logo />
         {status === "done" ? (
           <div className="flex flex-col items-center gap-2.5">
-            <IconCheck size={20} className="text-muted-foreground" />
+            <Check size={20} className="text-muted-foreground" />
             <h1 className="text-lg font-medium text-foreground">
               {t(($) => {
                 return $.lifecycle.emailUnsubscribe.doneTitle;
@@ -43,7 +43,7 @@ export function EmailUnsubscribePage() {
           </div>
         ) : status === "error" || !token ? (
           <div className="flex flex-col items-center gap-2.5">
-            <IconAlertCircle size={20} className="text-destructive" />
+            <AlertCircle size={20} className="text-destructive" />
             <h1 className="text-lg font-medium text-foreground">
               {t(($) => {
                 return $.lifecycle.emailUnsubscribe.errorTitle;
@@ -79,7 +79,7 @@ export function EmailUnsubscribePage() {
               }}
             >
               {status === "submitting" ? (
-                <IconLoader2 size={16} className="animate-spin" />
+                <Loader2 size={16} className="animate-spin" />
               ) : null}
               {t(($) => {
                 return $.lifecycle.emailUnsubscribe.action;

--- a/turbo/apps/platform/src/views/export-page/export-page.tsx
+++ b/turbo/apps/platform/src/views/export-page/export-page.tsx
@@ -1,14 +1,14 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
-  IconAlertCircle,
-  IconArrowLeft,
-  IconCircleCheck,
-  IconDatabaseExport,
-  IconDownload,
-  IconLoader2,
-  IconRefresh,
-} from "@tabler/icons-react";
+  AlertCircle,
+  ArrowLeft,
+  CircleCheck,
+  DatabaseBackup,
+  Download,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
 import type { UserExportStatusResponse } from "@vm0/api-contracts/contracts/user-export";
 import { Button } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
@@ -120,15 +120,15 @@ function errorMessage(error: unknown, fallback: string): string {
 
 function StatusIcon({ viewState }: { readonly viewState: ExportViewState }) {
   if (viewState === "loading" || viewState === "in-progress") {
-    return <IconLoader2 size={22} className="animate-spin" stroke={1.8} />;
+    return <Loader2 size={22} className="animate-spin" strokeWidth={1.8} />;
   }
   if (viewState === "download") {
-    return <IconCircleCheck size={22} stroke={1.8} />;
+    return <CircleCheck size={22} strokeWidth={1.8} />;
   }
   if (viewState === "failed") {
-    return <IconAlertCircle size={22} stroke={1.8} />;
+    return <AlertCircle size={22} strokeWidth={1.8} />;
   }
-  return <IconDatabaseExport size={22} stroke={1.8} />;
+  return <DatabaseBackup size={22} strokeWidth={1.8} />;
 }
 
 function StatusCopy({
@@ -294,7 +294,7 @@ function ExportActions({
       <div className="flex w-full flex-col gap-2">
         <Button asChild className={PRIMARY_ACTION_BUTTON_CLASS}>
           <a href={downloadUrl} download>
-            <IconDownload size={16} stroke={1.8} />
+            <Download size={16} strokeWidth={1.8} />
             {t(($) => {
               return $.settings.export.actions.download;
             })}
@@ -309,9 +309,9 @@ function ExportActions({
             onClick={onTrigger}
           >
             {triggering ? (
-              <IconLoader2 size={16} className="animate-spin" stroke={1.8} />
+              <Loader2 size={16} className="animate-spin" strokeWidth={1.8} />
             ) : (
-              <IconRefresh size={16} stroke={1.8} />
+              <RefreshCw size={16} strokeWidth={1.8} />
             )}
             {t(($) => {
               return $.settings.export.actions.again;
@@ -338,9 +338,9 @@ function ExportActions({
       onClick={onTrigger}
     >
       {triggering ? (
-        <IconLoader2 size={16} className="animate-spin" stroke={1.8} />
+        <Loader2 size={16} className="animate-spin" strokeWidth={1.8} />
       ) : (
-        <IconDatabaseExport size={16} stroke={1.8} />
+        <DatabaseBackup size={16} strokeWidth={1.8} />
       )}
       {triggering
         ? t(($) => {
@@ -442,7 +442,7 @@ export function ExportPage() {
               pathname="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground no-underline transition-colors hover:text-foreground"
             >
-              <IconArrowLeft size={14} stroke={1.8} />
+              <ArrowLeft size={14} strokeWidth={1.8} />
               {t(($) => {
                 return $.settings.export.backToZero;
               })}

--- a/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useGet } from "ccstate-react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
-import { IconCheck, IconLoader2, IconX } from "@tabler/icons-react";
+import { Check, Loader2, X } from "lucide-react";
 import { Button } from "@vm0/ui";
 import {
   morningBriefUnsubscribeStatus$,
@@ -47,9 +47,9 @@ function CardIcon({
   status: MorningBriefUnsubscribeStatus;
 }): ReactNode {
   if (status === "unsubscribed") {
-    return <IconCheck size={40} className="text-green-600 opacity-80" />;
+    return <Check size={40} className="text-green-600 opacity-80" />;
   }
-  return <IconX size={40} className="text-destructive opacity-70" />;
+  return <X size={40} className="text-destructive opacity-70" />;
 }
 
 export function MorningBriefUnsubscribePage() {
@@ -59,7 +59,7 @@ export function MorningBriefUnsubscribePage() {
   if (!status) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center">
-        <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
+        <Loader2 size={40} className="animate-spin text-muted-foreground" />
         <span className="sr-only">
           {t(($) => {
             return $.lifecycle.morningBriefUnsubscribe.loadingLabel;

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1,10 +1,6 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import {
-  IconChevronDown,
-  IconChevronLeft,
-  IconChevronRight,
-} from "@tabler/icons-react";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { emptyInsightsImg } from "../zero-page/platform-assets.ts";
 import {
   Skeleton,
@@ -310,7 +306,7 @@ function CustomRangePicker({
             })}
             className="h-7 w-7 inline-flex items-center justify-center rounded-md hover:bg-state-hover transition-colors"
           >
-            <IconChevronLeft size={14} stroke={1.5} />
+            <ChevronLeft size={14} strokeWidth={1.5} />
           </button>
           <p className="text-sm font-semibold">{monthLabel}</p>
           <button
@@ -321,7 +317,7 @@ function CustomRangePicker({
             })}
             className="h-7 w-7 inline-flex items-center justify-center rounded-md hover:bg-state-hover transition-colors"
           >
-            <IconChevronRight size={14} stroke={1.5} />
+            <ChevronRight size={14} strokeWidth={1.5} />
           </button>
         </div>
         <CalendarMonth
@@ -370,9 +366,9 @@ function DateRangeFilter({
           className="flex items-center gap-2 rounded-lg border bg-background px-3 py-1.5 text-sm font-medium text-foreground hover:bg-state-hover transition-colors"
         >
           {dateRangeLabel(value)}
-          <IconChevronDown
+          <ChevronDown
             size={14}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="text-muted-foreground"
           />
         </button>

--- a/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
-import { IconLoader2 } from "@tabler/icons-react";
+import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog,
@@ -105,7 +105,7 @@ export function OnboardingFooter({
         className="inline-flex h-10 min-w-[100px] items-center justify-center gap-2 rounded-lg bg-primary px-6 text-sm font-medium text-white hover:bg-primary-hover disabled:cursor-not-allowed disabled:bg-[hsl(var(--primary-500))]"
       >
         {busy ? (
-          <IconLoader2 size={16} className="animate-spin" aria-hidden="true" />
+          <Loader2 size={16} className="animate-spin" aria-hidden="true" />
         ) : null}
         {primaryLabel}
       </button>

--- a/turbo/apps/platform/src/views/onboarding/onboarding-template-picker-pages.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-template-picker-pages.tsx
@@ -1,11 +1,6 @@
 import type { SyntheticEvent } from "react";
 import { useGet, useSet } from "ccstate-react";
-import {
-  IconChevronLeft,
-  IconChevronRight,
-  IconCircleCheckFilled,
-  IconEye,
-} from "@tabler/icons-react";
+import { ChevronLeft, ChevronRight, CircleCheckBig, Eye } from "lucide-react";
 import {
   r2ImageTransformUrl,
   type IllustrationTemplateItem,
@@ -37,7 +32,7 @@ import {
 
 function SelectionCheck({ selected }: { readonly selected: boolean }) {
   return selected ? (
-    <IconCircleCheckFilled
+    <CircleCheckBig
       size={18}
       className="shrink-0 text-primary"
       aria-hidden="true"
@@ -115,7 +110,7 @@ function PresentationPreview({
             move(-1);
           }}
         >
-          <IconChevronLeft size={20} aria-hidden="true" />
+          <ChevronLeft size={20} aria-hidden="true" />
         </button>
         <button
           type="button"
@@ -127,7 +122,7 @@ function PresentationPreview({
             move(1);
           }}
         >
-          <IconChevronRight size={20} aria-hidden="true" />
+          <ChevronRight size={20} aria-hidden="true" />
         </button>
       </div>
       <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
@@ -218,7 +213,7 @@ function PresentationTemplateCard({
         )}
         onClick={onPreview}
       >
-        <IconEye size={13} aria-hidden="true" />
+        <Eye size={13} aria-hidden="true" />
       </button>
       <div className="flex min-w-0 items-center justify-between gap-2 px-2.5 py-[9px]">
         <span className="truncate text-[11px] font-semibold leading-4">

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
@@ -1,20 +1,20 @@
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
-  IconBox,
-  IconBriefcase,
-  IconChartBar,
-  IconCircleCheckFilled,
-  IconCode,
-  IconMessageCircle,
-  IconMessagePlus,
-  IconScanEye,
-  IconSparkles,
-  IconSpeakerphone,
-  IconSun,
-  IconTrendingUp,
-  type Icon,
-} from "@tabler/icons-react";
+  Box,
+  Briefcase,
+  ChartBar,
+  CircleCheckBig,
+  Code,
+  MessageCircle,
+  MessageSquarePlus,
+  ScanEye,
+  Sparkles,
+  Megaphone,
+  Sun,
+  TrendingUp,
+  type LucideIcon,
+} from "lucide-react";
 import { cn } from "@vm0/ui";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { useTranslation } from "react-i18next";
@@ -46,16 +46,18 @@ import {
 } from "./onboarding-shell.tsx";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 
-const CATEGORY_ICONS: Readonly<Record<OnboardingWorkflowCategoryId, Icon>> = {
-  engineering: IconCode,
-  product: IconBox,
-  data: IconChartBar,
-  marketing: IconSpeakerphone,
-  sales: IconTrendingUp,
-  support: IconMessageCircle,
-  ceo: IconBriefcase,
-  operations: IconSun,
-  everyone: IconSparkles,
+const CATEGORY_ICONS: Readonly<
+  Record<OnboardingWorkflowCategoryId, LucideIcon>
+> = {
+  engineering: Code,
+  product: Box,
+  data: ChartBar,
+  marketing: Megaphone,
+  sales: TrendingUp,
+  support: MessageCircle,
+  ceo: Briefcase,
+  operations: Sun,
+  everyone: Sparkles,
 };
 
 function WorkflowConnectorIcon({
@@ -242,11 +244,11 @@ function WorkflowCard({
           })}
           onClick={onPreview}
         >
-          <IconScanEye size={16} stroke={1.6} aria-hidden="true" />
+          <ScanEye size={16} strokeWidth={1.6} aria-hidden="true" />
         </button>
       </span>
       {selected ? (
-        <IconCircleCheckFilled
+        <CircleCheckBig
           size={18}
           className="absolute right-3 top-3 text-primary"
           aria-hidden="true"
@@ -299,7 +301,7 @@ function WorkflowOptions({
         )}
       >
         <span className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-muted/40 text-primary">
-          <IconMessagePlus size={19} aria-hidden="true" />
+          <MessageSquarePlus size={19} aria-hidden="true" />
         </span>
         <span className="text-sm font-semibold text-foreground">
           {t(($) => {
@@ -337,7 +339,7 @@ function CategoryOptions({
             className="flex min-h-[130px] min-w-0 flex-col items-start gap-2.5 rounded-xl border border-border bg-background p-4 text-left shadow-[var(--zero-card-shadow)] transition-colors hover:border-primary"
           >
             <span className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-muted/40">
-              <CategoryIcon size={21} stroke={1.7} aria-hidden="true" />
+              <CategoryIcon size={21} strokeWidth={1.7} aria-hidden="true" />
             </span>
             <span className="text-sm font-semibold">{category.title}</span>
             <span className="text-xs leading-[1.35] text-muted-foreground">

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
@@ -1,5 +1,5 @@
 import { useGet, useSet } from "ccstate-react";
-import { IconScanEye } from "@tabler/icons-react";
+import { ScanEye } from "lucide-react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
@@ -110,7 +110,7 @@ export function OnboardingWorkflowRunPage() {
                   setUi({ workflowPreviewId: workflow.id });
                 }}
               >
-                <IconScanEye size={16} stroke={1.6} aria-hidden="true" />
+                <ScanEye size={16} strokeWidth={1.6} aria-hidden="true" />
               </button>
             </div>
           </section>

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -3,12 +3,7 @@ import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { Button } from "@vm0/ui";
-import {
-  IconAlertTriangle,
-  IconBan,
-  IconCheck,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { AlertTriangle, Ban, Check, Loader2 } from "lucide-react";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type {
   PlatformConnectorPermissionMetadata,
@@ -129,15 +124,9 @@ function ConnectorPermissionCard({
         </div>
         <div className="flex items-center gap-2 py-2">
           {action === "allow" ? (
-            <IconCheck
-              size={20}
-              className="shrink-0 text-green-600 opacity-70"
-            />
+            <Check size={20} className="shrink-0 text-green-600 opacity-70" />
           ) : (
-            <IconBan
-              size={20}
-              className="shrink-0 text-destructive opacity-70"
-            />
+            <Ban size={20} className="shrink-0 text-destructive opacity-70" />
           )}
           <span className="min-w-0 flex-1 text-sm text-foreground truncate">
             {permission.description ?? permission.name}
@@ -156,7 +145,7 @@ function LoadingCard() {
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
         <VM0Logo />
-        <IconLoader2 size={20} className="animate-spin text-muted-foreground" />
+        <Loader2 size={20} className="animate-spin text-muted-foreground" />
       </div>
     </div>
   );
@@ -214,9 +203,9 @@ function ResultCard({
         <VM0Logo />
         <div className="flex flex-col items-center gap-4">
           {allowed ? (
-            <IconCheck size={40} className="text-green-600 opacity-70" />
+            <Check size={40} className="text-green-600 opacity-70" />
           ) : (
-            <IconBan size={40} className="text-destructive opacity-70" />
+            <Ban size={40} className="text-destructive opacity-70" />
           )}
           <p className="text-center text-lg font-medium leading-7 text-foreground">
             {title}
@@ -247,7 +236,7 @@ function ErrorMessage({ message }: { message: string }) {
   return (
     <StatusMessage>
       <div className="flex flex-col items-center gap-2">
-        <IconAlertTriangle size={24} />
+        <AlertTriangle size={24} />
         <p className="text-sm">{message}</p>
       </div>
     </StatusMessage>
@@ -494,7 +483,7 @@ function ConfirmGrantCard({
         <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col gap-3 px-[26px]">
           {saveError && (
             <div className="flex items-center justify-center gap-2 text-sm font-medium text-destructive">
-              <IconAlertTriangle size={16} />
+              <AlertTriangle size={16} />
               <span>
                 {t(($) => {
                   return $.authorization.permission.errors.updateFailed;

--- a/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
+++ b/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
@@ -1,11 +1,6 @@
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import {
-  IconDownload,
-  IconShare2,
-  IconSquarePlus,
-  IconX,
-} from "@tabler/icons-react";
+import { Download, Share2, SquarePlus, X } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -38,7 +33,7 @@ export function InstallBanner() {
 
   return (
     <div className="shrink-0 flex items-center gap-2 bg-primary/5 border-b border-primary/20 px-3 py-2 text-sm">
-      <IconDownload size={16} className="text-primary shrink-0" />
+      <Download size={16} className="text-primary shrink-0" />
       <span className="flex-1 min-w-0 truncate text-foreground">
         {t(($) => {
           return $.lifecycle.pwaInstall.banner;
@@ -68,7 +63,7 @@ export function InstallBanner() {
           return $.lifecycle.pwaInstall.dismiss;
         })}
       >
-        <IconX size={14} />
+        <X size={14} />
       </button>
     </div>
   );
@@ -107,7 +102,7 @@ export function IosInstallModal() {
               1
             </span>
             <span className="flex-1 flex items-center gap-1.5 flex-wrap">
-              <IconShare2 size={16} className="inline" aria-hidden />
+              <Share2 size={16} className="inline" aria-hidden />
               {t(($) => {
                 return $.lifecycle.pwaInstall.stepOne;
               })}
@@ -118,7 +113,7 @@ export function IosInstallModal() {
               2
             </span>
             <span className="flex-1 flex items-center gap-1.5 flex-wrap">
-              <IconSquarePlus size={16} className="inline" aria-hidden />
+              <SquarePlus size={16} className="inline" aria-hidden />
               {t(($) => {
                 return $.lifecycle.pwaInstall.stepTwo;
               })}

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -337,7 +337,7 @@ function ConcurrencyQuantityControl({
               onQuantityChange(quantity - 1);
             }}
           >
-            <Minus size={14} strokeWidth={2} data-explicit-stroke-width />
+            <Minus size={14} strokeWidth={2} data-stroke />
           </button>
           <span className="flex h-9 w-12 items-center justify-center border-x border-border/70 text-sm font-medium tabular-nums text-foreground">
             {quantity}
@@ -353,7 +353,7 @@ function ConcurrencyQuantityControl({
               onQuantityChange(quantity + 1);
             }}
           >
-            <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
+            <Plus size={14} strokeWidth={2} data-stroke />
           </button>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -15,7 +15,7 @@ import {
   SheetTitle,
   Button,
 } from "@vm0/ui";
-import { IconCrown, IconMinus, IconPlus } from "@tabler/icons-react";
+import { Crown, Minus, Plus } from "lucide-react";
 import {
   CONCURRENCY_QUANTITY_MAX,
   CONCURRENCY_QUANTITY_MIN,
@@ -240,7 +240,7 @@ function UpgradeCard({
           {upgrade.targetLabel}
         </h3>
         <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <IconCrown size={12} stroke={1.8} className="text-amber-500" />
+          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
           {t(($) => {
             return $.queue.upgrade.recommended;
           })}
@@ -337,7 +337,7 @@ function ConcurrencyQuantityControl({
               onQuantityChange(quantity - 1);
             }}
           >
-            <IconMinus size={14} stroke={2} />
+            <Minus size={14} strokeWidth={2} data-explicit-stroke-width />
           </button>
           <span className="flex h-9 w-12 items-center justify-center border-x border-border/70 text-sm font-medium tabular-nums text-foreground">
             {quantity}
@@ -353,7 +353,7 @@ function ConcurrencyQuantityControl({
               onQuantityChange(quantity + 1);
             }}
           >
-            <IconPlus size={14} stroke={2} />
+            <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
           </button>
         </div>
       </div>
@@ -392,7 +392,7 @@ function ConcurrencyPurchaseCard({
           })}
         </h3>
         <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <IconCrown size={12} stroke={1.8} className="text-amber-500" />
+          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
           {t(($) => {
             return $.queue.purchase.addOn;
           })}

--- a/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
+++ b/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
@@ -2,13 +2,7 @@ import type { ReactNode } from "react";
 import { useGet, useLastLoadable } from "ccstate-react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
-import {
-  IconCheck,
-  IconGift,
-  IconLoader2,
-  IconLock,
-  IconX,
-} from "@tabler/icons-react";
+import { Check, Gift, Loader2, Lock, X } from "lucide-react";
 import { Button } from "@vm0/ui";
 import type { RedeemResponse } from "@vm0/api-contracts/contracts/zero-billing";
 import {
@@ -150,23 +144,21 @@ function resolveCard(
 function CardIcon({ kind }: { kind: CardKind }): ReactNode {
   switch (kind) {
     case "ready": {
-      return <IconGift size={40} className="text-foreground opacity-80" />;
+      return <Gift size={40} className="text-foreground opacity-80" />;
     }
     case "granted": {
-      return <IconCheck size={40} className="text-green-600 opacity-80" />;
+      return <Check size={40} className="text-green-600 opacity-80" />;
     }
     case "processing": {
       return (
-        <IconLoader2 size={40} className="animate-spin text-muted-foreground" />
+        <Loader2 size={40} className="animate-spin text-muted-foreground" />
       );
     }
     case "auth": {
-      return (
-        <IconLock size={40} className="text-muted-foreground opacity-70" />
-      );
+      return <Lock size={40} className="text-muted-foreground opacity-70" />;
     }
     case "broken": {
-      return <IconX size={40} className="text-destructive opacity-70" />;
+      return <X size={40} className="text-destructive opacity-70" />;
     }
   }
 }

--- a/turbo/apps/platform/src/views/report-error/report-error-page.tsx
+++ b/turbo/apps/platform/src/views/report-error/report-error-page.tsx
@@ -1,12 +1,7 @@
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Button, Input } from "@vm0/ui";
-import {
-  IconAlertTriangle,
-  IconCheck,
-  IconLoader2,
-  IconX,
-} from "@tabler/icons-react";
+import { AlertTriangle, Check, Loader2, X } from "lucide-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   reportErrorRun$,
@@ -75,7 +70,7 @@ function LoadingCard() {
         role="status"
         className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12"
       >
-        <IconLoader2 size={20} className="animate-spin text-muted-foreground" />
+        <Loader2 size={20} className="animate-spin text-muted-foreground" />
         <span className="sr-only">
           {t(($) => {
             return $.reportError.loading;
@@ -150,7 +145,7 @@ function ConfirmCard({
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-6 rounded-[20px] border border-border bg-background px-8 py-10">
-        <IconAlertTriangle size={40} className="text-orange-500 opacity-70" />
+        <AlertTriangle size={40} className="text-orange-500 opacity-70" />
 
         <div className="flex flex-col items-center gap-2">
           <p className="text-center text-lg font-medium leading-7 text-foreground">
@@ -219,9 +214,7 @@ function ConfirmCard({
           onClick={onSubmit}
           disabled={loading || !canSubmit}
         >
-          {loading ? (
-            <IconLoader2 size={16} className="animate-spin mr-2" />
-          ) : null}
+          {loading ? <Loader2 size={16} className="animate-spin mr-2" /> : null}
           {loading
             ? t(($) => {
                 return $.reportError.sending;
@@ -240,7 +233,7 @@ function SuccessCard({ reference }: { reference: string }) {
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-6 rounded-[20px] border border-border bg-background px-8 py-10">
-        <IconCheck size={40} className="text-green-600 opacity-70" />
+        <Check size={40} className="text-green-600 opacity-70" />
         <div className="flex flex-col items-center gap-2">
           <p className="text-center text-lg font-medium leading-7 text-foreground">
             {t(($) => {
@@ -277,7 +270,7 @@ function ErrorCard({
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-6 rounded-[20px] border border-border bg-background px-8 py-10">
-        <IconX size={40} className="text-destructive opacity-70" />
+        <X size={40} className="text-destructive opacity-70" />
         <div className="flex flex-col items-center gap-2">
           <p className="text-center text-lg font-medium leading-7 text-foreground">
             {t(($) => {

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -2,7 +2,7 @@ import type {
   SharedMessage,
   SharedThreadResponse,
 } from "@vm0/api-contracts/contracts/shared-threads";
-import { IconMessageCircle } from "@tabler/icons-react";
+import { MessageCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Markdown } from "../components/markdown.tsx";
@@ -136,7 +136,7 @@ export function SharedThreadPage({
             className="inline-flex items-center gap-2 text-sm font-semibold text-foreground"
           >
             <span className="inline-flex h-7 w-7 items-center justify-center rounded-lg bg-[#ed4e01] text-white">
-              <IconMessageCircle size={17} stroke={1.8} />
+              <MessageCircle size={17} strokeWidth={1.8} />
             </span>
             {t(($) => {
               return $.sharedThread.brand;

--- a/turbo/apps/platform/src/views/team-page/custom-connector-permissions-drawer.tsx
+++ b/turbo/apps/platform/src/views/team-page/custom-connector-permissions-drawer.tsx
@@ -1,4 +1,4 @@
-import { IconLoader2 } from "@tabler/icons-react";
+import { Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { CustomConnectorPermissionBundleResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
@@ -234,7 +234,7 @@ export function CustomConnectorPermissionsDrawer({
             <div className="flex flex-1 items-center justify-center">
               {loading ? (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <IconLoader2 size={16} className="animate-spin" />
+                  <Loader2 size={16} className="animate-spin" />
                   {t(($) => {
                     return $.connectors.permissions.loading;
                   })}

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -7,7 +7,7 @@ import {
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
+import { SlidersHorizontal } from "lucide-react";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   Tooltip,
@@ -95,7 +95,7 @@ function CustomConnectorPermissionRow({
                   { connector: connector.displayName },
                 )}
               >
-                <IconAdjustmentsHorizontal size={15} stroke={1.5} />
+                <SlidersHorizontal size={15} strokeWidth={1.5} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -11,15 +11,15 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
-  IconFileText,
-  IconUserCircle,
-  IconShield,
-  IconUsers,
-  IconSearch,
-  IconX,
-  IconMessageCircle,
-  IconWand,
-} from "@tabler/icons-react";
+  FileText,
+  UserCircle,
+  Shield,
+  Users,
+  Search,
+  X,
+  MessageCircle,
+  Wand,
+} from "lucide-react";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   Button,
@@ -158,7 +158,7 @@ function Breadcrumb({
         pathname="/agents"
         className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-state-hover hover:text-foreground transition-colors no-underline text-inherit"
       >
-        <IconUsers size={14} stroke={1.5} className="shrink-0" />
+        <Users size={14} strokeWidth={1.5} className="shrink-0" />
         {t(($) => {
           return $.list.title;
         })}
@@ -317,14 +317,14 @@ function AgentTabNav({
       {/* Desktop: tab list */}
       <TabsList className="zero-tabs hidden sm:inline-flex h-9 gap-1 px-1 py-1">
         <TabsTrigger value="authorization" className={TAB_TRIGGER_CLASS}>
-          <IconShield size={14} stroke={1.5} />
+          <Shield size={14} strokeWidth={1.5} />
           {t(($) => {
             return $.detail.tabs.authorization;
           })}
         </TabsTrigger>
         {showProfileAndInstructions && (
           <TabsTrigger value="profile" className={TAB_TRIGGER_CLASS}>
-            <IconUserCircle size={14} stroke={1.5} />
+            <UserCircle size={14} strokeWidth={1.5} />
             {t(($) => {
               return $.detail.tabs.profile;
             })}
@@ -332,7 +332,7 @@ function AgentTabNav({
         )}
         {showProfileAndInstructions && (
           <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
-            <IconFileText size={14} stroke={1.5} />
+            <FileText size={14} strokeWidth={1.5} />
             {t(($) => {
               return $.detail.tabs.instructions;
             })}
@@ -464,9 +464,9 @@ function ConnectedConnectorPermissions({
           </div>
           {searchActive && (
             <div className="absolute inset-0 flex items-center gap-2 px-5">
-              <IconSearch
+              <Search
                 size={14}
-                stroke={1.5}
+                strokeWidth={1.5}
                 className="shrink-0 text-muted-foreground"
               />
               <input
@@ -500,7 +500,7 @@ function ConnectedConnectorPermissions({
                   return $.authorization.closeSearch;
                 })}
               >
-                <IconX size={14} stroke={1.5} />
+                <X size={14} strokeWidth={1.5} />
               </button>
             </div>
           )}
@@ -515,7 +515,7 @@ function ConnectedConnectorPermissions({
                 return $.authorization.findConnectors;
               })}
             >
-              <IconSearch size={14} stroke={1.5} />
+              <Search size={14} strokeWidth={1.5} />
             </button>
           )}
         </div>
@@ -880,7 +880,7 @@ function AgentHeader({
                         return $.avatar.actions.customize;
                       })}
                     >
-                      <IconWand size={12} stroke={1.5} />
+                      <Wand size={12} strokeWidth={1.5} />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
@@ -922,7 +922,12 @@ function AgentHeader({
             { agentName: displayName },
           )}
         >
-          <IconMessageCircle size={14} stroke={2} className="shrink-0" />
+          <MessageCircle
+            size={14}
+            strokeWidth={2}
+            className="shrink-0"
+            data-explicit-stroke-width
+          />
           <span className="truncate">
             {t(
               ($) => {

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -926,7 +926,7 @@ function AgentHeader({
             size={14}
             strokeWidth={2}
             className="shrink-0"
-            data-explicit-stroke-width
+            data-stroke
           />
           <span className="truncate">
             {t(

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -32,40 +32,37 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import type { PlatformWorkflowConnectorReadinessEntry } from "../../signals/connector-domain.ts";
 import {
-  IconAlertTriangle,
-  IconBrandGithub,
-  IconBrandNotion,
-  IconBrandStripe,
-  IconCalendarTime,
-  IconCircleCheck,
-  IconChevronDown,
-  IconClock,
-  IconCopy,
-  IconDatabasePlus,
-  IconFilePencil,
-  IconFilePlus,
-  IconFileText,
-  IconHistory,
-  IconInfoCircle,
-  IconLink,
-  IconLoader2,
-  IconMail,
-  IconMessageCircle,
-  IconPlayerPlay,
-  IconPlus,
-  IconPencil,
-  IconRepeat,
-  IconRoute,
-  IconTrash,
-  IconUpload,
-  IconDotsVertical,
-  IconEye,
-  IconExternalLink,
-  IconPlugConnected,
-  IconVideo,
-  IconWebhook,
-  IconX,
-} from "@tabler/icons-react";
+  AlertTriangle,
+  CalendarClock,
+  CircleCheck,
+  ChevronDown,
+  Clock,
+  Copy,
+  DatabasePlus,
+  FilePen,
+  FilePlus,
+  FileText,
+  History,
+  Info,
+  Link as LinkIcon,
+  Loader2,
+  Mail,
+  MessageCircle,
+  Play,
+  Plus,
+  Pencil,
+  Repeat,
+  Route,
+  Trash,
+  Upload,
+  EllipsisVertical,
+  Eye,
+  ExternalLink,
+  PlugZap,
+  Video,
+  Webhook,
+  X,
+} from "lucide-react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   Button,
@@ -95,6 +92,9 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  BrandGithub,
+  BrandNotion,
+  BrandStripe,
 } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
@@ -1018,7 +1018,7 @@ function WorkflowBreadcrumb({
     <DetailPageBreadcrumbBar>
       <BreadcrumbLink
         pathname={ROUTES.workflows}
-        icon={<IconRoute size={14} stroke={1.5} className="shrink-0" />}
+        icon={<Route size={14} strokeWidth={1.5} className="shrink-0" />}
       >
         {i18n.t(($) => {
           return $.workflows.common.workflows;
@@ -1065,7 +1065,7 @@ function WorkflowHeaderIcon({
   }
   return (
     <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gray-100 text-muted-foreground sm:h-16 sm:w-16">
-      <IconRoute size={28} stroke={1.7} />
+      <Route size={28} strokeWidth={1.7} />
     </span>
   );
 }
@@ -1184,7 +1184,7 @@ function WorkflowTabNav({
       </div>
       <TabsList className="zero-tabs hidden h-9 gap-1 px-1 py-1 sm:inline-flex">
         <TabsTrigger value="automations" className={WORKFLOW_TAB_TRIGGER_CLASS}>
-          <IconClock size={14} stroke={1.5} />
+          <Clock size={14} strokeWidth={1.5} />
           {i18n.t(($) => {
             return $.workflows.list.automations;
           })}
@@ -1193,13 +1193,13 @@ function WorkflowTabNav({
           value="instructions"
           className={WORKFLOW_TAB_TRIGGER_CLASS}
         >
-          <IconFileText size={14} stroke={1.5} />
+          <FileText size={14} strokeWidth={1.5} />
           {i18n.t(($) => {
             return $.workflows.common.instructions;
           })}
         </TabsTrigger>
         <TabsTrigger value="info" className={WORKFLOW_TAB_TRIGGER_CLASS}>
-          <IconInfoCircle size={14} stroke={1.5} />
+          <Info size={14} strokeWidth={1.5} />
           {i18n.t(($) => {
             return $.workflows.common.settings;
           })}
@@ -1285,9 +1285,14 @@ function WorkflowChatButton({
       }}
     >
       {opening ? (
-        <IconLoader2 size={14} className="shrink-0 animate-spin" />
+        <Loader2 size={14} className="shrink-0 animate-spin" />
       ) : (
-        <IconMessageCircle size={14} stroke={2} className="shrink-0" />
+        <MessageCircle
+          size={14}
+          strokeWidth={2}
+          className="shrink-0"
+          data-explicit-stroke-width
+        />
       )}
       <span className="truncate">{chatLabel}</span>
     </Button>
@@ -1370,7 +1375,7 @@ function WorkflowInfoTab({
                 setActionDialog("copy");
               }}
             >
-              <IconCopy size={14} stroke={1.5} />
+              <Copy size={14} strokeWidth={1.5} />
               {i18n.t(($) => {
                 return $.workflows.common.copyWorkflow;
               })}
@@ -1404,7 +1409,7 @@ function WorkflowInfoTab({
                     setActionDialog("delete");
                   }}
                 >
-                  <IconTrash size={14} stroke={1.5} />
+                  <Trash size={14} strokeWidth={1.5} />
                   {i18n.t(($) => {
                     return $.workflows.common.deleteWorkflow;
                   })}
@@ -1683,9 +1688,9 @@ function WorkflowConnectorReadiness({
               }}
             >
               {checking ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconPlugConnected size={14} stroke={1.5} />
+                <PlugZap size={14} strokeWidth={1.5} />
               )}
               {checkLabel}
             </Button>
@@ -1702,9 +1707,9 @@ function WorkflowConnectorReadiness({
           role="alert"
           className="flex items-start gap-2 border-t border-border/50 px-4 py-3 text-sm text-destructive sm:px-5"
         >
-          <IconAlertTriangle
+          <AlertTriangle
             size={16}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="mt-0.5 shrink-0"
           />
           <p>{errorMessage}</p>
@@ -1731,9 +1736,9 @@ function WorkflowConnectorReadiness({
             className="flex items-center gap-2 border-t border-border/50 px-4 py-4 text-sm text-muted-foreground sm:px-5"
             aria-live="polite"
           >
-            <IconCircleCheck
+            <CircleCheck
               size={16}
-              stroke={1.5}
+              strokeWidth={1.5}
               className="shrink-0 text-emerald-500"
             />
             {copy.empty}
@@ -1799,7 +1804,7 @@ function WorkflowConnectorReadinessRow({
               aria-label={`${action.label} ${entry.label}`}
             >
               {action.label}
-              <IconExternalLink size={13} stroke={1.5} />
+              <ExternalLink size={13} strokeWidth={1.5} />
             </a>
           </Button>
         ) : null}
@@ -2049,7 +2054,7 @@ function ShadowWarning({
 
   return (
     <div className="mb-4 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
-      <IconAlertTriangle size={16} stroke={1.5} className="mt-0.5 shrink-0" />
+      <AlertTriangle size={16} strokeWidth={1.5} className="mt-0.5 shrink-0" />
       <p className="min-w-0">
         <span className="font-medium">/{detail.name}</span>{" "}
         {i18n.t(($) => {
@@ -2144,7 +2149,7 @@ function WorkflowPublicToggle({
             <DialogDescription>{copy.confirmDescription}</DialogDescription>
           </DialogHeader>
           <Alert variant="destructive">
-            <IconAlertTriangle size={16} stroke={1.5} />
+            <AlertTriangle size={16} strokeWidth={1.5} />
             <AlertTitle>{copy.automationWarning}</AlertTitle>
             <AlertDescription>
               {i18n.t(
@@ -2175,7 +2180,7 @@ function WorkflowPublicToggle({
                 submitVisibilityAction("demote");
               }}
             >
-              {busy ? <IconLoader2 size={14} className="animate-spin" /> : null}
+              {busy ? <Loader2 size={14} className="animate-spin" /> : null}
               {copy.makePrivate}
             </Button>
           </DialogFooter>
@@ -2349,7 +2354,7 @@ function WorkflowCopyForm({
       </label>
       {form.removeOriginal ? (
         <Alert variant="destructive">
-          <IconAlertTriangle size={16} stroke={1.5} />
+          <AlertTriangle size={16} strokeWidth={1.5} />
           <AlertTitle>
             {i18n.t(($) => {
               return $.workflows.detail.copy.removalAlert;
@@ -2519,7 +2524,7 @@ function WorkflowCopyDialogFooter({
         })}
       </Button>
       <Button type="button" disabled={disabled} onClick={onSubmit}>
-        {submitting ? <IconLoader2 size={14} className="animate-spin" /> : null}
+        {submitting ? <Loader2 size={14} className="animate-spin" /> : null}
         {removeOriginal
           ? i18n.t(($) => {
               return $.workflows.detail.copy.copyAndRemove;
@@ -2597,9 +2602,7 @@ function WorkflowDeleteDialog({
               );
             }}
           >
-            {deleting ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : null}
+            {deleting ? <Loader2 size={14} className="animate-spin" /> : null}
             {i18n.t(($) => {
               return $.workflows.common.delete;
             })}
@@ -2684,9 +2687,9 @@ function WorkflowFilePicker({
           className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm px-0.5 py-0.5 text-sm font-medium text-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <span className="min-w-0 truncate">{selectedLabel}</span>
-          <IconChevronDown
+          <ChevronDown
             size={14}
-            stroke={1.5}
+            strokeWidth={1.5}
             className="shrink-0 text-muted-foreground"
           />
         </button>
@@ -2777,9 +2780,9 @@ function WorkflowFileManagementItems({
         )}
       >
         {saving ? (
-          <IconLoader2 size={15} className="animate-spin" />
+          <Loader2 size={15} className="animate-spin" />
         ) : (
-          <IconUpload size={15} stroke={1.5} />
+          <Upload size={15} strokeWidth={1.5} />
         )}
         <span>
           {i18n.t(($) => {
@@ -2817,7 +2820,7 @@ function WorkflowFileManagementItems({
           className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-destructive transition-colors hover:bg-state-hover disabled:opacity-60"
           onClick={onDeleteSelectedFile}
         >
-          <IconTrash size={15} stroke={1.5} />
+          <Trash size={15} strokeWidth={1.5} />
           <span>
             {i18n.t(($) => {
               return $.workflows.detail.files.deleteSelected;
@@ -4453,14 +4456,14 @@ type AutomationCreateOption = {
   readonly kind: AutomationCreateDialogKind;
   readonly title: string;
   readonly description: string;
-  readonly icon: typeof IconClock;
+  readonly icon: typeof Clock;
   readonly badge?: string;
 };
 
 type AutomationCreateCategory = {
   readonly key: AutomationCategoryKey;
   readonly label: string;
-  readonly icon: typeof IconClock;
+  readonly icon: typeof Clock;
   readonly options: readonly AutomationCreateOption[];
 };
 
@@ -4477,7 +4480,7 @@ function buildStripeInvoicePaidAutomationOptions(
           description: i18n.t(($) => {
             return $.workflows.automations.stripe.invoicePaidDescription;
           }),
-          icon: IconBrandStripe,
+          icon: BrandStripe,
         },
       ]
     : [];
@@ -4505,7 +4508,7 @@ function buildIntegrationAutomationOptions({
       description: i18n.t(($) => {
         return $.workflows.automations.chat.runFinishedDescription;
       }),
-      icon: IconMessageCircle,
+      icon: MessageCircle,
     },
   ];
   if (githubLabelAutomationsEnabled) {
@@ -4517,7 +4520,7 @@ function buildIntegrationAutomationOptions({
       description: i18n.t(($) => {
         return $.workflows.automations.github.labelAppliedDescription;
       }),
-      icon: IconBrandGithub,
+      icon: BrandGithub,
     });
   }
   integrationOptions.push({
@@ -4528,7 +4531,7 @@ function buildIntegrationAutomationOptions({
     description: i18n.t(($) => {
       return $.workflows.automations.github.workflowRunDescription;
     }),
-    icon: IconBrandGithub,
+    icon: BrandGithub,
   });
   if (githubWebhookAutomationsEnabled) {
     integrationOptions.push(
@@ -4540,7 +4543,7 @@ function buildIntegrationAutomationOptions({
         description: i18n.t(($) => {
           return $.workflows.automations.github.workflowJobDescription;
         }),
-        icon: IconBrandGithub,
+        icon: BrandGithub,
       },
       {
         kind: "github-pull-request-review",
@@ -4550,7 +4553,7 @@ function buildIntegrationAutomationOptions({
         description: i18n.t(($) => {
           return $.workflows.automations.github.reviewDescription;
         }),
-        icon: IconBrandGithub,
+        icon: BrandGithub,
       },
       {
         kind: "github-deployment-status",
@@ -4560,7 +4563,7 @@ function buildIntegrationAutomationOptions({
         description: i18n.t(($) => {
           return $.workflows.automations.github.deploymentStatusDescription;
         }),
-        icon: IconBrandGithub,
+        icon: BrandGithub,
       },
       {
         kind: "github-issue-comment",
@@ -4570,7 +4573,7 @@ function buildIntegrationAutomationOptions({
         description: i18n.t(($) => {
           return $.workflows.automations.github.issueCommentDescription;
         }),
-        icon: IconBrandGithub,
+        icon: BrandGithub,
       },
     );
   }
@@ -4588,7 +4591,7 @@ function buildIntegrationAutomationOptions({
       description: i18n.t(($) => {
         return $.workflows.automations.strapi.entryPublishedDescription;
       }),
-      icon: IconWebhook,
+      icon: Webhook,
     });
   }
   integrationOptions.push({
@@ -4599,7 +4602,7 @@ function buildIntegrationAutomationOptions({
     description: i18n.t(($) => {
       return $.workflows.automations.webhook.createDescription;
     }),
-    icon: IconLink,
+    icon: LinkIcon,
     ...(webhookTierEligible
       ? {}
       : {
@@ -4626,7 +4629,7 @@ function buildNotionAutomationOptions(
       description: i18n.t(($) => {
         return $.workflows.automations.notion.childPageDescription;
       }),
-      icon: IconFilePlus,
+      icon: FilePlus,
     },
     {
       kind: "notion-database-item",
@@ -4636,7 +4639,7 @@ function buildNotionAutomationOptions(
       description: i18n.t(($) => {
         return $.workflows.automations.notion.databaseItemDescription;
       }),
-      icon: IconDatabasePlus,
+      icon: DatabasePlus,
     },
     {
       kind: "notion-page-content-updated",
@@ -4646,7 +4649,7 @@ function buildNotionAutomationOptions(
       description: i18n.t(($) => {
         return $.workflows.automations.notion.contentUpdatedDescription;
       }),
-      icon: IconFilePencil,
+      icon: FilePen,
     },
   ];
 }
@@ -4666,7 +4669,7 @@ function buildGoogleFormsAutomationOptions(
       description: i18n.t(($) => {
         return $.workflows.automations.forms.responseSubmittedDescription;
       }),
-      icon: IconFileText,
+      icon: FileText,
     },
   ];
 }
@@ -4699,7 +4702,7 @@ function buildCalendarAutomationOptions(
         description: i18n.t(($) => {
           return $.workflows.automations.calendar.createdDescription;
         }),
-        icon: IconCalendarTime,
+        icon: CalendarClock,
       },
       {
         kind: "google-calendar-updated",
@@ -4709,7 +4712,7 @@ function buildCalendarAutomationOptions(
         description: i18n.t(($) => {
           return $.workflows.automations.calendar.updatedDescription;
         }),
-        icon: IconCalendarTime,
+        icon: CalendarClock,
       },
       {
         kind: "google-calendar-cancelled",
@@ -4719,7 +4722,7 @@ function buildCalendarAutomationOptions(
         description: i18n.t(($) => {
           return $.workflows.automations.calendar.cancelledDescription;
         }),
-        icon: IconCalendarTime,
+        icon: CalendarClock,
       },
     );
   }
@@ -4732,7 +4735,7 @@ function buildCalendarAutomationOptions(
       description: i18n.t(($) => {
         return $.workflows.automations.meet.transcriptReadyDescription;
       }),
-      icon: IconVideo,
+      icon: Video,
     });
   }
   return options;
@@ -4748,7 +4751,7 @@ function buildScheduleAutomationOptions(): AutomationCreateOption[] {
       description: i18n.t(($) => {
         return $.workflows.automations.schedule.frequencyIntervalDescription;
       }),
-      icon: IconRepeat,
+      icon: Repeat,
     },
     {
       kind: "scheduled",
@@ -4758,7 +4761,7 @@ function buildScheduleAutomationOptions(): AutomationCreateOption[] {
       description: i18n.t(($) => {
         return $.workflows.automations.schedule.frequencyScheduleDescription;
       }),
-      icon: IconClock,
+      icon: Clock,
     },
     {
       kind: "once",
@@ -4768,7 +4771,7 @@ function buildScheduleAutomationOptions(): AutomationCreateOption[] {
       description: i18n.t(($) => {
         return $.workflows.automations.schedule.frequencyOnceDescription;
       }),
-      icon: IconClock,
+      icon: Clock,
     },
   ];
 }
@@ -4783,7 +4786,7 @@ function buildEmailAutomationOptions(): AutomationCreateOption[] {
       description: i18n.t(($) => {
         return $.workflows.automations.gmail.newMessageDescription;
       }),
-      icon: IconMail,
+      icon: Mail,
     },
     {
       kind: "gmail-label",
@@ -4793,7 +4796,7 @@ function buildEmailAutomationOptions(): AutomationCreateOption[] {
       description: i18n.t(($) => {
         return $.workflows.automations.gmail.addLabelDescription;
       }),
-      icon: IconMail,
+      icon: Mail,
     },
   ];
 }
@@ -4843,7 +4846,7 @@ function buildAutomationCreateCategories({
       label: i18n.t(($) => {
         return $.workflows.automations.picker.schedule;
       }),
-      icon: IconClock,
+      icon: Clock,
       options: buildScheduleAutomationOptions(),
     },
     {
@@ -4851,7 +4854,7 @@ function buildAutomationCreateCategories({
       label: i18n.t(($) => {
         return $.workflows.automations.picker.email;
       }),
-      icon: IconMail,
+      icon: Mail,
       options: buildEmailAutomationOptions(),
     },
     {
@@ -4859,7 +4862,7 @@ function buildAutomationCreateCategories({
       label: i18n.t(($) => {
         return $.workflows.automations.picker.calendar;
       }),
-      icon: IconCalendarTime,
+      icon: CalendarClock,
       options: calendarOptions,
     },
     {
@@ -4867,7 +4870,7 @@ function buildAutomationCreateCategories({
       label: i18n.t(($) => {
         return $.workflows.automations.picker.forms;
       }),
-      icon: IconFileText,
+      icon: FileText,
       options: googleFormsOptions,
     },
     {
@@ -4875,7 +4878,7 @@ function buildAutomationCreateCategories({
       label: i18n.t(($) => {
         return $.workflows.automations.picker.notion;
       }),
-      icon: IconBrandNotion,
+      icon: BrandNotion,
       options: notionOptions,
     },
     {
@@ -4883,7 +4886,7 @@ function buildAutomationCreateCategories({
       label: i18n.t(($) => {
         return $.workflows.automations.picker.integrations;
       }),
-      icon: IconLink,
+      icon: LinkIcon,
       options: integrationOptions,
     },
   ];
@@ -4917,7 +4920,7 @@ function AutomationCreateCategoryButton({
           : "text-sidebar-foreground hover:bg-state-hover",
       )}
     >
-      <Icon size={16} stroke={1.5} className="shrink-0" />
+      <Icon size={16} strokeWidth={1.5} className="shrink-0" />
       <span className="truncate">{category.label}</span>
     </button>
   );
@@ -4945,7 +4948,7 @@ function AutomationCreateOptionCard({
           accentChip,
         )}
       >
-        <Icon size={20} stroke={1.5} />
+        <Icon size={20} strokeWidth={1.5} />
       </span>
       <span className="flex min-w-0 flex-col gap-1">
         <span className="text-sm font-semibold">{option.title}</span>
@@ -5015,7 +5018,7 @@ function AutomationCreateMenu({
           type="button"
           className="zero-btn-morandi inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-lg px-3 text-sm font-medium"
         >
-          <IconPlus size={14} stroke={1.5} />
+          <Plus size={14} strokeWidth={1.5} />
           <span>
             {i18n.t(($) => {
               return $.workflows.automations.common.addAutomation;
@@ -5208,9 +5211,9 @@ function CreateGoogleFormsResponseSubmittedAutomationDialog({
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconFileText size={14} stroke={1.5} />
+                <FileText size={14} strokeWidth={1.5} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.forms.addAction;
@@ -5319,9 +5322,9 @@ function CreateGoogleMeetTranscriptGeneratedAutomationDialog({
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconVideo size={14} stroke={1.5} />
+                <Video size={14} strokeWidth={1.5} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.meet.addAction;
@@ -5500,7 +5503,7 @@ function CreateChatRunFinishedAutomationDialog({
             </Button>
             <Button type="submit" disabled={creating}>
               {creating && (
-                <IconLoader2 size={14} className="mr-1.5 animate-spin" />
+                <Loader2 size={14} className="mr-1.5 animate-spin" />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.chat.addAction;
@@ -5783,9 +5786,9 @@ function StrapiAutomationForm({
         </Button>
         <Button type="submit" disabled={creating}>
           {creating ? (
-            <IconLoader2 size={14} className="animate-spin" />
+            <Loader2 size={14} className="animate-spin" />
           ) : (
-            <IconWebhook size={14} />
+            <Webhook size={14} />
           )}
           {i18n.t(($) => {
             return $.workflows.automations.strapi.addAction;
@@ -5855,7 +5858,11 @@ function StripeAutomationCreateError({
       className="flex flex-col gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
     >
       <div className="flex items-start gap-2">
-        <IconAlertTriangle size={16} stroke={1.5} className="mt-0.5 shrink-0" />
+        <AlertTriangle
+          size={16}
+          strokeWidth={1.5}
+          className="mt-0.5 shrink-0"
+        />
         <p>{message}</p>
       </div>
       <Link
@@ -5950,9 +5957,9 @@ function CreateStripeInvoicePaidAutomationDialog({
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconBrandStripe size={14} />
+                <BrandStripe size={14} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.stripe.addAction;
@@ -6293,9 +6300,9 @@ function CreateNotionDatabaseItemAutomationDialog({
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconBrandNotion size={14} stroke={1.5} />
+                <BrandNotion size={14} strokeWidth={1.5} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.notion.addAction;
@@ -6497,9 +6504,9 @@ function CreateNotionPageContentUpdatedAutomationDialog({
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconBrandNotion size={14} stroke={1.5} />
+                <BrandNotion size={14} strokeWidth={1.5} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.notion.addAction;
@@ -6604,9 +6611,9 @@ function CreateNotionChildPageAutomationDialog({
             </Button>
             <Button type="submit" disabled={creating}>
               {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconBrandNotion size={14} stroke={1.5} />
+                <BrandNotion size={14} strokeWidth={1.5} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.notion.addAction;
@@ -6697,9 +6704,7 @@ function CreateIntervalAutomationDialog({
               })}
             </Button>
             <Button type="submit" disabled={creating}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {i18n.t(($) => {
                 return $.workflows.automations.schedule.addIntervalAction;
               })}
@@ -6799,9 +6804,7 @@ function CreateScheduledAutomationDialog({
               })}
             </Button>
             <Button type="submit" disabled={creating}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {i18n.t(($) => {
                 return $.workflows.automations.schedule.addScheduleAction;
               })}
@@ -6900,9 +6903,7 @@ function CreateOnceAutomationDialog({
               })}
             </Button>
             <Button type="submit" disabled={creating}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {i18n.t(($) => {
                 return $.workflows.automations.schedule.addOnceAction;
               })}
@@ -7521,7 +7522,7 @@ function GmailMatchConditionRow({
           onChange(removeGmailMatchCondition(conditions, index));
         }}
       >
-        <IconX size={16} stroke={1.5} />
+        <X size={16} strokeWidth={1.5} />
       </Button>
     </div>
   );
@@ -7563,7 +7564,7 @@ function GmailMatchConditionsEditor({
           }
         }}
       >
-        <IconPlus size={14} stroke={1.5} />
+        <Plus size={14} strokeWidth={1.5} />
         {i18n.t(($) => {
           return $.workflows.automations.gmail.addCondition;
         })}
@@ -7646,9 +7647,7 @@ function CreateGmailNewMessageAutomationDialog({
               })}
             </Button>
             <Button type="submit" disabled={creating}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {i18n.t(($) => {
                 return $.workflows.automations.gmail.addMessageAction;
               })}
@@ -7764,9 +7763,7 @@ function CreateGmailLabelAppliedAutomationDialog({
               })}
             </Button>
             <Button type="submit" disabled={creating}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {i18n.t(($) => {
                 return $.workflows.automations.gmail.addLabelAction;
               })}
@@ -8684,9 +8681,7 @@ function CreateGithubLabelAppliedAutomationDialog({
               {actionCopy.cancel}
             </Button>
             <Button type="submit" disabled={submitDisabled}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {githubLabelAddActionLabel()}
             </Button>
           </DialogFooter>
@@ -8777,9 +8772,7 @@ function CreateGithubWorkflowRunCompletedAutomationDialog({
               })}
             </Button>
             <Button type="submit" disabled={submitDisabled}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {i18n.t(($) => {
                 return $.workflows.automations.github.addWorkflowAction;
               })}
@@ -8943,9 +8936,9 @@ function CreateGithubWebhookAutomationDialog({
             </Button>
             <Button type="submit" disabled={submitDisabled}>
               {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconBrandGithub size={14} stroke={1.5} />
+                <BrandGithub size={14} strokeWidth={1.5} />
               )}
               {copy.action}
             </Button>
@@ -9093,9 +9086,7 @@ function CreateGoogleCalendarEventAutomationDialog({
               {copy.cancel}
             </Button>
             <Button type="submit" disabled={creating}>
-              {creating ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
               {copy.action}
             </Button>
           </DialogFooter>
@@ -9237,7 +9228,7 @@ function CreatedWebhookAutomationView({
               copyText(curlExample);
             }}
           >
-            <IconCopy size={13} />
+            <Copy size={13} />
             {i18n.t(($) => {
               return $.workflows.automations.webhook.copy;
             })}
@@ -9266,7 +9257,7 @@ function WebhookReadonlyField({
     <div className="flex min-w-0 gap-2">
       <Input readOnly value={value} className="min-w-0" />
       <Button type="button" variant="outline" onClick={onCopy}>
-        <IconCopy size={14} />
+        <Copy size={14} />
         {i18n.t(($) => {
           return $.workflows.automations.webhook.copy;
         })}
@@ -9345,7 +9336,7 @@ function RevealWebhookSecretDialog({
                       copyText(curlExample);
                     }}
                   >
-                    <IconCopy size={13} />
+                    <Copy size={13} />
                     {copy.copy}
                   </Button>
                 </div>
@@ -9387,9 +9378,9 @@ function RevealWebhookSecretDialog({
               }}
             >
               {revealing ? (
-                <IconLoader2 size={14} className="animate-spin" />
+                <Loader2 size={14} className="animate-spin" />
               ) : (
-                <IconEye size={14} stroke={1.5} />
+                <Eye size={14} strokeWidth={1.5} />
               )}
               {copy.reveal}
             </Button>
@@ -9428,7 +9419,7 @@ function CreateWebhookAutomationView({
           })}
         </Button>
         <Button type="button" disabled={creating} onClick={onCreate}>
-          {creating ? <IconLoader2 size={14} className="animate-spin" /> : null}
+          {creating ? <Loader2 size={14} className="animate-spin" /> : null}
           {i18n.t(($) => {
             return $.workflows.automations.webhook.create;
           })}
@@ -9555,7 +9546,7 @@ function AutomationRowStats({
     return (
       <>
         <AutomationRunStat
-          icon={<IconHistory size={14} stroke={1.5} />}
+          icon={<History size={14} strokeWidth={1.5} />}
           label={i18n.t(($) => {
             return $.workflows.automations.stripe.lastEvent;
           })}
@@ -9565,7 +9556,7 @@ function AutomationRowStats({
           )}
         />
         <AutomationRunStat
-          icon={<IconCircleCheck size={14} stroke={1.5} />}
+          icon={<CircleCheck size={14} strokeWidth={1.5} />}
           label={i18n.t(($) => {
             return $.workflows.automations.stripe.delivery;
           })}
@@ -9579,7 +9570,7 @@ function AutomationRowStats({
   return (
     <>
       <AutomationRunStat
-        icon={<IconHistory size={14} stroke={1.5} />}
+        icon={<History size={14} strokeWidth={1.5} />}
         label={i18n.t(($) => {
           return $.workflows.automations.schedule.last;
         })}
@@ -9591,7 +9582,7 @@ function AutomationRowStats({
       />
       {automation.kind === "schedule" ? (
         <AutomationRunStat
-          icon={<IconClock size={14} stroke={1.5} />}
+          icon={<Clock size={14} strokeWidth={1.5} />}
           label={i18n.t(($) => {
             return $.workflows.automations.schedule.next;
           })}
@@ -9686,9 +9677,9 @@ function AutomationRow({
                 role="alert"
                 className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400"
               >
-                <IconAlertTriangle
+                <AlertTriangle
                   size={14}
-                  stroke={1.5}
+                  strokeWidth={1.5}
                   className="mt-0.5 shrink-0"
                 />
                 <p>
@@ -9880,9 +9871,9 @@ function AutomationControls({
                 }}
               >
                 {busy ? (
-                  <IconLoader2 size={14} className="animate-spin" />
+                  <Loader2 size={14} className="animate-spin" />
                 ) : (
-                  <IconPlayerPlay size={14} stroke={1.5} />
+                  <Play size={14} strokeWidth={1.5} />
                 )}
               </Button>
             </TooltipTrigger>
@@ -9915,7 +9906,7 @@ function AutomationControls({
                     setEditingAutomationId(automation.id);
                   }}
                 >
-                  <IconPencil size={14} stroke={1.5} />
+                  <Pencil size={14} strokeWidth={1.5} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -9980,7 +9971,7 @@ function AutomationMoreActionsMenu({
               })}
               className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-state-selected-hover hover:text-foreground data-[state=open]:bg-state-selected-hover data-[state=open]:text-foreground"
             >
-              <IconDotsVertical size={14} stroke={1.5} />
+              <EllipsisVertical size={14} strokeWidth={1.5} />
             </Button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
@@ -9999,7 +9990,7 @@ function AutomationMoreActionsMenu({
             className="gap-2"
             onModalSelect={onRevealWebhookSecret}
           >
-            <IconEye size={14} stroke={1.5} />
+            <Eye size={14} strokeWidth={1.5} />
             {i18n.t(($) => {
               return $.workflows.automations.webhook.revealTitle;
             })}
@@ -10016,9 +10007,9 @@ function AutomationMoreActionsMenu({
           }}
         >
           {deleting ? (
-            <IconLoader2 size={14} className="animate-spin" />
+            <Loader2 size={14} className="animate-spin" />
           ) : (
-            <IconTrash size={14} stroke={1.5} />
+            <Trash size={14} strokeWidth={1.5} />
           )}
           {i18n.t(($) => {
             return $.workflows.automations.common.deleteAutomation;
@@ -10321,9 +10312,9 @@ function UpdateScheduleAutomationForm({
         </Button>
         <Button type="submit" disabled={saving}>
           {saving ? (
-            <IconLoader2 size={13} className="animate-spin" />
+            <Loader2 size={13} className="animate-spin" />
           ) : (
-            <IconClock size={13} stroke={1.5} />
+            <Clock size={13} strokeWidth={1.5} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10404,9 +10395,9 @@ function UpdateGmailNewMessageAutomationForm({
         </Button>
         <Button type="submit" disabled={saving}>
           {saving ? (
-            <IconLoader2 size={13} className="animate-spin" />
+            <Loader2 size={13} className="animate-spin" />
           ) : (
-            <IconMail size={13} stroke={1.5} />
+            <Mail size={13} strokeWidth={1.5} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10494,9 +10485,9 @@ function UpdateGmailLabelAppliedAutomationForm({
         </Button>
         <Button type="submit" disabled={saving}>
           {saving ? (
-            <IconLoader2 size={13} className="animate-spin" />
+            <Loader2 size={13} className="animate-spin" />
           ) : (
-            <IconMail size={13} stroke={1.5} />
+            <Mail size={13} strokeWidth={1.5} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10620,9 +10611,9 @@ function UpdateGithubLabelAppliedAutomationForm({
         </Button>
         <Button type="submit" disabled={submitDisabled}>
           {saving ? (
-            <IconLoader2 size={13} className="animate-spin" />
+            <Loader2 size={13} className="animate-spin" />
           ) : (
-            <IconBrandGithub size={13} stroke={1.5} />
+            <BrandGithub size={13} strokeWidth={1.5} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10693,9 +10684,9 @@ function UpdateGithubWorkflowRunCompletedAutomationForm({
         </Button>
         <Button type="submit" disabled={saving}>
           {saving ? (
-            <IconLoader2 size={13} className="animate-spin" />
+            <Loader2 size={13} className="animate-spin" />
           ) : (
-            <IconBrandGithub size={13} stroke={1.5} />
+            <BrandGithub size={13} strokeWidth={1.5} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10765,9 +10756,9 @@ function UpdateGithubWebhookAutomationForm({
         </Button>
         <Button type="submit" disabled={saving}>
           {saving ? (
-            <IconLoader2 size={13} className="animate-spin" />
+            <Loader2 size={13} className="animate-spin" />
           ) : (
-            <IconBrandGithub size={13} stroke={1.5} />
+            <BrandGithub size={13} strokeWidth={1.5} />
           )}
           <span>
             {i18n.t(($) => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1291,7 +1291,7 @@ function WorkflowChatButton({
           size={14}
           strokeWidth={2}
           className="shrink-0"
-          data-explicit-stroke-width
+          data-stroke
         />
       )}
       <span className="truncate">{chatLabel}</span>

--- a/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
@@ -1,5 +1,5 @@
 import { useGet, useLastResolved, useSet } from "ccstate-react";
-import { IconLock } from "@tabler/icons-react";
+import { Lock } from "lucide-react";
 import {
   Button,
   Dialog,
@@ -47,7 +47,7 @@ export function WorkflowWebhookUpgradeDialog() {
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <div className="mb-1 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-amber-700">
-            <IconLock size={19} stroke={1.6} />
+            <Lock size={19} strokeWidth={1.6} />
           </div>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -8,14 +8,14 @@ import {
 } from "ccstate-react";
 import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
-  IconArrowsSort,
-  IconChevronDown,
-  IconLock,
-  IconPlus,
-  IconRoute,
-  IconUser,
-  IconWorld,
-} from "@tabler/icons-react";
+  ArrowUpDown,
+  ChevronDown,
+  Lock,
+  Plus,
+  Route,
+  User,
+  Globe,
+} from "lucide-react";
 import {
   Button,
   DropdownMenu,
@@ -187,11 +187,11 @@ function VisibilityIcon({
   readonly workflow: ZeroWorkflowSummary;
 }) {
   const isPublic = workflow.visibility === "public";
-  const Icon = isPublic ? IconWorld : IconLock;
+  const Icon = isPublic ? Globe : Lock;
   return (
     <Icon
       size={15}
-      stroke={1.7}
+      strokeWidth={1.7}
       className={cn("shrink-0", isPublic ? "text-blue-500" : "text-[#45A7A8]")}
       aria-label={
         isPublic
@@ -364,7 +364,7 @@ function WorkflowRowIcon({
   }
   return (
     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-muted-foreground">
-      <IconRoute size={16} stroke={1.7} />
+      <Route size={16} strokeWidth={1.7} />
     </span>
   );
 }
@@ -841,16 +841,16 @@ function SortDropdown({
           size="sm"
           className="zero-btn-morandi h-9 shrink-0 gap-1.5 rounded-lg border"
         >
-          <IconArrowsSort
+          <ArrowUpDown
             size={15}
-            stroke={1.8}
+            strokeWidth={1.8}
             className="text-muted-foreground"
           />
           {current?.label ??
             i18n.t(($) => {
               return $.workflows.list.sort.label;
             })}
-          <IconChevronDown size={14} stroke={1.8} />
+          <ChevronDown size={14} strokeWidth={1.8} />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
@@ -900,9 +900,9 @@ function AgentFilterDropdown({
               size={16}
             />
           ) : (
-            <IconUser
+            <User
               size={15}
-              stroke={1.8}
+              strokeWidth={1.8}
               className="text-muted-foreground"
             />
           )}
@@ -912,7 +912,7 @@ function AgentFilterDropdown({
                 return $.workflows.list.allAgents;
               })}
           </span>
-          <IconChevronDown size={14} stroke={1.8} />
+          <ChevronDown size={14} strokeWidth={1.8} />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -924,7 +924,7 @@ function AgentFilterDropdown({
             onChange(WORKFLOW_ALL_AGENTS);
           }}
         >
-          <IconUser size={15} stroke={1.8} className="text-muted-foreground" />
+          <User size={15} strokeWidth={1.8} className="text-muted-foreground" />
           {i18n.t(($) => {
             return $.workflows.list.allAgents;
           })}
@@ -1109,7 +1109,7 @@ export function WorkflowsPage() {
               openCreateWorkflowDialog();
             }}
           >
-            <IconPlus size={14} stroke={2} />
+            <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
             {t(($) => {
               return $.workflows.list.createInChat;
             })}

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -1109,7 +1109,7 @@ export function WorkflowsPage() {
               openCreateWorkflowDialog();
             }}
           >
-            <Plus size={14} strokeWidth={2} data-explicit-stroke-width />
+            <Plus size={14} strokeWidth={2} data-stroke />
             {t(($) => {
               return $.workflows.list.createInChat;
             })}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -535,9 +535,6 @@ importers:
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      '@tabler/icons-react':
-        specifier: 3.44.0
-        version: 3.44.0(react@19.2.6)
       '@tiptap/core':
         specifier: 3.21.0
         version: 3.21.0(@tiptap/pm@3.21.0)


### PR DESCRIPTION
## Summary

- migrate the remaining platform pages from Tabler icons to Lucide
- update renamed icons and the shared `LucideIcon` type mapping from issue #25458
- preserve explicit icon stroke weights while renaming `stroke` props to `strokeWidth`
- remove the platform Tabler dependency and add an ESLint guard against reintroduction

## Testing

- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`
- `pnpm exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm exec vitest run src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx`

Stacked on #25877. Part of #25458.