### PR TITLE
refactor: remove quickbooks connector feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -108,6 +108,7 @@ describe("GET /api/zero/connectors", () => {
       [200],
     );
     expect(nonStaff.body.configuredConnectorSlugs).toContain("aws");
+    expect(nonStaff.body.configuredConnectorSlugs).toContain("quickbooks");
     expect(nonStaff.body.configuredConnectorSlugs).not.toContain("test-oauth");
     expect(nonStaff.body.configuredConnectorSlugs).toContain("nintendo-store");
     expect(nonStaff.body.configuredConnectorSlugs).toContain(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -108,7 +108,6 @@ describe("GET /api/zero/connectors", () => {
       [200],
     );
     expect(nonStaff.body.configuredConnectorSlugs).toContain("aws");
-    expect(nonStaff.body.configuredConnectorSlugs).toContain("quickbooks");
     expect(nonStaff.body.configuredConnectorSlugs).not.toContain("test-oauth");
     expect(nonStaff.body.configuredConnectorSlugs).toContain("nintendo-store");
     expect(nonStaff.body.configuredConnectorSlugs).toContain(

--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -34,7 +34,6 @@ const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
   "netsuite\0api-token": FeatureSwitchKey.NetSuiteConnector,
   "paypal\0api-token": FeatureSwitchKey.PayPalConnector,
   "posthog\0oauth": FeatureSwitchKey.PosthogConnector,
-  "quickbooks\0oauth": FeatureSwitchKey.QuickBooksConnector,
   "ramp\0api-token": FeatureSwitchKey.RampConnector,
   "reddit\0oauth": FeatureSwitchKey.RedditConnector,
   "spotify\0oauth": FeatureSwitchKey.SpotifyConnector,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -23,7 +23,6 @@ export enum FeatureSwitchKey {
   NeonConnector = "neonConnector",
   NetSuiteConnector = "netSuiteConnector",
   GarminConnectConnector = "garminConnectConnector",
-  QuickBooksConnector = "quickbooksConnector",
   RedditConnector = "redditConnector",
   SupabaseConnector = "supabaseConnector",
   WebflowConnector = "webflowConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -134,11 +134,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Garmin Connect wellness connector",
     enabled: false,
   },
-  [FeatureSwitchKey.QuickBooksConnector]: {
-    maintainer: "yuma@vm0.ai",
-    description: "Enable the QuickBooks accounting connector",
-    enabled: false,
-  },
   [FeatureSwitchKey.RedditConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the Reddit connector integration",


### PR DESCRIPTION
## Summary

Remove the `quickbooksConnector` feature switch and make the QuickBooks OAuth connector permanently available through connector discovery.

## Terminal state

**Fully rolled out.** The user explicitly confirmed this terminal state in the cleanup request.

## History and behavior comparison

- Introducing commit: `6f4aa424c5` (`feat: add QuickBooks OAuth connector (#18273)`).
- Its parent had no QuickBooks connector. The commit added the connector implementation and a disabled discovery gate together.
- `11071e0563` later moved the switch key into `@vm0/core`; `6670ff6f17` later moved the auth-method rollout association into the API-owned mapping.
- On current `main`, the disabled path hides `quickbooks\0oauth` from discovery, while the enabled path exposes the otherwise complete connector.
- For the fully rolled-out state, this PR keeps the enabled connector behavior and removes only the discovery gate and its registry/type artifacts.

## What changed

Removed:

- `FeatureSwitchKey.QuickBooksConnector`
- The `quickbooksConnector` registry entry
- The `"quickbooks\0oauth" -> QuickBooksConnector` rollout association

Kept:

- QuickBooks catalog metadata and Platform fixture
- OAuth authorization, token exchange, refresh, user-info, and `realmId` handling
- Provider registration, environment wiring, firewall behavior, icon/resources, and connector tests

Tests:

- No QuickBooks true/false switch matrix, override fixture, or feature-specific fallback test existed to remove.
- Existing catalog rollout coverage verifies that auth methods without a vm0-owned rollout association remain visible.

## Cross-repository check

- `vm0-ai/vm0-connectors` owns connector source and artifacts but explicitly delegates rollout policy to `vm0`.
- Its QuickBooks method is already `visible: true` and contains no rollout key.
- `e9318713e3` removed `featureSwitch: quickbooksConnector` when catalog v3 became feature-switch-free, and current schemas reject `featureSwitch` in connector artifacts.
- The latest `vm0-connectors` production publication succeeded, so no companion repository change or republish is required.

## Search audit

- Exact and naming-variant searches covered `QuickBooksConnector`, `quickbooksConnector`, the supplied `quickbookConnector` spelling, and kebab/snake variants; no switch references remain.
- Association searches combining QuickBooks with `feature switch` also return no matches.
- The semantic follow-up covered `quickbooks`, `Intuit`, `realmId`, `QUICKBOOKS_OAUTH_*`, catalog/provider names, fixtures, tests, resources, and changelogs. Remaining matches are retained enabled-product behavior or historical changelog entries.

## Knip

- Baseline: `pnpm knip` exited successfully with 42 existing configuration hints and no unused-code findings.
- After cleanup: `pnpm knip` exited successfully with the same 42 configuration hints and no new orphaned files, exports, types, or dependencies.

## Verification

Passed locally:

- Prettier on all changed files
- `pnpm --filter @vm0/core lint`
- `pnpm --filter api lint` (exit 0; emitted the repository's existing unrelated warnings)
- Targeted type-aware Oxlint and ESLint on the changed API source
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter api check-types`
- `pnpm --filter @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/quickbooks.test.ts` — 8/8 passed
- `git diff --check`
- Exact-key, association, and semantic follow-up searches described above

Environment-blocked local check:

- The database-backed API catalog test could not start locally because no PostgreSQL listener is available at `localhost:5432` (`ECONNREFUSED ::1:5432` and `ECONNREFUSED 127.0.0.1:5432`).
- The PR pipeline owns this database-backed coverage and the repository's full required checks.
