### PR TITLE
refactor(platform): make chat event pagination termination explicit

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
@@ -107,7 +107,8 @@ const syncChatThreadRowsToIndexedDb$ = command(
 
     const syncedEvents: ChatEvent[] = [];
     let sinceSeqId = lastSeqId;
-    for (;;) {
+    let shouldLoadNextPage = true;
+    while (shouldLoadNextPage) {
       const page = await set(listRowsAfter$, { threadId, sinceSeqId }, signal);
       signal.throwIfAborted();
       if (page.kind === "expired") {
@@ -129,10 +130,9 @@ const syncChatThreadRowsToIndexedDb$ = command(
         }),
       );
       sinceSeqId = page.rows.at(-1)!.seqId;
-      if (page.rows.length < CHAT_EVENT_ROWS_PAGE_LIMIT) {
-        return syncedEvents;
-      }
+      shouldLoadNextPage = page.rows.length === CHAT_EVENT_ROWS_PAGE_LIMIT;
     }
+    return syncedEvents;
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
@@ -364,7 +364,8 @@ function createSyncRemoteRowsCommand({
       sinceSeqId = cachedLastSeqId;
     }
 
-    for (;;) {
+    let shouldLoadNextPage = true;
+    while (shouldLoadNextPage) {
       const page = await set(listRowsAfter$, { threadId, sinceSeqId }, signal);
       signal.throwIfAborted();
       set(initialRemoteEventsResolved$, true);
@@ -389,9 +390,7 @@ function createSyncRemoteRowsCommand({
       if (lastRow !== undefined) {
         sinceSeqId = lastRow.seqId;
       }
-      if (page.rows.length < CHAT_EVENT_ROWS_PAGE_LIMIT) {
-        return;
-      }
+      shouldLoadNextPage = page.rows.length === CHAT_EVENT_ROWS_PAGE_LIMIT;
     }
   });
 }


### PR DESCRIPTION
## Summary

- replace two unconditional `for (;;)` chat-event pagination loops with an explicit full-page continuation condition
- keep the shared `setLoop` implementation as the only match in the custom-loop scan
- preserve the existing command-owned `AbortSignal`, row cursor updates, cache writes, and cursor-expiry recovery

## Violations found

The snapshot-read foreground and background row synchronizers used unconditional `for (;;)` control flow for finite pagination. Their stopping condition was only expressed through interior returns, so they appeared as unbounded platform loops outside the shared loop abstraction.

## Signal ownership

This change adds no timer. Each pagination pass continues to use the command lifecycle's `AbortSignal` for the row request, IndexedDB operations, snapshot recovery, and abort checks.

## Behavior preserved

- a full page advances the cursor and requests the next page
- a partial or empty page ends the one-shot traversal
- background cursor expiry clears the row cache and ends that pass
- foreground cursor expiry rebuilds once from the server snapshot and continues; a second expiry still fails loudly

## Verification

- Prettier on both changed files
- changed-file ESLint and Oxlint, including type-aware Oxlint
- `pnpm --filter @vm0/app run check-types`
- targeted Vitest: `chat-event-snapshot-read.test.ts` (6 passed)
- custom-loop scan only matches the shared `setLoop` implementation
- native Platform timer scan is empty
- Lefthook pre-commit: Prettier, Knip, full repository type checks (14/14), file-size check, and commitlint passed

Full CI validation is delegated to the PR pipeline.

## Fallbacks

None.
