### PR TITLE
fix(guest-agent): disable codex native goals

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -78,10 +78,11 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 const ZERO_AGENT_ID_ENV_KEY: &str = "ZERO_AGENT_ID";
 const WEB_SEARCH_TOOL_NAME: &str = "WebSearch";
-const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 4] = [
     "analytics.enabled=false",
     "features.plugins=false",
     "features.apps=false",
+    "features.goals=false",
 ];
 const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
     ["features.fast_mode=true", r#"service_tier="fast""#];

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -12,10 +12,11 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 4] = [
     "analytics.enabled=false",
     "features.plugins=false",
     "features.apps=false",
+    "features.goals=false",
 ];
 
 #[tokio::test]

--- a/crates/guest-agent/tests/common/codex_app_server_startup.rs
+++ b/crates/guest-agent/tests/common/codex_app_server_startup.rs
@@ -6,10 +6,11 @@ use std::time::Duration;
 
 use crate::common;
 
-const CODEX_FIXED_STARTUP_CONFIGS: [&str; 3] = [
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 4] = [
     "analytics.enabled=false",
     "features.plugins=false",
     "features.apps=false",
+    "features.goals=false",
 ];
 const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
     ["features.fast_mode=true", r#"service_tier="fast""#];


### PR DESCRIPTION
## Summary

- disable Codex native Goals for every app-server process started by guest-agent
- keep VM0's independent `zero goal` lifecycle unchanged
- verify the fixed startup configuration in existing app-server integration coverage

## Out of scope

- no migration or deletion of existing Codex-native goal state
- no changes to VM0 goal APIs, persistence, or continuation scheduling

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --all-features --no-deps`
- `cd crates && cargo test -p guest-agent --all-features`

Closes #25971
