### PR TITLE
chore(api): refresh preview marker for focus investigation

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-31)
+// (no-op API release marker refreshed again on 2026-08-10)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- refresh the existing no-op API release marker
- create an isolated preview for reproducing the sidebar account-menu focus outline
- leave product behavior unchanged

## Verification

- `git diff --check`
- local test suite not run because this is a comment-only preview trigger
- PASS: manually reproduced both reported focus sequences on `https://pr-26179-app.omby.ai`
  - after a pointer-driven open/close cycle, the trigger is focused but does not match `:focus-visible`
  - pressing Shift makes the still-focused trigger match `:focus-visible` and enables the orange native outline
  - pressing Shift before the open/close cycle produces the same orange outline after close

## Browser evidence

- [Before Shift](https://cdn.vm0.io/artifacts/ac4wohbd1c.png)
- [After Shift](https://cdn.vm0.io/artifacts/vsygzr1oii.png)
- [Shift before the menu cycle](https://cdn.vm0.io/artifacts/c6ca4pfppy.png)
