### PR TITLE
refactor(chat-search): remove chat search index feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -6,8 +6,6 @@ import {
   cronCompactChatThreadSnapshotsContract,
   cronProjectChatEventSearchContract,
 } from "@vm0/api-contracts/contracts/cron";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@vm0/api-contracts/contracts/runners";
 import {
   chatThreadsContract,
@@ -72,7 +70,6 @@ import { cronPassCount, latestCronPassFields } from "./helpers/cron-pass-log";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { seedVm0ManagedDefaultModelKey } from "./helpers/runtime-state";
-import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import {
   generatedStripeCustomerId,
   generatedStripeSubscriptionId,
@@ -86,7 +83,6 @@ import { cronCleanupSandboxesRoutes } from "../cron-cleanup-sandboxes";
 import { cronCompactChatThreadSnapshotsRoutes } from "../cron-compact-chat-thread-snapshots";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
-import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
 import { zeroGoalsRoutes } from "../zero-goals";
 
 const TEST_APP_ROUTES = Object.freeze([
@@ -94,7 +90,6 @@ const TEST_APP_ROUTES = Object.freeze([
   ...cronCompactChatThreadSnapshotsRoutes,
   ...cronProjectChatEventSearchRoutes,
   ...zeroChatThreadRoutes,
-  ...zeroFeatureSwitchesRoutes,
   ...zeroGoalsRoutes,
 ]);
 
@@ -106,7 +101,7 @@ const TEST_APP_ROUTES = Object.freeze([
  *
  * Most Given state is constructed through public APIs (Stripe-webhook
  * entitlement, org model provider routes, runner heartbeat/claim, sandbox
- * report webhooks, connector OAuth flows, feature-switch and skills routes).
+ * report webhooks, connector OAuth flows, and skills routes).
  * Targeted database checks are kept for migration and side-effect coverage
  * where the persisted row shape is the contract under test.
  */
@@ -2418,25 +2413,21 @@ describe("CHAT-03 run usage events", () => {
   }, 60_000);
 });
 
-async function setChatSearchIndex(
-  actor: ApiTestUser,
-  enabled: boolean,
-): Promise<void> {
-  createZeroRouteMocks(context).clerk.session(
-    actor.userId,
-    actor.orgId,
-    actor.orgRole,
-  );
-  const client = setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
-    zeroFeatureSwitchesContract,
-  );
-  await accept(
-    client.update({
-      headers: { authorization: "Bearer clerk-session" },
-      body: { switches: { [FeatureSwitchKey.ChatSearchIndex]: enabled } },
+const CHAT_EVENT_SEARCH_CRON_SECRET = "chat-event-search-cron-secret";
+
+async function projectChatEventSearch() {
+  mockEnv("CRON_SECRET", CHAT_EVENT_SEARCH_CRON_SECRET);
+  const client = setupApp({
+    context,
+    routes: cronProjectChatEventSearchRoutes,
+  })(cronProjectChatEventSearchContract);
+  const response = await accept(
+    client.project({
+      headers: { authorization: `Bearer ${CHAT_EVENT_SEARCH_CRON_SECRET}` },
     }),
     [200],
   );
+  return response.body;
 }
 
 describe("CHAT-01 chat search", () => {
@@ -2470,11 +2461,10 @@ describe("CHAT-01 chat search", () => {
     expect(forbidden.body.error.message).toContain("chat-event:read");
   });
 
-  it("searches own messages with filters, context, and like-escaping", async () => {
+  it("searches own messages with filters and context", async () => {
     const orgId = `org_${randomUUID()}`;
     const owner = bdd.user({ orgId });
     const peer = bdd.user({ orgId });
-    await setChatSearchIndex(owner, false);
     bdd.acceptAgentStorageWrites();
     const agentA = await bdd.createAgent(owner, {
       displayName: "Search agent A",
@@ -2502,6 +2492,7 @@ describe("CHAT-01 chat search", () => {
       agentId: agentA.agentId,
       prompt: "owner says supercalifragilistic",
     });
+    await projectChatEventSearch();
     const isolation = await chat.searchChat(owner, "supercalifragilistic");
     expect(isolation.results).toHaveLength(1);
     expect(isolation.results[0]?.chatThreadId).toBe(ownerThreadA);
@@ -2530,6 +2521,7 @@ describe("CHAT-01 chat search", () => {
         ],
       },
     });
+    await projectChatEventSearch();
     const canonicalSearch = await chat.searchChat(owner, canonicalKeyword);
     expect(canonicalSearch.results).toHaveLength(1);
     expect(canonicalSearch.results[0]?.matchedMessage.content).toBe(
@@ -2556,6 +2548,7 @@ describe("CHAT-01 chat search", () => {
         ],
       },
     });
+    await projectChatEventSearch();
     const mentionSearch = await chat.searchChat(owner, mentionKeyword);
     expect(mentionSearch.results).toHaveLength(1);
     expect(mentionSearch.results[0]?.matchedMessage.content).toBe(
@@ -2571,6 +2564,7 @@ describe("CHAT-01 chat search", () => {
       agentId: otherOrgAgent.agentId,
       prompt: "other-org supercalifragilistic sighting",
     });
+    await projectChatEventSearch();
     const crossOrg = await chat.searchChat(owner, "supercalifragilistic");
     expect(crossOrg.results).toHaveLength(1);
     expect(crossOrg.results[0]?.chatThreadId).toBe(ownerThreadA);
@@ -2585,6 +2579,7 @@ describe("CHAT-01 chat search", () => {
       agentId: agentA.agentId,
       prompt: "recent quokka spotted",
     });
+    await projectChatEventSearch();
     const since = await chat.searchChat(owner, "quokka", {
       since: sinceBoundary,
     });
@@ -2602,6 +2597,7 @@ describe("CHAT-01 chat search", () => {
       agentId: agentA.agentId,
       prompt: "agent A mentions narwhal",
     });
+    await projectChatEventSearch();
     const byAgent = await chat.searchChat(owner, "narwhal", {
       agentId: agentA.agentId,
     });
@@ -2626,6 +2622,7 @@ describe("CHAT-01 chat search", () => {
       threadId: contextThread,
       prompt: "context round three",
     });
+    await projectChatEventSearch();
     const contextual = await chat.searchChat(owner, "okapi", {
       before: 2,
       after: 2,
@@ -2685,29 +2682,14 @@ describe("CHAT-01 chat search", () => {
       agentId: agentA.agentId,
       prompt: "capybara sighting three",
     });
+    await projectChatEventSearch();
     const limited = await chat.searchChat(owner, "capybara", { limit: 2 });
     expect(limited.results).toHaveLength(2);
     expect(limited.hasMore).toBeTruthy();
-
-    // LIKE wildcards in the keyword are escaped, not interpreted.
-    await sendNoCreditMessage(owner, {
-      agentId: agentA.agentId,
-      prompt: "discount is 50% today",
-    });
-    await sendNoCreditMessage(owner, {
-      agentId: agentA.agentId,
-      prompt: "50 apples and bananas",
-    });
-    const escaped = await chat.searchChat(owner, "50%");
-    expect(escaped.results).toHaveLength(1);
-    expect(escaped.results[0]?.matchedMessage.content).toBe(
-      "discount is 50% today",
-    );
   }, 60_000);
 
   it("associates batched context windows across matches and threads", async () => {
     const owner = bdd.user();
-    await setChatSearchIndex(owner, false);
     bdd.acceptAgentStorageWrites();
     const agentA = await bdd.createAgent(owner, {
       displayName: "Batched search agent A",
@@ -2761,6 +2743,7 @@ describe("CHAT-01 chat search", () => {
       prompt: `${marker} second tail`,
     });
 
+    await projectChatEventSearch();
     const contextual = await chat.searchChat(owner, `${marker} needle`, {
       limit: 3,
       before: 2,
@@ -2870,23 +2853,6 @@ describe("CHAT-01 chat search", () => {
 });
 
 describe("CHAT-01 chat search index", () => {
-  const CHAT_EVENT_SEARCH_CRON_SECRET = "chat-event-search-cron-secret";
-
-  async function projectChatEventSearch() {
-    mockEnv("CRON_SECRET", CHAT_EVENT_SEARCH_CRON_SECRET);
-    const client = setupApp({
-      context,
-      routes: cronProjectChatEventSearchRoutes,
-    })(cronProjectChatEventSearchContract);
-    const response = await accept(
-      client.project({
-        headers: { authorization: `Bearer ${CHAT_EVENT_SEARCH_CRON_SECRET}` },
-      }),
-      [200],
-    );
-    return response.body;
-  }
-
   function assistantOutputEvent(
     sequenceNumber: number,
     text: string,
@@ -2909,8 +2875,6 @@ describe("CHAT-01 chat search index", () => {
     const peerAgent = await bdd.createAgent(peer, {
       displayName: "Search index peer agent",
     });
-    await setChatSearchIndex(peer, false);
-
     const threadId = await sendNoCreditMessage(owner, {
       agentId: agent.agentId,
       prompt: "今天天气很好，vercel 部署完成",
@@ -2920,13 +2884,10 @@ describe("CHAT-01 chat search index", () => {
       prompt: "peer 今天天气 message",
     });
 
-    // The index is globally enabled but the projector has not indexed the
-    // thread yet, so the index path recalls nothing while the peer's explicit
-    // legacy override still works.
+    // The projector has not indexed either thread yet, so search recalls
+    // nothing until the first projection tick.
     const beforeProjection = await chat.searchChat(owner, "天气");
     expect(beforeProjection.results).toStrictEqual([]);
-    const peerLegacy = await chat.searchChat(peer, "天气");
-    expect(peerLegacy.results).toHaveLength(1);
 
     const firstTick = await projectChatEventSearch();
     expect(firstTick.success).toBeTruthy();
@@ -2943,8 +2904,8 @@ describe("CHAT-01 chat search index", () => {
       );
     }
 
-    // Unindexable keywords stay on the index path instead of falling back to
-    // ILIKE, so neither a single CJK character nor punctuation can match.
+    // Neither a single CJK character nor punctuation has an indexable form,
+    // so those keywords cannot match.
     const singleChar = await chat.searchChat(owner, "好");
     expect(singleChar.results).toStrictEqual([]);
     const punctuation = await chat.searchChat(owner, "，");

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -1,6 +1,4 @@
 import { computed } from "ccstate";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   chatSearchContract,
   chatThreadByIdContract,
@@ -31,7 +29,6 @@ import {
   zeroChatThreadUnreadThreadIds,
   zeroChatThreadUnreads,
 } from "../services/zero-chat-thread.service";
-import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import {
   zeroChatThreadEventRows,
   zeroChatThreadEventSnapshot,
@@ -338,18 +335,11 @@ const listChatThreadArtifactsInner$ = computed(async (get) => {
 const searchChatInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const query = get(queryOf(chatSearchContract.search));
-  const featureContext = await get(
-    userFeatureSwitchContext(auth.orgId, auth.userId),
-  );
   const result = await get(
     zeroChatSearch({
       userId: auth.userId,
       orgId: auth.orgId,
       keyword: query.keyword,
-      useSearchIndex: isFeatureEnabled(
-        FeatureSwitchKey.ChatSearchIndex,
-        featureContext,
-      ),
       agentId: query.agentId,
       since: query.since,
       limit: query.limit,

--- a/turbo/apps/api/src/signals/services/zero-chat-event-type.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-type.service.ts
@@ -22,13 +22,3 @@ export function chatEventTextCondition(): SQL {
     ),
   ) as SQL;
 }
-
-export function chatEventTextMatchCondition(args: {
-  readonly userMessage: SQL;
-  readonly content: SQL;
-}): SQL {
-  return or(
-    and(chatEventTypeIn(CHAT_EVENT_USER_MESSAGE_TEXT_TYPES), args.userMessage),
-    and(chatEventTypeIn(CHAT_EVENT_CONTENT_TEXT_TYPES), args.content),
-  ) as SQL;
-}

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -52,7 +52,6 @@ import {
   exists,
   gt,
   gte,
-  ilike,
   inArray,
   isNotNull,
   isNull,
@@ -81,10 +80,7 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
-import {
-  chatEventTextCondition,
-  chatEventTextMatchCondition,
-} from "./zero-chat-event-type.service";
+import { chatEventTextCondition } from "./zero-chat-event-type.service";
 import { cancellationRecoveryPendingForThread } from "./zero-chat-active-run.service";
 
 const matchedChatEvent = alias(chatEvents, "matched_chat_event");
@@ -199,13 +195,6 @@ const searchContextMessageColumns = {
     .mapWith(chatEvents.eventType)
     .as("context_event_type"),
 } as const;
-
-function escapeLikePattern(value: string): string {
-  return value
-    .replace(/\\/g, String.raw`\\`)
-    .replace(/%/g, String.raw`\%`)
-    .replace(/_/g, String.raw`\_`);
-}
 
 function parseHostedArtifactKind(
   value: unknown,
@@ -1031,27 +1020,6 @@ function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
   };
 }
 
-function userMessageSearchText(): SQL {
-  return sql`concat_ws(
-    ' ',
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].text')::text,
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].titleSnapshot')::text,
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].nameSnapshot')::text,
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].filenameSnapshot')::text,
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].quote')::text,
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].note[*].text')::text,
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].note[*].titleSnapshot')::text,
-    jsonb_path_query_array(${chatEvents.userMessage}, '$.parts[*].note[*].nameSnapshot')::text
-  )`;
-}
-
-function chatSearchKeywordCondition(pattern: string): SQL {
-  return chatEventTextMatchCondition({
-    userMessage: ilike(userMessageSearchText(), pattern),
-    content: ilike(chatEvents.content, pattern),
-  });
-}
-
 /**
  * Resolves matches from the chat_event_search_docs projection alone: keyword,
  * ownership, agent scope, `since`, ordering and the limit are all answered by
@@ -1127,49 +1095,6 @@ async function chatSearchIndexedMatches(
       ),
     )
     .orderBy(desc(chatEvents.createdAt));
-}
-
-/**
- * Pre-projection fallback: scans the caller's own chat_events with ILIKE and
- * evaluates visibility while matching.
- */
-async function chatSearchLegacyMatches(
-  db: ReadonlyDb,
-  args: {
-    readonly userId: string;
-    readonly orgId: string;
-    readonly keyword: string;
-    readonly agentId?: string;
-    readonly since?: Date;
-    readonly limit: number;
-  },
-): Promise<ChatSearchMatchRow[]> {
-  const matchConditions = [
-    eq(chatThreads.userId, args.userId),
-    eq(agentComposes.orgId, args.orgId),
-    chatEventTextCondition(),
-    visibleChatEventCondition(db),
-    excludeGoalMarkerCondition(),
-    chatSearchKeywordCondition(`%${escapeLikePattern(args.keyword)}%`),
-  ];
-  if (args.since) {
-    matchConditions.push(gte(chatEvents.createdAt, args.since));
-  }
-  if (args.agentId) {
-    matchConditions.push(eq(zeroAgents.id, args.agentId));
-  }
-  return await db
-    .select({
-      ...searchMessageColumns,
-      agentName: agentComposes.name,
-    })
-    .from(chatEvents)
-    .innerJoin(chatThreads, eq(chatEvents.chatThreadId, chatThreads.id))
-    .innerJoin(agentComposes, eq(chatThreads.agentComposeId, agentComposes.id))
-    .innerJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
-    .where(and(...matchConditions))
-    .orderBy(desc(chatEvents.createdAt))
-    .limit(args.limit);
 }
 
 function chatSearchMatchesTable(messageIds: readonly string[]): SQL {
@@ -1300,7 +1225,6 @@ export function zeroChatSearch(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly keyword: string;
-  readonly useSearchIndex: boolean;
   readonly agentId?: string;
   readonly since?: number;
   readonly limit: number;
@@ -1316,27 +1240,18 @@ export function zeroChatSearch(args: {
     const db = get(db$);
     const sinceDate = args.since ? new Date(args.since) : undefined;
 
-    const matches = args.useSearchIndex
-      ? await chatSearchIndexedMatches(db, {
-          userId: args.userId,
-          orgId: args.orgId,
-          eventIds: await chatSearchIndexedEventIds(db, {
-            userId: args.userId,
-            orgId: args.orgId,
-            keyword: args.keyword,
-            agentId: args.agentId,
-            since: sinceDate,
-            limit: args.limit + 1,
-          }),
-        })
-      : await chatSearchLegacyMatches(db, {
-          userId: args.userId,
-          orgId: args.orgId,
-          keyword: args.keyword,
-          agentId: args.agentId,
-          since: sinceDate,
-          limit: args.limit + 1,
-        });
+    const matches = await chatSearchIndexedMatches(db, {
+      userId: args.userId,
+      orgId: args.orgId,
+      eventIds: await chatSearchIndexedEventIds(db, {
+        userId: args.userId,
+        orgId: args.orgId,
+        keyword: args.keyword,
+        agentId: args.agentId,
+        since: sinceDate,
+        limit: args.limit + 1,
+      }),
+    });
 
     const hasMore = matches.length > args.limit;
     const truncated = hasMore ? matches.slice(0, args.limit) : matches;

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -15,7 +15,6 @@ describe("isFeatureEnabled", () => {
       true,
     );
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.ChatSearchIndex, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -72,6 +72,5 @@ export enum FeatureSwitchKey {
   SharedThreadSharing = "sharedThreadSharing",
   PiLoop = "piLoop",
   VideoTemplateOptions = "videoTemplateOptions",
-  ChatSearchIndex = "chatSearchIndex",
   ChatEventSnapshotRead = "chatEventSnapshotRead",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -325,12 +325,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Run web chat runs through the in-API Pi edge loop with sandbox handoff instead of dispatching a runner job immediately.",
     enabled: false,
   },
-  [FeatureSwitchKey.ChatSearchIndex]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Serve chat keyword search from the chat_event_search_docs projection instead of scanning chat_events with ILIKE.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ChatEventSnapshotRead]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/packages/db/src/schema/chat-event-search.ts
+++ b/turbo/packages/db/src/schema/chat-event-search.ts
@@ -44,7 +44,7 @@ export const chatEventSearchDocs = pgTable(
     agentComposeId: uuid("agent_compose_id").notNull(),
     role: text("role").$type<"user" | "assistant">().notNull(),
     createdAt: timestamp("created_at").notNull(),
-    /** Raw searchable text, also used for fallback ILIKE matching. */
+    /** Raw searchable text mirrored from the event. */
     text: text("text").notNull(),
     /** CJK-bigram normalized form fed to to_tsvector('simple', ...). */
     textBigram: text("text_bigram").notNull(),


### PR DESCRIPTION
## Summary

- Remove the globally enabled `chatSearchIndex` feature switch and its user override lookup.
- Make `chat_event_search_docs` the unconditional chat keyword search path.
- Delete the pre-projection `ILIKE` query, its `useSearchIndex` plumbing, and tests that forced the retired path.
- Keep the projector, bigram normalization, projection schema, indexed query, and positive product behavior coverage.

## Terminal state

- State: `fully-rolled-out`.
- Decision basis: explicit user instruction in the cleanup request and merged PR #25887, which enabled indexed chat search for all users after production validation.
- Global rollout commit: `8cdca52c3b75e021dbab3a6573f991a6ceea84f9`.

## Commit archaeology

- The switch and initial gated projection path were introduced by `4bf1a0773458c915c4443ed027dd202878765088` (#25736).
- Its parent implementation searched `chat_events` directly with escaped `ILIKE` predicates.
- #25763 made unindexable keywords stay on the index path instead of falling back to `ILIKE`.
- #25836 moved keyword selection, ownership, agent scope, `since`, ordering, and limit handling into the projection.
- #25856 completed the projected agent compose rollout.
- #25887 changed the registry default to globally enabled.
- Comparison conclusion: the projection, projector, bigram query, schema, migrations, and context decoration are the permanent behavior; only the switch and direct `chat_events` matching branch are retired.

## Cleanup details

- Removed `FeatureSwitchKey.ChatSearchIndex`, its registry metadata, and its core registry assertion.
- Removed the route-level feature context read and `useSearchIndex` argument.
- Removed `chatSearchLegacyMatches`, `chatSearchKeywordCondition`, `userMessageSearchText`, `escapeLikePattern`, and their `ilike`/match-helper imports.
- Updated the search integration tests to project events before asserting the permanent indexed behavior.
- Removed explicit false overrides, peer legacy-path assertions, and the legacy LIKE-wildcard assertion.
- Updated the projection schema comment that referred to fallback matching.

## Second-pass search

Searched for `ChatSearchIndex`, `chatSearchIndex`, `useSearchIndex`, `setChatSearchIndex`, `chatSearchLegacyMatches`, `chatSearchKeywordCondition`, `escapeLikePattern`, `fallback ILIKE`, and `legacy override`.

No switch, override, parameter, or retired-query references remain. `chatSearchIndexText`, `chatSearchIndexedEventIds`, and `chatSearchIndexedMatches` remain intentionally as names for the permanent search-index implementation. Historical migrations, generated snapshots, and changelog entries remain unchanged.

## Knip

- Baseline `pnpm knip`: clean.
- After cleanup `pnpm knip`: clean.
- No cleanup-related unused files, exports, types, or dependencies were reported.

## Validation

Passed:

- `git diff --check`
- Prettier on all seven changed files
- `pnpm knip` before and after the cleanup
- `pnpm turbo run lint --concurrency=1 --log-order grouped --filter=api --filter=@vm0/core --filter=@vm0/db`
- `pnpm turbo run check-types --concurrency=1 --log-order grouped --filter=api --filter=@vm0/core --filter=@vm0/db` (8 tasks)
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 tests)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'rejects search without|associates batched context windows|serves index-backed keyword search'` (3 tests)

Local baseline limitation:

- The broader `CHAT-01 chat search` target reports four failures locally: two `since` boundary assertions include records created in the same timestamp tick, and two runner-backed cases return `Job not found in queue` while claiming the created run.
- Stashing this PR's complete diff and rerunning the identical target against clean `main` reproduced the same four failures at the same assertions.
- The PR pipeline is left to run the repository's complete supported test environment.
