### PR TITLE
refactor(api): extract immutable storage version registration

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
+import { gunzipSync } from "node:zlib";
 
+import { HeadObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  testSystemStoragePresignedUrlCacheStateContract,
+  type TestSystemStoragePresignedUrlCacheStateActionBody,
+} from "@vm0/api-contracts/contracts/test-system-storage-presigned-url-cache-state";
 import {
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
@@ -9,6 +15,11 @@ import {
   type ZeroWorkflowUpdateRequest,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
+import {
+  getCustomSkillStorageName,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
+import { synthesizeWorkflowSkillMd } from "@vm0/core/zero-workflow-skill";
 import { HttpResponse, http } from "msw";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -35,6 +46,7 @@ import {
 } from "./helpers/zero-route-test";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 import { zeroWorkflowsRoutes } from "../zero-workflows";
+import { testSystemStoragePresignedUrlCacheStateRoutes } from "../test-system-storage-presigned-url-cache-state";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -109,6 +121,124 @@ function detailClient() {
   return setupApp({ context, routes: zeroWorkflowsRoutes })(
     zeroWorkflowsDetailContract,
   );
+}
+
+function storageStateClient() {
+  return setupApp({
+    context,
+    routes: testSystemStoragePresignedUrlCacheStateRoutes,
+  })(testSystemStoragePresignedUrlCacheStateContract);
+}
+
+async function storageStateAction(
+  body: TestSystemStoragePresignedUrlCacheStateActionBody,
+) {
+  return await accept(storageStateClient().action({ body }), [200]);
+}
+
+async function readWorkflowStorageState(
+  actor: ApiTestUser,
+  workflowId: string,
+) {
+  if (!actor.orgId) {
+    throw new Error("Expected an organization-scoped workflow actor");
+  }
+  const response = await storageStateAction({
+    action: "read-storage-state",
+    org_id: actor.orgId,
+    user_id: VOLUME_ORG_USER_ID,
+    storage_name: getCustomSkillStorageName(workflowId),
+  });
+  return response.body.storage_state ?? null;
+}
+
+async function readWorkflowStorageVersion(
+  actor: ApiTestUser,
+  workflowId: string,
+  versionId: string,
+) {
+  if (!actor.orgId) {
+    throw new Error("Expected an organization-scoped workflow actor");
+  }
+  const response = await storageStateAction({
+    action: "read-storage-version",
+    org_id: actor.orgId,
+    user_id: VOLUME_ORG_USER_ID,
+    storage_name: getCustomSkillStorageName(workflowId),
+    version_id: versionId,
+  });
+  return response.body.storage_version ?? null;
+}
+
+function s3BodyBuffer(body: unknown): Buffer {
+  if (Buffer.isBuffer(body)) {
+    return Buffer.from(body);
+  }
+  if (typeof body === "string") {
+    return Buffer.from(body, "utf8");
+  }
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body);
+  }
+  throw new Error("Expected an S3 object body");
+}
+
+function missingS3Object(key: string): Error {
+  return Object.assign(new Error(`Missing S3 object ${key}`), {
+    name: "NotFound",
+    $metadata: { httpStatusCode: 404 },
+  });
+}
+
+function installVolumeS3Fixture() {
+  const objects = new Map<string, Buffer>();
+  const writes: { readonly key: string; readonly body: Buffer }[] = [];
+  let beforeNextArchiveWrite:
+    | ((key: string, body: Buffer) => Promise<void>)
+    | undefined;
+
+  context.mocks.s3.send.mockImplementation(async (command: unknown) => {
+    if (command instanceof PutObjectCommand) {
+      const key = command.input.Key;
+      if (!key) {
+        throw new Error("Expected an S3 object key");
+      }
+      const body = s3BodyBuffer(command.input.Body);
+      if (key.endsWith("/archive.tar.gz") && beforeNextArchiveWrite) {
+        const callback = beforeNextArchiveWrite;
+        beforeNextArchiveWrite = undefined;
+        await callback(key, body);
+      }
+      objects.set(key, body);
+      writes.push({ key, body });
+      return {};
+    }
+    if (command instanceof HeadObjectCommand) {
+      const key = command.input.Key;
+      if (!key) {
+        throw new Error("Expected an S3 object key");
+      }
+      const body = objects.get(key);
+      if (!body) {
+        throw missingS3Object(key);
+      }
+      return { ContentLength: body.length };
+    }
+    return {};
+  });
+
+  return {
+    objects,
+    writes,
+    clearWrites(): void {
+      writes.length = 0;
+    },
+    beforeNextArchiveWrite(
+      callback: (key: string, body: Buffer) => Promise<void>,
+    ): void {
+      beforeNextArchiveWrite = callback;
+    },
+  };
 }
 
 function mockConnectorReadinessModel(
@@ -1479,6 +1609,157 @@ describe("zero workflows", () => {
       workflow.body.name,
     );
     await api.requestCancelRun(actor, sourceRun.body.runId, [200]);
+  });
+
+  it("reuses and repairs immutable workflow volume versions without moving HEAD during preparation", async () => {
+    const actor = user();
+    const agent = await createAgent(actor, {
+      displayName: "Immutable Volume Agent",
+      visibility: "private",
+    });
+    const s3 = installVolumeS3Fixture();
+    const name = `immutable-volume-${randomUUID().slice(0, 8)}`;
+    const description = "Exercises immutable workflow volume publication.";
+    const firstInstruction = "# immutable volume one";
+    const firstFiles = [
+      { path: "zeta.txt", content: "zeta one" },
+      { path: "alpha.txt", content: "alpha one" },
+    ];
+    const workflow = await createWorkflow(actor, {
+      agentId: agent.agentId,
+      name,
+      description,
+      instruction: firstInstruction,
+      files: firstFiles,
+    });
+
+    const firstState = await readWorkflowStorageState(actor, workflow.body.id);
+    if (!firstState?.head_version_id) {
+      throw new Error("Expected the first workflow volume version");
+    }
+    const firstVersionId = firstState.head_version_id;
+    const firstArchiveKey = `${firstState.s3_prefix}/${firstVersionId}/archive.tar.gz`;
+    const firstArchive = s3.objects.get(firstArchiveKey);
+    if (!firstArchive) {
+      throw new Error("Expected the first workflow archive");
+    }
+    const firstVersion = await readWorkflowStorageVersion(
+      actor,
+      workflow.body.id,
+      firstVersionId,
+    );
+    const firstSkillMd = synthesizeWorkflowSkillMd({
+      name,
+      description,
+      instruction: firstInstruction,
+    });
+    const firstSize = [
+      firstSkillMd,
+      ...firstFiles.map((file) => {
+        return file.content;
+      }),
+    ]
+      .map((content) => {
+        return Buffer.byteLength(content, "utf8");
+      })
+      .reduce((sum, size) => {
+        return sum + size;
+      }, 0);
+    expect(firstVersion).toStrictEqual({
+      version_id: firstVersionId,
+      s3_key: `${firstState.s3_prefix}/${firstVersionId}`,
+      size: firstSize,
+      archive_size: firstArchive.length,
+      file_count: 3,
+      message: null,
+      created_by: "user",
+    });
+
+    const tar = gunzipSync(firstArchive);
+    const encodedMtime = tar
+      .subarray(136, 148)
+      .toString("ascii")
+      .replaceAll("\0", "")
+      .trim();
+    expect(Number.parseInt(encodedMtime, 8)).toBe(0);
+
+    const secondInstruction = "# immutable volume two";
+    const secondFiles = [
+      { path: "alpha.txt", content: "alpha two" },
+      { path: "zeta.txt", content: "zeta two" },
+    ];
+    await updateWorkflow(actor, workflow.body.id, {
+      instruction: secondInstruction,
+      files: secondFiles,
+    });
+    const secondState = await readWorkflowStorageState(actor, workflow.body.id);
+    if (!secondState?.head_version_id) {
+      throw new Error("Expected the second workflow volume version");
+    }
+    const secondVersionId = secondState.head_version_id;
+    expect(secondVersionId).not.toBe(firstVersionId);
+
+    s3.clearWrites();
+    await updateWorkflow(actor, workflow.body.id, {
+      instruction: firstInstruction,
+      files: [...firstFiles].reverse(),
+    });
+    expect(s3.writes).toHaveLength(0);
+    expect(
+      (await readWorkflowStorageState(actor, workflow.body.id))
+        ?.head_version_id,
+    ).toBe(firstVersionId);
+
+    await updateWorkflow(actor, workflow.body.id, {
+      instruction: secondInstruction,
+      files: secondFiles,
+    });
+    expect(s3.writes).toHaveLength(0);
+    expect(
+      (await readWorkflowStorageState(actor, workflow.body.id))
+        ?.head_version_id,
+    ).toBe(secondVersionId);
+
+    s3.objects.delete(firstArchiveKey);
+    s3.clearWrites();
+    let observedRepairPreparation = false;
+    s3.beforeNextArchiveWrite(async (key, body) => {
+      expect(key).toBe(firstArchiveKey);
+      expect(body).toStrictEqual(firstArchive);
+      expect(
+        (await readWorkflowStorageState(actor, workflow.body.id))
+          ?.head_version_id,
+      ).toBe(secondVersionId);
+      observedRepairPreparation = true;
+    });
+
+    await updateWorkflow(actor, workflow.body.id, {
+      instruction: firstInstruction,
+      files: firstFiles,
+    });
+    expect(observedRepairPreparation).toBeTruthy();
+    expect(
+      s3.writes.map((write) => {
+        return write.key;
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining([
+        firstArchiveKey,
+        `${firstState.s3_prefix}/${firstVersionId}/manifest.json`,
+      ]),
+    );
+    expect(
+      s3.writes.find((write) => {
+        return write.key === firstArchiveKey;
+      })?.body,
+    ).toStrictEqual(firstArchive);
+    expect(
+      (await readWorkflowStorageState(actor, workflow.body.id))
+        ?.head_version_id,
+    ).toBe(firstVersionId);
+    await expect(
+      readWorkflowStorageVersion(actor, workflow.body.id, firstVersionId),
+    ).resolves.toMatchObject({ archive_size: firstArchive.length });
   });
 
   it("reads and updates workflow content, audit metadata, and deletion through API responses", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -194,7 +194,7 @@ function installVolumeS3Fixture() {
   const objects = new Map<string, Buffer>();
   const writes: { readonly key: string; readonly body: Buffer }[] = [];
   let beforeNextArchiveWrite:
-    | ((key: string, body: Buffer) => Promise<void>)
+    | ((key: string, body: Buffer) => void | Promise<void>)
     | undefined;
 
   context.mocks.s3.send.mockImplementation(async (command: unknown) => {
@@ -234,7 +234,7 @@ function installVolumeS3Fixture() {
       writes.length = 0;
     },
     beforeNextArchiveWrite(
-      callback: (key: string, body: Buffer) => Promise<void>,
+      callback: (key: string, body: Buffer) => void | Promise<void>,
     ): void {
       beforeNextArchiveWrite = callback;
     },
@@ -1760,6 +1760,57 @@ describe("zero workflows", () => {
     await expect(
       readWorkflowStorageVersion(actor, workflow.body.id, firstVersionId),
     ).resolves.toMatchObject({ archive_size: firstArchive.length });
+  });
+
+  it("repairs duplicate workflow paths with deterministic archive bytes", async () => {
+    const actor = user();
+    const agent = await createAgent(actor, {
+      displayName: "Duplicate Path Volume Agent",
+      visibility: "private",
+    });
+    const s3 = installVolumeS3Fixture();
+    const duplicateFiles = [
+      { path: "duplicate.txt", content: "first duplicate" },
+      { path: "duplicate.txt", content: "second duplicate" },
+    ];
+    const workflow = await createWorkflow(actor, {
+      agentId: agent.agentId,
+      name: `duplicate-volume-${randomUUID().slice(0, 8)}`,
+      description: "Exercises deterministic duplicate-path archives.",
+      instruction: "# duplicate path volume",
+      files: duplicateFiles,
+    });
+
+    const initialState = await readWorkflowStorageState(
+      actor,
+      workflow.body.id,
+    );
+    if (!initialState?.head_version_id) {
+      throw new Error("Expected the duplicate-path workflow volume version");
+    }
+    const archiveKey = `${initialState.s3_prefix}/${initialState.head_version_id}/archive.tar.gz`;
+    const initialArchive = s3.objects.get(archiveKey);
+    if (!initialArchive) {
+      throw new Error("Expected the duplicate-path workflow archive");
+    }
+
+    s3.objects.delete(archiveKey);
+    let observedRepair = false;
+    s3.beforeNextArchiveWrite((key, body) => {
+      expect(key).toBe(archiveKey);
+      expect(body).toStrictEqual(initialArchive);
+      observedRepair = true;
+    });
+
+    await updateWorkflow(actor, workflow.body.id, {
+      files: [...duplicateFiles].reverse(),
+    });
+
+    expect(observedRepair).toBeTruthy();
+    expect(
+      (await readWorkflowStorageState(actor, workflow.body.id))
+        ?.head_version_id,
+    ).toBe(initialState.head_version_id);
   });
 
   it("reads and updates workflow content, audit metadata, and deletion through API responses", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@vm0/core/storage-names";
 import { synthesizeWorkflowSkillMd } from "@vm0/core/zero-workflow-skill";
 import { HttpResponse, http } from "msw";
+import { onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -1787,7 +1788,7 @@ describe("zero workflows", () => {
     ).resolves.toMatchObject({ archive_size: firstArchive.length });
   });
 
-  it("repairs duplicate workflow paths with deterministic archive bytes", async () => {
+  it("repairs workflow archives deterministically across path order and umask", async () => {
     const actor = user();
     const agent = await createAgent(actor, {
       displayName: "Duplicate Path Volume Agent",
@@ -1798,6 +1799,10 @@ describe("zero workflows", () => {
       { path: "duplicate.txt", content: "first duplicate" },
       { path: "duplicate.txt", content: "second duplicate" },
     ];
+    const originalUmask = process.umask(0o022);
+    onTestFinished(() => {
+      process.umask(originalUmask);
+    });
     const workflow = await createWorkflow(actor, {
       agentId: agent.agentId,
       name: `duplicate-volume-${randomUUID().slice(0, 8)}`,
@@ -1827,9 +1832,11 @@ describe("zero workflows", () => {
       observedRepair = true;
     });
 
+    process.umask(0o077);
     await updateWorkflow(actor, workflow.body.id, {
       files: [...duplicateFiles].reverse(),
     });
+    process.umask(originalUmask);
 
     expect(observedRepair).toBeTruthy();
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -170,6 +170,25 @@ async function readWorkflowStorageVersion(
   return response.body.storage_version ?? null;
 }
 
+async function setWorkflowStorageVersionArchiveSize(
+  actor: ApiTestUser,
+  workflowId: string,
+  versionId: string,
+  archiveSize: number,
+): Promise<void> {
+  if (!actor.orgId) {
+    throw new Error("Expected an organization-scoped workflow actor");
+  }
+  await storageStateAction({
+    action: "set-storage-version-archive-size",
+    org_id: actor.orgId,
+    user_id: VOLUME_ORG_USER_ID,
+    storage_name: getCustomSkillStorageName(workflowId),
+    version_id: versionId,
+    archive_size: archiveSize,
+  });
+}
+
 function s3BodyBuffer(body: unknown): Buffer {
   if (Buffer.isBuffer(body)) {
     return Buffer.from(body);
@@ -1720,6 +1739,12 @@ describe("zero workflows", () => {
         ?.head_version_id,
     ).toBe(secondVersionId);
 
+    await setWorkflowStorageVersionArchiveSize(
+      actor,
+      workflow.body.id,
+      firstVersionId,
+      firstArchive.length + 1,
+    );
     s3.objects.delete(firstArchiveKey);
     s3.clearWrites();
     let observedRepairPreparation = false;

--- a/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
@@ -237,6 +237,38 @@ async function readStorageVersionForAction(
   });
 }
 
+async function setStorageVersionArchiveSizeForAction(
+  db: Db,
+  body: CacheStateAction<"set-storage-version-archive-size">,
+  signal: AbortSignal,
+) {
+  const [storage] = await db
+    .select({ id: storages.id })
+    .from(storages)
+    .where(storageIdentityCondition(body))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!storage) {
+    throw new Error("Storage is unavailable");
+  }
+
+  const updated = await db
+    .update(storageVersions)
+    .set({ archiveSize: body.archive_size })
+    .where(
+      and(
+        eq(storageVersions.storageId, storage.id),
+        eq(storageVersions.id, body.version_id),
+      ),
+    )
+    .returning({ id: storageVersions.id });
+  signal.throwIfAborted();
+  if (updated.length === 0) {
+    throw new Error("Storage version is unavailable");
+  }
+  return actionOk();
+}
+
 async function deleteStorageVersionForAction(
   db: Db,
   body: CacheStateAction<"delete-storage-version">,
@@ -380,6 +412,9 @@ const mutateSystemStoragePresignedUrlCacheState$ = command(
       }
       case "read-storage-version": {
         return await readStorageVersionForAction(db, body, signal);
+      }
+      case "set-storage-version-archive-size": {
+        return await setStorageVersionArchiveSizeForAction(db, body, signal);
       }
       case "delete-storage-version": {
         return await deleteStorageVersionForAction(db, body, signal);

--- a/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
@@ -197,6 +197,46 @@ async function seedStorageVersionForAction(
   return actionOk();
 }
 
+async function readStorageVersionForAction(
+  db: Db,
+  body: CacheStateAction<"read-storage-version">,
+  signal: AbortSignal,
+) {
+  const [version] = await db
+    .select({
+      versionId: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      size: storageVersions.size,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+      message: storageVersions.message,
+      createdBy: storageVersions.createdBy,
+    })
+    .from(storageVersions)
+    .innerJoin(storages, eq(storages.id, storageVersions.storageId))
+    .where(
+      and(
+        storageIdentityCondition(body),
+        eq(storageVersions.id, body.version_id),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return actionOk({
+    storage_version: version
+      ? {
+          version_id: version.versionId,
+          s3_key: version.s3Key,
+          size: version.size,
+          archive_size: version.archiveSize,
+          file_count: version.fileCount,
+          message: version.message,
+          created_by: version.createdBy,
+        }
+      : null,
+  });
+}
+
 async function deleteStorageVersionForAction(
   db: Db,
   body: CacheStateAction<"delete-storage-version">,
@@ -337,6 +377,9 @@ const mutateSystemStoragePresignedUrlCacheState$ = command(
       }
       case "seed-storage-version": {
         return await seedStorageVersionForAction(db, body, signal);
+      }
+      case "read-storage-version": {
+        return await readStorageVersionForAction(db, body, signal);
       }
       case "delete-storage-version": {
         return await deleteStorageVersionForAction(db, body, signal);

--- a/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts
@@ -5,10 +5,17 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db, ReadonlyDb } from "../external/db";
+import { settle } from "../utils";
 import type {
   ConnectorCatalogArtifact,
   ConnectorCatalogArtifactConnector,
 } from "./connector-catalog-artifacts/artifacts";
+import {
+  registerPreparedStorageVersions,
+  storageVersionMatches,
+  StorageVersionIdentityConflictError,
+  type PreparedStorageVersion,
+} from "./storage-version-registration.service";
 
 const SYSTEM_STORAGE_CREATOR = "system";
 
@@ -19,6 +26,7 @@ type BundledConnectorSkill = Extract<
 
 interface ExistingStorageVersion {
   readonly id: string;
+  readonly storageId: string;
   readonly orgId: string;
   readonly userId: string;
   readonly name: string;
@@ -117,13 +125,36 @@ function existingVersionMatchesRegistration(
     existing.userId === VOLUME_ORG_USER_ID &&
     existing.name === registration.storageName &&
     existing.s3Prefix === registration.s3Prefix &&
-    existing.s3Key === registration.s3Key &&
-    existing.size === registration.size &&
-    existing.archiveSize === registration.archiveSize &&
-    existing.fileCount === registration.fileCount &&
-    existing.message === null &&
-    existing.createdBy === SYSTEM_STORAGE_CREATOR
+    storageVersionMatches(
+      {
+        storageId: existing.storageId,
+        versionId: existing.id,
+        s3Key: existing.s3Key,
+        size: existing.size,
+        archiveSize: existing.archiveSize,
+        fileCount: existing.fileCount,
+        message: existing.message,
+        createdBy: existing.createdBy,
+      },
+      preparedStorageVersion(registration, existing.storageId),
+    )
   );
+}
+
+function preparedStorageVersion(
+  registration: PreparedConnectorSkillRegistration,
+  storageId: string,
+): PreparedStorageVersion {
+  return {
+    storageId,
+    versionId: registration.versionId,
+    s3Key: registration.s3Key,
+    size: registration.size,
+    archiveSize: registration.archiveSize,
+    fileCount: registration.fileCount,
+    message: null,
+    createdBy: SYSTEM_STORAGE_CREATOR,
+  };
 }
 
 async function readExistingVersions(
@@ -137,6 +168,7 @@ async function readExistingVersions(
   const rows = await db
     .select({
       id: storageVersions.id,
+      storageId: storageVersions.storageId,
       orgId: storages.orgId,
       userId: storages.userId,
       name: storages.name,
@@ -277,56 +309,30 @@ async function createAndReadCanonicalStorages(
   return byName;
 }
 
-async function insertAndValidateStorageVersions(
+async function registerMissingStorageVersions(
   db: Db,
   registrations: readonly PreparedConnectorSkillRegistration[],
   storageByName: ReadonlyMap<string, CanonicalStorage>,
   signal: AbortSignal,
 ): Promise<ReadonlySet<string>> {
-  const inserted = await db
-    .insert(storageVersions)
-    .values(
-      registrations.map((registration) => {
-        const storage = storageByName.get(registration.storageName);
-        if (!storage) {
-          throw new Error("Connector skill storage is unavailable");
-        }
-        return {
-          id: registration.versionId,
-          storageId: storage.id,
-          s3Key: registration.s3Key,
-          size: registration.size,
-          archiveSize: registration.archiveSize,
-          fileCount: registration.fileCount,
-          message: null,
-          createdBy: SYSTEM_STORAGE_CREATOR,
-        };
-      }),
-    )
-    .onConflictDoNothing()
-    .returning({ id: storageVersions.id });
-  signal.throwIfAborted();
-  const existingByVersion = await readExistingVersions(
-    db,
-    registrations.map((registration) => {
-      return registration.versionId;
-    }),
+  const versions = registrations.map((registration) => {
+    const storage = storageByName.get(registration.storageName);
+    if (!storage) {
+      throw new Error("Connector skill storage is unavailable");
+    }
+    return preparedStorageVersion(registration, storage.id);
+  });
+  const result = await settle(
+    registerPreparedStorageVersions({ db, versions }, signal),
     signal,
   );
-  for (const registration of registrations) {
-    const existing = existingByVersion.get(registration.versionId);
-    if (
-      !existing ||
-      !existingVersionMatchesRegistration(existing, registration)
-    ) {
-      fail("invalid-reference", false);
-    }
+  if (result.ok) {
+    return result.value;
   }
-  return new Set(
-    inserted.map((row) => {
-      return row.id;
-    }),
-  );
+  if (result.error instanceof StorageVersionIdentityConflictError) {
+    fail("invalid-reference", false);
+  }
+  throw result.error;
 }
 
 async function updateNewStorageHeads(
@@ -382,7 +388,7 @@ async function registerConnectorCatalogSkills(
     missing,
     signal,
   );
-  const insertedVersionIds = await insertAndValidateStorageVersions(
+  const insertedVersionIds = await registerMissingStorageVersions(
     db,
     missing,
     storageByName,

--- a/turbo/apps/api/src/signals/services/storage-version-registration.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-version-registration.service.ts
@@ -1,0 +1,110 @@
+import { storageVersions } from "@vm0/db/schema/storage";
+import { inArray } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+export interface PreparedStorageVersion {
+  readonly storageId: string;
+  readonly versionId: string;
+  readonly s3Key: string;
+  readonly size: number;
+  readonly archiveSize: number;
+  readonly fileCount: number;
+  readonly message: string | null;
+  readonly createdBy: string;
+}
+
+export class StorageVersionIdentityConflictError extends Error {
+  constructor(readonly versionId: string) {
+    super(`Storage version ${versionId} conflicts with prepared metadata`);
+    this.name = "StorageVersionIdentityConflictError";
+  }
+}
+
+export function storageVersionMatches(
+  stored: PreparedStorageVersion,
+  prepared: PreparedStorageVersion,
+): boolean {
+  return (
+    stored.storageId === prepared.storageId &&
+    stored.versionId === prepared.versionId &&
+    stored.s3Key === prepared.s3Key &&
+    stored.size === prepared.size &&
+    stored.archiveSize === prepared.archiveSize &&
+    stored.fileCount === prepared.fileCount &&
+    stored.message === prepared.message &&
+    stored.createdBy === prepared.createdBy
+  );
+}
+
+export async function registerPreparedStorageVersions(
+  args: {
+    readonly db: Db;
+    readonly versions: readonly PreparedStorageVersion[];
+  },
+  signal: AbortSignal,
+): Promise<ReadonlySet<string>> {
+  if (args.versions.length === 0) {
+    return new Set();
+  }
+
+  const inserted = await args.db
+    .insert(storageVersions)
+    .values(
+      args.versions.map((version) => {
+        return {
+          id: version.versionId,
+          storageId: version.storageId,
+          s3Key: version.s3Key,
+          size: version.size,
+          archiveSize: version.archiveSize,
+          fileCount: version.fileCount,
+          message: version.message,
+          createdBy: version.createdBy,
+        };
+      }),
+    )
+    .onConflictDoNothing()
+    .returning({ versionId: storageVersions.id });
+  signal.throwIfAborted();
+
+  const stored = await args.db
+    .select({
+      storageId: storageVersions.storageId,
+      versionId: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      size: storageVersions.size,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+      message: storageVersions.message,
+      createdBy: storageVersions.createdBy,
+    })
+    .from(storageVersions)
+    .where(
+      inArray(
+        storageVersions.id,
+        args.versions.map((version) => {
+          return version.versionId;
+        }),
+      ),
+    );
+  signal.throwIfAborted();
+
+  const storedByVersionId = new Map(
+    stored.map((version) => {
+      return [version.versionId, version] as const;
+    }),
+  );
+  for (const prepared of args.versions) {
+    const existing = storedByVersionId.get(prepared.versionId);
+    if (!existing || !storageVersionMatches(existing, prepared)) {
+      throw new StorageVersionIdentityConflictError(prepared.versionId);
+    }
+  }
+
+  return new Set(
+    inserted.map((version) => {
+      return version.versionId;
+    }),
+  );
+}

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -1,0 +1,504 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import { VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { command } from "ccstate";
+import { and, eq, isNull } from "drizzle-orm";
+import { create } from "tar";
+
+import { env } from "../../lib/env";
+import { nowDate } from "../../lib/time";
+import { writeDb$, type Db } from "../external/db";
+import {
+  putS3Object,
+  s3ObjectExists,
+  s3ObjectHead,
+  verifyS3FilesExist,
+} from "../external/s3";
+import { onRejection } from "../utils";
+import {
+  computeContentHashFromHashes,
+  hashFileContent,
+  type FileEntryWithHash,
+} from "./storage-content-hash.service";
+import { newStorageS3Location } from "./storage-s3-prefix.utils";
+import {
+  registerPreparedStorageVersions,
+  storageVersionMatches,
+  StorageVersionIdentityConflictError,
+  type PreparedStorageVersion,
+} from "./storage-version-registration.service";
+
+const SERVER_SIDE_STORAGE_VERSION_CREATOR = "user";
+
+interface VolumeFileInput {
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface PrepareVolumeServerSideInput {
+  readonly orgId: string;
+  readonly storageName: string;
+  readonly files: readonly VolumeFileInput[];
+}
+
+interface PreparedServerSideVolume {
+  readonly storageName: string;
+  readonly version: PreparedStorageVersion;
+  readonly updatedAt: Date;
+}
+
+interface S3StorageManifest {
+  readonly version: string;
+  readonly createdAt: string;
+  readonly totalSize: number;
+  readonly fileCount: number;
+  readonly files: readonly FileEntryWithHash[];
+}
+
+interface MaterializedVolumeFile extends FileEntryWithHash {
+  readonly content: Buffer;
+}
+
+type RegisteredVolumeObjects =
+  | { readonly kind: "missing" }
+  | { readonly kind: "available"; readonly archiveSize: number };
+
+async function bufferFromStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function compareFilePaths(
+  left: MaterializedVolumeFile,
+  right: MaterializedVolumeFile,
+): number {
+  if (left.path < right.path) {
+    return -1;
+  }
+  if (left.path > right.path) {
+    return 1;
+  }
+  return 0;
+}
+
+function materializeFiles(
+  files: readonly VolumeFileInput[],
+): readonly MaterializedVolumeFile[] {
+  const materialized = files.map((file) => {
+    const content = Buffer.from(file.content, "utf8");
+    return {
+      path: file.path,
+      content,
+      hash: hashFileContent(content),
+      size: content.length,
+    };
+  });
+  return materialized.sort(compareFilePaths);
+}
+
+function writeFilesToDirectory(
+  tmpDir: string,
+  files: readonly MaterializedVolumeFile[],
+): void {
+  for (const file of files) {
+    const filePath = resolve(join(tmpDir, file.path));
+    const relativePath = relative(tmpDir, filePath);
+    if (
+      relativePath === ".." ||
+      relativePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativePath)
+    ) {
+      throw new Error(`Invalid file path: ${file.path}`);
+    }
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, file.content);
+  }
+}
+
+function createArchiveBuffer(
+  tmpDir: string,
+  files: readonly MaterializedVolumeFile[],
+): Promise<Buffer> {
+  return bufferFromStream(
+    create(
+      {
+        gzip: { portable: true },
+        portable: true,
+        mtime: new Date(0),
+        cwd: tmpDir,
+      },
+      files.map((file) => {
+        return file.path;
+      }),
+    ),
+  );
+}
+
+async function buildVolumeArchive(
+  tmpDir: string,
+  files: readonly MaterializedVolumeFile[],
+  signal: AbortSignal,
+): Promise<Buffer> {
+  signal.throwIfAborted();
+  writeFilesToDirectory(tmpDir, files);
+  const archiveBuffer = await createArchiveBuffer(tmpDir, files);
+  signal.throwIfAborted();
+  return archiveBuffer;
+}
+
+async function createVolumeArchive(
+  files: readonly MaterializedVolumeFile[],
+  signal: AbortSignal,
+): Promise<Buffer> {
+  const tmpDir = await mkdtemp(join(tmpdir(), "vm0-api-volume-"));
+  const archiveBuffer = await onRejection(
+    buildVolumeArchive(tmpDir, files, signal),
+    () => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    },
+  );
+  rmSync(tmpDir, { recursive: true, force: true });
+  return archiveBuffer;
+}
+
+const uploadAndVerifyVolumeObjects$ = command(
+  async (
+    { get },
+    args: {
+      readonly bucketName: string;
+      readonly s3Key: string;
+      readonly archiveBuffer: Buffer;
+      readonly manifest: S3StorageManifest;
+      readonly fileCount: number;
+      readonly storageName: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await Promise.all([
+      get(
+        putS3Object(
+          args.bucketName,
+          `${args.s3Key}/archive.tar.gz`,
+          args.archiveBuffer,
+          "application/gzip",
+        ),
+      ),
+      get(
+        putS3Object(
+          args.bucketName,
+          `${args.s3Key}/manifest.json`,
+          JSON.stringify(args.manifest),
+          "application/json",
+        ),
+      ),
+    ]);
+    signal.throwIfAborted();
+
+    const uploadVerified = await get(
+      verifyS3FilesExist(args.bucketName, args.s3Key, args.fileCount),
+    );
+    signal.throwIfAborted();
+    if (!uploadVerified) {
+      throw new Error(
+        `Uploaded volume files are not available for ${args.storageName}`,
+      );
+    }
+  },
+);
+
+const registeredVolumeObjects$ = command(
+  async (
+    { get },
+    args: {
+      readonly bucketName: string;
+      readonly s3Key: string;
+      readonly fileCount: number;
+      readonly storedArchiveSize: number;
+    },
+    signal: AbortSignal,
+  ): Promise<RegisteredVolumeObjects> => {
+    const [manifestExists, archiveHead] = await Promise.all([
+      get(s3ObjectExists(args.bucketName, `${args.s3Key}/manifest.json`)),
+      args.fileCount > 0
+        ? get(s3ObjectHead(args.bucketName, `${args.s3Key}/archive.tar.gz`))
+        : Promise.resolve(null),
+    ]);
+    signal.throwIfAborted();
+    if (!manifestExists) {
+      return { kind: "missing" };
+    }
+    if (archiveHead === null) {
+      return { kind: "available", archiveSize: args.storedArchiveSize };
+    }
+    if (
+      archiveHead.kind === "missing" ||
+      archiveHead.contentLength === undefined ||
+      !Number.isSafeInteger(archiveHead.contentLength) ||
+      archiveHead.contentLength <= 0
+    ) {
+      return { kind: "missing" };
+    }
+    return { kind: "available", archiveSize: archiveHead.contentLength };
+  },
+);
+
+async function readStorageVersion(
+  db: Db,
+  versionId: string,
+  signal: AbortSignal,
+): Promise<PreparedStorageVersion | undefined> {
+  const [version] = await db
+    .select({
+      storageId: storageVersions.storageId,
+      versionId: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      size: storageVersions.size,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+      message: storageVersions.message,
+      createdBy: storageVersions.createdBy,
+    })
+    .from(storageVersions)
+    .where(eq(storageVersions.id, versionId))
+    .limit(1);
+  signal.throwIfAborted();
+  return version;
+}
+
+function assertServerSideVersionIdentity(
+  stored: PreparedStorageVersion,
+  expected: Omit<PreparedStorageVersion, "archiveSize">,
+): void {
+  if (
+    !storageVersionMatches(stored, {
+      ...expected,
+      archiveSize: stored.archiveSize,
+    })
+  ) {
+    throw new StorageVersionIdentityConflictError(expected.versionId);
+  }
+}
+
+async function reconcileArchiveSize(
+  db: Db,
+  expected: Omit<PreparedStorageVersion, "archiveSize">,
+  archiveSize: number,
+  signal: AbortSignal,
+): Promise<PreparedStorageVersion | undefined> {
+  const [updated] = await db
+    .update(storageVersions)
+    .set({ archiveSize })
+    .where(
+      and(
+        eq(storageVersions.id, expected.versionId),
+        eq(storageVersions.storageId, expected.storageId),
+        eq(storageVersions.s3Key, expected.s3Key),
+        eq(storageVersions.size, expected.size),
+        eq(storageVersions.fileCount, expected.fileCount),
+        isNull(storageVersions.message),
+        eq(storageVersions.createdBy, expected.createdBy),
+      ),
+    )
+    .returning({
+      storageId: storageVersions.storageId,
+      versionId: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      size: storageVersions.size,
+      archiveSize: storageVersions.archiveSize,
+      fileCount: storageVersions.fileCount,
+      message: storageVersions.message,
+      createdBy: storageVersions.createdBy,
+    });
+  signal.throwIfAborted();
+  if (updated) {
+    return updated;
+  }
+
+  const current = await readStorageVersion(db, expected.versionId, signal);
+  if (!current) {
+    return undefined;
+  }
+  const prepared = { ...expected, archiveSize };
+  if (!storageVersionMatches(current, prepared)) {
+    throw new StorageVersionIdentityConflictError(expected.versionId);
+  }
+  return current;
+}
+
+async function resolveCanonicalVolumeStorage(
+  db: Db,
+  args: { readonly orgId: string; readonly storageName: string },
+  signal: AbortSignal,
+): Promise<{ readonly id: string; readonly s3Prefix: string }> {
+  const { storageId, s3Prefix } = newStorageS3Location(args.orgId);
+  await db
+    .insert(storages)
+    .values({
+      id: storageId,
+      userId: VOLUME_ORG_USER_ID,
+      orgId: args.orgId,
+      name: args.storageName,
+      s3Prefix,
+      size: 0,
+      fileCount: 0,
+    })
+    .onConflictDoNothing();
+  signal.throwIfAborted();
+
+  const [storage] = await db
+    .select({ id: storages.id, s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, args.orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, args.storageName),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  if (!storage) {
+    throw new Error(`Failed to create storage for ${args.storageName}`);
+  }
+  return storage;
+}
+
+export const prepareVolumeServerSide$ = command(
+  async (
+    { set },
+    args: PrepareVolumeServerSideInput,
+    signal: AbortSignal,
+  ): Promise<PreparedServerSideVolume> => {
+    const files = materializeFiles(args.files);
+    const totalSize = files.reduce((sum, file) => {
+      return sum + file.size;
+    }, 0);
+    const fileEntries = files.map((file) => {
+      return {
+        path: file.path,
+        hash: file.hash,
+        size: file.size,
+      };
+    });
+    const updatedAt = nowDate();
+    const writeDb = set(writeDb$);
+    const storage = await resolveCanonicalVolumeStorage(writeDb, args, signal);
+
+    const versionId = computeContentHashFromHashes(storage.id, fileEntries);
+    const s3Key = `${storage.s3Prefix}/${versionId}`;
+    const expectedVersion: Omit<PreparedStorageVersion, "archiveSize"> = {
+      storageId: storage.id,
+      versionId,
+      s3Key,
+      size: totalSize,
+      fileCount: files.length,
+      message: null,
+      createdBy: SERVER_SIDE_STORAGE_VERSION_CREATOR,
+    };
+    const bucketName = env("R2_USER_STORAGES_BUCKET_NAME");
+    const existing = await readStorageVersion(writeDb, versionId, signal);
+    if (existing) {
+      assertServerSideVersionIdentity(existing, expectedVersion);
+      const objects = await set(
+        registeredVolumeObjects$,
+        {
+          bucketName,
+          s3Key,
+          fileCount: files.length,
+          storedArchiveSize: existing.archiveSize,
+        },
+        signal,
+      );
+      if (objects.kind === "available") {
+        const version =
+          objects.archiveSize === existing.archiveSize
+            ? existing
+            : await reconcileArchiveSize(
+                writeDb,
+                expectedVersion,
+                objects.archiveSize,
+                signal,
+              );
+        return {
+          storageName: args.storageName,
+          version: version ?? {
+            ...expectedVersion,
+            archiveSize: objects.archiveSize,
+          },
+          updatedAt,
+        };
+      }
+    }
+
+    const archiveBuffer = await createVolumeArchive(files, signal);
+    const manifest: S3StorageManifest = {
+      version: versionId,
+      createdAt: updatedAt.toISOString(),
+      totalSize,
+      fileCount: files.length,
+      files: fileEntries,
+    };
+    await set(
+      uploadAndVerifyVolumeObjects$,
+      {
+        bucketName,
+        s3Key,
+        archiveBuffer,
+        manifest,
+        fileCount: files.length,
+        storageName: args.storageName,
+      },
+      signal,
+    );
+
+    const uploadedVersion = {
+      ...expectedVersion,
+      archiveSize: archiveBuffer.length,
+    };
+    const version = existing
+      ? await reconcileArchiveSize(
+          writeDb,
+          expectedVersion,
+          archiveBuffer.length,
+          signal,
+        )
+      : undefined;
+    return {
+      storageName: args.storageName,
+      version: version ?? uploadedVersion,
+      updatedAt,
+    };
+  },
+);
+
+export async function commitPreparedVolumeServerSide(
+  args: {
+    readonly db: Db;
+    readonly volume: PreparedServerSideVolume;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await registerPreparedStorageVersions(
+    { db: args.db, versions: [args.volume.version] },
+    signal,
+  );
+  await args.db
+    .update(storages)
+    .set({
+      headVersionId: args.volume.version.versionId,
+      size: args.volume.version.size,
+      fileCount: args.volume.version.fileCount,
+      updatedAt: args.volume.updatedAt,
+    })
+    .where(eq(storages.id, args.volume.version.storageId));
+  signal.throwIfAborted();
+}

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -94,7 +94,7 @@ function materializeFiles(
   files: readonly VolumeFileInput[],
 ): readonly MaterializedVolumeFile[] {
   const validationRoot = resolve(tmpdir(), "vm0-api-volume-validation");
-  const materialized = files.map((file) => {
+  return files.map((file) => {
     resolveVolumeFilePath(validationRoot, file.path);
     const content = Buffer.from(file.content, "utf8");
     return {
@@ -104,7 +104,6 @@ function materializeFiles(
       size: content.length,
     };
   });
-  return materialized.sort(compareFilePaths);
 }
 
 function resolveVolumeFilePath(root: string, path: string): string {
@@ -167,9 +166,10 @@ async function createVolumeArchive(
   files: readonly MaterializedVolumeFile[],
   signal: AbortSignal,
 ): Promise<Buffer> {
+  const archiveFiles = [...files].sort(compareFilePaths);
   const tmpDir = await mkdtemp(join(tmpdir(), "vm0-api-volume-"));
   const archiveBuffer = await onRejection(
-    buildVolumeArchive(tmpDir, files, signal),
+    buildVolumeArchive(tmpDir, archiveFiles, signal),
     () => {
       rmSync(tmpDir, { recursive: true, force: true });
     },

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -111,6 +111,7 @@ function resolveVolumeFilePath(root: string, path: string): string {
   const filePath = resolve(join(root, path));
   const relativePath = relative(root, filePath);
   if (
+    isAbsolute(path) ||
     relativePath === ".." ||
     relativePath.startsWith(`..${sep}`) ||
     isAbsolute(relativePath)

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -93,7 +93,9 @@ function compareFilePaths(
 function materializeFiles(
   files: readonly VolumeFileInput[],
 ): readonly MaterializedVolumeFile[] {
+  const validationRoot = resolve(tmpdir(), "vm0-api-volume-validation");
   const materialized = files.map((file) => {
+    resolveVolumeFilePath(validationRoot, file.path);
     const content = Buffer.from(file.content, "utf8");
     return {
       path: file.path,
@@ -105,20 +107,25 @@ function materializeFiles(
   return materialized.sort(compareFilePaths);
 }
 
+function resolveVolumeFilePath(root: string, path: string): string {
+  const filePath = resolve(join(root, path));
+  const relativePath = relative(root, filePath);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(`Invalid file path: ${path}`);
+  }
+  return filePath;
+}
+
 function writeFilesToDirectory(
   tmpDir: string,
   files: readonly MaterializedVolumeFile[],
 ): void {
   for (const file of files) {
-    const filePath = resolve(join(tmpDir, file.path));
-    const relativePath = relative(tmpDir, filePath);
-    if (
-      relativePath === ".." ||
-      relativePath.startsWith(`..${sep}`) ||
-      isAbsolute(relativePath)
-    ) {
-      throw new Error(`Invalid file path: ${file.path}`);
-    }
+    const filePath = resolveVolumeFilePath(tmpDir, file.path);
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, file.content);
   }

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -134,6 +134,8 @@ function writeFilesToDirectory(
     const filePath = resolveVolumeFilePath(tmpDir, file.path);
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, file.content);
+    // `tar` portable mode retains file permissions, so canonicalize them.
+    chmodSync(filePath, 0o644);
   }
 }
 

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -77,7 +77,7 @@ async function bufferFromStream(
   return Buffer.concat(chunks);
 }
 
-function compareFilePaths(
+function compareArchiveFiles(
   left: MaterializedVolumeFile,
   right: MaterializedVolumeFile,
 ): number {
@@ -85,6 +85,12 @@ function compareFilePaths(
     return -1;
   }
   if (left.path > right.path) {
+    return 1;
+  }
+  if (left.hash < right.hash) {
+    return -1;
+  }
+  if (left.hash > right.hash) {
     return 1;
   }
   return 0;
@@ -166,7 +172,7 @@ async function createVolumeArchive(
   files: readonly MaterializedVolumeFile[],
   signal: AbortSignal,
 ): Promise<Buffer> {
-  const archiveFiles = [...files].sort(compareFilePaths);
+  const archiveFiles = [...files].sort(compareArchiveFiles);
   const tmpDir = await mkdtemp(join(tmpdir(), "vm0-api-volume-"));
   const archiveBuffer = await onRejection(
     buildVolumeArchive(tmpDir, archiveFiles, signal),

--- a/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
@@ -1,293 +1,32 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { mkdtemp } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
-import { tmpdir } from "node:os";
+import { command } from "ccstate";
 
-import { VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
-import { storages, storageVersions } from "@vm0/db/schema/storage";
-import { command, type Computed } from "ccstate";
-import { and, eq } from "drizzle-orm";
-import { create } from "tar";
-
-import { env } from "../../lib/env";
-import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
-import { putS3Object, verifyS3FilesExist } from "../external/s3";
-import { onRejection, safeSync } from "../utils";
 import {
-  computeContentHashFromHashes,
-  hashFileContent,
-  type FileEntryWithHash,
-} from "./storage-content-hash.service";
-import { newStorageS3Location } from "./storage-s3-prefix.utils";
-
-interface VolumeFileInput {
-  readonly path: string;
-  readonly content: string;
-}
-
-interface UploadVolumeInput {
-  readonly orgId: string;
-  readonly storageName: string;
-  readonly files: readonly VolumeFileInput[];
-}
+  commitPreparedVolumeServerSide,
+  prepareVolumeServerSide$,
+  type PrepareVolumeServerSideInput,
+} from "./storage-volume-publication.service";
 
 interface UploadedVolume {
   readonly storageName: string;
   readonly versionId: string;
 }
 
-interface S3StorageManifest {
-  readonly version: string;
-  readonly createdAt: string;
-  readonly totalSize: number;
-  readonly fileCount: number;
-  readonly files: readonly FileEntryWithHash[];
-}
-
-interface MaterializedVolumeFile extends FileEntryWithHash {
-  readonly content: Buffer;
-}
-
-async function bufferFromStream(
-  stream: AsyncIterable<Uint8Array>,
-): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream) {
-    chunks.push(Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks);
-}
-
-function materializeFiles(
-  files: readonly VolumeFileInput[],
-): readonly MaterializedVolumeFile[] {
-  return files.map((file) => {
-    const content = Buffer.from(file.content, "utf8");
-    return {
-      path: file.path,
-      content,
-      hash: hashFileContent(content),
-      size: content.length,
-    };
-  });
-}
-
-function writeFilesToDirectory(
-  tmpDir: string,
-  files: readonly MaterializedVolumeFile[],
-): void {
-  for (const file of files) {
-    const filePath = resolve(join(tmpDir, file.path));
-    const relativePath = relative(tmpDir, filePath);
-    if (
-      relativePath === ".." ||
-      relativePath.startsWith(`..${sep}`) ||
-      isAbsolute(relativePath)
-    ) {
-      throw new Error(`Invalid file path: ${file.path}`);
-    }
-    mkdirSync(dirname(filePath), { recursive: true });
-    writeFileSync(filePath, file.content);
-  }
-}
-
-function createArchiveBuffer(
-  tmpDir: string,
-  files: readonly MaterializedVolumeFile[],
-): Promise<Buffer> {
-  return bufferFromStream(
-    create(
-      {
-        gzip: true,
-        cwd: tmpDir,
-      },
-      files.map((file) => {
-        return file.path;
-      }),
-    ),
-  );
-}
-
-async function uploadAndVerifyVolumeObjects(
-  get: <T>(computedValue: Computed<T>) => T,
-  args: {
-    readonly bucketName: string;
-    readonly s3Key: string;
-    readonly archiveBuffer: Buffer;
-    readonly manifest: S3StorageManifest;
-    readonly fileCount: number;
-    readonly storageName: string;
-  },
-): Promise<void> {
-  await Promise.all([
-    get(
-      putS3Object(
-        args.bucketName,
-        `${args.s3Key}/archive.tar.gz`,
-        args.archiveBuffer,
-        "application/gzip",
-      ),
-    ),
-    get(
-      putS3Object(
-        args.bucketName,
-        `${args.s3Key}/manifest.json`,
-        JSON.stringify(args.manifest),
-        "application/json",
-      ),
-    ),
-  ]);
-
-  const uploadVerified = await get(
-    verifyS3FilesExist(args.bucketName, args.s3Key, args.fileCount),
-  );
-  if (!uploadVerified) {
-    throw new Error(
-      `Uploaded volume files are not available for ${args.storageName}`,
-    );
-  }
-}
-
-const uploadVolumeServerSideInner$ = command(
+export const uploadVolumeServerSide$ = command(
   async (
-    { get, set },
-    args: UploadVolumeInput,
+    { set },
+    args: PrepareVolumeServerSideInput,
     signal: AbortSignal,
   ): Promise<UploadedVolume> => {
-    const files = materializeFiles(args.files);
-    const totalSize = files.reduce((sum, file) => {
-      return sum + file.size;
-    }, 0);
-
-    const tmpDir = await mkdtemp(join(tmpdir(), "vm0-api-volume-"));
-    signal.throwIfAborted();
-
-    const writeResult = safeSync(() => {
-      writeFilesToDirectory(tmpDir, files);
-    });
-    if ("error" in writeResult) {
-      rmSync(tmpDir, { recursive: true, force: true });
-      throw writeResult.error;
-    }
-    const archiveBuffer = await onRejection(
-      createArchiveBuffer(tmpDir, files),
-      () => {
-        rmSync(tmpDir, { recursive: true, force: true });
-      },
-    );
-    signal.throwIfAborted();
-    rmSync(tmpDir, { recursive: true, force: true });
-
+    const volume = await set(prepareVolumeServerSide$, args, signal);
     const writeDb = set(writeDb$);
-    const { storageId, s3Prefix } = newStorageS3Location(args.orgId);
-    const timestamp = nowDate();
-
-    const [storage] = await writeDb
-      .insert(storages)
-      .values({
-        id: storageId,
-        userId: VOLUME_ORG_USER_ID,
-        orgId: args.orgId,
-        name: args.storageName,
-        s3Prefix,
-        size: 0,
-        fileCount: 0,
-      })
-      .onConflictDoUpdate({
-        target: [storages.orgId, storages.userId, storages.name],
-        set: { updatedAt: timestamp },
-      })
-      .returning({
-        id: storages.id,
-        s3Prefix: storages.s3Prefix,
-      });
-    signal.throwIfAborted();
-
-    if (!storage) {
-      throw new Error(`Failed to create storage for ${args.storageName}`);
-    }
-
-    const fileEntries = files.map((file) => {
-      return {
-        path: file.path,
-        hash: file.hash,
-        size: file.size,
-      };
-    });
-    const versionId = computeContentHashFromHashes(storage.id, fileEntries);
-    // On upsert conflict the row keeps its original prefix, which can differ
-    // from the freshly generated one — always key objects off the stored value.
-    const s3Key = `${storage.s3Prefix}/${versionId}`;
-    const bucketName = env("R2_USER_STORAGES_BUCKET_NAME");
-    const manifest: S3StorageManifest = {
-      version: versionId,
-      createdAt: timestamp.toISOString(),
-      totalSize,
-      fileCount: files.length,
-      files: fileEntries,
-    };
-
-    await uploadAndVerifyVolumeObjects(get, {
-      bucketName,
-      s3Key,
-      archiveBuffer,
-      manifest,
-      fileCount: files.length,
-      storageName: args.storageName,
-    });
-    signal.throwIfAborted();
-
     await writeDb.transaction(async (tx) => {
-      await tx
-        .insert(storageVersions)
-        .values({
-          id: versionId,
-          storageId: storage.id,
-          s3Key,
-          size: totalSize,
-          archiveSize: archiveBuffer.length,
-          fileCount: files.length,
-          message: null,
-          createdBy: "user",
-        })
-        .onConflictDoUpdate({
-          target: storageVersions.id,
-          set: { archiveSize: archiveBuffer.length },
-        });
-      signal.throwIfAborted();
-
-      const [version] = await tx
-        .select({ id: storageVersions.id })
-        .from(storageVersions)
-        .where(
-          and(
-            eq(storageVersions.storageId, storage.id),
-            eq(storageVersions.id, versionId),
-          ),
-        )
-        .limit(1);
-      signal.throwIfAborted();
-
-      if (!version) {
-        throw new Error(`Version ${versionId} not found after insert`);
-      }
-
-      await tx
-        .update(storages)
-        .set({
-          headVersionId: versionId,
-          size: totalSize,
-          fileCount: files.length,
-          updatedAt: timestamp,
-        })
-        .where(eq(storages.id, storage.id));
-      signal.throwIfAborted();
+      await commitPreparedVolumeServerSide({ db: tx, volume }, signal);
     });
     signal.throwIfAborted();
-
-    return { storageName: args.storageName, versionId };
+    return {
+      storageName: volume.storageName,
+      versionId: volume.version.versionId,
+    };
   },
 );
-
-export const uploadVolumeServerSide$ = uploadVolumeServerSideInner$;

--- a/turbo/packages/api-contracts/src/contracts/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-system-storage-presigned-url-cache-state.ts
@@ -75,6 +75,14 @@ export const testSystemStoragePresignedUrlCacheStateActionBodySchema =
       version_id: z.string(),
     }),
     z.object({
+      action: z.literal("set-storage-version-archive-size"),
+      org_id: z.string(),
+      user_id: z.string(),
+      storage_name: z.string(),
+      version_id: z.string(),
+      archive_size: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    }),
+    z.object({
       action: z.literal("delete-storage-version"),
       org_id: z.string(),
       user_id: z.string(),

--- a/turbo/packages/api-contracts/src/contracts/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-system-storage-presigned-url-cache-state.ts
@@ -28,6 +28,16 @@ const storageStateSchema = z.object({
   head_version_id: z.string().nullable(),
 });
 
+const storageVersionStateSchema = z.object({
+  version_id: z.string(),
+  s3_key: z.string(),
+  size: z.number(),
+  archive_size: z.number(),
+  file_count: z.number(),
+  message: z.string().nullable(),
+  created_by: z.string(),
+});
+
 export const testSystemStoragePresignedUrlCacheStateActionBodySchema =
   z.discriminatedUnion("action", [
     z.object({
@@ -56,6 +66,13 @@ export const testSystemStoragePresignedUrlCacheStateActionBodySchema =
       s3_prefix: z.string(),
       s3_key: z.string(),
       archive_size: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    }),
+    z.object({
+      action: z.literal("read-storage-version"),
+      org_id: z.string(),
+      user_id: z.string(),
+      storage_name: z.string(),
+      version_id: z.string(),
     }),
     z.object({
       action: z.literal("delete-storage-version"),
@@ -87,6 +104,7 @@ export const testSystemStoragePresignedUrlCacheStateActionResponseSchema =
     ok: z.literal(true),
     rows: z.array(cacheRowSchema).optional(),
     storage_state: storageStateSchema.nullable().optional(),
+    storage_version: storageVersionStateSchema.nullable().optional(),
   });
 
 export const testSystemStoragePresignedUrlCacheStateContract = c.router({


### PR DESCRIPTION
## Summary

- extract one batch immutable storage-version insert-or-validate primitive for server-side and Builtin publication
- split server-side volume preparation from transactional registration and HEAD projection while preserving the existing upload wrapper
- reuse healthy registered versions without PUTs, and make new or repaired archives byte-stable with canonical archive ordering, duplicate-path tie-breaking, and fixed metadata while preserving manifest file order
- repair missing registered objects and reconcile encoded size without advancing HEAD during preparation

## Compatibility

- preserves Builtin ownership, prefix, provenance, error mapping, atomicity, and new-version-only HEAD behavior
- preserves workflow, compose, instruction, and custom connector volume callers through `uploadVolumeServerSide$`
- does not change database schema, public APIs, queue payloads, storage manifest schema, runner contracts, or Custom connector activation
- leaves Custom activation to #26134 and orphan cleanup to #26137

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflows.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/zero-agents-update.test.ts --maxWorkers=1 --silent=passed-only` (160 passed)
- `pnpm -F @vm0/api-contracts test -- --maxWorkers=1 --silent=passed-only` (544 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --workspace api`
- repository pre-commit hooks, including full Turbo Knip and type checks

Closes #26133

Parent: #26075
