### PR TITLE
refactor(connectors): canonicalize custom oauth state writes

### DIFF
--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -55,7 +55,6 @@ import {
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import type { StoredCustomConnectorOAuthState } from "./connector-oauth-state.service";
 
-const CUSTOM_CONNECTOR_OAUTH_METHOD_ID = "oauth2";
 const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
 const TOKEN_REFRESH_LEEWAY_MS = 60 * 1000;
 
@@ -542,7 +541,7 @@ export const startCustomConnectorOAuth2$ = command(
         state,
         customConnectorId: connector.id,
         storageVersion: connector.storageVersion,
-        authMethod: CUSTOM_CONNECTOR_OAUTH_METHOD_ID,
+        authMethod: "oauth",
         userId: args.userId,
         orgId: args.orgId,
         agentId: args.agentId,


### PR DESCRIPTION
## Summary

- write `oauth` as the canonical auth method for new Custom OAuth state rows
- remove the obsolete Custom OAuth `oauth2` state identifier constant
- rely on the structurally validated state reader delivered by #26128 for existing rows

## Scope

- no database schema or migration changes
- no OAuth callback, protocol, or connector definition changes
- no legacy-value branch is added to the write path

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm exec prettier --check apps/api/src/signals/services/custom-connector-oauth2.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts --silent=passed-only` (47 passed)
- `pnpm knip --workspace api`
- pre-commit full Turbo Knip and type checks

Closes #26129

Parent: #26090
