### PR TITLE
refactor(runner): preserve process-control outcomes

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::io;
 use std::num::NonZeroU64;
 use std::path::Path;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -10,8 +10,9 @@ use async_trait::async_trait;
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestMemorySnapshot,
     GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter,
-    ProcessControlAck, ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
-    Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkObserver,
+    ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
+    ProcessControlOutcome, ProcessControlWriteState, ProcessExit, ProcessOutputChunk,
+    ProcessOutputMode, Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkObserver,
     SandboxFinalExecParkOutcome, SandboxFinalExecParkStage, SandboxIdleTransition,
     SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
     SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
@@ -22,8 +23,9 @@ use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace, warn};
 use vsock_host::{
-    ExecOutputEvent, ExecOwnedCapturedOutput, FencedExecError, NormalOperationFence,
-    NormalOperationFenceRejection, SupervisedExecControl, SupervisedExecRequest, VsockHost,
+    ExecOutputEvent, ExecOwnedCapturedOutput, FencedExecError, FrameWriteObserver,
+    NormalOperationFence, NormalOperationFenceRejection, SupervisedExecControl,
+    SupervisedExecRequest, VsockHost,
 };
 use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy};
 
@@ -856,6 +858,52 @@ impl FirecrackerSandbox {
         io::Error::other(error)
     }
 
+    fn process_control_guest_status(
+        status: vsock_proto::ExecControlStatus,
+    ) -> io::Result<ProcessControlGuestStatus> {
+        let status = match status {
+            vsock_proto::ExecControlStatus::Inactive => ProcessControlGuestStatus::Inactive,
+            vsock_proto::ExecControlStatus::NonceMismatch => {
+                ProcessControlGuestStatus::NonceMismatch
+            }
+            vsock_proto::ExecControlStatus::Unsupported => ProcessControlGuestStatus::Unsupported,
+            vsock_proto::ExecControlStatus::Rejected => ProcessControlGuestStatus::Rejected,
+            vsock_proto::ExecControlStatus::SinkUnavailable => {
+                ProcessControlGuestStatus::SinkUnavailable
+            }
+            vsock_proto::ExecControlStatus::SinkTimeout => ProcessControlGuestStatus::SinkTimeout,
+            vsock_proto::ExecControlStatus::QueueFull => ProcessControlGuestStatus::QueueFull,
+            vsock_proto::ExecControlStatus::SinkError => ProcessControlGuestStatus::SinkError,
+            vsock_proto::ExecControlStatus::Delivered => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "delivered exec-control status used a guest-status outcome",
+                ));
+            }
+        };
+        Ok(status)
+    }
+
+    fn process_control_write_state(write_started: &AtomicBool) -> ProcessControlWriteState {
+        if write_started.load(Ordering::Acquire) {
+            ProcessControlWriteState::PossiblyWritten
+        } else {
+            ProcessControlWriteState::NotWritten
+        }
+    }
+
+    fn process_control_failure(
+        kind: ProcessControlFailureKind,
+        write_started: &AtomicBool,
+        error: io::Error,
+    ) -> ProcessControlOutcome {
+        ProcessControlOutcome::Failed {
+            kind,
+            write_state: Self::process_control_write_state(write_started),
+            error,
+        }
+    }
+
     async fn exec_process_control(
         coordinator: ParkCoordinator,
         state: Arc<AtomicU8>,
@@ -864,41 +912,88 @@ impl FirecrackerSandbox {
         message_id: String,
         payload: Vec<u8>,
         timeout: Duration,
-    ) -> io::Result<ProcessControlAck> {
+    ) -> ProcessControlOutcome {
         enum ControlOutcome {
-            Returned(io::Result<vsock_host::ExecControlAck>),
+            Returned(io::Result<vsock_host::ExecControlOutcome>),
             BackendCrashed,
         }
 
         let operation = SandboxOperation::ProcessControl;
-        Self::begin_process_control(&coordinator, || Self::current_state_from(&state)).map_err(
-            |error| {
-                Self::operation_start_io_error(operation, error, Self::current_state_from(&state))
-            },
-        )?;
+        let write_started = Arc::new(AtomicBool::new(false));
+        if let Err(error) =
+            Self::begin_process_control(&coordinator, || Self::current_state_from(&state))
+        {
+            let kind = if matches!(&error, GuestOperationStartError::BackendCrashed) {
+                ProcessControlFailureKind::BackendCrashed
+            } else {
+                ProcessControlFailureKind::Operation
+            };
+            return Self::process_control_failure(
+                kind,
+                &write_started,
+                Self::operation_start_io_error(operation, error, Self::current_state_from(&state)),
+            );
+        }
+
+        let write_observer = FrameWriteObserver::new({
+            let write_started = Arc::clone(&write_started);
+            move || {
+                write_started.store(true, Ordering::Release);
+                Ok(())
+            }
+        });
 
         let outcome = tokio::select! {
-            result = control.control_owned(
+            result = control.control_owned_with_write_observer(
                 message_id,
                 payload,
                 timeout,
+                write_observer,
             ) => ControlOutcome::Returned(result),
             () = wait_for_backend_crash(state_rx) => ControlOutcome::BackendCrashed,
         };
 
         match outcome {
-            ControlOutcome::Returned(Ok(ack)) => Ok(ProcessControlAck {
-                message_id: ack.message_id,
-            }),
+            ControlOutcome::Returned(Ok(vsock_host::ExecControlOutcome::Delivered(ack))) => {
+                ProcessControlOutcome::Delivered(ProcessControlAck {
+                    message_id: ack.message_id,
+                })
+            }
+            ControlOutcome::Returned(Ok(vsock_host::ExecControlOutcome::GuestStatus(status))) => {
+                match Self::process_control_guest_status(status.status) {
+                    Ok(guest_status) => ProcessControlOutcome::GuestStatus {
+                        status: guest_status,
+                        diagnostic: status.diagnostic,
+                    },
+                    Err(error) => Self::process_control_failure(
+                        ProcessControlFailureKind::Operation,
+                        &write_started,
+                        error,
+                    ),
+                }
+            }
+            ControlOutcome::Returned(Ok(vsock_host::ExecControlOutcome::GuestError(message))) => {
+                ProcessControlOutcome::GuestError(message)
+            }
             ControlOutcome::Returned(Err(error)) => {
                 if Self::current_state_from(&state) == SandboxState::Crashed {
-                    return Err(io::Error::other(Self::backend_crashed_error(operation)));
+                    return Self::process_control_failure(
+                        ProcessControlFailureKind::BackendCrashed,
+                        &write_started,
+                        io::Error::other(Self::backend_crashed_error(operation)),
+                    );
                 }
-                Err(error)
+                Self::process_control_failure(
+                    ProcessControlFailureKind::Operation,
+                    &write_started,
+                    error,
+                )
             }
-            ControlOutcome::BackendCrashed => {
-                Err(io::Error::other(Self::backend_crashed_error(operation)))
-            }
+            ControlOutcome::BackendCrashed => Self::process_control_failure(
+                ProcessControlFailureKind::BackendCrashed,
+                &write_started,
+                io::Error::other(Self::backend_crashed_error(operation)),
+            ),
         }
     }
 
@@ -2342,7 +2437,8 @@ impl Sandbox for FirecrackerSandbox {
                     let coordinator = self.park_coordinator.clone();
                     let state = Arc::clone(&self.state);
                     let state_rx = self.state_tx.subscribe();
-                    GuestProcessControlHandle::new(move |message_id, payload, timeout| {
+                    GuestProcessControlHandle::new_with_outcome(
+                        move |message_id, payload, timeout| {
                         let control = control.clone();
                         let coordinator = coordinator.clone();
                         let state = Arc::clone(&state);
@@ -2353,7 +2449,8 @@ impl Sandbox for FirecrackerSandbox {
                             )
                             .await
                         })
-                    })
+                        },
+                    )
                 });
                 let (stdout_rx, close_stdout) = if request.output.streams_stdout() {
                     match handle.take_stream_receiver() {

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -447,6 +447,47 @@ async fn send_mismatched_exec_control_result(stream: &mut UnixStream, request: R
     stream.write_all(&response).await.unwrap();
 }
 
+fn expect_process_control_delivered(outcome: ProcessControlOutcome) -> ProcessControlAck {
+    match outcome {
+        ProcessControlOutcome::Delivered(ack) => ack,
+        other => panic!("expected delivered process-control outcome, got {other:?}"),
+    }
+}
+
+fn expect_process_control_failure(
+    outcome: ProcessControlOutcome,
+    expected_kind: ProcessControlFailureKind,
+    expected_write_state: ProcessControlWriteState,
+) -> io::Error {
+    match outcome {
+        ProcessControlOutcome::Failed {
+            kind,
+            write_state,
+            error,
+        } => {
+            assert_eq!(kind, expected_kind);
+            assert_eq!(write_state, expected_write_state);
+            error
+        }
+        other => panic!("expected failed process-control outcome, got {other:?}"),
+    }
+}
+
+fn assert_process_control_guest_status(
+    outcome: &ProcessControlOutcome,
+    expected_status: ProcessControlGuestStatus,
+    expected_diagnostic: &str,
+) {
+    assert!(
+        matches!(
+            outcome,
+            ProcessControlOutcome::GuestStatus { status, diagnostic }
+                if *status == expected_status && diagnostic == expected_diagnostic
+        ),
+        "unexpected process-control outcome: {outcome:?}",
+    );
+}
+
 async fn send_exec_exit(stream: &mut UnixStream, exec_seq: u32) {
     let payload = vsock_proto::encode_exec_result(
         vsock_proto::ExecTermination::Exited { exit_code: 0 },
@@ -2686,7 +2727,7 @@ async fn process_control_rejects_closed_policy_gate_without_dirtying() {
         .expect("begin prepare park");
     let (state, state_tx) = running_process_state();
 
-    let error = FirecrackerSandbox::exec_process_control(
+    let outcome = FirecrackerSandbox::exec_process_control(
         coordinator.clone(),
         state,
         state_tx.subscribe(),
@@ -2695,8 +2736,12 @@ async fn process_control_rejects_closed_policy_gate_without_dirtying() {
         b"payload".to_vec(),
         Duration::from_secs(5),
     )
-    .await
-    .unwrap_err();
+    .await;
+    let error = expect_process_control_failure(
+        outcome,
+        ProcessControlFailureKind::Operation,
+        ProcessControlWriteState::NotWritten,
+    );
 
     assert!(
         error.to_string().contains("sandbox operation gate closed"),
@@ -2721,7 +2766,7 @@ async fn process_control_rejects_stopped_state_without_dirtying() {
     let coordinator = ParkCoordinator::new();
     let (state, state_tx) = process_state(SandboxState::Stopped);
 
-    let error = FirecrackerSandbox::exec_process_control(
+    let outcome = FirecrackerSandbox::exec_process_control(
         coordinator.clone(),
         state,
         state_tx.subscribe(),
@@ -2730,11 +2775,53 @@ async fn process_control_rejects_stopped_state_without_dirtying() {
         b"payload".to_vec(),
         Duration::from_secs(5),
     )
-    .await
-    .unwrap_err();
+    .await;
+    let error = expect_process_control_failure(
+        outcome,
+        ProcessControlFailureKind::Operation,
+        ProcessControlWriteState::NotWritten,
+    );
 
     assert!(
         error.to_string().contains("sandbox not running"),
+        "unexpected error: {error}",
+    );
+    assert_eq!(coordinator.state(), CoordinatorState::Open);
+
+    send_exec_exit(&mut guest, exec_seq).await;
+    handle.wait(Duration::from_secs(5)).await.unwrap();
+}
+
+#[tokio::test]
+async fn process_control_reports_backend_crash_before_guest_write() {
+    let ExecProcessControlFixture {
+        host: _host,
+        handle,
+        mut guest,
+        exec_seq,
+    } = setup_exec_process_control_fixture().await;
+    let control = handle.control_handle().unwrap();
+    let coordinator = ParkCoordinator::new();
+    let (state, state_tx) = process_state(SandboxState::Crashed);
+
+    let outcome = FirecrackerSandbox::exec_process_control(
+        coordinator.clone(),
+        state,
+        state_tx.subscribe(),
+        control,
+        "crashed-before-write".to_owned(),
+        b"payload".to_vec(),
+        Duration::from_secs(5),
+    )
+    .await;
+    let error = expect_process_control_failure(
+        outcome,
+        ProcessControlFailureKind::BackendCrashed,
+        ProcessControlWriteState::NotWritten,
+    );
+
+    assert!(
+        error.to_string().contains("firecracker process crashed"),
         "unexpected error: {error}",
     );
     assert_eq!(coordinator.state(), CoordinatorState::Open);
@@ -2756,7 +2843,7 @@ async fn process_control_local_validation_failure_keeps_gate_clean() {
     let (state, state_tx) = running_process_state();
     let too_large = vec![0; vsock_proto::EXEC_CONTROL_MAX_PAYLOAD_BYTES + 1];
 
-    let error = FirecrackerSandbox::exec_process_control(
+    let outcome = FirecrackerSandbox::exec_process_control(
         coordinator.clone(),
         Arc::clone(&state),
         state_tx.subscribe(),
@@ -2765,8 +2852,12 @@ async fn process_control_local_validation_failure_keeps_gate_clean() {
         too_large,
         Duration::from_secs(5),
     )
-    .await
-    .unwrap_err();
+    .await;
+    let error = expect_process_control_failure(
+        outcome,
+        ProcessControlFailureKind::Operation,
+        ProcessControlWriteState::NotWritten,
+    );
 
     assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(coordinator.state(), CoordinatorState::Open);
@@ -2783,7 +2874,7 @@ async fn process_control_local_validation_failure_keeps_gate_clean() {
     let request = read_vsock_message(&mut guest).await;
     send_exec_control_result(&mut guest, request, ExecControlStatus::Delivered, "").await;
 
-    let ack = control_task.await.unwrap().unwrap();
+    let ack = expect_process_control_delivered(control_task.await.unwrap());
     assert_eq!(ack.message_id, "valid-after-local-failure");
     assert_eq!(coordinator.state(), CoordinatorState::Open);
 
@@ -2792,7 +2883,7 @@ async fn process_control_local_validation_failure_keeps_gate_clean() {
 }
 
 #[tokio::test]
-async fn process_control_guest_status_keeps_policy_open() {
+async fn process_control_preserves_guest_statuses_and_legacy_errors() {
     let ExecProcessControlFixture {
         host: _host,
         handle,
@@ -2803,12 +2894,85 @@ async fn process_control_guest_status_keeps_policy_open() {
     let coordinator = ParkCoordinator::new();
     let (state, state_tx) = running_process_state();
 
+    let cases = [
+        (
+            ExecControlStatus::Inactive,
+            ProcessControlGuestStatus::Inactive,
+            io::ErrorKind::NotFound,
+            "exec operation is not active",
+        ),
+        (
+            ExecControlStatus::NonceMismatch,
+            ProcessControlGuestStatus::NonceMismatch,
+            io::ErrorKind::PermissionDenied,
+            "exec operation nonce mismatch",
+        ),
+        (
+            ExecControlStatus::Unsupported,
+            ProcessControlGuestStatus::Unsupported,
+            io::ErrorKind::Unsupported,
+            "exec control is not supported by this operation",
+        ),
+        (
+            ExecControlStatus::Rejected,
+            ProcessControlGuestStatus::Rejected,
+            io::ErrorKind::PermissionDenied,
+            "exec control request rejected",
+        ),
+        (
+            ExecControlStatus::SinkUnavailable,
+            ProcessControlGuestStatus::SinkUnavailable,
+            io::ErrorKind::NotConnected,
+            "exec control sink is not connected",
+        ),
+        (
+            ExecControlStatus::SinkTimeout,
+            ProcessControlGuestStatus::SinkTimeout,
+            io::ErrorKind::TimedOut,
+            "exec control sink timed out",
+        ),
+        (
+            ExecControlStatus::QueueFull,
+            ProcessControlGuestStatus::QueueFull,
+            io::ErrorKind::WouldBlock,
+            "exec control queue is full",
+        ),
+        (
+            ExecControlStatus::SinkError,
+            ProcessControlGuestStatus::SinkError,
+            io::ErrorKind::BrokenPipe,
+            "exec control sink error",
+        ),
+    ];
+
+    for (index, (guest_status, status, error_kind, error_message)) in cases.into_iter().enumerate()
+    {
+        let message_id = format!("guest-status-{index}");
+        let control_task = tokio::spawn(FirecrackerSandbox::exec_process_control(
+            coordinator.clone(),
+            Arc::clone(&state),
+            state_tx.subscribe(),
+            control.clone(),
+            message_id,
+            b"payload".to_vec(),
+            Duration::from_secs(5),
+        ));
+        let request = read_vsock_message(&mut guest).await;
+        send_exec_control_result(&mut guest, request, guest_status, "").await;
+
+        let outcome = control_task.await.unwrap();
+        assert_process_control_guest_status(&outcome, status, "");
+        let error = outcome.into_ack().unwrap_err();
+        assert_eq!(error.kind(), error_kind);
+        assert_eq!(error.to_string(), error_message);
+    }
+
     let control_task = tokio::spawn(FirecrackerSandbox::exec_process_control(
         coordinator.clone(),
         state,
         state_tx.subscribe(),
         control,
-        "sink-timeout".to_owned(),
+        "guest-diagnostic".to_owned(),
         b"payload".to_vec(),
         Duration::from_secs(5),
     ));
@@ -2816,14 +2980,20 @@ async fn process_control_guest_status_keeps_policy_open() {
     send_exec_control_result(
         &mut guest,
         request,
-        ExecControlStatus::SinkTimeout,
-        "guest sink timed out",
+        ExecControlStatus::Rejected,
+        "guest rejected this request",
     )
     .await;
 
-    let error = control_task.await.unwrap().unwrap_err();
-    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-    assert_eq!(error.to_string(), "guest sink timed out");
+    let outcome = control_task.await.unwrap();
+    assert_process_control_guest_status(
+        &outcome,
+        ProcessControlGuestStatus::Rejected,
+        "guest rejected this request",
+    );
+    let error = outcome.into_ack().unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    assert_eq!(error.to_string(), "guest rejected this request");
     assert_eq!(coordinator.state(), CoordinatorState::Open);
 
     send_exec_exit(&mut guest, exec_seq).await;
@@ -2854,7 +3024,15 @@ async fn process_control_guest_error_keeps_policy_open() {
     let request = read_vsock_message(&mut guest).await;
     send_exec_control_error(&mut guest, request, "guest rejected control").await;
 
-    let error = control_task.await.unwrap().unwrap_err();
+    let outcome = control_task.await.unwrap();
+    assert!(
+        matches!(
+            &outcome,
+            ProcessControlOutcome::GuestError(message) if message == "guest rejected control"
+        ),
+        "unexpected process-control outcome: {outcome:?}",
+    );
+    let error = outcome.into_ack().unwrap_err();
     assert_eq!(error.kind(), io::ErrorKind::Other);
     assert_eq!(error.to_string(), "guest rejected control");
     assert_eq!(coordinator.state(), CoordinatorState::Open);
@@ -2912,8 +3090,8 @@ async fn process_control_allows_concurrent_requests_while_policy_open() {
     send_exec_control_result(&mut guest, second_request, ExecControlStatus::Delivered, "").await;
     send_exec_control_result(&mut guest, first_request, ExecControlStatus::Delivered, "").await;
 
-    let first_ack = first_task.await.unwrap().unwrap();
-    let second_ack = second_task.await.unwrap().unwrap();
+    let first_ack = expect_process_control_delivered(first_task.await.unwrap());
+    let second_ack = expect_process_control_delivered(second_task.await.unwrap());
     assert_eq!(first_ack.message_id, "concurrent-a");
     assert_eq!(second_ack.message_id, "concurrent-b");
     assert_eq!(coordinator.state(), CoordinatorState::Open);
@@ -2946,7 +3124,11 @@ async fn process_control_protocol_poison_after_guest_write_keeps_policy_open() {
     let request = read_vsock_message(&mut guest).await;
     send_mismatched_exec_control_result(&mut guest, request).await;
 
-    let error = control_task.await.unwrap().unwrap_err();
+    let error = expect_process_control_failure(
+        control_task.await.unwrap(),
+        ProcessControlFailureKind::Operation,
+        ProcessControlWriteState::PossiblyWritten,
+    );
     assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
     assert_eq!(coordinator.state(), CoordinatorState::Open);
 }
@@ -2978,11 +3160,15 @@ async fn process_control_backend_crash_after_guest_write_keeps_policy_open() {
     state.store(SandboxState::Crashed as u8, Ordering::Release);
     state_tx.send(SandboxState::Crashed).unwrap();
 
-    let error = tokio::time::timeout(Duration::from_secs(1), control_task)
+    let outcome = tokio::time::timeout(Duration::from_secs(1), control_task)
         .await
         .unwrap()
-        .unwrap()
-        .unwrap_err();
+        .unwrap();
+    let error = expect_process_control_failure(
+        outcome,
+        ProcessControlFailureKind::BackendCrashed,
+        ProcessControlWriteState::PossiblyWritten,
+    );
     assert!(
         error.to_string().contains("firecracker process crashed"),
         "unexpected error: {error}",
@@ -3017,11 +3203,15 @@ async fn process_control_timeout_after_guest_write_keeps_policy_open() {
     let request = read_vsock_message(&mut guest).await;
     assert_eq!(request.msg_type, MSG_EXEC_CONTROL);
 
-    let error = tokio::time::timeout(Duration::from_secs(1), control_task)
+    let outcome = tokio::time::timeout(Duration::from_secs(1), control_task)
         .await
         .unwrap()
-        .unwrap()
-        .unwrap_err();
+        .unwrap();
+    let error = expect_process_control_failure(
+        outcome,
+        ProcessControlFailureKind::Operation,
+        ProcessControlWriteState::PossiblyWritten,
+    );
     assert_eq!(error.kind(), io::ErrorKind::TimedOut);
     assert_eq!(coordinator.state(), CoordinatorState::Open);
 

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -160,7 +160,8 @@ async fn process_control_calls_are_recorded_when_overrides_are_enabled() {
 #[tokio::test]
 async fn queued_process_control_errors_are_consumed_fifo() {
     let overrides = Arc::new(MockSandboxOverrides::new());
-    overrides.push_process_control_error("control failed");
+    overrides.push_process_control_error("first control failed");
+    overrides.push_process_control_error("second control failed");
     let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
     let handle = sandbox
         .start_process(&StartProcessRequest {
@@ -177,18 +178,79 @@ async fn queued_process_control_errors_are_consumed_fifo() {
         .control_handle()
         .expect("enabled control should expose a handle");
 
-    let err = control
-        .control("msg-1", b"payload-1", Duration::from_secs(1))
+    let outcome = control
+        .control_outcome("msg-1", b"payload-1", Duration::from_secs(1))
+        .await;
+    let first_error = match outcome {
+        ProcessControlOutcome::Failed {
+            kind,
+            write_state,
+            error,
+        } => {
+            assert_eq!(kind, ProcessControlFailureKind::Operation);
+            assert_eq!(write_state, ProcessControlWriteState::PossiblyWritten);
+            error
+        }
+        other => panic!("expected failed process-control outcome, got {other:?}"),
+    };
+    let second_error = control
+        .control("msg-2", b"payload-2", Duration::from_secs(1))
         .await
         .unwrap_err();
     let ack = control
-        .control("msg-2", b"payload-2", Duration::from_secs(1))
+        .control("msg-3", b"payload-3", Duration::from_secs(1))
         .await
         .unwrap();
 
-    assert!(err.to_string().contains("control failed"));
-    assert_eq!(ack.message_id, "msg-2");
-    assert_eq!(overrides.process_control_calls().len(), 2);
+    assert!(first_error.to_string().contains("first control failed"));
+    assert!(second_error.to_string().contains("second control failed"));
+    assert_eq!(ack.message_id, "msg-3");
+    assert_eq!(overrides.process_control_calls().len(), 3);
+}
+
+#[tokio::test]
+async fn structured_process_control_distinguishes_timeout_write_state() {
+    for write_state in [
+        ProcessControlWriteState::NotWritten,
+        ProcessControlWriteState::PossiblyWritten,
+    ] {
+        let control =
+            GuestProcessControlHandle::new_with_outcome(move |_message_id, _payload, _timeout| {
+                Box::pin(async move {
+                    ProcessControlOutcome::Failed {
+                        kind: ProcessControlFailureKind::Operation,
+                        write_state,
+                        error: std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "process control timed out",
+                        ),
+                    }
+                })
+            });
+
+        let outcome = control
+            .control_outcome("msg", b"payload", Duration::from_secs(1))
+            .await;
+        match outcome {
+            ProcessControlOutcome::Failed {
+                kind,
+                write_state: actual_write_state,
+                error,
+            } => {
+                assert_eq!(kind, ProcessControlFailureKind::Operation);
+                assert_eq!(actual_write_state, write_state);
+                assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+            }
+            other => panic!("expected failed process-control outcome, got {other:?}"),
+        }
+
+        let error = control
+            .control("msg-1", b"payload-1", Duration::from_secs(1))
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "process control timed out");
+    }
 }
 
 #[tokio::test]

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -55,7 +55,9 @@ pub use snapshot::{
 pub use types::{
     CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB,
     EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ExecTermination,
-    GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter,
-    ProcessControlAck, ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
-    ProcessOutputReceiver, StartProcessRequest, WriteFileEntry,
+    GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessControlOutcomeFuture,
+    GuestProcessHandle, GuestProcessWaiter, ProcessControlAck, ProcessControlFailureKind,
+    ProcessControlGuestStatus, ProcessControlMode, ProcessControlOutcome, ProcessControlWriteState,
+    ProcessExit, ProcessOutputChunk, ProcessOutputMode, ProcessOutputReceiver, StartProcessRequest,
+    WriteFileEntry,
 };

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -446,10 +447,14 @@ impl GuestProcessCancelHandle {
 
 /// Backend-owned future that resolves when a process-control message is acknowledged.
 pub type GuestProcessControlFuture =
-    Pin<Box<dyn Future<Output = std::io::Result<ProcessControlAck>> + Send + 'static>>;
+    Pin<Box<dyn Future<Output = io::Result<ProcessControlAck>> + Send + 'static>>;
+
+/// Backend-owned future that preserves a process-control delivery outcome.
+pub type GuestProcessControlOutcomeFuture =
+    Pin<Box<dyn Future<Output = ProcessControlOutcome> + Send + 'static>>;
 
 type GuestProcessControlFn =
-    dyn Fn(String, Vec<u8>, Duration) -> GuestProcessControlFuture + Send + Sync + 'static;
+    dyn Fn(String, Vec<u8>, Duration) -> GuestProcessControlOutcomeFuture + Send + Sync + 'static;
 
 /// Acknowledgement returned by an operation-bound process-control sink.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -457,6 +462,116 @@ pub struct ProcessControlAck {
     /// Message id acknowledged by the provider for the submitted control
     /// payload.
     pub message_id: String,
+}
+
+/// Matched non-delivered status returned by a guest process-control sink.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProcessControlGuestStatus {
+    /// The supervised guest process is no longer active.
+    Inactive,
+    /// The request did not match the operation's control nonce.
+    NonceMismatch,
+    /// The supervised operation does not support process control.
+    Unsupported,
+    /// The guest rejected the control request.
+    Rejected,
+    /// The guest process-control sink is not connected.
+    SinkUnavailable,
+    /// The guest process-control sink timed out.
+    SinkTimeout,
+    /// The guest process-control queue is full.
+    QueueFull,
+    /// The guest process-control sink returned an error.
+    SinkError,
+}
+
+impl ProcessControlGuestStatus {
+    fn error_kind(self) -> io::ErrorKind {
+        match self {
+            Self::Inactive => io::ErrorKind::NotFound,
+            Self::NonceMismatch | Self::Rejected => io::ErrorKind::PermissionDenied,
+            Self::Unsupported => io::ErrorKind::Unsupported,
+            Self::SinkUnavailable => io::ErrorKind::NotConnected,
+            Self::SinkTimeout => io::ErrorKind::TimedOut,
+            Self::QueueFull => io::ErrorKind::WouldBlock,
+            Self::SinkError => io::ErrorKind::BrokenPipe,
+        }
+    }
+
+    fn default_error_message(self) -> &'static str {
+        match self {
+            Self::Inactive => "exec operation is not active",
+            Self::NonceMismatch => "exec operation nonce mismatch",
+            Self::Unsupported => "exec control is not supported by this operation",
+            Self::Rejected => "exec control request rejected",
+            Self::SinkUnavailable => "exec control sink is not connected",
+            Self::SinkTimeout => "exec control sink timed out",
+            Self::QueueFull => "exec control queue is full",
+            Self::SinkError => "exec control sink error",
+        }
+    }
+}
+
+/// Root cause for an unmatched process-control failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProcessControlFailureKind {
+    /// The provider operation failed without a confirmed backend crash.
+    Operation,
+    /// The provider backend crashed while the operation was in flight.
+    BackendCrashed,
+}
+
+/// Provider evidence about whether a failed request reached its write boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProcessControlWriteState {
+    /// The provider knows that the request did not reach its write boundary.
+    NotWritten,
+    /// The request reached its write boundary and may have reached the Guest.
+    PossiblyWritten,
+}
+
+/// Provider-neutral terminal outcome for one process-control request.
+#[derive(Debug)]
+pub enum ProcessControlOutcome {
+    /// The Guest delivered the request to the process-control sink.
+    Delivered(ProcessControlAck),
+    /// The Guest returned a matched non-delivered status.
+    GuestStatus {
+        /// Structured Guest status.
+        status: ProcessControlGuestStatus,
+        /// Guest-provided diagnostic text, which may be empty.
+        diagnostic: String,
+    },
+    /// The Guest returned a generic matched error response.
+    GuestError(String),
+    /// The provider failed without receiving a matched Guest response.
+    Failed {
+        /// Root cause for the provider failure.
+        kind: ProcessControlFailureKind,
+        /// Whether the request may have crossed the provider write boundary.
+        write_state: ProcessControlWriteState,
+        /// Original provider error retained for acknowledgement compatibility.
+        error: io::Error,
+    },
+}
+
+impl ProcessControlOutcome {
+    /// Return the delivered acknowledgement or convert other outcomes to legacy errors.
+    pub fn into_ack(self) -> io::Result<ProcessControlAck> {
+        match self {
+            Self::Delivered(ack) => Ok(ack),
+            Self::GuestStatus { status, diagnostic } => {
+                let message = if diagnostic.is_empty() {
+                    status.default_error_message().to_owned()
+                } else {
+                    diagnostic
+                };
+                Err(io::Error::new(status.error_kind(), message))
+            }
+            Self::GuestError(message) => Err(io::Error::other(message)),
+            Self::Failed { error, .. } => Err(error),
+        }
+    }
 }
 
 /// Cloneable handle for sending opaque control payloads to a live guest process.
@@ -471,9 +586,40 @@ impl GuestProcessControlHandle {
     /// The `sandbox` crate treats control payloads as opaque bytes. The
     /// provider and guest process define the payload schema and acknowledgement
     /// semantics for a given started process.
+    ///
+    /// Provider errors are conservatively exposed by the outcome methods as
+    /// [`ProcessControlWriteState::PossiblyWritten`]. Providers with precise
+    /// delivery evidence should use [`Self::new_with_outcome`].
     pub fn new<F>(control: F) -> Self
     where
         F: Fn(String, Vec<u8>, Duration) -> GuestProcessControlFuture + Send + Sync + 'static,
+    {
+        let control = Arc::new(control);
+        Self::new_with_outcome(move |message_id, payload, timeout| {
+            let control = Arc::clone(&control);
+            Box::pin(async move {
+                match control(message_id, payload, timeout).await {
+                    Ok(ack) => ProcessControlOutcome::Delivered(ack),
+                    Err(error) => ProcessControlOutcome::Failed {
+                        kind: ProcessControlFailureKind::Operation,
+                        write_state: ProcessControlWriteState::PossiblyWritten,
+                        error,
+                    },
+                }
+            })
+        })
+    }
+
+    /// Construct a handle from provider logic that preserves delivery outcomes.
+    ///
+    /// The provider must classify unmatched failures relative to its write
+    /// boundary and retain matched guest responses as structured outcomes.
+    pub fn new_with_outcome<F>(control: F) -> Self
+    where
+        F: Fn(String, Vec<u8>, Duration) -> GuestProcessControlOutcomeFuture
+            + Send
+            + Sync
+            + 'static,
     {
         Self {
             control: Arc::new(control),
@@ -490,9 +636,10 @@ impl GuestProcessControlHandle {
         message_id: &str,
         payload: &[u8],
         timeout: Duration,
-    ) -> std::io::Result<ProcessControlAck> {
-        self.control_owned(message_id.to_owned(), payload.to_vec(), timeout)
+    ) -> io::Result<ProcessControlAck> {
+        self.control_outcome(message_id, payload, timeout)
             .await
+            .into_ack()
     }
 
     /// Send an owned opaque control payload to the live guest process.
@@ -505,7 +652,36 @@ impl GuestProcessControlHandle {
         message_id: String,
         payload: Vec<u8>,
         timeout: Duration,
-    ) -> std::io::Result<ProcessControlAck> {
+    ) -> io::Result<ProcessControlAck> {
+        self.control_owned_outcome(message_id, payload, timeout)
+            .await
+            .into_ack()
+    }
+
+    /// Send an opaque control payload and preserve its terminal delivery outcome.
+    ///
+    /// Cancelling this future yields no outcome. A caller that needs to decide
+    /// whether retry is safe must retain ownership until the future resolves.
+    pub async fn control_outcome(
+        &self,
+        message_id: &str,
+        payload: &[u8],
+        timeout: Duration,
+    ) -> ProcessControlOutcome {
+        self.control_owned_outcome(message_id.to_owned(), payload.to_vec(), timeout)
+            .await
+    }
+
+    /// Send owned control data and preserve its terminal delivery outcome.
+    ///
+    /// This has the same behavior as [`Self::control_outcome`] but transfers
+    /// ownership of `message_id` and `payload` to the provider callback.
+    pub async fn control_owned_outcome(
+        &self,
+        message_id: String,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> ProcessControlOutcome {
         (self.control)(message_id, payload, timeout).await
     }
 }

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -840,7 +840,11 @@ impl ExecControlHandle {
         .await
     }
 
-    async fn control_owned_with_write_observer(
+    /// Send owned exec-control data and return the raw outcome.
+    ///
+    /// This is the owned-data counterpart to
+    /// [`Self::control_with_write_observer`].
+    pub async fn control_owned_with_write_observer(
         &self,
         message_id: String,
         payload: Vec<u8>,


### PR DESCRIPTION
## Summary

- add provider-neutral process-control outcomes for delivered acknowledgements, matched guest statuses, guest errors, backend crashes, and unmatched operation failures
- preserve whether an unmatched failure occurred before the provider write boundary or after the request may have been written
- map raw Firecracker/vsock outcomes without changing existing acknowledgement-only callers or mock-provider behavior
- cover every guest status, legacy error conversion, pre-write and post-write failures, and backend crashes through the existing process-control boundaries

## Scope

This PR does not switch Runner active-input, cancellation, or Pi standby callers to the structured methods. It does not add database state, guest receipts, protocol negotiation, payload changes, or deployment gates.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox -p sandbox-fc -p sandbox-mock -p vsock-host -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p sandbox -p sandbox-fc -p sandbox-mock -p vsock-host -p runner --all-features`
- `cargo test -p sandbox -p sandbox-fc -p sandbox-mock -p vsock-host --all-targets --all-features`
- `cargo test -p runner --bin runner active_input --all-features`
- `lefthook run pre-commit`

Closes #26055

Parent delivery issue: #26034
