### PR TITLE
fix(api): clean connector state on clerk deletion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -4,6 +4,7 @@ import { createStore } from "ccstate";
 import { LIMITED_FREE1_DEFAULT_RUN_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import { RESUME_SESSION_HISTORY_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
 import { MAX_FILE_SIZE_BYTES } from "@vm0/api-contracts/contracts/storages";
+import type { CreateCustomConnectorBody } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it, onTestFinished } from "vitest";
 
@@ -28,7 +29,11 @@ import {
 } from "./helpers/api-bdd";
 import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
-import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import {
+  createConnectorBddApi,
+  mockCustomConnectorOAuth2Provider,
+  mockSlackConnectorOAuth,
+} from "./helpers/api-bdd-connectors";
 import { createGithubBddApi, newGithubUserId } from "./helpers/api-bdd-github";
 import {
   createRunsApi,
@@ -36,6 +41,7 @@ import {
 } from "./helpers/api-bdd-runs";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { createUserConfigBddApi } from "./helpers/api-bdd-user-config";
 import {
   generatedStripeCustomerId,
   generatedStripeSubscriptionId,
@@ -94,6 +100,62 @@ function orgOf(actor: ApiTestUser): string {
     throw new Error("Expected an org-scoped actor");
   }
   return actor.orgId;
+}
+
+function oauthStateFromAuthorizationUrl(authorizationUrl: string): string {
+  const state = new URL(authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected connector authorization URL to include state");
+  }
+  return state;
+}
+
+function customManualConnectorBodyForTeardown(
+  scope: "org" | "user",
+): CreateCustomConnectorBody {
+  const slug = `_${scope}-teardown-${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+  return {
+    slug,
+    displayName: `BDD ${scope === "org" ? "Org" : "User"} Teardown Custom`,
+    prefixes: [`https://${slug.slice(1)}.example.test/v1/`],
+    headerName: "Authorization",
+    headerTemplate: "Bearer {{secret}}",
+  };
+}
+
+function customOauthConnectorBodyForTeardown(
+  scope: "org" | "user",
+  provider: {
+    readonly authorizationUrl: string;
+    readonly tokenUrl: string;
+  },
+): CreateCustomConnectorBody {
+  return {
+    displayName: `BDD ${scope} Teardown OAuth ${randomUUID()}`,
+    prefixTemplates: [
+      `https://${scope}-teardown-oauth-${randomUUID()}.example.test/v1/`,
+    ],
+    fields: [],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{oauth.access_token}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "oauth",
+    oauthConfig: {
+      providerAdapter: "standard",
+      clientId: `${scope}-teardown-client-id`,
+      clientSecret: `${scope}-teardown-client-secret`,
+      authorizationUrl: provider.authorizationUrl,
+      tokenUrl: provider.tokenUrl,
+      tokenEndpointAuthMethod: "client_secret_post",
+      pkceMethod: "none",
+      scopes: ["read"],
+      authorizationParams: {},
+    },
+  };
 }
 
 function epochSeconds(offsetDays: number): number {
@@ -5098,6 +5160,8 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     runs.acceptTelemetryIngest();
     runs.configureRunnerGroup();
     acceptGithubGrantRevocations();
+    mockSlackConnectorOAuth();
+    const customOAuthProvider = mockCustomConnectorOAuth2Provider(context);
 
     const actor = bdd.user();
     const granted = await runs.grantProEntitlement(actor);
@@ -5121,6 +5185,33 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       displayName: "BDD Org Teardown Agent",
       visibility: "public",
     });
+    const customManual = await connectors.createCustomConnector(
+      actor,
+      customManualConnectorBodyForTeardown("org"),
+    );
+    await connectors.setCustomConnectorSecret(
+      actor,
+      customManual.id,
+      "org-teardown-custom-secret",
+    );
+    await connectors.updateAgentCustomConnectors(actor, agent.agentId, [
+      customManual.id,
+    ]);
+    const customOauth = await connectors.createCustomConnector(
+      actor,
+      customOauthConnectorBodyForTeardown("org", customOAuthProvider),
+    );
+    const builtinOauthState = oauthStateFromAuthorizationUrl(
+      (await connectors.startOauth(actor, "slack", "oauth", agent.agentId))
+        .authorizationUrl,
+    );
+    const customOauthState = oauthStateFromAuthorizationUrl(
+      await connectors.startCustomConnectorOAuth2(
+        actor,
+        customOauth.id,
+        agent.agentId,
+      ),
+    );
     const run = await runs.createRun(actor, {
       agentId: agent.agentId,
       prompt: "survive until teardown",
@@ -5318,6 +5409,33 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
           connectionStatus: "connected",
         }),
       );
+    });
+    await waitForExpectation(async () => {
+      await expect(
+        connectors.listCustomConnectors(actor),
+      ).resolves.toStrictEqual([]);
+    });
+    await expect(
+      connectors.completeOauthCallbackResult("slack", {
+        code: "org-teardown-deleted-state",
+        state: builtinOauthState,
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        status: "error",
+        message: "Invalid state - please try again",
+      },
+    });
+    await expect(
+      connectors.completeCustomConnectorOAuth2CallbackResult({
+        code: "org-teardown-deleted-custom-state",
+        state: customOauthState,
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        status: "error",
+        message: "Invalid OAuth state - please try again",
+      },
     });
     // An org without a live subscription skips the Stripe update.
     const updateCalls =
@@ -5543,6 +5661,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     const bdd = createBddApi(context);
     const runs = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
+    const userConfig = createUserConfigBddApi(context);
     const gh = createGithubBddApi(context);
     api.configureClerkWebhookSecret();
     bdd.acceptAgentStorageWrites();
@@ -5550,6 +5669,8 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     runs.acceptTelemetryIngest();
     const runnerGroup = runs.configureRunnerGroup();
     acceptGithubGrantRevocations();
+    mockSlackConnectorOAuth();
+    const customOAuthProvider = mockCustomConnectorOAuth2Provider(context);
 
     const doomed = bdd.user();
     await runs.grantProEntitlement(doomed);
@@ -5566,6 +5687,68 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       displayName: "BDD Doomed Agent",
       visibility: "private",
     });
+    await runs.enableAgentConnectors(doomed, sharedAgent.agentId, ["openai"]);
+    await connectors.connectManualGrant(
+      peer,
+      "openai",
+      "api-token",
+      { apiKey: "peer-teardown-connector-token" },
+      sharedAgent.agentId,
+    );
+
+    const customManual = await connectors.createCustomConnector(
+      doomed,
+      customManualConnectorBodyForTeardown("user"),
+    );
+    await connectors.setCustomConnectorSecret(
+      doomed,
+      customManual.id,
+      "doomed-custom-secret",
+    );
+    await connectors.setCustomConnectorSecret(
+      peer,
+      customManual.id,
+      "peer-custom-secret",
+    );
+    await connectors.updateAgentCustomConnectors(doomed, sharedAgent.agentId, [
+      customManual.id,
+    ]);
+    await connectors.updateAgentCustomConnectors(peer, sharedAgent.agentId, [
+      customManual.id,
+    ]);
+
+    const customOauth = await connectors.createCustomConnector(
+      doomed,
+      customOauthConnectorBodyForTeardown("user", customOAuthProvider),
+    );
+    const doomedBuiltinOauthState = oauthStateFromAuthorizationUrl(
+      (
+        await connectors.startOauth(
+          doomed,
+          "slack",
+          "oauth",
+          sharedAgent.agentId,
+        )
+      ).authorizationUrl,
+    );
+    const peerBuiltinOauthState = oauthStateFromAuthorizationUrl(
+      (await connectors.startOauth(peer, "slack", "oauth", sharedAgent.agentId))
+        .authorizationUrl,
+    );
+    const doomedCustomOauthState = oauthStateFromAuthorizationUrl(
+      await connectors.startCustomConnectorOAuth2(
+        doomed,
+        customOauth.id,
+        sharedAgent.agentId,
+      ),
+    );
+    const peerCustomOauthState = oauthStateFromAuthorizationUrl(
+      await connectors.startCustomConnectorOAuth2(
+        peer,
+        customOauth.id,
+        sharedAgent.agentId,
+      ),
+    );
 
     const doomedKey = await runs.createCliToken(doomed);
     const doomedBearer = `Bearer ${doomedKey.token}`;
@@ -5741,6 +5924,65 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       permission: "chat:write",
       action: "deny",
     });
+    await expect(
+      userConfig.readUserConnectors(doomed, sharedAgent.agentId),
+    ).resolves.toStrictEqual({ enabledConnectorSlugs: [] });
+    await expect(
+      userConfig.readUserConnectors(peer, sharedAgent.agentId),
+    ).resolves.toMatchObject({ enabledConnectorSlugs: ["openai"] });
+    await expect(
+      connectors.readAgentCustomConnectors(doomed, sharedAgent.agentId),
+    ).resolves.toStrictEqual([]);
+    await expect(
+      connectors.readAgentCustomConnectors(peer, sharedAgent.agentId),
+    ).resolves.toStrictEqual([customManual.id]);
+    await expect(
+      connectors.readCustomConnector(doomed, customManual.id),
+    ).resolves.toMatchObject({
+      connected: false,
+      hasSecret: false,
+      configuredFieldKeys: [],
+    });
+    await expect(
+      connectors.readCustomConnector(peer, customManual.id),
+    ).resolves.toMatchObject({
+      connected: true,
+      hasSecret: true,
+    });
+    await expect(
+      connectors.completeOauthCallbackResult("slack", {
+        code: "doomed-deleted-state",
+        state: doomedBuiltinOauthState,
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        status: "error",
+        message: "Invalid state - please try again",
+      },
+    });
+    await expect(
+      connectors.completeCustomConnectorOAuth2CallbackResult({
+        code: "doomed-deleted-custom-state",
+        state: doomedCustomOauthState,
+      }),
+    ).resolves.toMatchObject({
+      body: {
+        status: "error",
+        message: "Invalid OAuth state - please try again",
+      },
+    });
+    await expect(
+      connectors.completeOauthCallbackResult("slack", {
+        code: "peer-surviving-state",
+        state: peerBuiltinOauthState,
+      }),
+    ).resolves.toMatchObject({ body: { status: "success" } });
+    await expect(
+      connectors.completeCustomConnectorOAuth2CallbackResult({
+        code: "peer-surviving-custom-state",
+        state: peerCustomOauthState,
+      }),
+    ).resolves.toMatchObject({ body: { status: "success" } });
     await expect(
       store.set(
         readUsageStorageCounts$,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -966,6 +966,71 @@ describe("Feishu integration", () => {
     return { firstMessageId, mainSessionId };
   }
 
+  it("removes only the deleted user's Feishu connection mapping", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const survivor = fixture.actor;
+    await connectFixtureUser(fixture, survivor, "ou_feishu_survivor");
+
+    const doomed = authOrgApi.user({
+      userId: `user_${randomUUID()}`,
+      orgId: survivor.orgId,
+      orgRole: "org:member",
+    });
+    await enableFeishuIntegration(doomed);
+    await connectFixtureUser(fixture, doomed, "ou_feishu_doomed");
+
+    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+      zeroFeishuConnectContract,
+    );
+    mocks.clerk.session(doomed.userId, doomed.orgId, "org:member");
+    const connectedBeforeDeletion = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(connectedBeforeDeletion.body).toMatchObject({
+      isConnected: true,
+      connectedUserName: "Feishu User",
+    });
+
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [{ publicUserData: { userId: survivor.userId } }],
+      },
+    );
+    webhooksApi.configureClerkWebhookSecret();
+    webhooksApi.verifyNextClerkWebhook({
+      type: "user.deleted",
+      data: { id: doomed.userId },
+    });
+    const response = await webhooksApi.requestClerkWebhook("{}", {}, [200]);
+    expect(response.body).toBe("OK");
+    await flushWaitUntilForTest();
+
+    mocks.clerk.session(doomed.userId, doomed.orgId, "org:member");
+    const deletedUserStatus = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(deletedUserStatus.body.isConnected).toBeFalsy();
+
+    mocks.clerk.session(survivor.userId, survivor.orgId, "org:admin");
+    const survivorStatus = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(survivorStatus.body).toMatchObject({
+      isConnected: true,
+      connectedUserName: "Feishu User",
+      installations: [expect.objectContaining({ id: fixture.installationId })],
+    });
+  });
+
   it("rejects configuration API access when the feature switch is disabled", async () => {
     const actor = authOrgApi.user({
       userId: `user_${randomUUID()}`,

--- a/turbo/apps/api/src/signals/services/connector-credential-storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-storage-write.service.ts
@@ -2,7 +2,7 @@ import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connector
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
-import { eq, isNotNull } from "drizzle-orm";
+import { eq, isNotNull, sql, type SQL } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
@@ -18,6 +18,25 @@ interface ConnectorOwnedCredentialWrite {
 interface ConnectorOwnedCredentialDescription {
   readonly description: string | null;
   readonly updatedDescription?: string | null;
+}
+
+export type ConnectorOwnerScope =
+  | {
+      readonly kind: "user";
+      readonly userId: string;
+    }
+  | {
+      readonly kind: "organization";
+      readonly orgId: string;
+    };
+
+interface ConnectorOwnedCredentialDeleteConditions {
+  readonly secret: SQL;
+  readonly variable: SQL;
+}
+
+interface ConnectorCredentialStorageDeleteConditions extends ConnectorOwnedCredentialDeleteConditions {
+  readonly connection: SQL;
 }
 
 function requireDeclaredStorageName(args: {
@@ -122,6 +141,27 @@ export async function upsertConnectorOwnedVariable(
   }
 }
 
+async function deleteConnectorOwnedCredentialRowsWhere(
+  db: Db,
+  conditions: ConnectorOwnedCredentialDeleteConditions,
+  signal: AbortSignal,
+): Promise<void> {
+  await db.delete(secrets).where(conditions.secret);
+  signal.throwIfAborted();
+  await db.delete(variables).where(conditions.variable);
+  signal.throwIfAborted();
+}
+
+async function deleteConnectorCredentialStorageConnectionsWhere(
+  db: Db,
+  conditions: ConnectorCredentialStorageDeleteConditions,
+  signal: AbortSignal,
+): Promise<void> {
+  await deleteConnectorOwnedCredentialRowsWhere(db, conditions, signal);
+  await db.delete(connectors).where(conditions.connection);
+  signal.throwIfAborted();
+}
+
 export async function deleteConnectorOwnedCredentialRows(
   db: Db,
   args: {
@@ -129,10 +169,14 @@ export async function deleteConnectorOwnedCredentialRows(
   },
   signal: AbortSignal,
 ): Promise<void> {
-  await db.delete(secrets).where(eq(secrets.connectorId, args.connectorId));
-  signal.throwIfAborted();
-  await db.delete(variables).where(eq(variables.connectorId, args.connectorId));
-  signal.throwIfAborted();
+  await deleteConnectorOwnedCredentialRowsWhere(
+    db,
+    {
+      secret: eq(secrets.connectorId, args.connectorId),
+      variable: eq(variables.connectorId, args.connectorId),
+    },
+    signal,
+  );
 }
 
 export async function deleteConnectorCredentialStorageConnection(
@@ -142,7 +186,37 @@ export async function deleteConnectorCredentialStorageConnection(
   },
   signal: AbortSignal,
 ): Promise<void> {
-  await deleteConnectorOwnedCredentialRows(db, args, signal);
-  await db.delete(connectors).where(eq(connectors.id, args.connectorId));
-  signal.throwIfAborted();
+  await deleteConnectorCredentialStorageConnectionsWhere(
+    db,
+    {
+      secret: eq(secrets.connectorId, args.connectorId),
+      variable: eq(variables.connectorId, args.connectorId),
+      connection: eq(connectors.id, args.connectorId),
+    },
+    signal,
+  );
+}
+
+export async function deleteConnectorCredentialStorageConnectionsForOwner(
+  db: Db,
+  owner: ConnectorOwnerScope,
+  signal: AbortSignal,
+): Promise<void> {
+  const conditions: ConnectorCredentialStorageDeleteConditions =
+    owner.kind === "user"
+      ? {
+          secret: sql`${eq(secrets.userId, owner.userId)} AND ${isNotNull(secrets.connectorId)}`,
+          variable: sql`${eq(variables.userId, owner.userId)} AND ${isNotNull(variables.connectorId)}`,
+          connection: eq(connectors.userId, owner.userId),
+        }
+      : {
+          secret: sql`${eq(secrets.orgId, owner.orgId)} AND ${isNotNull(secrets.connectorId)}`,
+          variable: sql`${eq(variables.orgId, owner.orgId)} AND ${isNotNull(variables.connectorId)}`,
+          connection: eq(connectors.orgId, owner.orgId),
+        };
+  await deleteConnectorCredentialStorageConnectionsWhere(
+    db,
+    conditions,
+    signal,
+  );
 }

--- a/turbo/apps/api/src/signals/services/connector-owner-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-owner-cleanup.service.ts
@@ -1,0 +1,67 @@
+import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { feishuOrgConnections } from "@vm0/db/schema/feishu-org-connection";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
+import { eq, type SQL } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import {
+  deleteConnectorCredentialStorageConnectionsForOwner,
+  type ConnectorOwnerScope,
+} from "./connector-credential-storage-write.service";
+import { deleteCustomConnectorStoredValuesForOwner } from "./custom-connector-credential-storage.service";
+
+interface ConnectorOwnerDeleteConditions {
+  readonly builtinGrant: SQL;
+  readonly customGrant: SQL;
+  readonly oauthState: SQL;
+}
+
+function connectorOwnerDeleteConditions(
+  owner: ConnectorOwnerScope,
+): ConnectorOwnerDeleteConditions {
+  return owner.kind === "user"
+    ? {
+        builtinGrant: eq(userConnectors.userId, owner.userId),
+        customGrant: eq(userCustomConnectors.userId, owner.userId),
+        oauthState: eq(connectorOauthStates.userId, owner.userId),
+      }
+    : {
+        builtinGrant: eq(userConnectors.orgId, owner.orgId),
+        customGrant: eq(userCustomConnectors.orgId, owner.orgId),
+        oauthState: eq(connectorOauthStates.orgId, owner.orgId),
+      };
+}
+
+export async function deleteConnectorOwnerState(
+  db: Db,
+  owner: ConnectorOwnerScope,
+  signal: AbortSignal,
+): Promise<void> {
+  await deleteCustomConnectorStoredValuesForOwner(db, owner, signal);
+
+  if (owner.kind === "user") {
+    await db
+      .delete(feishuOrgConnections)
+      .where(eq(feishuOrgConnections.vm0UserId, owner.userId));
+    signal.throwIfAborted();
+  }
+
+  const conditions = connectorOwnerDeleteConditions(owner);
+  await db.delete(userConnectors).where(conditions.builtinGrant);
+  signal.throwIfAborted();
+  await db.delete(userCustomConnectors).where(conditions.customGrant);
+  signal.throwIfAborted();
+  await db.delete(connectorOauthStates).where(conditions.oauthState);
+  signal.throwIfAborted();
+
+  await deleteConnectorCredentialStorageConnectionsForOwner(db, owner, signal);
+
+  if (owner.kind === "organization") {
+    await db
+      .delete(orgCustomConnectors)
+      .where(eq(orgCustomConnectors.orgId, owner.orgId));
+    signal.throwIfAborted();
+  }
+}

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -1,10 +1,13 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql, type SQL } from "drizzle-orm";
 import { connectors } from "@vm0/db/schema/connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 
 import type { Db } from "../external/db";
-import { deleteConnectorCredentialStorageConnection } from "./connector-credential-storage-write.service";
+import {
+  deleteConnectorCredentialStorageConnection,
+  type ConnectorOwnerScope,
+} from "./connector-credential-storage-write.service";
 
 interface CustomConnectorMemberConnection {
   readonly connectorId: string;
@@ -12,31 +15,53 @@ interface CustomConnectorMemberConnection {
   readonly userId: string;
 }
 
+interface CustomConnectorStoredValueDeleteConditions {
+  readonly legacySecret: SQL;
+  readonly value: SQL;
+}
+
+async function deleteCustomConnectorStoredValuesWhere(
+  db: Db,
+  conditions: CustomConnectorStoredValueDeleteConditions,
+  signal: AbortSignal,
+): Promise<void> {
+  await db.delete(orgCustomConnectorValues).where(conditions.value);
+  signal.throwIfAborted();
+  await db.delete(orgCustomConnectorSecrets).where(conditions.legacySecret);
+  signal.throwIfAborted();
+}
+
 export async function deleteCustomConnectorStoredValues(
   db: Db,
   args: CustomConnectorMemberConnection,
   signal: AbortSignal,
 ): Promise<void> {
-  await db
-    .delete(orgCustomConnectorValues)
-    .where(
-      and(
-        eq(orgCustomConnectorValues.connectorId, args.connectorId),
-        eq(orgCustomConnectorValues.userId, args.userId),
-        eq(orgCustomConnectorValues.orgId, args.orgId),
-      ),
-    );
-  signal.throwIfAborted();
-  await db
-    .delete(orgCustomConnectorSecrets)
-    .where(
-      and(
-        eq(orgCustomConnectorSecrets.connectorId, args.connectorId),
-        eq(orgCustomConnectorSecrets.userId, args.userId),
-        eq(orgCustomConnectorSecrets.orgId, args.orgId),
-      ),
-    );
-  signal.throwIfAborted();
+  await deleteCustomConnectorStoredValuesWhere(
+    db,
+    {
+      value: sql`${eq(orgCustomConnectorValues.connectorId, args.connectorId)} AND ${eq(orgCustomConnectorValues.userId, args.userId)} AND ${eq(orgCustomConnectorValues.orgId, args.orgId)}`,
+      legacySecret: sql`${eq(orgCustomConnectorSecrets.connectorId, args.connectorId)} AND ${eq(orgCustomConnectorSecrets.userId, args.userId)} AND ${eq(orgCustomConnectorSecrets.orgId, args.orgId)}`,
+    },
+    signal,
+  );
+}
+
+export async function deleteCustomConnectorStoredValuesForOwner(
+  db: Db,
+  owner: ConnectorOwnerScope,
+  signal: AbortSignal,
+): Promise<void> {
+  const conditions: CustomConnectorStoredValueDeleteConditions =
+    owner.kind === "user"
+      ? {
+          value: eq(orgCustomConnectorValues.userId, owner.userId),
+          legacySecret: eq(orgCustomConnectorSecrets.userId, owner.userId),
+        }
+      : {
+          value: eq(orgCustomConnectorValues.orgId, owner.orgId),
+          legacySecret: eq(orgCustomConnectorSecrets.orgId, owner.orgId),
+        };
+  await deleteCustomConnectorStoredValuesWhere(db, conditions, signal);
 }
 
 export async function deleteCustomConnectorMemberConnection(

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -65,6 +65,7 @@ import {
 } from "./usage-event-cleanup.service";
 import { deleteZeroConnectorLocalState$ } from "./zero-connector-data.service";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import { deleteConnectorOwnerState } from "./connector-owner-cleanup.service";
 
 const L = logger("WebhookClerkCleanup");
 const CLERK_ORG_MEMBERSHIP_PAGE_SIZE = 100;
@@ -385,7 +386,9 @@ const revokeOrgConnectorTokens$ = command(
         connectorSlug: connectors.connectorSlug,
       })
       .from(connectors)
-      .where(eq(connectors.orgId, orgId));
+      .where(
+        and(eq(connectors.orgId, orgId), isNotNull(connectors.connectorSlug)),
+      );
     signal.throwIfAborted();
 
     for (const row of rows) {
@@ -427,7 +430,9 @@ const revokeUserConnectorTokens$ = command(
         connectorSlug: connectors.connectorSlug,
       })
       .from(connectors)
-      .where(eq(connectors.userId, userId));
+      .where(
+        and(eq(connectors.userId, userId), isNotNull(connectors.connectorSlug)),
+      );
     signal.throwIfAborted();
 
     for (const row of rows) {
@@ -747,7 +752,11 @@ function deleteUserS3Data(db: Db, userId: string): Computed<Promise<void>> {
   });
 }
 
-async function deleteOrgData(db: Db, orgId: string): Promise<void> {
+async function deleteOrgData(
+  db: Db,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<void> {
   await cancelOrgRuns(db, orgId);
 
   const installations = await db
@@ -784,9 +793,9 @@ async function deleteOrgData(db: Db, orgId: string): Promise<void> {
   await db
     .delete(modelProviderAuthSessions)
     .where(eq(modelProviderAuthSessions.orgId, orgId));
+  await deleteConnectorOwnerState(db, { kind: "organization", orgId }, signal);
   await db.delete(secrets).where(eq(secrets.orgId, orgId));
   await db.delete(variables).where(eq(variables.orgId, orgId));
-  await db.delete(connectors).where(eq(connectors.orgId, orgId));
   await db
     .delete(connectorOauthDeviceAuthorizationSessions)
     .where(eq(connectorOauthDeviceAuthorizationSessions.orgId, orgId));
@@ -810,7 +819,11 @@ async function deleteOrgData(db: Db, orgId: string): Promise<void> {
   await db.delete(orgMetadata).where(eq(orgMetadata.orgId, orgId));
 }
 
-async function deleteUserData(db: Db, userId: string): Promise<void> {
+async function deleteUserData(
+  db: Db,
+  userId: string,
+  signal: AbortSignal,
+): Promise<void> {
   await cancelUserRuns(db, userId);
 
   await db
@@ -854,9 +867,9 @@ async function deleteUserData(db: Db, userId: string): Promise<void> {
   await db
     .delete(modelProviderAuthSessions)
     .where(eq(modelProviderAuthSessions.userId, userId));
+  await deleteConnectorOwnerState(db, { kind: "user", userId }, signal);
   await db.delete(secrets).where(eq(secrets.userId, userId));
   await db.delete(variables).where(eq(variables.userId, userId));
-  await db.delete(connectors).where(eq(connectors.userId, userId));
   await db.delete(usageDaily).where(eq(usageDaily.userId, userId));
   await db.delete(exportJobs).where(eq(exportJobs.userId, userId));
   await db.delete(cliTokens).where(eq(cliTokens.userId, userId));
@@ -886,7 +899,7 @@ export const cleanupClerkDeletedOrg$ = command(
     signal.throwIfAborted();
     await get(deleteOrgS3Data(db, orgId));
     signal.throwIfAborted();
-    await deleteOrgData(db, orgId);
+    await deleteOrgData(db, orgId, signal);
   },
 );
 
@@ -915,10 +928,10 @@ export const cleanupClerkDeletedUser$ = command(
       signal.throwIfAborted();
     }
 
-    await deleteUserData(db, userId);
+    await deleteUserData(db, userId, signal);
     signal.throwIfAborted();
     for (const orgId of emptyOrgIds) {
-      await deleteOrgData(db, orgId);
+      await deleteOrgData(db, orgId, signal);
       signal.throwIfAborted();
     }
   },


### PR DESCRIPTION
## Summary

- route Clerk user and organization deletion through one owner-scoped connector cleanup service
- clean Builtin and Custom grants, OAuth state, Custom values, generic connector storage, and organization definitions in dependency-safe order
- remove deleted-user Feishu mappings while preserving connector state owned by surviving organization members
- restrict external token revocation discovery to Builtin connector rows with a non-null slug

The shared storage deletion path now uses the same `secrets -> variables -> connections` ordering for single-connection and owner-wide cleanup. Custom-only state remains in the same owner orchestration because it has no Builtin equivalent.

## Compatibility and exclusions

- no database schema or migration changes
- no API, queue, runner, or persisted-state contract changes
- no membership-semantics changes
- no new external provider revocation behavior

## Validation

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts src/signals/routes/__tests__/zero-feishu-integration.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=1 --silent=passed-only` (115 passed)
- staged pre-commit hooks, including full Turbo type checks and full Knip

Closes #26071

Parent: #25312
