### PR TITLE
test(runner): cover rollback after enablement read failure

### DIFF
--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -1403,6 +1403,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn drain_reload_failure_reports_unavailable_prior_enablement() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            enablement_results: VecDeque::from([Err(fake_error("enablement read failed"))]),
+            reload_errors: VecDeque::from([true, false]),
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains(
+            "drain failed for vm0-runner-test: internal error: reload failed; additionally rollback failed"
+        ));
+        assert!(
+            message.contains(
+                "failed to roll back drain transition for vm0-runner-test (daemon_reload)"
+            )
+        );
+        assert!(message.contains("prior boot enablement is unavailable"));
+        assert_eq!(
+            ops.events,
+            [
+                "lifecycle_state",
+                "is_enabled",
+                "write_restart_override",
+                "disable",
+                "daemon_reload",
+                "remove_restart_override",
+                "daemon_reload",
+            ]
+        );
+        assert!(
+            ops.events
+                .iter()
+                .all(|event| !event.starts_with("restore_"))
+        );
+        assert_eq!(
+            ops.reload_requirements,
+            [
+                SystemdReloadRequirement::dirty().with_drain_override(true),
+                SystemdReloadRequirement::dirty().with_drain_override(false),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn repeated_drain_reload_failure_preserves_restart_override() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
@@ -2288,6 +2335,51 @@ mod tests {
                 "write_restart_override",
                 "restore_not_enabled",
                 "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_reload_failure_reports_unavailable_prior_enablement() {
+        let mut ops = FakeResumeOps {
+            enablement_results: VecDeque::from([Err(fake_error("enablement read failed"))]),
+            reload_errors: VecDeque::from([true, false]),
+            ..FakeResumeOps::default()
+        };
+
+        let error = resume_after_preflight_for_test(&mut ops).await.unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains(
+            "resume failed for vm0-runner-test: internal error: reload failed; additionally rollback failed"
+        ));
+        assert!(
+            message.contains(
+                "failed to roll back resume transition for vm0-runner-test (daemon_reload)"
+            )
+        );
+        assert!(message.contains("prior boot enablement is unavailable"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_enabled",
+                "remove_restart_override",
+                "enable",
+                "daemon_reload",
+                "write_restart_override",
+                "daemon_reload",
+            ]
+        );
+        assert!(
+            ops.events
+                .iter()
+                .all(|event| !event.starts_with("restore_"))
+        );
+        assert_eq!(
+            ops.reload_requirements,
+            [
+                SystemdReloadRequirement::dirty().with_drain_override(false),
+                SystemdReloadRequirement::dirty().with_drain_override(true),
             ]
         );
     }


### PR DESCRIPTION
## Summary

- add deterministic drain and resume regression coverage for rollback after a boot-enablement read failure
- verify unavailable prior enablement skips unsafe restoration while all valid corrective operations continue with the required systemd reload state
- preserve both the primary transition error and the partial-rollback diagnostic without changing production or signal-convergence behavior

## Scope

- test-only changes in the runner service transition module
- no runtime behavior, API, protocol, persisted state, migration, dependency, documentation, timeout, or CI changes

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner unavailable_prior_enablement` (2 passed)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3,085 unit tests passed, 20 existing child fixtures ignored; 1 integration test passed)
- `git diff --check`

Closes #25863
