### PR TITLE
refactor(platform): remove file-url rollout fallback

### DIFF
--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -44,19 +44,9 @@ export function createAttachmentResourceUrl$(
         query: { file_id: fileId },
         fetchOptions: { signal },
       }),
-      [200, 404],
+      [200],
       signal,
     );
-    // A newly promoted app can briefly reach an API build from before this
-    // additive route existed. Surface: old web clients, ~2 days observed
-    // maximum exposure. Falling back to the canonical URL keeps the existing
-    // broken-image placeholder instead of raising one error toast per
-    // attachment; the same branch also covers a genuinely deleted file.
-    // Remove once this API version is outside the production rollback window;
-    // follow-up #25828.
-    if (response.status === 404) {
-      return url;
-    }
     return response.body.url;
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -12,8 +12,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
-import { toast } from "@vm0/ui/components/ui/sonner";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { initializeI18n } from "../../../i18n/index.ts";
@@ -952,46 +951,6 @@ describe("zero attachment chips", () => {
       preview!.compareDocumentPosition(textBubble!) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-  });
-
-  it("falls back to the canonical url when the api predates the file-url route", async () => {
-    const toastError = vi.spyOn(toast, "error");
-    context.mocks.http.get("/api/zero/web/file-url", () => {
-      return HttpResponse.json(
-        { error: { message: "Attachment is unavailable", code: "NOT_FOUND" } },
-        { status: 404 },
-      );
-    });
-    mockChatLifecycle(context, {
-      threadId: THREAD_ID,
-      chatEvents: [
-        {
-          id: "msg-rollout-photo",
-          role: "user",
-          content: "Review this image",
-          fileParts: [
-            {
-              type: "file",
-              fileId: "attachment-photo",
-              filenameSnapshot: "photo.png",
-              contentType: "image/png",
-            },
-          ],
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
-
-    const image = await screen.findByAltText("photo.png");
-    await waitFor(() => {
-      expect(image.getAttribute("src")).toBe(
-        canonicalUserMessageFileUrl("attachment-photo"),
-      );
-    });
-    expect(toastError).not.toHaveBeenCalledWith("Attachment is unavailable");
-    toastError.mockRestore();
   });
 
   it("keeps the user image preview frame stable while the image loads", async () => {


### PR DESCRIPTION
## Summary

- stop treating `404` from `GET /api/zero/web/file-url` as a successful attachment URL resolution
- remove the rollout-only canonical-URL branch, comment, and regression test
- keep the current API contract and route behavior for genuinely missing or non-owned files

## Rollout evidence

- [#25825](https://github.com/vm0-ai/vm0/pull/25825) merged at `2026-08-08T14:44:34Z` as `77bd95468d08df94b68643841055942ccb3c9c45`.
- Release [#25832](https://github.com/vm0-ai/vm0/pull/25832) includes that commit in App `0.711.0` and API `1.407.0`.
- Production run [31265400524](https://github.com/vm0-ai/vm0/actions/runs/31265400524) completed `promote-api-production` at `2026-08-08T15:59:56Z` and `promote-app-production` at `2026-08-08T16:02:09Z`.
- At the final evidence cutoff (`2026-08-09T16:10:14Z`), the API had been live for `24h10m18s` and the App for `24h08m05s`, beyond the 24-hour rollback window.
- Immediately before the commit, the branch was fast-forwarded to current `origin/main`; neither target file changed upstream, and no open PR overlapped either target file.

## Axiom evidence and coverage

Dataset: `vm0-request-log-prod`

Window: `2026-08-08T16:02:09Z` through `2026-08-09T16:10:14Z`

Filter: `path_template == '/api/zero/web/file-url' and x_client_type == 'App'`

- 2,180 App requests were observed across App versions `0.711.0` through `0.714.2`.
- 2,179 returned `200`.
- 1 returned `401`.
- 0 returned `404`; a dedicated `status == 404` query matched zero rows and was not partial.

## Fallbacks removed/retained

Removed:

- `404` from the `accept(...)` success list in `createAttachmentResourceUrl$`
- the rollout comment and `response.status === 404` canonical-URL branch
- the test that exercised an API predating the additive route, plus imports used only by that test

Retained:

- `404` in `zeroWebFilesContract.fileUrl`, because the current API still returns it for a missing or non-owned file
- all attachment URL dispatch and signing behavior outside the temporary rollout branch

## Verification

- `pnpm format` (Prettier `3.8.1`, pinned by the lockfile)
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx` (`42` tests passed)
- after fast-forwarding to current `origin/main`, reran the focused Prettier check, App lint, App type checks, and the targeted test (`42` tests passed)

Closes #25828
