### PR TITLE
test(api): narrow snapshot progress lock scope

### DIFF
--- a/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
 import { appendChatThreadEvent } from "../signals/services/zero-chat-thread-event.service";
-import { createDeferredPromise, settleIncludingAbort } from "../signals/utils";
+import { createDeferredPromise } from "../signals/utils";
 
 const databasePidRowSchema = z.object({ pid: z.int() });
 const waiterCountRowSchema = z.object({ waiterCount: z.int() });
@@ -36,24 +36,13 @@ async function withScopeWritesPausedFixture<T>(
   lockTables: SQL,
   args: ScopeWritesPausedFixtureArgs<T>,
 ): Promise<T> {
-  const started = createDeferredPromise<void>(args.signal);
-  const released = createDeferredPromise<void>(args.signal);
-  const done = db().transaction(async (tx) => {
+  return await db().transaction(async (tx) => {
     await tx.execute(lockTables);
-    started.resolve(undefined);
-    await released.promise;
+    args.signal.throwIfAborted();
+    const result = await args.run();
+    args.signal.throwIfAborted();
+    return result;
   });
-  await started.promise;
-
-  const result = await settleIncludingAbort(args.run());
-  if (!released.settled()) {
-    released.resolve(undefined);
-  }
-  await done;
-  if (!result.ok) {
-    throw result.error;
-  }
-  return result.value;
 }
 
 /**
@@ -86,7 +75,10 @@ export async function withChatEventSnapshotScopeWritesPausedFixture<T>(args: {
   readonly run: () => Promise<T>;
 }): Promise<T> {
   return await withScopeWritesPausedFixture(
-    sql`LOCK TABLE ${chatThreads}, ${chatEventSearchWatermarks} IN SHARE MODE`,
+    // Every new or advanced archiver target writes its watermark. Locking that
+    // table alone freezes fresh backlog without blocking unrelated chat-thread
+    // writers while the archiver publishes snapshot heads on another connection.
+    sql`LOCK TABLE ${chatEventSearchWatermarks} IN SHARE MODE`,
     args,
   );
 }


### PR DESCRIPTION
## Summary

- own the scope lock transaction around the fixture callback instead of starting a child transaction before it can be awaited
- freeze snapshot-archiver targets by locking only `chat_event_search_watermarks`, avoiding interference with unrelated chat-thread writers
- preserve the absolute progress, snapshot-head, and table-scale assertions unchanged

## Root cause

The first causal nondeterminism is shared PostgreSQL lock contention in the test fixture. The snapshot progress fixture took `SHARE` locks on both `chat_threads` and `chat_event_search_watermarks` while the API shard ran files concurrently against one database. That broad `chat_threads` lock could join a lock queue with unrelated lifecycle writers and the archiver's second connection. The helper also started the locking transaction as a child promise before awaiting its "started" barrier, so a test timeout could abort the barrier while the PostgreSQL lock remained pending outside the test body's direct ownership.

This explains the exact 60-second stall first, followed by unrelated database/test-context timeouts and the after-finish `AbortError`; those later failures are cascade and teardown evidence, not separate roots. The same fingerprint occurred in two independent merge-group runs whose represented PRs did not touch this service or fixture, while adjacent source-head and base runs completed the file in about 1.5 seconds.

The watermark is the narrow domain barrier: every new or advanced archiver target writes it. Holding only that lock keeps the strict global backlog assertion deterministic without blocking unrelated `chat_threads` writes. Running the callback directly inside the lock transaction makes success, failure, and cancellation release the lock through one owned `await` chain.

## Failure evidence

- Trigger: [Turbo run 31306388103](https://github.com/vm0-ai/vm0/actions/runs/31306388103), [`test-api (8)` job 93227367449](https://github.com/vm0-ai/vm0/actions/runs/31306388103/job/93227367449)
- Independent repeat: [Turbo run 31306997540](https://github.com/vm0-ai/vm0/actions/runs/31306997540), [`test-api (8)` job 93228854523](https://github.com/vm0-ai/vm0/actions/runs/31306997540/job/93228854523)
- PR source-head pass: [`test-api (8)` job 93225526589](https://github.com/vm0-ai/vm0/actions/runs/31305646287/job/93225526589), all five tests passed in 1.431 seconds
- Base/main pass: [`test-api (8)` job 93227242774](https://github.com/vm0-ai/vm0/actions/runs/31306253707/job/93227242774), all five tests passed in 1.503 seconds

The aggregate `ci-gate-turbo` result and the unrelated Playwright/Clerk failure are intentionally excluded from this API fingerprint.

## Validation

- Prettier check for the changed fixture
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `git diff --check`

The target Vitest file requires PostgreSQL. No local database, application, API, runner, or development server was started; the PR Turbo `test-api` shard is the required dynamic validation environment.

Preview validation is not applicable because this changes only an API test fixture and has no user-facing runtime or browser surface.

## Rollout compatibility

No fallback or compatibility path is added.
