### PR TITLE
fix(chat): canonicalize automation-tagged goal rows in backfill

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
@@ -121,7 +121,7 @@ describe("chat event row reader union", () => {
     expect(owned.runId).toBe(target);
   });
 
-  it("completes compatible goal context pointers from runGroupId", () => {
+  it("adopts the canonical goal context on goal-grouped rows", () => {
     const goalId = "00000000-0000-4000-8000-000000000011";
     const grouped = canonicalChatEventRow(v3Row({ runGroupId: goalId }));
     expect(grouped.contextType).toBe("goal");
@@ -138,6 +138,35 @@ describe("chat event row reader union", () => {
     );
     expect(goalInput.contextType).toBe("goal");
     expect(goalInput.contextId).toBe(goalId);
+
+    // Historical goal continuations tagged with a bare automation source keep
+    // their goal grouping: the goal pointer replaces the source tag exactly as
+    // the dual-writer does.
+    const automationTagged = canonicalChatEventRow(
+      v3Row({
+        eventType: "input.prompt",
+        runGroupId: goalId,
+        contextType: "automation",
+        contextId: null,
+        userMessage: { version: 1, parts: [] },
+      }),
+    );
+    expect(automationTagged.contextType).toBe("goal");
+    expect(automationTagged.contextId).toBe(goalId);
+
+    // A goal pointer naming a different goal id is a genuine conflict and is
+    // preserved as-is.
+    const conflictingGoal = canonicalChatEventRow(
+      v3Row({
+        runGroupId: goalId,
+        contextType: "goal",
+        contextId: "00000000-0000-4000-8000-000000000013",
+      }),
+    );
+    expect(conflictingGoal.contextType).toBe("goal");
+    expect(conflictingGoal.contextId).toBe(
+      "00000000-0000-4000-8000-000000000013",
+    );
 
     const foreignContext = canonicalChatEventRow(
       v3Row({
@@ -191,6 +220,26 @@ describe("canonical row projection keeps the v3 ChatEvent shape", () => {
     expect(projected).toMatchObject({
       eventType: "output.message",
       content: "goal result",
+      runGroupId: goalId,
+    });
+
+    // The historical automation-tagged goal continuation keeps its grouping
+    // through normalization, matching the legacy runGroupId projection.
+    const automationPrompt = chatEventFromRow(
+      canonicalChatEventRow(
+        v3Row({
+          eventType: "input.prompt",
+          runGroupId: goalId,
+          contextType: "automation",
+          userMessage: {
+            version: 1,
+            parts: [{ type: "text", text: "goal continuation" }],
+          },
+        }),
+      ),
+    );
+    expect(automationPrompt).toMatchObject({
+      eventType: "input.prompt",
       runGroupId: goalId,
     });
   });

--- a/turbo/packages/api-contracts/src/contracts/chat-event-rows.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-event-rows.ts
@@ -113,8 +113,10 @@ function canonicalChatEventRowPayload(
  * Normalize one raw row from either generation into the canonical model.
  * The v3 mapping mirrors the server-side backfill exactly: payload from every
  * non-null legacy leaf, interrupts_run_id as the canonical runId of a
- * control.interrupt row that has none, and goal context pointers completed
- * from runGroupId only when the existing context is compatible.
+ * control.interrupt row that has none, and the canonical
+ * ('goal', runGroupId) pointer replacing any non-goal source tag on a
+ * goal-grouped row, exactly as the dual-writer does. Only a goal pointer
+ * naming a different goal id is preserved as-is.
  */
 export function canonicalChatEventRow(
   row: ChatEventRow | ChatEventRowV4,
@@ -124,8 +126,9 @@ export function canonicalChatEventRow(
   }
   const goalContext =
     row.runGroupId !== null &&
-    (row.contextType === null ||
-      (row.contextType === "goal" && row.contextId === null))
+    (row.contextType !== "goal" ||
+      row.contextId === null ||
+      row.contextId === row.runGroupId)
       ? { contextType: "goal", contextId: row.runGroupId }
       : { contextType: row.contextType, contextId: row.contextId };
   return {

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -5502,6 +5502,7 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
     missingGoalId: "00000000-0000-4000-8000-000000088636",
     duplicateProbeEventId: "00000000-0000-4000-8000-000000088637",
     conflictContextId: "00000000-0000-4000-8000-000000088638",
+    automationTaggedEventId: "00000000-0000-4000-8000-000000088639",
   } as const;
   const nestedNullUserMessage = JSON.stringify({
     version: 1,
@@ -5631,7 +5632,9 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
             ($20, $14, NULL, NULL, NULL, $19, 'input.goal', NULL, 'goal', NULL,
               NULL, $17::jsonb, NULL, NULL, 11),
             ($21, $15, NULL, NULL, NULL, $22, 'output.message', NULL, NULL, NULL,
-              'dangling goal result', NULL, NULL, NULL, 1)
+              'dangling goal result', NULL, NULL, NULL, 1),
+            ($23, $14, NULL, NULL, NULL, $19, 'input.prompt', NULL, 'automation', NULL,
+              NULL, $16::jsonb, NULL, NULL, 13)
         `,
         [
           fixture.multiLeafEventId,
@@ -5656,6 +5659,7 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
           fixture.goalInputEventId,
           fixture.goalDanglingEventId,
           fixture.goalBId,
+          fixture.automationTaggedEventId,
         ],
       );
       // A row the dual-write release already stored canonically must survive
@@ -5734,7 +5738,7 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
             "id", "chat_thread_id", "run_group_id", "event_type", "context_type",
             "context_id", "content", "seq_id"
           )
-          VALUES ($1, $2, $3, 'output.message', 'teams', $4, 'conflicting context', 20)
+          VALUES ($1, $2, $3, 'output.message', 'goal', $4, 'conflicting goal id', 20)
         `,
         [
           fixture.conflictContextEventId,
@@ -5745,7 +5749,7 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
       );
       await assert.rejects(
         applyMigrationsUpToTag(client, CANONICAL_CHAT_EVENT_STORAGE_MIGRATION),
-        /goal-grouped rows whose context conflicts with run_group_id/u,
+        /goal-grouped rows whose goal context_id conflicts with run_group_id/u,
       );
       await client.query(`DELETE FROM "chat_events" WHERE "id" = $1`, [
         fixture.conflictContextEventId,
@@ -5857,6 +5861,7 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
             fixture.goalOutputEventId,
             fixture.goalInputEventId,
             fixture.goalDanglingEventId,
+            fixture.automationTaggedEventId,
             fixture.concurrentInsertEventId,
           ],
         ],
@@ -5944,6 +5949,17 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
         runGroupId: fixture.goalBId,
         contextType: "goal",
         contextId: fixture.goalBId,
+      });
+      // The production shape behind the 0886 smoke abort: an automation-tagged
+      // goal continuation adopts the canonical goal pointer.
+      assert.deepEqual(canonicalRow(fixture.automationTaggedEventId), {
+        id: fixture.automationTaggedEventId,
+        payload: { userMessage: JSON.parse(nestedNullUserMessage) },
+        runId: null,
+        interruptsRunId: null,
+        runGroupId: fixture.goalAId,
+        contextType: "goal",
+        contextId: fixture.goalAId,
       });
       assert.deepEqual(canonicalRow(fixture.concurrentInsertEventId).payload, {
         content: "concurrent dual write",

--- a/turbo/packages/db/src/migrations/0886_backfill_canonical_chat_event_storage.sql
+++ b/turbo/packages/db/src/migrations/0886_backfill_canonical_chat_event_storage.sql
@@ -28,9 +28,14 @@ END;
 $$;--> statement-breakpoint
 
 -- Fail before touching any data when the legacy and canonical columns
--- disagree. The backfill only fills canonical values that are still NULL; a
--- populated value that contradicts its legacy source has no deterministic
--- resolution and must abort instead of guessing.
+-- genuinely disagree. A control.interrupt whose run_id contradicts
+-- interrupts_run_id, two different goal ids on one row, or a zero_run whose
+-- goal_id contradicts run_group_id have no deterministic resolution and must
+-- abort instead of guessing. A non-goal source tag on a goal-grouped row is
+-- NOT a conflict: the dual-writer replaces the display context with the
+-- canonical goal pointer whenever run_group_id is present, and production
+-- holds 18,300 historical input.prompt rows tagged ('automation', NULL) that
+-- canonicalize the same way.
 DO $$
 DECLARE
   conflict_count bigint;
@@ -52,13 +57,12 @@ BEGIN
   INTO conflict_count
   FROM "chat_events"
   WHERE "run_group_id" IS NOT NULL
-    AND (
-      ("context_type" IS NOT NULL AND "context_type" <> 'goal')
-      OR ("context_id" IS NOT NULL AND "context_id" <> "run_group_id")
-    );
+    AND "context_type" = 'goal'
+    AND "context_id" IS NOT NULL
+    AND "context_id" <> "run_group_id";
   IF conflict_count > 0 THEN
     RAISE EXCEPTION
-      'chat_events has % goal-grouped rows whose context conflicts with run_group_id',
+      'chat_events has % goal-grouped rows whose goal context_id conflicts with run_group_id',
       conflict_count;
   END IF;
 
@@ -118,10 +122,12 @@ $$;--> statement-breakpoint
 -- transition per row: the deterministic canonical image of its legacy
 -- columns. payload may only become the derived payload (or stay put once
 -- populated), run_id may only adopt interrupts_run_id on a control.interrupt
--- row that has none, and the goal context pointers may only be completed from
--- run_group_id when the existing context is compatible. Every other column
--- and every other transition remain immutable, so a conflicting row cannot be
--- rewritten even by the backfill itself.
+-- row that has none, and a goal-grouped row may only adopt the canonical
+-- ('goal', run_group_id) pointer — replacing a non-goal source tag exactly as
+-- the dual-writer does. A goal pointer naming a different goal id stays
+-- immutable, so a genuinely conflicting row cannot be rewritten even by the
+-- backfill itself. Every other column and every other transition remain
+-- immutable.
 CREATE OR REPLACE FUNCTION "reject_chat_event_source_update"() RETURNS trigger AS $$
 BEGIN
   IF TG_TABLE_NAME = 'chat_events'
@@ -138,15 +144,17 @@ BEGIN
     END)
     AND NEW."context_type" IS NOT DISTINCT FROM (CASE
       WHEN OLD."run_group_id" IS NOT NULL
-        AND (OLD."context_type" IS NULL
-          OR (OLD."context_type" = 'goal' AND OLD."context_id" IS NULL))
+        AND (OLD."context_type" IS DISTINCT FROM 'goal'
+          OR OLD."context_id" IS NULL
+          OR OLD."context_id" = OLD."run_group_id")
       THEN 'goal'
       ELSE OLD."context_type"
     END)
     AND NEW."context_id" IS NOT DISTINCT FROM (CASE
       WHEN OLD."run_group_id" IS NOT NULL
-        AND (OLD."context_type" IS NULL
-          OR (OLD."context_type" = 'goal' AND OLD."context_id" IS NULL))
+        AND (OLD."context_type" IS DISTINCT FROM 'goal'
+          OR OLD."context_id" IS NULL
+          OR OLD."context_id" = OLD."run_group_id")
       THEN OLD."run_group_id"
       ELSE OLD."context_id"
     END)
@@ -182,9 +190,11 @@ BEGIN
             AND "candidate"."run_id" IS NULL
             AND "candidate"."interrupts_run_id" IS NOT NULL)
           OR ("candidate"."run_group_id" IS NOT NULL
-            AND ("candidate"."context_type" IS NULL
-              OR ("candidate"."context_type" = 'goal'
-                AND "candidate"."context_id" IS NULL)))
+            AND ("candidate"."context_type" IS DISTINCT FROM 'goal'
+              OR "candidate"."context_id" IS DISTINCT FROM "candidate"."run_group_id")
+            AND ("candidate"."context_type" IS DISTINCT FROM 'goal'
+              OR "candidate"."context_id" IS NULL
+              OR "candidate"."context_id" = "candidate"."run_group_id"))
         )
       ORDER BY "candidate"."id"
       LIMIT 500
@@ -203,17 +213,17 @@ BEGIN
         END,
         "context_type" = CASE
           WHEN "target"."run_group_id" IS NOT NULL
-            AND ("target"."context_type" IS NULL
-              OR ("target"."context_type" = 'goal'
-                AND "target"."context_id" IS NULL))
+            AND ("target"."context_type" IS DISTINCT FROM 'goal'
+              OR "target"."context_id" IS NULL
+              OR "target"."context_id" = "target"."run_group_id")
           THEN 'goal'
           ELSE "target"."context_type"
         END,
         "context_id" = CASE
           WHEN "target"."run_group_id" IS NOT NULL
-            AND ("target"."context_type" IS NULL
-              OR ("target"."context_type" = 'goal'
-                AND "target"."context_id" IS NULL))
+            AND ("target"."context_type" IS DISTINCT FROM 'goal'
+              OR "target"."context_id" IS NULL
+              OR "target"."context_id" = "target"."run_group_id")
           THEN "target"."run_group_id"
           ELSE "target"."context_id"
         END
@@ -252,9 +262,11 @@ BEGIN
           AND "candidate"."run_id" IS NULL
           AND "candidate"."interrupts_run_id" IS NOT NULL)
         OR ("candidate"."run_group_id" IS NOT NULL
-          AND ("candidate"."context_type" IS NULL
-            OR ("candidate"."context_type" = 'goal'
-              AND "candidate"."context_id" IS NULL)))
+          AND ("candidate"."context_type" IS DISTINCT FROM 'goal'
+            OR "candidate"."context_id" IS DISTINCT FROM "candidate"."run_group_id")
+          AND ("candidate"."context_type" IS DISTINCT FROM 'goal'
+            OR "candidate"."context_id" IS NULL
+            OR "candidate"."context_id" = "candidate"."run_group_id"))
     ) THEN
       last_id := NULL;
       PERFORM pg_sleep(0.25);


### PR DESCRIPTION
Unblocks the production release train: the `0886_backfill_canonical_chat_event_storage` migration aborted in the release pipeline's Production Migration Smoke Test (release-please run 31404752899, `promote-api-production`) with:

```
PostgresError: chat_events has 18300 goal-grouped rows whose context conflicts with run_group_id
```

The abort worked as designed — production data was never touched and the API was not promoted — but every subsequent release hits the same abort until the backfill handles this class.

## Root cause (maskdb evidence, read-only)

All 18,300 conflicting rows are one uniform historical class: `event_type = 'input.prompt'`, `context_type = 'automation'`, **`context_id = NULL` on every row**, with a non-null `run_group_id` (goal-thread continuations tagged with a bare automation source before goal context pointers existed). The deployed dual-writer's semantics for such rows are unambiguous: `persistedChatEventValues` replaces any display context with the canonical `('goal', runGroupId)` pointer whenever `run_group_id` is present. Treating the bare source tag as a hard conflict was over-strict; nothing is lost by adopting the goal pointer (`context_id` is NULL on every affected row), and the v3 wire/UI behavior is unchanged either way (masking hides canonical goal contexts; `runGroupId` keeps being emitted).

## Changes

- **Migration `0886` (in-place edit)**: the goal-context pre-check now aborts only on genuine conflicts — a `'goal'` context whose non-null `context_id` names a *different* goal id. Rows with any non-goal context (or an incomplete goal pointer) canonicalize to `('goal', run_group_id)`, exactly matching the dual-writer; the narrowed append-only trigger, batch predicate, and restart pass follow the same rule, and a conflicting goal pointer stays immutable so the unchanged final assertions still fail loudly on it. Editing the merged file is deliberate: 0886 has never applied to production (the smoke abort precedes any write), the chain cannot advance past it otherwise, and no DDL changes are involved so the drizzle snapshot chain is untouched.
- **`canonicalChatEventRow` (api-contracts)**: mirrors the same rule so the client normalizer keeps goal grouping (`runGroupId` projection) for this class instead of preserving the stale source tag.
- **Tests**: consistency-harness validator seeds the exact production shape (automation-tagged goal continuation → canonicalized) and re-targets the abort scenario to a true goal-id mismatch; contract tests cover the automation-tagged normalization, the preserved goal-id conflict, and the end-to-end `runGroupId` projection for the historical class.

## Verification

- `pnpm test:migration-consistency` — all validations green, including the new automation-tagged canonicalization and the goal-id-mismatch abort with clean rerun.
- Full-chain `db:migrate` on a fresh database.
- api-contracts tests 8/8; platform snapshot-read + IDB tests 23/23; format/lint/check-types green on api-contracts, db, app, api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
