### PR TITLE
fix(onboarding): preserve marketing entry contract

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding.test.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  onboardingCompleteContract,
+  onboardingStatusContract,
+} from "@vm0/api-contracts/contracts/onboarding";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { zeroOnboardingCompleteRoutes } from "../zero-onboarding-complete";
+import { zeroOnboardingStatusRoutes } from "../zero-onboarding-status";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function onboardingStatusClient() {
+  return setupApp({ context, routes: zeroOnboardingStatusRoutes })(
+    onboardingStatusContract,
+  );
+}
+
+function onboardingCompleteClient() {
+  return setupApp({ context, routes: zeroOnboardingCompleteRoutes })(
+    onboardingCompleteContract,
+  );
+}
+
+function orgActor(role: "org:admin" | "org:member" = "org:admin") {
+  return {
+    userId: `user_${randomUUID()}`,
+    orgId: `org_${randomUUID()}`,
+    role,
+  } as const;
+}
+
+describe("GET /api/zero/onboarding/status", () => {
+  it("returns 401 when the request is unauthenticated", async () => {
+    const response = await accept(
+      onboardingStatusClient().getStatus({ headers: {} }),
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("does not start onboarding for an organization member", async () => {
+    const actor = orgActor("org:member");
+    mocks.clerk.session(actor.userId, actor.orgId, actor.role);
+
+    const response = await accept(
+      onboardingStatusClient().getStatus({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      needsOnboarding: false,
+      onboardingComplete: false,
+      isAdmin: false,
+      hasOrg: true,
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+      defaultAgentMetadata: null,
+    });
+  });
+});
+
+describe("POST /api/zero/onboarding/complete", () => {
+  it("returns 403 when an organization member tries to complete onboarding", async () => {
+    const actor = orgActor("org:member");
+    mocks.clerk.session(actor.userId, actor.orgId, actor.role);
+
+    const response = await accept(
+      onboardingCompleteClient().complete({
+        headers: authHeaders(),
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can complete onboarding",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("persists an admin's completed onboarding state", async () => {
+    const actor = orgActor();
+    mocks.clerk.session(actor.userId, actor.orgId, actor.role);
+    context.mocks.s3.send.mockResolvedValue({ ContentLength: 1024 });
+    context.mocks.s3.getSignedUrl.mockResolvedValue(
+      "https://r2.example.test/default-agent.tar.gz?signature=test",
+    );
+
+    const before = await accept(
+      onboardingStatusClient().getStatus({ headers: authHeaders() }),
+      [200],
+    );
+    expect(before.body).toMatchObject({
+      needsOnboarding: true,
+      onboardingComplete: false,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: true,
+    });
+    expect(before.body.defaultAgentId).toBeTruthy();
+
+    const completed = await accept(
+      onboardingCompleteClient().complete({
+        headers: authHeaders(),
+        body: {},
+      }),
+      [200],
+    );
+    expect(completed.body).toStrictEqual({
+      onboardingComplete: true,
+      needsOnboarding: false,
+    });
+
+    const after = await accept(
+      onboardingStatusClient().getStatus({ headers: authHeaders() }),
+      [200],
+    );
+    expect(after.body).toMatchObject({
+      needsOnboarding: false,
+      onboardingComplete: true,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: true,
+      defaultAgentId: before.body.defaultAgentId,
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -37,6 +37,7 @@ export const ROUTES = {
   githubConnect: "/github/connect",
   telegramConnect: "/telegram/connect",
   agentphoneConnect: "/agentphone/connect",
+  // Stable public handoff from vm0-marketing into App onboarding.
   onboarding: "/onboarding",
   onboardingWorkflowPicker: "/onboarding/workflow-picker",
   onboardingWorkflowRun: "/onboarding/workflow-run",

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -31,6 +31,15 @@ import { mockChatLifecycle } from "../../zero-page/__tests__/chat-test-helpers.t
 
 const context = testContext();
 
+const MARKETING_PRESENTATION_PROMPT = [
+  "/gen presentation with template `html-ppt-playful-launch`, create a 15-slide launch deck for SproutPop, a playful habit-building app for remote teams introducing a shared 30-day wellness challenge.",
+  "Present it to people and culture leaders with cover, agenda, launch story, audience pain points, product vision, feature tour, rollout timeline, activation moments, team, early metrics, testimonials, pricing, and next steps.",
+  "Make it saturated, joyful, idea-led, and structured.",
+].join(" ");
+
+const MARKETING_PRESENTATION_SHOWCASE =
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8199ef0a-c692-4c20-8267-e91ffe060b4c/playful-launch-presentation.html";
+
 function templateTypeFromUserMessage(
   document: UserMessageDocument | undefined,
 ): string | undefined {
@@ -555,6 +564,50 @@ describe("onboarding flow", () => {
       screen.queryByText("You've successfully connected with Ahrefs!"),
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("dialog", { name: "Ahrefs" })).toBeNull();
+  });
+
+  it("runs a presentation prompt from a marketing deep link without connectors", async () => {
+    let runPrompt: string | undefined;
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        runPrompt = body.prompt;
+      },
+    });
+    mockOnboardingNeeded();
+    const params = new URLSearchParams({
+      prompt: MARKETING_PRESENTATION_PROMPT,
+      showcase: MARKETING_PRESENTATION_SHOWCASE,
+      vm0_source: "presentation",
+      landing_host: "www.vm0.ai",
+      landing_path: "/en/presentation",
+      source_type: "direct",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/onboarding?${params.toString()}`,
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Try this prompt" }),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByLabelText("Onboarding prompt")).toHaveValue(
+      MARKETING_PRESENTATION_PROMPT,
+    );
+    expect(context.store.get(searchParams$).get("connector")).toBeNull();
+
+    click(buttonByText("Next"));
+
+    await waitFor(() => {
+      expect(runPrompt).toBe(MARKETING_PRESENTATION_PROMPT);
+      expect(pathname()).toMatch(/^\/chats\//u);
+    });
+    const handoffParams = context.store.get(searchParams$);
+    expect(handoffParams.get("showcase")).toBe(MARKETING_PRESENTATION_SHOWCASE);
+    expect(handoffParams.get("vm0_source")).toBe("presentation");
+    expect(handoffParams.get("landing_host")).toBe("www.vm0.ai");
+    expect(handoffParams.get("landing_path")).toBe("/en/presentation");
+    expect(handoffParams.get("source_type")).toBe("direct");
   });
 
   it("selects and reviews a presentation template", async () => {

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -4,6 +4,7 @@ import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_PICKER_ITEMS,
   VIDEO_TEMPLATE_ITEMS,
+  WEBSITE_TEMPLATE_ITEMS,
 } from "@vm0/core";
 import { zeroBillingCheckoutContract } from "@vm0/api-contracts/contracts/zero-billing";
 import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
@@ -40,13 +41,17 @@ const MARKETING_PRESENTATION_PROMPT = [
 const MARKETING_PRESENTATION_SHOWCASE =
   "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8199ef0a-c692-4c20-8267-e91ffe060b4c/playful-launch-presentation.html";
 
-function templateTypeFromUserMessage(
-  document: UserMessageDocument | undefined,
-): string | undefined {
+function templateFromUserMessage(document: UserMessageDocument | undefined) {
   const part = document?.parts.find((candidate) => {
     return candidate.type === "template";
   });
-  return part?.type === "template" ? part.template.type : undefined;
+  return part?.type === "template" ? part.template : undefined;
+}
+
+function templateTypeFromUserMessage(
+  document: UserMessageDocument | undefined,
+): string | undefined {
+  return templateFromUserMessage(document)?.type;
 }
 
 function firstItem<Item>(items: readonly Item[]): Item {
@@ -566,48 +571,131 @@ describe("onboarding flow", () => {
     expect(screen.queryByRole("dialog", { name: "Ahrefs" })).toBeNull();
   });
 
-  it("runs a presentation prompt from a marketing deep link without connectors", async () => {
-    let runPrompt: string | undefined;
-    mockChatLifecycle(context, {
-      onRunCreate: (body) => {
-        runPrompt = body.prompt;
-      },
-    });
-    mockOnboardingNeeded();
-    const params = new URLSearchParams({
-      prompt: MARKETING_PRESENTATION_PROMPT,
-      showcase: MARKETING_PRESENTATION_SHOWCASE,
-      vm0_source: "presentation",
-      landing_host: "www.vm0.ai",
-      landing_path: "/en/presentation",
-      source_type: "direct",
+  describe("vm0-marketing onboarding entry contract", () => {
+    it("runs a presentation prompt from a marketing deep link without connectors", async () => {
+      let runPrompt: string | undefined;
+      mockChatLifecycle(context, {
+        onRunCreate: (body) => {
+          runPrompt = body.prompt;
+        },
+      });
+      mockOnboardingNeeded();
+      const params = new URLSearchParams({
+        prompt: MARKETING_PRESENTATION_PROMPT,
+        showcase: MARKETING_PRESENTATION_SHOWCASE,
+        vm0_source: "presentation",
+        landing_host: "www.vm0.ai",
+        landing_path: "/en/presentation",
+        source_type: "direct",
+      });
+
+      detachedSetupPage({
+        context,
+        path: `/onboarding?${params.toString()}`,
+      });
+
+      await expect(
+        screen.findByRole("heading", { name: "Try this prompt" }),
+      ).resolves.toBeInTheDocument();
+      expect(screen.getByLabelText("Onboarding prompt")).toHaveValue(
+        MARKETING_PRESENTATION_PROMPT,
+      );
+      expect(context.store.get(searchParams$).get("connector")).toBeNull();
+
+      click(buttonByText("Next"));
+
+      await waitFor(() => {
+        expect(runPrompt).toBe(MARKETING_PRESENTATION_PROMPT);
+        expect(pathname()).toMatch(/^\/chats\//u);
+      });
+      const handoffParams = context.store.get(searchParams$);
+      expect(handoffParams.get("showcase")).toBe(
+        MARKETING_PRESENTATION_SHOWCASE,
+      );
+      expect(handoffParams.get("vm0_source")).toBe("presentation");
+      expect(handoffParams.get("landing_host")).toBe("www.vm0.ai");
+      expect(handoffParams.get("landing_path")).toBe("/en/presentation");
+      expect(handoffParams.get("source_type")).toBe("direct");
     });
 
-    detachedSetupPage({
-      context,
-      path: `/onboarding?${params.toString()}`,
+    it("keeps a website template through first-time onboarding", async () => {
+      const websiteTemplate = WEBSITE_TEMPLATE_ITEMS.find((item) => {
+        return item.id === "website-template:warm-cards";
+      });
+      if (!websiteTemplate) {
+        throw new Error("Expected the Warm Cards website template");
+      }
+
+      let websiteTemplateId: string | undefined;
+      mockChatLifecycle(context, {
+        onRunCreate: (body) => {
+          const template = templateFromUserMessage(body.userMessage);
+          websiteTemplateId =
+            template?.type === "website"
+              ? template.selection.websiteTemplateId
+              : undefined;
+        },
+      });
+      mockOnboardingNeeded();
+      const params = new URLSearchParams({
+        prompt: "Build a warm launch page",
+        template: websiteTemplate.id,
+        showcase: websiteTemplate.previewUrl,
+        vm0_source: "web_design",
+      });
+
+      detachedSetupPage({
+        context,
+        path: `/onboarding?${params.toString()}`,
+      });
+
+      await expect(
+        screen.findByRole("heading", { name: "Try this prompt" }),
+      ).resolves.toBeInTheDocument();
+      click(buttonByText("Next"));
+
+      await waitFor(() => {
+        expect(websiteTemplateId).toBe(websiteTemplate.id);
+        expect(pathname()).toMatch(/^\/chats\//u);
+      });
+      expect(context.store.get(searchParams$).get("showcase")).toBe(
+        websiteTemplate.previewUrl,
+      );
+      expect(context.store.get(searchParams$).get("vm0_source")).toBe(
+        "web_design",
+      );
     });
 
-    await expect(
-      screen.findByRole("heading", { name: "Try this prompt" }),
-    ).resolves.toBeInTheDocument();
-    expect(screen.getByLabelText("Onboarding prompt")).toHaveValue(
-      MARKETING_PRESENTATION_PROMPT,
-    );
-    expect(context.store.get(searchParams$).get("connector")).toBeNull();
+    it("runs directly for an onboarded workspace", async () => {
+      let runPrompt: string | undefined;
+      mockChatLifecycle(context, {
+        onRunCreate: (body) => {
+          runPrompt = body.prompt;
+        },
+      });
+      const params = new URLSearchParams({
+        prompt: "Summarize this week's launch metrics",
+        connector: "google-analytics,slack",
+        vm0_source: "marketing",
+        landing_path: "/en/workflow-automation-examples",
+      });
 
-    click(buttonByText("Next"));
+      detachedSetupPage({
+        context,
+        path: `/onboarding?${params.toString()}`,
+      });
 
-    await waitFor(() => {
-      expect(runPrompt).toBe(MARKETING_PRESENTATION_PROMPT);
-      expect(pathname()).toMatch(/^\/chats\//u);
+      await waitFor(() => {
+        expect(runPrompt).toBe("Summarize this week's launch metrics");
+        expect(pathname()).toMatch(/^\/chats\//u);
+      });
+      const handoffParams = context.store.get(searchParams$);
+      expect(handoffParams.get("connector")).toBeNull();
+      expect(handoffParams.get("vm0_source")).toBe("marketing");
+      expect(handoffParams.get("landing_path")).toBe(
+        "/en/workflow-automation-examples",
+      );
     });
-    const handoffParams = context.store.get(searchParams$);
-    expect(handoffParams.get("showcase")).toBe(MARKETING_PRESENTATION_SHOWCASE);
-    expect(handoffParams.get("vm0_source")).toBe("presentation");
-    expect(handoffParams.get("landing_host")).toBe("www.vm0.ai");
-    expect(handoffParams.get("landing_path")).toBe("/en/presentation");
-    expect(handoffParams.get("source_type")).toBe("direct");
   });
 
   it("selects and reviews a presentation template", async () => {

--- a/turbo/apps/platform/src/views/onboarding/onboarding-make-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-make-page.tsx
@@ -57,6 +57,7 @@ function PromptOnboarding() {
   const searchParams = useGet(searchParams$);
   const pageSignal = useGet(pageSignal$);
   const { runPrompt } = useOnboardingNavigation();
+  const template = searchParams.get("template")?.trim() || undefined;
   const connectorSlugs = (searchParams.get("connector") ?? "")
     .split(",")
     .map((value) => {
@@ -68,7 +69,7 @@ function PromptOnboarding() {
     const redeemCode = searchParams.get("redeemCode")?.trim() || null;
     const completeAndRun = async (): Promise<void> => {
       await complete(redeemCode, pageSignal);
-      runPrompt(draft.prompt);
+      runPrompt(draft.prompt, template);
     };
     detach(completeAndRun(), Reason.DomCallback);
   };


### PR DESCRIPTION
## Summary

- designate `/onboarding` as the stable public handoff from `vm0-marketing` into Platform
- cover production-shaped presentation, website-template, and existing-workspace handoffs with page-level Vitest
- preserve the optional `template` parameter through first-time onboarding so marketing website remix CTAs reach chat intact
- add focused API route tests for onboarding status and completion, including auth, member permissions, admin bootstrap, and persisted completion state

## Entry contract

`vm0-marketing` already funnels task CTAs through `buildVm0OnboardingEntryUrl()`, which owns the single `/onboarding` path. This PR hardens the vm0 consumer side for the query shapes currently emitted by marketing.

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter="!api" --filter="!@vm0/app"`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm -F @vm0/app exec vitest run src/views/onboarding/__tests__/onboarding-flow.test.tsx -t "vm0-marketing onboarding entry contract"` (3 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-onboarding.test.ts` (4 passed)