### PR TITLE
refactor: remove next-run model notice feature switch

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -151,7 +151,7 @@ async function enableResponsiveFollowupCards(page: Page): Promise<void> {
   });
 }
 
-async function enableModelChangeNotices(page: Page): Promise<void> {
+async function disableChatEventSnapshotRead(page: Page): Promise<void> {
   await page.route("**/api/zero/feature-switches", async (route) => {
     const response = await route.fetch();
     const body: unknown = await response.json();
@@ -165,7 +165,6 @@ async function enableModelChangeNotices(page: Page): Promise<void> {
         effectiveSwitches: {
           ...body.effectiveSwitches,
           chatEventSnapshotRead: false,
-          chatNextRunModelNotice: true,
         },
       },
     });
@@ -598,7 +597,7 @@ test("chat composer keeps the Send button inside on narrow screens", async ({
 test("model change labels follow the divider at the right edge", async ({
   page,
 }) => {
-  await enableModelChangeNotices(page);
+  await disableChatEventSnapshotRead(page);
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -424,7 +424,6 @@ describe("chat run queue", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
       path: CHAT_PATH,
     });
 
@@ -437,21 +436,6 @@ describe("chat run queue", () => {
     expectTextBefore(NEXT_RUN_MODEL_COPY, "Follow up after the active run");
   });
 
-  it("keeps the model change notice hidden when its switch is off", async () => {
-    mockActiveRunModelChange();
-
-    detachedSetupPage({
-      context,
-      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: false },
-      path: CHAT_PATH,
-    });
-
-    await expect(
-      screen.findByText("Follow up after the active run"),
-    ).resolves.toBeInTheDocument();
-    expect(screen.queryByText(NEXT_RUN_MODEL_COPY)).not.toBeInTheDocument();
-  });
-
   it("inserts a model change divider between adjacent runs", async () => {
     mockCompletedRunModelHistory({
       previousModel: "gpt-5.5",
@@ -460,7 +444,6 @@ describe("chat run queue", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
       path: CHAT_PATH,
     });
 
@@ -518,7 +501,6 @@ describe("chat run queue", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
       path: AGENT_CHAT_PATH,
     });
 
@@ -650,7 +632,6 @@ describe("chat run queue", () => {
     });
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
       path: CHAT_PATH,
     });
 
@@ -758,7 +739,6 @@ describe("chat run queue", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
       path: CHAT_PATH,
     });
 
@@ -789,7 +769,6 @@ describe("chat run queue", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatNextRunModelNotice]: true },
       path: CHAT_PATH,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2717,11 +2717,7 @@ function ChatThreadRenderedEventGroups({
     }) ?? [];
   const { activeGroups: renderedActiveGroups } =
     splitQueuedEventsForThinkingIndicator(renderedGroups);
-  const chatModelNoticesEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatNextRunModelNotice] ?? false;
-  const modelChanges = chatModelNoticesEnabled
-    ? modelChangesByEventId(renderedActiveGroups)
-    : new Map<string, string>();
+  const modelChanges = modelChangesByEventId(renderedActiveGroups);
   const scrollTargetEventId =
     useGet(thread.threadScrollPosition$)?.targetEventId ?? null;
   const runGroupExpansionOverrides = useGet(runGroupExpansionOverrides$);
@@ -2842,14 +2838,11 @@ function ChatThreadNextRunModelNotice({
   thread: ChatPanelSignals;
 }) {
   const { t } = useTranslation();
-  const enabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatNextRunModelNotice] ?? false;
   const selectedModel = useLastResolved(
     thread.composer.model.modelSelection$,
   )?.selectedModel;
   const runningModel = useLastResolved(thread.composer.model.runningModel$);
   if (
-    !enabled ||
     selectedModel === undefined ||
     runningModel === undefined ||
     runningModel === null ||

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -52,7 +52,6 @@ export enum FeatureSwitchKey {
   WorkdayConnector = "workdayConnector",
   CodexFastMode = "codexFastMode",
   NewChatDefaultModelAction = "newChatDefaultModelAction",
-  ChatNextRunModelNotice = "chatNextRunModelNotice",
   RealAgentInPreview = "realAgentInPreview",
   UsagePackPlans = "usagePackPlans",
   PaymentMethodManagement = "paymentMethodManagement",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -300,12 +300,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatNextRunModelNotice]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show a composer notice when the selected model differs from the running chat model.",
-    enabled: true,
-  },
   [FeatureSwitchKey.RealAgentInPreview]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- graduate `chatNextRunModelNotice` as fully rolled out
- always render model-change history dividers and the next-run model notice when their product conditions apply
- remove the registry entry, enum key, disabled fallback test, and feature-switch overrides

## Terminal state

- State: `fully-rolled-out`
- Basis: Ethan confirmed the terminal state in the originating chat on 2026-08-09.

## Archaeology and behavior comparison

- Introduction commit: `08db95480227b2618579f85477adffa0b61346ed` (`feat(chat): show next-run model changes`, PR #25502)
- Its parent contained none of the model-change notice behavior, derived running-model state, translations, tests, or switch registration.
- The enabled path showed a notice when the selected model differed from the active run model; the disabled path omitted that notice.
- `4abbd65dbe90c4105aad5db54c614653c7979dff` later moved the notice into the chat thread and added model-change dividers in history behind the same switch. Later commits refined copy, optimistic run reconciliation, and divider alignment without changing the terminal behavior.
- This cleanup preserves the complete enabled behavior and removes only the disabled fallback and switch plumbing.
- The temporary runless model-annotation compatibility associated with #25879 remains because it protects cross-version persisted events and is independent of this feature-switch terminal state.

## Cleanup scope

- Removed `FeatureSwitchKey.ChatNextRunModelNotice` and its registry metadata.
- Replaced both runtime gates with unconditional product logic.
- Deleted the switch-off integration test.
- Removed six switch-on test overrides while retaining their positive behavior coverage.
- Removed the E2E override for `chatNextRunModelNotice`; the helper now only disables snapshot reads required by the mocked chat-thread setup.

## Follow-up search

- Searched exact camel/Pascal/kebab/snake-like variants of `chatNextRunModelNotice`, `ChatNextRunModelNotice`, and `chat-next-run-model-notice`: no remaining matches.
- Searched `enableModelChangeNotices` and the retired `modelChangeAppliesNextRun` name: no remaining matches.
- Retained positive product symbols and copy including `runningModelFromChatEvents`, `modelChangesByEventId`, `ChatThreadNextRunModelNotice`, `modelChangedTo`, and `selectedModelAppliesAfterCurrentRun`.

## Knip

- Baseline: `pnpm knip --workspace apps/platform --workspace packages/core --reporter compact` exited successfully with no diagnostics.
- After cleanup: the same command exited successfully with no diagnostics.

## Verification

- `pnpm exec prettier --write` on all five changed files
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-queue.test.tsx --maxWorkers=4 --silent=passed-only` (25 tests passed)
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=4 --silent=passed-only` (24 tests passed)
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/app lint`
- `pnpm --filter @vm0/core --filter @vm0/app --workspace-concurrency=1 run check-types`
- `cd e2e && pnpm check-types`
- `git diff --check`
- exact-key and semantic follow-up searches described above
- scoped Knip baseline/after comparison described above

The local Playwright scenario and full Vitest suite were not run because repository instructions prohibit starting a local dev server and running full local Vitest for this task. The PR pipeline will run the broader checks.
