### PR TITLE
feat(runs): write automation-event, automation-schedule and goal trigger sources

### DIFF
--- a/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
@@ -116,7 +116,7 @@ describe("dev bench seed profile rows", () => {
       ).toBe(expected.usageEvents);
       expect(
         countWhere(rows.zeroRunRows, (row) => {
-          return row.triggerSource === "workflow-schedule";
+          return row.triggerSource === "automation-schedule";
         }),
       ).toBe(expected.workflowScheduleRuns);
       expect(

--- a/turbo/apps/api/src/scripts/dev-bench-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-bench-seed.ts
@@ -685,7 +685,7 @@ function appendRunEvents(
   });
   args.rows.zeroRunRows.push({
     id: runId,
-    triggerSource: args.workflowAutomationBrief ? "workflow-schedule" : "web",
+    triggerSource: args.workflowAutomationBrief ? "automation-schedule" : "web",
     selectedModel: args.profile.selectedModel,
     chatThreadId: args.threadId,
     summary: `Synthetic ${args.profile.slug} run ${String(args.runIndex)}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -842,7 +842,7 @@ async function expectGoalDrainPreCreateTiming(args: {
         success: true,
         run_id: args.runId,
         span_kind: "nested",
-        trigger_source: "workflow-event",
+        trigger_source: "goal",
         zero_run_origin: "goal_continuation",
         goal_drain_timing_role: isGoalDrainWaitingTimingAction(actionType)
           ? "waiting"
@@ -875,7 +875,7 @@ async function expectGoalDrainPreCreateTiming(args: {
       success: true,
       run_id: args.runId,
       span_kind: "nested",
-      trigger_source: "workflow-event",
+      trigger_source: "goal",
       zero_run_origin: "goal_continuation",
       goal_drain_attempt: "initial",
       goal_drain_timing_role: "aggregate",
@@ -899,7 +899,7 @@ async function expectGoalDrainPreCreateTiming(args: {
   expect(preCreate).toStrictEqual(
     expect.objectContaining({
       span_kind: "top_level",
-      trigger_source: "workflow-event",
+      trigger_source: "goal",
       zero_run_origin: "goal_continuation",
     }),
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -621,7 +621,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
           expect.objectContaining({
             op_type: "api_dispatch_pre_create_zero_workflow_event_handoff_run",
             workflow_event_source: "github",
-            trigger_source: "workflow-event",
+            trigger_source: "automation-event",
             zero_run_origin: "workflow_automation",
             span_kind: "nested",
           }),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -922,7 +922,7 @@ describe("POST /api/webhooks/gmail", () => {
         expect.objectContaining({
           op_type: "api_dispatch_pre_create_zero_workflow_event_handoff_run",
           workflow_event_source: "gmail",
-          trigger_source: "workflow-event",
+          trigger_source: "automation-event",
           zero_run_origin: "workflow_automation",
           span_kind: "nested",
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -407,7 +407,7 @@ describe("POST /api/webhooks/google-calendar", () => {
         expect.objectContaining({
           op_type: "api_dispatch_pre_create_zero_workflow_event_handoff_run",
           workflow_event_source: "google_calendar",
-          trigger_source: "workflow-event",
+          trigger_source: "automation-event",
           zero_run_origin: "workflow_automation",
           span_kind: "nested",
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
@@ -206,7 +206,7 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
         expect.objectContaining({
           op_type: "api_dispatch_pre_create_zero_workflow_event_handoff_run",
           workflow_event_source: "webhook",
-          trigger_source: "workflow-event",
+          trigger_source: "automation-event",
           zero_run_origin: "workflow_automation",
           span_kind: "nested",
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -451,7 +451,7 @@ describe("zero workflow automation scheduler", () => {
     expect(logs.body.data).toContainEqual(
       expect.objectContaining({
         id: run.runId,
-        triggerSource: "workflow-schedule",
+        triggerSource: "automation-schedule",
       }),
     );
     expect(run.triggerBrief).toMatch(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -4022,7 +4022,7 @@ describe("zero workflow automations", () => {
       expect.arrayContaining([
         expect.objectContaining({
           op_type: "api_dispatch_pre_create_agent_run",
-          trigger_source: "workflow-schedule",
+          trigger_source: "automation-schedule",
           zero_run_origin: "workflow_automation",
         }),
       ]),
@@ -4049,7 +4049,7 @@ describe("zero workflow automations", () => {
         expect.objectContaining({
           op_type:
             "api_dispatch_pre_create_zero_workflow_automation_create_run",
-          trigger_source: "workflow-schedule",
+          trigger_source: "automation-schedule",
           zero_run_origin: "workflow_automation",
           span_kind: "nested",
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -614,7 +614,7 @@ describe("workflow queue", () => {
     );
     await expect(
       readWorkflowRunTriggerSourceFixture(workflowRunId),
-    ).resolves.toBe("workflow-event");
+    ).resolves.toBe("automation-event");
     const events = await wf.readThreadEvents(automation.threadId);
     expect(events).toContainEqual(
       expect.objectContaining({
@@ -966,7 +966,7 @@ describe("workflow queue", () => {
     const runIds = await workflowRunIds(webhookAutomation.threadId);
     expect(runIds).toHaveLength(2);
     await expect(readWorkflowRunTriggerSourceFixture(runIds[1]!)).resolves.toBe(
-      "workflow-schedule",
+      "automation-schedule",
     );
     const claimedTick = (
       await wf.readThreadEvents(webhookAutomation.threadId)

--- a/turbo/apps/api/src/signals/services/chat-run-finished-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-workflow-event.service.ts
@@ -258,7 +258,7 @@ export const dispatchChatRunFinishedWorkflowEvents$ = command(
           },
           automationContext: context,
           apiStartTime: now(),
-          triggerSource: "workflow-event",
+          triggerSource: "automation-event",
           triggerBrief: `Chat run ${event.runStatus} in watched thread`,
           dispatchFailedCallbacks: dispatchFailedRunCallbacks,
         },

--- a/turbo/apps/api/src/signals/services/github-webhook-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-webhook-automation-event.service.ts
@@ -810,7 +810,7 @@ const startGithubWebhookAutomation$ = command(
         },
         automationContext: context,
         apiStartTime: args.apiStartTime,
-        triggerSource: "workflow-event",
+        triggerSource: "automation-event",
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
         timing: args.timing.collectorForRunStart(),
       },

--- a/turbo/apps/api/src/signals/services/github-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-workflow-event.service.ts
@@ -489,7 +489,7 @@ const startGithubWorkflowRun$ = command(
         },
         automationContext: runInput.context,
         apiStartTime: args.apiStartTime,
-        triggerSource: "workflow-event",
+        triggerSource: "automation-event",
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
         timing: args.timing.collectorForRunStart(),
       },

--- a/turbo/apps/api/src/signals/services/github-workflow-run-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-workflow-run-event.service.ts
@@ -363,7 +363,7 @@ const startGithubWorkflowRunAutomation$ = command(
         },
         automationContext: context,
         apiStartTime: args.apiStartTime,
-        triggerSource: "workflow-event",
+        triggerSource: "automation-event",
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
         timing: args.timing.collectorForRunStart(),
       },

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -2434,7 +2434,7 @@ const startGmailWorkflowRun$ = command(
         },
         automationContext: runInput.context,
         apiStartTime: args.apiStartTime,
-        triggerSource: "workflow-event",
+        triggerSource: "automation-event",
         triggerBrief: runInput.triggerBrief,
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
         timing: args.timing.collectorForRunStart(),

--- a/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-workflow-event.service.ts
@@ -2777,7 +2777,7 @@ export const dispatchGoogleCalendarWebhook$ = command(
               },
               automationContext: runInput.context,
               apiStartTime: args.apiStartTime,
-              triggerSource: "workflow-event",
+              triggerSource: "automation-event",
               dispatchFailedCallbacks: dispatchFailedRunCallbacks,
               timing: timing.collectorForRunStart(),
             },

--- a/turbo/apps/api/src/signals/services/google-forms-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-forms-workflow-event.service.ts
@@ -1505,7 +1505,7 @@ const startGoogleFormsWorkflowRun$ = command(
           },
           automationContext: context,
           apiStartTime: args.apiStartTime,
-          triggerSource: "workflow-event",
+          triggerSource: "automation-event",
           triggerBrief: googleFormsTriggerBrief(args),
           persistSourceTransition: async (tx) => {
             await persistGoogleFormsSourceTransition(

--- a/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-workflow-event.service.ts
@@ -1486,7 +1486,7 @@ export const dispatchGoogleWorkspaceEventsPubSubPush$ = command(
               },
               automationContext: runInput.context,
               apiStartTime: args.apiStartTime,
-              triggerSource: "workflow-event",
+              triggerSource: "automation-event",
               triggerBrief: runInput.triggerBrief,
               dispatchFailedCallbacks: dispatchFailedRunCallbacks,
               timing: timing.collectorForRunStart(),

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -2200,7 +2200,7 @@ async function startNotionWorkflowRun(
       },
       automationContext: args.context,
       apiStartTime: now(),
-      triggerSource: "workflow-event",
+      triggerSource: "automation-event",
       triggerBrief: args.triggerBrief,
       dispatchFailedCallbacks: dispatchFailedRunCallbacks,
     },

--- a/turbo/apps/api/src/signals/services/strapi-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/strapi-workflow-event.service.ts
@@ -656,7 +656,7 @@ async function processPendingEvent(
       },
       automationContext: context,
       apiStartTime: now(),
-      triggerSource: "workflow-event",
+      triggerSource: "automation-event",
       triggerBrief: `Strapi published ${args.pending.uid} ${args.pending.documentId} (${args.pending.locales.length} locale${args.pending.locales.length === 1 ? "" : "s"})`,
       coalescePendingScheduleRun: false,
       persistSourceTransition: async (tx) => {

--- a/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
@@ -1356,7 +1356,7 @@ async function processClaimedDelivery(
           target,
         }),
         apiStartTime: now(),
-        triggerSource: "workflow-event",
+        triggerSource: "automation-event",
         triggerBrief: `Stripe invoice paid: ${args.delivery.snapshot.invoice.id}`,
         coalescePendingScheduleRun: false,
         persistSourceTransition: async (tx) => {

--- a/turbo/apps/api/src/signals/services/workflow-automation-trigger-source.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-trigger-source.ts
@@ -2,6 +2,8 @@ import type { ZeroWorkflowAutomationKind } from "@vm0/db/schema/zero-workflow";
 
 export function manualTriggerSource(automation: {
   readonly kind: ZeroWorkflowAutomationKind;
-}): "workflow-event" | "workflow-schedule" {
-  return automation.kind === "event" ? "workflow-event" : "workflow-schedule";
+}): "automation-event" | "automation-schedule" {
+  return automation.kind === "event"
+    ? "automation-event"
+    : "automation-schedule";
 }

--- a/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
@@ -699,7 +699,7 @@ const startWorkflowWebhookRun$ = command(
         },
         automationContext: runInput.context,
         apiStartTime: args.apiStartTime,
-        triggerSource: "workflow-event",
+        triggerSource: "automation-event",
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
         timing: args.timing.collectorForRunStart(),
       },

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -69,7 +69,7 @@ export type QueuedUserMessageTriggerSource =
   | "telegram"
   | "agentphone"
   | "github"
-  | "workflow-schedule";
+  | "automation-schedule";
 
 function unreachableQueuedContextType(contextType: never): never {
   throw new Error(`Unsupported queued context type: ${String(contextType)}`);
@@ -101,7 +101,7 @@ export function queuedUserMessageTriggerSource(
       return "agent";
     }
     case "morning_brief": {
-      return "workflow-schedule";
+      return "automation-schedule";
     }
     case "automation":
     case "goal": {

--- a/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
@@ -163,7 +163,7 @@ function buildQueueFirstGoalRunInput(args: {
         : {}),
     },
     apiStartTime: args.apiStartTime,
-    triggerSource: "workflow-event",
+    triggerSource: "goal",
     appendSystemPrompt,
     chatThreadId: normalizedGoal.threadId,
     modelProviderId: modelPin.modelProviderId ?? undefined,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -595,7 +595,7 @@ export const launchQueuedWorkflowAutomation$ = command(
             : {}),
         },
         apiStartTime: args.apiStartTime,
-        triggerSource: args.triggerSource ?? "workflow-schedule",
+        triggerSource: args.triggerSource ?? "automation-schedule",
         chatThreadId,
         computerUseHostId: computerUseHostGrant?.hostId,
         modelProviderId: modelPin.modelProviderId ?? undefined,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -54,7 +54,7 @@ export const runWorkflowAutomationNow$ = command(
               args.automationContext.event,
             ),
           chatThreadId,
-          triggerSource: args.triggerSource ?? "workflow-schedule",
+          triggerSource: args.triggerSource ?? "automation-schedule",
           triggerBrief: args.triggerBrief,
           coalescePendingScheduleRun: args.coalescePendingScheduleRun !== false,
           persistSourceTransition: args.persistSourceTransition,

--- a/turbo/apps/api/src/test-fixtures/workflow-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/workflow-queue.ts
@@ -67,7 +67,7 @@ export async function admitWorkflowAutomationEventFixture(
     workflowAutomationEventPayload:
       persistedWorkflowAutomationEventPayload(eventPayload),
     chatThreadId: args.chatThreadId,
-    triggerSource: "workflow-event",
+    triggerSource: "automation-event",
     triggerBrief: args.triggerBrief,
     coalescePendingScheduleRun: false,
   });


### PR DESCRIPTION
## Summary

- switch event automation writers to `automation-event`
- switch scheduled automation writers, including morning briefs, to `automation-schedule`
- store goal continuation provenance as `goal`
- update writer-facing fixtures and integration expectations without changing readers, legacy enums, migrations, file names, or dispatch-timing strings

## Why

This is step 4 of #26015. Step 3 has already deployed dual-read support, so new rows can now use the truthful trigger-source values. The goal change fixes the existing provenance mislabel while preserving unattended banking and automation usage classification through the readers shipped in step 3.

## Validation

- `grep -rn '"workflow-event"\|"workflow-schedule"' turbo/apps/api/src --exclude-dir='__tests__'` returns only `zero-banking.service.ts` and `zero-usage-insight.service.ts`
- changed files pass the repository Prettier check
- `git diff --check` passes
- verified no migration, rename, `packages/core/`, `contracts/logs.ts`, `schema/run-uploaded-file.ts`, reader, or dispatch-timing-string changes
- full local test suite not run per issue instructions; PR CI will run checks

Closes #26112