### PR TITLE
fix(connectors): align custom client invalidation with builtin mutations

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -60,6 +60,7 @@ export interface ApiTestMocks {
     readonly flush: AsyncMock;
   };
   readonly ably: {
+    readonly channelGet: Mock<(channelName: string) => void>;
     readonly publish: AsyncMock;
     readonly createTokenRequest: AsyncMock;
     readonly requestToken: AsyncMock;
@@ -420,6 +421,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       timeout: vi.fn<(milliseconds: number) => AbortSignal | undefined>(),
     },
     ably: {
+      channelGet: vi.fn<(channelName: string) => void>(),
       publish: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       createTokenRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       requestToken: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -854,7 +856,8 @@ vi.mock("signal-timers", async (importOriginal) => {
 vi.mock("ably", () => {
   class MockRest {
     readonly channels = {
-      get: () => {
+      get: (channelName: string) => {
+        apiTestMocks.ably.channelGet(channelName);
         return { publish: apiTestMocks.ably.publish };
       },
     };
@@ -1095,6 +1098,7 @@ export function getApiTestMocks(): ApiTestMocks {
 
 export function resetApiTestMocks(): void {
   apiTestMocks.abortSignal.timeout.mockReset();
+  apiTestMocks.ably.channelGet.mockReset();
   apiTestMocks.ably.publish.mockReset();
   apiTestMocks.ably.publish.mockResolvedValue(undefined);
   apiTestMocks.ably.createTokenRequest.mockReset();

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -5,8 +5,9 @@ import type { TestContext } from "./test-context";
 interface SetupAppOptions {
   readonly context: TestContext;
   readonly routes: readonly RouteEntry[];
+  readonly signal?: AbortSignal;
 }
 
-export function setupApp({ context, routes }: SetupAppOptions) {
-  return setupAppWithRoutes({ context, routes });
+export function setupApp({ context, routes, signal }: SetupAppOptions) {
+  return setupAppWithRoutes({ context, routes, signal });
 }

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -1,8 +1,6 @@
 import Ably from "ably";
-import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type {
   BrowserSessionChangedPayload,
-  ConnectorChangedPayload,
   UserPreferenceChangedPayload,
 } from "@vm0/api-contracts/contracts/realtime";
 import type {
@@ -80,7 +78,7 @@ export async function createRunnerGroupRealtimeToken(
  *
  * NOT best-effort: rejections from Ably propagate to the caller. Use this
  * directly only when delivery failure should fail the operation. Post-commit
- * invalidations should expose a topic-specific safe publisher instead.
+ * invalidations should use their post-commit dispatcher instead.
  */
 export async function publishUserSignal(
   userIds: readonly string[],
@@ -95,36 +93,6 @@ export async function publishUserSignal(
     }),
   );
   L.debug(`Published "${topic}" to ${userIds.length} user(s)`);
-}
-
-export async function publishConnectorChangedForUserSafely(
-  userId: string,
-  connectorSlug: ConnectorSlug,
-): Promise<void> {
-  await tapError(
-    publishUserSignal([userId], "connector:changed", {
-      connectorSlug,
-    } satisfies ConnectorChangedPayload),
-    (error) => {
-      L.warn("Failed to publish connector changed signal", {
-        connectorSlug,
-        error,
-      });
-    },
-  );
-}
-
-export async function publishCustomConnectorListChangedForUserSafely(
-  userId: string,
-): Promise<void> {
-  await tapError(
-    publishUserSignal([userId], "customConnectorListChanged"),
-    (error) => {
-      L.warn("Failed to publish custom connector list changed signal", {
-        error,
-      });
-    },
-  );
 }
 
 export async function publishUserPreferenceChangedForUserSafely(

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -57,6 +57,43 @@ const context = testContext();
 const connectorsApi = createConnectorBddApi(context);
 const authOrgApi = createAuthOrgAgentsBddApi(context);
 
+function mockAuthoritativeOrganizationMembers(
+  actors: readonly ApiTestUser[],
+): void {
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+    {
+      data: actors.map((actor) => {
+        return { publicUserData: { userId: actor.userId } };
+      }),
+    },
+  );
+}
+
+function clearConnectorInvalidationMocks(): void {
+  context.mocks.ably.channelGet.mockClear();
+  context.mocks.ably.publish.mockClear();
+}
+
+function expectCustomConnectorInvalidations(userIds: readonly string[]): void {
+  expect(
+    context.mocks.ably.channelGet.mock.calls
+      .map(([channelName]) => {
+        return channelName;
+      })
+      .sort(),
+  ).toStrictEqual(
+    userIds
+      .map((userId) => {
+        return `user:${userId}`;
+      })
+      .sort(),
+  );
+  expect(context.mocks.ably.publish).toHaveBeenCalledTimes(userIds.length);
+  for (const call of context.mocks.ably.publish.mock.calls) {
+    expect(call).toStrictEqual(["customConnectorListChanged", null]);
+  }
+}
+
 function uniqueSlug(prefix: string): string {
   return `_${prefix}-${randomUUID().replace(/-/g, "").slice(0, 12)}`;
 }
@@ -1646,11 +1683,13 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     );
     expect(runtimeUpdated).toMatchObject({ storageVersion: 1 });
 
+    clearConnectorInvalidationMocks();
     const callback =
       await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
         code: "bdd-custom-oauth-code",
         state: oauthState,
       });
+    expectCustomConnectorInvalidations([member.userId]);
     expect(callback.body).toStrictEqual({
       status: "success",
       username: null,
@@ -2815,10 +2854,13 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     const bdd = createBddApi(context);
     bdd.acceptAgentStorageWrites();
     const admin = bdd.user({ orgRole: "org:admin" });
+    const member = bdd.user({ orgId: admin.orgId, orgRole: "org:member" });
     const agent = await bdd.createAgent(admin, {
       displayName: "BDD Proposal Agent",
     });
     const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+    mockAuthoritativeOrganizationMembers([admin, member]);
+    clearConnectorInvalidationMocks();
 
     const saved = await connectorsApi.saveCustomConnectorProposal(admin, {
       proposal: {
@@ -2859,6 +2901,11 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       agentId: agent.agentId,
     });
 
+    expectCustomConnectorInvalidations([
+      admin.userId,
+      member.userId,
+      admin.userId,
+    ]);
     expect(saved.authorizedAgentId).toBe(agent.agentId);
     expect(saved.connector).toMatchObject({
       displayName: "BDD Proposal API",
@@ -3211,6 +3258,54 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     }
   });
 
+  it("invalidates every organization member for definitions and only the owner for credentials", async () => {
+    const bdd = createBddApi(context);
+    const admin = bdd.user({ orgRole: "org:admin" });
+    const member = bdd.user({ orgId: admin.orgId, orgRole: "org:member" });
+    const slug = uniqueSlug("bdd-invalidation-audience");
+    mockAuthoritativeOrganizationMembers([admin, member]);
+
+    clearConnectorInvalidationMocks();
+    const created = await connectorsApi.createCustomConnector(
+      admin,
+      customConnectorBody(slug),
+    );
+    expectCustomConnectorInvalidations([admin.userId, member.userId]);
+
+    clearConnectorInvalidationMocks();
+    await connectorsApi.setCustomConnectorValues(admin, created.id, [
+      { key: "secret", kind: "secret", value: "values-endpoint-secret" },
+    ]);
+    expectCustomConnectorInvalidations([admin.userId]);
+
+    clearConnectorInvalidationMocks();
+    await connectorsApi.setCustomConnectorSecret(
+      admin,
+      created.id,
+      "legacy-endpoint-secret",
+    );
+    expectCustomConnectorInvalidations([admin.userId]);
+
+    clearConnectorInvalidationMocks();
+    await connectorsApi.updateCustomConnector(admin, created.id, {
+      displayName: "BDD Invalidation Audience Updated",
+      prefixTemplates: [`https://${slug.slice(1)}.example.test/v2/`],
+      fields: created.fields,
+      headerInjections: created.headerInjections,
+      queryInjections: created.queryInjections,
+      authMode: created.authMode,
+    });
+    expectCustomConnectorInvalidations([admin.userId, member.userId]);
+
+    clearConnectorInvalidationMocks();
+    await connectorsApi.disconnectCustomConnector(admin, created.id);
+    expectCustomConnectorInvalidations([admin.userId]);
+
+    clearConnectorInvalidationMocks();
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+    expectCustomConnectorInvalidations([admin.userId, member.userId]);
+  });
+
   it("validates and normalises custom connector creation through visible create and list responses", async () => {
     const bdd = createBddApi(context);
     const admin = bdd.user();
@@ -3220,6 +3315,8 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await expect(
       connectorsApi.listCustomConnectors(admin),
     ).resolves.toStrictEqual([]);
+
+    mockAuthoritativeOrganizationMembers([admin]);
 
     const autoSlug = await connectorsApi.createCustomConnector(admin, {
       displayName: "BDD Auto Slug",
@@ -3606,6 +3703,8 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     const bdd = createBddApi(context);
     const admin = bdd.user();
     const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+    mockAuthoritativeOrganizationMembers([admin]);
+    clearConnectorInvalidationMocks();
     context.mocks.ably.publish.mockRejectedValueOnce(
       new Error("Ably channel rate limit exceeded"),
     );
@@ -3616,6 +3715,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       headerName: "Authorization",
       headerTemplate: "Bearer {{secret}}",
     });
+    expectCustomConnectorInvalidations([admin.userId]);
 
     await expect(
       connectorsApi.listCustomConnectors(admin),
@@ -3629,6 +3729,95 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     );
 
     await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("keeps a created custom connector when organization membership discovery fails", async () => {
+    const admin = createBddApi(context).user();
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValueOnce(
+      new Error("Clerk membership lookup unavailable"),
+    );
+    clearConnectorInvalidationMocks();
+
+    const created = await connectorsApi.createCustomConnector(admin, {
+      displayName: "BDD Membership Failure",
+      prefixes: [`https://membership-${rand}.example.test/v1/`],
+      headerName: "Authorization",
+      headerTemplate: "Bearer {{secret}}",
+    });
+
+    expect(context.mocks.ably.channelGet).not.toHaveBeenCalled();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+    await expect(
+      connectorsApi.listCustomConnectors(admin),
+    ).resolves.toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: created.id,
+          displayName: "BDD Membership Failure",
+        }),
+      ]),
+    );
+
+    mockAuthoritativeOrganizationMembers([admin]);
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("attempts invalidation before surfacing a post-commit request abort", async () => {
+    const admin = createBddApi(context).user();
+    const controller = new AbortController();
+    const abortError = new Error("custom connector request cancelled");
+    abortError.name = "AbortError";
+    let committedConnectorId: string | undefined;
+
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockImplementation(
+      async () => {
+        const listed = await connectorsApi.listCustomConnectors(admin);
+        const committed = listed.find((connector) => {
+          return connector.displayName === "BDD Post-Commit Abort";
+        });
+        if (!committed) {
+          throw new Error(
+            "Expected the custom connector definition to be committed before membership discovery",
+          );
+        }
+        committedConnectorId = committed.id;
+        controller.abort(abortError);
+        return {
+          data: [{ publicUserData: { userId: admin.userId } }],
+        };
+      },
+    );
+    clearConnectorInvalidationMocks();
+
+    const response = await connectorsApi.requestCreateCustomConnector(
+      admin,
+      {
+        displayName: "BDD Post-Commit Abort",
+        prefixes: ["https://post-commit-abort.example.test/v1/"],
+        headerName: "Authorization",
+        headerTemplate: "Bearer {{secret}}",
+      },
+      [500],
+      controller.signal,
+    );
+
+    expect(response.status).toBe(500);
+    expectCustomConnectorInvalidations([admin.userId]);
+    expect(committedConnectorId).toBeDefined();
+    await expect(
+      connectorsApi.listCustomConnectors(admin),
+    ).resolves.toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: committedConnectorId }),
+      ]),
+    );
+
+    mockAuthoritativeOrganizationMembers([admin]);
+    if (!committedConnectorId) {
+      throw new Error("Expected committed connector id");
+    }
+    await connectorsApi.deleteCustomConnector(admin, committedConnectorId);
   });
 
   it("persists permission bundles and skill markdown", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1762,10 +1762,13 @@ export function createConnectorBddApi(context: TestContext) {
       actor: ApiTestUser | null,
       body: CreateCustomConnectorBody,
       statuses: readonly (201 | 400 | 401 | 403 | 500)[],
+      signal?: AbortSignal,
     ) {
-      const client = setupApp({ context, routes: zeroCustomConnectorsRoutes })(
-        zeroCustomConnectorsContract,
-      );
+      const client = setupApp({
+        context,
+        routes: zeroCustomConnectorsRoutes,
+        signal,
+      })(zeroCustomConnectorsContract);
       return await accept(
         client.create({ headers: authenticate(actor), body }),
         statuses,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts
@@ -820,7 +820,8 @@ describe("POST /api/zero/connectors/:connectorSlug/manual-grant", () => {
   });
 
   it("publishes one connector change event on successful replacement", async () => {
-    await seedFixture();
+    const fixture = seedFixture();
+    context.mocks.ably.channelGet.mockClear();
     context.mocks.ably.publish.mockClear();
     const client = setupApp({ context, routes: zeroConnectorsRoutes })(
       zeroConnectorManualGrantContract,
@@ -835,6 +836,10 @@ describe("POST /api/zero/connectors/:connectorSlug/manual-grant", () => {
       [200],
     );
 
+    expect(context.mocks.ably.channelGet).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.channelGet).toHaveBeenCalledWith(
+      `user:${fixture.userId}`,
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "connector:changed",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -94,6 +94,46 @@ const VERIFICATION_TOKEN = "feishu-test-verification-token";
 const APP_SECRET = "feishu-test-secret";
 const TENANT_KEY = "tenant_feishu_integration_test";
 const BOT_OPEN_ID = "ou_feishu_bot";
+
+function mockAuthoritativeOrganizationMembers(
+  actors: readonly ApiTestUser[],
+): void {
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+    {
+      data: actors.map((actor) => {
+        return { publicUserData: { userId: actor.userId } };
+      }),
+    },
+  );
+}
+
+function clearConnectorInvalidationMocks(): void {
+  context.mocks.ably.channelGet.mockClear();
+  context.mocks.ably.publish.mockClear();
+}
+
+function expectCustomConnectorInvalidations(userIds: readonly string[]): void {
+  const channels = context.mocks.ably.publish.mock.calls.flatMap(
+    ([topic], index) => {
+      if (topic !== "customConnectorListChanged") {
+        return [];
+      }
+      const channelName = context.mocks.ably.channelGet.mock.calls[index]?.[0];
+      if (!channelName) {
+        throw new Error("Expected every Ably publication to select a channel");
+      }
+      return [channelName];
+    },
+  );
+  expect(channels.sort()).toStrictEqual(
+    userIds
+      .map((userId) => {
+        return `user:${userId}`;
+      })
+      .sort(),
+  );
+}
+
 const EXPECTED_FEISHU_OAUTH_SCOPES = [
   "offline_access",
   "contact:contact.base:readonly",
@@ -1432,10 +1472,12 @@ describe("Feishu integration", () => {
       displayName: "Feishu OAuth agent",
       visibility: "public",
     });
+    mockAuthoritativeOrganizationMembers([admin, member]);
     mocks.clerk.session(admin.userId, admin.orgId, "org:admin");
     const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
+    clearConnectorInvalidationMocks();
     const configured = await accept(
       client.setup({
         headers: { authorization: "Bearer clerk-session" },
@@ -1449,10 +1491,12 @@ describe("Feishu integration", () => {
       }),
       [200],
     );
+    expectCustomConnectorInvalidations([admin.userId, member.userId]);
     const installationId = configured.body.installationId;
     if (!installationId) {
       throw new Error("Expected Feishu setup to return an installation id");
     }
+    clearConnectorInvalidationMocks();
     await accept(
       client.updateInstallation({
         headers: { authorization: "Bearer clerk-session" },
@@ -1464,6 +1508,7 @@ describe("Feishu integration", () => {
       }),
       [200],
     );
+    expectCustomConnectorInvalidations([admin.userId, member.userId]);
 
     const customConnectorClient = setupApp({
       context,
@@ -1580,6 +1625,7 @@ describe("Feishu integration", () => {
       signal: context.signal,
       routes: zeroFeishuOauthRoutes,
     });
+    clearConnectorInvalidationMocks();
     const customConnectorCallback = await oauthApp.request(
       `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({
         code: "feishu-custom-connector-code",
@@ -1588,6 +1634,7 @@ describe("Feishu integration", () => {
       })}`,
     );
     expect(customConnectorCallback.status).toBe(200);
+    expectCustomConnectorInvalidations([admin.userId]);
     await expect(customConnectorCallback.json()).resolves.toStrictEqual({
       redirectUrl: `${APP_ORIGIN}/connectors/custom/callback/success`,
     });
@@ -1668,6 +1715,7 @@ describe("Feishu integration", () => {
       [200],
     );
     expect(restoredFeishuStatus.body.isConnected).toBeTruthy();
+    clearConnectorInvalidationMocks();
     await accept(
       setupApp({ context, routes: zeroCustomConnectorSecretTestRoutes })(
         zeroCustomConnectorSecretContract,
@@ -1677,6 +1725,7 @@ describe("Feishu integration", () => {
       }),
       [204],
     );
+    expectCustomConnectorInvalidations([admin.userId]);
     const disconnectedFromCustomConnector = await accept(
       customConnectorClient.list({
         headers: { authorization: "Bearer clerk-session" },
@@ -1773,6 +1822,7 @@ describe("Feishu integration", () => {
     expect(handoffUrl.searchParams.get("code")).toBe("feishu-oauth-code");
     expect(handoffUrl.searchParams.get("state")).toBe(state);
 
+    clearConnectorInvalidationMocks();
     const callbackResponse = await oauthApp.request(
       `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({
         code: "feishu-oauth-code",
@@ -1781,6 +1831,7 @@ describe("Feishu integration", () => {
       })}`,
     );
     expect(callbackResponse.status).toBe(200);
+    expectCustomConnectorInvalidations([member.userId]);
     await expect(callbackResponse.json()).resolves.toStrictEqual({
       redirectUrl: `https://applink.feishu.cn/client/bot/open?appId=${appId}`,
     });
@@ -1788,6 +1839,7 @@ describe("Feishu integration", () => {
       `${APP_ORIGIN}/connectors/feishu/callback`,
     ]);
 
+    clearConnectorInvalidationMocks();
     const legacyCallbackResponse = await oauthApp.request(
       `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({
         code: "legacy-feishu-oauth-code",
@@ -1800,6 +1852,7 @@ describe("Feishu integration", () => {
       })}`,
     );
     expect(legacyCallbackResponse.status).toBe(200);
+    expectCustomConnectorInvalidations([member.userId]);
     expect(oauthTokenRedirectUris).toStrictEqual([
       `${APP_ORIGIN}/connectors/feishu/callback`,
       "https://www.vm0.test/api/zero/feishu/oauth/callback",
@@ -1839,6 +1892,7 @@ describe("Feishu integration", () => {
     });
     expect(welcome?.msgType).toBe("interactive");
 
+    clearConnectorInvalidationMocks();
     await accept(
       client.disconnectInstallation({
         headers: { authorization: "Bearer clerk-session" },
@@ -1846,6 +1900,7 @@ describe("Feishu integration", () => {
       }),
       [200],
     );
+    expectCustomConnectorInvalidations([member.userId]);
     await expect(
       readCustomConnectorCredentialStorageParent(context, {
         orgId: requireValue(
@@ -1882,6 +1937,8 @@ describe("Feishu integration", () => {
     ]);
 
     mocks.clerk.session(admin.userId, admin.orgId, admin.orgRole);
+    mockAuthoritativeOrganizationMembers([admin, member]);
+    clearConnectorInvalidationMocks();
     await accept(
       client.removeInstallation({
         headers: { authorization: "Bearer clerk-session" },
@@ -1889,6 +1946,7 @@ describe("Feishu integration", () => {
       }),
       [200],
     );
+    expectCustomConnectorInvalidations([admin.userId, member.userId]);
     const removedConnectorList = await accept(
       customConnectorClient.list({
         headers: { authorization: "Bearer clerk-session" },
@@ -2363,19 +2421,23 @@ describe("Feishu integration", () => {
         return content.includes("Choose a model");
       }),
     ).toBeTruthy();
+    clearConnectorInvalidationMocks();
     await postEvent(callbackUrl, directMessage(appId, "/disconnect"), {
       encrypted: true,
     });
     await flushWaitUntilForTest();
+    expectCustomConnectorInvalidations([fixture.actor.userId]);
     expect(
       outboundMessages.some((message) => {
         return messageContent(message).includes("Disconnected");
       }),
     ).toBeTruthy();
+    clearConnectorInvalidationMocks();
     await postEvent(callbackUrl, directMessage(appId, "/disconnect"), {
       encrypted: true,
     });
     await flushWaitUntilForTest();
+    expectCustomConnectorInvalidations([]);
     expect(
       outboundMessages.some((message) => {
         return messageContent(message).includes("You are not connected.");

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
@@ -9,7 +9,6 @@ import {
   serialiseCustomConnector,
 } from "../services/zero-custom-connector.service";
 import type { RouteEntry } from "../route-entry";
-import { publishCustomConnectorListChangedForUserSafely } from "../external/realtime";
 
 const adminRequired = Object.freeze({
   status: 403 as const,
@@ -43,9 +42,6 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if ("status" in result) {
     return result;
   }
-
-  await publishCustomConnectorListChangedForUserSafely(auth.userId);
-  signal.throwIfAborted();
 
   return {
     status: 201 as const,

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
@@ -24,6 +24,7 @@ import {
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { addUserCustomConnector } from "../services/user-connectors.service";
 import { commitConnectorRuntimeMutation } from "../services/connector-runtime-wakeup.service";
+import { publishCustomConnectorUserInvalidationAfterCommit as publishCustomUserInvalidation } from "../services/connector-client-invalidation.service";
 import { isCustomConnectorMcpEnabled } from "../services/custom-connector-mcp-feature.service";
 import { getCustomConnectorById } from "../services/zero-custom-connector.service";
 import { tapError } from "../utils";
@@ -281,7 +282,7 @@ const completeOAuth2Callback$ = command(
             targets: [{ kind: "custom", customConnectorId: connector.id }],
           };
         });
-        signal.throwIfAborted();
+        await publishCustomUserInvalidation(claimed.state.userId, signal);
         return true;
       })(),
     );

--- a/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-feishu-oauth.ts
@@ -49,6 +49,7 @@ import {
   lockUserCustomConnectorGrantScope,
 } from "../services/user-connectors.service";
 import { commitConnectorRuntimeMutation } from "../services/connector-runtime-wakeup.service";
+import { publishCustomConnectorUserInvalidationAfterCommit } from "../services/connector-client-invalidation.service";
 import {
   getCustomConnectorById,
   type CustomConnectorHttpRow,
@@ -478,10 +479,15 @@ async function finishFeishuOAuthConnection(
         : undefined;
     },
   );
-  signal.throwIfAborted();
   if (!connection.connected) {
+    signal.throwIfAborted();
     return "account_in_use";
   }
+
+  await publishCustomConnectorUserInvalidationAfterCommit(
+    args.state.userId,
+    signal,
+  );
 
   await publishFeishuOrgChanged(
     args.db,

--- a/turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts
@@ -6,8 +6,8 @@ import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { writeDb$, type Db } from "../external/db";
-import { publishConnectorChangedForUserSafely } from "../external/realtime";
 import { recomposeAgentIfStale$ } from "./agent-compose.service";
+import { publishBuiltinConnectorInvalidationAfterCommit } from "./connector-client-invalidation.service";
 import { updateUserConnectors } from "./user-connectors.service";
 
 interface AuthorizableAgent {
@@ -182,8 +182,13 @@ export const authorizeConnectedConnector$ = command(
         message: agentNotFoundMessage(agent.id),
       };
     }
-    await publishConnectorChangedForUserSafely(args.userId, args.connectorSlug);
-    signal.throwIfAborted();
+    await publishBuiltinConnectorInvalidationAfterCommit(
+      {
+        userId: args.userId,
+        connectorSlug: args.connectorSlug,
+      },
+      signal,
+    );
     return { status: "authorized", agentId: agent.id };
   },
 );

--- a/turbo/apps/api/src/signals/services/connector-client-invalidation.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-client-invalidation.service.ts
@@ -1,0 +1,190 @@
+import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
+import type { ConnectorChangedPayload } from "@vm0/api-contracts/contracts/realtime";
+
+import { logger } from "../../lib/log";
+import type { ClerkOrganizationsApi } from "../external/clerk";
+import { listAllOrganizationMemberships } from "../external/clerk-organization-lists";
+import { publishUserSignal } from "../external/realtime";
+import { settleIncludingAbort } from "../utils";
+
+const L = logger("ConnectorClientInvalidation");
+
+interface UserAudience {
+  readonly kind: "user";
+  readonly userId: string;
+}
+
+interface OrganizationAudience {
+  readonly kind: "organization";
+  readonly orgId: string;
+  readonly organizations: Pick<
+    ClerkOrganizationsApi,
+    "getOrganizationMembershipList"
+  >;
+}
+
+type ConnectorClientInvalidation =
+  | {
+      readonly kind: "builtin";
+      readonly audience: UserAudience;
+      readonly connectorSlug: ConnectorSlug;
+    }
+  | {
+      readonly kind: "custom";
+      readonly audience: UserAudience | OrganizationAudience;
+    };
+
+export interface CapturedConnectorClientInvalidationAbort {
+  readonly reason: unknown;
+}
+
+function invalidationLogFields(
+  invalidation: ConnectorClientInvalidation,
+): Readonly<Record<string, unknown>> {
+  return {
+    kind: invalidation.kind,
+    audience: invalidation.audience.kind,
+    ...(invalidation.audience.kind === "organization"
+      ? { orgId: invalidation.audience.orgId }
+      : { userId: invalidation.audience.userId }),
+    ...(invalidation.kind === "builtin"
+      ? { connectorSlug: invalidation.connectorSlug }
+      : {}),
+  };
+}
+
+async function resolveInvalidationUserIds(
+  invalidation: ConnectorClientInvalidation,
+): Promise<readonly string[]> {
+  if (invalidation.audience.kind === "user") {
+    return [invalidation.audience.userId];
+  }
+
+  const memberships = await settleIncludingAbort(
+    listAllOrganizationMemberships(
+      invalidation.audience.organizations,
+      invalidation.audience.orgId,
+    ),
+  );
+  if (!memberships.ok) {
+    L.warn("Failed to resolve connector client invalidation audience", {
+      ...invalidationLogFields(invalidation),
+      error: memberships.error,
+    });
+    return [];
+  }
+
+  const userIds = new Set<string>();
+  let unidentifiedMembershipCount = 0;
+  for (const membership of memberships.value) {
+    const userId = membership.publicUserData?.userId;
+    if (userId) {
+      userIds.add(userId);
+    } else {
+      unidentifiedMembershipCount++;
+    }
+  }
+  if (unidentifiedMembershipCount > 0) {
+    L.warn("Skipped unidentified connector client invalidation members", {
+      ...invalidationLogFields(invalidation),
+      unidentifiedMembershipCount,
+    });
+  }
+  return [...userIds];
+}
+
+async function publishInvalidationForUser(
+  invalidation: ConnectorClientInvalidation,
+  userId: string,
+): Promise<void> {
+  const publication =
+    invalidation.kind === "builtin"
+      ? publishUserSignal([userId], "connector:changed", {
+          connectorSlug: invalidation.connectorSlug,
+        } satisfies ConnectorChangedPayload)
+      : publishUserSignal([userId], "customConnectorListChanged");
+  const outcome = await settleIncludingAbort(publication);
+  if (!outcome.ok) {
+    L.warn("Failed to publish connector client invalidation", {
+      ...invalidationLogFields(invalidation),
+      recipientUserId: userId,
+      error: outcome.error,
+    });
+  }
+}
+
+function captureAbort(
+  captured: CapturedConnectorClientInvalidationAbort | undefined,
+  signal: AbortSignal,
+): CapturedConnectorClientInvalidationAbort | undefined {
+  return captured ?? (signal.aborted ? { reason: signal.reason } : undefined);
+}
+
+/**
+ * Attempts browser cache invalidation after an authoritative connector mutation
+ * commits, then surfaces any request abort observed across that boundary.
+ */
+async function publishConnectorClientInvalidationAfterCommit(
+  invalidation: ConnectorClientInvalidation,
+  signal: AbortSignal,
+  previouslyCapturedAbort?: CapturedConnectorClientInvalidationAbort,
+): Promise<void> {
+  let capturedAbort = captureAbort(previouslyCapturedAbort, signal);
+  const userIds = await resolveInvalidationUserIds(invalidation);
+  await Promise.all(
+    userIds.map(async (userId) => {
+      await publishInvalidationForUser(invalidation, userId);
+    }),
+  );
+  capturedAbort = captureAbort(capturedAbort, signal);
+  if (capturedAbort) {
+    throw capturedAbort.reason;
+  }
+}
+
+export async function publishBuiltinConnectorInvalidationAfterCommit(
+  args: {
+    readonly userId: string;
+    readonly connectorSlug: ConnectorSlug;
+    readonly previouslyCapturedAbort?: CapturedConnectorClientInvalidationAbort;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await publishConnectorClientInvalidationAfterCommit(
+    {
+      kind: "builtin",
+      audience: { kind: "user", userId: args.userId },
+      connectorSlug: args.connectorSlug,
+    },
+    signal,
+    args.previouslyCapturedAbort,
+  );
+}
+
+export async function publishCustomConnectorUserInvalidationAfterCommit(
+  userId: string,
+  signal: AbortSignal,
+  previouslyCapturedAbort?: CapturedConnectorClientInvalidationAbort,
+): Promise<void> {
+  await publishConnectorClientInvalidationAfterCommit(
+    { kind: "custom", audience: { kind: "user", userId } },
+    signal,
+    previouslyCapturedAbort,
+  );
+}
+
+export async function publishCustomConnectorOrganizationInvalidationAfterCommit(
+  orgId: string,
+  organizations: Pick<ClerkOrganizationsApi, "getOrganizationMembershipList">,
+  signal: AbortSignal,
+  previouslyCapturedAbort?: CapturedConnectorClientInvalidationAbort,
+): Promise<void> {
+  await publishConnectorClientInvalidationAfterCommit(
+    {
+      kind: "custom",
+      audience: { kind: "organization", orgId, organizations },
+    },
+    signal,
+    previouslyCapturedAbort,
+  );
+}

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -8,7 +8,12 @@ import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connec
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { nowDate } from "../../lib/time";
+import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import {
+  publishCustomConnectorOrganizationInvalidationAfterCommit,
+  type CapturedConnectorClientInvalidationAbort,
+} from "./connector-client-invalidation.service";
 import { deleteCustomConnectorMemberConnection } from "./custom-connector-credential-storage.service";
 import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
 import { commitConnectorRuntimeMutation } from "./connector-runtime-wakeup.service";
@@ -57,6 +62,7 @@ interface ExistingFeishuCustomConnector {
 interface ReconciledFeishuCustomConnector {
   readonly connectorId: string;
   readonly displayName: string;
+  readonly definitionChanged: boolean;
   readonly runtimeChanged: boolean;
 }
 
@@ -270,6 +276,7 @@ async function createFeishuCustomConnector(
   return {
     connectorId: connector.id,
     displayName: feishuCustomConnectorDisplayName(installation.botName),
+    definitionChanged: true,
     runtimeChanged: false,
   };
 }
@@ -314,6 +321,7 @@ async function repairFeishuCustomConnector(
   return {
     connectorId: existing.connector.id,
     displayName: feishuCustomConnectorDisplayName(installation.botName),
+    definitionChanged: true,
     runtimeChanged: true,
   };
 }
@@ -388,6 +396,7 @@ async function reconcileFeishuCustomConnector(
     return {
       connectorId: existing.connector.id,
       displayName: feishuCustomConnectorDisplayName(installation.botName),
+      definitionChanged: false,
       runtimeChanged: false,
     };
   }
@@ -402,7 +411,7 @@ async function reconcileFeishuCustomConnector(
 
 export const ensureFeishuCustomConnector$ = command(
   async (
-    { set },
+    { get, set },
     args: EnsureFeishuCustomConnectorArgs,
     signal: AbortSignal,
   ): Promise<string | null> => {
@@ -410,6 +419,7 @@ export const ensureFeishuCustomConnector$ = command(
     const reconciliation = db.transaction(async (tx) => {
       return await reconcileFeishuCustomConnector(tx, args, signal);
     });
+    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const result = await commitConnectorRuntimeMutation(
       reconciliation,
       (connector) => {
@@ -427,9 +437,22 @@ export const ensureFeishuCustomConnector$ = command(
           : undefined;
       },
     );
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort = { reason: signal.reason };
+    }
     if (!result) {
+      signal.throwIfAborted();
       return null;
+    }
+    if (result.definitionChanged) {
+      await publishCustomConnectorOrganizationInvalidationAfterCommit(
+        args.orgId,
+        get(clerk$).organizations,
+        signal,
+        postCommitAbort,
+      );
+    } else {
+      signal.throwIfAborted();
     }
     await set(
       syncCustomConnectorSkillVolume$,
@@ -451,7 +474,7 @@ export const ensureFeishuCustomConnector$ = command(
 
 export const deleteFeishuCustomConnector$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly installationId: string;
@@ -470,6 +493,7 @@ export const deleteFeishuCustomConnector$ = command(
         ),
       )
       .returning({ id: orgCustomConnectors.id });
+    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const [deleted] = await commitConnectorRuntimeMutation(
       deletion,
       ([connector]) => {
@@ -482,10 +506,19 @@ export const deleteFeishuCustomConnector$ = command(
           : undefined;
       },
     );
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort = { reason: signal.reason };
+    }
     if (!deleted) {
+      signal.throwIfAborted();
       return;
     }
+    await publishCustomConnectorOrganizationInvalidationAfterCommit(
+      args.orgId,
+      get(clerk$).organizations,
+      signal,
+      postCommitAbort,
+    );
     await set(
       syncCustomConnectorSkillVolume$,
       {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -36,7 +36,6 @@ import { optionalEnv } from "../../lib/env";
 import { pgTextDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
-import { publishConnectorChangedForUserSafely } from "../external/realtime";
 import { bestEffort } from "../utils";
 import {
   decryptStoredSecretValue,
@@ -57,6 +56,7 @@ import {
   resolveConnectorCredentialAccess,
   type ConnectorCredentialAccess,
 } from "./connector-credential-access.service";
+import { publishBuiltinConnectorInvalidationAfterCommit } from "./connector-client-invalidation.service";
 import {
   deleteConnectorCredentialStorageConnection,
   deleteConnectorOwnedCredentialRows,
@@ -294,11 +294,16 @@ async function finalizeConnectorStateChangeAfterCommit(
     }
   }
 
-  await publishConnectorChangedForUserSafely(args.userId, args.connectorSlug);
-  if (signal.aborted) {
-    postCommitAbort ??= signal.reason;
-  }
-  throwCapturedAbort(postCommitAbort);
+  await publishBuiltinConnectorInvalidationAfterCommit(
+    {
+      userId: args.userId,
+      connectorSlug: args.connectorSlug,
+      ...(postCommitAbort === null
+        ? {}
+        : { previouslyCapturedAbort: { reason: postCommitAbort } }),
+    },
+    signal,
+  );
 }
 
 function prepareManualGrantConnect(

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -39,6 +39,7 @@ import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 
+import { clerk$ } from "../external/clerk";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -72,6 +73,11 @@ import {
   commitConnectorRuntimeMutation,
   publishConnectorRuntimeSyncWakeups,
 } from "./connector-runtime-wakeup.service";
+import {
+  publishCustomConnectorOrganizationInvalidationAfterCommit,
+  publishCustomConnectorUserInvalidationAfterCommit,
+  type CapturedConnectorClientInvalidationAbort,
+} from "./connector-client-invalidation.service";
 import { isCustomConnectorMcpEnabled } from "./custom-connector-mcp-feature.service";
 import type { Tx } from "../../lib/db-types";
 
@@ -1863,6 +1869,7 @@ export const createCustomConnector$ = command(
     const slug = v.slug ?? `_${slugHost}-${randomShortId()}`;
     L.debug("creating custom connector", { orgId: args.orgId, slug });
 
+    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const created = await persistCustomConnectorCreate(writeDb, {
       orgId: args.orgId,
       userId: args.userId,
@@ -1872,14 +1879,23 @@ export const createCustomConnector$ = command(
       oauthConfigUpdate,
       encryptedClientSecret,
     });
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort = { reason: signal.reason };
+    }
     if (isBadRequest(created)) {
+      signal.throwIfAborted();
       return created;
     }
 
     const result = normaliseCustomConnectorRow(
       created.row,
       created.oauthConfig,
+    );
+    await publishCustomConnectorOrganizationInvalidationAfterCommit(
+      args.orgId,
+      get(clerk$).organizations,
+      signal,
+      postCommitAbort,
     );
     if (result.skillMarkdown !== null) {
       await set(
@@ -2072,10 +2088,17 @@ async function persistCustomConnectorUpdate(
 async function persistCustomConnectorUpdateAndPublishRuntimeWakeup(
   db: Db,
   args: PersistCustomConnectorUpdateArgs,
-): Promise<CustomConnectorRow | BadRequestResponse | null> {
+  signal: AbortSignal,
+): Promise<{
+  readonly result: CustomConnectorRow | BadRequestResponse | null;
+  readonly postCommitAbort?: CapturedConnectorClientInvalidationAbort;
+}> {
   const result = await persistCustomConnectorUpdate(db, args);
   if (isBadRequest(result) || !result) {
-    return result;
+    return {
+      result,
+      ...(signal.aborted ? { postCommitAbort: { reason: signal.reason } } : {}),
+    };
   }
   const connector = normaliseCustomConnectorRow(result.row, result.oauthConfig);
   if (
@@ -2088,7 +2111,10 @@ async function persistCustomConnectorUpdateAndPublishRuntimeWakeup(
       targets: [{ kind: "custom", customConnectorId: connector.id }],
     });
   }
-  return connector;
+  return {
+    result: connector,
+    ...(signal.aborted ? { postCommitAbort: { reason: signal.reason } } : {}),
+  };
 }
 
 interface PreparedCustomConnectorUpdate {
@@ -2191,6 +2217,12 @@ function resolveCustomConnectorUpdateWrite(args: {
   };
 }
 
+type UpdateCustomConnectorDefinitionResult =
+  | CustomConnectorRow
+  | BadRequestResponse
+  | NotFoundResponse
+  | ForbiddenResponse;
+
 export const updateCustomConnectorDefinition$ = command(
   async (
     { get, set },
@@ -2201,12 +2233,7 @@ export const updateCustomConnectorDefinition$ = command(
       readonly input: UpdateCustomConnectorBody;
     },
     signal: AbortSignal,
-  ): Promise<
-    | CustomConnectorRow
-    | BadRequestResponse
-    | NotFoundResponse
-    | ForbiddenResponse
-  > => {
+  ): Promise<UpdateCustomConnectorDefinitionResult> => {
     const writeDb = set(writeDb$);
     const existingConnector = await loadCustomConnectorForUpdate(writeDb, args);
     signal.throwIfAborted();
@@ -2280,24 +2307,31 @@ export const updateCustomConnectorDefinition$ = command(
     if (isBadRequest(resolved)) {
       return resolved;
     }
-    const normalized =
-      await persistCustomConnectorUpdateAndPublishRuntimeWakeup(writeDb, {
-        orgId: args.orgId,
-        id: args.id,
-        definition: prepared.definition,
-        existing: existingConnector,
-        oauthConfigUpdate: prepared.oauthConfigUpdate,
-        encryptedClientSecret,
-        grantConfigurationChanged: resolved.grantConfigurationChanged,
-        storageVersion: resolved.storageVersion,
-      });
-    signal.throwIfAborted();
-    if (isBadRequest(normalized)) {
-      return normalized;
+    const { result: normalized, postCommitAbort } =
+      await persistCustomConnectorUpdateAndPublishRuntimeWakeup(
+        writeDb,
+        {
+          orgId: args.orgId,
+          id: args.id,
+          definition: prepared.definition,
+          existing: existingConnector,
+          oauthConfigUpdate: prepared.oauthConfigUpdate,
+          encryptedClientSecret,
+          grantConfigurationChanged: resolved.grantConfigurationChanged,
+          storageVersion: resolved.storageVersion,
+        },
+        signal,
+      );
+    if (isBadRequest(normalized) || !normalized) {
+      signal.throwIfAborted();
+      return normalized ?? notFound("Custom connector not found");
     }
-    if (!normalized) {
-      return notFound("Custom connector not found");
-    }
+    await publishCustomConnectorOrganizationInvalidationAfterCommit(
+      args.orgId,
+      get(clerk$).organizations,
+      signal,
+      postCommitAbort,
+    );
     if (
       normalized.skillMarkdown !== null ||
       args.input.skillMarkdown !== undefined
@@ -2321,7 +2355,7 @@ export const updateCustomConnectorDefinition$ = command(
 
 export const deleteCustomConnector$ = command(
   async (
-    { set },
+    { get, set },
     args: { readonly orgId: string; readonly id: string },
     signal: AbortSignal,
   ): Promise<NotFoundResponse | undefined> => {
@@ -2356,6 +2390,7 @@ export const deleteCustomConnector$ = command(
         );
       return true;
     });
+    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const deleted = await commitConnectorRuntimeMutation(deletion, (result) => {
       return result
         ? {
@@ -2365,10 +2400,19 @@ export const deleteCustomConnector$ = command(
           }
         : undefined;
     });
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort = { reason: signal.reason };
+    }
     if (!deleted) {
+      signal.throwIfAborted();
       return notFound("Custom connector not found");
     }
+    await publishCustomConnectorOrganizationInvalidationAfterCommit(
+      args.orgId,
+      get(clerk$).organizations,
+      signal,
+      postCommitAbort,
+    );
     await set(
       syncCustomConnectorSkillVolume$,
       {
@@ -2938,6 +2982,7 @@ export const setCustomConnectorValues$ = command(
         signal,
       );
     });
+    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const writeResult = await commitConnectorRuntimeMutation(
       valueWrite,
       (result) => {
@@ -2952,10 +2997,18 @@ export const setCustomConnectorValues$ = command(
           : undefined;
       },
     );
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort = { reason: signal.reason };
+    }
     if ("status" in writeResult) {
+      signal.throwIfAborted();
       return writeResult;
     }
+    await publishCustomConnectorUserInvalidationAfterCommit(
+      args.userId,
+      signal,
+      postCommitAbort,
+    );
 
     const db = get(db$);
     const markers = await loadCurrentCustomConnectorValueMarkers(db, {
@@ -2981,6 +3034,7 @@ export const disconnectCustomConnector$ = command(
     signal: AbortSignal,
   ): Promise<NotFoundResponse | undefined> => {
     const writeDb = set(writeDb$);
+    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const disconnected = await writeDb.transaction(async (tx) => {
       const [connector] = await tx
         .select({
@@ -3039,10 +3093,18 @@ export const disconnectCustomConnector$ = command(
       await deleteCustomConnectorMemberConnection(tx, args, signal);
       return true;
     });
-    signal.throwIfAborted();
+    if (signal.aborted) {
+      postCommitAbort = { reason: signal.reason };
+    }
     if (!disconnected) {
+      signal.throwIfAborted();
       return notFound("Custom connector not found");
     }
+    await publishCustomConnectorUserInvalidationAfterCommit(
+      args.userId,
+      signal,
+      postCommitAbort,
+    );
     return undefined;
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts
@@ -25,6 +25,10 @@ import {
   ensureFeishuCustomConnector$,
   hasFeishuCustomConnectorOAuthConnection,
 } from "./feishu-custom-connector.service";
+import {
+  publishCustomConnectorUserInvalidationAfterCommit,
+  type CapturedConnectorClientInvalidationAbort,
+} from "./connector-client-invalidation.service";
 import { feishuCallbackUrl, feishuOAuthAppCallbackUrl } from "./feishu-config";
 import { buildFeishuOAuthConnectUrl } from "./feishu-oauth-state";
 
@@ -532,6 +536,7 @@ export const disconnectFeishuConnection$ = command(
     if (installations.length === 0) {
       return false;
     }
+    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const rows = await db.transaction(async (tx) => {
       await disconnectFeishuCustomConnectorOAuthConnection(
         tx,
@@ -559,8 +564,19 @@ export const disconnectFeishuConnection$ = command(
       signal.throwIfAborted();
       return deleted;
     });
-    signal.throwIfAborted();
-    return rows.length > 0;
+    if (signal.aborted) {
+      postCommitAbort = { reason: signal.reason };
+    }
+    if (rows.length === 0) {
+      signal.throwIfAborted();
+      return false;
+    }
+    await publishCustomConnectorUserInvalidationAfterCommit(
+      args.userId,
+      signal,
+      postCommitAbort,
+    );
+    return true;
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
@@ -29,6 +29,7 @@ import type { Db } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { safeJsonParse, tapError } from "../utils";
 import { buildFeishuConnectUrl } from "./feishu-connect-token";
+import { publishCustomConnectorUserInvalidationAfterCommit } from "./connector-client-invalidation.service";
 import { disconnectFeishuCustomConnectorOAuthConnection } from "./feishu-custom-connector.service";
 import { publishFeishuOrgChanged } from "./zero-feishu-realtime.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
@@ -791,7 +792,10 @@ async function handleDisconnectCommand(
       .where(eq(feishuOrgConnections.id, args.connection.id));
     signal.throwIfAborted();
   });
-  signal.throwIfAborted();
+  await publishCustomConnectorUserInvalidationAfterCommit(
+    args.connection.vm0UserId,
+    signal,
+  );
   await publishFeishuOrgChanged(
     args.db,
     args.installation.orgId,


### PR DESCRIPTION
## Summary

- add one shared best-effort post-commit connector client invalidation dispatcher for builtin and custom mutations
- notify every authoritative organization member for custom definition changes and only the affected user for credential changes, including direct, proposal, OAuth, and Feishu paths
- preserve the existing realtime topics and payloads while attempting invalidation before surfacing a request abort observed after commit

## Compatibility

- no database schema, migration, persisted data, API contract, or runner protocol changes
- existing `connector:changed` and `customConnectorListChanged` wire formats remain unchanged

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts src/signals/routes/__tests__/zero-feishu-integration.test.ts --maxWorkers=1 --silent=passed-only` (100 tests passed)
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm knip --workspace api`
- pre-commit Prettier, full-workspace Knip, and full-workspace type checks

A local full API run completed 2,860 of 2,867 tests. Its seven failures were distributed across unrelated 5-second contention/queue cases plus the persistent local Moonshot dev-seed collision; the changed connector and Feishu scope passed in the isolated 100-test rerun above.

Closes #26078

Parent: #25312
