### PR TITLE
refactor(python): centralize usage counter ownership

### DIFF
--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -14,6 +14,7 @@ import threading
 import time
 import uuid
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,13 +24,9 @@ import runner_flush_request
 
 _counter_lock = threading.Lock()
 _pending_write_lock = threading.Lock()
-_in_flight_flows = 0
 _buffered_usage_events = 0
-_buffered_reports = 0
-_pending_reports = 0
 _pending_path = ""
 _usage_state_id = str(uuid.uuid4())
-_counter_underflow_logged: set[str] = set()
 # One-shot guard: sustained pending snapshot write failure makes the runner
 # hit the bounded usage-drain timeout without any local signal pointing at
 # filesystem trouble.  Emit one error signal per addon process on first failure —
@@ -41,24 +38,31 @@ _counter_underflow_logged: set[str] = set()
 # leading key=value fields and re-emits them as structured tracing fields.
 _pending_write_error_logged = False
 _FLUSH_REQUEST_FILE = "usage-flush-request"
-_COUNTER_BUFFERED_REPORTS = "buffered_reports"
-_COUNTER_FLOWS = "flows"
-_COUNTER_REPORTS = "reports"
+
+
+@dataclass
+class _PendingCounter:
+    name: str
+    value: int = 0
+    underflow_logged: bool = False
+
+
+_in_flight_flows = _PendingCounter("flows")
+_buffered_reports = _PendingCounter("buffered_reports")
+_pending_reports = _PendingCounter("reports")
 
 
 def reset_for_tests() -> None:
     """Reset mutable counter state between tests."""
-    global _in_flight_flows, _buffered_reports, _buffered_usage_events, _pending_reports
-    global _pending_path, _usage_state_id, _pending_write_error_logged
+    global _buffered_usage_events, _pending_path, _usage_state_id, _pending_write_error_logged
     with _counter_lock:
-        _in_flight_flows = 0
+        for counter in (_in_flight_flows, _buffered_reports, _pending_reports):
+            counter.value = 0
+            counter.underflow_logged = False
         _buffered_usage_events = 0
-        _buffered_reports = 0
-        _pending_reports = 0
         _pending_path = ""
         _usage_state_id = str(uuid.uuid4())
         _pending_write_error_logged = False
-        _counter_underflow_logged.clear()
 
 
 def set_pending_path(path: str, usage_state_id: str | None = None) -> None:
@@ -83,9 +87,9 @@ def _pending_snapshot_locked(flush_request_id: str | None = None) -> tuple[str, 
         "pid": os.getpid(),
         "usageStateId": _usage_state_id,
         "updatedAtMs": int(time.time() * 1000),
-        "flows": _in_flight_flows,
-        "buffered": _buffered_usage_events + _buffered_reports,
-        "reports": _pending_reports,
+        "flows": _in_flight_flows.value,
+        "buffered": _buffered_usage_events + _buffered_reports.value,
+        "reports": _pending_reports.value,
     }
     if flush_request_id:
         state["flushRequestId"] = flush_request_id
@@ -156,38 +160,24 @@ def increment_in_flight_flows() -> None:
     terminal hooks enqueue billing events and model-usage observations before
     the runner shutdown drain advances.
     """
-    global _in_flight_flows
-    with _counter_lock:
-        _in_flight_flows += 1
+    _increment_counter(_in_flight_flows)
 
 
 def decrement_in_flight_flows() -> None:
     """Mark a tracked in-flight flow as complete (call from response/error)."""
-    global _in_flight_flows
-    should_log = False
-    with _counter_lock:
-        if _in_flight_flows > 0:
-            _in_flight_flows -= 1
-        else:
-            should_log = _mark_counter_underflow_locked(_COUNTER_FLOWS)
-    if should_log:
-        _log_counter_underflow(_COUNTER_FLOWS)
+    _decrement_counter(_in_flight_flows)
 
 
-def increment_pending_reports() -> None:
-    global _pending_reports
-    with _counter_lock:
-        _pending_reports += 1
+class _CounterLease:
+    """Thread-safe one-shot ownership token for one pending counter unit."""
 
-
-class PendingReportLease:
-    """One-shot ownership token for an admitted pending webhook report."""
-
-    def __init__(self) -> None:
+    def __init__(self, counter: _PendingCounter) -> None:
+        self._counter = counter
         self._released = False
         self._lock = threading.Lock()
 
     def release(self) -> None:
+        """Decrement the owned counter once and report repeated release."""
         should_release = False
         should_log = False
         with self._lock:
@@ -198,35 +188,29 @@ class PendingReportLease:
                 should_release = True
 
         if should_release:
-            decrement_pending_reports()
-        if should_log and _mark_counter_underflow(_COUNTER_REPORTS):
-            _log_counter_underflow(_COUNTER_REPORTS)
+            _decrement_counter(self._counter)
+        if should_log and _mark_counter_underflow(self._counter):
+            _log_counter_underflow(self._counter.name)
+
+
+class PendingReportLease(_CounterLease):
+    """Own the runner-visible count for one admitted webhook report.
+
+    Release exactly once after delivery finishes or admission is rolled back.
+    Concurrent or repeated release preserves other reports' counts and emits
+    the process-wide ``reports`` underflow diagnostic.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(_pending_reports)
 
 
 def admit_pending_report() -> PendingReportLease:
-    increment_pending_reports()
+    _increment_counter(_pending_reports)
     return PendingReportLease()
 
 
-def decrement_pending_reports() -> None:
-    global _pending_reports
-    should_log = False
-    with _counter_lock:
-        if _pending_reports > 0:
-            _pending_reports -= 1
-        else:
-            should_log = _mark_counter_underflow_locked(_COUNTER_REPORTS)
-    if should_log:
-        _log_counter_underflow(_COUNTER_REPORTS)
-
-
-def _increment_buffered_reports() -> None:
-    global _buffered_reports
-    with _counter_lock:
-        _buffered_reports += 1
-
-
-class BufferedReportLease:
+class BufferedReportLease(_CounterLease):
     """Own the runner-visible count for one retained, unadmitted webhook report.
 
     Keep the lease with its report while webhook-delivery admission remains
@@ -240,31 +224,7 @@ class BufferedReportLease:
     """
 
     def __init__(self) -> None:
-        self._released = False
-        self._lock = threading.Lock()
-
-    def release(self) -> None:
-        """Release retained-report ownership exactly once.
-
-        Concurrent calls are serialized, and only the first decrements the
-        buffered-report contribution. A repeated call preserves other reports'
-        counts but emits the addon-process-wide, one-shot ``buffered_reports``
-        underflow diagnostic. Repeated release is an ownership error, not
-        ordinary idempotent cleanup.
-        """
-        should_release = False
-        should_log = False
-        with self._lock:
-            if self._released:
-                should_log = True
-            else:
-                self._released = True
-                should_release = True
-
-        if should_release:
-            _decrement_buffered_reports()
-        if should_log and _mark_counter_underflow(_COUNTER_BUFFERED_REPORTS):
-            _log_counter_underflow(_COUNTER_BUFFERED_REPORTS)
+        super().__init__(_buffered_reports)
 
 
 def admit_buffered_report() -> BufferedReportLease:
@@ -276,20 +236,24 @@ def admit_buffered_report() -> BufferedReportLease:
     admission returns ``False``, then release it according to the lease
     contract. A report rejected before this function is called owns no lease.
     """
-    _increment_buffered_reports()
+    _increment_counter(_buffered_reports)
     return BufferedReportLease()
 
 
-def _decrement_buffered_reports() -> None:
-    global _buffered_reports
+def _increment_counter(counter: _PendingCounter) -> None:
+    with _counter_lock:
+        counter.value += 1
+
+
+def _decrement_counter(counter: _PendingCounter) -> None:
     should_log = False
     with _counter_lock:
-        if _buffered_reports > 0:
-            _buffered_reports -= 1
+        if counter.value > 0:
+            counter.value -= 1
         else:
-            should_log = _mark_counter_underflow_locked(_COUNTER_BUFFERED_REPORTS)
+            should_log = _mark_counter_underflow_locked(counter)
     if should_log:
-        _log_counter_underflow(_COUNTER_BUFFERED_REPORTS)
+        _log_counter_underflow(counter.name)
 
 
 def set_buffered_usage_events(count: int) -> None:
@@ -298,15 +262,15 @@ def set_buffered_usage_events(count: int) -> None:
         _buffered_usage_events = max(0, count)
 
 
-def _mark_counter_underflow(counter: str) -> bool:
+def _mark_counter_underflow(counter: _PendingCounter) -> bool:
     with _counter_lock:
         return _mark_counter_underflow_locked(counter)
 
 
-def _mark_counter_underflow_locked(counter: str) -> bool:
-    if counter in _counter_underflow_logged:
+def _mark_counter_underflow_locked(counter: _PendingCounter) -> bool:
+    if counter.underflow_logged:
         return False
-    _counter_underflow_logged.add(counter)
+    counter.underflow_logged = True
     return True
 
 

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import flow_metadata_keys as metadata_keys
 import usage
 from tests.pending_helpers import assert_current_pending, assert_pending
@@ -27,7 +29,7 @@ class TestUsagePendingCounter:
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path), usage_state_id="before-reset")
         usage.increment_in_flight_flows()
-        usage.counters.increment_pending_reports()
+        usage.counters.admit_pending_report()
         usage.counters.set_buffered_usage_events(2)
         usage.write_pending_snapshot(flush_request_id="before-reset")
         pending_state = assert_pending(
@@ -93,20 +95,6 @@ class TestUsagePendingCounter:
             pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-3"
         )
 
-    def test_increment_decrement_pending_reports(self, tmp_path):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path))
-        usage.counters.increment_pending_reports()
-        assert_pending(pending_path, flows=0, buffered=0, reports=0)
-        assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=1, flush_request_id="request-1"
-        )
-
-        usage.counters.decrement_pending_reports()
-        assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2"
-        )
-
     def test_pending_report_lease_release_drains_report(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
@@ -129,10 +117,10 @@ class TestUsagePendingCounter:
         with patch.object(usage.counters.ctx, "log", mock_log, create=True):
             usage.increment_in_flight_flows()
             usage.decrement_in_flight_flows()
-            usage.counters.increment_pending_reports()
-            usage.counters.decrement_pending_reports()
-            lease = usage.counters.admit_pending_report()
-            lease.release()
+            pending_report = usage.counters.admit_pending_report()
+            buffered_report = usage.admit_buffered_report()
+            pending_report.release()
+            buffered_report.release()
 
         assert mock_log.error.call_count == 0
         assert_current_pending(
@@ -253,7 +241,7 @@ class TestUsagePendingCounter:
 
         assert usage.read_usage_flush_request_id() == "request-1"
 
-    def test_decrement_underflow_stays_non_negative_and_logs_once_per_counter(self, tmp_path):
+    def test_flow_decrement_underflow_stays_non_negative_and_logs_once(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
 
@@ -261,28 +249,49 @@ class TestUsagePendingCounter:
         with patch.object(usage.counters.ctx, "log", mock_log, create=True):
             usage.decrement_in_flight_flows()
             usage.decrement_in_flight_flows()
-            usage.counters.decrement_pending_reports()
-            usage.counters.decrement_pending_reports()
 
         assert_current_pending(
             pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
         )
 
-        assert mock_log.error.call_count == 2
-        messages = [call.args[0] for call in mock_log.error.call_args_list]
-        assert_counter_underflow_message(messages[0], "flows")
-        assert_counter_underflow_message(messages[1], "reports")
+        assert mock_log.error.call_count == 1
+        assert_counter_underflow_message(mock_log.error.call_args[0][0], "flows")
         assert mock_log.warn.call_count == 0
 
-    def test_pending_report_lease_double_release_logs_without_decrementing_other_reports(
-        self, tmp_path
+    @pytest.mark.parametrize(
+        (
+            "admit_report",
+            "counter",
+            "admitted_buffered",
+            "admitted_reports",
+            "remaining_buffered",
+            "remaining_reports",
+        ),
+        [
+            (usage.counters.admit_pending_report, "reports", 0, 2, 0, 1),
+            (usage.admit_buffered_report, "buffered_reports", 2, 0, 1, 0),
+        ],
+    )
+    def test_report_lease_double_release_logs_without_decrementing_other_reports(
+        self,
+        tmp_path,
+        admit_report,
+        counter,
+        admitted_buffered,
+        admitted_reports,
+        remaining_buffered,
+        remaining_reports,
     ):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
-        first = usage.counters.admit_pending_report()
-        second = usage.counters.admit_pending_report()
+        first = admit_report()
+        second = admit_report()
         assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=2, flush_request_id="admitted"
+            pending_path,
+            flows=0,
+            buffered=admitted_buffered,
+            reports=admitted_reports,
+            flush_request_id="admitted",
         )
 
         mock_log = MagicMock()
@@ -291,37 +300,14 @@ class TestUsagePendingCounter:
             first.release()
 
         assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=1, flush_request_id="first-released"
+            pending_path,
+            flows=0,
+            buffered=remaining_buffered,
+            reports=remaining_reports,
+            flush_request_id="first-released",
         )
         assert mock_log.error.call_count == 1
-        assert_counter_underflow_message(mock_log.error.call_args[0][0], "reports")
-
-        second.release()
-        assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=0, flush_request_id="all-released"
-        )
-
-    def test_buffered_report_lease_double_release_logs_without_decrementing_other_reports(
-        self, tmp_path
-    ):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path))
-        first = usage.admit_buffered_report()
-        second = usage.admit_buffered_report()
-        assert_current_pending(
-            pending_path, flows=0, buffered=2, reports=0, flush_request_id="admitted"
-        )
-
-        mock_log = MagicMock()
-        with patch.object(usage.counters.ctx, "log", mock_log, create=True):
-            first.release()
-            first.release()
-
-        assert_current_pending(
-            pending_path, flows=0, buffered=1, reports=0, flush_request_id="first-released"
-        )
-        assert mock_log.error.call_count == 1
-        assert_counter_underflow_message(mock_log.error.call_args[0][0], "buffered_reports")
+        assert_counter_underflow_message(mock_log.error.call_args[0][0], counter)
 
         second.release()
         assert_current_pending(
@@ -347,8 +333,8 @@ class TestUsagePendingCounter:
         usage.set_pending_path("")
         usage.increment_in_flight_flows()
         usage.decrement_in_flight_flows()
-        usage.counters.increment_pending_reports()
-        usage.counters.decrement_pending_reports()
+        pending_report = usage.counters.admit_pending_report()
+        pending_report.release()
         usage.write_pending_snapshot(flush_request_id="request-1")
         # Should not raise — just no file written.
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -368,8 +368,8 @@ class TestRunnerUsageFlushSignal:
 
         def flush_usage_events(*, trigger: str) -> int:
             assert trigger == "runner"
-            usage.counters.increment_pending_reports()
-            usage.counters.decrement_pending_reports()
+            pending_report = usage.counters.admit_pending_report()
+            pending_report.release()
             flushed.set()
             return 0
 
@@ -584,7 +584,7 @@ class TestRunnerUsageFlushSignal:
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
         snapshotted = threading.Event()
-        usage.counters.increment_pending_reports()
+        pending_report = usage.counters.admit_pending_report()
         runner_usage_flush_files.write_usage_flush_request()
 
         original_write_pending_snapshot = usage.write_pending_snapshot
@@ -617,6 +617,7 @@ class TestRunnerUsageFlushSignal:
             reports=1,
             flush_request_id="request-1",
         )
+        pending_report.release()
 
     def test_jsonl_watcher_acknowledges_flush_request(
         self, runner_usage_flush_files: RunnerUsageFlushFiles

--- a/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
@@ -25,7 +25,7 @@ def test_sync_executor_worker_error_preserves_other_pending_reports(tmp_path, sy
     proxy_log = tmp_path / "proxy.jsonl"
     pending_path = tmp_path / "usage-pending"
     usage.set_pending_path(str(pending_path))
-    usage.counters.increment_pending_reports()
+    other_pending_report = usage.counters.admit_pending_report()
 
     usage.webhook.enqueue_webhook_delivery(
         "not-a-url",
@@ -46,6 +46,7 @@ def test_sync_executor_worker_error_preserves_other_pending_reports(tmp_path, sy
     assert "non-retryable" in read_jsonl_text_after_flush(proxy_log)
     with pytest.raises(ValueError, match="absolute http"):
         sync_usage_executor.shutdown(wait=True)
+    other_pending_report.release()
 
 
 def test_enqueue_logs_body_free_payload_summary(


### PR DESCRIPTION
## Summary

- centralize the three decrementable usage pending counters in one private state model
- share one thread-safe, one-shot release implementation across pending and buffered report leases
- remove test-only raw pending-report mutations and parameterize the shared lease contract

## Compatibility

- preserves the runner-visible `flows`, aggregate `buffered`, and `reports` snapshot fields
- preserves `usage_pending_counter_underflow` diagnostic fields and counter names
- preserves distinct `PendingReportLease` and `BufferedReportLease` caller types
- changes no API, schema, migration, queue payload, or durable persisted data

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_counters.py tests/test_webhook_delivery_admission.py tests/test_runner_usage_flush_signal.py tests/test_usage_buffer_timer_shutdown.py tests/test_done_hook.py` (104 passed)
- `uv run --no-sync python -m pytest tests/` (5180 passed)

Closes #25974
