### PR TITLE
fix: install noto fonts in sandbox images

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -351,7 +351,7 @@ install_packages() {
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
   apt-get install -y \
-    procps wget git ripgrep jq file iproute2 sudo ffmpeg \
+    procps wget git ripgrep jq file iproute2 sudo ffmpeg fonts-noto \
     libnss3 p11-kit-modules unzip \
     nodejs \
     python3 python3-pip \

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -351,7 +351,8 @@ install_packages() {
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
   apt-get install -y \
-    procps wget git ripgrep jq file iproute2 sudo ffmpeg fonts-noto \
+    procps wget git ripgrep jq file iproute2 sudo ffmpeg \
+    fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
     libnss3 p11-kit-modules unzip \
     nodejs \
     python3 python3-pip \

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -298,6 +298,7 @@ check_required_executable "/usr/bin/ffmpeg" "ffmpeg"
 
 # Browser screenshots and exports need system fallbacks for multilingual text.
 check_bin "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf" "Noto Sans"
+check_bin "/usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf" "Noto Sans Arabic"
 check_bin "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc" "Noto Sans CJK"
 check_bin "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf" "Noto Color Emoji"
 

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -296,6 +296,11 @@ check_required_executable "/usr/bin/mkdir" "mkdir"
 # Media workflows rely on ffmpeg being available in fresh agent runtimes.
 check_required_executable "/usr/bin/ffmpeg" "ffmpeg"
 
+# Browser screenshots and exports need system fallbacks for multilingual text.
+check_bin "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf" "Noto Sans"
+check_bin "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc" "Noto Sans CJK"
+check_bin "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf" "Noto Color Emoji"
+
 # Browser automation relies on the native vm0 fork binary.
 check_required_executable "/usr/local/bin/agent-browser" "agent-browser CLI"
 

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -594,15 +594,25 @@ wait
 
     #[test]
     fn template_installs_and_verifies_noto_fonts() {
-        assert!(
-            template_build_installs_apt_package("fonts-noto"),
-            "build-template.sh should install the complete Noto font metapackage"
-        );
+        for package in [
+            "fonts-noto-core",
+            "fonts-noto-cjk",
+            "fonts-noto-color-emoji",
+        ] {
+            assert!(
+                template_build_installs_apt_package(package),
+                "build-template.sh should install {package}"
+            );
+        }
 
         for (path, name) in [
             (
                 "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
                 "Noto Sans",
+            ),
+            (
+                "/usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf",
+                "Noto Sans Arabic",
             ),
             (
                 "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -593,6 +593,35 @@ wait
     }
 
     #[test]
+    fn template_installs_and_verifies_noto_fonts() {
+        assert!(
+            template_build_installs_apt_package("fonts-noto"),
+            "build-template.sh should install the complete Noto font metapackage"
+        );
+
+        for (path, name) in [
+            (
+                "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+                "Noto Sans",
+            ),
+            (
+                "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+                "Noto Sans CJK",
+            ),
+            (
+                "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf",
+                "Noto Color Emoji",
+            ),
+        ] {
+            let check = format!(r#"check_bin "{path}" "{name}""#);
+            assert!(
+                VERIFY_SCRIPT.contains(&check),
+                "verify-rootfs.sh should verify {name} is present in sandbox images"
+            );
+        }
+    }
+
+    #[test]
     fn template_installs_and_verifies_pgvector() {
         assert!(
             template_build_installs_apt_package("postgresql-18-pgvector"),


### PR DESCRIPTION
## Summary

- install `fonts-noto-core`, `fonts-noto-cjk`, and `fonts-noto-color-emoji` in sandbox rootfs templates
- verify representative Noto Sans, Arabic, CJK, and color emoji files in built images
- add a Runner contract test covering the selected package installation and verification checks

This package set covers all six UN official languages, including Latin, Cyrillic, Arabic, Simplified Chinese, and Traditional Chinese, while also providing Japanese, Korean, and emoji fallbacks. It adds approximately 149 MB (141.8 MiB) to the rootfs instead of the complete metapackage's approximately 789 MB.

## Exclusions

- extra font weights, condensed variants, and UI-specific families from the complete `fonts-noto` metapackage are not installed

## Verification

- `shellcheck -e SC2034,SC2155 crates/runner/scripts/build-template.sh crates/runner/scripts/verify-rootfs.sh`
- `bash -n crates/runner/scripts/build-template.sh crates/runner/scripts/verify-rootfs.sh`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --tests --no-deps -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner template_installs_and_verifies_noto_fonts`
- installed the selected packages locally and verified their 149 MB installed footprint
- verified fontconfig matching for English, French, Spanish, Russian, Arabic, Simplified Chinese, Traditional Chinese, Japanese, and Korean
- re-rendered the same Chinese presentation screenshot and confirmed the glyphs display without tofu boxes

Fixes #26093
