### PR TITLE
test(mitm-addon): cover semantically invalid captured dates

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_capture_headers.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_headers.py
@@ -56,6 +56,18 @@ class TestSanitizeHeadersForCapture:
         assert result[name] == expected
 
     @pytest.mark.parametrize(
+        "value",
+        [
+            "Fri, 31 Feb 2026 03:29:48 GMT",
+            "Thu, 31 Apr 2026 03:29:48 GMT",
+            "Thu, 29 Feb 2025 03:29:48 GMT",
+        ],
+    )
+    def test_imf_fixdate_values_with_impossible_dates_are_redacted(self, headers, value):
+        result = _sanitize_headers_for_capture(headers(("Date", value)))
+        assert result["Date"] == "***"
+
+    @pytest.mark.parametrize(
         ("name", "value"),
         [
             ("Content-Type", "https://app.example/private/secret-token"),


### PR DESCRIPTION
## Summary

- add table-driven capture coverage for IMF-fixdate-shaped impossible calendar dates
- exercise the sanitizer through real `mitmproxy.http.Headers`
- preserve the existing valid IMF-fixdate behavior contract

## Scope

Test-only. This PR does not change production sanitizer behavior, dependencies, configuration, or runtime contracts.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_body_capture_headers.py` (79 passed)
- `uv run --no-sync python -m pytest tests/` (5070 passed)
- temporarily bypassed semantic date parsing and confirmed the three new cases fail, then restored production code

Closes #25876
