### PR TITLE
feat: add conversation locator rail behind a feature switch

### DIFF
--- a/turbo/apps/platform/src/i18n/format.ts
+++ b/turbo/apps/platform/src/i18n/format.ts
@@ -36,3 +36,13 @@ export function formatUsd(dollars: number, fractionDigits = 2): string {
     maximumFractionDigits: fractionDigits,
   });
 }
+
+/** Short date + time used for chat event timestamps. */
+export function formatChatTimestamp(value: string): string {
+  return new Date(value).toLocaleString(resolvedAppLocale(), {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1672,6 +1672,9 @@
       "frequentlyUsed": "Häufig verwendet",
       "icon": "Chat-Thread-Symbol",
       "loadingEarlier": "Frühere Nachrichten werden geladen",
+      "locator": {
+        "you": "Du"
+      },
       "noEmojiFound": "Kein Emoji gefunden",
       "notFound": "Chat-Thread nicht gefunden",
       "openArtifacts": "Artefakte öffnen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1672,6 +1672,9 @@
       "frequentlyUsed": "Frequently used",
       "icon": "Chat thread icon",
       "loadingEarlier": "Loading earlier messages",
+      "locator": {
+        "you": "You"
+      },
       "noEmojiFound": "No emoji found",
       "notFound": "Chat thread not found",
       "openArtifacts": "Open artifacts",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1712,6 +1712,9 @@
       "frequentlyUsed": "Usados con frecuencia",
       "icon": "Icono del hilo de chat",
       "loadingEarlier": "Cargando mensajes anteriores",
+      "locator": {
+        "you": "Tú"
+      },
       "noEmojiFound": "No se ha encontrado ningún emoji",
       "notFound": "Hilo de chat no encontrado",
       "openArtifacts": "Abrir artefactos",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1712,6 +1712,9 @@
       "frequentlyUsed": "Fréquemment utilisé",
       "icon": "Icône de fil de discussion",
       "loadingEarlier": "Chargement des messages précédents",
+      "locator": {
+        "you": "Vous"
+      },
       "noEmojiFound": "Aucun emoji trouvé",
       "notFound": "Fil de discussion introuvable",
       "openArtifacts": "Ouvrir les artéfacts",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1672,6 +1672,9 @@
       "frequentlyUsed": "बहुधा प्रयुक्त",
       "icon": "चैट थ्रेड आइकन",
       "loadingEarlier": "पहले के संदेश लोड हो रहे हैं",
+      "locator": {
+        "you": "आप"
+      },
       "noEmojiFound": "कोई इमोजी नहीं मिला",
       "notFound": "चैट थ्रेड नहीं मिला",
       "openArtifacts": "आर्टिफ़ैक्ट खोलें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1671,6 +1671,9 @@
       "frequentlyUsed": "Sering digunakan",
       "icon": "Ikon thread chat",
       "loadingEarlier": "Memuat pesan sebelumnya",
+      "locator": {
+        "you": "Anda"
+      },
       "noEmojiFound": "Emoji tidak ditemukan",
       "notFound": "Utas chat tidak ditemukan",
       "openArtifacts": "Buka artefak",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1712,6 +1712,9 @@
       "frequentlyUsed": "Usato frequentemente",
       "icon": "Icona del thread di chat",
       "loadingEarlier": "Caricamento dei messaggi precedenti",
+      "locator": {
+        "you": "Tu"
+      },
       "noEmojiFound": "Nessuna emoji trovata",
       "notFound": "Conversazione non trovata",
       "openArtifacts": "Artefatti aperti",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1671,6 +1671,9 @@
       "frequentlyUsed": "頻繁に使用される",
       "icon": "チャットスレッドアイコン",
       "loadingEarlier": "以前のメッセージを読み込んでいます",
+      "locator": {
+        "you": "あなた"
+      },
       "noEmojiFound": "絵文字が見つかりませんでした",
       "notFound": "チャットスレッドが見つかりません",
       "openArtifacts": "オープンアーティファクト",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1671,6 +1671,9 @@
       "frequentlyUsed": "자주 사용하는 항목",
       "icon": "채팅 스레드 아이콘",
       "loadingEarlier": "이전 메시지 불러오는 중",
+      "locator": {
+        "you": "나"
+      },
       "noEmojiFound": "이모지가 없습니다",
       "notFound": "채팅 스레드를 찾을 수 없습니다",
       "openArtifacts": "아티팩트 열기",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1712,6 +1712,9 @@
       "frequentlyUsed": "Usados com frequência",
       "icon": "Ícone da conversa",
       "loadingEarlier": "Carregando mensagens anteriores",
+      "locator": {
+        "you": "Você"
+      },
       "noEmojiFound": "Nenhum emoji encontrado",
       "notFound": "Conversa não encontrada",
       "openArtifacts": "Abrir artefatos",

--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -509,7 +509,6 @@ function createJump(
   store: LocatorStore,
   threadId: string,
   scrollContainer$: Computed<HTMLElement | null>,
-  scrollToTurn: (container: HTMLElement, top: number) => void,
 ) {
   return command(({ get }, turnIndex: number) => {
     const container = get(scrollContainer$);
@@ -518,10 +517,10 @@ function createJump(
       return;
     }
     L.debug("jump to turn", { threadId, turnIndex });
-    scrollToTurn(
-      container,
-      Math.max(0, turn.top - container.clientHeight * JUMP_VIEWPORT_RATIO),
-    );
+    container.scrollTo({
+      top: Math.max(0, turn.top - container.clientHeight * JUMP_VIEWPORT_RATIO),
+      behavior: "smooth",
+    });
     turn.element.dataset.locatorLanded = "";
     turn.element.ownerDocument.defaultView?.setTimeout(() => {
       delete turn.element.dataset.locatorLanded;
@@ -871,24 +870,14 @@ function createPreviewOnRef(store: LocatorStore) {
 export function createChatConversationLocatorSignals({
   threadId,
   scrollContainer$,
-  scrollToTurn = (container, top) => {
-    container.scrollTo({ top, behavior: "smooth" });
-  },
 }: {
   threadId: string;
   scrollContainer$: Computed<HTMLElement | null>;
-  /** Smooth-scrolls the container; kept injectable so tests can observe it. */
-  scrollToTurn?: (container: HTMLElement, top: number) => void;
 }): ChatConversationLocatorSignals {
   const store = createStore();
   const recompute$ = createRecompute(store, scrollContainer$);
   const paint$ = createPaint(store);
-  const jumpToTurn$ = createJump(
-    store,
-    threadId,
-    scrollContainer$,
-    scrollToTurn,
-  );
+  const jumpToTurn$ = createJump(store, threadId, scrollContainer$);
   const railOnRef$ = createRailOnRef(store, threadId, scrollContainer$, {
     recompute$,
     paint$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -88,6 +88,8 @@ export interface LocatorPreview {
   readonly turnIndex: number;
   readonly role: LocatorRole;
   readonly text: string;
+  /** ISO timestamp of the turn, or undefined when it carries none. */
+  readonly createdAt: string | undefined;
   /** 1-based, for the "12/32" counter. */
   readonly position: number;
   readonly total: number;
@@ -120,6 +122,8 @@ function emptyLayout(): LocatorLayout {
 interface DomTurn {
   readonly element: HTMLElement;
   readonly role: LocatorRole;
+  /** ISO timestamp stamped on the turn wrapper, absent on optimistic rows. */
+  readonly createdAt: string | undefined;
   /** Offset inside the scroll content, not the offsetParent chain. */
   readonly top: number;
   readonly height: number;
@@ -187,6 +191,7 @@ function readTurns(container: HTMLElement): DomTurn[] {
     turns.push({
       element,
       role: roleOf(element),
+      createdAt: element.dataset.turnCreatedAt,
       top: rect.top - containerTop + scrollTop,
       height: rect.height,
     });
@@ -493,6 +498,7 @@ function createPaint(store: LocatorStore) {
       turnIndex: tick.turnIndex,
       role: tick.role,
       text: previewTextFor(turn.element),
+      createdAt: turn.createdAt,
       position: tick.turnIndex + 1,
       total: layout.turnCount,
     });

--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -1,0 +1,910 @@
+/**
+ * Conversation locator
+ *
+ * A tick rail beside a long chat thread. One tick per rendered turn, evenly
+ * spaced; hovering magnifies neighbouring ticks, names the turn under the
+ * cursor in a floating preview, and clicking jumps to it.
+ *
+ * Turn geometry is read from the DOM rather than the group signals, the same
+ * way `chat-thread-scroll.ts` reads its anchors: only rendered turns can be
+ * pointed at, and the paged renderer decides what is rendered.
+ */
+
+import {
+  command,
+  computed,
+  state,
+  type Command,
+  type Computed,
+  type State,
+} from "ccstate";
+import { animationFrame } from "signal-timers";
+import { logger } from "../log.ts";
+import { onRef } from "../utils.ts";
+
+const L = logger("ConversationLocator");
+
+/** Rail padding above and below the tick group. */
+const RAIL_PADDING_PX = 24;
+/** Comfortable tick spacing; the rail pages rather than packs tighter. */
+const PITCH_MAX_PX = 10;
+const PITCH_MIN_PX = 3;
+/** Ticks drawn at once. Beyond this the rail becomes a window over the turns. */
+const MAX_TICKS = 24;
+/** Appearance floor A: fewer ticks read as stray dashes, not as a scale. */
+const SHOW_MIN_TURNS = 8;
+/** Appearance floor B: below this the reader can still scroll back by eye. */
+const SHOW_MIN_SCREENS = 3;
+/** Fraction of the viewport that decides which turn counts as "current". */
+const CURRENT_TURN_VIEWPORT_RATIO = 0.38;
+/** Where a jump parks its target inside the viewport. */
+const JUMP_VIEWPORT_RATIO = 0.28;
+/** Wheel travel that advances the window by one tick. */
+const WHEEL_STEP_PX = 26;
+/** Follow coefficient for the preview card; below 1 it trails the cursor. */
+const POINTER_FOLLOW = 0.22;
+const POINTER_OFFSET_X_PX = 26;
+const POINTER_EDGE_MARGIN_PX = 16;
+/** Falloff radius, as a multiple of pitch, so density does not change feel. */
+const MAGNIFY_SIGMA_RATIO = 2.6;
+const MAGNIFY_SIGMA_MIN_PX = 26;
+/** How long a jumped-to turn stays marked. */
+const LANDED_MARK_MS = 1200;
+/** Turns overlapping the viewport by less than this do not extend the band. */
+const BAND_EDGE_SLACK_PX = 8;
+
+/** Resting length and magnification, per role. Two discrete steps, no more. */
+const TICK_METRICS = {
+  user: { base: 7, grow: 3.1 },
+  assistant: { base: 12, grow: 2.5 },
+} as const;
+
+const GROUP_SELECTOR = '[data-role="user"], [data-role="assistant"]';
+
+export type LocatorRole = keyof typeof TICK_METRICS;
+
+interface LocatorTick {
+  readonly turnIndex: number;
+  readonly role: LocatorRole;
+  /** Integer offset from the rail top, so ticks land on device pixels. */
+  readonly y: number;
+  /** 0 = fully shown; 1 and 2 fade toward an edge that still has turns. */
+  readonly edge: 0 | 1 | 2;
+  readonly current: boolean;
+}
+
+export interface LocatorLayout {
+  /** False until the thread is long enough to be worth an instrument. */
+  readonly visible: boolean;
+  readonly ticks: readonly LocatorTick[];
+  readonly pitch: number;
+  /** Band marking the turns currently inside the viewport. */
+  readonly bandTop: number;
+  readonly bandHeight: number;
+  readonly turnCount: number;
+}
+
+export interface LocatorPreview {
+  readonly turnIndex: number;
+  readonly role: LocatorRole;
+  readonly text: string;
+  /** 1-based, for the "12/32" counter. */
+  readonly position: number;
+  readonly total: number;
+}
+
+export interface ChatConversationLocatorSignals {
+  readonly railOnRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
+  readonly previewOnRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
+  >;
+  readonly layout$: Computed<LocatorLayout>;
+  readonly preview$: Computed<LocatorPreview | null>;
+  /** True while the pointer is over the rail. */
+  readonly engaged$: Computed<boolean>;
+  readonly jumpToTurn$: Command<void, [number]>;
+}
+
+function emptyLayout(): LocatorLayout {
+  return {
+    visible: false,
+    ticks: [],
+    pitch: PITCH_MAX_PX,
+    bandTop: 0,
+    bandHeight: 0,
+    turnCount: 0,
+  };
+}
+
+interface DomTurn {
+  readonly element: HTMLElement;
+  readonly role: LocatorRole;
+  /** Offset inside the scroll content, not the offsetParent chain. */
+  readonly top: number;
+  readonly height: number;
+}
+
+interface LocatorStore {
+  readonly rail$: State<HTMLElement | null>;
+  readonly previewElement$: State<HTMLElement | null>;
+  readonly layout$: State<LocatorLayout>;
+  readonly preview$: State<LocatorPreview | null>;
+  readonly engaged$: State<boolean>;
+  readonly windowStart$: State<number>;
+  readonly pagedByReader$: State<boolean>;
+  /** Last measurement, reused while only the scroll offset changes. */
+  turns: DomTurn[];
+}
+
+/** Per-binding pointer and scheduling bookkeeping. */
+interface RailRuntime {
+  pointerX: number | null;
+  pointerY: number | null;
+  followX: number;
+  followY: number;
+  followStarted: boolean;
+  followRunning: boolean;
+  wheelTravel: number;
+  remeasurePending: boolean;
+  recomputeQueued: boolean;
+  magnifyQueued: boolean;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function roleOf(element: HTMLElement): LocatorRole {
+  return element.dataset.role === "user" ? "user" : "assistant";
+}
+
+/**
+ * Outermost group wrappers only. Assistant events nest their own `data-role`
+ * markers, and the thinking indicator carries one without being a turn.
+ */
+function readTurns(container: HTMLElement): DomTurn[] {
+  const content = container.querySelector<HTMLElement>(
+    "[data-message-container]",
+  );
+  if (!content) {
+    return [];
+  }
+  const containerTop = container.getBoundingClientRect().top;
+  const scrollTop = container.scrollTop;
+  const turns: DomTurn[] = [];
+  for (const element of content.querySelectorAll<HTMLElement>(GROUP_SELECTOR)) {
+    if (Object.hasOwn(element.dataset, "thinkingIndicator")) {
+      continue;
+    }
+    if (element.parentElement?.closest(GROUP_SELECTOR)) {
+      continue;
+    }
+    const rect = element.getBoundingClientRect();
+    if (rect.height === 0) {
+      continue;
+    }
+    turns.push({
+      element,
+      role: roleOf(element),
+      top: rect.top - containerTop + scrollTop,
+      height: rect.height,
+    });
+  }
+  return turns;
+}
+
+/** The message body alone — tool chrome and action labels are not a preview. */
+function previewTextFor(element: HTMLElement): string {
+  const bubble = element.querySelector<HTMLElement>(
+    ".zero-chat-bubble-user, .zero-chat-bubble-assistant",
+  );
+  return (bubble ?? element).textContent?.replace(/\s+/gu, " ").trim() ?? "";
+}
+
+function currentTurnIndex(
+  turns: readonly DomTurn[],
+  scrollTop: number,
+  clientHeight: number,
+): number {
+  const focus = scrollTop + clientHeight * CURRENT_TURN_VIEWPORT_RATIO;
+  let best = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const [index, turn] of turns.entries()) {
+    const distance = Math.abs(turn.top + turn.height / 2 - focus);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = index;
+    }
+  }
+  return best;
+}
+
+function edgeFor(
+  offset: number,
+  windowCount: number,
+  moreAbove: boolean,
+  moreBelow: boolean,
+): 0 | 1 | 2 {
+  if (
+    (moreAbove && offset === 0) ||
+    (moreBelow && offset === windowCount - 1)
+  ) {
+    return 2;
+  }
+  if (
+    (moreAbove && offset === 1) ||
+    (moreBelow && offset === windowCount - 2)
+  ) {
+    return 1;
+  }
+  return 0;
+}
+
+interface WindowGeometry {
+  readonly windowStart: number;
+  readonly windowCount: number;
+  readonly pitch: number;
+  readonly origin: number;
+}
+
+function windowGeometry(
+  turnCount: number,
+  railHeight: number,
+  current: number,
+  requestedStart: number | null,
+): WindowGeometry {
+  const usable = railHeight - RAIL_PADDING_PX * 2;
+  const windowCount = Math.min(turnCount, MAX_TICKS);
+  // Without a reader-paged window the rail follows the reading position,
+  // centring the current turn.
+  const preferredStart =
+    requestedStart ?? Math.round(current - windowCount / 2);
+  const windowStart = clamp(preferredStart, 0, turnCount - windowCount);
+  // Integer pitch and origin keep every tick on a whole device pixel; a
+  // half-pixel bar renders as a blurred triple line instead of a hairline.
+  const pitch =
+    windowCount > 1
+      ? clamp(
+          Math.floor(usable / (windowCount - 1)),
+          PITCH_MIN_PX,
+          PITCH_MAX_PX,
+        )
+      : 0;
+  const origin = Math.round(
+    RAIL_PADDING_PX + (usable - pitch * (windowCount - 1)) / 2,
+  );
+  return { windowStart, windowCount, pitch, origin };
+}
+
+function buildTicks(
+  turns: readonly DomTurn[],
+  geometry: WindowGeometry,
+  current: number,
+): LocatorTick[] {
+  const { windowStart, windowCount, pitch, origin } = geometry;
+  const moreAbove = windowStart > 0;
+  const moreBelow = windowStart + windowCount < turns.length;
+  const ticks: LocatorTick[] = [];
+  for (let offset = 0; offset < windowCount; offset += 1) {
+    const turnIndex = windowStart + offset;
+    const turn = turns[turnIndex];
+    if (!turn) {
+      continue;
+    }
+    ticks.push({
+      turnIndex,
+      role: turn.role,
+      y: origin + offset * pitch,
+      edge: edgeFor(offset, windowCount, moreAbove, moreBelow),
+      current: turnIndex === current,
+    });
+  }
+  return ticks;
+}
+
+function buildBand(
+  turns: readonly DomTurn[],
+  geometry: WindowGeometry,
+  scrollTop: number,
+  clientHeight: number,
+): { bandTop: number; bandHeight: number } {
+  const { windowStart, windowCount, pitch, origin } = geometry;
+  const viewportBottom = scrollTop + clientHeight;
+  let first = -1;
+  let last = -1;
+  for (let offset = 0; offset < windowCount; offset += 1) {
+    const turn = turns[windowStart + offset];
+    if (!turn) {
+      continue;
+    }
+    const overlaps =
+      turn.top + turn.height > scrollTop + BAND_EDGE_SLACK_PX &&
+      turn.top < viewportBottom - BAND_EDGE_SLACK_PX;
+    if (overlaps) {
+      if (first < 0) {
+        first = offset;
+      }
+      last = offset;
+    }
+  }
+  if (first < 0) {
+    return { bandTop: 0, bandHeight: 0 };
+  }
+  return {
+    bandTop: origin + first * pitch - pitch / 2 - 3,
+    bandHeight: (last - first) * pitch + pitch + 6,
+  };
+}
+
+function tickNodes(rail: HTMLElement): HTMLElement[] {
+  return [...rail.querySelectorAll<HTMLElement>("[data-locator-tick]")];
+}
+
+function resetTickWidths(rail: HTMLElement): void {
+  for (const node of tickNodes(rail)) {
+    const role: LocatorRole =
+      node.dataset.locatorTick === "user" ? "user" : "assistant";
+    node.style.width = `${TICK_METRICS[role].base}px`;
+    delete node.dataset.locatorHot;
+  }
+}
+
+/**
+ * Writes magnified widths and returns the tick under the cursor. Widths change
+ * every pointer frame, so they bypass the layout signal: re-rendering the rail
+ * at that rate to move a few pixels is work nobody sees.
+ */
+function applyMagnification(
+  rail: HTMLElement,
+  layout: LocatorLayout,
+  pointerY: number,
+): number | null {
+  const nodes = tickNodes(rail);
+  const sigma = Math.max(
+    MAGNIFY_SIGMA_MIN_PX,
+    layout.pitch * MAGNIFY_SIGMA_RATIO,
+  );
+  let nearest = -1;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (const [index, tick] of layout.ticks.entries()) {
+    const node = nodes[index];
+    if (!node) {
+      continue;
+    }
+    const distance = Math.abs(tick.y - pointerY);
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = index;
+    }
+    const weight = Math.exp(-(distance * distance) / (2 * sigma * sigma));
+    const metrics = TICK_METRICS[tick.role];
+    const width = metrics.base * (1 + weight * metrics.grow);
+    node.style.width = `${width.toFixed(2)}px`;
+  }
+
+  // Anywhere inside the group the nearest tick is at most half a pitch away,
+  // so only overshooting the first or last tick misses.
+  const hit = nearest >= 0 && nearestDistance <= layout.pitch / 2 + 6;
+  for (const [index, node] of nodes.entries()) {
+    if (hit && index === nearest) {
+      node.dataset.locatorHot = "";
+    } else {
+      delete node.dataset.locatorHot;
+    }
+  }
+  return hit ? nearest : null;
+}
+
+function createStore(): LocatorStore {
+  return {
+    rail$: state<HTMLElement | null>(null),
+    previewElement$: state<HTMLElement | null>(null),
+    layout$: state<LocatorLayout>(emptyLayout()),
+    preview$: state<LocatorPreview | null>(null),
+    engaged$: state(false),
+    windowStart$: state(0),
+    pagedByReader$: state(false),
+    turns: [],
+  };
+}
+
+/**
+ * Turn offsets only move when the content reflows, so scrolling reuses the
+ * last measurement instead of walking every rendered group each frame.
+ */
+function createRecompute(
+  store: LocatorStore,
+  scrollContainer$: Computed<HTMLElement | null>,
+) {
+  return command(({ get, set }, remeasure: boolean) => {
+    const container = get(scrollContainer$);
+    const rail = get(store.rail$);
+    if (!container || !rail) {
+      return;
+    }
+    if (remeasure) {
+      store.turns = readTurns(container);
+    }
+    const turns = store.turns;
+    const enoughScroll =
+      container.clientHeight > 0 &&
+      container.scrollHeight >= container.clientHeight * SHOW_MIN_SCREENS;
+    if (turns.length < SHOW_MIN_TURNS || !enoughScroll) {
+      set(store.layout$, { ...emptyLayout(), turnCount: turns.length });
+      return;
+    }
+
+    const current = currentTurnIndex(
+      turns,
+      container.scrollTop,
+      container.clientHeight,
+    );
+    const geometry = windowGeometry(
+      turns.length,
+      rail.clientHeight,
+      current,
+      get(store.pagedByReader$) ? get(store.windowStart$) : null,
+    );
+    if (geometry.windowStart !== get(store.windowStart$)) {
+      set(store.windowStart$, geometry.windowStart);
+    }
+    set(store.layout$, {
+      visible: true,
+      ticks: buildTicks(turns, geometry, current),
+      pitch: geometry.pitch,
+      ...buildBand(
+        turns,
+        geometry,
+        container.scrollTop,
+        container.clientHeight,
+      ),
+      turnCount: turns.length,
+    });
+  });
+}
+
+function createPaint(store: LocatorStore) {
+  return command(({ get, set }, pointerY: number | null) => {
+    const rail = get(store.rail$);
+    const layout = get(store.layout$);
+    if (!rail || !layout.visible) {
+      return;
+    }
+    if (pointerY === null) {
+      resetTickWidths(rail);
+      set(store.preview$, null);
+      return;
+    }
+    const nearest = applyMagnification(rail, layout, pointerY);
+    const tick = nearest === null ? undefined : layout.ticks[nearest];
+    const turn = tick ? store.turns[tick.turnIndex] : undefined;
+    const shown = get(store.preview$);
+    if (!tick || !turn) {
+      if (shown) {
+        set(store.preview$, null);
+      }
+      return;
+    }
+    if (shown?.turnIndex === tick.turnIndex) {
+      return;
+    }
+    set(store.preview$, {
+      turnIndex: tick.turnIndex,
+      role: tick.role,
+      text: previewTextFor(turn.element),
+      position: tick.turnIndex + 1,
+      total: layout.turnCount,
+    });
+  });
+}
+
+function createJump(
+  store: LocatorStore,
+  threadId: string,
+  scrollContainer$: Computed<HTMLElement | null>,
+  scrollToTurn: (container: HTMLElement, top: number) => void,
+) {
+  return command(({ get }, turnIndex: number) => {
+    const container = get(scrollContainer$);
+    const turn = store.turns[turnIndex];
+    if (!container || !turn) {
+      return;
+    }
+    L.debug("jump to turn", { threadId, turnIndex });
+    scrollToTurn(
+      container,
+      Math.max(0, turn.top - container.clientHeight * JUMP_VIEWPORT_RATIO),
+    );
+    turn.element.dataset.locatorLanded = "";
+    turn.element.ownerDocument.defaultView?.setTimeout(() => {
+      delete turn.element.dataset.locatorLanded;
+    }, LANDED_MARK_MS);
+  });
+}
+
+/**
+ * The preview trails the cursor instead of tracking it exactly, which is what
+ * makes it read as floating beside the pointer rather than pinned to it.
+ */
+function followPreview(
+  preview: HTMLElement,
+  rail: HTMLElement,
+  runtime: RailRuntime,
+): void {
+  if (runtime.pointerX === null || runtime.pointerY === null) {
+    return;
+  }
+  const targetX = runtime.pointerX + POINTER_OFFSET_X_PX;
+  const targetY = runtime.pointerY + rail.getBoundingClientRect().top;
+  runtime.followX += (targetX - runtime.followX) * POINTER_FOLLOW;
+  runtime.followY += (targetY - runtime.followY) * POINTER_FOLLOW;
+
+  const view = rail.ownerDocument.defaultView;
+  const viewportWidth = view?.innerWidth ?? 0;
+  const viewportHeight = view?.innerHeight ?? 0;
+  const width = preview.offsetWidth;
+  const height = preview.offsetHeight;
+  // Flip to the other side of the cursor rather than let the card clip.
+  const x =
+    runtime.followX + width > viewportWidth - POINTER_EDGE_MARGIN_PX
+      ? targetX - width - POINTER_OFFSET_X_PX * 2
+      : runtime.followX;
+  const y = clamp(
+    runtime.followY - height / 2,
+    POINTER_EDGE_MARGIN_PX,
+    Math.max(
+      POINTER_EDGE_MARGIN_PX,
+      viewportHeight - height - POINTER_EDGE_MARGIN_PX,
+    ),
+  );
+  preview.style.transform = `translate3d(${x.toFixed(1)}px, ${y.toFixed(1)}px, 0)`;
+}
+
+function createFollowStep(store: LocatorStore) {
+  return command(({ get }, rail: HTMLElement, runtime: RailRuntime) => {
+    const preview = get(store.previewElement$);
+    if (preview && runtime.followStarted) {
+      followPreview(preview, rail, runtime);
+    }
+  });
+}
+
+function createLeaveRail(
+  store: LocatorStore,
+  recompute$: Command<void, [boolean]>,
+  paint$: Command<void, [number | null]>,
+) {
+  return command(({ get, set }) => {
+    set(store.engaged$, false);
+    set(paint$, null);
+    // A window the reader paged by hand is theirs only while they are on the
+    // rail; leaving hands it back to the reading position.
+    if (get(store.pagedByReader$)) {
+      set(store.pagedByReader$, false);
+      set(recompute$, false);
+    }
+  });
+}
+
+function createClickJump(
+  store: LocatorStore,
+  jumpToTurn$: Command<void, [number]>,
+) {
+  return command(({ get, set }) => {
+    const preview = get(store.preview$);
+    if (preview) {
+      set(jumpToTurn$, preview.turnIndex);
+    }
+  });
+}
+
+/** Returns true when the rail took the wheel, so the caller can repaint. */
+function createPageWindow(
+  store: LocatorStore,
+  recompute$: Command<void, [boolean]>,
+) {
+  return command(({ get, set }, steps: number) => {
+    const layout = get(store.layout$);
+    if (!layout.visible || layout.turnCount <= MAX_TICKS) {
+      return false;
+    }
+    const start = get(store.windowStart$);
+    const next = clamp(start + steps, 0, layout.turnCount - MAX_TICKS);
+    if (next === start) {
+      return false;
+    }
+    set(store.pagedByReader$, true);
+    set(store.windowStart$, next);
+    set(recompute$, false);
+    return true;
+  });
+}
+
+/** True while the rail owns the wheel instead of the page. */
+function createOwnsWheel(store: LocatorStore) {
+  return command(({ get }) => {
+    const layout = get(store.layout$);
+    return layout.visible && layout.turnCount > MAX_TICKS;
+  });
+}
+
+interface RailHandlers {
+  readonly pointerEnter: () => void;
+  readonly pointerMove: (event: PointerEvent) => void;
+  readonly pointerLeave: () => void;
+  readonly click: () => void;
+  readonly wheel: (event: WheelEvent) => void;
+  readonly scroll: () => void;
+  readonly contentResize: () => void;
+}
+
+function installRailListeners(
+  rail: HTMLElement,
+  container: HTMLElement,
+  handlers: RailHandlers,
+): () => void {
+  rail.addEventListener("pointerenter", handlers.pointerEnter);
+  rail.addEventListener("pointermove", handlers.pointerMove);
+  rail.addEventListener("pointerleave", handlers.pointerLeave);
+  rail.addEventListener("click", handlers.click);
+  rail.addEventListener("wheel", handlers.wheel, { passive: false });
+  container.addEventListener("scroll", handlers.scroll, { passive: true });
+
+  const contentObserver = new ResizeObserver(handlers.contentResize);
+  const content = container.querySelector<HTMLElement>(
+    "[data-message-container]",
+  );
+  if (content) {
+    contentObserver.observe(content);
+  }
+  contentObserver.observe(container);
+
+  return () => {
+    rail.removeEventListener("pointerenter", handlers.pointerEnter);
+    rail.removeEventListener("pointermove", handlers.pointerMove);
+    rail.removeEventListener("pointerleave", handlers.pointerLeave);
+    rail.removeEventListener("click", handlers.click);
+    rail.removeEventListener("wheel", handlers.wheel);
+    container.removeEventListener("scroll", handlers.scroll);
+    contentObserver.disconnect();
+  };
+}
+
+function createRuntime(): RailRuntime {
+  return {
+    pointerX: null,
+    pointerY: null,
+    followX: 0,
+    followY: 0,
+    followStarted: false,
+    followRunning: false,
+    wheelTravel: 0,
+    remeasurePending: false,
+    recomputeQueued: false,
+    magnifyQueued: false,
+  };
+}
+
+/** Records a pointer sample; returns the rail-relative Y to magnify around. */
+function trackPointer(
+  rail: HTMLElement,
+  runtime: RailRuntime,
+  event: PointerEvent,
+): void {
+  runtime.pointerY = event.clientY - rail.getBoundingClientRect().top;
+  runtime.pointerX = event.clientX;
+  if (!runtime.followStarted) {
+    runtime.followX = runtime.pointerX + POINTER_OFFSET_X_PX;
+    runtime.followY = event.clientY;
+    runtime.followStarted = true;
+  }
+}
+
+/** Consumes wheel travel and reports how many whole ticks it is worth. */
+function takeWheelSteps(runtime: RailRuntime, deltaY: number): number {
+  runtime.wheelTravel += deltaY;
+  const steps = Math.trunc(runtime.wheelTravel / WHEEL_STEP_PX);
+  runtime.wheelTravel -= steps * WHEEL_STEP_PX;
+  return steps;
+}
+
+interface RailCommands {
+  readonly recompute$: Command<void, [boolean]>;
+  readonly paint$: Command<void, [number | null]>;
+  readonly followStep$: Command<void, [HTMLElement, RailRuntime]>;
+  readonly leaveRail$: Command<void, []>;
+  readonly clickJump$: Command<void, []>;
+  readonly pageWindow$: Command<boolean, [number]>;
+  readonly ownsWheel$: Command<boolean, []>;
+}
+
+function createRailOnRef(
+  store: LocatorStore,
+  threadId: string,
+  scrollContainer$: Computed<HTMLElement | null>,
+  commands: RailCommands,
+) {
+  return onRef(
+    command(({ get, set }, rail: HTMLElement, signal: AbortSignal) => {
+      set(store.rail$, rail);
+      L.debug("rail bound", { threadId });
+      const runtime = createRuntime();
+      let detachListeners: (() => void) | null = null;
+
+      const flushFrame = () => {
+        runtime.recomputeQueued = false;
+        const remeasure = runtime.remeasurePending;
+        runtime.remeasurePending = false;
+        set(commands.recompute$, remeasure);
+        // React repaints ticks at their resting width whenever the layout
+        // changes, so a pointer parked on the rail needs its magnification
+        // written back.
+        if (runtime.pointerY !== null) {
+          set(commands.paint$, runtime.pointerY);
+        }
+      };
+      const scheduleRecompute = (remeasure: boolean) => {
+        runtime.remeasurePending ||= remeasure;
+        if (runtime.recomputeQueued) {
+          return;
+        }
+        runtime.recomputeQueued = true;
+        animationFrame(flushFrame, { signal });
+      };
+      const scheduleMagnify = () => {
+        if (runtime.magnifyQueued) {
+          return;
+        }
+        runtime.magnifyQueued = true;
+        animationFrame(
+          () => {
+            runtime.magnifyQueued = false;
+            set(commands.paint$, runtime.pointerY);
+          },
+          { signal },
+        );
+      };
+      const followFrame = () => {
+        if (!runtime.followRunning) {
+          return;
+        }
+        set(commands.followStep$, rail, runtime);
+        animationFrame(followFrame, { signal });
+      };
+
+      const handlers: RailHandlers = {
+        pointerEnter: () => {
+          set(store.engaged$, true);
+          if (!runtime.followRunning) {
+            runtime.followRunning = true;
+            animationFrame(followFrame, { signal });
+          }
+        },
+        pointerMove: (event) => {
+          trackPointer(rail, runtime, event);
+          scheduleMagnify();
+        },
+        pointerLeave: () => {
+          runtime.pointerX = null;
+          runtime.pointerY = null;
+          runtime.followStarted = false;
+          runtime.followRunning = false;
+          runtime.wheelTravel = 0;
+          set(commands.leaveRail$);
+        },
+        click: () => {
+          set(commands.clickJump$);
+        },
+        wheel: (event) => {
+          if (!set(commands.ownsWheel$)) {
+            return;
+          }
+          event.preventDefault();
+          const steps = takeWheelSteps(runtime, event.deltaY);
+          if (steps !== 0 && set(commands.pageWindow$, steps)) {
+            scheduleMagnify();
+          }
+        },
+        scroll: () => {
+          scheduleRecompute(false);
+        },
+        contentResize: () => {
+          scheduleRecompute(true);
+        },
+      };
+
+      // The scroll viewport binds in the same commit, but ref order is not a
+      // contract worth relying on, so retry rather than give up.
+      const attach = () => {
+        if (signal.aborted || detachListeners) {
+          return;
+        }
+        const container = get(scrollContainer$);
+        if (!container) {
+          animationFrame(attach, { signal });
+          return;
+        }
+        detachListeners = installRailListeners(rail, container, handlers);
+        set(commands.recompute$, true);
+      };
+      attach();
+
+      signal.addEventListener(
+        "abort",
+        () => {
+          runtime.followRunning = false;
+          detachListeners?.();
+          set(store.rail$, null);
+          set(store.layout$, emptyLayout());
+          set(store.preview$, null);
+          set(store.engaged$, false);
+          L.debug("rail unbound", { threadId });
+        },
+        { once: true },
+      );
+    }),
+  );
+}
+
+function createPreviewOnRef(store: LocatorStore) {
+  return onRef(
+    command(({ set }, element: HTMLElement, signal: AbortSignal) => {
+      set(store.previewElement$, element);
+      signal.addEventListener(
+        "abort",
+        () => {
+          set(store.previewElement$, null);
+        },
+        { once: true },
+      );
+    }),
+  );
+}
+
+export function createChatConversationLocatorSignals({
+  threadId,
+  scrollContainer$,
+  scrollToTurn = (container, top) => {
+    container.scrollTo({ top, behavior: "smooth" });
+  },
+}: {
+  threadId: string;
+  scrollContainer$: Computed<HTMLElement | null>;
+  /** Smooth-scrolls the container; kept injectable so tests can observe it. */
+  scrollToTurn?: (container: HTMLElement, top: number) => void;
+}): ChatConversationLocatorSignals {
+  const store = createStore();
+  const recompute$ = createRecompute(store, scrollContainer$);
+  const paint$ = createPaint(store);
+  const jumpToTurn$ = createJump(
+    store,
+    threadId,
+    scrollContainer$,
+    scrollToTurn,
+  );
+  const railOnRef$ = createRailOnRef(store, threadId, scrollContainer$, {
+    recompute$,
+    paint$,
+    followStep$: createFollowStep(store),
+    leaveRail$: createLeaveRail(store, recompute$, paint$),
+    clickJump$: createClickJump(store, jumpToTurn$),
+    pageWindow$: createPageWindow(store, recompute$),
+    ownsWheel$: createOwnsWheel(store),
+  });
+
+  return {
+    railOnRef$,
+    previewOnRef$: createPreviewOnRef(store),
+    layout$: computed((get) => {
+      return get(store.layout$);
+    }),
+    preview$: computed((get) => {
+      return get(store.preview$);
+    }),
+    engaged$: computed((get) => {
+      return get(store.engaged$);
+    }),
+    jumpToTurn$,
+  };
+}

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -24,6 +24,7 @@ import type { ComposerSignals } from "../zero-page/composer-signals.ts";
 import type { ChatThreadFeedbackSignals } from "./chat-thread-feedback.ts";
 import type { ChatThreadSharingSignals } from "./chat-thread-sharing.ts";
 import type { ChatForwardContext } from "./chat-forward.ts";
+import type { ChatConversationLocatorSignals } from "./chat-conversation-locator.ts";
 
 type RecommendedFollowup = ChatRecommendedFollowup;
 
@@ -150,6 +151,8 @@ export interface ChatPanelSignals {
   readonly readyScrollAfterRenderRequest$: Computed<
     Promise<ReadyScrollAfterRenderRequest | null>
   >;
+  /** The mounted scroll viewport, for readers that measure it themselves. */
+  readonly scrollContainer$: Computed<HTMLElement | null>;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly scrollTo$: Command<void, [ThreadScrollPosition]>;
   readonly scrollToBottom$: Command<Promise<void>, [AbortSignal]>;
@@ -169,6 +172,7 @@ export interface ChatPanelSignals {
   readonly composer: ComposerSignals;
   readonly feedback: ChatThreadFeedbackSignals;
   readonly sharing: ChatThreadSharingSignals;
+  readonly locator: ChatConversationLocatorSignals;
   // -- Thread-owned automation resources -----------------------------------
   readonly headerAutomations: HeaderAutomationSignals;
   // -- Thread-owned utility sidebar -----------------------------------------

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -38,6 +38,8 @@ export interface ChatThreadScrollSignals {
     [HTMLElement | null]
   >;
   readonly pendingScrollAfterRenderRequest$: Computed<ScrollAfterRenderRequest | null>;
+  /** The mounted scroll viewport, for readers that measure it themselves. */
+  readonly scrollContainer$: Computed<HTMLElement | null>;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
   readonly readRenderedThreadScrollPosition$: Command<
@@ -716,6 +718,7 @@ export function createChatThreadScrollSignals(
     scrollContentOnRef$,
     scrollCommitOnRef$: render.scrollCommitOnRef$,
     pendingScrollAfterRenderRequest$: render.pendingScrollAfterRenderRequest$,
+    scrollContainer$: scroll.scrollContainer$,
     threadScrollPosition$: scroll.threadScrollPosition$,
     awayFromBottom$: scroll.awayFromBottom$,
     readRenderedThreadScrollPosition$: scroll.readRenderedThreadScrollPosition$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -209,6 +209,7 @@ import {
 } from "./chat-goal.ts";
 import { createChatThreadFeedbackSignals } from "./chat-thread-feedback.ts";
 import { createChatThreadSharingSignals } from "./chat-thread-sharing.ts";
+import { createChatConversationLocatorSignals } from "./chat-conversation-locator.ts";
 import type {
   ChatEventSignals,
   SendChatEventInput,
@@ -3881,6 +3882,10 @@ function createChatPanelSignalsWithDraft(
     ...artifact,
   };
   const sharing = createChatThreadSharingSignals(threadId, messages.scroll);
+  const locator = createChatConversationLocatorSignals({
+    threadId,
+    scrollContainer$: messages.scroll.scrollContainer$,
+  });
   const runTracking = createRunTracking({
     threadId,
     setupChatEvents$: messages.setup$,
@@ -3900,6 +3905,7 @@ function createChatPanelSignalsWithDraft(
     scrollContainerOnRef$: messages.scroll.scrollContainerOnRef$,
     scrollContentOnRef$: messages.scroll.scrollContentOnRef$,
     scrollCommitOnRef$: messages.scroll.scrollCommitOnRef$,
+    scrollContainer$: messages.scroll.scrollContainer$,
     threadScrollPosition$: messages.scroll.threadScrollPosition$,
     awayFromBottom$: messages.scroll.awayFromBottom$,
     scrollTo$: messages.scroll.scrollTo$,
@@ -3909,6 +3915,7 @@ function createChatPanelSignalsWithDraft(
     composer,
     feedback,
     sharing,
+    locator,
     ...threadOwned,
     sidebar: messages.sidebar,
     ...publicChatThreadEventSignals(messages),

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -388,6 +388,27 @@ body {
   animation: zero-chat-skeleton-reveal 0s 100ms forwards;
 }
 
+/* Conversation locator: mark where a rail jump landed, then fade back out. */
+@keyframes zero-locator-landed {
+  from {
+    background-color: hsl(var(--primary) / 0.1);
+    box-shadow: 0 0 0 0.75rem hsl(var(--primary) / 0.1);
+  }
+  to {
+    background-color: transparent;
+    box-shadow: 0 0 0 0.75rem transparent;
+  }
+}
+[data-locator-landed] {
+  border-radius: 0.75rem;
+  animation: zero-locator-landed 1.15s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-locator-landed] {
+    animation-duration: 0.01ms;
+  }
+}
+
 /* Thinking indicator: 3-block loader */
 .zero-blocks {
   display: inline-grid;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
@@ -1,0 +1,93 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import { context, detachedSetupPage } from "./chat-lifecycle-test-helpers.ts";
+
+const THREAD_ID = "b0000000-0000-4000-a000-000000000806";
+
+/** Ten alternating turns: past the locator's turn floor on its own. */
+function conversation(): MockChatEventInput[] {
+  const events: MockChatEventInput[] = [];
+  for (let index = 0; index < 5; index += 1) {
+    const minute = String(index).padStart(2, "0");
+    events.push(
+      {
+        id: `locator-prompt-${index}`,
+        eventType: "input.prompt",
+        role: "user",
+        content: `Question ${index}`,
+        createdAt: `2026-06-09T10:${minute}:00Z`,
+      },
+      {
+        id: `locator-reply-${index}`,
+        eventType: "output.message",
+        role: "assistant",
+        content: `Answer ${index}`,
+        runId: `run-locator-${index}`,
+        createdAt: `2026-06-09T10:${minute}:30Z`,
+      },
+    );
+  }
+  return events;
+}
+
+function renderThread(enabled: boolean): void {
+  mockChatLifecycle(context, {
+    threadId: THREAD_ID,
+    threadTitle: "Conversation locator",
+    chatEvents: conversation(),
+  });
+  detachedSetupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: {
+      [FeatureSwitchKey.ChatConversationLocator]: enabled,
+    },
+  });
+}
+
+describe("chat conversation locator", () => {
+  it("stays out of the thread while the feature switch is off", async () => {
+    renderThread(false);
+
+    await screen.findByText("Answer 4");
+    expect(document.querySelector("[data-conversation-locator]")).toBeNull();
+    expect(
+      document.querySelector("[data-conversation-locator-preview]"),
+    ).toBeNull();
+  });
+
+  it("mounts the rail and its preview card once the switch is on", async () => {
+    renderThread(true);
+
+    await screen.findByText("Answer 4");
+    const rail = await waitFor(() => {
+      const element = document.querySelector("[data-conversation-locator]");
+      expect(element).not.toBeNull();
+      return element as HTMLElement;
+    });
+    // The rail is a pointer-only shortcut to turns the thread already lists in
+    // order, so it must not add a control to the accessibility tree.
+    expect(rail.getAttribute("aria-hidden")).toBe("true");
+    expect(
+      document.querySelector("[data-conversation-locator-preview]"),
+    ).not.toBeNull();
+  });
+
+  it("draws no ticks until the thread outgrows the viewport", async () => {
+    renderThread(true);
+
+    await screen.findByText("Answer 4");
+    const rail = await waitFor(() => {
+      const element = document.querySelector("[data-conversation-locator]");
+      expect(element).not.toBeNull();
+      return element as HTMLElement;
+    });
+    // Turn count alone does not open the rail: the thread also has to be
+    // taller than a few viewports, and an unlaid-out container never is.
+    expect(rail.querySelectorAll("[data-locator-tick]")).toHaveLength(0);
+    expect(rail.className).toContain("opacity-0");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
@@ -1,11 +1,202 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
-import { context, detachedSetupPage } from "./chat-lifecycle-test-helpers.ts";
+import {
+  context,
+  detachedSetupPage,
+  mockResizeObserver,
+} from "./chat-lifecycle-test-helpers.ts";
 
 const THREAD_ID = "b0000000-0000-4000-a000-000000000806";
+const GEOMETRY_THREAD_ID = "b0000000-0000-4000-a000-000000000807";
+
+const VIEWPORT_PX = 600;
+const RAIL_PX = 600;
+const TURN_PX = 200;
+/** Enough turns to overflow the 24-tick window and force paging. */
+const LONG_TURN_COUNT = 30;
+const TURN_SELECTOR = '[data-role="user"], [data-role="assistant"]';
+
+/**
+ * happy-dom has no layout engine, so the locator would measure every element
+ * as zero-sized and never open. This models the one layout it cares about: a
+ * fixed-height viewport scrolling over turns of equal height.
+ */
+function stubLayout(): void {
+  const prototype = globalThis.HTMLElement.prototype;
+  const rectDescriptor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "getBoundingClientRect",
+  );
+  const clientHeightDescriptor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "clientHeight",
+  );
+  const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "scrollHeight",
+  );
+  const originalRect = prototype.getBoundingClientRect;
+  const scrollTops = new WeakMap<HTMLElement, number>();
+
+  const isScroller = (element: HTMLElement) => {
+    return Object.hasOwn(element.dataset, "scrollContainer");
+  };
+  const isRail = (element: HTMLElement) => {
+    return Object.hasOwn(element.dataset, "conversationLocator");
+  };
+  const turnIndexOf = (element: HTMLElement) => {
+    const scroller = element.closest<HTMLElement>("[data-scroll-container]");
+    if (!scroller || !element.matches(TURN_SELECTOR)) {
+      return -1;
+    }
+    return [...scroller.querySelectorAll<HTMLElement>(TURN_SELECTOR)].indexOf(
+      element,
+    );
+  };
+
+  Object.defineProperty(prototype, "scrollTop", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      return scrollTops.get(this) ?? 0;
+    },
+    set(this: HTMLElement, value: number) {
+      scrollTops.set(this, Math.max(0, value));
+    },
+  });
+  Object.defineProperty(prototype, "clientHeight", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      if (isScroller(this)) {
+        return VIEWPORT_PX;
+      }
+      return isRail(this) ? RAIL_PX : 0;
+    },
+  });
+  Object.defineProperty(prototype, "scrollHeight", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      if (!isScroller(this)) {
+        return 0;
+      }
+      return this.querySelectorAll(TURN_SELECTOR).length * TURN_PX;
+    },
+  });
+  Object.defineProperty(prototype, "getBoundingClientRect", {
+    configurable: true,
+    value(this: HTMLElement): DOMRect {
+      const rect = (top: number, height: number) => {
+        return {
+          top,
+          bottom: top + height,
+          left: 0,
+          right: 0,
+          width: 0,
+          height,
+          x: 0,
+          y: top,
+          toJSON: () => {
+            return {};
+          },
+        } as DOMRect;
+      };
+      if (isScroller(this)) {
+        return rect(0, VIEWPORT_PX);
+      }
+      if (isRail(this)) {
+        return rect(0, RAIL_PX);
+      }
+      const index = turnIndexOf(this);
+      if (index < 0) {
+        return originalRect.call(this);
+      }
+      const scroller = this.closest<HTMLElement>("[data-scroll-container]");
+      return rect(index * TURN_PX - (scroller?.scrollTop ?? 0), TURN_PX);
+    },
+  });
+
+  const restore = (
+    name: string,
+    descriptor: PropertyDescriptor | undefined,
+  ) => {
+    if (descriptor) {
+      Object.defineProperty(prototype, name, descriptor);
+    } else {
+      Reflect.deleteProperty(prototype, name);
+    }
+  };
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      restore("getBoundingClientRect", rectDescriptor);
+      restore("clientHeight", clientHeightDescriptor);
+      restore("scrollHeight", scrollHeightDescriptor);
+      Reflect.deleteProperty(prototype, "scrollTop");
+    },
+    { once: true },
+  );
+}
+
+function longConversation(): MockChatEventInput[] {
+  return Array.from({ length: LONG_TURN_COUNT }, (_unused, index) => {
+    const minute = String(index).padStart(2, "0");
+    return {
+      id: `locator-long-${index}`,
+      eventType: "input.prompt" as const,
+      role: "user" as const,
+      content: `Prompt ${index}`,
+      createdAt: `2026-06-09T11:${minute}:00Z`,
+    };
+  });
+}
+
+function pointerAt(rail: HTMLElement, y: number, type: string): void {
+  rail.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, clientX: 20, clientY: y }),
+  );
+}
+
+function ticksOf(rail: HTMLElement): HTMLElement[] {
+  return [...rail.querySelectorAll<HTMLElement>("[data-locator-tick]")];
+}
+
+async function renderLongThread(): Promise<{
+  rail: HTMLElement;
+  resize: { automationAll: () => void };
+}> {
+  stubLayout();
+  const resize = mockResizeObserver();
+  mockChatLifecycle(context, {
+    threadId: GEOMETRY_THREAD_ID,
+    threadTitle: "Locator geometry",
+    chatEvents: longConversation(),
+  });
+  detachedSetupPage({
+    context,
+    path: `/chats/${GEOMETRY_THREAD_ID}`,
+    featureSwitches: {
+      [FeatureSwitchKey.ChatConversationLocator]: true,
+    },
+  });
+
+  await screen.findByText(`Prompt ${LONG_TURN_COUNT - 1}`);
+  const rail = await waitFor(() => {
+    const element = document.querySelector<HTMLElement>(
+      "[data-conversation-locator]",
+    );
+    expect(element).not.toBeNull();
+    return element as HTMLElement;
+  });
+  // The turns render after the rail binds, so nudge the observer the locator
+  // relies on for reflow instead of waiting on a resize happy-dom never emits.
+  resize.automationAll();
+  await waitFor(() => {
+    expect(ticksOf(rail).length).toBeGreaterThan(0);
+  });
+  return { rail, resize };
+}
 
 /** Ten alternating turns: past the locator's turn floor on its own. */
 function conversation(): MockChatEventInput[] {
@@ -124,5 +315,120 @@ describe("chat conversation locator", () => {
       '[data-role="assistant-thinking"]',
     );
     expect(thinking?.dataset.turnCreatedAt).toBeUndefined();
+  });
+
+  it("caps the rail at 24 evenly spaced ticks over a longer thread", async () => {
+    const { rail } = await renderLongThread();
+
+    const ticks = ticksOf(rail);
+    // 30 turns, 24 ticks: the rail pages rather than packing tighter.
+    expect(ticks).toHaveLength(24);
+
+    const tops = ticks.map((tick) => {
+      return Number.parseFloat(tick.style.top);
+    });
+    const gaps = new Set(
+      tops.slice(1).map((top, index) => {
+        return top - (tops[index] ?? 0);
+      }),
+    );
+    // One pitch for the whole rail, and a whole number of pixels: a bar on a
+    // half pixel renders as a blurred triple line.
+    expect([...gaps]).toStrictEqual([10]);
+    for (const top of tops) {
+      expect(Number.isInteger(top)).toBeTruthy();
+    }
+
+    // Two discrete lengths, both tied to the role rather than to content.
+    const widths = new Set(
+      ticks.map((tick) => {
+        return `${tick.dataset.locatorTick}:${tick.style.width}`;
+      }),
+    );
+    expect([...widths].sort()).toStrictEqual(["user:7px"]);
+  });
+
+  it("magnifies neighbours but marks only the tick under the cursor", async () => {
+    const { rail } = await renderLongThread();
+
+    const ticks = ticksOf(rail);
+    const target = ticks[12] as HTMLElement;
+    pointerAt(rail, 0, "pointerenter");
+    pointerAt(rail, Number.parseFloat(target.style.top), "pointermove");
+
+    await waitFor(() => {
+      expect(rail.querySelectorAll("[data-locator-hot]")).toHaveLength(1);
+    });
+    expect(target.dataset.locatorHot).toBe("");
+
+    const widthOf = (tick: HTMLElement) => {
+      return Number.parseFloat(tick.style.width);
+    };
+    const hotWidth = widthOf(target);
+    const neighbourWidth = widthOf(ticks[13] as HTMLElement);
+    const farWidth = widthOf(ticks[23] as HTMLElement);
+    // Size falls off with distance, so a neighbour grows too...
+    expect(hotWidth).toBeGreaterThan(neighbourWidth);
+    expect(neighbourWidth).toBeGreaterThan(farWidth);
+    // ...but the selected state belongs to one tick alone, and thickness
+    // never moves.
+    expect(ticks[13]?.dataset.locatorHot).toBeUndefined();
+    for (const tick of ticks) {
+      expect(tick.className).toContain("h-0.5");
+    }
+  });
+
+  it("pages the window on wheel and hands it back when the pointer leaves", async () => {
+    const { rail } = await renderLongThread();
+
+    const firstIndex = () => {
+      const tick = ticksOf(rail)[0];
+      return Number.parseFloat(tick?.dataset.turnIndex ?? "-1");
+    };
+    pointerAt(rail, 0, "pointerenter");
+    pointerAt(rail, 200, "pointermove");
+    await waitFor(() => {
+      expect(rail.querySelectorAll("[data-locator-hot]")).toHaveLength(1);
+    });
+
+    // A freshly opened thread sits at its tail, so the window starts at the
+    // end of the turns and can only be paged backward.
+    const before = firstIndex();
+    expect(before).toBeGreaterThan(0);
+    const wheel = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -300,
+    });
+    rail.dispatchEvent(wheel);
+    // The rail owns the wheel while it is showing a window, so the thread
+    // underneath must not scroll with it.
+    expect(wheel.defaultPrevented).toBeTruthy();
+    await waitFor(() => {
+      expect(firstIndex()).toBeLessThan(before);
+    });
+
+    pointerAt(rail, 200, "pointerleave");
+    await waitFor(() => {
+      expect(firstIndex()).toBe(before);
+    });
+  });
+
+  it("marks the turn a click lands on", async () => {
+    const { rail } = await renderLongThread();
+
+    const target = ticksOf(rail)[8] as HTMLElement;
+    pointerAt(rail, 0, "pointerenter");
+    pointerAt(rail, Number.parseFloat(target.style.top), "pointermove");
+    await waitFor(() => {
+      expect(rail.querySelectorAll("[data-locator-hot]")).toHaveLength(1);
+    });
+    rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("[data-locator-landed]")).toHaveLength(
+        1,
+      );
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
@@ -90,4 +90,39 @@ describe("chat conversation locator", () => {
     expect(rail.querySelectorAll("[data-locator-tick]")).toHaveLength(0);
     expect(rail.className).toContain("opacity-0");
   });
+
+  it("stamps every turn with the timestamp the preview card reads", async () => {
+    renderThread(true);
+
+    await screen.findByText("Answer 4");
+    const turns = [
+      ...document.querySelectorAll<HTMLElement>(
+        '[data-role="user"], [data-role="assistant"]',
+      ),
+    ];
+    expect(turns.length).toBeGreaterThan(0);
+    // The locator reads timestamps off the turn wrappers rather than the group
+    // signals, so every wrapper it can point at has to carry a parseable one.
+    for (const turn of turns) {
+      expect(
+        Number.isNaN(Date.parse(turn.dataset.turnCreatedAt ?? "")),
+      ).toBeFalsy();
+    }
+    expect(
+      turns.some((turn) => {
+        return turn.dataset.role === "user";
+      }),
+    ).toBeTruthy();
+    expect(
+      turns.some((turn) => {
+        return turn.dataset.role === "assistant";
+      }),
+    ).toBeTruthy();
+    // The thinking indicator also carries data-role but is not a turn, and it
+    // is excluded by the exact-value selector rather than by a timestamp.
+    const thinking = document.querySelector<HTMLElement>(
+      '[data-role="assistant-thinking"]',
+    );
+    expect(thinking?.dataset.turnCreatedAt).toBeUndefined();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/chat-conversation-locator.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-conversation-locator.tsx
@@ -1,0 +1,130 @@
+import { useGet, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@vm0/ui";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
+import type { LocatorRole } from "../../signals/chat-page/chat-conversation-locator.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
+
+/** Resting tick length per role. Two discrete steps keep the rail regular. */
+const TICK_BASE_WIDTH_PX = {
+  user: 7,
+  assistant: 12,
+} as const satisfies Record<LocatorRole, number>;
+
+/** Ticks fade toward an edge that still has turns behind it. */
+const EDGE_OPACITY = [1, 0.55, 0.25] as const;
+
+function LocatorPreviewCard({ thread }: { thread: ChatPanelSignals }) {
+  const { t } = useTranslation();
+  const previewOnRef = useSet(thread.locator.previewOnRef$);
+  const preview = useGet(thread.locator.preview$);
+
+  return (
+    <div
+      ref={previewOnRef}
+      data-conversation-locator-preview
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none fixed left-0 top-0 z-50 w-[340px] rounded-xl border border-border bg-background px-4 py-3.5 shadow-lg transition-opacity duration-150",
+        preview ? "opacity-100" : "opacity-0",
+      )}
+    >
+      <div className="mb-2 flex items-center gap-2 text-[11.5px] font-medium text-muted-foreground">
+        {preview?.role === "assistant" ? (
+          <AgentAvatarImg
+            name={thread.agentId}
+            alt=""
+            className="h-5 w-5 shrink-0 rounded-full object-cover object-top"
+            size={20}
+          />
+        ) : null}
+        <span>
+          {preview?.role === "user"
+            ? t(($) => {
+                return $.chat.thread.locator.you;
+              })
+            : null}
+        </span>
+        <span className="ml-auto tabular-nums">
+          {preview ? `${preview.position}/${preview.total}` : null}
+        </span>
+      </div>
+      <p className="line-clamp-2 text-sm leading-[1.62] text-muted-foreground [overflow-wrap:anywhere]">
+        {preview?.text}
+      </p>
+    </div>
+  );
+}
+
+function ConversationLocatorRail({ thread }: { thread: ChatPanelSignals }) {
+  const railOnRef = useSet(thread.locator.railOnRef$);
+  const layout = useGet(thread.locator.layout$);
+  const engaged = useGet(thread.locator.engaged$);
+
+  return (
+    <>
+      <div
+        ref={railOnRef}
+        data-conversation-locator
+        // Pointer-only shortcut to content the thread already exposes in
+        // order, so it stays out of the accessibility tree rather than adding
+        // an unreachable control to it.
+        aria-hidden="true"
+        className={cn(
+          // Hidden on narrow viewports: the rail needs a gutter the phone
+          // layout does not have, and those threads are short enough to scroll.
+          "absolute inset-y-0 left-0 z-10 hidden w-14 cursor-pointer transition-opacity duration-300 md:block",
+          !layout.visible && "pointer-events-none opacity-0",
+          layout.visible && (engaged ? "opacity-100" : "opacity-[0.68]"),
+        )}
+      >
+        {layout.visible && layout.bandHeight > 0 ? (
+          <div
+            data-conversation-locator-band
+            className="pointer-events-none absolute left-[7px] w-8 rounded-[5px] bg-primary opacity-[0.05]"
+            style={{ top: layout.bandTop, height: layout.bandHeight }}
+          />
+        ) : null}
+        {layout.ticks.map((tick) => {
+          return (
+            <div
+              key={tick.turnIndex}
+              data-locator-tick={tick.role}
+              className={cn(
+                // Width is written per pointer frame by the locator signals;
+                // React owns everything that only changes with the layout.
+                "absolute left-[14px] h-0.5 -translate-y-1/2 rounded-full transition-colors duration-150",
+                tick.current ? "bg-primary/60" : "bg-border",
+                // The turn under the cursor only changes colour — thickness
+                // stays put so the rail keeps one rhythm.
+                "[&[data-locator-hot]]:bg-foreground",
+              )}
+              style={{
+                top: tick.y,
+                width: TICK_BASE_WIDTH_PX[tick.role],
+                opacity: EDGE_OPACITY[tick.edge],
+              }}
+            />
+          );
+        })}
+      </div>
+      <LocatorPreviewCard thread={thread} />
+    </>
+  );
+}
+
+/** Tick rail beside a long thread: hover to preview a turn, click to jump. */
+export function ChatConversationLocator({
+  thread,
+}: {
+  thread: ChatPanelSignals;
+}) {
+  const enabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatConversationLocator] ?? false;
+  if (!enabled) {
+    return null;
+  }
+  return <ConversationLocatorRail thread={thread} />;
+}

--- a/turbo/apps/platform/src/views/zero-page/chat-conversation-locator.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-conversation-locator.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { cn } from "@vm0/ui";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { cn } from "@okouai/ui";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
 import type { LocatorRole } from "../../signals/chat-page/chat-conversation-locator.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
@@ -96,6 +96,7 @@ function ConversationLocatorRail({ thread }: { thread: ChatPanelSignals }) {
             <div
               key={tick.turnIndex}
               data-locator-tick={tick.role}
+              data-turn-index={tick.turnIndex}
               className={cn(
                 // Width is written per pointer frame by the locator signals;
                 // React owns everything that only changes with the layout.

--- a/turbo/apps/platform/src/views/zero-page/chat-conversation-locator.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-conversation-locator.tsx
@@ -6,6 +6,7 @@ import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signal
 import type { LocatorRole } from "../../signals/chat-page/chat-conversation-locator.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
+import { formatChatTimestamp } from "../../i18n/format.ts";
 
 /** Resting tick length per role. Two discrete steps keep the rail regular. */
 const TICK_BASE_WIDTH_PX = {
@@ -46,6 +47,9 @@ function LocatorPreviewCard({ thread }: { thread: ChatPanelSignals }) {
                 return $.chat.thread.locator.you;
               })
             : null}
+        </span>
+        <span className="tabular-nums">
+          {preview?.createdAt ? formatChatTimestamp(preview.createdAt) : null}
         </span>
         <span className="ml-auto tabular-nums">
           {preview ? `${preview.position}/${preview.total}` : null}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -16,7 +16,7 @@ import {
 import type { TFunction } from "i18next";
 import { equalArrays } from "../../lib/equality.ts";
 import { useTranslation } from "react-i18next";
-import { resolvedAppLocale } from "../../i18n/format.ts";
+import { formatChatTimestamp } from "../../i18n/format.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   runUsagePopoverOpenRunId$,
@@ -1547,15 +1547,6 @@ function ChatThreadEmojiGrid({
       })}
     </div>
   );
-}
-
-function formatChatTimestamp(value: string): string {
-  return new Date(value).toLocaleString(resolvedAppLocale(), {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
 }
 
 function formatHeaderWorkflowAutomationRun(value: string | null): string {
@@ -7413,6 +7404,7 @@ function WorkflowUserMessage({
     <div
       data-role="user"
       data-chat-scroll-anchor-event-id={event.id}
+      data-turn-created-at={event.createdAt}
       className="group"
     >
       <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
@@ -7465,6 +7457,7 @@ function GoalUserMessage({
     <div
       data-role="user"
       data-chat-scroll-anchor-event-id={event.id}
+      data-turn-created-at={event.createdAt}
       className="group"
     >
       <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
@@ -7596,6 +7589,7 @@ function PagedUserMessage({
       id={inputPromptRunAnchor(inputEvent)}
       data-role="user"
       data-chat-scroll-anchor-event-id={event.id}
+      data-turn-created-at={event.createdAt}
       className={cn("group", stackedOnPrevious && MESSAGE_STACK_PULL_CLASS)}
     >
       <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
@@ -7693,6 +7687,7 @@ function PagedAssistantGroup({
       id={groupElementId}
       data-role="assistant"
       data-chat-run-id={runId}
+      data-turn-created-at={group.events[0]?.createdAt}
       className="flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
     >
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -128,6 +128,7 @@ import {
   ChatVideoPreviewButton,
 } from "./chat-body-cards.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
+import { ChatConversationLocator } from "./chat-conversation-locator.tsx";
 import {
   customConnectorMcpEnabled$,
   featureSwitch$,
@@ -4419,6 +4420,7 @@ function ChatThreadEventsPane({ thread }: { thread: ChatPanelSignals }) {
       </div>
       <ChatThreadSkeletonOverlay thread={thread} />
       <ScrollToBottomButton thread={thread} />
+      <ChatConversationLocator thread={thread} />
     </div>
   );
 }

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -79,4 +79,5 @@ export enum FeatureSwitchKey {
   EmojiPickerCategoryRail = "emojiPickerCategoryRail",
   PresentationTemplates = "presentationTemplates",
   LatestWebsiteTemplates = "latestWebsiteTemplates",
+  ChatConversationLocator = "chatConversationLocator",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -321,6 +321,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatConversationLocator]: {
+    maintainer: "tongx@vm0.ai",
+    description:
+      "Show the conversation locator rail beside long chat threads, with hover preview and click-to-jump.",
+    enabled: false,
+  },
   [FeatureSwitchKey.UsagePackPlans]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## What

A tick rail beside long chat threads. One evenly spaced tick per rendered turn; hovering magnifies the neighbouring ticks, a floating card previews the turn under the cursor, and clicking jumps to it.

Gated by a new `chatConversationLocator` feature switch, **off by default**.

Interactive prototype the design was settled on: https://conversation-locator.sites.vm0.io

## Behaviour

- **Appears only when it earns its place** — at least 8 turns *and* at least 3 viewports of content. Turn count alone is not enough: one assistant turn can be a line or a screenful, so a short thread with long answers still gets the rail and a long thread of one-liners does not.
- **Regular geometry** — 10px pitch, two discrete tick lengths (assistant 12px, user 7px), constant 2px thickness. Nothing about a tick is derived from message length, which would read as noise rather than as a scale.
- **Magnification ≠ selection** — a Gaussian falloff widens neighbouring ticks, but only the tick under the cursor changes colour and opens the preview. Thickness never changes.
- **Windowed at 24 ticks** — beyond that the rail becomes a window over the turns and takes the wheel while the pointer is on it. Leaving the rail hands the window back to the reading position, so no forgotten state is left behind.
- **Recedes at rest** — `opacity: 0.68`, rising to 1 on approach. It should not compete with the thread.
- Hidden below `md`, and light/dark come from existing tokens (`--border`, `--foreground`, `--primary`).

## Implementation notes

- Turn geometry is read from the DOM group wrappers (`[data-role]`), mirroring how `chat-thread-scroll.ts` reads its anchors. The rail therefore indexes exactly what the paged renderer has rendered, instead of fighting the render window.
- Offsets are re-measured only when the content reflows (`ResizeObserver`, which also covers streaming). Scrolling reuses the last measurement rather than walking every rendered group per frame.
- Tick widths are written imperatively per pointer frame, outside the layout signal — re-rendering the rail at pointer rate to move a few pixels is work nobody sees. React owns everything that only changes with the layout.
- Positions snap to whole pixels, and magnification animates `width` rather than `transform: scaleX()`: a half-pixel bar renders as a blurred triple line, and scaling a rounded bar stretches its `border-radius` into a wedge.
- Adds `scrollContainer$` to the chat scroll signals so a reader can measure the viewport itself.
- Each turn wrapper is stamped with `data-turn-created-at`, so the preview card reads a turn's time the same way it reads its role and body. `formatChatTimestamp` moved into the shared locale-formatting module — importing it from the chat thread page would have made the page and the locator a cycle.

## Testing

- `pnpm -F @vm0/app run check-types`, `pnpm -F @vm0/core run check-types` — pass
- `pnpm -F @vm0/app run lint`, `pnpm -F @vm0/core run lint` — pass
- `pnpm knip` — clean
- `vitest run chat-conversation-locator.test.tsx` — 8 passed
- `vitest run chat-scroll-position.test.tsx` — 22 passed (no regression from the `scrollContainer$` addition)

New tests cover the feature-switch gate, that the rail mounts `aria-hidden` (it is a pointer-only shortcut to turns the thread already lists in order), that it draws no ticks until the thread outgrows the viewport, and that every turn wrapper carries a parseable timestamp while the thinking indicator carries none.

**Geometry is covered too.** happy-dom has no layout engine, so the locator measured everything as zero-sized and its geometry initially went untested. The suite now models the one layout it cares about — a fixed-height viewport scrolling over turns of equal height — and drives the real rail through pointer, wheel and click events:

| Behaviour | Asserted |
|---|---|
| 24-tick cap | 30 turns render exactly 24 ticks |
| Even spacing | every gap is the same, and every offset is a whole pixel |
| Discrete lengths | tick length comes from the role, not from content |
| Magnification | width falls off with distance from the cursor |
| Exclusive selection | exactly one tick is marked, and no tick changes thickness |
| Wheel paging | window moves and the wheel is taken from the page |
| Window handback | leaving the rail restores the reading position |
| Click to jump | the target turn gets the landing mark |

## Known gaps

- **No browser verification yet.** A local dev server is off the table for me by standing instruction, but the per-PR preview is not — once the deploy job lands I can verify there (enabling the switch as a user override) rather than relying on the prototype for visual sign-off. Not done in this revision because CI had not produced a preview yet.
- **No keyboard affordance — deliberate, not missing.** The rail gives a keyboard user no capability they lack: the thread is already a linear document and every turn is reachable by scrolling. Adding a tab stop to an invisible pointer-driven rail costs every keyboard user a stop and buys nothing. The genuinely useful keyboard equivalent is a different affordance — a "jump to turn" list or palette — which is its own feature rather than a bolt-on here. Kept `aria-hidden` on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)