### PR TITLE
test(mitm-addon): cover content-type whitespace limits

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_capture_headers.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_headers.py
@@ -41,6 +41,45 @@ class TestSanitizeHeadersForCapture:
         assert result["Content-Type"] == expected
 
     @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(
+                (" " * 256) + "application/json",
+                "application/json",
+                id="leading-at-limit",
+            ),
+            pytest.param(
+                (" " * 257) + "application/json",
+                "***",
+                id="leading-over-limit",
+            ),
+            pytest.param(
+                "application/json" + (" " * 256),
+                "application/json",
+                id="trailing-at-limit",
+            ),
+            pytest.param(
+                "application/json" + (" " * 257),
+                "***",
+                id="trailing-over-limit",
+            ),
+            pytest.param(
+                "application/json" + (" " * 256) + "; charset=utf-8",
+                "application/json",
+                id="before-parameter-at-limit",
+            ),
+            pytest.param(
+                "application/json" + (" " * 257) + "; charset=utf-8",
+                "***",
+                id="before-parameter-over-limit",
+            ),
+        ],
+    )
+    def test_content_type_optional_whitespace_is_bounded(self, headers, value, expected):
+        result = _sanitize_headers_for_capture(headers(("Content-Type", value)))
+        assert result["Content-Type"] == expected
+
+    @pytest.mark.parametrize(
         ("name", "value", "expected"),
         [
             ("Accept-Encoding", "\tgzip, br ", "gzip, br"),


### PR DESCRIPTION
## Summary

- cover the 256/257-character leading content-type OWS boundary
- cover the same post-media-type boundary at end-of-value and before a parameter delimiter
- assert captured-header preservation and redaction through real mitmproxy headers

## Scope

- test-only change; production sanitizer behavior is unchanged
- no API, data, dependency, deployment, or documentation changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_body_capture_headers.py` (82 passed)
- independent mutation checks: removing the leading guard failed `leading-over-limit`; removing the post-media-type guard failed both post-media-type over-limit cases
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,073 passed)

Closes #25872
