### PR TITLE
fix(connectors): align custom firewall auth with builtin semantics

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9357,7 +9357,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("preserves runtime auth templates while omitting missing optional values", async () => {
+  it("fails closed when a custom auth header references an optional missing value", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
@@ -9388,15 +9388,18 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
             kind: "variable",
             required: false,
           },
+          {
+            key: "unused_note",
+            label: "Unused note",
+            kind: "variable",
+            required: false,
+          },
         ],
         headerInjections: [
           {
             name: "Authorization",
-            valueTemplate: "Bearer {{secrets.api_key}}",
-          },
-          {
-            name: "X-Secondary",
-            valueTemplate: "{{secrets.secondary_token}}",
+            valueTemplate:
+              "Bearer {{secrets.api_key}}:{{secrets.secondary_token}}",
           },
         ],
         queryInjections: [
@@ -9406,7 +9409,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
           },
         ],
       },
-      values: [{ key: "api_key", kind: "secret", value: "optional-primary" }],
+      values: [
+        { key: "api_key", kind: "secret", value: "optional-primary" },
+        { key: "tenant_id", kind: "variable", value: "initial-tenant" },
+      ],
       agentId,
     });
 
@@ -9425,8 +9431,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const tenantVarKey = `CUSTOM_${idPart}_V_TENANT_ID`;
     const customApis = inlineFirewallApis(claim.firewalls, internalName);
     expect(customApis[0]?.auth?.headers).toStrictEqual({
-      Authorization: `Bearer \${{ secrets.${secretKey} }}`,
-      "X-Secondary": `\${{ secrets.${secondarySecretKey} }}`,
+      Authorization:
+        `Bearer \${{ secrets.${secretKey} }}:` +
+        `\${{ secrets.${secondarySecretKey} }}`,
     });
     expect(customApis[0]?.auth?.query).toStrictEqual({
       tenant: `\${{ secrets.${tenantVarKey} }}`,
@@ -9439,20 +9446,43 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const { api: runtimeApi, body: runtimeAuthBody } =
       customConnectorRuntimeAuthBody(runtime, fw.encryptedSecretsBody({}));
     expect(runtimeApi.auth.headers).toStrictEqual({
-      Authorization: `Bearer \${{ secrets.${secretKey} }}`,
-      "X-Secondary": `\${{ secrets.${secondarySecretKey} }}`,
+      Authorization:
+        `Bearer \${{ secrets.${secretKey} }}:` +
+        `\${{ secrets.${secondarySecretKey} }}`,
     });
     expect(runtimeApi.auth.query).toStrictEqual({
       tenant: `\${{ secrets.${tenantVarKey} }}`,
     });
-    const runtimeResolved = await fw.requestFirewallAuth(
+    const missingHeaderAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      runtimeAuthBody,
+      [424],
+    );
+    if (missingHeaderAuth.status !== 424) {
+      throw new Error("Expected missing matched Custom auth to fail");
+    }
+    expect(missingHeaderAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+
+    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
+      {
+        key: "secondary_token",
+        kind: "secret",
+        value: "optional-secondary",
+      },
+    ]);
+    const restoredAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       runtimeAuthBody,
       [200],
     );
-    expect(runtimeResolved.body).toMatchObject({
-      headers: { Authorization: "Bearer optional-primary" },
-      query: {},
+    if (restoredAuth.status !== 200) {
+      throw new Error("Expected restored matched Custom auth to resolve");
+    }
+    expect(restoredAuth.body).toMatchObject({
+      headers: {
+        Authorization: "Bearer optional-primary:optional-secondary",
+      },
+      query: { tenant: "initial-tenant" },
     });
 
     await api.requestCancelRun(actor, run.runId, [200]);
@@ -9667,7 +9697,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await connectors.deleteCustomConnector(actor, saved.connector.id);
   });
 
-  it("keeps optional-only firewall policy while omitting absent auth", async () => {
+  it("keeps an active custom firewall while optional query auth is unavailable", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
@@ -9684,7 +9714,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
             key: "secret",
             label: "API key",
             kind: "secret",
-            required: false,
+            required: true,
           },
           {
             key: "tenant",
@@ -9712,16 +9742,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
           kind: "secret",
           value: "optional-only-secret",
         },
-        {
-          key: "tenant",
-          kind: "variable",
-          value: "retained-tenant",
-        },
       ],
       agentId,
     });
     expect(saved.authorizedAgentId).toBe(agentId);
-    await connectors.deleteCustomConnectorSecret(actor, saved.connector.id);
 
     const run = await api.createRun(actor, {
       agentId,
@@ -9734,6 +9758,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const idPart = saved.connector.id.replaceAll("-", "");
     const internalName = `custom_connector_${idPart}`;
     const secretKey = `CUSTOM_${idPart}_S_SECRET`;
+    const tenantVarKey = `CUSTOM_${idPart}_V_TENANT`;
     expect(findFirewallEntry(claim.firewalls, internalName)).toMatchObject({
       kind: "inline",
       customConnectorId: saved.connector.id,
@@ -9750,31 +9775,26 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(runtimeApi.auth.headers).toStrictEqual({
       Authorization: `Bearer \${{ secrets.${secretKey} }}`,
     });
-    const resolvedAuth = await fw.requestFirewallAuth(
+    expect(runtimeApi.auth.query).toStrictEqual({
+      tenant: `\${{ secrets.${tenantVarKey} }}`,
+    });
+    const missingQueryAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       runtimeAuthBody,
-      [200],
+      [424],
     );
-    if (resolvedAuth.status !== 200) {
-      throw new Error("Expected optional-only custom connector auth");
+    if (missingQueryAuth.status !== 424) {
+      throw new Error("Expected missing Custom query auth to fail");
     }
-    expect(resolvedAuth.body.headers).toStrictEqual({});
-    expect(resolvedAuth.body.query).toStrictEqual({
-      tenant: "retained-tenant",
-    });
+    expect(missingQueryAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
 
-    context.mocks.ably.publish.mockClear();
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
       {
-        key: "secret",
-        kind: "secret",
-        value: "restored-optional-secret",
+        key: "tenant",
+        kind: "variable",
+        value: "restored-tenant",
       },
     ]);
-    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      expect.anything(),
-    );
     const restoredAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       runtimeAuthBody,
@@ -9784,10 +9804,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       throw new Error("Expected restored optional custom connector auth");
     }
     expect(restoredAuth.body.headers).toStrictEqual({
-      Authorization: "Bearer restored-optional-secret",
+      Authorization: "Bearer optional-only-secret",
     });
     expect(restoredAuth.body.query).toStrictEqual({
-      tenant: "retained-tenant",
+      tenant: "restored-tenant",
     });
 
     await api.requestCancelRun(actor, run.runId, [200]);

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -4220,7 +4220,6 @@ interface CurrentCustomConnectorAuthRef {
   readonly kind: "secret" | "variable";
   readonly key: string;
   readonly encryptedValue: string | null;
-  readonly required: boolean;
 }
 
 async function loadCurrentCustomConnectorAuthRefs(args: {
@@ -4270,7 +4269,6 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
       kind: value.kind,
       key: value.key,
       encryptedValue: value.encryptedValue,
-      required: field.required,
     });
   }
   for (const [secretName, field] of declaredFields) {
@@ -4283,7 +4281,6 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
       kind: field.kind,
       key: field.key,
       encryptedValue: null,
-      required: field.required,
     });
   }
   if (runtime.connector.authMode === "oauth") {
@@ -4298,7 +4295,6 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
       kind: "secret",
       key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
       encryptedValue: null,
-      required: true,
     });
   }
   return [...refs.values()];
@@ -4308,7 +4304,6 @@ type CurrentCustomConnectorSecretsResolution =
   | {
       readonly kind: "available";
       readonly secrets: Record<string, string>;
-      readonly missingOptionalSecrets: readonly string[];
       readonly expiresAt: number | null;
       readonly refreshedConnectors: readonly string[];
       readonly refreshedSecrets: readonly string[];
@@ -4320,23 +4315,17 @@ type CurrentCustomConnectorSecretsResolution =
 async function resolveCurrentCustomConnectorSecrets(args: {
   readonly db: Db;
   readonly auth: SandboxAuth;
-  readonly body: FirewallAuthBody;
   readonly authRefs: readonly CurrentCustomConnectorAuthRef[];
   readonly forceRefresh: boolean;
+  readonly referencedSecretKeys: ReadonlySet<string>;
 }): Promise<CurrentCustomConnectorSecretsResolution> {
-  const referenced = collectReferencedKeys(
-    args.body.authHeaders,
-    args.body.authBase,
-    args.body.authQuery,
-    args.body.authAwsSigv4,
-  );
   const refsByAlias = new Map(
     args.authRefs.map((ref) => {
       return [ref.secretName, ref] as const;
     }),
   );
   if (
-    [...referenced.secrets].some((alias) => {
+    [...args.referencedSecretKeys].some((alias) => {
       return !refsByAlias.has(alias);
     })
   ) {
@@ -4349,11 +4338,10 @@ async function resolveCurrentCustomConnectorSecrets(args: {
     args.auth.userId,
   );
   const currentSecrets: Record<string, string> = {};
-  const missingOptionalSecrets: string[] = [];
   let expiresAt: number | null = null;
   const refreshedConnectors: string[] = [];
   const refreshedSecrets: string[] = [];
-  for (const alias of referenced.secrets) {
+  for (const alias of args.referencedSecretKeys) {
     const ref = refsByAlias.get(alias);
     if (!ref) {
       return { kind: "unavailable" };
@@ -4400,11 +4388,7 @@ async function resolveCurrentCustomConnectorSecrets(args: {
       }
     }
     if (!encryptedValue) {
-      if (!ref.required) {
-        missingOptionalSecrets.push(alias);
-        continue;
-      }
-      return { kind: "unavailable" };
+      continue;
     }
     currentSecrets[alias] = await decryptStoredSecretValue(
       encryptedValue,
@@ -4414,62 +4398,9 @@ async function resolveCurrentCustomConnectorSecrets(args: {
   return {
     kind: "available",
     secrets: currentSecrets,
-    missingOptionalSecrets,
     expiresAt,
     refreshedConnectors,
     refreshedSecrets,
-  };
-}
-
-function templateReferencesMissingOptionalSecret(args: {
-  readonly template: string;
-  readonly missingOptionalSecrets: ReadonlySet<string>;
-  readonly kind: "header" | "simple";
-}): boolean {
-  let referencesMissingSecret = false;
-  const collect = (namespace: string, key: string): void => {
-    if (namespace === "secrets" && args.missingOptionalSecrets.has(key)) {
-      referencesMissingSecret = true;
-    }
-  };
-  if (args.kind === "header") {
-    collectHeaderReferencedKeys(args.template, collect);
-  } else {
-    collectSimpleReferencedKeys(args.template, collect);
-  }
-  return referencesMissingSecret;
-}
-
-function omitMissingOptionalCustomAuthEntries(args: {
-  readonly authHeaders: Record<string, string>;
-  readonly authQuery: Record<string, string> | undefined;
-  readonly missingOptionalSecrets: readonly string[];
-}): {
-  readonly authHeaders: Record<string, string>;
-  readonly authQuery: Record<string, string> | undefined;
-} {
-  const missingOptionalSecrets = new Set(args.missingOptionalSecrets);
-  return {
-    authHeaders: Object.fromEntries(
-      Object.entries(args.authHeaders).filter(([, template]) => {
-        return !templateReferencesMissingOptionalSecret({
-          template,
-          missingOptionalSecrets,
-          kind: "header",
-        });
-      }),
-    ),
-    authQuery: args.authQuery
-      ? Object.fromEntries(
-          Object.entries(args.authQuery).filter(([, template]) => {
-            return !templateReferencesMissingOptionalSecret({
-              template,
-              missingOptionalSecrets,
-              kind: "simple",
-            });
-          }),
-        )
-      : undefined,
   };
 }
 
@@ -4506,7 +4437,8 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
   }
   // The trusted host already matched this request against its effective
   // firewall. Runtime sync owns firewall changes; auth resolves only the
-  // referenced values from the connector's current credential storage.
+  // referenced values from the connector's current credential storage. Every
+  // referenced value must resolve even when its connector field is optional.
   const authRefs = await loadCurrentCustomConnectorAuthRefs({
     db: args.db,
     orgId,
@@ -4516,12 +4448,18 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
   if (!authRefs) {
     return connectorNotConfigured();
   }
+  const referenced = collectReferencedKeys(
+    args.body.authHeaders,
+    args.body.authBase,
+    args.body.authQuery,
+    args.body.authAwsSigv4,
+  );
   const currentSecrets = await resolveCurrentCustomConnectorSecrets({
     db: args.db,
     auth: args.auth,
-    body: args.body,
     authRefs,
     forceRefresh: args.body.forceRefresh === true,
+    referencedSecretKeys: referenced.secrets,
   });
   if (currentSecrets.kind === "unavailable") {
     return connectorNotConfigured();
@@ -4533,6 +4471,15 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
     return connectorReconnectRequired([args.customConnectorId]);
   }
 
+  const effectiveSecrets = applyCustomConnectorRoutingVariables({
+    currentSecrets: currentSecrets.secrets,
+    authRefs,
+    routingVariables: args.routingVariables,
+  });
+  if (hasMissingResolvedSecrets(effectiveSecrets, referenced.secrets)) {
+    return connectorNotConfigured();
+  }
+
   const billableCacheExpiry = await resolveBillableFirewallCacheExpiry({
     db: args.db,
     auth: args.auth,
@@ -4541,24 +4488,12 @@ async function resolveCurrentCustomConnectorFirewallAuth(args: {
   if ("status" in billableCacheExpiry) {
     return billableCacheExpiry;
   }
-  // Runtime sync keeps firewall shape definition-driven. Optional credential
-  // availability affects only the auth entries returned for this request.
-  const availableAuth = omitMissingOptionalCustomAuthEntries({
-    authHeaders: args.body.authHeaders,
-    authQuery: args.body.authQuery,
-    missingOptionalSecrets: currentSecrets.missingOptionalSecrets,
-  });
-  const effectiveSecrets = applyCustomConnectorRoutingVariables({
-    currentSecrets: currentSecrets.secrets,
-    authRefs,
-    routingVariables: args.routingVariables,
-  });
   const resolved = resolveTemplates({
-    authHeaders: availableAuth.authHeaders,
+    authHeaders: args.body.authHeaders,
     secrets: effectiveSecrets,
     vars: args.body.vars ?? {},
     authBase: args.body.authBase,
-    authQuery: availableAuth.authQuery,
+    authQuery: args.body.authQuery,
     authAwsSigv4: args.body.authAwsSigv4,
   });
   if (hasEmptyAwsSigv4Credential(resolved.awsSigv4)) {


### PR DESCRIPTION
## Summary

- make Custom connector firewall auth fail closed when any referenced credential is unavailable, matching Builtin connector behavior
- reuse the shared reference collection, missing-value validation, template resolution, and not-configured response path
- remove the Custom-only optional-template omission path while preserving active firewall policy and current credential refresh behavior

## Scope

- no database, API schema, runner protocol, runtime admission, or cache lifecycle changes
- Builtin connector behavior is unchanged

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (147 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks: full Turbo Knip and type checks

Closes #25958

Parent: #25312
