### PR TITLE
fix(runner): preserve codex catalog identity responses

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -42,6 +42,7 @@ _ASCII_CONTROL_BOUNDARY = 0x20
 _ASCII_DELETE = 0x7F
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _HTTP_STATUS_OK = 200
+_HTTP_STATUS_BAD_GATEWAY = 502
 _FLOW_STATE = "_codex_model_catalog_cache_state"
 _FLOW_TELEMETRY = "_codex_model_catalog_cache_telemetry"
 _PREFETCH_REQUEST = "_codex_model_catalog_prefetch_request"
@@ -641,7 +642,8 @@ async def prepare_request(flow: http.HTTPFlow, *, request_end_stream: bool) -> b
             prefetch_owner=is_prefetch,
         )
         flow.metadata[_FLOW_STATE] = state
-        flow.request.headers["Accept-Encoding"] = _BROTLI_ENCODING
+        if is_prefetch:
+            flow.request.headers["Accept-Encoding"] = _BROTLI_ENCODING
         return wait_deadline is not None
 
 
@@ -695,14 +697,34 @@ def _bypass_response(
     _release_flow_capacity(state)
 
 
+def _discard_upstream_response_body(_chunk: bytes) -> bytes:
+    return b""
+
+
+def _reject_encoded_response(
+    flow: http.HTTPFlow,
+    state: _FlowState,
+) -> None:
+    _set_not_stored(flow, state, "response_encoding")
+    state.finalized = True
+    _release_flow_capacity(state)
+    flow.response = http.Response.make(
+        _HTTP_STATUS_BAD_GATEWAY,
+        b"",
+        {"Content-Type": "text/plain"},
+    )
+    flow.response.stream = _discard_upstream_response_body
+
+
 def handle_response_headers(flow: http.HTTPFlow) -> bool:
     """Prepare catalog handling and tell mitm_addon.responseheaders() whether to continue.
 
-    Return False only for a fresh response served from the local catalog cache; the hook
-    must stop the normal response-header pipeline in that case. Return True for all other flows,
-    including unrelated traffic, cache bypasses, and eligible cold responses, so the hook
-    continues that pipeline. For an eligible cold response, ordinary streaming is installed before
-    wrap_response_stream() composes the bounded catalog capture.
+    Return False when the hook must stop the normal response-header pipeline: either for a
+    fresh response served from the local catalog cache or for an encoded ordinary response
+    replaced with a fixed proxy error. Return True for all other flows, including unrelated
+    traffic, cache bypasses, and eligible cold responses. For an eligible cold response,
+    ordinary streaming is installed before wrap_response_stream() composes the bounded catalog
+    capture.
 
     ``mitm_addon.responseheaders()`` implements this contract. Focused coverage is
     ``test_fresh_hit_is_partitioned_and_expiry_never_uses_conditions`` for the stop branch and
@@ -725,6 +747,11 @@ def handle_response_headers(flow: http.HTTPFlow) -> bool:
         if bypass_reason is not None:
             _bypass_response(flow, state, bypass_reason)
         return True
+    if not state.prefetch_owner:
+        if encoding == _BROTLI_ENCODING:
+            state.upstream_encoding = _BROTLI_ENCODING
+        _reject_encoded_response(flow, state)
+        return False
     if encoding != _BROTLI_ENCODING:
         _bypass_response(flow, state, "response_encoding")
         return True

--- a/crates/runner/mitm-addon/tests/codex_model_catalog_cache_helpers.py
+++ b/crates/runner/mitm-addon/tests/codex_model_catalog_cache_helpers.py
@@ -131,11 +131,17 @@ def catalog_response(
     )
 
 
-async def prepare_miss(flow: http.HTTPFlow) -> None:
+async def prepare_miss(flow: http.HTTPFlow, *, expected_encoding: str = "identity") -> None:
     await catalog_cache.prepare_request(flow, request_end_stream=True)
     assert flow.response is None
-    assert flow.request.headers["Accept-Encoding"] == "br"
+    assert flow.request.headers["Accept-Encoding"] == expected_encoding
     assert "If-None-Match" not in flow.request.headers
+
+
+async def prepare_prefetch_miss(flow: http.HTTPFlow) -> None:
+    flow.request.headers["X-VM0-Codex-Model-Catalog-Prefetch"] = "1"
+    catalog_cache.capture_and_strip_prefetch_marker(flow)
+    await prepare_miss(flow, expected_encoding="br")
 
 
 async def finish_response(flow: http.HTTPFlow) -> dict[str, object]:
@@ -160,8 +166,11 @@ async def install_catalog(
     *,
     body: bytes = CATALOG_BODY,
     etag: str = CATALOG_ETAG,
-    encoding: str = "br",
+    encoding: str = "identity",
 ) -> dict[str, object]:
-    await prepare_miss(flow)
+    if encoding == "br":
+        await prepare_prefetch_miss(flow)
+    else:
+        await prepare_miss(flow)
     flow.response = catalog_response(body=body, etag=etag, encoding=encoding)
     return await finish_response(flow)

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_async_validation.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_async_validation.py
@@ -238,7 +238,7 @@ async def test_catalog_validation_cancellation_preserves_atomic_ownership(
                     await waiting_task
                 await asyncio.wait_for(follower_prepare, timeout=1)
                 assert follower.response is None
-                assert follower.request.headers["Accept-Encoding"] == "br"
+                assert follower.request.headers["Accept-Encoding"] == "identity"
                 assert executor.submission_count == 1
                 catalog_cache.handle_error(follower)
 

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
@@ -31,7 +31,7 @@ async def test_singleflight_delivers_owner_response_to_follower(real_flow):
     assert second.request.headers["Accept-Encoding"] == "identity"
 
     first_body = b'{"models":[{"slug":"first"}]}'
-    first.response = catalog_response(body=first_body, encoding="br")
+    first.response = catalog_response(body=first_body)
     assert (await finish_response(first))["model_catalog_cache_status"] == (
         "model_catalog_cold_stored"
     )
@@ -56,7 +56,7 @@ async def test_prefetch_marker_is_stripped_and_roles_distinguish_consumers(real_
     )
     catalog_cache.capture_and_strip_prefetch_marker(prefetch)
     assert "X-VM0-Codex-Model-Catalog-Prefetch" not in prefetch.request.headers
-    await prepare_miss(prefetch)
+    await prepare_miss(prefetch, expected_encoding="br")
 
     in_flight_consumer = catalog_flow(real_flow, version="prefetched")
     consumer_prepare = asyncio.create_task(
@@ -90,7 +90,7 @@ async def test_failed_prefetch_releases_consumer_to_retry_upstream(real_flow):
         extra_headers={"X-VM0-Codex-Model-Catalog-Prefetch": "1"},
     )
     catalog_cache.capture_and_strip_prefetch_marker(prefetch)
-    await prepare_miss(prefetch)
+    await prepare_miss(prefetch, expected_encoding="br")
 
     consumer = catalog_flow(real_flow, version="prefetch-failure")
     consumer_prepare = asyncio.create_task(
@@ -104,7 +104,7 @@ async def test_failed_prefetch_releases_consumer_to_retry_upstream(real_flow):
     await consumer_prepare
 
     assert consumer.response is None
-    assert consumer.request.headers["Accept-Encoding"] == "br"
+    assert consumer.request.headers["Accept-Encoding"] == "identity"
     consumer_telemetry: dict[str, object] = {}
     catalog_cache.add_network_log_fields(consumer, consumer_telemetry)
     assert consumer_telemetry == {}
@@ -129,7 +129,7 @@ async def test_non_cacheable_identity_headers_release_singleflight_follower(real
 
     await asyncio.wait_for(follower_prepare, timeout=0.1)
     assert follower.response is None
-    assert follower.request.headers["Accept-Encoding"] == "br"
+    assert follower.request.headers["Accept-Encoding"] == "identity"
     owner_telemetry: dict[str, object] = {}
     catalog_cache.add_network_log_fields(owner, owner_telemetry)
     validation_latency = owner_telemetry.pop("model_catalog_cache_validation_latency_ms")
@@ -140,6 +140,26 @@ async def test_non_cacheable_identity_headers_release_singleflight_follower(real
         "model_catalog_cache_bypass_reason": "response_cache_control",
         "model_catalog_cache_upstream_encoding": "identity",
     }
+    catalog_cache.handle_error(follower)
+
+
+async def test_unsolicited_encoded_response_releases_follower_as_identity_owner(real_flow):
+    owner = catalog_flow(real_flow, version="encoded-owner")
+    await prepare_miss(owner)
+    follower = catalog_flow(real_flow, version="encoded-owner")
+    follower_prepare = asyncio.create_task(
+        catalog_cache.prepare_request(follower, request_end_stream=True)
+    )
+    await asyncio.sleep(0)
+    assert not follower_prepare.done()
+
+    owner.response = catalog_response(encoding="br")
+    mitm_addon.responseheaders(owner)
+
+    await asyncio.wait_for(follower_prepare, timeout=0.1)
+    assert owner.response.status_code == 502
+    assert follower.response is None
+    assert follower.request.headers["Accept-Encoding"] == "identity"
     catalog_cache.handle_error(follower)
 
 
@@ -157,7 +177,7 @@ async def test_released_owner_wakes_singleflight_follower(real_flow):
     await follower_prepare
 
     assert follower.response is None
-    assert follower.request.headers["Accept-Encoding"] == "br"
+    assert follower.request.headers["Accept-Encoding"] == "identity"
     catalog_cache.handle_error(follower)
 
 
@@ -183,7 +203,7 @@ async def test_cancelled_follower_does_not_cancel_singleflight_owner(real_flow):
     await asyncio.sleep(0)
     assert not surviving_prepare.done()
 
-    owner.response = catalog_response(encoding="br")
+    owner.response = catalog_response()
     await finish_response(owner)
     await surviving_prepare
     assert surviving_follower.response is not None
@@ -207,7 +227,7 @@ async def test_singleflight_wait_is_bounded_without_canceling_owner(real_flow):
         "model_catalog_cache_bypass_reason": "request_capacity",
     }
 
-    owner.response = catalog_response(encoding="br")
+    owner.response = catalog_response()
     await finish_response(owner)
     hit = catalog_flow(real_flow, version="bounded-wait")
     await catalog_cache.prepare_request(hit, request_end_stream=True)
@@ -254,14 +274,14 @@ async def test_singleflight_rechecks_entry_after_etag_invalidation(real_flow):
     await asyncio.sleep(0)
     assert not follower_prepare.done()
 
-    owner.response = catalog_response(encoding="br")
+    owner.response = catalog_response()
     await finish_response(owner)
     invalidation = responses_flow(real_flow, etag='"catalog-v2"')
     mitm_addon.responseheaders(invalidation)
 
     await asyncio.wait_for(follower_prepare, timeout=0.1)
     assert follower.response is None
-    assert follower.request.headers["Accept-Encoding"] == "br"
+    assert follower.request.headers["Accept-Encoding"] == "identity"
     catalog_cache.handle_error(follower)
 
 
@@ -290,7 +310,7 @@ async def test_etag_signal_supersedes_in_flight_owner_and_releases_follower(real
     matching_owner.response = catalog_response(
         body=matching_body,
         etag='"catalog-v2"',
-        encoding="br",
+        encoding="identity",
     )
     assert (await finish_response(matching_owner))["model_catalog_cache_status"] == (
         "model_catalog_cold_stored"
@@ -300,13 +320,13 @@ async def test_etag_signal_supersedes_in_flight_owner_and_releases_follower(real
     isolated_owner.response = catalog_response(
         body=isolated_body,
         etag='"catalog-v1"',
-        encoding="br",
+        encoding="identity",
     )
     assert (await finish_response(isolated_owner))["model_catalog_cache_status"] == (
         "model_catalog_cold_stored"
     )
 
-    superseded_owner.response = catalog_response(etag='"catalog-v1"', encoding="br")
+    superseded_owner.response = catalog_response(etag='"catalog-v1"')
     superseded_telemetry = await finish_response(superseded_owner)
     await asyncio.wait_for(follower_prepare, timeout=0.1)
 
@@ -316,16 +336,16 @@ async def test_etag_signal_supersedes_in_flight_owner_and_releases_follower(real
     assert superseded_telemetry == {
         "model_catalog_cache_status": "model_catalog_cold_not_stored",
         "model_catalog_cache_bypass_reason": "concurrent_change",
-        "model_catalog_cache_upstream_encoding": "br",
+        "model_catalog_cache_upstream_encoding": "identity",
     }
     assert follower.response is None
-    assert follower.request.headers["Accept-Encoding"] == "br"
+    assert follower.request.headers["Accept-Encoding"] == "identity"
 
     replacement_body = b'{"models":[{"slug":"replacement"}]}'
     follower.response = catalog_response(
         body=replacement_body,
         etag='"catalog-v2"',
-        encoding="br",
+        encoding="identity",
     )
     assert (await finish_response(follower))["model_catalog_cache_status"] == (
         "model_catalog_cold_stored"

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -24,6 +24,7 @@ from tests.codex_model_catalog_cache_helpers import (
     finish_response,
     install_catalog,
     prepare_miss,
+    prepare_prefetch_miss,
     responses_flow,
 )
 from tests.flow_helpers import header_map, response_stream
@@ -357,7 +358,7 @@ async def test_catalog_wait_revalidates_only_provider_continuation(
                 owner.error = Error("upstream reset")
                 catalog_cache.handle_error(owner)
             elif owner_result == "local-response":
-                owner.response = catalog_response(encoding="br")
+                owner.response = catalog_response()
                 await finish_response(owner)
 
             await follower_task
@@ -479,7 +480,7 @@ async def test_network_log_contains_bounded_encoding_telemetry_and_cleanup(
         account="sensitive-account",
     )
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "network.jsonl")
-    await prepare_miss(flow)
+    await prepare_prefetch_miss(flow)
     flow.response = catalog_response(encoding="br")
     mitm_addon.responseheaders(flow)
     compressed_body = flow.response.raw_content or b""
@@ -493,6 +494,7 @@ async def test_network_log_contains_bounded_encoding_telemetry_and_cleanup(
     [entry] = read_jsonl_entries_after_flush(tmp_path / "network.jsonl")
     assert entry["model_catalog_cache_status"] == "model_catalog_cold_stored"
     assert entry["model_catalog_cache_upstream_encoding"] == "br"
+    assert entry["model_catalog_prefetch_role"] == "producer"
     assert entry["model_catalog_cache_validation_latency_ms"] >= 0
     assert entry["response_size"] == len(compressed_body)
     serialized = json.dumps(entry)

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
@@ -23,7 +23,7 @@ async def test_fresh_hit_is_partitioned_and_expiry_never_uses_conditions(real_fl
         assert await install_catalog(cold) == {
             "model_catalog_cache_status": "model_catalog_cold_stored",
             "model_catalog_cache_validation_latency_ms": 0,
-            "model_catalog_cache_upstream_encoding": "br",
+            "model_catalog_cache_upstream_encoding": "identity",
         }
 
         monotonic.return_value = 150.0

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
@@ -18,13 +18,14 @@ from tests.codex_model_catalog_cache_helpers import (
     finish_response,
     install_catalog,
     prepare_miss,
+    prepare_prefetch_miss,
 )
 from tests.flow_helpers import header_map, response_stream
 
 
 async def test_brotli_miss_without_length_is_cached_and_passed_through(real_flow):
     brotli_flow = catalog_flow(real_flow)
-    await prepare_miss(brotli_flow)
+    await prepare_prefetch_miss(brotli_flow)
     brotli_flow.response = catalog_response(encoding="br")
     compressed_body = brotli_flow.response.raw_content or b""
     del brotli_flow.response.headers["Content-Length"]
@@ -49,6 +50,7 @@ async def test_brotli_miss_without_length_is_cached_and_passed_through(real_flow
     assert brotli_telemetry == {
         "model_catalog_cache_status": "model_catalog_cold_stored",
         "model_catalog_cache_upstream_encoding": "br",
+        "model_catalog_prefetch_role": "producer",
     }
     brotli_hit = catalog_flow(real_flow)
     await catalog_cache.prepare_request(brotli_hit, request_end_stream=True)
@@ -70,9 +72,61 @@ async def test_brotli_miss_without_length_is_cached_and_passed_through(real_flow
     }
 
 
+@pytest.mark.parametrize("encoding", ["br", "gzip"])
+async def test_ordinary_owner_rejects_unsolicited_encoded_response(real_flow, encoding: str):
+    flow = catalog_flow(real_flow, version=f"unsolicited-{encoding}")
+    await prepare_miss(flow)
+    upstream_response = catalog_response(encoding=encoding)
+    upstream_body = upstream_response.raw_content or b""
+    flow.response = upstream_response
+
+    mitm_addon.responseheaders(flow)
+
+    assert flow.response.status_code == 502
+    assert "Content-Encoding" not in flow.response.headers
+    assert callable(flow.response.stream)
+    assert response_stream(flow)(upstream_body) == b""
+    assert catalog_cache.finalize_response(flow) is None
+    telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(flow, telemetry)
+    validation_latency = telemetry.pop("model_catalog_cache_validation_latency_ms")
+    assert isinstance(validation_latency, int)
+    assert validation_latency >= 0
+    expected: dict[str, object] = {
+        "model_catalog_cache_status": "model_catalog_cold_not_stored",
+        "model_catalog_cache_bypass_reason": "response_encoding",
+    }
+    if encoding == "br":
+        expected["model_catalog_cache_upstream_encoding"] = "br"
+    assert telemetry == expected
+
+    retry = catalog_flow(real_flow, version=f"unsolicited-{encoding}")
+    await prepare_miss(retry)
+    catalog_cache.handle_error(retry)
+
+
+async def test_ordinary_identity_miss_without_length_streams_and_caches(real_flow):
+    flow = catalog_flow(real_flow, version="identity-without-length")
+    await prepare_miss(flow)
+    flow.response = catalog_response()
+    del flow.response.headers["Content-Length"]
+
+    telemetry = await finish_response(flow)
+
+    assert flow.response.status_code == 200
+    assert flow.response.raw_content == CATALOG_BODY
+    assert "Content-Encoding" not in flow.response.headers
+    assert "Content-Length" not in flow.response.headers
+    assert telemetry["model_catalog_cache_status"] == "model_catalog_cold_stored"
+    hit = catalog_flow(real_flow, version="identity-without-length")
+    await catalog_cache.prepare_request(hit, request_end_stream=True)
+    assert hit.response is not None
+    assert hit.response.content == CATALOG_BODY
+
+
 async def test_set_cookie_is_not_replayed_from_cached_brotli_response(real_flow):
     cold = catalog_flow(real_flow, version="set-cookie")
-    await prepare_miss(cold)
+    await prepare_prefetch_miss(cold)
     cold.response = catalog_response(
         encoding="br",
         headers={"Set-Cookie": "catalog_session=opaque; Secure"},
@@ -280,7 +334,7 @@ async def test_invalid_streamed_brotli_passes_through_without_installing(
     reason: str,
 ):
     flow = catalog_flow(real_flow)
-    await prepare_miss(flow)
+    await prepare_prefetch_miss(flow)
     length = len(wire_body) if declared_length is None else declared_length
     flow.response = tutils.tresp(
         status_code=200,
@@ -315,6 +369,7 @@ async def test_invalid_streamed_brotli_passes_through_without_installing(
         "model_catalog_cache_status": "model_catalog_cold_not_stored",
         "model_catalog_cache_bypass_reason": reason,
         "model_catalog_cache_upstream_encoding": "br",
+        "model_catalog_prefetch_role": "producer",
     }
 
 
@@ -336,7 +391,7 @@ async def test_brotli_cache_policy_bypasses_body_validation(
     body: bytes,
 ):
     flow = catalog_flow(real_flow, version=f"cache-policy-{len(body)}")
-    await prepare_miss(flow)
+    await prepare_prefetch_miss(flow)
     flow.response = catalog_response(
         body=body,
         etag=None,
@@ -363,7 +418,10 @@ async def test_catalog_responses_with_trailers_are_never_cached(
     encoding: str,
 ):
     flow = catalog_flow(real_flow, version=f"trailers-{encoding}")
-    await prepare_miss(flow)
+    if encoding == "br":
+        await prepare_prefetch_miss(flow)
+    else:
+        await prepare_miss(flow)
     flow.response = catalog_response(encoding=encoding)
     flow.response.trailers = header_map({"Digest": "sha-256=:opaque:"})
 
@@ -460,7 +518,7 @@ async def test_unsafe_encoded_headers_pass_through_without_caching(
     expected_encoding: str | None,
 ):
     flow = catalog_flow(real_flow, version=f"unsafe-{encoding}-{reason}")
-    await prepare_miss(flow)
+    await prepare_prefetch_miss(flow)
     response = catalog_response(encoding=encoding, headers=headers)
     if headers.get("Content-Length") == "":
         del response.headers["Content-Length"]
@@ -488,6 +546,7 @@ async def test_unsafe_encoded_headers_pass_through_without_caching(
     }
     if expected_encoding is not None:
         expected["model_catalog_cache_upstream_encoding"] = expected_encoding
+    expected["model_catalog_prefetch_role"] = "producer"
     assert telemetry == expected
 
 
@@ -498,9 +557,9 @@ async def test_complete_decoded_body_bound_is_cached(real_flow):
         prefix + b"x" * (catalog_cache.MAX_ENTRY_BYTES - len(prefix) - len(suffix)) + suffix
     )
     exact = catalog_flow(real_flow, version="exact-cap")
-    assert (await install_catalog(exact, body=exact_body))["model_catalog_cache_status"] == (
-        "model_catalog_cold_stored"
-    )
+    assert (await install_catalog(exact, body=exact_body, encoding="br"))[
+        "model_catalog_cache_status"
+    ] == "model_catalog_cold_stored"
     exact_hit = catalog_flow(real_flow, version="exact-cap")
     await catalog_cache.prepare_request(exact_hit, request_end_stream=True)
     assert exact_hit.response is not None

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -1,5 +1,6 @@
 """Request framing integration tests through mitmproxy's real hook pipeline."""
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Literal
@@ -595,6 +596,7 @@ async def _catalog_http_stream(
     addon_context: taddons.context,
     *,
     catalog_path: str,
+    prefetch: bool = False,
 ) -> tuple[HttpStream, http.HTTPFlow]:
     _, http_layer = _start_http_layer(
         addon_context,
@@ -617,6 +619,7 @@ async def _catalog_http_stream(
                 "Content-Length": "0",
                 "Authorization": "Bearer resolved-access",
                 "ChatGPT-Account-ID": "resolved-account",
+                "Accept-Encoding": "identity",
             }
         ),
     )
@@ -629,8 +632,12 @@ async def _catalog_http_stream(
     flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:codex-oauth-token"
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.metadata[metadata_keys.ORIGINAL_URL] = f"https://chatgpt.com{catalog_path}"
+    if prefetch:
+        flow.request.headers["X-VM0-Codex-Model-Catalog-Prefetch"] = "1"
+        codex_model_catalog_cache.capture_and_strip_prefetch_marker(flow)
     await codex_model_catalog_cache.prepare_request(flow, request_end_stream=True)
-    assert flow.request.headers["Accept-Encoding"] == "br"
+    assert flow.request.headers["Accept-Encoding"] == ("br" if prefetch else "identity")
+    assert "X-VM0-Codex-Model-Catalog-Prefetch" not in flow.request.headers
     assert "If-None-Match" not in flow.request.headers
 
     stream.flow = flow
@@ -727,13 +734,217 @@ async def test_head_connector_diagnostic_emits_no_response_data(
     assert any(isinstance(event, ResponseEndOfMessage) for event in client_events)
 
 
-async def test_http2_brotli_catalog_is_streamed_unchanged_while_cached(
+async def test_http2_prefetch_brotli_catalog_is_streamed_unchanged_while_cached(
     tmp_path: Path,
     real_flow,
 ) -> None:
     catalog_path = "/backend-api/codex/models?client_version=0.145.0"
     catalog_body = b'{"models":[{"slug":"gpt-test"}]}'
     compressed_body = brotli.compress(catalog_body)
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        stream, flow = await _catalog_http_stream(
+            addon_context,
+            catalog_path=catalog_path,
+            prefetch=True,
+        )
+        upstream_response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {
+                    "Content-Type": "application/json",
+                    "Content-Encoding": "br",
+                    "ETag": '"catalog-v1"',
+                }
+            ),
+        )
+        response_header_commands = list(
+            stream.handle_event(ResponseHeaders(1, upstream_response, end_stream=False))
+        )
+        response_headers_hook = next(
+            command
+            for command in response_header_commands
+            if isinstance(command, HttpResponseHeadersHook)
+        )
+        await addon_context.master.addons.invoke_addon(
+            mitm_addon,
+            response_headers_hook,
+        )
+        assert flow.response is not None
+        assert flow.response.status_code == 200
+        assert callable(flow.response.stream)
+        assert flow.response.headers["Content-Encoding"] == "br"
+        assert "Content-Length" not in flow.response.headers
+
+        after_headers = list(stream.handle_event(events.HookCompleted(response_headers_hook, None)))
+        assert any(
+            isinstance(command, SendHttp)
+            and isinstance(command.event, ResponseHeaders)
+            and command.event.response.status_code == 200
+            for command in after_headers
+        )
+
+        follower = catalog_flow(
+            real_flow,
+            version="0.145.0",
+            auth_value="resolved-access",
+            account="resolved-account",
+        )
+        follower_prepare = asyncio.create_task(
+            codex_model_catalog_cache.prepare_request(follower, request_end_stream=True)
+        )
+        await asyncio.sleep(0)
+        assert not follower_prepare.done()
+        assert follower.request.headers["Accept-Encoding"] == "identity"
+
+        body_commands = list(stream.handle_event(ResponseData(1, compressed_body)))
+        assert (
+            b"".join(
+                command.event.data
+                for command in body_commands
+                if isinstance(command, SendHttp) and isinstance(command.event, ResponseData)
+            )
+            == compressed_body
+        )
+
+        end_commands = list(stream.handle_event(ResponseEndOfMessage(1)))
+        response_hook = next(
+            command for command in end_commands if isinstance(command, HttpResponseHook)
+        )
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, response_hook)
+        assert flow.response.status_code == 200
+        assert flow.response.headers["Content-Encoding"] == "br"
+        assert "Content-Length" not in flow.response.headers
+
+        await asyncio.wait_for(follower_prepare, timeout=0.1)
+        assert follower.response is not None
+        assert follower.response.content == catalog_body
+        assert "Content-Encoding" not in follower.response.headers
+        follower_telemetry: dict[str, object] = {}
+        codex_model_catalog_cache.add_network_log_fields(follower, follower_telemetry)
+        assert follower_telemetry["model_catalog_prefetch_role"] == "inflight_consumer"
+
+        cache_hit = catalog_flow(
+            real_flow,
+            version="0.145.0",
+            auth_value="resolved-access",
+            account="resolved-account",
+        )
+        await codex_model_catalog_cache.prepare_request(cache_hit, request_end_stream=True)
+        assert cache_hit.response is not None
+        assert cache_hit.response.content == catalog_body
+        codex_model_catalog_cache.release_flow_state(follower)
+        codex_model_catalog_cache.release_flow_state(cache_hit)
+
+        after_response = list(stream.handle_event(events.HookCompleted(response_hook, None)))
+
+    client_commands = [*after_headers, *body_commands, *end_commands, *after_response]
+    client_events = [command.event for command in client_commands if isinstance(command, SendHttp)]
+    assert any(
+        isinstance(event, ResponseHeaders)
+        and event.response.status_code == 200
+        and event.response.headers["Content-Encoding"] == "br"
+        for event in client_events
+    )
+    assert (
+        b"".join(event.data for event in client_events if isinstance(event, ResponseData))
+        == compressed_body
+    )
+    assert any(isinstance(event, ResponseEndOfMessage) for event in client_events)
+
+
+async def test_http2_ordinary_identity_catalog_is_streamed_unchanged_while_cached(
+    tmp_path: Path,
+    real_flow,
+) -> None:
+    catalog_path = "/backend-api/codex/models?client_version=0.145.0"
+    catalog_body = b'{"models":[{"slug":"gpt-test"}]}'
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+    ):
+        stream, flow = await _catalog_http_stream(
+            addon_context,
+            catalog_path=catalog_path,
+        )
+        upstream_response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {
+                    "Content-Type": "application/json",
+                    "ETag": '"catalog-v1"',
+                }
+            ),
+        )
+        response_header_commands = list(
+            stream.handle_event(ResponseHeaders(1, upstream_response, end_stream=False))
+        )
+        response_headers_hook = next(
+            command
+            for command in response_header_commands
+            if isinstance(command, HttpResponseHeadersHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, response_headers_hook)
+        assert flow.response is not None
+        assert flow.response.status_code == 200
+        assert callable(flow.response.stream)
+        assert "Content-Encoding" not in flow.response.headers
+        assert "Content-Length" not in flow.response.headers
+
+        after_headers = list(stream.handle_event(events.HookCompleted(response_headers_hook, None)))
+        body_commands = list(stream.handle_event(ResponseData(1, catalog_body)))
+        assert (
+            b"".join(
+                command.event.data
+                for command in body_commands
+                if isinstance(command, SendHttp) and isinstance(command.event, ResponseData)
+            )
+            == catalog_body
+        )
+
+        end_commands = list(stream.handle_event(ResponseEndOfMessage(1)))
+        response_hook = next(
+            command for command in end_commands if isinstance(command, HttpResponseHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, response_hook)
+        after_response = list(stream.handle_event(events.HookCompleted(response_hook, None)))
+
+        cache_hit = catalog_flow(
+            real_flow,
+            version="0.145.0",
+            auth_value="resolved-access",
+            account="resolved-account",
+        )
+        await codex_model_catalog_cache.prepare_request(cache_hit, request_end_stream=True)
+        assert cache_hit.response is not None
+        assert cache_hit.response.content == catalog_body
+        codex_model_catalog_cache.release_flow_state(cache_hit)
+
+    client_commands = [*after_headers, *body_commands, *end_commands, *after_response]
+    client_events = [command.event for command in client_commands if isinstance(command, SendHttp)]
+    assert any(
+        isinstance(event, ResponseHeaders)
+        and event.response.status_code == 200
+        and "Content-Encoding" not in event.response.headers
+        for event in client_events
+    )
+    assert (
+        b"".join(event.data for event in client_events if isinstance(event, ResponseData))
+        == catalog_body
+    )
+    assert any(isinstance(event, ResponseEndOfMessage) for event in client_events)
+
+
+async def test_http2_ordinary_catalog_rejects_unsolicited_brotli_before_body(
+    tmp_path: Path,
+) -> None:
+    catalog_path = "/backend-api/codex/models?client_version=0.145.0"
+    compressed_body = brotli.compress(b'{"models":[{"slug":"gpt-test"}]}')
 
     with (
         patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
@@ -762,24 +973,12 @@ async def test_http2_brotli_catalog_is_streamed_unchanged_while_cached(
             for command in response_header_commands
             if isinstance(command, HttpResponseHeadersHook)
         )
-        await addon_context.master.addons.invoke_addon(
-            mitm_addon,
-            response_headers_hook,
-        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, response_headers_hook)
         assert flow.response is not None
-        assert flow.response.status_code == 200
-        assert callable(flow.response.stream)
-        assert flow.response.headers["Content-Encoding"] == "br"
-        assert flow.response.headers["Content-Length"] == str(len(compressed_body))
+        assert flow.response.status_code == 502
+        assert "Content-Encoding" not in flow.response.headers
 
         after_headers = list(stream.handle_event(events.HookCompleted(response_headers_hook, None)))
-        assert any(
-            isinstance(command, SendHttp)
-            and isinstance(command.event, ResponseHeaders)
-            and command.event.response.status_code == 200
-            for command in after_headers
-        )
-
         body_commands = list(stream.handle_event(ResponseData(1, compressed_body)))
         assert (
             b"".join(
@@ -787,44 +986,25 @@ async def test_http2_brotli_catalog_is_streamed_unchanged_while_cached(
                 for command in body_commands
                 if isinstance(command, SendHttp) and isinstance(command.event, ResponseData)
             )
-            == compressed_body
+            == b""
         )
 
         end_commands = list(stream.handle_event(ResponseEndOfMessage(1)))
         response_hook = next(
             command for command in end_commands if isinstance(command, HttpResponseHook)
         )
-
         await addon_context.master.addons.invoke_addon(mitm_addon, response_hook)
-        assert flow.response.status_code == 200
-        assert flow.response.headers["Content-Encoding"] == "br"
-        assert flow.response.headers["Content-Length"] == str(len(compressed_body))
-
-        cache_hit = catalog_flow(
-            real_flow,
-            version="0.145.0",
-            auth_value="resolved-access",
-            account="resolved-account",
-        )
-        await codex_model_catalog_cache.prepare_request(cache_hit, request_end_stream=True)
-        assert cache_hit.response is not None
-        assert cache_hit.response.content == catalog_body
-        codex_model_catalog_cache.release_flow_state(cache_hit)
-
         after_response = list(stream.handle_event(events.HookCompleted(response_hook, None)))
 
     client_commands = [*after_headers, *body_commands, *end_commands, *after_response]
     client_events = [command.event for command in client_commands if isinstance(command, SendHttp)]
     assert any(
         isinstance(event, ResponseHeaders)
-        and event.response.status_code == 200
-        and event.response.headers["Content-Encoding"] == "br"
+        and event.response.status_code == 502
+        and "Content-Encoding" not in event.response.headers
         for event in client_events
     )
-    assert (
-        b"".join(event.data for event in client_events if isinstance(event, ResponseData))
-        == compressed_body
-    )
+    assert b"".join(event.data for event in client_events if isinstance(event, ResponseData)) == b""
     assert any(isinstance(event, ResponseEndOfMessage) for event in client_events)
 
 
@@ -842,6 +1022,7 @@ async def test_http2_invalid_brotli_catalog_passes_through_without_cache_rewrite
         stream, flow = await _catalog_http_stream(
             addon_context,
             catalog_path=catalog_path,
+            prefetch=True,
         )
         upstream_response = tutils.tresp(
             status_code=200,
@@ -925,6 +1106,7 @@ async def test_http2_unbounded_brotli_catalog_is_passed_through_but_not_retained
         stream, flow = await _catalog_http_stream(
             addon_context,
             catalog_path=catalog_path,
+            prefetch=True,
         )
         upstream_response = tutils.tresp(
             status_code=200,


### PR DESCRIPTION
## Summary

- preserve `Accept-Encoding: identity` for ordinary Codex model-catalog miss owners
- negotiate Brotli only for runner-owned prefetch producers and continue publishing validated identity cache entries to waiting Codex consumers
- reject unsolicited encoded ordinary responses with an empty 502 while draining the upstream body and releasing singleflight waiters
- cover ordinary, prefetch, failure, takeover, and missing-`Content-Length` behavior through the real mitmproxy HTTP/2 lifecycle

## Compatibility

- no database, persisted state, queue payload, runner/guest protocol, API, frontend, feature switch, or network-log schema changes
- rollback is limited to the runner image; no cleanup issue is required

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (4,993 passed)
- `git diff --check`

Closes #25869
