### PR TITLE
refactor: rename internal workflow-event discriminators to automation-event

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -155,7 +155,7 @@ export type QueueFirstRunAssociation =
       readonly morningBriefDeliveryId?: string;
     }
   | {
-      readonly kind: "workflow_event";
+      readonly kind: "automation_event";
       readonly threadId: string;
       readonly eventId: string;
       readonly prompt: string;
@@ -395,7 +395,7 @@ async function resolveUserQueueFirstClaimSnapshot(
 
 async function resolveWorkflowQueueFirstClaimSnapshot(
   db: DbTransaction,
-  args: Extract<QueueFirstClaimArgs, { readonly kind: "workflow_event" }>,
+  args: Extract<QueueFirstClaimArgs, { readonly kind: "automation_event" }>,
 ): Promise<QueueFirstClaimSnapshot | null> {
   const [head] = await db
     .select({
@@ -531,7 +531,7 @@ async function resolveQueueFirstClaimSnapshot(
   if (args.kind === "user_message") {
     return await resolveUserQueueFirstClaimSnapshot(db, args);
   }
-  if (args.kind === "workflow_event") {
+  if (args.kind === "automation_event") {
     return await resolveWorkflowQueueFirstClaimSnapshot(db, args);
   }
   return await resolveGoalQueueFirstClaimSnapshot(db, args);

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -608,7 +608,7 @@ export const launchQueuedWorkflowAutomation$ = command(
         callbacks: runInput.callbacks,
         zeroRunMetadata: runInput.zeroRunMetadata,
         queueFirstAssociation: {
-          kind: "workflow_event",
+          kind: "automation_event",
           threadId: chatThreadId,
           eventId: args.queueEventId,
           prompt: runInput.prompt,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3685,7 +3685,7 @@ function createThreadPendingActionSignals(
       await set(messageActions.recallMessage$, eventId, signal);
     },
   );
-  const removeWorkflowEvent$ = command(
+  const removeAutomationEvent$ = command(
     async ({ set }, eventId: string, signal: AbortSignal): Promise<void> => {
       await set(messageActions.skipAutomationEvent$, eventId, signal);
     },
@@ -3700,7 +3700,7 @@ function createThreadPendingActionSignals(
   });
   return {
     removeQueuedMessage$,
-    removeWorkflowEvent$,
+    removeAutomationEvent$,
     cancelActiveGoal$,
     openActiveGoal$,
   };

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -159,7 +159,7 @@ function createAgentComposerSignalsWithDraft(
     cancelRun$: noOpAction$,
     cancellationRecoveryPending$: idle$,
     removeQueuedMessage$: noOpEventAction$,
-    removeWorkflowEvent$: noOpEventAction$,
+    removeAutomationEvent$: noOpEventAction$,
     cancelActiveGoal$: noOpAction$,
     openActiveGoal$: noOp$,
   });

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -189,7 +189,10 @@ interface ComposerQueueSignals {
   readonly pendingEvents$: Computed<Promise<readonly ComposerPendingEvent[]>>;
   readonly cancellationRecoveryPending$: Computed<Promise<boolean>>;
   readonly removeQueuedMessage$: Command<Promise<void>, [string, AbortSignal]>;
-  readonly removeWorkflowEvent$: Command<Promise<void>, [string, AbortSignal]>;
+  readonly removeAutomationEvent$: Command<
+    Promise<void>,
+    [string, AbortSignal]
+  >;
 }
 
 interface ComposerGoalSignals {
@@ -247,7 +250,7 @@ interface CreateComposerSignalsOptions {
   readonly cancelRun$: Command<Promise<void>, [AbortSignal]>;
   readonly cancellationRecoveryPending$: ComposerQueueSignals["cancellationRecoveryPending$"];
   readonly removeQueuedMessage$: ComposerQueueSignals["removeQueuedMessage$"];
-  readonly removeWorkflowEvent$: ComposerQueueSignals["removeWorkflowEvent$"];
+  readonly removeAutomationEvent$: ComposerQueueSignals["removeAutomationEvent$"];
   readonly cancelActiveGoal$: ComposerGoalSignals["cancelActiveGoal$"];
   readonly openActiveGoal$: ComposerGoalSignals["openActiveGoal$"];
 }
@@ -519,7 +522,7 @@ export function createComposerSignals(
         options.removeQueuedMessage$,
         workflowComposer,
       ),
-      removeWorkflowEvent$: options.removeWorkflowEvent$,
+      removeAutomationEvent$: options.removeAutomationEvent$,
     },
     goal: {
       activeGoalObjective$: eventSignals.activeGoalObjective$,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -441,7 +441,7 @@ function ComposerStripRow({
   removeAriaLabel,
   cancellationRecoveryPending,
 }: {
-  kind: "queued" | "workflow-event" | "goal";
+  kind: "queued" | "automation-event" | "goal";
   text: string;
   onRemove?: () => void;
   onOpenDetail?: () => void;
@@ -450,12 +450,12 @@ function ComposerStripRow({
 }) {
   const { t } = useTranslation();
   const isGoal = kind === "goal";
-  const isWorkflowEvent = kind === "workflow-event";
+  const isAutomationEvent = kind === "automation-event";
   const itemAriaLabel = isGoal
     ? t(($) => {
         return $.chat.queue.activeGoal;
       })
-    : isWorkflowEvent
+    : isAutomationEvent
       ? t(($) => {
           return $.chat.queue.pendingAutomationEvent;
         })
@@ -466,7 +466,7 @@ function ComposerStripRow({
     ? t(($) => {
         return $.chat.queue.aboutGoal;
       })
-    : isWorkflowEvent
+    : isAutomationEvent
       ? t(($) => {
           return $.chat.queue.aboutAutomationEvent;
         })
@@ -477,7 +477,7 @@ function ComposerStripRow({
     ? t(($) => {
         return $.chat.queue.goal;
       })
-    : isWorkflowEvent
+    : isAutomationEvent
       ? t(($) => {
           return $.chat.queue.automationEvent;
         })
@@ -493,7 +493,7 @@ function ComposerStripRow({
         ? t(($) => {
             return $.chat.queue.goalDescription;
           })
-        : isWorkflowEvent
+        : isAutomationEvent
           ? t(($) => {
               return $.chat.queue.automationEventDescription;
             })
@@ -533,7 +533,7 @@ function ComposerStripRow({
               >
                 {isGoal ? (
                   <Target size={16} aria-hidden="true" />
-                ) : isWorkflowEvent ? (
+                ) : isAutomationEvent ? (
                   <Bolt size={16} aria-hidden="true" />
                 ) : (
                   <ComposerQueueGlyph />
@@ -610,7 +610,7 @@ function PendingItemsStrip({ signals }: { signals: ComposerSignals }) {
     signals.goal.activeGoalObjective$,
   );
   const removeQueuedMessage = useSet(signals.queue.removeQueuedMessage$);
-  const removeWorkflowEvent = useSet(signals.queue.removeWorkflowEvent$);
+  const removeAutomationEvent = useSet(signals.queue.removeAutomationEvent$);
   const cancelActiveGoal = useSet(signals.goal.cancelActiveGoal$);
   const openActiveGoal = useSet(signals.goal.openActiveGoal$);
   const pageSignal = useGet(pageSignal$);
@@ -704,11 +704,11 @@ function PendingItemsStrip({ signals }: { signals: ComposerSignals }) {
           return (
             <ComposerStripRow
               key={event.id}
-              kind="workflow-event"
+              kind="automation-event"
               text={event.text}
               onRemove={() => {
                 detach(
-                  removeWorkflowEvent(event.id, pageSignal),
+                  removeAutomationEvent(event.id, pageSignal),
                   Reason.DomCallback,
                 );
               }}


### PR DESCRIPTION
## Summary

- rename the process-local queue-first association discriminator from `workflow_event` to `automation_event`
- rename the composer strip discriminator and removal command identifiers from workflow-event to automation-event
- leave persisted trigger sources, i18n source keys, contracts, database code, and file names unchanged

## Validation

- `git diff --check`
- `grep -rn '"workflow_event"' turbo` returns no matches
- `grep -rn 'removeWorkflowEvent\|isWorkflowEvent' turbo` returns no matches
- `grep -rn 'workflow-event' turbo/apps/platform/src` returns only `signals/zero-page/log-types.ts:74`, the explicitly out-of-scope persisted trigger-source branch
- no changes under `turbo/packages/api-contracts/`, `turbo/packages/db/`, `turbo/packages/core/`, or locale JSON files
- full local test suite not run; PR CI is the requested validation path

Closes #26019