### PR TITLE
fix(mitm-addon): reject partial firewall auth success

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -693,22 +693,12 @@ def _parse_firewall_auth_success(
     query = _parse_optional_string_map(decoded_map, "query")
     aws_sigv4 = _parse_optional_aws_sigv4_credentials(decoded_map)
 
-    # The API owns required-versus-optional credential semantics. Both builtin
-    # and custom auth may omit entries backed by unavailable optional fields,
-    # but the API must never introduce an entry the matched firewall did not
-    # define.
-    configured_header_names = set(request.auth_headers)
-    resolved_header_names = set(headers)
-    configured_query_names = set(request.auth_query or {})
-    resolved_query_names = set(query or {})
-    if not resolved_header_names.issubset(configured_header_names):
+    if set(headers) != set(request.auth_headers):
         raise _malformed_firewall_auth_success(
-            "headers must not contain unconfigured auth header names"
+            "headers must match the configured auth header names"
         )
-    if not resolved_query_names.issubset(configured_query_names):
-        raise _malformed_firewall_auth_success(
-            "query must not contain unconfigured auth query names"
-        )
+    if set(query or {}) != set(request.auth_query or {}):
+        raise _malformed_firewall_auth_success("query must match the configured auth query names")
     if (base is not None) != (request.auth_base is not None):
         raise _malformed_firewall_auth_success("base presence must match the configured auth base")
     if (aws_sigv4 is not None) != (request.auth_aws_sigv4 is not None):

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -265,21 +265,46 @@ class TestFetchFirewallHeaders:
         assert result.refreshed_secrets == ["NOTION_TOKEN"]
         assert not hasattr(result, "futureField")
 
-    async def test_response_may_omit_configured_header_and_query_entries(self, mitm_ctx):
+    @pytest.mark.parametrize(
+        ("response", "expected_reason"),
+        [
+            pytest.param(
+                firewall_auth_success_response(
+                    {"Authorization": "Bearer sensitive-resolved-token"},
+                )
+                | {"query": {"tenant": "resolved-tenant"}},
+                "headers must match the configured auth header names",
+                id="missing-header",
+            ),
+            pytest.param(
+                firewall_auth_success_response(
+                    {
+                        "Authorization": "Bearer sensitive-resolved-token",
+                        "X-Secondary": "sensitive-secondary-token",
+                    },
+                )
+                | {"query": {}},
+                "query must match the configured auth query names",
+                id="missing-query",
+            ),
+        ],
+    )
+    async def test_response_must_include_all_configured_header_and_query_entries(
+        self,
+        mitm_ctx,
+        response: dict[str, object],
+        expected_reason: str,
+    ):
         endpoint = FakeAuthEndpoint()
-        endpoint.queue_json_response(
-            firewall_auth_success_response(
-                {"Authorization": "Bearer primary-token"},
-            )
-            | {"query": {}}
-        )
+        endpoint.queue_json_response(response)
 
         with (
             endpoint.run(),
             mitm_ctx(api_url=endpoint.api_url),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
+            pytest.raises(ValueError, match=_MALFORMED_SUCCESS_PREFIX) as exc_info,
         ):
-            result = await auth_client.fetch_firewall_headers(
+            await auth_client.fetch_firewall_headers(
                 firewall_auth_request(
                     auth_headers={
                         "Authorization": "Bearer ${{ secrets.PRIMARY_TOKEN }}",
@@ -289,10 +314,9 @@ class TestFetchFirewallHeaders:
                 )
             )
 
-        assert result.payload.headers == {
-            "Authorization": "Bearer primary-token",
-        }
-        assert result.payload.query == {}
+        message = str(exc_info.value)
+        assert message == f"{_MALFORMED_SUCCESS_PREFIX}: {expected_reason}"
+        assert "sensitive-resolved-token" not in message
 
     @pytest.mark.parametrize(
         "session_token",


### PR DESCRIPTION
## Summary

- require successful firewall-auth responses to contain the exact configured header and query name sets
- replace the obsolete partial-success test with integration coverage for omitted header and query entries
- verify malformed-success errors do not expose resolved credential values

## Scope

This changes only the runner mitm add-on consumer after the partial-success API producer was removed and promoted. Unknown top-level fields, valid absence of query data when no query is configured, and existing base/SigV4 checks remain unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_firewall_auth_client.py -v` (84 passed)
- `uv run --no-sync python -m pytest tests/` (5184 passed)
- `lefthook run pre-commit`

Closes #26045
