### PR TITLE
refactor(db): isolate custom connector insert columns

### DIFF
--- a/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
@@ -1,4 +1,5 @@
 import { initContract } from "@vm0/api-contracts/contracts/trpc-contract";
+import { connectorOauthStatesInsertTarget } from "@vm0/db/custom-connector-insert-targets";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { telegramMessages } from "@vm0/db/schema/telegram-message";
 import { command } from "ccstate";
@@ -120,11 +121,11 @@ async function seedConnectorStates(
     offset += FIXTURE_INSERT_BATCH_SIZE
   ) {
     await db
-      .insert(connectorOauthStates)
+      .insert(connectorOauthStatesInsertTarget)
       .values(expiredStates.slice(offset, offset + FIXTURE_INSERT_BATCH_SIZE));
     signal.throwIfAborted();
   }
-  await db.insert(connectorOauthStates).values([
+  await db.insert(connectorOauthStatesInsertTarget).values([
     {
       state: connectorState(body.marker, "equal"),
       connectorSlug: "github",

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -10,7 +10,7 @@ import {
   zeroConnectorsSearchContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import type { PublicConnectorCatalogDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { connectorOauthStatesInsertTarget } from "@vm0/db/custom-connector-insert-targets";
 
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -537,7 +537,7 @@ const startConnectorOauthInner$ = command(
     }
 
     const writeDb = set(writeDb$);
-    await writeDb.insert(connectorOauthStates).values({
+    await writeDb.insert(connectorOauthStatesInsertTarget).values({
       state: prepared.state,
       connectorSlug: resolved.connectorSlug,
       authMethod: resolved.authMethodId,
@@ -650,7 +650,7 @@ const startConnectorOpenIdInner$ = command(
     signal.throwIfAborted();
 
     const writeDb = set(writeDb$);
-    await writeDb.insert(connectorOauthStates).values({
+    await writeDb.insert(connectorOauthStatesInsertTarget).values({
       state: prepared.state,
       connectorSlug: resolved.connectorSlug,
       authMethod: resolved.authMethodId,

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -11,6 +11,7 @@ import {
   isOAuthProviderHttpError,
   OAuthProviderHttpError,
 } from "@vm0/connectors/auth-providers/oauth/error";
+import { connectorOauthStatesInsertTarget } from "@vm0/db/custom-connector-insert-targets";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
@@ -531,7 +532,7 @@ export const startCustomConnectorOAuth2$ = command(
         : {}),
     };
     await set(writeDb$)
-      .insert(connectorOauthStates)
+      .insert(connectorOauthStatesInsertTarget)
       .values({
         state,
         customConnectorId: connector.id,

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
 import { FEISHU_OAUTH_SCOPES } from "@vm0/api-contracts/contracts/zero-feishu-connect";
+import { orgCustomConnectorsInsertTarget } from "@vm0/db/custom-connector-insert-targets";
 import { connectors } from "@vm0/db/schema/connector";
 import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
 import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
@@ -249,7 +250,7 @@ async function createFeishuCustomConnector(
   signal: AbortSignal,
 ): Promise<ReconciledFeishuCustomConnector> {
   const [connector] = await tx
-    .insert(orgCustomConnectors)
+    .insert(orgCustomConnectorsInsertTarget)
     .values({
       orgId: args.orgId,
       slug,

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -17,9 +17,9 @@ import {
 import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connector-config";
 import type { ConnectorAuthMethodId } from "@vm0/api-contracts/contracts/connector-identity";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
+import { connectorOauthStatesInsertTarget } from "@vm0/db/custom-connector-insert-targets";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { connectors } from "@vm0/db/schema/connector";
-import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { githubInstallations } from "@vm0/db/schema/github-installation";
 import { githubUserLinks } from "@vm0/db/schema/github-user-link";
 
@@ -444,7 +444,7 @@ export async function buildGithubUserConnectAuthorizationUrl(
     }),
   );
 
-  await args.db.insert(connectorOauthStates).values({
+  await args.db.insert(connectorOauthStatesInsertTarget).values({
     state,
     connectorSlug: "github",
     authMethod: args.authMethodId,

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import { userCustomConnectorsInsertTarget } from "@vm0/db/custom-connector-insert-targets";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import {
   orgCustomConnectors,
@@ -823,7 +824,7 @@ async function persistUserCustomConnectorUpdate(
 
   if (args.operation !== "remove" && args.enabledIds.length > 0) {
     await tx
-      .insert(userCustomConnectors)
+      .insert(userCustomConnectorsInsertTarget)
       .values(
         args.enabledIds.map((customConnectorId) => {
           return {

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -22,6 +22,7 @@ import {
   canonicalizeFirewallBaseUrl,
   expandHostWildcardsInBaseUrl,
 } from "@vm0/connectors/firewall-types";
+import { orgCustomConnectorsInsertTarget } from "@vm0/db/custom-connector-insert-targets";
 import { connectors } from "@vm0/db/schema/connector";
 import { feishuOrgConnections } from "@vm0/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
@@ -1400,7 +1401,7 @@ export const createCustomConnector$ = command(
         return prefixConflict;
       }
       const [row] = await tx
-        .insert(orgCustomConnectors)
+        .insert(orgCustomConnectorsInsertTarget)
         .values({
           orgId: args.orgId,
           slug,

--- a/turbo/packages/db/package.json
+++ b/turbo/packages/db/package.json
@@ -16,6 +16,10 @@
       "import": "./src/jsonb-contracts/*.ts",
       "types": "./src/jsonb-contracts/*.ts"
     },
+    "./custom-connector-insert-targets": {
+      "import": "./src/custom-connector-insert-targets.ts",
+      "types": "./src/custom-connector-insert-targets.ts"
+    },
     "./types": {
       "import": "./src/types.ts",
       "types": "./src/types.ts"

--- a/turbo/packages/db/src/custom-connector-insert-targets.ts
+++ b/turbo/packages/db/src/custom-connector-insert-targets.ts
@@ -1,0 +1,100 @@
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  boolean,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+import type {
+  OrgCustomConnectorFields,
+  OrgCustomConnectorHeaderInjections,
+  OrgCustomConnectorPrefixes,
+  OrgCustomConnectorPrefixTemplates,
+  OrgCustomConnectorQueryInjections,
+} from "./jsonb-contracts/org-custom-connector";
+import type { OrgCustomConnectorAuthMode } from "./schema/org-custom-connector";
+
+/**
+ * Temporary insert targets for the #25352 schema contraction.
+ *
+ * Drizzle inserts every column declared by their target, including omitted
+ * columns as DEFAULT. Remove these projections and restore canonical insert
+ * targets in #25352 after this API release is promoted and drained.
+ */
+export const orgCustomConnectorsInsertTarget = pgTable(
+  "org_custom_connectors",
+  {
+    orgId: text("org_id").notNull(),
+    slug: varchar("slug", { length: 64 }).notNull(),
+    displayName: varchar("display_name", { length: 128 }).notNull(),
+    prefixes: jsonb("prefixes").notNull().$type<OrgCustomConnectorPrefixes>(),
+    headerName: varchar("header_name", { length: 128 }).notNull(),
+    headerTemplate: text("header_template").notNull(),
+    prefixTemplates: jsonb("prefix_templates")
+      .notNull()
+      .default(sql`'[]'::jsonb`)
+      .$type<OrgCustomConnectorPrefixTemplates>(),
+    fields: jsonb("fields")
+      .notNull()
+      .default(sql`'[]'::jsonb`)
+      .$type<OrgCustomConnectorFields>(),
+    headerInjections: jsonb("header_injections")
+      .notNull()
+      .default(sql`'[]'::jsonb`)
+      .$type<OrgCustomConnectorHeaderInjections>(),
+    queryInjections: jsonb("query_injections")
+      .notNull()
+      .default(sql`'[]'::jsonb`)
+      .$type<OrgCustomConnectorQueryInjections>(),
+    authMode: varchar("auth_mode", { length: 16 })
+      .$type<OrgCustomConnectorAuthMode>()
+      .notNull()
+      .default("manual"),
+    enabled: boolean("enabled").notNull().default(true),
+    permissionBundleRef: varchar("permission_bundle_ref", { length: 128 }),
+    skillMarkdown: text("skill_markdown"),
+    storageVersion: bigint("storage_version", { mode: "number" })
+      .notNull()
+      .default(1),
+    createdBy: text("created_by").notNull(),
+  },
+);
+
+export const userCustomConnectorsInsertTarget = pgTable(
+  "user_custom_connectors",
+  {
+    orgId: text("org_id").notNull(),
+    userId: text("user_id").notNull(),
+    agentId: uuid("agent_id").notNull(),
+    customConnectorId: uuid("custom_connector_id").notNull(),
+    permissionNames: text("permission_names")
+      .array()
+      .notNull()
+      .default(sql`'{}'::text[]`),
+  },
+);
+
+export const connectorOauthStatesInsertTarget = pgTable(
+  "connector_oauth_states",
+  {
+    state: text("state").notNull(),
+    connectorSlug: varchar("connector_slug", { length: 64 }),
+    customConnectorId: uuid("custom_connector_id"),
+    storageVersion: bigint("storage_version", { mode: "number" }),
+    authMethod: varchar("auth_method", { length: 50 }).notNull(),
+    userId: text("user_id").notNull(),
+    orgId: text("org_id").notNull(),
+    agentId: uuid("agent_id"),
+    authorizeAgent: boolean("authorize_agent").default(false).notNull(),
+    redirectUri: text("redirect_uri").notNull(),
+    authorizationUrl: text("authorization_url"),
+    codeVerifier: text("code_verifier"),
+    oauthContext: text("oauth_context"),
+    expiresAt: timestamp("expires_at").notNull(),
+  },
+);


### PR DESCRIPTION
## Summary

- add temporary typed insert-only targets for the three Custom connector tables that still contain retired revision columns
- route every API insert through the current-column targets while preserving canonical tables for reads, updates, conflict targets, and returning selections
- keep the physical schema unchanged so this API can deploy before the final contraction in #25352

Drizzle's PostgreSQL insert builder enumerates every column declared by its target and emits `DEFAULT` for omitted values. The serving predecessor therefore still named the retired columns after #25351 even though no business logic used them. These targets make the generated insert column lists independent of those columns before migration-first deployment removes them.

The transition module is intentionally outside Drizzle's migration schema and has an explicit #25352 cleanup condition. #25352 will delete it and restore canonical insert targets after this release is promoted and drained.

## Validation

- one-time Drizzle `toSQL()` inspection for all three insert targets; no retired revision column appears
- representative `RETURNING` and bulk upsert/conflict SQL inspection
- `pnpm format`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `pnpm -F @vm0/db test` — 29 tests passed
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @vm0/db --workspace api`
- targeted API integration suite — 7 files, 158 tests passed
- pre-commit full Knip and TypeScript checks
- `git diff --check`

No migration, raw SQL, additional query, fallback, or API contract change is included.

Closes #25952

Parent: #25312

Blocks: #25352
