### PR TITLE
fix(test): arbitrate managed key fixture acquisition

### DIFF
--- a/turbo/apps/api/src/signals/services/test-vm0-managed-model-key-fixture.service.ts
+++ b/turbo/apps/api/src/signals/services/test-vm0-managed-model-key-fixture.service.ts
@@ -53,20 +53,20 @@ export async function acquireVm0ManagedModelKeyFixture(
 ): Promise<void> {
   for (const value of rows) {
     await db.transaction(async (tx) => {
-      await tx
+      const [row] = await tx
         .insert(vm0ApiKeys)
         .values({
           ...value,
           label: vm0ManagedModelKeyFixtureLabel([fixtureId]),
         })
-        .onConflictDoNothing({ target: vm0ApiKeys.vendor });
-
-      const [row] = await tx
-        .select({ id: vm0ApiKeys.id, label: vm0ApiKeys.label })
-        .from(vm0ApiKeys)
-        .where(eq(vm0ApiKeys.vendor, value.vendor))
-        .for("update")
-        .limit(1);
+        .onConflictDoUpdate({
+          target: vm0ApiKeys.vendor,
+          // Keep the existing key while atomically locking and returning its
+          // vendor row. DO NOTHING followed by SELECT FOR UPDATE leaves a
+          // window where the previous fixture owner can delete the row.
+          set: { vendor: value.vendor },
+        })
+        .returning({ id: vm0ApiKeys.id, label: vm0ApiKeys.label });
       if (!row) {
         throw new Error(`Expected VM0 managed key for vendor: ${value.vendor}`);
       }


### PR DESCRIPTION
## Summary

- arbitrate VM0 managed-key fixture acquisition and row locking in one PostgreSQL upsert
- keep the existing platform-managed key while registering each fixture owner under the same transaction lock
- preserve the lifecycle assertion that DeepSeek V4 Flash claims use the Responses adapter

## Root cause

[Turbo run 31343866586](https://github.com/vm0-ai/vm0/actions/runs/31343866586) failed in [`test-api (8)`](https://github.com/vm0-ai/vm0/actions/runs/31343866586/job/93322083138) before the DeepSeek lifecycle assertion. `acquireVm0ManagedModelKeyFixture` executed `INSERT ... ON CONFLICT DO NOTHING` for the vendor-unique `deepseek` row and then attempted a separate `SELECT ... FOR UPDATE`. A concurrent final-owner fixture cleanup could delete the conflicting row between those two statements, leaving the select empty and producing `Expected VM0 managed key for vendor: deepseek`.

The failing merge-group SHA and current `main` have the same source tree. The same shard passed on the feature PR, the preceding merge group, the base-main push, and the re-enqueued merge group, so the triggering platform file-url change is unrelated. This is distinct from #25679: that repair recorded shared ownership to prevent a later chat-events 503, while this occurrence failed earlier in the acquisition gap with a fixture-seed 500.

## Fix

Use `ON CONFLICT DO UPDATE ... RETURNING` with a no-op vendor assignment. PostgreSQL now locks and returns either the inserted or conflicting vendor row in the same statement. A concurrent cleanup cannot delete that row until the transaction has appended the new fixture owner, after which last-owner cleanup preserves it.

No retries, sleeps, timeouts, skipped tests, cleanup detachment, or assertion changes are included.

## Validation

- focused Prettier check
- focused standard Oxlint, type-aware Oxlint, and ESLint
- `pnpm -F api lint`
- `pnpm knip`
- `pnpm -F api run check-types`
- `git diff --check`

Targeted API Vitest runs were not executed locally because they require PostgreSQL and this repair contract prohibits starting a local database service. The standard PR pipeline provides the database-backed integration run. Deployment-preview validation is not applicable because the changed fixture service and route are test-environment-only.
