### PR TITLE
test(guest-agent): tolerate sid-zero session scans

### DIFF
--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -34,7 +34,7 @@ zstd.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true
-nix = { workspace = true, features = ["inotify"] }
+nix = { workspace = true, features = ["inotify", "process"] }
 shell-quote.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 vsock-host.workspace = true

--- a/crates/guest-agent/tests/command_output_timeout.rs
+++ b/crates/guest-agent/tests/command_output_timeout.rs
@@ -30,6 +30,14 @@ impl Drop for DescendantCleanup {
     }
 }
 
+#[test]
+fn command_session_rejects_zero_session_id() {
+    assert!(!common::process_session::session_id_matches_target(
+        rustix::process::Pid::INIT,
+        Ok(0),
+    ));
+}
+
 #[tokio::test]
 async fn command_output_timeout_preserves_completed_output()
 -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -17,7 +17,7 @@
 
 #![allow(dead_code)] // consumed across multiple test binaries
 
-mod process_session;
+pub(crate) mod process_session;
 mod system_log;
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};

--- a/crates/guest-agent/tests/common/process_session.rs
+++ b/crates/guest-agent/tests/common/process_session.rs
@@ -185,7 +185,7 @@ async fn scan_session_members(session_id: Pid) -> Result<SessionScan, String> {
                 continue;
             }
         };
-        if process_session_id(pid) != Ok(session_id) {
+        if !session_id_matches_target(session_id, process_session_id(pid)) {
             continue;
         }
 
@@ -228,7 +228,7 @@ async fn scan_session_members(session_id: Pid) -> Result<SessionScan, String> {
                 continue;
             }
         }
-        if process_session_id(pid) != Ok(session_id) {
+        if !session_id_matches_target(session_id, process_session_id(pid)) {
             continue;
         }
 
@@ -250,7 +250,7 @@ fn record_owned_stat_error(
     live_pids: &mut Vec<Pid>,
     first_error: &mut Option<String>,
 ) {
-    if process_session_id(pid) != Ok(session_id) {
+    if !session_id_matches_target(session_id, process_session_id(pid)) {
         return;
     }
     live_pids.push(pid);
@@ -261,8 +261,16 @@ fn record_owned_stat_error(
     }
 }
 
-fn process_session_id(pid: Pid) -> rustix::io::Result<Pid> {
-    rustix::process::getsid(Some(pid))
+pub(crate) fn session_id_matches_target(
+    target_session_id: Pid,
+    observed_session_id: Result<libc::pid_t, nix::errno::Errno>,
+) -> bool {
+    observed_session_id == Ok(target_session_id.as_raw_pid())
+}
+
+fn process_session_id(pid: Pid) -> Result<libc::pid_t, nix::errno::Errno> {
+    nix::unistd::getsid(Some(nix::unistd::Pid::from_raw(pid.as_raw_pid())))
+        .map(nix::unistd::Pid::as_raw)
 }
 
 async fn read_process_stat(pid: Pid) -> ProcessStatRead {


### PR DESCRIPTION
## Summary

- query scanned process session IDs through nix so a successful raw SID zero remains representable
- keep managed sessions and process handles as positive rustix PIDs, preserving pidfd and PID-reuse protections
- add a deterministic command-timeout integration regression for SID-zero non-membership

## Scope

- guest-agent integration-test infrastructure only
- enables the existing nix dev dependency's `process` feature
- no production runtime, API, protocol, persisted data, migration, or deployment compatibility changes
- does not patch or fork rustix

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps --all-features --quiet`
- `cargo test -p guest-agent --test command_output_timeout --all-features -- --nocapture`
- `cargo test -p guest-agent --all-targets --all-features --quiet`
- `lefthook run pre-commit --no-tty --file crates/guest-agent/Cargo.toml --file crates/guest-agent/tests/command_output_timeout.rs --file crates/guest-agent/tests/common/mod.rs --file crates/guest-agent/tests/common/process_session.rs`
- `git diff --check`

Closes #26097
