### PR TITLE
fix(app): preserve sampled voice before silence timeout

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -972,7 +972,9 @@ function createVoiceSegmentSession(
       }
     },
     startSilenceTimeout(): void {
-      silenceTimer.start();
+      if (!currentSegmentHasVoice) {
+        silenceTimer.start();
+      }
     },
     async stopAndTranscribe(stopSignal: AbortSignal): Promise<void> {
       stopped = true;


### PR DESCRIPTION
## Problem

Turbo push run [31364373895](https://github.com/vm0-ai/vm0/actions/runs/31364373895) failed in [`test-app (1)`](https://github.com/vm0-ai/vm0/actions/runs/31364373895/job/93380168047) at:

`chat-computer-use-and-voice.test.tsx > chat lifecycle > transcribes a voice input segment after silence while recording`

The recorder lifecycle was `start -> stop` instead of `start -> stop -> start`. This is a recurrence after #25943, not a duplicate of its test-only repair.

## Root cause

`startAudioActivityMonitor` intentionally samples the first analyser frame synchronously before reporting the monitor ready, as established by #19914. That first sample can record active voice in the segment before `startRecording$` calls `startSilenceTimeout()`.

The first voice callback tries to clear the silence timer before the timer exists. Startup then unconditionally armed the 50 ms Vitest auto-stop timer even though the session had already observed voice.

Two schedules followed:

- when a later animation-frame state change arrived within 50 ms, it cleared the timer and the normal silence transition later rotated the recorder;
- when a loaded shard delayed that frame, the startup timer stopped the initial recorder and the STT request came from final stop capture, so no replacement recorder existed.

The failed test completed in 1071 ms, while the adjacent parent-main pass took 1912 ms, consistent with auto-stop winning before the 500 ms voice-activity hold reached the silence-segmentation path. The source PR changed only Runner Python code.

## Fix

Only arm the initial silence timeout when the recording session has not already captured voice.

This preserves both product contracts:

- a recording with no initial voice still auto-stops;
- after real silence, the segment is uploaded, the recorder rotates, and the continued session receives its normal long-silence timeout.

No retry, sleep, timeout increase, skipped test, weakened assertion, detached cleanup, or swallowed rejection was added.

## Verification

- full `chat-computer-use-and-voice.test.tsx`: 28/28 passed in 7 post-fix runs, including one after rebasing onto the latest `origin/main`;
- `pnpm format`;
- `pnpm turbo run lint --concurrency=1 --log-order grouped`;
- `pnpm knip`;
- staged TypeScript checks for non-API/App packages, App, and API;
- `git diff --check`.

Preview validation is not applicable. This invariant requires the Vitest browser-boundary mock to inject an RMS sequence and observe synthetic `MediaRecorder` transitions; a deployed preview cannot inject or inspect that microphone lifecycle deterministically.