### PR TITLE
refactor: rename the eight connector automation-event services

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-strapi-integration.test.ts
@@ -145,7 +145,7 @@ async function postStrapiEvent(args: {
   return { status: response.status, body: await response.json() };
 }
 
-async function pendingWorkflowEvents(threadId: string) {
+async function pendingAutomationEvents(threadId: string) {
   const events = await workflows.readThreadEvents(threadId);
   const revokedIds = new Set(
     events.flatMap((event) => {
@@ -576,7 +576,7 @@ describe("Strapi integration", () => {
       executed: 1,
     });
     await expect(
-      pendingWorkflowEvents(automation.body.chatThreadId),
+      pendingAutomationEvents(automation.body.chatThreadId),
     ).resolves.toHaveLength(1);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -304,7 +304,7 @@ async function workflowRunIds(threadId: string): Promise<readonly string[]> {
   });
 }
 
-async function pendingWorkflowEvents(threadId: string) {
+async function pendingAutomationEvents(threadId: string) {
   const events = await wf.readThreadEvents(threadId);
   const revokedIds = new Set(
     events.flatMap((event) => {
@@ -331,7 +331,7 @@ async function pendingWorkflowAutomationIds(
   threadId: string,
 ): Promise<readonly string[]> {
   return await Promise.all(
-    (await pendingWorkflowEvents(threadId)).map(async (event) => {
+    (await pendingAutomationEvents(threadId)).map(async (event) => {
       const eventContext = await readChatEventContextFixture(event.id);
       if (!eventContext?.automationId) {
         throw new Error("Expected pending workflow automation context");
@@ -345,7 +345,7 @@ async function pendingWorkflowEventForAutomation(
   threadId: string,
   automationId: string,
 ) {
-  for (const event of await pendingWorkflowEvents(threadId)) {
+  for (const event of await pendingAutomationEvents(threadId)) {
     const eventContext = await readChatEventContextFixture(event.id);
     if (eventContext?.automationId === automationId) {
       return event;
@@ -462,7 +462,7 @@ async function expectSweepLeftQueueUntouched(
   pendingEventIds: readonly string[],
 ): Promise<void> {
   expect(
-    (await pendingWorkflowEvents(threadId)).map((event) => {
+    (await pendingAutomationEvents(threadId)).map((event) => {
       return event.id;
     }),
   ).toStrictEqual(pendingEventIds);
@@ -533,7 +533,7 @@ describe("workflow queue", () => {
     expect(goalQueue.eventIds).toContain(goal.eventId);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
     await expect(
-      pendingWorkflowEvents(automation.threadId),
+      pendingAutomationEvents(automation.threadId),
     ).resolves.toHaveLength(1);
 
     const [goalRunId] = goalQueue.runIds;
@@ -585,7 +585,7 @@ describe("workflow queue", () => {
     expect(goalQueue.eventIds).toContain(goal.eventId);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
     await expect(
-      pendingWorkflowEvents(automation.threadId),
+      pendingAutomationEvents(automation.threadId),
     ).resolves.toHaveLength(1);
 
     const [goalRunId] = goalQueue.runIds;
@@ -643,7 +643,7 @@ describe("workflow queue", () => {
 
     const workflowRequest = postWorkflowWebhook(automation, "fresh event");
     await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
-    const event = (await pendingWorkflowEvents(automation.threadId))[0];
+    const event = (await pendingAutomationEvents(automation.threadId))[0];
     if (!event) {
       throw new Error("Expected a pending workflow event");
     }
@@ -677,7 +677,7 @@ describe("workflow queue", () => {
 
     const workflowRequest = postWorkflowWebhook(automation, "stale event");
     await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
-    const event = (await pendingWorkflowEvents(automation.threadId))[0];
+    const event = (await pendingAutomationEvents(automation.threadId))[0];
     if (!event) {
       throw new Error("Expected a pending workflow event");
     }
@@ -740,7 +740,7 @@ describe("workflow queue", () => {
     expectAcceptedWithoutRun(
       await postWorkflowWebhook(automation, "stale pending event"),
     );
-    const event = (await pendingWorkflowEvents(automation.threadId))[0];
+    const event = (await pendingAutomationEvents(automation.threadId))[0];
     if (!event) {
       throw new Error("Expected a pending workflow event");
     }
@@ -756,7 +756,7 @@ describe("workflow queue", () => {
     await cleanupSandboxes();
 
     await expect(
-      pendingWorkflowEvents(automation.threadId),
+      pendingAutomationEvents(automation.threadId),
     ).resolves.toHaveLength(0);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(2);
   });
@@ -837,7 +837,7 @@ describe("workflow queue", () => {
     mockNow(secondApiStartTime + 1000);
     expectAcceptedWithoutRun(await postWorkflowWebhook(automation, "third"));
     expect(kms.generateDataKeyCalls).toBe(1);
-    const pendingEvents = await pendingWorkflowEvents(automation.threadId);
+    const pendingEvents = await pendingAutomationEvents(automation.threadId);
     expect(pendingEvents).toHaveLength(2);
     const secondEvent = pendingEvents[0];
     const thirdEvent = pendingEvents[1];
@@ -1061,7 +1061,7 @@ describe("workflow queue", () => {
     mockNow(Date.parse(updated.body.nextRunAt) + 60_000);
     await executeDueWorkflowAutomations(created.body.id);
     expect(coalescedKms.generateDataKeyCalls).toBe(0);
-    const coalescedEvents = await pendingWorkflowEvents(
+    const coalescedEvents = await pendingAutomationEvents(
       webhookAutomation.threadId,
     );
     expect(coalescedEvents).toHaveLength(1);
@@ -1103,7 +1103,7 @@ describe("workflow queue", () => {
     const secondRequest = postWorkflowWebhook(automation, "second concurrent");
     await expect.poll(admissionLock.directWaiterCount).toBe(2);
     await expect(
-      pendingWorkflowEvents(automation.threadId),
+      pendingAutomationEvents(automation.threadId),
     ).resolves.toStrictEqual([]);
 
     admissionLock.release();
@@ -1117,7 +1117,7 @@ describe("workflow queue", () => {
     ).toStrictEqual([200, 200]);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(1);
     await expect(
-      pendingWorkflowEvents(automation.threadId),
+      pendingAutomationEvents(automation.threadId),
     ).resolves.toHaveLength(1);
   });
 
@@ -1180,7 +1180,7 @@ describe("workflow queue", () => {
         : undefined,
     ).toBe(databaseFirst.brief);
     expect(
-      (await pendingWorkflowEvents(automation.threadId)).map((event) => {
+      (await pendingAutomationEvents(automation.threadId)).map((event) => {
         return event.id;
       }),
     ).toContain(databaseSecond.id);
@@ -1245,7 +1245,7 @@ describe("workflow queue", () => {
         : undefined,
     ).toBe(preemptingBrief);
     const pendingEventIds = (
-      await pendingWorkflowEvents(automation.threadId)
+      await pendingAutomationEvents(automation.threadId)
     ).map((event) => {
       return event.id;
     });
@@ -1311,7 +1311,7 @@ describe("workflow queue", () => {
     });
 
     await expect(
-      pendingWorkflowEvents(automation.threadId),
+      pendingAutomationEvents(automation.threadId),
     ).resolves.toHaveLength(0);
     const failedEvents = await accept(
       chatThreadEventsClient().list({
@@ -1386,7 +1386,7 @@ describe("workflow queue", () => {
     const automation = await wf.readAutomation(created.body.id);
     expect(automation.nextRunAt).not.toBeNull();
     await expect(
-      pendingWorkflowEvents(created.body.chatThreadId),
+      pendingAutomationEvents(created.body.chatThreadId),
     ).resolves.toHaveLength(0);
 
     await runsApi.ensureOrgModelProvider(scenario.actor);
@@ -1677,7 +1677,7 @@ describe("workflow queue", () => {
   it("revokes one pending automation event with the caller's client event id", async () => {
     const { scenario, automation, runningRunId } = await busyQueueFixture(2);
 
-    const before = await pendingWorkflowEvents(automation.threadId);
+    const before = await pendingAutomationEvents(automation.threadId);
     const target = before[0];
     if (!target) {
       throw new Error("Expected a pending workflow event");
@@ -1696,7 +1696,7 @@ describe("workflow queue", () => {
       [201],
     );
     await expect(
-      pendingWorkflowEvents(automation.threadId),
+      pendingAutomationEvents(automation.threadId),
     ).resolves.toHaveLength(1);
     await expect(
       wf.readThreadEvents(automation.threadId),

--- a/turbo/apps/api/src/signals/routes/cron-execute-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/cron-execute-workflow-automations.ts
@@ -2,8 +2,8 @@ import { cronExecuteWorkflowAutomationsContract } from "@vm0/api-contracts/contr
 import { command } from "ccstate";
 
 import type { RouteEntry } from "../route-entry";
-import { executeDueNotionWorkflowEvents$ } from "../services/notion-workflow-event.service";
-import { executeDueStrapiWorkflowEvents$ } from "../services/strapi-workflow-event.service";
+import { executeDueNotionAutomationEvents$ } from "../services/notion-automation-event.service";
+import { executeDueStrapiAutomationEvents$ } from "../services/strapi-automation-event.service";
 import { executeDueStripeAutomationEvents$ } from "../services/stripe-automation-event.service";
 import { executeDueWorkflowAutomations$ } from "../services/zero-workflow-automation-poller.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
@@ -17,8 +17,8 @@ const executeWorkflowAutomationsRoute$: RouteEntry["handler"] = command(
     }
 
     const result = await set(executeDueWorkflowAutomations$, signal);
-    const notionResult = await set(executeDueNotionWorkflowEvents$, signal);
-    const strapiResult = await set(executeDueStrapiWorkflowEvents$, signal);
+    const notionResult = await set(executeDueNotionAutomationEvents$, signal);
+    const strapiResult = await set(executeDueStrapiAutomationEvents$, signal);
     const stripeResult = await set(executeDueStripeAutomationEvents$, signal);
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/cron-renew-gmail-watches.ts
+++ b/turbo/apps/api/src/signals/routes/cron-renew-gmail-watches.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { cronRenewGmailWatchesContract } from "@vm0/api-contracts/contracts/cron";
 
 import type { RouteEntry } from "../route-entry";
-import { renewGmailWatches$ } from "../services/gmail-workflow-event.service";
+import { renewGmailWatches$ } from "../services/gmail-automation-event.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const renewGmailWatchesRoute$ = command(

--- a/turbo/apps/api/src/signals/routes/cron-renew-google-calendar-watches.ts
+++ b/turbo/apps/api/src/signals/routes/cron-renew-google-calendar-watches.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { cronRenewGoogleCalendarWatchesContract } from "@vm0/api-contracts/contracts/cron";
 
 import type { RouteEntry } from "../route-entry";
-import { renewGoogleCalendarWatches$ } from "../services/google-calendar-workflow-event.service";
+import { renewGoogleCalendarWatches$ } from "../services/google-calendar-automation-event.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const renewGoogleCalendarWatchesRoute$ = command(

--- a/turbo/apps/api/src/signals/routes/cron-renew-google-forms-watches.ts
+++ b/turbo/apps/api/src/signals/routes/cron-renew-google-forms-watches.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { cronRenewGoogleFormsWatchesContract } from "@vm0/api-contracts/contracts/cron";
 
 import type { RouteEntry } from "../route-entry";
-import { renewGoogleFormsWatches$ } from "../services/google-forms-workflow-event.service";
+import { renewGoogleFormsWatches$ } from "../services/google-forms-automation-event.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const renewGoogleFormsWatchesRoute$ = command(

--- a/turbo/apps/api/src/signals/routes/cron-renew-google-workspace-event-subscriptions.ts
+++ b/turbo/apps/api/src/signals/routes/cron-renew-google-workspace-event-subscriptions.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { cronRenewGoogleWorkspaceEventSubscriptionsContract } from "@vm0/api-contracts/contracts/cron";
 
 import type { RouteEntry } from "../route-entry";
-import { renewGoogleWorkspaceEventSubscriptions$ } from "../services/google-meet-workflow-event.service";
+import { renewGoogleWorkspaceEventSubscriptions$ } from "../services/google-meet-automation-event.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const renewGoogleWorkspaceEventSubscriptionsRoute$ = command(

--- a/turbo/apps/api/src/signals/routes/test-workflow-automation-execution.ts
+++ b/turbo/apps/api/src/signals/routes/test-workflow-automation-execution.ts
@@ -4,8 +4,8 @@ import { command } from "ccstate";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
-import { executeDueNotionWorkflowEventsForAutomation$ } from "../services/notion-workflow-event.service";
-import { executeDueStrapiWorkflowEventsForAutomation$ } from "../services/strapi-workflow-event.service";
+import { executeDueNotionAutomationEventsForAutomation$ } from "../services/notion-automation-event.service";
+import { executeDueStrapiAutomationEventsForAutomation$ } from "../services/strapi-automation-event.service";
 import { executeDueWorkflowAutomationsForAutomation$ } from "../services/zero-workflow-automation-poller.service";
 import {
   isTestEndpointAllowed,
@@ -33,12 +33,12 @@ const executeTestWorkflowAutomation$ = command(
       signal,
     );
     const notion = await set(
-      executeDueNotionWorkflowEventsForAutomation$,
+      executeDueNotionAutomationEventsForAutomation$,
       automationId,
       signal,
     );
     const strapi = await set(
-      executeDueStrapiWorkflowEventsForAutomation$,
+      executeDueStrapiAutomationEventsForAutomation$,
       automationId,
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/webhooks-gmail.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-gmail.ts
@@ -4,7 +4,7 @@ import { webhookGmailContract } from "@vm0/api-contracts/contracts/webhooks";
 import type { RouteEntry } from "../route-entry";
 import { request$ } from "../context/hono";
 import { now } from "../../lib/time";
-import { dispatchGmailPubSubPush$ } from "../services/gmail-workflow-event.service";
+import { dispatchGmailPubSubPush$ } from "../services/gmail-automation-event.service";
 
 function jsonError(message: string, status: 400 | 401 | 429 | 503): Response {
   return Response.json({ error: message }, { status });

--- a/turbo/apps/api/src/signals/routes/webhooks-google-calendar.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-google-calendar.ts
@@ -4,7 +4,7 @@ import { webhookGoogleCalendarContract } from "@vm0/api-contracts/contracts/webh
 import type { RouteEntry } from "../route-entry";
 import { request$ } from "../context/hono";
 import { now } from "../../lib/time";
-import { dispatchGoogleCalendarWebhook$ } from "../services/google-calendar-workflow-event.service";
+import { dispatchGoogleCalendarWebhook$ } from "../services/google-calendar-automation-event.service";
 
 function jsonError(message: string, status: 400 | 401 | 429 | 503): Response {
   return Response.json({ error: message }, { status });

--- a/turbo/apps/api/src/signals/routes/webhooks-google-forms.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-google-forms.ts
@@ -4,7 +4,7 @@ import { webhookGoogleFormsContract } from "@vm0/api-contracts/contracts/webhook
 import { now } from "../../lib/time";
 import { request$ } from "../context/hono";
 import type { RouteEntry } from "../route-entry";
-import { dispatchGoogleFormsPubSubPush$ } from "../services/google-forms-workflow-event.service";
+import { dispatchGoogleFormsPubSubPush$ } from "../services/google-forms-automation-event.service";
 
 function jsonError(message: string, status: 400 | 401 | 429 | 503): Response {
   return Response.json({ error: message }, { status });

--- a/turbo/apps/api/src/signals/routes/webhooks-google-workspace-events.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-google-workspace-events.ts
@@ -4,7 +4,7 @@ import { webhookGoogleWorkspaceEventsContract } from "@vm0/api-contracts/contrac
 import type { RouteEntry } from "../route-entry";
 import { request$ } from "../context/hono";
 import { now } from "../../lib/time";
-import { dispatchGoogleWorkspaceEventsPubSubPush$ } from "../services/google-meet-workflow-event.service";
+import { dispatchGoogleWorkspaceEventsPubSubPush$ } from "../services/google-meet-automation-event.service";
 
 function jsonError(message: string, status: 400 | 401 | 429 | 503): Response {
   return Response.json({ error: message }, { status });

--- a/turbo/apps/api/src/signals/routes/webhooks-notion.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-notion.ts
@@ -3,7 +3,7 @@ import { webhookNotionContract } from "@vm0/api-contracts/contracts/webhooks";
 
 import { request$ } from "../context/hono";
 import type { RouteEntry } from "../route-entry";
-import { dispatchNotionWebhook$ } from "../services/notion-workflow-event.service";
+import { dispatchNotionWebhook$ } from "../services/notion-automation-event.service";
 
 function jsonError(message: string, status: 400 | 401 | 503): Response {
   return Response.json({ error: message }, { status });

--- a/turbo/apps/api/src/signals/routes/zero-strapi-events.ts
+++ b/turbo/apps/api/src/signals/routes/zero-strapi-events.ts
@@ -9,7 +9,7 @@ import type { RouteEntry } from "../route-entry";
 import {
   dispatchStrapiWebhook$,
   STRAPI_WEBHOOK_BODY_LIMIT_BYTES,
-} from "../services/strapi-workflow-event.service";
+} from "../services/strapi-automation-event.service";
 
 function errorResponse(message: string, status: 400 | 401 | 403 | 404 | 413) {
   const code = {

--- a/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
@@ -6,9 +6,9 @@ import {
 } from "@vm0/api-contracts/contracts/zero-workflows";
 
 import type { Db } from "../external/db";
-import { reconcileGmailWatchesForUser } from "./gmail-workflow-event.service";
-import { reconcileGoogleCalendarWatchesForUser } from "./google-calendar-workflow-event.service";
-import { reconcileGoogleFormsWatchesForUser } from "./google-forms-workflow-event.service";
+import { reconcileGmailWatchesForUser } from "./gmail-automation-event.service";
+import { reconcileGoogleCalendarWatchesForUser } from "./google-calendar-automation-event.service";
+import { reconcileGoogleFormsWatchesForUser } from "./google-forms-automation-event.service";
 
 interface AutomationEventWatchAutomation {
   readonly orgId: string;

--- a/turbo/apps/api/src/signals/services/chat-run-finished-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-automation-event.service.ts
@@ -147,7 +147,7 @@ function chatRunFinishedTriggerContext(args: {
  * reached a terminal state. Called from the terminal chat callback after the
  * run lifecycle marker is durable, so the matched output is final.
  */
-export const dispatchChatRunFinishedWorkflowEvents$ = command(
+export const dispatchChatRunFinishedAutomationEvents$ = command(
   async ({ set }, event: ChatRunFinishedEvent, signal: AbortSignal) => {
     const db = set(writeDb$);
     const sourceAutonomyBudget = await loadRunAutonomyBudget(db, event.runId);

--- a/turbo/apps/api/src/signals/services/chat-run-finished-event-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-event-registration.service.ts
@@ -1,7 +1,9 @@
 import { configureChatRunFinishedEventCommand } from "./chat-run-finished-event-dispatch.service";
-import { dispatchChatRunFinishedWorkflowEvents$ } from "./chat-run-finished-workflow-event.service";
+import { dispatchChatRunFinishedAutomationEvents$ } from "./chat-run-finished-automation-event.service";
 
 /** Wire the chat-run-finished implementation at the API composition root. */
 export function configureChatRunFinishedEventDispatcher(): void {
-  configureChatRunFinishedEventCommand(dispatchChatRunFinishedWorkflowEvents$);
+  configureChatRunFinishedEventCommand(
+    dispatchChatRunFinishedAutomationEvents$,
+  );
 }

--- a/turbo/apps/api/src/signals/services/github-label-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-label-automation-event.service.ts
@@ -28,7 +28,7 @@ import type { WorkflowAutomationContext } from "./workflow-automation-context.se
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 
-const log = logger("api:github-workflow-event");
+const log = logger("api:github-label-automation-event");
 
 type GithubInstallationRecord = typeof githubInstallations.$inferSelect;
 type GithubWorkflowSubjectKind = "issue" | "pull_request";
@@ -58,7 +58,7 @@ interface GithubInstallationRef {
   readonly id: number;
 }
 
-interface GithubLabelWorkflowEventPayload {
+interface GithubLabelAutomationEventPayload {
   readonly action: string;
   readonly issue: GithubIssueLike;
   readonly label: GithubLabel | undefined;
@@ -78,7 +78,7 @@ interface GithubLabelEventAutomationRow {
 type GithubWorkflowRunStartArgs = {
   readonly automation: GithubLabelEventAutomationRow;
   readonly deliveryId: string;
-  readonly payload: GithubLabelWorkflowEventPayload;
+  readonly payload: GithubLabelAutomationEventPayload;
   readonly subjectKind: GithubWorkflowSubjectKind;
   readonly matchedLabelName: string;
   readonly timing: AutomationEventRunTiming;
@@ -356,7 +356,7 @@ async function insertGithubProcessedEvent(args: {
   readonly db: Db;
   readonly automation: GithubLabelEventAutomationRow;
   readonly deliveryId: string;
-  readonly payload: GithubLabelWorkflowEventPayload;
+  readonly payload: GithubLabelAutomationEventPayload;
   readonly subjectKind: GithubWorkflowSubjectKind;
 }): Promise<string | null> {
   const [processed] = await args.db
@@ -390,7 +390,7 @@ function githubSubjectUrl(args: {
 function githubLabelTriggerContext(args: {
   readonly automation: GithubLabelEventAutomationRow;
   readonly deliveryId: string;
-  readonly payload: GithubLabelWorkflowEventPayload;
+  readonly payload: GithubLabelAutomationEventPayload;
   readonly subjectKind: GithubWorkflowSubjectKind;
   readonly matchedLabelName: string;
 }): WorkflowAutomationContext {
@@ -436,7 +436,7 @@ async function dispatchGithubAutomationEvent(args: {
   readonly db: Db;
   readonly automation: GithubLabelEventAutomationRow;
   readonly deliveryId: string;
-  readonly payload: GithubLabelWorkflowEventPayload;
+  readonly payload: GithubLabelAutomationEventPayload;
   readonly subjectKind: GithubWorkflowSubjectKind;
   readonly matchedLabelName: string;
   readonly timing: AutomationEventRunTiming;
@@ -565,7 +565,7 @@ const dispatchMatchedGithubAutomations$ = command(
       readonly automations: readonly GithubLabelEventAutomationRow[];
       readonly labelNames: readonly string[];
       readonly deliveryId: string;
-      readonly payload: GithubLabelWorkflowEventPayload;
+      readonly payload: GithubLabelAutomationEventPayload;
       readonly subjectKind: GithubWorkflowSubjectKind;
       readonly apiStartTime: number;
       readonly sourceTiming: AutomationEventSourceTiming;
@@ -646,7 +646,7 @@ export const dispatchGithubLabelWorkflowAutomations$ = command(
     { set },
     args: {
       readonly deliveryId: string;
-      readonly payload: GithubLabelWorkflowEventPayload;
+      readonly payload: GithubLabelAutomationEventPayload;
       readonly subjectKind: GithubWorkflowSubjectKind;
       readonly apiStartTime: number;
       readonly backgroundScheduledAt?: number;

--- a/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
@@ -45,7 +45,7 @@ import type { WorkflowAutomationContext } from "./workflow-automation-context.se
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 
-const log = logger("api:gmail-workflow-event");
+const log = logger("api:gmail-automation-event");
 
 const GMAIL_ACCESS_TOKEN_ENVIRONMENT_NAME = "GMAIL_TOKEN";
 const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -42,7 +42,7 @@ import type { WorkflowAutomationContext } from "./workflow-automation-context.se
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 
-const log = logger("api:google-calendar-workflow-event");
+const log = logger("api:google-calendar-automation-event");
 
 const GOOGLE_CALENDAR_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_CALENDAR_TOKEN";
 const GOOGLE_CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";

--- a/turbo/apps/api/src/signals/services/google-forms-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-forms-automation-event.service.ts
@@ -47,7 +47,7 @@ import { runWorkflowAutomationNow$ } from "./zero-workflow-automation-run.servic
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 
-const log = logger("api:google-forms-workflow-event");
+const log = logger("api:google-forms-automation-event");
 
 const GOOGLE_FORMS_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_FORMS_TOKEN";
 const GOOGLE_FORMS_API_BASE = "https://forms.googleapis.com/v1/forms";

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -36,7 +36,7 @@ import type { AutomationRow } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 
-const log = logger("api:google-meet-workflow-event");
+const log = logger("api:google-meet-automation-event");
 
 const GOOGLE_MEET_ACCESS_TOKEN_ENVIRONMENT_NAME = "GOOGLE_MEET_TOKEN";
 const GOOGLE_WORKSPACE_EVENTS_API_BASE =

--- a/turbo/apps/api/src/signals/services/notion-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-automation-event.service.ts
@@ -53,7 +53,7 @@ import type {
 } from "./zero-workflow-automation-launch.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 
-const log = logger("api:notion-workflow-event");
+const log = logger("api:notion-automation-event");
 
 const NOTION_ACCESS_TOKEN_ENVIRONMENT_NAME = "NOTION_TOKEN";
 const NOTION_API_BASE = "https://api.notion.com/v1";
@@ -1734,7 +1734,7 @@ async function loadDueNotionPendingEvents(
   return rows;
 }
 
-async function executeDueNotionWorkflowEvents(
+async function executeDueNotionAutomationEvents(
   args: {
     readonly db: Db;
     readonly automationId?: string;
@@ -2686,12 +2686,12 @@ async function processClaimedNotionPendingEvent(
   );
 }
 
-export const executeDueNotionWorkflowEvents$ = command(
+export const executeDueNotionAutomationEvents$ = command(
   async (
     { set },
     signal: AbortSignal,
   ): Promise<ExecuteDueNotionEventsResult> => {
-    return await executeDueNotionWorkflowEvents(
+    return await executeDueNotionAutomationEvents(
       {
         db: set(writeDb$),
         startRun: (input, childSignal) => {
@@ -2703,13 +2703,13 @@ export const executeDueNotionWorkflowEvents$ = command(
   },
 );
 
-export const executeDueNotionWorkflowEventsForAutomation$ = command(
+export const executeDueNotionAutomationEventsForAutomation$ = command(
   async (
     { set },
     automationId: string,
     signal: AbortSignal,
   ): Promise<ExecuteDueNotionEventsResult> => {
-    return await executeDueNotionWorkflowEvents(
+    return await executeDueNotionAutomationEvents(
       {
         db: set(writeDb$),
         automationId,

--- a/turbo/apps/api/src/signals/services/strapi-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/strapi-automation-event.service.ts
@@ -35,7 +35,7 @@ import type {
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import type { Tx } from "../../lib/db-types";
 
-const log = logger("api:strapi-workflow-event");
+const log = logger("api:strapi-automation-event");
 
 export const STRAPI_WEBHOOK_BODY_LIMIT_BYTES = 1_000_000;
 const STRAPI_PUBLISH_QUIET_WINDOW_MS = 45_000;
@@ -685,7 +685,7 @@ type ExecuteDueStrapiResult = {
   readonly skipped: number;
 };
 
-async function executeDueStrapiWorkflowEvents(
+async function executeDueStrapiAutomationEvents(
   args: {
     readonly db: Db;
     readonly automationId?: string;
@@ -758,9 +758,9 @@ async function executeDueStrapiWorkflowEvents(
   return { executed, skipped };
 }
 
-export const executeDueStrapiWorkflowEvents$ = command(
+export const executeDueStrapiAutomationEvents$ = command(
   async ({ set }, signal: AbortSignal): Promise<ExecuteDueStrapiResult> => {
-    return await executeDueStrapiWorkflowEvents(
+    return await executeDueStrapiAutomationEvents(
       {
         db: set(writeDb$),
         startRun: (input, childSignal) => {
@@ -772,13 +772,13 @@ export const executeDueStrapiWorkflowEvents$ = command(
   },
 );
 
-export const executeDueStrapiWorkflowEventsForAutomation$ = command(
+export const executeDueStrapiAutomationEventsForAutomation$ = command(
   async (
     { set },
     automationId: string,
     signal: AbortSignal,
   ): Promise<ExecuteDueStrapiResult> => {
-    return await executeDueStrapiWorkflowEvents(
+    return await executeDueStrapiAutomationEvents(
       {
         db: set(writeDb$),
         automationId,

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
-import { dispatchGithubLabelWorkflowAutomations$ } from "./github-workflow-event.service";
+import { dispatchGithubLabelWorkflowAutomations$ } from "./github-label-automation-event.service";
 import {
   dispatchGithubWebhookAutomations$,
   type GithubDeploymentStatusEventPayload,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -72,9 +72,9 @@ import {
   type ConnectorRuntimeMethod,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
-import { cleanupGmailWatchesForConnector } from "./gmail-workflow-event.service";
-import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-workflow-event.service";
-import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-workflow-event.service";
+import { cleanupGmailWatchesForConnector } from "./gmail-automation-event.service";
+import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
+import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
 
 type StoredConnectorRow = {
   readonly id: string;

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -85,25 +85,25 @@ import {
   ensureGmailWatchForUser,
   hasEnabledGmailConsumer,
   resolveGmailLabelForUser,
-} from "./gmail-workflow-event.service";
+} from "./gmail-automation-event.service";
 import {
   ensureGoogleCalendarWatchForUser,
   hasEnabledGoogleCalendarConsumer,
-} from "./google-calendar-workflow-event.service";
+} from "./google-calendar-automation-event.service";
 import {
   ensureGoogleFormsWatchForUser,
   hasEnabledGoogleFormsConsumer,
   prepareGoogleFormsResponseEventConfigForPersist,
-} from "./google-forms-workflow-event.service";
-import { ensureGoogleMeetTranscriptGeneratedSubscriptionForUser } from "./google-meet-workflow-event.service";
-import { prepareGithubLabelEventConfigForPersist } from "./github-workflow-event.service";
+} from "./google-forms-automation-event.service";
+import { ensureGoogleMeetTranscriptGeneratedSubscriptionForUser } from "./google-meet-automation-event.service";
+import { prepareGithubLabelEventConfigForPersist } from "./github-label-automation-event.service";
 import { prepareGithubWebhookEventConfigForPersist } from "./github-webhook-automation-event.service";
 import { prepareGithubWorkflowRunEventConfigForPersist } from "./github-workflow-run-event.service";
 import {
   prepareNotionChildPageEventConfigForPersist,
   prepareNotionDatabaseItemEventConfigForPersist,
   prepareNotionPageContentUpdatedEventConfigForPersist,
-} from "./notion-workflow-event.service";
+} from "./notion-automation-event.service";
 import { notionWorkflowAutomationCreationEnabledForOwner } from "./notion-workflow-automation-feature-switch.service";
 import { googleFormsWorkflowAutomationCreationEnabledForOwner } from "./google-forms-workflow-automation-feature-switch.service";
 import {


### PR DESCRIPTION
## Summary

- rename the eight connector automation-event services, including the semantic GitHub label service rename
- update import paths, the four scoped identifiers, and seven logger namespaces to the automation-event terminology
- preserve workflow automation entity names, workflow event contracts/types, GitHub Actions naming, dispatch-timing values, trigger-source values, routes, and migrations

## Validation

- `find turbo -name "*workflow-event*" -not -path "*/node_modules/*"` returns no results
- `grep -rn "WorkflowEvents\\|WorkflowEventPayload" turbo` returns no results
- `grep -rn 'logger("api:[a-z-]*workflow-event' turbo` returns no results
- `grep -rn "api_dispatch_pre_create_zero_workflow_event" turbo | wc -l` returns `89`
- `git diff --check` passes
- `git log --stat --summary --find-renames -1` records all eight moves as renames

The full local test suite was intentionally not run; PR CI is the validation gate for this rename-only change.

Closes #26126