### PR TITLE
feat(cli): invoke mcp custom connectors

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -29,6 +29,7 @@
     "check-types": "pnpm --filter @vm0/pi-agent-runtime run build && tsc --noEmit"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@sentry/node": "^10.50.0",
     "@types/node": "^24.3.0",
     "@types/prompts": "^2.4.9",

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -18,6 +18,7 @@ function buildCommands(): Command[] {
     new Command("model-provider"),
     new Command("agent"),
     new Command("connector"),
+    new Command("mcp"),
     new Command("credit"),
     new Command("upgrade"),
     new Command("logs"),
@@ -146,7 +147,7 @@ describe("registerZeroCommands", () => {
     vi.stubEnv("ZERO_TOKEN", undefined);
 
     const prog = buildProgram();
-    expect(hiddenCommandNames(prog)).toEqual(["recognize", "translate"]);
+    expect(hiddenCommandNames(prog)).toEqual(["mcp", "recognize", "translate"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -173,6 +174,7 @@ describe("registerZeroCommands", () => {
     expect(hiddenCommandNames(prog)).toEqual([
       "org",
       "connector",
+      "mcp",
       "credit",
       "logs",
       "chat",
@@ -204,7 +206,7 @@ describe("registerZeroCommands", () => {
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual(["recognize", "translate"]);
+    expect(hiddenCommandNames(prog)).toEqual(["mcp", "recognize", "translate"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -218,7 +220,7 @@ describe("registerZeroCommands", () => {
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual(["recognize", "translate"]);
+    expect(hiddenCommandNames(prog)).toEqual(["mcp", "recognize", "translate"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -1116,6 +1118,7 @@ describe("registerZeroCommands", () => {
       "model",
       "model-provider",
       "connector",
+      "mcp",
       "upgrade",
       "resource",
       "whoami",
@@ -1136,6 +1139,25 @@ describe("registerZeroCommands", () => {
 
     expect(visibleCommandNames(prog)).toContain("connector");
     expect(visibleCommandNames(prog)).toContain("whoami");
+  });
+
+  it("should show run-only mcp only with connector:read capability", () => {
+    const readToken = buildZeroToken({
+      scope: "zero",
+      capabilities: ["connector:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", readToken);
+    expect(visibleCommandNames(buildProgram())).toContain("mcp");
+
+    const writeToken = buildZeroToken({
+      scope: "zero",
+      capabilities: ["connector:write"],
+    });
+    vi.stubEnv("ZERO_TOKEN", writeToken);
+    expect(hiddenCommandNames(buildProgram())).toContain("mcp");
+
+    vi.stubEnv("ZERO_TOKEN", undefined);
+    expect(hiddenCommandNames(buildProgram())).toContain("mcp");
   });
 
   it("should show connector when connector:write capability is present", () => {

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -20,6 +20,7 @@ describe("zero CLI program", () => {
       "model-provider",
       "agent",
       "connector",
+      "mcp",
       "mail",
       "credit",
       "upgrade",
@@ -86,7 +87,7 @@ describe("zero CLI program", () => {
     expect(publicCommandNames).not.toContain("__agent-loop");
   });
 
-  it("should have exactly 39 public commands", () => {
-    expect(publicCommandNames).toHaveLength(39);
+  it("should have exactly 40 public commands", () => {
+    expect(publicCommandNames).toHaveLength(40);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import type {
   CustomConnectorHttpResponse,
+  CustomConnectorMcpResponse,
   CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 
@@ -34,6 +35,48 @@ export function customConnector(
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     hasSecret: false,
+    ...overrides,
+  };
+}
+
+export function mcpCustomConnector(
+  overrides: Partial<CustomConnectorMcpResponse> = {},
+): CustomConnectorMcpResponse {
+  return {
+    kind: "mcp",
+    id: "44444444-4444-4444-8444-444444444444",
+    slug: "_acme-mcp",
+    displayName: "Acme MCP",
+    endpoint: "https://mcp.example.test/server",
+    transport: "streamable-http",
+    prefixes: [],
+    headerName: "",
+    headerTemplate: "",
+    prefixTemplates: [],
+    permissionBundleRef: null,
+    fields: [
+      {
+        key: "secret",
+        label: "Secret",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "manual",
+    storageVersion: 1,
+    connected: true,
+    missingRequiredFields: [],
+    configuredFieldKeys: ["secret"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    hasSecret: true,
     ...overrides,
   };
 }

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -49,7 +49,7 @@ interface McpServerOptions {
   readonly callResult?: CallToolResult;
   readonly callResponse?: () => Response;
   readonly listResponse?: (requestId: RequestId) => Response;
-  readonly deleteResponse?: () => Response;
+  readonly deleteResponse?: () => Response | Promise<Response>;
 }
 
 function processExit(): never {
@@ -788,6 +788,43 @@ describe("zero mcp command", () => {
     const errors = outputText(consoleError);
     expect(errors).toContain("MCP session cleanup did not complete");
     expect(errors).not.toContain("cleanup failed");
+  });
+
+  it("preserves the primary failure when cleanup reaches the deadline", async () => {
+    stubConnectorList();
+    stubMcpServer({
+      era: "legacy",
+      pages: [
+        [
+          {
+            name: "search",
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+      deleteResponse: async () => {
+        await delay(2_000);
+        return new HttpResponse(null, { status: 204 });
+      },
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "missing",
+        "--input",
+        "{}",
+        "--timeout",
+        "1s",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = outputText(consoleError);
+    expect(errors).toContain('MCP tool "missing" was not found');
+    expect(errors).not.toContain("timed out");
   });
 
   it("rejects repeated pagination cursors", async () => {

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -885,11 +885,11 @@ describe("zero mcp command", () => {
   });
 
   it("rejects discovery above 2,000 tools", async () => {
-    const tools = Array.from({ length: 2_001 }, (_, index) => {
+    const tools = Array.from({ length: 2_001 }, (_, index): Tool => {
       return {
         name: `tool-${index}`,
-        inputSchema: { type: "object" as const },
-      } satisfies Tool;
+        inputSchema: { type: "object" },
+      };
     });
     stubConnectorList();
     stubMcpServer({ era: "modern", pages: [tools] });

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -526,6 +526,34 @@ describe("zero mcp command", () => {
     });
   });
 
+  it("rejects conflicting input sources before resolving the connector", async () => {
+    const inputPath = join(inputDirectory, "conflicting-input.json");
+    await writeFile(inputPath, "{}", "utf8");
+    let apiCalls = 0;
+    server.use(
+      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
+        apiCalls++;
+        return HttpResponse.json({ connectors: [] });
+      }),
+    );
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "search",
+        "--input",
+        "{}",
+        "--input-file",
+        inputPath,
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(apiCalls).toBe(0);
+  });
+
   it("rejects invalid JSON before opening an MCP connection", async () => {
     stubConnectorList();
     const seen = stubMcpServer({ era: "modern" });

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -1,0 +1,950 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  isJSONRPCNotification,
+  isJSONRPCRequest,
+  type CallToolResult,
+  type RequestId,
+  type RequestParams,
+  type Tool,
+} from "@modelcontextprotocol/client";
+import chalk from "chalk";
+import { delay, http, HttpResponse } from "msw";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { server } from "../../../../mocks/server";
+import {
+  customConnector,
+  mcpCustomConnector,
+  stubCustomConnectors,
+} from "../../__tests__/helpers/custom-connectors";
+import { zeroMcpCommand } from "../index";
+
+const CONNECTOR_ID = "44444444-4444-4444-8444-444444444444";
+const MCP_ENDPOINT = "https://mcp.example.test/server";
+const SESSION_ID = "mcp-session-test";
+
+type ProtocolEra = "modern" | "legacy";
+
+interface SeenMcpRequest {
+  readonly httpMethod: string;
+  readonly method?: string;
+  readonly params?: RequestParams;
+  readonly intent: string | null;
+}
+
+interface McpServerOptions {
+  readonly era: ProtocolEra;
+  readonly pages?: readonly (readonly Tool[])[];
+  readonly callResult?: CallToolResult;
+  readonly callResponse?: () => Response;
+  readonly listResponse?: (requestId: RequestId) => Response;
+  readonly deleteResponse?: () => Response;
+}
+
+function processExit(): never {
+  throw new Error("process.exit called");
+}
+
+function pageCursor(params: RequestParams | undefined): string | undefined {
+  if (params === undefined || !("cursor" in params)) {
+    return undefined;
+  }
+  const cursor: unknown = params.cursor;
+  return typeof cursor === "string" ? cursor : undefined;
+}
+
+function stubMcpServer(options: McpServerOptions): SeenMcpRequest[] {
+  const seen: SeenMcpRequest[] = [];
+  const pages = options.pages ?? [[]];
+  const callResult = options.callResult ?? {
+    content: [{ type: "text", text: "tool completed" }],
+  };
+
+  server.use(
+    http.all(MCP_ENDPOINT, async ({ request }) => {
+      const intent = request.headers.get("x-vm0-connector-intent");
+      if (request.method === "DELETE") {
+        seen.push({ httpMethod: request.method, intent });
+        if (options.deleteResponse) {
+          return options.deleteResponse();
+        }
+        return new HttpResponse(null, { status: 204 });
+      }
+
+      const message: unknown = await request.json();
+      if (isJSONRPCNotification(message)) {
+        seen.push({
+          httpMethod: request.method,
+          method: message.method,
+          params: message.params,
+          intent,
+        });
+        return new HttpResponse(null, { status: 204 });
+      }
+      if (!isJSONRPCRequest(message)) {
+        return HttpResponse.json(
+          {
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32600, message: "Invalid request" },
+          },
+          { status: 400 },
+        );
+      }
+
+      seen.push({
+        httpMethod: request.method,
+        method: message.method,
+        params: message.params,
+        intent,
+      });
+
+      if (message.method === "server/discover") {
+        if (options.era === "legacy") {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            id: message.id,
+            error: { code: -32601, message: "Method not found" },
+          });
+        }
+        return HttpResponse.json(
+          {
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              supportedVersions: ["2026-07-28"],
+              capabilities: { tools: {} },
+            },
+          },
+          { headers: { "mcp-session-id": SESSION_ID } },
+        );
+      }
+
+      if (message.method === "initialize") {
+        return HttpResponse.json(
+          {
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              protocolVersion: "2025-06-18",
+              capabilities: { tools: {} },
+              serverInfo: { name: "test-mcp", version: "1.0.0" },
+            },
+          },
+          { headers: { "mcp-session-id": SESSION_ID } },
+        );
+      }
+
+      if (message.method === "tools/list") {
+        if (options.listResponse) {
+          return options.listResponse(message.id);
+        }
+        const cursor = pageCursor(message.params);
+        const pageIndex = cursor === undefined ? 0 : Number(cursor);
+        const tools = pages[pageIndex];
+        if (tools === undefined) {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            id: message.id,
+            error: { code: -32602, message: "Unknown cursor" },
+          });
+        }
+        return HttpResponse.json({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            ...(options.era === "modern" ? { resultType: "complete" } : {}),
+            ttlMs: 0,
+            cacheScope: "private",
+            tools,
+            ...(pageIndex + 1 < pages.length
+              ? { nextCursor: String(pageIndex + 1) }
+              : {}),
+          },
+        });
+      }
+
+      if (message.method === "tools/call") {
+        if (options.callResponse) {
+          return options.callResponse();
+        }
+        return HttpResponse.json({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            ...(options.era === "modern" ? { resultType: "complete" } : {}),
+            ...callResult,
+          },
+        });
+      }
+
+      return HttpResponse.json({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32601, message: "Method not found" },
+      });
+    }),
+  );
+  return seen;
+}
+
+function stubConnectorList(
+  overrides: Parameters<typeof mcpCustomConnector>[0] = {},
+): void {
+  server.use(stubCustomConnectors([mcpCustomConnector(overrides)]));
+}
+
+function outputText(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.flat().join("\n");
+}
+
+describe("zero mcp command", () => {
+  const exit = vi.spyOn(process, "exit").mockImplementation(processExit);
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  let inputDirectory: string;
+
+  beforeAll(async () => {
+    inputDirectory = await mkdtemp(join(process.cwd(), ".zero-mcp-test-"));
+  });
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", JSON.stringify([CONNECTOR_ID]));
+  });
+
+  afterEach(() => {
+    exit.mockClear();
+    consoleLog.mockClear();
+    consoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    await rm(inputDirectory, { recursive: true, force: true });
+  });
+
+  it("lists only admitted MCP definitions in slug order with safe JSON fields", async () => {
+    const secondId = "55555555-5555-4555-8555-555555555555";
+    const httpId = "33333333-3333-4333-8333-333333333333";
+    vi.stubEnv(
+      "ZERO_CUSTOM_CONNECTOR_IDS",
+      JSON.stringify([secondId, CONNECTOR_ID, httpId]),
+    );
+    server.use(
+      stubCustomConnectors([
+        mcpCustomConnector({ slug: "_zulu" }),
+        customConnector(),
+        mcpCustomConnector({
+          id: secondId,
+          slug: "_alpha",
+          displayName: "Alpha MCP",
+          endpoint: "https://alpha-mcp.example.test/server",
+          connected: false,
+        }),
+        mcpCustomConnector({
+          id: "66666666-6666-4666-8666-666666666666",
+          slug: "_not-admitted",
+        }),
+      ]),
+    );
+
+    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      JSON.stringify({
+        connectors: [
+          {
+            slug: "_alpha",
+            displayName: "Alpha MCP",
+            transport: "streamable-http",
+            endpoint: "https://alpha-mcp.example.test/server",
+            connected: false,
+          },
+          {
+            slug: "_zulu",
+            displayName: "Acme MCP",
+            transport: "streamable-http",
+            endpoint: MCP_ENDPOINT,
+            connected: true,
+          },
+        ],
+      }),
+    );
+    const output = outputText(consoleLog);
+    expect(output).not.toContain("Authorization");
+    expect(output).not.toContain("secrets.secret");
+    expect(output).not.toContain(httpId);
+  });
+
+  it("rejects malformed run metadata before requesting connector definitions", async () => {
+    let apiCalls = 0;
+    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "x".repeat(128 * 1024 + 1));
+    server.use(
+      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
+        apiCalls++;
+        return HttpResponse.json({ connectors: [] });
+      }),
+    );
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(apiCalls).toBe(0);
+    expect(outputText(consoleError)).toContain("Start a new Agent Run");
+    expect(outputText(consoleError)).not.toContain("xxxx");
+  });
+
+  it("rejects duplicate run IDs without a broad fallback", async () => {
+    vi.stubEnv(
+      "ZERO_CUSTOM_CONNECTOR_IDS",
+      JSON.stringify([CONNECTOR_ID, CONNECTOR_ID.toUpperCase()]),
+    );
+    server.use(stubCustomConnectors([mcpCustomConnector()]));
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain("Start a new Agent Run");
+    expect(outputText(consoleLog)).not.toContain("Acme MCP");
+  });
+
+  it("does not apply the 256-item runtime-sync batch as a membership limit", async () => {
+    const ids = Array.from({ length: 257 }, (_, index) => {
+      return `00000000-0000-4000-8000-${index.toString(16).padStart(12, "0")}`;
+    });
+    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", JSON.stringify(ids));
+    server.use(
+      stubCustomConnectors([
+        mcpCustomConnector({ id: ids[256], slug: "_after-batch" }),
+      ]),
+    );
+
+    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
+
+    expect(outputText(consoleLog)).toContain("_after-batch");
+  });
+
+  it("discovers modern tools page by page with exact intent and cleanup", async () => {
+    const searchTool = {
+      name: "search",
+      description: "Search documents",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    } satisfies Tool;
+    const fetchTool = {
+      name: "fetch",
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "string" } },
+      },
+    } satisfies Tool;
+    const tools = [searchTool, fetchTool];
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      pages: [[searchTool], [fetchTool]],
+    });
+
+    await zeroMcpCommand.parseAsync([
+      "node",
+      "zero",
+      "list-tools",
+      "_acme-mcp",
+      "--json",
+    ]);
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      JSON.stringify({ connectorSlug: "_acme-mcp", tools }),
+    );
+    expect(
+      seen.map((request) => {
+        return request.method ?? request.httpMethod;
+      }),
+    ).toEqual(["server/discover", "tools/list", "tools/list"]);
+    expect(seen[2]?.params).toMatchObject({ cursor: "1" });
+    expect(
+      seen.every((request) => {
+        return request.intent === CONNECTOR_ID;
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to the 2025 handshake and calls the exact tool once", async () => {
+    const tool = {
+      name: "search",
+      description: "Search documents",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    } satisfies Tool;
+    const callResult = {
+      content: [{ type: "text", text: "one result" }],
+    } satisfies CallToolResult;
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "legacy",
+      pages: [[tool]],
+      callResult,
+    });
+
+    await zeroMcpCommand.parseAsync([
+      "node",
+      "zero",
+      "call",
+      "_acme-mcp",
+      "search",
+      "--input",
+      '{"query":"vm0"}',
+      "--json",
+    ]);
+
+    expect(consoleLog).toHaveBeenCalledWith(JSON.stringify(callResult));
+    expect(
+      seen.map((request) => {
+        return request.method ?? request.httpMethod;
+      }),
+    ).toEqual([
+      "server/discover",
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+      "tools/call",
+      "DELETE",
+    ]);
+    const calls = seen.filter((request) => {
+      return request.method === "tools/call";
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.params).toMatchObject({
+      name: "search",
+      arguments: { query: "vm0" },
+    });
+    expect(
+      seen.every((request) => {
+        return request.intent === CONNECTOR_ID;
+      }),
+    ).toBe(true);
+  });
+
+  it("reads call input from a file without exposing its contents", async () => {
+    const inputPath = join(inputDirectory, "input.json");
+    await writeFile(inputPath, '{"query":"from-file"}', "utf8");
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      pages: [
+        [
+          {
+            name: "search",
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+    });
+
+    await zeroMcpCommand.parseAsync([
+      "node",
+      "zero",
+      "call",
+      "_acme-mcp",
+      "search",
+      "--input-file",
+      inputPath,
+      "--json",
+    ]);
+
+    const call = seen.find((request) => {
+      return request.method === "tools/call";
+    });
+    expect(call?.params).toMatchObject({
+      arguments: { query: "from-file" },
+    });
+  });
+
+  it("reads call input from piped stdin", async () => {
+    const stdinIterator = vi
+      .spyOn(process.stdin, Symbol.asyncIterator)
+      .mockImplementation(async function* (): AsyncGenerator<
+        Buffer,
+        undefined,
+        unknown
+      > {
+        yield Buffer.from('{"query":"from-stdin"}');
+        return undefined;
+      });
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      pages: [
+        [
+          {
+            name: "search",
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+    });
+
+    try {
+      await zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "search",
+        "--json",
+      ]);
+    } finally {
+      stdinIterator.mockRestore();
+    }
+
+    const call = seen.find((request) => {
+      return request.method === "tools/call";
+    });
+    expect(call?.params).toMatchObject({
+      arguments: { query: "from-stdin" },
+    });
+  });
+
+  it("rejects invalid JSON before opening an MCP connection", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({ era: "modern" });
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "search",
+        "--input",
+        "{",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(seen).toHaveLength(0);
+    expect(outputText(consoleError)).toContain(
+      "MCP tool input must be valid JSON",
+    );
+  });
+
+  it("rejects non-object JSON before opening an MCP connection", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({ era: "modern" });
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "search",
+        "--input",
+        "[]",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(seen).toHaveLength(0);
+    expect(outputText(consoleError)).toContain(
+      "MCP tool input must be a JSON object",
+    );
+  });
+
+  it("does not retry a failed tool call or expose its upstream body", async () => {
+    const upstreamSecret = "upstream-secret-value";
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      pages: [
+        [
+          {
+            name: "side-effect",
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+      callResponse: () => {
+        return HttpResponse.text(upstreamSecret, { status: 500 });
+      },
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "side-effect",
+        "--input",
+        "{}",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(
+      seen.filter((request) => {
+        return request.method === "tools/call";
+      }),
+    ).toHaveLength(1);
+    const errors = outputText(consoleError);
+    expect(errors).toContain("MCP server request failed");
+    expect(errors).not.toContain(upstreamSecret);
+    expect(errors).not.toContain("Error POSTing");
+  });
+
+  it("rejects an unknown tool without sending tools/call", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      pages: [
+        [
+          {
+            name: "search",
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "missing",
+        "--input",
+        "{}",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(
+      seen.filter((request) => {
+        return request.method === "tools/call";
+      }),
+    ).toHaveLength(0);
+    expect(outputText(consoleError)).toContain(
+      'MCP tool "missing" was not found',
+    );
+  });
+
+  it("refuses MCP endpoint redirects", async () => {
+    stubConnectorList();
+    server.use(
+      http.post(MCP_ENDPOINT, () => {
+        return HttpResponse.redirect(
+          "https://redirected.example.test/server",
+          307,
+        );
+      }),
+    );
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain("MCP server request failed");
+  });
+
+  it("treats an empty fixed run set as an ordinary empty result", async () => {
+    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "[]");
+    server.use(stubCustomConnectors([mcpCustomConnector()]));
+
+    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
+
+    expect(consoleLog).toHaveBeenCalledWith('{"connectors":[]}');
+  });
+
+  it("rejects an unknown slug before opening an MCP connection", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({ era: "modern" });
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "list-tools",
+        "_not-admitted",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(seen).toHaveLength(0);
+    expect(outputText(consoleError)).toContain(
+      'MCP connector "_not-admitted" is not available in this run',
+    );
+  });
+
+  it("rejects tool input above 1 MiB before opening an MCP connection", async () => {
+    stubConnectorList();
+    const seen = stubMcpServer({ era: "modern" });
+    const oversizedInput = JSON.stringify({
+      value: "x".repeat(1024 * 1024),
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "search",
+        "--input",
+        oversizedInput,
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(seen).toHaveLength(0);
+    expect(outputText(consoleError)).toContain("exceeds the 1 MiB limit");
+    expect(outputText(consoleError)).not.toContain("xxxx");
+  });
+
+  it("returns tool-level MCP errors without retrying", async () => {
+    const toolError = {
+      content: [{ type: "text", text: "invalid query" }],
+      isError: true,
+    } satisfies CallToolResult;
+    stubConnectorList();
+    const seen = stubMcpServer({
+      era: "modern",
+      pages: [
+        [
+          {
+            name: "search",
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+      callResult: toolError,
+    });
+
+    await zeroMcpCommand.parseAsync([
+      "node",
+      "zero",
+      "call",
+      "_acme-mcp",
+      "search",
+      "--input",
+      "{}",
+      "--json",
+    ]);
+
+    expect(consoleLog).toHaveBeenCalledWith(JSON.stringify(toolError));
+    expect(
+      seen.filter((request) => {
+        return request.method === "tools/call";
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("warns instead of failing after a successful call whose legacy cleanup fails", async () => {
+    stubConnectorList();
+    stubMcpServer({
+      era: "legacy",
+      pages: [
+        [
+          {
+            name: "side-effect",
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+      deleteResponse: () => {
+        return HttpResponse.text("cleanup failed", { status: 500 });
+      },
+    });
+
+    await zeroMcpCommand.parseAsync([
+      "node",
+      "zero",
+      "call",
+      "_acme-mcp",
+      "side-effect",
+      "--input",
+      "{}",
+      "--json",
+    ]);
+
+    expect(exit).not.toHaveBeenCalled();
+    expect(outputText(consoleLog)).toContain("tool completed");
+    const errors = outputText(consoleError);
+    expect(errors).toContain("MCP session cleanup did not complete");
+    expect(errors).not.toContain("cleanup failed");
+  });
+
+  it("rejects repeated pagination cursors", async () => {
+    let listRequests = 0;
+    stubConnectorList();
+    stubMcpServer({
+      era: "modern",
+      listResponse: (requestId) => {
+        listRequests++;
+        return HttpResponse.json({
+          jsonrpc: "2.0",
+          id: requestId,
+          result: {
+            resultType: "complete",
+            ttlMs: 0,
+            cacheScope: "private",
+            tools: [],
+            nextCursor: "same-cursor",
+          },
+        });
+      },
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(listRequests).toBe(2);
+    expect(outputText(consoleError)).toContain("repeated a tool page cursor");
+  });
+
+  it("rejects discovery above 2,000 tools", async () => {
+    const tools = Array.from({ length: 2_001 }, (_, index) => {
+      return {
+        name: `tool-${index}`,
+        inputSchema: { type: "object" as const },
+      } satisfies Tool;
+    });
+    stubConnectorList();
+    stubMcpServer({ era: "modern", pages: [tools] });
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain("2,000 tool limit");
+  });
+
+  it("rejects discovery above 100 pages", async () => {
+    let listRequests = 0;
+    stubConnectorList();
+    stubMcpServer({
+      era: "modern",
+      listResponse: (requestId) => {
+        listRequests++;
+        return HttpResponse.json({
+          jsonrpc: "2.0",
+          id: requestId,
+          result: {
+            resultType: "complete",
+            ttlMs: 0,
+            cacheScope: "private",
+            tools: [],
+            nextCursor: `cursor-${listRequests}`,
+          },
+        });
+      },
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(listRequests).toBe(100);
+    expect(outputText(consoleError)).toContain("100 page limit");
+  });
+
+  it("rejects aggregate discovery above 16 MiB", async () => {
+    const largeDescription = "d".repeat(8 * 1024 * 1024);
+    stubConnectorList();
+    stubMcpServer({
+      era: "modern",
+      pages: [
+        [
+          {
+            name: "first",
+            description: largeDescription,
+            inputSchema: { type: "object" },
+          },
+        ],
+        [
+          {
+            name: "second",
+            description: largeDescription,
+            inputSchema: { type: "object" },
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain("16 MiB aggregate limit");
+    expect(outputText(consoleError)).not.toContain("dddd");
+  });
+
+  it("rejects an oversized streamed response without buffering it", async () => {
+    stubConnectorList();
+    stubMcpServer({
+      era: "modern",
+      listResponse: () => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(16 * 1024 * 1024 + 1));
+            controller.close();
+          },
+        });
+        return new HttpResponse(body, {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list-tools", "_acme-mcp"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain(
+      "MCP response exceeds the 16 MiB limit",
+    );
+  });
+
+  it("uses one overall deadline", async () => {
+    stubConnectorList();
+    server.use(
+      http.post(MCP_ENDPOINT, async () => {
+        await delay(2_000);
+        return HttpResponse.json({});
+      }),
+    );
+
+    await expect(
+      zeroMcpCommand.parseAsync([
+        "node",
+        "zero",
+        "call",
+        "_acme-mcp",
+        "search",
+        "--input",
+        "{}",
+        "--timeout",
+        "1s",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(outputText(consoleError)).toContain("timed out after 1s");
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/mcp/client.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/client.ts
@@ -162,9 +162,14 @@ async function closeMcpClient(
 function safeMcpError(
   error: unknown,
   deadlineSignal: AbortSignal,
+  deadlineAt: number,
   timeoutSeconds: number,
 ): Error {
-  if (deadlineSignal.aborted || error instanceof McpDeadlineError) {
+  if (
+    deadlineSignal.aborted ||
+    Date.now() >= deadlineAt ||
+    error instanceof McpDeadlineError
+  ) {
     return new Error(`MCP command timed out after ${timeoutSeconds}s`);
   }
   if (error instanceof McpCommandError) {
@@ -235,7 +240,12 @@ async function runMcpOperation<T>(
   } catch (error) {
     outcome = {
       ok: false,
-      error: safeMcpError(error, deadlineController.signal, timeoutSeconds),
+      error: safeMcpError(
+        error,
+        deadlineController.signal,
+        deadlineAt,
+        timeoutSeconds,
+      ),
     };
   }
 

--- a/turbo/apps/cli/src/commands/zero/mcp/client.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/client.ts
@@ -1,0 +1,350 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+  type CallToolResult,
+  type FetchLike,
+  type JSONObject,
+  type Tool,
+} from "@modelcontextprotocol/client";
+import type { CustomConnectorMcpResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+
+declare const __CLI_VERSION__: string;
+
+const CONNECTOR_INTENT_HEADER = "X-VM0-Connector-Intent";
+const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+const MAX_ERROR_RESPONSE_BYTES = 8 * 1024;
+const MAX_DISCOVERY_BYTES = 16 * 1024 * 1024;
+const MAX_DISCOVERY_PAGES = 100;
+const MAX_DISCOVERY_TOOLS = 2_000;
+
+class McpCommandError extends Error {}
+class McpDeadlineError extends McpCommandError {}
+class McpResponseLimitError extends McpCommandError {}
+
+interface McpOperationResult<T> {
+  readonly value: T;
+  readonly cleanupWarning: boolean;
+}
+
+function cancelResponse(response: Response, reason: Error): void {
+  if (response.body) {
+    void response.body.cancel(reason).catch(() => {
+      return undefined;
+    });
+  }
+}
+
+function contentLengthExceeds(response: Response, limit: number): boolean {
+  const value = response.headers.get("content-length");
+  if (value === null || !/^\d+$/.test(value)) {
+    return false;
+  }
+  const length = Number(value);
+  return Number.isSafeInteger(length) && length > limit;
+}
+
+function limitResponse(response: Response): Response {
+  const limit = response.ok ? MAX_RESPONSE_BYTES : MAX_ERROR_RESPONSE_BYTES;
+  if (contentLengthExceeds(response, limit)) {
+    const error = new McpResponseLimitError(
+      response.ok
+        ? "MCP response exceeds the 16 MiB limit"
+        : "MCP server error response exceeds the 8 KiB limit",
+    );
+    cancelResponse(response, error);
+    throw error;
+  }
+
+  if (response.body === null) {
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let receivedBytes = 0;
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const next = await reader.read();
+      if (next.done) {
+        controller.close();
+        return;
+      }
+
+      receivedBytes += next.value.byteLength;
+      if (receivedBytes > limit) {
+        const error = new McpResponseLimitError(
+          response.ok
+            ? "MCP response exceeds the 16 MiB limit"
+            : "MCP server error response exceeds the 8 KiB limit",
+        );
+        await reader.cancel(error).catch(() => {
+          return undefined;
+        });
+        controller.error(error);
+        return;
+      }
+      controller.enqueue(next.value);
+    },
+    async cancel(reason: unknown) {
+      await reader.cancel(reason);
+    },
+  });
+
+  return new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function createMcpFetch(
+  connectorId: string,
+  deadlineSignal: AbortSignal,
+): FetchLike {
+  return async (url: string | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    headers.set(CONNECTOR_INTENT_HEADER, connectorId);
+    const request = new Request(url, {
+      ...init,
+      headers,
+      redirect: "error",
+    });
+    const signal = AbortSignal.any([request.signal, deadlineSignal]);
+    const response = await globalThis.fetch(request, { signal });
+    return limitResponse(response);
+  };
+}
+
+function remainingMilliseconds(deadlineAt: number): number {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) {
+    throw new McpDeadlineError("MCP command timed out");
+  }
+  return remaining;
+}
+
+function requestOptions(
+  deadlineAt: number,
+  deadlineSignal: AbortSignal,
+): {
+  readonly signal: AbortSignal;
+  readonly timeout: number;
+  readonly maxTotalTimeout: number;
+} {
+  const remaining = remainingMilliseconds(deadlineAt);
+  return {
+    signal: deadlineSignal,
+    timeout: remaining,
+    maxTotalTimeout: remaining,
+  };
+}
+
+async function closeMcpClient(
+  client: Client,
+  transport: StreamableHTTPClientTransport,
+): Promise<boolean> {
+  let cleanupWarning = false;
+  if (transport.sessionId !== undefined) {
+    try {
+      await transport.terminateSession();
+    } catch {
+      cleanupWarning = true;
+    }
+  }
+
+  try {
+    await client.close();
+  } catch {
+    cleanupWarning = true;
+  }
+  return cleanupWarning;
+}
+
+function safeMcpError(
+  error: unknown,
+  deadlineSignal: AbortSignal,
+  timeoutSeconds: number,
+): Error {
+  if (deadlineSignal.aborted || error instanceof McpDeadlineError) {
+    return new Error(`MCP command timed out after ${timeoutSeconds}s`);
+  }
+  if (error instanceof McpCommandError) {
+    return new Error(error.message);
+  }
+  return new Error("MCP server request failed");
+}
+
+async function runMcpOperation<T>(
+  connector: CustomConnectorMcpResponse,
+  timeoutSeconds: number,
+  operation: (
+    client: Client,
+    deadlineAt: number,
+    deadlineSignal: AbortSignal,
+  ) => Promise<T>,
+): Promise<McpOperationResult<T>> {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(connector.endpoint);
+  } catch {
+    throw new Error("MCP connector definition has an invalid endpoint");
+  }
+
+  const deadlineController = new AbortController();
+  const deadlineAt = Date.now() + timeoutSeconds * 1_000;
+  const transport = new StreamableHTTPClientTransport(endpoint, {
+    fetch: createMcpFetch(connector.id, deadlineController.signal),
+    requestInit: { redirect: "error" },
+    reconnectionOptions: {
+      initialReconnectionDelay: 1_000,
+      maxReconnectionDelay: 1_000,
+      reconnectionDelayGrowFactor: 1,
+      maxRetries: 0,
+    },
+    onInsufficientScope: "throw",
+    maxStepUpRetries: 0,
+  });
+  const client = new Client(
+    { name: "zero-cli", version: __CLI_VERSION__ },
+    {
+      versionNegotiation: {
+        mode: "auto",
+        probe: { maxRetries: 0 },
+      },
+      inputRequired: { autoFulfill: false },
+    },
+  );
+  const timer = setTimeout(() => {
+    deadlineController.abort(new McpDeadlineError("MCP command timed out"));
+  }, timeoutSeconds * 1_000);
+
+  let outcome:
+    | { readonly ok: true; readonly value: T }
+    | {
+        readonly ok: false;
+        readonly error: unknown;
+      };
+  try {
+    await client.connect(
+      transport,
+      requestOptions(deadlineAt, deadlineController.signal),
+    );
+    outcome = {
+      ok: true,
+      value: await operation(client, deadlineAt, deadlineController.signal),
+    };
+  } catch (error) {
+    outcome = { ok: false, error };
+  }
+
+  const cleanupWarning = await closeMcpClient(client, transport);
+  clearTimeout(timer);
+
+  if (!outcome.ok) {
+    throw safeMcpError(
+      outcome.error,
+      deadlineController.signal,
+      timeoutSeconds,
+    );
+  }
+  return { value: outcome.value, cleanupWarning };
+}
+
+async function discoverMcpTools(
+  client: Client,
+  deadlineAt: number,
+  deadlineSignal: AbortSignal,
+): Promise<Tool[]> {
+  const tools: Tool[] = [];
+  const toolNames = new Set<string>();
+  const cursors = new Set<string>();
+  let cursor: string | undefined;
+  let discoveryBytes = 0;
+
+  for (let pageNumber = 1; pageNumber <= MAX_DISCOVERY_PAGES; pageNumber++) {
+    const page = await client.request(
+      {
+        method: "tools/list",
+        params: cursor === undefined ? {} : { cursor },
+      },
+      requestOptions(deadlineAt, deadlineSignal),
+    );
+
+    discoveryBytes += Buffer.byteLength(JSON.stringify(page), "utf8");
+    if (discoveryBytes > MAX_DISCOVERY_BYTES) {
+      throw new McpCommandError(
+        "MCP tool discovery exceeds the 16 MiB aggregate limit",
+      );
+    }
+    if (tools.length + page.tools.length > MAX_DISCOVERY_TOOLS) {
+      throw new McpCommandError(
+        "MCP tool discovery exceeds the 2,000 tool limit",
+      );
+    }
+
+    for (const tool of page.tools) {
+      if (toolNames.has(tool.name)) {
+        throw new McpCommandError("MCP server returned duplicate tool names");
+      }
+      toolNames.add(tool.name);
+      tools.push(tool);
+    }
+
+    if (page.nextCursor === undefined) {
+      return tools;
+    }
+    if (pageNumber === MAX_DISCOVERY_PAGES) {
+      throw new McpCommandError(
+        "MCP tool discovery exceeds the 100 page limit",
+      );
+    }
+    if (cursors.has(page.nextCursor)) {
+      throw new McpCommandError("MCP server repeated a tool page cursor");
+    }
+    cursors.add(page.nextCursor);
+    cursor = page.nextCursor;
+  }
+
+  return tools;
+}
+
+export async function listMcpTools(
+  connector: CustomConnectorMcpResponse,
+  timeoutSeconds: number,
+): Promise<McpOperationResult<Tool[]>> {
+  return runMcpOperation(
+    connector,
+    timeoutSeconds,
+    async (client, deadlineAt, deadlineSignal) => {
+      return discoverMcpTools(client, deadlineAt, deadlineSignal);
+    },
+  );
+}
+
+export async function callMcpTool(
+  connector: CustomConnectorMcpResponse,
+  toolName: string,
+  input: JSONObject,
+  timeoutSeconds: number,
+): Promise<McpOperationResult<CallToolResult>> {
+  return runMcpOperation(
+    connector,
+    timeoutSeconds,
+    async (client, deadlineAt, deadlineSignal) => {
+      const tools = await discoverMcpTools(client, deadlineAt, deadlineSignal);
+      const tool = tools.find((candidate) => {
+        return candidate.name === toolName;
+      });
+      if (!tool) {
+        throw new McpCommandError(`MCP tool "${toolName}" was not found`);
+      }
+
+      return client.callTool(
+        { name: tool.name, arguments: input },
+        {
+          ...requestOptions(deadlineAt, deadlineSignal),
+          toolDefinition: tool,
+        },
+      );
+    },
+  );
+}

--- a/turbo/apps/cli/src/commands/zero/mcp/client.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/client.ts
@@ -221,7 +221,7 @@ async function runMcpOperation<T>(
     | { readonly ok: true; readonly value: T }
     | {
         readonly ok: false;
-        readonly error: unknown;
+        readonly error: Error;
       };
   try {
     await client.connect(
@@ -233,18 +233,17 @@ async function runMcpOperation<T>(
       value: await operation(client, deadlineAt, deadlineController.signal),
     };
   } catch (error) {
-    outcome = { ok: false, error };
+    outcome = {
+      ok: false,
+      error: safeMcpError(error, deadlineController.signal, timeoutSeconds),
+    };
   }
 
   const cleanupWarning = await closeMcpClient(client, transport);
   clearTimeout(timer);
 
   if (!outcome.ok) {
-    throw safeMcpError(
-      outcome.error,
-      deadlineController.signal,
-      timeoutSeconds,
-    );
+    throw outcome.error;
   }
   return { value: outcome.value, cleanupWarning };
 }

--- a/turbo/apps/cli/src/commands/zero/mcp/index.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/index.ts
@@ -1,0 +1,192 @@
+import chalk from "chalk";
+import { Command, Option } from "commander";
+
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { callMcpTool, listMcpTools } from "./client";
+import {
+  DEFAULT_TIMEOUT_SECONDS,
+  parseMcpTimeoutSeconds,
+  resolveMcpToolInput,
+} from "./input";
+import { listRunMcpConnectors, resolveRunMcpConnector } from "./run-connectors";
+
+interface JsonOptions {
+  readonly json?: boolean;
+}
+
+interface CallOptions extends JsonOptions {
+  readonly input?: string;
+  readonly inputFile?: string;
+  readonly timeout: number;
+}
+
+function printCleanupWarning(cleanupWarning: boolean): void {
+  if (cleanupWarning) {
+    console.error(
+      chalk.yellow("Warning: MCP session cleanup did not complete"),
+    );
+  }
+}
+
+const listCommand = new Command()
+  .name("list")
+  .description("List MCP Custom Connectors admitted to this run")
+  .option("--json", "Print compact JSON")
+  .action(
+    withErrorHandler(async (options: JsonOptions) => {
+      const connectors = (await listRunMcpConnectors()).map((connector) => {
+        return {
+          slug: connector.slug,
+          displayName: connector.displayName,
+          transport: connector.transport,
+          endpoint: connector.endpoint,
+          connected: connector.connected,
+        };
+      });
+
+      if (options.json) {
+        console.log(JSON.stringify({ connectors }));
+        return;
+      }
+      if (connectors.length === 0) {
+        console.log(chalk.dim("No MCP connectors are available in this run"));
+        return;
+      }
+
+      const slugWidth = Math.max(
+        "SLUG".length,
+        ...connectors.map((connector) => {
+          return connector.slug.length;
+        }),
+      );
+      const statusWidth = "DISCONNECTED".length;
+      console.log(
+        chalk.dim(
+          [
+            "SLUG".padEnd(slugWidth),
+            "STATUS".padEnd(statusWidth),
+            "TRANSPORT",
+            "ENDPOINT",
+          ].join("  "),
+        ),
+      );
+      for (const connector of connectors) {
+        const status = connector.connected ? "connected" : "disconnected";
+        console.log(
+          [
+            connector.slug.padEnd(slugWidth),
+            status.padEnd(statusWidth),
+            connector.transport,
+            connector.endpoint,
+          ].join("  "),
+        );
+      }
+    }),
+  );
+
+const listToolsCommand = new Command()
+  .name("list-tools")
+  .description("List tools exposed by an admitted MCP connector")
+  .argument("<connector-slug>", "MCP Custom Connector slug")
+  .option("--json", "Print compact JSON")
+  .action(
+    withErrorHandler(async (connectorSlug: string, options: JsonOptions) => {
+      const connector = await resolveRunMcpConnector(connectorSlug);
+      const result = await listMcpTools(connector, DEFAULT_TIMEOUT_SECONDS);
+      printCleanupWarning(result.cleanupWarning);
+
+      if (options.json) {
+        console.log(
+          JSON.stringify({
+            connectorSlug: connector.slug,
+            tools: result.value,
+          }),
+        );
+        return;
+      }
+      if (result.value.length === 0) {
+        console.log(
+          chalk.dim(`MCP connector "${connector.slug}" exposes no tools`),
+        );
+        return;
+      }
+
+      for (const tool of result.value) {
+        console.log(chalk.cyan(`Tool: ${JSON.stringify(tool.name)}`));
+        if (tool.description !== undefined) {
+          console.log(`  Description: ${JSON.stringify(tool.description)}`);
+        }
+        console.log("  Input schema:");
+        const schema = JSON.stringify(tool.inputSchema, null, 2)
+          .split("\n")
+          .map((line) => {
+            return `    ${line}`;
+          })
+          .join("\n");
+        console.log(schema);
+      }
+    }),
+  );
+
+const inputOption = new Option(
+  "--input <json>",
+  "Tool input as a JSON object",
+).conflicts("inputFile");
+const inputFileOption = new Option(
+  "--input-file <path>",
+  "Read the tool input JSON object from a file",
+).conflicts("input");
+
+const callCommand = new Command()
+  .name("call")
+  .description("Call one tool on an admitted MCP connector")
+  .argument("<connector-slug>", "MCP Custom Connector slug")
+  .argument("<tool-name>", "Exact MCP tool name")
+  .addOption(inputOption)
+  .addOption(inputFileOption)
+  .option(
+    "--timeout <duration>",
+    "Overall timeout from 1s to 15m",
+    parseMcpTimeoutSeconds,
+    DEFAULT_TIMEOUT_SECONDS,
+  )
+  .option("--json", "Print compact JSON")
+  .action(
+    withErrorHandler(
+      async (connectorSlug: string, toolName: string, options: CallOptions) => {
+        const connector = await resolveRunMcpConnector(connectorSlug);
+        const input = await resolveMcpToolInput(options);
+        const result = await callMcpTool(
+          connector,
+          toolName,
+          input,
+          options.timeout,
+        );
+        printCleanupWarning(result.cleanupWarning);
+        console.log(
+          JSON.stringify(result.value, null, options.json ? undefined : 2),
+        );
+      },
+    ),
+  );
+
+export const zeroMcpCommand = new Command()
+  .name("mcp")
+  .description("Use MCP Custom Connectors admitted to this Agent Run")
+  .addCommand(listCommand)
+  .addCommand(listToolsCommand)
+  .addCommand(callCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  List admitted MCP connectors:  zero mcp list
+  List connector tools:          zero mcp list-tools _acme-mcp --json
+  Call a tool:                   zero mcp call _acme-mcp search --input '{"query":"vm0"}' --json
+  Pipe tool input:               printf '{"query":"vm0"}' | zero mcp call _acme-mcp search
+
+Notes:
+  - Available only inside an Agent Run that admitted the connector
+  - Runner applies endpoint policy and injects connector credentials
+  - Tool calls are never automatically retried`,
+  );

--- a/turbo/apps/cli/src/commands/zero/mcp/input.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/input.ts
@@ -1,0 +1,113 @@
+import { createReadStream } from "node:fs";
+
+import type { JSONObject } from "@modelcontextprotocol/client";
+import { InvalidArgumentError } from "commander";
+import { z } from "zod";
+
+import { parseDurationSeconds } from "../shared/duration";
+
+const MAX_TOOL_INPUT_BYTES = 1024 * 1024;
+const DEFAULT_TIMEOUT_SECONDS = 60;
+const MAX_TIMEOUT_SECONDS = 15 * 60;
+
+const toolInputSchema = z.record(z.string(), z.json());
+
+interface McpCallInputOptions {
+  readonly input?: string;
+  readonly inputFile?: string;
+}
+
+class InputTooLargeError extends Error {}
+
+async function readBoundedUtf8(
+  source: AsyncIterable<Buffer | string>,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+
+  for await (const chunk of source) {
+    const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    bytes += buffer.byteLength;
+    if (bytes > MAX_TOOL_INPUT_BYTES) {
+      throw new InputTooLargeError();
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks, bytes).toString("utf8");
+}
+
+async function readInputFile(path: string): Promise<string> {
+  try {
+    return await readBoundedUtf8(createReadStream(path));
+  } catch (error) {
+    if (error instanceof InputTooLargeError) {
+      throw error;
+    }
+    throw new Error(`Unable to read MCP tool input file "${path}"`);
+  }
+}
+
+function parseToolInput(rawInput: string): JSONObject {
+  if (Buffer.byteLength(rawInput, "utf8") > MAX_TOOL_INPUT_BYTES) {
+    throw new InputTooLargeError();
+  }
+
+  const normalizedInput = rawInput.trim() === "" ? "{}" : rawInput;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(normalizedInput);
+  } catch {
+    throw new Error("MCP tool input must be valid JSON");
+  }
+
+  const result = toolInputSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error("MCP tool input must be a JSON object");
+  }
+  return result.data;
+}
+
+export async function resolveMcpToolInput(
+  options: McpCallInputOptions,
+): Promise<JSONObject> {
+  if (options.input !== undefined && options.inputFile !== undefined) {
+    throw new Error("Use only one of --input or --input-file");
+  }
+
+  try {
+    if (options.input !== undefined) {
+      return parseToolInput(options.input);
+    }
+    if (options.inputFile !== undefined) {
+      return parseToolInput(await readInputFile(options.inputFile));
+    }
+    if (!process.stdin.isTTY) {
+      return parseToolInput(await readBoundedUtf8(process.stdin));
+    }
+    return {};
+  } catch (error) {
+    if (error instanceof InputTooLargeError) {
+      throw new Error("MCP tool input exceeds the 1 MiB limit");
+    }
+    throw error;
+  }
+}
+
+export function parseMcpTimeoutSeconds(value: string): number {
+  let seconds: number;
+  try {
+    seconds = parseDurationSeconds(value);
+  } catch {
+    throw new InvalidArgumentError(
+      "timeout must use <number><unit> with unit s or m",
+    );
+  }
+
+  if (seconds < 1 || seconds > MAX_TIMEOUT_SECONDS) {
+    throw new InvalidArgumentError("timeout must be between 1s and 15m");
+  }
+  return seconds;
+}
+
+export { DEFAULT_TIMEOUT_SECONDS };

--- a/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
@@ -1,0 +1,76 @@
+import {
+  ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY,
+  type CustomConnectorMcpResponse,
+} from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { z } from "zod";
+
+import { listZeroCustomConnectors } from "../../../lib/api/domains/zero-connectors";
+
+const MAX_RUN_CONNECTOR_IDS_BYTES = 128 * 1024;
+const RUN_METADATA_ERROR =
+  "MCP connector metadata is unavailable for this run. Start a new Agent Run and try again.";
+
+const runConnectorIdsSchema = z.array(z.uuid());
+
+function readRunConnectorIds(): Set<string> {
+  const raw = process.env[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY];
+  if (
+    raw === undefined ||
+    Buffer.byteLength(raw, "utf8") > MAX_RUN_CONNECTOR_IDS_BYTES
+  ) {
+    throw new Error(RUN_METADATA_ERROR);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(RUN_METADATA_ERROR);
+  }
+
+  const result = runConnectorIdsSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(RUN_METADATA_ERROR);
+  }
+
+  const normalizedIds = result.data.map((id) => {
+    return id.toLowerCase();
+  });
+  const uniqueIds = new Set(normalizedIds);
+  if (uniqueIds.size !== normalizedIds.length) {
+    throw new Error(RUN_METADATA_ERROR);
+  }
+  return uniqueIds;
+}
+
+export async function listRunMcpConnectors(): Promise<
+  CustomConnectorMcpResponse[]
+> {
+  const admittedIds = readRunConnectorIds();
+  const connectors = await listZeroCustomConnectors();
+
+  return connectors
+    .filter((connector): connector is CustomConnectorMcpResponse => {
+      return (
+        connector.kind === "mcp" && admittedIds.has(connector.id.toLowerCase())
+      );
+    })
+    .sort((left, right) => {
+      return left.slug.localeCompare(right.slug);
+    });
+}
+
+export async function resolveRunMcpConnector(
+  connectorSlug: string,
+): Promise<CustomConnectorMcpResponse> {
+  const connectors = await listRunMcpConnectors();
+  const connector = connectors.find((candidate) => {
+    return candidate.slug === connectorSlug;
+  });
+  if (!connector) {
+    throw new Error(
+      `MCP connector "${connectorSlug}" is not available in this run`,
+    );
+  }
+  return connector;
+}

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -31,6 +31,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   workflow: "agent:read",
   goal: ["goal:read", "goal:agent-result:write", "goal:user-control:write"],
   connector: ["connector:read", "connector:write"],
+  mcp: "connector:read",
   mail: "connector:read",
   doctor: null,
   credit: ["billing:read", "billing:write"],
@@ -73,7 +74,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   banking: "banking:read",
 };
 
-const RUN_ONLY_COMMANDS = new Set(["recognize", "translate"]);
+const RUN_ONLY_COMMANDS = new Set(["mcp", "recognize", "translate"]);
 
 const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
   {
@@ -111,6 +112,13 @@ const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
     description: "Check third-party service connections (GitHub, Slack, etc.)",
     load: async () => {
       return (await import("./commands/zero/connector")).zeroConnectorCommand;
+    },
+  },
+  {
+    name: "mcp",
+    description: "Use MCP Custom Connectors admitted to this Agent Run",
+    load: async () => {
+      return (await import("./commands/zero/mcp")).zeroMcpCommand;
     },
   },
   {

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
 
   apps/cli:
     devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sentry/node':
         specifier: ^10.50.0
         version: 10.50.0(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))
@@ -2702,6 +2705,14 @@ packages:
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
+
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -13200,6 +13211,20 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.3.6
 
   '@modelcontextprotocol/sdk@1.30.0':
     dependencies:


### PR DESCRIPTION
## Summary

- add Run-only `zero mcp list`, `list-tools`, and `call` commands for admitted MCP Custom Connectors
- intersect the fixed server-provided connector IDs with current non-secret definitions and invoke Streamable HTTP through Runner's existing proxy boundary
- bound metadata, input, discovery, responses, deadlines, retries, cleanup, and error output around the official MCP v2 client
- cover current and 2025-era negotiation, pagination, exact one-shot calls, proxy intent, input sources, resource limits, cleanup, redirects, and sanitized failures

## Exclusions

- no database schema or persisted-data changes
- no API contract, server admission, Runner protocol/firewall, or rollout-default changes
- deployed authenticated smoke testing and default activation remain in #26012

## Validation

- `pnpm exec prettier --check apps/cli/package.json apps/cli/src/zero.ts apps/cli/src/__tests__/zero.test.ts apps/cli/src/__tests__/zero-capability-visibility.test.ts apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts apps/cli/src/commands/zero/mcp`
- `pnpm -F @vm0/zero-cli lint`
- `pnpm -F @vm0/zero-cli check-types`
- `pnpm -F @vm0/zero-cli exec vitest run --maxWorkers=4 --silent=passed-only` (972 passed, 1 existing skip)
- `pnpm -F @vm0/zero-cli build`
- `pnpm knip --workspace @vm0/zero-cli`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- repository pre-commit formatter, full Knip, full Turbo type checks, file-size check, and commitlint

Closes #26011

Parent delivery: #25031
