### PR TITLE
test(runner): make workspace lock retry coverage deterministic

### DIFF
--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -2,6 +2,9 @@ use super::*;
 use async_trait::async_trait;
 use httpmock::prelude::*;
 use sha2::{Digest, Sha256};
+use std::os::unix::fs::PermissionsExt;
+use std::sync::mpsc;
+use std::time::Instant;
 
 use crate::executor::session_history_cpu::{SessionHistoryCpuPool, SessionHistoryCpuTestGate};
 use crate::executor::tests::support::RUN_IN_SANDBOX_TEST_TIMEOUT;
@@ -801,6 +804,8 @@ async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
 
 #[tokio::test]
 async fn execute_inner_waits_for_transient_workspace_cache_lock() {
+    const LOCK_ATTEMPT_WATCHDOG: Duration = Duration::from_secs(1);
+
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = WorkspaceImageCache::new(runner_paths.clone());
@@ -823,16 +828,34 @@ async fn execute_inner_waits_for_transient_workspace_cache_lock() {
         CANONICAL_WORKING_DIR,
         u64::from(params.workspace_disk_mb) * 1024 * 1024,
     );
-    let held_lock = crate::lock::acquire(crate::paths::workspace_image_cache_lock_path(
+    let lock_path = crate::paths::workspace_image_cache_lock_path(
         &runner_paths.base_dir().join("locks"),
         &cache_key,
-    ))
-    .await
-    .unwrap();
+    );
+    let held_lock = crate::lock::acquire(lock_path.clone()).await.unwrap();
+    std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let (controller_ready_tx, controller_ready_rx) = mpsc::sync_channel(0);
     let release = std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(20));
+        let wait_for_attempt = |attempt| {
+            let deadline = Instant::now() + LOCK_ATTEMPT_WATCHDOG;
+            while std::fs::metadata(&lock_path).unwrap().permissions().mode() & 0o777 != 0o600 {
+                assert!(
+                    Instant::now() < deadline,
+                    "workspace cache lock attempt {attempt} did not tighten the lock file"
+                );
+                std::thread::yield_now();
+            }
+        };
+
+        controller_ready_tx.send(()).unwrap();
+        wait_for_attempt(1);
+        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        wait_for_attempt(2);
         drop(held_lock);
     });
+    controller_ready_rx
+        .recv_timeout(LOCK_ATTEMPT_WATCHDOG)
+        .expect("workspace cache lock controller should become ready");
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let outcome = tokio::time::timeout(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -833,6 +833,8 @@ async fn execute_inner_waits_for_transient_workspace_cache_lock() {
         &cache_key,
     );
     let held_lock = crate::lock::acquire(lock_path.clone()).await.unwrap();
+    // Each acquisition attempt tightens this safe mode to 0600 before flock.
+    // Two tightenings while the guard is held prove the first attempt observed contention.
     std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
     let (controller_ready_tx, controller_ready_rx) = mpsc::sync_channel(0);
     let release = std::thread::spawn(move || {


### PR DESCRIPTION
## Summary

- replace the fixed 20 ms workspace-cache lock release with a two-attempt real-filesystem rendezvous
- release the held entry lock only after preparation has retried the unchanged lock path
- retain the seeded move-image and successful prepare/cache-hit telemetry assertions

## Scope

- test-only runner change; production lock and workspace-cache code is unchanged
- no API, protocol, persisted-state, dependency, production-timeout, or deployment-compatibility change

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner execute_inner_waits_for_transient_workspace_cache_lock -- --nocapture`
- `cargo test -p runner executor::tests::sandbox_run_tests::workspace_cache`
- `cargo test -p runner workspace_image_cache::tests`
- `cargo test -p runner`
- focused test repeated 50 times
- temporary one-shot acquisition mutation: focused test failed on the missing second attempt; source restored and the test passed again
- applicable Lefthook pre-commit and commit-message checks

Closes #25975
