### PR TITLE
fix(runner): accept valid templated firewall catalog bases

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -14,7 +14,7 @@ import builtin_host_policy
 import connector_template_syntax
 import matching
 import state_file
-from path_security import has_unsafe_path, has_unsafe_url_path
+from path_security import has_unsafe_url_path
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 MAX_BUILTIN_FIREWALL_CATALOG_BYTES = 16 * 1024 * 1024
@@ -22,6 +22,12 @@ _CACHE_SCHEMA_VERSION = 1
 _SHA256_HEX_LENGTH = 64
 _RESERVED_PERMISSION_NAMES = frozenset(("all", "__unknown__"))
 _UNTRUSTED_WRITE_BITS = stat.S_IWGRP | stat.S_IWOTH
+# Use the shortest valid witness for each URL component so materialization does
+# not push an otherwise satisfiable DNS label past its 63-byte limit.
+_BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER = "https://x.y"
+_BASE_URL_TEMPLATE_HOST_PLACEHOLDER = "x.y"
+_BASE_URL_TEMPLATE_PORT_PLACEHOLDER = "1"
+_BASE_URL_TEMPLATE_PATH_PLACEHOLDER = "x"
 
 
 CatalogFileKey = state_file.StateFileIdentity
@@ -364,25 +370,11 @@ def _validate_api_entry(firewall_name: str, api: dict) -> None:
         raise BuiltinFirewallCatalogCacheError(
             f'catalog cache firewall "{firewall_name}" api base has invalid syntax'
         )
-    if template_syntax_target is not None:
-        if template_syntax_target.startswith("template/"):
-            known_path = template_syntax_target.removeprefix("template")
-        else:
-            known_path = ""
-        if has_unsafe_url_path(template_syntax_target) or has_unsafe_path(known_path):
-            raise BuiltinFirewallCatalogCacheError(
-                f'catalog cache firewall "{firewall_name}" api base has unsafe path'
-            )
-    if (
-        template_syntax_target is not None
-        and ("{" in template_syntax_target or "}" in template_syntax_target)
-        and "://" in template_syntax_target
-        and not matching.firewall_base_config_is_valid(template_syntax_target)
-    ):
+    if template_syntax_target is not None and has_unsafe_url_path(template_syntax_target):
         raise BuiltinFirewallCatalogCacheError(
-            f'catalog cache firewall "{firewall_name}" api base has invalid parameters'
+            f'catalog cache firewall "{firewall_name}" api base has unsafe path'
         )
-    if template_syntax_target is None and not matching.firewall_base_config_is_valid(raw_base):
+    if not matching.firewall_base_config_is_valid(raw_syntax_target):
         raise BuiltinFirewallCatalogCacheError(
             f'catalog cache firewall "{firewall_name}" api base is invalid'
         )
@@ -473,8 +465,56 @@ def _base_url_template_syntax_target(firewall_name: str, raw_base: str) -> str |
                 f'catalog cache firewall "{firewall_name}" api base template must use vars'
             )
         result.append(raw_base[search_start:start])
-        result.append("template")
+        result.append(
+            _base_url_template_syntax_placeholder(
+                firewall_name,
+                raw_base,
+                start,
+                template_end,
+            )
+        )
         search_start = template_end
+
+
+def _base_url_template_syntax_placeholder(
+    firewall_name: str,
+    raw_base: str,
+    start: int,
+    template_end: int,
+) -> str:
+    prefix = raw_base[:start]
+    suffix = raw_base[template_end:]
+    ends_base_or_starts_path = suffix == "" or suffix.startswith("/")
+
+    if prefix == "" and ends_base_or_starts_path:
+        return _BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER
+    if prefix.endswith("://") and ends_base_or_starts_path:
+        return _BASE_URL_TEMPLATE_HOST_PLACEHOLDER
+    if _base_url_prefix_is_inside_authority(prefix):
+        if prefix.endswith(":") and ends_base_or_starts_path:
+            return _BASE_URL_TEMPLATE_PORT_PLACEHOLDER
+        return _BASE_URL_TEMPLATE_HOST_PLACEHOLDER
+    if _base_url_prefix_is_inside_path(prefix):
+        return _BASE_URL_TEMPLATE_PATH_PLACEHOLDER
+    raise BuiltinFirewallCatalogCacheError(
+        f'catalog cache firewall "{firewall_name}" api base template variable '
+        "is used in an unsupported position"
+    )
+
+
+def _base_url_prefix_is_inside_authority(prefix: str) -> bool:
+    _, delimiter, after_scheme = prefix.partition("://")
+    return delimiter != "" and not any(char in after_scheme for char in "/?#")
+
+
+def _base_url_prefix_is_inside_path(prefix: str) -> bool:
+    _, delimiter, after_scheme = prefix.partition("://")
+    return (
+        delimiter != ""
+        and "?" not in after_scheme
+        and "#" not in after_scheme
+        and "/" in after_scheme
+    )
 
 
 def _warn(message: str) -> None:

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -24,7 +24,7 @@ _RESERVED_PERMISSION_NAMES = frozenset(("all", "__unknown__"))
 _UNTRUSTED_WRITE_BITS = stat.S_IWGRP | stat.S_IWOTH
 # Use the shortest valid witness for each URL component so materialization does
 # not push an otherwise satisfiable DNS label past its 63-byte limit.
-_BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER = "https://x.y"
+_BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER = "https://x.y"
 _BASE_URL_TEMPLATE_HOST_PLACEHOLDER = "x.y"
 _BASE_URL_TEMPLATE_PORT_PLACEHOLDER = "1"
 _BASE_URL_TEMPLATE_PATH_PLACEHOLDER = "x"
@@ -45,6 +45,13 @@ class CatalogIdentity(NamedTuple):
     catalog_digest: str
     catalog_version: str
     file_key: CatalogFileKey
+
+
+# Precompute fixed URL delimiters once; a catalog base can contain many templates.
+class _BaseUrlTemplateComponentBoundaries(NamedTuple):
+    authority_start: int | None
+    path_start: int | None
+    query_or_fragment_start: int | None
 
 
 CatalogUnavailableReason = Literal[
@@ -439,6 +446,7 @@ def _base_url_template_syntax_target(firewall_name: str, raw_base: str) -> str |
     search_start = 0
     result: list[str] = []
     found = False
+    boundaries = _base_url_template_component_boundaries(raw_base)
     while True:
         start = raw_base.find("${{", search_start)
         if start == -1:
@@ -471,9 +479,32 @@ def _base_url_template_syntax_target(firewall_name: str, raw_base: str) -> str |
                 raw_base,
                 start,
                 template_end,
+                boundaries,
             )
         )
         search_start = template_end
+
+
+def _base_url_template_component_boundaries(
+    raw_base: str,
+) -> _BaseUrlTemplateComponentBoundaries:
+    scheme_delimiter = raw_base.find("://")
+    if scheme_delimiter == -1:
+        return _BaseUrlTemplateComponentBoundaries(None, None, None)
+
+    authority_start = scheme_delimiter + len("://")
+    path_start = raw_base.find("/", authority_start)
+    query_start = raw_base.find("?", authority_start)
+    fragment_start = raw_base.find("#", authority_start)
+    query_or_fragment_start = min(
+        (index for index in (query_start, fragment_start) if index != -1),
+        default=None,
+    )
+    return _BaseUrlTemplateComponentBoundaries(
+        authority_start=authority_start,
+        path_start=None if path_start == -1 else path_start,
+        query_or_fragment_start=query_or_fragment_start,
+    )
 
 
 def _base_url_template_syntax_placeholder(
@@ -481,20 +512,21 @@ def _base_url_template_syntax_placeholder(
     raw_base: str,
     start: int,
     template_end: int,
+    boundaries: _BaseUrlTemplateComponentBoundaries,
 ) -> str:
-    prefix = raw_base[:start]
-    suffix = raw_base[template_end:]
-    ends_base_or_starts_path = suffix == "" or suffix.startswith("/")
+    ends_base_or_starts_path = template_end == len(raw_base) or raw_base.startswith(
+        "/", template_end
+    )
 
-    if prefix == "" and ends_base_or_starts_path:
-        return _BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER
-    if prefix.endswith("://") and ends_base_or_starts_path:
+    if start == 0 and ends_base_or_starts_path:
+        return _BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER
+    if raw_base.endswith("://", 0, start) and ends_base_or_starts_path:
         return _BASE_URL_TEMPLATE_HOST_PLACEHOLDER
-    if _base_url_prefix_is_inside_authority(prefix):
-        if prefix.endswith(":") and ends_base_or_starts_path:
+    if _base_url_prefix_is_inside_authority(start, boundaries):
+        if raw_base.endswith(":", 0, start) and ends_base_or_starts_path:
             return _BASE_URL_TEMPLATE_PORT_PLACEHOLDER
         return _BASE_URL_TEMPLATE_HOST_PLACEHOLDER
-    if _base_url_prefix_is_inside_path(prefix):
+    if _base_url_prefix_is_inside_path(start, boundaries):
         return _BASE_URL_TEMPLATE_PATH_PLACEHOLDER
     raise BuiltinFirewallCatalogCacheError(
         f'catalog cache firewall "{firewall_name}" api base template variable '
@@ -502,18 +534,29 @@ def _base_url_template_syntax_placeholder(
     )
 
 
-def _base_url_prefix_is_inside_authority(prefix: str) -> bool:
-    _, delimiter, after_scheme = prefix.partition("://")
-    return delimiter != "" and not any(char in after_scheme for char in "/?#")
+def _base_url_prefix_is_inside_authority(
+    template_start: int,
+    boundaries: _BaseUrlTemplateComponentBoundaries,
+) -> bool:
+    if boundaries.authority_start is None or boundaries.authority_start > template_start:
+        return False
+    return all(
+        boundary is None or template_start <= boundary
+        for boundary in (boundaries.path_start, boundaries.query_or_fragment_start)
+    )
 
 
-def _base_url_prefix_is_inside_path(prefix: str) -> bool:
-    _, delimiter, after_scheme = prefix.partition("://")
+def _base_url_prefix_is_inside_path(
+    template_start: int,
+    boundaries: _BaseUrlTemplateComponentBoundaries,
+) -> bool:
     return (
-        delimiter != ""
-        and "?" not in after_scheme
-        and "#" not in after_scheme
-        and "/" in after_scheme
+        boundaries.path_start is not None
+        and boundaries.path_start < template_start
+        and (
+            boundaries.query_or_fragment_start is None
+            or template_start <= boundaries.query_or_fragment_start
+        )
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pytest
 
 import builtin_base_url
+import builtin_firewall_cache
 import matching
+from tests.registry_builtin_helpers import write_catalog_cache
 
 _CONTRACT_PATH = (
     Path(__file__).resolve().parents[4]
@@ -38,6 +40,7 @@ def _case_name(case: dict[str, object]) -> str:
 
 
 _BASE_URL_VALIDATION_CASES = _load_cases("baseUrlValidationCases")
+_CATALOG_BASE_URL_VALIDATION_CASES = _load_cases("catalogBaseUrlValidationCases")
 _BASE_URL_TEMPLATE_RESOLUTION_CASES = _load_cases("baseUrlTemplateResolutionCases")
 
 
@@ -51,6 +54,36 @@ def test_firewall_base_url_config_validity_matches_shared_contract(
     assert isinstance(expected_valid, bool)
 
     assert matching.firewall_base_config_is_valid(base) is expected_valid
+
+
+@pytest.mark.parametrize("case", _CATALOG_BASE_URL_VALIDATION_CASES, ids=_case_name)
+def test_firewall_catalog_base_url_validity_matches_shared_contract(
+    case: dict[str, object],
+    tmp_path: Path,
+    mitm_ctx,
+) -> None:
+    base = case["base"]
+    assert isinstance(base, str)
+    expected_valid = case["expectedValid"]
+    assert isinstance(expected_valid, bool)
+
+    cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+    write_catalog_cache(
+        cache_path,
+        digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        version="catalog-contract",
+        firewalls={
+            "contract": {
+                "name": "contract",
+                "apis": [{"base": base, "auth": {}}],
+            }
+        },
+    )
+    with mitm_ctx():
+        snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+    assert (snapshot.catalog is not None) is expected_valid
+    assert snapshot.unavailable_reason == (None if expected_valid else "cache_invalid")
 
 
 @pytest.mark.parametrize("case", _BASE_URL_TEMPLATE_RESOLUTION_CASES, ids=_case_name)

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
@@ -179,6 +179,62 @@ class TestRegistryBuiltinCatalogValidation:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.example.com"
 
+    def test_runner_catalog_cache_resolves_whole_host_template_with_path_parameter(
+        self, tmp_path, mitm_ctx
+    ):
+        registry_path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        write_multi_vm_registry(
+            registry_path,
+            {
+                "10.200.0.1": builtin_vm(
+                    "run-template",
+                    "templated",
+                    {"WORKSPACE_HOST": "acme.uspacy.com"},
+                )
+            },
+        )
+        write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={
+                "templated": {
+                    "name": "templated",
+                    "apis": [
+                        {
+                            "base": "https://${{ vars.WORKSPACE_HOST }}/v1/hooks/{hookKey}",
+                            "hostPolicy": {
+                                "kind": "providerOwned",
+                                "suffixes": [".uspacy.com"],
+                            },
+                            "auth": {"headers": {}},
+                            "permissions": [
+                                {
+                                    "name": "read",
+                                    "rules": ["GET /v1/hooks/{hookKey}"],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert (
+            vm_info["firewalls"][0]["apis"][0]["base"]
+            == "https://acme.uspacy.com/v1/hooks/{hookKey}"
+        )
+
     def test_malformed_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -1131,27 +1131,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_catalog_cache_accepts_valid_template_base() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
-        let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
-        let mut valid = catalog("github");
-        valid
-            .firewalls
-            .get_mut("github")
-            .expect("catalog should contain github")
-            .apis[0]
-            .base = "https://${{ vars.TENANT }}.example.com".to_string();
+    async fn write_catalog_cache_accepts_valid_template_bases() {
+        let valid_cases =
+            crate::test_fixtures::firewall_base_url_contract::catalog_firewall_base_url_validation_cases(
+            )
+            .into_iter()
+            .filter(|test_case| test_case.expected_valid);
 
-        write_catalog_cache(&cache_path, &lock_path, valid)
-            .await
-            .unwrap();
+        for test_case in valid_cases {
+            let dir = tempfile::tempdir().unwrap();
+            let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+            let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+            let mut valid = catalog("github");
+            valid
+                .firewalls
+                .get_mut("github")
+                .expect("catalog should contain github")
+                .apis[0]
+                .base = test_case.base.clone();
 
-        let cache = read_catalog_cache(&cache_path).await.unwrap().unwrap();
-        assert_eq!(
-            cache.firewalls["github"].apis[0].base,
-            "https://${{ vars.TENANT }}.example.com"
-        );
+            write_catalog_cache(&cache_path, &lock_path, valid)
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "valid shared template base {:?} failed: {error}",
+                        test_case.name
+                    )
+                });
+
+            let cache = read_catalog_cache(&cache_path).await.unwrap().unwrap();
+            assert_eq!(cache.firewalls["github"].apis[0].base, test_case.base);
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/test_fixtures/firewall_base_url_contract.rs
+++ b/crates/runner/src/test_fixtures/firewall_base_url_contract.rs
@@ -11,6 +11,7 @@ const CONTRACT_JSON: &str = include_str!(
 #[serde(rename_all = "camelCase")]
 struct FirewallBaseUrlValidationContract {
     hostname_policy: String,
+    catalog_base_url_validation_cases: Vec<FirewallBaseUrlValidationCase>,
     base_url_validation_cases: Vec<FirewallBaseUrlValidationCase>,
 }
 
@@ -23,6 +24,19 @@ pub(crate) struct FirewallBaseUrlValidationCase {
 }
 
 pub(crate) fn firewall_base_url_validation_cases() -> Vec<FirewallBaseUrlValidationCase> {
+    let contract = load_contract();
+    contract
+        .base_url_validation_cases
+        .into_iter()
+        .chain(contract.catalog_base_url_validation_cases)
+        .collect()
+}
+
+pub(crate) fn catalog_firewall_base_url_validation_cases() -> Vec<FirewallBaseUrlValidationCase> {
+    load_contract().catalog_base_url_validation_cases
+}
+
+fn load_contract() -> FirewallBaseUrlValidationContract {
     let contract: FirewallBaseUrlValidationContract = serde_json::from_str(CONTRACT_JSON)
         .expect("shared firewall base URL contract should parse");
     assert_eq!(
@@ -30,12 +44,17 @@ pub(crate) fn firewall_base_url_validation_cases() -> Vec<FirewallBaseUrlValidat
         "shared firewall hostname policy changed without a runner compatibility review"
     );
     assert!(
-        !contract.base_url_validation_cases.is_empty(),
-        "shared firewall base URL contract should contain cases"
+        !contract.base_url_validation_cases.is_empty()
+            && !contract.catalog_base_url_validation_cases.is_empty(),
+        "shared firewall base URL contract should contain runtime and catalog cases"
     );
 
     let mut names = HashSet::new();
-    for test_case in &contract.base_url_validation_cases {
+    for test_case in contract
+        .base_url_validation_cases
+        .iter()
+        .chain(&contract.catalog_base_url_validation_cases)
+    {
         assert!(
             names.insert(test_case.name.as_str()),
             "shared firewall base URL contract contains duplicate case {:?}",
@@ -43,5 +62,5 @@ pub(crate) fn firewall_base_url_validation_cases() -> Vec<FirewallBaseUrlValidat
         );
     }
 
-    contract.base_url_validation_cases
+    contract
 }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -537,10 +537,56 @@ fn is_unsafe_url_codepoint(ch: char) -> bool {
 
 // Use the shortest valid witness for each URL component so materialization does
 // not push an otherwise satisfiable DNS label past its 63-byte limit.
-const BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER: &str = "https://x.y";
+const BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER: &str = "https://x.y";
 const BASE_URL_TEMPLATE_HOST_PLACEHOLDER: &str = "x.y";
 const BASE_URL_TEMPLATE_PORT_PLACEHOLDER: &str = "1";
 const BASE_URL_TEMPLATE_PATH_PLACEHOLDER: &str = "x";
+
+// Precompute fixed URL delimiters once; a catalog base can contain many templates.
+struct BaseUrlTemplateComponentBoundaries {
+    authority_start: Option<usize>,
+    path_start: Option<usize>,
+    query_or_fragment_start: Option<usize>,
+}
+
+impl BaseUrlTemplateComponentBoundaries {
+    fn new(base: &str) -> Self {
+        let authority_start = base.find("://").map(|index| index + "://".len());
+        let path_start = authority_start.and_then(|start| {
+            base[start..]
+                .find('/')
+                .map(|relative_index| start + relative_index)
+        });
+        let query_or_fragment_start = authority_start.and_then(|start| {
+            base[start..]
+                .find(['?', '#'])
+                .map(|relative_index| start + relative_index)
+        });
+        Self {
+            authority_start,
+            path_start,
+            query_or_fragment_start,
+        }
+    }
+
+    fn prefix_is_inside_authority(&self, template_start: usize) -> bool {
+        self.authority_start
+            .is_some_and(|start| start <= template_start)
+            && self
+                .path_start
+                .into_iter()
+                .chain(self.query_or_fragment_start)
+                .all(|boundary| template_start <= boundary)
+    }
+
+    fn prefix_is_inside_path(&self, template_start: usize) -> bool {
+        self.path_start
+            .is_some_and(|path_start| path_start < template_start)
+            && self
+                .query_or_fragment_start
+                .is_none_or(|boundary| template_start <= boundary)
+    }
+}
 
 fn validate_firewall_base_for_cache(base: &str) -> Result<(), String> {
     let template_syntax_target = base_url_template_syntax_target_for_cache(base)?;
@@ -604,6 +650,7 @@ fn base_url_template_syntax_target_for_cache(base: &str) -> Result<Option<String
     let mut search_start = 0;
     let mut result = String::new();
     let mut found = false;
+    let boundaries = BaseUrlTemplateComponentBoundaries::new(base);
     while let Some(relative_start) = base[search_start..].find("${{") {
         found = true;
         let start = search_start + relative_start;
@@ -619,6 +666,7 @@ fn base_url_template_syntax_target_for_cache(base: &str) -> Result<Option<String
             base,
             start,
             template_end,
+            &boundaries,
         )?);
         search_start = template_end;
     }
@@ -658,41 +706,27 @@ fn base_url_template_syntax_placeholder_for_cache(
     base: &str,
     start: usize,
     template_end: usize,
+    boundaries: &BaseUrlTemplateComponentBoundaries,
 ) -> Result<&'static str, String> {
-    let prefix = &base[..start];
-    let suffix = &base[template_end..];
-    let ends_base_or_starts_path = suffix.is_empty() || suffix.starts_with('/');
+    let ends_base_or_starts_path =
+        template_end == base.len() || base[template_end..].starts_with('/');
 
-    if prefix.is_empty() && ends_base_or_starts_path {
-        return Ok(BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER);
+    if start == 0 && ends_base_or_starts_path {
+        return Ok(BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER);
     }
-    if prefix.ends_with("://") && ends_base_or_starts_path {
+    if base[..start].ends_with("://") && ends_base_or_starts_path {
         return Ok(BASE_URL_TEMPLATE_HOST_PLACEHOLDER);
     }
-    if base_url_prefix_is_inside_authority(prefix) {
-        if prefix.ends_with(':') && ends_base_or_starts_path {
+    if boundaries.prefix_is_inside_authority(start) {
+        if base[..start].ends_with(':') && ends_base_or_starts_path {
             return Ok(BASE_URL_TEMPLATE_PORT_PLACEHOLDER);
         }
         return Ok(BASE_URL_TEMPLATE_HOST_PLACEHOLDER);
     }
-    if base_url_prefix_is_inside_path(prefix) {
+    if boundaries.prefix_is_inside_path(start) {
         return Ok(BASE_URL_TEMPLATE_PATH_PLACEHOLDER);
     }
     Err("base URL template variable is used in an unsupported position".to_string())
-}
-
-fn base_url_prefix_is_inside_authority(prefix: &str) -> bool {
-    let Some((_, after_scheme)) = prefix.split_once("://") else {
-        return false;
-    };
-    !after_scheme.contains(['/', '?', '#'])
-}
-
-fn base_url_prefix_is_inside_path(prefix: &str) -> bool {
-    let Some((_, after_scheme)) = prefix.split_once("://") else {
-        return false;
-    };
-    !after_scheme.contains(['?', '#']) && after_scheme.contains('/')
 }
 
 fn validate_template_identifier(name: &str, label: &str) -> Result<(), String> {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -535,6 +535,13 @@ fn is_unsafe_url_codepoint(ch: char) -> bool {
     ch < '\u{0020}' || ch == '\u{007f}'
 }
 
+// Use the shortest valid witness for each URL component so materialization does
+// not push an otherwise satisfiable DNS label past its 63-byte limit.
+const BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER: &str = "https://x.y";
+const BASE_URL_TEMPLATE_HOST_PLACEHOLDER: &str = "x.y";
+const BASE_URL_TEMPLATE_PORT_PLACEHOLDER: &str = "1";
+const BASE_URL_TEMPLATE_PATH_PLACEHOLDER: &str = "x";
+
 fn validate_firewall_base_for_cache(base: &str) -> Result<(), String> {
     let template_syntax_target = base_url_template_syntax_target_for_cache(base)?;
     let raw_syntax_target = template_syntax_target.as_deref().unwrap_or(base);
@@ -553,35 +560,21 @@ fn validate_firewall_base_for_cache(base: &str) -> Result<(), String> {
     if raw_syntax_target.contains('#') {
         return Err("base URL must not contain fragment".to_string());
     }
-    let raw_path = if template_syntax_target.is_some() && !raw_syntax_target.contains("://") {
-        raw_syntax_target
-            .strip_prefix("template")
-            .filter(|suffix| suffix.starts_with('/'))
-            .unwrap_or("")
-    } else {
-        raw_url_path(raw_syntax_target)
-    };
+    let raw_path = raw_url_path(raw_syntax_target);
     if path_has_unsafe_segments_for_cache(raw_path) {
         return Err("base URL must not contain unsafe path".to_string());
     }
-    if template_syntax_target.is_some() {
-        if (raw_syntax_target.contains('{') || raw_syntax_target.contains('}'))
-            && raw_syntax_target.contains("://")
-        {
-            validate_parameterized_firewall_base_for_cache(raw_syntax_target)?;
-        }
-        return Ok(());
+    if raw_syntax_target.contains('{') || raw_syntax_target.contains('}') {
+        return validate_parameterized_firewall_base_for_cache(raw_syntax_target);
     }
-    if base.contains('{') || base.contains('}') {
-        return validate_parameterized_firewall_base_for_cache(base);
-    }
-    let parsed = url::Url::parse(base).map_err(|_| "base URL is invalid".to_string())?;
-    let authority = raw_url_authority(base)
+    let parsed =
+        url::Url::parse(raw_syntax_target).map_err(|_| "base URL is invalid".to_string())?;
+    let authority = raw_url_authority(raw_syntax_target)
         .ok_or_else(|| "base URL must include :// after the scheme".to_string())?;
     if authority.is_empty() {
         return Err("base URL must include a host".to_string());
     }
-    if raw_authority_has_empty_port(base) {
+    if raw_authority_has_empty_port(raw_syntax_target) {
         return Err("base URL authority must not include an empty port".to_string());
     }
     crate::firewall_hostname_policy::validate_base_host_for_cache(raw_host_from_authority(
@@ -621,8 +614,13 @@ fn base_url_template_syntax_target_for_cache(base: &str) -> Result<Option<String
         let end = content_start + relative_end;
         validate_base_url_var_reference(&base[content_start..end])?;
         result.push_str(&base[search_start..start]);
-        result.push_str("template");
-        search_start = end + "}}".len();
+        let template_end = end + "}}".len();
+        result.push_str(base_url_template_syntax_placeholder_for_cache(
+            base,
+            start,
+            template_end,
+        )?);
+        search_start = template_end;
     }
     if !found {
         return Ok(None);
@@ -632,11 +630,69 @@ fn base_url_template_syntax_target_for_cache(base: &str) -> Result<Option<String
 }
 
 fn validate_base_url_var_reference(content: &str) -> Result<(), String> {
-    let trimmed = content.trim();
+    let trimmed = content.trim_matches(is_ecmascript_whitespace);
     let Some(name) = trimmed.strip_prefix("vars.") else {
         return Err("base URL template reference must use vars".to_string());
     };
     validate_template_identifier(name, "base URL template variable")
+}
+
+fn is_ecmascript_whitespace(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{0009}'..='\u{000d}'
+            | '\u{0020}'
+            | '\u{00a0}'
+            | '\u{1680}'
+            | '\u{2000}'..='\u{200a}'
+            | '\u{2028}'
+            | '\u{2029}'
+            | '\u{202f}'
+            | '\u{205f}'
+            | '\u{3000}'
+            | '\u{feff}'
+    )
+}
+
+fn base_url_template_syntax_placeholder_for_cache(
+    base: &str,
+    start: usize,
+    template_end: usize,
+) -> Result<&'static str, String> {
+    let prefix = &base[..start];
+    let suffix = &base[template_end..];
+    let ends_base_or_starts_path = suffix.is_empty() || suffix.starts_with('/');
+
+    if prefix.is_empty() && ends_base_or_starts_path {
+        return Ok(BASE_URL_TEMPLATE_PREFIX_PLACEHOLDER);
+    }
+    if prefix.ends_with("://") && ends_base_or_starts_path {
+        return Ok(BASE_URL_TEMPLATE_HOST_PLACEHOLDER);
+    }
+    if base_url_prefix_is_inside_authority(prefix) {
+        if prefix.ends_with(':') && ends_base_or_starts_path {
+            return Ok(BASE_URL_TEMPLATE_PORT_PLACEHOLDER);
+        }
+        return Ok(BASE_URL_TEMPLATE_HOST_PLACEHOLDER);
+    }
+    if base_url_prefix_is_inside_path(prefix) {
+        return Ok(BASE_URL_TEMPLATE_PATH_PLACEHOLDER);
+    }
+    Err("base URL template variable is used in an unsupported position".to_string())
+}
+
+fn base_url_prefix_is_inside_authority(prefix: &str) -> bool {
+    let Some((_, after_scheme)) = prefix.split_once("://") else {
+        return false;
+    };
+    !after_scheme.contains(['/', '?', '#'])
+}
+
+fn base_url_prefix_is_inside_path(prefix: &str) -> bool {
+    let Some((_, after_scheme)) = prefix.split_once("://") else {
+        return false;
+    };
+    !after_scheme.contains(['?', '#']) && after_scheme.contains('/')
 }
 
 fn validate_template_identifier(name: &str, label: &str) -> Result<(), String> {
@@ -1040,7 +1096,7 @@ fn auth_base_static_validation_target_for_cache(
 }
 
 fn validate_auth_base_template_reference(content: &str) -> Result<(), String> {
-    let trimmed = content.trim();
+    let trimmed = content.trim_matches(is_ecmascript_whitespace);
     let name = trimmed
         .strip_prefix("secrets.")
         .or_else(|| trimmed.strip_prefix("vars."))

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -16,6 +16,13 @@
       "expectedResolvedBase": "https://api-tenant.example.com"
     },
     {
+      "category": "whole-authority",
+      "name": "whole host before parameterized path resolves",
+      "base": "https://${{ vars.WORKSPACE_HOST }}/v1/{resource}",
+      "vars": { "WORKSPACE_HOST": "tenant.example.com" },
+      "expectedResolvedBase": "https://tenant.example.com/v1/{resource}"
+    },
+    {
       "category": "query-fragment",
       "name": "trailing authority fragment before query is invalid",
       "base": "https://api-${{ vars.HOST }}?page=1",
@@ -41,6 +48,162 @@
       "name": "trailing authority fragment rejects encoded structure",
       "base": "https://api-${{ vars.HOST }}/v1",
       "vars": { "HOST": "tenant.example.com%2fcapture" },
+      "expectedResolvedBase": null
+    }
+  ],
+  "catalogBaseUrlValidationCases": [
+    {
+      "category": "valid",
+      "name": "whole host template with parameterized path",
+      "base": "https://${{ vars.WORKSPACE_HOST }}/v1/{resource}",
+      "vars": { "WORKSPACE_HOST": "tenant.example.com" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://tenant.example.com/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "whole base template with parameterized path",
+      "base": "${{ vars.API_BASE_URL }}/v1/{resource}",
+      "vars": { "API_BASE_URL": "https://api.example.com" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://api.example.com/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host label template with parameterized path",
+      "base": "https://${{ vars.TENANT }}.example.com/v1/{resource}",
+      "vars": { "TENANT": "acme" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://acme.example.com/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host fragment template with parameterized path",
+      "base": "https://api-${{ vars.TENANT }}.example.com/v1/{resource}",
+      "vars": { "TENANT": "acme" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://api-acme.example.com/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host fragment template at DNS label length limit",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.SUFFIX }}.example/v1/{resource}",
+      "vars": {
+        "SUFFIX": "x"
+      },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaax.example/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "port template with parameterized path",
+      "base": "https://api.example.com:${{ vars.PORT }}/v1/{resource}",
+      "vars": { "PORT": "8443" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://api.example.com:8443/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host and port templates with parameterized path",
+      "base": "https://${{ vars.HOST }}:${{ vars.PORT }}/v1/{resource}",
+      "vars": { "HOST": "api.example.com", "PORT": "8443" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://api.example.com:8443/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "path template with parameterized path",
+      "base": "https://api.example.com/${{ vars.TENANT }}/v1/{resource}",
+      "vars": { "TENANT": "acme" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://api.example.com/acme/v1/{resource}"
+    },
+    {
+      "category": "template-grammar",
+      "name": "byte order mark template whitespace with parameterized path",
+      "base": "https://${{\ufeffvars.HOST\ufeff}}/v1/{resource}",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://api.example.com/v1/{resource}"
+    },
+    {
+      "category": "template-position",
+      "name": "scheme template is invalid",
+      "base": "${{ vars.SCHEME }}://api.example.com/v1/{resource}",
+      "vars": { "SCHEME": "https" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "scheme",
+      "name": "unsupported fixed scheme with host template is invalid",
+      "base": "ftp://${{ vars.HOST }}/v1/{resource}",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "authority",
+      "name": "userinfo template is invalid",
+      "base": "https://${{ vars.USER }}@api.example.com/v1/{resource}",
+      "vars": { "USER": "alice" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "template-grammar",
+      "name": "next line template whitespace is invalid",
+      "base": "https://${{\u0085vars.HOST\u0085}}/v1/{resource}",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "template-grammar",
+      "name": "secret reference in base is invalid",
+      "base": "https://${{ secrets.HOST }}/v1/{resource}",
+      "vars": {},
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "parameters",
+      "name": "templated base with greedy path parameter is invalid",
+      "base": "https://${{ vars.HOST }}/v1/{resource+}",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "parameters",
+      "name": "templated base with duplicate path parameter is invalid",
+      "base": "https://${{ vars.HOST }}/v1/{resource}/{resource}",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "query-fragment",
+      "name": "templated base with query string is invalid",
+      "base": "https://${{ vars.HOST }}/v1/{resource}?page=1",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "query-fragment",
+      "name": "templated base with fragment is invalid",
+      "base": "https://${{ vars.HOST }}/v1/{resource}#section",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": false,
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "path-safety",
+      "name": "templated base with parent path segment is invalid",
+      "base": "https://${{ vars.HOST }}/v1/../{resource}",
+      "vars": { "HOST": "api.example.com" },
+      "expectedValid": false,
       "expectedResolvedBase": null
     }
   ],

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
@@ -27,11 +27,29 @@ const baseUrlValidationCaseSchema = z.object({
   expectedCanonicalBase: z.string().optional(),
 });
 
+const catalogBaseUrlValidationCaseSchema = baseUrlTemplateResolutionCaseSchema
+  .extend({
+    expectedValid: z.boolean(),
+  })
+  .superRefine((testCase, ctx) => {
+    if (testCase.expectedValid === (testCase.expectedResolvedBase === null)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["expectedResolvedBase"],
+        message:
+          "expectedResolvedBase must be present exactly when expectedValid is true",
+      });
+    }
+  });
+
 const contractSchema = z
   .object({
     hostnamePolicy: z.literal(FIREWALL_HOSTNAME_POLICY_VERSION),
     baseUrlTemplateResolutionCases: z
       .array(baseUrlTemplateResolutionCaseSchema)
+      .min(1),
+    catalogBaseUrlValidationCases: z
+      .array(catalogBaseUrlValidationCaseSchema)
       .min(1),
     baseUrlValidationCases: z.array(baseUrlValidationCaseSchema).min(1),
   })
@@ -41,6 +59,7 @@ const contractSchema = z
         "baseUrlTemplateResolutionCases",
         contract.baseUrlTemplateResolutionCases,
       ],
+      ["catalogBaseUrlValidationCases", contract.catalogBaseUrlValidationCases],
       ["baseUrlValidationCases", contract.baseUrlValidationCases],
     ] as const) {
       const seenNames = new Set<string>();
@@ -58,6 +77,9 @@ const contractSchema = z
   });
 
 type BaseUrlValidationCase = z.infer<typeof baseUrlValidationCaseSchema>;
+type CatalogBaseUrlValidationCase = z.infer<
+  typeof catalogBaseUrlValidationCaseSchema
+>;
 type BaseUrlTemplateResolutionCase = z.infer<
   typeof baseUrlTemplateResolutionCaseSchema
 >;
@@ -112,12 +134,41 @@ function assertTemplateResolutionResult(
   expect(resolve()).toBe(testCase.expectedResolvedBase);
 }
 
+function assertCatalogValidationResult(
+  testCase: CatalogBaseUrlValidationCase,
+): void {
+  const validate = (): string => {
+    validateBaseUrl(testCase.base, "contract");
+    return resolveFirewallBaseUrlTemplate({
+      serviceName: "contract",
+      base: testCase.base,
+      vars: testCase.vars,
+    });
+  };
+
+  if (!testCase.expectedValid) {
+    expect(validate).toThrow();
+    return;
+  }
+
+  expect(testCase.expectedResolvedBase).not.toBeNull();
+  expect(validate()).toBe(testCase.expectedResolvedBase);
+}
+
 const contract = loadContract();
 
 describe("firewall base URL validation contract", () => {
   for (const testCase of contract.baseUrlValidationCases) {
     it(testCase.name, () => {
       assertValidationResult(testCase);
+    });
+  }
+});
+
+describe("firewall catalog base URL validation contract", () => {
+  for (const testCase of contract.catalogBaseUrlValidationCases) {
+    it(testCase.name, () => {
+      assertCatalogValidationResult(testCase);
     });
   }
 });


### PR DESCRIPTION
## Summary

- validate unresolved firewall base URL variables with component-appropriate URL witnesses in Rust and Python
- keep the TypeScript, Rust, and Python catalog boundaries aligned through a shared behavioral contract
- cover whole-base, whole-host, authority-fragment, port, path, parameter, whitespace, and DNS-label boundary cases
- precompute fixed URL component boundaries once per base so validation stays linear with many template references
- add an end-to-end registry test for the Uspacy-shaped whole-host template with a parameterized path

## Why

The connector compiler accepts bases such as `https://${{ vars.WORKSPACE_HOST }}/v1/{resource}`. The runner previously replaced every variable with the single-label string `template`; when the base also contained a path parameter, parameterized URL validation rejected that artificial host even though the resolved host was valid.

The new validation materializes each variable according to its URL component, then runs the existing full syntax and parameter checks. Runtime variable resolution, credential transport validation, and host-policy enforcement remain unchanged.

## Compatibility

- no API, catalog schema, cache schema, or persisted-state changes
- malformed templates and unsafe fixed syntax continue to fail closed
- no runtime request-path performance change; this work only affects catalog validation and refresh

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner`
- `cd crates/runner/mitm-addon && uv lock --check`
- `cd crates/runner/mitm-addon && uv sync --locked`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff format --check .`
- `cd crates/runner/mitm-addon && uv run --no-sync ruff check .`
- `cd crates/runner/mitm-addon && uv run --no-sync basedpyright -p .`
- `cd crates/runner/mitm-addon && uv run --no-sync python -m pytest tests/`
- `cd turbo && pnpm -F @vm0/connectors lint`
- `cd turbo && pnpm -F @vm0/connectors check-types`
- `cd turbo && pnpm -F @vm0/connectors test`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm knip`
- audited the generated `2026-08-10.421` catalog through the complete Rust boundary: 633 firewalls, 858 APIs, and 83 templated bases
