### PR TITLE
test(vsock-test): make blocking controls path-length safe

### DIFF
--- a/crates/vsock-test/src/bin/guest-write-file-test-helper.rs
+++ b/crates/vsock-test/src/bin/guest-write-file-test-helper.rs
@@ -1,15 +1,17 @@
 use std::io;
-use std::os::unix::net::UnixListener;
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 const BLOCKING_PATH_SUFFIX: &str = ".vm0-vsock-test-block";
+const RELEASE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if let Some(path) = blocking_path(&args)
         && let Err(error) = wait_for_release(path)
     {
-        eprintln!("failed to prepare blocking write helper: {error}");
+        report_setup_failure(path, &error);
         std::process::exit(1);
     }
 
@@ -18,14 +20,59 @@ fn main() {
 }
 
 fn wait_for_release(path: &Path) -> io::Result<()> {
-    let listener = UnixListener::bind(path_with_suffix(path, ".release"))?;
-    std::fs::write(
-        path_with_suffix(path, ".pid"),
-        std::process::id().to_string(),
+    write_marker(
+        &path_with_suffix(path, ".pid"),
+        std::process::id().to_string().as_bytes(),
+        "write PID marker",
     )?;
-    std::fs::write(path_with_suffix(path, ".started"), b"")?;
-    let _ = listener.accept()?;
-    Ok(())
+    write_marker(
+        &path_with_suffix(path, ".started"),
+        b"",
+        "write started marker",
+    )?;
+
+    let release_path = path_with_suffix(path, ".release");
+    loop {
+        match std::fs::remove_file(&release_path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                thread::sleep(RELEASE_POLL_INTERVAL);
+            }
+            Err(error) => return Err(path_error("consume release marker", &release_path, error)),
+        }
+    }
+}
+
+fn write_marker(path: &Path, content: &[u8], action: &str) -> io::Result<()> {
+    std::fs::write(path, content).map_err(|error| path_error(action, path, error))
+}
+
+fn report_setup_failure(path: &Path, error: &io::Error) {
+    let message = format!("failed to prepare blocking write helper: {error}");
+    if let Err(report_error) = publish_failure(path, &message) {
+        eprintln!("{message}; failed to publish setup failure: {report_error}");
+    } else {
+        eprintln!("{message}");
+    }
+}
+
+fn publish_failure(path: &Path, message: &str) -> io::Result<()> {
+    let temporary_path = path_with_suffix(path, ".failed.tmp");
+    let failure_path = path_with_suffix(path, ".failed");
+    write_marker(
+        &temporary_path,
+        message.as_bytes(),
+        "write temporary failure marker",
+    )?;
+    std::fs::rename(&temporary_path, &failure_path)
+        .map_err(|error| path_error("publish failure marker", &failure_path, error))
+}
+
+fn path_error(action: &str, path: &Path, error: io::Error) -> io::Error {
+    io::Error::new(
+        error.kind(),
+        format!("{action} {}: {error}", path.display()),
+    )
 }
 
 fn blocking_path(args: &[String]) -> Option<&Path> {

--- a/crates/vsock-test/tests/integration/support.rs
+++ b/crates/vsock-test/tests/integration/support.rs
@@ -75,20 +75,24 @@ pub(crate) fn blocking_write_path(dir: &Path, name: &str) -> std::path::PathBuf 
     dir.join(format!("{name}{BLOCKING_WRITE_SUFFIX}"))
 }
 
-pub(crate) fn blocking_write_started_path(path: &Path) -> std::path::PathBuf {
+fn blocking_write_started_path(path: &Path) -> std::path::PathBuf {
     path_with_suffix(path, ".started")
 }
 
-pub(crate) fn blocking_write_release_path(path: &Path) -> std::path::PathBuf {
+fn blocking_write_release_path(path: &Path) -> std::path::PathBuf {
     path_with_suffix(path, ".release")
 }
 
 pub(crate) fn release_blocking_write(path: &Path) {
-    UnixStream::connect(blocking_write_release_path(path)).expect("release blocked write helper");
+    std::fs::write(blocking_write_release_path(path), b"").expect("release blocked write helper");
 }
 
 pub(crate) fn blocking_write_pid_path(path: &Path) -> std::path::PathBuf {
     path_with_suffix(path, ".pid")
+}
+
+fn blocking_write_failed_path(path: &Path) -> std::path::PathBuf {
+    path_with_suffix(path, ".failed")
 }
 
 pub(crate) fn pid_alive(pid: u32) -> bool {
@@ -154,6 +158,28 @@ pub(crate) async fn wait_for_path(path: &Path, timeout: Duration) {
     wait_for_path_result(path, timeout)
         .await
         .unwrap_or_else(|error| panic!("timed out waiting for path {path:?}: {error}"));
+}
+
+pub(crate) async fn wait_for_blocking_write(path: &Path, timeout: Duration) -> io::Result<()> {
+    let started_path = blocking_write_started_path(path);
+    let failed_path = blocking_write_failed_path(path);
+    tokio::time::timeout(timeout, async {
+        tokio::select! {
+            result = wait_for_path_event(&started_path) => result,
+            result = wait_for_path_event(&failed_path) => {
+                result?;
+                let message = tokio::fs::read_to_string(&failed_path).await?;
+                Err(io::Error::other(message))
+            }
+        }
+    })
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            "blocking write readiness timed out",
+        )
+    })?
 }
 
 pub(crate) async fn run_exec(

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -1,8 +1,8 @@
 use crate::support::{
-    Harness, blocking_write_path, blocking_write_pid_path, blocking_write_started_path,
-    captured_output_bytes, exec_exit_code, finish_raw_guest_connection, join_raw_guest_connection,
-    pid_alive, read_raw_message, release_blocking_write, run_exec, shell_quote,
-    start_raw_guest_connection, wait_for_path,
+    Harness, blocking_write_path, blocking_write_pid_path, captured_output_bytes, exec_exit_code,
+    finish_raw_guest_connection, join_raw_guest_connection, pid_alive, read_raw_message,
+    release_blocking_write, run_exec, shell_quote, start_raw_guest_connection,
+    wait_for_blocking_write,
 };
 use std::fs;
 use std::io::{Read, Write};
@@ -35,11 +35,9 @@ async fn blocked_write_keeps_ping_responsive_and_rejects_overlap() {
     stream
         .write_all(&vsock_proto::encode(MSG_WRITE_FILE, 10, &payload).expect("frame blocked write"))
         .expect("send blocked write");
-    wait_for_path(
-        &blocking_write_started_path(&blocked_path),
-        Duration::from_secs(5),
-    )
-    .await;
+    wait_for_blocking_write(&blocked_path, Duration::from_secs(5))
+        .await
+        .expect("blocked write helper should start");
 
     stream
         .write_all(&vsock_proto::encode(MSG_PING, 11, &[]).expect("encode ping"))
@@ -107,6 +105,34 @@ async fn blocked_write_keeps_ping_responsive_and_rejects_overlap() {
 }
 
 #[tokio::test]
+async fn blocked_write_reports_helper_setup_failure() {
+    let h = Harness::new().await;
+    let blocked_path = blocking_write_path(&h.dir, "setup-failure");
+    let blocked_path_string = blocked_path.to_string_lossy().to_string();
+    fs::create_dir(blocking_write_pid_path(&blocked_path))
+        .expect("create conflicting PID marker directory");
+
+    let write = h.host().write_file(&blocked_path_string, b"content", false);
+    let readiness = wait_for_blocking_write(&blocked_path, Duration::from_secs(2));
+    let (write_result, readiness_result) = tokio::join!(write, readiness);
+
+    let readiness_error = readiness_result.expect_err("helper setup should fail");
+    assert!(
+        readiness_error.to_string().contains("write PID marker"),
+        "unexpected readiness error: {readiness_error}"
+    );
+    let write_error = write_result.expect_err("blocked write should report helper failure");
+    assert!(
+        write_error
+            .to_string()
+            .contains("failed to prepare blocking write helper: write PID marker"),
+        "unexpected write error: {write_error}"
+    );
+
+    h.finish();
+}
+
+#[tokio::test]
 async fn blocked_write_allows_exec_cancel_and_quiesce() {
     let h = Harness::new().await;
     let handle = h
@@ -134,11 +160,9 @@ async fn blocked_write_allows_exec_cancel_and_quiesce() {
         .host()
         .write_file(&blocked_path_string, b"control content", false);
     let control = async {
-        wait_for_path(
-            &blocking_write_started_path(&blocked_path),
-            Duration::from_secs(5),
-        )
-        .await;
+        wait_for_blocking_write(&blocked_path, Duration::from_secs(5))
+            .await
+            .expect("blocked write helper should start");
         tokio::time::timeout(
             Duration::from_secs(2),
             h.host().quiesce_operations(Duration::from_secs(1)),
@@ -186,8 +210,9 @@ async fn shutdown_cancels_blocked_write_helper_before_connection_exit() {
                 .expect("frame shutdown blocked write"),
         )
         .expect("send shutdown blocked write");
-    let started_path = blocking_write_started_path(&blocked_path);
-    wait_for_path(&started_path, Duration::from_secs(5)).await;
+    wait_for_blocking_write(&blocked_path, Duration::from_secs(5))
+        .await
+        .expect("blocked write helper should start");
     let pid: u32 = fs::read_to_string(blocking_write_pid_path(&blocked_path))
         .expect("read shutdown helper pid")
         .parse()
@@ -242,11 +267,9 @@ async fn disconnect_cancels_blocked_write_helper_before_connection_exit() {
                 .expect("frame disconnect blocked write"),
         )
         .expect("send disconnect blocked write");
-    wait_for_path(
-        &blocking_write_started_path(&blocked_path),
-        Duration::from_secs(5),
-    )
-    .await;
+    wait_for_blocking_write(&blocked_path, Duration::from_secs(5))
+        .await
+        .expect("blocked write helper should start");
     let pid: u32 = fs::read_to_string(blocking_write_pid_path(&blocked_path))
         .expect("read disconnect helper pid")
         .parse()

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -20,9 +20,11 @@ fn shell_quote_escapes_single_quotes() {
 }
 
 #[tokio::test]
-async fn blocked_write_keeps_ping_responsive_and_rejects_overlap() {
+async fn long_path_blocked_write_keeps_ping_responsive_and_rejects_overlap() {
     let dir = tempfile::tempdir().expect("create blocked-write temp dir");
-    let blocked_path = blocking_write_path(dir.path(), "blocked");
+    let long_dir = dir.path().join("x".repeat(96));
+    fs::create_dir(&long_dir).expect("create long blocked-write directory");
+    let blocked_path = blocking_write_path(&long_dir, "blocked");
     let blocked_path_string = blocked_path.to_string_lossy();
     let blocked_content = b"blocked content";
     let overlap_path = dir.path().join("overlap.txt");


### PR DESCRIPTION
## Summary

- replace the blocking-write test helper's release Unix socket with a per-test filesystem marker, preserving configured `TMPDIR` isolation without the shorter socket pathname limit
- atomically publish helper setup failures and make every blocking scenario wait for either readiness or the underlying diagnostic
- add integration coverage for prompt setup-failure reporting and make an existing raw-protocol scenario always exercise a target path beyond the Unix socket limit

## Scope

This changes only the private `vsock-test` helper and integration harness. Production guest file writes, host/guest protocols, runner behavior, dependencies, and persisted state are unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-test --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-test --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test`
- exact long-`TMPDIR` reproduction from #25984
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test --test integration write_file::blocked_write_reports_helper_setup_failure -- --exact --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-test --test integration write_file::long_path_blocked_write_keeps_ping_responsive_and_rejects_overlap -- --exact --nocapture`
- repository pre-commit hook (workspace Rust formatting, Clippy, documentation, and file-size checks)

Closes #25984
