### PR TITLE
fix(connectors): preserve active connection during oauth reconnect

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -372,10 +372,36 @@ describe("Steam OpenID connector", () => {
     });
   });
 
-  it("rejects invalid Steam OpenID verification without storing a connection", async () => {
+  it("keeps the active Steam connection until a verified replacement succeeds", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
+    const initialAuthorizationUrl = await startSteamOpenId(actor);
+    await completeSteamOpenIdCallback(initialAuthorizationUrl);
+
+    mockSession(actor);
+    const initial = await accept(
+      setupApp({ context, routes: zeroConnectorsRoutes })(
+        zeroConnectorsBySlugContract,
+      ).get({
+        params: { connectorSlug: "steam" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
     const authorizationUrl = await startSteamOpenId(actor);
+    mockSession(actor);
+    const whilePending = await accept(
+      setupApp({ context, routes: zeroConnectorsRoutes })(
+        zeroConnectorsBySlugContract,
+      ).get({
+        params: { connectorSlug: "steam" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(whilePending.body).toStrictEqual(initial.body);
+
     mockSteamOpenIdVerification(false);
 
     const response = await accept(
@@ -402,9 +428,24 @@ describe("Steam OpenID connector", () => {
         params: { connectorSlug: "steam" },
         headers: authHeaders(),
       }),
-      [404],
+      [200],
     );
-    expect(connector.body.error.code).toBe("NOT_FOUND");
+    expect(connector.body).toStrictEqual(initial.body);
+
+    const replacementAuthorizationUrl = await startSteamOpenId(actor);
+    await completeSteamOpenIdCallback(replacementAuthorizationUrl);
+    mockSession(actor);
+    const replaced = await accept(
+      setupApp({ context, routes: zeroConnectorsRoutes })(
+        zeroConnectorsBySlugContract,
+      ).get({
+        params: { connectorSlug: "steam" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+    expect(replaced.body.id).toBe(initial.body.id);
+    expect(replaced.body.externalId).toBe(STEAM_ID);
   });
 
   it("rejects OpenID start requests for non-OpenID connector methods", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -47,6 +47,7 @@ import {
 import { readUserSecrets } from "./helpers/user-config-state";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import {
+  readConnectorCredentialStorageState,
   readCustomConnectorCredentialStorageParent,
   readCustomConnectorOAuthStorageState,
   setCustomConnectorCredentialStorageState,
@@ -1709,17 +1710,22 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       "93.184.216.34",
     );
 
-    await expect(
-      readCustomConnectorCredentialStorageParent(context, {
+    const initialStorage = await readCustomConnectorCredentialStorageParent(
+      context,
+      {
         orgId: requiredOrgId(member),
         userId: member.userId,
         customConnectorId: created.id,
-      }),
-    ).resolves.toMatchObject({
+      },
+    );
+    expect(initialStorage).toMatchObject({
       connector: {
         storage_version: 1,
       },
     });
+    if (!initialStorage.connector) {
+      throw new Error("Expected custom OAuth connector storage");
+    }
 
     const oauthConnected = await connectorsApi.listCustomConnectors(member);
     expect(
@@ -1736,6 +1742,29 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await expect(
       connectorsApi.readAgentCustomConnectors(member, agent.agentId),
     ).resolves.toContain(created.id);
+
+    const replacementUrl = await connectorsApi.startCustomConnectorOAuth2(
+      member,
+      created.id,
+      agent.agentId,
+    );
+    await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+      code: "bdd-custom-oauth-replacement-code",
+      state: stateFromAuthorizationUrl(replacementUrl),
+    });
+    const replacementStorage = await readCustomConnectorCredentialStorageParent(
+      context,
+      {
+        orgId: requiredOrgId(member),
+        userId: member.userId,
+        customConnectorId: created.id,
+      },
+    );
+    expect(replacementStorage.connector?.id).toBe(initialStorage.connector.id);
+    expect(provider.tokenBodies).toHaveLength(2);
+    expect(provider.tokenBodies[1]?.get("code")).toBe(
+      "bdd-custom-oauth-replacement-code",
+    );
 
     await setCustomConnectorCredentialStorageState(context, {
       orgId: requiredOrgId(member),
@@ -1819,8 +1848,8 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       code: "bdd-custom-oauth-reconnect-code",
       state: stateFromAuthorizationUrl(reconnectUrl),
     });
-    expect(provider.tokenBodies).toHaveLength(2);
-    expect(provider.tokenBodies[1]?.get("code")).toBe(
+    expect(provider.tokenBodies).toHaveLength(3);
+    expect(provider.tokenBodies[2]?.get("code")).toBe(
       "bdd-custom-oauth-reconnect-code",
     );
     await expect(
@@ -4262,6 +4291,41 @@ describe("CONN-02: OAuth callback validation and state claiming", () => {
 
     const connected = await connectorsApi.readConnectorBySlug(actor, "github");
 
+    const missingCodeStart = await connectorsApi.startOauth(
+      actor,
+      "github",
+      "oauth",
+    );
+    const reconnectWithoutCode = await connectorsApi.completeOauthCallback(
+      "github",
+      { state: stateFromAuthorizationUrl(missingCodeStart.authorizationUrl) },
+    );
+    expectConnectorErrorRedirect(reconnectWithoutCode, {
+      connectorSlug: "github",
+      message: "Missing authorization code",
+    });
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "github"),
+    ).resolves.toStrictEqual(connected);
+
+    const deniedStart = await connectorsApi.startOauth(
+      actor,
+      "github",
+      "oauth",
+    );
+    const denied = await connectorsApi.completeOauthCallback("github", {
+      error: "access_denied",
+      error_description: "Provider denied access",
+      state: stateFromAuthorizationUrl(deniedStart.authorizationUrl),
+    });
+    expectConnectorErrorRedirect(denied, {
+      connectorSlug: "github",
+      message: "Provider denied access",
+    });
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "github"),
+    ).resolves.toStrictEqual(connected);
+
     const consumedWithoutCode = await connectorsApi.completeOauthCallback(
       "github",
       { state },
@@ -4307,13 +4371,9 @@ describe("CONN-02: OAuth callback validation and state claiming", () => {
     });
     clearMockNow();
 
-    const afterExpiry = await connectorsApi.requestReadConnectorBySlug(
-      actor,
-      "github",
-      [404],
-    );
-    expectApiError(afterExpiry.body);
-    expect(afterExpiry.body.error.code).toBe("NOT_FOUND");
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "github"),
+    ).resolves.toStrictEqual(connected);
   });
 
   it("routes callbacks through canonical and trusted web origins", async () => {
@@ -4568,6 +4628,7 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       actor,
       "test-oauth",
     );
+    expect(defaultExpiry.id).toBe(explicitExpiry.id);
     if (!defaultExpiry.tokenExpiresAt) {
       throw new Error("Expected the default token expiry to be stored");
     }
@@ -4576,6 +4637,16 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       defaultBefore + 15 * 60 * 1000,
     );
     expect(defaultExpiryMs).toBeLessThanOrEqual(defaultAfter + 15 * 60 * 1000);
+    const storageBeforeFailures = await readConnectorCredentialStorageState(
+      context,
+      {
+        orgId: requiredOrgId(actor),
+        userId: actor.userId,
+        connectorSlug: "test-oauth",
+        secretNames: ["TEST_OAUTH_ACCESS_TOKEN", "TEST_OAUTH_REFRESH_TOKEN"],
+        variableNames: ["TEST_OAUTH_API_TENANT_ID"],
+      },
+    );
 
     mockSlackConnectorOAuth();
     const slackStart = await connectorsApi.startOauth(actor, "slack", "oauth");
@@ -4614,13 +4685,18 @@ describe("CONN-02: test-oauth auth-code journey", () => {
     expect(tokenFail.headers.getSetCookie()).toStrictEqual(
       expect.arrayContaining([...CONNECTOR_OAUTH_COOKIE_CLEARS]),
     );
-    const afterTokenFail = await connectorsApi.requestReadConnectorBySlug(
-      actor,
-      "test-oauth",
-      [404],
-    );
-    expectApiError(afterTokenFail.body);
-    expect(afterTokenFail.body.error.code).toBe("NOT_FOUND");
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "test-oauth"),
+    ).resolves.toStrictEqual(defaultExpiry);
+    await expect(
+      readConnectorCredentialStorageState(context, {
+        orgId: requiredOrgId(actor),
+        userId: actor.userId,
+        connectorSlug: "test-oauth",
+        secretNames: ["TEST_OAUTH_ACCESS_TOKEN", "TEST_OAUTH_REFRESH_TOKEN"],
+        variableNames: ["TEST_OAUTH_API_TENANT_ID"],
+      }),
+    ).resolves.toStrictEqual(storageBeforeFailures);
 
     mockTestOAuthAuthCodeProvider({ userinfoError: true });
     const userinfoFailStart = await connectorsApi.startOauth(
@@ -4639,13 +4715,44 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       connectorSlug: "test-oauth",
       message: "OAuth authorization failed. Please try again.",
     });
-    const afterUserinfoFail = await connectorsApi.requestReadConnectorBySlug(
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "test-oauth"),
+    ).resolves.toStrictEqual(defaultExpiry);
+    await expect(
+      readConnectorCredentialStorageState(context, {
+        orgId: requiredOrgId(actor),
+        userId: actor.userId,
+        connectorSlug: "test-oauth",
+        secretNames: ["TEST_OAUTH_ACCESS_TOKEN", "TEST_OAUTH_REFRESH_TOKEN"],
+        variableNames: ["TEST_OAUTH_API_TENANT_ID"],
+      }),
+    ).resolves.toStrictEqual(storageBeforeFailures);
+
+    mockTestOAuthAuthCodeProvider({
+      accessToken: "bdd-replacement-account-token",
+      userId: "bdd-test-oauth-replacement-user",
+      username: "bdd-test-oauth-replacement",
+      email: "bdd-test-oauth-replacement@example.test",
+    });
+    const replacementStart = await connectorsApi.startOauth(
       actor,
       "test-oauth",
-      [404],
+      "oauth",
     );
-    expectApiError(afterUserinfoFail.body);
-    expect(afterUserinfoFail.body.error.code).toBe("NOT_FOUND");
+    await connectorsApi.completeOauthCallback("test-oauth", {
+      code: "bdd-code-replacement-account",
+      state: stateFromAuthorizationUrl(replacementStart.authorizationUrl),
+    });
+    const replacementAccount = await connectorsApi.readConnectorBySlug(
+      actor,
+      "test-oauth",
+    );
+    expect(replacementAccount).toMatchObject({
+      id: defaultExpiry.id,
+      externalId: "bdd-test-oauth-replacement-user",
+      externalUsername: "bdd-test-oauth-replacement",
+      externalEmail: "bdd-test-oauth-replacement@example.test",
+    });
 
     await connectorsApi.deleteConnectorBySlug(actor, "slack");
     await connectorsApi.deleteFeatureSwitches(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -325,6 +325,9 @@ interface TestOAuthAuthCodeProviderOptions {
   readonly scope?: string;
   readonly tokenError?: boolean;
   readonly userinfoError?: boolean;
+  readonly userId?: string;
+  readonly username?: string;
+  readonly email?: string;
 }
 
 interface TestOAuthAuthCodeProviderRecorder {
@@ -373,9 +376,9 @@ export function mockTestOAuthAuthCodeProvider(
         );
       }
       return HttpResponse.json({
-        id: "bdd-test-oauth-user",
-        username: "bdd-test-oauth",
-        email: "bdd-test-oauth@example.test",
+        id: options.userId ?? "bdd-test-oauth-user",
+        username: options.username ?? "bdd-test-oauth",
+        email: options.email ?? "bdd-test-oauth@example.test",
       });
     }),
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -451,10 +451,12 @@ async function grantVisibleCredits(
 async function connectGmail(
   actor: ApiTestUser,
   gmailEmail: string,
+  subject = "bdd-gmail-user-id",
 ): Promise<void> {
   mockGmailConnectorOAuth({
     accessToken: "gmail-access-token",
     email: gmailEmail,
+    subject,
   });
   const start = await connectorsApi.startOauth(actor, "gmail", "oauth");
   const state = new URL(start.authorizationUrl).searchParams.get("state");
@@ -626,6 +628,80 @@ async function completeRunThroughSandbox(
 }
 
 describe("POST /api/webhooks/gmail", () => {
+  it("keeps same-account watch state and drops it when reconnect changes accounts", async () => {
+    const gmailEmail = uniqueGmailEmail();
+    configureGmailEnv();
+    const watch = configureGmailWatchMock();
+    server.use(
+      http.get("https://gmail.googleapis.com/gmail/v1/users/me/history", () => {
+        return HttpResponse.json({ history: [], historyId: "101" });
+      }),
+    );
+
+    const { actor, workflowId } = await setupFixture();
+    await connectGmail(actor, gmailEmail, "gmail-account-one");
+    const initialConnection = await connectorsApi.readConnectorBySlug(
+      actor,
+      "gmail",
+    );
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(actor),
+        params: { workflowId },
+        body: {
+          kind: "event",
+          eventType: "gmail-new-message",
+          eventConfig: { provider: "gmail", event: "new_message" },
+        },
+      }),
+      [201],
+    );
+    expect(watch.calls).toBe(1);
+
+    await connectGmail(actor, gmailEmail, "gmail-account-one");
+    const sameAccountConnection = await connectorsApi.readConnectorBySlug(
+      actor,
+      "gmail",
+    );
+    expect(sameAccountConnection.id).toBe(initialConnection.id);
+    const sameAccountEvent = await postGmailWebhook(
+      gmailPushBody({
+        emailAddress: gmailEmail,
+        historyId: 101,
+        messageId: "pubsub-same-account",
+      }),
+    );
+    expectResponseStatus(sameAccountEvent, 200);
+    expect(sameAccountEvent.body).toMatchObject({ watchStates: 1 });
+
+    await connectGmail(actor, `replacement-${gmailEmail}`, "gmail-account-two");
+    const replacementConnection = await connectorsApi.readConnectorBySlug(
+      actor,
+      "gmail",
+    );
+    expect(replacementConnection).toMatchObject({
+      id: initialConnection.id,
+      externalId: "gmail-account-two",
+    });
+    const oldAccountEvent = await postGmailWebhook(
+      gmailPushBody({
+        emailAddress: gmailEmail,
+        historyId: 102,
+        messageId: "pubsub-old-account",
+      }),
+    );
+    expectResponseStatus(oldAccountEvent, 200);
+    expect(oldAccountEvent.body).toMatchObject({ watchStates: 0 });
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(actor),
+        params: { id: created.body.id },
+      }),
+      [204],
+    );
+  });
+
   it("short-circuits before Gmail history reads when no consumer remains", async () => {
     const gmailEmail = uniqueGmailEmail();
     configureGmailEnv();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -690,7 +690,7 @@ describe("POST /api/webhooks/gmail", () => {
     });
     const oldAccountEvent = await postGmailWebhook(
       gmailPushBody({
-        emailAddress: gmailEmail,
+        emailAddress: renamedGmailEmail,
         historyId: 102,
         messageId: "pubsub-old-account",
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -668,9 +668,10 @@ describe("POST /api/webhooks/gmail", () => {
       id: initialConnection.id,
       externalEmail: renamedGmailEmail,
     });
+    expect(watch.calls).toBe(1);
     const sameAccountEvent = await postGmailWebhook(
       gmailPushBody({
-        emailAddress: gmailEmail,
+        emailAddress: renamedGmailEmail,
         historyId: 101,
         messageId: "pubsub-same-account",
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -658,12 +658,16 @@ describe("POST /api/webhooks/gmail", () => {
     );
     expect(watch.calls).toBe(1);
 
-    await connectGmail(actor, gmailEmail, "gmail-account-one");
+    const renamedGmailEmail = `renamed-${gmailEmail}`;
+    await connectGmail(actor, renamedGmailEmail, "gmail-account-one");
     const sameAccountConnection = await connectorsApi.readConnectorBySlug(
       actor,
       "gmail",
     );
-    expect(sameAccountConnection.id).toBe(initialConnection.id);
+    expect(sameAccountConnection).toMatchObject({
+      id: initialConnection.id,
+      externalEmail: renamedGmailEmail,
+    });
     const sameAccountEvent = await postGmailWebhook(
       gmailPushBody({
         emailAddress: gmailEmail,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mail.test.ts
@@ -543,6 +543,42 @@ describe("POST /api/zero/mail/drafts/link", () => {
     expect(gmail.draftReadCount).toBe(2);
   });
 
+  it("does not attach an existing draft to a different Gmail account", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    const gmail = mockGmailDraftApi();
+    const linked = await linkDraft(fixture);
+
+    mockGmailConnectorOAuth({
+      accessToken: "replacement-gmail-token",
+      subject: "replacement-gmail-account",
+      email: "replacement@example.com",
+    });
+    const start = await connectors.startOauth(fixture.actor, "gmail", "oauth");
+    const state = new URL(start.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Gmail OAuth state");
+    }
+    await connectors.completeOauthCallback("gmail", {
+      code: "zero-mail-replacement-account-code",
+      state,
+    });
+
+    const detached = await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+    expect(detached.body.mailDraft).toMatchObject({
+      accessStatus: "reconnect",
+      detailAvailable: false,
+      status: "draft",
+      subject: "Attachment review",
+    });
+    expect(gmail.draftReadCount).toBe(1);
+  });
+
   it("rejects a missing Gmail draft and cross-chat relinking", async () => {
     const fixture = await seedGmailMailCardFixture();
     const gmail = mockGmailDraftApi();

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -23,7 +23,7 @@ import {
 } from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
 import { nowDate } from "../../lib/time";
-import { db$, writeDb$ } from "../external/db";
+import { writeDb$ } from "../external/db";
 import {
   authorizeConnectedConnector$,
   connectorAgentAuthorizationRequested,
@@ -520,22 +520,6 @@ const startConnectorOauthInner$ = command(
     });
     signal.throwIfAborted();
 
-    // Stripe automations persist connector IDs as immutable bindings. Keep the
-    // row until the callback atomically replaces its credential state.
-    if (resolved.connectorSlug !== "stripe") {
-      await set(
-        deleteZeroConnectorLocalState$,
-        {
-          orgId: auth.orgId,
-          userId: auth.userId,
-          connectorSlug: resolved.connectorSlug,
-          snapshot: resolved.snapshot,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-    }
-
     const writeDb = set(writeDb$);
     await writeDb.insert(connectorOauthStates).values({
       state: prepared.state,
@@ -635,18 +619,6 @@ const startConnectorOpenIdInner$ = command(
       realm: prepared.realm,
       state: prepared.state,
     });
-    signal.throwIfAborted();
-
-    await set(
-      deleteZeroConnectorLocalState$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        connectorSlug: resolved.connectorSlug,
-        snapshot: resolved.snapshot,
-      },
-      signal,
-    );
     signal.throwIfAborted();
 
     const writeDb = set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
@@ -263,15 +263,18 @@ const completeOAuth2Callback$ = command(
           signal,
         );
         signal.throwIfAborted();
-        const connectionStorage = storeCustomConnectorOAuth2Connection({
-          db: set(writeDb$),
-          orgId: claimed.state.orgId,
-          userId: claimed.state.userId,
-          connectorId: connector.id,
-          storageVersion: connector.storageVersion,
-          token,
-          featureContext,
-        });
+        const connectionStorage = storeCustomConnectorOAuth2Connection(
+          {
+            db: set(writeDb$),
+            orgId: claimed.state.orgId,
+            userId: claimed.state.userId,
+            connectorId: connector.id,
+            storageVersion: connector.storageVersion,
+            token,
+            featureContext,
+          },
+          signal,
+        );
         await commitConnectorRuntimeMutation(connectionStorage, () => {
           return {
             db: set(writeDb$),

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { zeroCustomConnectorOAuth2Contract } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type { ConnectorOauthCallbackResult } from "@vm0/api-contracts/contracts/connectors-slug-callback";
+import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 
 import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -20,6 +21,7 @@ import {
   parseValidCustomConnectorOAuthState,
   startCustomConnectorOAuth2$,
   storeCustomConnectorOAuth2Connection,
+  type OAuthTokenResult,
 } from "../services/custom-connector-oauth2.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { addUserCustomConnector } from "../services/user-connectors.service";
@@ -178,6 +180,29 @@ async function authorizeCustomConnectorAgent(
   }
 }
 
+async function persistCustomConnectorOAuth2Connection(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly storageVersion: number;
+    readonly token: OAuthTokenResult;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const connectionStorage = storeCustomConnectorOAuth2Connection(args, signal);
+  await commitConnectorRuntimeMutation(connectionStorage, () => {
+    return {
+      db: args.db,
+      scope: { orgId: args.orgId, userId: args.userId },
+      targets: [{ kind: "custom", customConnectorId: args.connectorId }],
+    };
+  });
+  await publishCustomUserInvalidation(args.userId, signal);
+}
+
 const completeOAuth2Callback$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<Response> => {
     const query = get(queryOf(zeroCustomConnectorOAuth2Contract.callback));
@@ -263,7 +288,7 @@ const completeOAuth2Callback$ = command(
           signal,
         );
         signal.throwIfAborted();
-        const connectionStorage = storeCustomConnectorOAuth2Connection(
+        await persistCustomConnectorOAuth2Connection(
           {
             db: set(writeDb$),
             orgId: claimed.state.orgId,
@@ -275,17 +300,6 @@ const completeOAuth2Callback$ = command(
           },
           signal,
         );
-        await commitConnectorRuntimeMutation(connectionStorage, () => {
-          return {
-            db: set(writeDb$),
-            scope: {
-              orgId: claimed.state.orgId,
-              userId: claimed.state.userId,
-            },
-            targets: [{ kind: "custom", customConnectorId: connector.id }],
-          };
-        });
-        await publishCustomUserInvalidation(claimed.state.userId, signal);
         return true;
       })(),
     );

--- a/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
@@ -402,15 +402,18 @@ async function persistFeishuOAuthConnection(
     if (!connection.connected) {
       return connection;
     }
-    await storeCustomConnectorOAuth2Connection({
-      db: tx,
-      orgId: args.state.orgId,
-      userId: args.state.userId,
-      connectorId: args.connector.id,
-      storageVersion: args.connector.storageVersion,
-      token: args.token,
-      featureContext: args.featureContext,
-    });
+    await storeCustomConnectorOAuth2Connection(
+      {
+        db: tx,
+        orgId: args.state.orgId,
+        userId: args.state.userId,
+        connectorId: args.connector.id,
+        storageVersion: args.connector.storageVersion,
+        token: args.token,
+        featureContext: args.featureContext,
+      },
+      signal,
+    );
     signal.throwIfAborted();
     if (!args.installation.tenantKey && args.userInfo.tenantKey) {
       await tx

--- a/turbo/apps/api/src/signals/services/connector-account-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-state.service.ts
@@ -5,15 +5,15 @@ import { googleWorkspaceEventSubscriptionStates } from "@vm0/db/schema/google-wo
 import { mailDrafts } from "@vm0/db/schema/mail-draft";
 import { eq } from "drizzle-orm";
 
+import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
-import type { Db } from "../external/db";
 
 /**
  * Reconciles account-bound state while keeping the logical connector row and
  * durable product configuration intact.
  */
 export async function reconcileConnectorAccountState(
-  db: Db,
+  db: Tx,
   args: {
     readonly connectorId: string;
     readonly previousPrincipalId: string | null;

--- a/turbo/apps/api/src/signals/services/connector-account-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-state.service.ts
@@ -1,0 +1,40 @@
+import { gmailWatchStates } from "@vm0/db/schema/gmail-event";
+import { googleCalendarWatchStates } from "@vm0/db/schema/google-calendar-event";
+import { googleFormsWatchStates } from "@vm0/db/schema/google-forms-event";
+import { googleWorkspaceEventSubscriptionStates } from "@vm0/db/schema/google-workspace-event";
+import { mailDrafts } from "@vm0/db/schema/mail-draft";
+import { eq } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+/**
+ * Removes state whose authority belongs to one external account while keeping
+ * the logical connector row and durable product configuration intact.
+ */
+export async function clearConnectorAccountState(
+  db: Db,
+  connectorId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  await db
+    .delete(gmailWatchStates)
+    .where(eq(gmailWatchStates.connectorId, connectorId));
+  signal.throwIfAborted();
+  await db
+    .delete(googleCalendarWatchStates)
+    .where(eq(googleCalendarWatchStates.connectorId, connectorId));
+  signal.throwIfAborted();
+  await db
+    .delete(googleFormsWatchStates)
+    .where(eq(googleFormsWatchStates.connectorId, connectorId));
+  signal.throwIfAborted();
+  await db
+    .delete(googleWorkspaceEventSubscriptionStates)
+    .where(eq(googleWorkspaceEventSubscriptionStates.connectorId, connectorId));
+  signal.throwIfAborted();
+  await db
+    .update(mailDrafts)
+    .set({ connectorId: null })
+    .where(eq(mailDrafts.connectorId, connectorId));
+  signal.throwIfAborted();
+}

--- a/turbo/apps/api/src/signals/services/connector-account-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-state.service.ts
@@ -5,36 +5,56 @@ import { googleWorkspaceEventSubscriptionStates } from "@vm0/db/schema/google-wo
 import { mailDrafts } from "@vm0/db/schema/mail-draft";
 import { eq } from "drizzle-orm";
 
+import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 
 /**
- * Removes state whose authority belongs to one external account while keeping
- * the logical connector row and durable product configuration intact.
+ * Reconciles account-bound state while keeping the logical connector row and
+ * durable product configuration intact.
  */
-export async function clearConnectorAccountState(
+export async function reconcileConnectorAccountState(
   db: Db,
-  connectorId: string,
+  args: {
+    readonly connectorId: string;
+    readonly previousPrincipalId: string | null;
+    readonly nextPrincipalId: string;
+    readonly previousEmail: string | null;
+    readonly nextEmail: string | null;
+  },
   signal: AbortSignal,
 ): Promise<void> {
+  if (args.previousPrincipalId === args.nextPrincipalId) {
+    if (args.nextEmail !== null && args.previousEmail !== args.nextEmail) {
+      await db
+        .update(gmailWatchStates)
+        .set({ emailAddress: args.nextEmail, updatedAt: nowDate() })
+        .where(eq(gmailWatchStates.connectorId, args.connectorId));
+      signal.throwIfAborted();
+    }
+    return;
+  }
+
   await db
     .delete(gmailWatchStates)
-    .where(eq(gmailWatchStates.connectorId, connectorId));
+    .where(eq(gmailWatchStates.connectorId, args.connectorId));
   signal.throwIfAborted();
   await db
     .delete(googleCalendarWatchStates)
-    .where(eq(googleCalendarWatchStates.connectorId, connectorId));
+    .where(eq(googleCalendarWatchStates.connectorId, args.connectorId));
   signal.throwIfAborted();
   await db
     .delete(googleFormsWatchStates)
-    .where(eq(googleFormsWatchStates.connectorId, connectorId));
+    .where(eq(googleFormsWatchStates.connectorId, args.connectorId));
   signal.throwIfAborted();
   await db
     .delete(googleWorkspaceEventSubscriptionStates)
-    .where(eq(googleWorkspaceEventSubscriptionStates.connectorId, connectorId));
+    .where(
+      eq(googleWorkspaceEventSubscriptionStates.connectorId, args.connectorId),
+    );
   signal.throwIfAborted();
   await db
     .update(mailDrafts)
     .set({ connectorId: null })
-    .where(eq(mailDrafts.connectorId, connectorId));
+    .where(eq(mailDrafts.connectorId, args.connectorId));
   signal.throwIfAborted();
 }

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -1,7 +1,7 @@
 import { connectors } from "@vm0/db/schema/connector";
 import { isNotNull, sql } from "drizzle-orm";
 
-import type { Db } from "../external/db";
+import type { Tx } from "../../lib/db-types";
 import { deleteConnectorOwnedCredentialRows } from "./connector-credential-storage-write.service";
 
 export interface StoredConnectorConnectionRow {
@@ -34,7 +34,7 @@ type ConnectorConnectionTarget =
     };
 
 interface ConnectorCredentialWriteContext {
-  readonly db: Db;
+  readonly db: Tx;
   readonly connectorId: string;
 }
 
@@ -69,7 +69,7 @@ function connectorConnectionSelection() {
 }
 
 async function upsertConnectorConnection(
-  db: Db,
+  db: Tx,
   args: Omit<ReplaceConnectorConnectionArgs, "writeCredentials">,
 ): Promise<StoredConnectorConnectionRow> {
   if (args.target.kind === "builtin") {
@@ -156,7 +156,7 @@ async function upsertConnectorConnection(
 }
 
 export async function replaceConnectorConnection(
-  db: Db,
+  db: Tx,
   args: ReplaceConnectorConnectionArgs,
   signal: AbortSignal,
 ): Promise<StoredConnectorConnectionRow> {

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -1,0 +1,175 @@
+import { connectors } from "@vm0/db/schema/connector";
+import { isNotNull, sql } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import { deleteConnectorOwnedCredentialRows } from "./connector-credential-storage-write.service";
+
+export interface StoredConnectorConnectionRow {
+  readonly id: string;
+  readonly authMethod: string;
+  readonly externalId: string | null;
+  readonly externalUsername: string | null;
+  readonly externalEmail: string | null;
+  readonly oauthScopes: string | null;
+  readonly needsReconnect: boolean;
+  readonly reconnectReason: string | null;
+  readonly storageVersion: number;
+  readonly tokenExpiresAt: Date | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+type ConnectorConnectionTarget =
+  | {
+      readonly kind: "builtin";
+      readonly connectorSlug: string;
+      readonly externalId: string;
+      readonly externalUsername: string | null;
+      readonly externalEmail: string | null;
+      readonly oauthScopes: readonly string[];
+    }
+  | {
+      readonly kind: "custom";
+      readonly customConnectorId: string;
+    };
+
+interface ConnectorCredentialWriteContext {
+  readonly db: Db;
+  readonly connectorId: string;
+}
+
+interface ReplaceConnectorConnectionArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly authMethod: string;
+  readonly storageVersion: number;
+  readonly tokenExpiresAt: Date | null;
+  readonly target: ConnectorConnectionTarget;
+  readonly writeCredentials: (
+    context: ConnectorCredentialWriteContext,
+    signal: AbortSignal,
+  ) => Promise<void>;
+}
+
+function connectorConnectionSelection() {
+  return {
+    id: connectors.id,
+    authMethod: connectors.authMethod,
+    externalId: connectors.externalId,
+    externalUsername: connectors.externalUsername,
+    externalEmail: connectors.externalEmail,
+    oauthScopes: connectors.oauthScopes,
+    needsReconnect: connectors.needsReconnect,
+    reconnectReason: connectors.reconnectReason,
+    storageVersion: connectors.storageVersion,
+    tokenExpiresAt: connectors.tokenExpiresAt,
+    createdAt: connectors.createdAt,
+    updatedAt: connectors.updatedAt,
+  };
+}
+
+async function upsertConnectorConnection(
+  db: Db,
+  args: Omit<ReplaceConnectorConnectionArgs, "writeCredentials">,
+): Promise<StoredConnectorConnectionRow> {
+  if (args.target.kind === "builtin") {
+    const [row] = await db
+      .insert(connectors)
+      .values({
+        userId: args.userId,
+        connectorSlug: args.target.connectorSlug,
+        authMethod: args.authMethod,
+        storageVersion: args.storageVersion,
+        externalId: args.target.externalId,
+        externalUsername: args.target.externalUsername,
+        externalEmail: args.target.externalEmail,
+        oauthScopes: JSON.stringify(args.target.oauthScopes),
+        tokenExpiresAt: args.tokenExpiresAt,
+        needsReconnect: false,
+        reconnectReason: null,
+        orgId: args.orgId,
+      })
+      .onConflictDoUpdate({
+        target: [connectors.orgId, connectors.userId, connectors.connectorSlug],
+        targetWhere: isNotNull(connectors.connectorSlug),
+        set: {
+          authMethod: args.authMethod,
+          storageVersion: args.storageVersion,
+          externalId: args.target.externalId,
+          externalUsername: args.target.externalUsername,
+          externalEmail: args.target.externalEmail,
+          oauthScopes: JSON.stringify(args.target.oauthScopes),
+          tokenExpiresAt: args.tokenExpiresAt,
+          needsReconnect: false,
+          reconnectReason: null,
+          updatedAt: sql`clock_timestamp()`,
+        },
+      })
+      .returning(connectorConnectionSelection());
+    if (!row) {
+      throw new Error("Failed to upsert Builtin connector connection");
+    }
+    return row;
+  }
+
+  const [row] = await db
+    .insert(connectors)
+    .values({
+      customConnectorId: args.target.customConnectorId,
+      authMethod: args.authMethod,
+      storageVersion: args.storageVersion,
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      oauthScopes: null,
+      tokenExpiresAt: args.tokenExpiresAt,
+      needsReconnect: false,
+      reconnectReason: null,
+      userId: args.userId,
+      orgId: args.orgId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        connectors.orgId,
+        connectors.userId,
+        connectors.customConnectorId,
+      ],
+      targetWhere: isNotNull(connectors.customConnectorId),
+      set: {
+        authMethod: args.authMethod,
+        storageVersion: args.storageVersion,
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        oauthScopes: null,
+        tokenExpiresAt: args.tokenExpiresAt,
+        needsReconnect: false,
+        reconnectReason: null,
+        updatedAt: sql`clock_timestamp()`,
+      },
+    })
+    .returning(connectorConnectionSelection());
+  if (!row) {
+    throw new Error("Failed to upsert Custom connector connection");
+  }
+  return row;
+}
+
+export async function replaceConnectorConnection(
+  db: Db,
+  args: ReplaceConnectorConnectionArgs,
+  signal: AbortSignal,
+): Promise<StoredConnectorConnectionRow> {
+  const connection = await upsertConnectorConnection(db, args);
+  signal.throwIfAborted();
+
+  await deleteConnectorOwnedCredentialRows(
+    db,
+    { connectorId: connection.id },
+    signal,
+  );
+  await args.writeCredentials({ db, connectorId: connection.id }, signal);
+  signal.throwIfAborted();
+
+  return connection;
+}

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -4,7 +4,7 @@ import { isIP } from "node:net";
 import { request as httpsRequest } from "node:https";
 
 import { command } from "ccstate";
-import { and, eq, exists, isNotNull } from "drizzle-orm";
+import { and, eq, exists } from "drizzle-orm";
 import { z } from "zod";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import {
@@ -57,6 +57,7 @@ import {
   customConnectorMcpDisabledResponse,
   isCustomConnectorMcpEnabled,
 } from "./custom-connector-mcp-feature.service";
+import { replaceConnectorConnection } from "./connector-connection-write.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
@@ -761,16 +762,20 @@ export async function lockCustomConnectorOAuth2CredentialContract(args: {
   }
 }
 
-export async function storeCustomConnectorOAuth2Connection(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorId: string;
-  readonly storageVersion: number;
-  readonly token: OAuthTokenResult;
-  readonly featureContext: FeatureSwitchContext;
-}): Promise<void> {
+export async function storeCustomConnectorOAuth2Connection(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly storageVersion: number;
+    readonly token: OAuthTokenResult;
+    readonly featureContext: FeatureSwitchContext;
+  },
+  signal: AbortSignal,
+): Promise<void> {
   const encrypted = await encryptTokenValues(args);
+  signal.throwIfAborted();
   await args.db.transaction(async (tx) => {
     await lockCustomConnectorOAuth2CredentialContract({
       db: tx,
@@ -778,43 +783,30 @@ export async function storeCustomConnectorOAuth2Connection(args: {
       connectorId: args.connectorId,
       storageVersion: args.storageVersion,
     });
-    const [connection] = await tx
-      .insert(connectors)
-      .values({
-        customConnectorId: args.connectorId,
+    signal.throwIfAborted();
+    await replaceConnectorConnection(
+      tx,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
         authMethod: "oauth",
         storageVersion: args.storageVersion,
         tokenExpiresAt: args.token.expiresAt,
-        userId: args.userId,
-        orgId: args.orgId,
-      })
-      .onConflictDoUpdate({
-        target: [
-          connectors.orgId,
-          connectors.userId,
-          connectors.customConnectorId,
-        ],
-        targetWhere: isNotNull(connectors.customConnectorId),
-        set: {
-          authMethod: "oauth",
-          storageVersion: args.storageVersion,
-          tokenExpiresAt: args.token.expiresAt,
-          needsReconnect: false,
-          reconnectReason: null,
-          updatedAt: nowDate(),
+        target: {
+          kind: "custom",
+          customConnectorId: args.connectorId,
         },
-      })
-      .returning({ id: connectors.id });
-    if (!connection) {
-      throw new Error("Expected custom connector OAuth connection");
-    }
-    await tx.delete(secrets).where(eq(secrets.connectorId, connection.id));
-    await tx.insert(secrets).values(
-      connectionTokenRows({
-        ...args,
-        connectionId: connection.id,
-        encrypted,
-      }),
+        writeCredentials: async ({ db, connectorId }) => {
+          await db.insert(secrets).values(
+            connectionTokenRows({
+              ...args,
+              connectionId: connectorId,
+              encrypted,
+            }),
+          );
+        },
+      },
+      signal,
     );
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -74,21 +74,11 @@ import {
 import { cleanupGmailWatchesForConnector } from "./gmail-automation-event.service";
 import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
 import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
-
-type StoredConnectorRow = {
-  readonly id: string;
-  readonly authMethod: ConnectorResponse["authMethod"];
-  readonly externalId: string | null;
-  readonly externalUsername: string | null;
-  readonly externalEmail: string | null;
-  readonly oauthScopes: string | null;
-  readonly needsReconnect: boolean;
-  readonly reconnectReason: string | null;
-  readonly storageVersion: number;
-  readonly tokenExpiresAt: Date | null;
-  readonly createdAt: Date;
-  readonly updatedAt: Date;
-};
+import { clearConnectorAccountState } from "./connector-account-state.service";
+import {
+  replaceConnectorConnection,
+  type StoredConnectorConnectionRow as StoredConnectorRow,
+} from "./connector-connection-write.service";
 
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
@@ -1659,12 +1649,14 @@ async function loadExistingConnectorIdentity(
   signal: AbortSignal,
 ): Promise<{
   readonly authMethod: string;
+  readonly externalId: string | null;
   readonly id: string;
   readonly storageVersion: number;
 } | null> {
   const [existingConnector] = await db
     .select({
       authMethod: connectors.authMethod,
+      externalId: connectors.externalId,
       id: connectors.id,
       storageVersion: connectors.storageVersion,
     })
@@ -1679,75 +1671,6 @@ async function loadExistingConnectorIdentity(
     .limit(1);
   signal.throwIfAborted();
   return existingConnector ?? null;
-}
-
-async function upsertConnectorTokenConnectionRow(
-  db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly connectorSlug: string;
-    readonly authMethod: string;
-    readonly storageVersion: number;
-    readonly userInfo: ExternalUserInfo;
-    readonly oauthScopes: readonly string[];
-    readonly tokenExpiresAt: Date | null;
-  },
-  signal: AbortSignal,
-): Promise<StoredConnectorRow> {
-  const [connectorRow] = await db
-    .insert(connectors)
-    .values({
-      userId: args.userId,
-      connectorSlug: args.connectorSlug,
-      authMethod: args.authMethod,
-      storageVersion: args.storageVersion,
-      externalId: args.userInfo.id,
-      externalUsername: args.userInfo.username,
-      externalEmail: args.userInfo.email,
-      oauthScopes: JSON.stringify(args.oauthScopes),
-      tokenExpiresAt: args.tokenExpiresAt,
-      needsReconnect: false,
-      reconnectReason: null,
-      orgId: args.orgId,
-    })
-    .onConflictDoUpdate({
-      target: [connectors.orgId, connectors.userId, connectors.connectorSlug],
-      targetWhere: isNotNull(connectors.connectorSlug),
-      set: {
-        authMethod: args.authMethod,
-        storageVersion: args.storageVersion,
-        externalId: args.userInfo.id,
-        externalUsername: args.userInfo.username,
-        externalEmail: args.userInfo.email,
-        oauthScopes: JSON.stringify(args.oauthScopes),
-        tokenExpiresAt: args.tokenExpiresAt,
-        needsReconnect: false,
-        reconnectReason: null,
-        updatedAt: sql`clock_timestamp()`,
-      },
-    })
-    .returning({
-      id: connectors.id,
-      authMethod: connectors.authMethod,
-      externalId: connectors.externalId,
-      externalUsername: connectors.externalUsername,
-      externalEmail: connectors.externalEmail,
-      oauthScopes: connectors.oauthScopes,
-      needsReconnect: connectors.needsReconnect,
-      reconnectReason: connectors.reconnectReason,
-      storageVersion: connectors.storageVersion,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-      createdAt: connectors.createdAt,
-      updatedAt: connectors.updatedAt,
-    });
-  signal.throwIfAborted();
-
-  if (!connectorRow) {
-    throw new Error("Failed to upsert connector");
-  }
-
-  return connectorRow;
 }
 
 async function commitConnectorTokenConnection(
@@ -1766,6 +1689,7 @@ async function commitConnectorTokenConnection(
   signal: AbortSignal,
 ): Promise<{
   readonly connectorRow: StoredConnectorRow;
+  readonly created: boolean;
   readonly pendingTokenRevoke: PendingConnectorTokenRevoke | null;
 }> {
   await lockConnectorState(args.db, {
@@ -1812,44 +1736,50 @@ async function commitConnectorTokenConnection(
         )
       : null;
 
-  if (existingConnector !== null) {
-    await deleteConnectorOwnedCredentialRows(
-      args.db,
-      {
-        connectorId: existingConnector.id,
-      },
-      signal,
-    );
+  if (
+    existingConnector !== null &&
+    existingConnector.externalId !== args.userInfo.id
+  ) {
+    await clearConnectorAccountState(args.db, existingConnector.id, signal);
   }
-  const connectorRow = await upsertConnectorTokenConnectionRow(
+  const connectorRow = await replaceConnectorConnection(
     args.db,
     {
       orgId: args.orgId,
       userId: args.userId,
-      connectorSlug: args.runtimeMethod.connectorSlug,
       authMethod: args.runtimeMethod.authMethodId,
       storageVersion: args.runtimeMethod.method.storage.version,
-      userInfo: args.userInfo,
-      oauthScopes: args.oauthScopes,
       tokenExpiresAt: args.tokenExpiresAt,
+      target: {
+        kind: "builtin",
+        connectorSlug: args.runtimeMethod.connectorSlug,
+        externalId: args.userInfo.id,
+        externalUsername: args.userInfo.username,
+        externalEmail: args.userInfo.email,
+        oauthScopes: args.oauthScopes,
+      },
+      writeCredentials: async ({ db, connectorId }, writeSignal) => {
+        await upsertPreparedConnectorTokenState(
+          {
+            db,
+            connectorId,
+            method: args.runtimeMethod.method,
+            orgId: args.orgId,
+            userId: args.userId,
+            state: args.connectorTokenState,
+          },
+          writeSignal,
+        );
+      },
     },
     signal,
   );
 
-  await upsertPreparedConnectorTokenState(
-    {
-      db: args.db,
-      connectorId: connectorRow.id,
-      method: args.runtimeMethod.method,
-      orgId: args.orgId,
-      userId: args.userId,
-      state: args.connectorTokenState,
-    },
-    signal,
-  );
-  signal.throwIfAborted();
-
-  return { connectorRow, pendingTokenRevoke };
+  return {
+    connectorRow,
+    created: existingConnector === null,
+    pendingTokenRevoke,
+  };
 }
 
 export const upsertConnectorTokenConnection$ = command(
@@ -1948,9 +1878,7 @@ export const upsertConnectorTokenConnection$ = command(
         args.runtimeMethod,
         nowDate(),
       ),
-      created:
-        connectionResult.connectorRow.createdAt.getTime() ===
-        connectionResult.connectorRow.updatedAt.getTime(),
+      created: connectionResult.created,
     };
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -74,7 +74,7 @@ import {
 import { cleanupGmailWatchesForConnector } from "./gmail-automation-event.service";
 import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
 import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
-import { clearConnectorAccountState } from "./connector-account-state.service";
+import { reconcileConnectorAccountState } from "./connector-account-state.service";
 import {
   replaceConnectorConnection,
   type StoredConnectorConnectionRow as StoredConnectorRow,
@@ -1649,6 +1649,7 @@ async function loadExistingConnectorIdentity(
   signal: AbortSignal,
 ): Promise<{
   readonly authMethod: string;
+  readonly externalEmail: string | null;
   readonly externalId: string | null;
   readonly id: string;
   readonly storageVersion: number;
@@ -1656,6 +1657,7 @@ async function loadExistingConnectorIdentity(
   const [existingConnector] = await db
     .select({
       authMethod: connectors.authMethod,
+      externalEmail: connectors.externalEmail,
       externalId: connectors.externalId,
       id: connectors.id,
       storageVersion: connectors.storageVersion,
@@ -1736,11 +1738,18 @@ async function commitConnectorTokenConnection(
         )
       : null;
 
-  if (
-    existingConnector !== null &&
-    existingConnector.externalId !== args.userInfo.id
-  ) {
-    await clearConnectorAccountState(args.db, existingConnector.id, signal);
+  if (existingConnector !== null) {
+    await reconcileConnectorAccountState(
+      args.db,
+      {
+        connectorId: existingConnector.id,
+        previousPrincipalId: existingConnector.externalId,
+        nextPrincipalId: args.userInfo.id,
+        previousEmail: existingConnector.externalEmail,
+        nextEmail: args.userInfo.email,
+      },
+      signal,
+    );
   }
   const connectorRow = await replaceConnectorConnection(
     args.db,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -34,6 +34,7 @@ import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
 import { pgTextDecoder } from "../../lib/db-structured-result";
+import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
 import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import { bestEffort } from "../utils";
@@ -1640,7 +1641,7 @@ async function upsertPreparedConnectorTokenState(
 }
 
 async function loadExistingConnectorIdentity(
-  db: Db,
+  db: Tx,
   args: {
     readonly orgId: string;
     readonly userId: string;
@@ -1677,7 +1678,7 @@ async function loadExistingConnectorIdentity(
 
 async function commitConnectorTokenConnection(
   args: {
-    readonly db: Db;
+    readonly db: Tx;
     readonly orgId: string;
     readonly userId: string;
     readonly runtimeMethod: ConnectorRuntimeMethod;


### PR DESCRIPTION
## Summary

- keep an active Builtin OAuth or OpenID connection usable while a reconnect is pending or fails before credential replacement
- use one target-discriminated, transactional connection-row and credential replacement path for Builtin token authorization and Custom OAuth while preserving the logical connection ID
- clear account-bound Gmail, Calendar, Forms, Meet, and mail-draft state only when a successful Builtin callback changes the stable provider principal
- retain a same-principal Gmail watch and reconcile its routing email when the provider reports a changed mailbox address
- preserve the existing post-commit runtime mutation and Builtin/Custom client invalidation ordering

## Scope boundaries

- keeps provider exchange, validation, authorization-state machines, source locks, Feishu handling, revocation policy, runtime wakeups, and client invalidation policy in their existing adapters
- the existing Builtin token persistence command is shared by auth-code, OpenID, device-authorization, and external-code flows, so their successful writes naturally use the shared replacement primitive without changing their protocol behavior
- does not change schemas, persisted formats, public APIs, runner protocols, or feature switches
- leaves remaining manual and direct refresh writer migration to #26086, OAuth-state claim work to #26090, and immediate remote subscription teardown out of scope

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- full staged pre-commit checks (Prettier, repository Knip, and all-workspace type checking)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (185 files, 2795 tests before subsequent main integration)
- after rebasing the overlapping Custom connector invalidation changes: 157/157 focused connector, invalidation, dependent-state, Feishu, and Stripe integration tests confirmed passing; API lint, type checks, and Knip passed

Closes #26076

Parent context: #25312
