### PR TITLE
perf(platform): eliminate idle animation paints

### DIFF
--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -10,6 +10,7 @@ import { locale$ } from "./locale.ts";
 // ---------------------------------------------------------------------------
 
 const internalVisible$ = state(true);
+const internalOverlayMounted$ = state(true);
 
 const APP_SKELETON_VISIBLE_EVENT = "vm0:app-skeleton-visible";
 const APP_SKELETON_VISIBLE_EVENT_QUEUED_KEY =
@@ -28,6 +29,7 @@ export const initBootstrapSkeleton$ = command(({ set }) => {
   if (active) {
     queueAppSkeletonVisibleEvent();
   }
+  set(internalOverlayMounted$, !active);
   set(internalBootstrapSkeletonActive$, active);
 });
 
@@ -172,6 +174,16 @@ export const appSkeletonVisible$ = computed((get) => {
   return get(internalVisible$);
 });
 
+export const appSkeletonOverlayMounted$ = computed((get) => {
+  return get(internalOverlayMounted$);
+});
+
+export const unmountAppSkeletonOverlay$ = command(({ get, set }) => {
+  if (!get(internalVisible$)) {
+    set(internalOverlayMounted$, false);
+  }
+});
+
 /**
  * Reveal the skeleton and reset the typewriter intro. `hideAppSkeleton$`
  * aborts the cycling loop via `resetSkeletonCycling$`; if the caller needs
@@ -180,8 +192,9 @@ export const appSkeletonVisible$ = computed((get) => {
  * restart the cycling itself by awaiting `startSkeletonCycling$` in its
  * own async context.
  */
-export const showAppSkeleton$ = command(({ set }) => {
+export const showAppSkeleton$ = command(({ get, set }) => {
   set(internalVisible$, true);
+  set(internalOverlayMounted$, !get(internalBootstrapSkeletonActive$));
   set(skeletonFirstCycle$, true);
 });
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -276,29 +276,87 @@ body {
 }
 
 /* Shimmer text effect for active/thinking states */
-@keyframes zero-shimmer {
-  0% {
-    background-position: 100% center;
+@keyframes zero-shimmer-window {
+  from {
+    transform: translate3d(-50%, 0, 0);
   }
-  100% {
-    background-position: -100% center;
+  to {
+    transform: translate3d(283.333333%, 0, 0);
   }
 }
+@keyframes zero-shimmer-highlight {
+  from {
+    transform: translate3d(30%, 0, 0);
+  }
+  to {
+    transform: translate3d(-170%, 0, 0);
+  }
+}
+@keyframes zero-shimmer-highlight-secondary {
+  from {
+    transform: translate3d(230%, 0, 0);
+  }
+  to {
+    transform: translate3d(30%, 0, 0);
+  }
+}
+.zero-shimmer-text-shell {
+  position: relative;
+  contain: paint;
+}
 .zero-shimmer-text {
-  background: linear-gradient(
-    90deg,
-    hsl(var(--muted-foreground) / 0.8) 0%,
-    hsl(var(--muted-foreground) / 0.8) 35%,
-    hsl(var(--foreground)) 48%,
-    hsl(var(--foreground)) 52%,
-    hsl(var(--muted-foreground) / 0.8) 65%,
-    hsl(var(--muted-foreground) / 0.8) 100%
-  );
-  background-size: 200% 100%;
+  background-color: hsl(var(--muted-foreground) / 0.8);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  animation: zero-shimmer 3.5s linear infinite;
+}
+.zero-shimmer-window {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 60%;
+  overflow: hidden;
+  background-color: hsl(var(--background));
+  pointer-events: none;
+  user-select: none;
+  /* Map the old 35%-65% band from its 200%-wide gradient into one window. */
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    black 43.333333%,
+    black 56.666667%,
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    black 43.333333%,
+    black 56.666667%,
+    transparent 100%
+  );
+  animation: zero-shimmer-window 3.5s linear infinite;
+  will-change: transform;
+}
+.zero-shimmer-highlight {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  display: block;
+  width: 166.666667%;
+  overflow: hidden;
+  white-space: nowrap;
+  background-color: hsl(var(--foreground));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: zero-shimmer-highlight 3.5s linear infinite;
+  will-change: transform;
+}
+.zero-shimmer-window-secondary {
+  left: -200%;
+}
+.zero-shimmer-window-secondary .zero-shimmer-highlight {
+  animation-name: zero-shimmer-highlight-secondary;
 }
 
 @keyframes zero-thinking-in {

--- a/turbo/apps/platform/src/views/router.tsx
+++ b/turbo/apps/platform/src/views/router.tsx
@@ -1,9 +1,11 @@
 import type { ReactNode } from "react";
-import { useGet } from "ccstate-react";
+import { useGet, useSet } from "ccstate-react";
 import { page$, pageLayout$ } from "../signals/react-router.ts";
 import {
+  appSkeletonOverlayMounted$,
   appSkeletonVisible$,
   bootstrapSkeletonActive$,
+  unmountAppSkeletonOverlay$,
 } from "../signals/app-skeleton.ts";
 import { AppSkeleton } from "./zero-page/app-skeleton.tsx";
 import { SidebarLayout } from "./zero-page/sidebar-layout.tsx";
@@ -27,13 +29,17 @@ function LayoutHost({ children }: { children: ReactNode }) {
 
 export function AppSkeletonOverlay() {
   const page = useGet(page$);
+  const mounted = useGet(appSkeletonOverlayMounted$);
   const skeletonVisible = useGet(appSkeletonVisible$);
   const bootstrapSkeletonActive = useGet(bootstrapSkeletonActive$);
-  return (
-    <AppSkeleton
-      visible={!bootstrapSkeletonActive && (!page || skeletonVisible)}
-    />
-  );
+  const unmountAppSkeletonOverlay = useSet(unmountAppSkeletonOverlay$);
+  const visible = !bootstrapSkeletonActive && (!page || skeletonVisible);
+
+  if (!mounted || bootstrapSkeletonActive) {
+    return null;
+  }
+
+  return <AppSkeleton visible={visible} onHidden={unmountAppSkeletonOverlay} />;
 }
 
 export function Router() {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/app-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/app-skeleton.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -53,10 +53,24 @@ describe("app skeleton", () => {
       expect(bootstrapSkeleton).toHaveClass("app-bootstrap-skeleton--hidden");
     });
     expect(bootstrapSkeleton).toHaveAttribute("aria-hidden", "true");
+    expect(screen.queryByTestId("app-skeleton")).not.toBeInTheDocument();
 
     bootstrapSkeleton.dispatchEvent(new Event("transitionend"));
 
     expect(document.getElementById("app-bootstrap-skeleton")).toBeNull();
+  });
+
+  it("unmounts the app skeleton after its fade-out completes", async () => {
+    detachedSetupPage({ context, path: "/_/error" });
+
+    const skeleton = await screen.findByTestId("app-skeleton");
+    await waitFor(() => {
+      expect(skeleton).toHaveClass("opacity-0");
+    });
+
+    fireEvent.transitionEnd(skeleton);
+
+    expect(screen.queryByTestId("app-skeleton")).not.toBeInTheDocument();
   });
 
   it("renders the loading state in the workspace locale", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import { click } from "../../../__tests__/page-helper.ts";
+import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { initializeI18n } from "../../../i18n/index.ts";
 import { DEFAULT_LOCALE } from "../../../i18n/resources.ts";
 import { mockChatLifecycle, mockSubagentThread } from "./chat-test-helpers.ts";
@@ -704,7 +704,11 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Start queued deployment")).toBeInTheDocument();
-      expect(screen.getByText("queue...")).toBeInTheDocument();
+      expect(
+        queryAllByRoleFast("button").some((button) => {
+          return button.textContent === "queue...";
+        }),
+      ).toBeTruthy();
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
 
@@ -714,7 +718,11 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Queued deployment is running now."),
       ).toBeInTheDocument();
-      expect(screen.queryByText("queue...")).not.toBeInTheDocument();
+      expect(
+        queryAllByRoleFast("button").some((button) => {
+          return button.textContent === "queue...";
+        }),
+      ).toBeFalsy();
       expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
+++ b/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
@@ -34,7 +34,13 @@ const skeletonCSS = `
  *
  * Cycling is started here and cancelled by hideAppSkeleton$ via resetSignal.
  */
-export function AppSkeleton({ visible = true }: { visible?: boolean }) {
+export function AppSkeleton({
+  onHidden,
+  visible = true,
+}: {
+  onHidden?: () => void;
+  visible?: boolean;
+}) {
   const skeletonConfig = useGet(skeletonAvatarConfig$);
   const { ariaLabel, staticCopy, typewriterCopy, isFirst, cycle } =
     useGet(skeletonCopy$);
@@ -49,6 +55,11 @@ export function AppSkeleton({ visible = true }: { visible?: boolean }) {
       aria-label={ariaLabel}
       aria-live="polite"
       role="status"
+      onTransitionEnd={(event) => {
+        if (!visible && event.target === event.currentTarget) {
+          onHidden?.();
+        }
+      }}
       className={`fixed inset-0 z-50 flex items-center justify-center bg-background ${
         visible
           ? "opacity-100"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4470,6 +4470,46 @@ interface ServerThinkingLabel {
   ) => (() => void) | undefined;
 }
 
+function ShimmerText({
+  ariaLabel,
+  children,
+  className,
+  setRef,
+  visualChildren = children,
+}: {
+  readonly ariaLabel?: string;
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly setRef?: ServerThinkingLabel["setRef"];
+  readonly visualChildren?: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "zero-shimmer-text-shell h-5 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem] leading-5",
+        className,
+      )}
+    >
+      <p
+        ref={setRef}
+        className="zero-shimmer-text h-5 w-full overflow-hidden whitespace-nowrap"
+        aria-label={ariaLabel}
+      >
+        {children}
+      </p>
+      <span className="zero-shimmer-window" aria-hidden>
+        <span className="zero-shimmer-highlight">{visualChildren}</span>
+      </span>
+      <span
+        className="zero-shimmer-window zero-shimmer-window-secondary"
+        aria-hidden
+      >
+        <span className="zero-shimmer-highlight">{visualChildren}</span>
+      </span>
+    </div>
+  );
+}
+
 function ThinkingLabel({
   isQueued,
   thinkingLabel,
@@ -4484,11 +4524,24 @@ function ThinkingLabel({
   const pageSignal = useGet(pageSignal$);
 
   if (isQueued) {
+    const waitingIn = t(($) => {
+      return $.chat.run.waitingIn;
+    });
+    const queueEllipsis = t(($) => {
+      return $.chat.run.queueEllipsis;
+    });
     return (
-      <p className="zero-shimmer-text h-5 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem] leading-5">
-        {t(($) => {
-          return $.chat.run.waitingIn;
-        })}{" "}
+      <ShimmerText
+        visualChildren={
+          <>
+            {waitingIn}{" "}
+            <span className="underline underline-offset-2">
+              {queueEllipsis}
+            </span>
+          </>
+        }
+      >
+        {waitingIn}{" "}
         <button
           type="button"
           onClick={() => {
@@ -4496,36 +4549,29 @@ function ThinkingLabel({
           }}
           className="cursor-pointer underline underline-offset-2"
         >
-          {t(($) => {
-            return $.chat.run.queueEllipsis;
-          })}
+          {queueEllipsis}
         </button>
-      </p>
+      </ShimmerText>
     );
   }
 
   if (serverThinkingLabel) {
     return (
-      <p
+      <ShimmerText
         key={serverThinkingLabel.id}
-        ref={serverThinkingLabel.setRef}
+        setRef={serverThinkingLabel.setRef}
         className={cn(
-          "zero-shimmer-text h-5 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem] leading-5",
           "transition-opacity duration-200",
           serverThinkingLabel.fadingOut ? "opacity-0" : "opacity-100",
         )}
-        aria-label={serverThinkingLabel.fullText}
+        ariaLabel={serverThinkingLabel.fullText}
       >
         {serverThinkingLabel.displayedText || "\u00a0"}
-      </p>
+      </ShimmerText>
     );
   }
 
-  return (
-    <p className="zero-shimmer-text h-5 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem] leading-5">
-      {thinkingLabel}
-    </p>
-  );
+  return <ShimmerText>{thinkingLabel}</ShimmerText>;
 }
 
 function InlineThinkingRow({


### PR DESCRIPTION
## Summary

- replace the thinking label's animated `background-position` with paired masked, transform-only highlight layers while preserving the 3.5-second loop and queue interaction
- unmount the app skeleton overlay after its 300 ms fade-out, and avoid mounting it behind the inline bootstrap skeleton
- cover skeleton cleanup and keep the queued indicator's visual copies non-interactive

## Why

The performance trace showed `zero-shimmer-text` producing a `PaintImage` on every frame. It also showed the hidden app skeleton's infinite cursor animation continuing after the overlay reached `opacity: 0`.

## Validation

- `pnpm exec prettier --check` on all changed files
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/app-skeleton.test.tsx src/views/zero-page/__tests__/chat-thinking-indicator.test.tsx --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-results.test.tsx -t "shows server queue state only while the queue marker is unresolved" --silent=passed-only`
