### PR TITLE
fix(runner): preserve sidecar export failure causes

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -124,7 +124,7 @@ fn helper_exit_code_from_args() -> Option<i32> {
                         }
                         Err(_) => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
                     },
-                    Err(error) => session_history_identity_helper_exit_code(&error),
+                    Err(error) => session_history_sidecar_export_helper_exit_code(&error),
                 },
             )
         }
@@ -162,6 +162,22 @@ fn session_history_identity_helper_exit_code(
         SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE
     } else {
         exit_code
+    }
+}
+
+fn session_history_sidecar_export_helper_exit_code(
+    error: &session_history_identity::FinalSessionHistorySidecarExportError,
+) -> i32 {
+    let exit_code = error.helper_exit_code();
+    let Some(failure) = error.output_failure() else {
+        return exit_code;
+    };
+    match serde_json::to_string(&failure) {
+        Ok(json) => {
+            println!("{json}");
+            exit_code
+        }
+        Err(_) => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
     }
 }
 

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -15,12 +15,14 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ, SessionHistorySidecarExportMetadata,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
     SessionHistorySidecarRepresentation,
 };
 use sha2::{Digest, Sha256};
 use std::fmt;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::Path;
 
 /// Build final session-history identity metadata for a successful checkpoint.
@@ -111,23 +113,14 @@ pub fn verify_final_session_history_identity_file(
 ///
 /// Returns:
 ///
-/// - [`FinalSessionHistoryIdentityVerifyError::MetadataRead`] when metadata
-///   cannot be read.
-/// - [`FinalSessionHistoryIdentityVerifyError::InvalidMetadata`] when metadata
-///   violates the shared identity contract.
-/// - [`FinalSessionHistoryIdentityVerifyError::FrameworkMismatch`] when the
-///   framework does not match the marker shape.
-/// - [`FinalSessionHistoryIdentityVerifyError::HistoryTooLarge`] when the
-///   declared decoded size exceeds the guest resume budget.
-/// - [`FinalSessionHistoryIdentityVerifyError::HistoryRead`] when the history
-///   cannot be resolved, read, or decoded, or when the output file cannot be
-///   created or written.
-/// - [`FinalSessionHistoryIdentityVerifyError::HistoryMismatch`] when the
-///   decoded size or SHA-256 identity differs from metadata.
+/// Returns [`FinalSessionHistorySidecarExportError::Verification`] when identity
+/// metadata or source history cannot be verified. Returns
+/// [`FinalSessionHistorySidecarExportError::OutputWrite`] when the verified
+/// sidecar bytes cannot be created or written at `export_path`.
 pub fn export_final_session_history_sidecar_file(
     metadata_path: impl AsRef<Path>,
     export_path: impl AsRef<Path>,
-) -> Result<SessionHistorySidecarExportMetadata, FinalSessionHistoryIdentityVerifyError> {
+) -> Result<SessionHistorySidecarExportMetadata, FinalSessionHistorySidecarExportError> {
     let identity = read_final_session_history_identity(metadata_path)?;
     verify_final_session_history_identity_constraints(&identity)?;
     let prepared = session_history::prepare_session_history_sidecar_from_payload_bounded(
@@ -147,8 +140,7 @@ pub fn export_final_session_history_sidecar_file(
         }
     };
     crate::paths::write_private(export_path.as_ref(), &bytes)
-        .map_err(AgentError::from)
-        .map_err(FinalSessionHistoryIdentityVerifyError::HistoryRead)?;
+        .map_err(FinalSessionHistorySidecarExportError::OutputWrite)?;
     Ok(SessionHistorySidecarExportMetadata {
         representation,
         encoded_size: bytes.len() as u64,
@@ -256,6 +248,62 @@ impl fmt::Display for FinalSessionHistoryIdentityBuildError {
 
 impl std::error::Error for FinalSessionHistoryIdentityBuildError {}
 
+/// Error returned while exporting a verified final session-history sidecar.
+#[derive(Debug)]
+pub enum FinalSessionHistorySidecarExportError {
+    /// Identity metadata or source history verification failed.
+    Verification(FinalSessionHistoryIdentityVerifyError),
+    /// The verified sidecar output could not be created or written.
+    OutputWrite(io::Error),
+}
+
+impl FinalSessionHistorySidecarExportError {
+    /// Return the stable helper exit code for this export failure.
+    pub fn helper_exit_code(&self) -> i32 {
+        match self {
+            Self::Verification(error) => error.helper_exit_code(),
+            Self::OutputWrite(_) => SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE,
+        }
+    }
+
+    /// Return safe output-failure metadata when the export write failed.
+    pub fn output_failure(&self) -> Option<SessionHistorySidecarExportFailure> {
+        let Self::OutputWrite(error) = self else {
+            return None;
+        };
+        Some(SessionHistorySidecarExportFailure {
+            io_error_class: sidecar_io_error_class(error),
+        })
+    }
+}
+
+impl From<FinalSessionHistoryIdentityVerifyError> for FinalSessionHistorySidecarExportError {
+    fn from(error: FinalSessionHistoryIdentityVerifyError) -> Self {
+        Self::Verification(error)
+    }
+}
+
+impl fmt::Display for FinalSessionHistorySidecarExportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Verification(error) => write!(f, "{error}"),
+            Self::OutputWrite(_) => f.write_str("session history sidecar could not be written"),
+        }
+    }
+}
+
+impl std::error::Error for FinalSessionHistorySidecarExportError {}
+
+fn sidecar_io_error_class(error: &io::Error) -> SessionHistorySidecarIoErrorClass {
+    match error.kind() {
+        io::ErrorKind::NotFound => SessionHistorySidecarIoErrorClass::NotFound,
+        io::ErrorKind::PermissionDenied => SessionHistorySidecarIoErrorClass::PermissionDenied,
+        io::ErrorKind::StorageFull => SessionHistorySidecarIoErrorClass::StorageFull,
+        io::ErrorKind::QuotaExceeded => SessionHistorySidecarIoErrorClass::QuotaExceeded,
+        _ => SessionHistorySidecarIoErrorClass::Unknown,
+    }
+}
+
 /// Error returned while verifying final identity metadata.
 #[derive(Debug)]
 pub enum FinalSessionHistoryIdentityVerifyError {
@@ -267,7 +315,7 @@ pub enum FinalSessionHistoryIdentityVerifyError {
     FrameworkMismatch,
     /// Metadata does not match the identity runner expected to verify.
     ExpectedIdentityMismatch,
-    /// Session history could not be read or an exported sidecar could not be written.
+    /// Session history could not be resolved, read, or decoded.
     HistoryRead(AgentError),
     /// Session history size or hash does not match metadata.
     HistoryMismatch,
@@ -341,6 +389,22 @@ mod tests {
             remaining -= chunk_len as u64;
         }
         hex::encode(hasher.finalize())
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn classifies_sidecar_storage_exhaustion_without_error_text() {
+        let storage_full = io::Error::from_raw_os_error(libc::ENOSPC);
+        let unknown = io::Error::other("sensitive path");
+
+        assert_eq!(
+            sidecar_io_error_class(&storage_full),
+            SessionHistorySidecarIoErrorClass::StorageFull
+        );
+        assert_eq!(
+            sidecar_io_error_class(&unknown),
+            SessionHistorySidecarIoErrorClass::Unknown
+        );
     }
 
     #[test]

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -11,7 +11,9 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS, SessionHistorySidecarExportMetadata,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
     SessionHistorySidecarRepresentation,
 };
 #[cfg(target_os = "linux")]
@@ -364,7 +366,52 @@ async fn export_session_history_sidecar_keeps_source_read_failures() -> TestResu
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
     assert!(!export_path.exists());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn export_session_history_sidecar_reports_safe_output_write_failure() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let history = br#"{"type":"system"}"#;
+    let history_path = dir.path().join("history.jsonl");
+    std::fs::write(&history_path, history)?;
+    let identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        sha256_hex(history),
+        history.len() as u64,
+        history_path.to_string_lossy(),
+    )?;
+    let metadata_path = write_metadata(dir.path(), "output-failure-identity.json", &identity)?;
+    let target_dir = dir.path().join("target");
+    let symlink_dir = dir.path().join("symlink");
+    std::fs::create_dir(&target_dir)?;
+    std::os::unix::fs::symlink(&target_dir, &symlink_dir)?;
+    let export_path = symlink_dir.join("sidecar");
+
+    let output = run_export_helper(&metadata_path, &export_path).await?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let failure = serde_json::from_slice::<SessionHistorySidecarExportFailure>(&output.stdout)?;
+    assert_eq!(
+        failure.io_error_class,
+        SessionHistorySidecarIoErrorClass::PermissionDenied
+    );
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains(dir.path().to_string_lossy().as_ref()));
+    assert!(!target_dir.join("sidecar").exists());
     Ok(())
 }
 

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -33,6 +33,11 @@ pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ: i32 = 7;
 pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH: i32 = 8;
 /// Guest helper exit code for local history exceeding the guest verification budget.
 pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE: i32 = 9;
+/// Guest helper exit code for sidecar output create or write failure.
+///
+/// Exit code 10 previously represented sidecar export unavailability and
+/// remains reserved for that historical meaning.
+pub const SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE: i32 = 11;
 /// Framework that owns a final session-history file.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -69,6 +74,43 @@ pub struct SessionHistorySidecarExportMetadata {
     pub representation: SessionHistorySidecarRepresentation,
     /// Exact byte length of the exported sidecar file.
     pub encoded_size: u64,
+}
+
+/// Safe low-cardinality I/O class emitted for a sidecar output failure.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SessionHistorySidecarIoErrorClass {
+    /// A required filesystem object was not found.
+    NotFound,
+    /// Filesystem permissions rejected the operation.
+    PermissionDenied,
+    /// The filesystem had no storage space available.
+    StorageFull,
+    /// The filesystem quota was exhausted.
+    QuotaExceeded,
+    /// The I/O failure has no more specific safe class.
+    Unknown,
+}
+
+impl SessionHistorySidecarIoErrorClass {
+    /// Return the stable telemetry label for this class.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotFound => "not-found",
+            Self::PermissionDenied => "permission-denied",
+            Self::StorageFull => "storage-full",
+            Self::QuotaExceeded => "quota-exceeded",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Safe metadata printed when sidecar output creation or writing fails.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionHistorySidecarExportFailure {
+    /// Low-cardinality class of the output I/O failure.
+    pub io_error_class: SessionHistorySidecarIoErrorClass,
 }
 
 /// Run-private final session-history identity metadata.
@@ -382,9 +424,25 @@ mod tests {
                 SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
                 SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
                 SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+                SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE,
             ],
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11]
         );
+    }
+
+    #[test]
+    fn sidecar_export_failure_round_trips_json() {
+        let failure = SessionHistorySidecarExportFailure {
+            io_error_class: SessionHistorySidecarIoErrorClass::StorageFull,
+        };
+
+        let json = serde_json::to_vec(&failure).unwrap();
+
+        assert_eq!(
+            serde_json::from_slice::<SessionHistorySidecarExportFailure>(&json).unwrap(),
+            failure
+        );
+        assert_eq!(failure.io_error_class.as_str(), "storage-full");
     }
 
     fn valid_identity() -> FinalSessionHistoryIdentity {

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -4,8 +4,12 @@ use std::time::Duration;
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use futures_util::FutureExt;
-use guest_contracts::session_history_identity::SessionHistorySidecarExportMetadata;
-use sandbox::{CopyFileOptions, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
+use guest_contracts::session_history_identity::{
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
+};
+use sandbox::{CopyFileOptions, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, Sandbox};
 use shell_quote::quote_shell_arg;
 use tokio::fs;
 use tracing::warn;
@@ -272,16 +276,52 @@ async fn export_session_history_sidecar(
         }
     };
     if !helper_exec_succeeded(&result) {
-        warn!(
-            run_id = %promotion.run_id(),
-            sandbox_id = %promotion.sandbox_id(),
-            profile_name = promotion.profile_name(),
-            reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
-            reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
-            reason,
-            error = %format_helper_exec_failure("session history sidecar export", &result),
-            "workspace image cache session history sidecar export failed"
-        );
+        let known_failure = match result.termination {
+            ExecTermination::Exited {
+                exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+            } => Some((
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+                "source-history",
+                SessionHistorySidecarIoErrorClass::Unknown,
+            )),
+            ExecTermination::Exited {
+                exit_code: SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE,
+            } => Some((
+                SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE,
+                "output-write",
+                serde_json::from_slice::<SessionHistorySidecarExportFailure>(&result.stdout)
+                    .map_or(SessionHistorySidecarIoErrorClass::Unknown, |failure| {
+                        failure.io_error_class
+                    }),
+            )),
+            _ => None,
+        };
+        if let Some((helper_exit_code, failure_stage, io_error_class)) = known_failure {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
+                reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
+                reason,
+                helper_exit_code,
+                failure_stage,
+                io_error_class = io_error_class.as_str(),
+                error = %format!("session history sidecar export failed (exit code {helper_exit_code})"),
+                "workspace image cache session history sidecar export failed"
+            );
+        } else {
+            warn!(
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
+                reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
+                reason,
+                error = %format_helper_exec_failure("session history sidecar export", &result),
+                "workspace image cache session history sidecar export failed"
+            );
+        }
         cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
             .await;
         return None;

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -12,7 +12,9 @@ use api_contracts::generated::constants::runners::{
 use async_trait::async_trait;
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ, SessionHistorySidecarExportMetadata,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
     SessionHistorySidecarRepresentation,
 };
 use sandbox::{
@@ -437,38 +439,93 @@ async fn active_workspace_permission_failure_skips_cache_publication() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn active_workspace_promotion_keeps_history_read_failure_warning() {
-    let reuse_key = "thread:active-sidecar-read-failure";
-    let session_id = "sess-active-sidecar-read-failure";
-    let history = br#"{"type":"message","content":"read failure"}"#;
-    let restored_identity = test_restored_session_identity(session_id, history);
-    let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
-        reuse_key,
-        Some(&restored_identity),
-    )
-    .await;
-    let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
-    sandbox.push_exec_result(Ok(ExecResult::new(
-        SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
-        Vec::new(),
-        Vec::new(),
-    )));
+async fn active_workspace_promotion_classifies_sidecar_export_failures() {
+    let storage_full = serde_json::to_vec(&SessionHistorySidecarExportFailure {
+        io_error_class: SessionHistorySidecarIoErrorClass::StorageFull,
+    })
+    .unwrap();
+    let private_helper_output = b"/home/user/private/session.jsonl".to_vec();
+    for (name, exit_code, stdout, expected_stage, expected_io_class) in [
+        (
+            "source-read",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+            Vec::new(),
+            "source-history",
+            "unknown",
+        ),
+        (
+            "output-storage-full",
+            SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE,
+            storage_full,
+            "output-write",
+            "storage-full",
+        ),
+        (
+            "output-malformed",
+            SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE,
+            private_helper_output.clone(),
+            "output-write",
+            "unknown",
+        ),
+    ] {
+        let reuse_key = format!("thread:active-sidecar-{name}");
+        let session_id = format!("sess-active-sidecar-{name}");
+        let history = br#"{"type":"message","content":"failure"}"#;
+        let restored_identity = test_restored_session_identity(&session_id, history);
+        let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
+            &reuse_key,
+            Some(&restored_identity),
+        )
+        .await;
+        let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
+        sandbox.push_exec_result(Ok(ExecResult::new(exit_code, stdout, Vec::new())));
 
-    let (promoted, events) = capture_promotion_events(prepare_and_publish_workspace_image(
-        &sandbox,
-        fixture.promotion,
-    ))
-    .await;
+        let (promoted, events) = capture_promotion_events(prepare_and_publish_workspace_image(
+            &sandbox,
+            fixture.promotion,
+        ))
+        .await;
 
-    assert!(promoted);
-    assert!(sandbox.copy_file_calls().is_empty());
-    captured_event(
-        &events,
-        "workspace image cache session history sidecar export failed",
-    );
-    let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 3);
-    assert!(exec_calls[0].expected_exit_codes.is_empty());
+        assert!(promoted, "{name}");
+        assert!(sandbox.copy_file_calls().is_empty(), "{name}");
+        let event = captured_event(
+            &events,
+            "workspace image cache session history sidecar export failed",
+        );
+        let expected_exit_code = exit_code.to_string();
+        let expected_error =
+            format!("session history sidecar export failed (exit code {exit_code})");
+        assert_eq!(
+            event.fields.get("helper_exit_code").map(String::as_str),
+            Some(expected_exit_code.as_str()),
+            "{name}: {event:#?}"
+        );
+        assert_eq!(
+            event.fields.get("failure_stage").map(String::as_str),
+            Some(expected_stage),
+            "{name}: {event:#?}"
+        );
+        assert_eq!(
+            event.fields.get("io_error_class").map(String::as_str),
+            Some(expected_io_class),
+            "{name}: {event:#?}"
+        );
+        assert_eq!(
+            event.fields.get("error").map(String::as_str),
+            Some(expected_error.as_str()),
+            "{name}: {event:#?}"
+        );
+        assert!(
+            event
+                .fields
+                .values()
+                .all(|value| !value.contains("/home/user/private")),
+            "{name}: {event:#?}"
+        );
+        let exec_calls = sandbox.exec_calls();
+        assert_eq!(exec_calls.len(), 3, "{name}");
+        assert!(exec_calls[0].expected_exit_codes.is_empty(), "{name}");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- distinguish source-history failures from sidecar output create/write failures with a stable export exit code
- emit only a bounded I/O error class and record structured runner diagnostics without raw helper output
- preserve best-effort workspace promotion, cleanup, and canonical remote-history fallback

## Compatibility and exclusions

- keeps existing helper exit-code meanings and reserves retired exit code 10
- does not change database, API, queue, persisted sidecar format, or feature-switch state
- does not change successful export or run completion behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test session_history_identity_helper` (post-rebase)
- `cargo test --manifest-path crates/Cargo.toml -p runner active_workspace_promotion_classifies_sidecar_export_failures` (post-rebase)
- `git diff --check`

Closes #25983
