### PR TITLE
test(python): cover keyword-only metadata alias defaults

### DIFF
--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/keyword_only_default_aliases.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/keyword_only_default_aliases.base.py.txt
@@ -1,0 +1,4 @@
+def function_case(*, metadata=flow.metadata):
+    return metadata["vm_run_id"]
+
+lambda_case = lambda *, metadata=flow.metadata: metadata["firewall_name"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/keyword_only_default_aliases.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/keyword_only_default_aliases.expected.txt
@@ -1,0 +1,2 @@
+keyword_only_default_aliases.py:2: use metadata_keys.VM_RUN_ID for flow.metadata access
+keyword_only_default_aliases.py:4: use metadata_keys.FIREWALL_NAME for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -191,6 +191,17 @@ def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
     )
 
 
+def test_registered_flow_metadata_guard_tracks_keyword_only_default_aliases(tmp_path):
+    source_path = tmp_path / "keyword_only_default_aliases.py"
+    _write_python_source(source_path, "keyword_only_default_aliases.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "keyword_only_default_aliases.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_flags_match_or_pattern_keys(tmp_path):
     source_path = tmp_path / "match_or_pattern_keys.py"
     _write_python_source(source_path, "match_or_pattern_keys.base.py.txt")


### PR DESCRIPTION
## Summary

- add focused function and lambda fixtures for keyword-only `flow.metadata` default aliases
- assert the exact registered metadata-key diagnostics through the public linter entry point
- isolate this contract from the version-specific monolithic violation fixtures

## Explicit exclusions

- no production visitor or runtime behavior changes
- no API, schema, migration, compatibility, or rollout changes

## Validation

- focused test passes with the production visitor
- mutation check: the existing positional-default test passes while the new keyword-only test fails when keyword-only propagation is disabled
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`5182 passed`)

Closes #25977
