### PR TITLE
fix(mitm-addon): retain aliases across context target unpacking

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass
 from typing import TypeGuard
 
 
+def _target_requires_unpacking(node: ast.AST | None) -> bool:
+    """Return whether binding ``node`` starts with structural sequence unpacking."""
+    return isinstance(node, ast.List | ast.Tuple)
+
+
 def _target_names(node: ast.AST | None) -> set[str]:
     if isinstance(node, ast.Name):
         return {node.id}
@@ -621,7 +626,7 @@ def _annotation_target_may_raise(node: ast.AST) -> bool:
 
 def _with_protected_region_may_raise(items: list[ast.withitem], body_flow: _FlowSummary) -> bool:
     target_may_raise = any(
-        _expression_may_raise(item.optional_vars)
+        _target_requires_unpacking(item.optional_vars) or _expression_may_raise(item.optional_vars)
         for item in items
         if item.optional_vars is not None
     )

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -21,6 +21,7 @@ from flow_metadata_linter.ast_helpers import (
     _static_first_call_argument_nodes,
     _static_truth_value,
     _target_names,
+    _target_requires_unpacking,
     _truth_test_may_raise,
     _type_alias_target_names,
     _type_alias_value,
@@ -173,7 +174,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
       backedges for the nearest loop, so the next iteration or truth test records
       the state that exists after the loop body. Assignment targets are visited in
       binding order so a later fallible attribute or subscript target observes
-      earlier name bindings.
+      earlier name bindings. Context-manager sequence targets record their outer
+      unpack before that traversal; because those bindings only remove metadata
+      aliases, the pre-binding state covers nested partial-binding failures.
     """
 
     def __init__(self, path: Path) -> None:
@@ -1052,6 +1055,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         exception_state = _ExceptionAliasState()
         self._exception_alias_scopes.append(exception_state)
         if item.optional_vars is not None:
+            if _target_requires_unpacking(item.optional_vars):
+                self._record_implicit_exception_aliases()
             self._visit_assignment_target(item.optional_vars, direct_value_is_metadata_alias=False)
         protected_region_falls_through = (
             self._visit_with_items(remaining_items, body)

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.base.py.txt
@@ -206,3 +206,24 @@ def class_nonlocal_removes_alias_before_failure(flow, manager):
             raise RuntimeError()
 
     return metadata["firewall_error"]
+
+
+def sync_sequence_target_unpack_may_preserve_alias(flow, manager):
+    metadata = flow.metadata
+    with manager as (metadata, other):
+        pass
+    return metadata["firewall_error"]
+
+
+async def async_starred_target_unpack_may_preserve_alias(flow, manager):
+    metadata = flow.metadata
+    async with manager as [metadata, *middle, other]:
+        pass
+    return metadata["trusted_authority_host"]
+
+
+def target_unpack_failure_reaches_after_terminal_body(flow, manager):
+    metadata = flow.metadata
+    with manager as (metadata, other):
+        return None
+    return metadata["auth_base_forward_admission"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/context_manager_flow.expected.txt
@@ -11,3 +11,6 @@ context_manager_flow.py:159: use metadata_keys.FIREWALL_PERMISSION for flow.meta
 context_manager_flow.py:170: use metadata_keys.FIREWALL_RULE_MATCH for flow.metadata access
 context_manager_flow.py:184: use metadata_keys.FIREWALL_ACTION for flow.metadata access
 context_manager_flow.py:196: use metadata_keys.FIREWALL_BILLABLE for flow.metadata access
+context_manager_flow.py:215: use metadata_keys.FIREWALL_ERROR for flow.metadata access
+context_manager_flow.py:222: use metadata_keys.TRUSTED_AUTHORITY_HOST for flow.metadata access
+context_manager_flow.py:229: use metadata_keys.AUTH_BASE_FORWARD_ADMISSION for flow.metadata access

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
@@ -30,6 +30,7 @@ implicit_exception_flow.py:363: use metadata_keys.VM_NETWORK_LOG_PATH for flow.m
 implicit_exception_flow.py:373: use metadata_keys.FIREWALL_BILLABLE for flow.metadata access
 implicit_exception_flow.py:381: use metadata_keys.REQUEST_STREAM_COMPLETE for flow.metadata access
 implicit_exception_flow.py:389: use metadata_keys.NETWORK_LOG_TARGET for flow.metadata access
+implicit_exception_flow.py:404: use metadata_keys.FIREWALL_NAME for flow.metadata access
 implicit_exception_flow.py:429: use metadata_keys.FIREWALL_PERMISSION for flow.metadata access
 implicit_exception_flow.py:501: use metadata_keys.CONNECTOR_ROUTE_REASON for flow.metadata access
 implicit_exception_flow.py:509: use metadata_keys.CONNECTOR_ROUTE_CANDIDATES for flow.metadata access


### PR DESCRIPTION
## Summary

- model structural list/tuple context targets as fallible before child bindings
- retain pre-binding metadata aliases when sync or async context managers suppress unpack failures
- preserve post-`with` reachability when a terminal body is bypassed by a suppressed target failure
- cover sync tuple, async starred-list, terminal-body, and ordered later-target cases through the public linter API

## Scope

This changes only repository flow-metadata lint tooling and its fixture contract. It does not change runner or addon runtime behavior, schemas, persisted data, APIs, protocols, dependencies, deployment compatibility, or rollout behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py` (18 passed)
- `uv run --no-sync python scripts/check-flow-metadata-keys.py`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5082 passed)
- mutation proof: removing the alias snapshot dropped the three new context diagnostics; removing structural reachability dropped only the terminal-body diagnostic

Closes #25892
