### PR TITLE
test(e2e): make mocked chat thread readiness deterministic

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -185,30 +185,54 @@ async function mockChatThread(
   page: Page,
   options: MockChatThreadOptions,
 ): Promise<void> {
+  const createdEventId = `d${options.threadId.slice(1)}`;
+  let createdEventSeqId: number | null = null;
+
   await page.route("**/api/zero/chat-threads/snapshot", async (route) => {
     await route.fulfill({
       json: {
-        chatThreads: [
-          {
-            id: options.threadId,
-            agentId: options.agentId,
-            title: options.title,
-            sortAt: options.createdAt,
-            createdAt: options.createdAt,
-            updatedAt: options.createdAt,
-            pinnedAt: null,
-            renamedAt: null,
-            selectedModel: options.selectedModel,
-            serviceTier: null,
-            computerUseHostId: null,
-            cloudBrowserEnabled: false,
-          },
-        ],
+        chatThreads: [],
         latestEventId: null,
         latestSeqId: null,
       },
     });
   });
+  await page.route(
+    (url) => url.pathname === "/api/zero/chat-threads/events",
+    async (route) => {
+      const requestUrl = new URL(route.request().url());
+      const rawSinceSeqId = requestUrl.searchParams.get("sinceSeqId");
+      const sinceSeqId = rawSinceSeqId === null ? 0 : Number(rawSinceSeqId);
+      if (!Number.isSafeInteger(sinceSeqId) || sinceSeqId < 0) {
+        throw new Error("Thread event cursor is invalid");
+      }
+
+      // The initial real page can persist a thread-list cursor before these
+      // routes are installed. Deliver the synthetic thread through the
+      // incremental event stream so both cold and already-cached starts own a
+      // deterministic path to the same thread metadata.
+      createdEventSeqId ??= sinceSeqId + 1;
+      const events =
+        sinceSeqId < createdEventSeqId
+          ? [
+              {
+                id: createdEventId,
+                seqId: createdEventSeqId,
+                kind: "created",
+                chatThreadId: options.threadId,
+                agentId: options.agentId,
+                title: options.title,
+                selectedModel: options.selectedModel,
+                serviceTier: null,
+                computerUseHostId: null,
+                cloudBrowserEnabled: false,
+                createdAt: options.createdAt,
+              },
+            ]
+          : [];
+      await route.fulfill({ json: { events, hasMore: false } });
+    },
+  );
   await page.route(
     (url) =>
       url.pathname === `/api/zero/chat-threads/${options.threadId}/events`,


### PR DESCRIPTION
## Summary

- make the mocked chat thread available through the event-sourced thread-list contract
- handle both a cold browser cache and an IndexedDB snapshot with an existing cursor
- preserve the mobile `Keep going` rail behavior and all alignment, equal-height, scrolling, and focus assertions

## Failure identity

- Turbo flaky key: `cli-e2e-playwright-chat-mobile-follow-up-card-rail-not-visible`
- Triggered run: https://github.com/vm0-ai/vm0/actions/runs/31294594743
- First substantive failed job: https://github.com/vm0-ai/vm0/actions/runs/31294594743/job/93197736345
- Test: `e2e/playwright/tests/chat.spec.ts` — `mobile follow-up card rail › responsive follow-up rail aligns its edges and equalizes card heights`
- Comparison pass on the intake base: https://github.com/vm0-ai/vm0/actions/runs/31294574858/job/93197678245
- Latest `main` used for this PR: `6052df2793702225b02087c67a29e0a7dce5ab78`

## Root cause

Classification: test isolation / persisted-state synchronization.

The failure artifact showed `Chat thread not found`, not a loading rail. The test first opens the real agent chat to discover its agent ID, then installs a synthetic thread fixture and navigates again. The first page starts the detached thread-list daemon. If that daemon commits a real snapshot and cursor to IndexedDB before the second navigation, the new page correctly resumes from `/api/zero/chat-threads/events` instead of fetching `/api/zero/chat-threads/snapshot`.

The old fixture mocked only the snapshot and per-thread endpoints. It did not own the global incremental thread-list endpoint, so the synthetic thread metadata never entered the event-sourced store on the cached-cursor interleaving. `waitForThreadMetaResolution$` then resolved the missing thread as not found. Whether the first daemon committed before navigation made the outcome intermittent.

Clerk setup and both worker sign-ins completed successfully. `ci-gate-turbo` was an aggregate failure only.

## Fix

The fixture now starts from an empty synthetic snapshot and emits the mocked thread as a cursor-relative `created` event from the exact global thread-list event endpoint. It records the emitted sequence and returns the event only while the caller is behind it. Cold starts and already-cached starts therefore converge on the same deterministic metadata state.

The existing E2E is also the regression: because the synthetic snapshot is empty, removing the incremental event handler makes the test deterministically resolve `Chat thread not found`. No product code, retry, sleep, polling workaround, timeout, or assertion was changed.

## Validation

- `pnpm format`
- `pnpm exec prettier --check ../e2e/playwright/tests/chat.spec.ts`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `cd e2e && pnpm check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-recommended-follow-ups.test.tsx -t 'preserves follow-up content and selection when the card rail is enabled|catches recommended follow-ups written before realtime subscription is ready'` — 5 consecutive invocations passed, 10/10 focused tests
- `pnpm --filter @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts -t 'settles optimistic create events once the matching persisted event arrives'` — passed
- `cd e2e && VM0_API_BACKEND_URL=https://api.example.com pnpm exec playwright test --config playwright/playwright.config.ts tests/chat.spec.ts --project=features --list` — passed discovery

## Preview verification

- App preview: https://pr-25882-app.omby.ai
- API preview: https://pr-25882-api.vm6.ai
- Verified PR head: `6c96f46290db9eee207197796df8f03f9c9fe461`
- Preview Playwright shard: https://github.com/vm0-ai/vm0/actions/runs/31296581905/job/93203814891 — 15/15 passed, including the repaired mobile follow-up rail test
- Final CI: all checks passed after rerunning an unrelated overloaded `test-api (8)` shard; its rerun completed 23/23 test files
- Vercel bypass was established separately for the app and API origins with both required headers; API `/health` returned `200 {"status":"ok"}`
- Mobile/touch probe: Chromium with a 390×844 viewport, `maxTouchPoints = 5`, and `(pointer: coarse) = true`
- The `Keep going` group and all three cards rendered. Each card measured 96px high; height delta 0px; leading-edge delta 0px; centered-card delta 0px; trailing-edge delta 0px
- On the same touch device at 1440×900, the rail remained a card rail with a 548px rail/card width delta; keyboard focus remained `:focus-visible` with a non-empty focus ring
- Console: no errors; only the expected Clerk development-key warning
- Network: the thread-list snapshot/event, thread events, draft, detail, and mark-read requests all returned 200. The synthetic thread's optional managed-browser lookup returned the expected 404 and produced no console error

![Mobile touch follow-up rail](https://cdn.vm0.io/artifacts/l6oft8n4b6.png)

## Fallbacks

None.
