### PR TITLE
refactor(python): centralize firewall auth phase policy

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -75,6 +75,14 @@ class FirewallHeaderPhaseAuthResult(Enum):
     FALLBACK = "fallback"
 
 
+class _FirewallAuthPlanFailure(Enum):
+    """Canonical pre-resolution policy failure for both hook phases."""
+
+    UNSAFE_METHOD = "unsafe_method"
+    INSECURE_TRANSPORT = "insecure_transport"
+    AUTH_UNAVAILABLE = "auth_unavailable"
+
+
 type CurrentFirewallAuthorizationGuard = Callable[[], bool]
 
 
@@ -120,6 +128,29 @@ class _FirewallAuthContext:
     proxy_log_path: str
     auth_request: FirewallAuthRequest
     auth_cache_key: FirewallAuthCacheKey
+
+
+@dataclass(frozen=True)
+class _FirewallAuthPlan:
+    """Pure firewall-auth policy shared by requestheaders and request hooks."""
+
+    injects_credentials: bool
+    needs_resolution: bool
+    uses_auth_base: bool
+    uses_aws_sigv4: bool
+    body_dependent: bool
+    failure: _FirewallAuthPlanFailure | None
+
+
+@dataclass(frozen=True)
+class _ResolvedFirewallAuth:
+    """Validated auth-service result consumed by either hook phase."""
+
+    token_meta: dict
+    headers: dict
+    query: dict | None
+    base: str | None
+    aws_sigv4: AwsSigV4Credentials | None
 
 
 def is_billable_firewall(firewall_name: str, vm_info: dict) -> bool:
@@ -274,25 +305,8 @@ def _cached_firewall_auth_identity(
     return auth_identity
 
 
-def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) -> bool:
-    return auth_config_injects_credentials(
-        {
-            "headers": context.auth_request.auth_headers,
-            "query": context.auth_request.auth_query,
-            "awsSigv4": context.auth_request.auth_aws_sigv4,
-            "base": context.auth_request.auth_base,
-        }
-    )
-
-
 def _request_method_forbids_managed_credentials(method: str) -> bool:
     return method.upper() in ("TRACE", "TRACK")
-
-
-def _firewall_auth_context_needs_resolution(context: _FirewallAuthContext) -> bool:
-    return context.auth_request.firewall_billable or _firewall_auth_context_injects_credentials(
-        context
-    )
 
 
 def _set_matched_firewall_failure_response(
@@ -395,6 +409,99 @@ def _auth_config_uses_body_dependent_auth(
     )
 
 
+def _build_firewall_auth_plan(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+) -> _FirewallAuthPlan:
+    """Derive shared firewall-auth policy without mutating request state."""
+    auth_config = allow.api_entry.get("auth", {})
+    uses_auth_base = (
+        isinstance(auth_config, dict)
+        and isinstance(auth_config.get("base"), str)
+        and bool(auth_config["base"])
+    )
+    uses_aws_sigv4 = (
+        isinstance(auth_config, dict)
+        and isinstance(auth_config.get("awsSigv4"), dict)
+        and bool(auth_config["awsSigv4"])
+    )
+    injects_credentials = auth_config_injects_credentials(auth_config)
+    needs_resolution = injects_credentials or is_billable_firewall(allow.name, vm_info)
+
+    failure = None
+    if injects_credentials and _request_method_forbids_managed_credentials(flow.request.method):
+        failure = _FirewallAuthPlanFailure.UNSAFE_METHOD
+    elif injects_credentials and flow.request.scheme.lower() != "https":
+        failure = _FirewallAuthPlanFailure.INSECURE_TRANSPORT
+    elif needs_resolution and not vm_info.get("encryptedSecrets"):
+        failure = _FirewallAuthPlanFailure.AUTH_UNAVAILABLE
+
+    return _FirewallAuthPlan(
+        injects_credentials=injects_credentials,
+        needs_resolution=needs_resolution,
+        uses_auth_base=uses_auth_base,
+        uses_aws_sigv4=uses_aws_sigv4,
+        body_dependent=_auth_config_uses_body_dependent_auth(flow, auth_config),
+        failure=failure,
+    )
+
+
+async def _resolve_firewall_auth(
+    plan: _FirewallAuthPlan,
+    context: _FirewallAuthContext,
+) -> dict:
+    if not plan.needs_resolution:
+        return _empty_firewall_auth_metadata()
+    return await get_firewall_headers(
+        context.auth_cache_key,
+        context.auth_request,
+    )
+
+
+def _validate_resolved_firewall_auth(
+    plan: _FirewallAuthPlan,
+    token_meta: object,
+) -> _ResolvedFirewallAuth:
+    if not isinstance(token_meta, dict):
+        raise TypeError("resolved firewall auth metadata must be an object")
+
+    headers = token_meta.get("headers")
+    if not isinstance(headers, dict):
+        raise TypeError("resolved auth headers are missing")
+    query = token_meta.get("query")
+    if query is not None and not isinstance(query, dict):
+        raise TypeError("resolved auth query must be an object")
+
+    base_value = token_meta.get("base")
+    if plan.uses_auth_base:
+        if not isinstance(base_value, str) or not base_value:
+            raise ValueError("resolved auth base is missing")
+        base = base_value
+    else:
+        if base_value is not None:
+            raise ValueError("resolved auth base is unexpected")
+        base = None
+
+    aws_sigv4_value = token_meta.get("aws_sigv4")
+    if plan.uses_aws_sigv4:
+        if not isinstance(aws_sigv4_value, AwsSigV4Credentials):
+            raise ValueError("resolved AWS SigV4 credentials are missing")
+        aws_sigv4 = aws_sigv4_value
+    else:
+        if aws_sigv4_value is not None:
+            raise ValueError("resolved AWS SigV4 credentials are unexpected")
+        aws_sigv4 = None
+
+    return _ResolvedFirewallAuth(
+        token_meta=token_meta,
+        headers=headers,
+        query=query,
+        base=base,
+        aws_sigv4=aws_sigv4,
+    )
+
+
 def _restore_header_phase_probe_state(
     flow: http.HTTPFlow,
     *,
@@ -488,12 +595,12 @@ def _sign_flow_request_with_aws_sigv4(
 async def _precompute_aws_sigv4_body_hash(
     flow: http.HTTPFlow,
     *,
-    context: _FirewallAuthContext,
-    token_meta: dict,
+    plan: _FirewallAuthPlan,
+    resolved_auth: _ResolvedFirewallAuth,
 ) -> AwsSigV4BodyHash | None:
-    if context.auth_request.auth_base is not None or context.auth_request.auth_aws_sigv4 is None:
+    if plan.uses_auth_base or not plan.uses_aws_sigv4:
         return None
-    if not isinstance(token_meta.get("aws_sigv4"), AwsSigV4Credentials):
+    if resolved_auth.aws_sigv4 is None:
         return None
     if not aws_sigv4_request_requires_body_for_signing(flow):
         return None
@@ -813,9 +920,10 @@ def mark_aws_sigv4_request_admission_saturated(
 def _preflight_firewall_auth(
     flow: http.HTTPFlow,
     context: _FirewallAuthContext,
+    plan: _FirewallAuthPlan,
 ) -> FirewallAuthHandlingResult | None:
     """Handle local firewall auth failures that must happen before auth resolution."""
-    if context.auth_request.auth_base and _request_body_exceeds_auth_base_limit(flow):
+    if plan.uses_auth_base and _request_body_exceeds_auth_base_limit(flow):
         _set_auth_base_request_too_large(
             flow,
             allow=context.allow,
@@ -826,7 +934,7 @@ def _preflight_firewall_auth(
 
     body = flow.request.raw_content
     if (
-        context.auth_request.auth_aws_sigv4 is not None
+        plan.uses_aws_sigv4
         and aws_sigv4_request_requires_body_for_signing(flow)
         and body is not None
         and len(body) > MAX_AWS_SIGV4_REQUEST_BODY_BYTES
@@ -839,9 +947,8 @@ def _preflight_firewall_auth(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    injects_credentials = _firewall_auth_context_injects_credentials(context)
-    request_method = flow.request.method.upper()
-    if _request_method_forbids_managed_credentials(request_method) and injects_credentials:
+    if plan.failure is _FirewallAuthPlanFailure.UNSAFE_METHOD:
+        request_method = flow.request.method.upper()
         log_proxy_entry(
             context.proxy_log_path,
             "warn",
@@ -860,8 +967,8 @@ def _preflight_firewall_auth(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    request_scheme = flow.request.scheme.lower()
-    if request_scheme != "https" and injects_credentials:
+    if plan.failure is _FirewallAuthPlanFailure.INSECURE_TRANSPORT:
+        request_scheme = flow.request.scheme.lower()
         log_proxy_entry(
             context.proxy_log_path,
             "warn",
@@ -880,9 +987,7 @@ def _preflight_firewall_auth(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    if not context.auth_request.encrypted_secrets and _firewall_auth_context_needs_resolution(
-        context
-    ):
+    if plan.failure is _FirewallAuthPlanFailure.AUTH_UNAVAILABLE:
         log_proxy_entry(
             context.proxy_log_path,
             "error",
@@ -1168,23 +1273,13 @@ async def _apply_resolved_firewall_auth(
     flow: http.HTTPFlow,
     *,
     context: _FirewallAuthContext,
-    token_meta: dict,
+    resolved_auth: _ResolvedFirewallAuth,
     auth_base_client_headers: list[tuple[str, str]] | None,
     aws_sigv4_body_hash: AwsSigV4BodyHash | None,
 ) -> FirewallAuthHandlingResult:
     """Apply resolved firewall auth and return request ownership outcome."""
-    headers = token_meta["headers"]
-    resolved_query = token_meta.get("query")
-
     try:
-        if context.auth_request.auth_base is not None:
-            resolved_base = token_meta.get("base")
-            if not isinstance(resolved_base, str) or not resolved_base:
-                return _set_firewall_auth_resolution_failure(
-                    flow,
-                    context,
-                    ValueError("resolved auth base is missing"),
-                )
+        if resolved_auth.base is not None:
             if auth_base_client_headers is None:
                 return _set_firewall_auth_resolution_failure(
                     flow,
@@ -1194,10 +1289,10 @@ async def _apply_resolved_firewall_auth(
             return await _apply_url_rewrite(
                 flow,
                 allow=context.allow,
-                resolved_base=resolved_base,
+                resolved_base=resolved_auth.base,
                 client_representation_headers=auth_base_client_headers,
-                headers=headers,
-                resolved_query=resolved_query,
+                headers=resolved_auth.headers,
+                resolved_query=resolved_auth.query,
                 firewall_base=context.firewall_base,
                 proxy_log_path=context.proxy_log_path,
             )
@@ -1205,8 +1300,8 @@ async def _apply_resolved_firewall_auth(
         release_forward_request_admission_from_flow(flow)
         _apply_header_query_injection(
             flow,
-            headers=headers,
-            resolved_query=resolved_query,
+            headers=resolved_auth.headers,
+            resolved_query=resolved_auth.query,
         )
     except InvalidResolvedAuthHeaderError as e:
         _set_invalid_resolved_auth_header_response(
@@ -1218,18 +1313,11 @@ async def _apply_resolved_firewall_auth(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    if context.auth_request.auth_aws_sigv4 is not None:
-        aws_sigv4 = token_meta.get("aws_sigv4")
-        if not isinstance(aws_sigv4, AwsSigV4Credentials):
-            return _set_firewall_auth_resolution_failure(
-                flow,
-                context,
-                ValueError("resolved AWS SigV4 credentials are missing"),
-            )
+    if resolved_auth.aws_sigv4 is not None:
         try:
             _sign_flow_request_with_aws_sigv4(
                 flow,
-                aws_sigv4,
+                resolved_auth.aws_sigv4,
                 precomputed_body_hash=aws_sigv4_body_hash,
             )
         except AwsSigV4SigningError as e:
@@ -1287,15 +1375,16 @@ async def handle_firewall_request(
     function then returns ``LOCAL_RESPONSE`` without applying resolved data.
     """
     try:
+        plan = _build_firewall_auth_plan(flow, allow, vm_info)
         _prepare_firewall_metadata(flow, allow, vm_info)
         context = _build_firewall_auth_context(flow, allow, vm_info)
 
-        preflight_result = _preflight_firewall_auth(flow, context)
+        preflight_result = _preflight_firewall_auth(flow, context, plan)
         if preflight_result is not None:
             return _finish_firewall_auth_result(flow, preflight_result)
 
         auth_base_client_headers: list[tuple[str, str]] | None = None
-        if context.auth_request.auth_base is not None:
+        if plan.uses_auth_base:
             try:
                 auth_base_client_headers = forwarded_auth_base_client_header_pairs(
                     flow.request.headers
@@ -1322,36 +1411,29 @@ async def handle_firewall_request(
                     FirewallAuthHandlingResult.LOCAL_RESPONSE,
                 )
 
-        if _firewall_auth_context_needs_resolution(context):
+        if plan.needs_resolution:
             probe_failure = flow.metadata.pop(metadata_keys.FIREWALL_AUTH_PROBE_FAILURE, None)
             if isinstance(probe_failure, Exception):
                 return _finish_firewall_auth_result(
                     flow,
                     _set_firewall_auth_resolution_failure(flow, context, probe_failure),
                 )
-            try:
-                token_meta = await get_firewall_headers(
-                    context.auth_cache_key,
-                    context.auth_request,
-                )
-            except Exception as exc:
-                return _finish_firewall_auth_result(
-                    flow,
-                    _set_firewall_auth_resolution_failure(flow, context, exc),
-                )
-        else:
-            token_meta = _empty_firewall_auth_metadata()
+        try:
+            token_meta = await _resolve_firewall_auth(plan, context)
+            resolved_auth = _validate_resolved_firewall_auth(plan, token_meta)
+        except Exception as exc:
+            return _finish_firewall_auth_result(
+                flow,
+                _set_firewall_auth_resolution_failure(flow, context, exc),
+            )
 
         aws_sigv4_body_hash = await _precompute_aws_sigv4_body_hash(
             flow,
-            context=context,
-            token_meta=token_meta,
+            plan=plan,
+            resolved_auth=resolved_auth,
         )
 
-        if (
-            auth_config_injects_credentials(context.allow.api_entry.get("auth"))
-            and not revalidate_current_firewall_authorization()
-        ):
+        if plan.injects_credentials and not revalidate_current_firewall_authorization():
             return _finish_firewall_auth_result(
                 flow,
                 FirewallAuthHandlingResult.LOCAL_RESPONSE,
@@ -1360,14 +1442,14 @@ async def handle_firewall_request(
         auth_result = await _apply_resolved_firewall_auth(
             flow,
             context=context,
-            token_meta=token_meta,
+            resolved_auth=resolved_auth,
             auth_base_client_headers=auth_base_client_headers,
             aws_sigv4_body_hash=aws_sigv4_body_hash,
         )
         if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
             return _finish_firewall_auth_result(flow, auth_result)
 
-        _finalize_firewall_auth_success(flow, context, token_meta)
+        _finalize_firewall_auth_success(flow, context, resolved_auth.token_meta)
         return auth_result
     except BaseException:
         release_forward_request_admission_from_flow(flow)
@@ -1389,25 +1471,8 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
     rejected current-authorization guard restores the probe snapshot and falls
     back before mutation.
     """
-    auth_config = allow.api_entry.get("auth", {})
-    if _auth_config_uses_body_dependent_auth(flow, auth_config):
-        return FirewallHeaderPhaseAuthResult.FALLBACK
-
-    configured_aws_sigv4 = (
-        isinstance(auth_config, dict)
-        and isinstance(auth_config.get("awsSigv4"), dict)
-        and bool(auth_config["awsSigv4"])
-    )
-    injects_credentials = auth_config_injects_credentials(auth_config)
-    if injects_credentials and _request_method_forbids_managed_credentials(flow.request.method):
-        return FirewallHeaderPhaseAuthResult.FALLBACK
-
-    needs_auth_resolution = injects_credentials or is_billable_firewall(allow.name, vm_info)
-    request_scheme = flow.request.scheme.lower()
-    if request_scheme != "https" and injects_credentials:
-        return FirewallHeaderPhaseAuthResult.FALLBACK
-
-    if not vm_info.get("encryptedSecrets") and needs_auth_resolution:
+    plan = _build_firewall_auth_plan(flow, allow, vm_info)
+    if plan.body_dependent or plan.failure is not None:
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
     metadata_snapshot = dict(flow.metadata)
@@ -1417,33 +1482,29 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
     _prepare_firewall_metadata(flow, allow, vm_info)
     context = _build_firewall_auth_context(flow, allow, vm_info)
 
-    if needs_auth_resolution:
-        try:
-            token_meta = await get_firewall_headers(
-                context.auth_cache_key,
-                context.auth_request,
-            )
-        except asyncio.CancelledError:
-            _restore_header_phase_probe_state(
-                flow,
-                metadata_snapshot=metadata_snapshot,
-                request_headers_snapshot=request_headers_snapshot,
-                request_url_snapshot=request_url_snapshot,
-            )
-            raise
-        except Exception as exc:
-            _restore_header_phase_probe_state(
-                flow,
-                metadata_snapshot=metadata_snapshot,
-                request_headers_snapshot=request_headers_snapshot,
-                request_url_snapshot=request_url_snapshot,
-            )
-            flow.metadata[metadata_keys.FIREWALL_AUTH_PROBE_FAILURE] = exc
-            return FirewallHeaderPhaseAuthResult.FALLBACK
-    else:
-        token_meta = _empty_firewall_auth_metadata()
+    try:
+        token_meta = await _resolve_firewall_auth(plan, context)
+    except asyncio.CancelledError:
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_url_snapshot=request_url_snapshot,
+        )
+        raise
+    except Exception as exc:
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_url_snapshot=request_url_snapshot,
+        )
+        flow.metadata[metadata_keys.FIREWALL_AUTH_PROBE_FAILURE] = exc
+        return FirewallHeaderPhaseAuthResult.FALLBACK
 
-    if not isinstance(token_meta, dict):
+    try:
+        resolved_auth = _validate_resolved_firewall_auth(plan, token_meta)
+    except (TypeError, ValueError):
         _restore_header_phase_probe_state(
             flow,
             metadata_snapshot=metadata_snapshot,
@@ -1452,26 +1513,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
         )
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
-    resolved_aws_sigv4_value = token_meta.get("aws_sigv4")
-    resolved_aws_sigv4 = (
-        resolved_aws_sigv4_value
-        if isinstance(resolved_aws_sigv4_value, AwsSigV4Credentials)
-        else None
-    )
-    if (
-        token_meta.get("base")
-        or (resolved_aws_sigv4_value is not None and not configured_aws_sigv4)
-        or (configured_aws_sigv4 and resolved_aws_sigv4 is None)
-    ):
-        _restore_header_phase_probe_state(
-            flow,
-            metadata_snapshot=metadata_snapshot,
-            request_headers_snapshot=request_headers_snapshot,
-            request_url_snapshot=request_url_snapshot,
-        )
-        return FirewallHeaderPhaseAuthResult.FALLBACK
-
-    if injects_credentials and not revalidate_current_firewall_authorization():
+    if plan.injects_credentials and not revalidate_current_firewall_authorization():
         _restore_header_phase_probe_state(
             flow,
             metadata_snapshot=metadata_snapshot,
@@ -1481,15 +1523,13 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
     try:
-        headers = token_meta["headers"]
-        resolved_query = token_meta.get("query")
         _apply_header_query_injection(
             flow,
-            headers=headers,
-            resolved_query=resolved_query,
+            headers=resolved_auth.headers,
+            resolved_query=resolved_auth.query,
         )
-        if resolved_aws_sigv4 is not None:
-            _sign_flow_request_with_aws_sigv4(flow, resolved_aws_sigv4)
+        if resolved_auth.aws_sigv4 is not None:
+            _sign_flow_request_with_aws_sigv4(flow, resolved_auth.aws_sigv4)
     except Exception:
         _restore_header_phase_probe_state(
             flow,
@@ -1499,5 +1539,5 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
         )
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
-    _finalize_firewall_auth_success(flow, context, token_meta)
+    _finalize_firewall_auth_success(flow, context, resolved_auth.token_meta)
     return FirewallHeaderPhaseAuthResult.APPLIED

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -4,9 +4,12 @@ import asyncio
 import json
 import os
 import urllib.error
+from collections.abc import Callable
+from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from mitmproxy import http
 
 import auth
 import auth_base_forwarder
@@ -26,7 +29,6 @@ from tests.aws_sigv4_helpers import (
     resolved_aws_sigv4_credentials,
 )
 from tests.firewall_auth_helpers import (
-    apply_requestheaders_auth_without_upstream_admission,
     firewall_auth_success,
     handle_firewall_request_without_upstream_admission,
 )
@@ -36,10 +38,38 @@ from url_utils import get_trusted_authority
 
 _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success response"
 _MISSING_FIELD = object()
+type HookPhase = Literal["request", "requestheaders"]
 
 
 def _fail_if_current_firewall_authorization_is_revalidated() -> bool:
     raise AssertionError("current firewall authorization guard must not run")
+
+
+def _allow_current_firewall_authorization() -> bool:
+    return True
+
+
+async def _run_firewall_auth_phase(
+    hook_phase: HookPhase,
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+    *,
+    revalidate: Callable[[], bool] = _allow_current_firewall_authorization,
+) -> auth.FirewallAuthHandlingResult | auth.FirewallHeaderPhaseAuthResult:
+    if hook_phase == "request":
+        return await auth.handle_firewall_request(
+            flow,
+            allow,
+            vm_info,
+            revalidate_current_firewall_authorization=revalidate,
+        )
+    return await auth.try_apply_stream_safe_firewall_auth_for_requestheaders(
+        flow,
+        allow,
+        vm_info,
+        revalidate_current_firewall_authorization=revalidate,
+    )
 
 
 def _allow(
@@ -188,48 +218,13 @@ class TestHandleFirewallRequest:
         log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "Firewall https://api.github.com: api.github.com" in log_text
 
+    @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
     async def test_empty_auth_config_preserves_existing_authorization(
-        self, real_flow, mitm_ctx, tmp_path
-    ):
-        flow = real_flow(
-            with_response=False,
-            host="api.cloudflare.com",
-            path="/client/v4/pages/assets/check-missing",
-            method="POST",
-        )
-        flow.request.headers["Authorization"] = "Bearer upload-jwt"
-        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
-        api_entry = _api_entry(
-            base="https://api.cloudflare.com/client",
-            auth_config={},
-            api_id="run-1:1",
-        )
-        vm_info = _vm_info(tmp_path, include_encrypted_secrets=False)
-        allow = _allow(
-            api_entry,
-            name="cloudflare",
-            permission="page.write",
-            rule="POST /v4/pages/assets/check-missing",
-            rel_path="/v4/pages/assets/check-missing",
-        )
-        mock_get_firewall_headers = AsyncMock()
-
-        with (
-            patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
-            mitm_ctx(),
-        ):
-            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
-
-        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
-        mock_get_firewall_headers.assert_not_called()
-        assert flow.request.headers["Authorization"] == "Bearer upload-jwt"
-        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-        assert flow.metadata[metadata_keys.FIREWALL_NAME] == "cloudflare"
-        assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "page.write"
-        assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
-
-    async def test_empty_auth_config_requestheaders_preserves_authorization_without_auth_resolution(
-        self, real_flow, mitm_ctx, tmp_path
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        hook_phase: HookPhase,
     ):
         flow = real_flow(
             with_response=False,
@@ -258,13 +253,14 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
             mitm_ctx(),
         ):
-            result = await apply_requestheaders_auth_without_upstream_admission(
-                flow,
-                allow,
-                vm_info,
-            )
+            result = await _run_firewall_auth_phase(hook_phase, flow, allow, vm_info)
 
-        assert result is auth.FirewallHeaderPhaseAuthResult.APPLIED
+        expected_result = (
+            auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+            if hook_phase == "request"
+            else auth.FirewallHeaderPhaseAuthResult.APPLIED
+        )
+        assert result is expected_result
         mock_get_firewall_headers.assert_not_called()
         assert flow.request.headers["Authorization"] == "Bearer upload-jwt"
         assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
@@ -272,8 +268,13 @@ class TestHandleFirewallRequest:
         assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "page.write"
         assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
 
+    @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
     async def test_billable_only_auth_does_not_require_upstream_admission(
-        self, real_flow, mitm_ctx, tmp_path
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        hook_phase: HookPhase,
     ):
         flow = _firewall_flow(real_flow)
         api_entry = _api_entry(auth_config={})
@@ -281,21 +282,92 @@ class TestHandleFirewallRequest:
         allow = _allow(api_entry)
         token_meta = _token_meta(headers={})
 
-        with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            result = await auth.handle_firewall_request(
+        get_firewall_headers = AsyncMock(return_value=token_meta)
+
+        with patch.object(auth, "get_firewall_headers", get_firewall_headers), mitm_ctx():
+            result = await _run_firewall_auth_phase(
+                hook_phase,
                 flow,
                 allow,
                 vm_info,
-                revalidate_current_firewall_authorization=(
-                    _fail_if_current_firewall_authorization_is_revalidated
-                ),
+                revalidate=_fail_if_current_firewall_authorization_is_revalidated,
             )
 
-        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        expected_result = (
+            auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+            if hook_phase == "request"
+            else auth.FirewallHeaderPhaseAuthResult.APPLIED
+        )
+        assert result is expected_result
+        get_firewall_headers.assert_awaited_once()
         assert flow.response is None
+
+    @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
+    @pytest.mark.parametrize(
+        ("method", "scheme", "include_encrypted_secrets", "status", "error_code"),
+        [
+            pytest.param("TRACE", "https", True, 403, "unsafe_auth_method", id="unsafe-method"),
+            pytest.param("GET", "http", True, 403, "insecure_transport", id="insecure-transport"),
+            pytest.param("GET", "https", False, 502, "auth_unavailable", id="missing-secret"),
+        ],
+    )
+    async def test_policy_failures_have_phase_specific_effects(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        hook_phase: HookPhase,
+        method: str,
+        scheme: str,
+        include_encrypted_secrets: bool,
+        status: int,
+        error_code: str,
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.github.com",
+            method=method,
+            scheme=scheme,
+        )
+        flow.metadata.update(
+            {
+                metadata_keys.VM_RUN_ID: "test-run",
+                "preexisting": "keep",
+            }
+        )
+        original_metadata = dict(flow.metadata)
+        original_url = flow.request.url
+        original_headers = flow.request.headers.fields
+        api_entry = _api_entry()
+        vm_info = _vm_info(
+            tmp_path,
+            include_encrypted_secrets=include_encrypted_secrets,
+        )
+        allow = _allow(api_entry)
+        get_firewall_headers = AsyncMock()
+
+        with patch.object(auth, "get_firewall_headers", get_firewall_headers), mitm_ctx():
+            result = await _run_firewall_auth_phase(
+                hook_phase,
+                flow,
+                allow,
+                vm_info,
+                revalidate=_fail_if_current_firewall_authorization_is_revalidated,
+            )
+
+        get_firewall_headers.assert_not_called()
+        if hook_phase == "requestheaders":
+            assert result is auth.FirewallHeaderPhaseAuthResult.FALLBACK
+            assert flow.response is None
+            assert flow.metadata == original_metadata
+            assert flow.request.url == original_url
+            assert flow.request.headers.fields == original_headers
+            return
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == status
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == error_code
 
     async def test_auth_cache_identity_tracks_request_auth_inputs(
         self, real_flow, mitm_ctx, tmp_path
@@ -443,8 +515,14 @@ class TestHandleFirewallRequest:
         assert first_cache_key.api_id == second_cache_key.api_id == "run-1:0"
         assert first_cache_key.auth_identity != second_cache_key.auth_identity
 
+    @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
     async def test_standard_auth_filters_unsafe_resolved_headers(
-        self, real_flow, headers, mitm_ctx, tmp_path
+        self,
+        real_flow,
+        headers,
+        mitm_ctx,
+        tmp_path,
+        hook_phase: HookPhase,
     ):
         flow = _firewall_flow(
             real_flow,
@@ -498,9 +576,14 @@ class TestHandleFirewallRequest:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+            result = await _run_firewall_auth_phase(hook_phase, flow, allow, vm_info)
 
-        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        expected_result = (
+            auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+            if hook_phase == "request"
+            else auth.FirewallHeaderPhaseAuthResult.APPLIED
+        )
+        assert result is expected_result
         header_names = {name.lower() for name, _value in flow.request.headers.items(multi=True)}
         assert flow.request.headers["Host"] == "api.github.com"
         assert "connection" not in header_names
@@ -575,6 +658,166 @@ class TestHandleFirewallRequest:
             in flow.request.headers["authorization"]
         )
         assert "evil.example.com" not in flow.request.headers["authorization"]
+
+    @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
+    async def test_stream_safe_aws_sigv4_applies_in_both_phases(
+        self,
+        headers,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        hook_phase: HookPhase,
+    ):
+        flow = real_flow(
+            with_response=False,
+            host=STS_HOST,
+            path="/",
+            method="POST",
+            request_headers=headers(
+                ("Host", STS_HOST),
+                ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
+                ("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD"),
+                (
+                    "Authorization",
+                    aws_sigv4_authorization(signed_headers="host;x-amz-content-sha256;x-amz-date"),
+                ),
+            ),
+        )
+        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = get_trusted_authority(flow).url
+        api_entry = _api_entry(
+            base="https://sts.amazonaws.com",
+            auth_config={
+                "awsSigv4": {
+                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                    "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                }
+            },
+        )
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry, rule="POST /", rel_path="/")
+        token_meta = _token_meta()
+        token_meta["aws_sigv4"] = resolved_aws_sigv4_credentials()
+        get_firewall_headers = AsyncMock(return_value=token_meta)
+
+        with patch.object(auth, "get_firewall_headers", get_firewall_headers), mitm_ctx():
+            result = await _run_firewall_auth_phase(hook_phase, flow, allow, vm_info)
+
+        expected_result = (
+            auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+            if hook_phase == "request"
+            else auth.FirewallHeaderPhaseAuthResult.APPLIED
+        )
+        assert result is expected_result
+        get_firewall_headers.assert_awaited_once()
+        assert flow.request.headers["x-amz-content-sha256"] == "UNSIGNED-PAYLOAD"
+        assert flow.request.headers["x-amz-security-token"] == RESOLVED_AWS_SESSION_TOKEN
+        assert "Credential=AKIDEXAMPLE/" in flow.request.headers["authorization"]
+
+    @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
+    async def test_unexpected_resolved_auth_base_fails_closed_in_both_phases(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        hook_phase: HookPhase,
+    ):
+        flow = _firewall_flow(real_flow)
+        flow.metadata["preexisting"] = "keep"
+        original_metadata = dict(flow.metadata)
+        original_url = flow.request.url
+        original_headers = flow.request.headers.fields
+        api_entry = _api_entry()
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry)
+        token_meta = _token_meta(headers={"Authorization": "Bearer token"})
+        token_meta["base"] = "https://unexpected.example.com"
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await _run_firewall_auth_phase(hook_phase, flow, allow, vm_info)
+
+        if hook_phase == "requestheaders":
+            assert result is auth.FirewallHeaderPhaseAuthResult.FALLBACK
+            assert flow.response is None
+            assert flow.metadata == original_metadata
+            assert flow.request.url == original_url
+            assert flow.request.headers.fields == original_headers
+            return
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
+        assert "Authorization" not in flow.request.headers
+
+    @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
+    async def test_missing_resolved_aws_sigv4_fails_closed_in_both_phases(
+        self,
+        headers,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        hook_phase: HookPhase,
+    ):
+        flow = real_flow(
+            with_response=False,
+            host=STS_HOST,
+            method="POST",
+            request_headers=headers(
+                ("Host", STS_HOST),
+                ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
+                ("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD"),
+                (
+                    "Authorization",
+                    aws_sigv4_authorization(signed_headers="host;x-amz-content-sha256;x-amz-date"),
+                ),
+            ),
+        )
+        flow.metadata.update(
+            {
+                metadata_keys.VM_RUN_ID: "test-run",
+                metadata_keys.ORIGINAL_URL: get_trusted_authority(flow).url,
+                "preexisting": "keep",
+            }
+        )
+        original_metadata = dict(flow.metadata)
+        original_url = flow.request.url
+        original_headers = flow.request.headers.fields
+        api_entry = _api_entry(
+            base="https://sts.amazonaws.com",
+            auth_config={
+                "awsSigv4": {
+                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                }
+            },
+        )
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry, rule="POST /", rel_path="/")
+        token_meta = _token_meta()
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await _run_firewall_auth_phase(hook_phase, flow, allow, vm_info)
+
+        if hook_phase == "requestheaders":
+            assert result is auth.FirewallHeaderPhaseAuthResult.FALLBACK
+            assert flow.response is None
+            assert flow.metadata == original_metadata
+            assert flow.request.url == original_url
+            assert flow.request.headers.fields == original_headers
+            return
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
 
     @pytest.mark.parametrize(
         "resolved_headers",

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -4,6 +4,7 @@ import asyncio
 import threading
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Never
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -28,6 +29,11 @@ _MODEL_PROVIDER_SANDBOX_MARKER = "tok-model"
 _MODEL_PROVIDER_PATH = "/v1/messages"
 _AUTH_URL_REWRITE_REQUEST_BODY = b'{"ok":true}'
 _FORWARD_START_TIMEOUT_SECONDS = 2.0
+
+
+class _UnexpectedAuthHeaders(dict[str, str]):
+    def items(self) -> Never:
+        raise KeyError("unexpected auth header iteration failure")
 
 
 async def _wait_for_forward_start(
@@ -523,7 +529,7 @@ async def test_unexpected_request_exception_releases_tracking(
     reg_path = _write_billable_x_tracking_registry(tmp_path)
     flow = _x_tracking_flow(real_flow)
 
-    async def return_invalid_auth_after_tracking(*_args, **_kwargs):
+    async def return_unexpected_auth_headers_after_tracking(*_args, **_kwargs):
         usage.write_pending_snapshot(flush_request_id="during-auth-failure")
         assert_pending(
             usage_pending_path,
@@ -532,11 +538,15 @@ async def test_unexpected_request_exception_releases_tracking(
             reports=0,
             flush_request_id="during-auth-failure",
         )
-        return {}
+        return {"headers": _UnexpectedAuthHeaders({"Authorization": "Bearer resolved-token"})}
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
-        patch.object(auth, "get_firewall_headers", return_invalid_auth_after_tracking),
+        patch.object(
+            auth,
+            "get_firewall_headers",
+            return_unexpected_auth_headers_after_tracking,
+        ),
         pytest.raises(KeyError),
     ):
         await mitm_addon.request(flow)


### PR DESCRIPTION
## Summary

- centralize shared firewall-auth phase decisions in one immutable request plan
- validate resolved auth strategies once before either hook phase consumes them
- preserve requestheaders rollback/fallback semantics and final-request local responses

## Scope

- no API, database, protocol, registry, or deployment changes
- no generic hook-phase framework; phase-specific ownership remains at each hook

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5197 passed)

Closes #26044
