### PR TITLE
fix(platform): keep agent chat default model cached

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -28,7 +28,6 @@ import {
   type EnsuredAgentDraft,
 } from "./agent-draft.ts";
 import { setAgentComposerContext$ } from "./agent-composer-signals.ts";
-import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { checkUnifiedSettingsParam$ } from "./settings/settings-dialog.ts";
 import { setupAgentChatKeyboardShortcuts$ } from "./agent-chat-keyboard.ts";
@@ -46,7 +45,6 @@ export const setupAgentChatPage$ = command(
     set(reloadTagline$);
 
     set(resetChatPageModelSelection$);
-    set(reloadUserModelPreference$);
 
     // Read agent ID from URL immediately (synchronous) and update sidebar
     // highlight early so the UI responds without waiting for async data.

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -155,6 +155,8 @@ export const updateCodexFastModeDefaultForSelection$ = command(
   },
 );
 
-export const resetChatPageModelSelection$ = command(({ set }) => {
-  set(internalChatPageUserOverride$, { kind: "unset" });
+export const resetChatPageModelSelection$ = command(({ get, set }) => {
+  if (get(internalChatPageUserOverride$).kind === "set") {
+    set(internalChatPageUserOverride$, { kind: "unset" });
+  }
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -36,6 +36,8 @@ import {
   userModelPreference$,
 } from "../../../signals/external/user-model-preference.ts";
 import { codexFastModeLocalDefault$ } from "../../../signals/zero-page/codex-fast-local-default.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
 import {
   resetChatPageModelSelection$,
   setChatPageModelSelection$,
@@ -148,6 +150,38 @@ describe("chat composer models", () => {
     });
 
     expect(policiesRequestCount).toBe(1);
+    expect(preferenceRequestCount).toBe(1);
+  });
+
+  it("keeps the default model cached when returning to agent chat", async () => {
+    let preferenceRequestCount = 0;
+
+    mockOrgModelRoutes("kimi-k2.7-code");
+    context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
+      preferenceRequestCount += 1;
+      return respond(200, { selectedModel: null, updatedAt: null });
+    });
+    mockAgent();
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await expectComposerModel("Kimi K2.7 Code");
+    expect(preferenceRequestCount).toBe(1);
+
+    act(() => {
+      context.store.set(detachedNavigateTo$, ROUTES.agentIdeas, {
+        pathParams: { agentId: AGENT_ID },
+      });
+    });
+    await screen.findByRole("heading", { name: "Ideas & Use Cases" });
+
+    act(() => {
+      context.store.set(detachedNavigateTo$, ROUTES.agentChat, {
+        pathParams: { agentId: AGENT_ID },
+      });
+    });
+
+    await expectComposerModel("Kimi K2.7 Code");
     expect(preferenceRequestCount).toBe(1);
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -153,27 +153,54 @@ describe("chat composer models", () => {
     expect(preferenceRequestCount).toBe(1);
   });
 
-  it("keeps the default model cached when returning to agent chat", async () => {
-    let preferenceRequestCount = 0;
+  it("shows the cached default model immediately when returning from agents", async () => {
+    const policy = buildModelPolicy({
+      id: "00000000-0000-4000-a000-000000000205",
+      model: "kimi-k2.7-code",
+      modelLabel: "Kimi K2.7 Code",
+      isDefault: true,
+      defaultProviderType: "moonshot-api-key",
+      credentialScope: "org",
+      modelProviderId: MOONSHOT_PROVIDER_ID,
+    });
+    const pendingModelRequests = context.mocks.deferred<void>();
+    let blockModelRequests = false;
 
     mockOrgModelRoutes("kimi-k2.7-code");
-    context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
-      preferenceRequestCount += 1;
-      return respond(200, { selectedModel: null, updatedAt: null });
-    });
+    context.mocks.api(
+      zeroModelPoliciesMainContract.list,
+      async ({ respond, withSignal }) => {
+        if (blockModelRequests) {
+          await withSignal(pendingModelRequests.promise);
+        }
+        return respond(200, {
+          policies: [policy],
+          workspaceDefaultModel: policy.model,
+          workspaceDefaultPolicyId: policy.id,
+        });
+      },
+    );
+    context.mocks.api(
+      zeroUserModelPreferenceContract.get,
+      async ({ respond, withSignal }) => {
+        if (blockModelRequests) {
+          await withSignal(pendingModelRequests.promise);
+        }
+        return respond(200, { selectedModel: null, updatedAt: null });
+      },
+    );
     mockAgent();
 
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
 
     await expectComposerModel("Kimi K2.7 Code");
-    expect(preferenceRequestCount).toBe(1);
 
     act(() => {
-      context.store.set(detachedNavigateTo$, ROUTES.agentIdeas, {
-        pathParams: { agentId: AGENT_ID },
-      });
+      context.store.set(detachedNavigateTo$, ROUTES.agents);
     });
-    await screen.findByRole("heading", { name: "Ideas & Use Cases" });
+    await screen.findByRole("heading", { name: "Agents" });
+
+    blockModelRequests = true;
 
     act(() => {
       context.store.set(detachedNavigateTo$, ROUTES.agentChat, {
@@ -181,8 +208,10 @@ describe("chat composer models", () => {
       });
     });
 
-    await expectComposerModel("Kimi K2.7 Code");
-    expect(preferenceRequestCount).toBe(1);
+    await findComposerEditor();
+    expect(
+      screen.getByRole("combobox", { name: "Kimi K2.7 Code" }),
+    ).toBeInTheDocument();
   });
 
   it("resolves workspace, user, and thread model choices in the visible picker", async () => {


### PR DESCRIPTION
## Summary

- stop reloading the user model preference whenever Agent Chat is entered
- make the landing composer model reset idempotent when no override exists
- verify the cached default model is present immediately after returning from `/agents`, even while model resource requests are blocked

## Regression proof

- the targeted test fails against the pre-fix behavior because the composer mounts without the model picker
- the fixed implementation passes all 45 tests in the target file

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx`
- `git diff --check`
