### PR TITLE
fix(connectors): align custom run admission

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9601,11 +9601,23 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         customConnectorId: saved.connector.id,
       }),
     );
-    await api.requestCancelRun(actor, incompleteRun.runId, [200]);
 
+    context.mocks.ably.publish.mockClear();
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
       { key: "api_key", kind: "secret", value: "recovered-key" },
     ]);
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      "connector-runtime-sync",
+      {
+        runId: incompleteRun.runId,
+        target: {
+          kind: "custom",
+          customConnectorId: saved.connector.id,
+        },
+      },
+    );
+    await api.requestCancelRun(actor, incompleteRun.runId, [200]);
+
     const longSubdomain = "a".repeat(55);
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
       { key: "subdomain", kind: "variable", value: longSubdomain },

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8571,7 +8571,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("enforces custom connector permission grants and mounts its generated skill", async () => {
+  it("keeps a granted custom skill independent from runtime admission", async () => {
     const api = createRunsApi(context);
     createBddApi(context).acceptAgentStorageWrites();
     const connectors = createConnectorBddApi(context);
@@ -8638,6 +8638,58 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     await api.requestCancelRun(actor, run.runId, [200]);
     expect((await api.readRun(actor, run.runId)).status).toBe("cancelled");
+
+    await connectors.deleteCustomConnectorSecret(actor, custom.id);
+    const disconnectedRun = await api.createRun(actor, {
+      agentId,
+      prompt: "use the disconnected custom connector skill",
+      modelProvider: "anthropic-api-key",
+    });
+    const disconnectedClaim = await api.claimRunnerJob(disconnectedRun.runId);
+    expect(
+      findFirewallEntry(disconnectedClaim.firewalls, internalName),
+    ).toBeUndefined();
+    expect(disconnectedClaim.networkPolicies ?? {}).not.toHaveProperty(
+      internalName,
+    );
+    expect(disconnectedClaim.connectorRuntimeTargets).not.toContainEqual(
+      expect.objectContaining({
+        kind: "custom",
+        customConnectorId: custom.id,
+      }),
+    );
+    const disconnectedSkillMount = expectCanonicalStorageManifest(
+      disconnectedClaim.storageManifest,
+    )?.storageMounts.find((storage) => {
+      return storage.name === getCustomConnectorSkillStorageName(custom.id);
+    });
+    expect(disconnectedSkillMount?.mountPath).toBe(skillMount?.mountPath);
+    await api.requestCancelRun(actor, disconnectedRun.runId, [200]);
+
+    await connectors.setCustomConnectorSecret(
+      actor,
+      custom.id,
+      "restored-permissioned-custom-secret",
+    );
+    const restoredRun = await api.createRun(actor, {
+      agentId,
+      prompt: "use the reconnected custom connector",
+      modelProvider: "anthropic-api-key",
+    });
+    const restoredClaim = await api.claimRunnerJob(restoredRun.runId);
+    expect(
+      findFirewallEntry(restoredClaim.firewalls, internalName),
+    ).toMatchObject({
+      kind: "inline",
+      customConnectorId: custom.id,
+    });
+    expect(restoredClaim.connectorRuntimeTargets).toContainEqual({
+      kind: "custom",
+      customConnectorId: custom.id,
+      baseUrlVars: {},
+    });
+
+    await api.requestCancelRun(actor, restoredRun.runId, [200]);
   });
 
   it("serializes and injects custom connector OAuth 2.0 refreshes", async () => {
@@ -9019,6 +9071,18 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       modelProvider: "anthropic-api-key",
     });
     expect(provider.tokenBodies).toHaveLength(2);
+    const secondClaim = await api.claimRunnerJob(secondRun.runId);
+    const internalName = `custom_connector_${custom.id.replaceAll("-", "")}`;
+    expect(
+      findFirewallEntry(secondClaim.firewalls, internalName),
+    ).toBeUndefined();
+    expect(secondClaim.networkPolicies ?? {}).not.toHaveProperty(internalName);
+    expect(secondClaim.connectorRuntimeTargets).not.toContainEqual(
+      expect.objectContaining({
+        kind: "custom",
+        customConnectorId: custom.id,
+      }),
+    );
 
     await api.requestCancelRun(actor, firstRun.runId, [200]);
     await api.requestCancelRun(actor, secondRun.runId, [200]);
@@ -9396,7 +9460,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("keeps the definition firewall while incompatible credentials stay unavailable", async () => {
+  it("omits storage-incompatible custom connectors from new runs", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -9432,16 +9496,27 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       ],
       agentId,
     });
-    if (!actor.orgId) {
-      throw new Error("Expected a custom connector actor with an organization");
-    }
-    await setCustomConnectorCredentialStorageState(context, {
-      orgId: actor.orgId,
-      userId: actor.userId,
-      customConnectorId: saved.connector.id,
-      authMethod: "manual",
-      storageVersion: 2,
-    });
+    const updated = await connectors.updateCustomConnector(
+      actor,
+      saved.connector.id,
+      {
+        displayName: saved.connector.displayName,
+        prefixTemplates: saved.connector.prefixTemplates,
+        fields: [
+          ...saved.connector.fields,
+          {
+            key: "replacement",
+            label: "Replacement API key",
+            kind: "secret",
+            required: true,
+          },
+        ],
+        headerInjections: saved.connector.headerInjections,
+        queryInjections: saved.connector.queryInjections,
+        authMode: "manual",
+      },
+    );
+    expect(updated.storageVersion).toBe(2);
 
     const run = await api.createRun(actor, {
       agentId,
@@ -9451,26 +9526,20 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
     const internalName = `custom_connector_${saved.connector.id.replaceAll("-", "")}`;
-    expect(findFirewallEntry(claim.firewalls, internalName)).toMatchObject({
-      kind: "inline",
-      customConnectorId: saved.connector.id,
-    });
-    expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("allow");
-
-    const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
-      targets: [{ kind: "custom", customConnectorId: saved.connector.id }],
-    });
-    const availableRuntime = availableCustomConnectorRuntime(runtimeResult);
-    expect(availableRuntime.firewall.customConnectorId).toBe(
-      saved.connector.id,
+    expect(findFirewallEntry(claim.firewalls, internalName)).toBeUndefined();
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty(internalName);
+    expect(claim.connectorRuntimeTargets).not.toContainEqual(
+      expect.objectContaining({
+        kind: "custom",
+        customConnectorId: saved.connector.id,
+      }),
     );
-    expect(availableRuntime.networkPolicy.unknownPolicy).toBe("allow");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     await connectors.deleteCustomConnector(actor, saved.connector.id);
   });
 
-  it("retains an unpinned custom target until complete credential recovery", async () => {
+  it("admits a custom connector only in runs created after full recovery", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -9510,110 +9579,90 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       ],
       agentId,
     });
-    const versionTwoFields = [
-      ...saved.connector.fields,
-      {
-        key: "tenant",
-        label: "Tenant",
-        kind: "variable" as const,
-        required: true,
-      },
-    ];
-    const versionTwo = await connectors.updateCustomConnector(
-      actor,
-      saved.connector.id,
-      {
-        displayName: saved.connector.displayName,
-        prefixTemplates: saved.connector.prefixTemplates,
-        fields: versionTwoFields,
-        headerInjections: saved.connector.headerInjections,
-        queryInjections: saved.connector.queryInjections,
-        authMode: "manual",
-      },
-    );
-    expect(versionTwo.storageVersion).toBe(2);
+    await connectors.deleteCustomConnectorSecret(actor, saved.connector.id);
 
-    const run = await api.createRun(actor, {
+    const incompleteRun = await api.createRun(actor, {
       agentId,
-      prompt: "wait for complete custom connector recovery",
+      prompt: "do not admit an incomplete custom connector",
       modelProvider: "anthropic-api-key",
     });
     await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-    const target = {
-      kind: "custom" as const,
-      customConnectorId: saved.connector.id,
-    };
-    expect(claim.connectorRuntimeTargets).toContainEqual(target);
+    const incompleteClaim = await api.claimRunnerJob(incompleteRun.runId);
     const internalName = `custom_connector_${saved.connector.id.replaceAll("-", "")}`;
-    expect(findFirewallEntry(claim.firewalls, internalName)).toBeUndefined();
+    expect(
+      findFirewallEntry(incompleteClaim.firewalls, internalName),
+    ).toBeUndefined();
+    expect(incompleteClaim.networkPolicies ?? {}).not.toHaveProperty(
+      internalName,
+    );
+    expect(incompleteClaim.connectorRuntimeTargets).not.toContainEqual(
+      expect.objectContaining({
+        kind: "custom",
+        customConnectorId: saved.connector.id,
+      }),
+    );
+    await api.requestCancelRun(actor, incompleteRun.runId, [200]);
 
-    const [unresolved] = await api.syncConnectorRuntime(run.runId, {
-      targets: [target],
-    });
-    expect(unresolved).toMatchObject({
-      target,
-      state: "unresolved",
-      reason: "runtime-configuration-unavailable",
-    });
-
-    context.mocks.ably.publish.mockClear();
+    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
+      { key: "api_key", kind: "secret", value: "recovered-key" },
+    ]);
     const longSubdomain = "a".repeat(55);
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
-      { key: "api_key", kind: "secret", value: "version-two-key" },
       { key: "subdomain", kind: "variable", value: longSubdomain },
-      { key: "tenant", kind: "variable", value: "tenant-two" },
     ]);
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      { runId: run.runId, target },
-    );
 
     const fixedPrefix = "very-long-fixed-prefix-for-custom-runtime-";
-    const rerouted = await connectors.updateCustomConnector(
-      actor,
-      saved.connector.id,
-      {
-        displayName: saved.connector.displayName,
-        prefixTemplates: [
-          `https://${fixedPrefix}{{variables.subdomain}}.${rand}.recovery.test/v1/`,
-        ],
-        fields: versionTwoFields,
-        headerInjections: saved.connector.headerInjections,
-        queryInjections: saved.connector.queryInjections,
-        authMode: "manual",
-      },
+    await connectors.updateCustomConnector(actor, saved.connector.id, {
+      displayName: saved.connector.displayName,
+      prefixTemplates: [
+        `https://${fixedPrefix}{{variables.subdomain}}.${rand}.recovery.test/v1/`,
+      ],
+      fields: saved.connector.fields,
+      headerInjections: saved.connector.headerInjections,
+      queryInjections: saved.connector.queryInjections,
+      authMode: "manual",
+    });
+
+    const unroutableRun = await api.createRun(actor, {
+      agentId,
+      prompt: "do not admit an unroutable custom connector",
+      modelProvider: "anthropic-api-key",
+    });
+    const unroutableClaim = await api.claimRunnerJob(unroutableRun.runId);
+    expect(
+      findFirewallEntry(unroutableClaim.firewalls, internalName),
+    ).toBeUndefined();
+    expect(unroutableClaim.networkPolicies ?? {}).not.toHaveProperty(
+      internalName,
     );
-    expect(rerouted.storageVersion).toBe(2);
+    expect(unroutableClaim.connectorRuntimeTargets).not.toContainEqual(
+      expect.objectContaining({
+        kind: "custom",
+        customConnectorId: saved.connector.id,
+      }),
+    );
+    await api.requestCancelRun(actor, unroutableRun.runId, [200]);
 
-    const [invalidRouting] = await api.syncConnectorRuntime(run.runId, {
-      targets: [target],
-    });
-    expect(invalidRouting).toMatchObject({
-      target,
-      state: "unresolved",
-      reason: "runtime-configuration-unavailable",
-    });
-
-    context.mocks.ably.publish.mockClear();
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
       { key: "subdomain", kind: "variable", value: "version-two" },
     ]);
-    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      expect.anything(),
-    );
 
-    const [restored] = await api.syncConnectorRuntime(run.runId, {
-      targets: [target],
+    const recoveredRun = await api.createRun(actor, {
+      agentId,
+      prompt: "use the fully recovered custom connector",
+      modelProvider: "anthropic-api-key",
     });
-    const available = availableCustomConnectorRuntime(restored);
-    expect(available.baseUrlVars).toStrictEqual({ subdomain: "version-two" });
-    expect(available.firewall.firewall.apis[0]?.base).toBe(
-      `https://${fixedPrefix}version-two.${rand}.recovery.test/v1/`,
-    );
+    const recoveredClaim = await api.claimRunnerJob(recoveredRun.runId);
+    expect(recoveredClaim.connectorRuntimeTargets).toContainEqual({
+      kind: "custom",
+      customConnectorId: saved.connector.id,
+      baseUrlVars: { subdomain: "version-two" },
+    });
+    expect(
+      inlineFirewallApis(recoveredClaim.firewalls, internalName)[0]?.base,
+    ).toBe(`https://${fixedPrefix}version-two.${rand}.recovery.test/v1/`);
 
-    await api.requestCancelRun(actor, run.runId, [200]);
+    await api.requestCancelRun(actor, recoveredRun.runId, [200]);
     await connectors.deleteCustomConnector(actor, saved.connector.id);
   });
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3865,14 +3865,45 @@ interface BuiltCustomConnectorRuntimeRow {
     ConnectorRuntimeTargetRegistration,
     { readonly kind: "custom" }
   >;
-  readonly skill:
-    | {
-        readonly connectorId: string;
-        readonly connectorSlug: string;
-      }
-    | undefined;
+  readonly skill: CustomConnectorRuntimeContext["skills"][number] | undefined;
   readonly firewall: ExpandedFirewallConfig | undefined;
   readonly permissionPolicy: FirewallPolicy | undefined;
+}
+
+function customConnectorRuntimeSkill(
+  row: CustomConnectorRuntimeDataRows[number],
+): CustomConnectorRuntimeContext["skills"][number] | undefined {
+  return row.connector.skillMarkdown === null
+    ? undefined
+    : {
+        connectorId: row.connector.id,
+        connectorSlug: row.connector.slug,
+      };
+}
+
+function customConnectorRuntimeCredentialsAreComplete(
+  row: CustomConnectorRuntimeDataRows[number],
+): boolean {
+  const valueMarkers = new Set(
+    row.values.map((value) => {
+      return customConnectorValueMarkerKey(value);
+    }),
+  );
+  const oauthConnected = valueMarkers.has(
+    customConnectorValueMarkerKey({
+      kind: "secret",
+      key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
+    }),
+  );
+  return (
+    (row.connector.authMode !== "oauth" || oauthConnected) &&
+    row.connector.fields.every((field) => {
+      return (
+        !field.required ||
+        valueMarkers.has(customConnectorValueMarkerKey(field))
+      );
+    })
+  );
 }
 
 function unavailableCustomConnectorRuntimeRow(
@@ -3950,33 +3981,11 @@ async function buildCustomConnectorRuntimeRow(args: {
     ...targetIdentity,
     ...(baseUrlVars === undefined ? {} : { baseUrlVars: { ...baseUrlVars } }),
   };
-  const skill =
-    args.row.connector.skillMarkdown === null
-      ? undefined
-      : {
-          connectorId: args.row.connector.id,
-          connectorSlug: args.row.connector.slug,
-        };
+  const skill = customConnectorRuntimeSkill(args.row);
   const missingRequiredStartedAt = now();
-  const valueMarkers = new Set(
-    args.row.values.map((value) => {
-      return customConnectorValueMarkerKey(value);
-    }),
+  const missingRequired = !customConnectorRuntimeCredentialsAreComplete(
+    args.row,
   );
-  const oauthConnected = valueMarkers.has(
-    customConnectorValueMarkerKey({
-      kind: "secret",
-      key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-    }),
-  );
-  const missingRequired =
-    (args.row.connector.authMode === "oauth" && !oauthConnected) ||
-    args.row.connector.fields.some((field) => {
-      return (
-        field.required &&
-        !valueMarkers.has(customConnectorValueMarkerKey(field))
-      );
-    });
   args.stats.recordPhaseDuration("assembleFirewalls", missingRequiredStartedAt);
   if (missingRequired) {
     args.stats.recordMissingRequiredConnector();
@@ -4092,6 +4101,39 @@ export async function buildCustomConnectorRuntimeContext(
   stats.recordPhaseDuration("assembleFirewalls", finalAssemblyStartedAt);
   stats.flush(args.timing);
   return result;
+}
+
+async function buildNewRunCustomConnectorRuntimeContext(
+  args: BuildCustomConnectorRuntimeContextArgs,
+): Promise<CustomConnectorRuntimeContext> {
+  // Active targets call the shared builder directly so credential loss does
+  // not remove their pinned firewall. Only new runs apply this admission gate.
+  const context = await buildCustomConnectorRuntimeContext({
+    ...args,
+    rows: args.rows.filter((row) => {
+      return (
+        row.credentialAccess.kind === "current" &&
+        customConnectorRuntimeCredentialsAreComplete(row)
+      );
+    }),
+  });
+  const admittedConnectorIds = new Set(
+    Object.values(context.customConnectorIdByFirewallName),
+  );
+  return {
+    ...context,
+    targets: context.targets.filter((target) => {
+      return (
+        target.kind === "custom" &&
+        target.baseUrlVars !== undefined &&
+        admittedConnectorIds.has(target.customConnectorId)
+      );
+    }),
+    skills: args.rows.flatMap((row) => {
+      const skill = customConnectorRuntimeSkill(row);
+      return skill ? [skill] : [];
+    }),
+  };
 }
 
 interface CustomConnectorRuntimeExecutionState {
@@ -4228,7 +4270,7 @@ async function loadCustomConnectorContext(
     "api_dispatch_prepare_context_build_custom_connector_firewalls",
     "nested",
     async () => {
-      return await buildCustomConnectorRuntimeContext({
+      return await buildNewRunCustomConnectorRuntimeContext({
         rows: refreshedRows,
         featureSwitchContext: args.featureSwitchContext,
         connectorCatalogSnapshot: args.connectorCatalogSnapshot,


### PR DESCRIPTION
## Summary

- admit Custom connector executable state into a new run only when the member connection is current, credential-complete, and produces a validated routed firewall
- keep granted Custom connector skills independent from executable admission
- preserve the shared active-target builder so existing runs retain pinned firewall and network policy when credentials become unavailable
- replace same-run first-admission expectations with API integration coverage for disconnected, reconnect-required, storage-incompatible, incomplete, unroutable, and later-run recovery states

## Exclusions

- no database migration or persisted schema change
- no API or runner protocol change
- no change to Builtin connectors, optional auth-entry semantics, disconnect ownership, or active-run last-known-good synchronization

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (147 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit: Prettier, full-repository Knip, full-repository type checks, file-size check, and commitlint

Closes #25957

Parent context: #25312
