### PR TITLE
fix(runner): publish finalizing sandbox before completion

### DIFF
--- a/crates/runner/src/cmd/start/active_runs.rs
+++ b/crates/runner/src/cmd/start/active_runs.rs
@@ -15,49 +15,70 @@ pub(super) struct ActiveRuns {
 struct ActiveRunEntry {
     reuse_key: Option<String>,
     profile_name: String,
-    phase: watch::Sender<ActiveRunPhase>,
+    reuse_state: watch::Sender<ActiveRunReuseState>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum ActiveRunPhase {
-    Running,
-    Finalized,
+pub(super) enum ActiveRunReuseState {
+    Pending,
+    ExactSandboxPublished,
+    NoExactSandbox,
     Released,
 }
 
-pub(super) struct ActiveRunProof {
-    phase: watch::Receiver<ActiveRunPhase>,
+pub(super) struct ActiveRunReuseProof {
+    reuse_state: watch::Receiver<ActiveRunReuseState>,
 }
 
-impl ActiveRunProof {
-    pub(super) fn phase(&self) -> ActiveRunPhase {
-        *self.phase.borrow()
+impl ActiveRunReuseProof {
+    pub(super) fn state(&self) -> ActiveRunReuseState {
+        *self.reuse_state.borrow()
     }
 
-    pub(super) async fn changed(&mut self) -> ActiveRunPhase {
-        if self.phase.changed().await.is_err() {
-            return ActiveRunPhase::Released;
+    pub(super) async fn changed(&mut self) -> ActiveRunReuseState {
+        if self.reuse_state.changed().await.is_err() {
+            return ActiveRunReuseState::Released;
         }
-        self.phase()
+        self.state()
     }
 }
 
 #[derive(Clone)]
-pub(super) struct ActiveRunFinalizationPublisher {
-    phase: watch::Sender<ActiveRunPhase>,
+pub(super) struct ActiveRunReusePublisher {
+    reuse_state: watch::Sender<ActiveRunReuseState>,
     changes: watch::Sender<u64>,
 }
 
-impl ActiveRunFinalizationPublisher {
-    pub(super) fn mark_finalized(&self) {
-        if self.phase.send_if_modified(|phase| {
-            if *phase != ActiveRunPhase::Running {
+impl ActiveRunReusePublisher {
+    pub(super) fn publish_exact_sandbox(&self) -> bool {
+        self.resolve_pending(ActiveRunReuseState::ExactSandboxPublished)
+    }
+
+    pub(super) fn publish_no_exact_sandbox(&self) -> bool {
+        self.resolve_pending(ActiveRunReuseState::NoExactSandbox)
+    }
+
+    fn resolve_pending(&self, next: ActiveRunReuseState) -> bool {
+        let changed = self.reuse_state.send_if_modified(|state| {
+            if *state != ActiveRunReuseState::Pending {
                 return false;
             }
-            *phase = ActiveRunPhase::Finalized;
+            *state = next;
             true
-        }) {
+        });
+        if changed {
             bump_changes(&self.changes);
+        }
+        changed
+    }
+
+    #[cfg(test)]
+    pub(super) fn detached() -> Self {
+        let (reuse_state, _reuse_state_rx) = watch::channel(ActiveRunReuseState::Pending);
+        let (changes, _changes_rx) = watch::channel(0);
+        Self {
+            reuse_state,
+            changes,
         }
     }
 }
@@ -66,7 +87,7 @@ pub(super) struct ActiveRunGuard {
     active_runs: ActiveRuns,
     run_id: Option<RunId>,
     has_reuse_key: bool,
-    phase: watch::Sender<ActiveRunPhase>,
+    reuse_state: watch::Sender<ActiveRunReuseState>,
 }
 
 impl ActiveRuns {
@@ -85,7 +106,7 @@ impl ActiveRuns {
         reuse_key: Option<String>,
         profile_name: String,
     ) -> ActiveRunGuard {
-        let (phase, _phase_rx) = watch::channel(ActiveRunPhase::Running);
+        let (reuse_state, _reuse_state_rx) = watch::channel(ActiveRunReuseState::Pending);
         let has_reuse_key = reuse_key.is_some();
         let mut entries = lock_entries(&self.entries);
         let entry = entries.entry(run_id);
@@ -97,7 +118,7 @@ impl ActiveRuns {
             entry.insert(ActiveRunEntry {
                 reuse_key,
                 profile_name,
-                phase: phase.clone(),
+                reuse_state: reuse_state.clone(),
             });
         }
         drop(entries);
@@ -106,7 +127,7 @@ impl ActiveRuns {
             active_runs: self.clone(),
             run_id: Some(run_id),
             has_reuse_key,
-            phase,
+            reuse_state,
         }
     }
 
@@ -115,28 +136,30 @@ impl ActiveRuns {
         run_id: RunId,
         reuse_key: &str,
         profile_name: &str,
-    ) -> Option<ActiveRunProof> {
+    ) -> Option<ActiveRunReuseProof> {
         let entries = lock_entries(&self.entries);
         let entry = entries.get(&run_id)?;
         if entry.reuse_key.as_deref() != Some(reuse_key) || entry.profile_name != profile_name {
             return None;
         }
-        Some(ActiveRunProof {
-            phase: entry.phase.subscribe(),
-        })
+        let proof = ActiveRunReuseProof {
+            reuse_state: entry.reuse_state.subscribe(),
+        };
+        (proof.state() == ActiveRunReuseState::Pending).then_some(proof)
     }
 
     pub(super) fn reuse_keys(&self) -> HashSet<String> {
         lock_entries(&self.entries)
             .values()
+            .filter(|entry| *entry.reuse_state.borrow() == ActiveRunReuseState::Pending)
             .filter_map(|entry| entry.reuse_key.clone())
             .collect()
     }
 
     pub(super) fn has_reusable_run(&self) -> bool {
-        lock_entries(&self.entries)
-            .values()
-            .any(|entry| entry.reuse_key.is_some())
+        lock_entries(&self.entries).values().any(|entry| {
+            entry.reuse_key.is_some() && *entry.reuse_state.borrow() == ActiveRunReuseState::Pending
+        })
     }
 
     #[cfg(test)]
@@ -150,9 +173,9 @@ impl ActiveRuns {
 }
 
 impl ActiveRunGuard {
-    pub(super) fn finalization_publisher(&self) -> ActiveRunFinalizationPublisher {
-        ActiveRunFinalizationPublisher {
-            phase: self.phase.clone(),
+    pub(super) fn reuse_publisher(&self) -> ActiveRunReusePublisher {
+        ActiveRunReusePublisher {
+            reuse_state: self.reuse_state.clone(),
             changes: self.active_runs.changes.clone(),
         }
     }
@@ -166,9 +189,10 @@ impl ActiveRunGuard {
             return false;
         };
         lock_entries(&self.active_runs.entries).remove(&run_id);
-        self.phase.send_replace(ActiveRunPhase::Released);
+        let was_pending = self.reuse_state.send_replace(ActiveRunReuseState::Released)
+            == ActiveRunReuseState::Pending;
         bump_changes(&self.active_runs.changes);
-        if self.has_reuse_key {
+        if self.has_reuse_key && was_pending {
             self.active_runs.reuse_state_notify.notify_one();
         }
         self.has_reuse_key
@@ -245,7 +269,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn proof_observes_finalization_then_release() {
+    async fn proof_observes_exact_publication_then_release() {
         let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
         let run_id = RunId::new_v4();
         let guard = active_runs.register(
@@ -253,15 +277,67 @@ mod tests {
             Some("thread:finalizing".into()),
             "vm0/default".into(),
         );
-        let publisher = guard.finalization_publisher();
+        let publisher = guard.reuse_publisher();
         let mut proof = active_runs
             .finalizing_predecessor(run_id, "thread:finalizing", "vm0/default")
             .unwrap();
 
-        publisher.mark_finalized();
-        assert_eq!(proof.changed().await, ActiveRunPhase::Finalized);
+        assert!(publisher.publish_exact_sandbox());
+        assert_eq!(
+            proof.changed().await,
+            ActiveRunReuseState::ExactSandboxPublished
+        );
+        assert!(active_runs.reuse_keys().is_empty());
+        assert!(!active_runs.has_reusable_run());
+        assert!(
+            active_runs
+                .finalizing_predecessor(run_id, "thread:finalizing", "vm0/default")
+                .is_none()
+        );
         drop(guard);
-        assert_eq!(proof.changed().await, ActiveRunPhase::Released);
+        assert_eq!(proof.changed().await, ActiveRunReuseState::Released);
         assert!(!active_runs.contains(run_id));
+    }
+
+    #[tokio::test]
+    async fn proof_observes_no_exact_and_direct_release_outcomes() {
+        let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
+        let no_exact_run_id = RunId::new_v4();
+        let no_exact_guard = active_runs.register(
+            no_exact_run_id,
+            Some("thread:no-exact".into()),
+            "vm0/default".into(),
+        );
+        let no_exact_publisher = no_exact_guard.reuse_publisher();
+        let mut no_exact_proof = active_runs
+            .finalizing_predecessor(no_exact_run_id, "thread:no-exact", "vm0/default")
+            .unwrap();
+
+        assert!(no_exact_publisher.publish_no_exact_sandbox());
+        assert_eq!(
+            no_exact_proof.changed().await,
+            ActiveRunReuseState::NoExactSandbox
+        );
+        assert!(!no_exact_publisher.publish_exact_sandbox());
+        drop(no_exact_guard);
+        assert_eq!(
+            no_exact_proof.changed().await,
+            ActiveRunReuseState::Released
+        );
+
+        let released_run_id = RunId::new_v4();
+        let released_guard = active_runs.register(
+            released_run_id,
+            Some("thread:released".into()),
+            "vm0/default".into(),
+        );
+        let mut released_proof = active_runs
+            .finalizing_predecessor(released_run_id, "thread:released", "vm0/default")
+            .unwrap();
+        drop(released_guard);
+        assert_eq!(
+            released_proof.changed().await,
+            ActiveRunReuseState::Released
+        );
     }
 }

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -286,6 +286,9 @@ async fn wait_for_finalizing_resource(
 ) -> FinalizingWaitOutcome {
     let cancel = cancellation.token();
     loop {
+        if cancel.is_cancelled() {
+            return FinalizingWaitOutcome::Cancelled;
+        }
         let state = admission.predecessor.state();
         let missing_exact_reason = match state {
             ActiveRunReuseState::ExactSandboxPublished => Some("published_exact_unavailable"),
@@ -305,6 +308,13 @@ async fn wait_for_finalizing_resource(
             )
             .await
             .map(Box::new);
+            if cancel.is_cancelled() {
+                if let Some(reservation) = reserved_exact.take() {
+                    rollback_reserved_idle_for_spawn(*reservation, ctx).await;
+                    ctx.reuse_state_notify.notify_one();
+                }
+                return FinalizingWaitOutcome::Cancelled;
+            }
             if let Some(reservation) = reserved_exact.take() {
                 info!(
                     run_id = %run_id,

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -7,6 +7,7 @@ use futures_util::FutureExt;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
+use super::active_runs::ActiveRunReuseState;
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
     destroy_idle_jobs_and_wait, evict_expired_idle_entries, evict_oldest_idle_entry,
@@ -285,8 +286,16 @@ async fn wait_for_finalizing_resource(
 ) -> FinalizingWaitOutcome {
     let cancel = cancellation.token();
     loop {
-        let phase = admission.predecessor.phase();
-        if phase != super::active_runs::ActiveRunPhase::Running && reserved_exact.is_none() {
+        let state = admission.predecessor.state();
+        let missing_exact_reason = match state {
+            ActiveRunReuseState::ExactSandboxPublished => Some("published_exact_unavailable"),
+            ActiveRunReuseState::Released => Some("predecessor_released_without_exact"),
+            ActiveRunReuseState::NoExactSandbox => {
+                return FinalizingWaitOutcome::Fallback("predecessor_no_exact");
+            }
+            ActiveRunReuseState::Pending => None,
+        };
+        if let Some(missing_exact_reason) = missing_exact_reason {
             *reserved_exact = reserve_reusable_idle_for_spawn(
                 &admission.reuse_key,
                 profile_name,
@@ -296,8 +305,6 @@ async fn wait_for_finalizing_resource(
             )
             .await
             .map(Box::new);
-        }
-        if phase == super::active_runs::ActiveRunPhase::Released {
             if let Some(reservation) = reserved_exact.take() {
                 info!(
                     run_id = %run_id,
@@ -306,7 +313,7 @@ async fn wait_for_finalizing_resource(
                 );
                 return FinalizingWaitOutcome::Exact(reservation);
             }
-            return FinalizingWaitOutcome::Fallback("predecessor_released_without_exact");
+            return FinalizingWaitOutcome::Fallback(missing_exact_reason);
         }
 
         let deadline = tokio::time::Instant::from_std(admission.deadline);
@@ -315,16 +322,12 @@ async fn wait_for_finalizing_resource(
             () = cancel.cancelled() => {
                 return FinalizingWaitOutcome::Cancelled;
             }
-            _ = tokio::time::sleep_until(deadline) => {
-                let reason = if let Some(reservation) = reserved_exact.take() {
-                    rollback_reserved_idle_for_spawn(*reservation, ctx).await;
-                    "predecessor_release_deadline"
-                } else {
-                    "preference_deadline"
-                };
-                return FinalizingWaitOutcome::Fallback(reason);
-            }
             _ = admission.predecessor.changed() => {}
+            _ = tokio::time::sleep_until(deadline) => {
+                if admission.predecessor.state() == ActiveRunReuseState::Pending {
+                    return FinalizingWaitOutcome::Fallback("preference_deadline");
+                }
+            }
         }
     }
 }

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -996,7 +996,7 @@ mod tests {
             ],
         );
         let active_runs = test_active_runs();
-        let _active_guard = active_runs.register(
+        let active_guard = active_runs.register(
             crate::ids::RunId::new_v4(),
             Some("sess-active".into()),
             "vm0/default".into(),
@@ -1010,6 +1010,16 @@ mod tests {
                 "2026-06-01T00:00:02.000Z",
                 &["vm0/default"],
             )]
+        );
+
+        assert!(active_guard.reuse_publisher().publish_no_exact_sandbox());
+        let states = snapshot.current_held_workspace_states(&active_runs, Some("sess-claimed"));
+        assert_eq!(
+            states,
+            vec![
+                held_workspace_state("sess-active", "2026-06-01T00:00:04.000Z", &["vm0/default"],),
+                held_workspace_state("sess-cache", "2026-06-01T00:00:02.000Z", &["vm0/default"],),
+            ]
         );
     }
 
@@ -1114,7 +1124,7 @@ mod tests {
     #[test]
     fn held_sandbox_states_filter_active_reuse_keys() {
         let active_runs = test_active_runs();
-        let _active_guard = active_runs.register(
+        let active_guard = active_runs.register(
             crate::ids::RunId::new_v4(),
             Some("thread-active".into()),
             "vm0/default".into(),
@@ -1138,11 +1148,20 @@ mod tests {
             },
         ];
 
-        let filtered =
-            filter_current_held_sandbox_states(states, &active_runs, Some("thread-claimed"));
+        let filtered = filter_current_held_sandbox_states(
+            states.clone(),
+            &active_runs,
+            Some("thread-claimed"),
+        );
 
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].reuse_key, "thread-held");
+
+        assert!(active_guard.reuse_publisher().publish_exact_sandbox());
+        let filtered = filter_current_held_sandbox_states(states, &active_runs, None);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].reuse_key, "thread-active");
+        assert_eq!(filtered[1].reuse_key, "thread-held");
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -15,7 +15,7 @@ use tokio::sync::OwnedMutexGuard;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
-use super::active_runs::{ActiveRunGuard, ActiveRunProof};
+use super::active_runs::{ActiveRunGuard, ActiveRunReuseProof};
 use super::factory_lifecycle::SharedFactory;
 use super::finalizing_claim::{FinalizingClaimRequest, spawn_finalizing_claim};
 use super::idle_lifecycle::{
@@ -119,7 +119,7 @@ enum SandboxAdmittedResource {
 }
 
 pub(super) struct FinalizingAdmission {
-    pub(super) predecessor: ActiveRunProof,
+    pub(super) predecessor: ActiveRunReuseProof,
     pub(super) deadline: Instant,
     pub(super) reuse_key: String,
     pub(super) history_generation_run_id: RunId,
@@ -1054,7 +1054,7 @@ fn exact_speculative_preparation(
 
 fn finalizing_preparation(
     candidate: JobCandidate,
-    predecessor: ActiveRunProof,
+    predecessor: ActiveRunReuseProof,
     deadline: Instant,
     reuse_key: &str,
     history_generation_run_id: RunId,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tracing::{error, warn};
 
-use super::active_runs::{ActiveRunFinalizationPublisher, ActiveRunGuard, ActiveRuns};
+use super::active_runs::{ActiveRunGuard, ActiveRunReusePublisher, ActiveRuns};
 use super::factory_lifecycle::SharedFactory;
 use super::heartbeat::WorkspaceCacheStateSnapshot;
 use super::idle_lifecycle::SharedIdlePool;
@@ -260,7 +260,7 @@ struct FinalizationPhase {
     network_log_drain: NetworkLogDrainCoordinator,
     cancel: RunCancellationHandle,
     cleanup_state: RunCleanupState,
-    active_run_finalization: ActiveRunFinalizationPublisher,
+    active_run_reuse: ActiveRunReusePublisher,
     #[cfg(test)]
     outer_job_panic: Option<OuterJobPanicPoint>,
     #[cfg(test)]
@@ -296,7 +296,7 @@ impl FinalizationPhase {
             network_log_drain,
             cancel,
             cleanup_state,
-            active_run_finalization,
+            active_run_reuse,
             #[cfg(test)]
             outer_job_panic,
             #[cfg(test)]
@@ -321,6 +321,7 @@ impl FinalizationPhase {
         } = outcome;
         let had_sandbox = sandbox.is_some();
         let has_restored_session_identity = restored_session_identity.is_some();
+        let has_reuse_key = reuse_key.is_some();
         let cleanup_state_after_finalize = cleanup_state.clone();
 
         let completion_payload = CompletionPayload::new(
@@ -365,7 +366,8 @@ impl FinalizationPhase {
                 factory,
                 idle_pool,
                 status,
-                reuse_state_notify,
+                reuse_state_notify: Arc::clone(&reuse_state_notify),
+                active_run_reuse: active_run_reuse.clone(),
                 workspace_cache_snapshot,
                 parking_gate,
                 network_log_drain,
@@ -380,7 +382,9 @@ impl FinalizationPhase {
             },
         )
         .await;
-        active_run_finalization.mark_finalized();
+        if has_reuse_key && active_run_reuse.publish_no_exact_sandbox() {
+            reuse_state_notify.notify_one();
+        }
         let finalization_duration = finalization_started.elapsed();
         let disposition = cleanup_state_after_finalize.disposition();
         let reuse_state_changed = completion_ready.reuse_state_changed();
@@ -449,7 +453,6 @@ struct CompletionPhase {
     provider: Arc<dyn JobProvider>,
     status: Arc<StatusTracker>,
     usage_flush_tx: mpsc::Sender<()>,
-    reuse_state_notify: Arc<tokio::sync::Notify>,
     active_run_guard: ActiveRunGuard,
     cleanup_state: RunCleanupState,
 }
@@ -461,7 +464,6 @@ impl CompletionPhase {
             provider,
             status,
             usage_flush_tx,
-            reuse_state_notify,
             active_run_guard,
             cleanup_state,
         } = self;
@@ -469,7 +471,6 @@ impl CompletionPhase {
         // Structural guarantee: claim (in provider) is always paired with complete.
         signal_usage_flush(run_id, &usage_flush_tx);
         let ownership = OwnershipTransitions::new(status.as_ref());
-        let reuse_state_changed = completion_ready.reuse_state_changed();
         let provider_completion_duration = completion_ready
             .complete_and_release(provider.as_ref(), &ownership, &cleanup_state)
             .await;
@@ -486,9 +487,6 @@ impl CompletionPhase {
                 true,
                 None,
             );
-        }
-        if reuse_state_changed {
-            reuse_state_notify.notify_one();
         }
     }
 }
@@ -587,7 +585,7 @@ pub(super) async fn run_job(
         session_history_restore_plan,
         active_run_guard,
     } = request;
-    let active_run_finalization = active_run_guard.finalization_publisher();
+    let active_run_reuse = active_run_guard.reuse_publisher();
     let (context, completion_auth, active_input_source, pi_standby_source) =
         claimed.into_run_parts();
     let run_id = context.run_id;
@@ -708,7 +706,7 @@ pub(super) async fn run_job(
         network_log_drain: exec_config.network_log_drain.clone(),
         cancel: job_cancel.clone(),
         cleanup_state: cleanup_state_for_body.clone(),
-        active_run_finalization,
+        active_run_reuse,
         #[cfg(test)]
         outer_job_panic,
         #[cfg(test)]
@@ -746,7 +744,6 @@ pub(super) async fn run_job(
             provider,
             status,
             usage_flush_tx,
-            reuse_state_notify,
             active_run_guard,
             cleanup_state: cleanup_state_for_body,
         }
@@ -855,36 +852,10 @@ mod tests {
     };
     use crate::idle_reuse_preparation::mock_sandbox_ready_for_idle_reuse;
     use crate::ids::RunId;
-    use crate::provider::JobCandidate;
     use crate::resource_budget::ResourceBudget;
     use crate::restored_session_identity::RestoredSessionIdentity;
     use crate::run_cancellation::RunCancellationRegistry;
     use crate::status::StatusTracker;
-    use crate::types::HeartbeatState;
-
-    struct NoopCompletionProvider;
-
-    #[async_trait::async_trait]
-    impl JobProvider for NoopCompletionProvider {
-        async fn discover(&self) -> Option<JobCandidate> {
-            None
-        }
-
-        async fn claim(&self, _candidate: JobCandidate) -> Option<ClaimedJob> {
-            None
-        }
-
-        async fn complete(
-            &self,
-            _request: crate::types::CompleteRequest,
-            _completion_auth: CompletionAuth,
-        ) {
-        }
-
-        async fn heartbeat(&self, _state: &HeartbeatState) {}
-
-        async fn shutdown(&self) {}
-    }
 
     fn test_http_client() -> HttpClient {
         HttpClient::new(HttpClientConfig {
@@ -979,7 +950,7 @@ mod tests {
             let active_run_guard =
                 self.active_runs
                     .register(run_id, Some(session_id.into()), "vm0/default".into());
-            let active_run_finalization = active_run_guard.finalization_publisher();
+            let active_run_reuse = active_run_guard.reuse_publisher();
             self.active_run_guards
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1006,7 +977,7 @@ mod tests {
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
                 cancel: RunCancellationHandle::new(),
                 cleanup_state,
-                active_run_finalization,
+                active_run_reuse,
                 outer_job_panic: None,
                 test_observer: StartLoopTestObserver::default(),
             }
@@ -1397,74 +1368,6 @@ mod tests {
         );
         assert_no_telemetry_action(&finalized.telemetry, "runner_host_idle_publication");
         assert_telemetry_action(&finalized.telemetry, "runner_host_finalization_no_resource");
-    }
-
-    #[tokio::test]
-    async fn completion_notifies_again_after_releasing_active_session_guard() {
-        let fixture = FinalizationTelemetryFixture::new().await;
-        let (_budget, lease) = test_budget_lease();
-        let run_id = RunId::new_v4();
-        let sandbox_id = SandboxId::new_v4();
-        let session_id = "sess-post-complete-refresh";
-        fixture.status.add_run(run_id, sandbox_id).await;
-        let finalization = fixture.finalization_phase(
-            run_id,
-            sandbox_id,
-            session_id,
-            lease,
-            RunCleanupState::new(),
-        );
-        let FinalizedJob {
-            completion_ready,
-            mut telemetry,
-        } = finalization
-            .finalize(executor_phase_outcome(
-                run_id,
-                "post-complete-refresh",
-                None,
-            ))
-            .await;
-        assert!(
-            fixture
-                .reuse_state_notify
-                .notified()
-                .now_or_never()
-                .is_some(),
-            "finalizer should send the early park refresh"
-        );
-
-        let active_runs = ActiveRuns::new(Arc::clone(&fixture.reuse_state_notify));
-        let active_run_guard =
-            active_runs.register(run_id, Some(session_id.to_owned()), "vm0/default".into());
-        let (usage_flush_tx, _usage_flush_rx) = mpsc::channel(1);
-
-        CompletionPhase {
-            run_id,
-            provider: Arc::new(NoopCompletionProvider),
-            status: Arc::clone(&fixture.status),
-            usage_flush_tx,
-            reuse_state_notify: Arc::clone(&fixture.reuse_state_notify),
-            active_run_guard,
-            cleanup_state: RunCleanupState::new(),
-        }
-        .complete(completion_ready, &mut telemetry)
-        .await;
-
-        assert_telemetry_action(&telemetry, "runner_host_completion_fallback");
-        assert_telemetry_action(&telemetry, "runner_active_reuse_key_released");
-
-        assert!(
-            active_runs.reuse_keys().is_empty(),
-            "completion should release the active reuse-key guard before notifying"
-        );
-        assert!(
-            fixture
-                .reuse_state_notify
-                .notified()
-                .now_or_never()
-                .is_some(),
-            "completion should send a post-guard-release refresh"
-        );
     }
 
     async fn status_idle_reuse_keys_and_active_runs(

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -15,6 +15,7 @@ use sandbox::{
 };
 use tracing::{info, warn};
 
+use super::active_runs::ActiveRunReusePublisher;
 use super::heartbeat::WorkspaceCacheStateSnapshot;
 use super::idle_lifecycle::{
     SharedIdlePool, destroy_idle_jobs_and_wait, destroy_idle_payload_and_wait,
@@ -172,6 +173,7 @@ pub(super) struct FinalizeContext {
     pub(super) idle_pool: SharedIdlePool,
     pub(super) status: Arc<StatusTracker>,
     pub(super) reuse_state_notify: Arc<tokio::sync::Notify>,
+    pub(super) active_run_reuse: ActiveRunReusePublisher,
     pub(super) workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
     pub(super) parking_gate: ParkingGate,
     pub(super) network_log_drain: NetworkLogDrainCoordinator,
@@ -256,6 +258,7 @@ async fn finalize_sandbox_for_completion_inner(
         idle_pool,
         status,
         reuse_state_notify,
+        active_run_reuse,
         workspace_cache_snapshot,
         parking_gate,
         network_log_drain,
@@ -318,6 +321,16 @@ async fn finalize_sandbox_for_completion_inner(
         // Inflate the guest balloon BEFORE acquiring the pool lock —
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
+        let history_generation_run_id = match sandbox_reuse_disposition {
+            SandboxReuseDisposition::Eligible(SandboxReuseTerminal::Success) => Some(run_id),
+            SandboxReuseDisposition::Eligible(
+                SandboxReuseTerminal::NonzeroExit
+                | SandboxReuseTerminal::ExecutionTimeout
+                | SandboxReuseTerminal::CooperativeCancellation,
+            )
+            | SandboxReuseDisposition::Ineligible(_) => None,
+        };
+        let publishes_exact_sandbox = history_generation_run_id == Some(run_id);
         let park_request = IdleParkRequest::new(IdleParkRequestParts {
             run_id,
             sandbox,
@@ -330,15 +343,7 @@ async fn finalize_sandbox_for_completion_inner(
             source_ip,
             storage_fingerprints,
             restored_session_identity,
-            history_generation_run_id: match sandbox_reuse_disposition {
-                SandboxReuseDisposition::Eligible(SandboxReuseTerminal::Success) => Some(run_id),
-                SandboxReuseDisposition::Eligible(
-                    SandboxReuseTerminal::NonzeroExit
-                    | SandboxReuseTerminal::ExecutionTimeout
-                    | SandboxReuseTerminal::CooperativeCancellation,
-                )
-                | SandboxReuseDisposition::Ineligible(_) => None,
-            },
+            history_generation_run_id,
             guest_timezone_intent,
             workspace_image_size_bytes,
             workspace_promotion,
@@ -603,6 +608,9 @@ async fn finalize_sandbox_for_completion_inner(
                         let snapshot = pool.status_snapshot();
                         drop(transfer_guard);
                         drop(pool);
+                        if publishes_exact_sandbox {
+                            active_run_reuse.publish_exact_sandbox();
+                        }
                         let ownership = OwnershipTransitions::new(status.as_ref());
                         ownership
                             .publish_idle_status_after_pool_transfer(snapshot)
@@ -629,6 +637,9 @@ async fn finalize_sandbox_for_completion_inner(
                         let snapshot = pool.status_snapshot();
                         drop(transfer_guard);
                         drop(pool);
+                        if publishes_exact_sandbox {
+                            active_run_reuse.publish_exact_sandbox();
+                        }
                         let ownership = OwnershipTransitions::new(status.as_ref());
                         ownership
                             .publish_idle_status_after_pool_transfer(snapshot)
@@ -1037,6 +1048,7 @@ mod tests {
                 idle_pool: Arc::clone(&self.idle_pool),
                 status: Arc::clone(&self.status),
                 reuse_state_notify: Arc::new(tokio::sync::Notify::new()),
+                active_run_reuse: ActiveRunReusePublisher::detached(),
                 workspace_cache_snapshot: WorkspaceCacheStateSnapshot::new(),
                 parking_gate: self.parking_gate.clone(),
                 network_log_drain: NetworkLogDrainCoordinator::noop(),

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1,11 +1,11 @@
 use super::super::super::*;
 use super::super::support::{
-    TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, assert_run_exits_within, context_with_session,
-    minimal_context, mock_run_config, mock_run_config_with_overrides, push_job, seed_idle_pool,
-    seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
+    SpeculativeIdleSeedSpec, TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, assert_run_exits_within,
+    context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
+    push_job, seed_idle_pool, seed_idle_pool_with_history_generation,
+    seed_idle_pool_with_overrides, seed_idle_pool_with_speculative_timezone,
     seed_workspace_cache_state, shutdown, test_profiles, wait_budget_count, wait_cancel_token,
-    wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
-    wait_status_idle_reuse_keys_and_active_runs,
+    wait_cancel_token_removed, wait_discover_entered, wait_status_idle_reuse_keys_and_active_runs,
 };
 use std::sync::Arc;
 
@@ -838,11 +838,15 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
 }
 
 #[tokio::test]
-async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wakeup() {
+async fn finalizing_successor_starts_before_replaced_sandbox_cleanup_finishes() {
     let predecessor_gate = sandbox_mock::MockLifecycleGate::new();
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_wait_process_lifecycle_gate(predecessor_gate.clone());
-    let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 2, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
     let reuse_key = "thread:pending-exact-resource";
     let history_generation_run_id = RunId::new_v4();
     let status_path = env._temp_dir.path().join("status.json");
@@ -865,6 +869,16 @@ async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wake
         .wait_entered(1, Duration::from_secs(5))
         .await
         .expect("predecessor should still be running when its successor is discovered");
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
 
     let run_id = RunId::new_v4();
     env.provider
@@ -892,101 +906,68 @@ async fn selected_finalizing_candidate_claims_exact_resource_on_reuse_state_wake
     .await;
 
     predecessor_gate.release_one();
-    env.handle
-        .wait_completion(history_generation_run_id, Duration::from_secs(5))
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
         .await
-        .expect("predecessor should complete and publish its sandbox");
+        .expect("replaced sandbox cleanup should remain in predecessor finalization");
     predecessor_gate
         .wait_entered(2, Duration::from_secs(5))
         .await
-        .expect("successor should activate the published sandbox");
-    predecessor_gate.release_one();
-
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await
-        .expect("predecessor finalization should wake the claimed successor");
-    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    shutdown(&env, run_handle).await;
-}
-
-#[tokio::test]
-async fn cancellation_after_finalizing_publication_restores_exact_resource() {
-    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
-    let budget = Arc::clone(&config.capacity.budget);
-    let reuse_key = "thread:cancel-after-finalization";
-    let history_generation_run_id = RunId::new_v4();
-    let predecessor_guard = env.active_runs.register(
-        history_generation_run_id,
-        Some(reuse_key.to_owned()),
-        "vm0/default".into(),
+        .expect("successor should activate the published sandbox before cleanup finishes");
+    assert!(
+        env.handle
+            .wait_completion(history_generation_run_id, Duration::ZERO)
+            .await
+            .is_none(),
+        "predecessor completion must still be blocked on replaced sandbox cleanup"
     );
-    let predecessor_finalization = predecessor_guard.finalization_publisher();
-    let run_handle = tokio::spawn(run(config));
-    wait_discover_entered(&env, Duration::from_secs(2)).await;
-
-    let run_id = RunId::new_v4();
-    env.provider
-        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    destroy_gate.release_one();
     env.handle
-        .discover_tx
-        .send(finalizing_candidate(
-            run_id,
-            reuse_key,
-            history_generation_run_id,
-            TEST_RUNNER_ID,
-            TEST_HEARTBEAT_GENERATION,
-        ))
-        .unwrap();
-    wait_discover_entered(&env, Duration::from_secs(5)).await;
-
-    seed_idle_pool_with_history_generation(
-        &env.idle_pool,
-        &budget,
-        reuse_key,
-        "vm0/default",
-        2,
-        4096,
-        history_generation_run_id,
+        .wait_completion(history_generation_run_id, Duration::from_secs(5))
+        .await
+        .expect("predecessor should complete after replaced sandbox cleanup");
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &[],
+        &[run_id.to_string()],
+        Duration::from_secs(5),
     )
     .await;
-    predecessor_finalization.mark_finalized();
-    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .wait_completion(run_id, Duration::ZERO)
+            .await
+            .is_none(),
+        "predecessor cleanup must not remove or cancel the active successor"
+    );
 
-    env.cancel_tokens
-        .handle(run_id)
-        .await
-        .expect("claimed finalizing successor should retain cancellation registration")
-        .request_hard_cancellation()
-        .await;
+    predecessor_gate.release_one();
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
         .await
-        .expect("cancelled finalizing successor should complete");
-    assert_eq!(completion.exit_code, 137);
-    assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
-    assert!(completion.sandbox_id.is_none());
-    wait_idle_pool_len(&env.idle_pool, 1, Duration::from_secs(5)).await;
-    wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
-
-    drop(predecessor_guard);
+        .expect("sandbox publication should wake the claimed successor");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    destroy_gate.release_one();
     shutdown(&env, run_handle).await;
 }
 
 #[tokio::test(start_paused = true)]
-async fn finalizing_release_deadline_restores_exact_before_fallback() {
-    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+async fn published_exact_remains_reusable_past_preference_deadline() {
+    let successor_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(successor_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
     let budget = Arc::clone(&config.capacity.budget);
-    let reuse_key = "thread:finalized-release-deadline";
+    let reuse_key = "thread:published-past-preference-deadline";
     let history_generation_run_id = RunId::new_v4();
     let predecessor_guard = env.active_runs.register(
         history_generation_run_id,
         Some(reuse_key.to_owned()),
         "vm0/default".into(),
     );
-    let predecessor_finalization = predecessor_guard.finalization_publisher();
+    let predecessor_reuse = predecessor_guard.reuse_publisher();
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
@@ -1009,25 +990,84 @@ async fn finalizing_release_deadline_restores_exact_before_fallback() {
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(5)).await;
 
-    seed_idle_pool_with_history_generation(
+    seed_idle_pool_with_speculative_timezone(
         &env.idle_pool,
         &budget,
-        reuse_key,
-        "vm0/default",
-        2,
-        4096,
-        history_generation_run_id,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id,
+            guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
+            timing: None,
+        },
     )
     .await;
-    predecessor_finalization.mark_finalized();
-    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+    assert!(predecessor_reuse.publish_exact_sandbox());
+    successor_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("published exact sandbox should start before predecessor release");
 
     tokio::time::advance(Duration::from_millis(101)).await;
+    successor_gate.release_one();
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
         .await
-        .expect("stuck predecessor release should enter fallback at the original deadline");
+        .expect("published exact sandbox should remain reusable past the preference deadline");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(
+        env.handle
+            .claim_candidates()
+            .iter()
+            .filter(|candidate| candidate.run_id() == run_id)
+            .count(),
+        1,
+        "exact activation should retain the original claim"
+    );
+
+    drop(predecessor_guard);
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn no_exact_resolution_falls_back_before_predecessor_release() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let reuse_key = "thread:no-exact-before-release";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        history_generation_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let predecessor_reuse = predecessor_guard.reuse_publisher();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    assert!(predecessor_reuse.publish_no_exact_sandbox());
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("no-exact outcome should start fallback before predecessor release");
     assert_ne!(completion.reuse_result, Some(SandboxReuseResult::Reused));
     assert_eq!(
         env.handle
@@ -1054,7 +1094,7 @@ async fn competing_finalizing_successors_reserve_exact_generation_once() {
         Some(reuse_key.to_owned()),
         "vm0/default".into(),
     );
-    let predecessor_finalization = predecessor_guard.finalization_publisher();
+    let predecessor_reuse = predecessor_guard.reuse_publisher();
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 
@@ -1086,8 +1126,7 @@ async fn competing_finalizing_successors_reserve_exact_generation_once() {
         history_generation_run_id,
     )
     .await;
-    predecessor_finalization.mark_finalized();
-    drop(predecessor_guard);
+    assert!(predecessor_reuse.publish_exact_sandbox());
 
     let first = env
         .handle
@@ -1108,6 +1147,7 @@ async fn competing_finalizing_successors_reserve_exact_generation_once() {
         "an exact history generation must be reserved by at most one successor"
     );
 
+    drop(predecessor_guard);
     shutdown(&env, run_handle).await;
 }
 


### PR DESCRIPTION
## Summary

- replace the predecessor lifecycle phase with an explicit process-local reuse outcome
- publish an exact sandbox as soon as idle-pool ownership commits, before status persistence, replacement cleanup, or provider completion
- let claimed successors reserve a published generation or enter no-exact fallback immediately while preserving single-winner ownership and heartbeat ordering

## Scope

- runner-only, process-local behavior
- no API, protocol, persisted-state, database, or preference-deadline changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-features` (3,075 passed, 20 ignored)

Closes #25960

Parent: #25405
