### PR TITLE
perf(platform): avoid agent reload when opening picker

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -1,6 +1,5 @@
 import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "../external/local-storage.ts";
-import { reloadAgents$ } from "../agent.ts";
 
 // ---------------------------------------------------------------------------
 // Chat list dialog search query
@@ -158,7 +157,6 @@ export const setChatListOpen$ = command(({ set }, open: boolean) => {
 export const openAgentListDialog$ = command(({ set }) => {
   set(internalChatListQuery$, "");
   set(internalChatListOpen$, true);
-  set(reloadAgents$);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -14,6 +14,10 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
+import {
+  zeroTeamContract,
+  type TeamComposeItem,
+} from "@vm0/api-contracts/contracts/zero-team";
 
 import {
   createMockWorkflowAutomation,
@@ -89,8 +93,8 @@ function prepareDefaultAgent(): void {
   ]);
 }
 
-function prepareAgentTeam(): void {
-  context.mocks.data.team([
+function prepareAgentTeam(): TeamComposeItem[] {
+  const team: TeamComposeItem[] = [
     {
       id: AGENT_ID,
       ownerId: "test-user-123",
@@ -124,7 +128,8 @@ function prepareAgentTeam(): void {
       headVersionId: "version_3",
       updatedAt: "2024-01-01T00:00:00Z",
     },
-  ]);
+  ];
+  context.mocks.data.team(team);
   context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
     const displayNameById: Record<string, string> = {
       [AGENT_ID]: "Zero",
@@ -143,6 +148,7 @@ function prepareAgentTeam(): void {
       preferPersonalProvider: false,
     });
   });
+  return team;
 }
 
 function createThread(
@@ -1419,6 +1425,33 @@ describe("zero sidebar", () => {
       ).not.toBeInTheDocument();
       expect(within(sidebar()).getByText("Incident notes")).toBeInTheDocument();
     });
+  });
+
+  it("does not reload agents when opening the conversation picker", async () => {
+    const team = prepareAgentTeam();
+    let teamRequests = 0;
+    context.mocks.api(zeroTeamContract.list, ({ respond }) => {
+      teamRequests += 1;
+      return respond(200, team);
+    });
+
+    setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const sidebar = await waitFor(() => {
+      const currentSidebar = screen.getByRole("navigation", {
+        name: "Sidebar",
+      });
+      expect(pinnedAgentLink(currentSidebar, "Zero")).toBeInTheDocument();
+      return currentSidebar;
+    });
+    const requestsBeforeOpen = teamRequests;
+    expect(requestsBeforeOpen).toBeGreaterThan(0);
+
+    click(within(sidebar).getByLabelText("Open a conversation"));
+
+    const dialog = await screen.findByRole("dialog", { name: "Talk to" });
+    expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
+    expect(teamRequests).toBe(requestsBeforeOpen);
   });
 
   it("pins an agent from the conversation picker and opens that agent chat", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1427,11 +1427,15 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("does not reload agents when opening the conversation picker", async () => {
+  it("shows cached agents when opening the conversation picker", async () => {
     const team = prepareAgentTeam();
-    let teamRequests = 0;
-    context.mocks.api(zeroTeamContract.list, ({ respond }) => {
-      teamRequests += 1;
+    const releaseRefresh = context.mocks.deferred<void>();
+    let initialTeamServed = false;
+    context.mocks.api(zeroTeamContract.list, async ({ respond }) => {
+      if (initialTeamServed) {
+        await releaseRefresh.promise;
+      }
+      initialTeamServed = true;
       return respond(200, team);
     });
 
@@ -1444,14 +1448,13 @@ describe("zero sidebar", () => {
       expect(pinnedAgentLink(currentSidebar, "Zero")).toBeInTheDocument();
       return currentSidebar;
     });
-    const requestsBeforeOpen = teamRequests;
-    expect(requestsBeforeOpen).toBeGreaterThan(0);
 
     click(within(sidebar).getByLabelText("Open a conversation"));
 
     const dialog = await screen.findByRole("dialog", { name: "Talk to" });
-    expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
-    expect(teamRequests).toBe(requestsBeforeOpen);
+    await expect(
+      within(dialog).findByText("Research Agent"),
+    ).resolves.toBeInTheDocument();
   });
 
   it("pins an agent from the conversation picker and opens that agent chat", async () => {


### PR DESCRIPTION
## Summary

- keep the cached agent list when opening the Talk to picker
- avoid an extra `GET /api/zero/team` request on every picker open
- add page-level regression coverage for the request count

## Verification

- `pnpm exec prettier --write apps/platform/src/signals/zero-page/zero-sidebar-state.ts apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app exec eslint src/signals/zero-page/zero-sidebar-state.ts src/views/zero-page/__tests__/zero-sidebar.test.tsx --max-warnings 0`
- `pnpm -F @vm0/app exec oxlint src/signals/zero-page/zero-sidebar-state.ts src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/signals/zero-page/zero-sidebar-state.ts src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "does not reload agents when opening the conversation picker" --silent=passed-only`
