### PR TITLE
fix(api): scope pi loop and isolate codex session history

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -734,7 +734,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(sends.messages).toHaveLength(sendsAfterCompletion);
   });
 
-  it("renders media prompts, provider recent history, and restarts sessions when the model route changes", async () => {
+  it("renders media prompts, provider recent history, and reuses sessions across same-framework routes", async () => {
     const ap = createAgentPhoneBddApi(context);
     const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
 
@@ -797,8 +797,8 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     await waitForSendCount(sends, beforeRun2Completion + 1);
     await waitForRunSessionId(actor, run2.runId, mediaSession);
 
-    // Re-pointing the default model policy at an incompatible provider
-    // forces the next DM onto a fresh session.
+    // Re-pointing the default model policy at another provider preserves the
+    // session because both routes use the Claude Code framework.
     await ap.switchDefaultModelRouteToOpenRouter(actor);
     await ap.postAgentPhoneInboundMessage({
       channel: "sms",
@@ -807,7 +807,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     });
     const run3 = await claimDispatchedRun(runnerGroup);
     await completeSandboxRun(run3.sandboxToken, run3.runId, 0);
-    await expect(ap.readRunSessionId(actor, run3.runId)).resolves.not.toBe(
+    await expect(ap.readRunSessionId(actor, run3.runId)).resolves.toBe(
       mediaSession,
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -4843,7 +4843,7 @@ describe("CHAT-02: auto-send after failures", () => {
 });
 
 describe("CHAT-02: auto-send across a model switch", () => {
-  it("recovers a queued message through the current same-family workspace default", async () => {
+  it("recovers a queued message through the current same-framework workspace default", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -4984,7 +4984,7 @@ describe("CHAT-02: auto-send across a model switch", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("resumes the CLI session by default when the queued model stays within the same family", async () => {
+  it("resumes the CLI session by default when the queued model stays on the same framework", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -5007,7 +5007,7 @@ describe("CHAT-02: auto-send across a model switch", () => {
 
     const first = await startChatRun(actor, {
       agentId,
-      prompt: "start on opus before queueing a Claude family switch",
+      prompt: "start on opus before queueing a Claude Code model switch",
       selectedModel: "claude-opus-4-6",
     });
     const firstHeaders = await claimChatRun(runnerGroup, first.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2833,13 +2833,14 @@ describe("CHAT-02: model-first provider policies", () => {
     }
   }, 90_000);
 
-  it("routes DeepSeek V4 Flash through the native Responses adapter", async () => {
+  it("reuses a Codex session when switching from DeepSeek to Luna with PiLoop disabled", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const { providerId } = await upsertOrgModelProvider(actor, {
       type: "deepseek",
       secret: "selected-deepseek-responses-key",
     });
+    await seedVm0ManagedModelKey("gpt-5.6-luna");
     await api.updateOrgModelPolicies(actor, [
       {
         model: "deepseek-v4-flash",
@@ -2847,6 +2848,13 @@ describe("CHAT-02: model-first provider policies", () => {
         defaultProviderType: "deepseek",
         credentialScope: "org",
         modelProviderId: providerId,
+      },
+      {
+        model: "gpt-5.6-luna",
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
       },
     ]);
 
@@ -2894,7 +2902,8 @@ describe("CHAT-02: model-first provider policies", () => {
     const followUp = await sendChatRun(actor, {
       agentId,
       threadId: run.threadId,
-      prompt: "continue with DeepSeek Responses",
+      prompt: "continue with Luna on the same Codex session",
+      model: "gpt-5.6-luna",
     });
     const { claim: followUpClaim } = await claimChatRun(
       runnerGroup,
@@ -2903,14 +2912,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const followUpEnvironment = claimEnvironment(followUpClaim);
     expect(followUpClaim.cliAgentType).toBe("codex");
     expect(followUpClaim.resumeSession?.sessionId).toBe(`bdd-cli-${run.runId}`);
-    expect(followUpClaim.codexRuntimeConfig?.providerId).toBe("deepseek");
-    expect(followUpEnvironment.OPENAI_API_KEY).toBe(
-      modelProviderSecretPlaceholder("deepseek", "DEEPSEEK_API_KEY"),
-    );
-    expect(followUpEnvironment.OPENAI_BASE_URL).toBe(
-      "https://api.deepseek.com/",
-    );
-    expect(followUpEnvironment.OPENAI_MODEL).toBe("deepseek-v4-flash");
+    expect(followUpEnvironment.OPENAI_MODEL).toBe("gpt-5.6-luna");
 
     await cancelChatRun(actor, followUp.runId);
   });
@@ -3701,7 +3703,7 @@ describe("CHAT-02: model-first provider policies", () => {
 });
 
 describe("CHAT-02: run-level model overrides", () => {
-  it("uses send model overrides without mutating the thread model while preserving same-family sessions", async () => {
+  it("uses send model overrides without mutating the thread model while preserving same-framework sessions", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -3751,7 +3753,7 @@ describe("CHAT-02: run-level model overrides", () => {
       (await api.readRun(actor, first.runId)).result?.agentSessionId,
     ).toMatch(/[0-9a-f-]{36}/);
 
-    // A run-level override of another model in the same family resumes the CLI
+    // A run-level override on the same framework resumes the CLI
     // session, which already carries the prior web round, so the prompt does
     // not replay it.
     const second = await sendChatRun(actor, {
@@ -3800,7 +3802,7 @@ describe("CHAT-02: run-level model overrides", () => {
     await flushWaitUntilForTest();
 
     // Follow-ups without a send model override go back to the thread's stored
-    // model. Both models remain in the Claude family, so session continuity is
+    // model. Both models remain on Claude Code, so session continuity is
     // preserved.
     const third = await sendChatRun(actor, {
       agentId,
@@ -3817,7 +3819,7 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, third.runId);
   }, 90_000);
 
-  it("resumes the CLI session across same-family model switches", async () => {
+  it("resumes the CLI session across same-framework model switches", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -4312,7 +4314,7 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
-  it("rebuilds Web prompt context when a stale retry rotates the session", async () => {
+  it("keeps the session when a same-framework gateway changes during a stale retry", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
       throw new Error("Expected an org-scoped actor for binding validation");
@@ -4471,15 +4473,15 @@ describe("CHAT-02: run-level model overrides", () => {
     expect(sandboxOperationEventsForRun(retried.runId)).toContainEqual(
       expect.objectContaining({
         op_type: "chat_thread_session_binding_persisted",
-        binding_action: "rotated",
+        binding_action: "reused",
       }),
     );
     const retriedRun = await api.readRun(actor, retried.runId);
     const appendSystemPrompt = retriedRun.appendSystemPrompt ?? "";
-    expect(appendSystemPrompt).toContain("# Web Chat Run Context");
-    expect(appendSystemPrompt).toContain(anchorPrompt);
+    expect(appendSystemPrompt).not.toContain("# Web Chat Run Context");
+    expect(appendSystemPrompt).not.toContain(anchorPrompt);
     expect(appendSystemPrompt).toContain(incompletePrompt);
-    expect(appendSystemPrompt).not.toContain("# Incomplete Rounds Context");
+    expect(appendSystemPrompt).toContain("# Incomplete Rounds Context");
 
     const retryTimingEvents = apiDispatchTimingEventsForRun(retried.runId);
     for (const actionType of [
@@ -4493,11 +4495,13 @@ describe("CHAT-02: run-level model overrides", () => {
       ).toHaveLength(2);
     }
     const retriedClaim = await claimChatRun(runnerGroup, retried.runId);
-    expect(retriedClaim.claim.resumeSession).toBeNull();
+    expect(retriedClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${anchor.runId}`,
+    );
     await cancelChatRun(actor, retried.runId);
   }, 90_000);
 
-  it("replays only each prior run's final answer when a model family rotates the session", async () => {
+  it("replays only each prior run's final answer when the framework changes", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -4547,7 +4551,7 @@ describe("CHAT-02: run-level model overrides", () => {
       });
     });
 
-    // Switching model family rotates the CLI session, so the prior round is
+    // Switching framework rotates the CLI session, so the prior round is
     // replayed. An agentic run emits one chat message per step; only its final
     // answer carries information the next run needs.
     await chat.updateThreadModelSelection(
@@ -4558,7 +4562,7 @@ describe("CHAT-02: run-level model overrides", () => {
     const second = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "continue after the family switch",
+      prompt: "continue after the framework switch",
     });
     const appended = (await api.readRun(actor, second.runId))
       .appendSystemPrompt;
@@ -4755,7 +4759,7 @@ describe("CHAT-02: run-level model overrides", () => {
     ).resolves.toStrictEqual(firstBinding);
   }, 90_000);
 
-  it("rotates after a custom gateway is deleted and replaced by its legacy adapter", async () => {
+  it("reuses the session after a custom gateway is replaced by its same-framework legacy adapter", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -4838,34 +4842,34 @@ describe("CHAT-02: run-level model overrides", () => {
     const second = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "rotate away from the deleted custom surface",
+      prompt: "continue after the custom surface is replaced",
     });
-    const rotatedBinding = await readThreadSessionBinding(
+    const reusedBinding = await readThreadSessionBinding(
       context,
       first.threadId,
     );
-    expect(rotatedBinding.agent_session_id).not.toBe(
-      originalBinding.agent_session_id,
-    );
-    expect(rotatedBinding).toMatchObject({
+    expect(reusedBinding).toMatchObject({
+      agent_session_id: originalBinding.agent_session_id,
       agent_session_run_id: second.runId,
-      run_session_id: rotatedBinding.agent_session_id,
+      run_session_id: originalBinding.agent_session_id,
     });
     expect(sandboxOperationEventsForRun(second.runId)).toContainEqual(
       expect.objectContaining({
         op_type: "chat_thread_session_binding_persisted",
         chat_thread_id: first.threadId,
-        agent_session_id: rotatedBinding.agent_session_id,
+        agent_session_id: originalBinding.agent_session_id,
         agent_session_run_id: second.runId,
-        binding_action: "rotated",
+        binding_action: "reused",
       }),
     );
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
-    expect(secondClaim.claim.resumeSession).toBeNull();
+    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${first.runId}`,
+    );
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
-  it("rotates from the latest session run when binding provenance is deleted", async () => {
+  it("reuses the latest session framework when binding provenance is deleted", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -4938,26 +4942,24 @@ describe("CHAT-02: run-level model overrides", () => {
     const third = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "rotate after the provenance run is removed",
+      prompt: "reuse after the provenance run is removed",
     });
-    const rotatedBinding = await readThreadSessionBinding(
+    const reusedBinding = await readThreadSessionBinding(
       context,
       first.threadId,
     );
-    expect(rotatedBinding.agent_session_id).not.toBe(
-      originalBinding.agent_session_id,
-    );
-    expect(rotatedBinding).toMatchObject({
+    expect(reusedBinding).toMatchObject({
+      agent_session_id: originalBinding.agent_session_id,
       agent_session_run_id: third.runId,
-      run_session_id: rotatedBinding.agent_session_id,
+      run_session_id: originalBinding.agent_session_id,
     });
     expect(sandboxOperationEventsForRun(third.runId)).toContainEqual(
       expect.objectContaining({
         op_type: "chat_thread_session_binding_persisted",
         chat_thread_id: first.threadId,
-        agent_session_id: rotatedBinding.agent_session_id,
+        agent_session_id: originalBinding.agent_session_id,
         agent_session_run_id: third.runId,
-        binding_action: "rotated",
+        binding_action: "reused",
       }),
     );
     const thirdClaim = await claimChatRun(runnerGroup, third.runId);
@@ -5073,18 +5075,18 @@ describe("CHAT-02: run-level model overrides", () => {
       ),
     );
     expect(thirdClaim.claim.cliAgentType).toBe("claude-code");
-    expect(thirdClaim.claim.resumeSession).toBeNull();
+    expect(thirdClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${second.runId}`,
+    );
     await completeChatRunOk(third.runId, thirdClaim.sandboxHeaders);
-    const rotatedBinding = await readThreadSessionBinding(
+    const reusedBinding = await readThreadSessionBinding(
       context,
       first.threadId,
     );
-    expect(rotatedBinding.agent_session_id).not.toBe(
-      originalBinding.agent_session_id,
-    );
-    expect(rotatedBinding).toMatchObject({
+    expect(reusedBinding).toMatchObject({
+      agent_session_id: originalBinding.agent_session_id,
       agent_session_run_id: third.runId,
-      run_session_id: rotatedBinding.agent_session_id,
+      run_session_id: originalBinding.agent_session_id,
     });
     await expectNoThreadModelUpdateEvent(
       actor,
@@ -5095,16 +5097,16 @@ describe("CHAT-02: run-level model overrides", () => {
     const fourth = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
-      prompt: "continue after the canonical session rotates",
+      prompt: "continue on the reused framework session",
     });
     const fourthBinding = await readThreadSessionBinding(
       context,
       first.threadId,
     );
     expect(fourthBinding).toMatchObject({
-      agent_session_id: rotatedBinding.agent_session_id,
+      agent_session_id: originalBinding.agent_session_id,
       agent_session_run_id: fourth.runId,
-      run_session_id: rotatedBinding.agent_session_id,
+      run_session_id: originalBinding.agent_session_id,
     });
     const fourthClaim = await claimChatRun(runnerGroup, fourth.runId);
     expect(fourthClaim.claim.resumeSession?.sessionId).toBe(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2833,7 +2833,7 @@ describe("CHAT-02: model-first provider policies", () => {
     }
   }, 90_000);
 
-  it("reuses a Codex session when switching from DeepSeek to Luna with PiLoop disabled", async () => {
+  it("rotates Codex sessions between DeepSeek and OpenAI with PiLoop disabled", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const { providerId } = await upsertOrgModelProvider(actor, {
@@ -2851,6 +2851,13 @@ describe("CHAT-02: model-first provider policies", () => {
       },
       {
         model: "gpt-5.6-luna",
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+      {
+        model: "gpt-5.6-sol",
         isDefault: false,
         defaultProviderType: "vm0",
         credentialScope: "org",
@@ -2902,19 +2909,62 @@ describe("CHAT-02: model-first provider policies", () => {
     const followUp = await sendChatRun(actor, {
       agentId,
       threadId: run.threadId,
-      prompt: "continue with Luna on the same Codex session",
+      prompt: "switch from DeepSeek to Luna",
       model: "gpt-5.6-luna",
     });
-    const { claim: followUpClaim } = await claimChatRun(
-      runnerGroup,
-      followUp.runId,
-    );
+    const { claim: followUpClaim, sandboxHeaders: followUpSandboxHeaders } =
+      await claimChatRun(runnerGroup, followUp.runId);
     const followUpEnvironment = claimEnvironment(followUpClaim);
     expect(followUpClaim.cliAgentType).toBe("codex");
-    expect(followUpClaim.resumeSession?.sessionId).toBe(`bdd-cli-${run.runId}`);
+    expect(followUpClaim.resumeSession).toBeNull();
     expect(followUpEnvironment.OPENAI_MODEL).toBe("gpt-5.6-luna");
 
-    await cancelChatRun(actor, followUp.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(followUp.runId, followUpSandboxHeaders, {
+      cliAgentType: "codex",
+    });
+
+    const openaiFollowUp = await sendChatRun(actor, {
+      agentId,
+      threadId: run.threadId,
+      prompt: "switch within the OpenAI model family",
+      model: "gpt-5.6-sol",
+    });
+    const {
+      claim: openaiFollowUpClaim,
+      sandboxHeaders: openaiFollowUpSandboxHeaders,
+    } = await claimChatRun(runnerGroup, openaiFollowUp.runId);
+    expect(openaiFollowUpClaim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${followUp.runId}`,
+    );
+    expect(claimEnvironment(openaiFollowUpClaim).OPENAI_MODEL).toBe(
+      "gpt-5.6-sol",
+    );
+
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(
+      openaiFollowUp.runId,
+      openaiFollowUpSandboxHeaders,
+      { cliAgentType: "codex" },
+    );
+
+    const deepseekReturn = await sendChatRun(actor, {
+      agentId,
+      threadId: run.threadId,
+      prompt: "switch from OpenAI back to DeepSeek",
+      model: "deepseek-v4-flash",
+    });
+    const { claim: deepseekReturnClaim } = await claimChatRun(
+      runnerGroup,
+      deepseekReturn.runId,
+    );
+    expect(deepseekReturnClaim.cliAgentType).toBe("codex");
+    expect(deepseekReturnClaim.resumeSession).toBeNull();
+    expect(claimEnvironment(deepseekReturnClaim).OPENAI_MODEL).toBe(
+      "deepseek-v4-flash",
+    );
+
+    await cancelChatRun(actor, deepseekReturn.runId);
   });
 
   it("resolves an unchanged existing thread without waiting for its row lock", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4473,7 +4473,7 @@ describe("CHAT-02: run-level model overrides", () => {
     expect(sandboxOperationEventsForRun(retried.runId)).toContainEqual(
       expect.objectContaining({
         op_type: "chat_thread_session_binding_persisted",
-        binding_action: "reused",
+        binding_action: "adopted",
       }),
     );
     const retriedRun = await api.readRun(actor, retried.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -20,7 +20,6 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { generateSandboxToken } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -32,7 +31,6 @@ import {
 } from "../../../test-fixtures/system-config-seeds";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
-import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
@@ -58,7 +56,6 @@ import { readSystemStorageVersionNameByS3KeyFixture } from "../../../test-fixtur
 
 const context = testContext();
 const bdd = createBddApi(context);
-const misc = createMiscRoutesApi(context);
 const api = createRunsApi(context);
 const chat = createChatFilesBddApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
@@ -71,12 +68,9 @@ type AgentUsageEventBody = Parameters<
 >[0];
 
 const MODEL = "deepseek-v4-flash";
-const MANAGED_MODEL = "gpt-5.6-luna";
+const MANAGED_MODEL = MODEL;
+const OPENAI_MODEL = "gpt-5.6-luna";
 const COMPLETIONS_URL = "https://api.deepseek.com/chat/completions";
-const CODEX_MODEL = "gpt-5.5";
-const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
-const CODEX_WHAM_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-const CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
 const OPENAI_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions";
 const AGENT_DISPLAY_NAME = "Pi edge integration agent";
 const STORAGE_ARCHIVE_SUFFIX = "/archive.tar.gz";
@@ -200,126 +194,6 @@ function systemPromptFromRequest(request: unknown): string | undefined {
     typeof systemMessage.content === "string"
     ? systemMessage.content
     : undefined;
-}
-
-function base64UrlEncode(input: string): string {
-  return Buffer.from(input, "utf8")
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
-
-function codexJwt(accountId: string, expiresInSeconds = 3600): string {
-  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
-  const payload = base64UrlEncode(
-    JSON.stringify({
-      exp: Math.floor(now() / 1000) + expiresInSeconds,
-      "https://api.openai.com/auth": {
-        chatgpt_account_id: accountId,
-        chatgpt_plan_type: "pro",
-      },
-    }),
-  );
-  return `${header}.${payload}.fake-signature`;
-}
-
-function codexAuthJson(accessToken: string): string {
-  const accountId = "ws_acct_from_id_token_pi_edge";
-  return JSON.stringify({
-    OPENAI_API_KEY: null,
-    tokens: {
-      access_token: accessToken,
-      refresh_token: "rt_pi_edge_synthetic_high_entropy",
-      account_id: "ws_acct_pi_edge_plain",
-      id_token: codexJwt(accountId),
-    },
-  });
-}
-
-function codexTextSsePayload(text: string): string {
-  const events = [
-    {
-      type: "response.created",
-      response: {
-        id: "resp_pi_codex",
-        object: "response",
-        status: "in_progress",
-        output: [],
-        usage: null,
-      },
-    },
-    {
-      type: "response.output_item.added",
-      output_index: 0,
-      item: {
-        type: "message",
-        id: "msg_pi_codex",
-        role: "assistant",
-        status: "in_progress",
-        content: [],
-      },
-    },
-    {
-      type: "response.output_text.delta",
-      output_index: 0,
-      content_index: 0,
-      delta: text,
-    },
-    {
-      type: "response.output_item.done",
-      output_index: 0,
-      item: {
-        type: "message",
-        id: "msg_pi_codex",
-        role: "assistant",
-        status: "completed",
-        content: [{ type: "output_text", text, annotations: [] }],
-      },
-    },
-    {
-      type: "response.completed",
-      response: {
-        id: "resp_pi_codex",
-        object: "response",
-        status: "completed",
-        output: [
-          {
-            type: "message",
-            id: "msg_pi_codex",
-            role: "assistant",
-            status: "completed",
-            content: [{ type: "output_text", text, annotations: [] }],
-          },
-        ],
-        usage: {
-          input_tokens: 5,
-          output_tokens: 3,
-          total_tokens: 8,
-        },
-      },
-    },
-  ];
-  return events
-    .map((event) => {
-      return `data: ${JSON.stringify(event)}\n\n`;
-    })
-    .join("");
-}
-
-function codexTextSseStream(text: string): Response {
-  // MSW's HttpResponse.text body does not close for the Codex stream reader in
-  // this environment; a raw Response with a ReadableStream does (same shape as
-  // the pi-agent-runtime unit coverage).
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(codexTextSsePayload(text)));
-      controller.close();
-    },
-  });
-  return new Response(stream, {
-    headers: { "content-type": "text/event-stream" },
-  });
 }
 
 function commandInput(command: unknown): Record<string, unknown> {
@@ -612,87 +486,6 @@ async function piEdgeFixture(
     workflowSkillName,
     storageObjects,
     model,
-  };
-}
-
-async function codexPiEdgeFixture(args?: {
-  readonly accessToken?: string;
-}): Promise<PiEdgeFixture> {
-  const orgId = `org_pi_codex_${randomUUID()}`;
-  const actor = bdd.user({ orgId });
-  const switchOwner = bdd.user({ orgId });
-  chatCallbacks.acceptChatObjectStorage();
-  chatCallbacks.disableVapid();
-  api.acceptStorageDownloads();
-  const storageObjects = acceptPiStorageObjects();
-  api.acceptTelemetryIngest();
-  mockOptionalEnv("OPENROUTER_API_KEY", undefined);
-  const runnerGroup = api.configureRunnerGroup();
-  await api.grantProEntitlement(actor);
-  server.use(
-    http.get(CODEX_WHAM_USAGE_URL, () => {
-      return HttpResponse.json({
-        plan_type: "pro",
-        rate_limit: {
-          primary_window: {
-            limit_window_seconds: 18_000,
-            reset_at: 1_893_441_600,
-          },
-          secondary_window: {
-            limit_window_seconds: 604_800,
-            reset_at: 1_893_456_000,
-          },
-        },
-      });
-    }),
-  );
-  await misc.upsertPersonalModelProvider(
-    actor,
-    {
-      type: "codex-oauth-token",
-      authMethod: "auth_json",
-      secrets: {
-        CODEX_AUTH_JSON: codexAuthJson(
-          args?.accessToken ?? codexJwt("ws_acct_pi_edge_access"),
-        ),
-      },
-    },
-    [200, 201],
-  );
-  await api.updateOrgModelPolicies(actor, [
-    {
-      model: CODEX_MODEL,
-      isDefault: true,
-      defaultProviderType: "codex-oauth-token",
-      credentialScope: "member",
-      modelProviderId: null,
-    },
-  ]);
-  const agent = await bdd.createAgent(actor, {
-    displayName: AGENT_DISPLAY_NAME,
-    description: "Exercises the in-API Pi edge turn with a Codex subscription.",
-    visibility: "private",
-  });
-  const agentInstructions =
-    "# Pinned Pi instructions\nAlways preserve the run snapshot.";
-  await bdd.updateAgentInstructions(actor, agent.agentId, agentInstructions);
-  const workflowSkillName = `pi-snapshot-${randomUUID().slice(0, 8)}`;
-  await workflows.createWorkflow(actor, {
-    agentId: agent.agentId,
-    name: workflowSkillName,
-  });
-  return {
-    actor,
-    switchOwner,
-    agentId: agent.agentId,
-    orgId,
-    runnerGroup,
-    runnerProfile: DEFAULT_PROFILE,
-    agentDisplayName: AGENT_DISPLAY_NAME,
-    agentInstructions,
-    workflowSkillName,
-    storageObjects,
-    model: CODEX_MODEL,
   };
 }
 
@@ -1477,177 +1270,33 @@ describe("PiLoop edge turn", () => {
     );
   });
 
-  it("refreshes an expired Codex subscription before the Pi edge turn", async () => {
-    const fixture = await codexPiEdgeFixture({
-      accessToken: codexJwt("ws_acct_pi_edge_expired", -60),
+  it("keeps OpenAI models on the Codex Sandbox lane when PiLoop is enabled", async () => {
+    const fixture = await piEdgeFixture({
+      provider: "vm0",
+      model: OPENAI_MODEL,
     });
     await enablePiLoop(fixture);
-    const refreshedAccessToken = codexJwt("ws_acct_pi_edge_refreshed");
-    const refreshBodies: unknown[] = [];
-    let codexAuthorization: string | null = null;
-    let codexAccountId: string | null = null;
-    const modelStarted = createDeferredPromise<void>(context.signal);
-    const releaseModel = createDeferredPromise<void>(context.signal);
-    onTestFinished(() => {
-      if (!releaseModel.settled()) {
-        releaseModel.resolve();
-      }
-    });
+    let edgeRequests = 0;
     server.use(
-      http.post(CODEX_OAUTH_TOKEN_URL, async ({ request }) => {
-        refreshBodies.push(await request.json());
-        return HttpResponse.json({
-          access_token: refreshedAccessToken,
-          refresh_token: "rt_pi_edge_rotated_high_entropy",
-          expires_in: 3600,
-        });
-      }),
-      http.post(CODEX_RESPONSES_URL, async ({ request }) => {
-        codexAuthorization = request.headers.get("authorization");
-        codexAccountId = request.headers.get("chatgpt-account-id");
-        modelStarted.resolve();
-        await releaseModel.promise;
-        return codexTextSseStream("codex edge answer");
-      }),
-    );
-
-    const prompt = "answer with the Codex subscription";
-    const run = await sendChatRun(fixture, prompt, undefined, CODEX_MODEL);
-    await modelStarted.promise;
-
-    const standbyPoll = await api.requestPollRunner(
-      true,
-      {
-        group: fixture.runnerGroup,
-        supportedProfiles: [fixture.runnerProfile],
-      },
-      [200],
-    );
-    if (standbyPoll.status !== 200) {
-      throw new Error("Expected Pi standby poll to return 200");
-    }
-    expect(standbyPoll.body.job).toMatchObject({
-      runId: run.runId,
-      experimentalProfile: fixture.runnerProfile,
-      piExecutionMode: "standby",
-    });
-    const standbyContext = await api.claimRunnerJob(run.runId);
-    expect(standbyContext.piModelConfig).toStrictEqual({
-      provider: "codex",
-      baseUrl: "https://chatgpt.com/backend-api",
-      model: CODEX_MODEL,
-      apiKeyEnv: "CHATGPT_ACCESS_TOKEN",
-    });
-
-    releaseModel.resolve();
-    await flushWaitUntilForTest();
-
-    expect(refreshBodies).toStrictEqual([
-      {
-        client_id: expect.any(String),
-        grant_type: "refresh_token",
-        refresh_token: "rt_pi_edge_synthetic_high_entropy",
-      },
-    ]);
-    expect(codexAuthorization).toBe(`Bearer ${refreshedAccessToken}`);
-    expect(codexAccountId).toBe("ws_acct_pi_edge_refreshed");
-
-    const transcript = await readTranscript(run.runId);
-    expect(transcript).toMatchObject({
-      version: 1,
-      lastOrdinal: 2,
-      messages: [
-        {
-          ordinal: 1,
-          messageId: `${run.runId}/1`,
-          runId: run.runId,
-          runEventSequenceNumber: 1,
-          role: "user",
-          payload: {
-            role: "user",
-            content: [{ type: "text", text: prompt }],
-          },
-        },
-        {
-          ordinal: 2,
-          messageId: `${run.runId}/2`,
-          runId: run.runId,
-          runEventSequenceNumber: 2,
-          role: "assistant",
-          payload: {
-            role: "assistant",
-            content: [{ type: "text", text: "codex edge answer" }],
-            stopReason: "stop",
-          },
-        },
-      ],
-    });
-    expect((await api.readRun(fixture.actor, run.runId)).status).toBe(
-      "completed",
-    );
-  });
-
-  it("uses the Sandbox lane when an expired Codex subscription cannot refresh", async () => {
-    const fixture = await codexPiEdgeFixture({
-      accessToken: codexJwt("ws_acct_pi_edge_expired", -60),
-    });
-    await enablePiLoop(fixture);
-    const refreshBodies: unknown[] = [];
-    let codexRequests = 0;
-    server.use(
-      http.post(CODEX_OAUTH_TOKEN_URL, async ({ request }) => {
-        refreshBodies.push(await request.json());
-        return HttpResponse.json(
-          {
-            error: {
-              code: "refresh_token_expired",
-              message: "expired refresh token",
-            },
-          },
-          { status: 401 },
+      http.post(OPENAI_COMPLETIONS_URL, () => {
+        edgeRequests += 1;
+        return assistantTextStream(
+          "unexpected Pi answer",
+          "OpenAI must not enter Pi",
         );
       }),
-      http.post(CODEX_RESPONSES_URL, () => {
-        codexRequests += 1;
-        return codexTextSseStream("unexpected edge answer");
-      }),
     );
 
-    const run = await sendChatRun(
-      fixture,
-      "fall back after Codex reconnect is required",
-      undefined,
-      CODEX_MODEL,
-    );
-    const defaultPoll = await api.pollRunner(fixture.runnerGroup);
+    const run = await sendChatRun(fixture, "stay on the Codex framework");
+    const poll = await api.pollRunner(fixture.runnerGroup);
 
-    expect(defaultPoll.body.job?.runId).toBe(run.runId);
-    expect(codexRequests).toBe(0);
-    expect(refreshBodies).toStrictEqual([
-      {
-        client_id: expect.any(String),
-        grant_type: "refresh_token",
-        refresh_token: "rt_pi_edge_synthetic_high_entropy",
-      },
-    ]);
-    expect((await api.readRun(fixture.actor, run.runId)).status).toBe(
-      "pending",
-    );
-    const providers = await misc.listPersonalModelProviders(
-      fixture.actor,
-      [200],
-    );
-    if (providers.status !== 200) {
-      throw new Error("Expected personal model providers to load");
-    }
-    expect(
-      providers.body.modelProviders.find((provider) => {
-        return provider.type === "codex-oauth-token";
-      }),
-    ).toMatchObject({
-      needsReconnect: true,
-      lastRefreshErrorCode: "refresh_token_expired",
-    });
+    expect(poll.body.job?.runId).toBe(run.runId);
+    expect(poll.body.job).not.toHaveProperty("piExecutionMode");
+    expect(edgeRequests).toBe(0);
+    const claim = await api.claimRunnerJob(run.runId);
+    expect(claim.cliAgentType).toBe("codex");
+    expect(claim.piExecutionMode).toBeUndefined();
+    await api.requestCancelRun(fixture.actor, run.runId, [200]);
   });
 
   it("bills each vm0-managed edge response once using normalized canonical-model usage", async () => {
@@ -1658,7 +1307,7 @@ describe("PiLoop edge turn", () => {
       .credits;
     const completionRequests: unknown[] = [];
     server.use(
-      http.post(OPENAI_COMPLETIONS_URL, async ({ request }) => {
+      http.post(COMPLETIONS_URL, async ({ request }) => {
         completionRequests.push(await request.json());
         return assistantToolStream({
           id: "read_billing_1",
@@ -1826,7 +1475,7 @@ describe("PiLoop edge turn", () => {
     const creditsBefore = (await billing.readBillingStatus(fixture.actor))
       .credits;
     server.use(
-      http.post(OPENAI_COMPLETIONS_URL, () => {
+      http.post(COMPLETIONS_URL, () => {
         return assistantErrorAfterUsageStream({
           text: "partial response before stream failure",
           usage: {
@@ -1867,7 +1516,7 @@ describe("PiLoop edge turn", () => {
     const completionRequests: unknown[] = [];
     let modelCall = 0;
     server.use(
-      http.post(OPENAI_COMPLETIONS_URL, async ({ request }) => {
+      http.post(COMPLETIONS_URL, async ({ request }) => {
         completionRequests.push(await request.json());
         modelCall += 1;
         return assistantToolStream({
@@ -1941,7 +1590,7 @@ describe("PiLoop edge turn", () => {
     const creditsBefore = (await billing.readBillingStatus(fixture.actor))
       .credits;
     server.use(
-      http.post(OPENAI_COMPLETIONS_URL, () => {
+      http.post(COMPLETIONS_URL, () => {
         return assistantTextStream(
           "this answer must not be projected",
           "usage is missing",
@@ -1977,65 +1626,53 @@ describe("PiLoop edge turn", () => {
     );
   });
 
-  it("uses the managed model long-context tier only above the exact boundary", async () => {
-    const model = "gpt-5.6-luna";
-    await withModelPricing(model, [
+  it("rotates the session between Pi DeepSeek and Codex OpenAI models", async () => {
+    const fixture = await piEdgeFixture({ provider: "vm0" });
+    await seedVm0ManagedModelKey(context, OPENAI_MODEL);
+    await api.updateOrgModelPolicies(fixture.actor, [
       {
-        category: "tokens.input",
-        unitPrice: 1,
-        unitSize: 272_001,
+        model: MODEL,
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
       },
       {
-        category: "tokens.input.long_context",
-        unitPrice: 2,
-        unitSize: 272_001,
+        model: OPENAI_MODEL,
+        isDefault: false,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
       },
     ]);
-    const fixture = await piEdgeFixture({ provider: "vm0", model });
     await enablePiLoop(fixture);
-    const inputTokens = [272_000, 272_001] as const;
-    let modelCall = 0;
     server.use(
-      http.post(OPENAI_COMPLETIONS_URL, () => {
-        const promptTokens = inputTokens[modelCall];
-        modelCall += 1;
-        if (promptTokens === undefined) {
-          throw new Error("Unexpected long-context model call");
-        }
-        return assistantTextStream(
-          `boundary response ${promptTokens}`,
-          "classify the canonical model tier",
-          {
-            responseModel: "untrusted-response-model",
-            usage: {
-              prompt_tokens: promptTokens,
-              completion_tokens: 0,
-            },
-          },
-        );
+      http.post(COMPLETIONS_URL, () => {
+        return assistantTextStream("DeepSeek Pi answer", "answer in Pi", {
+          usage: { prompt_tokens: 5, completion_tokens: 2 },
+        });
       }),
     );
 
-    const baseRun = await sendChatRun(fixture, "base context boundary");
+    const deepseekRun = await sendChatRun(fixture, "start on the Pi framework");
     await flushWaitUntilForTest();
-    const longRun = await sendChatRun(fixture, "long context boundary");
-    await flushWaitUntilForTest();
+    expect((await api.readRun(fixture.actor, deepseekRun.runId)).status).toBe(
+      "completed",
+    );
 
-    expect(modelCall).toBe(2);
-    await expect(usageRun(fixture.actor, baseRun.runId)).resolves.toMatchObject(
-      {
-        model,
-        inputTokens: 272_000,
-        creditsCharged: 1,
-      },
+    const openaiRun = await sendChatRun(
+      fixture,
+      "switch to the Codex framework",
+      deepseekRun.threadId,
+      OPENAI_MODEL,
     );
-    await expect(usageRun(fixture.actor, longRun.runId)).resolves.toMatchObject(
-      {
-        model,
-        inputTokens: 272_001,
-        creditsCharged: 2,
-      },
-    );
+    const poll = await api.pollRunner(fixture.runnerGroup);
+    expect(poll.body.job?.runId).toBe(openaiRun.runId);
+    expect(poll.body.job).not.toHaveProperty("piExecutionMode");
+    const claim = await api.claimRunnerJob(openaiRun.runId);
+    expect(claim.cliAgentType).toBe("codex");
+    expect(claim.resumeSession).toBeNull();
+    await api.requestCancelRun(fixture.actor, openaiRun.runId, [200]);
   });
 
   it("continues direct Pi activation when the request aborts after commit", async () => {
@@ -2099,14 +1736,14 @@ describe("PiLoop edge turn", () => {
     );
   });
 
-  it("starts and bills a concurrency-queued managed OpenAI-compatible Pi run when promoted", async () => {
+  it("starts and bills a concurrency-queued managed DeepSeek Pi run when promoted", async () => {
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
     await unitPriceModelTokens(MANAGED_MODEL);
     const fixture = await piEdgeFixture({ provider: "vm0" });
     const queuedRun = await expectQueuedPiEdgePromotion({
       fixture,
       model: fixture.model,
-      completionsUrl: OPENAI_COMPLETIONS_URL,
+      completionsUrl: COMPLETIONS_URL,
       completionResponse: () => {
         return assistantTextStream(
           "promoted edge answer",
@@ -2129,19 +1766,6 @@ describe("PiLoop edge turn", () => {
       outputTokens: 3,
       cacheTokens: 2,
       creditsCharged: 19,
-    });
-  });
-
-  it("starts the Pi edge turn when a concurrency-queued Codex run is promoted", async () => {
-    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
-    const fixture = await codexPiEdgeFixture();
-    await expectQueuedPiEdgePromotion({
-      fixture,
-      model: CODEX_MODEL,
-      completionsUrl: CODEX_RESPONSES_URL,
-      completionResponse: () => {
-        return codexTextSseStream("promoted codex edge answer");
-      },
     });
   });
 
@@ -2368,7 +1992,7 @@ describe("PiLoop edge turn", () => {
       .credits;
     const completionRequests: unknown[] = [];
     server.use(
-      http.post(OPENAI_COMPLETIONS_URL, async ({ request }) => {
+      http.post(COMPLETIONS_URL, async ({ request }) => {
         completionRequests.push(await request.json());
         return assistantToolStream({
           id: "bash_handoff_1",

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -3,6 +3,7 @@ import {
   getVm0ConcreteProviderType,
   isSupportedRunModel,
   modelProviderTypeSchema,
+  type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import {
@@ -68,6 +69,7 @@ interface HistoricalThreadSession {
   readonly sessionId: string;
   readonly conversationId: string | null;
   readonly framework: string | null;
+  readonly selectedModel: string | null;
 }
 
 interface SessionRunRoute {
@@ -80,8 +82,32 @@ interface SessionRunRoute {
 function shouldStartNewChatSession(args: {
   readonly latestFramework: string | null;
   readonly nextFramework: string | null;
+  readonly latestModel: string | null;
+  readonly nextModel: string | null;
 }): boolean {
-  return args.latestFramework !== args.nextFramework;
+  if (args.latestFramework !== args.nextFramework) {
+    return true;
+  }
+  if (args.latestFramework !== "codex") {
+    return false;
+  }
+  const latestProvider = codexSessionHistoryProvider(args.latestModel);
+  const nextProvider = codexSessionHistoryProvider(args.nextModel);
+  return (
+    latestProvider !== null &&
+    nextProvider !== null &&
+    latestProvider !== nextProvider
+  );
+}
+
+function codexSessionHistoryProvider(
+  model: string | null,
+): ModelProviderType | null {
+  if (model === null || !isSupportedRunModel(model)) {
+    return null;
+  }
+  const provider = getVm0ConcreteProviderType(model);
+  return getFrameworkForType(provider) === "codex" ? provider : null;
 }
 
 async function runUsesPiFramework(args: {
@@ -152,6 +178,7 @@ async function latestHistoricalThreadSession(args: {
       sessionId: agentSessions.id,
       conversationId: agentSessions.conversationId,
       cliAgentType: conversations.cliAgentType,
+      selectedModel: zeroRuns.selectedModel,
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
@@ -179,6 +206,7 @@ async function latestHistoricalThreadSession(args: {
     sessionId: row.sessionId,
     conversationId: row.conversationId,
     framework: row.cliAgentType,
+    selectedModel: row.selectedModel,
   };
 }
 
@@ -270,6 +298,8 @@ export async function resolveChatThreadSession(args: {
     const rotate = shouldStartNewChatSession({
       latestFramework: previousFramework,
       nextFramework: args.route.framework,
+      latestModel: latestRoute?.selectedModel ?? thread.selectedModel,
+      nextModel: args.route.selectedModel,
     });
     return {
       sessionId: rotate ? undefined : thread.sessionId,
@@ -297,6 +327,8 @@ export async function resolveChatThreadSession(args: {
   const rotate = shouldStartNewChatSession({
     latestFramework: historical.framework,
     nextFramework: args.route.framework,
+    latestModel: historical.selectedModel,
+    nextModel: args.route.selectedModel,
   });
   return {
     sessionId: rotate ? undefined : historical.sessionId,

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -1,27 +1,47 @@
 import {
-  MODEL_PROVIDER_TYPES,
-  areProvidersCompatible,
-  normalizeRunModelId,
-  type ModelProviderType,
+  getFrameworkForType,
+  getVm0ConcreteProviderType,
+  isSupportedRunModel,
+  modelProviderTypeSchema,
 } from "@vm0/api-contracts/contracts/model-providers";
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { conversations } from "@vm0/db/schema/conversation";
-import {
-  modelProviderConnections,
-  modelProviderSurfaces,
-} from "@vm0/db/schema/model-provider-gateway";
+import { piThreadMessages } from "@vm0/db/schema/pi-thread-message";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 
 import type { Db, ReadonlyDb } from "../external/db";
+import { isPiEdgeLoopRoute, PI_CHAT_SESSION_FRAMEWORK } from "./pi-edge-config";
+import { isWebChatTriggerSource } from "./zero-chat-trigger-source.service";
 
 export interface ChatThreadSessionRoute {
   readonly selectedModel: string | null;
   readonly modelProvider: string | null;
   readonly modelProviderId: string | null;
-  readonly cliAgentType: string | null;
+  readonly framework: string | null;
+}
+
+export function effectiveChatThreadSessionRoute(args: {
+  readonly route: ChatThreadSessionRoute;
+  readonly triggerSource: TriggerSource | undefined;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): ChatThreadSessionRoute {
+  return args.triggerSource !== undefined &&
+    isWebChatTriggerSource(args.triggerSource) &&
+    isFeatureEnabled(FeatureSwitchKey.PiLoop, args.featureSwitchContext) &&
+    args.route.framework === "codex" &&
+    isPiEdgeLoopRoute(args.route)
+    ? { ...args.route, framework: PI_CHAT_SESSION_FRAMEWORK }
+    : args.route;
 }
 
 export type ChatThreadSessionResolutionAction =
@@ -47,77 +67,77 @@ export interface ChatThreadSessionResolution {
 interface HistoricalThreadSession {
   readonly sessionId: string;
   readonly conversationId: string | null;
-  readonly route: ChatThreadSessionRoute;
-  readonly routeRunCreatedAt: Date;
+  readonly framework: string | null;
 }
 
 interface SessionRunRoute {
+  readonly runId: string;
+  readonly cliAgentType: string | null;
   readonly selectedModel: string | null;
   readonly modelProvider: string | null;
-  readonly modelProviderId: string | null;
-  readonly createdAt: Date;
-}
-
-function isKnownModelProvider(
-  value: string | null | undefined,
-): value is ModelProviderType {
-  return (
-    value !== null &&
-    value !== undefined &&
-    Object.hasOwn(MODEL_PROVIDER_TYPES, value)
-  );
-}
-
-/**
- * Return the vendor/model stem used for chat session continuity.
- *
- * Model IDs may be provider-qualified (for example, anthropic/claude-opus),
- * while the session family is the first part of the canonical model ID
- * (claude, gpt, glm, ...). This intentionally treats model variants in one
- * family as compatible while keeping different families isolated.
- */
-function chatSessionModelFamily(model: string): string {
-  const normalized = normalizeRunModelId(model.trim()).toLowerCase();
-  const modelName = normalized.includes("/")
-    ? normalized.slice(normalized.lastIndexOf("/") + 1)
-    : normalized;
-  return modelName.split(/[-_.]/, 1)[0] ?? modelName;
 }
 
 function shouldStartNewChatSession(args: {
-  readonly latestModel: string | null | undefined;
-  readonly nextModel: string | null;
-  readonly latestModelProvider?: string | null;
-  readonly nextModelProvider?: string | null;
-  readonly latestCliAgentType?: string | null;
-  readonly nextCliAgentType?: string | null;
+  readonly latestFramework: string | null;
+  readonly nextFramework: string | null;
 }): boolean {
-  if (
-    args.latestCliAgentType &&
-    args.nextCliAgentType &&
-    args.latestCliAgentType !== args.nextCliAgentType
-  ) {
-    return true;
-  }
-  if (
-    isKnownModelProvider(args.latestModelProvider) &&
-    isKnownModelProvider(args.nextModelProvider) &&
-    !areProvidersCompatible(args.latestModelProvider, args.nextModelProvider)
-  ) {
-    return true;
-  }
-  if (
-    args.latestModel === undefined ||
-    args.latestModel === null ||
-    args.nextModel === null
-  ) {
-    return false;
-  }
+  return args.latestFramework !== args.nextFramework;
+}
 
-  return (
-    chatSessionModelFamily(args.latestModel) !==
-    chatSessionModelFamily(args.nextModel)
-  );
+async function runUsesPiFramework(args: {
+  readonly db: Db | ReadonlyDb;
+  readonly runId: string;
+}): Promise<boolean> {
+  // Completed Pi turns persist transcript rows instead of a CLI conversation.
+  // Before the first Pi message arrives, the active standby/cold-start job is
+  // the durable framework marker for the bound run.
+  const [message] = await args.db
+    .select({ runId: piThreadMessages.runId })
+    .from(piThreadMessages)
+    .where(eq(piThreadMessages.runId, args.runId))
+    .limit(1);
+  if (message) {
+    return true;
+  }
+  const [job] = await args.db
+    .select({ runId: runnerJobQueue.runId })
+    .from(runnerJobQueue)
+    .where(
+      and(
+        eq(runnerJobQueue.runId, args.runId),
+        sql`${runnerJobQueue.executionContext}->>'piExecutionMode'
+          IN ('standby', 'cold-start')`,
+      ),
+    )
+    .limit(1);
+  return job !== undefined;
+}
+
+async function sessionFramework(args: {
+  readonly db: Db | ReadonlyDb;
+  readonly runId: string | null;
+  readonly cliAgentType: string | null;
+  readonly selectedModel: string | null;
+  readonly modelProvider: string | null;
+}): Promise<string | null> {
+  if (
+    args.runId !== null &&
+    (await runUsesPiFramework({ db: args.db, runId: args.runId }))
+  ) {
+    return PI_CHAT_SESSION_FRAMEWORK;
+  }
+  if (args.cliAgentType !== null) {
+    return args.cliAgentType;
+  }
+  const provider = modelProviderTypeSchema.safeParse(args.modelProvider);
+  if (!provider.success) {
+    return null;
+  }
+  const concreteProvider =
+    provider.data === "vm0" && isSupportedRunModel(args.selectedModel)
+      ? getVm0ConcreteProviderType(args.selectedModel)
+      : provider.data;
+  return getFrameworkForType(concreteProvider);
 }
 
 async function latestHistoricalThreadSession(args: {
@@ -131,11 +151,7 @@ async function latestHistoricalThreadSession(args: {
     .select({
       sessionId: agentSessions.id,
       conversationId: agentSessions.conversationId,
-      selectedModel: zeroRuns.selectedModel,
-      modelProvider: zeroRuns.modelProvider,
-      modelProviderId: zeroRuns.modelProviderId,
       cliAgentType: conversations.cliAgentType,
-      routeRunCreatedAt: agentRuns.createdAt,
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
@@ -162,13 +178,7 @@ async function latestHistoricalThreadSession(args: {
   return {
     sessionId: row.sessionId,
     conversationId: row.conversationId,
-    route: {
-      selectedModel: row.selectedModel,
-      modelProvider: row.modelProvider,
-      modelProviderId: row.modelProviderId,
-      cliAgentType: row.cliAgentType,
-    },
-    routeRunCreatedAt: row.routeRunCreatedAt,
+    framework: row.cliAgentType,
   };
 }
 
@@ -178,111 +188,18 @@ async function latestSessionRunRoute(args: {
 }): Promise<SessionRunRoute | null> {
   const [row] = await args.db
     .select({
+      runId: agentRuns.id,
+      cliAgentType: conversations.cliAgentType,
       selectedModel: zeroRuns.selectedModel,
       modelProvider: zeroRuns.modelProvider,
-      modelProviderId: zeroRuns.modelProviderId,
-      createdAt: agentRuns.createdAt,
     })
     .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+    .leftJoin(conversations, eq(conversations.runId, agentRuns.id))
     .where(eq(agentRuns.sessionId, args.sessionId))
     .orderBy(desc(agentRuns.createdAt))
     .limit(1);
   return row ?? null;
-}
-
-async function customSurfaceRouteChanged(args: {
-  readonly db: Db | ReadonlyDb;
-  readonly orgId: string;
-  readonly previousModelProviderId: string | null;
-  readonly nextModelProviderId: string | null;
-  readonly previousRunCreatedAt: Date | null;
-}): Promise<boolean> {
-  const candidateSurfaceIds = [
-    args.previousModelProviderId,
-    args.nextModelProviderId,
-  ].filter((id): id is string => {
-    return id !== null;
-  });
-  if (candidateSurfaceIds.length === 0) {
-    return false;
-  }
-  const surfaces = await args.db
-    .select({
-      surfaceUpdatedAt: modelProviderSurfaces.updatedAt,
-      connectionUpdatedAt: modelProviderConnections.updatedAt,
-    })
-    .from(modelProviderSurfaces)
-    .innerJoin(
-      modelProviderConnections,
-      eq(modelProviderSurfaces.connectionId, modelProviderConnections.id),
-    )
-    .where(
-      and(
-        inArray(modelProviderSurfaces.id, candidateSurfaceIds),
-        eq(modelProviderConnections.orgId, args.orgId),
-      ),
-    );
-  if (args.previousModelProviderId !== args.nextModelProviderId) {
-    return surfaces.length > 0;
-  }
-  const [surface] = surfaces;
-  return (
-    surface !== undefined &&
-    args.previousRunCreatedAt !== null &&
-    (surface.surfaceUpdatedAt > args.previousRunCreatedAt ||
-      surface.connectionUpdatedAt > args.previousRunCreatedAt)
-  );
-}
-
-function shouldRotateCanonicalSession(args: {
-  readonly previousRoute: ChatThreadSessionRoute;
-  readonly nextRoute: ChatThreadSessionRoute;
-}): boolean {
-  const providerIdChanged =
-    args.previousRoute.modelProviderId !== args.nextRoute.modelProviderId;
-  const gatewayAdapterInUse =
-    args.previousRoute.modelProvider === "vercel-ai-gateway" ||
-    args.previousRoute.modelProvider === "vercel-ai-gateway-codex" ||
-    args.nextRoute.modelProvider === "vercel-ai-gateway" ||
-    args.nextRoute.modelProvider === "vercel-ai-gateway-codex";
-  if (providerIdChanged && gatewayAdapterInUse) {
-    // A custom surface uses the same runtime adapter type as a legacy Vercel
-    // provider. Once its connection is deleted, the surface row can no longer
-    // prove that the previous route was custom, so the provider identity must
-    // remain part of the canonical continuity boundary.
-    return true;
-  }
-  return shouldStartNewChatSession({
-    latestModel: args.previousRoute.selectedModel,
-    nextModel: args.nextRoute.selectedModel,
-    latestModelProvider: args.previousRoute.modelProvider,
-    nextModelProvider: args.nextRoute.modelProvider,
-    latestCliAgentType: args.previousRoute.cliAgentType,
-    nextCliAgentType: args.nextRoute.cliAgentType,
-  });
-}
-
-async function shouldRotateResolvedSession(args: {
-  readonly db: Db | ReadonlyDb;
-  readonly orgId: string;
-  readonly previousRoute: ChatThreadSessionRoute;
-  readonly nextRoute: ChatThreadSessionRoute;
-  readonly previousRunCreatedAt: Date | null;
-}): Promise<boolean> {
-  const routeConfigurationChanged = await customSurfaceRouteChanged({
-    db: args.db,
-    orgId: args.orgId,
-    previousModelProviderId: args.previousRoute.modelProviderId,
-    nextModelProviderId: args.nextRoute.modelProviderId,
-    previousRunCreatedAt: args.previousRunCreatedAt,
-  });
-  return routeConfigurationChanged
-    ? true
-    : shouldRotateCanonicalSession({
-        previousRoute: args.previousRoute,
-        nextRoute: args.nextRoute,
-      });
 }
 
 export async function resolveChatThreadSession(args: {
@@ -299,11 +216,9 @@ export async function resolveChatThreadSession(args: {
       agentSessionRunId: chatThreads.agentSessionRunId,
       sessionId: agentSessions.id,
       conversationId: agentSessions.conversationId,
+      routeRunId: chatThreads.agentSessionRunId,
       selectedModel: zeroRuns.selectedModel,
       modelProvider: zeroRuns.modelProvider,
-      modelProviderId: zeroRuns.modelProviderId,
-      routeRunId: zeroRuns.id,
-      routeRunCreatedAt: agentRuns.createdAt,
       cliAgentType: conversations.cliAgentType,
       cloudBrowserEnabled: chatThreads.cloudBrowserEnabled,
     })
@@ -318,7 +233,6 @@ export async function resolveChatThreadSession(args: {
       ),
     )
     .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
-    .leftJoin(agentRuns, eq(agentRuns.id, chatThreads.agentSessionRunId))
     .leftJoin(zeroRuns, eq(zeroRuns.id, chatThreads.agentSessionRunId))
     .where(
       and(
@@ -346,19 +260,16 @@ export async function resolveChatThreadSession(args: {
             sessionId: thread.sessionId,
           })
         : null;
-    const previousRoute = {
+    const previousFramework = await sessionFramework({
+      db: args.db,
+      runId: latestRoute?.runId ?? thread.routeRunId,
+      cliAgentType: latestRoute?.cliAgentType ?? thread.cliAgentType,
       selectedModel: latestRoute?.selectedModel ?? thread.selectedModel,
       modelProvider: latestRoute?.modelProvider ?? thread.modelProvider,
-      modelProviderId: latestRoute?.modelProviderId ?? thread.modelProviderId,
-      cliAgentType: thread.cliAgentType,
-    };
-    const rotate = await shouldRotateResolvedSession({
-      db: args.db,
-      orgId: args.orgId,
-      previousRoute,
-      nextRoute: args.route,
-      previousRunCreatedAt:
-        latestRoute?.createdAt ?? thread.routeRunCreatedAt ?? null,
+    });
+    const rotate = shouldStartNewChatSession({
+      latestFramework: previousFramework,
+      nextFramework: args.route.framework,
     });
     return {
       sessionId: rotate ? undefined : thread.sessionId,
@@ -383,12 +294,9 @@ export async function resolveChatThreadSession(args: {
     };
   }
 
-  const rotate = await shouldRotateResolvedSession({
-    db: args.db,
-    orgId: args.orgId,
-    previousRoute: historical.route,
-    nextRoute: args.route,
-    previousRunCreatedAt: historical.routeRunCreatedAt,
+  const rotate = shouldStartNewChatSession({
+    latestFramework: historical.framework,
+    nextFramework: args.route.framework,
   });
   return {
     sessionId: rotate ? undefined : historical.sessionId,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -11,7 +11,10 @@ import {
   type ChatRecommendedFollowup,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { modelProviderCredentialScopeSchema } from "@vm0/api-contracts/contracts/model-providers";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -168,7 +171,10 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { formatIntegrationRunError$ } from "./integration-run-errors.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../../lib/thread-generation-template";
-import { resolveChatThreadSession } from "./chat-session-continuity.service";
+import {
+  effectiveChatThreadSessionRoute,
+  resolveChatThreadSession,
+} from "./chat-session-continuity.service";
 import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
 import { resolveRunChatThreadModelContext } from "./zero-chat-run-event.service";
 import { releaseThreadBrowsersForRun$ } from "./zero-browser.service";
@@ -929,7 +935,7 @@ function buildQueuedCreateZeroRunArgs(
       selectedModel: input.modelPin.selectedModel,
       modelProvider: input.effectiveModelProvider ?? null,
       modelProviderId: input.modelPin.modelProviderId,
-      cliAgentType: input.cliAgentType,
+      framework: input.cliAgentType,
     },
     body: {
       prompt: input.prompt,
@@ -2671,6 +2677,7 @@ interface CreateQueuedChatRunInputArgs {
 function loadQueuedMessageSessionState(
   args: CreateQueuedChatRunInputArgs,
   modelRoute: QueuedMessageModelRoute,
+  featureSwitchContext: FeatureSwitchContext,
 ) {
   return measureChatCallbackPreCreateTiming(
     args.timing,
@@ -2683,12 +2690,18 @@ function loadQueuedMessageSessionState(
         userId: args.userId,
         orgId: args.agent.orgId,
         agentComposeId: args.agent.id,
-        route: {
-          selectedModel: modelRoute.modelPin.selectedModel,
-          modelProvider: modelRoute.effectiveModelProvider ?? null,
-          modelProviderId: modelRoute.modelPin.modelProviderId,
-          cliAgentType: modelRoute.cliAgentType,
-        },
+        route: effectiveChatThreadSessionRoute({
+          route: {
+            selectedModel: modelRoute.modelPin.selectedModel,
+            modelProvider: modelRoute.effectiveModelProvider ?? null,
+            modelProviderId: modelRoute.modelPin.modelProviderId,
+            framework: modelRoute.cliAgentType,
+          },
+          triggerSource: queuedUserMessageTriggerSource(
+            args.queuedMessage.contextType,
+          ),
+          featureSwitchContext,
+        }),
       });
       const incompleteContext = isWebChatContextType(
         args.queuedMessage.contextType,
@@ -3108,7 +3121,7 @@ async function buildCreateQueuedChatRunInput(
   const modelRoute = modelRouteResolution.route;
 
   const [startNewSession, loadedIncompleteContext] =
-    await loadQueuedMessageSessionState(args, modelRoute);
+    await loadQueuedMessageSessionState(args, modelRoute, featureSwitchContext);
   const incompleteContext = startNewSession ? "" : loadedIncompleteContext;
   const priorContext = await measureChatCallbackPreCreateTiming(
     args.timing,

--- a/turbo/apps/api/src/signals/services/pi-edge-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-edge-config.ts
@@ -24,6 +24,22 @@ import { z } from "zod";
 
 export type PiEdgeModelConfig = PiAgentModelConfig;
 
+export const PI_CHAT_SESSION_FRAMEWORK = "pi";
+
+function isPiEdgeLoopModel(model: string | null | undefined): boolean {
+  return model === "deepseek-v4-flash";
+}
+
+export function isPiEdgeLoopRoute(route: {
+  readonly selectedModel: string | null;
+  readonly modelProvider: string | null;
+}): boolean {
+  return (
+    isPiEdgeLoopModel(route.selectedModel) &&
+    (route.modelProvider === "deepseek" || route.modelProvider === "vm0")
+  );
+}
+
 export const piEdgeModelConfigSchema = z
   .object({
     provider: z.enum(PI_OPENAI_COMPATIBLE_PROVIDERS),
@@ -136,7 +152,11 @@ export function resolvePiEdgeModelConfig(
     readonly inlineFirewall?: boolean;
   } | null,
 ): PiEdgeModelConfig | null {
-  if (!provider || !provider.selectedModel || provider.inlineFirewall) {
+  if (
+    !provider ||
+    !isPiEdgeLoopModel(provider.selectedModel) ||
+    provider.inlineFirewall
+  ) {
     return null;
   }
   const concreteType = provider.concreteType ?? provider.type;

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -2818,7 +2818,7 @@ function buildCreateZeroRunArgs(params: {
       selectedModel: modelPin.selectedModel,
       modelProvider: providerAdmission.effectiveModelProvider ?? null,
       modelProviderId: modelPin.modelProviderId,
-      cliAgentType: providerAdmission.cliAgentType,
+      framework: providerAdmission.cliAgentType,
     },
     codexServiceTier,
     callbacks: [

--- a/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
@@ -174,7 +174,7 @@ function buildQueueFirstGoalRunInput(args: {
       selectedModel: modelPin.selectedModel,
       modelProvider: effectiveModelProvider ?? null,
       modelProviderId: modelPin.modelProviderId,
-      cliAgentType,
+      framework: cliAgentType,
     },
     codexServiceTier,
     callbacks: buildGoalChatCallbacks({

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -34,6 +34,7 @@ import {
   type ZeroRunModelPin,
 } from "./agent-run-create.service";
 import {
+  effectiveChatThreadSessionRoute,
   resolveChatThreadSession,
   type ChatThreadSessionResolution,
   type ChatThreadSessionRoute,
@@ -869,6 +870,11 @@ async function resolveThreadSessionForZeroRun(
   if (!threadSessionRoute) {
     throw new Error("Thread-bound Zero run is missing its model route");
   }
+  const sessionRoute = effectiveChatThreadSessionRoute({
+    route: threadSessionRoute,
+    triggerSource: input.command.triggerSource,
+    featureSwitchContext: input.featureSwitchContext,
+  });
   const resolution = await measureZeroPreCreate(
     input.timing,
     "api_dispatch_pre_create_zero_resolve_thread_session",
@@ -879,7 +885,7 @@ async function resolveThreadSessionForZeroRun(
         userId: input.command.auth.userId,
         orgId: input.command.auth.orgId,
         agentComposeId: input.agent.id,
-        route: threadSessionRoute,
+        route: sessionRoute,
       });
     },
   );

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -308,7 +308,7 @@ function workflowThreadSessionRoute(
     selectedModel: modelContext.modelPin.selectedModel,
     modelProvider: modelContext.effectiveModelProvider ?? null,
     modelProviderId: modelContext.modelPin.modelProviderId,
-    cliAgentType: modelContext.cliAgentType,
+    framework: modelContext.cliAgentType,
   };
 }
 


### PR DESCRIPTION
## Summary

- restrict PiLoop execution to DeepSeek V4 Flash while OpenAI models stay on Codex
- reuse chat sessions only when both the effective framework and Codex history provider are compatible
- keep queued chat sends and persisted Pi runs aligned with the same framework decision
- cover DeepSeek/OpenAI switching in both directions and reuse within the OpenAI model family

## Behavior

- PiLoop disabled: DeepSeek and OpenAI both use Codex, but switching between their incompatible history providers rotates the session
- PiLoop disabled: switching between OpenAI models continues to reuse the Codex session
- PiLoop enabled: DeepSeek uses Pi while OpenAI stays on Codex, so the framework switch rotates the session

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/chat-session-continuity.service.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types:core`
- `pnpm -F api check-types:tests`
- `pnpm knip --workspace api`
- targeted `chat-events.bdd.test.ts`: DeepSeek/OpenAI rotation plus stale-retry baseline passed (2 tests)
- targeted `pi-edge-loop.test.ts`: Pi DeepSeek/Codex OpenAI rotation passed (1 test)
- pre-commit: full Knip, 14 TypeScript tasks, file-size, and commitlint passed
- local browser plus database inspection: switching a DeepSeek-bound thread to Luna created a new application session and queued Codex with `resumeSession: null`; the prior `input[7].content` validation error did not recur
- the local live-model turn was manually cancelled after session rotation was confirmed because it remained pending while streaming reasoning, so terminal model completion was not used as the acceptance signal
- PR CI is green, including all 8 API shards, browser E2E, Playwright, lint, types, Knip, and security gates