### PR TITLE
fix(mitm-addon): reject non-list custom connector apis

### DIFF
--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -306,7 +306,10 @@ def resolve_firewall_entries(
             custom_connector_id = _custom_connector_id(entry)
             if custom_connector_id is not None:
                 resolved_firewall["customConnectorId"] = custom_connector_id
-                for api in resolved_firewall.get("apis", []):
+                raw_apis = resolved_firewall.get("apis")
+                if not isinstance(raw_apis, list):
+                    raise FirewallEntryResolutionError("inline firewall apis must be a list")
+                for api in raw_apis:
                     if isinstance(api, dict):
                         api["customConnectorId"] = custom_connector_id
             resolved.append(resolved_firewall)

--- a/crates/runner/mitm-addon/tests/test_registry_inline_firewalls.py
+++ b/crates/runner/mitm-addon/tests/test_registry_inline_firewalls.py
@@ -114,3 +114,30 @@ class TestRegistryInlineFirewalls:
             "custom-api-id",
             "run-inline:1",
         ]
+
+    def test_malformed_custom_connector_apis_reject_only_affected_vm(self, tmp_path, mitm_ctx):
+        path = tmp_path / "registry.json"
+        malformed_vm = inline_vm("run-malformed")
+        malformed_entry = malformed_vm["firewalls"][0]
+        malformed_entry["customConnectorId"] = "550e8400-e29b-41d4-a716-446655440000"
+        malformed_entry["firewall"]["apis"] = None
+        write_multi_vm_registry(
+            path,
+            {
+                "10.200.0.1": malformed_vm,
+                "10.200.0.2": inline_vm("run-valid"),
+            },
+        )
+
+        with mitm_ctx():
+            state = registry.load_registry_state(str(path))
+            valid_context = registry.get_vm_context("10.200.0.2", str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert set(state.vms) == {"10.200.0.2"}
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert invalid_vm.message == "inline firewall apis must be a list"
+        assert valid_context is not None
+        _, compiled_firewalls, _ = valid_context
+        assert compiled_firewalls is not None


### PR DESCRIPTION
## Summary

- reject non-list API containers before propagating custom connector identity
- classify the malformed VM through the existing `invalid_firewalls` boundary
- cover a mixed registry snapshot where a valid peer VM remains available

## Scope

This changes only Python registry resolution for inline entries with a valid `customConnectorId`. It does not change the TypeScript or Rust execution-firewall contracts, general inline firewall matcher tolerance, database schemas, or deployment protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_registry_inline_firewalls.py` (4 passed)
- `uv run --no-sync python -m pytest tests/` (5214 passed)

Closes #26092
