### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -550,16 +550,6 @@ export async function setComputerUseHostAsPreviousApi(
   });
 }
 
-export async function setChatSlackContextAsPreviousApi(
-  context: TestContext,
-  eventId: string,
-): Promise<void> {
-  await postAction(context, {
-    action: "set-chat-slack-context-as-previous-api",
-    event_id: eventId,
-  });
-}
-
 export async function setBrowserTabSnapshotAsPreviousApi(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -26,10 +26,7 @@ import {
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
-import {
-  setChatSlackContextAsPreviousApi,
-  readThreadSessionBinding,
-} from "./helpers/runtime-state";
+import { readThreadSessionBinding } from "./helpers/runtime-state";
 
 /*
 helper gap:
@@ -1665,132 +1662,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     await flushWaitUntilForTest();
   });
-
-  it("launches a queued Slack context written by the previous API version", async () => {
-    const actor = bdd.user();
-    runs.acceptStorageDownloads();
-    runs.acceptTelemetryIngest();
-    const runnerGroup = runs.configureRunnerGroup();
-    integrations.configureSlackAppMocks();
-    await runs.grantProEntitlement(actor);
-    await runs.ensureOrgModelProvider(actor);
-    const slackUserId = uniqueSlackUserId();
-    const { teamId, botUserId } = await integrations.installSlackWorkspace(
-      actor,
-      {
-        installerSlackUserId: slackUserId,
-      },
-    );
-    const channelId = "C_BDD_PREVIOUS_API_CONTEXT";
-    const threadTs = "2902.000100";
-    const fileBody = "previous API Slack attachment";
-    context.mocks.slack.fetchFile.mockResolvedValue(
-      new Response(fileBody, {
-        headers: { "Content-Type": "text/plain" },
-      }),
-    );
-    const openingBody = JSON.stringify({
-      type: "event_callback",
-      team_id: teamId,
-      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
-      event: {
-        type: "app_mention",
-        user: slackUserId,
-        text: `<@${botUserId}> hold this session open`,
-        ts: threadTs,
-        channel: channelId,
-        channel_type: "channel",
-      },
-    });
-    await integrations.requestSlackEvent(
-      openingBody,
-      integrations.signedSlackIngressHeaders(openingBody),
-      [200],
-    );
-    await flushWaitUntilForTest();
-    const openingRunId = await pollSlackRun(runnerGroup);
-    const openingClaim = await runs.claimRunnerJob(openingRunId);
-
-    // The follow-up queues behind the active run, so its context row can be
-    // downgraded to the shape the previous API wrote before it launches.
-    const queuedBody = JSON.stringify({
-      type: "event_callback",
-      team_id: teamId,
-      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
-      event: {
-        type: "app_mention",
-        user: slackUserId,
-        text: `<@${botUserId}> launch from the previous API context`,
-        ts: "2902.000200",
-        thread_ts: threadTs,
-        channel: channelId,
-        channel_type: "channel",
-        files: [
-          {
-            id: "F_PREVIOUS_API",
-            name: "previous-api-notes.txt",
-            mimetype: "text/plain",
-            size: fileBody.length,
-            url_private_download: "https://files.slack.com/F_PREVIOUS_API",
-          },
-        ],
-      },
-    });
-    await integrations.requestSlackEvent(
-      queuedBody,
-      integrations.signedSlackIngressHeaders(queuedBody),
-      [200],
-    );
-    await flushWaitUntilForTest();
-
-    const state = await integrations.readSlackTestState(teamId);
-    const canonicalChatThreadId = state.chat_thread_routes[0]?.chatThreadId;
-    if (!canonicalChatThreadId) {
-      throw new Error("Expected the Slack route to own a chat thread");
-    }
-    const queuedSlackEvent = slackInputMessageByText(
-      (await chat.listThreadEvents(actor, canonicalChatThreadId)).events,
-      "launch from the previous API context",
-    );
-    if (!queuedSlackEvent) {
-      throw new Error("Expected the queued Slack input message");
-    }
-    await setChatSlackContextAsPreviousApi(context, queuedSlackEvent.id);
-    await expect(
-      readChatEventContextFixture(queuedSlackEvent.id),
-    ).resolves.toMatchObject({
-      slackBotUserId: null,
-      slackMessageAssets: null,
-    });
-
-    await completeSlackTriggeredRun({
-      runId: openingRunId,
-      sandboxToken: openingClaim.sandboxToken,
-      cliAgentType: openingClaim.cliAgentType,
-      assistantText: "Session held open",
-    });
-    await flushWaitUntilForTest();
-
-    const queuedRunId = await pollSlackRun(runnerGroup);
-    const queuedRun = await runs.readRun(actor, queuedRunId);
-    // The launch still renders: the bot user ID falls back to the workspace
-    // installation, and the un-snapshotted file degrades to its raw Slack block.
-    expect(queuedRun.appendSystemPrompt).toContain(
-      `Your bot user ID: ${botUserId}`,
-    );
-    expect(queuedRun.prompt).toContain(
-      "[Slack file] previous-api-notes.txt (text/plain)\n   [ID] F_PREVIOUS_API",
-    );
-    expect(queuedRun.prompt).not.toContain("[Web file]");
-    const queuedClaim = await runs.claimRunnerJob(queuedRunId);
-    await completeSlackTriggeredRun({
-      runId: queuedRunId,
-      sandboxToken: queuedClaim.sandboxToken,
-      cliAgentType: queuedClaim.cliAgentType,
-      assistantText: "Previous API context answer",
-    });
-    await flushWaitUntilForTest();
-  }, 20_000);
 
   it("keeps queued Web and Slack sends on one canonical session", async () => {
     const actor = bdd.user();

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -17,7 +17,6 @@ import {
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatEventSnapshots } from "@vm0/db/schema/chat-event-snapshot";
-import { chatSlackContext } from "@vm0/db/schema/chat-slack-context";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { hostedSites } from "@vm0/db/schema/hosted-site";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
@@ -1119,37 +1118,6 @@ async function setComputerUseHostAsPreviousApi(
   return { status: 200 as const, body: { ok: true as const } };
 }
 
-type PreviousApiChatSlackContextAction = Extract<
-  TestRuntimeStateActionBody,
-  { action: "set-chat-slack-context-as-previous-api" }
->;
-
-async function setChatSlackContextAsPreviousApi(
-  db: Db,
-  body: PreviousApiChatSlackContextAction,
-  signal: AbortSignal,
-) {
-  // The API version immediately before the Slack launch snapshot wrote no
-  // bot_user_id and no message_assets. No current production route can
-  // reproduce that mixed-version writer shape.
-  const [updated] = await db
-    .update(chatSlackContext)
-    .set({ botUserId: null, messageAssets: null })
-    .from(chatEvents)
-    .where(
-      and(
-        eq(chatEvents.id, body.event_id),
-        eq(chatSlackContext.id, chatEvents.contextId),
-      ),
-    )
-    .returning({ id: chatSlackContext.id });
-  signal.throwIfAborted();
-  if (!updated) {
-    throw new Error("Expected a Slack context for previous API downgrade");
-  }
-  return { status: 200 as const, body: { ok: true as const } };
-}
-
 type PreviousApiRunnerJobContextProfileAction = Extract<
   TestRuntimeStateActionBody,
   { action: "set-runner-job-context-profile-as-previous-api" }
@@ -1230,7 +1198,6 @@ type CompatibilityFixtureAction =
   | PreviousApiHostedSiteAction
   | PreviousApiHostedDeploymentAction
   | PreviousApiComputerAccessAction
-  | PreviousApiChatSlackContextAction
   | PreviousApiBrowserTabSnapshotAction
   | PreviousApiRunnerJobContextProfileAction
   | ConnectorPermissionBaselineMutationAction;
@@ -1319,7 +1286,6 @@ function isCompatibilityFixtureAction(
     "insert-hosted-site-as-previous-api",
     "insert-hosted-deployment-as-previous-api",
     "set-computer-use-host-as-previous-api",
-    "set-chat-slack-context-as-previous-api",
     "set-browser-tab-snapshot-as-previous-api",
     "set-runner-job-context-profile-as-previous-api",
     "mutate-runner-job-connector-permission-baseline",
@@ -1346,9 +1312,6 @@ async function compatibilityFixtureActionResponse(
     }
     case "set-computer-use-host-as-previous-api": {
       return await setComputerUseHostAsPreviousApi(db, body, signal);
-    }
-    case "set-chat-slack-context-as-previous-api": {
-      return await setChatSlackContextAsPreviousApi(db, body, signal);
     }
     case "set-browser-tab-snapshot-as-previous-api": {
       return await setBrowserTabSnapshotAsPreviousApi(db, body, signal);

--- a/turbo/apps/api/src/signals/services/slack-queued-launch-context.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-queued-launch-context.service.ts
@@ -41,15 +41,17 @@ type SlackLaunchContextRow = Pick<
   | "channelType"
   | "threadTs"
   | "routeThreadTs"
-> & { readonly installationBotUserId: string };
+>;
 
 function requiredSlackLaunchContext(row: SlackLaunchContextRow | undefined) {
   if (
     !row ||
     row.channelId === null ||
+    row.botUserId === null ||
     row.conversationContext === null ||
     row.messageText === null ||
     row.messageFiles === null ||
+    row.messageAssets === null ||
     row.mentionDisplayNames === null ||
     row.channelType === null ||
     row.threadTs === null
@@ -59,26 +61,11 @@ function requiredSlackLaunchContext(row: SlackLaunchContextRow | undefined) {
   return {
     ...row,
     channelId: row.channelId,
-    // Rollout fallback for context rows the previous API wrote without the
-    // launch snapshot: bot_user_id and message_assets are null there. The bot
-    // user ID falls back to the workspace installation; the assets degrade to
-    // the raw Slack file blocks those runs rendered before canonical Slack
-    // inputs existed.
-    //
-    // Surface: persisted Slack launch context read by this API. This loader is
-    // only reached while admitting a queued message
-    // (internal-chat-run-callback.service.ts) or steering a live run
-    // (active-input-prompt.service.ts), so the window is bounded by how long a
-    // pre-cutover Slack input event can still sit in the thread queue or in an
-    // active run, not by the ~102 min DB/API skew — historical rows are never
-    // re-read. Remove both branches, the installationBotUserId projection, and
-    // the "previous API version" launch test once no such event can remain;
-    // follow-up: https://github.com/vm0-ai/vm0/issues/25830
-    botUserId: row.botUserId ?? row.installationBotUserId,
+    botUserId: row.botUserId,
     conversationContext: row.conversationContext,
     messageText: row.messageText,
     messageFiles: row.messageFiles,
-    messageAssets: row.messageAssets ?? [],
+    messageAssets: row.messageAssets,
     mentionDisplayNames: row.mentionDisplayNames,
     channelType: row.channelType,
     threadTs: row.threadTs,
@@ -96,7 +83,6 @@ async function loadSlackLaunchContext(
 ) {
   const [row] = await db
     .select({
-      installationBotUserId: slackOrgInstallations.botUserId,
       channelId: chatSlackContext.channelId,
       botUserId: chatSlackContext.botUserId,
       conversationContext: chatSlackContext.conversationContext,

--- a/turbo/apps/platform/src/signals/zero-page/avatar-template-selection.ts
+++ b/turbo/apps/platform/src/signals/zero-page/avatar-template-selection.ts
@@ -24,25 +24,16 @@ export function toAvatarGenerationTemplate(
   voice: ZeroAvatarVideoVoice,
   aspectRatio: "portrait" | "landscape",
 ): GenerationTemplateRequest {
-  const avatarOptions = {
-    titleSnapshot: avatar.name,
-    previewUrl: avatar.coverUrl,
-    voiceId: voice.id,
-    aspectRatio,
-  };
   return {
     type: "video",
     selection: {
       stylePresetId: avatarTemplateStylePresetId(avatar.id),
-      avatarOptions,
-      // Mirrored flat because an API or frontend bundle that predates
-      // avatarOptions drops the nested object, and losing the voice would
-      // silently generate the avatar with a different one.
-      //
-      // Delete once the web-client floor in web-client-compatibility.json has
-      // been raised past the app version shipping this change. Tracked in
-      // https://github.com/vm0-ai/vm0/issues/25620.
-      ...avatarOptions,
+      avatarOptions: {
+        titleSnapshot: avatar.name,
+        previewUrl: avatar.coverUrl,
+        voiceId: voice.id,
+        aspectRatio,
+      },
     },
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -1145,20 +1145,16 @@ describe("chat composer templates", () => {
     await appendAndSend(user, "Introduce our new product");
 
     await waitFor(() => {
-      const avatarOptions = {
-        titleSnapshot: selectedAvatar.name,
-        previewUrl: selectedAvatar.coverUrl,
-        voiceId: selectedVoice.id,
-        aspectRatio: "landscape" as const,
-      };
-      // Nested options carry the selection; the flat fields are mirrored for
-      // readers that predate avatarOptions.
       expect(submittedTemplate).toStrictEqual({
         type: "video",
         selection: {
           stylePresetId: avatarTemplateStylePresetId(selectedAvatar.id),
-          avatarOptions,
-          ...avatarOptions,
+          avatarOptions: {
+            titleSnapshot: selectedAvatar.name,
+            previewUrl: selectedAvatar.coverUrl,
+            voiceId: selectedVoice.id,
+            aspectRatio: "landscape" as const,
+          },
         },
       });
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -1160,6 +1160,45 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("keeps the chosen voice selected when the avatar picker reopens", async () => {
+    const user = userEvent.setup({ delay: null });
+    const selectedAvatar = createSelectedAvatar();
+    const selectedVoice = createSelectedVoice();
+    const alternateVoice = createAlternateVoice();
+    mockAvatarCatalog({ firstPage: [selectedAvatar] });
+    mockVoiceCatalog();
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    const dialog = await openAvatarPicker(user);
+    await user.click(
+      await within(dialog).findByLabelText("Select template Ada"),
+    );
+    await within(dialog).findByText("Choose a voice for Ada");
+    await user.click(
+      await within(dialog).findByLabelText(
+        `Select voice ${selectedVoice.name}`,
+      ),
+    );
+    await expectInlineTemplateInComposer("Ada");
+
+    // Reopening from the inline chip hands the stored template back to the
+    // picker, so the voice it carries must still read as the chosen one.
+    await user.click(await screen.findByLabelText("Preview template Ada"));
+    const reopened = await screen.findByRole("dialog");
+    await user.click(
+      await within(reopened).findByLabelText("Select template Ada"),
+    );
+
+    await waitFor(() => {
+      expect(
+        within(reopened).getByLabelText(`Select voice ${selectedVoice.name}`),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+    expect(
+      within(reopened).getByLabelText(`Select voice ${alternateVoice.name}`),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
   it("disables send while a template draft attachment is uploading", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -27,6 +27,7 @@ import {
   Skeleton,
   cn,
 } from "@vm0/ui";
+import { readAvatarTemplateOptions } from "@vm0/core/avatar-template";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import type {
   KeyboardEvent as ReactKeyboardEvent,
@@ -1040,7 +1041,9 @@ function AvatarVoiceCatalog({
         : undefined;
   const pageSignal = useGet(pageSignal$);
   const selectedVoiceId =
-    value?.type === "video" ? value.selection.voiceId : undefined;
+    value?.type === "video"
+      ? readAvatarTemplateOptions(value.selection).voiceId
+      : undefined;
   const recommendedVoice =
     recommendation.state === "hasData"
       ? (recommendation.data ?? visibleCatalog?.voices[0] ?? null)

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -252,11 +252,13 @@ const videoGenerationTemplateRequestSchema = z.object({
     avatarOptions: avatarGenerationOptionsSchema.optional(),
 
     /**
-     * The four fields below are still written alongside avatarOptions so that
-     * readers predating it do not lose the selection. Stop writing them once
-     * the web-client floor has been raised past the app version shipping this
-     * change; keep reading them until a backfill moves existing rows.
-     * Tracked in https://github.com/vm0-ai/vm0/issues/25620.
+     * The four fields below are no longer written: the web-client floor has
+     * been raised past the app version that introduced avatarOptions, so no
+     * live reader predates the nested object. They stay parseable because rows
+     * persisted before the split only carry the flat shape, and
+     * readAvatarTemplateOptions still reads them. Dropping them here would
+     * strip those historical selections on parse; they can only go away with a
+     * jsonb backfill. Tracked in https://github.com/vm0-ai/vm0/issues/25620.
      *
      * @deprecated Read-only fallback; write avatarOptions.titleSnapshot.
      */

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -166,10 +166,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     computer_use_host_id: z.uuid(),
   }),
   z.object({
-    action: z.literal("set-chat-slack-context-as-previous-api"),
-    event_id: z.uuid(),
-  }),
-  z.object({
     action: z.literal("set-browser-tab-snapshot-as-previous-api"),
     thread_id: z.uuid(),
     tab_urls: z.array(z.string().max(8192)).max(50),


### PR DESCRIPTION
Daily deployment-compatibility cleanup. Two cohorts whose consumer windows have closed, in one branch. Evidence is production deployment history, `vm0-request-log-prod` (Axiom), and `vm0-prod-ro` (MaskDB, read-only, aggregates only).

## Cohort 1 — Slack queued launch context (#25830)

**Old → new boundary.** Before [#25824](https://github.com/vm0-ai/vm0/pull/25824) the API wrote `chat_slack_context` rows without `bot_user_id` or `message_assets`. `requiredSlackLaunchContext` filled the gap with `row.botUserId ?? row.installationBotUserId` and `row.messageAssets ?? []`.

**Surface and window.** Persisted Slack launch context read by this API. `loadSlackQueuedLaunchMaterial` is only reached while admitting a queued message (`internal-chat-run-callback.service.ts`) or steering a live run (`active-input-prompt.service.ts`). Historical rows are never re-read, so the window is bounded by how long a pre-cutover Slack input event can still sit in a thread queue or an active run — not by the DB/API skew.

**Rollout.** #25824 merged 2026-08-08T14:53:37Z; `api/production` promoted the containing release the same day. The draining previous API stopped writing the incomplete shape at **2026-08-08T15:32:38Z**.

**MaskDB evidence** (`vm0-prod-ro`, snapshot current to 2026-08-09T21:10Z):

- `chat_slack_context`: 379 rows total, 375 with `bot_user_id IS NULL`. Newest `NULL` row `2026-08-08T15:32:38.951Z` — **29.6 h** before this run.
- All 4 rows written since (2026-08-09T04:28Z → 14:17Z) carry a non-null `bot_user_id`. The new writer is the only writer.
- `agent_runs` in `running`/`pending`/`queued`/`starting` created before `2026-08-08T15:32:39Z`: **0**. Oldest active run overall is `2026-08-09T21:01:45Z`. No thread has been blocked since before the cutover, so neither the queue-admission nor the live-run steering path can still reach a pre-cutover row.
- `run_id IS NULL` on a `slack` `input.prompt` event is *not* a queue marker: it holds for 253/506 (50.0%) of such events in 2026-07-15..08-01, a fully drained window, and 4/8 since 2026-08-09. Counted alone it would have been a false positive.

**Axiom coverage** (`vm0-request-log-prod`, 2026-08-08T15:32:39Z → 2026-08-09T21:30:00Z): the Slack surface is live and instrumented — `/api/zero/integrations/slack` 856 requests, `/api/zero/slack/events` 24, `/api/zero/slack/oauth/install` 21, `/api/zero/integrations/slack/message` 16, `/api/zero/integrations/slack/download-file` 1; **0** responses ≥ 500 on any of them.

**Removed.** Both `??` branches; the `installationBotUserId` projection; the `SlackLaunchContextRow` intersection carrying it; the `launches a queued Slack context written by the previous API version` BDD test; the `set-chat-slack-context-as-previous-api` fixture action, its contract entry, and its helper. The `slackOrgInstallations` join stays — it is the authorization check, not the fallback source. `requiredSlackLaunchContext` now rejects rows missing `bot_user_id` or `message_assets` instead of repairing them.

## Cohort 2 — Avatar template flat-field write (#25620)

**Old → new boundary.** [#25613](https://github.com/vm0-ai/vm0/pull/25613) nested the talking-avatar fields under `selection.avatarOptions`. Because `videoGenerationTemplateRequestSchema.selection` is not `.strict()`, a bundle predating `avatarOptions` silently strips the nested object, so `toAvatarGenerationTemplate` also mirrored the four fields flat.

**Rollout.** #25613 merged 2026-08-07T07:40:22Z and first shipped in app **v0.701.0** (release `2876cca5`, 2026-08-07T08:39:35Z). `minimumSupportedVersion` is now **0.708.2**, raised in later releases (#25771 on 2026-08-08T03:53Z, then #25818) — after the 0.701.0 build was live, which is the ordering `docs/deployment-compatibility.md` requires.

**Axiom evidence** (`vm0-request-log-prod`, `x_client_type == "App"`, 2026-08-08T21:00Z → 2026-08-09T21:30Z), requests by minor version and how many were rejected with `426`:

| minor | requests | 426 |
|---|---|---|
| 656 | 11 | 11 |
| 696 | 71 | 71 |
| 700 | 7 | 7 |
| 703 | 7 514 | 7 514 |
| 704 | 26 | 26 |
| 706 | 4 710 | 4 710 |
| 707 | 219 | 219 |
| 708 | 531 | 42 |
| 710–714 | 316 526 | 0 |

Every App request below the floor is rejected (12 558 requests, 100% `426`); within 708 only the 42 below 0.708.2 are. **No served App traffic comes from a bundle older than 0.708.2**, which is seven minor versions above the 0.701.0 that introduced `avatarOptions`. Observed sub-floor traffic is disclosed here rather than treated as a veto: it is expired clients being told to upgrade, exactly the surface the floor governs.

**Removed.** The `...avatarOptions` flat mirror in `toAvatarGenerationTemplate`, and the test assertion that pinned it.

**Deliberately kept.** The four `@deprecated` fields stay in `videoGenerationTemplateRequestSchema`. #25620 proposes dropping them, but `generationTemplateRequestSchema` also parses persisted content (`user-message-document-codec.ts`, `tiptap-workflow-composer.ts`); dropping the fields would make zod strip them from rows written before the split and lose the voice and cover image, which is the data loss that issue's own "removing the read fallback" section warns about. That half needs the jsonb backfill first, so #25620 stays open and its comment now records why. Only the write side is expired.

## Checks

Run once against the combined diff: `pnpm format`; `pnpm check-types` (all 14 tasks); `pnpm turbo run lint --filter=api --filter=@vm0/app --filter=@vm0/api-contracts` (0 errors); `pnpm knip` (exit 0); `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/chat-threads.test.ts` (24 passed); `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx` (30 passed). Per repo guidance the full local Vitest suite was not run and no dev server was started; `integrations.bdd.test.ts` is left to the PR pipeline.

## Open-PR overlap

Disclosed, not hidden. #25722 and #25527 also touch the shared test-fixture registries `routes/test-runtime-state.ts` / `contracts/test-runtime-state.ts` / `helpers/runtime-state.ts`, but only to **add** unrelated actions (worker-preview, usage-pack). Neither references `set-chat-slack-context-as-previous-api`, so the compat symbol itself is uncontested; the adjacency is registry-level only.

Deferred this run: the #25716 payment-method portal cohort (open PRs #25529/#25510 hold `org-billing-tab.tsx` and #23676 holds the exact `feature-switch.test.ts` assertion block), #25913 matchedRanges and #25879 runless-model annotations (windows still open until 2026-08-11), #25828 file-url tolerance (open PR #25955), and the `browser_*` schema contraction (`browser_*` tables are not exposed in MaskDB, so the persisted-data story cannot be proven from here).
