### PR TITLE
test(api): pin usage pack preview proration clock

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -2233,6 +2233,10 @@ describe("usage pack allocation management", () => {
   });
 
   it("replaces an unconfirmed package change preview", async () => {
+    mockNow(new Date("2035-01-16T00:00:00.000Z"));
+    onTestFinished(() => {
+      clearMockNow();
+    });
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(


### PR DESCRIPTION
## Summary

- pin the repository clock for the unconfirmed package-change preview test
- keep the exact purchased, bonus, total-credit, and expiry assertions intact
- restore the clock through the test lifecycle

## Root cause

Turbo run https://github.com/vm0-ai/vm0/actions/runs/31372179891 failed only in test-api (4): usage pack allocation management > replaces an unconfirmed package change preview.

The fixture captured floor(now / 1000) to build a 30-day billing period. The preview route later captured floor(nowDate / 1000) as the proration timestamp. When those reads crossed one second, the remaining period became 1,295,999 of 2,592,000 seconds. Flooring each independent credit delta produced 14,999 purchased credits and 1,099 bonus credits instead of the exact half-period values 15,000 and 1,100. The unchanged expiry and received total of 16,098 match that boundary exactly.

The other API shards were fail-fast cancellations, and ci-gate-turbo only aggregated the substantive test failure. The triggering PR #26117 changed Runner Python files and is unrelated.

## Validation

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- git diff --check

The targeted API integration test was not run locally because it requires PostgreSQL and the repair contract forbids starting a local service. PR CI provides the real test database environment. Preview/browser validation is not applicable because this changes only a test clock and no deployable behavior.