### PR TITLE
fix(runner): frame rootfs hash inputs

### DIFF
--- a/crates/runner/src/cmd/build/hashes.rs
+++ b/crates/runner/src/cmd/build/hashes.rs
@@ -20,7 +20,7 @@ const TEMPLATE_CACHE_VERSION: u32 = 1;
 ///
 /// Rootfs images are not shared through R2 because they include guest binaries
 /// and host-local CA material.
-const ROOTFS_CACHE_VERSION: u32 = 1;
+const ROOTFS_CACHE_VERSION: u32 = 2;
 
 /// Bump to invalidate all cached snapshots (local only; R2 stores only the template).
 const SNAPSHOT_CACHE_VERSION: u32 = 3;
@@ -58,10 +58,27 @@ pub(super) fn compute_template_hash(rootfs_disk_mb: u32) -> String {
     hex::encode(hasher.finalize())
 }
 
+fn update_rootfs_hash_field(hasher: &mut Sha256, label: &[u8], value: &[u8]) -> RunnerResult<()> {
+    let value_len = u64::try_from(value.len())
+        .map_err(|_| RunnerError::Internal("rootfs hash field exceeds u64 length".into()))?;
+    hasher.update(label);
+    hasher.update(value_len.to_be_bytes());
+    hasher.update(value);
+    Ok(())
+}
+
 /// Compute the local rootfs hash.
 ///
 /// This hash is what runner configs use. It includes the shared template hash plus
 /// every rootfs-only input that changes the bootable rootfs content.
+///
+/// The canonical encoding is a sequence of fields, each encoded as its fixed ASCII
+/// label, the value's byte length as a big-endian `u64`, then the value bytes. The
+/// fields are ordered as version, template hash, customization script, rootfs disk
+/// size, CA fingerprint, DNS resolver, then one destination/content pair per guest
+/// binary in inventory order. Fixed-width integers use big-endian bytes and IPv4
+/// addresses use their four network-order octets. Future inputs must use
+/// `update_rootfs_hash_field` so arbitrary value bytes cannot shift field boundaries.
 async fn compute_rootfs_hash(
     template_hash: &str,
     guest_bins: &[(&Path, &str)],
@@ -71,27 +88,31 @@ async fn compute_rootfs_hash(
 ) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
 
-    hasher.update(b"rootfs_version:");
-    hasher.update(ROOTFS_CACHE_VERSION.to_le_bytes());
-    hasher.update(b"template:");
-    hasher.update(template_hash.as_bytes());
-    hasher.update(b"customize_script:");
-    hasher.update(CUSTOMIZE_SCRIPT.as_bytes());
-    hasher.update(b"rootfs_disk_mb:");
-    hasher.update(rootfs_disk_mb.to_le_bytes());
-    hasher.update(b"ca_fingerprint:");
-    hasher.update(ca_fingerprint.as_bytes());
-    hasher.update(b"dns_nameserver:");
-    let dns_nameserver = dns_nameserver.to_string();
-    hasher.update(dns_nameserver.as_bytes());
+    update_rootfs_hash_field(
+        &mut hasher,
+        b"rootfs_version:",
+        &ROOTFS_CACHE_VERSION.to_be_bytes(),
+    )?;
+    update_rootfs_hash_field(&mut hasher, b"template:", template_hash.as_bytes())?;
+    update_rootfs_hash_field(
+        &mut hasher,
+        b"customize_script:",
+        CUSTOMIZE_SCRIPT.as_bytes(),
+    )?;
+    update_rootfs_hash_field(
+        &mut hasher,
+        b"rootfs_disk_mb:",
+        &rootfs_disk_mb.to_be_bytes(),
+    )?;
+    update_rootfs_hash_field(&mut hasher, b"ca_fingerprint:", ca_fingerprint.as_bytes())?;
+    update_rootfs_hash_field(&mut hasher, b"dns_nameserver:", &dns_nameserver.octets())?;
 
     for (src, dest) in guest_bins {
         let content = tokio::fs::read(src)
             .await
             .map_err(|e| RunnerError::Internal(format!("read {}: {e}", src.display())))?;
-        let tag = format!("bin:{dest}:");
-        hasher.update(tag.as_bytes());
-        hasher.update(&content);
+        update_rootfs_hash_field(&mut hasher, b"bin_destination:", dest.as_bytes())?;
+        update_rootfs_hash_field(&mut hasher, b"bin_content:", &content)?;
     }
 
     Ok(hex::encode(hasher.finalize()))
@@ -170,6 +191,15 @@ pub(super) fn compute_snapshot_hash(
 mod tests {
     use super::*;
 
+    fn legacy_guest_hash_input(guest_bins: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut input = Vec::new();
+        for (dest, content) in guest_bins {
+            input.extend_from_slice(format!("bin:{dest}:").as_bytes());
+            input.extend_from_slice(content);
+        }
+        input
+    }
+
     #[test]
     fn compute_template_hash_deterministic() {
         let h1 = compute_template_hash(16384);
@@ -214,6 +244,76 @@ mod tests {
         .unwrap();
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64); // SHA-256 hex
+    }
+
+    #[tokio::test]
+    async fn compute_rootfs_hash_separates_legacy_guest_boundary_collision() {
+        const AGENT_DESTINATION: &str = "/usr/local/bin/guest-agent";
+        const DOWNLOAD_DESTINATION: &str = "/usr/local/bin/guest-download";
+
+        let dir = tempfile::tempdir().unwrap();
+        let tuple_a_agent = dir.path().join("tuple-a-agent");
+        let tuple_a_download = dir.path().join("tuple-a-download");
+        let tuple_b_agent = dir.path().join("tuple-b-agent");
+        let tuple_b_download = dir.path().join("tuple-b-download");
+
+        let prefix: &[u8] = b"agent-content";
+        let suffix: &[u8] = b"download-content";
+        let legacy_boundary = format!("bin:{DOWNLOAD_DESTINATION}:").into_bytes();
+        let tuple_a_download_content = [legacy_boundary.as_slice(), suffix].concat();
+        let tuple_b_agent_content = [prefix, legacy_boundary.as_slice()].concat();
+
+        tokio::fs::write(&tuple_a_agent, prefix).await.unwrap();
+        tokio::fs::write(&tuple_a_download, &tuple_a_download_content)
+            .await
+            .unwrap();
+        tokio::fs::write(&tuple_b_agent, &tuple_b_agent_content)
+            .await
+            .unwrap();
+        tokio::fs::write(&tuple_b_download, suffix).await.unwrap();
+
+        let legacy_a = legacy_guest_hash_input(&[
+            (AGENT_DESTINATION, prefix),
+            (DOWNLOAD_DESTINATION, &tuple_a_download_content),
+        ]);
+        let legacy_b = legacy_guest_hash_input(&[
+            (AGENT_DESTINATION, &tuple_b_agent_content),
+            (DOWNLOAD_DESTINATION, suffix),
+        ]);
+        assert_eq!(
+            legacy_a, legacy_b,
+            "the distinct tuples must reproduce the legacy boundary collision"
+        );
+
+        let hash_a = compute_rootfs_hash(
+            "template-hash",
+            &[
+                (&tuple_a_agent, AGENT_DESTINATION),
+                (&tuple_a_download, DOWNLOAD_DESTINATION),
+            ],
+            "ca-fingerprint",
+            DNS_PROBE_RESOLVER_IPV4,
+            16384,
+        )
+        .await
+        .unwrap();
+        let hash_b = compute_rootfs_hash(
+            "template-hash",
+            &[
+                (&tuple_b_agent, AGENT_DESTINATION),
+                (&tuple_b_download, DOWNLOAD_DESTINATION),
+            ],
+            "ca-fingerprint",
+            DNS_PROBE_RESOLVER_IPV4,
+            16384,
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(
+            hash_a, hash_b,
+            "length framing must distinguish the legacy-colliding tuples"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- encode every local rootfs hash field with an explicit big-endian byte length
- separate guest destinations from guest contents so arbitrary bytes cannot shift field boundaries
- invalidate legacy local rootfs entries and cover the demonstrated two-binary collision

## Details

The canonical rootfs hash stream now uses `label || u64_be(value_length) || value` for every field. Fixed-width integers use big-endian bytes, IPv4 uses network-order octets, and each ordered guest binary contributes separate destination and content fields.

`ROOTFS_CACHE_VERSION` is bumped to `2`. This intentionally rebuilds local rootfs and derived snapshot entries while preserving shared R2 template cache identities.

The regression first proves that two distinct `guest-agent`/`guest-download` tuples produce identical bytes under the legacy assembly, then verifies that their new hashes differ.

## Exclusions

- no template hash or template cache version change
- no snapshot cache version change
- no API, database, protocol, or deployment configuration change

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::hashes::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`

Closes #26096
