### PR TITLE
refactor: rename shared automation-event infrastructure and stripe modules

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import { testStripeWorkflowEventFixtureContract } from "@vm0/api-contracts/contracts/test-stripe-workflow-events";
+import { testStripeAutomationEventFixtureContract } from "@vm0/api-contracts/contracts/test-stripe-automation-events";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -23,7 +23,7 @@ import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
-import { testStripeWorkflowEventRoutes } from "../test-stripe-workflow-events";
+import { testStripeAutomationEventRoutes } from "../test-stripe-automation-events";
 import { webhooksStripeAutomationEventsRoutes } from "../webhooks-stripe-automation-events";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 
@@ -98,7 +98,7 @@ async function setupScenario(
   });
   const workflowId = await workflows.createWorkflow(actor, {
     agentId,
-    name: `stripe-workflow-events-${randomUUID()}`,
+    name: `stripe-automation-events-${randomUUID()}`,
   });
   await connectors.updateFeatureSwitches(actor, {
     [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
@@ -227,7 +227,7 @@ function invoicePaidEvent(
   };
 }
 
-async function postStripeWorkflowEvent(
+async function postStripeAutomationEvent(
   event: object,
   expectedStatus = 200,
 ): Promise<Response> {
@@ -272,8 +272,8 @@ async function applyDeliveryFixture(
     | "clear-forced-failures",
 ): Promise<void> {
   const response = await accept(
-    setupApp({ context, routes: testStripeWorkflowEventRoutes })(
-      testStripeWorkflowEventFixtureContract,
+    setupApp({ context, routes: testStripeAutomationEventRoutes })(
+      testStripeAutomationEventFixtureContract,
     ).apply({
       body: { automation_id: scenario.automationId, action },
     }),
@@ -428,24 +428,24 @@ describe("Stripe automation event webhook", () => {
     });
     expect(invalidSignature.status).toBe(401);
 
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       { type: "invoice.paid", livemode: true },
       400,
     );
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       {
         ...invoicePaidEvent({ eventId: "evt_missing_account" }),
         account: undefined,
       },
       400,
     );
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_test_mode", livemode: false }),
       200,
     );
-    await postStripeWorkflowEvent({ type: "customer.created" }, 200);
+    await postStripeAutomationEvent({ type: "customer.created" }, 200);
     const unmapped = invoicePaidEvent({ eventId: "evt_unmapped_live" });
-    await postStripeWorkflowEvent(unmapped, 200);
+    await postStripeAutomationEvent(unmapped, 200);
 
     expect(
       context.mocks.stripe.webhooks.constructEvent,
@@ -474,8 +474,8 @@ describe("Stripe automation event webhook", () => {
     });
 
     await Promise.all([
-      postStripeWorkflowEvent(event),
-      postStripeWorkflowEvent(event),
+      postStripeAutomationEvent(event),
+      postStripeAutomationEvent(event),
     ]);
 
     expect((await readStripeAutomation(scenario)).health).toStrictEqual({
@@ -563,7 +563,7 @@ describe("Stripe automation event webhook", () => {
       };
     });
 
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({
         accountId: "acct_stripe_current_snapshot",
         eventId: "evt_current_snapshot",
@@ -607,7 +607,7 @@ describe("Stripe automation event webhook", () => {
         },
       }),
     );
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({
         accountId: "acct_stripe_legacy_snapshot",
         eventId: "evt_legacy_snapshot",
@@ -713,7 +713,7 @@ describe("Stripe automation event webhook", () => {
     const second = await setupScenario();
     expect(first.actor.orgId).not.toBe(second.actor.orgId);
     expect(first.actor.userId).not.toBe(second.actor.userId);
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_cross_tenant_seed" }),
     );
     expect((await executeCron()).executed).toBeGreaterThanOrEqual(2);
@@ -725,7 +725,7 @@ describe("Stripe automation event webhook", () => {
     const retryEvent = invoicePaidEvent({
       eventId: "evt_cross_tenant_retry",
     });
-    await postStripeWorkflowEvent(retryEvent, 500);
+    await postStripeAutomationEvent(retryEvent, 500);
     expect(
       (await readStripeAutomation(first)).health.lastMatchingEventReceivedAt,
     ).toBe("2026-08-07T08:30:00.000Z");
@@ -734,7 +734,7 @@ describe("Stripe automation event webhook", () => {
     ).toBe("2026-08-07T08:30:00.000Z");
 
     await applyDeliveryFixture(second, "clear-forced-failures");
-    await postStripeWorkflowEvent(retryEvent);
+    await postStripeAutomationEvent(retryEvent);
     expect((await executeCron()).executed).toBeGreaterThanOrEqual(2);
     await expect(automationInputEvents(first)).resolves.toHaveLength(2);
     await expect(automationInputEvents(second)).resolves.toHaveLength(2);
@@ -742,7 +742,7 @@ describe("Stripe automation event webhook", () => {
 
   it("retries a queue-admission failure without admitting a second source event", async () => {
     const scenario = await setupScenario();
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_queue_admission_retry" }),
     );
     await applyDeliveryFixture(
@@ -771,11 +771,11 @@ describe("Stripe automation event webhook", () => {
     const firstReceipt = Date.parse("2026-08-07T09:00:00.000Z");
     mockNow(firstReceipt);
     const scenario = await setupScenario();
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_health_older" }),
     );
     mockNow(firstReceipt + 60_000);
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_health_newer" }),
     );
     await applyDeliveryFixture(scenario, "hold-latest-claim");
@@ -803,7 +803,7 @@ describe("Stripe automation event webhook", () => {
       accountId: "acct_stripe_disabled_at_receipt",
     });
     await setAutomationEnabled(disabledAtReceipt, false);
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({
         accountId: "acct_stripe_disabled_at_receipt",
         eventId: "evt_disabled_at_receipt",
@@ -822,7 +822,7 @@ describe("Stripe automation event webhook", () => {
     await connectors.updateFeatureSwitches(featureOffAtReceipt.actor, {
       [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: false,
     });
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({
         accountId: "acct_stripe_feature_off_at_receipt",
         eventId: "evt_feature_off_at_receipt",
@@ -842,7 +842,7 @@ describe("Stripe automation event webhook", () => {
       billingReason: "future_reason",
     });
 
-    await postStripeWorkflowEvent(unknownReasonEvent);
+    await postStripeAutomationEvent(unknownReasonEvent);
 
     expect((await readStripeAutomation(filtered)).health).toMatchObject({
       lastMatchingEventReceivedAt: expect.any(String),
@@ -864,7 +864,7 @@ describe("Stripe automation event webhook", () => {
       eventContextFromPrompt(unknownClaim.appendSystemPrompt),
     ).toMatchObject({ invoice: { billingReason: "future_reason" } });
 
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({
         eventId: "evt_known_filter_miss",
         billingReason: "subscription_cycle",
@@ -896,7 +896,7 @@ describe("Stripe automation event webhook", () => {
     const changedAccount = await setupScenario();
     const testMode = await setupScenario();
     const deletedConnector = await setupScenario();
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_lifecycle_changes" }),
     );
 
@@ -936,7 +936,7 @@ describe("Stripe automation event webhook", () => {
     const unaffected = await setupScenario({
       accountId: "acct_stripe_workflow_other",
     });
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_before_deauthorization" }),
     );
     const deauthorization = {
@@ -947,8 +947,8 @@ describe("Stripe automation event webhook", () => {
       created: Math.floor(now() / 1000),
       data: { object: {} },
     };
-    await postStripeWorkflowEvent(deauthorization);
-    await postStripeWorkflowEvent(deauthorization);
+    await postStripeAutomationEvent(deauthorization);
+    await postStripeAutomationEvent(deauthorization);
 
     const affectedConnector = await connectors.readConnectorBySlug(
       affected.actor,
@@ -976,7 +976,7 @@ describe("Stripe automation event webhook", () => {
     const startedAt = Date.parse("2026-08-07T10:00:00.000Z");
     mockNow(startedAt);
     const recoverable = await setupScenario();
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_recoverable_claim" }),
     );
     await applyDeliveryFixture(recoverable, "hold-latest-claim");
@@ -994,7 +994,7 @@ describe("Stripe automation event webhook", () => {
     const exhausted = await setupScenario({
       accountId: "acct_stripe_workflow_retry",
     });
-    await postStripeWorkflowEvent(
+    await postStripeAutomationEvent(
       invoicePaidEvent({
         accountId: "acct_stripe_workflow_retry",
         eventId: "evt_retry_cutoff",

--- a/turbo/apps/api/src/signals/routes/cron-execute-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/cron-execute-workflow-automations.ts
@@ -4,7 +4,7 @@ import { command } from "ccstate";
 import type { RouteEntry } from "../route-entry";
 import { executeDueNotionWorkflowEvents$ } from "../services/notion-workflow-event.service";
 import { executeDueStrapiWorkflowEvents$ } from "../services/strapi-workflow-event.service";
-import { executeDueStripeWorkflowEvents$ } from "../services/stripe-workflow-event.service";
+import { executeDueStripeAutomationEvents$ } from "../services/stripe-automation-event.service";
 import { executeDueWorkflowAutomations$ } from "../services/zero-workflow-automation-poller.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
@@ -19,7 +19,7 @@ const executeWorkflowAutomationsRoute$: RouteEntry["handler"] = command(
     const result = await set(executeDueWorkflowAutomations$, signal);
     const notionResult = await set(executeDueNotionWorkflowEvents$, signal);
     const strapiResult = await set(executeDueStrapiWorkflowEvents$, signal);
-    const stripeResult = await set(executeDueStripeWorkflowEvents$, signal);
+    const stripeResult = await set(executeDueStripeAutomationEvents$, signal);
     signal.throwIfAborted();
 
     return {

--- a/turbo/apps/api/src/signals/routes/test-stripe-automation-events.ts
+++ b/turbo/apps/api/src/signals/routes/test-stripe-automation-events.ts
@@ -13,7 +13,9 @@ import {
   testEndpointNotFoundResponse,
 } from "./test-endpoint-helpers";
 
-const fixtureBody$ = bodyResultOf(testStripeAutomationEventFixtureContract.apply);
+const fixtureBody$ = bodyResultOf(
+  testStripeAutomationEventFixtureContract.apply,
+);
 
 async function installIngressFailureTrigger(db: Db): Promise<void> {
   await db.execute(sql`

--- a/turbo/apps/api/src/signals/routes/test-stripe-automation-events.ts
+++ b/turbo/apps/api/src/signals/routes/test-stripe-automation-events.ts
@@ -1,5 +1,5 @@
-import { testStripeWorkflowEventFixtureContract } from "@vm0/api-contracts/contracts/test-stripe-workflow-events";
-import { stripeWorkflowDeliveries } from "@vm0/db/schema/stripe-workflow-event";
+import { testStripeAutomationEventFixtureContract } from "@vm0/api-contracts/contracts/test-stripe-automation-events";
+import { stripeWorkflowDeliveries } from "@vm0/db/schema/stripe-automation-event";
 import { command } from "ccstate";
 import { desc, eq, sql } from "drizzle-orm";
 
@@ -13,7 +13,7 @@ import {
   testEndpointNotFoundResponse,
 } from "./test-endpoint-helpers";
 
-const fixtureBody$ = bodyResultOf(testStripeWorkflowEventFixtureContract.apply);
+const fixtureBody$ = bodyResultOf(testStripeAutomationEventFixtureContract.apply);
 
 async function installIngressFailureTrigger(db: Db): Promise<void> {
   await db.execute(sql`
@@ -94,7 +94,7 @@ async function clearFailureTriggers(db: Db): Promise<void> {
   );
 }
 
-const applyStripeWorkflowEventFixture$ = command(
+const applyStripeAutomationEventFixture$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (!isTestEndpointAllowed(get(request$))) {
       return testEndpointNotFoundResponse();
@@ -214,9 +214,9 @@ const applyStripeWorkflowEventFixture$ = command(
   },
 );
 
-export const testStripeWorkflowEventRoutes: readonly RouteEntry[] = [
+export const testStripeAutomationEventRoutes: readonly RouteEntry[] = [
   {
-    route: testStripeWorkflowEventFixtureContract.apply,
-    handler: applyStripeWorkflowEventFixture$,
+    route: testStripeAutomationEventFixtureContract.apply,
+    handler: applyStripeAutomationEventFixture$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/webhooks-stripe-automation-events.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-stripe-automation-events.ts
@@ -6,7 +6,7 @@ import { logger } from "../../lib/log";
 import { request$ } from "../context/hono";
 import { constructStripeWebhookEvent } from "../external/stripe-client";
 import type { RouteEntry } from "../route-entry";
-import { dispatchStripeWorkflowEvent$ } from "../services/stripe-workflow-event.service";
+import { dispatchStripeAutomationEvent$ } from "../services/stripe-automation-event.service";
 import { safeSync, settle } from "../utils";
 
 const log = logger("api:webhooks-stripe-automation-events");
@@ -38,7 +38,7 @@ const postStripeAutomationEvent$ = command(
     }
 
     const dispatched = await settle(
-      set(dispatchStripeWorkflowEvent$, constructed.ok, signal),
+      set(dispatchStripeAutomationEvent$, constructed.ok, signal),
       signal,
     );
     if (!dispatched.ok) {

--- a/turbo/apps/api/src/signals/services/automation-event-source-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/automation-event-source-timing.service.ts
@@ -6,7 +6,7 @@ import {
   type ApiDispatchTimingDimensions,
 } from "./api-dispatch-timing.service";
 
-type WorkflowEventSource =
+type AutomationEventSource =
   | "github"
   | "gmail"
   | "google_calendar"
@@ -14,36 +14,36 @@ type WorkflowEventSource =
   | "google_meet"
   | "webhook";
 
-type WorkflowEventSourceTimingActionType = Extract<
+type AutomationEventSourceTimingActionType = Extract<
   ApiDispatchTimingActionType,
   `api_dispatch_pre_create_zero_workflow_event_${string}`
 >;
 
-interface WorkflowEventSourceTimingRecord {
-  readonly actionType: WorkflowEventSourceTimingActionType;
+interface AutomationEventSourceTimingRecord {
+  readonly actionType: AutomationEventSourceTimingActionType;
   readonly startedAt: number;
   readonly finishedAt: number;
 }
 
-function workflowEventSourceDimensions(
-  source: WorkflowEventSource,
+function automationEventSourceDimensions(
+  source: AutomationEventSource,
 ): ApiDispatchTimingDimensions {
   return { workflow_event_source: source };
 }
 
-export class WorkflowEventSourceTiming {
-  private readonly records: WorkflowEventSourceTimingRecord[];
+export class AutomationEventSourceTiming {
+  private readonly records: AutomationEventSourceTimingRecord[];
 
   constructor(
-    private readonly source: WorkflowEventSource,
+    private readonly source: AutomationEventSource,
     private readonly apiStartTime: number,
-    records: readonly WorkflowEventSourceTimingRecord[] = [],
+    records: readonly AutomationEventSourceTimingRecord[] = [],
   ) {
     this.records = [...records];
   }
 
   recordElapsed(
-    actionType: WorkflowEventSourceTimingActionType,
+    actionType: AutomationEventSourceTimingActionType,
     startedAt: number,
     finishedAt: number = now(),
   ): void {
@@ -51,7 +51,7 @@ export class WorkflowEventSourceTiming {
   }
 
   async measure<T>(
-    actionType: WorkflowEventSourceTimingActionType,
+    actionType: AutomationEventSourceTimingActionType,
     operation: () => T | Promise<T>,
   ): Promise<T> {
     const startedAt = now();
@@ -60,16 +60,16 @@ export class WorkflowEventSourceTiming {
     return result;
   }
 
-  createRunTiming(): WorkflowEventRunTiming {
-    return new WorkflowEventRunTiming(
+  createRunTiming(): AutomationEventRunTiming {
+    return new AutomationEventRunTiming(
       this.source,
       this.apiStartTime,
       this.records,
     );
   }
 
-  fork(): WorkflowEventSourceTiming {
-    return new WorkflowEventSourceTiming(
+  fork(): AutomationEventSourceTiming {
+    return new AutomationEventSourceTiming(
       this.source,
       this.apiStartTime,
       this.records,
@@ -77,14 +77,14 @@ export class WorkflowEventSourceTiming {
   }
 }
 
-export class WorkflowEventRunTiming {
+export class AutomationEventRunTiming {
   private readonly collector = new ApiDispatchTimingCollector();
   private finalized = false;
 
   constructor(
-    private readonly source: WorkflowEventSource,
+    private readonly source: AutomationEventSource,
     private readonly apiStartTime: number,
-    records: readonly WorkflowEventSourceTimingRecord[],
+    records: readonly AutomationEventSourceTimingRecord[],
   ) {
     for (const record of records) {
       this.recordElapsed(
@@ -96,7 +96,7 @@ export class WorkflowEventRunTiming {
   }
 
   recordElapsed(
-    actionType: WorkflowEventSourceTimingActionType,
+    actionType: AutomationEventSourceTimingActionType,
     startedAt: number,
     finishedAt: number = now(),
   ): void {
@@ -105,12 +105,12 @@ export class WorkflowEventRunTiming {
       "nested",
       startedAt,
       finishedAt,
-      workflowEventSourceDimensions(this.source),
+      automationEventSourceDimensions(this.source),
     );
   }
 
   async measure<T>(
-    actionType: WorkflowEventSourceTimingActionType,
+    actionType: AutomationEventSourceTimingActionType,
     operation: () => T | Promise<T>,
   ): Promise<T> {
     return await measureApiDispatchTiming(
@@ -118,7 +118,7 @@ export class WorkflowEventRunTiming {
       actionType,
       "nested",
       operation,
-      workflowEventSourceDimensions(this.source),
+      automationEventSourceDimensions(this.source),
     );
   }
 
@@ -135,7 +135,7 @@ export class WorkflowEventRunTiming {
         "nested",
         this.apiStartTime,
         finishedAt,
-        workflowEventSourceDimensions(this.source),
+        automationEventSourceDimensions(this.source),
       );
       this.finalized = true;
     }

--- a/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
@@ -10,14 +10,14 @@ import { reconcileGmailWatchesForUser } from "./gmail-workflow-event.service";
 import { reconcileGoogleCalendarWatchesForUser } from "./google-calendar-workflow-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "./google-forms-workflow-event.service";
 
-interface WorkflowEventWatchAutomation {
+interface AutomationEventWatchAutomation {
   readonly orgId: string;
   readonly ownerUserId: string;
   readonly eventType: string | null;
   readonly eventConfig: unknown;
 }
 
-type WorkflowEventWatchTarget =
+type AutomationEventWatchTarget =
   | {
       readonly provider: "gmail";
       readonly orgId: string;
@@ -37,7 +37,7 @@ type WorkflowEventWatchTarget =
     };
 
 function googleCalendarId(
-  automation: WorkflowEventWatchAutomation,
+  automation: AutomationEventWatchAutomation,
 ): string | null {
   if (automation.eventType === "google-calendar-event-created") {
     const config = googleCalendarEventCreatedEventConfigSchema.safeParse(
@@ -60,9 +60,9 @@ function googleCalendarId(
   return null;
 }
 
-function workflowEventWatchTarget(
-  automation: WorkflowEventWatchAutomation,
-): WorkflowEventWatchTarget | null {
+function automationEventWatchTarget(
+  automation: AutomationEventWatchAutomation,
+): AutomationEventWatchTarget | null {
   if (
     automation.eventType === "gmail-new-message" ||
     automation.eventType === "gmail-label-applied"
@@ -99,7 +99,7 @@ function workflowEventWatchTarget(
   };
 }
 
-function targetKey(target: WorkflowEventWatchTarget): string {
+function targetKey(target: AutomationEventWatchTarget): string {
   if (target.provider === "gmail") {
     return `gmail:${target.orgId}:${target.userId}`;
   }
@@ -109,16 +109,16 @@ function targetKey(target: WorkflowEventWatchTarget): string {
   return `google_calendar:${target.orgId}:${target.userId}:${target.calendarId}`;
 }
 
-export async function reconcileWorkflowEventWatches(
+export async function reconcileAutomationEventWatches(
   args: {
     readonly db: Db;
-    readonly automations: readonly WorkflowEventWatchAutomation[];
+    readonly automations: readonly AutomationEventWatchAutomation[];
   },
   signal: AbortSignal,
 ): Promise<void> {
-  const targets = new Map<string, WorkflowEventWatchTarget>();
+  const targets = new Map<string, AutomationEventWatchTarget>();
   for (const automation of args.automations) {
-    const target = workflowEventWatchTarget(automation);
+    const target = automationEventWatchTarget(automation);
     if (target) {
       targets.set(targetKey(target), target);
     }

--- a/turbo/apps/api/src/signals/services/github-webhook-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-webhook-automation-event.service.ts
@@ -33,9 +33,9 @@ import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 
 const log = logger("api:github-webhook-automation-event");
 
@@ -795,7 +795,7 @@ const startGithubWebhookAutomation$ = command(
       readonly deliveryId: string;
       readonly event: GithubWebhookAutomationEvent;
       readonly apiStartTime: number;
-      readonly timing: WorkflowEventRunTiming;
+      readonly timing: AutomationEventRunTiming;
     },
     signal: AbortSignal,
   ): Promise<"ok" | "error"> => {
@@ -840,7 +840,7 @@ export const dispatchGithubWebhookAutomations$ = command(
       return { kind: "ok", dispatched: 0, duplicates: 0 };
     }
 
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "github",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/github-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-workflow-event.service.ts
@@ -19,9 +19,9 @@ import { nowDate } from "../../lib/time";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { workflowAutomationColumns } from "./autonomy-budget-schema.service";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
@@ -81,7 +81,7 @@ type GithubWorkflowRunStartArgs = {
   readonly payload: GithubLabelWorkflowEventPayload;
   readonly subjectKind: GithubWorkflowSubjectKind;
   readonly matchedLabelName: string;
-  readonly timing: WorkflowEventRunTiming;
+  readonly timing: AutomationEventRunTiming;
 };
 
 interface GithubWorkflowDispatchCounts {
@@ -439,7 +439,7 @@ async function dispatchGithubAutomationEvent(args: {
   readonly payload: GithubLabelWorkflowEventPayload;
   readonly subjectKind: GithubWorkflowSubjectKind;
   readonly matchedLabelName: string;
-  readonly timing: WorkflowEventRunTiming;
+  readonly timing: AutomationEventRunTiming;
   readonly startRun: () => Promise<"ok" | "error">;
 }): Promise<"dispatched" | "duplicate" | { readonly kind: "run_error" }> {
   const processedId = await args.timing.measure(
@@ -568,7 +568,7 @@ const dispatchMatchedGithubAutomations$ = command(
       readonly payload: GithubLabelWorkflowEventPayload;
       readonly subjectKind: GithubWorkflowSubjectKind;
       readonly apiStartTime: number;
-      readonly sourceTiming: WorkflowEventSourceTiming;
+      readonly sourceTiming: AutomationEventSourceTiming;
     },
     signal: AbortSignal,
   ): Promise<GithubWorkflowDispatchCounts> => {
@@ -671,7 +671,7 @@ export const dispatchGithubLabelWorkflowAutomations$ = command(
       return { kind: "ok", dispatched: 0, duplicates: 0 };
     }
 
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "github",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/github-workflow-run-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-workflow-run-event.service.ts
@@ -23,9 +23,9 @@ import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 
 const log = logger("api:github-workflow-run-event");
 
@@ -348,7 +348,7 @@ const startGithubWorkflowRunAutomation$ = command(
       readonly deliveryId: string;
       readonly payload: GithubWorkflowRunEventPayload;
       readonly apiStartTime: number;
-      readonly timing: WorkflowEventRunTiming;
+      readonly timing: AutomationEventRunTiming;
     },
     signal: AbortSignal,
   ): Promise<"ok" | "error"> => {
@@ -396,7 +396,7 @@ export const dispatchGithubWorkflowRunAutomations$ = command(
       return { kind: "ok", dispatched: 0, duplicates: 0 };
     }
 
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "github",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -36,9 +36,9 @@ import {
   refreshConnectorCredentialAccess,
 } from "./connector-credential-runtime.service";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
@@ -1614,7 +1614,7 @@ type GmailRunStarter = (args: {
   readonly automation: GmailEventAutomationRow;
   readonly decoded: DecodedGmailPubSubPush;
   readonly message: GmailMessageContext;
-  readonly timing: WorkflowEventRunTiming;
+  readonly timing: AutomationEventRunTiming;
 }) => Promise<"ok" | "error">;
 
 interface GmailWorkflowRunStartTestInput {
@@ -1891,7 +1891,7 @@ async function dispatchGmailAutomationEvent(
     readonly decoded: DecodedGmailPubSubPush;
     readonly event: GmailHistoryMessageAdded;
     readonly message: GmailMessageContext;
-    readonly timing: WorkflowEventRunTiming;
+    readonly timing: AutomationEventRunTiming;
     readonly startRun: GmailRunStarter;
   },
   signal: AbortSignal,
@@ -2032,7 +2032,7 @@ async function dispatchGmailNewMessageHistoryEvent(
     readonly automations: readonly GmailEventAutomationRow[];
     readonly event: GmailHistoryMessageAdded;
     readonly messageCache: Map<string, GmailMessageContext | null>;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GmailRunStarter;
   },
   signal: AbortSignal,
@@ -2107,7 +2107,7 @@ async function dispatchGmailLabelAppliedHistoryEvent(
     readonly event: GmailHistoryLabelAdded;
     readonly messageCache: Map<string, GmailMessageContext | null>;
     readonly labelCache: Map<string, GmailLabelResolveResult>;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GmailRunStarter;
   },
   signal: AbortSignal,
@@ -2121,7 +2121,7 @@ async function dispatchGmailLabelAppliedHistoryEvent(
 
   const matchingAutomations: {
     readonly automation: (typeof labelAutomations)[number];
-    readonly timing: WorkflowEventRunTiming;
+    readonly timing: AutomationEventRunTiming;
   }[] = [];
   for (const automation of labelAutomations) {
     const runTiming = args.sourceTiming.createRunTiming();
@@ -2210,7 +2210,7 @@ async function dispatchGmailHistoryEvents(
       }
     >;
     readonly automations: readonly GmailEventAutomationRow[];
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GmailRunStarter;
   },
   signal: AbortSignal,
@@ -2273,7 +2273,7 @@ async function dispatchGmailWatchState(
     readonly db: Db;
     readonly state: GmailWatchStateRow;
     readonly decoded: DecodedGmailPubSubPush;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GmailRunStarter;
   },
   signal: AbortSignal,
@@ -2399,7 +2399,7 @@ const startGmailWorkflowRun$ = command(
       readonly automation: GmailEventAutomationRow;
       readonly decoded: DecodedGmailPubSubPush;
       readonly message: GmailMessageContext;
-      readonly timing: WorkflowEventRunTiming;
+      readonly timing: AutomationEventRunTiming;
       readonly apiStartTime: number;
     },
     signal: AbortSignal,
@@ -2480,7 +2480,7 @@ export const dispatchGmailPubSubPush$ = command(
       };
     }
 
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "gmail",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
@@ -33,9 +33,9 @@ import {
   refreshConnectorCredentialAccess,
 } from "./connector-credential-runtime.service";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
@@ -220,7 +220,7 @@ type GoogleCalendarRunStarter = (args: {
   // Unique per change of the same calendar event; repeated updates of one event
   // are otherwise indistinguishable.
   readonly eventChangeKey: string;
-  readonly timing: WorkflowEventRunTiming;
+  readonly timing: AutomationEventRunTiming;
 }) => Promise<"ok" | "error">;
 
 interface GoogleCalendarWorkflowRunStartTestInput {
@@ -2378,7 +2378,7 @@ async function dispatchGoogleCalendarAutomationEvent(
     readonly notification: GoogleCalendarWebhookNotification;
     readonly event: CalendarEventContext;
     readonly eventChangeKey: string;
-    readonly timing: WorkflowEventRunTiming;
+    readonly timing: AutomationEventRunTiming;
     readonly startRun: GoogleCalendarRunStarter;
   },
   signal: AbortSignal,
@@ -2433,7 +2433,7 @@ async function dispatchCalendarEventChanges(
     readonly notification: GoogleCalendarWebhookNotification;
     readonly changes: readonly CalendarEventChange[];
     readonly automations: readonly GoogleCalendarEventAutomationRow[];
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GoogleCalendarRunStarter;
   },
   signal: AbortSignal,
@@ -2493,7 +2493,7 @@ async function dispatchGoogleCalendarChanges(
     readonly state: GoogleCalendarWatchStateRow;
     readonly notification: GoogleCalendarWebhookNotification;
     readonly changes: CalendarEventsListOk;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GoogleCalendarRunStarter;
   },
   signal: AbortSignal,
@@ -2579,7 +2579,7 @@ async function dispatchGoogleCalendarWatchState(
     readonly db: Db;
     readonly state: GoogleCalendarWatchStateRow;
     readonly notification: GoogleCalendarWebhookNotification;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GoogleCalendarRunStarter;
   },
   signal: AbortSignal,
@@ -2720,7 +2720,7 @@ export const dispatchGoogleCalendarWebhook$ = command(
       };
     }
 
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "google_calendar",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/google-forms-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-forms-workflow-event.service.ts
@@ -38,9 +38,9 @@ import {
 } from "./connector-credential-runtime.service";
 import type { WorkflowQueueAdmissionTransaction } from "./workflow-chat-event-queue.service";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
@@ -1475,7 +1475,7 @@ type GoogleFormsRunStarter = (args: {
   readonly response: GoogleFormResponse;
   readonly cursor: string;
   readonly previouslyDelivered: boolean;
-  readonly timing: WorkflowEventRunTiming;
+  readonly timing: AutomationEventRunTiming;
 }) => Promise<"ok" | "duplicate" | "error">;
 
 const startGoogleFormsWorkflowRun$ = command(
@@ -1488,7 +1488,7 @@ const startGoogleFormsWorkflowRun$ = command(
       readonly response: GoogleFormResponse;
       readonly cursor: string;
       readonly previouslyDelivered: boolean;
-      readonly timing: WorkflowEventRunTiming;
+      readonly timing: AutomationEventRunTiming;
       readonly apiStartTime: number;
     },
     signal: AbortSignal,
@@ -1577,7 +1577,7 @@ async function dispatchGoogleFormsAutomation(
     readonly state: GoogleFormsWatchStateRow;
     readonly automation: GoogleFormsEventAutomationRow;
     readonly decoded: DecodedGoogleFormsPubSubPush;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GoogleFormsRunStarter;
   },
   signal: AbortSignal,
@@ -1674,7 +1674,7 @@ async function dispatchGoogleFormsWatchState(
     readonly db: Db;
     readonly state: GoogleFormsWatchStateRow;
     readonly decoded: DecodedGoogleFormsPubSubPush;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
     readonly startRun: GoogleFormsRunStarter;
   },
   signal: AbortSignal,
@@ -1748,7 +1748,7 @@ export const dispatchGoogleFormsPubSubPush$ = command(
       };
     }
     const db = set(writeDb$);
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "google_forms",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
@@ -28,9 +28,9 @@ import {
   refreshConnectorCredentialAccess,
 } from "./connector-credential-runtime.service";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
@@ -1317,9 +1317,9 @@ async function dispatchGoogleMeetTranscriptEventForState(
     readonly startRun: (args: {
       readonly automation: GoogleMeetEventAutomationRow;
       readonly event: GoogleMeetTranscriptEventContext;
-      readonly timing: WorkflowEventRunTiming;
+      readonly timing: AutomationEventRunTiming;
     }) => Promise<"ok" | "error">;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
   },
   signal: AbortSignal,
 ): Promise<
@@ -1433,7 +1433,7 @@ export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
       return event;
     }
 
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "google_meet",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
@@ -4,15 +4,15 @@ import {
   type StripeInvoiceBillingReason,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import type {
-  StripeWorkflowEventSnapshot,
-  StripeWorkflowEventSnapshotLine,
-  StripeWorkflowEventSnapshotMetadata,
-} from "@vm0/db/jsonb-contracts/stripe-workflow-event";
+  StripeAutomationEventSnapshot,
+  StripeAutomationEventSnapshotLine,
+  StripeAutomationEventSnapshotMetadata,
+} from "@vm0/db/jsonb-contracts/stripe-automation-event";
 import { connectors } from "@vm0/db/schema/connector";
 import {
   stripeWorkflowAutomationHealth,
   stripeWorkflowDeliveries,
-} from "@vm0/db/schema/stripe-workflow-event";
+} from "@vm0/db/schema/stripe-automation-event";
 import {
   workflowUserAutomationThreads,
   zeroWorkflowAutomations,
@@ -43,7 +43,7 @@ import type {
 } from "./zero-workflow-automation-launch.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 
-const log = logger("api:stripe-workflow-event");
+const log = logger("api:stripe-automation-event");
 
 const STRIPE_DELIVERY_BATCH_SIZE = 25;
 const STRIPE_DELIVERY_CLAIM_MS = 300_000;
@@ -240,7 +240,7 @@ const stripeDeauthorizedEventSchema = stripeDeauthorizedEventBaseSchema.extend({
 type StripeWorkflowDeliveryRow = typeof stripeWorkflowDeliveries.$inferSelect;
 type StripeWorkflowTransaction = Tx;
 
-type DispatchStripeWorkflowEventResult =
+type DispatchStripeAutomationEventResult =
   | {
       readonly kind: "ok";
       readonly eventKind: "test" | "ignored" | "deauthorized" | "invoice";
@@ -260,7 +260,7 @@ type StripeDeliveryValidation =
   | { readonly kind: "ok"; readonly target: StripeDeliveryTarget }
   | { readonly kind: "skip"; readonly reason: string };
 
-interface ExecuteDueStripeWorkflowEventsResult {
+interface ExecuteDueStripeAutomationEventsResult {
   readonly executed: number;
   readonly skipped: number;
   readonly failed: number;
@@ -297,13 +297,13 @@ function unixSecondsToIso(value: number | null | undefined): string | null {
 
 function normalizeMetadata(
   metadata: Record<string, string> | undefined,
-): StripeWorkflowEventSnapshotMetadata {
+): StripeAutomationEventSnapshotMetadata {
   return metadata ?? {};
 }
 
 function normalizeLine(
   line: z.infer<typeof stripeInvoiceLineSchema>,
-): StripeWorkflowEventSnapshotLine {
+): StripeAutomationEventSnapshotLine {
   const price = stripeLinePriceSchema.safeParse(line.price);
   const pricing = stripeLinePricingSchema.safeParse(line.pricing);
   return {
@@ -343,7 +343,7 @@ function normalizeLine(
 
 function normalizeCustomer(
   value: unknown,
-): StripeWorkflowEventSnapshot["customer"] {
+): StripeAutomationEventSnapshot["customer"] {
   if (typeof value === "string") {
     return { id: value, name: null, email: null };
   }
@@ -431,7 +431,7 @@ function subscriptionId(
 
 function invoiceSnapshot(
   event: z.infer<typeof stripeInvoicePaidEventSchema>,
-): StripeWorkflowEventSnapshot {
+): StripeAutomationEventSnapshot {
   const invoice = event.data.object;
   const payments = normalizePayments(invoice.payments);
   return {
@@ -526,7 +526,7 @@ async function insertStripeWorkflowDelivery(
   args: {
     readonly tx: StripeWorkflowTransaction;
     readonly candidate: StripeInvoiceFanoutCandidate;
-    readonly snapshot: StripeWorkflowEventSnapshot;
+    readonly snapshot: StripeAutomationEventSnapshot;
     readonly receivedAt: Date;
   },
   signal: AbortSignal,
@@ -631,7 +631,7 @@ async function loadStripeInvoiceFanoutCandidates(
 async function recordInvoiceFanout(
   args: {
     readonly tx: StripeWorkflowTransaction;
-    readonly snapshot: StripeWorkflowEventSnapshot;
+    readonly snapshot: StripeAutomationEventSnapshot;
   },
   signal: AbortSignal,
 ): Promise<StripeInvoiceFanoutResult> {
@@ -748,7 +748,7 @@ async function dispatchStripeDeauthorization(
   db: Db,
   event: unknown,
   signal: AbortSignal,
-): Promise<DispatchStripeWorkflowEventResult> {
+): Promise<DispatchStripeAutomationEventResult> {
   const supported = stripeDeauthorizedEventBaseSchema.safeParse(event);
   if (!supported.success) {
     log.debug("Processed Stripe workflow ingress", {
@@ -803,7 +803,7 @@ async function dispatchStripeInvoice(
   db: Db,
   event: unknown,
   signal: AbortSignal,
-): Promise<DispatchStripeWorkflowEventResult> {
+): Promise<DispatchStripeAutomationEventResult> {
   const supported = stripeInvoicePaidEventBaseSchema.safeParse(event);
   if (!supported.success) {
     log.debug("Processed Stripe workflow ingress", {
@@ -849,12 +849,12 @@ async function dispatchStripeInvoice(
   return { kind: "ok", eventKind: "invoice", ...fanout };
 }
 
-export const dispatchStripeWorkflowEvent$ = command(
+export const dispatchStripeAutomationEvent$ = command(
   async (
     { set },
     event: unknown,
     signal: AbortSignal,
-  ): Promise<DispatchStripeWorkflowEventResult> => {
+  ): Promise<DispatchStripeAutomationEventResult> => {
     const eventType = stripeEventTypeSchema.safeParse(event);
     if (!eventType.success) {
       log.debug("Processed Stripe workflow ingress", {
@@ -1410,7 +1410,7 @@ async function processClaimedDelivery(
   return await retryDelivery(args, signal);
 }
 
-async function executeDueStripeWorkflowEvents(
+async function executeDueStripeAutomationEvents(
   args: {
     readonly db: Db;
     readonly startRun: (
@@ -1419,7 +1419,7 @@ async function executeDueStripeWorkflowEvents(
     ) => Promise<RunWorkflowAutomationResult>;
   },
   signal: AbortSignal,
-): Promise<ExecuteDueStripeWorkflowEventsResult> {
+): Promise<ExecuteDueStripeAutomationEventsResult> {
   const result = {
     executed: 0,
     skipped: 0,
@@ -1472,12 +1472,12 @@ async function executeDueStripeWorkflowEvents(
   return result;
 }
 
-export const executeDueStripeWorkflowEvents$ = command(
+export const executeDueStripeAutomationEvents$ = command(
   async (
     { set },
     signal: AbortSignal,
-  ): Promise<ExecuteDueStripeWorkflowEventsResult> => {
-    return await executeDueStripeWorkflowEvents(
+  ): Promise<ExecuteDueStripeAutomationEventsResult> => {
+    return await executeDueStripeAutomationEvents(
       {
         db: set(writeDb$),
         startRun: (input, childSignal) => {

--- a/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
@@ -23,9 +23,9 @@ import {
   encryptPersistentSecretValue,
 } from "./crypto.utils";
 import {
-  WorkflowEventSourceTiming,
-  type WorkflowEventRunTiming,
-} from "./workflow-event-source-timing.service";
+  AutomationEventSourceTiming,
+  type AutomationEventRunTiming,
+} from "./automation-event-source-timing.service";
 import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.service";
 import type {
   RunWorkflowAutomationResult,
@@ -550,7 +550,7 @@ async function prepareWorkflowWebhookDispatch(
     readonly rawBody: string;
     readonly signature: string;
     readonly timestamp: string;
-    readonly sourceTiming: WorkflowEventSourceTiming;
+    readonly sourceTiming: AutomationEventSourceTiming;
   },
   signal: AbortSignal,
 ): Promise<PreparedWorkflowWebhookDispatch> {
@@ -657,7 +657,7 @@ const startWorkflowWebhookRun$ = command(
       readonly headers: Readonly<Record<string, string>>;
       readonly currentTime: Date;
       readonly apiStartTime: number;
-      readonly timing: WorkflowEventRunTiming;
+      readonly timing: AutomationEventRunTiming;
     },
     signal: AbortSignal,
   ): Promise<RunWorkflowAutomationResult | "error"> => {
@@ -733,7 +733,7 @@ export const dispatchWorkflowWebhook$ = command(
     const signature = args.signature;
     const timestamp = args.timestamp;
 
-    const sourceTiming = new WorkflowEventSourceTiming(
+    const sourceTiming = new AutomationEventSourceTiming(
       "webhook",
       args.apiStartTime,
     );

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -393,7 +393,7 @@ async function resolveUserQueueFirstClaimSnapshot(
   };
 }
 
-async function resolveWorkflowQueueFirstClaimSnapshot(
+async function resolveAutomationEventQueueFirstClaimSnapshot(
   db: DbTransaction,
   args: Extract<QueueFirstClaimArgs, { readonly kind: "automation_event" }>,
 ): Promise<QueueFirstClaimSnapshot | null> {
@@ -532,7 +532,7 @@ async function resolveQueueFirstClaimSnapshot(
     return await resolveUserQueueFirstClaimSnapshot(db, args);
   }
   if (args.kind === "automation_event") {
-    return await resolveWorkflowQueueFirstClaimSnapshot(db, args);
+    return await resolveAutomationEventQueueFirstClaimSnapshot(db, args);
   }
   return await resolveGoalQueueFirstClaimSnapshot(db, args);
 }

--- a/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
@@ -21,7 +21,7 @@ import { db$, writeDb$ } from "../external/db";
 import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
 import { env } from "../../lib/env";
 import { conflict } from "../../lib/error";
-import { reconcileWorkflowEventWatches } from "./workflow-event-watch-lifecycle.service";
+import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecycle.service";
 
 export function zeroComposeExists(args: {
   readonly orgId: string;
@@ -182,7 +182,7 @@ export const deleteComposeById$ = command(
       return conflict("Cannot delete agent: agent is currently running");
     }
 
-    await reconcileWorkflowEventWatches(
+    await reconcileAutomationEventWatches(
       {
         db: writeDb,
         automations: result.automations,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -51,7 +51,7 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { parseScheduledAtTime } from "@vm0/core/timezone";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
-import { stripeWorkflowAutomationHealth } from "@vm0/db/schema/stripe-workflow-event";
+import { stripeWorkflowAutomationHealth } from "@vm0/db/schema/stripe-automation-event";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import {
   strapiIntegrations,
@@ -132,7 +132,7 @@ import {
 } from "./zero-workflow-user-automation-thread.service";
 import { buildWorkflowScheduleAutomationBrief } from "./zero-workflow-automation-brief.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
-import { reconcileWorkflowEventWatches } from "./workflow-event-watch-lifecycle.service";
+import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecycle.service";
 
 type AutomationRow = typeof zeroWorkflowAutomations.$inferSelect;
 type WorkflowRow = typeof zeroWorkflows.$inferSelect;
@@ -1814,7 +1814,7 @@ async function createGmailEventAutomationForWorkflow(
   await args.context.db
     .delete(zeroWorkflowAutomations)
     .where(eq(zeroWorkflowAutomations.id, summary.id));
-  await reconcileWorkflowEventWatches(
+  await reconcileAutomationEventWatches(
     {
       db: args.context.db,
       automations: [
@@ -2081,7 +2081,7 @@ async function createGoogleCalendarEventAutomationForWorkflow(
     await args.context.db
       .delete(zeroWorkflowAutomations)
       .where(eq(zeroWorkflowAutomations.id, summary.id));
-    await reconcileWorkflowEventWatches(
+    await reconcileAutomationEventWatches(
       {
         db: args.context.db,
         automations: [
@@ -2190,7 +2190,7 @@ async function createGoogleFormsEventAutomationForWorkflow(
     .delete(zeroWorkflowAutomations)
     .where(eq(zeroWorkflowAutomations.id, summary.id));
   if (!hadConsumer) {
-    await reconcileWorkflowEventWatches(
+    await reconcileAutomationEventWatches(
       {
         db: args.context.db,
         automations: [
@@ -3285,7 +3285,7 @@ export const deleteWorkflowAutomation$ = command(
       .delete(zeroWorkflowAutomations)
       .where(eq(zeroWorkflowAutomations.id, owned.automation.id));
     signal.throwIfAborted();
-    await reconcileWorkflowEventWatches(
+    await reconcileAutomationEventWatches(
       {
         db: writeDb,
         automations: [owned.automation],
@@ -3392,7 +3392,7 @@ async function enabledWatchHadConsumer(
   );
 }
 
-async function ensureEnabledWorkflowEventWatch(
+async function ensureEnabledAutomationEventWatch(
   args: {
     readonly db: Db;
     readonly automation: AutomationRow;
@@ -3469,7 +3469,7 @@ async function restoreDisabledWorkflowAutomation(
     .where(eq(zeroWorkflowAutomations.id, automation.id));
 }
 
-async function ensureEnabledWorkflowEventWatchWithRollback(
+async function ensureEnabledAutomationEventWatchWithRollback(
   args: {
     readonly db: Db;
     readonly previousAutomation: AutomationRow;
@@ -3479,7 +3479,7 @@ async function ensureEnabledWorkflowEventWatchWithRollback(
   signal: AbortSignal,
 ): Promise<AutomationActionFailure | null> {
   const failure = await onRejection(
-    ensureEnabledWorkflowEventWatch(
+    ensureEnabledAutomationEventWatch(
       {
         db: args.db,
         automation: args.enabledAutomation,
@@ -3498,7 +3498,7 @@ async function ensureEnabledWorkflowEventWatchWithRollback(
 
   await restoreDisabledWorkflowAutomation(args.db, args.previousAutomation);
   signal.throwIfAborted();
-  await reconcileWorkflowEventWatches(
+  await reconcileAutomationEventWatches(
     {
       db: args.db,
       automations: [args.enabledAutomation],
@@ -3735,7 +3735,7 @@ export const enableWorkflowAutomation$ = command(
     if (!row) {
       throw new Error("Failed to enable workflow automation");
     }
-    const watchFailure = await ensureEnabledWorkflowEventWatchWithRollback(
+    const watchFailure = await ensureEnabledAutomationEventWatchWithRollback(
       {
         db: writeDb,
         previousAutomation: automation,
@@ -3789,7 +3789,7 @@ export const disableWorkflowAutomation$ = command(
     if (!row) {
       throw new Error("Failed to disable workflow automation");
     }
-    await reconcileWorkflowEventWatches(
+    await reconcileAutomationEventWatches(
       {
         db: writeDb,
         automations: [owned.automation],

--- a/turbo/apps/api/src/signals/services/zero-workflow-delete.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-delete.service.ts
@@ -13,7 +13,7 @@ import { and, eq } from "drizzle-orm";
 import { env } from "../../lib/env";
 import { writeDb$ } from "../external/db";
 import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
-import { reconcileWorkflowEventWatches } from "./workflow-event-watch-lifecycle.service";
+import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecycle.service";
 
 interface DeleteZeroWorkflowInput {
   readonly orgId: string;
@@ -85,7 +85,7 @@ export const deleteZeroWorkflow$ = command(
       return false;
     }
 
-    await reconcileWorkflowEventWatches(
+    await reconcileAutomationEventWatches(
       {
         db: writeDb,
         automations: result.automations,

--- a/turbo/packages/api-contracts/src/contracts/test-stripe-automation-events.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-stripe-automation-events.ts
@@ -4,7 +4,7 @@ import { initContract } from "./base";
 
 const c = initContract();
 
-export const testStripeWorkflowEventFixtureActionSchema = z.enum([
+export const testStripeAutomationEventFixtureActionSchema = z.enum([
   "corrupt-latest-snapshot",
   "hold-latest-claim",
   "expire-latest-retry-window",
@@ -13,18 +13,18 @@ export const testStripeWorkflowEventFixtureActionSchema = z.enum([
   "fail-next-queue-admission-for-automation",
   "clear-forced-failures",
 ]);
-export type TestStripeWorkflowEventFixtureAction = z.infer<
-  typeof testStripeWorkflowEventFixtureActionSchema
+export type TestStripeAutomationEventFixtureAction = z.infer<
+  typeof testStripeAutomationEventFixtureActionSchema
 >;
 
-export const testStripeWorkflowEventFixtureContract = c.router({
+export const testStripeAutomationEventFixtureContract = c.router({
   apply: {
     method: "POST",
-    path: "/api/test/stripe-workflow-event-fixture",
+    path: "/api/test/stripe-automation-event-fixture",
     body: z
       .object({
         automation_id: z.uuid(),
-        action: testStripeWorkflowEventFixtureActionSchema,
+        action: testStripeAutomationEventFixtureActionSchema,
       })
       .strict(),
     responses: {

--- a/turbo/packages/db/src/index.ts
+++ b/turbo/packages/db/src/index.ts
@@ -119,7 +119,7 @@ import * as bankingSchema from "./schema/banking";
 import * as gmailEventSchema from "./schema/gmail-event";
 import * as notionEventSchema from "./schema/notion-event";
 import * as strapiIntegrationSchema from "./schema/strapi-integration";
-import * as stripeWorkflowEventSchema from "./schema/stripe-workflow-event";
+import * as stripeAutomationEventSchema from "./schema/stripe-automation-event";
 import * as googleCalendarEventSchema from "./schema/google-calendar-event";
 import * as googleFormsEventSchema from "./schema/google-forms-event";
 import * as googleWorkspaceEventSchema from "./schema/google-workspace-event";
@@ -249,7 +249,7 @@ export const schema = {
   ...gmailEventSchema,
   ...notionEventSchema,
   ...strapiIntegrationSchema,
-  ...stripeWorkflowEventSchema,
+  ...stripeAutomationEventSchema,
   ...googleCalendarEventSchema,
   ...googleFormsEventSchema,
   ...googleWorkspaceEventSchema,

--- a/turbo/packages/db/src/jsonb-contracts/stripe-automation-event.ts
+++ b/turbo/packages/db/src/jsonb-contracts/stripe-automation-event.ts
@@ -1,8 +1,8 @@
-export interface StripeWorkflowEventSnapshotMetadata {
+export interface StripeAutomationEventSnapshotMetadata {
   readonly [key: string]: string;
 }
 
-export interface StripeWorkflowEventSnapshotLinePrice {
+export interface StripeAutomationEventSnapshotLinePrice {
   readonly id: string | null;
   readonly productId: string | null;
   readonly currency: string | null;
@@ -10,30 +10,30 @@ export interface StripeWorkflowEventSnapshotLinePrice {
   readonly recurringInterval: string | null;
 }
 
-export interface StripeWorkflowEventSnapshotLinePricing {
+export interface StripeAutomationEventSnapshotLinePricing {
   readonly type: string | null;
   readonly priceId: string | null;
   readonly productId: string | null;
   readonly unitAmountDecimal: string | null;
 }
 
-export interface StripeWorkflowEventSnapshotLine {
+export interface StripeAutomationEventSnapshotLine {
   readonly id: string | null;
   readonly type: string | null;
   readonly description: string | null;
   readonly quantity: number | null;
   readonly amount: number | null;
   readonly currency: string | null;
-  readonly metadata: StripeWorkflowEventSnapshotMetadata;
+  readonly metadata: StripeAutomationEventSnapshotMetadata;
   readonly period: {
     readonly start: string | null;
     readonly end: string | null;
   } | null;
-  readonly price: StripeWorkflowEventSnapshotLinePrice | null;
-  readonly pricing: StripeWorkflowEventSnapshotLinePricing | null;
+  readonly price: StripeAutomationEventSnapshotLinePrice | null;
+  readonly pricing: StripeAutomationEventSnapshotLinePricing | null;
 }
 
-export interface StripeWorkflowEventSnapshot {
+export interface StripeAutomationEventSnapshot {
   readonly event: {
     readonly id: string;
     readonly type: "invoice.paid";
@@ -51,9 +51,9 @@ export interface StripeWorkflowEventSnapshot {
     readonly collectionMethod: string | null;
     readonly hostedInvoiceUrl: string | null;
     readonly invoicePdf: string | null;
-    readonly metadata: StripeWorkflowEventSnapshotMetadata;
+    readonly metadata: StripeAutomationEventSnapshotMetadata;
     readonly lines: {
-      readonly data: readonly StripeWorkflowEventSnapshotLine[];
+      readonly data: readonly StripeAutomationEventSnapshotLine[];
       readonly hasMore: boolean;
       readonly totalCount: number | null;
     };

--- a/turbo/packages/db/src/schema/stripe-automation-event.ts
+++ b/turbo/packages/db/src/schema/stripe-automation-event.ts
@@ -1,4 +1,4 @@
-import type { StripeWorkflowEventSnapshot } from "@vm0/db/jsonb-contracts/stripe-workflow-event";
+import type { StripeAutomationEventSnapshot } from "@vm0/db/jsonb-contracts/stripe-automation-event";
 import { sql } from "drizzle-orm";
 import {
   boolean,
@@ -34,7 +34,7 @@ export const stripeWorkflowDeliveries = pgTable(
     stripeEventId: varchar("stripe_event_id", { length: 255 }).notNull(),
     stripeEventCreatedAt: timestamp("stripe_event_created_at").notNull(),
     billingReason: text("billing_reason"),
-    snapshot: jsonb("snapshot").$type<StripeWorkflowEventSnapshot>().notNull(),
+    snapshot: jsonb("snapshot").$type<StripeAutomationEventSnapshot>().notNull(),
     status: varchar("status", { length: 32 })
       .$type<StripeWorkflowDeliveryStatus>()
       .default("pending")

--- a/turbo/packages/db/src/schema/stripe-automation-event.ts
+++ b/turbo/packages/db/src/schema/stripe-automation-event.ts
@@ -34,7 +34,9 @@ export const stripeWorkflowDeliveries = pgTable(
     stripeEventId: varchar("stripe_event_id", { length: 255 }).notNull(),
     stripeEventCreatedAt: timestamp("stripe_event_created_at").notNull(),
     billingReason: text("billing_reason"),
-    snapshot: jsonb("snapshot").$type<StripeAutomationEventSnapshot>().notNull(),
+    snapshot: jsonb("snapshot")
+      .$type<StripeAutomationEventSnapshot>()
+      .notNull(),
     status: varchar("status", { length: 32 })
       .$type<StripeWorkflowDeliveryStatus>()
       .default("pending")


### PR DESCRIPTION
## Summary

- rename the shared automation-event timing and watch infrastructure
- rename the Stripe automation-event service, schema modules, snapshot types, and test fixture route
- rename the queue-first automation-event claim helper

## Compatibility

- preserve all 89 `api_dispatch_pre_create_zero_workflow_event_*` telemetry action literals
- preserve the `workflow_event_source` dimension key
- preserve Stripe table, column, and index names; no migration added
- preserve the eight connector service filenames and GitHub Actions workflow-run vocabulary
- do not touch trigger-source readers or values

## Validation

- issue acceptance greps pass, including 89 telemetry literal occurrences and exactly eight remaining `*workflow-event*` connector files
- `git diff --check`
- Git records all eight moved files as renames
- full checks and affected integration suites delegated to PR CI as requested

Closes #26066
