### PR TITLE
refactor(python): centralize synthetic json framing

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -46,6 +46,7 @@ import builtin_connector_diagnostics
 import connector_intent
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import http_local_responses
 import matching
 import request_classification
 import runtime_url_parsing
@@ -343,10 +344,10 @@ def maybe_replace_response(
         if isinstance(body, bytes) and not flow.metadata.get(
             _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT
         ):
-            _apply_diagnostic_response_content(
+            http_local_responses.apply_synthetic_json_response_content(
+                flow,
                 flow.response,
-                body,
-                omit_content_length=_is_head_request(flow),
+                lambda: body,
             )
         _log_proxy_entry(
             flow,
@@ -632,10 +633,6 @@ def _response_body(
     return json.dumps(body, separators=(",", ":")).encode()
 
 
-def _is_head_request(flow: http.HTTPFlow) -> bool:
-    return flow.request.method.upper() == "HEAD"
-
-
 def _set_diagnostic_response_content(
     flow: http.HTTPFlow,
     response: http.Response,
@@ -643,26 +640,11 @@ def _set_diagnostic_response_content(
     *,
     upstream_status: int,
 ) -> bytes:
-    bodyless = _is_head_request(flow)
-    content = b"" if bodyless else _response_body(candidate, upstream_status=upstream_status)
-    _apply_diagnostic_response_content(
+    return http_local_responses.apply_synthetic_json_response_content(
+        flow,
         response,
-        content,
-        omit_content_length=bodyless,
+        lambda: _response_body(candidate, upstream_status=upstream_status),
     )
-    return content
-
-
-def _apply_diagnostic_response_content(
-    response: http.Response,
-    content: bytes,
-    *,
-    omit_content_length: bool,
-) -> None:
-    response.content = content
-    response.headers["Content-Type"] = "application/json"
-    if omit_content_length:
-        del response.headers["Content-Length"]
 
 
 def _make_local_response(

--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -2,6 +2,7 @@
 
 import json
 import urllib.parse
+from collections.abc import Callable
 from typing import Final
 
 from mitmproxy import http
@@ -30,20 +31,32 @@ def _diagnostic_url_without_query_or_fragment(original_url: str) -> str:
     return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
+def apply_synthetic_json_response_content(
+    flow: http.HTTPFlow,
+    response: http.Response,
+    content_factory: Callable[[], bytes],
+) -> bytes:
+    """Apply method-aware JSON content framing to a synthetic response."""
+    is_head_request = flow.request.method.upper() == "HEAD"
+    content = b"" if is_head_request else content_factory()
+    response.content = content
+    response.headers["Content-Type"] = "application/json"
+    if is_head_request:
+        del response.headers["Content-Length"]
+    return content
+
+
 def make_local_json_response(
     flow: http.HTTPFlow,
     status_code: int,
     body: dict[str, object],
 ) -> http.Response:
-    is_head_request = flow.request.method.upper() == "HEAD"
-    content = b"" if is_head_request else json.dumps(body).encode()
-    response = http.Response.make(
-        status_code,
-        content,
-        {"Content-Type": "application/json"},
+    response = http.Response.make(status_code)
+    apply_synthetic_json_response_content(
+        flow,
+        response,
+        lambda: json.dumps(body).encode(),
     )
-    if is_head_request:
-        del response.headers["Content-Length"]
     return response
 
 


### PR DESCRIPTION
## Summary

- add one method-aware applicator for synthetic JSON response content and framing
- migrate general local responses and connector-diagnostic local, replacement, stream, and restoration paths to the shared owner
- preserve lazy `HEAD` handling, existing JSON byte formats, connector cleanup, status, metadata, and logging while removing duplicate connector framing helpers

## Scope

This is a behavior-preserving Python refactor. It does not change schemas, persisted data, APIs, queue payloads, runner protocols, dependencies, configuration, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_firewall_auth.py` (81 passed)
- `uv run --no-sync python -m pytest tests/test_request_handler_connector_diagnostics.py tests/test_response_handler_connector_diagnostics.py tests/test_error_handler.py` (73 passed)
- `uv run --no-sync python -m pytest tests/test_mitmproxy_request_framing.py` (18 passed)
- `uv run --no-sync python -m pytest tests/` (5213 passed)

Closes #26094
