### PR TITLE
test(connectors): decouple admission from wakeup transport

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9602,20 +9602,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       }),
     );
 
-    context.mocks.ably.publish.mockClear();
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
       { key: "api_key", kind: "secret", value: "recovered-key" },
     ]);
-    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      {
-        runId: incompleteRun.runId,
-        target: {
-          kind: "custom",
-          customConnectorId: saved.connector.id,
-        },
-      },
-    );
     await api.requestCancelRun(actor, incompleteRun.runId, [200]);
 
     const longSubdomain = "a".repeat(55);


### PR DESCRIPTION
## Summary

- remove the Ably publish negative assertion added by #25962
- keep the test focused on persisted connector target membership and later-run recovery

## Rationale

The runner's registered target set prevents a reconnect notification from expanding an active run. Notification suppression is not the invariant: after a non-standby claim removes the queue row, the existing wakeup fallback may legitimately broadcast a target that the runner then ignores because it was not registered. Asserting that the API never publishes therefore couples the test to one execution mode without strengthening the product guarantee.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (147 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`

Follow-up to #25962.
