### PR TITLE
test(app): assert voice recorder rotation at lifecycle boundary

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -579,6 +579,7 @@ function mockAudioContext(signal: AbortSignal): void {
 interface VoiceInputMockOptions {
   readonly audioContextReady?: Promise<void>;
   readonly getUserMediaReady?: Promise<void>;
+  readonly onRecorderStart?: () => void;
   readonly onRecorderStop?: () => void;
   readonly rms?: number | readonly number[] | (() => number);
 }
@@ -679,6 +680,7 @@ function mockVoiceInput(
 
     start(): void {
       this.state = "recording";
+      options.onRecorderStart?.();
     }
 
     requestData(): void {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -1074,8 +1074,17 @@ describe("chat lifecycle", () => {
     const draftPatches: unknown[] = [];
     const uploadedAudio: string[] = [];
     const transcriptionRequested = context.mocks.deferred<void>();
+    const recorderTransitions: ("start" | "stop")[] = [];
     let transcriptionCalls = 0;
-    context.mocks.browser.voiceInput({ rms: [0.1, 0.1, 0, 0, 0] });
+    context.mocks.browser.voiceInput({
+      onRecorderStart: () => {
+        recorderTransitions.push("start");
+      },
+      onRecorderStop: () => {
+        recorderTransitions.push("stop");
+      },
+      rms: [0.1, 0.1, 0, 0, 0],
+    });
     mockChatLifecycle(context, { threadId });
     context.mocks.http.patch(
       "*/api/zero/chat-threads/:id",
@@ -1109,12 +1118,12 @@ describe("chat lifecycle", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
     });
-    // The silence-triggered segment upload reaching the server proves the
-    // capture rotated recorders instead of ending the session; recording may
-    // legitimately auto-stop moments later, so check the label now rather
-    // than after the transcription response renders.
     await transcriptionRequested.promise;
-    expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+    expect(recorderTransitions.slice(0, 3)).toStrictEqual([
+      "start",
+      "stop",
+      "start",
+    ]);
     await waitFor(() => {
       expect(composer).toHaveTextContent("First sentence");
     });
@@ -1134,6 +1143,12 @@ describe("chat lifecycle", () => {
       expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
     });
     expect(transcriptionCalls).toBe(1);
+    expect(recorderTransitions).toStrictEqual([
+      "start",
+      "stop",
+      "start",
+      "stop",
+    ]);
   });
 
   it("uploads voice input segments one at a time", async () => {


### PR DESCRIPTION
## Problem

Turbo merge-group run [31313412968](https://github.com/vm0-ai/vm0/actions/runs/31313412968) failed in [`test-app (1)`](https://github.com/vm0-ai/vm0/actions/runs/31313412968/job/93244724878) at:

`chat-computer-use-and-voice.test.tsx > chat lifecycle > transcribes a voice input segment after silence while recording`

The test could not find the `Stop recording` label immediately after the STT request entered its mock handler. This is a recurrence of the signature addressed by #22845, but the earlier request-arrival deferred did not own the recording lifecycle.

## Root cause

When the voice activity tracker reports silence, the product starts two independent operations in the same callback:

1. capture the current segment, rotate to a new `MediaRecorder`, and upload the captured blob in the background;
2. start the 50 ms Vitest long-silence auto-stop timer.

The STT mock request proves that upload began, but it does not prove the auto-stop timer has not already completed. Event-loop scheduling therefore decided whether the transient `Stop recording` label was still present when the test resumed. Both the source PR run and adjacent base-main run passed the test, and #25936 did not change voice code.

## Fix

- expose `onRecorderStart` from the existing browser-boundary voice-input mock;
- replace the transient post-request label assertion with the recorder lifecycle sequence `start -> stop -> start`, which directly proves that silence capture rotated the recorder instead of ending the session;
- assert the final sequence `start -> stop -> start -> stop` after the legitimate long-silence auto-stop.

The test retains the initial user-visible `Stop recording` assertion, the uploaded `voice-1` blob, one transcription, composer and draft delivery, and the final `Voice input` state. No product behavior, retry, timeout, sleep, or assertion polling was added.

## Verification

- full `chat-computer-use-and-voice.test.tsx`: 28/28 passed in 7 consecutive runs, including one after rebasing onto the latest `origin/main`;
- `pnpm format`;
- `pnpm turbo run lint --concurrency=1 --log-order grouped`;
- `pnpm knip`;
- staged TypeScript checks for non-API/App packages, App, and API;
- `git diff --check`.

Preview validation is not applicable: this PR changes only Vitest code and the browser boundary mock; a deployed app preview cannot exercise the synthetic RMS and `MediaRecorder` lifecycle used by this regression test.
