### PR TITLE
docs(vsock-proto): clarify message type invariants

### DIFF
--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -20,9 +20,12 @@
 //!
 //! ## Message Types
 //!
-//! Non-error message types are continuous and grouped by protocol domain:
-//! connection lifecycle, operation gates, file operations, exec operations, and
-//! the generic protocol error sentinel at `0xFF`.
+//! Non-error message types currently occupy the contiguous range `0x00..=0x13`
+//! in allocation order. Existing values are stable wire assignments: do not
+//! renumber or reuse them. Allocate new non-error messages at the next unused
+//! value below `0xFF`, even when related operations are not adjacent. `0xFF` is
+//! reserved for generic protocol errors. Changing an existing assignment
+//! requires an explicit, versioned host/guest protocol migration.
 //!
 //! | Type | Direction | Name              | Payload |
 //! |------|-----------|-------------------|---------|

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -69,6 +69,8 @@ pub const MSG_EXEC_CONTROL: u8 = 0x10;
 /// Guest-to-host exec control delivery result.
 pub const MSG_EXEC_CONTROL_RESULT: u8 = 0x11;
 
+// Batched file operations.
+
 /// Host-to-guest multi-file write request.
 pub const MSG_WRITE_FILES: u8 = 0x12;
 
@@ -106,34 +108,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn message_type_wire_values_are_grouped_by_domain() {
-        let non_error_types = [
-            MSG_READY,
-            MSG_PING,
-            MSG_PONG,
-            MSG_SHUTDOWN,
-            MSG_SHUTDOWN_ACK,
-            MSG_QUIESCE_OPERATIONS,
-            MSG_OPERATIONS_QUIESCED,
-            MSG_RESUME_OPERATIONS,
-            MSG_OPERATIONS_RESUMED,
-            MSG_WRITE_FILE,
-            MSG_WRITE_FILE_RESULT,
-            MSG_EXEC_START,
-            MSG_EXEC_STARTED,
-            MSG_EXEC_OUTPUT,
-            MSG_EXEC_RESULT,
-            MSG_EXEC_CANCEL,
-            MSG_EXEC_CONTROL,
-            MSG_EXEC_CONTROL_RESULT,
-            MSG_WRITE_FILES,
-            MSG_WRITE_FILES_RESULT,
+    fn message_type_wire_values_are_stable() {
+        let message_types = [
+            ("MSG_READY", MSG_READY, 0x00),
+            ("MSG_PING", MSG_PING, 0x01),
+            ("MSG_PONG", MSG_PONG, 0x02),
+            ("MSG_SHUTDOWN", MSG_SHUTDOWN, 0x03),
+            ("MSG_SHUTDOWN_ACK", MSG_SHUTDOWN_ACK, 0x04),
+            ("MSG_QUIESCE_OPERATIONS", MSG_QUIESCE_OPERATIONS, 0x05),
+            ("MSG_OPERATIONS_QUIESCED", MSG_OPERATIONS_QUIESCED, 0x06),
+            ("MSG_RESUME_OPERATIONS", MSG_RESUME_OPERATIONS, 0x07),
+            ("MSG_OPERATIONS_RESUMED", MSG_OPERATIONS_RESUMED, 0x08),
+            ("MSG_WRITE_FILE", MSG_WRITE_FILE, 0x09),
+            ("MSG_WRITE_FILE_RESULT", MSG_WRITE_FILE_RESULT, 0x0A),
+            ("MSG_EXEC_START", MSG_EXEC_START, 0x0B),
+            ("MSG_EXEC_STARTED", MSG_EXEC_STARTED, 0x0C),
+            ("MSG_EXEC_OUTPUT", MSG_EXEC_OUTPUT, 0x0D),
+            ("MSG_EXEC_RESULT", MSG_EXEC_RESULT, 0x0E),
+            ("MSG_EXEC_CANCEL", MSG_EXEC_CANCEL, 0x0F),
+            ("MSG_EXEC_CONTROL", MSG_EXEC_CONTROL, 0x10),
+            ("MSG_EXEC_CONTROL_RESULT", MSG_EXEC_CONTROL_RESULT, 0x11),
+            ("MSG_WRITE_FILES", MSG_WRITE_FILES, 0x12),
+            ("MSG_WRITE_FILES_RESULT", MSG_WRITE_FILES_RESULT, 0x13),
+            ("MSG_ERROR", MSG_ERROR, 0xFF),
         ];
 
-        for (expected, actual) in (0_u8..).zip(non_error_types) {
-            assert_eq!(actual, expected);
+        for (name, actual, expected) in message_types {
+            assert_eq!(actual, expected, "{name} wire value changed");
         }
-
-        assert_eq!(MSG_ERROR, 0xFF);
     }
 }


### PR DESCRIPTION
## Summary

- document the current append-only vsock message type layout and wire compatibility rules
- label the later batch-file constants separately from the exec block
- replace the misleading domain-grouping test with an explicit named snapshot of every wire value

## Compatibility

- preserves every existing message type ID and all runtime behavior
- adds no API, schema, migration, persisted-data, protocol-negotiation, or rollout change

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
- pre-commit hooks: workspace Rustfmt, Clippy, rustdoc, file-size check, and commitlint

Closes #25980
