### PR TITLE
feat: admit mcp custom connectors to agent runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -124,6 +124,34 @@ export async function seedConnectorStorageRow(
   return response.connector_id;
 }
 
+export async function seedCustomConnectorRuntimeConnectors(
+  context: TestContext,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly customConnectors: readonly {
+      readonly id: string;
+      readonly slug: string;
+      readonly displayName: string;
+      readonly prefixTemplate: string;
+    }[];
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "seed-custom-runtime-connectors",
+    org_id: args.orgId,
+    user_id: args.userId,
+    custom_connectors: args.customConnectors.map((connector) => {
+      return {
+        id: connector.id,
+        slug: connector.slug,
+        display_name: connector.displayName,
+        prefix_template: connector.prefixTemplate,
+      };
+    }),
+  });
+}
+
 export async function setConnectorCredentialStorageState(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -93,6 +93,7 @@ import {
   seedSlackOrgInstallation$,
 } from "./helpers/zero-integrations-slack";
 import {
+  seedCustomConnectorRuntimeConnectors,
   setConnectorCredentialStorageState,
   setCustomConnectorCredentialStorageState,
 } from "./helpers/connector-credential-storage-state";
@@ -8916,55 +8917,30 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected a custom connector actor with an organization");
+    }
     const suffix = randomUUID().slice(0, 8);
     const connectorCount = CONNECTOR_RUNTIME_SYNC_TARGETS_MAX + 1;
-    const createdIds: string[] = [];
-
-    for (let offset = 0; offset < connectorCount; offset += 32) {
-      const batchSize = Math.min(32, connectorCount - offset);
-      const batch = await Promise.all(
-        Array.from({ length: batchSize }, async (_unused, index) => {
-          const sequence = offset + index;
-          const connector = await connectors.createCustomConnector(actor, {
-            kind: "http",
-            displayName: `BDD Runtime Batch ${sequence}`,
-            prefixTemplates: [
-              `https://batch-${sequence}-${suffix}.example.test/api/`,
-            ],
-            fields: [
-              {
-                key: "secret",
-                label: "API key",
-                kind: "secret",
-                required: true,
-              },
-            ],
-            headerInjections: [
-              {
-                name: "Authorization",
-                valueTemplate: "Bearer {{secrets.secret}}",
-              },
-            ],
-            queryInjections: [],
-            authMode: "manual",
-          });
-          const connected = await connectors.setCustomConnectorValues(
-            actor,
-            connector.id,
-            [
-              {
-                key: "secret",
-                kind: "secret",
-                value: `batch-secret-${sequence}`,
-              },
-            ],
-          );
-          expect(connected.connected).toBeTruthy();
-          return connector.id;
-        }),
-      );
-      createdIds.push(...batch);
-    }
+    const runtimeConnectors = Array.from(
+      { length: connectorCount },
+      (_unused, sequence) => {
+        return {
+          id: randomUUID(),
+          slug: `_bdd-batch-${suffix}-${sequence}`,
+          displayName: `BDD Runtime Batch ${sequence}`,
+          prefixTemplate: `https://batch-${sequence}-${suffix}.example.test/api/`,
+        };
+      },
+    );
+    await seedCustomConnectorRuntimeConnectors(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectors: runtimeConnectors,
+    });
+    const createdIds = runtimeConnectors.map((connector) => {
+      return connector.id;
+    });
     const enabledIds = await connectors.updateAgentCustomConnectors(
       actor,
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9,9 +9,14 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import {
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
+  CONNECTOR_RUNTIME_SYNC_TARGETS_MAX,
   type ConnectorRuntimeSyncResult,
   type Job as RunnerJob,
 } from "@vm0/api-contracts/contracts/runners";
+import {
+  type CreateCustomConnectorBody,
+  ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY,
+} from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   getCustomConnectorSkillStorageName,
@@ -131,6 +136,43 @@ const fixtureStore = createStore();
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const ASSISTANT_EVENT_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+type McpCustomConnectorCreateBody = Extract<
+  CreateCustomConnectorBody,
+  { readonly kind: "mcp" }
+>;
+
+function manualMcpRuntimeConnectorBody(args: {
+  readonly displayName: string;
+  readonly endpoint: string;
+  readonly skillMarkdown?: string;
+}): McpCustomConnectorCreateBody {
+  return {
+    kind: "mcp",
+    displayName: args.displayName,
+    endpoint: args.endpoint,
+    transport: "streamable-http",
+    fields: [
+      {
+        key: "secret",
+        label: "API token",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "manual",
+    ...(args.skillMarkdown === undefined
+      ? {}
+      : { skillMarkdown: args.skillMarkdown }),
+  };
+}
 
 function runnerPreference(job: RunnerJob | null | undefined) {
   return job?.runnerPreference;
@@ -8604,6 +8646,354 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
+  it("admits feature-gated MCP connectors with exact synchronized runtime state", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const mcpDefinition = manualMcpRuntimeConnectorBody({
+      displayName: "BDD MCP Runtime",
+      endpoint: "https://mcp-runtime.example.test/api/mcp",
+      skillMarkdown: "Use the admitted MCP server.",
+    });
+    const mcp = await connectors.createCustomConnector(actor, mcpDefinition);
+    await connectors.setCustomConnectorValues(actor, mcp.id, [
+      { key: "secret", kind: "secret", value: "mcp-runtime-token" },
+    ]);
+
+    const http = await connectors.createCustomConnector(actor, {
+      displayName: "BDD HTTP Runtime Peer",
+      prefixes: ["https://http-runtime.example.test/api/"],
+      headerName: "Authorization",
+      headerTemplate: "Bearer {{secret}}",
+    });
+    await connectors.setCustomConnectorSecret(
+      actor,
+      http.id,
+      "http-runtime-token",
+    );
+    await connectors.updateAgentCustomConnectors(actor, agentId, [
+      mcp.id,
+      http.id,
+    ]);
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: false,
+    });
+    const disabledRun = await api.createRun(actor, {
+      agentId,
+      prompt: "do not admit MCP while rollout is disabled",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const disabledClaim = await api.claimRunnerJob(disabledRun.runId);
+    const mcpInternalName = `custom_connector_${mcp.id.replaceAll("-", "")}`;
+    expect(disabledClaim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
+      JSON.stringify([http.id]),
+    );
+    expect(disabledClaim.connectorRuntimeTargets).not.toContainEqual(
+      expect.objectContaining({
+        kind: "custom",
+        customConnectorId: mcp.id,
+      }),
+    );
+    expect(
+      findFirewallEntry(disabledClaim.firewalls, mcpInternalName),
+    ).toBeUndefined();
+    expect(
+      expectCanonicalStorageManifest(disabledClaim.storageManifest)
+        ?.storageMounts,
+    ).not.toContainEqual(
+      expect.objectContaining({
+        name: getCustomConnectorSkillStorageName(mcp.id),
+      }),
+    );
+    await api.requestCancelRun(actor, disabledRun.runId, [200]);
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const composeName = `bdd-mcp-runtime-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "bdd-inline-key",
+            [ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]: JSON.stringify([randomUUID()]),
+          },
+        },
+      },
+    });
+    const run = await api.createDirectRun(
+      actor,
+      zeroBackedDirectRunBody({
+        agentId,
+        agentComposeVersionId: compose.versionId,
+        prompt: "use the admitted MCP connector",
+      }),
+    );
+    const claim = await api.claimRunnerJob(run.runId);
+    const admittedIds = [http.id, mcp.id].sort();
+    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
+      JSON.stringify(admittedIds),
+    );
+    expect(
+      claim.connectorRuntimeTargets
+        .flatMap((target) => {
+          return target.kind === "custom" ? [target.customConnectorId] : [];
+        })
+        .sort(),
+    ).toStrictEqual(admittedIds);
+    expect(claim.connectorRuntimeTargets).toContainEqual({
+      kind: "custom",
+      customConnectorId: mcp.id,
+      baseUrlVars: {},
+    });
+
+    const [mcpApi] = inlineFirewallApis(claim.firewalls, mcpInternalName);
+    expect(mcpApi).toMatchObject({
+      base: "https://mcp-runtime.example.test",
+      hostPolicy: { kind: "publicDestination" },
+      permissions: [
+        {
+          name: "mcp-endpoint",
+          rules: ["POST /api/mcp", "GET /api/mcp", "DELETE /api/mcp"],
+        },
+      ],
+    });
+    const mcpSecretKey = `CUSTOM_${mcp.id.replaceAll("-", "")}_S_SECRET`;
+    expect(mcpApi?.auth.headers?.Authorization).toBe(
+      `Bearer \${{ secrets.${mcpSecretKey} }}`,
+    );
+    expect(claim.networkPolicies?.[mcpInternalName]).toMatchObject({
+      allow: ["mcp-endpoint"],
+      unknownPolicy: "deny",
+    });
+    expect(claim.secretValues).not.toContain("mcp-runtime-token");
+    expect(
+      expectCanonicalStorageManifest(claim.storageManifest)?.storageMounts,
+    ).toContainEqual(
+      expect.objectContaining({
+        name: getCustomConnectorSkillStorageName(mcp.id),
+      }),
+    );
+
+    const target = {
+      kind: "custom" as const,
+      customConnectorId: mcp.id,
+      baseUrlVars: {},
+    };
+    const [initialResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    const initialRuntime = availableCustomConnectorRuntime(initialResult);
+    const { body: initialAuthBody } = customConnectorRuntimeAuthBody(
+      initialRuntime,
+      fw.encryptedSecretsBody({}),
+    );
+    const initialAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      initialAuthBody,
+      [200],
+    );
+    expect(initialAuth.body).toMatchObject({
+      headers: { Authorization: "Bearer mcp-runtime-token" },
+    });
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: false,
+    });
+    const [activeWhileDisabledResult] = await api.syncConnectorRuntime(
+      run.runId,
+      { targets: [target] },
+    );
+    expect(
+      availableCustomConnectorRuntime(activeWhileDisabledResult).baseUrlVars,
+    ).toStrictEqual({});
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const movedDefinition = manualMcpRuntimeConnectorBody({
+      displayName: "BDD MCP Runtime Moved",
+      endpoint: "https://mcp-runtime.example.test/v2/mcp/",
+      skillMarkdown: "Use the moved MCP server.",
+    });
+    await connectors.updateCustomConnector(actor, mcp.id, movedDefinition);
+    const [movedResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    const movedRuntime = availableCustomConnectorRuntime(movedResult);
+    expect(movedRuntime.firewall.firewall.apis[0]).toMatchObject({
+      base: "https://mcp-runtime.example.test",
+      permissions: [
+        {
+          name: "mcp-endpoint",
+          rules: ["POST /v2/mcp/", "GET /v2/mcp/", "DELETE /v2/mcp/"],
+        },
+      ],
+    });
+
+    await connectors.disconnectCustomConnector(actor, mcp.id);
+    const [disconnectedResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    const disconnectedRuntime =
+      availableCustomConnectorRuntime(disconnectedResult);
+    const { body: disconnectedAuthBody } = customConnectorRuntimeAuthBody(
+      disconnectedRuntime,
+      fw.encryptedSecretsBody({}),
+    );
+    const disconnectedAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      disconnectedAuthBody,
+      [424],
+    );
+    if (disconnectedAuth.status !== 424) {
+      throw new Error("Expected disconnected MCP connector credentials");
+    }
+    expect(disconnectedAuth.body.error).toMatchObject({
+      code: "CONNECTOR_NOT_CONFIGURED",
+    });
+
+    const [mismatchedRoutingResult] = await api.syncConnectorRuntime(
+      run.runId,
+      {
+        targets: [
+          {
+            kind: "custom",
+            customConnectorId: mcp.id,
+            baseUrlVars: { unexpected: "value" },
+          },
+        ],
+      },
+    );
+    expect(mismatchedRoutingResult).toMatchObject({
+      target: { kind: "custom", customConnectorId: mcp.id },
+      state: "unresolved",
+      reason: "runtime-configuration-unavailable",
+    });
+
+    await connectors.setCustomConnectorValues(actor, mcp.id, [
+      { key: "secret", kind: "secret", value: "mcp-restored-token" },
+    ]);
+    await connectors.updateAgentCustomConnectors(
+      actor,
+      agentId,
+      [mcp.id],
+      "remove",
+    );
+    const [removedGrantResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    expect(
+      availableCustomConnectorRuntime(removedGrantResult).baseUrlVars,
+    ).toStrictEqual({});
+    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
+      JSON.stringify(admittedIds),
+    );
+
+    await connectors.deleteCustomConnector(actor, mcp.id);
+    const [deletedResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    expect(deletedResult).toMatchObject({
+      target: { kind: "custom", customConnectorId: mcp.id },
+      state: "absent",
+      reason: "connector-unavailable",
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("hands off more than one runtime-sync batch without truncation", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const suffix = randomUUID().slice(0, 8);
+    const connectorCount = CONNECTOR_RUNTIME_SYNC_TARGETS_MAX + 1;
+    const createdIds: string[] = [];
+
+    for (let offset = 0; offset < connectorCount; offset += 32) {
+      const batchSize = Math.min(32, connectorCount - offset);
+      const batch = await Promise.all(
+        Array.from({ length: batchSize }, async (_unused, index) => {
+          const sequence = offset + index;
+          const connector = await connectors.createCustomConnector(actor, {
+            kind: "http",
+            displayName: `BDD Runtime Batch ${sequence}`,
+            prefixTemplates: [
+              `https://batch-${sequence}-${suffix}.example.test/api/`,
+            ],
+            fields: [
+              {
+                key: "secret",
+                label: "API key",
+                kind: "secret",
+                required: true,
+              },
+            ],
+            headerInjections: [
+              {
+                name: "Authorization",
+                valueTemplate: "Bearer {{secrets.secret}}",
+              },
+            ],
+            queryInjections: [],
+            authMode: "manual",
+          });
+          const connected = await connectors.setCustomConnectorValues(
+            actor,
+            connector.id,
+            [
+              {
+                key: "secret",
+                kind: "secret",
+                value: `batch-secret-${sequence}`,
+              },
+            ],
+          );
+          expect(connected.connected).toBeTruthy();
+          return connector.id;
+        }),
+      );
+      createdIds.push(...batch);
+    }
+    const enabledIds = await connectors.updateAgentCustomConnectors(
+      actor,
+      agentId,
+      createdIds,
+    );
+    expect(enabledIds).toHaveLength(connectorCount);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use more than one connector runtime sync batch",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const expectedIds = [...createdIds].sort();
+    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
+      JSON.stringify(expectedIds),
+    );
+    expect(
+      claim.connectorRuntimeTargets
+        .flatMap((target) => {
+          return target.kind === "custom" ? [target.customConnectorId] : [];
+        })
+        .sort(),
+    ).toStrictEqual(expectedIds);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
   it("keeps a granted custom skill independent from runtime admission", async () => {
     const api = createRunsApi(context);
     createBddApi(context).acceptAgentStorageWrites();
@@ -9124,6 +9514,107 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     await api.requestCancelRun(actor, firstRun.runId, [200]);
     await api.requestCancelRun(actor, secondRun.runId, [200]);
+  });
+
+  it("resolves current OAuth credentials for admitted MCP connectors", async () => {
+    const provider = mockCustomConnectorOAuth2Provider(context, {
+      initialExpiresIn: 3600,
+    });
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const mcp = await connectors.createCustomConnector(actor, {
+      kind: "mcp",
+      displayName: "BDD MCP OAuth Runtime",
+      endpoint: "https://mcp-oauth.example.test/oauth/mcp",
+      transport: "streamable-http",
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth",
+      oauthConfig: {
+        providerAdapter: "standard",
+        clientId: "mcp-runtime-client-id",
+        clientSecret: "mcp-runtime-client-secret",
+        authorizationUrl: provider.authorizationUrl,
+        tokenUrl: provider.tokenUrl,
+        tokenEndpointAuthMethod: "client_secret_basic",
+        pkceMethod: "none",
+        scopes: ["read"],
+        authorizationParams: {},
+      },
+    });
+    const authorizationUrl = await connectors.startCustomConnectorOAuth2(
+      actor,
+      mcp.id,
+    );
+    const state = new URL(authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected MCP custom connector OAuth state");
+    }
+    await connectors.completeCustomConnectorOAuth2Callback({
+      code: "mcp-runtime-authorization-code",
+      state,
+    });
+    await connectors.updateAgentCustomConnectors(actor, agentId, [mcp.id]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use the OAuth MCP connector",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
+      JSON.stringify([mcp.id]),
+    );
+    const internalName = `custom_connector_${mcp.id.replaceAll("-", "")}`;
+    expect(inlineFirewallApis(claim.firewalls, internalName)[0]).toMatchObject({
+      base: "https://mcp-oauth.example.test",
+      permissions: [
+        {
+          name: "mcp-endpoint",
+          rules: ["POST /oauth/mcp", "GET /oauth/mcp", "DELETE /oauth/mcp"],
+        },
+      ],
+    });
+    const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [
+        {
+          kind: "custom",
+          customConnectorId: mcp.id,
+          baseUrlVars: {},
+        },
+      ],
+    });
+    const runtime = availableCustomConnectorRuntime(runtimeResult);
+    const { body: authBody } = customConnectorRuntimeAuthBody(
+      runtime,
+      fw.encryptedSecretsBody({}),
+    );
+    const resolved = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      authBody,
+      [200],
+    );
+    expect(resolved.body).toMatchObject({
+      headers: { Authorization: "Bearer custom-oauth-initial-access-token" },
+    });
+    expect(claim.secretValues).not.toContain(
+      "custom-oauth-initial-access-token",
+    );
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("injects only enabled custom connector firewalls for Zero-backed direct runs", async () => {

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -5,6 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/test-connector-credential-storage-state";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
 import { and, eq, inArray } from "drizzle-orm";
@@ -243,6 +244,57 @@ async function seedConnector(
   return actionOk({ connector_id: connector.id });
 }
 
+async function seedCustomRuntimeConnectors(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"seed-custom-runtime-connectors">,
+  signal: AbortSignal,
+) {
+  await db.transaction(async (tx) => {
+    await tx.insert(orgCustomConnectors).values(
+      body.custom_connectors.map((connector) => {
+        return {
+          id: connector.id,
+          orgId: body.org_id,
+          slug: connector.slug,
+          displayName: connector.display_name,
+          prefixes: [connector.prefix_template],
+          headerName: "X-Connector",
+          headerTemplate: "runtime-batch",
+          prefixTemplates: [connector.prefix_template],
+          fields: [
+            {
+              key: "optional_secret",
+              label: "Optional secret",
+              kind: "secret" as const,
+              required: false,
+            },
+          ],
+          headerInjections: [
+            { name: "X-Connector", valueTemplate: "runtime-batch" },
+          ],
+          queryInjections: [],
+          authMode: "manual" as const,
+          storageVersion: 1,
+          createdBy: body.user_id,
+        };
+      }),
+    );
+    await tx.insert(connectors).values(
+      body.custom_connectors.map((connector) => {
+        return {
+          orgId: body.org_id,
+          userId: body.user_id,
+          customConnectorId: connector.id,
+          authMethod: "manual",
+          storageVersion: 1,
+        };
+      }),
+    );
+  });
+  signal.throwIfAborted();
+  return actionOk();
+}
+
 async function setConnectorState(
   db: Db,
   body: ConnectorCredentialStorageAction<"set-connector-state">,
@@ -387,6 +439,9 @@ const mutateConnectorCredentialStorageState$ = command(
       }
       case "seed-connector": {
         return await seedConnector(db, body, signal);
+      }
+      case "seed-custom-runtime-connectors": {
+        return await seedCustomRuntimeConnectors(db, body, signal);
       }
       case "set-connector-state": {
         return await setConnectorState(db, body, signal);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -18,6 +18,7 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { CodexServiceTier } from "@vm0/api-contracts/contracts/chat-threads";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import { ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   connectorSlugSchema,
   type ConnectorAuthMethodId,
@@ -67,7 +68,9 @@ import {
   type FirewallPolicy,
   type NetworkPolicies,
   type NetworkPolicy,
+  canonicalizeFirewallBaseUrl,
   normalizeFirewallFixedHost,
+  validateBaseUrlHostPolicy,
 } from "@vm0/connectors/firewall-types";
 import {
   type CreateRunResponse,
@@ -3855,7 +3858,12 @@ class CustomConnectorRuntimeBuildStats {
       return total + row.values.length;
     }, 0);
     this.prefixTemplateCount = rows.reduce((total, row) => {
-      return total + row.connector.prefixTemplates.length;
+      return (
+        total +
+        (row.connector.kind === "http"
+          ? row.connector.prefixTemplates.length
+          : 0)
+      );
     }, 0);
   }
 
@@ -3998,6 +4006,52 @@ function buildCustomConnectorRuntimeApis(args: {
   if (args.baseUrlVars === undefined) {
     return [];
   }
+  const prefixStartedAt = now();
+  const connector = args.row.connector;
+  if (connector.kind === "mcp") {
+    const endpointResult = safeSync(() => {
+      const canonicalEndpoint = canonicalizeFirewallBaseUrl(
+        connector.endpoint,
+        "MCP custom connector",
+      );
+      const endpoint = new URL(canonicalEndpoint);
+      if (endpoint.protocol !== "https:") {
+        throw new Error("MCP endpoint must use https://");
+      }
+      validateBaseUrlHostPolicy({
+        base: canonicalEndpoint,
+        serviceName: "MCP custom connector",
+        hostPolicy: { kind: "publicDestination" },
+      });
+      return endpoint;
+    });
+    if ("error" in endpointResult) {
+      args.stats.recordInvalidPrefix();
+      args.stats.recordPhaseDuration("renderPrefixes", prefixStartedAt);
+      return [];
+    }
+    const endpoint = endpointResult.ok;
+    const endpointPath = endpoint.pathname;
+    args.stats.recordRenderedApi();
+    args.stats.recordPhaseDuration("renderPrefixes", prefixStartedAt);
+    return [
+      {
+        base: endpoint.origin,
+        hostPolicy: { kind: "publicDestination" },
+        auth: { headers: args.headers, query: args.query },
+        permissions: [
+          {
+            name: "mcp-endpoint",
+            rules: [
+              `POST ${endpointPath}`,
+              `GET ${endpointPath}`,
+              `DELETE ${endpointPath}`,
+            ],
+          },
+        ],
+      },
+    ];
+  }
   const templateValues = Object.fromEntries(
     Object.entries(args.baseUrlVars).map(([key, value]) => {
       return [customConnectorValueMarkerKey({ kind: "variable", key }), value];
@@ -4005,12 +4059,11 @@ function buildCustomConnectorRuntimeApis(args: {
   );
 
   const apis: ExpandedFirewallConfig["apis"] = [];
-  const prefixStartedAt = now();
-  for (const prefixTemplate of args.row.connector.prefixTemplates) {
+  for (const prefixTemplate of connector.prefixTemplates) {
     const renderedPrefix = renderCustomConnectorRuntimePrefix({
       template: prefixTemplate,
       values: templateValues,
-      connectorName: args.row.connector.displayName,
+      connectorName: connector.displayName,
     });
     if (!renderedPrefix) {
       args.stats.recordInvalidPrefix();
@@ -4036,6 +4089,12 @@ async function resolveCustomConnectorBaseUrlVars(args: {
   readonly hasProvided: boolean;
   readonly stats: CustomConnectorRuntimeBuildStats;
 }): Promise<Readonly<Record<string, string>> | undefined> {
+  if (args.row.connector.kind === "mcp") {
+    if (!args.hasProvided) {
+      return {};
+    }
+    return Object.keys(args.provided ?? {}).length === 0 ? {} : undefined;
+  }
   const variableKeys = [
     ...customConnectorPrefixTemplateVariableKeys(
       args.row.connector.prefixTemplates,
@@ -4162,6 +4221,9 @@ export async function loadEffectiveCustomConnectorPermissionBundle(args: {
   readonly row: CustomConnectorRuntimeDataRows[number];
   readonly snapshot: ConnectorRuntimeSnapshot;
 }): Promise<CustomConnectorPermissionBundle | null | undefined> {
+  if (args.row.connector.kind === "mcp") {
+    return null;
+  }
   const ref = effectiveCustomConnectorPermissionBundleRef({
     slug: args.row.connector.slug,
     authMode: args.row.connector.authMode,
@@ -4237,6 +4299,9 @@ async function buildCustomConnectorRuntimeRow(args: {
   args.stats.recordPhaseDuration("renderAuthTemplates", authTemplateStartedAt);
   if (Object.keys(headers).length === 0 && Object.keys(query).length === 0) {
     args.stats.recordNoAuthInjectionConnector();
+    if (args.row.connector.kind === "mcp") {
+      return unavailableCustomConnectorRuntimeRow(target, skill);
+    }
   }
   const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle({
     row: args.row,
@@ -4274,12 +4339,18 @@ async function buildCustomConnectorRuntimeRow(args: {
       description: args.row.connector.displayName,
       apis,
     },
-    permissionPolicy: permissionBundle
-      ? buildCustomConnectorPermissionPolicy({
-          bundle: permissionBundle,
-          selectedPermissionNames: args.selectedPermissionNames,
-        })
-      : undefined,
+    permissionPolicy:
+      args.row.connector.kind === "mcp"
+        ? {
+            policies: { "mcp-endpoint": "allow" },
+            unknownPolicy: "deny",
+          }
+        : permissionBundle
+          ? buildCustomConnectorPermissionPolicy({
+              bundle: permissionBundle,
+              selectedPermissionNames: args.selectedPermissionNames,
+            })
+          : undefined,
   };
 }
 
@@ -4485,8 +4556,17 @@ async function loadCustomConnectorContext(
       skills: [],
     };
   }
+  const newRunRows = rows.filter((row) => {
+    return (
+      row.connector.kind !== "mcp" ||
+      isFeatureEnabled(
+        FeatureSwitchKey.CustomConnectorMcp,
+        args.featureSwitchContext,
+      )
+    );
+  });
   const refreshedRows: CustomConnectorRuntimeDataRows[number][] = [];
-  for (const row of rows) {
+  for (const row of newRunRows) {
     refreshedRows.push({
       connector: row.connector,
       credentialAccess: row.credentialAccess,
@@ -5810,6 +5890,17 @@ async function buildStoredExecutionContextDraft(args: {
   const secretValues = executionSecrets.secrets
     ? Object.values(executionSecrets.secrets)
     : [];
+  const connectorRuntimeTargets = storedConnectorRuntimeTargets({
+    permissionManifest: permissions,
+    customTargets: args.customConnectorContext.targets,
+  });
+  const customConnectorIds = [
+    ...new Set(
+      connectorRuntimeTargets.flatMap((target) => {
+        return target.kind === "custom" ? [target.customConnectorId] : [];
+      }),
+    ),
+  ].sort();
   const environment = {
     ...expandEnvironment({
       content: args.resolved.content,
@@ -5822,6 +5913,7 @@ async function buildStoredExecutionContextDraft(args: {
     }),
     ...args.extraEnvironment,
     CLI_PKG_URL: env("CLI_PKG_URL"),
+    [ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]: JSON.stringify(customConnectorIds),
   };
   const environmentKeyByValue = new Map<string, string>();
   for (const [key, value] of Object.entries(environment)) {
@@ -5835,11 +5927,6 @@ async function buildStoredExecutionContextDraft(args: {
         return key === undefined ? [] : [key];
       })
     : null;
-  const connectorRuntimeTargets = storedConnectorRuntimeTargets({
-    permissionManifest: permissions,
-    customTargets: args.customConnectorContext.targets,
-  });
-
   return {
     context: {
       environment,

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -47,7 +47,6 @@ import {
   CUSTOM_CONNECTOR_OAUTH_REFRESH_TOKEN_SECRET_NAME,
   getCustomConnectorById,
   normaliseCustomConnectorRow,
-  type CustomConnectorHttpRow,
   type CustomConnectorOAuthConfigRow,
   type CustomConnectorRow,
   type StoredValueRow,
@@ -1010,7 +1009,7 @@ interface ResolveCustomConnectorOAuth2AccessTokenArgs {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly connector: CustomConnectorHttpRow;
+  readonly connector: CustomConnectorRow;
   readonly featureContext: FeatureSwitchContext;
   readonly forceRefresh?: boolean;
 }
@@ -1144,7 +1143,7 @@ export async function refreshCustomConnectorOAuth2ValuesIfNeeded(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
-    readonly connector: CustomConnectorHttpRow;
+    readonly connector: CustomConnectorRow;
     readonly values: readonly StoredValueRow[];
     readonly featureContext: FeatureSwitchContext;
   },
@@ -1210,11 +1209,7 @@ export async function resolveCurrentCustomConnectorOAuth2AccessToken(
 ): Promise<CustomConnectorOAuth2AccessTokenResolution> {
   const connector = await loadLiveCustomConnector(args);
   signal.throwIfAborted();
-  if (
-    !connector ||
-    connector.kind !== "http" ||
-    connector.authMode !== "oauth"
-  ) {
+  if (!connector || connector.authMode !== "oauth") {
     return { kind: "unavailable" };
   }
   return await resolveCustomConnectorOAuth2AccessToken(

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1,7 +1,7 @@
 import { command, computed, type Computed } from "ccstate";
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
-import { and, eq, gte, inArray, isNotNull, isNull, lt, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
 import type {
   CreateCustomConnectorBody,
   CustomConnectorAuthMode,
@@ -3349,7 +3349,7 @@ export async function loadCustomConnectorRuntimeData(
   },
 ): Promise<
   readonly {
-    readonly connector: CustomConnectorHttpRow;
+    readonly connector: CustomConnectorRow;
     readonly values: readonly StoredValueRow[];
     readonly credentialAccess: CustomConnectorCredentialAccess;
   }[]
@@ -3384,13 +3384,11 @@ export async function loadCustomConnectorRuntimeData(
           ? and(
               eq(orgCustomConnectors.orgId, args.orgId),
               eq(orgCustomConnectors.enabled, true),
-              isNull(orgCustomConnectors.mcpTransport),
               inArray(orgCustomConnectors.id, [...args.connectorIds]),
             )
           : and(
               eq(orgCustomConnectors.orgId, args.orgId),
               eq(orgCustomConnectors.enabled, true),
-              isNull(orgCustomConnectors.mcpTransport),
             ),
       );
   });
@@ -3416,9 +3414,6 @@ export async function loadCustomConnectorRuntimeData(
           row.connector,
           row.oauthConfig,
         );
-        if (connector.kind !== "http") {
-          throw new Error("Expected HTTP Custom Connector runtime data");
-        }
         const credentialAccess = credentialAccesses.get(connector.id);
         if (!credentialAccess) {
           throw new Error("Expected custom connector credential access");

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -66,6 +66,21 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       storage_version: z.number().int().positive(),
     }),
     z.object({
+      action: z.literal("seed-custom-runtime-connectors"),
+      org_id: z.string(),
+      user_id: z.string(),
+      custom_connectors: z
+        .array(
+          z.object({
+            id: z.uuid(),
+            slug: z.string(),
+            display_name: z.string(),
+            prefix_template: z.string(),
+          }),
+        )
+        .min(1),
+    }),
+    z.object({
       action: z.literal("set-connector-state"),
       org_id: z.string(),
       user_id: z.string(),

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -5,6 +5,8 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY = "ZERO_CUSTOM_CONNECTOR_IDS";
+
 export const customConnectorSlugSchema = z
   .string()
   .regex(/^_[a-z0-9][a-z0-9-]{0,60}[a-z0-9]$/u);

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -2687,6 +2687,371 @@
         "permission": "first-read",
         "rule": "GET /items/{id}"
       }
+    },
+    {
+      "name": "MCP origin base allows exact POST endpoint path",
+      "firewalls": [
+        {
+          "name": "custom_connector_00000000000040008000000000000001",
+          "customConnectorId": "00000000-0000-4000-8000-000000000001",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "hostPolicy": { "kind": "publicDestination" },
+              "auth": { "headers": { "Authorization": "Bearer token" } },
+              "permissions": [
+                {
+                  "name": "mcp-endpoint",
+                  "rules": ["POST /api/mcp", "GET /api/mcp", "DELETE /api/mcp"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "custom_connector_00000000000040008000000000000001": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://mcp.example.com/api/mcp",
+        "connectorIntent": {
+          "status": "present",
+          "value": "00000000-0000-4000-8000-000000000001"
+        }
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "custom_connector_00000000000040008000000000000001",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/mcp",
+        "permission": "mcp-endpoint",
+        "rule": "POST /api/mcp"
+      }
+    },
+    {
+      "name": "MCP origin base allows compatibility GET endpoint path",
+      "firewalls": [
+        {
+          "name": "mcp",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "mcp-endpoint",
+                  "rules": ["GET /api/mcp", "DELETE /api/mcp"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "mcp": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://mcp.example.com/api/mcp"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "mcp",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/mcp",
+        "permission": "mcp-endpoint",
+        "rule": "GET /api/mcp"
+      }
+    },
+    {
+      "name": "MCP origin base allows compatibility DELETE endpoint path",
+      "firewalls": [
+        {
+          "name": "mcp",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "mcp-endpoint",
+                  "rules": ["GET /api/mcp", "DELETE /api/mcp"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "mcp": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "DELETE",
+        "url": "https://mcp.example.com/api/mcp"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "mcp",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/mcp",
+        "permission": "mcp-endpoint",
+        "rule": "DELETE /api/mcp"
+      }
+    },
+    {
+      "name": "MCP exact endpoint denies a distinct trailing slash",
+      "firewalls": [
+        {
+          "name": "mcp",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": {},
+              "permissions": [
+                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "mcp": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://mcp.example.com/api/mcp/"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "mcp",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/mcp/",
+        "reason": "unknown_endpoint",
+        "permissions": []
+      }
+    },
+    {
+      "name": "MCP exact endpoint denies a child path",
+      "firewalls": [
+        {
+          "name": "mcp",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": {},
+              "permissions": [
+                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "mcp": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://mcp.example.com/api/mcp/child"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "mcp",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/mcp/child",
+        "reason": "unknown_endpoint",
+        "permissions": []
+      }
+    },
+    {
+      "name": "MCP exact endpoint denies an unsupported method",
+      "firewalls": [
+        {
+          "name": "mcp",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": {},
+              "permissions": [
+                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "mcp": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "https://mcp.example.com/api/mcp"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "mcp",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/mcp",
+        "reason": "unknown_endpoint",
+        "permissions": []
+      }
+    },
+    {
+      "name": "MCP exact endpoint denies a sibling path",
+      "firewalls": [
+        {
+          "name": "mcp",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": {},
+              "permissions": [
+                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "mcp": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://mcp.example.com/api/other"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "mcp",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/other",
+        "reason": "unknown_endpoint",
+        "permissions": []
+      }
+    },
+    {
+      "name": "MCP exact endpoint does not match another host",
+      "firewalls": [
+        {
+          "name": "mcp",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": {},
+              "permissions": [
+                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "mcp": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://other.example.com/api/mcp"
+      },
+      "expected": { "kind": "no_match" }
+    },
+    {
+      "name": "MCP shared exact endpoint uses stable custom connector intent",
+      "firewalls": [
+        {
+          "name": "custom_connector_00000000000040008000000000000001",
+          "customConnectorId": "00000000-0000-4000-8000-000000000001",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": { "headers": { "Authorization": "Bearer first" } },
+              "permissions": [
+                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "custom_connector_00000000000040008000000000000002",
+          "customConnectorId": "00000000-0000-4000-8000-000000000002",
+          "apis": [
+            {
+              "base": "https://mcp.example.com",
+              "auth": { "headers": { "Authorization": "Bearer second" } },
+              "permissions": [
+                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "custom_connector_00000000000040008000000000000001": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        },
+        "custom_connector_00000000000040008000000000000002": {
+          "allow": ["mcp-endpoint"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://mcp.example.com/api/mcp",
+        "connectorIntent": {
+          "status": "present",
+          "value": "00000000-0000-4000-8000-000000000002"
+        }
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "custom_connector_00000000000040008000000000000002",
+        "base": "https://mcp.example.com",
+        "relativePath": "/api/mcp",
+        "permission": "mcp-endpoint",
+        "rule": "POST /api/mcp"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- admit feature-gated MCP Custom Connectors into new Cloud Agent Runs through the existing custom runtime target lifecycle
- generate an origin-based firewall with exact `POST`, `GET`, and `DELETE` rules for the canonical MCP endpoint path, public-destination enforcement, current manual/OAuth auth, and unknown deny
- hand off every admitted Custom Connector ID as sorted, unique `ZERO_CUSTOM_CONNECTOR_IDS` metadata without applying the per-request runtime-sync batch limit
- keep active Run membership fixed while allowing existing runtime sync to reflect endpoint, credential, disable, and delete changes

## Compatibility and exclusions

- preserves the existing HTTP Custom Connector runtime path
- adds no database schema, persisted Run membership, Runner wire field, MCP descriptor API, or Zero CLI invocation command
- keeps the rollout switch as a new-Run admission gate; it does not revoke already admitted active targets

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (190 files, 2863 tests)
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors test -- --silent=passed-only` (41 files, 1009 tests)
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test -- --silent=passed-only` (26 files, 544 tests)
- `pnpm knip`
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5233 tests)
- repository pre-commit hooks, including full Turbo type checks

Closes #26010

Parent delivery context: #25031
