### PR TITLE
chore(api): require mcp-aware platform reader

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -994,16 +994,16 @@ describe("createApp", () => {
   });
 
   describe("web client compatibility", () => {
-    it("rejects pre-canonical-chat-event app clients before route handlers run", async () => {
+    it("rejects pre-MCP-reader app clients before custom connector route matching", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
       });
-      const response = await app.request("/health", {
+      const response = await app.request("/api/zero/custom-connectors", {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.706.4",
+          [CLIENT_VERSION_HEADER]: "0.715.1",
         },
       });
 

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.708.2"
+  "minimumSupportedVersion": "0.716.0"
 }


### PR DESCRIPTION
## Summary

- raise the existing Platform compatibility floor to the deployed MCP-aware reader release,
  `0.716.0`
- verify a `0.715.1` App client is rejected before Custom Connector route matching with the
  established no-store HTTP 426 response
- preserve exact-floor, newer-client, non-App, and existing retired-route behavior

## Scope

This PR changes only the existing compatibility configuration and its API entry-point integration
test. It adds no schema or persisted state, MCP writer, Run admission, firewall, Runner, Platform
source, or CLI behavior.

The reader-bearing `app-v0.716.0` and `api-v1.413.0` releases were confirmed deployed before raising
the floor.

## Validation

- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm exec prettier --check apps/api/src/lib/web-client-compatibility.json apps/api/src/__tests__/app-factory.test.ts`
- pre-commit full Turbo type and Knip checks

Closes #26008
Parent: #25031
