### PR TITLE
fix(mitm-addon): track chat completions usage

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1565,7 +1565,7 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     websocket_retention.schedule_message_trim(flow)
     if not response_streaming.is_model_websocket_usage_enabled(flow):
         return
-    uses_openai_responses = response_streaming.uses_openai_responses_usage_protocol(flow)
+    uses_openai_responses = response_streaming.model_usage_protocol(flow) == "openai_responses"
     if getattr(message, "from_client", False):
         if uses_openai_responses:
             body = message.content.encode() if isinstance(message.content, str) else message.content
@@ -1783,10 +1783,18 @@ def _finish_response_handling(
         and stream_buf
         and response_streaming.uses_model_json_fallback(flow)
     ):
-        if response_streaming.uses_openai_responses_usage_protocol(flow):
+        model_protocol = response_streaming.model_usage_protocol(flow)
+        if model_protocol == "openai_responses":
             json_usage, json_error = usage.extract_openai_responses_usage_with_error_from_json(
                 bytes(stream_buf),
                 flow.response.headers if flow.response else None,
+            )
+        elif model_protocol == "openai_chat_completions":
+            json_usage, json_error = (
+                usage.extract_openai_chat_completions_usage_with_error_from_json(
+                    bytes(stream_buf),
+                    flow.response.headers if flow.response else None,
+                )
             )
         else:
             json_usage, json_error = usage.extract_anthropic_messages_usage_with_error_from_json(

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -18,7 +18,7 @@ Lifecycle:
 """
 
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from mitmproxy import http
 from wsproto.utilities import generate_accept_token
@@ -28,6 +28,7 @@ import body_decoding
 import claude_output_timing
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import runtime_url_parsing
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from logging_utils import log_proxy_entry
@@ -49,8 +50,16 @@ _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
 _HTTP_OWS_CHARS = " \t"
 
 _ANTHROPIC_MESSAGES_SSE_PROTOCOL = "anthropic_messages_sse"
+_OPENAI_CHAT_COMPLETIONS_SSE_PROTOCOL = "openai_chat_completions_sse"
+_OPENAI_RESPONSES_SSE_PROTOCOL = "openai_responses_sse"
 _ANTHROPIC_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 _ANTHROPIC_MESSAGE_STOP_EVENT = "message_stop"
+
+ModelUsageProtocol = Literal[
+    "anthropic_messages",
+    "openai_chat_completions",
+    "openai_responses",
+]
 
 _ResponseChunkParser = Callable[[bytes], None]
 _SseUsageParseErrorLogger = Callable[[str, str], None]
@@ -81,14 +90,15 @@ class _ResponseUsageStreamSetup(NamedTuple):
     needs_buffered_fallback: bool
 
 
-def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
-    """Return whether a flow should use OpenAI Responses usage parsing.
-
-    Read-only predicate used from parser setup and response fallback extraction.
-    Codex flows use the OpenAI Responses
-    usage protocol, while other model-provider flows use the Anthropic protocol.
-    """
-    return flow_metadata.cli_agent_type(flow.metadata) == "codex"
+def model_usage_protocol(flow: http.HTTPFlow) -> ModelUsageProtocol:
+    """Classify model usage from the observed request and CLI fallback."""
+    request_target = flow_metadata.original_url(flow.metadata) or flow.request.path
+    request_path = runtime_url_parsing.strip_url_query_and_fragment(request_target).rstrip("/")
+    if request_path.endswith("/chat/completions"):
+        return "openai_chat_completions"
+    if flow_metadata.cli_agent_type(flow.metadata) == "codex":
+        return "openai_responses"
+    return "anthropic_messages"
 
 
 def _response_has_event_stream_media_type(response: http.Response) -> bool:
@@ -226,9 +236,10 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
     # extraction. Model-provider usage reporting is gated separately.
     is_billable_flow = flow_metadata.is_firewall_billable(flow.metadata)
     is_observable_model_provider = usage.is_model_provider_usage_observable(flow)
+    model_protocol = model_usage_protocol(flow) if is_observable_model_provider else None
     if (
         is_observable_model_provider
-        and uses_openai_responses_usage_protocol(flow)
+        and model_protocol == "openai_responses"
         and _is_confirmed_websocket_upgrade_response(flow)
     ):
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {}
@@ -242,8 +253,8 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
             lifecycle_observer: _AnthropicLifecycleObserver | None = None
             anthropic_accounting_events: set[str] = set()
             openai_recoverable_usage: dict = {}
-            if uses_openai_responses_usage_protocol(flow):
-                usage_protocol = "openai_responses_sse"
+            if model_protocol == "openai_responses":
+                usage_protocol = _OPENAI_RESPONSES_SSE_PROTOCOL
                 log_parse_error = _make_model_sse_parse_error_logger(
                     flow,
                     usage_protocol=usage_protocol,
@@ -258,6 +269,15 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                 parser_fn, usage_dict = usage.create_openai_responses_sse_usage_extractor(
                     on_parse_error=log_parse_error,
                     on_terminal_usage=record_openai_terminal_usage,
+                )
+            elif model_protocol == "openai_chat_completions":
+                usage_protocol = _OPENAI_CHAT_COMPLETIONS_SSE_PROTOCOL
+                log_parse_error = _make_model_sse_parse_error_logger(
+                    flow,
+                    usage_protocol=usage_protocol,
+                )
+                parser_fn, usage_dict = usage.create_openai_chat_completions_sse_usage_extractor(
+                    on_parse_error=log_parse_error,
                 )
             else:
                 usage_protocol = _ANTHROPIC_MESSAGES_SSE_PROTOCOL
@@ -294,7 +314,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                             accounting_status,
                         )
                     elif (
-                        usage_protocol == "openai_responses_sse"
+                        usage_protocol == _OPENAI_RESPONSES_SSE_PROTOCOL
                         and decode_error == body_decoding.INCOMPLETE_COMPRESSED_BODY
                     ):
                         usage_dict.clear()
@@ -312,8 +332,10 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = finish_sse_usage
             return _ResponseUsageStreamSetup(decode_session.feed, False)
 
-        if uses_openai_responses_usage_protocol(flow):
+        if model_protocol == "openai_responses":
             extractor = usage.create_openai_responses_json_usage_extractor()
+        elif model_protocol == "openai_chat_completions":
+            extractor = usage.create_openai_chat_completions_json_usage_extractor()
         else:
             extractor = usage.create_anthropic_messages_json_usage_extractor()
         decode_session = _make_response_decode_session(

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -54,6 +54,11 @@ from .counters import (
     set_pending_path,
     write_pending_snapshot,
 )
+from .openai_chat_completions import (
+    create_openai_chat_completions_json_usage_extractor,
+    create_openai_chat_completions_sse_usage_extractor,
+    extract_openai_chat_completions_usage_with_error_from_json,
+)
 from .openai_responses import (
     OpenAIResponsesEvent,
     create_openai_responses_json_usage_extractor,
@@ -92,12 +97,15 @@ __all__ = [
     "create_anthropic_messages_json_usage_extractor",
     "create_anthropic_messages_sse_usage_extractor",
     "create_connector_response_parser",
+    "create_openai_chat_completions_json_usage_extractor",
+    "create_openai_chat_completions_sse_usage_extractor",
     "create_openai_responses_json_usage_extractor",
     "create_openai_responses_sse_usage_extractor",
     "current_usage_state_id",
     "decrement_in_flight_flows",
     "drain_usage_events_after_executor_shutdown",
     "extract_anthropic_messages_usage_with_error_from_json",
+    "extract_openai_chat_completions_usage_with_error_from_json",
     "extract_openai_responses_usage_from_event",
     "extract_openai_responses_usage_with_error_from_json",
     "flush_usage_events",

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -7,29 +7,49 @@ byte chunks, and call :meth:`JsonSelectiveExtractor.finish` once to finalize the
 result.
 
 Paths are tuples of object keys. For example, ``("usage", "input_tokens")``
-matches ``{"usage": {"input_tokens": 1}}``. Wildcards are supported only by
-``wildcard_array_count_paths`` and each wildcard pattern must contain exactly one
-``"*"`` segment. For example, ``("includes", "*")`` records the array lengths
-for keys such as ``includes.users`` and ``includes.tweets``.
+matches ``{"usage": {"input_tokens": 1}}``. ``FIRST_ARRAY_ELEMENT`` selects
+only index zero of an array. Wildcards are supported only by
+``wildcard_array_count_paths`` and each wildcard pattern must contain exactly
+one ``"*"`` segment. For example, ``("includes", "*")`` records the array
+lengths for keys such as ``includes.users`` and ``includes.tweets``.
 """
 
 import json
 import json.decoder
 import re
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Literal, cast
+from enum import Enum, auto
+from typing import Literal, TypeVar, cast
 
-Path = tuple[str, ...]
+
+class _PathMarker(Enum):
+    UNKNOWN_KEY = auto()
+    FIRST_ARRAY_ELEMENT = auto()
+    OTHER_ARRAY_ELEMENT = auto()
+
+
+FIRST_ARRAY_ELEMENT = _PathMarker.FIRST_ARRAY_ELEMENT
+PathSegment = str | _PathMarker
+Path = tuple[PathSegment, ...]
 WildcardPath = tuple[str, ...]
+_ScalarPath = TypeVar("_ScalarPath", bound=Path)
 ScalarKind = Literal["string", "int"]
 ScalarOverflowPolicy = Literal["error", "discard"]
 _JsonStringScanner = Callable[[str, int, bool], tuple[str, int]]
 # `scanstring` is the stdlib JSON string scanner, but typeshed does not expose it.
 _SCAN_JSON_STRING = cast(_JsonStringScanner, vars(json.decoder)["scanstring"])
-_UNKNOWN_KEY = "\0__vm0_json_unknown_key__"
-_ARRAY_ELEMENT = "\0__vm0_json_array_element__"
-_INTERNAL_PATH_MARKERS = frozenset((_UNKNOWN_KEY, _ARRAY_ELEMENT))
+_UNKNOWN_KEY = _PathMarker.UNKNOWN_KEY
+_OTHER_ARRAY_ELEMENT = _PathMarker.OTHER_ARRAY_ELEMENT
+_INTERNAL_PATH_MARKERS = frozenset(
+    (
+        _UNKNOWN_KEY,
+        FIRST_ARRAY_ELEMENT,
+        _OTHER_ARRAY_ELEMENT,
+        "\0__vm0_json_unknown_key__",
+        "\0__vm0_json_array_element__",
+    )
+)
 _JSON_CONTROL_CHAR_MAX = 0x20
 # These are the only bytes that can change discarded string state. Non-ASCII
 # bytes stay on the bytewise path so UTF-8 validation remains unchanged.
@@ -122,7 +142,8 @@ class JsonExtractionResult:
     ``complete`` is true only when the JSON document parsed successfully.
     ``values`` contains selected scalar values, ``array_counts`` contains exact
     array path lengths, ``wildcard_array_counts`` contains per-wildcard-key array
-    lengths, and ``object_present`` contains observed object paths.
+    lengths, ``object_present`` contains observed object paths, and
+    ``value_present`` contains paths where any JSON value appeared.
 
     When ``complete`` is false, all observation containers are empty and
     ``error`` describes the parse or bound failure. This prevents callers from
@@ -134,6 +155,7 @@ class JsonExtractionResult:
     array_counts: dict[Path, int] = field(default_factory=dict)
     wildcard_array_counts: dict[WildcardPath, dict[str, int]] = field(default_factory=dict)
     object_present: set[Path] = field(default_factory=set)
+    value_present: set[Path] = field(default_factory=set)
     error: str | None = None
 
 
@@ -143,7 +165,7 @@ class _Frame:
     path: Path
     state: str
     collect_keys: bool | None = None
-    pending_key: str | None = None
+    pending_key: PathSegment | None = None
     count_path: Path | None = None
     wildcard_counts: list[tuple[WildcardPath, str]] = field(default_factory=list)
 
@@ -190,13 +212,14 @@ class _ScalarConsistency:
 class JsonSelectiveExtractor:
     """Streaming, bounded JSON extractor for a fixed observation set.
 
-    The extractor observes four kinds of data while parsing:
+    The extractor observes five kinds of data while parsing:
 
     - ``scalar_fields`` captures selected string or integer values.
     - ``array_count_paths`` counts arrays at exact paths.
     - ``wildcard_array_count_paths`` counts arrays at wildcard paths with one
       ``"*"`` segment, recording counts by the concrete wildcard key.
     - ``object_presence_paths`` records exact paths where JSON objects appear.
+    - ``value_presence_paths`` records exact paths where any JSON value appears.
 
     Oversized selected scalars fail extraction by default. Selected strings with
     ``overflow_policy="discard"`` instead drop that observation and continue
@@ -208,11 +231,12 @@ class JsonSelectiveExtractor:
     def __init__(
         self,
         *,
-        scalar_fields: dict[Path, ScalarField] | None = None,
-        array_count_paths: set[Path] | None = None,
-        wildcard_array_count_paths: set[WildcardPath] | None = None,
-        object_presence_paths: set[Path] | None = None,
-        scalar_consistency_paths: set[Path] | None = None,
+        scalar_fields: Mapping[_ScalarPath, ScalarField] | None = None,
+        array_count_paths: Iterable[Path] | None = None,
+        wildcard_array_count_paths: Iterable[WildcardPath] | None = None,
+        object_presence_paths: Iterable[Path] | None = None,
+        value_presence_paths: Iterable[Path] | None = None,
+        scalar_consistency_paths: Iterable[Path] | None = None,
         max_depth: int = _DEFAULT_MAX_DEPTH,
         max_key_bytes: int = 1024,
         max_number_bytes: int = 128,
@@ -232,15 +256,23 @@ class JsonSelectiveExtractor:
         ``scalar_consistency_paths`` tracks whether every occurrence of a
         selected scalar path has the expected kind and the same value.
         """
-        self.scalar_fields = dict(scalar_fields) if scalar_fields is not None else {}
-        self.array_count_paths = set(array_count_paths) if array_count_paths is not None else set()
-        self.wildcard_array_count_paths = (
+        self.scalar_fields: dict[Path, ScalarField] = {}
+        if scalar_fields is not None:
+            for path, field_config in scalar_fields.items():
+                self.scalar_fields[path] = field_config
+        self.array_count_paths: set[Path] = (
+            set(array_count_paths) if array_count_paths is not None else set()
+        )
+        self.wildcard_array_count_paths: set[WildcardPath] = (
             set(wildcard_array_count_paths) if wildcard_array_count_paths is not None else set()
         )
-        self.object_presence_paths = (
+        self.object_presence_paths: set[Path] = (
             set(object_presence_paths) if object_presence_paths is not None else set()
         )
-        self._scalar_consistency_paths = (
+        self.value_presence_paths: set[Path] = (
+            set(value_presence_paths) if value_presence_paths is not None else set()
+        )
+        self._scalar_consistency_paths: set[Path] = (
             set(scalar_consistency_paths) if scalar_consistency_paths is not None else set()
         )
         self.max_depth = max_depth
@@ -253,6 +285,7 @@ class JsonSelectiveExtractor:
             self.array_count_paths,
             self.wildcard_array_count_paths,
             self.object_presence_paths,
+            self.value_presence_paths,
             self._scalar_consistency_paths,
             max_depth=self.max_depth,
             max_key_bytes=self.max_key_bytes,
@@ -265,6 +298,7 @@ class JsonSelectiveExtractor:
             | self.array_count_paths
             | self.wildcard_array_count_paths
             | self.object_presence_paths
+            | self.value_presence_paths
         )
         self._exact_key_collection_paths = {
             path for path in key_collection_paths if "*" not in path
@@ -273,13 +307,17 @@ class JsonSelectiveExtractor:
             self._exact_key_collection_paths
         )
         self._clearable_exact_observation_paths = _build_observation_clear_paths(
-            set(self.scalar_fields) | self.array_count_paths | self.object_presence_paths
+            set(self.scalar_fields)
+            | self.array_count_paths
+            | self.object_presence_paths
+            | self.value_presence_paths
         )
 
         self.values: dict[Path, object] = {}
         self.array_counts: dict[Path, int] = {}
         self.wildcard_array_counts: dict[WildcardPath, dict[str, int]] = {}
         self.object_present: set[Path] = set()
+        self.value_present: set[Path] = set()
         self._scalar_consistency: dict[Path, _ScalarConsistency] = {}
 
         self._stack: list[_Frame] = []
@@ -389,6 +427,7 @@ class JsonSelectiveExtractor:
             if complete
             else {},
             object_present=set(self.object_present) if complete else set(),
+            value_present=set(self.value_present) if complete else set(),
             error=self._error,
         )
 
@@ -478,8 +517,10 @@ class JsonSelectiveExtractor:
             if not _is_json_value_start(b):
                 self._error = "expected json value"
                 return i + 1
+            is_first_element = frame.state == "value_or_end"
             self._count_array_element(frame)
-            return self._start_value((*frame.path, _ARRAY_ELEMENT), chunk, i, from_array=True)
+            element_path = FIRST_ARRAY_ELEMENT if is_first_element else _OTHER_ARRAY_ELEMENT
+            return self._start_value((*frame.path, element_path), chunk, i, from_array=True)
 
         if frame.state == "comma_or_end":
             if b == ord(","):
@@ -494,6 +535,8 @@ class JsonSelectiveExtractor:
         return i + 1
 
     def _start_value(self, path: Path, chunk: bytes, i: int, *, from_array: bool = False) -> int:
+        if path in self.value_presence_paths:
+            self.value_present.add(path)
         if path in self._scalar_consistency_paths:
             consistency = self._scalar_consistency.setdefault(path, _ScalarConsistency())
             consistency.occurrences += 1
@@ -582,6 +625,8 @@ class JsonSelectiveExtractor:
                 continue
             wildcard_index = pattern.index("*")
             key = path[wildcard_index]
+            if not isinstance(key, str):
+                continue
             counts = self.wildcard_array_counts.setdefault(pattern, {})
             if key not in counts and len(counts) >= self.max_wildcard_keys:
                 self._error = "max wildcard keys exceeded"
@@ -606,6 +651,8 @@ class JsonSelectiveExtractor:
                 del self.array_counts[observed_path]
             for observed_path in _find_paths_with_prefix(self.object_present, path) or ():
                 self.object_present.remove(observed_path)
+            for observed_path in _find_paths_with_prefix(self.value_present, path) or ():
+                self.value_present.remove(observed_path)
 
         if can_clear_wildcard:
             for pattern, counts in list(self.wildcard_array_counts.items()):
@@ -632,7 +679,9 @@ class JsonSelectiveExtractor:
         if len(path) <= wildcard_index:
             counts.clear()
             return
-        counts.pop(path[wildcard_index], None)
+        key = path[wildcard_index]
+        if isinstance(key, str):
+            counts.pop(key, None)
 
     def _count_array_element(self, frame: _Frame) -> None:
         if frame.count_path is not None:
@@ -1049,6 +1098,7 @@ def _validate_extractor_config(
     array_count_paths: set[Path],
     wildcard_array_count_paths: set[WildcardPath],
     object_presence_paths: set[Path],
+    value_presence_paths: set[Path],
     scalar_consistency_paths: set[Path],
     *,
     max_depth: int,
@@ -1074,12 +1124,13 @@ def _validate_extractor_config(
     _validate_exact_paths("scalar field paths", set(scalar_fields))
     _validate_exact_paths("array count paths", array_count_paths)
     _validate_exact_paths("object presence paths", object_presence_paths)
+    _validate_exact_paths("value presence paths", value_presence_paths)
     _validate_exact_paths("scalar consistency paths", scalar_consistency_paths)
     if not scalar_consistency_paths <= set(scalar_fields):
         raise ValueError("scalar consistency paths must reference scalar fields")
 
     for path in wildcard_array_count_paths:
-        _validate_path("wildcard array count paths", path)
+        _validate_wildcard_path(path)
         if path.count("*") != 1:
             raise ValueError("wildcard array count paths must contain exactly one '*'")
 
@@ -1092,8 +1143,15 @@ def _validate_exact_paths(name: str, paths: set[Path]) -> None:
 
 
 def _validate_path(name: str, path: Path) -> None:
+    if not isinstance(path, tuple) or any(
+        not isinstance(segment, str) and segment is not FIRST_ARRAY_ELEMENT for segment in path
+    ):
+        raise TypeError(f"{name} must be tuple[str | FIRST_ARRAY_ELEMENT, ...]")
+
+
+def _validate_wildcard_path(path: WildcardPath) -> None:
     if not isinstance(path, tuple) or any(not isinstance(segment, str) for segment in path):
-        raise TypeError(f"{name} must be tuple[str, ...]")
+        raise TypeError("wildcard array count paths must be tuple[str, ...]")
 
 
 def _is_utf8_continuation(b: int) -> bool:

--- a/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
+++ b/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
@@ -1,0 +1,256 @@
+"""OpenAI-compatible Chat Completions usage parsing primitives."""
+
+from collections.abc import Callable
+
+from mitmproxy import http
+
+import body_decoding
+from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
+
+from .json_selective import (
+    FIRST_ARRAY_ELEMENT,
+    JsonExtractionResult,
+    JsonSelectiveExtractor,
+    Path,
+    ScalarField,
+)
+from .model_tokens import (
+    MODEL_USAGE_CATEGORIES,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION,
+    MODEL_USAGE_CATEGORY_CACHE_READ,
+    MODEL_USAGE_CATEGORY_INPUT,
+    MODEL_USAGE_CATEGORY_OUTPUT,
+)
+from .openai_tokens import is_usage_quantity, partition_input_tokens
+from .sse import SseUsageScanner
+
+_CHAT_COMPLETIONS_MAX_WORK_UNITS = 65_536
+_DONE_SENTINEL = b"[DONE]"
+_DONE_PREFIX_MAX_BYTES = 16
+_SseUsageParseErrorCallback = Callable[[str, str], None]
+
+_TOP_LEVEL_USAGE_PATH = ("usage",)
+_FIRST_CHOICE_USAGE_PATH = ("choices", FIRST_ARRAY_ELEMENT, "usage")
+_USAGE_PATHS = (_TOP_LEVEL_USAGE_PATH, _FIRST_CHOICE_USAGE_PATH)
+_CACHED_TOKENS_SUFFIX = ("prompt_tokens_details", "cached_tokens")
+
+_CHAT_COMPLETIONS_SCALAR_FIELDS = {
+    ("id",): ScalarField("string", max_bytes=1024),
+    ("model",): ScalarField("string", max_bytes=1024),
+    **{
+        (*prefix, field): ScalarField("int", max_bytes=64)
+        for prefix in _USAGE_PATHS
+        for field in (
+            "prompt_tokens",
+            "completion_tokens",
+            "prompt_cache_hit_tokens",
+        )
+    },
+    **{
+        (*prefix, "prompt_tokens_details", field): ScalarField("int", max_bytes=64)
+        for prefix in _USAGE_PATHS
+        for field in ("cached_tokens", "cache_write_tokens")
+    },
+}
+_USAGE_VALUE_PRESENCE_PATHS = {
+    *_USAGE_PATHS,
+    *{(*prefix, *_CACHED_TOKENS_SUFFIX) for prefix in _USAGE_PATHS},
+}
+
+
+def _new_extractor() -> JsonSelectiveExtractor:
+    return JsonSelectiveExtractor(
+        scalar_fields=_CHAT_COMPLETIONS_SCALAR_FIELDS,
+        object_presence_paths=set(_USAGE_PATHS),
+        value_presence_paths=_USAGE_VALUE_PRESENCE_PATHS,
+        max_work_units=_CHAT_COMPLETIONS_MAX_WORK_UNITS,
+    )
+
+
+def _selected_usage_path(result: JsonExtractionResult) -> Path | None:
+    if _TOP_LEVEL_USAGE_PATH in result.value_present:
+        return _TOP_LEVEL_USAGE_PATH
+    if _FIRST_CHOICE_USAGE_PATH in result.value_present:
+        return _FIRST_CHOICE_USAGE_PATH
+    return None
+
+
+def _store_quantity(target: dict, category: str, value: object) -> None:
+    if is_usage_quantity(value):
+        target[category] = value
+
+
+def _usage_snapshot(result: JsonExtractionResult) -> dict | None:
+    usage_path = _selected_usage_path(result)
+    if usage_path is None:
+        return None
+    if usage_path not in result.object_present:
+        return {}
+
+    cached_tokens_path = (*usage_path, *_CACHED_TOKENS_SUFFIX)
+    cached_tokens = (
+        result.values.get(cached_tokens_path)
+        if cached_tokens_path in result.value_present
+        else result.values.get((*usage_path, "prompt_cache_hit_tokens"))
+    )
+    input_tokens, cache_read_tokens, cache_creation_tokens = partition_input_tokens(
+        result.values.get((*usage_path, "prompt_tokens")),
+        cached_tokens,
+        result.values.get((*usage_path, "prompt_tokens_details", "cache_write_tokens")),
+    )
+
+    usage: dict = {}
+    _store_quantity(usage, MODEL_USAGE_CATEGORY_INPUT, input_tokens)
+    _store_quantity(
+        usage,
+        MODEL_USAGE_CATEGORY_OUTPUT,
+        result.values.get((*usage_path, "completion_tokens")),
+    )
+    _store_quantity(usage, MODEL_USAGE_CATEGORY_CACHE_READ, cache_read_tokens)
+    _store_quantity(
+        usage,
+        MODEL_USAGE_CATEGORY_CACHE_CREATION,
+        cache_creation_tokens,
+    )
+
+    if not any(category in usage for category in MODEL_USAGE_CATEGORIES):
+        return {}
+
+    model = result.values.get(("model",))
+    if isinstance(model, str) and model:
+        usage["model"] = model
+    message_id = result.values.get(("id",))
+    if isinstance(message_id, str) and message_id:
+        usage["message_id"] = message_id
+    return usage
+
+
+class _OpenAIChatCompletionsSseUsageHandler:
+    def __init__(
+        self,
+        usage: dict,
+        *,
+        on_parse_error: _SseUsageParseErrorCallback | None = None,
+    ) -> None:
+        self._usage = usage
+        self._on_parse_error = on_parse_error
+        self._extractor: JsonSelectiveExtractor | None = None
+        self._data_prefix = bytearray()
+        self._data_prefix_complete = True
+
+    def should_capture_event(self, event_name: str | None) -> bool:
+        """Capture named and eventless compatible frames."""
+        return True
+
+    def on_event_start(self, event_name: str | None) -> None:
+        self._extractor = _new_extractor()
+        self._data_prefix.clear()
+        self._data_prefix_complete = True
+
+    def on_data(self, chunk: bytes) -> None:
+        extractor = self._extractor
+        if extractor is None:
+            return
+        extractor.feed(chunk)
+
+        remaining = max(_DONE_PREFIX_MAX_BYTES - len(self._data_prefix), 0)
+        self._data_prefix.extend(chunk[:remaining])
+        if len(chunk) > remaining:
+            self._data_prefix_complete = False
+
+    def on_data_separator(self) -> None:
+        self.on_data(b"\n")
+
+    def on_event_end(self, event_name: str | None) -> None:
+        extractor = self._extractor
+        data_prefix = bytes(self._data_prefix)
+        data_prefix_complete = self._data_prefix_complete
+        self._extractor = None
+        self._data_prefix.clear()
+        self._data_prefix_complete = True
+        if extractor is None:
+            return
+
+        result = extractor.finish()
+        if not result.complete:
+            if data_prefix_complete and data_prefix.strip() == _DONE_SENTINEL:
+                return
+            self._usage.clear()
+            if result.error is not None and self._on_parse_error is not None:
+                self._on_parse_error(event_name or "eventless", result.error)
+            return
+
+        snapshot = _usage_snapshot(result)
+        if snapshot is None:
+            return
+        self._usage.clear()
+        self._usage.update(snapshot)
+
+    def on_event_discard(self, event_name: str | None) -> None:
+        self._extractor = None
+        self._data_prefix.clear()
+        self._data_prefix_complete = True
+
+
+def create_openai_chat_completions_sse_usage_extractor(
+    on_parse_error: _SseUsageParseErrorCallback | None = None,
+) -> tuple[SseUsageScanner, dict]:
+    """Create an incremental usage parser for Chat Completions SSE bytes."""
+    usage: dict = {}
+    parser = SseUsageScanner(
+        _OpenAIChatCompletionsSseUsageHandler(
+            usage,
+            on_parse_error=on_parse_error,
+        ),
+        capture_data_without_event=True,
+    )
+    return parser, usage
+
+
+class OpenAIChatCompletionsJsonUsageExtractor:
+    """Incrementally extract usage from a Chat Completions JSON response."""
+
+    def __init__(self) -> None:
+        self._extractor = _new_extractor()
+
+    def feed(self, chunk: bytes) -> None:
+        self._extractor.feed(chunk)
+
+    def accepts_more_input(self) -> bool:
+        return self._extractor.accepts_more_input()
+
+    def finish(self) -> tuple[dict | None, str | None]:
+        result = self._extractor.finish()
+        if not result.complete:
+            return None, result.error
+        usage = _usage_snapshot(result)
+        if usage is None or not any(category in usage for category in MODEL_USAGE_CATEGORIES):
+            return None, None
+        return usage, None
+
+
+def create_openai_chat_completions_json_usage_extractor() -> (
+    OpenAIChatCompletionsJsonUsageExtractor
+):
+    """Create an incremental parser for a Chat Completions JSON response."""
+    return OpenAIChatCompletionsJsonUsageExtractor()
+
+
+def extract_openai_chat_completions_usage_with_error_from_json(
+    body: bytes,
+    headers: http.Headers | None,
+) -> tuple[dict | None, str | None]:
+    """Extract usage from a complete, optionally encoded Chat Completions body."""
+    if headers:
+        body, decompress_error = body_decoding.decompress_json_usage_body(
+            body,
+            headers,
+            max_output=LARGE_RESPONSE_DECOMPRESS_LIMIT,
+        )
+        if decompress_error:
+            return None, decompress_error
+    if not body:
+        return None, None
+    extractor = create_openai_chat_completions_json_usage_extractor()
+    extractor.feed(body)
+    return extractor.finish()

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -23,7 +23,7 @@ model-provider usage billing:
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Literal, TypeGuard
+from typing import Literal
 
 from mitmproxy import http
 
@@ -43,6 +43,8 @@ from .model_tokens import (
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
 )
+from .openai_tokens import is_usage_quantity as _is_usage_quantity
+from .openai_tokens import partition_input_tokens as _partition_input_tokens
 from .sse import SseUsageScanner
 
 # Terminal Responses events whose Response object may carry usage. WebSocket
@@ -246,10 +248,6 @@ def _is_known_non_usage_event(value: object) -> bool:
     return isinstance(value, str) and value in _RESPONSES_KNOWN_NON_USAGE_EVENTS
 
 
-def _is_usage_quantity(value: object) -> TypeGuard[int]:
-    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
-
-
 def _store_quantity(target: dict, category: str, value: object) -> None:
     """Store usage quantities using positive-wins, zero-does-not-clobber semantics.
 
@@ -271,31 +269,6 @@ def _has_positive_usage_quantity(values: dict) -> bool:
 
 def _has_usage_quantity(values: dict) -> bool:
     return any(_is_usage_quantity(values.get(category)) for category in MODEL_USAGE_CATEGORIES)
-
-
-def _partition_input_tokens(
-    input_tokens: object,
-    cached_tokens: object,
-    cache_write_tokens: object,
-) -> tuple[int | None, int | None, int | None]:
-    # OpenAI reports cache reads and writes as details of ``input_tokens``. The
-    # usage-event ledger prices all three categories independently, so partition
-    # the upstream total before reporting to avoid charging any token twice.
-    if not _is_usage_quantity(input_tokens):
-        return None, None, None
-
-    remaining_input_tokens = input_tokens
-    cached_input_tokens = None
-    if _is_usage_quantity(cached_tokens):
-        cached_input_tokens = min(cached_tokens, remaining_input_tokens)
-        remaining_input_tokens -= cached_input_tokens
-
-    cache_creation_tokens = None
-    if _is_usage_quantity(cache_write_tokens):
-        cache_creation_tokens = min(cache_write_tokens, remaining_input_tokens)
-        remaining_input_tokens -= cache_creation_tokens
-
-    return remaining_input_tokens, cached_input_tokens, cache_creation_tokens
 
 
 def _normalized_input_snapshot(values: dict) -> tuple[int, int | None, int | None] | None:

--- a/crates/runner/mitm-addon/src/usage/openai_tokens.py
+++ b/crates/runner/mitm-addon/src/usage/openai_tokens.py
@@ -1,0 +1,31 @@
+"""Shared OpenAI-compatible token normalization."""
+
+from typing import TypeGuard
+
+
+def is_usage_quantity(value: object) -> TypeGuard[int]:
+    """Return whether a provider value is a nonnegative integer token count."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def partition_input_tokens(
+    input_tokens: object,
+    cached_tokens: object,
+    cache_write_tokens: object,
+) -> tuple[int | None, int | None, int | None]:
+    """Partition an OpenAI-compatible total input count into billing categories."""
+    if not is_usage_quantity(input_tokens):
+        return None, None, None
+
+    remaining_input_tokens = input_tokens
+    cached_input_tokens = None
+    if is_usage_quantity(cached_tokens):
+        cached_input_tokens = min(cached_tokens, remaining_input_tokens)
+        remaining_input_tokens -= cached_input_tokens
+
+    cache_creation_tokens = None
+    if is_usage_quantity(cache_write_tokens):
+        cache_creation_tokens = min(cache_write_tokens, remaining_input_tokens)
+        remaining_input_tokens -= cache_creation_tokens
+
+    return remaining_input_tokens, cached_input_tokens, cache_creation_tokens

--- a/crates/runner/mitm-addon/tests/test_json_selective_config.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_config.py
@@ -88,6 +88,7 @@ def test_rejects_non_integer_extractor_bounds(bound, value):
         {"scalar_fields": {("data", "*"): ScalarField("string")}},
         {"array_count_paths": {("data", "*")}},
         {"object_presence_paths": {("data", "*")}},
+        {"value_presence_paths": {("data", "*")}},
     ],
 )
 def test_rejects_wildcards_in_exact_observation_paths(kwargs):
@@ -102,10 +103,11 @@ def test_rejects_wildcards_in_exact_observation_paths(kwargs):
         {"array_count_paths": {"data"}},
         {"wildcard_array_count_paths": {"includes"}},
         {"object_presence_paths": {"data"}},
+        {"value_presence_paths": {"data"}},
     ],
 )
 def test_rejects_non_tuple_observation_paths(kwargs):
-    with pytest.raises(TypeError, match=r"tuple\[str, \.\.\.\]"):
+    with pytest.raises(TypeError, match="must be tuple"):
         JsonSelectiveExtractor(**kwargs)
 
 
@@ -116,10 +118,11 @@ def test_rejects_non_tuple_observation_paths(kwargs):
         {"array_count_paths": {(1,)}},
         {"wildcard_array_count_paths": {("includes", 1)}},
         {"object_presence_paths": {(1,)}},
+        {"value_presence_paths": {(1,)}},
     ],
 )
 def test_rejects_non_string_path_segments(kwargs):
-    with pytest.raises(TypeError, match=r"tuple\[str, \.\.\.\]"):
+    with pytest.raises(TypeError, match="must be tuple"):
         JsonSelectiveExtractor(**kwargs)
 
 
@@ -128,17 +131,20 @@ def test_constructor_copies_observation_config():
     array_count_paths = set()
     wildcard_array_count_paths = {("includes", "*")}
     object_presence_paths = set()
+    value_presence_paths = set()
 
     extractor = JsonSelectiveExtractor(
         scalar_fields=scalar_fields,
         array_count_paths=array_count_paths,
         wildcard_array_count_paths=wildcard_array_count_paths,
         object_presence_paths=object_presence_paths,
+        value_presence_paths=value_presence_paths,
     )
     scalar_fields[("model",)] = ScalarField("string")
     array_count_paths.add(("data",))
     wildcard_array_count_paths.add(("extras", "*"))
     object_presence_paths.add(("data",))
+    value_presence_paths.add(("errors",))
 
     extractor.feed(b'{"model":"claude","data":[],"includes":{"users":[]},"extras":{"items":[]}}')
     result = extractor.finish()
@@ -148,6 +154,7 @@ def test_constructor_copies_observation_config():
     assert result.array_counts == {}
     assert result.wildcard_array_counts == {("includes", "*"): {"users": 0}}
     assert result.object_present == set()
+    assert result.value_present == set()
 
 
 def test_rejects_wildcard_pattern_without_exactly_one_wildcard():

--- a/crates/runner/mitm-addon/tests/test_json_selective_observations.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_observations.py
@@ -4,8 +4,10 @@ import json
 import sys
 from types import FrameType
 
+import pytest
+
 from usage import json_selective
-from usage.json_selective import JsonSelectiveExtractor, ScalarField
+from usage.json_selective import FIRST_ARRAY_ELEMENT, JsonSelectiveExtractor, ScalarField
 
 _COMMON_SCALAR_FIELDS = {
     ("id",): ScalarField("string"),
@@ -287,6 +289,50 @@ def test_array_element_object_fields_do_not_match_object_paths():
     assert result.wildcard_array_counts == {}
 
 
+def test_selects_only_first_array_element_across_chunks():
+    prompt_tokens_path = (
+        "choices",
+        FIRST_ARRAY_ELEMENT,
+        "usage",
+        "prompt_tokens",
+    )
+    usage_path = ("choices", FIRST_ARRAY_ELEMENT, "usage")
+    payload = b'{"choices":[{"usage":{"prompt_tokens":7}},{"usage":{"prompt_tokens":99}}]}'
+
+    for chunk_size in (1, 2, 5, len(payload)):
+        extractor = JsonSelectiveExtractor(
+            scalar_fields={prompt_tokens_path: ScalarField("int")},
+            object_presence_paths={usage_path},
+            value_presence_paths={usage_path},
+        )
+        for offset in range(0, len(payload), chunk_size):
+            extractor.feed(payload[offset : offset + chunk_size])
+        result = extractor.finish()
+
+        assert result.complete is True
+        assert result.values == {prompt_tokens_path: 7}
+        assert result.object_present == {usage_path}
+        assert result.value_present == {usage_path}
+
+
+def test_first_array_element_marker_cannot_match_an_object_key():
+    prompt_tokens_path = (
+        "choices",
+        FIRST_ARRAY_ELEMENT,
+        "usage",
+        "prompt_tokens",
+    )
+    extractor = JsonSelectiveExtractor(scalar_fields={prompt_tokens_path: ScalarField("int")})
+
+    extractor.feed(
+        b'{"choices":{"\\u0000__vm0_json_array_element__":{"usage":{"prompt_tokens":99}}}}'
+    )
+    result = extractor.finish()
+
+    assert result.complete is True
+    assert result.values == {}
+
+
 def test_array_value_fields_do_not_match_object_paths():
     extractor = JsonSelectiveExtractor(
         scalar_fields={
@@ -390,6 +436,32 @@ def test_records_object_presence():
 
     assert result.complete is True
     assert result.object_present == {("data",)}
+
+
+@pytest.mark.parametrize(
+    "value",
+    [b"null", b"false", b"0", b'"text"', b"[]", b"{}"],
+)
+def test_records_any_selected_value_presence(value):
+    extractor = JsonSelectiveExtractor(value_presence_paths={("usage",)})
+
+    extractor.feed(b'{"usage":' + value + b"}")
+    result = extractor.finish()
+
+    assert result.complete is True
+    assert result.value_present == {("usage",)}
+
+
+def test_duplicate_parent_clears_descendant_value_presence():
+    extractor = JsonSelectiveExtractor(
+        value_presence_paths={("usage",), ("usage", "cached_tokens")}
+    )
+
+    extractor.feed(b'{"usage":{"cached_tokens":7},"usage":null}')
+    result = extractor.finish()
+
+    assert result.complete is True
+    assert result.value_present == {("usage",)}
 
 
 def test_rejects_excessive_depth():

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -1,0 +1,346 @@
+"""Integration coverage for OpenAI-compatible Chat Completions usage."""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from mitmproxy import http
+from mitmproxy.test import tutils
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import usage
+from tests.flow_helpers import header_map, response_stream
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.model_provider_flow_helpers import make_model_provider_flow
+from tests.stream_buffer_helpers import set_response_stream_buffer
+from tests.usage_helpers import compact_observation_quantities
+
+
+def _chat_completions_flow(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    *,
+    content_type: str,
+    billable: bool = True,
+    cli_agent_type: str = "codex",
+    original_url: str = "https://api.openai.com/v1/chat/completions",
+) -> http.HTTPFlow:
+    flow = make_model_provider_flow(
+        real_flow,
+        tmp_path,
+        host="api.openai.com",
+        path="/v1/chat/completions",
+        method="POST",
+        original_url=original_url,
+        firewall_name="model-provider:openai-api-key",
+        firewall_billable=billable,
+        cli_agent_type=cli_agent_type,
+        model_usage_provider="gpt-5.5",
+    )
+    flow.response = tutils.tresp(
+        status_code=200,
+        headers=header_map({"content-type": content_type}),
+    )
+    return flow
+
+
+def _chat_payload(*, usage_payload: dict[str, object] | None = None) -> bytes:
+    payload: dict[str, object] = {
+        "id": "chatcmpl_1",
+        "model": "gpt-5.5",
+        "choices": [{"index": 0, "finish_reason": "stop"}],
+    }
+    if usage_payload is not None:
+        payload["usage"] = usage_payload
+    return json.dumps(payload, separators=(",", ":")).encode()
+
+
+def _run_response(flow: http.HTTPFlow, usage_webhook_api):
+    with usage_webhook_api() as webhook:
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+    return webhook
+
+
+class TestOpenAIChatCompletionsUsage:
+    @pytest.fixture(autouse=True)
+    def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
+        self._usage_webhook_api = usage_webhook_api
+
+    def test_managed_sse_uses_top_level_usage_and_partitions_cache(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+            cli_agent_type="claude-code",
+            original_url="https://api.openai.com/v1/chat/completions/?trace=1",
+        )
+        payload = {
+            "id": "chatcmpl_1",
+            "model": "gpt-5.5",
+            "choices": [
+                {
+                    "usage": {
+                        "prompt_tokens": 999,
+                        "completion_tokens": 999,
+                    }
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 20,
+                "prompt_cache_hit_tokens": 40,
+                "prompt_tokens_details": {
+                    "cached_tokens": 10,
+                    "cache_write_tokens": 15,
+                },
+            },
+        }
+        encoded = json.dumps(payload, separators=(",", ":")).encode()
+
+        mitm_addon.responseheaders(flow)
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        callback = response_stream(flow)
+        callback(b"data: " + encoded[:37])
+        callback(encoded[37:] + b"\n\ndata: [DONE]\n\n")
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert len(events) == len(by_category)
+        assert by_category == {
+            "tokens.input": 25,
+            "tokens.output": 20,
+            "tokens.cache_read": 10,
+            "tokens.cache_creation": 15,
+        }
+        assert compact_observation_quantities(webhook.model_usage_observation_events()) == {
+            "tokens.input": 25,
+            "tokens.output": 20,
+            "tokens.cache_read": 10,
+            "tokens.cache_creation": 15,
+        }
+
+    def test_sse_uses_first_choice_and_legacy_cache_fallback(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+        )
+        payload = {
+            "id": "chatcmpl_2",
+            "model": "gpt-5.5",
+            "choices": [
+                {
+                    "usage": {
+                        "prompt_tokens": 70,
+                        "completion_tokens": 9,
+                        "prompt_cache_hit_tokens": 20,
+                    }
+                },
+                {
+                    "usage": {
+                        "prompt_tokens": 900,
+                        "completion_tokens": 900,
+                    }
+                },
+            ],
+        }
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            b"data: "
+            + json.dumps(payload, separators=(",", ":")).encode()
+            + b"\n\ndata: [DONE]\n\n"
+        )
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 50,
+            "tokens.output": 9,
+            "tokens.cache_read": 20,
+        }
+
+    @pytest.mark.parametrize(
+        "top_level_usage",
+        [
+            {},
+            None,
+            0,
+            {"prompt_tokens": 0, "completion_tokens": 0},
+        ],
+        ids=("empty", "null", "non-object", "zero"),
+    )
+    def test_present_top_level_usage_blocks_positive_choice_fallback(
+        self,
+        tmp_path,
+        real_flow,
+        top_level_usage,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+        )
+        payload = {
+            "id": "chatcmpl_3",
+            "model": "gpt-5.5",
+            "usage": top_level_usage,
+            "choices": [
+                {
+                    "usage": {
+                        "prompt_tokens": 100,
+                        "completion_tokens": 50,
+                    }
+                }
+            ],
+        }
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            b"data: "
+            + json.dumps(payload, separators=(",", ":")).encode()
+            + b"\n\ndata: [DONE]\n\n"
+        )
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+
+    def test_sse_without_usage_stays_quiet(self, tmp_path, real_flow):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(b"data: " + _chat_payload() + b"\n\ndata: [DONE]\n\n")
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+
+    def test_malformed_sse_fails_closed_with_chat_protocol_diagnostic(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(b'data: {"id":"chatcmpl_bad","usage":{"prompt_tokens":30}\n\n')
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+        warnings = [
+            entry
+            for entry in read_jsonl_entries_after_flush(
+                Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+            )
+            if entry.get("message") == "Model provider SSE usage extraction failed"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["usage_protocol"] == "openai_chat_completions_sse"
+        assert warnings[0]["event"] == "eventless"
+        assert warnings[0]["error"] == "incomplete json"
+
+    @pytest.mark.parametrize("nested_usage", [False, True], ids=("top-level", "choice"))
+    def test_non_streaming_json_reports_usage_without_buffering(
+        self,
+        tmp_path,
+        real_flow,
+        nested_usage,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="application/json",
+        )
+        usage_payload: dict[str, object] = {
+            "prompt_tokens": 30,
+            "completion_tokens": 5,
+        }
+        payload = _chat_payload(usage_payload=None if nested_usage else usage_payload)
+        if nested_usage:
+            decoded = json.loads(payload)
+            decoded["choices"][0]["usage"] = usage_payload
+            payload = json.dumps(decoded, separators=(",", ":")).encode()
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        midpoint = len(payload) // 2
+        callback(payload[:midpoint])
+        callback(payload[midpoint:])
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 30,
+            "tokens.output": 5,
+        }
+
+    def test_non_billable_sse_reports_observation_without_usage_event(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+            billable=False,
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            b"data: "
+            + _chat_payload(usage_payload={"prompt_tokens": 30, "completion_tokens": 5})
+            + b"\n\n"
+        )
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert webhook.usage_events() == []
+        assert compact_observation_quantities(webhook.model_usage_observation_events()) == {
+            "tokens.input": 30,
+            "tokens.output": 5,
+        }
+
+    def test_buffered_json_fallback_uses_chat_completions_parser(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="application/json",
+        )
+        body = _chat_payload(usage_payload={"prompt_tokens": 30, "completion_tokens": 5})
+        set_response_stream_buffer(flow, body)
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 30,
+            "tokens.output": 5,
+        }


### PR DESCRIPTION
## Summary

- classify OpenAI Chat Completions traffic from the normalized request path instead of the CLI framework
- extract bounded usage from SSE and JSON responses, including compatible top-level and first-choice usage shapes
- normalize cached-input accounting while preserving the existing trusted addon webhook boundary

## Testing

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/pi-edge-loop.test.ts --maxWorkers=1 --silent=passed-only`

## Explicit exclusions

- no API schema, database, pricing, or guest-event billing changes
- no changes to Anthropic, OpenAI Responses WebSocket, or existing trusted webhook ownership

Closes #17899
