### PR TITLE
perf(guest-mock-codex): stream oversized stdout fixture

### DIFF
--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -19,7 +19,9 @@ use uuid::Uuid;
 const HANG_ON_TURN_START_READY_FILE: &str = ".vm0-mock-codex-turn-start-ready";
 const HANG_ON_TURN_START_READY_EVENT: &str = "vm0_mock_codex_turn_start_ready";
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
-const OVERSIZED_STDOUT_BYTES: usize = 65 * 1024 * 1024;
+// Integration contract with guest-agent's Codex app-server stdout framing policy.
+const APP_SERVER_STDOUT_MAX_LINE_BYTES: usize = 64 * 1024 * 1024;
+const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 const EVENT_DELIVERY_FLOOD_COUNT: usize = 640;
 const EVENT_DELIVERY_LARGE_EVENT_COUNT: usize = 10;
 const EVENT_DELIVERY_LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
@@ -48,7 +50,11 @@ impl AppServerState {
             return Ok(ServerAction::Stop);
         }
         if self.scenario == Scenario::OversizedStdout {
-            writeln!(output, "{}", "x".repeat(OVERSIZED_STDOUT_BYTES))?;
+            let chunk = [b'x'; STDOUT_STREAM_CHUNK_BYTES];
+            for _ in 0..APP_SERVER_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
+                output.write_all(&chunk)?;
+            }
+            output.write_all(b"x\n")?;
             output.flush()?;
             return Ok(ServerAction::Stop);
         }


### PR DESCRIPTION
## Summary

- stream the oversized Codex app-server stdout fixture through one reusable 8 KiB buffer
- emit the exact 64 MiB accepted boundary followed by the minimum over-limit byte and newline
- preserve the production stdout limit, protocol error, flush, shutdown, and child-reaping behavior

## Scope

- test mock only; no production runtime, API, database, schema, migration, or deployment changes
- no new helper or cross-crate contract

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent --test codex_app_server_client codex_app_server_oversized_stdout_line_is_rejected`
- `cargo test -p guest-mock-codex`
- `cargo test -p guest-agent`
- `cargo clippy -p guest-mock-codex -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-mock-codex -p guest-agent --all-features --no-deps`

Closes #26091
