### PR TITLE
refactor(connectors): unify oauth state claim readers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -1755,6 +1755,149 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await bdd.deleteAgent(member, agent.agentId);
   });
 
+  it("keeps OAuth callback state scoped to its Builtin or Custom target", async () => {
+    mockEnv("APP_URL", "https://app.vm0.test");
+    mockGitHubConnectorOAuth();
+    const provider = mockCustomConnectorOAuth2Provider(context, {
+      initialExpiresIn: 3600,
+    });
+    const bdd = createBddApi(context);
+    const admin = bdd.user({ orgRole: "org:admin" });
+    const owner = bdd.user({
+      orgId: admin.orgId,
+      orgRole: "org:member",
+    });
+    const peer = bdd.user({
+      orgId: admin.orgId,
+      orgRole: "org:member",
+    });
+    const host = uniqueSlug("oauth-state").slice(1);
+    const connector = await connectorsApi.createCustomConnector(admin, {
+      displayName: "BDD OAuth State Connector",
+      prefixTemplates: [`https://${host}.example.test/v1/`],
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth",
+      oauthConfig: {
+        providerAdapter: "standard",
+        clientId: "bdd-oauth-state-client-id",
+        clientSecret: "bdd-oauth-state-client-secret",
+        authorizationUrl: provider.authorizationUrl,
+        tokenUrl: provider.tokenUrl,
+        tokenEndpointAuthMethod: "client_secret_post",
+        pkceMethod: "none",
+        scopes: ["read"],
+        authorizationParams: {},
+      },
+    });
+
+    const customAuthorizationUrl =
+      await connectorsApi.startCustomConnectorOAuth2(owner, connector.id);
+    const customState = stateFromAuthorizationUrl(customAuthorizationUrl);
+    const wrongBuiltinCallback = await connectorsApi.completeOauthCallback(
+      "github",
+      { code: "wrong-source-code", state: customState },
+    );
+    expectConnectorErrorRedirect(wrongBuiltinCallback, {
+      connectorSlug: "github",
+      message: "Invalid state - please try again",
+    });
+
+    const customSuccess =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "custom-success-code",
+        state: customState,
+      });
+    expect(customSuccess.body).toStrictEqual({
+      status: "success",
+      username: null,
+    });
+    const ownerConnectors = await connectorsApi.listCustomConnectors(owner);
+    expect(
+      ownerConnectors.find((candidate) => {
+        return candidate.id === connector.id;
+      }),
+    ).toMatchObject({ connected: true });
+    const peerConnectors = await connectorsApi.listCustomConnectors(peer);
+    expect(
+      peerConnectors.find((candidate) => {
+        return candidate.id === connector.id;
+      }),
+    ).toMatchObject({ connected: false });
+
+    const customReplay =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "custom-replay-code",
+        state: customState,
+      });
+    expect(customReplay.body).toStrictEqual({
+      status: "error",
+      message: "Invalid OAuth state - please try again",
+    });
+
+    const builtinAuthorization = await connectorsApi.startOauth(
+      peer,
+      "github",
+      "oauth",
+    );
+    const builtinState = stateFromAuthorizationUrl(
+      builtinAuthorization.authorizationUrl,
+    );
+    const wrongCustomCallback =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "wrong-custom-source-code",
+        state: builtinState,
+      });
+    expect(wrongCustomCallback.body).toStrictEqual({
+      status: "error",
+      message: "Invalid OAuth state - please try again",
+    });
+
+    const builtinSuccess = await connectorsApi.completeOauthCallback("github", {
+      code: "github-correct-source-code",
+      state: builtinState,
+    });
+    expect(redirectLocation(builtinSuccess).pathname).toBe(
+      "/connector/success",
+    );
+    await expect(
+      connectorsApi.readConnectorBySlug(peer, "github"),
+    ).resolves.toMatchObject({
+      slug: "github",
+      connectionStatus: "connected",
+    });
+
+    const expiringAuthorizationUrl =
+      await connectorsApi.startCustomConnectorOAuth2(peer, connector.id);
+    const expiringState = stateFromAuthorizationUrl(expiringAuthorizationUrl);
+    mockNow(now() + 16 * 60 * 1000);
+    const expired =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "expired-custom-code",
+        state: expiringState,
+      });
+    clearMockNow();
+    expect(expired.body).toStrictEqual({
+      status: "error",
+      message: "Invalid OAuth state - please try again",
+    });
+    const peerAfterExpiry = await connectorsApi.listCustomConnectors(peer);
+    expect(
+      peerAfterExpiry.find((candidate) => {
+        return candidate.id === connector.id;
+      }),
+    ).toMatchObject({ connected: false });
+
+    await connectorsApi.deleteConnectorBySlug(peer, "github");
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
+  });
+
   it("updates OAuth settings and preserves member OAuth data as incompatible", async () => {
     const provider = mockCustomConnectorOAuth2Provider(context);
     const bdd = createBddApi(context);

--- a/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
@@ -25,7 +25,7 @@ import { optionalEnv } from "../../lib/env";
 import {
   claimConnectorOAuthState,
   getConnectorOAuthStateStatus,
-  type StoredOAuthState,
+  type StoredBuiltinOAuthState,
 } from "../services/connector-oauth-state.service";
 import { authorizeConnectedConnector$ } from "../services/connected-connector-authorization.service";
 import {
@@ -90,14 +90,14 @@ type CompleteOpenIdCallbackInput = {
 type ResolveCallbackStateInput = {
   readonly origin: string;
   readonly connectorSlug: ConnectorSlug;
-  readonly storedState: StoredOAuthState;
+  readonly storedState: StoredBuiltinOAuthState;
   readonly resolver: ConnectorActionResolver;
 };
 
 type ResolveOpenIdCallbackStateInput = {
   readonly origin: string;
   readonly connectorSlug: ConnectorSlug;
-  readonly storedState: StoredOAuthState;
+  readonly storedState: StoredBuiltinOAuthState;
   readonly resolver: ConnectorActionResolver;
 };
 
@@ -135,7 +135,7 @@ type ResolvedOpenIdCallbackState =
 type ClaimedCallbackState =
   | {
       readonly ok: true;
-      readonly storedState: StoredOAuthState;
+      readonly storedState: StoredBuiltinOAuthState;
     }
   | {
       readonly ok: false;
@@ -307,7 +307,10 @@ async function claimStoredOAuthStateForCallback(
 ): Promise<ClaimedCallbackState> {
   const storedStateResolution = await claimConnectorOAuthState(
     args.db,
-    { state: args.state, connectorSlug: args.connectorSlug },
+    {
+      state: args.state,
+      target: { kind: "builtin", connectorSlug: args.connectorSlug },
+    },
     signal,
   );
   if (storedStateResolution.kind === "invalid") {

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
@@ -9,8 +9,8 @@ import { setResHeader$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import {
-  claimCustomConnectorOAuthState,
-  type StoredOAuthState,
+  claimConnectorOAuthState,
+  type StoredCustomConnectorOAuthState,
 } from "../services/connector-oauth-state.service";
 import { validateConnectorAuthorizationTarget$ } from "../services/connected-connector-authorization.service";
 import {
@@ -121,7 +121,7 @@ const startOAuth2Inner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: result };
 });
 
-function validateClaimedState(storedState: StoredOAuthState):
+function validateClaimedState(storedState: StoredCustomConnectorOAuthState):
   | {
       readonly ok: true;
       readonly context: NonNullable<
@@ -139,7 +139,7 @@ function validateClaimedState(storedState: StoredOAuthState):
 async function authorizeCustomConnectorAgent(
   args: {
     readonly db: Db;
-    readonly state: StoredOAuthState;
+    readonly state: StoredCustomConnectorOAuthState;
     readonly connectorId: string;
   },
   signal: AbortSignal,
@@ -183,9 +183,9 @@ const completeOAuth2Callback$ = command(
     if (!query.state) {
       return callbackError(origin, "Missing OAuth state");
     }
-    const claimed = await claimCustomConnectorOAuthState(
+    const claimed = await claimConnectorOAuthState(
       set(writeDb$),
-      { state: query.state },
+      { state: query.state, target: { kind: "custom" } },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
@@ -17,9 +17,9 @@ import {
 import { nowDate } from "../../lib/time";
 import type { RouteEntry } from "../route-entry";
 import {
-  claimCustomConnectorOAuthState,
+  claimConnectorOAuthState,
   readCustomConnectorOAuthState,
-  type StoredOAuthState,
+  type StoredCustomConnectorOAuthState,
 } from "../services/connector-oauth-state.service";
 import {
   customConnectorOAuthStateMatchesDefinition,
@@ -173,7 +173,7 @@ function callbackRedirectResponse(
 }
 
 function validCustomFeishuState(
-  storedState: StoredOAuthState,
+  storedState: StoredCustomConnectorOAuthState,
 ): FeishuCustomConnectorOAuthContext | null {
   const context = parseValidCustomConnectorOAuthState(storedState);
   if (
@@ -727,7 +727,7 @@ const completeClaimedCustomFeishuOAuth$ = command(
     args: {
       readonly db: Db;
       readonly query: FeishuOAuthCallbackQuery & { readonly state: string };
-      readonly state: StoredOAuthState;
+      readonly state: StoredCustomConnectorOAuthState;
       readonly context: FeishuCustomConnectorOAuthContext;
     },
     signal: AbortSignal,
@@ -880,9 +880,9 @@ const completeCustomFeishuOAuth$ = command(
       return redirectResponse(appCallbackUrl(query));
     }
 
-    const claimed = await claimCustomConnectorOAuthState(
+    const claimed = await claimConnectorOAuthState(
       db,
-      { state: query.state },
+      { state: query.state, target: { kind: "custom" } },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -1,6 +1,6 @@
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
-import { and, eq, gt, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, gt, isNotNull, isNull, type SQL } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db, ReadonlyDb } from "../external/db";
@@ -25,25 +25,136 @@ const storedOAuthStateSelection = Object.freeze({
   consumedAt: connectorOauthStates.consumedAt,
 });
 
-export type StoredOAuthState = Pick<
+type StoredOAuthStateRow = Pick<
   typeof connectorOauthStates.$inferSelect,
   keyof typeof storedOAuthStateSelection
 >;
 
-type ConnectorOAuthStateClaimResult =
+export type StoredBuiltinOAuthState = Omit<
+  StoredOAuthStateRow,
+  "connectorSlug" | "customConnectorId" | "storageVersion"
+> & {
+  readonly connectorSlug: ConnectorSlug;
+  readonly customConnectorId: null;
+  readonly storageVersion: null;
+};
+
+export type StoredCustomConnectorOAuthState = Omit<
+  StoredOAuthStateRow,
+  "authMethod" | "connectorSlug" | "customConnectorId"
+> & {
+  readonly connectorSlug: null;
+  readonly customConnectorId: string;
+};
+
+type BuiltinOAuthStateTarget = {
+  readonly kind: "builtin";
+  readonly connectorSlug: ConnectorSlug;
+};
+
+type CustomOAuthStateTarget = {
+  readonly kind: "custom";
+};
+
+type OAuthStateTarget = BuiltinOAuthStateTarget | CustomOAuthStateTarget;
+
+type ConnectorOAuthStateClaimResult<TState> =
   | { readonly kind: "missing" }
   | { readonly kind: "invalid" }
-  | { readonly kind: "usable"; readonly state: StoredOAuthState };
+  | { readonly kind: "usable"; readonly state: TState };
 
 type CustomConnectorOAuthStateReadResult =
   | { readonly kind: "missing" }
   | { readonly kind: "invalid" }
-  | { readonly kind: "usable"; readonly state: StoredOAuthState };
+  | {
+      readonly kind: "usable";
+      readonly state: StoredCustomConnectorOAuthState;
+    };
 
 type ConnectorOAuthStateStatus =
   | { readonly kind: "missing" }
   | { readonly kind: "invalid" }
   | { readonly kind: "usable" };
+
+function oauthStateTargetConditions(
+  target: OAuthStateTarget,
+): readonly [SQL, SQL] {
+  if (target.kind === "builtin") {
+    return [
+      eq(connectorOauthStates.connectorSlug, target.connectorSlug),
+      isNull(connectorOauthStates.customConnectorId),
+    ] as const;
+  }
+  return [
+    isNull(connectorOauthStates.connectorSlug),
+    isNotNull(connectorOauthStates.customConnectorId),
+  ] as const;
+}
+
+function matchesOAuthStateTarget(
+  state: Pick<StoredOAuthStateRow, "connectorSlug" | "customConnectorId">,
+  target: OAuthStateTarget,
+): boolean {
+  if (target.kind === "builtin") {
+    return (
+      state.connectorSlug === target.connectorSlug &&
+      state.customConnectorId === null
+    );
+  }
+  return state.connectorSlug === null && state.customConnectorId !== null;
+}
+
+function narrowStoredOAuthState(
+  state: StoredOAuthStateRow,
+  target: BuiltinOAuthStateTarget,
+): StoredBuiltinOAuthState | null;
+function narrowStoredOAuthState(
+  state: StoredOAuthStateRow,
+  target: CustomOAuthStateTarget,
+): StoredCustomConnectorOAuthState | null;
+function narrowStoredOAuthState(
+  state: StoredOAuthStateRow,
+  target: OAuthStateTarget,
+): StoredBuiltinOAuthState | StoredCustomConnectorOAuthState | null;
+function narrowStoredOAuthState(
+  state: StoredOAuthStateRow,
+  target: OAuthStateTarget,
+): StoredBuiltinOAuthState | StoredCustomConnectorOAuthState | null {
+  if (!matchesOAuthStateTarget(state, target)) {
+    return null;
+  }
+  if (target.kind === "builtin") {
+    if (state.connectorSlug === null || state.storageVersion !== null) {
+      return null;
+    }
+    return {
+      ...state,
+      connectorSlug: state.connectorSlug,
+      customConnectorId: null,
+      storageVersion: null,
+    };
+  }
+  if (state.customConnectorId === null) {
+    return null;
+  }
+  const { authMethod: _authMethod, ...customState } = state;
+  return {
+    ...customState,
+    connectorSlug: null,
+    customConnectorId: state.customConnectorId,
+  };
+}
+
+function requireStoredOAuthState(
+  state: StoredOAuthStateRow,
+  target: OAuthStateTarget,
+): StoredBuiltinOAuthState | StoredCustomConnectorOAuthState {
+  const narrowed = narrowStoredOAuthState(state, target);
+  if (!narrowed) {
+    throw new Error(`Claimed ${target.kind} OAuth state has invalid identity`);
+  }
+  return narrowed;
+}
 
 export async function getConnectorOAuthStateStatus(
   db: Db,
@@ -53,9 +164,14 @@ export async function getConnectorOAuthStateStatus(
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
+  const target: BuiltinOAuthStateTarget = {
+    kind: "builtin",
+    connectorSlug: args.connectorSlug,
+  };
   const [storedState] = await db
     .select({
       connectorSlug: connectorOauthStates.connectorSlug,
+      customConnectorId: connectorOauthStates.customConnectorId,
       consumedAt: connectorOauthStates.consumedAt,
       expiresAt: connectorOauthStates.expiresAt,
     })
@@ -69,7 +185,7 @@ export async function getConnectorOAuthStateStatus(
   }
 
   if (
-    storedState.connectorSlug !== args.connectorSlug ||
+    !matchesOAuthStateTarget(storedState, target) ||
     storedState.consumedAt ||
     storedState.expiresAt <= nowDate()
   ) {
@@ -79,21 +195,41 @@ export async function getConnectorOAuthStateStatus(
   return { kind: "usable" };
 }
 
+export function claimConnectorOAuthState(
+  db: Db,
+  args: {
+    readonly state: string;
+    readonly target: BuiltinOAuthStateTarget;
+  },
+  signal: AbortSignal,
+): Promise<ConnectorOAuthStateClaimResult<StoredBuiltinOAuthState>>;
+export function claimConnectorOAuthState(
+  db: Db,
+  args: {
+    readonly state: string;
+    readonly target: CustomOAuthStateTarget;
+  },
+  signal: AbortSignal,
+): Promise<ConnectorOAuthStateClaimResult<StoredCustomConnectorOAuthState>>;
 export async function claimConnectorOAuthState(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorSlug: ConnectorSlug;
+    readonly target: OAuthStateTarget;
   },
   signal: AbortSignal,
-): Promise<ConnectorOAuthStateClaimResult> {
+): Promise<
+  ConnectorOAuthStateClaimResult<
+    StoredBuiltinOAuthState | StoredCustomConnectorOAuthState
+  >
+> {
   const claimedAt = nowDate();
   const [claimedState] = await db
     .delete(connectorOauthStates)
     .where(
       and(
         eq(connectorOauthStates.state, args.state),
-        eq(connectorOauthStates.connectorSlug, args.connectorSlug),
+        ...oauthStateTargetConditions(args.target),
         isNull(connectorOauthStates.consumedAt),
         gt(connectorOauthStates.expiresAt, claimedAt),
       ),
@@ -102,44 +238,10 @@ export async function claimConnectorOAuthState(
   signal.throwIfAborted();
 
   if (claimedState) {
-    return { kind: "usable", state: claimedState };
-  }
-
-  const [existingState] = await db
-    .select({ id: connectorOauthStates.id })
-    .from(connectorOauthStates)
-    .where(eq(connectorOauthStates.state, args.state))
-    .limit(1);
-  signal.throwIfAborted();
-
-  return existingState ? { kind: "invalid" } : { kind: "missing" };
-}
-
-export async function claimCustomConnectorOAuthState(
-  db: Db,
-  args: {
-    readonly state: string;
-  },
-  signal: AbortSignal,
-): Promise<ConnectorOAuthStateClaimResult> {
-  const claimedAt = nowDate();
-  const [claimedState] = await db
-    .delete(connectorOauthStates)
-    .where(
-      and(
-        eq(connectorOauthStates.state, args.state),
-        isNull(connectorOauthStates.connectorSlug),
-        isNotNull(connectorOauthStates.customConnectorId),
-        eq(connectorOauthStates.authMethod, "oauth2"),
-        isNull(connectorOauthStates.consumedAt),
-        gt(connectorOauthStates.expiresAt, claimedAt),
-      ),
-    )
-    .returning(storedOAuthStateSelection);
-  signal.throwIfAborted();
-
-  if (claimedState) {
-    return { kind: "usable", state: claimedState };
+    return {
+      kind: "usable",
+      state: requireStoredOAuthState(claimedState, args.target),
+    };
   }
 
   const [existingState] = await db
@@ -168,14 +270,13 @@ export async function readCustomConnectorOAuthState(
   if (!storedState) {
     return { kind: "missing" };
   }
+  const narrowed = narrowStoredOAuthState(storedState, { kind: "custom" });
   if (
-    storedState.connectorSlug !== null ||
-    !storedState.customConnectorId ||
-    storedState.authMethod !== "oauth2" ||
+    !narrowed ||
     storedState.consumedAt ||
     storedState.expiresAt <= nowDate()
   ) {
     return { kind: "invalid" };
   }
-  return { kind: "usable", state: storedState };
+  return { kind: "usable", state: narrowed };
 }

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -53,6 +53,7 @@ import {
   type StoredValueRow,
 } from "./zero-custom-connector.service";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
+import type { StoredCustomConnectorOAuthState } from "./connector-oauth-state.service";
 
 const CUSTOM_CONNECTOR_OAUTH_METHOD_ID = "oauth2";
 const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
@@ -571,15 +572,6 @@ export function parseCustomConnectorOAuthStateContext(
   return parsed.success ? parsed.data : null;
 }
 
-type StoredCustomConnectorOAuthState = Pick<
-  typeof connectorOauthStates.$inferSelect,
-  | "authMethod"
-  | "connectorSlug"
-  | "customConnectorId"
-  | "oauthContext"
-  | "storageVersion"
->;
-
 export function parseValidCustomConnectorOAuthState(
   storedState: StoredCustomConnectorOAuthState,
 ): CustomConnectorOAuthStateContext | null {
@@ -588,9 +580,7 @@ export function parseValidCustomConnectorOAuthState(
   );
   if (
     !context ||
-    storedState.connectorSlug !== null ||
     storedState.customConnectorId !== context.connectorId ||
-    storedState.authMethod !== CUSTOM_CONNECTOR_OAUTH_METHOD_ID ||
     storedState.storageVersion !== context.storageVersion
   ) {
     return null;


### PR DESCRIPTION
## Summary

- consolidate Builtin and Custom connector OAuth state consumption into one typed, atomic claim path
- narrow stored state by connector identity so callbacks cannot consume state from another source or Builtin slug
- remove Custom reader dependence on the persisted `auth_method` spelling while preserving the current `oauth2` writer
- cover Custom success, replay, expiry, ownership isolation, and both cross-source non-consumption directions through API routes

## Rollout

This is the reader-preparation release for parent #26090. Follow-up #26129 must remain blocked until this change is deployed to production; merge alone is not sufficient.

This PR intentionally does not change the database schema, migrate data, change public callback behavior, or switch new Custom OAuth state writes from `oauth2` to `oauth`.

## Validation

- `pnpm exec prettier --check <changed API files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts`
- `pnpm knip --workspace api`
- pre-commit full Turbo Knip and type checks

Closes #26128
Relates to #26090
