### PR TITLE
docs(rust): document pi standby current-run takeover gate

### DIFF
--- a/crates/guest-agent/src/pi_standby.rs
+++ b/crates/guest-agent/src/pi_standby.rs
@@ -29,10 +29,13 @@
 //!    canonical transcript page with its authenticated HTTP client. A runner
 //!    `pi-handoff` only accelerates the next read; an API-driven
 //!    `pi-standby-release` retires an unused standby.
-//! 3. When the latest persisted message is an assistant tool-use batch, the
-//!    child takes over without waiting for runner control and ignores later
-//!    controls. If no tool-use batch is persisted before the standby TTL, the
-//!    child fails and guest-agent completes the run with an error.
+//! 3. When the latest persisted message belongs to the current run and is an
+//!    assistant tool-use batch, the child takes over without waiting for runner
+//!    control and ignores later controls. When the latest message belongs to a
+//!    previous run, it does not trigger takeover even if it is a tool-use batch,
+//!    so the child keeps polling. If no qualifying message is persisted before
+//!    the standby TTL, the child fails and guest-agent completes the run with an
+//!    error.
 //! 4. The child sends each completed native message as a `pi-message` with an
 //!    intended sequence and `<run-id>/<sequence>` message id. Guest-agent
 //!    validates the event identity, writes it through the API, requires


### PR DESCRIPTION
## Summary

- clarify that Pi standby takeover requires the latest persisted message to belong to the current run
- document that a previous-run tool-use batch leaves the standby child polling

## Scope

- documentation-only change in the public Rust Pi standby lifecycle contract
- no runtime logic, test code, API, JSONL protocol, schema, persistence, migration, feature switch, or rollout change
- retain the existing TypeScript previous-run regression test as the executable behavior specification

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-features`
- repository pre-commit hooks: workspace cargo fmt, cargo doc, cargo clippy, file-size check, and commitlint

Closes #26031
