### PR TITLE
fix(ui): put every icon on one stroke width and match paired icon colour

### DIFF
--- a/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
+++ b/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
@@ -84,7 +84,7 @@ function InspectBreadcrumb({ title }: { title: string }) {
   return (
     <nav className="hidden md:flex shrink-0 items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
       <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5">
-        <ChartLine size={14} strokeWidth={1.5} className="shrink-0" />
+        <ChartLine size={14} className="shrink-0" />
         {t(($) => {
           return $.activity.detail.activity;
         })}
@@ -111,11 +111,7 @@ function InspectEmptyState() {
         })}
       />
       <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
-        <Upload
-          size={48}
-          strokeWidth={1}
-          className="text-muted-foreground/40"
-        />
+        <Upload size={48} className="" />
         <h2 className="text-lg font-semibold text-foreground">
           {t(($) => {
             return $.activity.inspect.noLog.title;
@@ -133,7 +129,7 @@ function InspectEmptyState() {
         )}
         <Button variant="outline" asChild>
           <label className="cursor-pointer">
-            <Upload size={16} strokeWidth={1.5} />
+            <Upload size={16} />
             {t(($) => {
               return $.activity.inspect.noLog.upload;
             })}

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -241,7 +241,7 @@ function AgentTabsView({
             return onCreate(activeTab);
           }}
         >
-          <Plus size={14} strokeWidth={2} data-stroke />
+          <Plus size={14} />
           {t(($) => {
             return $.list.actions.new;
           })}
@@ -422,7 +422,7 @@ function CreateAgentAvatarPreview() {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="absolute -right-0.5 -bottom-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border">
-                      <Wand size={10} strokeWidth={1.5} />
+                      <Wand size={10} />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -60,19 +60,19 @@ function ArtifactKindIcon({ kind }: { readonly kind: ArtifactCatalogKind }) {
   const { t } = useTranslation();
   const icon =
     kind === "presentation" ? (
-      <Presentation size={16} strokeWidth={1.7} />
+      <Presentation size={16} />
     ) : kind === "hosted-site" ? (
-      <Globe size={16} strokeWidth={1.7} />
+      <Globe size={16} />
     ) : kind === "image" ? (
-      <Image size={16} strokeWidth={1.7} />
+      <Image size={16} />
     ) : kind === "video" ? (
-      <Video size={16} strokeWidth={1.7} />
+      <Video size={16} />
     ) : kind === "avatar" ? (
-      <User size={16} strokeWidth={1.7} />
+      <User size={16} />
     ) : kind === "shared-thread" ? (
-      <MessagesSquare size={16} strokeWidth={1.7} />
+      <MessagesSquare size={16} />
     ) : (
-      <File size={16} strokeWidth={1.7} />
+      <File size={16} />
     );
   const kindLabel =
     kind === "presentation"
@@ -235,7 +235,7 @@ function ArtifactSharedConversationList({
               className="group flex w-full items-center gap-3 px-4 py-3 text-left outline-none transition-colors hover:bg-state-hover focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
             >
               <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-muted-foreground transition-colors group-hover:text-foreground">
-                <MessagesSquare size={16} strokeWidth={1.7} aria-hidden />
+                <MessagesSquare size={16} aria-hidden />
               </span>
               <span
                 title={artifact.title}
@@ -245,9 +245,8 @@ function ArtifactSharedConversationList({
               </span>
               <ChevronRight
                 size={16}
-                strokeWidth={1.7}
                 aria-hidden
-                className="shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
+                className="shrink-0 transition-colors group-hover:text-foreground"
               />
             </button>
           </li>
@@ -340,7 +339,7 @@ export function ArtifactCatalogError() {
   const { t } = useTranslation();
   return (
     <Alert variant="destructive">
-      <AlertTriangle size={16} strokeWidth={1.5} aria-hidden />
+      <AlertTriangle size={16} aria-hidden />
       <AlertDescription>
         {t(($) => {
           return $.artifacts.catalog.error;

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -388,11 +388,7 @@ export function AuthLayout({ children }: AuthLayoutProps) {
             return $.auth.toggleTheme;
           })}
         >
-          {theme === "dark" ? (
-            <Sun size={16} strokeWidth={2} data-stroke />
-          ) : (
-            <Moon size={16} strokeWidth={2} data-stroke />
-          )}
+          {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
         </button>
 
         {/* Logo Header */}

--- a/turbo/apps/platform/src/views/components/loading-switch.tsx
+++ b/turbo/apps/platform/src/views/components/loading-switch.tsx
@@ -40,7 +40,6 @@ export function LoadingSwitch({
       {loading && (
         <Loader2
           size={10}
-          strokeWidth={2.5}
           className={cn(
             "absolute top-1/2 -translate-x-1/2 -translate-y-1/2 animate-spin text-muted-foreground/70",
             checked ? "left-1/4" : "left-3/4",

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -276,9 +276,9 @@ function MediaImage({ src, alt }: { src: string; alt: string }) {
           className="absolute inset-0 flex h-full w-full items-center justify-center bg-muted/70 text-muted-foreground"
         >
           {imageStatus === "loading" ? (
-            <Loader2 size={18} strokeWidth={1.8} className="animate-spin" />
+            <Loader2 size={18} className="animate-spin" />
           ) : (
-            <Image size={18} strokeWidth={1.5} />
+            <Image size={18} />
           )}
         </span>
       )}

--- a/turbo/apps/platform/src/views/components/mermaid-diagram.tsx
+++ b/turbo/apps/platform/src/views/components/mermaid-diagram.tsx
@@ -79,7 +79,7 @@ export function MermaidDiagram({
           />
         ) : (
           <span className="mermaid-diagram-pending" aria-hidden="true">
-            <Loader2 size={18} strokeWidth={1.8} className="animate-spin" />
+            <Loader2 size={18} className="animate-spin" />
           </span>
         )}
       </button>

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -636,14 +636,6 @@ body {
   border-color: hsl(var(--gray-400));
 }
 
-/* Lighter icons and "Recent dialogue" label; other styles unchanged */
-.zero-nav svg {
-  opacity: 0.7;
-}
-.zero-nav .zero-nav-recent-label {
-  opacity: 1;
-}
-
 @layer base {
   *,
   *::before,

--- a/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
@@ -26,7 +26,7 @@ export function EmailUnsubscribePage() {
         <VM0Logo />
         {status === "done" ? (
           <div className="flex flex-col items-center gap-2.5">
-            <Check size={20} className="text-muted-foreground" />
+            <Check size={20} className="" />
             <h1 className="text-lg font-medium text-foreground">
               {t(($) => {
                 return $.lifecycle.emailUnsubscribe.doneTitle;

--- a/turbo/apps/platform/src/views/export-page/export-page.tsx
+++ b/turbo/apps/platform/src/views/export-page/export-page.tsx
@@ -120,15 +120,15 @@ function errorMessage(error: unknown, fallback: string): string {
 
 function StatusIcon({ viewState }: { readonly viewState: ExportViewState }) {
   if (viewState === "loading" || viewState === "in-progress") {
-    return <Loader2 size={22} className="animate-spin" strokeWidth={1.8} />;
+    return <Loader2 size={22} className="animate-spin" />;
   }
   if (viewState === "download") {
-    return <CircleCheck size={22} strokeWidth={1.8} />;
+    return <CircleCheck size={22} />;
   }
   if (viewState === "failed") {
-    return <AlertCircle size={22} strokeWidth={1.8} />;
+    return <AlertCircle size={22} />;
   }
-  return <DatabaseBackup size={22} strokeWidth={1.8} />;
+  return <DatabaseBackup size={22} />;
 }
 
 function StatusCopy({
@@ -294,7 +294,7 @@ function ExportActions({
       <div className="flex w-full flex-col gap-2">
         <Button asChild className={PRIMARY_ACTION_BUTTON_CLASS}>
           <a href={downloadUrl} download>
-            <Download size={16} strokeWidth={1.8} />
+            <Download size={16} />
             {t(($) => {
               return $.settings.export.actions.download;
             })}
@@ -309,9 +309,9 @@ function ExportActions({
             onClick={onTrigger}
           >
             {triggering ? (
-              <Loader2 size={16} className="animate-spin" strokeWidth={1.8} />
+              <Loader2 size={16} className="animate-spin" />
             ) : (
-              <RefreshCw size={16} strokeWidth={1.8} />
+              <RefreshCw size={16} />
             )}
             {t(($) => {
               return $.settings.export.actions.again;
@@ -338,9 +338,9 @@ function ExportActions({
       onClick={onTrigger}
     >
       {triggering ? (
-        <Loader2 size={16} className="animate-spin" strokeWidth={1.8} />
+        <Loader2 size={16} className="animate-spin" />
       ) : (
-        <DatabaseBackup size={16} strokeWidth={1.8} />
+        <DatabaseBackup size={16} />
       )}
       {triggering
         ? t(($) => {
@@ -442,7 +442,7 @@ export function ExportPage() {
               pathname="/"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground no-underline transition-colors hover:text-foreground"
             >
-              <ArrowLeft size={14} strokeWidth={1.8} />
+              <ArrowLeft size={14} />
               {t(($) => {
                 return $.settings.export.backToZero;
               })}

--- a/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
@@ -59,7 +59,7 @@ export function MorningBriefUnsubscribePage() {
   if (!status) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center">
-        <Loader2 size={40} className="animate-spin text-muted-foreground" />
+        <Loader2 size={40} className="animate-spin" />
         <span className="sr-only">
           {t(($) => {
             return $.lifecycle.morningBriefUnsubscribe.loadingLabel;

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -306,7 +306,7 @@ function CustomRangePicker({
             })}
             className="h-7 w-7 inline-flex items-center justify-center rounded-md hover:bg-state-hover transition-colors"
           >
-            <ChevronLeft size={14} strokeWidth={1.5} />
+            <ChevronLeft size={14} />
           </button>
           <p className="text-sm font-semibold">{monthLabel}</p>
           <button
@@ -317,7 +317,7 @@ function CustomRangePicker({
             })}
             className="h-7 w-7 inline-flex items-center justify-center rounded-md hover:bg-state-hover transition-colors"
           >
-            <ChevronRight size={14} strokeWidth={1.5} />
+            <ChevronRight size={14} />
           </button>
         </div>
         <CalendarMonth
@@ -366,11 +366,7 @@ function DateRangeFilter({
           className="flex items-center gap-2 rounded-lg border bg-background px-3 py-1.5 text-sm font-medium text-foreground hover:bg-state-hover transition-colors"
         >
           {dateRangeLabel(value)}
-          <ChevronDown
-            size={14}
-            strokeWidth={1.5}
-            className="text-muted-foreground"
-          />
+          <ChevronDown size={14} className="text-muted-foreground" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
@@ -244,7 +244,7 @@ function WorkflowCard({
           })}
           onClick={onPreview}
         >
-          <ScanEye size={16} strokeWidth={1.6} aria-hidden="true" />
+          <ScanEye size={16} aria-hidden="true" />
         </button>
       </span>
       {selected ? (
@@ -339,7 +339,7 @@ function CategoryOptions({
             className="flex min-h-[130px] min-w-0 flex-col items-start gap-2.5 rounded-xl border border-border bg-background p-4 text-left shadow-[var(--zero-card-shadow)] transition-colors hover:border-primary"
           >
             <span className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-muted/40">
-              <CategoryIcon size={21} strokeWidth={1.7} aria-hidden="true" />
+              <CategoryIcon size={21} aria-hidden="true" />
             </span>
             <span className="text-sm font-semibold">{category.title}</span>
             <span className="text-xs leading-[1.35] text-muted-foreground">

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
@@ -110,7 +110,7 @@ export function OnboardingWorkflowRunPage() {
                   setUi({ workflowPreviewId: workflow.id });
                 }}
               >
-                <ScanEye size={16} strokeWidth={1.6} aria-hidden="true" />
+                <ScanEye size={16} aria-hidden="true" />
               </button>
             </div>
           </section>

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -142,7 +142,7 @@ function CheckCircleIcon() {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="shrink-0 text-muted-foreground/40"
+      className="lucide shrink-0 text-muted-foreground/40"
     >
       <circle cx="12" cy="12" r="10" />
       <polyline points="16 9 10.5 15 8 12.5" />
@@ -297,7 +297,7 @@ function UpgradeCard({
           {upgrade.targetLabel}
         </h3>
         <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
+          <Crown size={12} className="text-amber-500" />
           {t(($) => {
             return $.queue.upgrade.recommended;
           })}
@@ -394,7 +394,7 @@ function ConcurrencyQuantityControl({
               onQuantityChange(quantity - 1);
             }}
           >
-            <Minus size={14} strokeWidth={2} data-stroke />
+            <Minus size={14} />
           </button>
           <span className="flex h-9 w-12 items-center justify-center border-x border-border/70 text-sm font-medium tabular-nums text-foreground">
             {quantity}
@@ -410,7 +410,7 @@ function ConcurrencyQuantityControl({
               onQuantityChange(quantity + 1);
             }}
           >
-            <Plus size={14} strokeWidth={2} data-stroke />
+            <Plus size={14} />
           </button>
         </div>
       </div>
@@ -447,7 +447,7 @@ function ConcurrencyPurchaseCard({
           })}
         </h3>
         <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
+          <Crown size={12} className="text-amber-500" />
           {t(($) => {
             return $.queue.purchase.addOn;
           })}

--- a/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
+++ b/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
@@ -144,18 +144,16 @@ function resolveCard(
 function CardIcon({ kind }: { kind: CardKind }): ReactNode {
   switch (kind) {
     case "ready": {
-      return <Gift size={40} className="text-foreground opacity-80" />;
+      return <Gift size={40} className="opacity-80" />;
     }
     case "granted": {
       return <Check size={40} className="text-green-600 opacity-80" />;
     }
     case "processing": {
-      return (
-        <Loader2 size={40} className="animate-spin text-muted-foreground" />
-      );
+      return <Loader2 size={40} className="animate-spin" />;
     }
     case "auth": {
-      return <Lock size={40} className="text-muted-foreground opacity-70" />;
+      return <Lock size={40} className="opacity-70" />;
     }
     case "broken": {
       return <X size={40} className="text-destructive opacity-70" />;

--- a/turbo/apps/platform/src/views/report-error/report-error-page.tsx
+++ b/turbo/apps/platform/src/views/report-error/report-error-page.tsx
@@ -70,7 +70,7 @@ function LoadingCard() {
         role="status"
         className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12"
       >
-        <Loader2 size={20} className="animate-spin text-muted-foreground" />
+        <Loader2 size={20} className="animate-spin" />
         <span className="sr-only">
           {t(($) => {
             return $.reportError.loading;

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -136,7 +136,7 @@ export function SharedThreadPage({
             className="inline-flex items-center gap-2 text-sm font-semibold text-foreground"
           >
             <span className="inline-flex h-7 w-7 items-center justify-center rounded-lg bg-[#ed4e01] text-white">
-              <MessageCircle size={17} strokeWidth={1.8} />
+              <MessageCircle size={17} />
             </span>
             {t(($) => {
               return $.sharedThread.brand;

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -95,7 +95,7 @@ function CustomConnectorPermissionRow({
                   { connector: connector.displayName },
                 )}
               >
-                <SlidersHorizontal size={15} strokeWidth={1.5} />
+                <SlidersHorizontal size={15} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -158,7 +158,7 @@ function Breadcrumb({
         pathname="/agents"
         className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-state-hover hover:text-foreground transition-colors no-underline text-inherit"
       >
-        <Users size={14} strokeWidth={1.5} className="shrink-0" />
+        <Users size={14} className="shrink-0" />
         {t(($) => {
           return $.list.title;
         })}
@@ -317,14 +317,14 @@ function AgentTabNav({
       {/* Desktop: tab list */}
       <TabsList className="zero-tabs hidden sm:inline-flex h-9 gap-1 px-1 py-1">
         <TabsTrigger value="authorization" className={TAB_TRIGGER_CLASS}>
-          <Shield size={14} strokeWidth={1.5} />
+          <Shield size={14} />
           {t(($) => {
             return $.detail.tabs.authorization;
           })}
         </TabsTrigger>
         {showProfileAndInstructions && (
           <TabsTrigger value="profile" className={TAB_TRIGGER_CLASS}>
-            <UserCircle size={14} strokeWidth={1.5} />
+            <UserCircle size={14} />
             {t(($) => {
               return $.detail.tabs.profile;
             })}
@@ -332,7 +332,7 @@ function AgentTabNav({
         )}
         {showProfileAndInstructions && (
           <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
-            <FileText size={14} strokeWidth={1.5} />
+            <FileText size={14} />
             {t(($) => {
               return $.detail.tabs.instructions;
             })}
@@ -464,11 +464,7 @@ function ConnectedConnectorPermissions({
           </div>
           {searchActive && (
             <div className="absolute inset-0 flex items-center gap-2 px-5">
-              <Search
-                size={14}
-                strokeWidth={1.5}
-                className="shrink-0 text-muted-foreground"
-              />
+              <Search size={14} className="shrink-0 text-muted-foreground" />
               <input
                 ref={(el) => {
                   return el?.focus();
@@ -500,7 +496,7 @@ function ConnectedConnectorPermissions({
                   return $.authorization.closeSearch;
                 })}
               >
-                <X size={14} strokeWidth={1.5} />
+                <X size={14} />
               </button>
             </div>
           )}
@@ -515,7 +511,7 @@ function ConnectedConnectorPermissions({
                 return $.authorization.findConnectors;
               })}
             >
-              <Search size={14} strokeWidth={1.5} />
+              <Search size={14} />
             </button>
           )}
         </div>
@@ -880,7 +876,7 @@ function AgentHeader({
                         return $.avatar.actions.customize;
                       })}
                     >
-                      <Wand size={12} strokeWidth={1.5} />
+                      <Wand size={12} />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
@@ -922,12 +918,7 @@ function AgentHeader({
             { agentName: displayName },
           )}
         >
-          <MessageCircle
-            size={14}
-            strokeWidth={2}
-            className="shrink-0"
-            data-stroke
-          />
+          <MessageCircle size={14} className="shrink-0" />
           <span className="truncate">
             {t(
               ($) => {

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-bar-chart.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-bar-chart.tsx
@@ -653,7 +653,6 @@ function ChartSvg({
           x2={tooltip.x}
           y2={CHART_PADDING.top + scales.drawH}
           stroke="hsl(var(--muted-foreground))"
-          strokeWidth={1}
           strokeDasharray="3,3"
           opacity={0.5}
         />

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1018,7 +1018,7 @@ function WorkflowBreadcrumb({
     <DetailPageBreadcrumbBar>
       <BreadcrumbLink
         pathname={ROUTES.workflows}
-        icon={<Route size={14} strokeWidth={1.5} className="shrink-0" />}
+        icon={<Route size={14} className="shrink-0" />}
       >
         {i18n.t(($) => {
           return $.workflows.common.workflows;
@@ -1065,7 +1065,7 @@ function WorkflowHeaderIcon({
   }
   return (
     <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gray-100 text-muted-foreground sm:h-16 sm:w-16">
-      <Route size={28} strokeWidth={1.7} />
+      <Route size={28} />
     </span>
   );
 }
@@ -1184,7 +1184,7 @@ function WorkflowTabNav({
       </div>
       <TabsList className="zero-tabs hidden h-9 gap-1 px-1 py-1 sm:inline-flex">
         <TabsTrigger value="automations" className={WORKFLOW_TAB_TRIGGER_CLASS}>
-          <Clock size={14} strokeWidth={1.5} />
+          <Clock size={14} />
           {i18n.t(($) => {
             return $.workflows.list.automations;
           })}
@@ -1193,13 +1193,13 @@ function WorkflowTabNav({
           value="instructions"
           className={WORKFLOW_TAB_TRIGGER_CLASS}
         >
-          <FileText size={14} strokeWidth={1.5} />
+          <FileText size={14} />
           {i18n.t(($) => {
             return $.workflows.common.instructions;
           })}
         </TabsTrigger>
         <TabsTrigger value="info" className={WORKFLOW_TAB_TRIGGER_CLASS}>
-          <Info size={14} strokeWidth={1.5} />
+          <Info size={14} />
           {i18n.t(($) => {
             return $.workflows.common.settings;
           })}
@@ -1287,12 +1287,7 @@ function WorkflowChatButton({
       {opening ? (
         <Loader2 size={14} className="shrink-0 animate-spin" />
       ) : (
-        <MessageCircle
-          size={14}
-          strokeWidth={2}
-          className="shrink-0"
-          data-stroke
-        />
+        <MessageCircle size={14} className="shrink-0" />
       )}
       <span className="truncate">{chatLabel}</span>
     </Button>
@@ -1375,7 +1370,7 @@ function WorkflowInfoTab({
                 setActionDialog("copy");
               }}
             >
-              <Copy size={14} strokeWidth={1.5} />
+              <Copy size={14} />
               {i18n.t(($) => {
                 return $.workflows.common.copyWorkflow;
               })}
@@ -1409,7 +1404,7 @@ function WorkflowInfoTab({
                     setActionDialog("delete");
                   }}
                 >
-                  <Trash size={14} strokeWidth={1.5} />
+                  <Trash size={14} />
                   {i18n.t(($) => {
                     return $.workflows.common.deleteWorkflow;
                   })}
@@ -1690,7 +1685,7 @@ function WorkflowConnectorReadiness({
               {checking ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <PlugZap size={14} strokeWidth={1.5} />
+                <PlugZap size={14} />
               )}
               {checkLabel}
             </Button>
@@ -1707,11 +1702,7 @@ function WorkflowConnectorReadiness({
           role="alert"
           className="flex items-start gap-2 border-t border-border/50 px-4 py-3 text-sm text-destructive sm:px-5"
         >
-          <AlertTriangle
-            size={16}
-            strokeWidth={1.5}
-            className="mt-0.5 shrink-0"
-          />
+          <AlertTriangle size={16} className="mt-0.5 shrink-0" />
           <p>{errorMessage}</p>
         </div>
       ) : null}
@@ -1736,11 +1727,7 @@ function WorkflowConnectorReadiness({
             className="flex items-center gap-2 border-t border-border/50 px-4 py-4 text-sm text-muted-foreground sm:px-5"
             aria-live="polite"
           >
-            <CircleCheck
-              size={16}
-              strokeWidth={1.5}
-              className="shrink-0 text-emerald-500"
-            />
+            <CircleCheck size={16} className="shrink-0 text-emerald-500" />
             {copy.empty}
           </div>
         )
@@ -1804,7 +1791,7 @@ function WorkflowConnectorReadinessRow({
               aria-label={`${action.label} ${entry.label}`}
             >
               {action.label}
-              <ExternalLink size={13} strokeWidth={1.5} />
+              <ExternalLink size={13} />
             </a>
           </Button>
         ) : null}
@@ -2054,7 +2041,7 @@ function ShadowWarning({
 
   return (
     <div className="mb-4 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
-      <AlertTriangle size={16} strokeWidth={1.5} className="mt-0.5 shrink-0" />
+      <AlertTriangle size={16} className="mt-0.5 shrink-0" />
       <p className="min-w-0">
         <span className="font-medium">/{detail.name}</span>{" "}
         {i18n.t(($) => {
@@ -2149,7 +2136,7 @@ function WorkflowPublicToggle({
             <DialogDescription>{copy.confirmDescription}</DialogDescription>
           </DialogHeader>
           <Alert variant="destructive">
-            <AlertTriangle size={16} strokeWidth={1.5} />
+            <AlertTriangle size={16} />
             <AlertTitle>{copy.automationWarning}</AlertTitle>
             <AlertDescription>
               {i18n.t(
@@ -2354,7 +2341,7 @@ function WorkflowCopyForm({
       </label>
       {form.removeOriginal ? (
         <Alert variant="destructive">
-          <AlertTriangle size={16} strokeWidth={1.5} />
+          <AlertTriangle size={16} />
           <AlertTitle>
             {i18n.t(($) => {
               return $.workflows.detail.copy.removalAlert;
@@ -2687,11 +2674,7 @@ function WorkflowFilePicker({
           className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm px-0.5 py-0.5 text-sm font-medium text-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <span className="min-w-0 truncate">{selectedLabel}</span>
-          <ChevronDown
-            size={14}
-            strokeWidth={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <ChevronDown size={14} className="shrink-0" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-80">
@@ -2782,7 +2765,7 @@ function WorkflowFileManagementItems({
         {saving ? (
           <Loader2 size={15} className="animate-spin" />
         ) : (
-          <Upload size={15} strokeWidth={1.5} />
+          <Upload size={15} />
         )}
         <span>
           {i18n.t(($) => {
@@ -2820,7 +2803,7 @@ function WorkflowFileManagementItems({
           className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-destructive transition-colors hover:bg-state-hover disabled:opacity-60"
           onClick={onDeleteSelectedFile}
         >
-          <Trash size={15} strokeWidth={1.5} />
+          <Trash size={15} />
           <span>
             {i18n.t(($) => {
               return $.workflows.detail.files.deleteSelected;
@@ -4920,7 +4903,7 @@ function AutomationCreateCategoryButton({
           : "text-sidebar-foreground hover:bg-state-hover",
       )}
     >
-      <Icon size={16} strokeWidth={1.5} className="shrink-0" />
+      <Icon size={16} className="shrink-0" />
       <span className="truncate">{category.label}</span>
     </button>
   );
@@ -4948,7 +4931,7 @@ function AutomationCreateOptionCard({
           accentChip,
         )}
       >
-        <Icon size={20} strokeWidth={1.5} />
+        <Icon size={20} />
       </span>
       <span className="flex min-w-0 flex-col gap-1">
         <span className="text-sm font-semibold">{option.title}</span>
@@ -5018,7 +5001,7 @@ function AutomationCreateMenu({
           type="button"
           className="zero-btn-morandi inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-lg px-3 text-sm font-medium"
         >
-          <Plus size={14} strokeWidth={1.5} />
+          <Plus size={14} />
           <span>
             {i18n.t(($) => {
               return $.workflows.automations.common.addAutomation;
@@ -5213,7 +5196,7 @@ function CreateGoogleFormsResponseSubmittedAutomationDialog({
               {creating ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <FileText size={14} strokeWidth={1.5} />
+                <FileText size={14} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.forms.addAction;
@@ -5324,7 +5307,7 @@ function CreateGoogleMeetTranscriptGeneratedAutomationDialog({
               {creating ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <Video size={14} strokeWidth={1.5} />
+                <Video size={14} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.meet.addAction;
@@ -5858,11 +5841,7 @@ function StripeAutomationCreateError({
       className="flex flex-col gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
     >
       <div className="flex items-start gap-2">
-        <AlertTriangle
-          size={16}
-          strokeWidth={1.5}
-          className="mt-0.5 shrink-0"
-        />
+        <AlertTriangle size={16} className="mt-0.5 shrink-0" />
         <p>{message}</p>
       </div>
       <Link
@@ -6302,7 +6281,7 @@ function CreateNotionDatabaseItemAutomationDialog({
               {creating ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <BrandNotion size={14} strokeWidth={1.5} />
+                <BrandNotion size={14} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.notion.addAction;
@@ -6506,7 +6485,7 @@ function CreateNotionPageContentUpdatedAutomationDialog({
               {creating ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <BrandNotion size={14} strokeWidth={1.5} />
+                <BrandNotion size={14} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.notion.addAction;
@@ -6613,7 +6592,7 @@ function CreateNotionChildPageAutomationDialog({
               {creating ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <BrandNotion size={14} strokeWidth={1.5} />
+                <BrandNotion size={14} />
               )}
               {i18n.t(($) => {
                 return $.workflows.automations.notion.addAction;
@@ -7522,7 +7501,7 @@ function GmailMatchConditionRow({
           onChange(removeGmailMatchCondition(conditions, index));
         }}
       >
-        <X size={16} strokeWidth={1.5} />
+        <X size={16} />
       </Button>
     </div>
   );
@@ -7564,7 +7543,7 @@ function GmailMatchConditionsEditor({
           }
         }}
       >
-        <Plus size={14} strokeWidth={1.5} />
+        <Plus size={14} />
         {i18n.t(($) => {
           return $.workflows.automations.gmail.addCondition;
         })}
@@ -8938,7 +8917,7 @@ function CreateGithubWebhookAutomationDialog({
               {creating ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <BrandGithub size={14} strokeWidth={1.5} />
+                <BrandGithub size={14} />
               )}
               {copy.action}
             </Button>
@@ -9380,7 +9359,7 @@ function RevealWebhookSecretDialog({
               {revealing ? (
                 <Loader2 size={14} className="animate-spin" />
               ) : (
-                <Eye size={14} strokeWidth={1.5} />
+                <Eye size={14} />
               )}
               {copy.reveal}
             </Button>
@@ -9546,7 +9525,7 @@ function AutomationRowStats({
     return (
       <>
         <AutomationRunStat
-          icon={<History size={14} strokeWidth={1.5} />}
+          icon={<History size={14} />}
           label={i18n.t(($) => {
             return $.workflows.automations.stripe.lastEvent;
           })}
@@ -9556,7 +9535,7 @@ function AutomationRowStats({
           )}
         />
         <AutomationRunStat
-          icon={<CircleCheck size={14} strokeWidth={1.5} />}
+          icon={<CircleCheck size={14} />}
           label={i18n.t(($) => {
             return $.workflows.automations.stripe.delivery;
           })}
@@ -9570,7 +9549,7 @@ function AutomationRowStats({
   return (
     <>
       <AutomationRunStat
-        icon={<History size={14} strokeWidth={1.5} />}
+        icon={<History size={14} />}
         label={i18n.t(($) => {
           return $.workflows.automations.schedule.last;
         })}
@@ -9582,7 +9561,7 @@ function AutomationRowStats({
       />
       {automation.kind === "schedule" ? (
         <AutomationRunStat
-          icon={<Clock size={14} strokeWidth={1.5} />}
+          icon={<Clock size={14} />}
           label={i18n.t(($) => {
             return $.workflows.automations.schedule.next;
           })}
@@ -9677,11 +9656,7 @@ function AutomationRow({
                 role="alert"
                 className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400"
               >
-                <AlertTriangle
-                  size={14}
-                  strokeWidth={1.5}
-                  className="mt-0.5 shrink-0"
-                />
+                <AlertTriangle size={14} className="mt-0.5 shrink-0" />
                 <p>
                   {i18n.t(($) => {
                     return $.workflows.automations.stripe.deliveryWarning;
@@ -9873,7 +9848,7 @@ function AutomationControls({
                 {busy ? (
                   <Loader2 size={14} className="animate-spin" />
                 ) : (
-                  <Play size={14} strokeWidth={1.5} />
+                  <Play size={14} />
                 )}
               </Button>
             </TooltipTrigger>
@@ -9906,7 +9881,7 @@ function AutomationControls({
                     setEditingAutomationId(automation.id);
                   }}
                 >
-                  <Pencil size={14} strokeWidth={1.5} />
+                  <Pencil size={14} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -9971,7 +9946,7 @@ function AutomationMoreActionsMenu({
               })}
               className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-state-selected-hover hover:text-foreground data-[state=open]:bg-state-selected-hover data-[state=open]:text-foreground"
             >
-              <EllipsisVertical size={14} strokeWidth={1.5} />
+              <EllipsisVertical size={14} />
             </Button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
@@ -9990,7 +9965,7 @@ function AutomationMoreActionsMenu({
             className="gap-2"
             onModalSelect={onRevealWebhookSecret}
           >
-            <Eye size={14} strokeWidth={1.5} />
+            <Eye size={14} />
             {i18n.t(($) => {
               return $.workflows.automations.webhook.revealTitle;
             })}
@@ -10009,7 +9984,7 @@ function AutomationMoreActionsMenu({
           {deleting ? (
             <Loader2 size={14} className="animate-spin" />
           ) : (
-            <Trash size={14} strokeWidth={1.5} />
+            <Trash size={14} />
           )}
           {i18n.t(($) => {
             return $.workflows.automations.common.deleteAutomation;
@@ -10314,7 +10289,7 @@ function UpdateScheduleAutomationForm({
           {saving ? (
             <Loader2 size={13} className="animate-spin" />
           ) : (
-            <Clock size={13} strokeWidth={1.5} />
+            <Clock size={13} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10397,7 +10372,7 @@ function UpdateGmailNewMessageAutomationForm({
           {saving ? (
             <Loader2 size={13} className="animate-spin" />
           ) : (
-            <Mail size={13} strokeWidth={1.5} />
+            <Mail size={13} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10487,7 +10462,7 @@ function UpdateGmailLabelAppliedAutomationForm({
           {saving ? (
             <Loader2 size={13} className="animate-spin" />
           ) : (
-            <Mail size={13} strokeWidth={1.5} />
+            <Mail size={13} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10613,7 +10588,7 @@ function UpdateGithubLabelAppliedAutomationForm({
           {saving ? (
             <Loader2 size={13} className="animate-spin" />
           ) : (
-            <BrandGithub size={13} strokeWidth={1.5} />
+            <BrandGithub size={13} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10686,7 +10661,7 @@ function UpdateGithubWorkflowRunCompletedAutomationForm({
           {saving ? (
             <Loader2 size={13} className="animate-spin" />
           ) : (
-            <BrandGithub size={13} strokeWidth={1.5} />
+            <BrandGithub size={13} />
           )}
           <span>
             {i18n.t(($) => {
@@ -10758,7 +10733,7 @@ function UpdateGithubWebhookAutomationForm({
           {saving ? (
             <Loader2 size={13} className="animate-spin" />
           ) : (
-            <BrandGithub size={13} strokeWidth={1.5} />
+            <BrandGithub size={13} />
           )}
           <span>
             {i18n.t(($) => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
@@ -47,7 +47,7 @@ export function WorkflowWebhookUpgradeDialog() {
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <div className="mb-1 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-amber-700">
-            <Lock size={19} strokeWidth={1.6} />
+            <Lock size={19} />
           </div>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -191,7 +191,6 @@ function VisibilityIcon({
   return (
     <Icon
       size={15}
-      strokeWidth={1.7}
       className={cn("shrink-0", isPublic ? "text-blue-500" : "text-[#45A7A8]")}
       aria-label={
         isPublic
@@ -364,7 +363,7 @@ function WorkflowRowIcon({
   }
   return (
     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-muted-foreground">
-      <Route size={16} strokeWidth={1.7} />
+      <Route size={16} />
     </span>
   );
 }
@@ -841,16 +840,12 @@ function SortDropdown({
           size="sm"
           className="zero-btn-morandi h-9 shrink-0 gap-1.5 rounded-lg border"
         >
-          <ArrowUpDown
-            size={15}
-            strokeWidth={1.8}
-            className="text-muted-foreground"
-          />
+          <ArrowUpDown size={15} className="" />
           {current?.label ??
             i18n.t(($) => {
               return $.workflows.list.sort.label;
             })}
-          <ChevronDown size={14} strokeWidth={1.8} />
+          <ChevronDown size={14} />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
@@ -900,11 +895,7 @@ function AgentFilterDropdown({
               size={16}
             />
           ) : (
-            <User
-              size={15}
-              strokeWidth={1.8}
-              className="text-muted-foreground"
-            />
+            <User size={15} className="" />
           )}
           <span className="max-w-[8rem] truncate">
             {selected?.label ??
@@ -912,7 +903,7 @@ function AgentFilterDropdown({
                 return $.workflows.list.allAgents;
               })}
           </span>
-          <ChevronDown size={14} strokeWidth={1.8} />
+          <ChevronDown size={14} />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -924,7 +915,7 @@ function AgentFilterDropdown({
             onChange(WORKFLOW_ALL_AGENTS);
           }}
         >
-          <User size={15} strokeWidth={1.8} className="text-muted-foreground" />
+          <User size={15} className="" />
           {i18n.t(($) => {
             return $.workflows.list.allAgents;
           })}
@@ -1109,7 +1100,7 @@ export function WorkflowsPage() {
               openCreateWorkflowDialog();
             }}
           >
-            <Plus size={14} strokeWidth={2} data-stroke />
+            <Plus size={14} />
             {t(($) => {
               return $.workflows.list.createInChat;
             })}

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -264,7 +264,7 @@ function InviteButton() {
       tabIndex={isAdmin ? undefined : -1}
       data-testid="invite-button"
     >
-      <UserPlus size={14} strokeWidth={1.5} />
+      <UserPlus size={14} />
       {t(($) => {
         return $.chat.agentPage.invitePeople;
       })}
@@ -304,7 +304,7 @@ function PinPill() {
               return $.sidebar.pin;
             })}
           >
-            <Pin size={12} strokeWidth={2} data-stroke />
+            <Pin size={12} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -401,9 +401,7 @@ function SuggestedPromptButton({
     >
       <ArrowUpRight
         size={14}
-        strokeWidth={2}
         className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-        data-stroke
       />
       <p className="text-sm font-semibold text-foreground pr-5">{item.title}</p>
       <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
@@ -449,9 +447,7 @@ function IdeasUseCasesButton() {
     >
       <ArrowUpRight
         size={14}
-        strokeWidth={2}
         className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-        data-stroke
       />
       <p className="text-sm font-semibold text-foreground pr-5">
         {t(($) => {
@@ -469,7 +465,7 @@ function IdeasUseCasesButton() {
             return $.ideation.entry.viewAll;
           })}
         </span>
-        <ArrowUpRight size={14} strokeWidth={2} data-stroke />
+        <ArrowUpRight size={14} />
       </div>
     </button>
   );

--- a/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agentphone-card.tsx
@@ -409,7 +409,7 @@ function AgentPhoneCardActions() {
                 return $.connectors.providerSettings.agentphone.options;
               })}
             >
-              <EllipsisVertical size={16} strokeWidth={1.5} />
+              <EllipsisVertical size={16} />
             </button>
           </PopoverTrigger>
           <PopoverContent

--- a/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
@@ -244,7 +244,6 @@ function AvatarPreviewWithShuffle() {
             >
               <Dices
                 size={14}
-                strokeWidth={1.5}
                 style={
                   shuffling
                     ? { animation: "avatar-dice-spin 0.6s ease-out" }
@@ -501,7 +500,7 @@ export function AvatarMaker({ onConfirm, trigger }: AvatarMakerProps) {
                   return $.avatar.create;
                 })}
               >
-                <Wand size={16} strokeWidth={1.5} />
+                <Wand size={16} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -197,7 +197,7 @@ function CatalogFiltersPopover({
           size="sm"
           className="h-9 gap-2 rounded-full bg-background px-3 shadow-none"
         >
-          <SlidersHorizontal size={15} strokeWidth={1.7} />
+          <SlidersHorizontal size={15} />
           {t(($) => {
             return $.artifacts.templates.filters.title;
           })}
@@ -392,12 +392,7 @@ function AvatarTemplateMedia({
           className="h-full w-full object-cover"
         />
       ) : (
-        <User
-          size={40}
-          strokeWidth={1.4}
-          className="text-muted-foreground"
-          aria-hidden="true"
-        />
+        <User size={40} className="text-muted-foreground" aria-hidden="true" />
       )}
     </div>
   );
@@ -432,7 +427,7 @@ function AvatarTemplateCardContent({
             className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
             aria-hidden="true"
           >
-            <Check size={13} strokeWidth={2.2} />
+            <Check size={13} />
           </span>
         )}
       </div>
@@ -813,12 +808,10 @@ function VoicePreviewControl({
       >
         <Play
           size={17}
-          strokeWidth={1.9}
           className="ml-0.5 group-data-[playing=true]/voice:hidden"
         />
         <Pause
           size={17}
-          strokeWidth={1.9}
           className="hidden group-data-[playing=true]/voice:block"
         />
       </button>
@@ -935,7 +928,7 @@ function AvatarVoiceCard({
                 className="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
                 aria-hidden="true"
               >
-                <Check size={13} strokeWidth={2.2} />
+                <Check size={13} />
               </span>
             )}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
@@ -52,7 +52,7 @@ function BrowserSessionStatus({ live }: { readonly live: boolean }) {
 function BrowserSessionPreviewPlaceholder() {
   return (
     <span className="absolute inset-0 flex items-center justify-center bg-muted/30 text-muted-foreground/60">
-      <AppWindow size={30} strokeWidth={1.5} />
+      <AppWindow size={30} />
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-panel.tsx
@@ -96,7 +96,7 @@ export function BrowserSessionLoading() {
   return (
     <PanelFrame>
       <div role="status" className="flex flex-1 items-center justify-center">
-        <Loader2 className="animate-spin text-muted-foreground" size={20} />
+        <Loader2 className="animate-spin" size={20} />
         <span className="sr-only">
           {t(($) => {
             return $.browserSession.status.starting;

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -53,9 +53,7 @@ function CollapsibleSection({
         <div className="flex items-center gap-2">
           <ChevronRight
             size={14}
-            strokeWidth={2}
-            className="transition-transform group-open:rotate-90 text-muted-foreground shrink-0"
-            data-stroke
+            className="transition-transform group-open:rotate-90 shrink-0"
           />
           <span className="text-xs font-medium text-foreground">{title}</span>
           {badge && <InlineBadge color="muted">{badge}</InlineBadge>}

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/event-group-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/event-group-card.tsx
@@ -523,7 +523,7 @@ function getTodoStatusIcon(status: string) {
       return <Loader className="h-4 w-4 text-yellow-500" />;
     }
     default: {
-      return <CircleDashed className="h-4 w-4 text-muted-foreground" />;
+      return <CircleDashed className="h-4 w-4" />;
     }
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -177,7 +177,7 @@ function ResponsiveTriggerContent({
         {iconType ? (
           <ProviderIcon type={iconType} size={18} />
         ) : (
-          <Cpu size={18} strokeWidth={1.5} />
+          <Cpu size={18} />
         )}
       </span>
       <span className="hidden min-w-0 sm:inline-flex sm:items-center sm:gap-1.5">
@@ -362,7 +362,7 @@ function ModelFirstTriggerLabel({
           </span>
           {codexServiceTier === "fast" && (
             <span className="inline-flex h-5 shrink-0 items-center gap-1 rounded bg-amber-500/10 px-1.5 text-[11px] font-medium leading-none text-amber-700 dark:text-amber-300">
-              <Bolt size={12} strokeWidth={1.8} />
+              <Bolt size={12} />
               {t(($) => {
                 return $.settings.models.picker.fast;
               })}
@@ -464,7 +464,7 @@ function ModelFirstPolicyRowContent({
       {restricted && <ProBadge />}
       {showSelectedIndicator && (
         <span className="flex h-4 w-4 shrink-0 items-center justify-center text-foreground">
-          {selected && <Check size={15} strokeWidth={1.8} />}
+          {selected && <Check size={15} />}
         </span>
       )}
     </span>
@@ -624,7 +624,7 @@ function CodexFastModeSplitPanel({
           }}
         >
           <span className="inline-flex items-center gap-1 text-xs font-medium">
-            <Bolt size={12} strokeWidth={1.8} />
+            <Bolt size={12} />
             {t(($) => {
               return $.settings.models.picker.fast;
             })}

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -280,10 +280,10 @@ function TypeFilter({
           className="flex h-8 min-w-[140px] items-center justify-between gap-1.5 rounded-md border border-border bg-input px-3 text-xs text-foreground outline-none transition-colors hover:bg-input-hover focus:border-primary focus:ring-[3px] focus:ring-primary/10"
         >
           <span className="flex items-center gap-1.5">
-            <Filter size={14} strokeWidth={1.5} className="shrink-0" />
+            <Filter size={14} className="shrink-0" />
             {typeFilterLabel(typeFilter)}
           </span>
-          <ChevronDown size={14} className="shrink-0 text-muted-foreground" />
+          <ChevronDown size={14} className="shrink-0" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-40">
@@ -1128,7 +1128,7 @@ export function NetworkContent({
       {hasMore && onLoadMore && (
         <div className="flex justify-center py-4">
           {loading ? (
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <Loader2 className="h-5 w-5 animate-spin" />
           ) : (
             <button
               type="button"

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -606,7 +606,7 @@ function PlanCard({
     <div className="relative flex flex-col rounded-xl transition-transform duration-200 hover:-translate-y-0.5 zero-border px-6 py-7">
       {plan.tier === "pro" && (
         <span className="absolute top-3 right-3 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
+          <Crown size={12} className="text-amber-500" />
           {i18n.t(($) => {
             return $.billing.plans.popular;
           })}
@@ -662,7 +662,7 @@ function PlanCard({
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="shrink-0 text-muted-foreground/40"
+                className="lucide shrink-0 text-muted-foreground/40"
               >
                 <circle cx="12" cy="12" r="10" />
                 <polyline points="16 9 10.5 15 8 12.5" />
@@ -771,7 +771,7 @@ function PricingPage({
                   return $.billing.common.back;
                 })}
               >
-                <ArrowLeft size={16} strokeWidth={1.8} />
+                <ArrowLeft size={16} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -1350,7 +1350,7 @@ function ConcurrencyQuantityControl({
             onQuantityChange(quantity - 1);
           }}
         >
-          <Minus size={13} strokeWidth={2} data-stroke />
+          <Minus size={13} />
         </button>
         <span className="flex h-8 w-11 items-center justify-center border-x border-border/70 text-sm font-medium tabular-nums text-foreground">
           {formatLocalizedNumber(quantity)}
@@ -1368,7 +1368,7 @@ function ConcurrencyQuantityControl({
             onQuantityChange(quantity + 1);
           }}
         >
-          <Plus size={13} strokeWidth={2} data-stroke />
+          <Plus size={13} />
         </button>
       </div>
     </div>
@@ -2225,7 +2225,7 @@ export function OrgBillingTab() {
                       {t(($) => {
                         return $.billing.common.manage;
                       })}
-                      <ExternalLink size={13} strokeWidth={1.5} />
+                      <ExternalLink size={13} />
                     </Button>
                   </div>
                 </>
@@ -2242,17 +2242,9 @@ export function OrgBillingTab() {
                   {t(($) => {
                     return $.billing.plans.compareAll;
                   })}
-                  <Coins
-                    size={14}
-                    strokeWidth={1.5}
-                    className="text-foreground/40"
-                  />
+                  <Coins size={14} className="text-foreground/40" />
                 </span>
-                <ChevronRight
-                  size={14}
-                  strokeWidth={1.5}
-                  className="shrink-0 text-muted-foreground/50"
-                />
+                <ChevronRight size={14} className="shrink-0" />
               </button>
             </>
           )}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -231,12 +231,7 @@ function ProfileSection({
               )}
               {isAdmin && (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <Upload
-                    size={14}
-                    strokeWidth={2}
-                    className="text-white"
-                    data-stroke
-                  />
+                  <Upload size={14} className="text-white" />
                 </div>
               )}
             </button>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -219,7 +219,7 @@ function DownloadReceiptsDialog({
           className="gap-1.5"
           disabled={downloading}
         >
-          <Download size={14} strokeWidth={1.5} />
+          <Download size={14} />
           {downloading
             ? t(($) => {
                 return $.billing.invoices.preparingReceipts;
@@ -396,7 +396,7 @@ export function OrgInvoicesTab() {
                               { month: invoiceMonth },
                             )}
                           >
-                            <Download size={14} strokeWidth={1.5} />
+                            <Download size={14} />
                           </a>
                         </TooltipTrigger>
                         <TooltipContent side="bottom">
@@ -413,7 +413,7 @@ export function OrgInvoicesTab() {
                     </TooltipProvider>
                   ) : (
                     <span className="flex h-7 w-7 items-center justify-center text-muted-foreground/30">
-                      <Download size={14} strokeWidth={1.5} />
+                      <Download size={14} />
                     </span>
                   )}
                 </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -143,7 +143,6 @@ export function OrgMembersTab() {
         <div className="relative flex-1">
           <Search
             size={15}
-            strokeWidth={1.5}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
           />
           <Input
@@ -216,7 +215,7 @@ export function OrgMembersTab() {
           <>
             <div className="px-5 pt-3 pb-1">
               <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                <UserPlus size={13} strokeWidth={1.8} />
+                <UserPlus size={13} />
                 {t(($) => {
                   return $.settings.workspace.members.joinRequests;
                 })}
@@ -305,7 +304,7 @@ function InviteDialog() {
     >
       <DialogTrigger asChild>
         <Button size="sm" className="gap-1.5 rounded-lg">
-          <Plus size={14} strokeWidth={2} data-stroke />
+          <Plus size={14} />
           {t(($) => {
             return $.settings.workspace.members.addMember;
           })}
@@ -466,7 +465,6 @@ function MemberRow({
         <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
           <ShieldCheck
             size={12}
-            strokeWidth={1.8}
             className={
               member.role === "admin"
                 ? "text-blue-500"
@@ -524,7 +522,7 @@ function SelfDemoteAction({ email }: { email: string }) {
             )}
             className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover transition-colors"
           >
-            <Ellipsis size={15} strokeWidth={1.5} />
+            <Ellipsis size={15} />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -633,7 +631,7 @@ function MemberActions({ member }: { member: OrgMember }) {
             disabled={changingRole}
             className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover transition-colors disabled:opacity-50 disabled:pointer-events-none"
           >
-            <Ellipsis size={15} strokeWidth={1.5} />
+            <Ellipsis size={15} />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -762,7 +760,7 @@ function PendingInvitationRow({
       </div>
       <div>
         <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <Clock size={12} strokeWidth={1.8} className="text-amber-500" />
+          <Clock size={12} className="text-amber-500" />
           {t(($) => {
             return $.settings.workspace.members.pending;
           })}
@@ -789,7 +787,7 @@ function PendingInvitationRow({
                   )}
                   className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover transition-colors"
                 >
-                  <Ellipsis size={15} strokeWidth={1.5} />
+                  <Ellipsis size={15} />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent
@@ -908,7 +906,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
       </div>
       <div>
         <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <UserPlus size={12} strokeWidth={1.8} className="text-blue-500" />
+          <UserPlus size={12} className="text-blue-500" />
           {t(($) => {
             return $.settings.workspace.members.membershipRequest.role;
           })}
@@ -923,7 +921,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
             return $.settings.workspace.members.membershipRequest.acceptTitle;
           })}
         >
-          <Check size={15} strokeWidth={2} data-stroke />
+          <Check size={15} />
         </button>
         <button
           className="flex h-7 w-7 items-center justify-center rounded-md text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
@@ -933,7 +931,7 @@ function MembershipRequestRow({ request }: { request: OrgMembershipRequest }) {
             return $.settings.workspace.members.membershipRequest.rejectTitle;
           })}
         >
-          <X size={15} strokeWidth={2} data-stroke />
+          <X size={15} />
         </button>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -548,7 +548,7 @@ function PolicyActionsMenu({
             },
           )}
         >
-          <EllipsisVertical size={14} strokeWidth={1.5} />
+          <EllipsisVertical size={14} />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
@@ -558,7 +558,7 @@ function PolicyActionsMenu({
             onEdit(policy);
           }}
         >
-          <Pencil size={14} strokeWidth={1.5} />
+          <Pencil size={14} />
           {t(($) => {
             return $.settings.models.actions.editModel;
           })}
@@ -571,7 +571,7 @@ function PolicyActionsMenu({
             onDelete(policy);
           }}
         >
-          <Trash size={14} strokeWidth={1.5} />
+          <Trash size={14} />
           {t(($) => {
             return $.settings.models.actions.deleteModel;
           })}
@@ -604,7 +604,7 @@ function AddModelButton({
       disabled={disabled}
       onClick={onClick}
     >
-      <Plus size={14} strokeWidth={2} data-stroke />
+      <Plus size={14} />
       {t(($) => {
         return $.settings.models.actions.addModel;
       })}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -411,9 +411,7 @@ function CreditGrantList({ grants }: { grants: CreditGrant[] }) {
         <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
           <ChevronRight
             size={13}
-            strokeWidth={2}
             className="shrink-0 transition-transform group-open:rotate-90"
-            data-stroke
           />
           <span>
             {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/unsaved-bar.tsx
@@ -28,11 +28,7 @@ export function UnsavedBar({
         className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
       >
         <div className="flex items-center gap-2 text-sm text-foreground">
-          <Pencil
-            size={18}
-            strokeWidth={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <Pencil size={18} className="shrink-0" />
           <span>
             {t(($) => {
               return $.settings.workspace.unsaved.message;
@@ -60,11 +56,7 @@ export function UnsavedBar({
             disabled={saving || saveDisabled}
           >
             {saving ? (
-              <Loader2
-                size={14}
-                strokeWidth={1.5}
-                className="animate-spin mr-1.5"
-              />
+              <Loader2 size={14} className="animate-spin mr-1.5" />
             ) : null}
             {t(($) => {
               return $.settings.shared.save;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -242,7 +242,7 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
             className="h-full w-full object-cover"
           />
         ) : (
-          <User size={15} strokeWidth={1.8} />
+          <User size={15} />
         )}
       </span>
       <span className="min-w-0">
@@ -443,11 +443,7 @@ function PlanFeatureList({ tier }: { readonly tier: UsagePackPlanTier }) {
       {planFeatures(tier).map((feature) => {
         return (
           <li key={feature} className="flex items-center gap-2">
-            <Check
-              size={14}
-              strokeWidth={1.8}
-              className="shrink-0 text-muted-foreground/50"
-            />
+            <Check size={14} className="shrink-0" />
             <span className="text-[13px] text-muted-foreground">{feature}</span>
           </li>
         );
@@ -481,7 +477,7 @@ function PlanSelectionCard({
     >
       {plan.popular && (
         <span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
-          <Crown size={12} strokeWidth={1.8} className="text-amber-500" />
+          <Crown size={12} className="text-amber-500" />
           {i18n.t(($) => {
             return $.billing.plans.popular;
           })}
@@ -581,7 +577,7 @@ function PricingPageHeader({
                 return $.billing.common.back;
               })}
             >
-              <ArrowLeft size={16} strokeWidth={1.8} />
+              <ArrowLeft size={16} />
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -688,7 +688,7 @@ function OAuthCredentialRow({
                       return $.settings.shared.moreOptions;
                     })}
                   >
-                    <EllipsisVertical size={14} strokeWidth={1.5} />
+                    <EllipsisVertical size={14} />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-44">

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -270,11 +270,7 @@ export function UsageRangeSelect({
           className="zero-btn-morandi h-9 shrink-0 rounded-lg border"
         >
           {rangeLabel(value)}
-          <ChevronDown
-            size={14}
-            strokeWidth={1.5}
-            className="ml-1.5 text-muted-foreground"
-          />
+          <ChevronDown size={14} className="ml-1.5 text-muted-foreground" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
@@ -436,7 +432,7 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
           aria-label={label}
           className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
         >
-          <Icon size={20} strokeWidth={1.5} />
+          <Icon size={20} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-h-8 min-w-0 items-center gap-3">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
@@ -33,7 +33,7 @@ function BuildInfoTarget({
       <div className="flex min-w-0 items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
-            <Icon size={15} strokeWidth={1.5} />
+            <Icon size={15} />
           </span>
           <div className="truncate text-sm font-medium text-foreground">
             {title}
@@ -87,11 +87,7 @@ export function BuildInfoBlock() {
     <div className="flex items-start gap-4 rounded-xl bg-card p-4 zero-border">
       <div className="shrink-0">
         <div className="flex h-7 w-7 items-center justify-center">
-          <GitCommit
-            size={22}
-            strokeWidth={1.5}
-            className="text-muted-foreground"
-          />
+          <GitCommit size={22} className="text-muted-foreground" />
         </div>
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-3">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -93,8 +93,7 @@ function ConnectorAccessSearch({
     <div className="relative">
       <Search
         size={15}
-        strokeWidth={1.5}
-        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
       />
       <input
         value={value}
@@ -120,7 +119,7 @@ function ConnectorAccessSearch({
             return $.connectors.access.clearSearch;
           })}
         >
-          <X size={13} strokeWidth={1.8} />
+          <X size={13} />
         </button>
       )}
     </div>
@@ -176,7 +175,7 @@ function AgentAccessRow({
                 )}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
               >
-                <SlidersHorizontal size={16} strokeWidth={1.5} />
+                <SlidersHorizontal size={16} />
               </button>
             </TooltipTrigger>
             <TooltipContent>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-card.tsx
@@ -157,9 +157,9 @@ function CatalogConnectorCard({
           aria-hidden="true"
         >
           {busy ? (
-            <Loader2 size={16} strokeWidth={1.5} className="animate-spin" />
+            <Loader2 size={16} className="animate-spin" />
           ) : (
-            <Plus size={14} strokeWidth={1.5} />
+            <Plus size={14} />
           )}
         </span>
       </div>
@@ -191,7 +191,7 @@ function ConnectorConnectionStatus({
   if (busy) {
     return (
       <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <Loader2 size={12} strokeWidth={1.5} className="animate-spin" />
+        <Loader2 size={12} className="animate-spin" />
         {t(($) => {
           return $.connectors.card.connecting;
         })}
@@ -303,7 +303,7 @@ function ConnectionConnectorCard({
                   })}
                   disabled={busy}
                 >
-                  <EllipsisVertical size={14} strokeWidth={1.5} />
+                  <EllipsisVertical size={14} />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-44">
@@ -560,7 +560,7 @@ function PermissionConnectorCard({
                       { connector: connector.label },
                     )}
                   >
-                    <SlidersHorizontal size={15} strokeWidth={1.5} />
+                    <SlidersHorizontal size={15} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -504,11 +504,7 @@ export function ConnectorCatalogDiagnosticsBlock() {
     >
       <div className="shrink-0">
         <div className="flex h-7 w-7 items-center justify-center">
-          <Database
-            size={22}
-            strokeWidth={1.5}
-            className="text-muted-foreground"
-          />
+          <Database size={22} className="text-muted-foreground" />
         </div>
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-3">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -20,7 +20,7 @@ function ConnectorIconFallback({
       })}
       className="inline-flex h-full w-full items-center justify-center text-muted-foreground"
     >
-      <Plug size={size * 0.65} strokeWidth={1.5} aria-hidden="true" />
+      <Plug size={size * 0.65} aria-hidden="true" />
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -367,7 +367,7 @@ function OAuth2AdvancedFields({ form, setField }: CreateFormFieldProps) {
       <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-sm font-medium text-foreground">
         <ChevronRight
           size={16}
-          className="shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+          className="shrink-0 transition-transform group-open:rotate-90"
         />
         <span>
           {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -299,7 +299,7 @@ function CustomConnectorRow({
                   return $.connectors.custom.moreOptions;
                 })}
               >
-                <EllipsisVertical size={14} strokeWidth={1.5} />
+                <EllipsisVertical size={14} />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-44">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/language-settings.tsx
@@ -144,11 +144,7 @@ export function LanguageSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Globe
-                size={22}
-                strokeWidth={1.5}
-                className="text-muted-foreground"
-              />
+              <Globe size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/morning-brief-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/morning-brief-settings.tsx
@@ -88,11 +88,7 @@ export function MorningBriefSettings() {
       <div className="flex flex-1 items-center gap-4 min-w-0">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
-            <Sunrise
-              size={22}
-              strokeWidth={1.5}
-              className="text-muted-foreground"
-            />
+            <Sunrise size={22} className="text-muted-foreground" />
           </div>
         </div>
         <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
@@ -66,7 +66,7 @@ export function PermissionPolicyToggle({
           tone: "allow",
         })}
       >
-        <Check size={12} strokeWidth={2.5} />
+        <Check size={12} />
         {t(($) => {
           return $.connectors.permissions.actions.allow;
         })}
@@ -83,7 +83,7 @@ export function PermissionPolicyToggle({
           tone: "deny",
         })}
       >
-        <Ban size={12} strokeWidth={2.5} />
+        <Ban size={12} />
         {t(($) => {
           return $.connectors.permissions.actions.deny;
         })}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -335,8 +335,8 @@ function PolicyPill({
                   : "text-muted-foreground hover:text-foreground hover:bg-state-hover"
             } ${disabled ? "cursor-default" : "cursor-pointer"}`}
           >
-            {option === "allow" && <Check size={12} strokeWidth={2.5} />}
-            {option === "deny" && <Ban size={12} strokeWidth={2.5} />}
+            {option === "allow" && <Check size={12} />}
+            {option === "deny" && <Ban size={12} />}
             {option === "allow"
               ? t(($) => {
                   return $.connectors.permissions.actions.allow;
@@ -552,7 +552,7 @@ function allowDurationMenuLabel(option: UserPermissionGrantExpiresIn): string {
 
 function MenuItemCheck({ active }: { active: boolean }) {
   return active ? (
-    <Check size={14} strokeWidth={2.5} />
+    <Check size={14} />
   ) : (
     <span className="h-3.5 w-3.5 shrink-0" />
   );
@@ -619,7 +619,7 @@ function PermissionAllowDurationDropdown({
         >
           <Clock size={12} className="shrink-0" />
           <span className="max-w-[90px] truncate">{label}</span>
-          <ChevronDown size={12} strokeWidth={2.5} className="shrink-0" />
+          <ChevronDown size={12} className="shrink-0" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -836,9 +836,7 @@ function PermissionGroupHeader({
       >
         <ChevronRight
           size={14}
-          strokeWidth={2}
           className={`transition-transform ${expanded ? "rotate-90" : ""}`}
-          data-stroke
         />
         {category} ({permissions.length})
       </button>
@@ -1500,8 +1498,7 @@ function LoadedPermissionsDrawerContent({
           <div className="relative w-full">
             <Search
               size={15}
-              strokeWidth={1.5}
-              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
             />
             <input
               value={search}
@@ -1527,7 +1524,7 @@ function LoadedPermissionsDrawerContent({
                   return $.connectors.permissions.clearSearch;
                 })}
               >
-                <X size={13} strokeWidth={1.8} />
+                <X size={13} />
               </button>
             )}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
@@ -39,11 +39,7 @@ function CaptureNetworkBodiesBlock() {
       <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
-            <Bug
-              size={22}
-              strokeWidth={1.5}
-              className="text-muted-foreground"
-            />
+            <Bug size={22} className="text-muted-foreground" />
           </div>
         </div>
         <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
@@ -45,11 +45,7 @@ function AppearanceBlock() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Palette
-                size={22}
-                strokeWidth={1.5}
-                className="text-muted-foreground"
-              />
+              <Palette size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">
@@ -95,7 +91,7 @@ function AppearanceBlock() {
                     : "zero-chip text-muted-foreground hover:text-foreground",
                 )}
               >
-                <Icon size={15} strokeWidth={1.5} />
+                <Icon size={15} />
                 {label}
               </button>
             );
@@ -130,11 +126,7 @@ function EnterBlock() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Keyboard
-                size={22}
-                strokeWidth={1.5}
-                className="text-muted-foreground"
-              />
+              <Keyboard size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -125,11 +125,7 @@ export function TimezoneSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Clock
-                size={22}
-                strokeWidth={1.5}
-                className="text-muted-foreground"
-              />
+              <Clock size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
@@ -50,11 +50,7 @@ function DeleteDangerHeader({ agentName }: { agentName: string }) {
     <>
       <DialogHeader className="space-y-0 text-left">
         <div className="flex items-center gap-2">
-          <AlertTriangle
-            size={20}
-            strokeWidth={1.5}
-            className="shrink-0 text-destructive"
-          />
+          <AlertTriangle size={20} className="shrink-0 text-destructive" />
           <DialogTitle>
             {t(
               ($) => {
@@ -360,7 +356,7 @@ export function AgentDeleteDialog({
                   size="sm"
                   className="h-9 gap-2 rounded-lg border-destructive/40 px-4 text-destructive hover:bg-destructive/10 hover:text-destructive"
                 >
-                  <Trash size={14} strokeWidth={1.5} />
+                  <Trash size={14} />
                   {t(($) => {
                     return $.actions.delete;
                   })}

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -1385,7 +1385,7 @@ export function FeishuCard() {
           </div>
         </div>
         <span className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
-          <Settings size={14} strokeWidth={1.5} />
+          <Settings size={14} />
           {t(($) => {
             return $.connectors.providerSettings.feishu.manage;
           })}
@@ -1512,7 +1512,7 @@ function FeishuBotMenu({
             { bot: title },
           )}
         >
-          <EllipsisVertical size={16} strokeWidth={1.5} />
+          <EllipsisVertical size={16} />
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="flex w-40 flex-col gap-0.5 p-2">
@@ -1787,7 +1787,7 @@ function FeishuSetupFaq() {
             <ChevronRight
               size={17}
               aria-hidden="true"
-              className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+              className="mt-0.5 shrink-0 transition-transform group-open:rotate-90"
             />
             <span>
               {t(($) => {
@@ -1807,7 +1807,7 @@ function FeishuSetupFaq() {
             <ChevronRight
               size={17}
               aria-hidden="true"
-              className="mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+              className="mt-0.5 shrink-0 transition-transform group-open:rotate-90"
             />
             <span>
               {t(($) => {
@@ -2177,7 +2177,7 @@ export function ZeroFeishuSettingsPage() {
                   return $.connectors.catalog.title;
                 })}
               >
-                <ArrowLeft size={17} strokeWidth={1.8} />
+                <ArrowLeft size={17} />
                 {t(($) => {
                   return $.connectors.providerSettings.feishu
                     .backToIntegrations;

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -133,9 +133,7 @@ function MailDraftCardContent({
                 })
               : statusLabel(draft.status)}
         </span>
-        {!deleted ? (
-          <ChevronRight size={16} className="text-muted-foreground" />
-        ) : null}
+        {!deleted ? <ChevronRight size={16} className="" /> : null}
       </span>
     </>
   );

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -193,11 +193,7 @@ function MailMessageHeader({
                 : "relative top-0.5 inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-400"
             }
           >
-            {active ? (
-              <Pencil size={11} strokeWidth={2} data-stroke />
-            ) : (
-              <CircleCheck size={11} strokeWidth={2} data-stroke />
-            )}
+            {active ? <Pencil size={11} /> : <CircleCheck size={11} />}
             {active
               ? t(($) => {
                   return $.chat.mail.status.draft;
@@ -277,7 +273,7 @@ function AttachmentSummary({
 }) {
   return (
     <div className="inline-flex h-7 max-w-[240px] items-center gap-1.5 rounded-md border border-foreground/15 bg-background/80 px-1.5">
-      <Paperclip size={14} className="shrink-0 text-muted-foreground" />
+      <Paperclip size={14} className="shrink-0" />
       <span className="min-w-0 truncate text-xs font-medium">
         {attachment.filename}
       </span>
@@ -409,7 +405,7 @@ function MailMediaAttachmentPreview({
             className="h-full w-full object-contain"
           />
           <span className="absolute inset-0 flex items-center justify-center bg-black/10 text-white transition-colors group-hover:bg-black/30">
-            <Play size={16} strokeWidth={1.8} />
+            <Play size={16} />
           </span>
         </>
       )}

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -79,7 +79,7 @@ function InviteButtonLeaf() {
       }}
       className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-state-hover transition-colors shrink-0"
     >
-      <UserPlus size={14} strokeWidth={1.5} />
+      <UserPlus size={14} />
       {t(($) => {
         return $.appShell.sidebar.mobile.invite;
       })}
@@ -112,7 +112,7 @@ function MobileArtifactsButtonInner({ thread }: { thread: ChatPanelSignals }) {
       })}
       aria-pressed={open}
     >
-      <Package size={16} strokeWidth={1.5} />
+      <Package size={16} />
     </button>
   );
 }
@@ -174,7 +174,7 @@ function MobileShareButtonInner({ thread }: { thread: ChatPanelSignals }) {
         return $.chat.sharing.start;
       })}
     >
-      <Share2 size={16} strokeWidth={1.5} />
+      <Share2 size={16} />
     </button>
   );
 }
@@ -267,7 +267,7 @@ function MobileTopBar() {
           return $.appShell.sidebar.mobile.openMenu;
         })}
       >
-        <Menu size={18} strokeWidth={1.8} />
+        <Menu size={18} />
       </button>
       {breadcrumb && (
         <div className="flex-1 min-w-0 flex items-center gap-2 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -134,9 +134,9 @@ function SessionStateIndicator({
       aria-label={t(($) => {
         return $.chat.sidebar.draft;
       })}
-      className="flex items-center justify-center text-sidebar-foreground/50"
+      className="flex items-center justify-center text-sidebar-foreground"
     >
-      <Pencil size={16} strokeWidth={2} data-stroke />
+      <Pencil className="opacity-35" size={16} />
     </span>
   );
 }
@@ -226,21 +226,14 @@ function ChatThreadMenu({
                 >
                   {usePinnedIndicatorTrigger ? (
                     <>
-                      <Pin
-                        size={16}
-                        strokeWidth={2}
-                        className="md:hidden"
-                        data-stroke
-                      />
+                      <Pin size={16} className="md:hidden opacity-70" />
                       <Ellipsis
                         size={16}
-                        strokeWidth={2}
-                        className="hidden md:block"
-                        data-stroke
+                        className="hidden md:block opacity-70"
                       />
                     </>
                   ) : (
-                    <Ellipsis size={16} strokeWidth={2} data-stroke />
+                    <Ellipsis className="opacity-70" size={16} />
                   )}
                 </span>
               </TooltipTrigger>
@@ -258,19 +251,14 @@ function ChatThreadMenu({
           <DropdownMenuItem onSelect={handleTogglePin}>
             {isPinned ? (
               <>
-                <PinOff
-                  size={16}
-                  strokeWidth={2}
-                  className="mr-2"
-                  data-stroke
-                />
+                <PinOff size={16} className="mr-2" />
                 {t(($) => {
                   return $.chat.sidebar.unpin;
                 })}
               </>
             ) : (
               <>
-                <Pin size={16} strokeWidth={2} className="mr-2" data-stroke />
+                <Pin size={16} className="mr-2" />
                 {t(($) => {
                   return $.chat.sidebar.pin;
                 })}
@@ -278,7 +266,7 @@ function ChatThreadMenu({
             )}
           </DropdownMenuItem>
           <DropdownMenuModalItem onModalSelect={openRenameDialog}>
-            <Pencil size={16} strokeWidth={2} className="mr-2" data-stroke />
+            <Pencil size={16} className="mr-2" />
             {t(($) => {
               return $.chat.sidebar.rename;
             })}
@@ -289,7 +277,7 @@ function ChatThreadMenu({
             }}
             className="text-destructive focus:text-destructive"
           >
-            <Trash size={16} strokeWidth={2} className="mr-2" data-stroke />
+            <Trash size={16} className="mr-2" />
             {t(($) => {
               return $.chat.sidebar.delete;
             })}
@@ -332,9 +320,9 @@ function ChatThreadSideDecorator({
                 aria-label={t(($) => {
                   return $.chat.sidebar.pinned;
                 })}
-                className="hidden items-center justify-center text-sidebar-foreground/70 group-hover:hidden peer-data-[state=open]:hidden md:flex"
+                className="hidden items-center justify-center text-sidebar-foreground group-hover:hidden peer-data-[state=open]:hidden md:flex"
               >
-                <Pin size={16} strokeWidth={2} data-stroke />
+                <Pin className="opacity-50" size={16} />
               </span>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -669,7 +657,7 @@ function ChatThreadsListMenuTooltip() {
     <Tooltip>
       <TooltipTrigger asChild>
         <span>
-          <Ellipsis size={16} strokeWidth={2} data-stroke />
+          <Ellipsis className="opacity-70" size={16} />
         </span>
       </TooltipTrigger>
       <TooltipContent side="bottom">
@@ -720,14 +708,12 @@ function ChatThreadsTitle() {
         return setCollapsed(!collapsed);
       }}
     >
-      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
+      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground group-hover:text-sidebar-foreground transition-colors">
         {titleLabel}
         <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
           <ChevronRight
+            className={`opacity-35 ${collapsed ? "" : "rotate-90"}`}
             size={12}
-            strokeWidth={2}
-            className={collapsed ? "" : "rotate-90"}
-            data-stroke
           />
         </span>
       </span>
@@ -761,7 +747,7 @@ function ChatThreadsTitle() {
                 }}
                 disabled={!currentChatAgentId || newChatDisabled}
               >
-                <Plus size={16} strokeWidth={2} className="mr-2" data-stroke />
+                <Plus size={16} className="mr-2" />
                 {t(($) => {
                   return $.chat.newChat;
                 })}
@@ -774,9 +760,7 @@ function ChatThreadsTitle() {
               >
                 <Check
                   size={16}
-                  strokeWidth={2}
                   className={`mr-2 ${unreadOnly ? "invisible" : ""}`}
-                  data-stroke
                 />
                 {t(($) => {
                   return $.chat.sidebar.allChats;
@@ -789,9 +773,7 @@ function ChatThreadsTitle() {
               >
                 <Check
                   size={16}
-                  strokeWidth={2}
                   className={`mr-2 ${unreadOnly ? "" : "invisible"}`}
-                  data-stroke
                 />
                 {t(($) => {
                   return $.chat.sidebar.unreadOnly;

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -155,11 +155,7 @@ export function SlashWorkflowMenu({
             className="flex h-8 w-full items-center justify-between rounded px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-state-hover"
           >
             <span className="flex min-w-0 items-center gap-2">
-              <FileText
-                size={16}
-                strokeWidth={1.8}
-                className="shrink-0 text-muted-foreground"
-              />
+              <FileText size={16} className="shrink-0 text-muted-foreground" />
               <span className="truncate">
                 {t(($) => {
                   return $.chat.composer.workflows.viewAll;
@@ -168,7 +164,6 @@ export function SlashWorkflowMenu({
             </span>
             <ChevronRight
               size={16}
-              strokeWidth={1.8}
               className="shrink-0 text-muted-foreground"
             />
           </Link>

--- a/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
@@ -338,7 +338,7 @@ function ThreadArtifactDetail({
             rel="noreferrer"
             className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary-hover"
           >
-            <ExternalLink size={16} strokeWidth={1.7} />
+            <ExternalLink size={16} />
             {t(($) => {
               return $.artifacts.sidebar.openSharedConversation;
             })}

--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -121,7 +121,6 @@ interface TiptapInstructionsEditorProps {
 }
 
 const ICON_SIZE = 18;
-const ICON_STROKE = 1.5;
 interface ToolbarLabels {
   bold: string;
   italic: string;
@@ -310,7 +309,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.bold}
           >
-            <Bold size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Bold size={ICON_SIZE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -320,7 +319,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.italic}
           >
-            <Italic size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Italic size={ICON_SIZE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -330,7 +329,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.strikethrough}
           >
-            <Strikethrough size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Strikethrough size={ICON_SIZE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -340,7 +339,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.inlineCode}
           >
-            <Code size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Code size={ICON_SIZE} />
           </ToolbarButton>
 
           <ToolbarDivider />
@@ -353,7 +352,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.heading1}
           >
-            <Heading1 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Heading1 size={ICON_SIZE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -363,7 +362,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.heading2}
           >
-            <Heading2 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Heading2 size={ICON_SIZE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -373,7 +372,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.heading3}
           >
-            <Heading3 size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Heading3 size={ICON_SIZE} />
           </ToolbarButton>
 
           <ToolbarDivider />
@@ -386,7 +385,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.bulletList}
           >
-            <List size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <List size={ICON_SIZE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -396,7 +395,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.orderedList}
           >
-            <ListOrdered size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <ListOrdered size={ICON_SIZE} />
           </ToolbarButton>
           <ToolbarButton
             onAction={() => {
@@ -406,7 +405,7 @@ export function TiptapInstructionsEditor({
             disabled={disabled}
             title={labels.blockquote}
           >
-            <Quote size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <Quote size={ICON_SIZE} />
           </ToolbarButton>
         </BubbleMenu>
       )}

--- a/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
@@ -712,7 +712,7 @@ export function AutomationListIcon({
       )}
       aria-hidden="true"
     >
-      <Icon size={compact ? 16 : 28} strokeWidth={1.6} />
+      <Icon size={compact ? 16 : 28} />
     </span>
   );
 }
@@ -807,7 +807,7 @@ function WorkflowSelectionStep({
         onClick={onCreateWorkflow}
       >
         <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-muted-foreground">
-          <MessageCircle size={16} strokeWidth={1.6} />
+          <MessageCircle size={16} />
         </span>
         <span className="min-w-0">
           <span className="block text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -64,11 +64,7 @@ function AppearanceSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Palette
-                size={22}
-                strokeWidth={1.5}
-                className="text-muted-foreground"
-              />
+              <Palette size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">
@@ -113,7 +109,7 @@ function AppearanceSettings() {
                     : "zero-chip text-muted-foreground hover:text-foreground",
                 )}
               >
-                <Icon size={15} strokeWidth={1.5} />
+                <Icon size={15} />
                 {label}
               </button>
             );
@@ -150,11 +146,7 @@ function SendModeSettings() {
         <div className="flex flex-1 items-center gap-4 min-w-0">
           <div className="shrink-0">
             <div className="flex h-7 w-7 items-center justify-center">
-              <Keyboard
-                size={22}
-                strokeWidth={1.5}
-                className="text-muted-foreground"
-              />
+              <Keyboard size={22} className="text-muted-foreground" />
             </div>
           </div>
           <div className="flex flex-1 flex-col gap-1 min-w-0">
@@ -247,11 +239,7 @@ function CaptureNetworkBodiesSettings() {
       <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
-            <Bug
-              size={22}
-              strokeWidth={1.5}
-              className="text-muted-foreground"
-            />
+            <Bug size={22} className="text-muted-foreground" />
           </div>
         </div>
         <div className="flex flex-1 flex-col gap-1 min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -220,7 +220,7 @@ function ActivityBreadcrumbLabel() {
   const { t } = useTranslation();
   return (
     <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5">
-      <ChartLine size={14} strokeWidth={1.5} className="shrink-0" />
+      <ChartLine size={14} className="shrink-0" />
       {t(($) => {
         return $.activity.detail.activity;
       })}
@@ -431,7 +431,7 @@ export function ActivityHeaderCard({
                         }
                       }}
                     >
-                      <Download size={14} strokeWidth={1.5} />
+                      <Download size={14} />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="left">
@@ -1224,11 +1224,7 @@ export function StepsList({
       )}
       {isLoading ? (
         <div className="flex justify-center py-8">
-          <Loader2
-            size={20}
-            strokeWidth={1.5}
-            className="animate-spin text-muted-foreground"
-          />
+          <Loader2 size={20} className="animate-spin text-muted-foreground" />
         </div>
       ) : groups.length === 0 && !hasContent ? (
         <div className="py-8 text-center text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
@@ -65,7 +65,7 @@ function MessageMark({
   }
 
   if (state === "loading") {
-    return <Loader2 size={40} className="animate-spin text-muted-foreground" />;
+    return <Loader2 size={40} className="animate-spin" />;
   }
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -328,7 +328,7 @@ export function ArtifactShareButton({
         title={publicAttachmentUrl(url)}
         className={iconButtonClassName(className)}
       >
-        <Share size={iconSize} strokeWidth={1.5} />
+        <Share size={iconSize} />
       </a>
     </ArtifactActionTooltip>
   );
@@ -434,7 +434,7 @@ function GoogleDriveDisabledMenuItem({
       className={muted ? "text-muted-foreground" : ""}
       disabled
     >
-      <BrandGoogleDrive size={14} strokeWidth={1.5} />
+      <BrandGoogleDrive size={14} />
       {text}
     </ArtifactDownloadMenuItem>
   );
@@ -531,7 +531,7 @@ function GoogleDriveMenuItem({
   if (googleDriveReady) {
     return (
       <ArtifactDownloadMenuItem onClick={syncOrConnect}>
-        <BrandGoogleDrive size={14} strokeWidth={1.5} />
+        <BrandGoogleDrive size={14} />
         {t(($) => {
           return $.artifacts.googleDrive.upload;
         })}
@@ -550,7 +550,7 @@ function GoogleDriveMenuItem({
             }
             onClick={syncOrConnect}
           >
-            <BrandGoogleDrive size={14} strokeWidth={1.5} />
+            <BrandGoogleDrive size={14} />
             {t(($) => {
               return $.artifacts.googleDrive.connect;
             })}
@@ -608,9 +608,9 @@ function ArtifactDownloadTrigger({
       )}
     >
       {downloadPending ? (
-        <Loader2 size={iconSize} strokeWidth={1.5} className="animate-spin" />
+        <Loader2 size={iconSize} className="animate-spin" />
       ) : (
-        <Download size={iconSize} strokeWidth={1.5} />
+        <Download size={iconSize} />
       )}
     </button>
   );
@@ -737,7 +737,7 @@ export function ArtifactDownloadMenu({
             });
           }}
         >
-          <Download size={14} strokeWidth={1.5} />
+          <Download size={14} />
           {t(($) => {
             return $.artifacts.actions.download;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1209,7 +1209,7 @@ function ArtifactImageNavigationControls({
           data-testid="artifact-sidebar-previous-image"
           className="absolute left-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <ChevronLeft size={22} strokeWidth={1.8} />
+          <ChevronLeft size={22} />
         </button>
       )}
       {navigation.onNext && (
@@ -1225,7 +1225,7 @@ function ArtifactImageNavigationControls({
           data-testid="artifact-sidebar-next-image"
           className="absolute right-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <ChevronRight size={22} strokeWidth={1.8} />
+          <ChevronRight size={22} />
         </button>
       )}
     </>
@@ -1291,7 +1291,7 @@ function ArtifactImageZoomControls({
         })}
         data-testid="artifact-sidebar-image-reset-zoom"
       >
-        <RotateCcw size={15} strokeWidth={1.8} />
+        <RotateCcw size={15} />
       </button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -281,7 +281,7 @@ function ArtifactDialogSplitViewButton({ onClick }: { onClick: () => void }) {
       })}
       onClick={onClick}
     >
-      <Columns2 size={18} strokeWidth={1.8} />
+      <Columns2 size={18} />
     </DialogIconButton>
   );
 }
@@ -307,11 +307,7 @@ function ArtifactDialogFullscreenButton({
       }
       onClick={onClick}
     >
-      {fullscreen ? (
-        <Minimize2 size={18} strokeWidth={1.8} />
-      ) : (
-        <Maximize2 size={18} strokeWidth={1.8} />
-      )}
+      {fullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
     </DialogIconButton>
   );
 }
@@ -410,7 +406,7 @@ function artifactDialogMetadataFromItem(params: {
 function ArtifactDialogLoadingBody() {
   return (
     <div className="flex h-full items-center justify-center p-6 text-muted-foreground">
-      <Loader2 size={20} strokeWidth={1.8} className="animate-spin" />
+      <Loader2 size={20} className="animate-spin" />
     </div>
   );
 }
@@ -536,7 +532,7 @@ function ArtifactDialogImageZoomControls({
           return $.artifacts.actions.resetZoom;
         })}
       >
-        <RotateCcw size={15} strokeWidth={1.8} />
+        <RotateCcw size={15} />
       </button>
     </div>
   );
@@ -567,7 +563,7 @@ function ArtifactDialogImageNavigationControls({
           data-testid="artifact-dialog-previous-image"
           className="absolute left-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <ChevronLeft size={22} strokeWidth={1.8} />
+          <ChevronLeft size={22} />
         </button>
       )}
       {navigation.onNext && (
@@ -583,7 +579,7 @@ function ArtifactDialogImageNavigationControls({
           data-testid="artifact-dialog-next-image"
           className="absolute right-4 top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-state-hover"
         >
-          <ChevronRight size={22} strokeWidth={1.8} />
+          <ChevronRight size={22} />
         </button>
       )}
     </>
@@ -867,7 +863,7 @@ function ArtifactDialogBody({
       <ArtifactDialogStage centered>
         <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
           <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/70 bg-muted/50 text-muted-foreground">
-            <FileMusic size={28} strokeWidth={1.6} />
+            <FileMusic size={28} />
           </span>
           <p className="max-w-full truncate text-sm text-muted-foreground">
             {filename}
@@ -1249,7 +1245,7 @@ function ArtifactPreviewDialogActions({
           closeLightboxWithDialogExit(rootSignal);
         }}
       >
-        <X size={18} strokeWidth={1.8} />
+        <X size={18} />
       </DialogIconButton>
     </div>
   );
@@ -1591,11 +1587,7 @@ function ComposerImagePreviewButton({
         title={filename}
         className="group/image-preview relative h-9 w-9 overflow-hidden rounded-lg border border-foreground/10 transition-colors hover:border-foreground/25"
       >
-        <Image
-          size={20}
-          strokeWidth={1.5}
-          className="text-muted-foreground m-auto h-full"
-        />
+        <Image size={20} className="text-muted-foreground m-auto h-full" />
       </button>
     );
   }
@@ -1623,9 +1615,9 @@ function ComposerImagePreviewButton({
           className="absolute inset-0 flex items-center justify-center bg-muted/70 text-muted-foreground"
         >
           {currentImageStatus === "loading" ? (
-            <Loader2 size={14} strokeWidth={1.8} className="animate-spin" />
+            <Loader2 size={14} className="animate-spin" />
           ) : (
-            <Image size={16} strokeWidth={1.5} />
+            <Image size={16} />
           )}
         </span>
       )}
@@ -1723,7 +1715,7 @@ function AttachmentChip({
               )
         }
       >
-        <X size={9} strokeWidth={2.5} />
+        <X size={9} />
       </button>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -593,7 +593,7 @@ function VideoThumbnailPreview({
         <div className="absolute inset-0 z-20 bg-black/15 transition-colors group-hover/video-preview:bg-black/35" />
         <span className="absolute inset-0 z-30 flex items-center justify-center">
           <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-preview:scale-105">
-            <Play size={20} strokeWidth={1.8} />
+            <Play size={20} />
           </span>
         </span>
         <div className="absolute right-2 top-2 z-30 inline-flex items-center gap-1 rounded-full bg-background/85 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground opacity-0 transition-opacity duration-200 group-hover/video-preview:opacity-100">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -517,7 +517,6 @@ function ComposerStripRow({
         >
           <Target
             size={16}
-            strokeWidth={1.5}
             className="shrink-0 text-emerald-800"
             aria-hidden="true"
           />
@@ -533,9 +532,9 @@ function ComposerStripRow({
                 aria-label={aboutAriaLabel}
               >
                 {isGoal ? (
-                  <Target size={16} strokeWidth={1.5} aria-hidden="true" />
+                  <Target size={16} aria-hidden="true" />
                 ) : isWorkflowEvent ? (
-                  <Bolt size={16} strokeWidth={1.5} aria-hidden="true" />
+                  <Bolt size={16} aria-hidden="true" />
                 ) : (
                   <ComposerQueueGlyph />
                 )}
@@ -568,7 +567,7 @@ function ComposerStripRow({
         }}
         aria-label={removeAriaLabel}
       >
-        <X size={16} strokeWidth={1.5} />
+        <X size={16} />
       </button>
     </div>
   );
@@ -1050,7 +1049,7 @@ function VideoTemplatePreview({ item }: { item: VideoTemplateItem }) {
         }}
       >
         <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-template-preview:scale-105">
-          <Play size={20} strokeWidth={1.8} />
+          <Play size={20} />
         </span>
       </button>
     </div>
@@ -1112,7 +1111,7 @@ function VideoTemplateCard({
         <VideoTemplatePreview item={item} />
         {selected ? (
           <span className="pointer-events-none absolute left-[7px] top-[7px] z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-            <Check size={14} strokeWidth={2.6} />
+            <Check size={14} />
           </span>
         ) : null}
         <button
@@ -1244,7 +1243,7 @@ function WebsiteTemplateCard({
         <div className={TEMPLATE_TILE_SCRIM} />
         {selected ? (
           <span className="pointer-events-none absolute left-[7px] top-[7px] z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-            <Check size={14} strokeWidth={2.6} />
+            <Check size={14} />
           </span>
         ) : null}
         <button
@@ -1532,10 +1531,7 @@ function TemplateEmptyPanel() {
   return (
     <div className="flex min-h-40 flex-1 items-center justify-center rounded-[22px] border-2 border-dashed border-border bg-background px-6 py-10 text-center">
       <div className="flex max-w-xl flex-col items-center">
-        <Search
-          className="mb-4 h-8 w-8 text-muted-foreground/70"
-          strokeWidth={1.7}
-        />
+        <Search className="mb-4 h-8 w-8" />
         <p className="text-sm font-semibold text-muted-foreground">
           {t(($) => {
             return $.artifacts.templates.noMatches;
@@ -3648,7 +3644,7 @@ function TemplatePreviewPage({
             </h3>
             <div className="my-5 border-t border-border" />
             <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-              <Palette size={14} strokeWidth={1.9} />
+              <Palette size={14} />
               <span>
                 {t(($) => {
                   return $.artifacts.templates.theme;
@@ -3826,7 +3822,7 @@ function PptCard({
         <div className={TEMPLATE_TILE_SCRIM} />
         {selected ? (
           <span className="pointer-events-none absolute left-[7px] top-[7px] z-20 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-            <Check size={14} strokeWidth={2.6} />
+            <Check size={14} />
           </span>
         ) : null}
         <button
@@ -3989,7 +3985,7 @@ function IllustrationTemplateHero({
         hidden
         className="absolute inset-0 flex items-center justify-center bg-muted text-muted-foreground"
       >
-        <LayoutTemplate size={28} strokeWidth={1.5} />
+        <LayoutTemplate size={28} />
       </div>
     </div>
   );
@@ -4592,7 +4588,7 @@ function TemplatePickerCategoryNav({
               return (
                 <SelectItem key={value} value={value}>
                   <span className="flex items-center gap-2">
-                    <Icon className="h-4 w-4" strokeWidth={1.8} />
+                    <Icon className="h-4 w-4" />
                     {label}
                   </span>
                 </SelectItem>
@@ -4662,7 +4658,6 @@ function TemplatePickerCategoryNav({
                         ? "text-foreground"
                         : "text-gray-700 group-hover:text-gray-800",
                     )}
-                    strokeWidth={1.8}
                   />
                   <span className="truncate">{label}</span>
                 </button>
@@ -4699,10 +4694,7 @@ function TemplatePickerWorkflowSearch({
   return (
     <div className="relative w-56 shrink-0">
       <div className="relative">
-        <Search
-          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-          strokeWidth={1.8}
-        />
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           aria-label={t(($) => {
             return $.artifacts.templates.searchConnectors;
@@ -5725,7 +5717,7 @@ function TemplatePickerButton({
                 setOpen(true);
               }}
             >
-              <SwatchBook size={18} strokeWidth={1.5} aria-hidden="true" />
+              <SwatchBook size={18} aria-hidden="true" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="top" className="text-xs">
@@ -5815,7 +5807,7 @@ function CreateWorkflowPromptButton({
             })}
             onClick={onCreateWorkflowPrompt}
           >
-            <Route size={18} strokeWidth={1.5} aria-hidden="true" />
+            <Route size={18} aria-hidden="true" />
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
@@ -5867,7 +5859,7 @@ function ConnectorTriggerIcons({
   ].slice(0, 3);
   const hasComputerAccess = hasComputerUse || hasCloudBrowser;
   if (enabled.length === 0 && !hasComputerUse && !hasCloudBrowser) {
-    return <Plug size={18} strokeWidth={1.5} />;
+    return <Plug size={18} />;
   }
   return (
     <span className="flex items-center sm:-space-x-1.5">
@@ -5899,14 +5891,14 @@ function ConnectorTriggerIcons({
       {hasComputerUse && (
         <span className="relative shrink-0">
           <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-primary zero-border sm:h-7 sm:w-7">
-            <Monitor size={16} strokeWidth={1.5} />
+            <Monitor size={16} />
           </span>
         </span>
       )}
       {hasCloudBrowser && (
         <span className="relative shrink-0">
           <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-primary zero-border sm:h-7 sm:w-7">
-            <Globe size={16} strokeWidth={1.5} />
+            <Globe size={16} />
           </span>
         </span>
       )}
@@ -5967,7 +5959,7 @@ function CustomConnectorCatalogCard({
           className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 text-muted-foreground"
           aria-hidden="true"
         >
-          <Plus size={14} strokeWidth={1.5} />
+          <Plus size={14} />
         </span>
       </span>
       <span className="block px-5 pb-4 pt-1">
@@ -6097,7 +6089,7 @@ function ComputerUseConnectorMenuSection({
         className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-state-hover"
       >
         <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-          <Globe size={16} strokeWidth={1.5} />
+          <Globe size={16} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block truncate text-sm text-foreground">
@@ -6168,7 +6160,7 @@ function ComputerUseConnectorMenuSection({
                 className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-state-hover"
               >
                 <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-                  <Monitor size={16} strokeWidth={1.5} />
+                  <Monitor size={16} />
                 </span>
                 <span className="min-w-0 flex-1">
                   <span className="block truncate text-sm text-foreground">
@@ -6222,11 +6214,7 @@ function ComputerUseConnectorMenuSection({
         </div>
       ) : (
         <div className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground">
-          <Monitor
-            size={16}
-            strokeWidth={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <Monitor size={16} className="shrink-0" />
           {t(($) => {
             return $.chat.computerUse.noOnlineComputers;
           })}
@@ -6238,11 +6226,7 @@ function ComputerUseConnectorMenuSection({
           className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-state-hover"
           onClick={onOpenDownloadDialog}
         >
-          <Plug
-            size={16}
-            strokeWidth={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <Plug size={16} className="shrink-0" />
           {t(($) => {
             return $.chat.computerUse.connectMyComputer;
           })}
@@ -6590,7 +6574,7 @@ function ConnectorsPopoverButton({
                             )}
                             className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
                           >
-                            <SlidersHorizontal size={15} strokeWidth={1.5} />
+                            <SlidersHorizontal size={15} />
                           </button>
                         )}
                       <LoadingSwitch
@@ -6639,7 +6623,7 @@ function ConnectorsPopoverButton({
             }}
           >
             <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-border/60 text-muted-foreground">
-              <Plus size={13} strokeWidth={1.5} />
+              <Plus size={13} />
             </span>
             {t(($) => {
               return $.chat.connectors.addConnectors;
@@ -6725,7 +6709,7 @@ function ComputerUseDownloadDialog({
         <div className="px-6 pb-6 pt-4">
           {downloadSupportStatus === "unsupported-intel-mac" ? (
             <Button type="button" size="lg" className="w-full" disabled>
-              <AlertTriangle size={16} strokeWidth={1.5} />
+              <AlertTriangle size={16} />
               {t(($) => {
                 return $.chat.computerUse.unsupportedIntelMac;
               })}
@@ -6746,7 +6730,7 @@ function ComputerUseDownloadDialog({
                   onOpenChange(false);
                 }}
               >
-                <Download size={16} strokeWidth={1.5} />
+                <Download size={16} />
                 {t(($) => {
                   return $.chat.computerUse.downloadMacos;
                 })}
@@ -6906,10 +6890,10 @@ function MicButton({ signals }: { signals: ComposerSignals }) {
                     } as CSSProperties
                   }
                 />
-                <Mic size={17} strokeWidth={1.8} className="relative" />
+                <Mic size={17} className="relative" />
               </>
             ) : (
-              <Mic size={18} strokeWidth={1.5} />
+              <Mic size={18} />
             )}
           </button>
         </TooltipTrigger>
@@ -6941,7 +6925,7 @@ function ComposerAttachButton({ signals }: { signals: ComposerSignals }) {
               fileInput?.click();
             }}
           >
-            <Paperclip size={18} strokeWidth={1.5} />
+            <Paperclip size={18} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
@@ -7288,7 +7272,7 @@ function ComposerSendButton({
         return $.chat.actions.send;
       })}
     >
-      <ArrowUp size={18} strokeWidth={2} data-stroke />
+      <ArrowUp size={18} />
     </Button>
   );
 }
@@ -7336,7 +7320,7 @@ function ModelConfigurationWarning({
             aria-label={`${blocker.actionLabel}: ${blocker.message}`}
             className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-amber-600 transition-colors hover:bg-amber-500/10 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
           >
-            <AlertTriangle size={15} strokeWidth={1.75} />
+            <AlertTriangle size={15} />
             <span className="hidden sm:inline">{blocker.actionLabel}</span>
           </button>
         </TooltipTrigger>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -71,7 +71,7 @@ function FeedbackToolbar({
           aria-keyshortcuts="c"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
         >
-          <Copy size={14} strokeWidth={2} data-stroke />
+          <Copy size={14} />
           {t(($) => {
             return $.chat.actions.copy;
           })}
@@ -84,7 +84,7 @@ function FeedbackToolbar({
           aria-keyshortcuts="f"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
         >
-          <MessageCircle size={14} strokeWidth={2} data-stroke />
+          <MessageCircle size={14} />
           {t(($) => {
             return $.chat.feedback.provide;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -506,7 +506,7 @@ function ArtifactsButtonInner({ thread }: { thread: ChatPanelSignals }) {
             })}
             aria-pressed={open}
           >
-            <Package size={17} strokeWidth={1.5} />
+            <Package size={17} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -609,7 +609,7 @@ function BrowserMenuButton({ thread }: { thread: ChatPanelSignals }) {
               openBrowserSidebar(thread.threadId);
             }}
           >
-            <Globe size={18} strokeWidth={1.5} />
+            <Globe size={18} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -715,7 +715,7 @@ function ChatThreadHeader({ thread }: { thread: ChatPanelSignals }) {
                     return $.chat.sharing.start;
                   })}
                 >
-                  <Share2 size={18} strokeWidth={1.5} />
+                  <Share2 size={18} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom">
@@ -850,7 +850,7 @@ function ChatThreadEmojiMenuButton({
                     {emoji}
                   </span>
                 ) : (
-                  <SmilePlus size={18} strokeWidth={1.75} aria-hidden="true" />
+                  <SmilePlus size={18} aria-hidden="true" />
                 )}
               </button>
             </PopoverTrigger>
@@ -1212,9 +1212,9 @@ function ChatImagePreviewLink({
           )}
         >
           {imageStatus === "loading" ? (
-            <Loader2 size={18} strokeWidth={1.8} className="animate-spin" />
+            <Loader2 size={18} className="animate-spin" />
           ) : (
-            <Image size={18} strokeWidth={1.5} />
+            <Image size={18} />
           )}
         </span>
       )}
@@ -1313,7 +1313,7 @@ function ChatVideoPreviewButton({
       )}
       <span className="absolute inset-0 flex items-center justify-center bg-black/10 transition-colors group-hover/video-preview:bg-black/35">
         <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black/55 text-white shadow-lg transition-transform group-hover/video-preview:scale-105">
-          <Play size={17} strokeWidth={1.8} />
+          <Play size={17} />
         </span>
       </span>
     </button>
@@ -1880,7 +1880,7 @@ function HeaderWorkflowAutomationCard({
           {t(($) => {
             return $.chat.actions.view;
           })}
-          <ArrowUpRight size={12} strokeWidth={1.5} />
+          <ArrowUpRight size={12} />
         </Link>
       </div>
       <WorkflowAutomationCard
@@ -1921,7 +1921,7 @@ function HeaderWorkflowAutomationCard({
               {running ? (
                 <Loader2 size={13} className="animate-spin" />
               ) : (
-                <Play size={13} strokeWidth={1.5} />
+                <Play size={13} />
               )}
               {running
                 ? t(($) => {
@@ -3572,11 +3572,7 @@ function CompletedWorkFoldRow({
         onClick={onToggle}
         className="mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover"
       >
-        <Hourglass
-          aria-hidden
-          size={14}
-          className="shrink-0 text-muted-foreground/70"
-        />
+        <Hourglass aria-hidden size={14} className="shrink-0" />
         <span className="text-[13px]">{label}</span>
         <ChevronRight
           aria-hidden
@@ -3785,11 +3781,7 @@ function RunGroupFoldRow({
           embedded && "mt-1.5",
         )}
       >
-        <Icon
-          aria-hidden
-          size={14}
-          className="shrink-0 text-muted-foreground/70"
-        />
+        <Icon aria-hidden size={14} className="shrink-0" />
         <span className="min-w-0 truncate whitespace-nowrap text-[13px]">
           {label}
         </span>
@@ -3983,7 +3975,7 @@ function ChatThreadBottomBar({ thread }: { thread: ChatPanelSignals }) {
                   );
                 }}
               >
-                <Copy size={16} strokeWidth={1.7} />
+                <Copy size={16} />
                 {t(($) => {
                   return $.chat.sharing.copyLink;
                 })}
@@ -4034,9 +4026,9 @@ function ChatThreadBottomBar({ thread }: { thread: ChatPanelSignals }) {
               }}
             >
               {creating ? (
-                <Loader2 size={16} strokeWidth={1.7} className="animate-spin" />
+                <Loader2 size={16} className="animate-spin" />
               ) : (
-                <Share2 size={16} strokeWidth={1.7} />
+                <Share2 size={16} />
               )}
               {t(($) => {
                 return $.chat.sharing.create;
@@ -4086,22 +4078,22 @@ function RecommendedFollowupIcon({
   followup: RecommendedFollowup;
 }) {
   if (followup.kind !== "generate") {
-    return <MessageCircle size={14} strokeWidth={1.8} />;
+    return <MessageCircle size={14} />;
   }
 
   if (followup.generationType === "image") {
-    return <Image size={14} strokeWidth={1.8} />;
+    return <Image size={14} />;
   }
   if (followup.generationType === "video") {
-    return <Video size={14} strokeWidth={1.8} />;
+    return <Video size={14} />;
   }
   if (followup.generationType === "presentation") {
-    return <ChartLine size={14} strokeWidth={1.8} />;
+    return <ChartLine size={14} />;
   }
   if (followup.generationType === "website") {
-    return <LinkIcon size={14} strokeWidth={1.8} />;
+    return <LinkIcon size={14} />;
   }
-  return <Package size={14} strokeWidth={1.8} />;
+  return <Package size={14} />;
 }
 
 function recommendedFollowupShownKey(
@@ -4221,7 +4213,6 @@ function RecommendedFollowupList({
             </span>
             <ArrowUpRight
               size={14}
-              strokeWidth={1.8}
               className={cn(
                 "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100",
                 showFollowupCards && "hidden",
@@ -4320,12 +4311,7 @@ function ActiveGoalObjectiveDialog({ threadId }: { threadId: string }) {
         <div className="max-h-[min(60vh,520px)] overflow-y-auto rounded-lg bg-muted/40 px-3 py-3 text-sm text-foreground sm:px-4">
           {goalLoadable.state === "loading" ? (
             <div className="flex min-h-28 items-center justify-center gap-2 text-muted-foreground">
-              <Loader2
-                size={16}
-                strokeWidth={1.7}
-                className="animate-spin"
-                aria-hidden="true"
-              />
+              <Loader2 size={16} className="animate-spin" aria-hidden="true" />
               <span>
                 {t(($) => {
                   return $.chat.queue.loadingGoal;
@@ -6237,9 +6223,7 @@ function assistantRecoveryResetText(
 }
 
 function AssistantRecoveryActionSpinner({ loading }: { loading: boolean }) {
-  return loading ? (
-    <Loader2 size={14} strokeWidth={1.75} className="animate-spin" />
-  ) : null;
+  return loading ? <Loader2 size={14} className="animate-spin" /> : null;
 }
 
 function AssistantRecoveryActions({
@@ -6340,9 +6324,9 @@ function AssistantErrorRecoveryCard({
       <div className="flex items-start gap-3">
         <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400">
           {recovery.kind === "usage-limit" ? (
-            <Clock size={17} strokeWidth={1.75} />
+            <Clock size={17} />
           ) : (
-            <AlertCircle size={17} strokeWidth={1.75} />
+            <AlertCircle size={17} />
           )}
         </div>
         <div className="min-w-0 flex-1">
@@ -6372,11 +6356,7 @@ function AssistantErrorRecoveryCard({
           </p>
           {resetText && (
             <div className="mt-2 inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
-              <Clock
-                size={14}
-                strokeWidth={1.75}
-                className="text-muted-foreground"
-              />
+              <Clock size={14} className="text-muted-foreground" />
               {resetText}
             </div>
           )}
@@ -6405,7 +6385,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
           borderRadius: "12px",
         }}
       >
-        <Hand size={14} strokeWidth={1.75} className="shrink-0" />
+        <Hand size={14} className="shrink-0" />
         <span>
           {t(($) => {
             return $.chat.errors.runCancelled;
@@ -6994,11 +6974,7 @@ function UserMessageActions({
           return $.chat.actions.copyMessage;
         })}
       >
-        {copied ? (
-          <Check size={18} strokeWidth={1.5} />
-        ) : (
-          <Copy size={18} strokeWidth={1.5} />
-        )}
+        {copied ? <Check size={18} /> : <Copy size={18} />}
       </button>
     </div>
   );
@@ -7072,7 +7048,7 @@ function MessageAnnotation({
         className={className}
         title={part.workflowName}
       >
-        <Route size={15} strokeWidth={1.8} className="shrink-0" />
+        <Route size={15} className="shrink-0" />
         <span className="min-w-0 truncate">{part.workflowName}</span>
       </div>
     );
@@ -7085,7 +7061,7 @@ function MessageAnnotation({
         })}
         className={className}
       >
-        <Target size={15} strokeWidth={1.8} className="shrink-0" />
+        <Target size={15} className="shrink-0" />
         <span>
           {t(($) => {
             return $.chat.queue.goal;
@@ -7102,7 +7078,7 @@ function MessageAnnotation({
         })}
         className={className}
       >
-        <Sunrise size={15} strokeWidth={1.8} className="shrink-0" />
+        <Sunrise size={15} className="shrink-0" />
         <span>
           {t(($) => {
             return $.settings.preferences.morningBrief.title;
@@ -7191,7 +7167,7 @@ function SourceMessageAnnotation({
   const content = (
     <>
       {part.kind === "slack" ? (
-        <BrandSlack size={15} strokeWidth={1.8} className="shrink-0" />
+        <BrandSlack size={15} className="shrink-0" />
       ) : (
         <img
           src={annotationIconImgs[part.kind]}
@@ -7204,7 +7180,7 @@ function SourceMessageAnnotation({
         <>
           <span className="shrink-0">·</span>
           <span className="min-w-0 truncate">{openLabel}</span>
-          <ArrowUpRight size={12} strokeWidth={1.5} className="shrink-0" />
+          <ArrowUpRight size={12} className="shrink-0" />
         </>
       ) : null}
     </>
@@ -7321,7 +7297,7 @@ function UserMessageTemplateReference({
         spec === null ? label : `${label} · ${videoTemplateSpecText(spec)}`
       }
     >
-      <SwatchBook size={13} strokeWidth={1.7} className="shrink-0" />
+      <SwatchBook size={13} className="shrink-0" />
       <span className="min-w-0 truncate">{part.titleSnapshot}</span>
       {spec !== null && <SentVideoTemplateSpec spec={spec} />}
     </span>
@@ -7424,7 +7400,7 @@ function UserMessageChatThreadReference({
       className={STRUCTURED_INLINE_LINK_REFERENCE_CLASS}
       title={title}
     >
-      <MessageCircle size={13} strokeWidth={1.7} className="shrink-0" />
+      <MessageCircle size={13} className="shrink-0" />
       <span className="min-w-0 truncate">{title}</span>
     </Link>
   );
@@ -8310,7 +8286,7 @@ function UsageChip({
           className="inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground/70 hover:bg-state-hover hover:text-foreground transition-colors duration-150"
           aria-label={`${ariaLabel} ${total}`}
         >
-          <Coins size={17} strokeWidth={1.5} />
+          <Coins size={17} />
           <span>{total}</span>
         </button>
       </PopoverTrigger>
@@ -8399,7 +8375,7 @@ function PagedGroupPrimaryActions({
                   return $.chat.run.viewLogs;
                 })}
               >
-                <ChartLine size={18} strokeWidth={1.5} />
+                <ChartLine size={18} />
               </Link>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -8422,11 +8398,7 @@ function PagedGroupPrimaryActions({
                   return $.chat.actions.copyMessage;
                 })}
               >
-                {copied ? (
-                  <Check size={18} strokeWidth={1.5} />
-                ) : (
-                  <Copy size={18} strokeWidth={1.5} />
-                )}
+                {copied ? <Check size={18} /> : <Copy size={18} />}
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -433,14 +433,7 @@ function ConnectorFilterOption({
   return (
     <DropdownMenuItem className="justify-between gap-2" onClick={onSelect}>
       <span className="flex min-w-0 items-center gap-2">{children}</span>
-      {active && (
-        <Check
-          size={15}
-          strokeWidth={2}
-          className="shrink-0 text-foreground"
-          data-stroke
-        />
-      )}
+      {active && <Check size={15} className="shrink-0 text-foreground" />}
     </DropdownMenuItem>
   );
 }
@@ -487,11 +480,7 @@ function ConnectorFilterDropdown({
           })}
           className="zero-btn-morandi hidden h-9 shrink-0 gap-1.5 rounded-lg border sm:inline-flex"
         >
-          <Filter
-            size={14}
-            strokeWidth={1.5}
-            className="text-muted-foreground"
-          />
+          <Filter size={14} className="" />
           {activeAgent && (
             <AvatarFromUrl
               avatarUrl={activeAgent.avatarUrl}
@@ -501,11 +490,7 @@ function ConnectorFilterDropdown({
             />
           )}
           <span className="max-w-[140px] truncate">{triggerLabel}</span>
-          <ChevronDown
-            size={14}
-            strokeWidth={1.5}
-            className="text-muted-foreground"
-          />
+          <ChevronDown size={14} className="" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -610,7 +595,6 @@ function ConnectorsToolbarActions({
         <div className="relative w-40 sm:w-52">
           <Search
             size={15}
-            strokeWidth={1.5}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
           />
           <input
@@ -640,7 +624,7 @@ function ConnectorsToolbarActions({
           className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
           onClick={onCreateCustom}
         >
-          <Plus size={14} strokeWidth={2} data-stroke />
+          <Plus size={14} />
           {t(($) => {
             return $.connectors.catalog.newConnector;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -227,10 +227,7 @@ function DirectedAuthorizeCardContent({
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (
-              <Loader2
-                size={20}
-                className="animate-spin text-muted-foreground"
-              />
+              <Loader2 size={20} className="animate-spin" />
             ) : (
               <>
                 <h1 className="text-lg font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -567,10 +567,7 @@ function DirectedConnectCardContent({
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (
-              <Loader2
-                size={20}
-                className="animate-spin text-muted-foreground"
-              />
+              <Loader2 size={20} className="animate-spin" />
             ) : (
               <>
                 <h1 className="text-lg font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
@@ -68,7 +68,7 @@ function GithubMark({
   }
 
   if (state === "loading") {
-    return <Loader2 size={40} className="animate-spin text-muted-foreground" />;
+    return <Loader2 size={40} className="animate-spin" />;
   }
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -122,7 +122,7 @@ export function ZeroIdeationPage() {
           onClick={handleBack}
           className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-state-hover hover:text-foreground transition-colors cursor-pointer"
         >
-          <MessageCircle size={14} strokeWidth={1.5} className="shrink-0" />
+          <MessageCircle size={14} className="shrink-0" />
           {t(($) => {
             return $.ideation.chat;
           })}
@@ -193,7 +193,6 @@ export function ZeroIdeationPage() {
                 <div className="relative w-full min-w-0 sm:max-w-[240px] sm:flex-1 sm:min-w-[12rem]">
                   <Search
                     className="pointer-events-none absolute left-3 top-1/2 z-10 size-[14px] -translate-y-1/2 text-muted-foreground"
-                    strokeWidth={1.5}
                     aria-hidden
                   />
                   <Input
@@ -254,9 +253,7 @@ export function ZeroIdeationPage() {
                               <CardContent className="p-4 group relative">
                                 <ArrowUpRight
                                   size={14}
-                                  strokeWidth={2}
                                   className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-                                  data-stroke
                                 />
                                 <p className="text-sm font-semibold text-foreground pr-5">
                                   {useCase.title}

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -154,11 +154,7 @@ function CreateWorkspaceItem() {
         disabled={clerk === null || creatingOrg}
         className="min-w-0 gap-3 px-3 py-2.5 rounded-lg"
       >
-        <Plus
-          size={18}
-          strokeWidth={1.5}
-          className="shrink-0 text-muted-foreground"
-        />
+        <Plus size={18} className="shrink-0" />
         <span>
           {creatingOrg
             ? t(($) => {
@@ -359,10 +355,7 @@ export function ZeroOrgSwitcher() {
             <span className="min-w-0 flex-1 text-left text-sm font-semibold leading-tight truncate">
               {orgName}
             </span>
-            <ChevronDown
-              size={16}
-              className="ml-auto shrink-0 text-muted-foreground"
-            />
+            <ChevronDown size={16} className="ml-auto shrink-0" />
           </button>
         </DropdownMenuTrigger>
         <OrgDropdownContent />

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -501,7 +501,7 @@ export function ZeroSettingsTab({
             </DialogDescription>
           </DialogHeader>
           <Alert variant="destructive">
-            <AlertTriangle size={16} strokeWidth={1.5} />
+            <AlertTriangle size={16} />
             <AlertTitle>
               {t(($) => {
                 return $.profile.makePrivate.warningTitle;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -411,7 +411,7 @@ function CreditBalanceItem({
       onModalSelect={onOpenCreditBalance}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <Coins size={18} strokeWidth={1.5} className="text-muted-foreground" />
+      <Coins size={18} className="" />
       <span className="min-w-0 flex-1 truncate text-sm tabular-nums">
         {loading ? (
           <span className="block h-4 w-24 rounded bg-muted/60" />
@@ -439,11 +439,7 @@ function UnifiedSettingsGroup({
         onModalSelect={onOpenSettings}
         className="gap-3 px-3 py-2.5 rounded-lg"
       >
-        <Settings
-          size={18}
-          strokeWidth={1.5}
-          className="text-muted-foreground"
-        />
+        <Settings size={18} className="" />
         <span>
           {t(($) => {
             return $.settings.accountMenu.settings;
@@ -457,11 +453,7 @@ function UnifiedSettingsGroup({
           }}
           className="gap-3 px-3 py-2.5 rounded-lg"
         >
-          <FlaskConical
-            size={18}
-            strokeWidth={1.5}
-            className="text-muted-foreground"
-          />
+          <FlaskConical size={18} className="" />
           <span>
             {t(($) => {
               return $.settings.accountMenu.lab;
@@ -490,7 +482,7 @@ function AccountManagementGroup({
         onClick={onAddAccount}
         className="gap-3 px-3 py-2.5 rounded-lg"
       >
-        <Plus size={18} strokeWidth={1.5} className="text-muted-foreground" />
+        <Plus size={18} className="" />
         <span>
           {t(($) => {
             return $.settings.accountMenu.addAccount;
@@ -502,21 +494,13 @@ function AccountManagementGroup({
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger className="gap-3 px-3 py-2.5 rounded-lg">
-        <ArrowRightLeft
-          size={18}
-          strokeWidth={1.5}
-          className="text-muted-foreground"
-        />
+        <ArrowRightLeft size={18} className="" />
         <span className="flex-1">
           {t(($) => {
             return $.settings.accountMenu.switchAccount;
           })}
         </span>
-        <ChevronRight
-          size={14}
-          strokeWidth={1.5}
-          className="text-muted-foreground"
-        />
+        <ChevronRight size={14} className="" />
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-[220px]">
         {others.map((account) => {
@@ -549,7 +533,7 @@ function AccountManagementGroup({
           onClick={onAddAccount}
           className="gap-3 px-3 py-2.5 rounded-lg"
         >
-          <Plus size={18} strokeWidth={1.5} className="text-muted-foreground" />
+          <Plus size={18} className="" />
           <span>
             {t(($) => {
               return $.settings.accountMenu.addAccount;
@@ -570,11 +554,7 @@ function ExtraAccountActions() {
       }}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <DatabaseBackup
-        size={18}
-        strokeWidth={1.5}
-        className="text-muted-foreground"
-      />
+      <DatabaseBackup size={18} className="" />
       <span>
         {t(($) => {
           return $.settings.accountMenu.exportData;
@@ -597,7 +577,7 @@ function SignOutItem({
       }}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
-      <LogOut size={18} strokeWidth={1.5} className="text-muted-foreground" />
+      <LogOut size={18} className="" />
       <span>
         {t(($) => {
           return $.settings.accountMenu.signOut;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
@@ -220,7 +220,7 @@ export function AgentRowSideActions({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex h-full w-full items-center justify-center">
-                      <Ellipsis size={16} strokeWidth={2} data-stroke />
+                      <Ellipsis size={16} />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -83,9 +83,7 @@ export function AgentDialogSearch({
       <div className="relative w-full">
         <Search
           size={16}
-          strokeWidth={2}
-          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-          data-stroke
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
         />
         <Input
           type="text"
@@ -109,7 +107,7 @@ export function AgentDialogSearch({
               return $.sidebar.clearSearch;
             })}
           >
-            <X size={14} strokeWidth={2} data-stroke />
+            <X size={14} />
           </button>
         )}
       </div>
@@ -204,7 +202,7 @@ function AgentCommandSearch({
               return $.sidebar.clearSearch;
             })}
           >
-            <X size={14} strokeWidth={2} data-stroke />
+            <X size={14} />
           </button>
         )}
       </div>
@@ -405,7 +403,7 @@ function PinnedAgentCommandItem({
                 return $.sidebar.unpin;
               }),
               disabled,
-              icon: <PinOff size={16} strokeWidth={2} data-stroke />,
+              icon: <PinOff size={16} />,
               onSelect: onUnpin,
             }}
           />
@@ -557,7 +555,7 @@ function UnpinnedAgentsCommandSection({
                     return $.sidebar.pin;
                   }),
                   disabled,
-                  icon: <Pin size={16} strokeWidth={2} data-stroke />,
+                  icon: <Pin size={16} />,
                   onSelect: () => {
                     return onTogglePin(agent.id);
                   },
@@ -874,11 +872,7 @@ function UnifiedAgentCommandItem({
                     return pinned ? $.sidebar.unpin : $.sidebar.pin;
                   }),
                   disabled: saving,
-                  icon: pinned ? (
-                    <PinOff size={16} strokeWidth={2} data-stroke />
-                  ) : (
-                    <Pin size={16} strokeWidth={2} data-stroke />
-                  ),
+                  icon: pinned ? <PinOff size={16} /> : <Pin size={16} />,
                   onSelect: () => {
                     return onTogglePin(agentId);
                   },

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -103,7 +103,7 @@ function PinnedAgentSideDecorator({
               return $.sidebar.markAllRead;
             }),
             disabled: markingRead,
-            icon: <CheckCheck size={16} strokeWidth={2} data-stroke />,
+            icon: <CheckCheck size={16} />,
             onSelect: markAllRead,
           },
         ]
@@ -116,7 +116,7 @@ function PinnedAgentSideDecorator({
                   return $.sidebar.unpin;
                 }),
                 disabled: savingPinned,
-                icon: <PinOff size={16} strokeWidth={2} data-stroke />,
+                icon: <PinOff size={16} />,
                 onSelect: unpinAgent,
               }
             : {
@@ -124,7 +124,7 @@ function PinnedAgentSideDecorator({
                   return $.sidebar.pin;
                 }),
                 disabled: savingPinned,
-                icon: <Pin size={16} strokeWidth={2} data-stroke />,
+                icon: <Pin size={16} />,
                 onSelect: pinAgent,
               },
         ]
@@ -280,10 +280,10 @@ export function PinnedAgentListSection({
             aria-label={t(($) => {
               return $.sidebar.openConversation;
             })}
-            className="flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground/70 transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
+            className="flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground opacity-70 transition-colors hover:opacity-100 hover:bg-state-hover"
           >
             <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
-              <Plus size={16} strokeWidth={2} data-stroke />
+              <Plus size={16} />
             </span>
             <span className="text-[11px] leading-tight">
               {t(($) => {
@@ -312,10 +312,8 @@ export function PinnedAgentListSection({
           })}
           <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
             <ChevronRight
+              className={`opacity-35 ${collapsed ? "" : "rotate-90"}`}
               size={12}
-              strokeWidth={2}
-              className={collapsed ? "" : "rotate-90"}
-              data-stroke
             />
           </span>
         </span>
@@ -328,12 +326,12 @@ export function PinnedAgentListSection({
                   e.stopPropagation();
                   openAgentListDialog();
                 }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-state-selected-hover transition-colors"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground hover:text-sidebar-foreground hover:bg-state-selected-hover transition-colors"
                 aria-label={t(($) => {
                   return $.sidebar.openConversation;
                 })}
               >
-                <Plus size={15} strokeWidth={2.5} />
+                <Plus className="opacity-50" size={15} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -230,11 +230,11 @@ function CollapsedExpandButton() {
           <TooltipTrigger asChild>
             <button
               type="button"
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
               onClick={onCollapse}
               aria-label={expandLabel}
             >
-              <PanelLeftClose size={18} className="rotate-180" />
+              <PanelLeftClose size={18} className="rotate-180 opacity-50" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">
@@ -305,7 +305,7 @@ function CollapsedNavList() {
                       aria-label={label}
                     >
                       <span className="relative inline-flex">
-                        <Icon size={16} className="shrink-0" />
+                        <Icon size={16} className="shrink-0 opacity-70" />
                         {id === "works" && slackScopeMismatch && (
                           <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
                         )}
@@ -353,7 +353,7 @@ function CollapsedFooter() {
               }`}
               aria-label={insightsLabel}
             >
-              <Sparkles size={16} className="shrink-0" />
+              <Sparkles size={16} className="shrink-0 opacity-70" />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="right">
@@ -411,11 +411,11 @@ function ExpandedHeader() {
             <TooltipTrigger asChild>
               <button
                 type="button"
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-state-hover transition-colors"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground hover:text-sidebar-foreground hover:bg-state-hover transition-colors"
                 onClick={onCollapse}
                 aria-label={collapseLabel}
               >
-                <PanelLeftClose size={18} />
+                <PanelLeftClose className="opacity-50" size={18} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -464,10 +464,8 @@ function ExpandedManageSection() {
           })}
           <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
             <ChevronRight
+              className={`opacity-35 ${manageCollapsed ? "" : "rotate-90"}`}
               size={12}
-              strokeWidth={2}
-              className={manageCollapsed ? "" : "rotate-90"}
-              data-stroke
             />
           </span>
         </span>
@@ -625,7 +623,7 @@ function ExpandedFooterAccountInsights() {
               }`}
               aria-label={insightsLabel}
             >
-              <Sparkles size={16} className="shrink-0" />
+              <Sparkles size={16} className="shrink-0 opacity-70" />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="top">
@@ -713,7 +711,7 @@ function LabeledRailLink({
             />
           </span>
         ) : (
-          <Icon size={19} className="shrink-0" />
+          <Icon size={19} className="shrink-0 opacity-70" />
         )}
         {showBadge && (
           <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-red-500" />
@@ -844,9 +842,9 @@ function ChatListColumn() {
                   openAgentList();
                 }}
                 aria-label={searchLabel}
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
               >
-                <Search size={17} strokeWidth={1.8} />
+                <Search className="opacity-50" size={17} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -866,9 +864,9 @@ function ChatListColumn() {
                 }}
                 aria-label={newChatLabel}
                 aria-current={isNewChatActive ? "page" : undefined}
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 no-underline transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground no-underline transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
               >
-                <Edit size={17} strokeWidth={1.8} />
+                <Edit className="opacity-50" size={17} />
               </Link>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -67,7 +67,7 @@ function CheckingState() {
   const { t } = useTranslation();
   return (
     <>
-      <Loader2 size={40} className="text-muted-foreground animate-spin" />
+      <Loader2 size={40} className="animate-spin" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -88,7 +88,7 @@ function InvalidState() {
   const { t } = useTranslation();
   return (
     <>
-      <AlertCircle size={40} className="text-muted-foreground/40" />
+      <AlertCircle size={40} className="" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -191,7 +191,7 @@ function PageContent() {
   if (workspaceId && slackUserId) {
     return (
       <>
-        <BrandSlack size={40} className="text-foreground" />
+        <BrandSlack size={40} className="" />
         <div className="text-center space-y-1.5">
           <h2 className="text-base font-semibold text-foreground">
             {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-teams-connect-page.tsx
@@ -108,7 +108,7 @@ function CheckingState() {
   const { t } = useTranslation();
   return (
     <>
-      <Loader2 size={40} className="text-muted-foreground animate-spin" />
+      <Loader2 size={40} className="animate-spin" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {
@@ -129,7 +129,7 @@ function InvalidState() {
   const { t } = useTranslation();
   return (
     <>
-      <AlertCircle size={40} className="text-muted-foreground/40" />
+      <AlertCircle size={40} className="" />
       <div className="text-center space-y-1.5">
         <h2 className="text-base font-semibold text-foreground">
           {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -76,7 +76,7 @@ function TelegramMark({
   }
 
   if (state === "loading") {
-    return <Loader2 size={40} className="animate-spin text-muted-foreground" />;
+    return <Loader2 size={40} className="animate-spin" />;
   }
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx
@@ -290,7 +290,7 @@ function TelegramBotIconFallback({ botId }: { botId: string }) {
       className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#2AABEE]/10 text-[#2AABEE]"
       data-testid={`telegram-bot-avatar-fallback-${botId}`}
     >
-      <Bot className="h-5 w-5" strokeWidth={1.75} />
+      <Bot className="h-5 w-5" />
     </div>
   );
 }
@@ -1597,7 +1597,7 @@ function TelegramMoreActions({
             { bot: botLabel },
           )}
         >
-          <EllipsisVertical size={16} strokeWidth={1.5} />
+          <EllipsisVertical size={16} />
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="flex w-40 flex-col gap-0.5 p-2">
@@ -2188,7 +2188,7 @@ export function ZeroTelegramSettingsPage() {
                     .backToIntegrations;
                 })}
               >
-                <ArrowLeft size={17} strokeWidth={1.8} />
+                <ArrowLeft size={17} />
                 {t(($) => {
                   return $.connectors.providerSettings.telegram
                     .backToIntegrations;

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -26,11 +26,7 @@ export function ZeroUnsavedBar({
         className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
       >
         <div className="flex items-center gap-2 text-sm text-foreground">
-          <Pencil
-            size={18}
-            strokeWidth={1.5}
-            className="shrink-0 text-muted-foreground"
-          />
+          <Pencil size={18} className="shrink-0" />
           <span>{message}</span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
@@ -55,7 +51,6 @@ export function ZeroUnsavedBar({
               <Loader2
                 data-testid="save-spinner"
                 size={14}
-                strokeWidth={1.5}
                 className="animate-spin mr-1.5"
               />
             ) : null}

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -144,7 +144,7 @@ function SlackCardActions({
             return openFreshOAuth(installUrl);
           }}
         >
-          <Download size={14} strokeWidth={1.5} />
+          <Download size={14} />
           {t(($) => {
             return $.works.slack.install;
           })}
@@ -174,7 +174,7 @@ function SlackCardActions({
                 return $.works.actions.moreOptions;
               })}
             >
-              <EllipsisVertical size={16} strokeWidth={1.5} />
+              <EllipsisVertical size={16} />
             </button>
           </PopoverTrigger>
           <PopoverContent
@@ -437,7 +437,7 @@ function TeamsCardActions({
             return openFreshOAuth(installActionUrl);
           }}
         >
-          <Download size={14} strokeWidth={1.5} />
+          <Download size={14} />
           {t(($) => {
             return $.works.teams.install;
           })}
@@ -468,7 +468,7 @@ function TeamsCardActions({
                 return $.works.teams.moreOptions;
               })}
             >
-              <EllipsisVertical size={16} strokeWidth={1.5} />
+              <EllipsisVertical size={16} />
             </button>
           </PopoverTrigger>
           <PopoverContent
@@ -783,7 +783,7 @@ function GithubCard() {
               target="_blank"
               rel="noreferrer"
             >
-              <Download size={14} strokeWidth={1.5} />
+              <Download size={14} />
               {t(($) => {
                 return $.works.github.install;
               })}
@@ -844,7 +844,7 @@ function TelegramCard() {
           </div>
         </div>
         <span className="shrink-0 inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
-          <Settings size={14} strokeWidth={1.5} />
+          <Settings size={14} />
           {t(($) => {
             return $.works.actions.manage;
           })}
@@ -878,7 +878,7 @@ function StrapiCard() {
           </div>
         </div>
         <span className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-secondary-foreground">
-          <Settings size={14} strokeWidth={1.5} />
+          <Settings size={14} />
           {t(($) => {
             return $.works.actions.manage;
           })}

--- a/turbo/packages/ui/src/components/ui/checkbox.tsx
+++ b/turbo/packages/ui/src/components/ui/checkbox.tsx
@@ -47,7 +47,6 @@ const Checkbox = React.forwardRef<
           className="h-3.5 w-3.5"
           style={{
             stroke: "hsl(var(--on-filled))",
-            strokeWidth: 2.5,
           }}
         />
       </CheckboxPrimitive.Indicator>

--- a/turbo/packages/ui/src/components/ui/command.tsx
+++ b/turbo/packages/ui/src/components/ui/command.tsx
@@ -77,12 +77,7 @@ const CommandInput = React.forwardRef<
         wrapperClassName,
       )}
     >
-      <Search
-        size={16}
-        strokeWidth={2}
-        data-stroke
-        className="shrink-0 text-muted-foreground"
-      />
+      <Search size={16} className="shrink-0 text-muted-foreground" />
       <CommandPrimitive.Input
         ref={ref}
         className={cn(


### PR DESCRIPTION
Three defects visible in the sidebar, all measured off the reported screenshots.

## 1. Icons render at eleven different stroke widths

`globals.css` normalises icons with

```css
svg[class*="lucide"][stroke-width="2"]:not([data-stroke]) { stroke-width: var(--icon-stroke-width); }
```

Only icons whose rendered attribute is exactly `2` reach the token. Every call site passing something else escapes it, and `data-stroke` opts 59 more out:

| rendered width | icons |
|---|---|
| 1.5 (the token) | 201 |
| 2.0 | 59 |
| 1.8 | 74 |
| 1.7 | 22 |
| 2.5 | 9 |
| 1.75 | 8 |
| 1.6 | 6 |
| 2.6 / 1.9 | 3 each |
| 2.2 / 1.0 | 2 each |
| 1.4 | 1 |

**188 icons render at something other than the token.** The Pinned `+` is `<Plus size={16} strokeWidth={2} data-stroke />` — it opts out and renders at 2 beside nav icons at 1.5, a third heavier. That is the thickness difference in the screenshots.

Fix: drop all 379 per-call-site `strokeWidth` props, the `ICON_STROKE` constant, the checkbox tick's hard-coded `2.5`, and the 59 `data-stroke` opt-outs, so every icon takes the token. The two hand-inlined `<svg>` icons get the `lucide` class so the rule reaches them. The CSS mechanism is left in place — the width is now genuinely settable in one line.

## 2. Icons paired with text are lighter than the text

```css
.zero-nav svg { opacity: 0.7; }
```

Every sidebar icon rendered 30% transparent while its label rendered at full strength. On the light theme that resolves to `rgb(89,92,96)` against a `rgb(21,24,30)` label.

Removed, and the neutral colour utility dropped from the **57** icons that have a text sibling — settings as well as the sidebar — so each inherits from the same element its label does. Where the row is muted both stay muted; where it isn't, both are full strength.

**Icon-only controls are deliberately untouched.** Each now carries the product it was already rendering at (`ancestor alpha x 0.7`) as its own element opacity, so collapse / `...` / pin look exactly as before.

## 3. Overlay

A translucent *colour* makes overlapping strokes composite against each other, so joints render darker than the stroke body. Element *opacity* flattens the icon first. Same shade, measured:

| | body | crossing | ratio |
|---|---|---|---|
| `rgba` colour @ 0.49 | rgb(137,138,142) | rgb(80,81,86) | 1.51x |
| opaque + `opacity: .49` | rgb(136,138,141) | rgb(136,138,141) | **1.00x** |

Where the alpha sat on an icon-only ancestor, the colour is now opaque. The Pinned "new" control holds both an icon and a label under one alpha, so the control is dimmed as a whole instead — which also keeps its icon and label the same colour.

## Not in this PR

The `Pin` glyph changed shape in the Lucide migration (Tabler's was a 45° pushpin; Lucide's is a head-on thumbtack). Lucide ships only `pin` and `pin-off`, neither diagonal. Raised separately for a design decision.

## Verification

- `pnpm turbo run lint` — 0 errors, `@vm0/app` warnings unchanged from `main` (53)
- `pnpm check-types` — passes for `@vm0/ui`, `@vm0/app`, `@vm0/desktop`
- `pnpm -F @vm0/app build` — succeeds
- `@vm0/ui` (59) and the CSS-entrypoint / composer tests pass
