### PR TITLE
fix(browser): handle missing thread browser actions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -2365,13 +2365,23 @@ describe("zero browser route", () => {
       }),
     );
 
+    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const beforeStartCloseEventId = randomUUID();
+    await accept(
+      client().close({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: first.threadId },
+        body: { eventId: beforeStartCloseEventId },
+      }),
+      [200],
+    );
+
     const firstStart = await accept(
       client().use({ headers: first.claim.browserHeaders, body: {} }),
       [200],
     );
     expect(firstStart.body.lifecycleEventId).toBeNull();
 
-    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const beforeReclaimCloseEventId = randomUUID();
     await accept(
       client().close({
@@ -2462,6 +2472,11 @@ describe("zero browser route", () => {
           : [];
       }),
     ).toStrictEqual([
+      {
+        id: beforeStartCloseEventId,
+        eventType: "browser.close",
+        content: null,
+      },
       {
         id: beforeReclaimCloseEventId,
         eventType: "browser.close",

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -176,6 +176,11 @@ interface BrowserSessionAccess extends BrowserOwnerAccess {
   readonly chatThreadId: string;
 }
 
+interface BrowserSidebarThread {
+  readonly chatThreadId: string;
+  readonly userId: string;
+}
+
 interface ProviderResult<T> {
   readonly kind: "ok";
   readonly value: T;
@@ -1042,7 +1047,7 @@ async function resolveViewerStartContext(
 
 async function browserSessionAccessError(
   db: Db,
-  browser: BrowserSessionRow,
+  browser: Pick<BrowserSessionRow, "chatThreadId">,
   access: BrowserOwnerAccess,
 ): Promise<BrowserServiceError | null> {
   // Session callers are authorized by ownership. Run-scoped callers must also
@@ -1077,6 +1082,28 @@ async function browserSessionAccessError(
     );
   }
   return null;
+}
+
+async function loadOwnedBrowserSidebarThread(
+  db: Db,
+  access: BrowserSessionAccess,
+): Promise<BrowserSidebarThread | null> {
+  const [thread] = await db
+    .select({
+      chatThreadId: chatThreads.id,
+      userId: chatThreads.userId,
+    })
+    .from(chatThreads)
+    .innerJoin(agentComposes, eq(agentComposes.id, chatThreads.agentComposeId))
+    .where(
+      and(
+        eq(chatThreads.id, access.chatThreadId),
+        eq(chatThreads.userId, access.userId),
+        eq(agentComposes.orgId, access.orgId),
+      ),
+    )
+    .limit(1);
+  return thread ?? null;
 }
 
 async function loadOwnedBrowser(
@@ -2227,12 +2254,12 @@ export const closeZeroBrowserForThread$ = command(
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<BrowserCloseMutation>> => {
     const db = set(writeDb$);
-    const browser = await loadOwnedBrowser(db, args);
+    const thread = await loadOwnedBrowserSidebarThread(db, args);
     signal.throwIfAborted();
-    if (!browser) {
+    if (!thread) {
       return notFound();
     }
-    const accessError = await browserSessionAccessError(db, browser, args);
+    const accessError = await browserSessionAccessError(db, thread, args);
     signal.throwIfAborted();
     if (accessError) {
       return accessError;
@@ -2242,7 +2269,7 @@ export const closeZeroBrowserForThread$ = command(
         tx,
         {
           id: args.lifecycleEventId,
-          chatThreadId: browser.chatThreadId,
+          chatThreadId: thread.chatThreadId,
           eventType: "browser.close",
           content: null,
         },
@@ -2257,8 +2284,8 @@ export const closeZeroBrowserForThread$ = command(
       );
     }
     await publishChatThreadMessageCreatedSafely(
-      browser.userId,
-      browser.chatThreadId,
+      thread.userId,
+      thread.chatThreadId,
       event.seqId,
     );
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/browser-session-block.ts
@@ -265,7 +265,7 @@ function createFitWindowSignals(
               body: { aspectRatio },
               fetchOptions: { signal },
             }),
-            [200],
+            [200, 404],
             signal,
           ),
           () => {
@@ -274,7 +274,7 @@ function createFitWindowSignals(
         ),
         signal,
       );
-      if (fitted.ok) {
+      if (fitted.ok && fitted.value.status === 200) {
         set(sessionOverride$, fitted.value.body.browser);
         set(
           browserFitDom.syncFitActionForScreen$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -21,6 +21,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-browser";
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -847,6 +848,14 @@ describe("thread-owned utility sidebar", () => {
       zeroBrowserContract.resizeByThread,
       ({ body, respond }) => {
         resizeAspectRatios.push(body.aspectRatio);
+        if (resizeAspectRatios.length === 2) {
+          return respond(404, {
+            error: {
+              code: "BROWSER_NOT_FOUND",
+              message: "Managed browser not found",
+            },
+          });
+        }
         browser = {
           ...browser,
           screen: { width: 1440, height: 1800, resizable: true },
@@ -937,6 +946,14 @@ describe("thread-owned utility sidebar", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Fit browser to window")).toBeVisible();
     });
+    const toastError = vi.spyOn(toast, "error");
+    click(screen.getByLabelText("Fit browser to window"));
+    await waitFor(() => {
+      expect(resizeAspectRatios).toStrictEqual([0.8, 1]);
+    });
+    expect(toastError).not.toHaveBeenCalledWith("Managed browser not found");
+    toastError.mockRestore();
+
     viewportWidth = 720;
     window.dispatchEvent(new Event("resize"));
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -21,7 +21,6 @@ import {
 } from "@vm0/api-contracts/contracts/zero-browser";
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
-import { toast } from "@vm0/ui/components/ui/sonner";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -946,13 +945,14 @@ describe("thread-owned utility sidebar", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Fit browser to window")).toBeVisible();
     });
-    const toastError = vi.spyOn(toast, "error");
     click(screen.getByLabelText("Fit browser to window"));
     await waitFor(() => {
       expect(resizeAspectRatios).toStrictEqual([0.8, 1]);
+      expect(screen.getByLabelText("Fit browser to window")).toBeEnabled();
     });
-    expect(toastError).not.toHaveBeenCalledWith("Managed browser not found");
-    toastError.mockRestore();
+    expect(
+      screen.queryByText("Managed browser not found"),
+    ).not.toBeInTheDocument();
 
     viewportWidth = 720;
     window.dispatchEvent(new Event("resize"));


### PR DESCRIPTION
## Summary

- make browser sidebar close depend on thread ownership instead of an existing browser session while preserving the close lifecycle event
- treat a missing browser during best-effort resize as an accepted outcome without replacing the current session
- cover closing before browser creation and a resize race that returns 404

## Verification

- `pnpm check-types` in `turbo/apps/api`
- `pnpm check-types` in `turbo/apps/platform`
- targeted Prettier, ESLint, and type-aware Oxlint for all changed files
- `pnpm knip --workspace api --workspace @vm0/app`
- `pnpm exec vitest run src/views/zero-page/__tests__/thread-sidebar.test.tsx -t "auto-opens the thread browser while its latest lifecycle event is open"`
- API regression test attempted locally but could not initialize because PostgreSQL was not running (`ECONNREFUSED :5432`); the PR pipeline will run it
