### PR TITLE
refactor: simplify autonomy budget inheritance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -350,7 +350,7 @@ describe("chat-run-finished workflow automations", () => {
       ).resolves.toMatchObject({ autonomyBudget: 1 });
       await expect(
         readLatestWorkflowAutomationRunFixture(context, patternMatch),
-      ).resolves.toMatchObject({ autonomyBudget: 0 });
+      ).resolves.toMatchObject({ autonomyBudget: 1 });
 
       const automationRuns = await api.listAgentRuns(fixture.actor, {
         status: "pending",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -280,6 +280,34 @@ describe("zero goals", () => {
     });
   });
 
+  it("refreshes reactivated goal budgets from the current run", async () => {
+    const fixture = await seedGoalApiFixture();
+    await setRunAutonomyBudgetFixture(context, fixture.runId, 1);
+    await createGoal(fixture, "refresh inherited goal budget");
+    await expect(
+      readThreadGoalAutonomyBudgetFixture(context, fixture.threadId),
+    ).resolves.toBe(0);
+
+    await accept(goalsClient().block({ headers: headers(fixture) }), [200]);
+    await setRunAutonomyBudgetFixture(context, fixture.runId, 5);
+    await accept(goalsClient().resume({ headers: headers(fixture) }), [200]);
+    await expect(
+      readThreadGoalAutonomyBudgetFixture(context, fixture.threadId),
+    ).resolves.toBe(4);
+
+    await setRunAutonomyBudgetFixture(context, fixture.runId, 7);
+    await accept(
+      goalsClient().edit({
+        headers: headers(fixture, ["goal:user-control:write"]),
+        body: { objective: "refresh inherited goal budget again" },
+      }),
+      [200],
+    );
+    await expect(
+      readThreadGoalAutonomyBudgetFixture(context, fixture.threadId),
+    ).resolves.toBe(6);
+  });
+
   it("bootstraps a provisioned goal thread through a claimed input.goal event", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -24,6 +24,7 @@ import {
   readRunAutonomyBudgetFixture,
   readWorkflowAutomationAutonomyFixture,
   setRunAutonomyBudgetFixture,
+  setWorkflowAutomationAutonomyBudgetFixture,
 } from "./helpers/runtime-state";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import {
@@ -4222,6 +4223,25 @@ describe("zero workflow automations", () => {
     await expect(
       readWorkflowAutomationAutonomyFixture(context, derivedAutomation.body.id),
     ).resolves.toMatchObject({ autonomyBudget: 1, enabled: true });
+
+    await accept(
+      automationsClient().disable({
+        headers: authHeaders(),
+        params: { id: derivedAutomation.body.id },
+      }),
+      [200],
+    );
+    await setRunAutonomyBudgetFixture(context, exhaustedRun.body.runId, 5);
+    await accept(
+      automationsClient().enable({
+        headers: { authorization: `Bearer ${exhaustedToken}` },
+        params: { id: derivedAutomation.body.id },
+      }),
+      [200],
+    );
+    await expect(
+      readWorkflowAutomationAutonomyFixture(context, derivedAutomation.body.id),
+    ).resolves.toMatchObject({ autonomyBudget: 4, enabled: true });
     await setRunAutonomyBudgetFixture(context, exhaustedRun.body.runId, 0);
 
     const blocked = await accept(
@@ -4238,7 +4258,7 @@ describe("zero workflow automations", () => {
     await runs.requestCancelRun(actor, exhaustedRun.body.runId, [200]);
   });
 
-  it("derives manual run budgets and rejects exhausted Zero callers", async () => {
+  it("derives manual run budgets from the source and rejects exhausted Zero callers", async () => {
     mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     const { actor, workflowId } = await setupFixture();
     const automation = await accept(
@@ -4250,6 +4270,11 @@ describe("zero workflow automations", () => {
         },
       }),
       [201],
+    );
+    await setWorkflowAutomationAutonomyBudgetFixture(
+      context,
+      automation.body.id,
+      0,
     );
     const sourceRun = await accept(
       automationsClient().run({
@@ -4269,7 +4294,7 @@ describe("zero workflow automations", () => {
     await runs.requestCancelRun(actor, sourceRun.body.runId, [200]);
     await flushWaitUntilForTest();
 
-    await setRunAutonomyBudgetFixture(context, sourceRun.body.runId, 1);
+    await setRunAutonomyBudgetFixture(context, sourceRun.body.runId, 2);
     const childRun = await accept(
       automationsClient().run({
         headers: { authorization: `Bearer ${sourceToken}` },
@@ -4278,11 +4303,14 @@ describe("zero workflow automations", () => {
       [201],
     );
     if (!childRun.body.runId) {
-      throw new Error("Expected a budget-one caller to start a child run");
+      throw new Error("Expected a budget-two caller to start a child run");
     }
     await expect(
       readRunAutonomyBudgetFixture(context, childRun.body.runId),
-    ).resolves.toBe(0);
+    ).resolves.toBe(1);
+    await expect(
+      readWorkflowAutomationAutonomyFixture(context, automation.body.id),
+    ).resolves.toMatchObject({ autonomyBudget: 0 });
     await runs.requestCancelRun(actor, childRun.body.runId, [200]);
     await flushWaitUntilForTest();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -1536,7 +1536,7 @@ describe("zero workflows", () => {
     ).toBeTruthy();
   });
 
-  it("caps copied automation budgets for Zero callers and rejects exhausted runs", async () => {
+  it("inherits copied automation budgets from Zero callers and rejects exhausted runs", async () => {
     const actor = user({ orgRole: "org:admin" });
     await enableWorkflowRuns(actor);
     const sourceAgent = await createAgent(actor, {
@@ -1552,7 +1552,7 @@ describe("zero workflows", () => {
       name: `budgeted-copy-${randomUUID().slice(0, 8)}`,
       instruction: "# budgeted copy source",
     });
-    await accept(
+    const sourceAutomation = await accept(
       automationsClient().create({
         headers: authHeaders(actor),
         params: { workflowId: workflow.body.id },
@@ -1562,6 +1562,11 @@ describe("zero workflows", () => {
         },
       }),
       [201],
+    );
+    await setWorkflowAutomationAutonomyBudgetFixture(
+      context,
+      sourceAutomation.body.id,
+      2,
     );
     const sourceRun = await accept(
       detailClient().run({
@@ -1579,7 +1584,7 @@ describe("zero workflows", () => {
       ["agent:write"],
     );
 
-    await setRunAutonomyBudgetFixture(context, sourceRun.body.runId, 1);
+    await setRunAutonomyBudgetFixture(context, sourceRun.body.runId, 10);
     const copied = await accept(
       detailClient().copy({
         headers: { authorization: `Bearer ${sourceToken}` },
@@ -1601,7 +1606,7 @@ describe("zero workflows", () => {
     }
     await expect(
       readWorkflowAutomationAutonomyFixture(context, copiedAutomation.id),
-    ).resolves.toMatchObject({ autonomyBudget: 0 });
+    ).resolves.toMatchObject({ autonomyBudget: 9 });
 
     await setRunAutonomyBudgetFixture(context, sourceRun.body.runId, 0);
     const blockedTargetAgent = await createAgent(actor, {

--- a/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-automations.ts
@@ -291,7 +291,7 @@ const enableAutomationInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(zeroWorkflowAutomationsContract.enable));
-    let autonomyBudgetCeiling: number | undefined;
+    let inheritedAutonomyBudget: number | undefined;
     const db = get(db$);
     if (auth.tokenType === "zero") {
       const sourceAutonomyBudget = await loadOwnedRunAutonomyBudget(db, {
@@ -307,7 +307,7 @@ const enableAutomationInner$ = command(
       if (derived.kind === "exhausted") {
         return autonomyBudgetExhausted();
       }
-      autonomyBudgetCeiling = derived.autonomyBudget;
+      inheritedAutonomyBudget = derived.autonomyBudget;
     }
     const result = await set(
       enableWorkflowAutomation$,
@@ -315,9 +315,9 @@ const enableAutomationInner$ = command(
         orgId: auth.orgId,
         member: memberFromAuth(auth),
         automationId: params.id,
-        ...(autonomyBudgetCeiling === undefined
+        ...(inheritedAutonomyBudget === undefined
           ? {}
-          : { autonomyBudgetCeiling }),
+          : { inheritedAutonomyBudget }),
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -715,7 +715,7 @@ interface CopyWorkflowRuntimeArgs {
   readonly sourceWorkflow: WorkflowRow;
   readonly targetAgentId: string;
   readonly currentTime: Date;
-  readonly autonomyBudgetLimit?: number;
+  readonly inheritedAutonomyBudget?: number;
 }
 
 interface CopyWorkflowScopedRowsArgs {
@@ -724,7 +724,7 @@ interface CopyWorkflowScopedRowsArgs {
   readonly sourceWorkflowId: string;
   readonly targetWorkflowId: string;
   readonly currentTime: Date;
-  readonly autonomyBudgetLimit?: number;
+  readonly inheritedAutonomyBudget?: number;
 }
 
 interface CopyWorkflowAutomationRowsArgs extends CopyWorkflowScopedRowsArgs {
@@ -828,10 +828,8 @@ async function copyWorkflowAutomationRow(
     lastRunAt: null,
     lastRunId: null,
     consecutiveFailures: 0,
-    autonomyBudget: Math.min(
-      args.automation.autonomyBudget,
-      args.autonomyBudgetLimit ?? args.automation.autonomyBudget,
-    ),
+    autonomyBudget:
+      args.inheritedAutonomyBudget ?? args.automation.autonomyBudget,
     createdAt: args.currentTime,
     updatedAt: args.currentTime,
   });
@@ -899,9 +897,9 @@ async function copyWorkflowRuntimeConfiguration(
     sourceWorkflowId: args.sourceWorkflow.id,
     targetWorkflowId: workflow.id,
     currentTime: args.currentTime,
-    ...(args.autonomyBudgetLimit === undefined
+    ...(args.inheritedAutonomyBudget === undefined
       ? {}
-      : { autonomyBudgetLimit: args.autonomyBudgetLimit }),
+      : { inheritedAutonomyBudget: args.inheritedAutonomyBudget }),
   };
   await copyWorkflowUserAutomations(tx, {
     ...scopedRowsArgs,
@@ -923,7 +921,7 @@ const copyWorkflowInner$ = command(
     }
 
     const writeDb = set(writeDb$);
-    let autonomyBudgetLimit: number | undefined;
+    let inheritedAutonomyBudget: number | undefined;
     if (auth.tokenType === "zero") {
       const sourceAutonomyBudget = await loadOwnedRunAutonomyBudget(writeDb, {
         runId: auth.runId,
@@ -938,7 +936,7 @@ const copyWorkflowInner$ = command(
       if (derived.kind === "exhausted") {
         return autonomyBudgetExhausted();
       }
-      autonomyBudgetLimit = derived.autonomyBudget;
+      inheritedAutonomyBudget = derived.autonomyBudget;
     }
     const source = await loadVisibleWorkflowById(writeDb, {
       orgId: auth.orgId,
@@ -990,7 +988,9 @@ const copyWorkflowInner$ = command(
         sourceWorkflow: source.workflow,
         targetAgentId: targetAgent.id,
         currentTime,
-        ...(autonomyBudgetLimit === undefined ? {} : { autonomyBudgetLimit }),
+        ...(inheritedAutonomyBudget === undefined
+          ? {}
+          : { inheritedAutonomyBudget }),
       });
     });
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -273,7 +273,7 @@ async function reactivateGoal(
   tx: Pick<Db, "update">,
   args: {
     readonly goal: GoalRow;
-    readonly autonomyBudgetCeiling: number;
+    readonly autonomyBudget: number;
     readonly objective?: string;
     readonly objectiveBrief?: string;
     readonly updatedAt: Date;
@@ -288,10 +288,7 @@ async function reactivateGoal(
       ...(args.objectiveBrief === undefined
         ? {}
         : { objectiveBrief: args.objectiveBrief }),
-      autonomyBudget: Math.min(
-        args.goal.autonomyBudget,
-        args.autonomyBudgetCeiling,
-      ),
+      autonomyBudget: args.autonomyBudget,
     })
     .where(eq(threadGoals.id, args.goal.id))
     .returning(threadGoalColumns());
@@ -645,7 +642,7 @@ export async function resumeCurrentGoal(
     }
     const row = await reactivateGoal(tx, {
       goal: current,
-      autonomyBudgetCeiling: reactivationBudget.autonomyBudget,
+      autonomyBudget: reactivationBudget.autonomyBudget,
       updatedAt: resumedAt,
     });
     await appendGoalOpenMarker(tx, {
@@ -720,7 +717,7 @@ export async function editCurrentGoal(
 
     const row = await reactivateGoal(tx, {
       goal: current,
-      autonomyBudgetCeiling: replacementBudget.autonomyBudget,
+      autonomyBudget: replacementBudget.autonomyBudget,
       objective: args.objective,
       objectiveBrief,
       updatedAt: editedAt,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -64,7 +64,7 @@ import {
   zeroWorkflows,
   type ZeroWorkflowScheduleType,
 } from "@vm0/db/schema/zero-workflow";
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { publishChatThreadAutomationsChangedSafely } from "../external/realtime";
@@ -3119,7 +3119,7 @@ interface AutomationActionInput {
   readonly member: WorkflowMember;
   readonly automationId: string;
   readonly sourceRunId?: string;
-  readonly autonomyBudgetCeiling?: number;
+  readonly inheritedAutonomyBudget?: number;
 }
 
 /**
@@ -3520,7 +3520,7 @@ async function persistEnabledWorkflowAutomation(
     readonly orgId: string;
     readonly nextRunAt: Date | null;
     readonly now: Date;
-    readonly autonomyBudgetCeiling?: number;
+    readonly inheritedAutonomyBudget?: number;
   },
   signal: AbortSignal,
 ): Promise<
@@ -3552,14 +3552,9 @@ async function persistEnabledWorkflowAutomation(
         nextRunAt: args.nextRunAt,
         consecutiveFailures: 0,
         updatedAt: args.now,
-        ...(args.autonomyBudgetCeiling === undefined
+        ...(args.inheritedAutonomyBudget === undefined
           ? {}
-          : {
-              autonomyBudget: sql`least(
-                ${zeroWorkflowAutomations.autonomyBudget},
-                ${args.autonomyBudgetCeiling}
-              )`,
-            }),
+          : { autonomyBudget: args.inheritedAutonomyBudget }),
       })
       .where(eq(zeroWorkflowAutomations.id, args.automation.id))
       .returning(workflowAutomationColumns());
@@ -3727,7 +3722,7 @@ export const enableWorkflowAutomation$ = command(
         orgId: args.orgId,
         nextRunAt,
         now,
-        autonomyBudgetCeiling: args.autonomyBudgetCeiling,
+        inheritedAutonomyBudget: args.inheritedAutonomyBudget,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -96,7 +96,7 @@ async function resolveWorkflowRunAutonomyBudget(
   }
   return {
     kind: "ok",
-    autonomyBudget: Math.min(automation.autonomyBudget, derived.autonomyBudget),
+    autonomyBudget: derived.autonomyBudget,
   };
 }
 


### PR DESCRIPTION
## Summary

- derive every parented child budget directly as `parentBudget - 1`, without capping it by an automation or goal's stored budget
- refresh inherited budgets when Zero enables an automation, copies a workflow, or resumes/edits a goal
- preserve stored budgets for parentless recurring triggers and human-initiated operations
- cover chat-run-finished dispatch, manual automation runs, automation re-enable, workflow copy, and goal reactivation

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-goals.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflow-automations.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflows.test.ts`

## Compatibility

- no schema, API contract, or payload changes
- existing autonomy budget range and exhausted-budget responses remain unchanged
