### PR TITLE
fix: use shared button for account menu trigger

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -249,7 +249,7 @@ function mockAdminAccountSidebar(): void {
 }
 
 describe("zero sidebar account menu", () => {
-  it("uses the shared focus treatment and preserves keyboard menu behavior", async () => {
+  it("restores visible focus to the account trigger when the menu closes", async () => {
     const user = userEvent.setup();
     prepareDefaultAgent();
 
@@ -269,19 +269,15 @@ describe("zero sidebar account menu", () => {
       throw new Error("Account menu trigger not found");
     }
 
-    expect(accountButton).toHaveClass("focus-visible:outline-none");
-    expect(accountButton).toHaveClass("focus-visible:ring-2");
-    expect(accountButton).toHaveClass("focus-visible:ring-ring");
-    expect(accountButton).toHaveClass("focus-visible:ring-offset-2");
-
-    accountButton.focus();
-    await user.keyboard("{Enter}");
+    await user.click(accountButton);
     const menu = await screen.findByRole("menu");
     expect(menu).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
     await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
       expect(accountButton).toHaveFocus();
+      expect(accountButton.matches(":focus-visible")).toBeTruthy();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -249,6 +249,42 @@ function mockAdminAccountSidebar(): void {
 }
 
 describe("zero sidebar account menu", () => {
+  it("uses the shared focus treatment and preserves keyboard menu behavior", async () => {
+    const user = userEvent.setup();
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+    });
+
+    const accountName = await screen.findByText("Alex Rivera");
+    const accountButton = accountName.closest("button");
+    if (!accountButton) {
+      throw new Error("Account menu trigger not found");
+    }
+
+    expect(accountButton).toHaveClass("focus-visible:outline-none");
+    expect(accountButton).toHaveClass("focus-visible:ring-2");
+    expect(accountButton).toHaveClass("focus-visible:ring-ring");
+    expect(accountButton).toHaveClass("focus-visible:ring-offset-2");
+
+    accountButton.focus();
+    await user.keyboard("{Enter}");
+    const menu = await screen.findByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(accountButton).toHaveFocus();
+    });
+  });
+
   it("opens credit balance and export data from the account menu", async () => {
     mockAdminAccountSidebar();
     const openMock = context.mocks.browser.open(null);

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
+  Button,
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
@@ -188,12 +189,12 @@ function accountDisplayFrom(
 
 function renderAccountTrigger(display: AccountDisplay, collapsed: boolean) {
   return (
-    <button
+    <Button
       type="button"
-      className={`rounded-lg transition-colors duration-200 ${
-        collapsed
-          ? "inline-flex h-8 w-8 shrink-0 items-center justify-center p-0 hover:bg-state-hover"
-          : "flex w-full items-center gap-2 p-2 text-left hover:bg-state-hover"
+      variant="ghost"
+      size={collapsed ? "icon-sm" : "default"}
+      className={`font-normal text-sidebar-foreground duration-200 ${
+        collapsed ? "shrink-0 p-0" : "h-auto w-full justify-start p-2 text-left"
       }`}
     >
       <AccountAvatar
@@ -211,7 +212,7 @@ function renderAccountTrigger(display: AccountDisplay, collapsed: boolean) {
           </p>
         </div>
       )}
-    </button>
+    </Button>
   );
 }
 


### PR DESCRIPTION
## Summary

- replace the raw account menu trigger with the shared shadcn-style Button while keeping Radix DropdownMenuTrigger asChild
- preserve the existing expanded and collapsed layout, typography, hover treatment, and transition timing
- cover the design-system focus treatment and Enter/Escape focus handoff in the existing page-level test

## Test plan

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx