### PR TITLE
refactor: reduce fallback slop in pi runtime

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/agent-loop.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.ts
@@ -3,7 +3,6 @@ import {
   runAgentLoopContinue,
   type AgentEvent,
   type AgentMessage,
-  type AgentTool,
   type ExecutionEnv,
   type StreamFn,
 } from "@earendil-works/pi-agent-core";
@@ -17,7 +16,7 @@ import { openrouterProvider } from "@earendil-works/pi-ai/providers/openrouter";
 import { vercelAIGatewayProvider } from "@earendil-works/pi-ai/providers/vercel-ai-gateway";
 import type { Api, Message, Model } from "@earendil-works/pi-ai";
 
-import { createPiExecutionTools } from "./tools";
+import { createPiExecutionTools, type PiAgentTool } from "./tools";
 import { executePiToolBatch } from "./tool-batch";
 import type { PiAgentModelConfig, PiOpenAICompatibleProvider } from "./types";
 
@@ -52,16 +51,12 @@ function sourceModel(
   });
 }
 
-function executionTools(env: ExecutionEnv): AgentTool[] {
-  return createPiExecutionTools(env).map((tool) => {
-    // pi-agent-core's heterogeneous native tool tuple is runtime-compatible
-    // with AgentTool[] after its schema validator narrows each call.
-    return tool as unknown as AgentTool;
-  });
+function executionTools(env: ExecutionEnv): PiAgentTool[] {
+  return [...createPiExecutionTools(env)];
 }
 
-function edgeHandoffTools(env: ExecutionEnv): AgentTool[] {
-  return executionTools(env).map((tool) => {
+function edgeHandoffTools(env: ExecutionEnv): PiAgentTool[] {
+  return executionTools(env).map((tool): PiAgentTool => {
     return {
       ...tool,
       execute() {
@@ -71,7 +66,7 @@ function edgeHandoffTools(env: ExecutionEnv): AgentTool[] {
           terminate: true,
         });
       },
-    } as unknown as AgentTool;
+    };
   });
 }
 

--- a/turbo/packages/pi-agent-runtime/src/tool-batch.ts
+++ b/turbo/packages/pi-agent-runtime/src/tool-batch.ts
@@ -6,13 +6,12 @@ import {
 import type {
   AgentEvent,
   AgentMessage,
-  AgentTool,
   AgentToolCall,
   AgentToolResult,
   ExecutionEnv,
 } from "@earendil-works/pi-agent-core";
 
-import { createPiExecutionTools } from "./tools";
+import { createPiExecutionTools, type PiAgentTool } from "./tools";
 
 type PiAgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
@@ -24,7 +23,7 @@ interface PiToolBatch {
 interface PreparedToolCall {
   readonly kind: "prepared";
   readonly toolCall: AgentToolCall;
-  readonly tool: AgentTool;
+  readonly tool: PiAgentTool;
   readonly args: unknown;
 }
 
@@ -70,7 +69,7 @@ function errorToolResult(message: string): AgentToolResult<unknown> {
 }
 
 function prepareToolCall(
-  tools: readonly AgentTool[],
+  tools: readonly PiAgentTool[],
   toolCall: AgentToolCall,
   signal: AbortSignal,
 ): ToolCallPreparation {
@@ -195,7 +194,7 @@ function toolResultMessage(finalized: FinalizedToolCall): ToolResultMessage {
 
 async function executeToolCalls(
   batch: PiToolBatch,
-  tools: readonly AgentTool[],
+  tools: readonly PiAgentTool[],
   signal: AbortSignal,
   onEvent: PiAgentEventSink,
 ): Promise<readonly ToolResultMessage[]> {
@@ -258,8 +257,6 @@ export async function executePiToolBatch(
   if (!batch) {
     return [];
   }
-  const tools = createPiExecutionTools(args.executionEnv).map((tool) => {
-    return tool as unknown as AgentTool;
-  });
+  const tools: PiAgentTool[] = [...createPiExecutionTools(args.executionEnv)];
   return await executeToolCalls(batch, tools, signal, args.onEvent);
 }

--- a/turbo/packages/pi-agent-runtime/src/tools.ts
+++ b/turbo/packages/pi-agent-runtime/src/tools.ts
@@ -3,117 +3,97 @@ import {
   createEditTool,
   createReadTool,
   createWriteTool,
+  type AgentContext,
   type AgentMessage,
-  type AgentToolUpdateCallback,
-  type BashToolDetails,
   type BashToolInput,
-  type EditToolDetails,
   type EditToolInput,
   type ExecutionEnv,
-  type ReadToolDetails,
   type ReadToolInput,
   type WriteToolInput,
 } from "@earendil-works/pi-agent-core";
+import { validateToolArguments } from "@earendil-works/pi-ai";
 
-type PiReadTool = Omit<ReturnType<typeof createReadTool>, "execute"> & {
-  execute(
-    toolCallId: string,
-    params: ReadToolInput,
-    signal?: AbortSignal,
-    onUpdate?: AgentToolUpdateCallback<ReadToolDetails | undefined>,
-  ): ReturnType<ReturnType<typeof createReadTool>["execute"]>;
-};
-
-type PiBashTool = Omit<ReturnType<typeof createBashTool>, "execute"> & {
-  execute(
-    toolCallId: string,
-    params: BashToolInput,
-    signal?: AbortSignal,
-    onUpdate?: AgentToolUpdateCallback<BashToolDetails | undefined>,
-  ): ReturnType<ReturnType<typeof createBashTool>["execute"]>;
-};
-
-type PiWriteTool = Omit<ReturnType<typeof createWriteTool>, "execute"> & {
-  execute(
-    toolCallId: string,
-    params: WriteToolInput,
-    signal?: AbortSignal,
-    onUpdate?: AgentToolUpdateCallback<undefined>,
-  ): ReturnType<ReturnType<typeof createWriteTool>["execute"]>;
-};
-
-type PiEditTool = Omit<ReturnType<typeof createEditTool>, "execute"> & {
-  execute(
-    toolCallId: string,
-    params: EditToolInput,
-    signal?: AbortSignal,
-    onUpdate?: AgentToolUpdateCallback<EditToolDetails | undefined>,
-  ): ReturnType<ReturnType<typeof createEditTool>["execute"]>;
-};
+export type PiAgentTool = NonNullable<AgentContext["tools"]>[number];
 
 type PiExecutionTools = readonly [
-  PiReadTool,
-  PiBashTool,
-  PiWriteTool,
-  PiEditTool,
+  PiAgentTool,
+  PiAgentTool,
+  PiAgentTool,
+  PiAgentTool,
 ];
 
-export function createPiReadTool(env: ExecutionEnv): PiReadTool {
+function validatedToolArguments(
+  tool: Parameters<typeof validateToolArguments>[0],
+  toolCallId: string,
+  params: unknown,
+): unknown {
+  if (typeof params !== "object" || params === null || Array.isArray(params)) {
+    throw new TypeError(`Tool ${tool.name} arguments must be an object`);
+  }
+  return validateToolArguments(tool, {
+    type: "toolCall",
+    id: toolCallId,
+    name: tool.name,
+    arguments: params,
+  });
+}
+
+export function createPiReadTool(env: ExecutionEnv): PiAgentTool {
   const tool = createReadTool();
   return {
     ...tool,
-    execute(
-      toolCallId: string,
-      params: ReadToolInput,
-      signal?: AbortSignal,
-      onUpdate?: AgentToolUpdateCallback<ReadToolDetails | undefined>,
-    ) {
-      return tool.execute(toolCallId, params, signal, onUpdate, { env });
+    execute(toolCallId, params, signal, onUpdate) {
+      const input = validatedToolArguments(
+        tool,
+        toolCallId,
+        params,
+      ) as ReadToolInput;
+      return tool.execute(toolCallId, input, signal, onUpdate, { env });
     },
   };
 }
 
-function createPiBashTool(env: ExecutionEnv): PiBashTool {
+function createPiBashTool(env: ExecutionEnv): PiAgentTool {
   const tool = createBashTool();
   return {
     ...tool,
-    execute(
-      toolCallId: string,
-      params: BashToolInput,
-      signal?: AbortSignal,
-      onUpdate?: AgentToolUpdateCallback<BashToolDetails | undefined>,
-    ) {
-      return tool.execute(toolCallId, params, signal, onUpdate, { env });
+    execute(toolCallId, params, signal, onUpdate) {
+      const input = validatedToolArguments(
+        tool,
+        toolCallId,
+        params,
+      ) as BashToolInput;
+      return tool.execute(toolCallId, input, signal, onUpdate, { env });
     },
   };
 }
 
-function createPiWriteTool(env: ExecutionEnv): PiWriteTool {
+function createPiWriteTool(env: ExecutionEnv): PiAgentTool {
   const tool = createWriteTool();
   return {
     ...tool,
-    execute(
-      toolCallId: string,
-      params: WriteToolInput,
-      signal?: AbortSignal,
-      onUpdate?: AgentToolUpdateCallback<undefined>,
-    ) {
-      return tool.execute(toolCallId, params, signal, onUpdate, { env });
+    execute(toolCallId, params, signal, onUpdate) {
+      const input = validatedToolArguments(
+        tool,
+        toolCallId,
+        params,
+      ) as WriteToolInput;
+      return tool.execute(toolCallId, input, signal, onUpdate, { env });
     },
   };
 }
 
-function createPiEditTool(env: ExecutionEnv): PiEditTool {
+function createPiEditTool(env: ExecutionEnv): PiAgentTool {
   const tool = createEditTool();
   return {
     ...tool,
-    execute(
-      toolCallId: string,
-      params: EditToolInput,
-      signal?: AbortSignal,
-      onUpdate?: AgentToolUpdateCallback<EditToolDetails | undefined>,
-    ) {
-      return tool.execute(toolCallId, params, signal, onUpdate, { env });
+    execute(toolCallId, params, signal, onUpdate) {
+      const input = validatedToolArguments(
+        tool,
+        toolCallId,
+        params,
+      ) as EditToolInput;
+      return tool.execute(toolCallId, input, signal, onUpdate, { env });
     },
   };
 }


### PR DESCRIPTION
## 摘要

本轮每日 AI-slop fallback 清理聚焦 Pi runtime 的异构工具适配边界：移除 3 处 `as unknown as AgentTool`，改为使用 `pi-agent-core` 自身 `AgentContext["tools"]` 暴露的异构工具元素类型，并在进入 read/bash/write/edit 的精确输入类型前执行对应 TypeBox schema 校验。

改动不改变工具名称、参数 schema、执行环境、流式更新回调、结果结构或 edge handoff 的 terminate 行为；它只把原先由双重断言隐藏的类型边界变成可验证的适配层。

## 扫描基线

- Scanner: `scan-ai-slop-fallbacks.mjs`
- Scan timestamp: `2026-08-09T20:02:52.322Z`
- Base commit: `7c55992a220093ff2b07e947daba4cc52f3bd3f6`
- Files scanned: 4,009

| Category | Baseline matches |
| --- | ---: |
| nullish | 6,401 |
| nullish-chain | 132 |
| field-fallback-chain | 102 |
| optional-prop | 6,612 |
| zod-optional | 2,665 |
| zod-loose-optional | 6 |
| loose-record | 1,123 |
| loose-index-signature | 6 |
| as-any | 0 |
| as-unknown-as | 32 |
| empty-fallback | 672 |
| string-fallback | 694 |
| null-undefined-fallback | 1,760 |
| empty-catch | 3 |
| promise-catch-swallow | 16 |
| rust-unwrap-or | 701 |
| rust-ok-discard | 161 |

- High-confidence production actionable total: **226**
- 5% minimum: **12**
- Candidates changed: **3**
- Re-scan remaining: **223**
- Shortfall: **9**

本轮低于 12 个 candidate 的最低目标；完整短缺证据见下文。

## 改动与证据

### 1. 统一 Pi 异构工具类型边界

涉及文件：

- `turbo/packages/pi-agent-runtime/src/agent-loop.ts`
- `turbo/packages/pi-agent-runtime/src/tool-batch.ts`
- `turbo/packages/pi-agent-runtime/src/tools.ts`

原代码在三个位置把 read/bash/write/edit 的异构工具 tuple 先转成 `unknown`，再断言为默认 `AgentTool`：

- API/edge agent loop 的 execution tools
- edge handoff 的 no-op tool 映射
- Sandbox handoff 的 tool batch execution

**为什么是 slop。** `as unknown as AgentTool` 会完全跳过参数类型兼容性检查。默认 `AgentTool` 的参数是 erased/unknown，而四个原生工具各自只接受精确的 Read/Bash/Write/Edit 输入；双重断言只是压制了这个真实差异。第三处断言由 `refactor(pi): replace handoff fallbacks with session polling (#25906)` 新增，也是相对上一轮 225 个剩余候选唯一新增的生产高置信项。

**为什么安全。**

1. 新的 `PiAgentTool` 直接取自第三方公开契约 `NonNullable<AgentContext["tools"]>[number]`，与 `runAgentLoop` 实际接收的工具集合完全一致。
2. 每个 read/bash/write/edit wrapper 在窄化前调用同一第三方 `validateToolArguments`，使用工具自身的 TypeBox `parameters` schema 校验并转换参数；校验失败会 fail fast，不再依赖无检查断言。
3. wrapper 继续 spread 原工具，因此 `name`、`label`、`parameters`、`prepareArguments` 与 `executionMode` 保持不变；执行时仍转发同一个 `ExecutionEnv`、AbortSignal、onUpdate 回调与原始 result。
4. edge handoff wrapper 仍只返回 `{ content: [], details: {}, terminate: true }`；这部分运行时行为没有改变。
5. package build、全仓分阶段 typecheck 和 9 个聚焦测试均通过，覆盖 API loop、edge handoff 和 Sandbox tool batch。

## 短缺说明

上一轮已合并的每日清理报告把剩余 225 个高置信项逐行审计为 140 个唯一源代码行。本轮基线为 226；通过扫描差异与 blame 核对，唯一新增项是 #25906 在 `edgeHandoffTools` 中加入的第三个 `as unknown as AgentTool`。本 PR 同时找到了可验证的统一适配方式，因此把该新增项和此前同类的两个断言全部清理，226 → 223。

剩余 223 个候选与上一轮审计集合一致，主要分类如下：

- 外部 API payload 适配：OAuth identity、Microsoft Graph、Stripe metadata、Telegram text/caption 等多版本或多字段规范化。
- 展示默认：avatar initials、名称、locale、错误信息与 UI 占位符。
- 合法优先级链：query 覆盖持久化值、event log 回落 snapshot、current/default/first option、模型路由。
- 真实 nullable 处理：nullable DB 字段、`Map.get()` 与 `noUncheckedIndexedAccess` 下的数组访问。
- 明确兼容读取器：`connectorPermissionBaseline: z.unknown().optional()`、Codex token exp 来源兼容。
- 多态外部契约：CDP method-specific result 与 Pi transcript tool details。
- scanner 将测试/工具文档误判为 production 的路径。

这些都是清理技能明确列出的 lower-confidence 类别。继续凑满 12 会删除真实兼容或错误处理，因此本轮按“安全优先于配额”停止在 3 个。

## 验证

- `pnpm format` — 通过，无额外文件变化
- `pnpm turbo run lint --concurrency=1 --log-order grouped` — 13/13 tasks 通过；main 既有 warning，0 errors
- `pnpm knip` — 通过；仅 42 条既有 configuration hints
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'` — 12/12 tasks 通过
- `pnpm --filter @vm0/app run check-types` — 通过
- `pnpm --filter api run check-types` — boundaries/gateways/core/bootstrap/tests/bootstrap-wiring 全部通过
- `pnpm --filter @vm0/pi-agent-runtime exec vitest run src/runtime.test.ts` — 3/3
- `pnpm --filter @vm0/pi-agent-runtime exec vitest run src/agent-loop.test.ts` — 4/4
- `pnpm --filter @vm0/pi-agent-runtime exec vitest run src/tool-batch.test.ts` — 2/2
- `git diff --check` — 通过
- Scanner re-run — high-confidence production actionable **226 → 223**；`as-unknown-as` 总数 **32 → 29**

提交阶段本地 PATH 中没有 Lefthook binary；以上检查已按 commit-check 顺序手工执行。按仓库约束未运行全量 Vitest，也未启动本地 dev server。

## Fallback / compatibility audit

- 本 PR 删除的是 3 处仅存在于 TypeScript 编译期的双重断言，不删除任何 DB、HTTP、queue、runner protocol 或持久化兼容行为。
- 新增的 schema validation 是 fail-fast 输入校验，不是 tolerant fallback。
- 无需 rollout window，无 retained temporary fallback，无后续迁移删除项。
