### PR TITLE
test(python): cover websocket framing installation

### DIFF
--- a/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
@@ -210,6 +210,8 @@ def _data_sends(observed: list[commands.Command]) -> list[commands.SendData]:
     ]
 
 
+# Only process composition can introduce a conflicting connection class; no
+# proxied WebSocket flow can construct this installer state.
 def test_install_websocket_framing_rejects_incompatible_connection_class(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
@@ -210,6 +210,41 @@ def _data_sends(observed: list[commands.Command]) -> list[commands.SendData]:
     ]
 
 
+def test_install_websocket_framing_rejects_incompatible_connection_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class IncompatibleWebsocketConnection:
+        pass
+
+    monkeypatch.setattr(websocket, "WebsocketConnection", IncompatibleWebsocketConnection)
+
+    with pytest.raises(
+        RuntimeError,
+        match="mitmproxy WebsocketConnection has an incompatible shape",
+    ):
+        websocket_framing.install_websocket_framing()
+
+    assert websocket.WebsocketConnection is IncompatibleWebsocketConnection
+
+
+def test_install_websocket_framing_preserves_marked_connection_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MarkedWebsocketConnection:
+        pass
+
+    setattr(
+        MarkedWebsocketConnection,
+        websocket_framing._CONNECTION_MARKER_ATTRIBUTE,
+        True,
+    )
+    monkeypatch.setattr(websocket, "WebsocketConnection", MarkedWebsocketConnection)
+
+    websocket_framing.install_websocket_framing()
+
+    assert websocket.WebsocketConnection is MarkedWebsocketConnection
+
+
 @pytest.mark.parametrize(
     ("from_client", "content"),
     [


### PR DESCRIPTION
## Summary

- cover the fail-closed `WebsocketConnection` installation guard with an unmarked sentinel
- assert an incompatible class is preserved when installation raises
- cover marker-based idempotency with an independent marked sentinel
- isolate both process-global replacements with pytest `monkeypatch`

## Scope

This is a test-only change. It does not change mitmproxy addon runtime behavior, dependencies, APIs, schemas, persisted state, runner protocols, configuration, or deployment ordering.

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused installation contract tests
- `uv run --no-sync python -m pytest tests/test_mitmproxy_websocket_framing.py tests/test_addon_configuration.py` (23 passed)
- mutation check: removing the incompatible-class guard makes the new case fail with `DID NOT RAISE`; the guard was restored and the focused cases passed again
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,185 passed)
- `git diff --check`

Closes #26050
