### PR TITLE
test(connectors): cover feishu installation disconnect cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1791,15 +1791,30 @@ describe("Feishu integration", () => {
         customConnectorId: managedConnector.id,
       }),
     ).resolves.toMatchObject({ connector: null });
+    const disconnectedConnectorList = await accept(
+      customConnectorClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(disconnectedConnectorList.body.connectors).toMatchObject([
+      {
+        id: managedConnector.id,
+        connected: false,
+      },
+    ]);
     const disconnectedMemberStatus = await accept(
       client.getStatus({
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
     );
-    expect(
-      disconnectedMemberStatus.body.installations?.[0]?.isConnected,
-    ).toBeFalsy();
+    expect(disconnectedMemberStatus.body.installations).toMatchObject([
+      {
+        id: installationId,
+        isConnected: false,
+      },
+    ]);
 
     mocks.clerk.session(admin.userId, admin.orgId, admin.orgRole);
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -1774,6 +1774,33 @@ describe("Feishu integration", () => {
     });
     expect(welcome?.msgType).toBe("interactive");
 
+    await accept(
+      client.disconnectInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId },
+      }),
+      [200],
+    );
+    await expect(
+      readCustomConnectorCredentialStorageParent(context, {
+        orgId: requireValue(
+          member.orgId,
+          "Expected Feishu member to have an organization",
+        ),
+        userId: member.userId,
+        customConnectorId: managedConnector.id,
+      }),
+    ).resolves.toMatchObject({ connector: null });
+    const disconnectedMemberStatus = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(
+      disconnectedMemberStatus.body.installations?.[0]?.isConnected,
+    ).toBeFalsy();
+
     mocks.clerk.session(admin.userId, admin.orgId, admin.orgRole);
     await accept(
       client.removeInstallation({


### PR DESCRIPTION
## Summary

- exercise the Feishu installation-scoped disconnect HTTP route in the existing integration lifecycle
- verify disconnect removes the member's shared Custom connector credential parent while preserving the organization-owned Custom connector definition
- verify the same installation remains present and explicitly reports the member as disconnected

## Context

Follow-up to #25959 and #26020. The implementation was merged before self-review identified that this public disconnect entry point lacked regression coverage.

## Testing

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts`
- pre-commit checks: Prettier, Knip, repository TypeScript checks, and file-size validation
