### PR TITLE
fix(platform): keep connectors stable across chat navigation

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -8,13 +8,48 @@ import { searchParams$ } from "../route.ts";
 import {
   SIDEBAR_PARAM,
   setupLeftThread$,
+  setupLeftThreadNotFound$,
   setupRightThread$,
+  setupRightThreadNotFound$,
   unloadRightThread$,
 } from "./chat-thread-panes.ts";
+import { resolvedThreadMeta } from "./chat-thread-event-sourcing.ts";
 import {
   captureNavigationTiming$,
   markRouteSetupBegin$,
 } from "../../lib/posthog.ts";
+
+const setupResolvedLeftThread$ = command(
+  async (
+    { get, set },
+    threadId: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const meta = await get(resolvedThreadMeta(threadId));
+    signal.throwIfAborted();
+    if (meta) {
+      await set(setupLeftThread$, meta, signal);
+      return;
+    }
+    await set(setupLeftThreadNotFound$, threadId, signal);
+  },
+);
+
+const setupResolvedRightThread$ = command(
+  async (
+    { get, set },
+    threadId: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const meta = await get(resolvedThreadMeta(threadId));
+    signal.throwIfAborted();
+    if (meta) {
+      await set(setupRightThread$, meta, signal);
+      return;
+    }
+    await set(setupRightThreadNotFound$, threadId, signal);
+  },
+);
 
 const internalSetupChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -29,12 +64,13 @@ const internalSetupChatPage$ = command(
     set(captureNavigationTiming$);
 
     const sidebarThreadId = get(searchParams$).get(SIDEBAR_PARAM);
-    const shouldLoadRight = sidebarThreadId && sidebarThreadId !== threadId;
+    const rightThreadId =
+      sidebarThreadId && sidebarThreadId !== threadId ? sidebarThreadId : null;
 
     await Promise.all([
-      set(setupLeftThread$, threadId, signal),
-      shouldLoadRight
-        ? set(setupRightThread$, sidebarThreadId, signal)
+      set(setupResolvedLeftThread$, threadId, signal),
+      rightThreadId
+        ? set(setupResolvedRightThread$, rightThreadId, signal)
         : set(unloadRightThread$),
     ]);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -6,7 +6,6 @@ import type {
   ChatThreadDraft,
   UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import type { ChatClipboardPayload } from "../zero-page/clipboard.ts";
 import type { BodyRenderBlock } from "./parse-body-blocks.ts";
 import type { ChatEventGroup } from "./chat-event.ts";
@@ -115,6 +114,7 @@ export interface QueueMessageOptions {
 
 export interface ChatPanelSignals {
   readonly threadId: string;
+  readonly agentId: string;
   /** Aborts when this chat panel is replaced or its page is left. */
   readonly signal: AbortSignal;
   // -- Data signals ----------------------------------------------------------
@@ -159,11 +159,6 @@ export interface ChatPanelSignals {
   readonly composer: ComposerSignals;
   readonly feedback: ChatThreadFeedbackSignals;
   readonly sharing: ChatThreadSharingSignals;
-  // -- Agent info (derived from threadMeta$.agentId) ------------------------
-  readonly agent$: Computed<Promise<ZeroAgentResponse>>;
-  readonly agentId$: Computed<string | null>;
-  readonly agentDisplayName$: Computed<Promise<string | null>>;
-  readonly agentPinned$: Computed<Promise<boolean | null>>;
   // -- Thread-owned automation resources -----------------------------------
   readonly headerAutomations: HeaderAutomationSignals;
   // -- Thread-owned utility sidebar -----------------------------------------

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -98,11 +98,11 @@ const initialRemoteChatThreadEventsSyncedDeferred$ = computed((get) => {
   return createDeferredPromise<void>(get(rootSignal$));
 });
 
-export const initialLocalChatThreadEventsLoaded$ = computed((get) => {
+const initialLocalChatThreadEventsLoaded$ = computed((get) => {
   return get(initialLocalChatThreadEventsLoadedDeferred$).promise;
 });
 
-export const initialRemoteChatThreadEventsSynced$ = computed((get) => {
+const initialRemoteChatThreadEventsSynced$ = computed((get) => {
   return get(initialRemoteChatThreadEventsSyncedDeferred$).promise;
 });
 
@@ -493,6 +493,25 @@ export const chatThreadMetaMap$ = computed((get) => {
 export function threadMeta(threadId: string) {
   return computed((get): ThreadMeta | null => {
     return get(chatThreadMetaMap$).get(threadId) ?? null;
+  });
+}
+
+export function resolvedThreadMeta(threadId: string) {
+  const meta$ = threadMeta(threadId);
+  return computed(async (get): Promise<ThreadMeta | null> => {
+    let meta = get(meta$);
+    if (meta) {
+      return meta;
+    }
+
+    await get(initialLocalChatThreadEventsLoaded$);
+    meta = get(meta$);
+    if (meta) {
+      return meta;
+    }
+
+    await get(initialRemoteChatThreadEventsSynced$);
+    return get(meta$);
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-pane-state.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-pane-state.ts
@@ -2,25 +2,46 @@ import { command, computed, state } from "ccstate";
 
 import type { ChatPanelSignals } from "./chat-panel-signals.ts";
 
-const internalLeftThread$ = state<ChatPanelSignals | null>(null);
-const internalRightThread$ = state<ChatPanelSignals | null>(null);
+export type ChatThreadPaneState =
+  | {
+      readonly kind: "thread";
+      readonly thread: ChatPanelSignals;
+    }
+  | {
+      readonly kind: "not-found";
+      readonly threadId: string;
+    }
+  | null;
+
+const internalLeftPane$ = state<ChatThreadPaneState>(null);
+const internalRightPane$ = state<ChatThreadPaneState>(null);
+
+export const currentLeftPane$ = computed((get): ChatThreadPaneState => {
+  return get(internalLeftPane$);
+});
+
+export const currentRightPane$ = computed((get): ChatThreadPaneState => {
+  return get(internalRightPane$);
+});
 
 export const currentLeftThread$ = computed((get): ChatPanelSignals | null => {
-  return get(internalLeftThread$);
+  const pane = get(internalLeftPane$);
+  return pane?.kind === "thread" ? pane.thread : null;
 });
 
 export const currentRightThread$ = computed((get): ChatPanelSignals | null => {
-  return get(internalRightThread$);
+  const pane = get(internalRightPane$);
+  return pane?.kind === "thread" ? pane.thread : null;
 });
 
-export const setCurrentLeftThread$ = command(
-  ({ set }, thread: ChatPanelSignals | null) => {
-    set(internalLeftThread$, thread);
+export const setCurrentLeftPane$ = command(
+  ({ set }, pane: ChatThreadPaneState) => {
+    set(internalLeftPane$, pane);
   },
 );
 
-export const setCurrentRightThread$ = command(
-  ({ set }, thread: ChatPanelSignals | null) => {
-    set(internalRightThread$, thread);
+export const setCurrentRightPane$ = command(
+  ({ set }, pane: ChatThreadPaneState) => {
+    set(internalRightPane$, pane);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -23,21 +23,28 @@ import {
 import { createCachedChatPanelSignals$ } from "./create-chat-thread.ts";
 import { createChatEventSignals } from "./chat-event-signals.ts";
 import type { ChatPanelSignals } from "./chat-panel-signals.ts";
+import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
 import {
-  initialLocalChatThreadEventsLoaded$,
-  initialRemoteChatThreadEventsSynced$,
-  threadMeta,
-} from "./chat-thread-event-sourcing.ts";
-import {
+  type ChatThreadPaneState,
+  currentLeftPane$,
   currentLeftThread$,
+  currentRightPane$,
   currentRightThread$,
-  setCurrentLeftThread$,
-  setCurrentRightThread$,
+  setCurrentLeftPane$,
+  setCurrentRightPane$,
 } from "./chat-thread-pane-state.ts";
-import { syncPrimaryThread$ } from "./sync-primary-thread.ts";
+import {
+  syncMissingPrimaryThread$,
+  syncPrimaryThread$,
+} from "./sync-primary-thread.ts";
 
 export const SIDEBAR_PARAM = "sidebar";
-export { currentLeftThread$, currentRightThread$ };
+export {
+  currentLeftPane$,
+  currentLeftThread$,
+  currentRightPane$,
+  currentRightThread$,
+};
 
 const L = logger("ChatPanes");
 
@@ -60,7 +67,7 @@ export const unloadRightThread$ = command(({ get, set }) => {
     set(currentRightThread.sidebar.close$);
   }
   set(resetRightSetupSignal$);
-  set(setCurrentRightThread$, null);
+  set(setCurrentRightPane$, null);
   const next = new URLSearchParams(get(searchParams$));
   if (next.has(SIDEBAR_PARAM)) {
     next.delete(SIDEBAR_PARAM);
@@ -69,7 +76,7 @@ export const unloadRightThread$ = command(({ get, set }) => {
 });
 
 interface PaneSpec {
-  setPaneThread$: Command<void, [ChatPanelSignals | null]>;
+  setPane$: Command<void, [ChatThreadPaneState]>;
   resetSetupSignal$: ReturnType<typeof resetSignal>;
   onReady$?: Command<void, [AbortSignal]>;
 }
@@ -179,62 +186,46 @@ const resolvePaneThread$ = command(
   },
 );
 
-const waitForThreadMetaResolution$ = command(
-  async ({ get }, threadId: string, signal: AbortSignal): Promise<void> => {
-    if (get(threadMeta(threadId))) {
-      return;
-    }
-
-    await get(initialLocalChatThreadEventsLoaded$);
-    signal.throwIfAborted();
-
-    if (get(threadMeta(threadId))) {
-      return;
-    }
-
-    await get(initialRemoteChatThreadEventsSynced$);
-    signal.throwIfAborted();
+const beginPaneSetup$ = command(
+  ({ get, set }, spec: PaneSpec, parentSignal: AbortSignal): AbortSignal => {
+    const signal = set(spec.resetSetupSignal$, parentSignal);
+    signal.addEventListener(
+      "abort",
+      () => {
+        // A non-chat page must never inherit this pane on re-entry.
+        // Chat-to-chat setup keeps the reference so the outer thread section
+        // can preserve its established DOM identity until replacement.
+        if (get(activeRoute$) !== "chat") {
+          set(spec.setPane$, null);
+        }
+      },
+      { once: true },
+    );
+    return signal;
   },
 );
 
 const setupPaneThread$ = command(
   async (
-    { get, set },
+    { set },
     spec: PaneSpec,
-    threadId: string,
+    meta: ThreadMeta,
     parentSignal: AbortSignal,
   ): Promise<void> => {
-    const signal = set(spec.resetSetupSignal$, parentSignal);
-    signal.addEventListener(
-      "abort",
-      () => {
-        // A non-chat page must never inherit this aborted panel on re-entry.
-        // Chat-to-chat setup keeps the reference so the outer thread section
-        // can preserve its established DOM identity until replacement.
-        if (get(activeRoute$) !== "chat") {
-          set(spec.setPaneThread$, null);
-        }
-      },
-      { once: true },
-    );
+    const signal = set(beginPaneSetup$, spec, parentSignal);
+    const threadId = meta.id;
 
     L.debug("setupPaneThread$ start", { threadId });
-    await set(waitForThreadMetaResolution$, threadId, signal);
-    signal.throwIfAborted();
-
     const chatEvents = createChatEventSignals(threadId);
     const { thread, isNew } = set(
       createCachedChatPanelSignals$,
       chatEvents,
+      meta.agentId,
       signal,
     );
-    set(spec.setPaneThread$, thread);
+    set(spec.setPane$, { kind: "thread", thread });
     if (spec.onReady$) {
       set(spec.onReady$, signal);
-    }
-
-    if (!get(thread.threadMeta$)) {
-      return;
     }
 
     await set(
@@ -248,21 +239,55 @@ const setupPaneThread$ = command(
   },
 );
 
+const setupPaneNotFound$ = command(
+  (
+    { set },
+    spec: PaneSpec,
+    threadId: string,
+    parentSignal: AbortSignal,
+  ): void => {
+    const signal = set(beginPaneSetup$, spec, parentSignal);
+    set(spec.setPane$, { kind: "not-found", threadId });
+    if (spec.onReady$) {
+      set(spec.onReady$, signal);
+    }
+  },
+);
+
 export const setupLeftThread$ = command(
+  async (
+    { set },
+    meta: ThreadMeta,
+    parentSignal: AbortSignal,
+  ): Promise<void> => {
+    await Promise.all([
+      set(syncPrimaryThread$, meta, parentSignal),
+      set(
+        setupPaneThread$,
+        {
+          setPane$: setCurrentLeftPane$,
+          resetSetupSignal$: resetLeftSetupSignal$,
+          onReady$: hideAppSkeleton$,
+        },
+        meta,
+        parentSignal,
+      ),
+    ]);
+  },
+);
+
+export const setupLeftThreadNotFound$ = command(
   async (
     { set },
     threadId: string,
     parentSignal: AbortSignal,
   ): Promise<void> => {
-    await set(waitForThreadMetaResolution$, threadId, parentSignal);
-    parentSignal.throwIfAborted();
-
     await Promise.all([
-      set(syncPrimaryThread$, threadId, parentSignal),
+      set(syncMissingPrimaryThread$, parentSignal),
       set(
-        setupPaneThread$,
+        setupPaneNotFound$,
         {
-          setPaneThread$: setCurrentLeftThread$,
+          setPane$: setCurrentLeftPane$,
           resetSetupSignal$: resetLeftSetupSignal$,
           onReady$: hideAppSkeleton$,
         },
@@ -276,13 +301,31 @@ export const setupLeftThread$ = command(
 export const setupRightThread$ = command(
   async (
     { set },
-    threadId: string,
+    meta: ThreadMeta,
     parentSignal: AbortSignal,
   ): Promise<void> => {
     await set(
       setupPaneThread$,
       {
-        setPaneThread$: setCurrentRightThread$,
+        setPane$: setCurrentRightPane$,
+        resetSetupSignal$: resetRightSetupSignal$,
+      },
+      meta,
+      parentSignal,
+    );
+  },
+);
+
+export const setupRightThreadNotFound$ = command(
+  async (
+    { set },
+    threadId: string,
+    parentSignal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      setupPaneNotFound$,
+      {
+        setPane$: setCurrentRightPane$,
         resetSetupSignal$: resetRightSetupSignal$,
       },
       threadId,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -56,7 +56,6 @@ import {
   type UserMessageInputDocument,
   type UserMessagePart,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import {
   chatEventCompatibilityRole,
   foldLatestChatUsageByRunId,
@@ -69,14 +68,12 @@ import type { ModelProviderSelection } from "../../views/zero-page/components/mo
 import { runOptionsFromModelProviderSelection } from "./model-selection-request.ts";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { agentById } from "../agent.ts";
 import {
   codexFastModeEnabled$,
   featureSwitch$,
   imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
-import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
 import {
   writeChatMessageToClipboard,
   type ChatClipboardPayload,
@@ -676,49 +673,8 @@ function createComputerUseHostSelection(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Sub-factory: agent info
-// ---------------------------------------------------------------------------
-
-function createAgentInfoSignals(threadMeta$: Computed<ThreadMeta | null>) {
-  // agentId$ is read by avatar and pinned UI on first paint.
-  // Resolving it via threadMeta$ avoids blocking the avatar render on the
-  // chat-threads/:id round-trip, even though the agentId rarely changes
-  // for a given thread.
-  const agentId$ = computed((get): string | null => {
-    return get(threadMeta$)?.agentId ?? null;
-  });
-
-  const agent$ = computed(async (get): Promise<ZeroAgentResponse> => {
-    const agentId = get(agentId$);
-    if (!agentId) {
-      throw new Error("Chat thread requires an active agent");
-    }
-    return await get(agentById(agentId));
-  });
-
-  const agentDisplayName$ = computed(async (get): Promise<string | null> => {
-    return (await get(agent$)).displayName ?? null;
-  });
-
-  const agentPinned$ = computed(async (get): Promise<boolean | null> => {
-    const agentId = await get(agentId$);
-    if (!agentId) {
-      return null;
-    }
-    const ids = await get(pinnedAgentIds$);
-    return ids.includes(agentId);
-  });
-
-  return { agent$, agentId$, agentDisplayName$, agentPinned$ };
-}
-
-function createThreadOwnedSignals(
-  threadId: string,
-  threadMeta$: Computed<ThreadMeta | null>,
-) {
+function createThreadOwnedSignals(threadId: string) {
   return {
-    ...createAgentInfoSignals(threadMeta$),
     headerAutomations: createHeaderAutomationSignals(threadId),
     ...createThreadUIState(),
   };
@@ -2585,8 +2541,8 @@ function sendRuntimeOptions(
 }
 
 interface SendMessageDeps {
-  threadId: string;
-  agentId$: Computed<string | null>;
+  readonly threadId: string;
+  readonly agentId: string;
   modelSelectionForSend$: Command<
     Promise<ModelProviderSelection | null>,
     [AbortSignal]
@@ -2693,7 +2649,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
 }
 
 function createSendMessage(deps: SendMessageDeps) {
-  const { threadId, agentId$, modelSelectionForSend$ } = deps;
+  const { threadId, agentId, modelSelectionForSend$ } = deps;
   const performSendMessage$ = createPerformSendMessage(deps);
   const optimisticCreateUnsettled$ =
     optimisticChatThreadCreateUnsettled(threadId);
@@ -2706,11 +2662,6 @@ function createSendMessage(deps: SendMessageDeps) {
     ): Promise<boolean> => {
       L.debug("sendMessage$ start", { threadId, promptLen: prompt.length });
       if (get(optimisticCreateUnsettled$)) {
-        return false;
-      }
-      const agentId = get(agentId$);
-      if (!agentId) {
-        L.debug("sendMessage$ no agentId, abort", { threadId });
         return false;
       }
       const modelSelection = await set(modelSelectionForSend$, signal);
@@ -2730,8 +2681,8 @@ function createSendMessage(deps: SendMessageDeps) {
 }
 
 interface QueueMessageDeps {
-  threadId: string;
-  agentId$: Computed<string | null>;
+  readonly threadId: string;
+  readonly agentId: string;
   modelSelectionForSend$: Command<
     Promise<ModelProviderSelection | null>,
     [AbortSignal]
@@ -2748,7 +2699,7 @@ interface QueueMessageDeps {
 function createQueueMessage(deps: QueueMessageDeps) {
   const {
     threadId,
-    agentId$,
+    agentId,
     modelSelectionForSend$,
     draft,
     cancelDraftSync$,
@@ -2769,11 +2720,6 @@ function createQueueMessage(deps: QueueMessageDeps) {
         L.debug("queueMessage$ optimistic thread create unsettled, abort", {
           threadId,
         });
-        return false;
-      }
-      const agentId = get(agentId$);
-      if (!agentId) {
-        L.debug("queueMessage$ no thread metadata, abort", { threadId });
         return false;
       }
       const modelSelection = await set(modelSelectionForSend$, signal);
@@ -2836,8 +2782,8 @@ function createQueueMessage(deps: QueueMessageDeps) {
 }
 
 interface RecallMessageDeps {
-  threadId: string;
-  agentId$: Computed<string | null>;
+  readonly threadId: string;
+  readonly agentId: string;
   chatEvents$: Computed<ChatEvent[]>;
   draft: DraftSignals;
   queueDraftSync$: Command<Promise<void>, [AbortSignal]>;
@@ -2848,7 +2794,7 @@ interface RecallMessageDeps {
 }
 
 function createRecallMessage(deps: RecallMessageDeps) {
-  const { agentId$, chatEvents$, draft, queueDraftSync$, sendEvent$ } = deps;
+  const { agentId, chatEvents$, draft, queueDraftSync$, sendEvent$ } = deps;
 
   return command(async ({ get, set }, eventId: string, signal: AbortSignal) => {
     const event = queuedEventsFromChatEvents(get(chatEvents$)).find(
@@ -2859,11 +2805,6 @@ function createRecallMessage(deps: RecallMessageDeps) {
     if (!event || event.eventType !== "input.prompt") {
       return;
     }
-    const agentId = get(agentId$);
-    if (!agentId) {
-      return;
-    }
-
     const userMessage = event.userMessage;
     const templatePart = userMessage.parts.find((part) => {
       return part.type === "template";
@@ -2894,7 +2835,7 @@ function createRecallMessage(deps: RecallMessageDeps) {
 }
 
 function createSkipAutomationEvent({
-  agentId$,
+  agentId,
   chatEvents$,
   sendEvent$,
 }: RecallMessageDeps) {
@@ -2912,8 +2853,7 @@ function createSkipAutomationEvent({
           );
         },
       );
-      const agentId = get(agentId$);
-      if (!event || !agentId) {
+      if (!event) {
         return;
       }
 
@@ -2952,12 +2892,12 @@ function createThreadMessageActions(deps: MessageCommandsDeps) {
 
 function createCancelRunWithQueuedRecall({
   threadId,
-  agentId$,
+  agentId,
   chatEvents$,
   sendEvent$,
 }: {
-  threadId: string;
-  agentId$: Computed<string | null>;
+  readonly threadId: string;
+  readonly agentId: string;
   chatEvents$: Computed<ChatEvent[]>;
   sendEvent$: Command<
     Promise<SendChatEventResult>,
@@ -2973,11 +2913,6 @@ function createCancelRunWithQueuedRecall({
       });
       return;
     }
-    const agentId = get(agentId$);
-    if (!agentId) {
-      return;
-    }
-
     const chatEvents = get(chatEvents$);
     const queuedEvents = queuedEventsFromChatEvents(chatEvents).filter(
       (event) => {
@@ -3606,7 +3541,7 @@ function publicChatThreadEventSignals(events: MessageListSignals) {
 
 interface CreateChatThreadComposerSignalsOptions {
   readonly chatEvents: ChatEventSignals;
-  readonly agent$: Computed<Promise<ZeroAgentResponse>>;
+  readonly agentId: string;
   readonly draft: DraftSignals;
   readonly queueDraftSync$: Command<Promise<void>, [AbortSignal]>;
   readonly modelSelection: ReturnType<typeof createModelSelection>;
@@ -3619,8 +3554,7 @@ interface CreateChatThreadComposerSignalsOptions {
 
 interface ChatThreadComposerContext {
   readonly threadMeta$: Computed<ThreadMeta | null>;
-  readonly agent$: Computed<Promise<ZeroAgentResponse>>;
-  readonly agentId$: Computed<string | null>;
+  readonly agentId: string;
   readonly cancellationRecoveryPending$: Computed<Promise<boolean>>;
 }
 
@@ -3722,7 +3656,7 @@ function createChatThreadComposerSignals(
     },
   );
   return createComposerSignals({
-    agent$: options.agent$,
+    agentId: options.agentId,
     draft: {
       signals: options.draft,
       save$: options.queueDraftSync$,
@@ -3761,7 +3695,7 @@ function createThreadComposerSignalsWithContext(
     createDraftSync(threadId, draft);
   const messageActions = createThreadMessageActions({
     threadId,
-    agentId$: context.agentId$,
+    agentId: context.agentId,
     modelSelectionForSend$,
     chatEvents$: chatEvents.chatEvents$,
     draft,
@@ -3772,7 +3706,7 @@ function createThreadComposerSignalsWithContext(
   });
   return createChatThreadComposerSignals({
     chatEvents,
-    agent$: context.agent$,
+    agentId: context.agentId,
     draft,
     queueDraftSync$,
     modelSelection,
@@ -3789,18 +3723,17 @@ function createThreadComposerSignalsWithContext(
  */
 export function createThreadComposerSignals(
   threadId: string,
+  agentId: string,
   chatEvents: ChatEventSignals,
 ): ComposerSignals {
   const threadMeta$ = createThreadMeta(threadId);
-  const agent = createAgentInfoSignals(threadMeta$);
   const cancellationRecovery = createCancellationRecoverySignals(threadId);
   return createThreadComposerSignalsWithContext(
     threadId,
     chatEvents,
     {
       threadMeta$,
-      agent$: agent.agent$,
-      agentId$: agent.agentId$,
+      agentId,
       cancellationRecoveryPending$: cancellationRecovery.pending$,
     },
     createDraftSignals(),
@@ -3809,6 +3742,7 @@ export function createThreadComposerSignals(
 
 function createChatPanelSignalsWithDraft(
   chatEvents: ChatEventSignals,
+  agentId: string,
   draft: DraftSignals,
   signal: AbortSignal,
 ): ChatPanelSignals {
@@ -3819,15 +3753,14 @@ function createChatPanelSignalsWithDraft(
   const threadTitle = createThreadTitleParts(threadMeta$);
   const threadSettledInServer$ = createThreadSettledInServer(threadId);
   const container = createChatThreadContainerSignals();
-  const threadOwned = createThreadOwnedSignals(threadId, threadMeta$);
+  const threadOwned = createThreadOwnedSignals(threadId);
   const cancellationRecovery = createCancellationRecoverySignals(threadId);
   const composer = createThreadComposerSignalsWithContext(
     threadId,
     chatEvents,
     {
       threadMeta$,
-      agent$: threadOwned.agent$,
-      agentId$: threadOwned.agentId$,
+      agentId,
       cancellationRecoveryPending$: cancellationRecovery.pending$,
     },
     draft,
@@ -3855,6 +3788,7 @@ function createChatPanelSignalsWithDraft(
   });
   return {
     threadId,
+    agentId,
     signal,
     threadDraft$,
     threadMeta$,
@@ -3891,20 +3825,32 @@ function createChatPanelSignalsWithDraft(
  */
 export function createChatPanelSignals(
   chatEvents: ChatEventSignals,
+  agentId: string,
   signal: AbortSignal,
 ): ChatPanelSignals {
   return createChatPanelSignalsWithDraft(
     chatEvents,
+    agentId,
     createDraftSignals(),
     signal,
   );
 }
 
 export const createCachedChatPanelSignals$ = command(
-  ({ set }, chatEvents: ChatEventSignals, signal: AbortSignal) => {
+  (
+    { set },
+    chatEvents: ChatEventSignals,
+    agentId: string,
+    signal: AbortSignal,
+  ) => {
     const { draft, isNew } = set(ensureDraft$, chatEvents.threadId);
     return {
-      thread: createChatPanelSignalsWithDraft(chatEvents, draft, signal),
+      thread: createChatPanelSignalsWithDraft(
+        chatEvents,
+        agentId,
+        draft,
+        signal,
+      ),
       isNew,
     };
   },

--- a/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
@@ -3,10 +3,29 @@ import { currentChatAgentId$, setChatAgentId$ } from "../agent-chat.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { resetSignal } from "../utils.ts";
-import { threadMeta } from "./chat-thread-event-sourcing.ts";
+import { threadMeta, type ThreadMeta } from "./chat-thread-event-sourcing.ts";
 import { i18n } from "../../i18n/index.ts";
 
 const resetSyncPrimarySignal$ = resetSignal();
+
+const beginPrimaryThreadSync$ = command(
+  ({ set }, parentSignal: AbortSignal): AbortSignal => {
+    const signal = set(resetSyncPrimarySignal$, parentSignal);
+    set(
+      updateDocumentTitle$,
+      i18n.t(($) => {
+        return $.chat.documentTitle;
+      }),
+    );
+    return signal;
+  },
+);
+
+export const syncMissingPrimaryThread$ = command(
+  ({ set }, parentSignal: AbortSignal): void => {
+    set(beginPrimaryThreadSync$, parentSignal);
+  },
+);
 
 /**
  * Drives the document title, the global agent context, and the Ably
@@ -21,25 +40,12 @@ const resetSyncPrimarySignal$ = resetSignal();
 export const syncPrimaryThread$ = command(
   async (
     { get, set },
-    threadId: string,
+    meta: ThreadMeta,
     parentSignal: AbortSignal,
   ): Promise<void> => {
-    const signal = set(resetSyncPrimarySignal$, parentSignal);
-
-    // Initial title, set synchronously so the document tab updates on the
-    // very first frame after the pane switch.
-    set(
-      updateDocumentTitle$,
-      i18n.t(($) => {
-        return $.chat.documentTitle;
-      }),
-    );
-
+    const signal = set(beginPrimaryThreadSync$, parentSignal);
+    const threadId = meta.id;
     const threadMeta$ = threadMeta(threadId);
-    const meta = get(threadMeta$);
-    if (!meta) {
-      return;
-    }
 
     const currentAgentId = await get(currentChatAgentId$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -2,7 +2,7 @@ import { command, computed, state } from "ccstate";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
-import { agentById, currentAgentId$ } from "../agent.ts";
+import { currentAgentId$ } from "../agent.ts";
 import { sendNewThread$ } from "../chat-page/optimistic-chat-thread-page.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { updateUserModelPreference$ } from "../external/user-model-preference.ts";
@@ -96,7 +96,6 @@ function createAgentComposerSignalsWithDraft(
   agentId: string,
   agentDraft: EnsuredAgentDraft,
 ) {
-  const agent$ = agentById(agentId);
   const submitMessage$ = command(
     async (
       { get, set },
@@ -140,7 +139,7 @@ function createAgentComposerSignalsWithDraft(
   );
 
   return createComposerSignals({
-    agent$,
+    agentId,
     draft: {
       signals: agentDraft.draft,
       save$: agentDraft.queueDraftSync$,

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -2,7 +2,6 @@ import type {
   GenerationTemplateRequest,
   PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import { foldActiveChatGoalObjective } from "@vm0/api-contracts/contracts/chat-events";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { command, computed, state, type Command, type Computed } from "ccstate";
@@ -208,7 +207,7 @@ interface ComposerTemplateSignals
 }
 
 export interface ComposerSignals {
-  readonly agent$: Computed<Promise<ZeroAgentResponse>>;
+  readonly agentId: string;
   readonly editor: ComposerEditorSignals;
   readonly feedback: WorkflowComposerSignals["feedback"];
   readonly workflow: ComposerWorkflowSignals;
@@ -224,7 +223,7 @@ export interface ComposerSignals {
 }
 
 interface CreateComposerSignalsOptions {
-  readonly agent$: ComposerSignals["agent$"];
+  readonly agentId: string;
   readonly draft: {
     readonly signals: DraftSignals;
     readonly save$: ComposerDraftSignals["save$"];
@@ -438,8 +437,8 @@ export function createComposerSignals(
 ): ComposerSignals {
   const eventSignals = createComposerChatEventSignals(options.chatEvents$);
   const draft = options.draft.signals;
-  const agentId$ = computed(async (get): Promise<string | null> => {
-    return (await get(options.agent$)).agentId;
+  const agentId$ = computed((): string => {
+    return options.agentId;
   });
   const feedback = createComposerFeedbackModel(options.threadId);
   const temporaryModelNoticeEnabled$ = computed((get): boolean => {
@@ -470,7 +469,7 @@ export function createComposerSignals(
   const ui = createComposerUiSignals();
 
   return {
-    agent$: options.agent$,
+    agentId: options.agentId,
     editor: composerEditorSignals(workflowComposer, options.singleLineOnMobile),
     feedback: workflowComposer.feedback,
     workflow: {
@@ -478,7 +477,7 @@ export function createComposerSignals(
       ...workflowPrompt,
     },
     suggestion: composerSuggestionSignals(workflowComposer),
-    connector: createComposerConnectorSignals(options.agent$),
+    connector: createComposerConnectorSignals(options.agentId),
     draft: {
       seed$: draft.seed$,
       setDraftInput$: draft.setInput$,

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -2,7 +2,6 @@ import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
-import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
@@ -164,23 +163,11 @@ function initialComposerConnectorUiState(): ComposerConnectorUiState {
   };
 }
 
-function createAgentIdSignal(
-  agent$: Computed<Promise<ZeroAgentResponse>>,
-): Computed<Promise<string>> {
-  return computed(async (get): Promise<string> => {
-    return (await get(agent$)).agentId;
-  });
-}
-
 function createConnectorAuthorizationSignal(
-  agentId$: Computed<Promise<string>>,
+  agentId: string,
 ): Computed<Promise<ComposerConnectorAuthorizationState>> {
-  const authorizations$ = computed(async (get) => {
-    const agentId = await get(agentId$);
-    return await get(agentConnectorAuthorizations({ agentId }));
-  });
+  const authorizations$ = agentConnectorAuthorizations({ agentId });
   const customAuthorizations$ = computed(async (get) => {
-    const agentId = await get(agentId$);
     const reloadGeneration = get(customConnectorAuthorizationReloadVersion$);
     return await get(agentCustomConnectorAuthorizationRequestBroker$).load({
       createClient: get(zeroClient$),
@@ -203,7 +190,7 @@ function createConnectorAuthorizationSignal(
 }
 
 function createBuiltinConnectorAuthorizationCommand(
-  agentId$: Computed<Promise<string>>,
+  agentId: string,
 ): Command<Promise<void>, [ConnectorSlug, boolean, AbortSignal]> {
   return command(
     async (
@@ -212,7 +199,6 @@ function createBuiltinConnectorAuthorizationCommand(
       authorized: boolean,
       signal: AbortSignal,
     ): Promise<void> => {
-      const agentId = await get(agentId$);
       signal.throwIfAborted();
       const client = get(zeroClient$)(zeroUserConnectorsContract);
       await withCleanup(
@@ -239,7 +225,7 @@ function createBuiltinConnectorAuthorizationCommand(
 }
 
 function createCustomConnectorAuthorizationCommand(
-  agentId$: Computed<Promise<string>>,
+  agentId: string,
 ): Command<Promise<void>, [string, boolean, AbortSignal]> {
   return command(
     async (
@@ -248,7 +234,6 @@ function createCustomConnectorAuthorizationCommand(
       authorized: boolean,
       signal: AbortSignal,
     ): Promise<void> => {
-      const agentId = await get(agentId$);
       signal.throwIfAborted();
       const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
       await withCleanup(
@@ -272,12 +257,12 @@ function createCustomConnectorAuthorizationCommand(
 }
 
 function createConnectorAuthorizationCommand(
-  agentId$: Computed<Promise<string>>,
+  agentId: string,
 ): ComposerConnectorSignals["setConnectorAuthorization$"] {
   const setBuiltinAuthorization$ =
-    createBuiltinConnectorAuthorizationCommand(agentId$);
+    createBuiltinConnectorAuthorizationCommand(agentId);
   const setCustomAuthorization$ =
-    createCustomConnectorAuthorizationCommand(agentId$);
+    createCustomConnectorAuthorizationCommand(agentId);
   return command(
     async (
       { set },
@@ -323,9 +308,8 @@ function createConnectorUiSignals(): Pick<
 }
 
 export function createComposerConnectorSignals(
-  agent$: Computed<Promise<ZeroAgentResponse>>,
+  agentId: string,
 ): ComposerConnectorSignals {
-  const agentId$ = createAgentIdSignal(agent$);
   const ui = createConnectorUiSignals();
   const connectorPermissionMetadata$ = computed(async (get) => {
     const connectorSlug = get(ui.connectorUiState$).permissionConnectorSlug;
@@ -336,14 +320,13 @@ export function createComposerConnectorSignals(
   });
   const connectorPermissionGrants$ = computed(
     async (get): Promise<readonly PlatformUserPermissionGrant[]> => {
-      const agentId = await get(agentId$);
       return await get(userPermissionGrantsByAgent({ agentId }));
     },
   );
 
   return {
-    connectorAuthorization$: createConnectorAuthorizationSignal(agentId$),
-    setConnectorAuthorization$: createConnectorAuthorizationCommand(agentId$),
+    connectorAuthorization$: createConnectorAuthorizationSignal(agentId),
+    setConnectorAuthorization$: createConnectorAuthorizationCommand(agentId),
     ...ui,
     connectorPermissionMetadata$,
     connectorPermissionGrants$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -11,6 +11,7 @@ import {
   type ChatThreadEvent,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
@@ -2383,6 +2384,68 @@ describe("chat composer models", () => {
       expect(screen.getByLabelText("Remove Slack")).toBeInTheDocument();
       expectTextBefore("GitHub", "Slack");
     });
+  });
+
+  it("keeps connector display stable without reloading the agent on same-agent navigation", async () => {
+    let agentRequestCount = 0;
+
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent();
+    mockManyConnectedConnectors();
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    mockComposerThreadSnapshot([
+      { id: THREAD_ID, agentId: AGENT_ID, title: "First Scout thread" },
+      {
+        id: OTHER_AGENT_THREAD_ID,
+        agentId: AGENT_ID,
+        title: "Second Scout thread",
+      },
+    ]);
+    context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
+      agentRequestCount += 1;
+      return respond(200, {
+        agentId: params.id,
+        ownerId: "test-user-123",
+        displayName: "Scout",
+        description: null,
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledConnectorSlugs: ["github"] });
+    });
+    context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledIds: [] });
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const initialConnectorButton = within(
+      await screen.findByLabelText("Chat thread"),
+    ).getByLabelText("Connectors");
+    await waitFor(() => {
+      expect(initialConnectorButton.querySelector("img")).not.toBeNull();
+    });
+    const settledAgentRequestCount = agentRequestCount;
+
+    await navigateToChatThread(OTHER_AGENT_THREAD_ID);
+    await waitFor(() => {
+      expect(
+        within(screen.getByLabelText("Chat thread")).getByText(
+          "Second Scout thread",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(agentRequestCount).toBe(settledAgentRequestCount);
+
+    const nextConnectorButton = within(
+      screen.getByLabelText("Chat thread"),
+    ).getByLabelText("Connectors");
+    expect(nextConnectorButton.querySelector("img")).not.toBeNull();
   });
 
   it("keeps connector access resolved across same-agent chat navigation", async () => {

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -7,7 +7,6 @@ import {
 import type { Editor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Popover, PopoverAnchor, type KeyboardEventLike } from "@vm0/ui";
-import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
 import type { ComposerAgentSuggestion } from "../../signals/zero-page/composer-agent-suggestion-domain.ts";
@@ -80,12 +79,6 @@ function resolveMacControlLineNavigation(
 interface ComposerSuggestionRange {
   readonly start: number;
   readonly end: number;
-}
-
-function resolvedAgentId(
-  agent: ZeroAgentResponse | undefined,
-): string | undefined {
-  return agent?.agentId;
 }
 
 interface ComposerSuggestionCaretVirtualRef {
@@ -307,7 +300,7 @@ function useComposerSuggestionMenu({
   const insertWorkflow = useSet(composer.workflow.insertWorkflow$);
   const insertAgent = useSet(composer.suggestion.insertAgent$);
   const insertChatThread = useSet(composer.suggestion.insertChatThread$);
-  const currentAgentId = resolvedAgentId(useLastResolved(composer.agent$));
+  const currentAgentId = composer.agentId;
   const workflowsLoadable = useLastLoadable(composer.workflow.workflows$);
   const workflows = buildComposerSlashWorkflows({
     agentId: currentAgentId,

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -144,7 +144,7 @@ function ArtifactSidebarWithThreadContext({
   thread,
 }: ArtifactSidebarProps) {
   const loadable = useLastLoadable(thread.artifacts$);
-  const agentId = useGet(thread.agentId$);
+  const agentId = thread.agentId;
   const eventGroups = useLastResolved(thread.eventImageGroups$, {
     equalityFn: equalEventImageGroups,
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1039,7 +1039,7 @@ function ArtifactPreviewDialogThreadResolver({
   thread: ChatPanelSignals;
 }) {
   const loadable = useLastLoadable(thread.artifacts$);
-  const agentId = useGet(thread.agentId$);
+  const agentId = thread.agentId;
   const eventGroups = useLastResolved(thread.eventImageGroups$, {
     equalityFn: equalEventImageGroups,
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -94,6 +94,7 @@ import {
   isVisualAttachment,
   shouldExcludeVisualAttachmentsForModel,
 } from "../../signals/chat-page/resolve-draft-attachments.ts";
+import { agents$ } from "../../signals/agent.ts";
 import type {
   GenerationTemplateRequest,
   PersistedAttachment,
@@ -103,7 +104,6 @@ import type {
   ZeroAvatarVideoAvatar,
   ZeroAvatarVideoVoice,
 } from "@vm0/api-contracts/contracts/zero-avatar-video";
-import type { ZeroAgentResponse } from "@vm0/api-contracts/contracts/zero-agents";
 import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import { TiptapWorkflowComposer } from "./tiptap-workflow-composer.tsx";
 import { computerUseIllustrationImg } from "./platform-assets.ts";
@@ -247,7 +247,6 @@ interface ComposerConnectorReadState {
     readonly PlatformConnectorCatalogStatusItem[]
   >;
   readonly customConnectors: Loadable<readonly CustomConnectorResponse[]>;
-  readonly agent: Loadable<ZeroAgentResponse>;
   readonly authorization: Loadable<ComposerConnectorAuthorizationState>;
 }
 
@@ -7496,14 +7495,6 @@ function ComposerTemporaryModelNoticeSlot({
 // Main composer
 // ---------------------------------------------------------------------------
 
-function loadableDataOrNull<T>(loadable: Loadable<T>): T | null {
-  return loadable.state === "hasData" ? loadable.data : null;
-}
-
-function nullToUndefined<T>(value: T | null): T | undefined {
-  return value === null ? undefined : value;
-}
-
 function equalComposerConnectorAuthorizationState(
   left: ComposerConnectorAuthorizationState,
   right: ComposerConnectorAuthorizationState,
@@ -7521,7 +7512,6 @@ function useComposerConnectorReadState(
   return {
     catalogItems: useLastLoadable(allConnectorCatalogItems$),
     customConnectors: useLastLoadable(customConnectors$),
-    agent: useLoadable(signals.agent$),
     authorization: useLastLoadable(signals.connector.connectorAuthorization$, {
       equalityFn: equalComposerConnectorAuthorizationState,
     }),
@@ -7529,26 +7519,26 @@ function useComposerConnectorReadState(
 }
 
 function matchingAuthorizedConnectorSlugs(
-  agent: Loadable<ZeroAgentResponse>,
+  agentId: string,
   authorization: Loadable<ComposerConnectorAuthorizationState>,
 ): readonly ConnectorSlug[] | null {
-  if (agent.state !== "hasData" || authorization.state !== "hasData") {
+  if (authorization.state !== "hasData") {
     return null;
   }
-  if (authorization.data.agentId !== agent.data.agentId) {
+  if (authorization.data.agentId !== agentId) {
     return null;
   }
   return authorization.data.enabledConnectorSlugs;
 }
 
 function matchingAuthorizedCustomConnectorIds(
-  agent: Loadable<ZeroAgentResponse>,
+  agentId: string,
   authorization: Loadable<ComposerConnectorAuthorizationState>,
 ): readonly string[] | null {
-  if (agent.state !== "hasData" || authorization.state !== "hasData") {
+  if (authorization.state !== "hasData") {
     return null;
   }
-  if (authorization.data.agentId !== agent.data.agentId) {
+  if (authorization.data.agentId !== agentId) {
     return null;
   }
   return authorization.data.enabledCustomConnectorIds;
@@ -7694,6 +7684,7 @@ function ComposerAttachments({ signals }: { signals: ComposerSignals }) {
 function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   const { t } = useTranslation();
   const connectorReadState = useComposerConnectorReadState(signals);
+  const agents = useLastResolved(agents$) ?? [];
   const connectorUi = useGet(signals.connector.connectorUiState$);
   const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
   const storedComputerUseHostId = useGet(signals.computer.computerUseHostId$);
@@ -7738,7 +7729,6 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   // Connectors: connected (org-level) + authorized (agent-level) → available
   const connectorCatalogItemsLoadable = connectorReadState.catalogItems;
   const customConnectorsLoadable = connectorReadState.customConnectors;
-  const agentLoadable = connectorReadState.agent;
   const authorizationLoadable = connectorReadState.authorization;
   const pageSignal = useGet(pageSignal$);
   const selectedConnectorSlug = connectorUi.selectedConnectorSlug;
@@ -7757,16 +7747,18 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   const optimisticConnected = useGet(justConnectedSlugs$);
   const savingConnectorSlug = connectorUi.savingConnectorSlug;
   const savingCustomConnectorId = connectorUi.savingCustomConnectorId;
-  const agent = loadableDataOrNull(agentLoadable);
-  const agentRecordId = agent?.agentId ?? null;
-  const displayName = agent?.displayName ?? "";
+  const agentRecordId = signals.agentId;
+  const displayName =
+    agents.find((agent) => {
+      return agent.id === agentRecordId;
+    })?.displayName ?? "";
 
   const authorizedConnectors = matchingAuthorizedConnectorSlugs(
-    agentLoadable,
+    agentRecordId,
     authorizationLoadable,
   );
   const authorizedCustomConnectors = matchingAuthorizedCustomConnectorIds(
-    agentLoadable,
+    agentRecordId,
     authorizationLoadable,
   );
 
@@ -7876,7 +7868,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
           {
             connectorLabel: connector.label,
             connectorIcon: connector.icon,
-            agentId: nullToUndefined(agentRecordId),
+            agentId: agentRecordId,
           },
           pageSignal,
         );
@@ -7895,7 +7887,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
             authMethod,
             options: {
               connectorLabel: connector.label,
-              agentId: nullToUndefined(agentRecordId),
+              agentId: agentRecordId,
             },
           },
           pageSignal,
@@ -7958,7 +7950,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
       {selectedConnectorSlug && (
         <ConnectModal
           selectedConnectorSlug={selectedConnectorSlug}
-          agentId={nullToUndefined(agentRecordId)}
+          agentId={agentRecordId}
           onClose={() => {
             return updateConnectorUi({ selectedConnectorSlug: null });
           }}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -304,9 +304,10 @@ import {
   setImageLoadStatus$,
 } from "../../signals/view-component-state.ts";
 import {
-  currentLeftThread$,
-  currentRightThread$,
+  currentLeftPane$,
+  currentRightPane$,
 } from "../../signals/chat-page/chat-thread-panes.ts";
+import type { ChatThreadPaneState } from "../../signals/chat-page/chat-thread-pane-state.ts";
 import {
   focusChatThreadContainer$,
   setChatKeyboardScrollRoot$,
@@ -2627,12 +2628,42 @@ function ChatThread({
   );
 }
 
-function ChatThreadArea({
-  leftThread,
-  rightThread,
+function MissingChatThread({ threadId }: { threadId: string }) {
+  const { t } = useTranslation();
+  return (
+    <section
+      aria-label={t(($) => {
+        return $.chat.thread.ariaLabel;
+      })}
+      className="flex min-w-0 basis-0 flex-1 flex-col min-h-0 bg-transparent focus:outline-none"
+      data-chat-thread-container-id={threadId}
+      tabIndex={-1}
+    >
+      <ChatThreadNotFound />
+    </section>
+  );
+}
+
+function ChatThreadPane({
+  isMain,
+  pane,
 }: {
-  leftThread: ChatPanelSignals | null;
-  rightThread: ChatPanelSignals | null;
+  isMain?: boolean;
+  pane: Exclude<ChatThreadPaneState, null>;
+}) {
+  return pane.kind === "thread" ? (
+    <ChatThread isMain={isMain} thread={pane.thread} />
+  ) : (
+    <MissingChatThread threadId={pane.threadId} />
+  );
+}
+
+function ChatThreadArea({
+  leftPane,
+  rightPane,
+}: {
+  leftPane: ChatThreadPaneState;
+  rightPane: ChatThreadPaneState;
 }) {
   const setKeyboardScrollRoot = useSet(setChatKeyboardScrollRoot$);
 
@@ -2641,11 +2672,11 @@ function ChatThreadArea({
       ref={setKeyboardScrollRoot}
       className="flex w-full flex-1 min-w-0 min-h-0 bg-transparent"
     >
-      {leftThread && <ChatThread isMain thread={leftThread} />}
-      {rightThread && (
+      {leftPane && <ChatThreadPane isMain pane={leftPane} />}
+      {rightPane && (
         <>
           <div className="w-px shrink-0 bg-border/60" aria-hidden="true" />
-          <ChatThread thread={rightThread} />
+          <ChatThreadPane pane={rightPane} />
         </>
       )}
     </div>
@@ -2663,8 +2694,8 @@ function ThreadAutomationsSidebarSlot({
 
 export function ZeroChatThreadPage() {
   const activeThreadSidebar = useGet(activeThreadSidebar$);
-  const leftThread = useGet(currentLeftThread$);
-  const rightThread = useGet(currentRightThread$);
+  const leftPane = useGet(currentLeftPane$);
+  const rightPane = useGet(currentRightPane$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
   return (
     <>
@@ -2687,7 +2718,7 @@ export function ZeroChatThreadPage() {
           ) : null
         }
       >
-        <ChatThreadArea leftThread={leftThread} rightThread={rightThread} />
+        <ChatThreadArea leftPane={leftPane} rightPane={rightPane} />
       </ChatThreadSidebarShell>
       {lightboxUrl && <AttachmentLightbox />}
       <ChatConnectorActionConnectModal />
@@ -6515,7 +6546,7 @@ function AssistantErrorContent({
 
 function AssistantBubbleAvatar({ thread }: { thread: ChatPanelSignals }) {
   const { t } = useTranslation();
-  const agentId = useGet(thread.agentId$) ?? "";
+  const agentId = thread.agentId;
   return (
     <Link
       pathname="/agents/:agentId"


### PR DESCRIPTION
## Summary

- resolve local or remote thread metadata during chat page setup before constructing a pane
- require an immutable `agentId` when creating chat panels, composers, message actions, and connector signals
- represent confirmed missing threads as pane state without constructing a panel or composer
- keep connector rendering independent from per-panel agent detail requests during same-agent navigation

## Verification

- `pnpm exec prettier --check <changed files>`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx -t "keeps connector (display stable|access resolved)"`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx -t "shows chat thread not found after remote metadata sync confirms a miss"`
