### PR TITLE
fix(mitm-addon): distinguish repeated-slash diagnostic bases

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -422,7 +422,7 @@ def static_firewall_base_config_key(raw_base: str) -> str | None:
     )
     if parts is None:
         return None
-    return f"{parts.scheme.lower()}://{parts.authority}{parts.path.rstrip('/')}"
+    return f"{parts.scheme.lower()}://{parts.authority}{parts.path}"
 
 
 def static_firewall_base_authority_key(raw_base: str) -> str | None:

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -515,6 +515,42 @@ def test_find_candidate_suppresses_multiple_shared_base_route_owners():
     assert candidate is None
 
 
+def test_find_candidate_distinguishes_repeated_slash_bases():
+    permissions = [{"name": "read", "rules": ["GET /{path+}"]}]
+    snapshot = _diagnostic_snapshot(
+        [
+            _firewall(
+                "broader",
+                "BROADER_TOKEN",
+                base="https://api.example.com/v1",
+                permissions=permissions,
+            ),
+            _firewall(
+                "repeated",
+                "REPEATED_TOKEN",
+                base="https://api.example.com/v1//",
+                permissions=permissions,
+            ),
+        ]
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
+        "https://api.example.com/v1//foo",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate == builtin_connector_diagnostics.ConnectorDiagnosticCandidate(
+        connector_slug="repeated",
+        reason="not_configured_for_run",
+        env_names=("REPEATED_TOKEN",),
+        base="https://api.example.com/v1//",
+        auth_header_names=("Authorization",),
+        auth_query_param_names=(),
+    )
+
+
 def test_shared_base_ownership_selects_route_specific_inactive_sibling():
     snapshot = _diagnostic_snapshot(
         [


### PR DESCRIPTION
## Summary

- preserve repeated terminal empty path segments in static connector diagnostic base keys
- keep exactly one terminal slash optional while retaining existing authority normalization
- select the more-specific repeated-slash connector instead of suppressing its diagnostic as ambiguous

## Scope

This changes only the runner mitm addon's in-memory connector diagnostic grouping. It does not change APIs, persisted state, migrations, shared-base ownership policy, or deployment protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_builtin_connector_diagnostics.py` (31 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5202 passed)
- `lefthook run pre-commit`

Closes #26051
