### PR TITLE
fix(platform): prevent chat crash on browser back

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -9,6 +9,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname, setPathname, setSearch } from "../../../signals/location.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const context = testContext();
@@ -480,11 +481,12 @@ describe("user messages", () => {
     ).toBeInstanceOf(HTMLElement);
   });
 
-  it("renders agent-run source annotations with avatar, link, and run anchor", async () => {
+  it("restores agent-run source annotations after browser Back from Activities", async () => {
+    const user = userEvent.setup({ delay: null });
     const threadId = "b0000000-0000-4000-a000-000000000750";
     const sourceThreadId = "b0000000-0000-4000-a000-000000000751";
     const sourceRunId = "d0000000-0000-4000-a000-000000000751";
-    const targetRunId = "d0000000-0000-4000-a000-000000000750";
+    const targetRunId = "a0000000-0000-4000-a000-000000000001";
     const sourceAgentId = "a1000000-0000-4000-a000-000000000010";
     const sourceAgentAvatarUrl = "https://example.com/source-agent-avatar.png";
     context.mocks.data.team([
@@ -533,6 +535,13 @@ describe("user messages", () => {
           },
           createdAt: "2026-08-04T10:00:00Z",
         },
+        {
+          id: "00000000-0000-4000-8000-000000000752",
+          role: "assistant",
+          content: "Delegated response",
+          runId: targetRunId,
+          createdAt: "2026-08-04T10:00:01Z",
+        },
       ],
     });
 
@@ -567,6 +576,46 @@ describe("user messages", () => {
       "data-role",
       "user",
     );
+
+    const activityLink = await waitFor(() => {
+      const found = queryAllByRoleFast("link").find((element) => {
+        return element.getAttribute("aria-label") === "View run logs";
+      });
+      if (!found) {
+        throw new Error("Expected the run activity link");
+      }
+      return found;
+    });
+    expect(activityLink).toHaveAttribute("href", `/activities/${targetRunId}`);
+    await user.click(activityLink);
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/activities/${targetRunId}`);
+      expect(
+        screen.queryByLabelText("Open chat Source thread"),
+      ).not.toBeInTheDocument();
+    });
+
+    setPathname(`/chats/${threadId}`);
+    setSearch("");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    const restoredSourceLink = await screen.findByLabelText(
+      "Open chat Source thread",
+    );
+    expect(restoredSourceLink).toHaveAttribute(
+      "href",
+      `/chats/${sourceThreadId}#run-${sourceRunId}`,
+    );
+    await waitFor(() => {
+      expect(restoredSourceLink.querySelector("img")).toHaveAttribute(
+        "src",
+        sourceAgentAvatarUrl,
+      );
+    });
+    expect(
+      screen.queryByText("Oops! Something went sideways"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders Morning Brief metadata outside the message body", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2630,11 +2630,14 @@ function ChatThreadArea({
       ref={setKeyboardScrollRoot}
       className="flex w-full flex-1 min-w-0 min-h-0 bg-transparent"
     >
-      {leftThread && <ChatThread isMain thread={leftThread} />}
+      {/* The same thread ID gets a new signal owner after route re-entry. */}
+      {leftThread && (
+        <ChatThread key={leftThread.lifecycleId} isMain thread={leftThread} />
+      )}
       {rightThread && (
         <>
           <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
-          <ChatThread thread={rightThread} />
+          <ChatThread key={rightThread.lifecycleId} thread={rightThread} />
         </>
       )}
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2611,7 +2611,8 @@ function ChatThread({
       ref={setContainerRef}
       tabIndex={-1}
     >
-      <ChatThreadContent thread={thread} />
+      {/* Preserve the pane container while resetting hooks for a new signal owner. */}
+      <ChatThreadContent key={thread.lifecycleId} thread={thread} />
     </section>
   );
 }
@@ -2630,14 +2631,11 @@ function ChatThreadArea({
       ref={setKeyboardScrollRoot}
       className="flex w-full flex-1 min-w-0 min-h-0 bg-transparent"
     >
-      {/* The same thread ID gets a new signal owner after route re-entry. */}
-      {leftThread && (
-        <ChatThread key={leftThread.lifecycleId} isMain thread={leftThread} />
-      )}
+      {leftThread && <ChatThread isMain thread={leftThread} />}
       {rightThread && (
         <>
           <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
-          <ChatThread key={rightThread.lifecycleId} thread={rightThread} />
+          <ChatThread thread={rightThread} />
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

- remount each chat pane's lifecycle-owned content when its `ChatPanelSignals` owner changes
- preserve the stable outer thread container while preventing old `useLastResolved` values from being paired with a new card registry
- cover Activity navigation followed by browser `popstate` back to a resource-backed chat

## Root cause

Returning to a chat can first expose the retained pane signals and then replace them with a new signal owner for the same thread ID. The unkeyed lifecycle-owned content stayed in the same React position, so its descendants could retain rendered groups from the old owner while receiving registry resolvers from the new owner. Rendering an agent source annotation through that mismatched registry threw `Card signals were not registered` and reached the global error boundary.

Keying `ChatThreadContent` by `lifecycleId` aligns React state retention with the existing signal ownership boundary. Stable `threadId` remains the data identity, the outer thread container retains its DOM identity, and every new resource owner receives a fresh content subtree.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, Platform, and API type checks
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-user-messages.test.tsx --silent=passed-only` (7 tests)
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --silent=passed-only` (30 tests)
- follow-up Platform lint and type checks after preserving the container boundary

Closes #25905
