### PR TITLE
perf(guest-agent): compact artifact manifests

### DIFF
--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -414,7 +414,7 @@ fn write_manifest(manifest_path: &Path, files: &[FileEntry]) -> Result<(), Manif
         created_at: guest_common::log::timestamp(),
     };
 
-    serde_json::to_writer_pretty(&mut writer, &manifest).map_err(ManifestWriteError::Serialize)?;
+    serde_json::to_writer(&mut writer, &manifest).map_err(ManifestWriteError::Serialize)?;
     writer.flush().map_err(ManifestWriteError::Flush)
 }
 
@@ -560,8 +560,10 @@ mod tests {
         let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
             return http_status(400);
         };
+        let compact_body_len = body.to_string().len();
         let expected_files = serde_json::Value::Array(expected_files.to_vec());
         if request_header_eq(req, "content-type", "application/json")
+            && req.body_ref().len() == compact_body_len
             && body.get("version") == Some(&serde_json::json!(1))
             && body.get("files") == Some(&expected_files)
             && body


### PR DESCRIPTION
## Summary

- serialize guest artifact manifests with compact JSON instead of pretty-printed JSON
- verify the uploaded manifest body has compact encoded length while preserving semantic field and content-type assertions

## Compatibility

- preserves the persisted `version`, `files`, and `createdAt` schema and field ordering
- preserves archive creation, disk-backed uploads, retry behavior, prepare/commit payloads, and `application/json`
- requires no API, database, migration, feature switch, or coordinated rollout change

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent artifact::tests::snapshot_uploads_archive_manifest_and_commits_new_version -- --exact`
- `cargo test -p guest-agent --all-targets --all-features --quiet`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --all-features --no-deps`
- repository Rust pre-commit hooks

Closes #25866
