### PR TITLE
fix(connectors): reconcile custom and builtin firewall candidates

### DIFF
--- a/crates/runner/mitm-addon/src/connector_runtime_metadata.py
+++ b/crates/runner/mitm-addon/src/connector_runtime_metadata.py
@@ -1,0 +1,23 @@
+"""Private connector-candidate metadata shared by registry resolution and matching."""
+
+from typing import Literal
+
+type ConnectorRuntimeKind = Literal["builtin", "custom"]
+
+CONNECTOR_RUNTIME_KIND_MARKER = "_vm0ConnectorRuntimeKind"
+
+
+def connector_runtime_kind(firewall: dict) -> ConnectorRuntimeKind | None:
+    """Return a trusted internal candidate kind, if registry resolution assigned one."""
+    value = firewall.get(CONNECTOR_RUNTIME_KIND_MARKER)
+    return value if value in ("builtin", "custom") else None
+
+
+def clear_connector_runtime_kind(firewall: dict) -> None:
+    """Remove untrusted source metadata before registry-owned classification."""
+    firewall.pop(CONNECTOR_RUNTIME_KIND_MARKER, None)
+
+
+def mark_connector_runtime_kind(firewall: dict, kind: ConnectorRuntimeKind) -> None:
+    """Mark a resolved firewall as a registered connector runtime candidate."""
+    firewall[CONNECTOR_RUNTIME_KIND_MARKER] = kind

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -16,6 +16,7 @@ from typing import Literal, NamedTuple
 from urllib.parse import urlsplit
 
 import connector_intent
+import connector_runtime_metadata
 import connector_template_syntax
 from firewall_auth_config import auth_config_injects_ordinary_upstream_credentials
 from firewall_matching import base_url as _firewall_base_url
@@ -182,6 +183,7 @@ class CompiledFirewallCore(NamedTuple):
 class _CompiledFirewall(NamedTuple):
     core: CompiledFirewallCore
     apis: tuple[_CompiledApi, ...]
+    connector_runtime_kind: connector_runtime_metadata.ConnectorRuntimeKind | None
 
     @property
     def name(self) -> str:
@@ -948,9 +950,10 @@ def bind_compiled_firewall_core(
     even when the target list still has a dictionary at that index.
 
     Fields excluded from core compilation may remain shell-local. Builtin reuse currently rebinds
-    generated API ``id`` values and snapshot-owned ``_builtinHostPolicyRuntime`` metadata. Such raw
-    fields remain subject to their own validity and lifecycle contracts; in particular, runtime
-    host-policy metadata must stay paired with the target shell's resolved registry snapshot.
+    generated API ``id`` values, snapshot-owned ``_builtinHostPolicyRuntime`` metadata, and the
+    registry-owned connector candidate kind. Such raw fields remain subject to their own validity
+    and lifecycle contracts; in particular, runtime host-policy metadata must stay paired with the
+    target shell's resolved registry snapshot.
 
     The caller or its cache key must enforce this compatibility before reuse. This function does
     not compare semantic content. It returns ``None`` only when the target ``apis`` value is not a
@@ -972,7 +975,11 @@ def bind_compiled_firewall_core(
 
     if not compiled_apis:
         return None
-    return _CompiledFirewall(core, tuple(compiled_apis))
+    return _CompiledFirewall(
+        core,
+        tuple(compiled_apis),
+        connector_runtime_metadata.connector_runtime_kind(fw_entry),
+    )
 
 
 def compile_firewalls(vm_firewalls: object | None) -> CompiledFirewallSet | None:
@@ -1704,6 +1711,7 @@ def _match_compiled_firewall_request_with_api_candidates(
     is_asterisk_form: bool,
 ) -> FirewallAllow | FirewallPolicyAllow | FirewallBlock | FirewallAmbiguous | None:
     collection = _FirewallMatchCollection()
+    base_matches: list[_MatchedApi] = []
     unsafe_path: bool | None = False if is_asterisk_form else (True if url_has_backslash else None)
     decision_path = "*" if is_asterisk_form else (url_parts.path or "/")
 
@@ -1744,17 +1752,25 @@ def _match_compiled_firewall_request_with_api_candidates(
             base_params,
             block_match,
         )
+        base_matches.append(api_match)
+
+    custom_connector_matches = any(
+        match.firewall.connector_runtime_kind == "custom" for match in base_matches
+    )
+    for api_match in base_matches:
+        if custom_connector_matches and api_match.firewall.connector_runtime_kind == "builtin":
+            continue
         if not collection.accept_api(api_match):
             continue
 
-        if is_asterisk_form or not api_entry.permissions:
+        if is_asterisk_form or not api_match.api.permissions:
             continue
 
-        rel_path_segs = _split_path_segments(rel_path)
+        rel_path_segs = _split_path_segments(api_match.rel_path)
         rule_entries = (
-            _indexed_rule_candidates(api_entry, upper_method, rel_path_segs)
+            _indexed_rule_candidates(api_match.api, upper_method, rel_path_segs)
             if indexed_rules
-            else api_entry.rule_index.all_rules
+            else api_match.api.rule_index.all_rules
         )
         _collect_rule_routes(
             collection=collection,

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import builtin_base_url
 import builtin_firewall_cache
 import builtin_host_policy
+import connector_runtime_metadata
 
 BuiltinFirewallCatalogFileKey = builtin_firewall_cache.CatalogFileKey
 BuiltinFirewallCatalogIdentity = builtin_firewall_cache.CatalogIdentity
@@ -36,6 +37,50 @@ def _custom_connector_id(entry: dict) -> str | None:
             "inline firewall customConnectorId must be a UUID"
         ) from error
     return custom_connector_id
+
+
+def _connector_runtime_target_ids(vm: dict) -> tuple[set[str], set[str]]:
+    raw_targets = vm.get("connectorRuntimeTargets", [])
+    if not isinstance(raw_targets, list):
+        raise FirewallEntryResolutionError("connectorRuntimeTargets must be a list")
+    builtin_slugs: set[str] = set()
+    custom_connector_ids: set[str] = set()
+    for target in raw_targets:
+        if not isinstance(target, dict):
+            raise FirewallEntryResolutionError("connector runtime targets must be objects")
+        kind = target.get("kind")
+        if kind == "builtin":
+            connector_slug = target.get("connectorSlug")
+            if not isinstance(connector_slug, str) or connector_slug == "":
+                raise FirewallEntryResolutionError(
+                    "builtin connector runtime target must have a connector slug"
+                )
+            if connector_slug in builtin_slugs:
+                raise FirewallEntryResolutionError(
+                    "builtin connector runtime targets must be unique"
+                )
+            builtin_slugs.add(connector_slug)
+            continue
+        if kind == "custom":
+            custom_connector_id = target.get("customConnectorId")
+            if not isinstance(custom_connector_id, str):
+                raise FirewallEntryResolutionError(
+                    "custom connector runtime target must have a UUID"
+                )
+            try:
+                uuid.UUID(custom_connector_id)
+            except ValueError as error:
+                raise FirewallEntryResolutionError(
+                    "custom connector runtime target must have a UUID"
+                ) from error
+            if custom_connector_id in custom_connector_ids:
+                raise FirewallEntryResolutionError(
+                    "custom connector runtime targets must be unique"
+                )
+            custom_connector_ids.add(custom_connector_id)
+            continue
+        raise FirewallEntryResolutionError("connector runtime targets must use a supported kind")
+    return builtin_slugs, custom_connector_ids
 
 
 @dataclass(frozen=True)
@@ -270,6 +315,7 @@ def resolve_firewall_entries(
     resolved: list[dict] = []
     builtin_cache_keys: list[BuiltinFirewallCoreCacheKey | None] = []
     omitted_builtin_names: set[str] = set()
+    builtin_target_slugs, custom_target_ids = _connector_runtime_target_ids(vm)
     for entry in raw_firewalls:
         if not isinstance(entry, dict):
             raise FirewallEntryResolutionError("firewall entries must be objects")
@@ -293,6 +339,11 @@ def resolve_firewall_entries(
             if resolved_builtin is None:
                 omitted_builtin_names.add(raw_name)
                 continue
+            connector_runtime_metadata.clear_connector_runtime_kind(resolved_builtin.firewall)
+            if raw_name in builtin_target_slugs:
+                connector_runtime_metadata.mark_connector_runtime_kind(
+                    resolved_builtin.firewall, "builtin"
+                )
             resolved.append(resolved_builtin.firewall)
             builtin_cache_keys.append(resolved_builtin.cache_key)
             continue
@@ -303,9 +354,14 @@ def resolve_firewall_entries(
                     "inline firewall entry firewall must be an object"
                 )
             resolved_firewall = copy.deepcopy(firewall)
+            connector_runtime_metadata.clear_connector_runtime_kind(resolved_firewall)
             custom_connector_id = _custom_connector_id(entry)
             if custom_connector_id is not None:
                 resolved_firewall["customConnectorId"] = custom_connector_id
+                if custom_connector_id in custom_target_ids:
+                    connector_runtime_metadata.mark_connector_runtime_kind(
+                        resolved_firewall, "custom"
+                    )
                 raw_apis = resolved_firewall.get("apis")
                 if not isinstance(raw_apis, list):
                     raise FirewallEntryResolutionError("inline firewall apis must be a list")

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_cross_firewall_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_cross_firewall_precedence.py
@@ -3,6 +3,7 @@
 import pytest
 
 import connector_intent
+import connector_runtime_metadata
 import matching
 from tests.firewall_helpers import (
     compile_firewalls_or_fail,
@@ -59,6 +60,160 @@ def _auditor_firewall():
             auth_label="auditor",
         ),
     )
+
+
+def _runtime_firewall(
+    kind: connector_runtime_metadata.ConnectorRuntimeKind,
+    name: str,
+    base: str,
+    *,
+    auth_label: str,
+) -> dict:
+    firewall = firewall_entry(
+        name,
+        firewall_api(base, [], auth_label=auth_label),
+    )
+    connector_runtime_metadata.mark_connector_runtime_kind(firewall, kind)
+    return firewall
+
+
+@pytest.mark.parametrize(
+    ("builtin_base", "custom_base"),
+    [
+        ("https://api.example.com/v1/", "https://api.example.com/v1/"),
+        ("https://api.example.com/v1/", "https://api.example.com/"),
+        ("https://api.example.com/", "https://api.example.com/v1/"),
+    ],
+)
+def test_registered_custom_candidate_wins_equal_broader_and_narrower_bases(
+    builtin_base: str,
+    custom_base: str,
+) -> None:
+    firewalls = [
+        _runtime_firewall(
+            "builtin",
+            "builtin-service",
+            builtin_base,
+            auth_label="builtin",
+        ),
+        _runtime_firewall(
+            "custom",
+            "custom-service",
+            custom_base,
+            auth_label="custom",
+        ),
+    ]
+    policies = {
+        "builtin-service": network_policy(unknown_policy="allow"),
+        "custom-service": network_policy(unknown_policy="allow"),
+    }
+
+    result = match_compiled_firewalls(
+        "https://api.example.com/v1/items/123",
+        firewalls,
+        policies,
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.name == "custom-service"
+    assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer custom"
+
+
+def test_denied_registered_custom_candidate_does_not_fall_back_to_builtin() -> None:
+    builtin = _runtime_firewall(
+        "builtin",
+        "builtin-service",
+        ITEMS_BASE,
+        auth_label="builtin",
+    )
+    custom = firewall_entry(
+        "custom-service",
+        firewall_api(
+            ITEMS_BASE,
+            [firewall_permission(ITEMS_READ_PERMISSION, ITEMS_RULE)],
+            auth_label="custom",
+        ),
+    )
+    connector_runtime_metadata.mark_connector_runtime_kind(custom, "custom")
+
+    result = match_compiled_firewalls(
+        ITEMS_URL,
+        [builtin, custom],
+        {
+            "builtin-service": network_policy(unknown_policy="allow"),
+            "custom-service": network_policy(deny=[ITEMS_READ_PERMISSION]),
+        },
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.name == "custom-service"
+    assert result.reason == "permission_denied"
+
+
+def test_malformed_registered_custom_candidate_does_not_fall_back_to_builtin() -> None:
+    builtin = _runtime_firewall(
+        "builtin",
+        "builtin-service",
+        ITEMS_BASE,
+        auth_label="builtin",
+    )
+    custom = firewall_entry(
+        "custom-service",
+        firewall_api(ITEMS_BASE, [], auth={"headers": None}),
+    )
+    connector_runtime_metadata.mark_connector_runtime_kind(custom, "custom")
+
+    result = match_compiled_firewalls(
+        ITEMS_URL,
+        [builtin, custom],
+        {
+            "builtin-service": network_policy(unknown_policy="allow"),
+            "custom-service": network_policy(unknown_policy="allow"),
+        },
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.name == "custom-service"
+    assert result.reason == "malformed_firewall_config"
+
+
+def test_registered_custom_precedence_keeps_same_tier_and_neutral_ambiguity() -> None:
+    first_custom = _runtime_firewall(
+        "custom",
+        "first-custom",
+        ITEMS_BASE,
+        auth_label="first",
+    )
+    second_custom = _runtime_firewall(
+        "custom",
+        "second-custom",
+        ITEMS_BASE,
+        auth_label="second",
+    )
+    neutral = firewall_entry(
+        "neutral",
+        firewall_api(ITEMS_BASE, [], auth_label="neutral"),
+    )
+    policies = {
+        name: network_policy(unknown_policy="allow")
+        for name in ("first-custom", "second-custom", "neutral")
+    }
+
+    same_tier = match_compiled_firewalls(
+        ITEMS_URL,
+        [first_custom, second_custom],
+        policies,
+    )
+    neutral_overlap = match_compiled_firewalls(
+        ITEMS_URL,
+        [first_custom, neutral],
+        policies,
+    )
+
+    assert isinstance(same_tier, matching.FirewallAmbiguous)
+    assert same_tier.candidates == ("first-custom", "second-custom")
+    assert isinstance(neutral_overlap, matching.FirewallAmbiguous)
+    assert neutral_overlap.candidates == ("first-custom", "neutral")
 
 
 def test_compiled_matches_ask_permission_block():

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_resolution.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_resolution.py
@@ -1,9 +1,14 @@
 """Tests for built-in registry catalog resolution."""
 
+import os
+
 import pytest
 
+import auth
 import builtin_firewall_cache
 import builtin_host_policy
+import connector_runtime_metadata
+import matching
 import registry
 import registry_firewalls
 from tests.registry_builtin_helpers import (
@@ -59,6 +64,257 @@ class TestRegistryBuiltinCatalogResolution:
         assert vm_info["firewalls"][0]["name"] == "github"
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://api.github.com"
         assert vm_info["firewalls"][0]["apis"][0]["id"] == "run-github:0"
+
+    def test_registered_custom_candidate_shadows_only_matching_builtin_api(
+        self, tmp_path, mitm_ctx
+    ):
+        custom_connector_id = "550e8400-e29b-41d4-a716-446655440000"
+        builtin_name = "multi-api-service"
+        custom_name = "custom_connector_550e8400e29b41d4a716446655440000"
+        vm = {
+            "runId": "run-overlap",
+            "connectorRuntimeTargets": [
+                {"kind": "builtin", "connectorSlug": builtin_name},
+                {"kind": "custom", "customConnectorId": custom_connector_id},
+            ],
+            "firewalls": [
+                {"kind": "builtin", "name": builtin_name},
+                {
+                    "kind": "inline",
+                    "customConnectorId": custom_connector_id,
+                    "firewall": {
+                        "name": custom_name,
+                        "apis": [
+                            {
+                                "base": "https://api.example.test/",
+                                "auth": {"headers": {"Authorization": "Bearer custom"}},
+                                "permissions": [
+                                    {
+                                        "name": "custom-read",
+                                        "rules": ["GET /v1/items/{id}"],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                },
+            ],
+            "networkPolicies": {
+                builtin_name: {
+                    "allow": ["item-read", "audit-read"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "deny",
+                },
+                custom_name: {
+                    "allow": ["custom-read"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "deny",
+                },
+            },
+        }
+        catalog_firewall = {
+            "name": builtin_name,
+            "apis": [
+                {
+                    "base": "https://api.example.test/v1/",
+                    "auth": {"headers": {"Authorization": "Bearer builtin-items"}},
+                    "permissions": [{"name": "item-read", "rules": ["GET /items/{id}"]}],
+                },
+                {
+                    "base": "https://audit.example.test/",
+                    "auth": {"headers": {"Authorization": "Bearer builtin-audit"}},
+                    "permissions": [{"name": "audit-read", "rules": ["GET /events/{id}"]}],
+                },
+            ],
+        }
+        registry_path, cache_path = write_registry_with_cache(
+            tmp_path,
+            {"10.200.0.1": vm},
+            {builtin_name: catalog_firewall},
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+        assert context is not None
+        _, compiled_firewalls, compiled_policies = context
+        overlapping = matching.match_compiled_firewall_request(
+            "https://api.example.test/v1/items/123",
+            "GET",
+            compiled_firewalls,
+            compiled_policies,
+        )
+        unrelated = matching.match_compiled_firewall_request(
+            "https://audit.example.test/events/456",
+            "GET",
+            compiled_firewalls,
+            compiled_policies,
+        )
+
+        assert isinstance(overlapping, matching.FirewallAllow)
+        assert overlapping.name == custom_name
+        assert overlapping.permission == "custom-read"
+        assert isinstance(unrelated, matching.FirewallAllow)
+        assert unrelated.name == builtin_name
+        assert unrelated.permission == "audit-read"
+
+    def test_registry_owns_connector_candidate_source_metadata(self, tmp_path, mitm_ctx):
+        custom_connector_id = "550e8400-e29b-41d4-a716-446655440000"
+        marker = connector_runtime_metadata.CONNECTOR_RUNTIME_KIND_MARKER
+        builtin = github_cache_firewall()
+        builtin[marker] = "custom"
+        vm = builtin_vm("run-source-metadata", "github")
+        vm["connectorRuntimeTargets"] = [
+            {"kind": "builtin", "connectorSlug": "github"},
+            {"kind": "custom", "customConnectorId": custom_connector_id},
+        ]
+        vm["firewalls"].extend(
+            [
+                {
+                    "kind": "inline",
+                    "customConnectorId": custom_connector_id,
+                    "firewall": {
+                        marker: "builtin",
+                        "name": "custom-service",
+                        "apis": [],
+                    },
+                },
+                {
+                    "kind": "inline",
+                    "firewall": {
+                        marker: "custom",
+                        "name": "neutral-service",
+                        "apis": [],
+                    },
+                },
+            ]
+        )
+        registry_path, cache_path = write_registry_with_cache(
+            tmp_path,
+            {"10.200.0.1": vm},
+            {"github": builtin},
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+        assert context is not None
+        vm_info, _, _ = context
+        assert vm_info["firewalls"][0][marker] == "builtin"
+        assert vm_info["firewalls"][1][marker] == "custom"
+        assert marker not in vm_info["firewalls"][2]
+
+    def test_custom_candidate_route_changes_reconcile_owner_and_billing(self, tmp_path, mitm_ctx):
+        custom_connector_id = "550e8400-e29b-41d4-a716-446655440000"
+        builtin_name = "builtin-service"
+        custom_name = "custom-service"
+        request_url = "https://api.example.test/v1/items/123"
+        catalog_firewall = {
+            "name": builtin_name,
+            "apis": [
+                {
+                    "base": "https://api.example.test/v1/",
+                    "auth": {"headers": {"Authorization": "Bearer builtin"}},
+                    "permissions": [],
+                }
+            ],
+        }
+        registry_path, cache_path = write_registry_with_cache(
+            tmp_path,
+            {},
+            {builtin_name: catalog_firewall},
+        )
+        revision = 0
+
+        def select_owner(custom_base: str | None) -> tuple[str, bool]:
+            nonlocal revision
+            firewalls: list[dict[str, object]] = [{"kind": "builtin", "name": builtin_name}]
+            network_policies: dict[str, dict[str, object]] = {
+                builtin_name: {
+                    "allow": [],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                }
+            }
+            vm: dict[str, object] = {
+                "runId": "run-dynamic-owner",
+                "connectorRuntimeTargets": [
+                    {"kind": "builtin", "connectorSlug": builtin_name},
+                    {"kind": "custom", "customConnectorId": custom_connector_id},
+                ],
+                "firewalls": firewalls,
+                "networkPolicies": network_policies,
+                "billableFirewalls": [builtin_name],
+            }
+            if custom_base is None:
+                vm["omittedCustomConnectorIds"] = [custom_connector_id]
+            else:
+                firewalls.append(
+                    {
+                        "kind": "inline",
+                        "customConnectorId": custom_connector_id,
+                        "firewall": {
+                            "name": custom_name,
+                            "apis": [
+                                {
+                                    "base": custom_base,
+                                    "auth": {"headers": {"Authorization": "Bearer custom"}},
+                                    "permissions": [],
+                                }
+                            ],
+                        },
+                    }
+                )
+                network_policies[custom_name] = {
+                    "allow": [],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                }
+            write_multi_vm_registry(registry_path, {"10.200.0.1": vm})
+            revision += 1
+            timestamp = 1_700_000_000_000_000_000 + revision
+            os.utime(registry_path, ns=(timestamp, timestamp))
+
+            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+            assert context is not None
+            vm_info, compiled_firewalls, compiled_policies = context
+            result = matching.match_compiled_firewall_request(
+                request_url,
+                "GET",
+                compiled_firewalls,
+                compiled_policies,
+            )
+            assert isinstance(result, matching.FirewallAllow)
+            return result.name, auth.is_billable_firewall(result.name, vm_info)
+
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            assert select_owner("https://api.example.test/") == (custom_name, False)
+            assert select_owner("https://api.example.test/v1/items/") == (
+                custom_name,
+                False,
+            )
+            assert select_owner("https://api.example.test/unrelated/") == (
+                builtin_name,
+                True,
+            )
+            assert select_owner(None) == (builtin_name, True)
+            assert select_owner("https://api.example.test/v1/") == (
+                custom_name,
+                False,
+            )
 
     def test_builtin_firewall_entry_prefers_runner_catalog_cache(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -18,6 +18,7 @@ import request_classification
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.firewall_helpers import cancel_pending_task
+from tests.registry_builtin_helpers import write_registry_with_cache
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import _assert_no_request_stream, await_requestheaders_result
 from tests.upstream_connection_helpers import mark_connected_tls_upstream
@@ -30,6 +31,9 @@ _FIREWALL_NAME = "model-provider:test"
 _ORIGINAL_RUN_ID = "run-before-auth-wait"
 _RESOLVED_AUTHORIZATION = "Bearer resolved-for-old-authorization"
 _RESOLVED_AUTH_BASE = "https://webhook.example.com/deliver"
+_CUSTOM_CONNECTOR_ID = "550e8400-e29b-41d4-a716-446655440000"
+_CANDIDATE_BUILTIN_NAME = "github"
+_CANDIDATE_CUSTOM_NAME = "custom_connector_550e8400e29b41d4a716446655440000"
 
 
 def _registry_vm(
@@ -113,6 +117,80 @@ def _switchable_permission_vm(
         billable_firewalls=[_FIREWALL_NAME],
         vm_fields={"captureNetworkBodies": True, "modelUsageProvider": "test"},
     )
+
+
+def _candidate_precedence_vm(tmp_path: Path, *, custom_available: bool) -> dict[str, object]:
+    firewalls: list[dict[str, object]] = [{"kind": "builtin", "name": _CANDIDATE_BUILTIN_NAME}]
+    network_policies: dict[str, dict[str, object]] = {
+        _CANDIDATE_BUILTIN_NAME: {
+            "allow": ["repos-write"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "deny",
+        }
+    }
+    vm: dict[str, object] = {
+        "runId": _ORIGINAL_RUN_ID,
+        "sandboxToken": "candidate-precedence-token",
+        "networkLogPath": str(tmp_path / "net.jsonl"),
+        "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+        "encryptedSecrets": "iv:tag:data",
+        "connectorRuntimeTargets": [
+            {"kind": "builtin", "connectorSlug": _CANDIDATE_BUILTIN_NAME},
+            {"kind": "custom", "customConnectorId": _CUSTOM_CONNECTOR_ID},
+        ],
+        "connectorRoutingVariables": {f"custom:{_CUSTOM_CONNECTOR_ID}": {}},
+        "firewalls": firewalls,
+        "networkPolicies": network_policies,
+        "billableFirewalls": [_CANDIDATE_BUILTIN_NAME],
+    }
+    if not custom_available:
+        vm["omittedCustomConnectorIds"] = [_CUSTOM_CONNECTOR_ID]
+        return vm
+
+    firewalls.append(
+        {
+            "kind": "inline",
+            "customConnectorId": _CUSTOM_CONNECTOR_ID,
+            "firewall": {
+                "name": _CANDIDATE_CUSTOM_NAME,
+                "apis": [
+                    {
+                        "base": "https://api.github.com",
+                        "auth": {
+                            "headers": {"Authorization": "Bearer ${{ secrets.CUSTOM_TOKEN }}"}
+                        },
+                        "permissions": [
+                            {
+                                "name": "custom-repos-write",
+                                "rules": ["POST /repos/{path+}"],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+    )
+    network_policies[_CANDIDATE_CUSTOM_NAME] = {
+        "allow": ["custom-repos-write"],
+        "deny": [],
+        "ask": [],
+        "unknownPolicy": "deny",
+    }
+    return vm
+
+
+def _candidate_builtin_firewall() -> dict[str, object]:
+    return {
+        "name": _CANDIDATE_BUILTIN_NAME,
+        "apis": [
+            {
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [{"name": "repos-write", "rules": ["POST /repos/{path+}"]}],
+            }
+        ],
+    }
 
 
 def _publish_registry(registry_path: Path, *, vm_info: dict[str, object] | None) -> None:
@@ -436,6 +514,62 @@ async def test_different_same_run_allow_decision_fails_closed_without_old_creden
     }
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "firewall_authorization_changed"
+    assert flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY) is None
+    assert "_usage_flow_tracked" not in flow.metadata
+
+
+async def test_custom_owner_change_during_auth_discards_builtin_credentials(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+):
+    registry_path, cache_path = write_registry_with_cache(
+        tmp_path,
+        {_CLIENT_IP: _candidate_precedence_vm(tmp_path, custom_available=False)},
+        {_CANDIDATE_BUILTIN_NAME: _candidate_builtin_firewall()},
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data)
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth()
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    request_task: asyncio.Task[None] | None = None
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_catalog_cache_path=str(cache_path),
+        api_url="https://api.vm0.ai",
+    ):
+        mitm_addon.tls_clienthello(tls_data)
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            _publish_registry(
+                registry_path,
+                vm_info=_candidate_precedence_vm(tmp_path, custom_available=True),
+            )
+            release_auth_resolution.set()
+            await asyncio.gather(request_task)
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(request_task)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is not None
+    assert flow.response.status_code == 409
+    assert flow.response.content is not None
+    assert json.loads(flow.response.content)["error"] == "firewall_authorization_changed"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "firewall_authorization_changed"
+    assert flow.request.headers.get("Authorization") is None
+    assert flow.request.query.get("managed") is None
     assert flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY) is None
     assert "_usage_flow_tracked" not in flow.metadata
 

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -46,7 +46,9 @@ use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::storage_cache::PreparedFreshStorage;
 use crate::storage_plan::build_storage_plan;
 use crate::telemetry::JobTelemetry;
-use crate::types::{ExecutionContext, WorkspaceReuseResult};
+use crate::types::{
+    ConnectorRuntimeTargetRegistration, ExecutionContext, FirewallEntry, WorkspaceReuseResult,
+};
 use crate::workspace_image_cache::{
     WorkspaceCacheCheckoutResult, WorkspaceImageLease, WorkspaceImageLeaseIdentity,
     WorkspaceImagePrepareRequest,
@@ -1526,6 +1528,57 @@ fn normalize_guest_cli_agent_session_id(
 }
 
 /// Register a VM in the proxy registry and network log manager.
+fn candidate_firewalls(
+    context: &ExecutionContext,
+    targets: &[ConnectorRuntimeTargetRegistration],
+) -> RunnerResult<Option<Vec<FirewallEntry>>> {
+    if context.connector_runtime_candidate_targets.is_none() {
+        return Ok(context.firewalls.clone());
+    }
+
+    let mut firewalls = context.firewalls.clone();
+    for target in targets {
+        let ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug,
+            base_url_vars,
+        } = target
+        else {
+            continue;
+        };
+        let existing = firewalls
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|entry| match entry {
+                FirewallEntry::Builtin { name, .. } => name == connector_slug,
+                FirewallEntry::Inline { firewall, .. } => firewall.name == *connector_slug,
+            });
+        match existing {
+            Some(FirewallEntry::Builtin {
+                base_url_vars: existing_base_url_vars,
+                ..
+            }) if existing_base_url_vars == base_url_vars => {}
+            Some(FirewallEntry::Builtin { .. }) => {
+                return Err(RunnerError::Internal(format!(
+                    "builtin connector {connector_slug} has conflicting pinned routing variables"
+                )));
+            }
+            Some(FirewallEntry::Inline { .. }) => {
+                return Err(RunnerError::Internal(format!(
+                    "builtin connector {connector_slug} conflicts with an inline firewall"
+                )));
+            }
+            None => firewalls
+                .get_or_insert_with(Vec::new)
+                .push(FirewallEntry::Builtin {
+                    name: connector_slug.clone(),
+                    base_url_vars: base_url_vars.clone(),
+                }),
+        }
+    }
+    Ok(firewalls)
+}
+
 pub(super) async fn register_proxy(
     config: &ExecutorConfig,
     context: &ExecutionContext,
@@ -1535,15 +1588,20 @@ pub(super) async fn register_proxy(
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
     let cli_agent_type = normalized_cli_agent_type(&context.cli_agent_type);
+    let connector_runtime_targets = context
+        .connector_runtime_candidate_targets
+        .as_deref()
+        .unwrap_or(&context.connector_runtime_targets);
+    let firewalls = candidate_firewalls(context, connector_runtime_targets)?;
     let registration = proxy::VmRegistration {
         run_id: &run_id_str,
         cli_agent_type,
         sandbox_token: &context.sandbox_token,
         network_log_path: &network_log_path,
         proxy_log_path: &proxy_log_path,
-        firewalls: context.firewalls.as_deref(),
+        firewalls: firewalls.as_deref(),
         network_policies: context.network_policies.as_ref(),
-        connector_runtime_targets: Some(&context.connector_runtime_targets),
+        connector_runtime_targets: Some(connector_runtime_targets),
         encrypted_secrets: context.encrypted_secrets.as_deref(),
         secret_connector_map: context.secret_connector_map.as_ref(),
         secret_connector_metadata_map: context.secret_connector_metadata_map.as_ref(),
@@ -1567,7 +1625,7 @@ pub(super) async fn register_proxy(
                 run_id: context.run_id,
                 source_ip,
                 registry: config.registry.clone(),
-                targets: &context.connector_runtime_targets,
+                targets: connector_runtime_targets,
                 refreshes: context.network_policy_refreshes.as_ref(),
             })
             .await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -44,7 +44,8 @@ use crate::ids::RunId;
 use crate::paths::{RunnerPaths, scoped_workspace_image_cache_key};
 use crate::storage_manifest::StorageManifest;
 use crate::types::{
-    ConnectorRuntimeTargetRegistration, FirewallEntry, ResumeSession, SandboxReuseResult,
+    ConnectorRuntimeTargetRegistration, Firewall, FirewallApi, FirewallAuth, FirewallEntry,
+    ResumeSession, SandboxReuseResult,
 };
 use crate::workspace_image_cache::{
     WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageCache,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -43,7 +43,9 @@ use super::support::{
 use crate::ids::RunId;
 use crate::paths::{RunnerPaths, scoped_workspace_image_cache_key};
 use crate::storage_manifest::StorageManifest;
-use crate::types::{FirewallEntry, ResumeSession, SandboxReuseResult};
+use crate::types::{
+    ConnectorRuntimeTargetRegistration, FirewallEntry, ResumeSession, SandboxReuseResult,
+};
 use crate::workspace_image_cache::{
     WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageCache,
     WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -90,6 +90,89 @@ fn proxy_register_failure_warns_with_error() {
 }
 
 #[tokio::test]
+async fn proxy_registration_prefers_complete_connector_candidates_with_legacy_fallback() {
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let candidate_config = test_executor_config(candidate_dir.path()).await;
+    let mut candidate_context = minimal_context();
+    candidate_context.firewalls = Some(vec![FirewallEntry::Builtin {
+        name: "model-provider:anthropic-api-key".to_string(),
+        base_url_vars: None,
+    }]);
+    candidate_context.connector_runtime_targets = Vec::new();
+    candidate_context.connector_runtime_candidate_targets =
+        Some(vec![ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "zendesk".to_string(),
+            base_url_vars: Some(HashMap::from([(
+                "ZENDESK_SUBDOMAIN".to_string(),
+                "xn--mnich-kva".to_string(),
+            )])),
+        }]);
+    candidate_context.vars = Some(HashMap::from([(
+        "ZENDESK_SUBDOMAIN".to_string(),
+        "münich".to_string(),
+    )]));
+
+    let _candidate_session = register_proxy(&candidate_config, &candidate_context, "10.200.0.2")
+        .await
+        .unwrap();
+    let candidate_registry: serde_json::Value = serde_json::from_str(
+        &tokio::fs::read_to_string(candidate_dir.path().join("proxy-registry.json"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let candidate_vm = &candidate_registry["vms"]["10.200.0.2"];
+    assert_eq!(
+        candidate_vm["firewalls"],
+        serde_json::json!([
+            {
+                "kind": "builtin",
+                "name": "model-provider:anthropic-api-key"
+            },
+            {
+                "kind": "builtin",
+                "name": "zendesk",
+                "baseUrlVars": {
+                    "ZENDESK_SUBDOMAIN": "xn--mnich-kva"
+                }
+            }
+        ])
+    );
+    assert_eq!(
+        candidate_vm["connectorRuntimeTargets"],
+        serde_json::json!([{
+            "kind": "builtin",
+            "connectorSlug": "zendesk"
+        }])
+    );
+    assert_eq!(
+        candidate_vm["connectorRoutingVariables"]["builtin:zendesk"],
+        serde_json::json!({"ZENDESK_SUBDOMAIN": "münich"})
+    );
+
+    let legacy_dir = tempfile::tempdir().unwrap();
+    let legacy_config = test_executor_config(legacy_dir.path()).await;
+    let mut legacy_context = minimal_context();
+    legacy_context.firewalls = None;
+    legacy_context.connector_runtime_targets = vec![ConnectorRuntimeTargetRegistration::Builtin {
+        connector_slug: "zendesk".to_string(),
+        base_url_vars: None,
+    }];
+    legacy_context.connector_runtime_candidate_targets = None;
+
+    let _legacy_session = register_proxy(&legacy_config, &legacy_context, "10.200.0.3")
+        .await
+        .unwrap();
+    let legacy_registry: serde_json::Value = serde_json::from_str(
+        &tokio::fs::read_to_string(legacy_dir.path().join("proxy-registry.json"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(legacy_registry["vms"]["10.200.0.3"]["firewalls"].is_null());
+}
+
+#[tokio::test]
 async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_start() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -173,6 +173,76 @@ async fn proxy_registration_prefers_complete_connector_candidates_with_legacy_fa
 }
 
 #[tokio::test]
+async fn proxy_registration_rejects_conflicting_builtin_candidate_sources() {
+    let routing_variables =
+        HashMap::from([("ZENDESK_SUBDOMAIN".to_string(), "xn--mnich-kva".to_string())]);
+
+    let routing_dir = tempfile::tempdir().unwrap();
+    let routing_config = test_executor_config(routing_dir.path()).await;
+    let mut routing_context = minimal_context();
+    routing_context.firewalls = Some(vec![FirewallEntry::Builtin {
+        name: "zendesk".to_string(),
+        base_url_vars: None,
+    }]);
+    routing_context.connector_runtime_candidate_targets =
+        Some(vec![ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "zendesk".to_string(),
+            base_url_vars: Some(routing_variables),
+        }]);
+
+    let routing_error = match register_proxy(&routing_config, &routing_context, "10.200.0.4").await
+    {
+        Ok(_) => panic!("conflicting pinned routing variables must fail registration"),
+        Err(error) => error,
+    };
+    assert!(
+        routing_error
+            .to_string()
+            .contains("zendesk has conflicting pinned routing variables"),
+        "unexpected error: {routing_error}"
+    );
+
+    let ownership_dir = tempfile::tempdir().unwrap();
+    let ownership_config = test_executor_config(ownership_dir.path()).await;
+    let mut ownership_context = minimal_context();
+    ownership_context.firewalls = Some(vec![FirewallEntry::Inline {
+        firewall: Firewall {
+            name: "zendesk".to_string(),
+            apis: vec![FirewallApi {
+                id: "custom-zendesk:0".to_string(),
+                base: "https://custom.example.test/".to_string(),
+                auth: FirewallAuth {
+                    headers: HashMap::new(),
+                    base: None,
+                    query: None,
+                    aws_sigv4: None,
+                },
+                host_policy: None,
+                permissions: None,
+            }],
+        },
+        custom_connector_id: None,
+    }]);
+    ownership_context.connector_runtime_candidate_targets =
+        Some(vec![ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "zendesk".to_string(),
+            base_url_vars: None,
+        }]);
+
+    let ownership_error =
+        match register_proxy(&ownership_config, &ownership_context, "10.200.0.5").await {
+            Ok(_) => panic!("inline ownership conflicts must fail registration"),
+            Err(error) => error,
+        };
+    assert!(
+        ownership_error
+            .to_string()
+            .contains("zendesk conflicts with an inline firewall"),
+        "unexpected error: {ownership_error}"
+    );
+}
+
+#[tokio::test]
 async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_start() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -7,14 +7,14 @@
 //! Nearby due targets for one run are coalesced and split to the shared API
 //! contract limit.
 //!
-//! A sync response must contain each requested target exactly
-//! once. Available builtin results patch only their existing network policy;
-//! available custom results atomically replace their firewall and policy.
-//! Authoritative custom absence removes both while builtin unresolved results
-//! retain last-known-good state and retry. Transport, validation, queue, and
-//! registry publication failures also retain last-known-good state and install
-//! a capped, jittered retry. Older queued or in-flight work cannot clear a newer
-//! realtime trigger.
+//! A sync response must contain each requested target exactly once. Valid
+//! builtin policy and custom firewall updates are prepared independently, then
+//! committed through one checked registry transaction. Authoritative custom
+//! absence removes only that candidate, while unresolved results retain
+//! last-known-good state and retry. Transport, validation, queue, and registry
+//! publication failures also retain last-known-good state and install a capped,
+//! jittered retry. Older queued or in-flight work cannot clear a newer realtime
+//! trigger.
 //!
 //! A typed terminal-run response removes the entire run from tracking, cancels
 //! scheduled work, and fail-closes every still-matching target. Registry writes
@@ -44,7 +44,9 @@ use tracing::{info, warn};
 use super::api::{ApiClient, ConnectorRuntimeSyncOutcome};
 use crate::error::RunnerError;
 use crate::ids::RunId;
-use crate::proxy::{CustomConnectorRuntimeRegistryState, ProxyRegistryHandle};
+use crate::proxy::{
+    ConnectorRuntimeRegistryUpdate, CustomConnectorRuntimeRegistryState, ProxyRegistryHandle,
+};
 use crate::types::{
     ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeSyncState, ConnectorRuntimeTarget,
     ConnectorRuntimeTargetRegistration, ConnectorRuntimeUnresolvedReason, FirewallEntry,
@@ -129,6 +131,13 @@ struct SyncRequest {
 struct ConnectorSyncTarget {
     target: ConnectorRuntimeTarget,
     generation: u64,
+}
+
+struct PreparedConnectorRuntimePublication {
+    target: ConnectorSyncTarget,
+    deadline: Option<tokio::time::Instant>,
+    candidate_base_url_vars: Option<HashMap<String, String>>,
+    update: ConnectorRuntimeRegistryUpdate,
 }
 
 impl ConnectorRuntimeSyncHandle {
@@ -541,6 +550,7 @@ impl ConnectorRuntimeSyncCore {
         }
 
         let mut retry_targets = Vec::new();
+        let mut prepared_publications = Vec::new();
         for target in active_targets {
             if duplicate_targets.contains(&target.target) {
                 retry_targets.push(target.clone());
@@ -609,9 +619,9 @@ impl ConnectorRuntimeSyncCore {
                     continue;
                 }
             };
-            let Some(snapshot) = self.active_snapshot_for_target(run_id, target).await else {
+            if !self.target_generation_is_current(run_id, target).await {
                 continue;
-            };
+            }
             if let Some(candidate) = &candidate_base_url_vars {
                 let Some(matches_pinned_values) = self
                     .custom_base_url_vars_match(run_id, target, candidate)
@@ -629,7 +639,7 @@ impl ConnectorRuntimeSyncCore {
                     continue;
                 }
             }
-            let publication = match (&target.target, &result.state) {
+            let update = match (&target.target, &result.state) {
                 (
                     ConnectorRuntimeTarget::Builtin { connector_slug },
                     ConnectorRuntimeSyncState::Available {
@@ -644,26 +654,10 @@ impl ConnectorRuntimeSyncCore {
                     {
                         Err(error)
                     } else {
-                        match patch_network_policy(
-                            run_id,
-                            connector_slug,
-                            snapshot.clone(),
-                            network_policy.clone(),
-                        )
-                        .await
-                        {
-                            Ok(published) => Ok(published),
-                            Err(error) => {
-                                warn!(
-                                    run_id = %run_id,
-                                    target = %target.target.log_identity(),
-                                    error = %error,
-                                    "failed to publish connector runtime target; retaining last-known-good state"
-                                );
-                                retry_targets.push(target.clone());
-                                continue;
-                            }
-                        }
+                        Ok(ConnectorRuntimeRegistryUpdate::BuiltinAvailable {
+                            connector_slug: connector_slug.clone(),
+                            network_policy: network_policy.clone(),
+                        })
                     }
                 }
                 (
@@ -714,35 +708,17 @@ impl ConnectorRuntimeSyncCore {
                             "custom connector runtime target is authoritatively absent"
                         );
                     }
-                    match snapshot
-                        .registry
-                        .replace_custom_connector_runtime_target_if_run_matches(
-                            &snapshot.source_ip,
-                            &run_id.to_string(),
-                            custom_connector_id,
-                            registry_state,
-                        )
-                        .await
-                    {
-                        Ok(published) => Ok(published),
-                        Err(error) => {
-                            warn!(
-                                run_id = %run_id,
-                                target = %target.target.log_identity(),
-                                error = %error,
-                                "failed to publish connector runtime target; retaining last-known-good state"
-                            );
-                            retry_targets.push(target.clone());
-                            continue;
-                        }
-                    }
+                    Ok(ConnectorRuntimeRegistryUpdate::Custom {
+                        custom_connector_id: custom_connector_id.clone(),
+                        state: registry_state,
+                    })
                 }
                 (ConnectorRuntimeTarget::Builtin { .. }, _) => {
                     Err("builtin connector runtime result has an invalid state")
                 }
             };
-            let published = match publication {
-                Ok(published) => published,
+            let update = match update {
+                Ok(update) => update,
                 Err(error) => {
                     warn!(
                         run_id = %run_id,
@@ -754,28 +730,74 @@ impl ConnectorRuntimeSyncCore {
                     continue;
                 }
             };
-            match published {
-                true => {
-                    if self
-                        .complete_successful_sync(
-                            run_id,
-                            target,
-                            deadline,
-                            candidate_base_url_vars.as_ref(),
-                        )
-                        .await
-                    {
-                        info!(
-                            run_id = %run_id,
-                            target = %target.target.log_identity(),
-                            generation = target.generation,
-                            "synced connector runtime target"
-                        );
+            prepared_publications.push(PreparedConnectorRuntimePublication {
+                target: target.clone(),
+                deadline,
+                candidate_base_url_vars,
+                update,
+            });
+        }
+
+        let Some((snapshot, prepared_publications)) = self
+            .current_connector_runtime_publications(run_id, prepared_publications)
+            .await
+        else {
+            return false;
+        };
+        if !prepared_publications.is_empty() {
+            let updates = prepared_publications
+                .iter()
+                .map(|publication| publication.update.clone())
+                .collect::<Vec<_>>();
+            let publication = snapshot
+                .registry
+                .apply_connector_runtime_updates_if_run_matches(
+                    &snapshot.source_ip,
+                    &run_id.to_string(),
+                    &updates,
+                )
+                .await;
+            match publication {
+                Ok(Some(outcomes)) => {
+                    for (prepared, published) in prepared_publications.into_iter().zip(outcomes) {
+                        if !published {
+                            retry_targets.push(prepared.target);
+                            continue;
+                        }
+                        if self
+                            .complete_successful_sync(
+                                run_id,
+                                &prepared.target,
+                                prepared.deadline,
+                                prepared.candidate_base_url_vars.as_ref(),
+                            )
+                            .await
+                        {
+                            info!(
+                                run_id = %run_id,
+                                target = %prepared.target.target.log_identity(),
+                                generation = prepared.target.generation,
+                                "synced connector runtime target"
+                            );
+                        }
                     }
                 }
-                false => {
+                Ok(None) => {
                     self.unregister_run(run_id).await;
                     return false;
+                }
+                Err(error) => {
+                    warn!(
+                        run_id = %run_id,
+                        error = %error,
+                        target_count = prepared_publications.len(),
+                        "failed to publish connector runtime targets; retaining last-known-good state"
+                    );
+                    retry_targets.extend(
+                        prepared_publications
+                            .into_iter()
+                            .map(|publication| publication.target),
+                    );
                 }
             }
         }
@@ -921,6 +943,7 @@ impl ConnectorRuntimeSyncCore {
                     ConnectorRuntimeTarget::Builtin { connector_slug } => {
                         ConnectorRuntimeTargetRegistration::Builtin {
                             connector_slug: connector_slug.clone(),
+                            base_url_vars: None,
                         }
                     }
                     ConnectorRuntimeTarget::Custom {
@@ -935,24 +958,46 @@ impl ConnectorRuntimeSyncCore {
             .collect()
     }
 
-    async fn active_snapshot_for_target(
+    async fn target_generation_is_current(
         &self,
         run_id: RunId,
         target: &ConnectorSyncTarget,
-    ) -> Option<ActiveRunConnectorRuntimeSnapshot> {
+    ) -> bool {
+        let active_runs = self.inner.active_runs.lock().await;
+        active_runs.get(&run_id).is_some_and(|active| {
+            active
+                .connectors
+                .get(&target.target)
+                .is_some_and(|connector| connector.generation == target.generation)
+        })
+    }
+
+    async fn current_connector_runtime_publications(
+        &self,
+        run_id: RunId,
+        publications: Vec<PreparedConnectorRuntimePublication>,
+    ) -> Option<(
+        ActiveRunConnectorRuntimeSnapshot,
+        Vec<PreparedConnectorRuntimePublication>,
+    )> {
         let active_runs = self.inner.active_runs.lock().await;
         let active = active_runs.get(&run_id)?;
-        if active
-            .connectors
-            .get(&target.target)
-            .is_none_or(|connector| connector.generation != target.generation)
-        {
-            return None;
-        }
-        Some(ActiveRunConnectorRuntimeSnapshot {
-            source_ip: active.source_ip.clone(),
-            registry: active.registry.clone(),
-        })
+        let current = publications
+            .into_iter()
+            .filter(|publication| {
+                active
+                    .connectors
+                    .get(&publication.target.target)
+                    .is_some_and(|connector| connector.generation == publication.target.generation)
+            })
+            .collect();
+        Some((
+            ActiveRunConnectorRuntimeSnapshot {
+                source_ip: active.source_ip.clone(),
+                registry: active.registry.clone(),
+            },
+            current,
+        ))
     }
 
     async fn custom_base_url_vars_match(
@@ -1231,23 +1276,6 @@ async fn run_sync_worker(
             }
         }
     }
-}
-
-async fn patch_network_policy(
-    run_id: RunId,
-    connector_slug: &str,
-    snapshot: ActiveRunConnectorRuntimeSnapshot,
-    policy: NetworkPolicy,
-) -> crate::error::RunnerResult<bool> {
-    snapshot
-        .registry
-        .patch_network_policy_if_run_matches(
-            &snapshot.source_ip,
-            &run_id.to_string(),
-            connector_slug,
-            policy,
-        )
-        .await
 }
 
 fn connector_runtime_unresolved_reason_is_valid(
@@ -1573,6 +1601,7 @@ mod tests {
                 .map(
                     |connector_slug| ConnectorRuntimeTargetRegistration::Builtin {
                         connector_slug: connector_slug.clone(),
+                        base_url_vars: None,
                     },
                 )
                 .collect::<Vec<_>>();
@@ -1612,7 +1641,7 @@ mod tests {
                         proxy_log_path: &proxy_log_path,
                         firewalls: Some(&firewalls),
                         network_policies: Some(&network_policies),
-                        connector_runtime_targets: None,
+                        connector_runtime_targets: Some(&runtime_targets),
                         encrypted_secrets: None,
                         secret_connector_map: None,
                         secret_connector_metadata_map: None,
@@ -1867,6 +1896,10 @@ mod tests {
         let run_id_string = run_id.to_string();
         let network_log_path = dir.path().join("network.jsonl");
         let proxy_log_path = dir.path().join("proxy.log");
+        let runtime_targets = [ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "slack".to_string(),
+            base_url_vars: None,
+        }];
         registry
             .register_vm(
                 "10.200.0.2",
@@ -1878,7 +1911,7 @@ mod tests {
                     proxy_log_path: &proxy_log_path,
                     firewalls: Some(&firewalls),
                     network_policies: Some(&network_policies),
-                    connector_runtime_targets: None,
+                    connector_runtime_targets: Some(&runtime_targets),
                     encrypted_secrets: None,
                     secret_connector_map: None,
                     secret_connector_metadata_map: None,
@@ -1898,6 +1931,41 @@ mod tests {
         firewalls: &[FirewallEntry],
         network_policies: &HashMap<String, NetworkPolicy>,
     ) -> (tempfile::TempDir, ProxyRegistryHandle, std::path::PathBuf) {
+        let runtime_targets = firewalls
+            .iter()
+            .filter_map(|firewall| match firewall {
+                FirewallEntry::Builtin {
+                    name,
+                    base_url_vars,
+                } => Some(ConnectorRuntimeTargetRegistration::Builtin {
+                    connector_slug: name.clone(),
+                    base_url_vars: base_url_vars.clone(),
+                }),
+                FirewallEntry::Inline {
+                    custom_connector_id: Some(custom_connector_id),
+                    ..
+                } => Some(ConnectorRuntimeTargetRegistration::Custom {
+                    custom_connector_id: custom_connector_id.clone(),
+                    base_url_vars: None,
+                }),
+                FirewallEntry::Inline { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        registered_runtime_registry_with_targets(
+            run_id,
+            firewalls,
+            network_policies,
+            &runtime_targets,
+        )
+        .await
+    }
+
+    async fn registered_runtime_registry_with_targets(
+        run_id: RunId,
+        firewalls: &[FirewallEntry],
+        network_policies: &HashMap<String, NetworkPolicy>,
+        runtime_targets: &[ConnectorRuntimeTargetRegistration],
+    ) -> (tempfile::TempDir, ProxyRegistryHandle, std::path::PathBuf) {
         let dir = tempfile::tempdir().expect("tempdir should be created");
         let registry_path = dir.path().join("proxy-registry.json");
         tokio::fs::write(&registry_path, br#"{"vms":{},"updatedAt":0}"#)
@@ -1910,6 +1978,21 @@ mod tests {
         let run_id = run_id.to_string();
         let network_log_path = dir.path().join("network.jsonl");
         let proxy_log_path = dir.path().join("proxy.log");
+        let runtime_vars = firewalls
+            .iter()
+            .filter_map(|firewall| match firewall {
+                FirewallEntry::Builtin {
+                    base_url_vars: Some(base_url_vars),
+                    ..
+                } => Some(base_url_vars),
+                FirewallEntry::Builtin {
+                    base_url_vars: None,
+                    ..
+                }
+                | FirewallEntry::Inline { .. } => None,
+            })
+            .flat_map(|base_url_vars| base_url_vars.clone())
+            .collect::<HashMap<_, _>>();
         registry
             .register_vm(
                 "10.200.0.2",
@@ -1921,11 +2004,11 @@ mod tests {
                     proxy_log_path: &proxy_log_path,
                     firewalls: Some(firewalls),
                     network_policies: Some(network_policies),
-                    connector_runtime_targets: None,
+                    connector_runtime_targets: Some(runtime_targets),
                     encrypted_secrets: None,
                     secret_connector_map: None,
                     secret_connector_metadata_map: None,
-                    vars: None,
+                    vars: (!runtime_vars.is_empty()).then_some(&runtime_vars),
                     capture_network_bodies: false,
                     billable_firewalls: &[],
                     model_usage_provider: None,
@@ -2599,14 +2682,20 @@ mod tests {
         let firewall = custom_runtime_firewall(custom_connector_id);
         let empty_firewalls = Vec::new();
         let empty_policies = HashMap::new();
-        let (_dir, registry, registry_path) =
-            registered_runtime_registry(run_id, &empty_firewalls, &empty_policies).await;
+        let registration = runtime_target_registration(&target);
+        let (_dir, registry, registry_path) = registered_runtime_registry_with_targets(
+            run_id,
+            &empty_firewalls,
+            &empty_policies,
+            std::slice::from_ref(&registration),
+        )
+        .await;
 
         core.register_run(ConnectorRuntimeSyncRegistration {
             run_id,
             source_ip: "10.200.0.2",
             registry,
-            targets: std::slice::from_ref(&runtime_target_registration(&target)),
+            targets: std::slice::from_ref(&registration),
             refreshes: None,
         })
         .await;
@@ -2723,8 +2812,13 @@ mod tests {
         });
         let empty_firewalls = Vec::new();
         let empty_policies = HashMap::new();
-        let (_dir, registry, registry_path) =
-            registered_runtime_registry(run_id, &empty_firewalls, &empty_policies).await;
+        let (_dir, registry, registry_path) = registered_runtime_registry_with_targets(
+            run_id,
+            &empty_firewalls,
+            &empty_policies,
+            std::slice::from_ref(&registration),
+        )
+        .await;
 
         core.register_run(ConnectorRuntimeSyncRegistration {
             run_id,
@@ -3099,15 +3193,21 @@ mod tests {
                 unknown_policy: "allow".to_string(),
             },
         )]);
-        let (_dir, registry, registry_path) =
-            registered_runtime_registry(run_id, &[], &policies).await;
+        let registration = runtime_target_registration(&target);
+        let (_dir, registry, registry_path) = registered_runtime_registry_with_targets(
+            run_id,
+            &[],
+            &policies,
+            std::slice::from_ref(&registration),
+        )
+        .await;
         let registry_before = tokio::fs::read(&registry_path).await.unwrap();
 
         core.register_run(ConnectorRuntimeSyncRegistration {
             run_id,
             source_ip: "10.200.0.2",
             registry,
-            targets: std::slice::from_ref(&runtime_target_registration(&target)),
+            targets: std::slice::from_ref(&registration),
             refreshes: None,
         })
         .await;
@@ -4132,10 +4232,10 @@ mod tests {
         assert_connector_field(
             captured_event(
                 &events,
-                "patched connector network policy in proxy registry",
+                "applied connector runtime updates to proxy registry",
             ),
-            "connector_slug",
-            "slack",
+            "update_count",
+            "1",
         );
         assert_connector_field(
             captured_event(&events, "synced connector runtime target"),

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -189,6 +189,7 @@ impl JobProvider for LocalProvider {
             network_policies: None,
             network_policy_refreshes: None,
             connector_runtime_targets: Vec::new(),
+            connector_runtime_candidate_targets: None,
             disallowed_tools: None,
             tools: None,
             settings: None,

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -66,5 +66,5 @@ pub use flush::{
 };
 pub(crate) use managed_process::ManagedMitmdump;
 pub use process::{MitmProxy, ProxyConfig};
-pub(crate) use registry::CustomConnectorRuntimeRegistryState;
+pub(crate) use registry::{ConnectorRuntimeRegistryUpdate, CustomConnectorRuntimeRegistryState};
 pub use registry::{ProxyRegistryHandle, VmRegistration};

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -10,7 +10,8 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::state_file::PROXY_REGISTRY_MAX_BYTES;
 use crate::types::{
-    ConnectorRuntimeTargetRegistration, FirewallEntry, NetworkPolicy, SecretConnectorMetadata,
+    ConnectorRuntimeTarget, ConnectorRuntimeTargetRegistration, FirewallEntry, NetworkPolicy,
+    SecretConnectorMetadata,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -31,6 +32,8 @@ struct VmEntry {
     proxy_log_path: String,
     firewalls: Option<Vec<FirewallEntry>>,
     network_policies: Option<HashMap<String, NetworkPolicy>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    connector_runtime_targets: Vec<ConnectorRuntimeTarget>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     omitted_builtin_firewalls: HashSet<String>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
@@ -155,6 +158,7 @@ pub struct ProxyRegistryHandle {
     pub(super) lock_path: PathBuf,
 }
 
+#[derive(Clone)]
 pub(crate) enum CustomConnectorRuntimeRegistryState {
     Available {
         firewall: FirewallEntry,
@@ -162,6 +166,18 @@ pub(crate) enum CustomConnectorRuntimeRegistryState {
         routing_variables: HashMap<String, String>,
     },
     Absent,
+}
+
+#[derive(Clone)]
+pub(crate) enum ConnectorRuntimeRegistryUpdate {
+    BuiltinAvailable {
+        connector_slug: String,
+        network_policy: NetworkPolicy,
+    },
+    Custom {
+        custom_connector_id: String,
+        state: CustomConnectorRuntimeRegistryState,
+    },
 }
 
 fn firewall_name(entry: &FirewallEntry) -> &str {
@@ -238,6 +254,176 @@ fn replace_first_matching_firewall(
     }
 }
 
+fn apply_custom_connector_runtime_state(
+    vm: &mut VmEntry,
+    custom_connector_id: &str,
+    state: &CustomConnectorRuntimeRegistryState,
+) -> RunnerResult<()> {
+    match state {
+        CustomConnectorRuntimeRegistryState::Available {
+            firewall,
+            network_policy,
+            routing_variables,
+        } => {
+            let FirewallEntry::Inline {
+                firewall: inline_firewall,
+                custom_connector_id: Some(entry_connector_id),
+            } = firewall
+            else {
+                return Err(RunnerError::Internal(format!(
+                    "custom connector runtime result {custom_connector_id} has no connector id"
+                )));
+            };
+            if entry_connector_id != custom_connector_id {
+                return Err(RunnerError::Internal(format!(
+                    "custom connector runtime result {custom_connector_id} has mismatched connector id"
+                )));
+            }
+            let inline_firewall_name = inline_firewall.name.clone();
+
+            let firewalls = vm.firewalls.get_or_insert_with(Vec::new);
+            if firewalls.iter().any(|entry| {
+                firewall_name(entry) == inline_firewall_name
+                    && custom_connector_owner(entry) != Some(custom_connector_id)
+            }) {
+                return Err(RunnerError::Internal(format!(
+                    "custom connector {custom_connector_id} cannot claim firewall {inline_firewall_name} owned by another connector"
+                )));
+            }
+            let removed_firewall_names = firewalls
+                .iter()
+                .filter_map(|entry| {
+                    if let FirewallEntry::Inline {
+                        firewall,
+                        custom_connector_id: Some(existing_connector_id),
+                    } = entry
+                        && existing_connector_id == custom_connector_id
+                    {
+                        Some(firewall.name.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            replace_first_matching_firewall(firewalls, firewall.clone(), |entry| {
+                if let FirewallEntry::Inline {
+                    custom_connector_id: Some(existing_connector_id),
+                    ..
+                } = entry
+                    && existing_connector_id == custom_connector_id
+                {
+                    true
+                } else {
+                    false
+                }
+            });
+            let retained_firewall_names = firewalls
+                .iter()
+                .map(firewall_name)
+                .map(ToOwned::to_owned)
+                .collect::<HashSet<_>>();
+            let network_policies = vm.network_policies.get_or_insert_with(HashMap::new);
+            for firewall_name in removed_firewall_names {
+                if !retained_firewall_names.contains(&firewall_name) {
+                    network_policies.remove(&firewall_name);
+                }
+            }
+            network_policies.insert(inline_firewall_name, (**network_policy).clone());
+            vm.connector_routing_variables.insert(
+                custom_connector_routing_key(custom_connector_id),
+                routing_variables.clone(),
+            );
+            vm.omitted_custom_connector_ids.remove(custom_connector_id);
+        }
+        CustomConnectorRuntimeRegistryState::Absent => {
+            let mut removed_firewall_names = Vec::new();
+            if let Some(firewalls) = vm.firewalls.as_mut() {
+                firewalls.retain(|entry| {
+                    if let FirewallEntry::Inline {
+                        firewall,
+                        custom_connector_id: Some(existing_connector_id),
+                    } = entry
+                        && existing_connector_id == custom_connector_id
+                    {
+                        removed_firewall_names.push(firewall.name.clone());
+                        false
+                    } else {
+                        true
+                    }
+                });
+            }
+            let retained_firewall_names = vm
+                .firewalls
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(firewall_name)
+                .map(ToOwned::to_owned)
+                .collect::<HashSet<_>>();
+            if let Some(network_policies) = vm.network_policies.as_mut() {
+                for firewall_name in removed_firewall_names {
+                    if !retained_firewall_names.contains(&firewall_name) {
+                        network_policies.remove(&firewall_name);
+                    }
+                }
+            }
+            vm.omitted_custom_connector_ids
+                .insert(custom_connector_id.to_string());
+        }
+    }
+    Ok(())
+}
+
+fn apply_connector_runtime_update(
+    vm: &mut VmEntry,
+    update: &ConnectorRuntimeRegistryUpdate,
+) -> RunnerResult<bool> {
+    let target_is_registered =
+        vm.connector_runtime_targets
+            .iter()
+            .any(|target| match (target, update) {
+                (
+                    ConnectorRuntimeTarget::Builtin { connector_slug },
+                    ConnectorRuntimeRegistryUpdate::BuiltinAvailable {
+                        connector_slug: update_slug,
+                        ..
+                    },
+                ) => connector_slug == update_slug,
+                (
+                    ConnectorRuntimeTarget::Custom {
+                        custom_connector_id,
+                    },
+                    ConnectorRuntimeRegistryUpdate::Custom {
+                        custom_connector_id: update_id,
+                        ..
+                    },
+                ) => custom_connector_id == update_id,
+                _ => false,
+            });
+    if !target_is_registered {
+        return Ok(false);
+    }
+
+    match update {
+        ConnectorRuntimeRegistryUpdate::BuiltinAvailable {
+            connector_slug,
+            network_policy,
+        } => {
+            if !vm_has_connector_firewall(vm, connector_slug) {
+                return Ok(false);
+            }
+            vm.network_policies
+                .get_or_insert_with(HashMap::new)
+                .insert(connector_slug.clone(), network_policy.clone());
+        }
+        ConnectorRuntimeRegistryUpdate::Custom {
+            custom_connector_id,
+            state,
+        } => apply_custom_connector_runtime_state(vm, custom_connector_id, state)?,
+    }
+    Ok(true)
+}
+
 fn initial_omitted_connector_runtime_targets(
     registration: &VmRegistration<'_>,
 ) -> (HashSet<String>, HashSet<String>) {
@@ -262,7 +448,7 @@ fn initial_omitted_connector_runtime_targets(
     let mut omitted_custom_connector_ids = HashSet::new();
     for target in registration.connector_runtime_targets.unwrap_or_default() {
         match target {
-            ConnectorRuntimeTargetRegistration::Builtin { connector_slug }
+            ConnectorRuntimeTargetRegistration::Builtin { connector_slug, .. }
                 if !active_builtin_firewalls.contains(connector_slug.as_str()) =>
             {
                 omitted_builtin_firewalls.insert(connector_slug.clone());
@@ -290,7 +476,7 @@ fn initial_connector_routing_variables(
         .unwrap_or_default()
         .iter()
         .filter_map(|target| match target {
-            ConnectorRuntimeTargetRegistration::Builtin { connector_slug } => {
+            ConnectorRuntimeTargetRegistration::Builtin { connector_slug, .. } => {
                 Some(connector_slug.as_str())
             }
             ConnectorRuntimeTargetRegistration::Custom { .. } => None,
@@ -377,6 +563,12 @@ impl ProxyRegistryHandle {
                 proxy_log_path: registration.proxy_log_path.to_string_lossy().into_owned(),
                 firewalls,
                 network_policies: registration.network_policies.cloned(),
+                connector_runtime_targets: registration
+                    .connector_runtime_targets
+                    .unwrap_or_default()
+                    .iter()
+                    .map(ConnectorRuntimeTargetRegistration::target)
+                    .collect(),
                 omitted_builtin_firewalls,
                 omitted_custom_connector_ids,
                 connector_routing_variables,
@@ -411,8 +603,45 @@ impl ProxyRegistryHandle {
         Ok(())
     }
 
-    /// Publish one authoritative custom connector runtime result under the same
-    /// file lock used by VM registration. A stale source IP/run pair is ignored.
+    /// Publish validated Builtin and Custom candidate updates in one registry
+    /// transaction. `None` means the VM disappeared or now belongs to another
+    /// run; otherwise each boolean corresponds to the same-index update.
+    pub(crate) async fn apply_connector_runtime_updates_if_run_matches(
+        &self,
+        source_ip: &str,
+        run_id: &str,
+        updates: &[ConnectorRuntimeRegistryUpdate],
+    ) -> RunnerResult<Option<Vec<bool>>> {
+        let _guard = lock::acquire(self.lock_path.clone()).await?;
+        let mut registry = read_registry(&self.registry_path).await?;
+        let Some(vm) = registry.vms.get_mut(source_ip) else {
+            return Ok(None);
+        };
+        if vm.run_id != run_id {
+            return Ok(None);
+        }
+
+        let outcomes = updates
+            .iter()
+            .map(|update| apply_connector_runtime_update(vm, update))
+            .collect::<RunnerResult<Vec<_>>>()?;
+        if !outcomes.iter().any(|applied| *applied) {
+            return Ok(Some(outcomes));
+        }
+
+        validate_custom_connector_resource_ownership(vm.firewalls.as_deref().unwrap_or_default())?;
+        registry.updated_at = chrono::Utc::now().timestamp_millis();
+        write_registry(&self.registry_path, &registry).await?;
+        info!(
+            source_ip,
+            run_id,
+            update_count = updates.len(),
+            "applied connector runtime updates to proxy registry"
+        );
+        Ok(Some(outcomes))
+    }
+
+    #[cfg(test)]
     pub(crate) async fn replace_custom_connector_runtime_target_if_run_matches(
         &self,
         source_ip: &str,
@@ -420,145 +649,20 @@ impl ProxyRegistryHandle {
         custom_connector_id: &str,
         state: CustomConnectorRuntimeRegistryState,
     ) -> RunnerResult<bool> {
-        let _guard = lock::acquire(self.lock_path.clone()).await?;
-        let mut registry = read_registry(&self.registry_path).await?;
-        let Some(vm) = registry.vms.get_mut(source_ip) else {
-            return Ok(false);
-        };
-        if vm.run_id != run_id {
-            return Ok(false);
-        }
-
-        match state {
-            CustomConnectorRuntimeRegistryState::Available {
-                firewall,
-                network_policy,
-                routing_variables,
-            } => {
-                let FirewallEntry::Inline {
-                    firewall: inline_firewall,
-                    custom_connector_id: Some(entry_connector_id),
-                } = &firewall
-                else {
-                    return Err(RunnerError::Internal(format!(
-                        "custom connector runtime result {} has no connector id",
-                        custom_connector_id
-                    )));
-                };
-                if entry_connector_id != custom_connector_id {
-                    return Err(RunnerError::Internal(format!(
-                        "custom connector runtime result {} has mismatched connector id",
-                        custom_connector_id
-                    )));
-                }
-                let inline_firewall_name = inline_firewall.name.clone();
-
-                let firewalls = vm.firewalls.get_or_insert_with(Vec::new);
-                if firewalls.iter().any(|entry| {
-                    firewall_name(entry) == inline_firewall_name
-                        && custom_connector_owner(entry) != Some(custom_connector_id)
-                }) {
-                    return Err(RunnerError::Internal(format!(
-                        "custom connector {custom_connector_id} cannot claim firewall {inline_firewall_name} owned by another connector"
-                    )));
-                }
-                let removed_firewall_names = firewalls
-                    .iter()
-                    .filter_map(|entry| {
-                        if let FirewallEntry::Inline {
-                            firewall,
-                            custom_connector_id: Some(existing_connector_id),
-                        } = entry
-                            && existing_connector_id == custom_connector_id
-                        {
-                            Some(firewall.name.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                replace_first_matching_firewall(firewalls, firewall, |entry| {
-                    if let FirewallEntry::Inline {
-                        custom_connector_id: Some(existing_connector_id),
-                        ..
-                    } = entry
-                        && existing_connector_id == custom_connector_id
-                    {
-                        true
-                    } else {
-                        false
-                    }
-                });
-                let retained_firewall_names = firewalls
-                    .iter()
-                    .map(firewall_name)
-                    .map(ToOwned::to_owned)
-                    .collect::<HashSet<_>>();
-                let network_policies = vm.network_policies.get_or_insert_with(HashMap::new);
-                for firewall_name in removed_firewall_names {
-                    if !retained_firewall_names.contains(&firewall_name) {
-                        network_policies.remove(&firewall_name);
-                    }
-                }
-                network_policies.insert(inline_firewall_name, *network_policy);
-                vm.connector_routing_variables.insert(
-                    custom_connector_routing_key(custom_connector_id),
-                    routing_variables,
-                );
-                vm.omitted_custom_connector_ids.remove(custom_connector_id);
-            }
-            CustomConnectorRuntimeRegistryState::Absent => {
-                let mut removed_firewall_names = Vec::new();
-                if let Some(firewalls) = vm.firewalls.as_mut() {
-                    firewalls.retain(|entry| {
-                        if let FirewallEntry::Inline {
-                            firewall,
-                            custom_connector_id: Some(existing_connector_id),
-                        } = entry
-                            && existing_connector_id == custom_connector_id
-                        {
-                            removed_firewall_names.push(firewall.name.clone());
-                            false
-                        } else {
-                            true
-                        }
-                    });
-                }
-                let retained_firewall_names = vm
-                    .firewalls
-                    .as_deref()
-                    .unwrap_or_default()
-                    .iter()
-                    .map(firewall_name)
-                    .map(ToOwned::to_owned)
-                    .collect::<HashSet<_>>();
-                if let Some(network_policies) = vm.network_policies.as_mut() {
-                    for firewall_name in removed_firewall_names {
-                        if !retained_firewall_names.contains(&firewall_name) {
-                            network_policies.remove(&firewall_name);
-                        }
-                    }
-                }
-                vm.omitted_custom_connector_ids
-                    .insert(custom_connector_id.to_string());
-            }
-        }
-
-        registry.updated_at = chrono::Utc::now().timestamp_millis();
-        write_registry(&self.registry_path, &registry).await?;
-        info!(
-            source_ip,
-            run_id,
-            custom_connector_id,
-            "replaced custom connector runtime target in proxy registry"
-        );
-        Ok(true)
+        let outcomes = self
+            .apply_connector_runtime_updates_if_run_matches(
+                source_ip,
+                run_id,
+                &[ConnectorRuntimeRegistryUpdate::Custom {
+                    custom_connector_id: custom_connector_id.to_string(),
+                    state,
+                }],
+            )
+            .await?;
+        Ok(outcomes.is_some_and(|outcomes| outcomes == [true]))
     }
 
-    /// Patch one network policy only if the source IP still belongs to `run_id`.
-    ///
-    /// Returns `Ok(false)` when the VM is gone, belongs to another run, or does
-    /// not contain the requested connector firewall.
+    #[cfg(test)]
     pub async fn patch_network_policy_if_run_matches(
         &self,
         source_ip: &str,
@@ -566,8 +670,17 @@ impl ProxyRegistryHandle {
         connector_slug: &str,
         policy: NetworkPolicy,
     ) -> RunnerResult<bool> {
-        self.patch_existing_network_policy(source_ip, run_id, connector_slug, policy)
-            .await
+        let outcomes = self
+            .apply_connector_runtime_updates_if_run_matches(
+                source_ip,
+                run_id,
+                &[ConnectorRuntimeRegistryUpdate::BuiltinAvailable {
+                    connector_slug: connector_slug.to_string(),
+                    network_policy: policy,
+                }],
+            )
+            .await?;
+        Ok(outcomes.is_some_and(|outcomes| outcomes == [true]))
     }
 
     /// Replace one network policy with deny-all if the source IP still belongs
@@ -667,37 +780,6 @@ impl ProxyRegistryHandle {
             run_id,
             connector_slug = connector_slug,
             "failed closed connector network policy in proxy registry"
-        );
-        Ok(true)
-    }
-
-    async fn patch_existing_network_policy(
-        &self,
-        source_ip: &str,
-        run_id: &str,
-        connector_slug: &str,
-        policy: NetworkPolicy,
-    ) -> RunnerResult<bool> {
-        let _guard = lock::acquire(self.lock_path.clone()).await?;
-
-        let mut registry = read_registry(&self.registry_path).await?;
-        let Some(vm) = registry.vms.get_mut(source_ip) else {
-            return Ok(false);
-        };
-        if vm.run_id != run_id || !vm_has_connector_firewall(vm, connector_slug) {
-            return Ok(false);
-        }
-
-        vm.network_policies
-            .get_or_insert_with(HashMap::new)
-            .insert(connector_slug.to_string(), policy);
-        registry.updated_at = chrono::Utc::now().timestamp_millis();
-        write_registry(&self.registry_path, &registry).await?;
-        info!(
-            source_ip,
-            run_id,
-            connector_slug = connector_slug,
-            "patched connector network policy in proxy registry"
         );
         Ok(true)
     }
@@ -827,6 +909,20 @@ mod tests {
             .collect()
     }
 
+    fn builtin_runtime_targets(
+        connector_slugs: &[&str],
+    ) -> Vec<ConnectorRuntimeTargetRegistration> {
+        connector_slugs
+            .iter()
+            .map(
+                |connector_slug| ConnectorRuntimeTargetRegistration::Builtin {
+                    connector_slug: (*connector_slug).to_string(),
+                    base_url_vars: None,
+                },
+            )
+            .collect()
+    }
+
     fn policy(allow: &[&str], deny: &[&str], ask: &[&str], unknown_policy: &str) -> NetworkPolicy {
         NetworkPolicy {
             allow: allow.iter().map(|value| (*value).to_string()).collect(),
@@ -930,6 +1026,7 @@ mod tests {
                 proxy_log_path: "/tmp/proxy-test-run.jsonl".to_string(),
                 firewalls: None,
                 network_policies: None,
+                connector_runtime_targets: Vec::new(),
                 omitted_builtin_firewalls: HashSet::new(),
                 omitted_custom_connector_ids: HashSet::new(),
                 connector_routing_variables: HashMap::new(),
@@ -1133,9 +1230,11 @@ mod tests {
         let targets = vec![
             ConnectorRuntimeTargetRegistration::Builtin {
                 connector_slug: "slack".to_string(),
+                base_url_vars: None,
             },
             ConnectorRuntimeTargetRegistration::Builtin {
                 connector_slug: "github".to_string(),
+                base_url_vars: None,
             },
             ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: available_custom_id.to_string(),
@@ -1180,6 +1279,23 @@ mod tests {
                 ),
                 (format!("custom:{available_custom_id}"), HashMap::new(),),
             ])
+        );
+        assert_eq!(
+            vm.connector_runtime_targets,
+            vec![
+                ConnectorRuntimeTarget::Builtin {
+                    connector_slug: "slack".to_string(),
+                },
+                ConnectorRuntimeTarget::Builtin {
+                    connector_slug: "github".to_string(),
+                },
+                ConnectorRuntimeTarget::Custom {
+                    custom_connector_id: available_custom_id.to_string(),
+                },
+                ConnectorRuntimeTarget::Custom {
+                    custom_connector_id: omitted_custom_id.to_string(),
+                },
+            ]
         );
     }
 
@@ -1244,6 +1360,16 @@ mod tests {
                 policy(&["chat:write"], &[], &[], "allow"),
             ),
         ]);
+        let runtime_targets = vec![
+            ConnectorRuntimeTargetRegistration::Builtin {
+                connector_slug: "slack".to_string(),
+                base_url_vars: None,
+            },
+            ConnectorRuntimeTargetRegistration::Custom {
+                custom_connector_id: custom_connector_id.to_string(),
+                base_url_vars: None,
+            },
+        ];
         harness
             .handle
             .register_vm(
@@ -1251,6 +1377,7 @@ mod tests {
                 &VmRegistration {
                     firewalls: Some(&firewalls),
                     network_policies: Some(&network_policies),
+                    connector_runtime_targets: Some(&runtime_targets),
                     ..base_registration()
                 },
             )
@@ -1260,15 +1387,23 @@ mod tests {
 
         let error = harness
             .handle
-            .replace_custom_connector_runtime_target_if_run_matches(
+            .apply_connector_runtime_updates_if_run_matches(
                 "10.200.0.2",
                 "run-test",
-                custom_connector_id,
-                CustomConnectorRuntimeRegistryState::Available {
-                    firewall: custom_runtime_firewall(custom_connector_id, "slack"),
-                    network_policy: Box::new(policy(&["custom.write"], &[], &[], "deny")),
-                    routing_variables: HashMap::new(),
-                },
+                &[
+                    ConnectorRuntimeRegistryUpdate::BuiltinAvailable {
+                        connector_slug: "slack".to_string(),
+                        network_policy: policy(&[], &["chat:write"], &[], "deny"),
+                    },
+                    ConnectorRuntimeRegistryUpdate::Custom {
+                        custom_connector_id: custom_connector_id.to_string(),
+                        state: CustomConnectorRuntimeRegistryState::Available {
+                            firewall: custom_runtime_firewall(custom_connector_id, "slack"),
+                            network_policy: Box::new(policy(&["custom.write"], &[], &[], "deny")),
+                            routing_variables: HashMap::new(),
+                        },
+                    },
+                ],
             )
             .await
             .expect_err("custom connector must not overwrite builtin resources");
@@ -1310,10 +1445,16 @@ mod tests {
         ]);
         let pinned_routing_variables =
             HashMap::from([("subdomain".to_string(), "pinned".to_string())]);
-        let runtime_targets = vec![ConnectorRuntimeTargetRegistration::Custom {
-            custom_connector_id: custom_connector_id.to_string(),
-            base_url_vars: Some(pinned_routing_variables.clone()),
-        }];
+        let runtime_targets = vec![
+            ConnectorRuntimeTargetRegistration::Builtin {
+                connector_slug: "slack".to_string(),
+                base_url_vars: None,
+            },
+            ConnectorRuntimeTargetRegistration::Custom {
+                custom_connector_id: custom_connector_id.to_string(),
+                base_url_vars: Some(pinned_routing_variables.clone()),
+            },
+        ];
         harness
             .handle
             .register_vm(
@@ -1329,17 +1470,26 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
+        assert_eq!(
             harness
                 .handle
-                .replace_custom_connector_runtime_target_if_run_matches(
+                .apply_connector_runtime_updates_if_run_matches(
                     "10.200.0.2",
                     "run-test",
-                    custom_connector_id,
-                    CustomConnectorRuntimeRegistryState::Absent,
+                    &[
+                        ConnectorRuntimeRegistryUpdate::BuiltinAvailable {
+                            connector_slug: "slack".to_string(),
+                            network_policy: policy(&[], &["chat:write"], &[], "deny"),
+                        },
+                        ConnectorRuntimeRegistryUpdate::Custom {
+                            custom_connector_id: custom_connector_id.to_string(),
+                            state: CustomConnectorRuntimeRegistryState::Absent,
+                        },
+                    ],
                 )
                 .await
-                .unwrap()
+                .unwrap(),
+            Some(vec![true, true])
         );
         let absent = read_registry(harness.registry_path()).await.unwrap();
         let absent_vm = &absent.vms["10.200.0.2"];
@@ -1367,6 +1517,11 @@ mod tests {
                 .unwrap()
                 .contains_key("slack")
         );
+        let slack_policy = &absent_vm.network_policies.as_ref().unwrap()["slack"];
+        assert!(slack_policy.allow.is_empty());
+        assert_eq!(slack_policy.deny, ["chat:write"]);
+        assert!(slack_policy.ask.is_empty());
+        assert_eq!(slack_policy.unknown_policy, "deny");
         assert_eq!(
             absent_vm.connector_routing_variables
                 [&custom_connector_routing_key(custom_connector_id)],
@@ -1507,11 +1662,13 @@ mod tests {
             ("github".to_string(), initial_policy.clone()),
             ("slack".to_string(), initial_policy),
         ]);
+        let runtime_targets = builtin_runtime_targets(&["github", "slack"]);
         let empty_padding = HashMap::from([("PADDING".to_string(), String::new())]);
         let measured = VmRegistration {
             run_id: "run-near-limit",
             firewalls: Some(&firewalls),
             network_policies: Some(&network_policies),
+            connector_runtime_targets: Some(&runtime_targets),
             vars: Some(&empty_padding),
             ..base_registration()
         };
@@ -1555,6 +1712,7 @@ mod tests {
             run_id: "run-near-limit",
             firewalls: Some(&firewalls),
             network_policies: Some(&network_policies),
+            connector_runtime_targets: Some(&runtime_targets),
             vars: Some(&padding),
             ..base_registration()
         };
@@ -1626,10 +1784,12 @@ mod tests {
             "github".to_string(),
             policy(&["repos.read"], &[], &[], "ask"),
         );
+        let runtime_targets = builtin_runtime_targets(&["github"]);
         let registration = VmRegistration {
             run_id: "run-1",
             firewalls: Some(&firewalls),
             network_policies: Some(&network_policies),
+            connector_runtime_targets: Some(&runtime_targets),
             ..base_registration()
         };
         harness

--- a/crates/runner/src/test_fixtures/execution_context.rs
+++ b/crates/runner/src/test_fixtures/execution_context.rs
@@ -26,6 +26,7 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
         network_policies: None,
         network_policy_refreshes: None,
         connector_runtime_targets: Vec::new(),
+        connector_runtime_candidate_targets: None,
         disallowed_tools: None,
         tools: None,
         settings: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -130,6 +130,10 @@ pub struct ExecutionContext {
     #[serde(default)]
     pub network_policy_refreshes: Option<std::collections::HashMap<String, NetworkPolicyRefresh>>,
     pub connector_runtime_targets: Vec<ConnectorRuntimeTargetRegistration>,
+    /// Complete target membership written by candidate-aware APIs. During
+    /// rollout, connector_runtime_targets remains the previous runner view.
+    #[serde(default)]
+    pub connector_runtime_candidate_targets: Option<Vec<ConnectorRuntimeTargetRegistration>>,
     #[serde(default)]
     pub disallowed_tools: Option<Vec<String>>,
     #[serde(default)]
@@ -1343,13 +1347,17 @@ pub enum ConnectorRuntimeTarget {
 }
 
 /// Stable connector identity plus run-pinned metadata used at registration and
-/// in runtime synchronization requests. Metadata never participates in target
-/// equality, result correlation, or realtime notification routing.
+/// in runtime synchronization requests. Metadata never participates in the
+/// derived target identity, result correlation, or realtime notification routing.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum ConnectorRuntimeTargetRegistration {
     #[serde(rename_all = "camelCase")]
-    Builtin { connector_slug: String },
+    Builtin {
+        connector_slug: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url_vars: Option<HashMap<String, String>>,
+    },
     #[serde(rename_all = "camelCase")]
     Custom {
         custom_connector_id: String,
@@ -1361,7 +1369,7 @@ pub enum ConnectorRuntimeTargetRegistration {
 impl ConnectorRuntimeTargetRegistration {
     pub(crate) fn target(&self) -> ConnectorRuntimeTarget {
         match self {
-            Self::Builtin { connector_slug } => ConnectorRuntimeTarget::Builtin {
+            Self::Builtin { connector_slug, .. } => ConnectorRuntimeTarget::Builtin {
                 connector_slug: connector_slug.clone(),
             },
             Self::Custom {
@@ -1384,7 +1392,10 @@ impl ConnectorRuntimeTargetRegistration {
 impl From<ConnectorRuntimeTarget> for ConnectorRuntimeTargetRegistration {
     fn from(target: ConnectorRuntimeTarget) -> Self {
         match target {
-            ConnectorRuntimeTarget::Builtin { connector_slug } => Self::Builtin { connector_slug },
+            ConnectorRuntimeTarget::Builtin { connector_slug } => Self::Builtin {
+                connector_slug,
+                base_url_vars: None,
+            },
             ConnectorRuntimeTarget::Custom {
                 custom_connector_id,
             } => Self::Custom {
@@ -1960,6 +1971,46 @@ mod tests {
         assert_eq!(snapshot.entries[0].version_id, "version-1");
         let serialized = serde_json::to_string(snapshot).unwrap();
         assert!(!serialized.contains("url"));
+    }
+
+    #[test]
+    fn execution_context_preserves_optional_connector_candidate_targets() {
+        let mut json = serde_json::json!({
+            "runId": "11111111-1111-4111-8111-111111111111",
+            "prompt": "hello",
+            "sandboxToken": "tok",
+            "cliAgentType": "claude-code",
+            "connectorRuntimeTargets": [],
+            "connectorRuntimeCandidateTargets": [{
+                "kind": "builtin",
+                "connectorSlug": "zendesk",
+                "baseUrlVars": {
+                    "ZENDESK_SUBDOMAIN": "xn--mnich-kva"
+                }
+            }]
+        });
+
+        let context: ExecutionContext = serde_json::from_value(json.clone()).unwrap();
+        let candidate = context
+            .connector_runtime_candidate_targets
+            .as_deref()
+            .and_then(|targets| targets.first())
+            .expect("candidate target should be preserved");
+        assert!(matches!(
+            candidate,
+            ConnectorRuntimeTargetRegistration::Builtin {
+                connector_slug,
+                base_url_vars: Some(base_url_vars),
+            } if connector_slug == "zendesk"
+                && base_url_vars.get("ZENDESK_SUBDOMAIN")
+                    .is_some_and(|value| value == "xn--mnich-kva")
+        ));
+
+        json.as_object_mut()
+            .unwrap()
+            .remove("connectorRuntimeCandidateTargets");
+        let legacy: ExecutionContext = serde_json::from_value(json).unwrap();
+        assert!(legacy.connector_runtime_candidate_targets.is_none());
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -273,6 +273,7 @@ export async function mutateRunnerJobConnectorPermissionBaseline(
   context: TestContext,
   runId: string,
   mode:
+    | "legacy-targets"
     | "remove"
     | "malformed"
     | "capability-mismatch"

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8152,7 +8152,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
 });
 
 describe("RUN-02: custom connectors, grants, and network policies", () => {
-  it("lets an enabled custom connector override a connected built-in connector", async () => {
+  it("keeps overlapping connector candidates behind the legacy runner view", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -8196,7 +8196,21 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         base: "https://api.figma.com/",
       },
     ]);
-    expect(claim.networkPolicies ?? {}).not.toHaveProperty("figma");
+    expect(claim.connectorRuntimeTargets).not.toContainEqual({
+      kind: "builtin",
+      connectorSlug: "figma",
+    });
+    expect(claim.connectorRuntimeCandidateTargets).toContainEqual({
+      kind: "builtin",
+      connectorSlug: "figma",
+    });
+    expect(claim.connectorRuntimeCandidateTargets).toContainEqual(
+      expect.objectContaining({
+        kind: "custom",
+        customConnectorId: custom.id,
+      }),
+    );
+    expect(claim.networkPolicies).toHaveProperty("figma");
     expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("allow");
 
     await api.requestCancelRun(actor, run.runId, [200]);
@@ -8251,6 +8265,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         base: "https://api.figma.com/v1/files/",
       },
     ]);
+    expect(claim.connectorRuntimeTargets).toContainEqual({
+      kind: "builtin",
+      connectorSlug: "figma",
+    });
+    expect(claim.connectorRuntimeCandidateTargets).toContainEqual({
+      kind: "builtin",
+      connectorSlug: "figma",
+    });
 
     await api.requestCancelRun(actor, run.runId, [200]);
     expect((await api.readRun(actor, run.runId)).status).toBe("cancelled");
@@ -10369,6 +10391,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(findFirewallEntry(claim.firewalls, "zendesk")).toStrictEqual({
       kind: "builtin",
       name: "zendesk",
+      baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
+    });
+    expect(claim.connectorRuntimeCandidateTargets).toContainEqual({
+      kind: "builtin",
+      connectorSlug: "zendesk",
       baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
     });
     expect(customApis[0]?.base).toBe("https://internal.example.com/api/");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10537,6 +10537,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     const cases = [
       {
+        mode: "legacy-targets",
+        path: "baseline",
+      },
+      {
         mode: "remove",
         path: "full_missing_baseline",
       },
@@ -10588,6 +10592,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expectClaimRouteResponseTimingActions({
         runId: run.runId,
         expectedActionTypes:
+          fallbackCase.mode === "legacy-targets" ||
           fallbackCase.mode === "catalog-mismatch"
             ? [
                 "claim_route_response_network_policy_refresh",

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1398,12 +1398,16 @@ function connectorPermissionBaselineMatchesStoredContext(
 ): boolean {
   const baselineConnectorSlugs = Object.keys(baseline.connectors);
   const storedBuiltinConnectorSlugs = new Set(
-    (storedContext.firewalls ?? []).flatMap((firewall) => {
-      return firewall.kind === "builtin" &&
-        connectorSlugSchema.safeParse(firewall.name).success
-        ? [firewall.name]
-        : [];
-    }),
+    storedContext.connectorRuntimeCandidateTargets === undefined
+      ? (storedContext.firewalls ?? []).flatMap((firewall) => {
+          return firewall.kind === "builtin" &&
+            connectorSlugSchema.safeParse(firewall.name).success
+            ? [firewall.name]
+            : [];
+        })
+      : storedContext.connectorRuntimeCandidateTargets.flatMap((target) => {
+          return target.kind === "builtin" ? [target.connectorSlug] : [];
+        }),
   );
   const storedNetworkPolicies = storedContext.networkPolicies ?? {};
   return (

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -554,6 +554,10 @@ async function mutateRunnerJobConnectorPermissionBaseline(
 ): Promise<void> {
   let executionContext: SQL;
   switch (body.mode) {
+    case "legacy-targets": {
+      executionContext = sql`${runnerJobQueue.executionContext} - 'connectorRuntimeCandidateTargets'`;
+      break;
+    }
     case "remove": {
       executionContext = sql`${runnerJobQueue.executionContext} - 'connectorPermissionBaseline'`;
       break;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -734,9 +734,16 @@ interface ResolvedModelProviderEnvironment {
   readonly codexRuntimeConfig?: ModelProviderCodexRuntimeConfig;
 }
 
+type BuiltinRuntimeTargetRegistration = Extract<
+  ConnectorRuntimeTargetRegistration,
+  { readonly kind: "builtin" }
+>;
+
 interface PermissionManifest {
   readonly firewalls: ExecutionFirewalls;
   readonly networkPolicies: NetworkPolicies;
+  readonly builtinRuntimeTargets?: readonly BuiltinRuntimeTargetRegistration[];
+  readonly builtinRuntimeCandidateTargets?: readonly BuiltinRuntimeTargetRegistration[];
   readonly connectorPermissionBaseline?: StoredConnectorPermissionBaseline;
   readonly environmentSecretPlaceholders:
     | Readonly<Record<string, string>>
@@ -5011,6 +5018,80 @@ function applyBuiltinConnectorMetadataPolicies(
   };
 }
 
+function builtinRuntimeTargetRegistration(
+  firewall: ExecutionFirewallEntry,
+): BuiltinRuntimeTargetRegistration {
+  if (firewall.kind !== "builtin") {
+    throw new Error("Builtin connector manifest contains an inline firewall");
+  }
+  return {
+    kind: "builtin",
+    connectorSlug: connectorSlugSchema.parse(firewall.name),
+    ...(firewall.baseUrlVars === undefined
+      ? {}
+      : { baseUrlVars: { ...firewall.baseUrlVars } }),
+  };
+}
+
+function mergePermissionManifests(args: {
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly builtinSources: readonly BuiltinConnectorManifestSource[];
+  readonly connectorManifest: PermissionManifest;
+  readonly customConnectorManifest: Pick<
+    PermissionManifest,
+    "firewalls" | "networkPolicies"
+  >;
+  readonly providerManifest: PermissionManifest | undefined;
+  readonly customConnectorFirewalls: readonly ExpandedFirewallConfig[];
+  readonly legacyBuiltinConnectorSlugs: ReadonlySet<ConnectorSlug>;
+}): PermissionManifest | undefined {
+  const builtinRuntimeCandidateTargets = args.connectorManifest.firewalls.map(
+    builtinRuntimeTargetRegistration,
+  );
+  const firewalls = [
+    ...(args.providerManifest?.firewalls ?? []),
+    ...args.connectorManifest.firewalls.filter((firewall) => {
+      return (
+        firewall.kind !== "builtin" ||
+        args.legacyBuiltinConnectorSlugs.has(
+          connectorSlugSchema.parse(firewall.name),
+        )
+      );
+    }),
+    ...args.customConnectorManifest.firewalls,
+  ];
+
+  if (firewalls.length === 0) {
+    return undefined;
+  }
+
+  return {
+    firewalls,
+    builtinRuntimeTargets: builtinRuntimeCandidateTargets.filter((target) => {
+      return args.legacyBuiltinConnectorSlugs.has(target.connectorSlug);
+    }),
+    builtinRuntimeCandidateTargets,
+    connectorPermissionBaseline: buildConnectorPermissionBaseline(
+      args.connectorCatalogSnapshot,
+      args.builtinSources,
+    ),
+    environmentSecretPlaceholders: mergeRecords(
+      args.providerManifest?.environmentSecretPlaceholders,
+      args.connectorManifest.environmentSecretPlaceholders,
+      firewallSecretPlaceholdersFromFirewalls(args.customConnectorFirewalls),
+    ),
+    billableFirewalls: [
+      ...(args.providerManifest?.billableFirewalls ?? []),
+      ...args.connectorManifest.billableFirewalls,
+    ],
+    networkPolicies: {
+      ...args.providerManifest?.networkPolicies,
+      ...args.connectorManifest.networkPolicies,
+      ...args.customConnectorManifest.networkPolicies,
+    },
+  };
+}
+
 interface BuildPermissionManifestArgs {
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
@@ -5034,18 +5115,21 @@ async function buildPermissionManifest(
     });
   const connectorBaseUrlVars = mergeRecords(args.vars, args.connectorVars);
   const customConnectorFirewalls = args.customConnectorFirewalls ?? [];
-  // Narrower custom bases already win by base specificity. Remove a built-in
-  // only when a custom base covers it, which avoids equal/broader ambiguity.
   const builtinConnectorSlugs = connectorSlugs.filter((connectorSlug) => {
-    return (
-      args.connectorCatalogSnapshot.serverFirewalls.has(connectorSlug) &&
-      !builtinConnectorOverriddenByCustomFirewalls({
+    return args.connectorCatalogSnapshot.serverFirewalls.has(connectorSlug);
+  });
+  // Previous runners cannot reconcile overlapping candidates. Keep their
+  // firewall and target view filtered until that runner generation drains;
+  // candidate-aware runners receive the complete membership separately.
+  const legacyBuiltinConnectorSlugs = new Set(
+    builtinConnectorSlugs.filter((connectorSlug) => {
+      return !builtinConnectorOverriddenByCustomFirewalls({
         snapshot: args.connectorCatalogSnapshot,
         connectorSlug,
         customFirewalls: customConnectorFirewalls,
-      })
-    );
-  });
+      });
+    }),
+  );
 
   const builtinSources = await measureApiDispatchTiming(
     args.timing,
@@ -5123,37 +5207,17 @@ async function buildPermissionManifest(
     "api_dispatch_prepare_context_merge_permission_manifest",
     "nested",
     () => {
-      const firewalls = [
-        ...(providerManifest?.firewalls ?? []),
-        ...connectorManifest.firewalls,
-        ...customConnectorManifest.firewalls,
-      ];
-
-      if (firewalls.length === 0) {
-        return Promise.resolve(undefined);
-      }
-
-      return Promise.resolve({
-        firewalls,
-        connectorPermissionBaseline: buildConnectorPermissionBaseline(
-          args.connectorCatalogSnapshot,
+      return Promise.resolve(
+        mergePermissionManifests({
+          connectorCatalogSnapshot: args.connectorCatalogSnapshot,
           builtinSources,
-        ),
-        environmentSecretPlaceholders: mergeRecords(
-          providerManifest?.environmentSecretPlaceholders,
-          connectorManifest.environmentSecretPlaceholders,
-          firewallSecretPlaceholdersFromFirewalls(customConnectorFirewalls),
-        ),
-        billableFirewalls: [
-          ...(providerManifest?.billableFirewalls ?? []),
-          ...connectorManifest.billableFirewalls,
-        ],
-        networkPolicies: {
-          ...providerManifest?.networkPolicies,
-          ...connectorManifest.networkPolicies,
-          ...customConnectorManifest.networkPolicies,
-        },
-      });
+          connectorManifest,
+          customConnectorManifest,
+          providerManifest,
+          customConnectorFirewalls,
+          legacyBuiltinConnectorSlugs,
+        }),
+      );
     },
   );
 }
@@ -5840,21 +5904,23 @@ async function insertLaunchRunRows(
   return { createdAt };
 }
 
-function storedConnectorRuntimeTargets(args: {
+function storedConnectorRuntimeTargetViews(args: {
   readonly permissionManifest: PermissionManifest | undefined;
   readonly customTargets: readonly ConnectorRuntimeTargetRegistration[];
-}): ConnectorRuntimeTargetRegistration[] {
-  const builtinTargets = Object.keys(
-    args.permissionManifest?.connectorPermissionBaseline?.connectors ?? {},
-  )
-    .sort()
-    .map((connectorSlug) => {
-      return {
-        kind: "builtin" as const,
-        connectorSlug: connectorSlugSchema.parse(connectorSlug),
-      };
-    });
-  return [...builtinTargets, ...args.customTargets];
+}): {
+  readonly legacy: ConnectorRuntimeTargetRegistration[];
+  readonly candidates: ConnectorRuntimeTargetRegistration[];
+} {
+  return {
+    legacy: [
+      ...(args.permissionManifest?.builtinRuntimeTargets ?? []),
+      ...args.customTargets,
+    ],
+    candidates: [
+      ...(args.permissionManifest?.builtinRuntimeCandidateTargets ?? []),
+      ...args.customTargets,
+    ],
+  };
 }
 
 async function buildStoredExecutionContextDraft(args: {
@@ -5890,13 +5956,13 @@ async function buildStoredExecutionContextDraft(args: {
   const secretValues = executionSecrets.secrets
     ? Object.values(executionSecrets.secrets)
     : [];
-  const connectorRuntimeTargets = storedConnectorRuntimeTargets({
+  const connectorRuntimeTargets = storedConnectorRuntimeTargetViews({
     permissionManifest: permissions,
     customTargets: args.customConnectorContext.targets,
   });
   const customConnectorIds = [
     ...new Set(
-      connectorRuntimeTargets.flatMap((target) => {
+      connectorRuntimeTargets.candidates.flatMap((target) => {
         return target.kind === "custom" ? [target.customConnectorId] : [];
       }),
     ),
@@ -5946,7 +6012,8 @@ async function buildStoredExecutionContextDraft(args: {
       userTimezone: args.userTimezone,
       firewalls: permissions?.firewalls,
       networkPolicies: permissions?.networkPolicies,
-      connectorRuntimeTargets,
+      connectorRuntimeTargets: connectorRuntimeTargets.legacy,
+      connectorRuntimeCandidateTargets: connectorRuntimeTargets.candidates,
       connectorPermissionBaseline: permissions?.connectorPermissionBaseline,
       disallowedTools: args.body.disallowedTools,
       tools: args.body.tools,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -324,6 +324,33 @@ describe("connector runtime synchronization contract", () => {
     ).toBe(true);
   });
 
+  it("preserves complete candidate targets and pinned built-in routing values", () => {
+    const fixture = executionContextSchema.parse(
+      loadRunnerClaimResponseFixture(),
+    );
+    const candidateTarget = {
+      kind: "builtin" as const,
+      connectorSlug: "zendesk",
+      baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
+    };
+
+    const execution = executionContextSchema.parse({
+      ...fixture,
+      connectorRuntimeTargets: [],
+      connectorRuntimeCandidateTargets: [candidateTarget],
+    });
+    const legacy = executionContextSchema.parse({
+      ...fixture,
+      connectorRuntimeTargets: [],
+    });
+
+    expect(execution.connectorRuntimeTargets).toEqual([]);
+    expect(execution.connectorRuntimeCandidateTargets).toEqual([
+      candidateTarget,
+    ]);
+    expect(legacy.connectorRuntimeCandidateTargets).toBeUndefined();
+  });
+
   it("requires stable API identities on available custom firewalls", () => {
     const result = {
       target: { kind: "custom" as const, customConnectorId },

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -198,10 +198,15 @@ export const connectorRuntimeCustomTargetRegistrationSchema =
     baseUrlVars: z.record(z.string(), z.string()).optional(),
   });
 
+export const connectorRuntimeBuiltinTargetRegistrationSchema =
+  connectorRuntimeBuiltinTargetSchema.extend({
+    baseUrlVars: z.record(z.string(), z.string()).optional(),
+  });
+
 export const connectorRuntimeTargetRegistrationSchema = z.discriminatedUnion(
   "kind",
   [
-    connectorRuntimeBuiltinTargetSchema,
+    connectorRuntimeBuiltinTargetRegistrationSchema,
     connectorRuntimeCustomTargetRegistrationSchema,
   ],
 );
@@ -834,6 +839,10 @@ const storedExecutionContextObjectSchema = z.object({
   // Stable connector targets pinned for this run. The runner owns this list
   // after claim independently of whether each target is currently available.
   connectorRuntimeTargets: connectorRuntimeTargetsSchema,
+  // Complete target membership for candidate-aware runners. During rollout,
+  // connectorRuntimeTargets remains the filtered compatibility view consumed
+  // by previous runners. Remove this field after that runner generation drains.
+  connectorRuntimeCandidateTargets: connectorRuntimeTargetsSchema.optional(),
   // API-only catalog-derived permission defaults for claim-time grant refresh.
   connectorPermissionBaseline:
     storedConnectorPermissionBaselineSchema.optional(),
@@ -936,6 +945,9 @@ const executionContextObjectSchema = z.object({
   // Stable connector targets pinned for this run. The runner owns this list
   // after claim independently of whether each target is currently available.
   connectorRuntimeTargets: connectorRuntimeTargetsSchema,
+  // Complete target membership for candidate-aware runners. Missing means the
+  // filtered connectorRuntimeTargets list is authoritative.
+  connectorRuntimeCandidateTargets: connectorRuntimeTargetsSchema.optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -75,6 +75,7 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     action: z.literal("mutate-runner-job-connector-permission-baseline"),
     run_id: z.uuid(),
     mode: z.enum([
+      "legacy-targets",
       "remove",
       "malformed",
       "capability-mismatch",


### PR DESCRIPTION
## Summary

- preserve every admitted Builtin and Custom connector as a runtime candidate while retaining the filtered legacy runner view during rollout
- normalize old and new execution contexts in the runner, publish validated Builtin/Custom runtime changes through one atomic registry batch, and retain last-known-good retry behavior
- resolve Custom-versus-Builtin ownership per matching API route in the mitm addon, without changing neutral or same-tier ambiguity behavior
- cover overlap, partial multi-API ownership, dynamic widen/narrow/delete/restore, billing, stale-auth revalidation, registration conflicts, and the old/new API-runner deployment matrix

## Compatibility and exclusions

- The execution-context change is additive and requires no relational database migration.
- Old runners continue to consume filtered `firewalls` and `connectorRuntimeTargets`; new runners prefer `connectorRuntimeCandidateTargets` and fall back when it is absent.
- Runner and mitm addon ship together, so the private candidate marker has no independent deployment boundary.
- Cleanup of the temporary rollout field and legacy projection is intentionally deferred to #26185, after the new runner is fully deployed and older runners have drained.

## Validation

- `scripts/prepare.sh`
- `cd turbo && pnpm format`
- API/contracts lint and type checks
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run` (553 passed on current head)
- affected connector plus intersecting MCP admission scenarios in `run-lifecycle.bdd.test.ts` (4 passed on current head)
- legacy queued-context claim through the API/database integration path (1 passed on current head)
- `cd turbo && pnpm knip`
- runner formatting, Clippy, and documentation checks
- runner registry tests (22 passed), runtime-sync tests (40 passed), and proxy-registration tests (2 passed) on current head
- mitm-addon uv lock/sync, Ruff, basedpyright, and full pytest suite (5,234 passed); the three affected files also passed all 43 tests after rebase

Before the final rebase, the full local API suite reached 2,862/2,864 passing; the two failures were pre-existing dev-seed `vm0_api_keys` uniqueness conflicts in `chat-events.bdd.test.ts`, while all affected connector scenarios passed. Two full high-concurrency runner-suite attempts also exposed different existing timing/port/cache flakes; every reported failure passed immediately in isolation, and all affected runner modules passed.

Closes #26077

Parent objective: #25312
