### PR TITLE
test(api): isolate stripe automation execution

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { testStripeAutomationEventFixtureContract } from "@vm0/api-contracts/contracts/test-stripe-automation-events";
+import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -24,6 +25,7 @@ import { chatEventDisplayText } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
 import { testStripeAutomationEventRoutes } from "../test-stripe-automation-events";
+import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { webhooksStripeAutomationEventsRoutes } from "../webhooks-stripe-automation-events";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 
@@ -58,6 +60,13 @@ function automationsClient() {
   return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
+}
+
+function workflowAutomationExecutionClient() {
+  return setupApp({
+    context,
+    routes: testWorkflowAutomationExecutionRoutes,
+  })(testWorkflowAutomationExecutionContract);
 }
 
 async function connectStripeOAuth(
@@ -258,6 +267,15 @@ async function executeCron(): Promise<{
   });
   expect(response.status).toBe(200);
   return cronResultSchema.parse(await response.json());
+}
+
+async function executeAutomation(scenario: Scenario) {
+  return await accept(
+    workflowAutomationExecutionClient().execute({
+      body: { automation_id: scenario.automationId },
+    }),
+    [200],
+  );
 }
 
 async function applyDeliveryFixture(
@@ -839,9 +857,14 @@ describe("Stripe automation event webhook", () => {
   });
 
   it("updates receipt health across filters and delivers unknown billing reasons to unfiltered automations", async () => {
-    const filtered = await setupScenario({ billingReasons: ["manual"] });
-    const unfiltered = await setupScenario();
+    const accountId = `acct_stripe_unknown_${randomUUID()}`;
+    const filtered = await setupScenario({
+      accountId,
+      billingReasons: ["manual"],
+    });
+    const unfiltered = await setupScenario({ accountId });
     const unknownReasonEvent = invoicePaidEvent({
+      accountId,
       eventId: "evt_unknown_billing_reason",
       billingReason: "future_reason",
     });
@@ -856,7 +879,7 @@ describe("Stripe automation event webhook", () => {
       lastMatchingEventReceivedAt: expect.any(String),
       lastDeliveryStatus: "pending",
     });
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(unfiltered)).body.executed).toBe(1);
     const unknownClaim = await claimScenarioRun(
       unfiltered,
       "evt_unknown_billing_reason",

--- a/turbo/apps/api/src/signals/routes/test-workflow-automation-execution.ts
+++ b/turbo/apps/api/src/signals/routes/test-workflow-automation-execution.ts
@@ -6,6 +6,7 @@ import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import { executeDueNotionAutomationEventsForAutomation$ } from "../services/notion-automation-event.service";
 import { executeDueStrapiAutomationEventsForAutomation$ } from "../services/strapi-automation-event.service";
+import { executeDueStripeAutomationEventsForAutomation$ } from "../services/stripe-automation-event.service";
 import { executeDueWorkflowAutomationsForAutomation$ } from "../services/zero-workflow-automation-poller.service";
 import {
   isTestEndpointAllowed,
@@ -42,14 +43,29 @@ const executeTestWorkflowAutomation$ = command(
       automationId,
       signal,
     );
+    const stripe = await set(
+      executeDueStripeAutomationEventsForAutomation$,
+      automationId,
+      signal,
+    );
     signal.throwIfAborted();
 
     return {
       status: 200 as const,
       body: {
         success: true as const,
-        executed: scheduled.executed + notion.executed + strapi.executed,
-        skipped: scheduled.skipped + notion.skipped + strapi.skipped,
+        executed:
+          scheduled.executed +
+          notion.executed +
+          strapi.executed +
+          stripe.executed,
+        skipped:
+          scheduled.skipped +
+          notion.skipped +
+          strapi.skipped +
+          stripe.skipped +
+          stripe.failed +
+          stripe.retried,
       },
     };
   },

--- a/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-automation-event.service.ts
@@ -900,6 +900,7 @@ function deliveryClaimCondition(delivery: StripeWorkflowDeliveryRow) {
 async function claimDueDelivery(
   args: {
     readonly db: Db;
+    readonly automationId?: string;
   },
   signal: AbortSignal,
 ): Promise<StripeWorkflowDeliveryRow | null> {
@@ -910,6 +911,9 @@ async function claimDueDelivery(
       .from(stripeWorkflowDeliveries)
       .where(
         and(
+          args.automationId === undefined
+            ? undefined
+            : eq(stripeWorkflowDeliveries.automationId, args.automationId),
           eq(stripeWorkflowDeliveries.status, "pending"),
           lte(stripeWorkflowDeliveries.nextAttemptAt, currentTime),
           or(
@@ -1413,6 +1417,7 @@ async function processClaimedDelivery(
 async function executeDueStripeAutomationEvents(
   args: {
     readonly db: Db;
+    readonly automationId?: string;
     readonly startRun: (
       input: RunWorkflowAutomationNowArgs,
       signal: AbortSignal,
@@ -1480,6 +1485,25 @@ export const executeDueStripeAutomationEvents$ = command(
     return await executeDueStripeAutomationEvents(
       {
         db: set(writeDb$),
+        startRun: (input, childSignal) => {
+          return set(runWorkflowAutomationNow$, input, childSignal);
+        },
+      },
+      signal,
+    );
+  },
+);
+
+export const executeDueStripeAutomationEventsForAutomation$ = command(
+  async (
+    { set },
+    automationId: string,
+    signal: AbortSignal,
+  ): Promise<ExecuteDueStripeAutomationEventsResult> => {
+    return await executeDueStripeAutomationEvents(
+      {
+        db: set(writeDb$),
+        automationId,
         startRun: (input, childSignal) => {
           return set(runWorkflowAutomationNow$, input, childSignal);
         },


### PR DESCRIPTION
## Summary

- add Stripe delivery processing to the existing test-only automation execution endpoint, scoped by automation ID
- give the unknown-billing-reason scenario a unique Stripe account and execute only its intended automation
- preserve the receipt-health, filtering, and unknown-billing-reason assertions without changing the production cron path

## Root cause

The first causal failure in [Turbo run 31407392023](https://github.com/vm0-ai/vm0/actions/runs/31407392023) was the named Stripe test reaching the global 5-second boundary at 5002 ms in [test-api (8)](https://github.com/vm0-ai/vm0/actions/runs/31407392023/job/93517052868). There was no business assertion mismatch or teardown failure.

The test called the global workflow-automation cron route. That route sequentially scans schedule, Notion, Strapi, and Stripe work across the persistent shared test database. Before the Stripe scenario ran, the failing log showed two unrelated due schedule automations reaching pre-run provider failures. Stripe delivery claiming was likewise global rather than scoped to the automation under test. The test therefore owned arbitrary shared-database work, allowing scheduler timing and unrelated backlog to consume its timeout budget.

Supporting comparisons:

- the same PR head completed this exact test in 772 ms in [run 31406226671](https://github.com/vm0-ai/vm0/actions/runs/31406226671/job/93513191100)
- the subsequent merge-group run completed it in 1070 ms in [run 31407859449](https://github.com/vm0-ai/vm0/actions/runs/31407859449)
- earlier failures in this file moved between neighboring Stripe lifecycle tests at the same 5000 ms boundary after the prior test split, consistent with shared scheduling work rather than product behavior

This repair removes that nondeterministic ownership boundary. It does not add retries, sleeps, timeout changes, skipped tests, or weaker assertions.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'` (12/12 tasks)
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api run lint`
- `git diff --check origin/main...HEAD`

The focused API integration test requires PostgreSQL. This environment has no local PostgreSQL or Docker, and the repair contract forbids starting a backend, so runtime repetition is intentionally delegated to the PR's API test shard. A deployed browser preview is not applicable to this test-only API boundary.
