### PR TITLE
feat(runs): accept unattended trigger sources

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -387,7 +387,13 @@ describe("video Artifact previews", () => {
 });
 
 describe("artifact upload provenance", () => {
-  it.each(["workflow-schedule", "workflow-event"] as const)(
+  it.each([
+    "workflow-schedule",
+    "workflow-event",
+    "automation-schedule",
+    "automation-event",
+    "goal",
+  ] as const)(
     "attributes run uploads to the %s source",
     async (triggerSource) => {
       const owner = await artifactActor(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -303,6 +303,79 @@ describe("RUN-03/RUN-04: direct run list, detail, and queue reads", () => {
     );
   });
 
+  it("reads legacy and expanded unattended trigger sources from queue and logs", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-trigger-sources");
+    if (!actor.orgId) {
+      throw new Error("Trigger source reads require an org-scoped actor");
+    }
+
+    const triggerSources = [
+      "workflow-schedule",
+      "workflow-event",
+      "automation-schedule",
+      "automation-event",
+      "goal",
+    ] as const;
+    const sourceRuns = [];
+    for (const triggerSource of triggerSources) {
+      const run = await store.set(
+        seedRun$,
+        {
+          orgId: actor.orgId,
+          userId: actor.userId,
+          composeId: compose.composeId,
+          prompt: `${triggerSource} read compatibility`,
+          status: "queued",
+          triggerSource,
+        },
+        context.signal,
+      );
+      sourceRuns.push({ runId: run.runId, triggerSource });
+    }
+
+    const queue = await api.readRunQueue(actor);
+    for (const sourceRun of sourceRuns) {
+      expect(queue.body.queue).toContainEqual(
+        expect.objectContaining(sourceRun),
+      );
+    }
+
+    for (const run of sourceRuns) {
+      await api.requestCancelRun(actor, run.runId, [200]);
+    }
+
+    const listed = await reads.requestListLogs(actor, {}, [200]);
+    mustOk(listed, "the trigger source logs list");
+    expect(listed.body.filters.sources).toStrictEqual(
+      expect.arrayContaining([...triggerSources]),
+    );
+
+    for (const sourceRun of sourceRuns) {
+      const detail = await reads.requestReadLogById(
+        actor,
+        sourceRun.runId,
+        [200],
+      );
+      expect(detail.body).toMatchObject({
+        id: sourceRun.runId,
+        triggerSource: sourceRun.triggerSource,
+      });
+
+      const filtered = await reads.requestListLogs(
+        actor,
+        { triggerSource: sourceRun.triggerSource },
+        [200],
+      );
+      mustOk(filtered, `${sourceRun.triggerSource} logs filter`);
+      expect(
+        filtered.body.data.map((entry) => {
+          return entry.id;
+        }),
+      ).toContain(sourceRun.runId);
+    }
+  });
+
   it("lists, reads, and queues direct runs with status, agent, and window filters", async () => {
     const actor = await entitledActor();
     const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { zeroBankingContract } from "@vm0/api-contracts/contracts/zero-banking";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
@@ -22,6 +23,14 @@ import {
 import { zeroBankingRoutes } from "../zero-banking";
 
 const context = testContext();
+
+const UNATTENDED_TRIGGER_SOURCES = [
+  "workflow-schedule",
+  "workflow-event",
+  "automation-schedule",
+  "automation-event",
+  "goal",
+] as const satisfies readonly TriggerSource[];
 
 const FINICITY_BASE_URL = "https://api.finicity.com";
 const FINICITY_AUTH_URL = `${FINICITY_BASE_URL}/aggregation/v2/partners/authentication`;
@@ -48,7 +57,7 @@ interface BankingFixture {
 }
 
 interface SeedBankingFixtureArgs {
-  readonly triggerSource?: "workflow-schedule" | "workflow-event";
+  readonly triggerSource?: (typeof UNATTENDED_TRIGGER_SOURCES)[number];
   readonly operationScopes?: readonly BankingOperationScope[];
   readonly allowAutomationRuns?: boolean;
   readonly connectionStatus?: BankingConnectionStatus;
@@ -422,7 +431,7 @@ describe("POST /api/zero/banking/*", () => {
     expect(authRequestCount).toBe(0);
   });
 
-  it.each(["workflow-schedule", "workflow-event"] as const)(
+  it.each(UNATTENDED_TRIGGER_SOURCES)(
     "denies %s runs unless the banking grant allows automations",
     async (triggerSource) => {
       const fixture = await seedBankingFixture({ triggerSource });
@@ -459,7 +468,7 @@ describe("POST /api/zero/banking/*", () => {
     },
   );
 
-  it.each(["workflow-schedule", "workflow-event"] as const)(
+  it.each(UNATTENDED_TRIGGER_SOURCES)(
     "allows %s runs when the banking grant allows automations",
     async (triggerSource) => {
       const fixture = await seedBankingFixture({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -367,7 +367,7 @@ describe("GET /api/zero/usage/insight", () => {
     expect(totalByBucket["chat"]).toBeGreaterThanOrEqual(50);
     expect(totalByBucket["slack"]).toBeGreaterThanOrEqual(50);
     expect(totalByBucket["email"]).toBeGreaterThanOrEqual(50);
-    expect(totalByBucket["automation"]).toBeGreaterThanOrEqual(100);
+    expect(totalByBucket["automation"]).toBeGreaterThanOrEqual(250);
     expect(totalByBucket["others"]).toBeGreaterThanOrEqual(250);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -541,7 +541,7 @@ describe("GET /api/zero/usage/record", () => {
     ]);
   });
 
-  it("normalizes current Workflow Automation sources without changing credits", async () => {
+  it("normalizes unattended sources without changing credits", async () => {
     const fixture = await entitledRecordActor();
     const connectorProvider = uniqueProvider("bdd-connector");
     await seedConnectorPricing(connectorProvider);
@@ -549,6 +549,9 @@ describe("GET /api/zero/usage/record", () => {
     const sources = [
       ["workflow-schedule", 2],
       ["workflow-event", 3],
+      ["automation-schedule", 4],
+      ["automation-event", 5],
+      ["goal", 6],
     ] as const;
     for (const [triggerSource, quantity] of sources) {
       const run = await createUnthreadedRun(fixture.actor, {
@@ -575,12 +578,12 @@ describe("GET /api/zero/usage/record", () => {
     );
 
     expect(response.body.rows).toHaveLength(1);
-    expect(response.body.totalCredits).toBe(50);
+    expect(response.body.totalCredits).toBe(200);
     expect(response.body.rows[0]).toMatchObject({
       source: "automation",
       threadId: null,
       runId: null,
-      credits: 50,
+      credits: 200,
       tokens: 0,
     });
   });

--- a/turbo/apps/api/src/signals/services/zero-banking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-banking.service.ts
@@ -122,9 +122,13 @@ function serviceUnavailable(message: string, code = "NOT_CONFIGURED") {
   return errorResponse(503, code, message);
 }
 
-function isAutomationTriggerSource(triggerSource: string | null): boolean {
+function isUnattendedTriggerSource(triggerSource: string | null): boolean {
   return (
-    triggerSource === "workflow-schedule" || triggerSource === "workflow-event"
+    triggerSource === "workflow-schedule" ||
+    triggerSource === "workflow-event" ||
+    triggerSource === "automation-schedule" ||
+    triggerSource === "automation-event" ||
+    triggerSource === "goal"
   );
 }
 
@@ -539,7 +543,7 @@ async function authorizeBankingAccess(
   }
 
   if (
-    isAutomationTriggerSource(run.triggerSource) &&
+    isUnattendedTriggerSource(run.triggerSource) &&
     !grant.allowAutomationRuns
   ) {
     // Historical audit rows persist the former "SCHEDULE_NOT_ALLOWED" code;

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -370,6 +370,9 @@ function sourceBucketExpr() {
     WHEN ${inArray(zeroRuns.triggerSource, [
       "workflow-schedule",
       "workflow-event",
+      "automation-schedule",
+      "automation-event",
+      "goal",
     ])} THEN 'automation'
     ELSE 'others'
   END`.mapWith(pgTextDecoder);

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -118,7 +118,13 @@ function sourceExpr() {
       WHEN ${eq(zeroRuns.triggerSource, sql`'web'`)} THEN 'chat'
       WHEN ${inArray(
         zeroRuns.triggerSource,
-        sql`('workflow-schedule', 'workflow-event')`,
+        sql`(
+          'workflow-schedule',
+          'workflow-event',
+          'automation-schedule',
+          'automation-event',
+          'goal'
+        )`,
       )} THEN 'automation'
       WHEN ${inArray(
         zeroRuns.triggerSource,

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -325,17 +325,18 @@
     "sources": {
       "agent": "Agent",
       "agentphone": "AgentPhone",
+      "automationEvent": "Automatisierungsereignis",
+      "automationSchedule": "Automatisierungszeitplan",
       "email": "E-Mail",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "Ziel",
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
       "test": "Test",
       "web": "Web",
-      "webhook": "Webhook",
-      "workflowEvent": "Workflow-Ereignis",
-      "workflowSchedule": "Workflowplan"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "Abgesagt",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -325,17 +325,18 @@
     "sources": {
       "agent": "Agent",
       "agentphone": "AgentPhone",
+      "automationEvent": "Automation event",
+      "automationSchedule": "Automation schedule",
       "email": "Email",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "Goal",
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
       "test": "Test",
       "web": "Web",
-      "webhook": "Webhook",
-      "workflowEvent": "Workflow event",
-      "workflowSchedule": "Workflow schedule"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "Cancelled",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -339,17 +339,18 @@
     "sources": {
       "agent": "Agente",
       "agentphone": "AgentPhone",
+      "automationEvent": "Evento de automatización",
+      "automationSchedule": "Programación de automatización",
       "email": "Correo electrónico",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "Objetivo",
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
       "test": "Prueba",
       "web": "Web",
-      "webhook": "Webhook",
-      "workflowEvent": "Evento de flujo de trabajo",
-      "workflowSchedule": "Calendario de flujo de trabajo"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "Cancelado",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -339,17 +339,18 @@
     "sources": {
       "agent": "Agent",
       "agentphone": "AgentPhone",
+      "automationEvent": "Événement d'automatisation",
+      "automationSchedule": "Planification d'automatisation",
       "email": "Email",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "Objectif",
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
       "test": "Test",
       "web": "Web",
-      "webhook": "Webhook",
-      "workflowEvent": "Événement de workflow",
-      "workflowSchedule": "Planification de workflow"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "Annulé",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -325,17 +325,18 @@
     "sources": {
       "agent": "एजेंट",
       "agentphone": "AgentPhone",
+      "automationEvent": "ऑटोमेशन घटना",
+      "automationSchedule": "ऑटोमेशन शेड्यूल",
       "email": "ईमेल",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "लक्ष्य",
       "slack": "Slack",
       "teams": "टीमें",
       "telegram": "Telegram",
       "test": "टेस्ट",
       "web": "वेब",
-      "webhook": "वेबहुक",
-      "workflowEvent": "वर्कफ़्लो घटना",
-      "workflowSchedule": "वर्कफ़्लो शेड्यूल"
+      "webhook": "वेबहुक"
     },
     "statuses": {
       "cancelled": "रद्द कर दिया गया",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -325,17 +325,18 @@
     "sources": {
       "agent": "Agen",
       "agentphone": "AgentPhone",
+      "automationEvent": "Peristiwa otomatisasi",
+      "automationSchedule": "Jadwal otomatisasi",
       "email": "Email",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "Tujuan",
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
       "test": "Tes",
       "web": "Web",
-      "webhook": "Webhook",
-      "workflowEvent": "Peristiwa alur kerja",
-      "workflowSchedule": "Jadwal alur kerja"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "Dibatalkan",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -339,17 +339,18 @@
     "sources": {
       "agent": "Agente",
       "agentphone": "AgentPhone",
+      "automationEvent": "Evento di automazione",
+      "automationSchedule": "Pianificazione dell'automazione",
       "email": "E-mail",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "Obiettivo",
       "slack": "Slack",
       "teams": "Microsoft Teams",
       "telegram": "Telegram",
       "test": "Test",
       "web": "Rete",
-      "webhook": "Webhook",
-      "workflowEvent": "Evento del flusso di lavoro",
-      "workflowSchedule": "Pianificazione del flusso di lavoro"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "Annullato",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -325,17 +325,18 @@
     "sources": {
       "agent": "エージェント",
       "agentphone": "エージェントフォン",
+      "automationEvent": "オートメーションイベント",
+      "automationSchedule": "オートメーションスケジュール",
       "email": "メール",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "目標",
       "slack": "Slack",
       "teams": "チーム",
       "telegram": "Telegram",
       "test": "テスト",
       "web": "ウェブ",
-      "webhook": "Webhook",
-      "workflowEvent": "ワークフローイベント",
-      "workflowSchedule": "ワークフロースケジュール"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "キャンセルされました",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -325,17 +325,18 @@
     "sources": {
       "agent": "에이전트",
       "agentphone": "AgentPhone",
+      "automationEvent": "자동화 이벤트",
+      "automationSchedule": "자동화 일정",
       "email": "이메일",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "목표",
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
       "test": "테스트",
       "web": "웹",
-      "webhook": "Webhook",
-      "workflowEvent": "워크플로 이벤트",
-      "workflowSchedule": "워크플로 일정"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "취소됨",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -339,17 +339,18 @@
     "sources": {
       "agent": "Agente",
       "agentphone": "AgentPhone",
+      "automationEvent": "Evento de automação",
+      "automationSchedule": "Agendamento de automação",
       "email": "E-mail",
       "feishu": "Feishu",
       "github": "GitHub",
+      "goal": "Objetivo",
       "slack": "Slack",
       "teams": "Teams",
       "telegram": "Telegram",
       "test": "Teste",
       "web": "Web",
-      "webhook": "Webhook",
-      "workflowEvent": "Evento de fluxo de trabalho",
-      "workflowSchedule": "Agendamento de fluxo de trabalho"
+      "webhook": "Webhook"
     },
     "statuses": {
       "cancelled": "Cancelado",

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -66,14 +66,21 @@ export function getTriggerSourceLabel(source: TriggerSource): string {
         return $.activity.sources.webhook;
       });
     }
-    case "workflow-schedule": {
+    case "workflow-schedule":
+    case "automation-schedule": {
       return i18n.t(($) => {
-        return $.activity.sources.workflowSchedule;
+        return $.activity.sources.automationSchedule;
       });
     }
-    case "workflow-event": {
+    case "workflow-event":
+    case "automation-event": {
       return i18n.t(($) => {
-        return $.activity.sources.workflowEvent;
+        return $.activity.sources.automationEvent;
+      });
+    }
+    case "goal": {
+      return i18n.t(($) => {
+        return $.activity.sources.goal;
       });
     }
   }

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-inspect-page.test.tsx
@@ -555,6 +555,17 @@ describe("activity inspect page", () => {
   it.each([
     { triggerSource: "teams", sourceLabel: "Teams" },
     { triggerSource: "feishu", sourceLabel: "Feishu" },
+    { triggerSource: "workflow-event", sourceLabel: "Automation event" },
+    { triggerSource: "automation-event", sourceLabel: "Automation event" },
+    {
+      triggerSource: "workflow-schedule",
+      sourceLabel: "Automation schedule",
+    },
+    {
+      triggerSource: "automation-schedule",
+      sourceLabel: "Automation schedule",
+    },
+    { triggerSource: "goal", sourceLabel: "Goal" },
   ] as const)(
     "preserves the $triggerSource source from an exported log",
     async ({ triggerSource, sourceLabel }) => {

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -57,6 +57,9 @@ export const triggerSourceSchema = z.enum([
   "webhook",
   "workflow-schedule",
   "workflow-event",
+  "automation-schedule",
+  "automation-event",
+  "goal",
 ]);
 
 export type TriggerSource = z.infer<typeof triggerSourceSchema>;

--- a/turbo/packages/core/src/usage-source-bucket.ts
+++ b/turbo/packages/core/src/usage-source-bucket.ts
@@ -23,6 +23,9 @@ export function triggerSourceToBucket(
       return "email";
     case "workflow-schedule":
     case "workflow-event":
+    case "automation-schedule":
+    case "automation-event":
+    case "goal":
       return "automation";
     default:
       // telegram, github, cli, agent, phone, agentphone, null

--- a/turbo/packages/db/src/schema/run-uploaded-file.ts
+++ b/turbo/packages/db/src/schema/run-uploaded-file.ts
@@ -24,6 +24,9 @@ import type {
 export const RUN_UPLOADED_FILE_SOURCES = [
   "workflow-schedule",
   "workflow-event",
+  "automation-schedule",
+  "automation-event",
+  "goal",
   "web",
   "slack",
   "teams",


### PR DESCRIPTION
## Summary

- accept `automation-event`, `automation-schedule`, and `goal` across every `trigger_source` reader while retaining both legacy spellings
- keep all five unattended sources in the existing `automation` usage bucket and banking gate, including `goal` with the unchanged `AUTOMATION_NOT_ALLOWED` denial code
- map legacy and new spellings to the renamed activity labels across all 10 locales
- cover queue/log list/detail/filter reads, usage aggregation, banking authorization, and uploaded-file provenance at integration boundaries

## Compatibility

This is the expand-only reader release. It does not change any trigger-source writer, remove legacy enum values, add a migration, or change `usageRecordSourceSchema`.

## Validation

- targeted API Vitest selection: 18 passed across 5 files
- type checks: `api`, `@vm0/app`, `@vm0/api-contracts`, `@vm0/core`, and `@vm0/db`
- lint: `@vm0/app`, `@vm0/api-contracts`, `@vm0/core`, `@vm0/db`, plus ordinary/type-aware oxlint and ESLint on every changed API file
- formatting and i18n extraction/status checks
- Non-goals diff audit for writers, migrations, Stripe workflow events, and GitHub Actions workflow vocabulary

Closes #26018