### PR TITLE
feat(platform): move avatar voice controls into dialog header

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -984,6 +984,13 @@ test("avatar catalog surfaces stay stable while scrolling and selecting", async 
   await expect(avatarToolbar).toBeInViewport();
 
   await page.getByRole("button", { name: "Select template Ada" }).click();
+  const voiceScroll = dialog.locator("[data-avatar-voice-list-scroll]");
+  const voiceToolbar = dialog.locator("[data-avatar-voice-toolbar]");
+  await expect(voiceToolbar).toBeVisible();
+  await expect(voiceScroll.locator("[data-avatar-voice-toolbar]")).toHaveCount(
+    0,
+  );
+  await expect(voiceToolbar).toBeInViewport();
   await page.getByRole("button", { name: "Select voice Christopher" }).click();
 
   await page.getByRole("button", { name: "Preview template Ada" }).click();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -952,11 +952,16 @@ describe("chat composer templates", () => {
     );
     const voicePicker = dialog.querySelector("[data-avatar-voice-picker]");
     const voiceScroll = dialog.querySelector("[data-avatar-voice-list-scroll]");
+    const voiceToolbar = dialog.querySelector("[data-avatar-voice-toolbar]");
     expect(voicePicker).toHaveClass("overflow-hidden");
     expect(voiceScroll).toHaveClass(
       "overflow-y-auto",
       "[scrollbar-width:none]",
     );
+    expect(voiceToolbar).not.toBeNull();
+    expect(voicePicker?.contains(voiceToolbar)).toBeFalsy();
+    expect(voiceScroll?.contains(voiceToolbar)).toBeFalsy();
+    expect(dialog.querySelector("[data-avatar-catalog-toolbar]")).toBeNull();
     expect(voiceScroll?.contains(selectedAvatarCard)).toBeFalsy();
     await waitFor(() => {
       expect(observedVoiceQueries).toContainEqual({

--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -676,6 +676,50 @@ function AvatarVoiceFilters({
   );
 }
 
+function AvatarVoicePickerToolbar({
+  signals,
+  avatar,
+}: {
+  readonly signals: ComposerSignals;
+  readonly avatar: ZeroAvatarVideoAvatar;
+}) {
+  const { t } = useTranslation();
+  const clearVoiceSelection = useSet(
+    signals.template.clearAvatarTemplateVoiceSelection$,
+  );
+
+  return (
+    <div
+      data-avatar-voice-toolbar=""
+      className="flex w-full items-center gap-3"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0"
+        aria-label={t(($) => {
+          return $.artifacts.templates.backToAvatars;
+        })}
+        onClick={() => {
+          clearVoiceSelection();
+        }}
+      >
+        <ArrowLeft className="size-4" />
+      </Button>
+      <h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+        {t(
+          ($) => {
+            return $.artifacts.templates.chooseVoice;
+          },
+          { title: avatar.name },
+        )}
+      </h3>
+      <AvatarVoiceFilters signals={signals} />
+    </div>
+  );
+}
+
 function AvatarTemplateSkeletonGrid({
   aspectRatio,
 }: {
@@ -1105,19 +1149,16 @@ function AvatarVoicePickerContent({
   signals,
   avatar,
   value,
-  onBack,
   onSelect,
 }: {
   readonly signals: ComposerSignals;
   readonly avatar: ZeroAvatarVideoAvatar;
   readonly value: GenerationTemplateRequest | undefined;
-  readonly onBack: () => void;
   readonly onSelect: (
     avatar: ZeroAvatarVideoAvatar,
     voice: ZeroAvatarVideoVoice,
   ) => void;
 }) {
-  const { t } = useTranslation();
   const aspectRatio = useGet(
     signals.template.avatarTemplateFilters$,
   ).aspectRatio;
@@ -1127,29 +1168,6 @@ function AvatarVoicePickerContent({
       data-avatar-voice-picker=""
       className="flex min-h-0 flex-1 flex-col overflow-hidden"
     >
-      <div className="mb-4 flex shrink-0 items-center gap-3">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 shrink-0"
-          aria-label={t(($) => {
-            return $.artifacts.templates.backToAvatars;
-          })}
-          onClick={onBack}
-        >
-          <ArrowLeft className="size-4" />
-        </Button>
-        <h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
-          {t(
-            ($) => {
-              return $.artifacts.templates.chooseVoice;
-            },
-            { title: avatar.name },
-          )}
-        </h3>
-        <AvatarVoiceFilters signals={signals} />
-      </div>
       <div className="grid min-h-0 min-w-0 flex-1 grid-rows-[auto_minmax(0,1fr)] gap-5 overflow-hidden md:grid-cols-[minmax(210px,0.72fr)_minmax(0,1.55fr)] md:grid-rows-1">
         <div
           className={cn(
@@ -1252,9 +1270,8 @@ function AvatarCatalogPickerContent({
 }
 
 /**
- * Avatar catalog filters, rendered by the template dialog into the header row
- * that already reserves space for the close button. Returns null on the voice
- * step, which carries its own back/title/filters row.
+ * Avatar picker toolbar, rendered by the template dialog into the header row
+ * that already reserves space for the close button.
  */
 export function AvatarTemplatePickerToolbar({
   signals,
@@ -1265,7 +1282,9 @@ export function AvatarTemplatePickerToolbar({
     signals.template.selectedAvatarTemplateForVoice$,
   );
   if (selectedAvatar) {
-    return null;
+    return (
+      <AvatarVoicePickerToolbar signals={signals} avatar={selectedAvatar} />
+    );
   }
   return <AvatarCatalogFilters signals={signals} />;
 }
@@ -1300,9 +1319,6 @@ export function AvatarTemplatePickerContent({
         signals={signals}
         avatar={selectedAvatar}
         value={value}
-        onBack={() => {
-          clearVoiceSelection();
-        }}
         onSelect={(avatar, voice) => {
           clearVoiceSelection();
           onSelect(avatar, voice, aspectRatio);


### PR DESCRIPTION
## Summary

- move the second-stage avatar voice controls into the template dialog header
- keep the back button, title, and voice filters outside the scrolling voice catalog
- add page-level and Playwright assertions for the shared-header placement

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx` (31 passed)
