### PR TITLE
refactor(vsock-guest): centralize file-write admission

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -19,9 +19,7 @@ use crate::exec_operation::{
     start_exec_operation,
 };
 use crate::file_write_worker::{FileWriteKind, FileWriteSubmitError, FileWriteWorker};
-use crate::handlers::{
-    MessageOutcome, decode_write_file_message, decode_write_files_message, handle_basic_message,
-};
+use crate::handlers::{MessageOutcome, handle_basic_message};
 use crate::log::log;
 use crate::process_containment::{ProcessContainmentMode, verify_exec_process_containment_empty};
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
@@ -288,8 +286,8 @@ impl ConnectionDispatcher {
             MSG_EXEC_START => self.handle_exec_start(msg)?,
             MSG_EXEC_CANCEL => self.handle_exec_cancel(msg)?,
             MSG_EXEC_CONTROL => self.handle_exec_control(msg)?,
-            MSG_WRITE_FILE => self.handle_write_file(msg)?,
-            MSG_WRITE_FILES => self.handle_write_files(msg)?,
+            MSG_WRITE_FILE => self.handle_file_write(msg, FileWriteKind::File)?,
+            MSG_WRITE_FILES => self.handle_file_write(msg, FileWriteKind::Files)?,
             MSG_QUIESCE_OPERATIONS => self.handle_quiesce_operations(msg)?,
             MSG_RESUME_OPERATIONS => self.handle_resume_operations(msg)?,
             _ => return self.handle_basic_message(msg),
@@ -397,14 +395,18 @@ impl ConnectionDispatcher {
         route_exec_control(msg.seq, decoded, &self.exec_control_registry, &self.writer)
     }
 
-    fn handle_write_file(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
-        if !require_non_zero_sequence(msg.seq, "write_file", &self.writer)? {
+    fn handle_file_write(
+        &self,
+        msg: BorrowedRawMessage<'_>,
+        kind: FileWriteKind,
+    ) -> io::Result<()> {
+        if !require_non_zero_sequence(msg.seq, kind.operation_label(), &self.writer)? {
             return Ok(());
         }
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        if let Err(error) = decode_write_file_message(msg.payload) {
+        if let Err(error) = kind.validate_payload(msg.payload) {
             send_error_response(msg.seq, &error.to_string(), &self.writer)?;
             return Ok(());
         }
@@ -417,51 +419,10 @@ impl ConnectionDispatcher {
         else {
             return Ok(());
         };
-        match self.file_write_worker.submit(
-            FileWriteKind::File,
-            msg.seq,
-            msg.payload,
-            operation_guard,
-            admission,
-        ) {
-            Ok(()) => Ok(()),
-            Err(FileWriteSubmitError::Busy) => {
-                send_error_response(msg.seq, "guest file write already active", &self.writer)
-            }
-            Err(FileWriteSubmitError::Disconnected) => Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "guest file-write worker stopped",
-            )),
-        }
-    }
-
-    fn handle_write_files(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
-        if !require_non_zero_sequence(msg.seq, "write_files", &self.writer)? {
-            return Ok(());
-        }
-        if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
-            return Ok(());
-        }
-        if let Err(error) = decode_write_files_message(msg.payload) {
-            send_error_response(msg.seq, &error.to_string(), &self.writer)?;
-            return Ok(());
-        }
-        let Some(admission) = self.file_write_worker.try_admit() else {
-            send_error_response(msg.seq, "guest file write already active", &self.writer)?;
-            return Ok(());
-        };
-        let Some(operation_guard) =
-            acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
-        else {
-            return Ok(());
-        };
-        match self.file_write_worker.submit(
-            FileWriteKind::Files,
-            msg.seq,
-            msg.payload,
-            operation_guard,
-            admission,
-        ) {
+        match self
+            .file_write_worker
+            .submit(kind, msg.seq, msg.payload, operation_guard, admission)
+        {
             Ok(()) => Ok(()),
             Err(FileWriteSubmitError::Busy) => {
                 send_error_response(msg.seq, "guest file write already active", &self.writer)

--- a/crates/vsock-guest/src/file_write_worker.rs
+++ b/crates/vsock-guest/src/file_write_worker.rs
@@ -20,6 +20,22 @@ pub(crate) enum FileWriteKind {
     Files,
 }
 
+impl FileWriteKind {
+    pub(crate) const fn operation_label(self) -> &'static str {
+        match self {
+            Self::File => "write_file",
+            Self::Files => "write_files",
+        }
+    }
+
+    pub(crate) fn validate_payload(self, payload: &[u8]) -> Result<(), vsock_proto::ProtocolError> {
+        match self {
+            Self::File => decode_write_file_message(payload).map(|_| ()),
+            Self::Files => decode_write_files_message(payload).map(|_| ()),
+        }
+    }
+}
+
 pub(crate) enum FileWriteSubmitError {
     Busy,
     Disconnected,

--- a/crates/vsock-guest/tests/connection/quiesce.rs
+++ b/crates/vsock-guest/tests/connection/quiesce.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use vsock_proto::{
     self, ExecOutputPolicy, ExecTermination, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_WRITE_FILE,
+    MSG_WRITE_FILES, WriteFileBatchEntry,
 };
 
 use super::support::*;
@@ -73,41 +74,62 @@ fn quiesce_busy_fences_new_exec_operations_until_pending_exec_finishes() {
 }
 
 #[test]
-fn quiesced_connection_rejects_write_file_without_creating_file() {
-    let (handle, mut host_stream) = start_guest_connection();
-    let path = unique_tmp_path("quiesce-write-file", ".txt");
+fn quiesced_connection_rejects_file_write_variants_without_creating_files() {
+    for (variant, msg_type) in [
+        ("write-file", MSG_WRITE_FILE),
+        ("write-files", MSG_WRITE_FILES),
+    ] {
+        let (handle, mut host_stream) = start_guest_connection();
+        let path = unique_tmp_path(&format!("quiesce-{variant}"), ".txt");
 
-    send_quiesce_operations(&mut host_stream, 211);
-    let quiesced = read_message(&mut host_stream);
-    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+        send_quiesce_operations(&mut host_stream, 211);
+        let quiesced = read_message(&mut host_stream);
+        assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
 
-    let payload = vsock_proto::encode_write_file(path.as_str(), b"blocked", false, false).unwrap();
-    let msg = vsock_proto::encode(MSG_WRITE_FILE, 212, &payload).unwrap();
-    host_stream.write_all(&msg).unwrap();
+        let payload = if msg_type == MSG_WRITE_FILE {
+            vsock_proto::encode_write_file(path.as_str(), b"blocked", false, false).unwrap()
+        } else {
+            vsock_proto::encode_write_files(&[WriteFileBatchEntry {
+                path: path.as_str(),
+                content: b"blocked",
+            }])
+            .unwrap()
+        };
+        let msg = vsock_proto::encode(msg_type, 212, &payload).unwrap();
+        host_stream.write_all(&msg).unwrap();
 
-    assert_error_contains(&mut host_stream, 212, "guest operations are quiescing");
-    assert!(!std::path::Path::new(path.as_str()).exists());
+        assert_error_contains(&mut host_stream, 212, "guest operations are quiescing");
+        assert!(!std::path::Path::new(path.as_str()).exists());
 
-    send_resume_operations(&mut host_stream, 213);
-    let resumed = read_message(&mut host_stream);
-    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+        send_resume_operations(&mut host_stream, 213);
+        let resumed = read_message(&mut host_stream);
+        assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
 
-    finish_guest_connection(handle, host_stream);
+        finish_guest_connection(handle, host_stream);
+    }
 }
 
 #[test]
-fn quiesced_connection_rejects_write_file_seq_zero_before_quiesce_state() {
-    let (handle, mut host_stream) = start_guest_connection();
+fn quiesced_connection_rejects_file_write_zero_sequences_before_quiesce_state() {
+    for (msg_type, operation_label) in [
+        (MSG_WRITE_FILE, "write_file"),
+        (MSG_WRITE_FILES, "write_files"),
+    ] {
+        let (handle, mut host_stream) = start_guest_connection();
 
-    send_quiesce_operations(&mut host_stream, 214);
-    let quiesced = read_message(&mut host_stream);
-    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+        send_quiesce_operations(&mut host_stream, 214);
+        let quiesced = read_message(&mut host_stream);
+        assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
 
-    send_control_payload(&mut host_stream, MSG_WRITE_FILE, 0, b"bad");
-    let error = read_error_response(&mut host_stream, 0);
-    assert_eq!(error, "write_file requires non-zero sequence");
+        send_control_payload(&mut host_stream, msg_type, 0, b"bad");
+        let error = read_error_response(&mut host_stream, 0);
+        assert_eq!(
+            error,
+            format!("{operation_label} requires non-zero sequence")
+        );
 
-    finish_guest_connection(handle, host_stream);
+        finish_guest_connection(handle, host_stream);
+    }
 }
 
 #[test]

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use vsock_host::{SupervisedExecControl, SupervisedExecRequest, WriteFileEntry};
 use vsock_proto::{
     ExecOutputPolicy, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_PING, MSG_PONG,
-    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT,
+    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES,
+    WriteFileBatchEntry,
 };
 
 #[test]
@@ -47,15 +48,17 @@ async fn blocked_write_keeps_ping_responsive_and_rejects_overlap() {
     assert_eq!(pong.msg_type, MSG_PONG);
     assert_eq!(pong.seq, 11);
 
-    let overlap_payload =
-        vsock_proto::encode_write_file(&overlap_path_string, b"rejected", false, false)
-            .expect("encode overlapping write");
+    let overlap_payload = vsock_proto::encode_write_files(&[WriteFileBatchEntry {
+        path: overlap_path_string.as_ref(),
+        content: b"rejected",
+    }])
+    .expect("encode overlapping batch write");
     stream
         .write_all(
-            &vsock_proto::encode(MSG_WRITE_FILE, 12, &overlap_payload)
-                .expect("frame overlapping write"),
+            &vsock_proto::encode(MSG_WRITE_FILES, 12, &overlap_payload)
+                .expect("frame overlapping batch write"),
         )
-        .expect("send overlapping write");
+        .expect("send overlapping batch write");
     let busy = read_raw_message(&mut stream);
     assert_eq!(busy.msg_type, MSG_ERROR);
     assert_eq!(busy.seq, 12);


### PR DESCRIPTION
## Summary

- route both guest file-write message variants through one ordered admission and submission handler
- derive each variant's operation label and validation decoder from the existing exhaustive `FileWriteKind`
- cover both variants at the quiesce boundary and prove single-file and batch writes share one busy admission domain

## Compatibility

- preserves wire messages, payloads, result frames, sequence handling, diagnostics, cancellation, shutdown, and connection-poisoning behavior
- preserves validate-before-admit ordering and the worker's bounded raw-payload ownership and re-decoding model
- does not change APIs, schemas, persisted state, queue payloads, feature switches, dependencies, or rollout state

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test`
- `git diff --check`
- staged Rust pre-commit checks

Closes #25884
