### PR TITLE
fix(connectors): keep runtime wakeups best effort

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -369,18 +369,34 @@ export async function publishCancelToRunnerGroup(
   L.debug(`Published ${mode} cancel ${runId} to runner-group:${group}`);
 }
 
-export async function publishNetworkPolicyRefreshToRunnerGroup(
+/**
+ * Best-effort post-commit wakeup. Delivery failure leaves an active run on its
+ * last-known-good policy and must not reinterpret the committed grant change.
+ */
+export async function publishNetworkPolicyRefreshToRunnerGroupSafely(
   group: string,
   runId: string,
   connectorSlug: string,
 ): Promise<void> {
-  const channel = ablyClient().channels.get(`runner-group:${group}`);
-  await channel.publish("network-policy-refresh", {
-    runId,
-    connectorSlug,
-  });
-  L.debug(
-    `Published network policy refresh ${runId}/${connectorSlug} to runner-group:${group}`,
+  await tapError(
+    (async () => {
+      const channel = ablyClient().channels.get(`runner-group:${group}`);
+      await channel.publish("network-policy-refresh", {
+        runId,
+        connectorSlug,
+      });
+      L.debug(
+        `Published network policy refresh ${runId}/${connectorSlug} to runner-group:${group}`,
+      );
+    })(),
+    (error) => {
+      L.warn("Failed to publish network policy refresh", {
+        group,
+        runId,
+        connectorSlug,
+        error,
+      });
+    },
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10523,9 +10523,24 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         permission: "files:write",
         action: "deny",
       },
-      [500],
+      [200],
     );
-    expect(failedRefreshNotification.status).toBe(500);
+    expect(failedRefreshNotification.status).toBe(200);
+    expect(failedRefreshNotification.body).toContainEqual(
+      expect.objectContaining({
+        connectorSlug: "slack",
+        permission: "files:write",
+        action: "deny",
+      }),
+    );
+    const committedGrants = await api.listUserPermissionGrants(actor, agentId);
+    expect(committedGrants).toContainEqual(
+      expect.objectContaining({
+        connectorSlug: "slack",
+        permission: "files:write",
+        action: "deny",
+      }),
+    );
 
     await api.requestCancelRun(actor, snapshotRun.runId, [200]);
     const cancelledRefresh = await api.requestRefreshRunnerNetworkPolicyAs(

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -40,7 +40,7 @@ import { notFound } from "../../lib/error";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import {
   publishConnectorPermissionUpdatedSafely,
-  publishNetworkPolicyRefreshToRunnerGroup,
+  publishNetworkPolicyRefreshToRunnerGroupSafely,
 } from "../external/realtime";
 import { nowDate } from "../../lib/time";
 import {
@@ -855,7 +855,7 @@ async function publishActiveNetworkPolicyRefreshes(
       if (!run.runnerGroup) {
         return [];
       }
-      return publishNetworkPolicyRefreshToRunnerGroup(
+      return publishNetworkPolicyRefreshToRunnerGroupSafely(
         run.runnerGroup,
         run.runId,
         connectorSlug,


### PR DESCRIPTION
## Summary

- make the Builtin active-run network-policy wakeup explicitly best effort after a permission-grant commit
- log Ably rejection with runner group, run, and connector identity without changing the committed API result
- update the existing lifecycle integration scenario to require HTTP 200 and verify the committed grant through a follow-up API read

## Behavior

An active run refreshes promptly when the existing Ably event is delivered. If publication fails, the mutation still succeeds and the run keeps its last-known-good connector state. Successful event targeting and payload are unchanged.

## Exclusions

- no durable outbox or retry cron
- no runner reconnect synchronization or fixed polling
- no database, API contract, event payload, or runner protocol change
- no Custom connector behavior change

## Validation

- `pnpm exec prettier --write apps/api/src/signals/external/realtime.ts apps/api/src/signals/services/zero-user-permission-grants.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` — 149 passed
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit hooks: Prettier, Knip, full Turbo type checks, file-size check, and commitlint

Closes #25820

Parent objective: #25312
