### PR TITLE
test(e2e): await mocked chat thread readiness

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -55,6 +55,32 @@ async function waitForAgentDraftClear(
   await draftCleared;
 }
 
+function isInitialChatThreadEventsResponse(
+  response: Response,
+  threadId: string,
+): boolean {
+  const request = response.request();
+  const url = new URL(response.url());
+  return (
+    response.ok() &&
+    request.method() === "GET" &&
+    url.pathname === `/api/zero/chat-threads/${threadId}/events` &&
+    !url.searchParams.has("sinceSeqId") &&
+    !url.searchParams.has("beforeSeqId")
+  );
+}
+
+async function navigateToMockChatThread(
+  page: Page,
+  threadId: string,
+): Promise<void> {
+  const initialEventsLoaded = page.waitForResponse((response) => {
+    return isInitialChatThreadEventsResponse(response, threadId);
+  });
+  await page.goto(new URL(`/chats/${threadId}`, appUrl).href);
+  await initialEventsLoaded;
+}
+
 async function clearComposerEditor(editor: Locator): Promise<void> {
   await editor.press("ControlOrMeta+A");
   await editor.press("Backspace");
@@ -608,7 +634,7 @@ test("model change labels follow the divider at the right edge", async ({
     throw new Error("Could not resolve the active agent from the chat URL");
   }
   await mockModelChangeThread(page, agentId);
-  await page.goto(new URL(`/chats/${modelChangeThreadId}`, appUrl).href);
+  await navigateToMockChatThread(page, modelChangeThreadId);
 
   await expectRightAlignedDivider(
     page.getByText("Model changed to Claude Sonnet 4.6", { exact: true }),
@@ -638,9 +664,7 @@ test.describe("mobile follow-up card rail", () => {
       throw new Error("Could not resolve the active agent from the chat URL");
     }
     await mockResponsiveFollowupThread(page, agentId);
-    await page.goto(
-      new URL(`/chats/${responsiveFollowupThreadId}`, appUrl).href,
-    );
+    await navigateToMockChatThread(page, responsiveFollowupThreadId);
 
     const rail = page.getByRole("group", { name: "Keep going" });
     const cards = responsiveFollowupPrompts.map((prompt) => {
@@ -750,7 +774,7 @@ test("keeps the flat follow-up list in a narrow desktop window", async ({
     throw new Error("Could not resolve the active agent from the chat URL");
   }
   await mockResponsiveFollowupThread(page, agentId);
-  await page.goto(new URL(`/chats/${responsiveFollowupThreadId}`, appUrl).href);
+  await navigateToMockChatThread(page, responsiveFollowupThreadId);
 
   const list = page.getByRole("group", { name: "Keep going" });
   const rows = responsiveFollowupPrompts.map((prompt) => {


### PR DESCRIPTION
## Summary

- wait for the initial successful synthetic-thread events response before starting UI assertions
- distinguish fixture-carrying initial requests from empty incremental and pagination requests
- apply the same readiness contract to all current `mockChatThread()` navigation scenarios

## Why

The affected follow-up layout tests could begin their 5-second locator assertions while a full-page chat navigation was still restoring application state. Failure artifacts showed only the bootstrap skeleton, and an identical-head rerun passed. Waiting for the mocked response that carries the test events separates application/data readiness from the existing rendering and layout assertions.

## Scope

This is test-only. It does not change product code, fixture payloads, retries, sleeps, skipped coverage, or timeout configuration. Existing content, geometry, scrolling, responsive behavior, and focus assertions remain intact.

## Validation

- `cd turbo && pnpm exec prettier --check ../e2e/playwright/tests/chat.spec.ts`
- `cd e2e && pnpm check-types`
- `cd e2e && VM0_API_BACKEND_URL=https://api.example.com pnpm exec playwright test --config playwright/playwright.config.ts tests/chat.spec.ts --project=features --list`
- `git diff --check`

Closes #26033
