### PR TITLE
fix(ui): render more icons as solid dots

### DIFF
--- a/turbo/packages/ui/src/styles/__tests__/globals.test.ts
+++ b/turbo/packages/ui/src/styles/__tests__/globals.test.ts
@@ -96,6 +96,13 @@ describe("global Lucide defaults", () => {
       /stroke-width:\s*var\(--icon-stroke-width\);/,
     );
   });
+
+  it("renders more icons as solid dots", () => {
+    const selector =
+      "svg.lucide-ellipsis circle,\n  svg.lucide-ellipsis-vertical circle";
+
+    expect(readRuleBody(globalCss, selector)).toMatch(/fill:\s*currentColor;/);
+  });
 });
 
 describe("interaction state ladder", () => {

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -459,6 +459,12 @@
   svg[class*="lucide"][stroke-width="2"]:not([data-stroke]) {
     stroke-width: var(--icon-stroke-width);
   }
+
+  /* More icons are dots, not hollow rings. */
+  svg.lucide-ellipsis circle,
+  svg.lucide-ellipsis-vertical circle {
+    fill: currentColor;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

- fill Lucide ellipsis circles so more icons render as solid dots
- cover horizontal and vertical more icons through the shared UI stylesheet
- add a CSS contract test for the solid-dot treatment

## Verification

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged TypeScript checks for non-platform packages, platform, and API
- pnpm --filter @vm0/ui exec vitest run src/styles/__tests__/globals.test.ts