### PR TITLE
test(runner): make reload coalescing test lock-sensitive

### DIFF
--- a/crates/runner/src/cmd/service/reload.rs
+++ b/crates/runner/src/cmd/service/reload.rs
@@ -185,17 +185,27 @@ pub(super) async fn coordinate_systemd_reload_bounded(
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future as _;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use super::*;
 
     #[derive(Clone)]
+    struct OperationGate {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[derive(Clone)]
     struct FakeSystemdReloadOps {
         dirty: Arc<AtomicBool>,
         drain_override_loaded: bool,
         query_error: bool,
+        read_count: Arc<AtomicUsize>,
+        read_gate: Option<OperationGate>,
         reload_count: Arc<AtomicUsize>,
+        reload_gate: Option<OperationGate>,
     }
 
     impl SystemdReloadOps for FakeSystemdReloadOps {
@@ -203,29 +213,50 @@ mod tests {
             &'a mut self,
             unit: &'a RunnerServiceUnit,
         ) -> ServiceFuture<'a, SystemdReloadState> {
-            Box::pin(std::future::ready(if self.query_error {
-                Err(RunnerError::Internal("query failed".to_string()))
-            } else {
-                Ok(SystemdReloadState::for_test(
-                    false,
-                    self.dirty.load(Ordering::SeqCst),
-                    if self.drain_override_loaded {
-                        vec![
-                            drain_restart_override_path(unit)
-                                .to_string_lossy()
-                                .into_owned(),
-                        ]
-                    } else {
-                        Vec::new()
-                    },
-                ))
-            }))
+            let dirty = Arc::clone(&self.dirty);
+            let drain_override_loaded = self.drain_override_loaded;
+            let query_error = self.query_error;
+            let read_count = Arc::clone(&self.read_count);
+            let read_gate = self.read_gate.clone();
+            Box::pin(async move {
+                if let Some(gate) = read_gate {
+                    gate.entered.notify_one();
+                    gate.release.notified().await;
+                }
+                read_count.fetch_add(1, Ordering::SeqCst);
+                if query_error {
+                    Err(RunnerError::Internal("query failed".to_string()))
+                } else {
+                    Ok(SystemdReloadState::for_test(
+                        false,
+                        dirty.load(Ordering::SeqCst),
+                        if drain_override_loaded {
+                            vec![
+                                drain_restart_override_path(unit)
+                                    .to_string_lossy()
+                                    .into_owned(),
+                            ]
+                        } else {
+                            Vec::new()
+                        },
+                    ))
+                }
+            })
         }
 
         fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
-            self.reload_count.fetch_add(1, Ordering::SeqCst);
-            self.dirty.store(false, Ordering::SeqCst);
-            Box::pin(std::future::ready(Ok(())))
+            let dirty = Arc::clone(&self.dirty);
+            let reload_count = Arc::clone(&self.reload_count);
+            let reload_gate = self.reload_gate.clone();
+            Box::pin(async move {
+                if let Some(gate) = reload_gate {
+                    gate.entered.notify_one();
+                    gate.release.notified().await;
+                }
+                reload_count.fetch_add(1, Ordering::SeqCst);
+                dirty.store(false, Ordering::SeqCst);
+                Ok(())
+            })
         }
     }
 
@@ -234,7 +265,10 @@ mod tests {
             dirty: Arc::new(AtomicBool::new(dirty)),
             drain_override_loaded: false,
             query_error: false,
+            read_count: Arc::new(AtomicUsize::new(0)),
+            read_gate: None,
             reload_count: Arc::new(AtomicUsize::new(0)),
+            reload_gate: None,
         }
     }
 
@@ -310,6 +344,8 @@ mod tests {
 
     #[tokio::test]
     async fn different_units_coalesce_one_dirty_generation_under_real_flock() {
+        const RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(5);
+
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
         let unit_a = RunnerServiceUnit::from_suffix("reload-a").unwrap();
@@ -317,29 +353,104 @@ mod tests {
         let ops = fake_ops(true);
         let mut ops_a = ops.clone();
         let mut ops_b = ops.clone();
+        let read_entered = Arc::new(tokio::sync::Notify::new());
+        let read_release = Arc::new(tokio::sync::Notify::new());
+        let reload_entered = Arc::new(tokio::sync::Notify::new());
+        let reload_release = Arc::new(tokio::sync::Notify::new());
+        ops_a.read_gate = Some(OperationGate {
+            entered: Arc::clone(&read_entered),
+            release: Arc::clone(&read_release),
+        });
+        ops_a.reload_gate = Some(OperationGate {
+            entered: Arc::clone(&reload_entered),
+            release: Arc::clone(&reload_release),
+        });
+        let (follower_start_tx, follower_start_rx) = tokio::sync::oneshot::channel();
+        let (follower_pending_tx, follower_pending_rx) = tokio::sync::oneshot::channel();
+        let read_count = Arc::clone(&ops.read_count);
+        let reload_count = Arc::clone(&ops.reload_count);
 
-        let (result_a, result_b) = tokio::join!(
-            coordinate_systemd_reload_with_ops(
-                &unit_a,
-                &home,
-                SystemdReloadRequirement::dirty(),
-                None,
-                &mut ops_a,
-            ),
-            coordinate_systemd_reload_with_ops(
-                &unit_b,
-                &home,
-                SystemdReloadRequirement::dirty(),
-                None,
-                &mut ops_b,
-            ),
-        );
+        let (leader_result, follower_result, ()) =
+            tokio::time::timeout(RENDEZVOUS_TIMEOUT, async {
+                tokio::join!(
+                    coordinate_systemd_reload_with_ops(
+                        &unit_a,
+                        &home,
+                        SystemdReloadRequirement::dirty(),
+                        None,
+                        &mut ops_a,
+                    ),
+                    async {
+                        follower_start_rx
+                            .await
+                            .expect("follower start signal should be sent");
+                        let follower = coordinate_systemd_reload_with_ops(
+                            &unit_b,
+                            &home,
+                            SystemdReloadRequirement::dirty(),
+                            None,
+                            &mut ops_b,
+                        );
+                        tokio::pin!(follower);
+                        let mut follower_pending_tx = Some(follower_pending_tx);
+                        std::future::poll_fn(|context| {
+                            let result = follower.as_mut().poll(context);
+                            if result.is_pending()
+                                && let Some(follower_pending_tx) = follower_pending_tx.take()
+                            {
+                                follower_pending_tx
+                                    .send(())
+                                    .expect("follower pending signal should be received");
+                            }
+                            result
+                        })
+                        .await
+                    },
+                    async {
+                        read_entered.notified().await;
+                        assert!(
+                            matches!(
+                                crate::lock::try_acquire_or_busy(home.systemd_daemon_reload_lock())
+                                    .await
+                                    .unwrap(),
+                                crate::lock::TryLock::Busy
+                            ),
+                            "leader must acquire the host-global lock before reading state"
+                        );
+                        assert_eq!(read_count.load(Ordering::SeqCst), 0);
+                        read_release.notify_one();
 
-        let performed = [result_a.unwrap(), result_b.unwrap()]
-            .into_iter()
-            .filter(|performed| *performed)
-            .count();
-        assert_eq!(performed, 1);
+                        reload_entered.notified().await;
+                        assert!(
+                            matches!(
+                                crate::lock::try_acquire_or_busy(home.systemd_daemon_reload_lock())
+                                    .await
+                                    .unwrap(),
+                                crate::lock::TryLock::Busy
+                            ),
+                            "leader must hold the host-global lock during daemon-reload"
+                        );
+
+                        follower_start_tx
+                            .send(())
+                            .expect("follower should wait for its start signal");
+                        follower_pending_rx
+                            .await
+                            .expect("follower should become pending on the held lock");
+                        // The busy probe proves the leader still owns the real flock;
+                        // this pending poll proves the follower started before release.
+                        assert_eq!(read_count.load(Ordering::SeqCst), 1);
+                        assert_eq!(reload_count.load(Ordering::SeqCst), 0);
+                        reload_release.notify_one();
+                    },
+                )
+            })
+            .await
+            .expect("lock-sensitive reload rendezvous should complete");
+
+        assert!(leader_result.unwrap());
+        assert!(!follower_result.unwrap());
+        assert_eq!(ops.read_count.load(Ordering::SeqCst), 2);
         assert_eq!(ops.reload_count.load(Ordering::SeqCst), 1);
     }
 


### PR DESCRIPTION
## Summary

- gate the fake systemd state read and reload phases so the leader's critical
  section is observable without scheduler timing
- probe the production lock path with independently opened flock handles before
  state read and during reload, proving both acquisition order and guard scope
- start the follower through an explicit pending-poll handshake, then verify it
  rechecks the cleared state and skips a duplicate reload after release

## Scope

This changes only inline `runner` test code. Production systemd coordination,
the shared lock implementation, runner behavior, dependencies, protocols,
persisted state, workflows, and deployment compatibility are unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- exact focused coalescing test
- temporary early-lock-drop mutation: focused test failed at the pre-read
  real-flock assertion as expected; mutation restored and test passed
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner`
  (3,075 passed, 20 ignored child fixtures)
- `git diff --check`
- repository pre-commit hook (workspace Rust formatting, documentation,
  Clippy, file-size check, and commitlint)

Closes #26029
