### PR TITLE
perf(platform): composite composer focus effects

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -420,16 +420,15 @@ body {
   --zero-card-border: hsl(var(--border));
   --zero-card-shadow:
     0 2px 12px hsl(220 12% 50% / 0.04), 0 0 0 0.5px hsl(220 12% 50% / 0.02);
-  /* Focus layer for the composer: a single very wide, very light veil laid over
-     the resting shadow. Kept under 10% alpha so it reads as depth, not a ring. */
-  --zero-composer-focus-shadow:
-    0 2px 12px hsl(220 12% 50% / 0.04), 0 10px 48px -8px hsl(220 14% 50% / 0.08);
+  /* Static focus veil for the composer. Fading this layer through opacity lets
+     the browser composite it without interpolating the wide blur every frame. */
+  --zero-composer-focus-veil: 0 10px 48px -8px hsl(220 14% 50% / 0.08);
 }
 
 /* A grey veil is invisible on a dark page, so the dark theme casts the same
    shape in black instead. The border step carries the state either way. */
 :where([data-theme="dark"]) .zero-app {
-  --zero-composer-focus-shadow: 0 10px 48px -8px rgb(0 0 0 / 0.45);
+  --zero-composer-focus-veil: 0 10px 48px -8px rgb(0 0 0 / 0.45);
 }
 
 /* Desktop shell: avoid accidental selection on app chrome while preserving content/editors. */
@@ -689,20 +688,28 @@ body {
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-composer-radius);
   box-shadow: var(--zero-card-shadow);
-  transition:
-    border-color 0.22s cubic-bezier(0.4, 0, 0.2, 1),
-    box-shadow 0.22s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Composer is focused: the border steps one stop down the grey ramp and the
-   veil widens. Both revert on blur — there is no persistent active state. */
-.zero-app .zero-composer:focus-within {
-  border-color: hsl(var(--gray-500));
-  box-shadow: var(--zero-composer-focus-shadow);
+/* Keep the finished border and shadow on their own layer so focus animates
+   through compositor-friendly opacity instead of repainting the card. */
+.zero-app .zero-composer::after {
+  content: "";
+  position: absolute;
+  inset: -0.7px;
+  border: 0.7px solid hsl(var(--gray-500));
+  border-radius: inherit;
+  box-shadow: var(--zero-composer-focus-veil);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: opacity;
+}
+.zero-app .zero-composer:focus-within::after {
+  opacity: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .zero-app .zero-composer {
+  .zero-app .zero-composer::after {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary

- render the focused composer border and wide shadow on a static `::after` layer
- transition only the layer's opacity so the browser can composite the focus animation without interpolating a 48px blur every frame
- preserve the existing `:focus-within`, dark-theme, and reduced-motion behavior

## Demo

- [Interactive before/after comparison](https://composer-focus-before-after.sites.vm0.io)

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`

Vitest was not run because this is a CSS rendering implementation change with no behavioral contract to assert; the existing testing guidance discourages tests coupled to styling implementation details.
