### PR TITLE
test(python): cover malformed network log fallback

### DIFF
--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -117,6 +117,52 @@ async def test_authority_validation_deny_response_logs_network_target(
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
 
+async def test_authority_validation_deny_logs_malformed_fallback_target(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    fallback_url = "https://target.example:not-a-port/repos"
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="target.example:not-a-port",
+        sni="",
+        path="/repos",
+        request_headers=headers(("Host", "request.example")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "missing_sni"
+    auth_fetch.assert_not_called()
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "missing_sni"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == fallback_url
+    assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET] == {
+        "url": fallback_url,
+        "host": "request.example",
+        "port": 443,
+    }
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert entry["action"] == "DENY"
+    assert entry["firewall_error"] == "missing_sni"
+    assert entry["host"] == "request.example"
+    assert entry["port"] == 443
+    assert entry["url"] == fallback_url
+    assert entry["status"] == 403
+
+
 async def test_browser_user_agent_marker_survives_authority_validation_block(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):


### PR DESCRIPTION
## Summary

- exercise the malformed network-log target fallback through the real authority-validation request hook
- verify a missing-SNI denial still returns 403 and falls back host and port as one request-derived pair
- verify the response hook persists the unchanged malformed URL and denial target to the network log

## Scope

Test-only change. No production source, schema, API, protocol, dependency, deployment, or compatibility behavior changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_authority_validation.py` (21 passed)
- `uv run --no-sync python -m pytest tests/` (5157 passed)
- mutation checks: re-raising `ValueError` and retaining the parsed host while only falling back the port both fail the new test

Closes #25895
