### PR TITLE
refactor(runner): centralize workspace cache entry paths

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1895,8 +1895,10 @@ mod tests {
         )
         .await;
         let seeded_entry = cache.inspect().await.unwrap().entries.remove(0);
-        let entry_dir = paths.workspace_image_cache_entry_dir(&seeded_entry.cache_key);
-        let sidecar_metadata_path = entry_dir.join("session-history.metadata.json");
+        let sidecar_metadata_path = cache
+            .entry_paths(&seeded_entry.cache_key)
+            .session_history_sidecar_metadata()
+            .to_path_buf();
 
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
@@ -1940,7 +1942,10 @@ mod tests {
             .await
             .unwrap();
         tokio::fs::rename(
-            paths.workspace_image_cache_current_image(&seeded_entry.cache_key),
+            cache
+                .entry_paths(&seeded_entry.cache_key)
+                .current_image()
+                .to_path_buf(),
             paths.active_workspace_image(&sandbox_id),
         )
         .await
@@ -1996,9 +2001,14 @@ mod tests {
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].reuse_key, reuse_key);
         let workspace_metadata: serde_json::Value = serde_json::from_slice(
-            &tokio::fs::read(paths.workspace_image_cache_metadata(&seeded_entry.cache_key))
-                .await
-                .unwrap(),
+            &tokio::fs::read(
+                cache
+                    .entry_paths(&seeded_entry.cache_key)
+                    .metadata()
+                    .to_path_buf(),
+            )
+            .await
+            .unwrap(),
         )
         .unwrap();
         assert!(workspace_metadata.get("cliAgentSessionId").is_none());
@@ -2082,7 +2092,10 @@ mod tests {
             .await
             .unwrap();
         tokio::fs::rename(
-            paths.workspace_image_cache_current_image(&seeded_entry.cache_key),
+            cache
+                .entry_paths(&seeded_entry.cache_key)
+                .current_image()
+                .to_path_buf(),
             paths.active_workspace_image(&sandbox_id),
         )
         .await
@@ -2332,7 +2345,10 @@ mod tests {
         );
         let metadata: serde_json::Value = serde_json::from_slice(
             &tokio::fs::read(
-                paths.workspace_image_cache_metadata(&inspection.entries[0].cache_key),
+                cache
+                    .entry_paths(&inspection.entries[0].cache_key)
+                    .metadata()
+                    .to_path_buf(),
             )
             .await
             .unwrap(),

--- a/crates/runner/src/cmd/workspace_image_cache.rs
+++ b/crates/runner/src/cmd/workspace_image_cache.rs
@@ -318,11 +318,10 @@ mod tests {
 
     use crate::ids::RunId;
     use crate::paths::workspace_image_cache_key;
+    use crate::workspace_image_cache::CacheEntryPaths;
 
     fn tmp_image_path(home: &HomePaths, cache_key: &str, run_id: RunId) -> PathBuf {
-        home.workspace_image_cache_dir()
-            .join(cache_key)
-            .join(format!("current.ext4.tmp.{run_id}"))
+        CacheEntryPaths::new(&home.workspace_image_cache_dir(), cache_key).tmp_image(run_id)
     }
 
     fn test_inspection() -> WorkspaceImageCacheInspection {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1387,7 +1387,7 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
         CANONICAL_WORKING_DIR,
         u64::from(params.workspace_disk_mb) * 1024 * 1024,
     );
-    let current_image = runner_paths.workspace_image_cache_current_image(&cache_key);
+    let current_image = cache.entry_paths(&cache_key).current_image().to_path_buf();
     tokio::fs::create_dir_all(current_image.parent().unwrap())
         .await
         .unwrap();

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -104,7 +104,7 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_sidecar(
         CANONICAL_WORKING_DIR,
         u64::from(workspace_disk_mb) * 1024 * 1024,
     );
-    runner_paths.workspace_image_cache_current_image(&cache_key)
+    cache.entry_paths(&cache_key).current_image().to_path_buf()
 }
 
 pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerprints(
@@ -161,5 +161,5 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache_with_fingerpr
         CANONICAL_WORKING_DIR,
         u64::from(workspace_disk_mb) * 1024 * 1024,
     );
-    runner_paths.workspace_image_cache_current_image(&cache_key)
+    cache.entry_paths(&cache_key).current_image().to_path_buf()
 }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -172,29 +172,6 @@ impl RunnerPaths {
     pub fn workspace_image_cache_dir(&self) -> PathBuf {
         self.base_dir.join("workspace-image-cache")
     }
-
-    #[cfg(test)]
-    pub fn workspace_image_cache_entry_dir(&self, cache_key: &str) -> PathBuf {
-        self.workspace_image_cache_dir().join(cache_key)
-    }
-
-    #[cfg(test)]
-    pub fn workspace_image_cache_metadata(&self, cache_key: &str) -> PathBuf {
-        self.workspace_image_cache_entry_dir(cache_key)
-            .join("metadata.json")
-    }
-
-    #[cfg(test)]
-    pub fn workspace_image_cache_current_image(&self, cache_key: &str) -> PathBuf {
-        self.workspace_image_cache_entry_dir(cache_key)
-            .join("current.ext4")
-    }
-
-    #[cfg(test)]
-    pub fn workspace_image_cache_tmp_image(&self, cache_key: &str, run_id: RunId) -> PathBuf {
-        self.workspace_image_cache_entry_dir(cache_key)
-            .join(format!("current.ext4.tmp.{run_id}"))
-    }
 }
 
 /// Paths rooted at /var/lib/vm0-runner/.

--- a/crates/runner/src/workspace_image_cache/entry.rs
+++ b/crates/runner/src/workspace_image_cache/entry.rs
@@ -10,7 +10,7 @@ use super::WorkspaceImageCache;
 use super::metadata::WorkspaceCacheMetadata;
 
 #[derive(Clone, Debug)]
-pub(super) struct CacheEntryPaths {
+pub(crate) struct CacheEntryPaths {
     entry_dir: PathBuf,
     metadata: PathBuf,
     current_image: PathBuf,
@@ -18,7 +18,7 @@ pub(super) struct CacheEntryPaths {
 }
 
 impl CacheEntryPaths {
-    pub(super) fn new(cache_dir: &Path, cache_key: &str) -> Self {
+    pub(crate) fn new(cache_dir: &Path, cache_key: &str) -> Self {
         let entry_dir = cache_dir.join(cache_key);
         Self {
             metadata: entry_dir.join("metadata.json"),
@@ -32,24 +32,28 @@ impl CacheEntryPaths {
         workspace_image_cache_lock_path(lock_dir, cache_key)
     }
 
-    pub(super) fn entry_dir(&self) -> &Path {
+    pub(crate) fn entry_dir(&self) -> &Path {
         &self.entry_dir
     }
 
-    pub(super) fn metadata(&self) -> &Path {
+    pub(crate) fn metadata(&self) -> &Path {
         &self.metadata
     }
 
-    pub(super) fn current_image(&self) -> &Path {
+    pub(crate) fn current_image(&self) -> &Path {
         &self.current_image
     }
 
-    pub(super) fn session_history_sidecar_metadata(&self) -> &Path {
+    pub(crate) fn session_history_sidecar_metadata(&self) -> &Path {
         &self.session_history_sidecar_metadata
     }
 
-    pub(super) fn tmp_image(&self, run_id: RunId) -> PathBuf {
+    pub(crate) fn tmp_image(&self, run_id: RunId) -> PathBuf {
         self.entry_dir.join(format!("current.ext4.tmp.{run_id}"))
+    }
+
+    pub(crate) fn tmp_metadata(&self, run_id: RunId) -> PathBuf {
+        self.entry_dir.join(format!("metadata.json.tmp.{run_id}"))
     }
 
     pub(super) fn tmp_session_history_sidecar(&self, run_id: RunId) -> PathBuf {
@@ -140,7 +144,7 @@ impl WorkspaceImageCache {
         ) == cache_key
     }
 
-    pub(super) fn entry_paths(&self, cache_key: &str) -> CacheEntryPaths {
+    pub(crate) fn entry_paths(&self, cache_key: &str) -> CacheEntryPaths {
         CacheEntryPaths::new(self.workspace_image_cache_dir(), cache_key)
     }
 

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -139,8 +139,9 @@ impl WorkspaceImageCache {
         run_id: RunId,
         metadata: WorkspaceCacheMetadata,
     ) -> RunnerResult<()> {
-        let metadata_path = self.workspace_image_cache_metadata(cache_key);
-        let tmp = metadata_path.with_file_name(format!("metadata.json.tmp.{run_id}"));
+        let entry_paths = self.entry_paths(cache_key);
+        let metadata_path = entry_paths.metadata();
+        let tmp = entry_paths.tmp_metadata(run_id);
         self.ensure_workspace_cache_entry_dir(cache_key).await?;
         let bytes = serde_json::to_vec_pretty(&metadata)
             .map_err(|e| RunnerError::Internal(format!("serialize workspace metadata: {e}")))?;
@@ -153,7 +154,7 @@ impl WorkspaceImageCache {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e);
         }
-        if let Err(e) = fs::rename(&tmp, &metadata_path).await {
+        if let Err(e) = fs::rename(&tmp, metadata_path).await {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
         }

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -53,6 +53,8 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+pub(crate) use entry::CacheEntryPaths;
 pub(crate) use lifecycle::{
     WorkspaceImageLease, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityFailure,
     WorkspaceImagePromotionOutcome, WorkspaceSessionHistorySidecarEntryGuard,

--- a/crates/runner/src/workspace_image_cache/tests/gc.rs
+++ b/crates/runner/src/workspace_image_cache/tests/gc.rs
@@ -108,7 +108,7 @@ async fn maintenance_gc_preserves_valid_group_scoped_entry() {
 
 #[tokio::test]
 async fn unknown_metadata_format_is_not_reused_or_advertised_and_is_reclaimed() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let checkout_reuse_key = "thread:unknown-format-checkout";
     let checkout_key = write_current_cache_entry(
         &cache,
@@ -119,7 +119,7 @@ async fn unknown_metadata_format_is_not_reused_or_advertised_and_is_reclaimed() 
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let checkout_metadata_path = paths.workspace_image_cache_metadata(&checkout_key);
+    let checkout_metadata_path = cache.entry_paths(&checkout_key).metadata().to_path_buf();
     let mut checkout_metadata = cache
         .read_metadata_file(&checkout_metadata_path)
         .await
@@ -140,7 +140,7 @@ async fn unknown_metadata_format_is_not_reused_or_advertised_and_is_reclaimed() 
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let gc_metadata_path = paths.workspace_image_cache_metadata(&gc_key);
+    let gc_metadata_path = cache.entry_paths(&gc_key).metadata().to_path_buf();
     let mut gc_metadata = cache.read_metadata_file(&gc_metadata_path).await.unwrap();
     gc_metadata.format_version = CACHE_FORMAT_VERSION + 1;
     cache
@@ -167,15 +167,23 @@ async fn unknown_metadata_format_is_not_reused_or_advertised_and_is_reclaimed() 
         super::super::WorkspaceCacheCheckoutResult::Miss
     );
     assert!(
-        !paths
-            .workspace_image_cache_entry_dir(&checkout_key)
+        !cache
+            .entry_paths(&checkout_key)
+            .entry_dir()
+            .to_path_buf()
             .exists()
     );
 
     let freed = cache.gc(false).await.unwrap();
 
     assert!(freed > 0);
-    assert!(!paths.workspace_image_cache_entry_dir(&gc_key).exists());
+    assert!(
+        !cache
+            .entry_paths(&gc_key)
+            .entry_dir()
+            .to_path_buf()
+            .exists()
+    );
 }
 
 #[tokio::test]
@@ -450,12 +458,12 @@ fn gc_budget_satisfied_enforces_entry_cap_even_without_disk_pressure() {
 
 #[tokio::test]
 async fn gc_candidate_detects_replaced_image_with_same_timestamp() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.workspace_image_cache_entry_dir(&cache_key);
+    let entry_dir = cache.entry_paths(&cache_key).entry_dir().to_path_buf();
     tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-    let current = paths.workspace_image_cache_current_image(&cache_key);
+    let current = cache.entry_paths(&cache_key).current_image().to_path_buf();
     tokio::fs::write(&current, b"old image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -498,12 +506,12 @@ async fn gc_candidate_detects_replaced_image_with_same_timestamp() {
 
 #[tokio::test]
 async fn gc_candidate_includes_current_image_without_metadata() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
+    tokio::fs::create_dir_all(cache.entry_paths(&cache_key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&cache_key);
+    let current = cache.entry_paths(&cache_key).current_image().to_path_buf();
     tokio::fs::write(&current, b"orphan image").await.unwrap();
 
     let candidate = cache.gc_candidate(cache_key.clone()).await.unwrap();
@@ -516,7 +524,7 @@ async fn gc_candidate_includes_current_image_without_metadata() {
 
 #[tokio::test]
 async fn gc_counts_busy_entry_when_pruning_above_held_workspace_limit() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
 
     let mut oldest_key = String::new();
@@ -553,20 +561,26 @@ async fn gc_counts_busy_entry_when_pruning_above_held_workspace_limit() {
 
     assert!(freed > 0);
     assert!(
-        paths
-            .workspace_image_cache_current_image(&oldest_key)
+        cache
+            .entry_paths(&oldest_key)
+            .current_image()
+            .to_path_buf()
             .exists(),
         "the oldest busy entry must remain protected by its entry lock"
     );
     assert!(
-        !paths
-            .workspace_image_cache_entry_dir(&second_oldest_key)
+        !cache
+            .entry_paths(&second_oldest_key)
+            .entry_dir()
+            .to_path_buf()
             .exists(),
         "a valid busy entry must still count toward the cap and force eviction of the next eligible candidate"
     );
     assert!(
-        paths
-            .workspace_image_cache_current_image(&newest_key)
+        cache
+            .entry_paths(&newest_key)
+            .current_image()
+            .to_path_buf()
             .exists(),
         "newest cache entry should be retained"
     );
@@ -582,7 +596,7 @@ async fn gc_counts_busy_entry_when_pruning_above_held_workspace_limit() {
 
 #[tokio::test]
 async fn gc_removes_stale_entry_without_current_image() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = write_current_cache_entry(
         &cache,
@@ -593,7 +607,7 @@ async fn gc_removes_stale_entry_without_current_image() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    tokio::fs::remove_file(paths.workspace_image_cache_current_image(&key))
+    tokio::fs::remove_file(cache.entry_paths(&key).current_image().to_path_buf())
         .await
         .unwrap();
 
@@ -601,20 +615,20 @@ async fn gc_removes_stale_entry_without_current_image() {
 
     assert!(freed > 0);
     assert!(
-        !paths.workspace_image_cache_entry_dir(&key).exists(),
+        !cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "stale metadata-only entries should not accumulate and slow heartbeat scans"
     );
 }
 
 #[tokio::test]
 async fn gc_removes_unusable_current_entry_without_metadata() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    tokio::fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     tokio::fs::write(
-        paths.workspace_image_cache_current_image(&key),
+        cache.entry_paths(&key).current_image().to_path_buf(),
         b"orphan image",
     )
     .await
@@ -624,47 +638,43 @@ async fn gc_removes_unusable_current_entry_without_metadata() {
 
     assert!(freed > 0);
     assert!(
-        !paths.workspace_image_cache_entry_dir(&key).exists(),
+        !cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "current images without metadata are not reusable and should not accumulate"
     );
 }
 
 #[tokio::test]
 async fn gc_removes_unusable_current_symlink_loop_without_aborting() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    tokio::fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    std::os::unix::fs::symlink(
-        "current.ext4",
-        paths.workspace_image_cache_current_image(&key),
-    )
-    .unwrap();
+    std::os::unix::fs::symlink("current.ext4", cache.entry_paths(&key).current_image()).unwrap();
 
     let freed = cache.gc(false).await.unwrap();
 
     assert!(freed > 0);
     assert!(
-        !paths.workspace_image_cache_entry_dir(&key).exists(),
+        !cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "symlink-loop current images are unusable and should not abort cache GC"
     );
 }
 
 #[tokio::test]
 async fn gc_removes_unusable_current_entry_with_unreadable_metadata_path() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    tokio::fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     tokio::fs::write(
-        paths.workspace_image_cache_current_image(&key),
+        cache.entry_paths(&key).current_image().to_path_buf(),
         b"orphan image",
     )
     .await
     .unwrap();
-    tokio::fs::create_dir(paths.workspace_image_cache_metadata(&key))
+    tokio::fs::create_dir(cache.entry_paths(&key).metadata().to_path_buf())
         .await
         .unwrap();
 
@@ -672,18 +682,18 @@ async fn gc_removes_unusable_current_entry_with_unreadable_metadata_path() {
 
     assert!(freed > 0);
     assert!(
-        !paths.workspace_image_cache_entry_dir(&key).exists(),
+        !cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "unreadable metadata paths make entries unusable and should not block cache GC"
     );
 }
 
 #[tokio::test]
 async fn gc_dry_run_counts_temporary_only_entry_once() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
+    let entry_dir = cache.entry_paths(&key).entry_dir().to_path_buf();
     tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
+    let tmp = cache.entry_paths(&key).tmp_image(RunId::new_v4());
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
     let expected = workspace_cache_path_allocated_bytes(&entry_dir).await;
 
@@ -699,13 +709,13 @@ async fn gc_dry_run_counts_temporary_only_entry_once() {
 
 #[tokio::test]
 async fn gc_dry_run_counts_unusable_entry_with_temporary_path_once() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
+    let entry_dir = cache.entry_paths(&key).entry_dir().to_path_buf();
     tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     tokio::fs::write(&current, b"orphan image").await.unwrap();
-    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
+    let tmp = cache.entry_paths(&key).tmp_image(RunId::new_v4());
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
     let expected = workspace_cache_path_allocated_bytes(&entry_dir).await;
 
@@ -736,7 +746,7 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let tmp = paths.workspace_image_cache_tmp_image(&key, run_id);
+    let tmp = setup_cache.entry_paths(&key).tmp_image(run_id);
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
     let temporary_allocated = workspace_cache_path_allocated_bytes(&tmp).await;
     assert!(temporary_allocated > 0);
@@ -763,14 +773,18 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
     );
     assert!(tmp.exists());
     assert!(
-        paths.workspace_image_cache_current_image(&key).exists(),
+        cache
+            .entry_paths(&key)
+            .current_image()
+            .to_path_buf()
+            .exists(),
         "dry-run must not preview deleting a valid entry when temporary cleanup would relieve disk pressure"
     );
 }
 
 #[tokio::test]
 async fn gc_removes_current_directory_even_when_metadata_matches() {
-    let (dir, paths, cache) = local_cache().await;
+    let (dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let reuse_key = "sess-1";
     let working_dir = "/workspace";
@@ -779,7 +793,7 @@ async fn gc_removes_current_directory_even_when_metadata_matches() {
     let image_size_bytes = fs::metadata(&probe).await.unwrap().len();
     tokio::fs::remove_dir_all(&probe).await.unwrap();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, working_dir, image_size_bytes);
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     tokio::fs::create_dir_all(&current).await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -811,20 +825,20 @@ async fn gc_removes_current_directory_even_when_metadata_matches() {
 
     assert!(freed > 0);
     assert!(
-        !paths.workspace_image_cache_entry_dir(&key).exists(),
+        !cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "current directories must not remain as reusable workspace cache entries"
     );
 }
 
 #[tokio::test]
 async fn gc_counts_nested_current_directory_bytes() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let reuse_key = "sess-1";
     let working_dir = "/workspace";
     let image_size_bytes = 1024 * 1024;
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, working_dir, image_size_bytes);
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     let nested = current.join("nested");
     tokio::fs::create_dir_all(&nested).await.unwrap();
     tokio::fs::write(
@@ -865,18 +879,18 @@ async fn gc_counts_nested_current_directory_bytes() {
         freed >= image_size_bytes,
         "GC must report nested current directory bytes so callers refresh disk stats after cleanup"
     );
-    assert!(!paths.workspace_image_cache_entry_dir(&key).exists());
+    assert!(!cache.entry_paths(&key).entry_dir().to_path_buf().exists());
 }
 
 #[tokio::test]
 async fn gc_keeps_unusable_current_entry_when_entry_lock_is_held() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    tokio::fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     tokio::fs::write(
-        paths.workspace_image_cache_current_image(&key),
+        cache.entry_paths(&key).current_image().to_path_buf(),
         b"orphan image",
     )
     .await
@@ -889,14 +903,14 @@ async fn gc_keeps_unusable_current_entry_when_entry_lock_is_held() {
 
     assert_eq!(freed, 0);
     assert!(
-        paths.workspace_image_cache_entry_dir(&key).exists(),
+        cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "entry locks must protect in-progress promotions from GC removal"
     );
 }
 
 #[tokio::test]
 async fn gc_keeps_stale_entry_without_current_image_when_entry_lock_is_held() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = write_current_cache_entry(
         &cache,
@@ -907,7 +921,7 @@ async fn gc_keeps_stale_entry_without_current_image_when_entry_lock_is_held() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    tokio::fs::remove_file(paths.workspace_image_cache_current_image(&key))
+    tokio::fs::remove_file(cache.entry_paths(&key).current_image().to_path_buf())
         .await
         .unwrap();
     let _lock = crate::lock::acquire(cache.entry_lock_path(&key))
@@ -918,23 +932,21 @@ async fn gc_keeps_stale_entry_without_current_image_when_entry_lock_is_held() {
 
     assert_eq!(freed, 0);
     assert!(
-        paths.workspace_image_cache_entry_dir(&key).exists(),
+        cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "entry locks must protect stale entries from GC removal"
     );
 }
 
 #[tokio::test]
 async fn gc_removes_orphan_temporary_workspace_cache_files() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
+    tokio::fs::create_dir_all(cache.entry_paths(&cache_key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
-    let metadata_tmp = paths
-        .workspace_image_cache_metadata(&cache_key)
-        .with_file_name(format!("metadata.json.tmp.{run_id}"));
+    let tmp = cache.entry_paths(&cache_key).tmp_image(run_id);
+    let metadata_tmp = cache.entry_paths(&cache_key).tmp_metadata(run_id);
     tokio::fs::write(&tmp, b"partial image").await.unwrap();
     tokio::fs::write(&metadata_tmp, b"partial metadata")
         .await
@@ -949,7 +961,7 @@ async fn gc_removes_orphan_temporary_workspace_cache_files() {
 
 #[tokio::test]
 async fn gc_removes_orphan_temporary_workspace_cache_directories() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = write_current_cache_entry(
         &cache,
@@ -960,10 +972,8 @@ async fn gc_removes_orphan_temporary_workspace_cache_directories() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
-    let metadata_tmp = paths
-        .workspace_image_cache_metadata(&cache_key)
-        .with_file_name(format!("metadata.json.tmp.{run_id}"));
+    let tmp = cache.entry_paths(&cache_key).tmp_image(run_id);
+    let metadata_tmp = cache.entry_paths(&cache_key).tmp_metadata(run_id);
     tokio::fs::create_dir_all(&tmp).await.unwrap();
     tokio::fs::write(tmp.join("partial-image"), b"partial image")
         .await
@@ -979,15 +989,17 @@ async fn gc_removes_orphan_temporary_workspace_cache_directories() {
     assert!(!tmp.exists());
     assert!(!metadata_tmp.exists());
     assert!(
-        paths
-            .workspace_image_cache_current_image(&cache_key)
+        cache
+            .entry_paths(&cache_key)
+            .current_image()
+            .to_path_buf()
             .exists()
     );
 }
 
 #[tokio::test]
 async fn gc_counts_nested_temporary_workspace_cache_directories() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = write_current_cache_entry(
         &cache,
@@ -998,7 +1010,7 @@ async fn gc_counts_nested_temporary_workspace_cache_directories() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
+    let tmp = cache.entry_paths(&cache_key).tmp_image(run_id);
     let nested = tmp.join("nested");
     tokio::fs::create_dir_all(&nested).await.unwrap();
     tokio::fs::write(nested.join("partial-image"), vec![1_u8; 4096])
@@ -1013,24 +1025,24 @@ async fn gc_counts_nested_temporary_workspace_cache_directories() {
     );
     assert!(!tmp.exists());
     assert!(
-        paths
-            .workspace_image_cache_current_image(&cache_key)
+        cache
+            .entry_paths(&cache_key)
+            .current_image()
+            .to_path_buf()
             .exists()
     );
 }
 
 #[tokio::test]
 async fn gc_keeps_temporary_workspace_cache_files_when_entry_lock_is_held() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
+    tokio::fs::create_dir_all(cache.entry_paths(&cache_key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
-    let metadata_tmp = paths
-        .workspace_image_cache_metadata(&cache_key)
-        .with_file_name(format!("metadata.json.tmp.{run_id}"));
+    let tmp = cache.entry_paths(&cache_key).tmp_image(run_id);
+    let metadata_tmp = cache.entry_paths(&cache_key).tmp_metadata(run_id);
     tokio::fs::write(&tmp, b"partial image").await.unwrap();
     tokio::fs::write(&metadata_tmp, b"partial metadata")
         .await

--- a/crates/runner/src/workspace_image_cache/tests/inspection.rs
+++ b/crates/runner/src/workspace_image_cache/tests/inspection.rs
@@ -36,13 +36,13 @@ async fn inspect_missing_cache_dir_returns_empty_summary() {
 
 #[tokio::test]
 async fn inspect_reports_reusable_entry_with_storage_counts() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -98,13 +98,13 @@ async fn inspect_reports_reusable_entry_with_storage_counts() {
 
 #[tokio::test]
 async fn inspect_reports_invalid_metadata_reason() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -142,7 +142,7 @@ async fn inspect_reports_invalid_metadata_reason() {
 
 #[tokio::test]
 async fn inspect_rejects_symlink_current_image() {
-    let (dir, paths, cache) = local_cache().await;
+    let (dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let image = b"image";
     let key = cache.scoped_cache_key(
@@ -151,12 +151,12 @@ async fn inspect_rejects_symlink_current_image() {
         "/workspace",
         image.len() as u64,
     );
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     let target = dir.path().join("target.ext4");
     fs::write(&target, image).await.unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     std::os::unix::fs::symlink(&target, &current).unwrap();
     let current_target_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -194,7 +194,7 @@ async fn inspect_rejects_symlink_current_image() {
 
 #[tokio::test]
 async fn inspect_reports_current_directory_as_invalid() {
-    let (dir, paths, cache) = local_cache().await;
+    let (dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let reuse_key = "sess-1";
     let working_dir = "/workspace";
@@ -203,7 +203,7 @@ async fn inspect_reports_current_directory_as_invalid() {
     let image_size_bytes = fs::metadata(&probe).await.unwrap().len();
     tokio::fs::remove_dir_all(&probe).await.unwrap();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, reuse_key, working_dir, image_size_bytes);
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::create_dir_all(&current).await.unwrap();
     fs::write(current.join("nested"), vec![1_u8; 4096])
         .await
@@ -248,7 +248,7 @@ async fn inspect_reports_current_directory_as_invalid() {
 
 #[tokio::test]
 async fn inspect_reports_stale_entry_without_current_image() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = write_current_cache_entry(
         &cache,
         RunId::new_v4(),
@@ -258,7 +258,7 @@ async fn inspect_reports_stale_entry_without_current_image() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    fs::remove_file(paths.workspace_image_cache_current_image(&key))
+    fs::remove_file(cache.entry_paths(&key).current_image().to_path_buf())
         .await
         .unwrap();
 
@@ -273,9 +273,9 @@ async fn inspect_reports_stale_entry_without_current_image() {
 
 #[tokio::test]
 async fn inspect_reports_temporary_only_entry() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
+    let tmp = cache.entry_paths(&key).tmp_image(RunId::new_v4());
     fs::create_dir_all(tmp.parent().unwrap()).await.unwrap();
     fs::write(&tmp, b"partial image").await.unwrap();
     let tmp_metadata = fs::metadata(&tmp).await.unwrap();
@@ -298,9 +298,9 @@ async fn inspect_reports_temporary_only_entry() {
 
 #[tokio::test]
 async fn inspect_reports_temporary_only_directory() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    let tmp = paths.workspace_image_cache_tmp_image(&key, RunId::new_v4());
+    let tmp = cache.entry_paths(&key).tmp_image(RunId::new_v4());
     fs::create_dir_all(&tmp).await.unwrap();
     fs::write(tmp.join("partial-image"), vec![1_u8; 4096])
         .await
@@ -326,13 +326,13 @@ async fn inspect_reports_temporary_only_directory() {
 
 #[tokio::test]
 async fn inspect_reports_locked_entry_without_blocking() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     fs::write(
-        paths.workspace_image_cache_tmp_image(&key, RunId::new_v4()),
+        cache.entry_paths(&key).tmp_image(RunId::new_v4()),
         b"partial image",
     )
     .await
@@ -357,7 +357,7 @@ async fn inspect_propagates_lock_path_errors() {
     let paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = WorkspaceImageCache::new(paths.clone());
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     fs::write(paths.base_dir().join("locks"), b"not a directory")
@@ -378,7 +378,7 @@ async fn inspect_entry_skips_directory_removed_after_scan() {
     let paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = WorkspaceImageCache::new(paths.clone());
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
+    let entry_dir = cache.entry_paths(&key).entry_dir().to_path_buf();
     fs::create_dir_all(&entry_dir).await.unwrap();
     fs::remove_dir_all(&entry_dir).await.unwrap();
 
@@ -393,7 +393,7 @@ async fn inspect_entry_skips_symlink_replacement_after_scan() {
     let paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = WorkspaceImageCache::new(paths.clone());
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
+    let entry_dir = cache.entry_paths(&key).entry_dir().to_path_buf();
     fs::create_dir_all(entry_dir.parent().unwrap())
         .await
         .unwrap();
@@ -412,13 +412,16 @@ async fn inspect_reports_non_file_metadata_as_invalid_entry() {
     let paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = WorkspaceImageCache::new(paths.clone());
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    fs::write(paths.workspace_image_cache_current_image(&key), b"image")
-        .await
-        .unwrap();
-    fs::create_dir(paths.workspace_image_cache_metadata(&key))
+    fs::write(
+        cache.entry_paths(&key).current_image().to_path_buf(),
+        b"image",
+    )
+    .await
+    .unwrap();
+    fs::create_dir(cache.entry_paths(&key).metadata().to_path_buf())
         .await
         .unwrap();
 
@@ -444,7 +447,7 @@ async fn inspect_rejects_metadata_symlink_without_following_it() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let metadata_path = paths.workspace_image_cache_metadata(&key);
+    let metadata_path = cache.entry_paths(&key).metadata().to_path_buf();
     let outside = dir.path().join("outside-metadata.json");
     fs::rename(&metadata_path, &outside).await.unwrap();
     std::os::unix::fs::symlink(&outside, &metadata_path).unwrap();
@@ -463,14 +466,17 @@ async fn inspect_rejects_oversized_metadata() {
     let paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = WorkspaceImageCache::new(paths.clone());
     let key = workspace_image_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
-        .await
-        .unwrap();
-    fs::write(paths.workspace_image_cache_current_image(&key), b"image")
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     fs::write(
-        paths.workspace_image_cache_metadata(&key),
+        cache.entry_paths(&key).current_image().to_path_buf(),
+        b"image",
+    )
+    .await
+    .unwrap();
+    fs::write(
+        cache.entry_paths(&key).metadata().to_path_buf(),
         vec![b' '; crate::state_file::WORKSPACE_METADATA_MAX_BYTES as usize + 1],
     )
     .await

--- a/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
@@ -147,18 +147,14 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
     }
     let key = cache_b.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
     assert!(
-        !home
-            .workspace_image_cache_dir()
-            .join(key)
-            .join("metadata.json")
-            .exists(),
+        !cache_b.entry_paths(&key).metadata().exists(),
         "move checkout must remove reusable cache metadata"
     );
 }
 
 #[tokio::test]
 async fn cache_hit_removes_metadata_and_returns_move_seed() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let key = write_current_cache_entry(
@@ -170,7 +166,7 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     let image_size = fs::metadata(&current).await.unwrap().len();
 
     let lease = cache
@@ -197,14 +193,14 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
     );
     assert!(current.exists());
     assert!(matches!(
-        fs::metadata(paths.workspace_image_cache_metadata(&key)).await,
+        fs::metadata(cache.entry_paths(&key).metadata().to_path_buf()).await,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound
     ));
 }
 
 #[tokio::test]
 async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = write_current_cache_entry(
         &cache,
@@ -215,7 +211,7 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     let image_size = fs::metadata(&current).await.unwrap().len();
 
     let lease = cache
@@ -240,7 +236,7 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
             .await
             .unwrap()
     );
-    assert!(!paths.workspace_image_cache_entry_dir(&key).exists());
+    assert!(!cache.entry_paths(&key).entry_dir().to_path_buf().exists());
 }
 
 #[tokio::test]
@@ -410,10 +406,18 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
         "/workspace",
         image.len() as u64,
     );
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
-        .await
-        .unwrap();
-    let current = paths.workspace_image_cache_current_image(&cache_key);
+    tokio::fs::create_dir_all(
+        setup_cache
+            .entry_paths(&cache_key)
+            .entry_dir()
+            .to_path_buf(),
+    )
+    .await
+    .unwrap();
+    let current = setup_cache
+        .entry_paths(&cache_key)
+        .current_image()
+        .to_path_buf();
     tokio::fs::write(&current, &image).await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     let actual_allocated_bytes = allocated_bytes(&current_metadata);
@@ -484,7 +488,7 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
         "move checkout keeps the source in place until sandbox preparation consumes it"
     );
     assert!(
-        !tokio::fs::try_exists(paths.workspace_image_cache_metadata(&cache_key))
+        !tokio::fs::try_exists(cache.entry_paths(&cache_key).metadata().to_path_buf())
             .await
             .unwrap(),
         "move checkout removes metadata before handing the current image to sandbox preparation"
@@ -519,13 +523,13 @@ async fn cache_hit_checkout_and_same_filesystem_promotion_do_not_require_copy_he
 
 #[tokio::test]
 async fn active_lease_hides_cached_reuse_key_until_dropped() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    tokio::fs::create_dir_all(paths.workspace_image_cache_entry_dir(&cache_key))
+    tokio::fs::create_dir_all(cache.entry_paths(&cache_key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&cache_key);
+    let current = cache.entry_paths(&cache_key).current_image().to_path_buf();
     tokio::fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache

--- a/crates/runner/src/workspace_image_cache/tests/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/tests/metadata.rs
@@ -16,7 +16,7 @@ use crate::storage_fingerprints::StorageFingerprints;
 
 #[tokio::test]
 async fn prepare_removes_symlink_cache_entry_without_following_it() {
-    let (dir, paths, cache) = local_cache().await;
+    let (dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let reuse_key = "sess-entry-symlink";
@@ -49,7 +49,7 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
     )
     .await
     .unwrap();
-    let entry_dir = paths.workspace_image_cache_entry_dir(&key);
+    let entry_dir = cache.entry_paths(&key).entry_dir().to_path_buf();
     fs::create_dir_all(entry_dir.parent().unwrap())
         .await
         .unwrap();
@@ -86,14 +86,17 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
 
 #[tokio::test]
 async fn metadata_missing_current_present_is_not_a_cache_hit() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-no-metadata", "/workspace", 5);
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    fs::write(paths.workspace_image_cache_current_image(&key), b"image")
-        .await
-        .unwrap();
+    fs::write(
+        cache.entry_paths(&key).current_image().to_path_buf(),
+        b"image",
+    )
+    .await
+    .unwrap();
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -125,10 +128,10 @@ async fn metadata_validation_rejects_metadata_mismatch() {
     let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 1024);
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -158,7 +161,7 @@ async fn metadata_validation_rejects_metadata_mismatch() {
 
     let err = cache
         .read_valid_metadata(
-            &paths.workspace_image_cache_metadata(&key),
+            cache.entry_paths(&key).metadata(),
             TEST_PROFILE_NAME,
             "sess-1",
             "/workspace",
@@ -171,20 +174,18 @@ async fn metadata_validation_rejects_metadata_mismatch() {
 
 #[tokio::test]
 async fn write_metadata_replaces_stale_tmp_symlink_without_following_it() {
-    let (dir, paths, cache) = local_cache().await;
+    let (dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     let outside = dir.path().join("outside-metadata-target");
     fs::write(&outside, b"outside").await.unwrap();
-    let metadata_tmp = paths
-        .workspace_image_cache_metadata(&key)
-        .with_file_name(format!("metadata.json.tmp.{run_id}"));
+    let metadata_tmp = cache.entry_paths(&key).tmp_metadata(run_id);
     std::os::unix::fs::symlink(&outside, &metadata_tmp).unwrap();
 
     cache
@@ -213,7 +214,7 @@ async fn write_metadata_replaces_stale_tmp_symlink_without_following_it() {
         .unwrap();
 
     assert_eq!(fs::read(&outside).await.unwrap(), b"outside");
-    let metadata_path = paths.workspace_image_cache_metadata(&key);
+    let metadata_path = cache.entry_paths(&key).metadata().to_path_buf();
     let metadata_file_type = fs::symlink_metadata(&metadata_path)
         .await
         .unwrap()
@@ -231,10 +232,10 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let image_size = b"old image".len() as u64;
     let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", image_size);
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"old image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -278,7 +279,7 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
 
     assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
     assert!(
-        !paths.workspace_image_cache_entry_dir(&key).exists(),
+        !cache.entry_paths(&key).entry_dir().to_path_buf().exists(),
         "invalid entry should be removed while the entry lock is held"
     );
 
@@ -299,7 +300,7 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
             .unwrap()
     );
 
-    let metadata_path = paths.workspace_image_cache_metadata(&key);
+    let metadata_path = cache.entry_paths(&key).metadata().to_path_buf();
     let metadata = cache.read_metadata_file(&metadata_path).await.unwrap();
     let serialized_metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(metadata_path).await.unwrap()).unwrap();
@@ -322,10 +323,10 @@ async fn metadata_validation_rejects_replaced_current_image() {
         "/workspace",
         b"old image".len() as u64,
     );
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"old image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -352,15 +353,17 @@ async fn metadata_validation_rejects_replaced_current_image() {
         )
         .await
         .unwrap();
-    let replacement = paths
-        .workspace_image_cache_entry_dir(&key)
+    let replacement = cache
+        .entry_paths(&key)
+        .entry_dir()
+        .to_path_buf()
         .join("replacement.ext4");
     fs::write(&replacement, b"new image").await.unwrap();
     fs::rename(&replacement, &current).await.unwrap();
 
     let err = cache
         .read_valid_metadata(
-            &paths.workspace_image_cache_metadata(&key),
+            cache.entry_paths(&key).metadata(),
             TEST_PROFILE_NAME,
             "sess-1",
             "/workspace",
@@ -388,12 +391,12 @@ async fn metadata_validation_rejects_symlink_current_image() {
         "/workspace",
         b"image".len() as u64,
     );
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
     let target = dir.path().join("target.ext4");
     fs::write(&target, b"image").await.unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     std::os::unix::fs::symlink(&target, &current).unwrap();
     let current_target_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -423,7 +426,7 @@ async fn metadata_validation_rejects_symlink_current_image() {
 
     let err = cache
         .read_valid_metadata(
-            &paths.workspace_image_cache_metadata(&key),
+            cache.entry_paths(&key).metadata(),
             TEST_PROFILE_NAME,
             "sess-1",
             "/workspace",
@@ -441,7 +444,7 @@ async fn metadata_validation_rejects_symlink_current_image() {
     let freed = cache.gc(false).await.unwrap();
 
     assert!(freed > 0);
-    assert!(!paths.workspace_image_cache_entry_dir(&key).exists());
+    assert!(!cache.entry_paths(&key).entry_dir().to_path_buf().exists());
     assert!(
         target.exists(),
         "GC must remove the symlink, not its target"

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -131,11 +131,11 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
 
     assert!(!promoted);
     let metadata = cache
-        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
+        .read_metadata_file(cache.entry_paths(&key).metadata())
         .await
         .unwrap();
     assert_eq!(metadata.last_completed_at, "2026-06-02T00:00:00.000Z");
-    let current = tokio::fs::read(paths.workspace_image_cache_current_image(&key))
+    let current = tokio::fs::read(cache.entry_paths(&key).current_image().to_path_buf())
         .await
         .unwrap();
     assert_eq!(current, existing_image);
@@ -193,11 +193,11 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
 
     assert!(!promoted);
     let metadata = cache
-        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
+        .read_metadata_file(cache.entry_paths(&key).metadata())
         .await
         .unwrap();
     assert_eq!(metadata.last_completed_at, completed_at);
-    let current = tokio::fs::read(paths.workspace_image_cache_current_image(&key))
+    let current = tokio::fs::read(cache.entry_paths(&key).current_image().to_path_buf())
         .await
         .unwrap();
     assert_eq!(current, existing_image);
@@ -252,11 +252,11 @@ async fn promotion_overwrites_older_cache_entry() {
 
     assert!(promoted);
     let metadata = cache
-        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
+        .read_metadata_file(cache.entry_paths(&key).metadata())
         .await
         .unwrap();
     assert_eq!(metadata.last_completed_at, "2026-06-02T00:00:00.000Z");
-    let current = tokio::fs::read(paths.workspace_image_cache_current_image(&key))
+    let current = tokio::fs::read(cache.entry_paths(&key).current_image().to_path_buf())
         .await
         .unwrap();
     assert_eq!(current, b"new image");
@@ -302,8 +302,10 @@ async fn successful_multi_entry_promotion_scans_cache_root_once() {
     );
     for cache_key in [first_key, second_key, promoted_key] {
         assert!(
-            paths
-                .workspace_image_cache_current_image(&cache_key)
+            cache
+                .entry_paths(&cache_key)
+                .current_image()
+                .to_path_buf()
                 .exists(),
             "healthy under-budget entries should remain after post-promotion GC"
         );
@@ -312,7 +314,7 @@ async fn successful_multi_entry_promotion_scans_cache_root_once() {
 
 #[tokio::test]
 async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let reuse_key = "sess-abandon-hit";
     let cache_run_id = RunId::new_v4();
     let cache_key = write_current_cache_entry(
@@ -324,7 +326,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.workspace_image_cache_current_image(&cache_key);
+    let current = cache.entry_paths(&cache_key).current_image().to_path_buf();
     let image_size_bytes = fs::metadata(&current).await.unwrap().len();
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
@@ -344,7 +346,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
     assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
     assert!(lease.consumed_cache_hit);
     assert!(
-        !fs::try_exists(paths.workspace_image_cache_metadata(&cache_key))
+        !fs::try_exists(cache.entry_paths(&cache_key).metadata().to_path_buf())
             .await
             .unwrap()
     );
@@ -366,7 +368,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
             .unwrap()
     );
     assert!(
-        !fs::try_exists(paths.workspace_image_cache_entry_dir(&cache_key))
+        !fs::try_exists(cache.entry_paths(&cache_key).entry_dir().to_path_buf())
             .await
             .unwrap()
     );
@@ -401,7 +403,7 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
         "2026-05-01T00:00:00.000Z",
     )
     .await;
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     let image_size = fs::metadata(&current).await.unwrap().len();
     let active_image = paths.active_workspace_image(&sandbox_id);
 
@@ -452,7 +454,7 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
         "same-filesystem promotion must publish the moved image without copying its extents"
     );
     let metadata = cache
-        .read_metadata_file(&paths.workspace_image_cache_metadata(&key))
+        .read_metadata_file(cache.entry_paths(&key).metadata())
         .await
         .unwrap();
     assert_eq!(metadata.logical_image_size_bytes, image_size);
@@ -731,7 +733,7 @@ async fn cross_filesystem_promotion_still_requires_copy_headroom() {
 
 #[tokio::test]
 async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 1024);
     let _held_lock = crate::lock::acquire(cache.entry_lock_path(&cache_key))
@@ -765,8 +767,10 @@ async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
             .unwrap()
     );
     assert!(
-        !paths
-            .workspace_image_cache_current_image(&cache_key)
+        !cache
+            .entry_paths(&cache_key)
+            .current_image()
+            .to_path_buf()
             .exists()
     );
 }
@@ -1026,8 +1030,10 @@ async fn promote_skips_symlink_active_image_without_following_it() {
     let cache_key = workspace_image_cache_key(reuse_key, "/workspace");
     assert!(!promoted);
     assert!(
-        !paths
-            .workspace_image_cache_current_image(&cache_key)
+        !cache
+            .entry_paths(&cache_key)
+            .current_image()
+            .to_path_buf()
             .exists()
     );
     assert_eq!(tokio::fs::read(&outside_image).await.unwrap(), b"image");
@@ -1065,7 +1071,7 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
         .unwrap();
     tokio::fs::write(&active_image, b"image").await.unwrap();
     let cache_key = workspace_image_cache_key(reuse_key, "/workspace");
-    let entry_dir = paths.workspace_image_cache_entry_dir(&cache_key);
+    let entry_dir = cache.entry_paths(&cache_key).entry_dir().to_path_buf();
     let outside_entry = dir.path().join("outside-promotion-entry");
     tokio::fs::create_dir_all(&outside_entry).await.unwrap();
     tokio::fs::write(outside_entry.join("marker"), b"marker")
@@ -1091,7 +1097,7 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
     assert!(entry_metadata.is_dir());
     assert!(!entry_metadata.file_type().is_symlink());
     assert_eq!(
-        fs::read(paths.workspace_image_cache_current_image(&cache_key))
+        fs::read(cache.entry_paths(&cache_key).current_image().to_path_buf())
             .await
             .unwrap(),
         b"image"
@@ -1128,7 +1134,7 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
     tokio::fs::write(&active_image, b"image").await.unwrap();
 
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    let metadata_path = paths.workspace_image_cache_metadata(&cache_key);
+    let metadata_path = cache.entry_paths(&cache_key).metadata().to_path_buf();
     tokio::fs::create_dir_all(&metadata_path).await.unwrap();
 
     let err = lease
@@ -1147,20 +1153,14 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
         "metadata failure after ownership transfer must not leave a second active image"
     );
     assert!(
-        !paths
-            .workspace_image_cache_current_image(&cache_key)
+        !cache
+            .entry_paths(&cache_key)
+            .current_image()
+            .to_path_buf()
             .exists()
     );
-    assert!(
-        !paths
-            .workspace_image_cache_tmp_image(&cache_key, run_id)
-            .exists()
-    );
-    assert!(
-        !metadata_path
-            .with_file_name(format!("metadata.json.tmp.{run_id}"))
-            .exists()
-    );
+    assert!(!cache.entry_paths(&cache_key).tmp_image(run_id).exists());
+    assert!(!cache.entry_paths(&cache_key).tmp_metadata(run_id).exists());
 }
 
 #[tokio::test]
@@ -1188,7 +1188,7 @@ async fn promote_removes_stale_temporary_directory_before_transfer() {
         .await
         .unwrap();
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    let tmp = paths.workspace_image_cache_tmp_image(&cache_key, run_id);
+    let tmp = cache.entry_paths(&cache_key).tmp_image(run_id);
     tokio::fs::create_dir_all(&tmp).await.unwrap();
     tokio::fs::write(tmp.join("stale"), b"stale").await.unwrap();
 
@@ -1204,7 +1204,7 @@ async fn promote_removes_stale_temporary_directory_before_transfer() {
             .unwrap()
     );
 
-    let current = paths.workspace_image_cache_current_image(&cache_key);
+    let current = cache.entry_paths(&cache_key).current_image().to_path_buf();
     assert!(!tmp.exists());
     assert!(fs::metadata(&current).await.unwrap().is_file());
     assert_eq!(fs::read(current).await.unwrap(), b"image");
@@ -1235,7 +1235,7 @@ async fn promote_replaces_stale_current_directory_before_rename() {
         .await
         .unwrap();
     let cache_key = workspace_image_cache_key("sess-1", "/workspace");
-    let current = paths.workspace_image_cache_current_image(&cache_key);
+    let current = cache.entry_paths(&cache_key).current_image().to_path_buf();
     tokio::fs::create_dir_all(&current).await.unwrap();
     tokio::fs::write(current.join("stale"), b"stale")
         .await
@@ -1295,8 +1295,10 @@ async fn promote_skips_transferred_image_with_unexpected_logical_size() {
             .unwrap()
     );
     assert!(
-        !paths
-            .workspace_image_cache_current_image(&cache_key)
+        !cache
+            .entry_paths(&cache_key)
+            .current_image()
+            .to_path_buf()
             .exists()
     );
     assert!(cache.held_workspace_states().await.is_empty());
@@ -1343,8 +1345,10 @@ async fn promote_skips_when_capacity_lock_is_busy() {
 
     assert!(!promoted);
     assert!(
-        !paths
-            .workspace_image_cache_current_image(&cache_key)
+        !cache
+            .entry_paths(&cache_key)
+            .current_image()
+            .to_path_buf()
             .exists()
     );
     assert!(cache.held_workspace_states().await.is_empty());

--- a/crates/runner/src/workspace_image_cache/tests/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/tests/sidecar.rs
@@ -68,7 +68,7 @@ async fn publish_test_session_history_sidecar(
 
 #[tokio::test]
 async fn session_history_sidecar_publish_and_probe_hit() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let session_id = "sess-sidecar-hit";
     let history = br#"{"type":"message","content":"hello"}"#;
@@ -84,9 +84,10 @@ async fn session_history_sidecar_publish_and_probe_hit() {
 
     let identity =
         publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let metadata_path = paths
-        .workspace_image_cache_entry_dir(&cache_key)
-        .join("session-history.metadata.json");
+    let metadata_path = cache
+        .entry_paths(&cache_key)
+        .session_history_sidecar_metadata()
+        .to_path_buf();
     let metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
     assert!(metadata.get("historyGenerationRunId").is_none());
@@ -118,7 +119,7 @@ async fn session_history_sidecar_publish_and_probe_hit() {
 
 #[tokio::test]
 async fn session_history_sidecar_rejects_group_writable_source() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let session_id = "sess-sidecar-group-writable";
     let history = br#"{"type":"message","content":"unsafe"}"#;
@@ -155,16 +156,17 @@ async fn session_history_sidecar_rejects_group_writable_source() {
     assert!(error.to_string().contains("group/other writable"));
     assert!(!tmp_path.exists());
     assert!(
-        !paths
-            .workspace_image_cache_entry_dir(&cache_key)
-            .join("session-history.metadata.json")
+        !cache
+            .entry_paths(&cache_key)
+            .session_history_sidecar_metadata()
+            .to_path_buf()
             .exists()
     );
 }
 
 #[tokio::test]
 async fn session_history_sidecar_does_not_publish_non_regular_source() {
-    let (dir, paths, cache) = local_cache().await;
+    let (dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let session_id = "sess-sidecar-symlink-source";
     let history = br#"{"type":"message","content":"outside"}"#;
@@ -200,16 +202,17 @@ async fn session_history_sidecar_does_not_publish_non_regular_source() {
     assert!(!tmp_path.exists());
     assert_eq!(fs::read(&outside).await.unwrap(), history);
     assert!(
-        !paths
-            .workspace_image_cache_entry_dir(&cache_key)
-            .join("session-history.metadata.json")
+        !cache
+            .entry_paths(&cache_key)
+            .session_history_sidecar_metadata()
+            .to_path_buf()
             .exists()
     );
 }
 
 #[tokio::test]
 async fn previous_session_history_sidecar_metadata_remains_restoreable() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let session_id = "sess-sidecar-previous";
     let history = br#"{"type":"message","content":"previous"}"#;
@@ -224,9 +227,10 @@ async fn previous_session_history_sidecar_metadata_remains_restoreable() {
     .await;
     let identity =
         publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let metadata_path = paths
-        .workspace_image_cache_entry_dir(&cache_key)
-        .join("session-history.metadata.json");
+    let metadata_path = cache
+        .entry_paths(&cache_key)
+        .session_history_sidecar_metadata()
+        .to_path_buf();
     let mut metadata: serde_json::Value =
         serde_json::from_slice(&fs::read(&metadata_path).await.unwrap()).unwrap();
     let metadata = metadata.as_object_mut().unwrap();
@@ -304,8 +308,9 @@ async fn invalid_session_history_sidecars_are_rejected_by_probe() {
         let identity =
             publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history)
                 .await;
-        let entry_dir = paths.workspace_image_cache_entry_dir(&cache_key);
-        let metadata_path = entry_dir.join("session-history.metadata.json");
+        let entry_paths = cache.entry_paths(&cache_key);
+        let entry_dir = entry_paths.entry_dir();
+        let metadata_path = entry_paths.session_history_sidecar_metadata().to_path_buf();
         let body_path = cache
             .probe_session_history_sidecar(&cache_key, &identity)
             .await
@@ -490,7 +495,7 @@ async fn session_history_sidecar_preserve_keeps_existing_sidecar() {
 
 #[tokio::test]
 async fn session_history_sidecar_body_rename_failure_preserves_committed_sidecar() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = write_current_cache_entry(
         &cache,
@@ -509,9 +514,10 @@ async fn session_history_sidecar_body_rename_failure_preserves_committed_sidecar
         .probe_session_history_sidecar(&cache_key, &identity_a)
         .await
         .unwrap();
-    let metadata_path = paths
-        .workspace_image_cache_entry_dir(&cache_key)
-        .join("session-history.metadata.json");
+    let metadata_path = cache
+        .entry_paths(&cache_key)
+        .session_history_sidecar_metadata()
+        .to_path_buf();
     let metadata_a = fs::read(&metadata_path).await.unwrap();
 
     let replacement_run_id = RunId::new_v4();
@@ -525,8 +531,10 @@ async fn session_history_sidecar_body_rename_failure_preserves_committed_sidecar
         encoded_size: history_b.len() as u64,
         restored_session_identity: identity_b,
     };
-    let blocked_slot = paths
-        .workspace_image_cache_entry_dir(&cache_key)
+    let blocked_slot = cache
+        .entry_paths(&cache_key)
+        .entry_dir()
+        .to_path_buf()
         .join("session-history.second.blob");
     fs::create_dir(&blocked_slot).await.unwrap();
 
@@ -550,7 +558,7 @@ async fn session_history_sidecar_body_rename_failure_preserves_committed_sidecar
 
 #[tokio::test]
 async fn session_history_sidecar_metadata_commit_failure_rolls_back_replacement() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let cache_key = write_current_cache_entry(
         &cache,
@@ -572,8 +580,9 @@ async fn session_history_sidecar_metadata_commit_failure_rolls_back_replacement(
     let body_a = committed_a.path;
     let body_a_identity =
         WorkspaceImageFileIdentity::from_metadata(&fs::symlink_metadata(&body_a).await.unwrap());
-    let entry_dir = paths.workspace_image_cache_entry_dir(&cache_key);
-    let metadata_path = entry_dir.join("session-history.metadata.json");
+    let entry_paths = cache.entry_paths(&cache_key);
+    let entry_dir = entry_paths.entry_dir().to_path_buf();
+    let metadata_path = entry_paths.session_history_sidecar_metadata().to_path_buf();
     let metadata_a = fs::read(&metadata_path).await.unwrap();
 
     let failed_run_id = RunId::new_v4();
@@ -742,7 +751,7 @@ async fn session_history_sidecar_probe_rejects_mismatched_body_identity() {
 
 #[tokio::test]
 async fn session_history_sidecar_counts_toward_gc_candidate_and_inspection() {
-    let (_dir, paths, cache) = local_cache().await;
+    let (_dir, _paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let session_id = "sess-sidecar-accounting";
     let history = br#"{"type":"message","content":"accounting"}"#;
@@ -756,10 +765,8 @@ async fn session_history_sidecar_counts_toward_gc_candidate_and_inspection() {
     )
     .await;
     publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let current_allocated = workspace_cache_path_allocated_bytes(
-        &paths.workspace_image_cache_current_image(&cache_key),
-    )
-    .await;
+    let current_allocated =
+        workspace_cache_path_allocated_bytes(cache.entry_paths(&cache_key).current_image()).await;
     let sidecar_allocated = cache
         .session_history_sidecar_allocated_bytes(&cache_key)
         .await;

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -417,10 +417,10 @@ async fn held_workspace_states_reject_metadata_under_wrong_cache_key() {
         "/workspace",
         b"old image".len() as u64,
     );
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache
@@ -461,10 +461,10 @@ async fn held_workspace_states_reject_unsafe_working_dir_metadata() {
     let cache = WorkspaceImageCache::new(paths.clone());
     let run_id = RunId::new_v4();
     let key = workspace_image_cache_key("sess-1", "/");
-    fs::create_dir_all(paths.workspace_image_cache_entry_dir(&key))
+    fs::create_dir_all(cache.entry_paths(&key).entry_dir().to_path_buf())
         .await
         .unwrap();
-    let current = paths.workspace_image_cache_current_image(&key);
+    let current = cache.entry_paths(&key).current_image().to_path_buf();
     fs::write(&current, b"image").await.unwrap();
     let current_metadata = fs::metadata(&current).await.unwrap();
     cache

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -374,10 +374,16 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     assert_eq!(copy_calls.len(), 1);
     assert!(copy_calls[0].path.ends_with("/session-history-sidecar"));
     assert_eq!(copy_calls[0].max_bytes, RESUME_SESSION_HISTORY_MAX_BYTES);
-    let sidecar_entry_dir = copy_calls[0].host_path.parent().unwrap();
-    let sidecar_metadata_path = sidecar_entry_dir.join("session-history.metadata.json");
+    let inspection = fixture.cache.inspect().await.unwrap();
+    let entry = inspection.entries.first().unwrap();
+    let entry_paths = fixture.cache.entry_paths(&entry.cache_key);
+    assert_eq!(
+        copy_calls[0].host_path.parent(),
+        Some(entry_paths.entry_dir())
+    );
+    let sidecar_metadata_path = entry_paths.session_history_sidecar_metadata();
     if !sidecar_metadata_path.is_file() {
-        let entries = std::fs::read_dir(sidecar_entry_dir)
+        let entries = std::fs::read_dir(entry_paths.entry_dir())
             .unwrap()
             .map(|entry| entry.unwrap().file_name())
             .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

- make `CacheEntryPaths` the crate-internal source of valid workspace image cache entry paths
- remove the duplicate test-only `RunnerPaths` entry helpers and migrate cache fixtures to the canonical value object
- derive metadata staging and stable session-history sidecar paths through the same path owner

## Scope

This is an internal path-ownership refactor. It does not change cache-key hashing, cache-root selection, locking, serialized metadata, external contracts, or the on-disk layout. Deliberately malformed and outside-entry paths remain explicit in adversarial tests.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --quiet`
- repository pre-commit and commit-message hooks

Closes #26032
