### PR TITLE
test(python): cover annotated flow metadata assignments

### DIFF
--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotated_direct_metadata_assignment.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotated_direct_metadata_assignment.base.py.txt
@@ -1,0 +1,1 @@
+flow.metadata: dict = {"vm_run_id": "run-1"}

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotated_direct_metadata_assignment.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/annotated_direct_metadata_assignment.expected.txt
@@ -1,0 +1,1 @@
+annotated_direct_metadata_assignment.py:1: use metadata_keys.VM_RUN_ID for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -191,6 +191,19 @@ def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
     )
 
 
+def test_registered_flow_metadata_guard_flags_annotated_direct_metadata_assignment(
+    tmp_path,
+):
+    source_path = tmp_path / "annotated_direct_metadata_assignment.py"
+    _write_python_source(source_path, "annotated_direct_metadata_assignment.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "annotated_direct_metadata_assignment.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_tracks_keyword_only_default_aliases(tmp_path):
     source_path = tmp_path / "keyword_only_default_aliases.py"
     _write_python_source(source_path, "keyword_only_default_aliases.base.py.txt")


### PR DESCRIPTION
## Summary

- add a focused fixture for a dictionary assigned directly to annotated `flow.metadata`
- assert the registered `vm_run_id` literal reports `metadata_keys.VM_RUN_ID`
- isolate the regression from shared, version-specific golden output

## Scope

This is a test-only change. It does not modify the linter implementation or runtime behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,182 passed)
- temporarily disabled the direct `AnnAssign` metadata-target check and confirmed the focused test failed with the expected missing diagnostic, then restored the implementation

Closes #25978
