### PR TITLE
fix(python): lint annotation-only metadata subscripts

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -310,6 +310,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_key_checked_node_ids.add(node_id)
         self._add_violations(violations)
 
+    def _record_metadata_subscript_key_violations(self, node: ast.Subscript) -> None:
+        if self._is_metadata_alias_value(node.value):
+            self._add_violations(_metadata_key_expression_violations(self.path, node.slice))
+
     def _metadata_default_argument_names(self, args: ast.arguments) -> set[str]:
         metadata_defaults: set[str] = set()
         positional_args = [*args.posonlyargs, *args.args]
@@ -411,6 +415,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if isinstance(node, ast.Subscript):
             self._record_metadata_merge_key_violations(node.value)
             self._record_metadata_merge_key_violations(node.slice)
+            self._record_metadata_subscript_key_violations(node)
             self.visit(node.value)
             self.visit(node.slice)
 
@@ -827,8 +832,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_Subscript(self, node: ast.Subscript) -> None:
         self._record_metadata_merge_key_violations(node.value)
         self._record_metadata_merge_key_violations(node.slice)
-        if self._is_metadata_alias_value(node.value):
-            self._add_violations(_metadata_key_expression_violations(self.path, node.slice))
+        self._record_metadata_subscript_key_violations(node)
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotation_only_subscript_targets.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotation_only_subscript_targets.base.py.txt
@@ -1,0 +1,4 @@
+flow.metadata["vm_run_id"]: str
+
+metadata = flow.metadata
+metadata["firewall_name"]: str

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotation_only_subscript_targets.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotation_only_subscript_targets.expected.txt
@@ -1,0 +1,2 @@
+annotation_only_subscript_targets.py:1: use metadata_keys.VM_RUN_ID for flow.metadata access
+annotation_only_subscript_targets.py:4: use metadata_keys.FIREWALL_NAME for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -202,6 +202,17 @@ def test_registered_flow_metadata_guard_tracks_keyword_only_default_aliases(tmp_
     )
 
 
+def test_registered_flow_metadata_guard_flags_annotation_only_subscript_targets(tmp_path):
+    source_path = tmp_path / "annotation_only_subscript_targets.py"
+    _write_python_source(source_path, "annotation_only_subscript_targets.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "annotation_only_subscript_targets.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_flags_match_or_pattern_keys(tmp_path):
     source_path = tmp_path / "match_or_pattern_keys.py"
     _write_python_source(source_path, "match_or_pattern_keys.base.py.txt")


### PR DESCRIPTION
## Summary

- share registered metadata subscript key diagnostics with annotation-only targets
- preserve annotation-only child evaluation without modeling an outer subscription operation
- cover direct and tracked-alias targets through the public linter entry point

## Scope

This changes only the Python metadata-key linter and its integration fixtures. It does not change runtime add-on behavior, schemas, APIs, runner protocols, persisted state, dependencies, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py -q` (20 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,182 passed)

Closes #25979
