### PR TITLE
fix(connectors): activate custom connector skills atomically

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -16,13 +16,16 @@ import {
   type CreateCustomConnectorBody,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { getCustomConnectorSkillStorageName } from "@vm0/core/storage-names";
 import { describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
+import { extractFileFromTarGz } from "../../../lib/tar";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { generateZeroToken } from "../../auth/tokens";
+import { createDeferredPromise } from "../../utils";
 import {
   createBddApi,
   expectApiError,
@@ -46,6 +49,7 @@ import {
 } from "./helpers/api-bdd-connectors";
 import { readUserSecrets } from "./helpers/user-config-state";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
+import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import {
   readConnectorCredentialStorageState,
   readCustomConnectorCredentialStorageParent,
@@ -57,6 +61,7 @@ import { zeroCustomConnectorsRoutes } from "../zero-custom-connectors";
 const context = testContext();
 const connectorsApi = createConnectorBddApi(context);
 const authOrgApi = createAuthOrgAgentsBddApi(context);
+const storagesApi = createStoragesBddApi(context);
 
 function mockAuthoritativeOrganizationMembers(
   actors: readonly ApiTestUser[],
@@ -97,6 +102,30 @@ function expectCustomConnectorInvalidations(userIds: readonly string[]): void {
 
 function uniqueSlug(prefix: string): string {
   return `_${prefix}-${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function uploadedSkillInstruction(command: unknown): string | null {
+  const input = commandInput(command);
+  if (
+    !String(input.Key).endsWith("/archive.tar.gz") ||
+    !Buffer.isBuffer(input.Body)
+  ) {
+    return null;
+  }
+  return extractFileFromTarGz(input.Body, "SKILL.md");
 }
 
 function customConnectorBody(slug: string) {
@@ -3849,7 +3878,165 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await connectorsApi.deleteCustomConnector(admin, committedConnectorId);
   });
 
-  it("persists permission bundles and skill markdown", async () => {
+  it("does not activate a custom connector when skill publication fails", async () => {
+    const bdd = createBddApi(context);
+    const admin = bdd.user();
+    const slug = uniqueSlug("bdd-skill-create-failure");
+    context.mocks.s3.send.mockRejectedValue(
+      new Error("Custom connector skill upload failed"),
+    );
+
+    const response = await connectorsApi.requestCreateCustomConnector(
+      admin,
+      {
+        ...customConnectorBody(slug),
+        skillMarkdown: "This skill must never become active.",
+      },
+      [500],
+    );
+
+    expect(response.status).toBe(500);
+    await expect(
+      connectorsApi.listCustomConnectors(admin),
+    ).resolves.not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ slug })]),
+    );
+  });
+
+  it("keeps the active definition and skill HEAD when an update upload fails", async () => {
+    const bdd = createBddApi(context);
+    const admin = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    const created = await connectorsApi.createCustomConnector(admin, {
+      ...customConnectorBody(uniqueSlug("bdd-skill-update-failure")),
+      skillMarkdown: "Keep these active instructions.",
+    });
+    const storageName = getCustomConnectorSkillStorageName(created.id);
+    const initialHead = await storagesApi.downloadStorage(admin, {
+      name: storageName,
+      owner: "organization",
+    });
+    context.mocks.s3.send.mockRejectedValue(
+      new Error("Custom connector skill update upload failed"),
+    );
+
+    const response = await connectorsApi.requestUpdateCustomConnector(
+      admin,
+      created.id,
+      {
+        displayName: "Must Not Become Active",
+        prefixTemplates: created.prefixTemplates,
+        fields: created.fields,
+        headerInjections: created.headerInjections,
+        queryInjections: created.queryInjections,
+        authMode: created.authMode,
+        skillMarkdown: "These failed instructions must not become active.",
+      },
+      [500],
+    );
+
+    expect(response.status).toBe(500);
+    context.mocks.s3.send.mockResolvedValue({ ContentLength: 1024 });
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject({
+      displayName: created.displayName,
+      skillMarkdown: "Keep these active instructions.",
+    });
+    await expect(
+      storagesApi.downloadStorage(admin, {
+        name: storageName,
+        owner: "organization",
+      }),
+    ).resolves.toMatchObject({ versionId: initialHead.versionId });
+
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("does not let a stale skill update move the winning definition or HEAD", async () => {
+    const bdd = createBddApi(context);
+    const admin = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    const created = await connectorsApi.createCustomConnector(admin, {
+      ...customConnectorBody(uniqueSlug("bdd-skill-update-race")),
+      skillMarkdown: "Initial active instructions.",
+    });
+    const storageName = getCustomConnectorSkillStorageName(created.id);
+    const initialHead = await storagesApi.downloadStorage(admin, {
+      name: storageName,
+      owner: "organization",
+    });
+    const staleUploadStarted = createDeferredPromise<void>(context.signal);
+    const releaseStaleUpload = createDeferredPromise<void>(context.signal);
+    context.mocks.s3.send.mockImplementation(async (command: unknown) => {
+      const skill = uploadedSkillInstruction(command);
+      if (skill?.includes("Stale writer instructions")) {
+        if (!staleUploadStarted.settled()) {
+          staleUploadStarted.resolve();
+        }
+        await releaseStaleUpload.promise;
+      }
+      return { ContentLength: 1024 };
+    });
+
+    const staleRequest = connectorsApi.requestUpdateCustomConnector(
+      admin,
+      created.id,
+      {
+        displayName: "Stale Writer",
+        prefixTemplates: created.prefixTemplates,
+        fields: created.fields,
+        headerInjections: created.headerInjections,
+        queryInjections: created.queryInjections,
+        authMode: created.authMode,
+        skillMarkdown: "Stale writer instructions.",
+      },
+      [400],
+    );
+    await staleUploadStarted.promise;
+    const winner = await connectorsApi.updateCustomConnector(
+      admin,
+      created.id,
+      {
+        displayName: "Winning Writer",
+        prefixTemplates: created.prefixTemplates,
+        fields: created.fields,
+        headerInjections: created.headerInjections,
+        queryInjections: created.queryInjections,
+        authMode: created.authMode,
+        skillMarkdown: "Winning writer instructions.",
+      },
+    );
+    const winningHead = await storagesApi.downloadStorage(admin, {
+      name: storageName,
+      owner: "organization",
+    });
+    releaseStaleUpload.resolve();
+    const staleResponse = await staleRequest;
+
+    expect(staleResponse.status).toBe(400);
+    expectApiError(staleResponse.body);
+    expect(staleResponse.body.error.message).toContain(
+      "changed while the definition was being saved",
+    );
+    expect(winningHead.versionId).not.toBe(initialHead.versionId);
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject({
+      displayName: winner.displayName,
+      skillMarkdown: "Winning writer instructions.",
+    });
+    await expect(
+      storagesApi.downloadStorage(admin, {
+        name: storageName,
+        owner: "organization",
+      }),
+    ).resolves.toMatchObject({ versionId: winningHead.versionId });
+
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("publishes exact skill versions and retains them after clearing and deletion", async () => {
     const bdd = createBddApi(context);
     const admin = bdd.user();
     bdd.acceptAgentStorageWrites();
@@ -3863,6 +4050,11 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expect(created).toMatchObject({
       permissionBundleRef: "builtin:slack@1",
       skillMarkdown: "Use this connector to coordinate Slack conversations.",
+    });
+    const storageName = getCustomConnectorSkillStorageName(created.id);
+    const createdHead = await storagesApi.downloadStorage(admin, {
+      name: storageName,
+      owner: "organization",
     });
 
     const skillUpdated = await connectorsApi.updateCustomConnector(
@@ -3882,6 +4074,18 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       permissionBundleRef: "builtin:slack@1",
       skillMarkdown: "Updated Slack operating instructions.",
     });
+    const updatedHead = await storagesApi.downloadStorage(admin, {
+      name: storageName,
+      owner: "organization",
+    });
+    expect(updatedHead.versionId).not.toBe(createdHead.versionId);
+    await expect(
+      storagesApi.downloadStorage(admin, {
+        name: storageName,
+        owner: "organization",
+        version: createdHead.versionId,
+      }),
+    ).resolves.toMatchObject({ versionId: createdHead.versionId });
 
     const permissionBundleCleared = await connectorsApi.updateCustomConnector(
       admin,
@@ -3914,7 +4118,35 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       "Unknown custom connector permission bundle",
     );
 
+    const skillCleared = await connectorsApi.updateCustomConnector(
+      admin,
+      created.id,
+      {
+        displayName: permissionBundleCleared.displayName,
+        prefixTemplates: permissionBundleCleared.prefixTemplates,
+        fields: permissionBundleCleared.fields,
+        headerInjections: permissionBundleCleared.headerInjections,
+        queryInjections: permissionBundleCleared.queryInjections,
+        authMode: permissionBundleCleared.authMode,
+        skillMarkdown: null,
+      },
+    );
+    expect(skillCleared.skillMarkdown).toBeNull();
+    await expect(
+      storagesApi.downloadStorage(admin, {
+        name: storageName,
+        owner: "organization",
+      }),
+    ).resolves.toMatchObject({ versionId: updatedHead.versionId });
+
     await connectorsApi.deleteCustomConnector(admin, created.id);
+    await expect(
+      storagesApi.downloadStorage(admin, {
+        name: storageName,
+        owner: "organization",
+        version: updatedHead.versionId,
+      }),
+    ).resolves.toMatchObject({ versionId: updatedHead.versionId });
   });
 
   it("rejects prefix collisions introduced by edits", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -3898,7 +3898,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expect(response.status).toBe(500);
     await expect(
       connectorsApi.listCustomConnectors(admin),
-    ).resolves.not.toEqual(
+    ).resolves.not.toStrictEqual(
       expect.arrayContaining([expect.objectContaining({ slug })]),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -48,6 +48,7 @@ import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
+import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import {
   createRunsApi,
   expectCanonicalStorageManifest,
@@ -87,6 +88,7 @@ const mocks = createZeroRouteMocks(context);
 const authOrgApi = createAuthOrgAgentsBddApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 const runsApi = createRunsApi(context);
+const storagesApi = createStoragesBddApi(context);
 const webhooksApi = createWebhookCallbackApi(context);
 const APP_ORIGIN = "https://app.vm0.test";
 const ENCRYPT_KEY = "feishu-test-encrypt-key";
@@ -347,6 +349,25 @@ async function postEvent(
     method: "POST",
     headers,
     body,
+  });
+}
+
+async function requestFeishuConfigurationFailure(args: {
+  readonly method: "POST" | "PATCH";
+  readonly path: string;
+  readonly body: unknown;
+}): Promise<Response> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: zeroFeishuConnectRoutes,
+  });
+  return await app.request(args.path, {
+    method: args.method,
+    headers: {
+      authorization: "Bearer clerk-session",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(args.body),
   });
 }
 
@@ -1348,6 +1369,226 @@ describe("Feishu integration", () => {
     );
   });
 
+  it("converges concurrent managed connector retries after skill publication fails", async () => {
+    const actor = authOrgApi.user({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      orgRole: "org:admin",
+    });
+    authOrgApi.acceptAgentStorageWrites();
+    await enableFeishuIntegration(actor);
+    const agent = await authOrgApi.createAgent(actor, {
+      displayName: "Feishu connector retry agent",
+      visibility: "public",
+    });
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+      zeroFeishuConnectContract,
+    );
+    context.mocks.s3.send.mockRejectedValue(
+      new Error("Managed connector skill upload failed"),
+    );
+
+    const failedSetup = await requestFeishuConfigurationFailure({
+      method: "POST",
+      path: zeroFeishuConnectContract.setup.path,
+      body: {
+        appId: `cli_${randomUUID()}`,
+        appSecret: APP_SECRET,
+        verificationToken: VERIFICATION_TOKEN,
+        defaultAgentId: agent.agentId,
+        createNew: true,
+      },
+    });
+    expect(failedSetup.status).toBe(500);
+
+    const customConnectorClient = setupApp({
+      context,
+      routes: zeroCustomConnectorsRoutes,
+    })(zeroCustomConnectorsContract);
+    const connectorsAfterFailure = await accept(
+      customConnectorClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(connectorsAfterFailure.body.connectors).toStrictEqual([]);
+    const status = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const installation = requireValue(
+      status.body.installations?.[0],
+      "Expected the failed setup to retain its Feishu installation",
+    );
+
+    const bothSkillUploadsStarted = createDeferredPromise<void>(context.signal);
+    const releaseSkillUploads = createDeferredPromise<void>(context.signal);
+    const archiveKeys: string[] = [];
+    context.mocks.s3.send.mockImplementation(async (command: unknown) => {
+      const input = commandInput(command);
+      if (
+        String(input.Key).endsWith("/archive.tar.gz") &&
+        Buffer.isBuffer(input.Body)
+      ) {
+        archiveKeys.push(String(input.Key));
+        if (archiveKeys.length === 2) {
+          bothSkillUploadsStarted.resolve();
+        }
+        if (archiveKeys.length <= 2) {
+          await releaseSkillUploads.promise;
+        }
+      }
+      return { ContentLength: 1024 };
+    });
+
+    const updateResponsesPromise = Promise.all([
+      client.updateInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId: installation.id },
+        body: { defaultAgentId: agent.agentId, setupCompleted: true },
+      }),
+      client.updateInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId: installation.id },
+        body: { defaultAgentId: agent.agentId, setupCompleted: true },
+      }),
+    ]);
+    await bothSkillUploadsStarted.promise;
+    releaseSkillUploads.resolve();
+    const updateResponses = await updateResponsesPromise;
+
+    expect(
+      updateResponses.map((response) => {
+        return response.status;
+      }),
+    ).toStrictEqual([200, 200]);
+    expect(new Set(archiveKeys).size).toBe(2);
+    const connectorList = await accept(
+      customConnectorClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(connectorList.body.connectors).toHaveLength(1);
+    const managedConnector = requireValue(
+      connectorList.body.connectors[0],
+      "Expected concurrent retries to converge on one connector",
+    );
+    await expect(
+      storagesApi.downloadStorage(actor, {
+        name: getCustomConnectorSkillStorageName(managedConnector.id),
+        owner: "organization",
+      }),
+    ).resolves.toMatchObject({ fileCount: 1 });
+
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId: installation.id },
+      }),
+      [200],
+    );
+  });
+
+  it("keeps the managed connector and skill HEAD active when repair publication fails", async () => {
+    const actor = authOrgApi.user({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      orgRole: "org:admin",
+    });
+    authOrgApi.acceptAgentStorageWrites();
+    await enableFeishuIntegration(actor);
+    const agent = await authOrgApi.createAgent(actor, {
+      displayName: "Feishu connector repair agent",
+      visibility: "public",
+    });
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+      zeroFeishuConnectContract,
+    );
+    const configured = await accept(
+      client.setup({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          appId: `cli_${randomUUID()}`,
+          appSecret: APP_SECRET,
+          verificationToken: VERIFICATION_TOKEN,
+          defaultAgentId: agent.agentId,
+          createNew: true,
+        },
+      }),
+      [200],
+    );
+    const installationId = requireValue(
+      configured.body.installationId,
+      "Expected Feishu setup to return an installation id",
+    );
+    const customConnectorClient = setupApp({
+      context,
+      routes: zeroCustomConnectorsRoutes,
+    })(zeroCustomConnectorsContract);
+    const initialList = await accept(
+      customConnectorClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const initialConnector = requireValue(
+      initialList.body.connectors[0],
+      "Expected Feishu setup to activate a managed connector",
+    );
+    const storageName = getCustomConnectorSkillStorageName(initialConnector.id);
+    const initialHead = await storagesApi.downloadStorage(actor, {
+      name: storageName,
+      owner: "organization",
+    });
+    context.mocks.s3.send.mockRejectedValue(
+      new Error("Managed connector repair skill upload failed"),
+    );
+
+    const failedRepair = await requestFeishuConfigurationFailure({
+      method: "PATCH",
+      path: zeroFeishuConnectContract.updateInstallation.path.replace(
+        ":installationId",
+        installationId,
+      ),
+      body: { defaultAgentId: agent.agentId, setupCompleted: true },
+    });
+
+    expect(failedRepair.status).toBe(500);
+    context.mocks.s3.send.mockResolvedValue({ ContentLength: 1024 });
+    const connectorAfterFailure = await accept(
+      customConnectorClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(connectorAfterFailure.body.connectors).toMatchObject([
+      {
+        id: initialConnector.id,
+        displayName: initialConnector.displayName,
+        skillMarkdown: initialConnector.skillMarkdown,
+      },
+    ]);
+    await expect(
+      storagesApi.downloadStorage(actor, {
+        name: storageName,
+        owner: "organization",
+      }),
+    ).resolves.toMatchObject({ versionId: initialHead.versionId });
+
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId },
+      }),
+      [200],
+    );
+  });
+
   it("requires organization admins even when the user created the bot", async () => {
     const actor = authOrgApi.user({
       userId: `user_${randomUUID()}`,
@@ -1557,6 +1798,13 @@ describe("Feishu integration", () => {
     expect(managedConnector.skillMarkdown).toContain(
       "does not grant whiteboard node update or delete scopes",
     );
+    const managedSkillStorageName = getCustomConnectorSkillStorageName(
+      managedConnector.id,
+    );
+    const managedSkillHead = await storagesApi.downloadStorage(admin, {
+      name: managedSkillStorageName,
+      owner: "organization",
+    });
     const skillMarkdown = uploadedSkillMarkdown();
     expect(skillMarkdown).toContain("---\nname: feishu\n");
     expect(skillMarkdown).toContain(
@@ -1954,6 +2202,13 @@ describe("Feishu integration", () => {
       [200],
     );
     expect(removedConnectorList.body.connectors).toStrictEqual([]);
+    await expect(
+      storagesApi.downloadStorage(admin, {
+        name: managedSkillStorageName,
+        owner: "organization",
+        version: managedSkillHead.versionId,
+      }),
+    ).resolves.toMatchObject({ versionId: managedSkillHead.versionId });
   });
 
   it("verifies and decrypts URL verification callbacks", async () => {

--- a/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
@@ -2,90 +2,78 @@ import { command } from "ccstate";
 import {
   getCustomConnectorSkillName,
   getCustomConnectorSkillStorageName,
-  VOLUME_ORG_USER_ID,
 } from "@vm0/core/storage-names";
 import { synthesizeSkillMd } from "@vm0/core/zero-workflow-skill";
-import { storages } from "@vm0/db/schema/storage";
-import { and, eq } from "drizzle-orm";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { eq } from "drizzle-orm";
 
-import { env } from "../../lib/env";
-import { writeDb$ } from "../external/db";
-import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
-import { uploadVolumeServerSide$ } from "./storage-volume-upload.service";
+import type { Db } from "../external/db";
+import {
+  commitPreparedVolumeServerSide,
+  prepareVolumeServerSide$,
+  type PreparedServerSideVolume,
+} from "./storage-volume-publication.service";
 import { SKILL_FILENAME } from "./zero-workflow-volume.service";
 
-export const syncCustomConnectorSkillVolume$ = command(
+interface PrepareCustomConnectorSkillVolumeInput {
+  readonly orgId: string;
+  readonly connectorId: string;
+  readonly connectorSlug: string;
+  readonly displayName: string;
+  readonly skillMarkdown: string;
+  readonly skillName?: string;
+  readonly skillDescription?: string;
+}
+
+export const prepareCustomConnectorSkillVolume$ = command(
   async (
-    { get, set },
-    args: {
-      readonly orgId: string;
-      readonly connectorId: string;
-      readonly connectorSlug: string;
-      readonly displayName: string;
-      readonly skillMarkdown: string | null;
-      readonly skillName?: string;
-      readonly skillDescription?: string;
-    },
+    { set },
+    args: PrepareCustomConnectorSkillVolumeInput,
     signal: AbortSignal,
-  ): Promise<void> => {
-    const storageName = getCustomConnectorSkillStorageName(args.connectorId);
-    if (args.skillMarkdown !== null) {
-      await set(
-        uploadVolumeServerSide$,
-        {
-          orgId: args.orgId,
-          storageName,
-          files: [
-            {
-              path: SKILL_FILENAME,
-              content: synthesizeSkillMd({
-                name:
-                  args.skillName ??
-                  getCustomConnectorSkillName(
-                    args.connectorSlug,
-                    args.connectorId,
-                  ),
-                description: args.skillDescription ?? args.displayName,
-                instruction: args.skillMarkdown,
-              }),
-            },
-          ],
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      return;
-    }
-
-    const writeDb = set(writeDb$);
-    const [storage] = await writeDb
-      .delete(storages)
-      .where(
-        and(
-          eq(storages.orgId, args.orgId),
-          eq(storages.userId, VOLUME_ORG_USER_ID),
-          eq(storages.name, storageName),
-        ),
-      )
-      .returning({ s3Prefix: storages.s3Prefix });
-    signal.throwIfAborted();
-    if (!storage) {
-      return;
-    }
-
-    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-    const objects = await get(
-      listS3ObjectsUnderPrefix(bucket, storage.s3Prefix),
+  ): Promise<PreparedServerSideVolume> => {
+    const volume = await set(
+      prepareVolumeServerSide$,
+      {
+        orgId: args.orgId,
+        storageName: getCustomConnectorSkillStorageName(args.connectorId),
+        files: [
+          {
+            path: SKILL_FILENAME,
+            content: synthesizeSkillMd({
+              name:
+                args.skillName ??
+                getCustomConnectorSkillName(
+                  args.connectorSlug,
+                  args.connectorId,
+                ),
+              description: args.skillDescription ?? args.displayName,
+              instruction: args.skillMarkdown,
+            }),
+          },
+        ],
+      },
+      signal,
     );
     signal.throwIfAborted();
-    await get(
-      deleteS3Objects(
-        bucket,
-        objects.map((object) => {
-          return object.key;
-        }),
-      ),
-    );
-    signal.throwIfAborted();
+    return volume;
   },
 );
+
+export async function commitPreparedCustomConnectorSkillVolume(
+  args: {
+    readonly db: Db;
+    readonly connectorId: string;
+    readonly volume: PreparedServerSideVolume;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await commitPreparedVolumeServerSide(
+    { db: args.db, volume: args.volume },
+    signal,
+  );
+  await args.db
+    .update(orgCustomConnectors)
+    .set({ skillStorageVersionId: args.volume.version.versionId })
+    .where(eq(orgCustomConnectors.id, args.connectorId));
+  signal.throwIfAborted();
+}

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
@@ -15,13 +16,17 @@ import {
   type CapturedConnectorClientInvalidationAbort,
 } from "./connector-client-invalidation.service";
 import { deleteCustomConnectorMemberConnection } from "./custom-connector-credential-storage.service";
-import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
+import {
+  commitPreparedCustomConnectorSkillVolume,
+  prepareCustomConnectorSkillVolume$,
+} from "./custom-connector-skill-volume.service";
 import { commitConnectorRuntimeMutation } from "./connector-runtime-wakeup.service";
 import {
   customConnectorDefinitionSelection,
   type CustomConnectorDefinitionRow,
 } from "./custom-connector-definition-selection";
 import type { Tx } from "../../lib/db-types";
+import type { PreparedServerSideVolume } from "./storage-volume-publication.service";
 
 const FEISHU_API_PREFIX = "https://open.feishu.cn/open-apis/";
 const FEISHU_AUTHORIZATION_URL =
@@ -61,10 +66,22 @@ interface ExistingFeishuCustomConnector {
 
 interface ReconciledFeishuCustomConnector {
   readonly connectorId: string;
-  readonly displayName: string;
   readonly definitionChanged: boolean;
   readonly runtimeChanged: boolean;
 }
+
+interface PreparedFeishuCustomConnectorSkill {
+  readonly connectorId: string;
+  readonly volume: PreparedServerSideVolume;
+}
+
+type FeishuCustomConnectorReconciliation =
+  | { readonly kind: "installation-missing" }
+  | { readonly kind: "stale-target"; readonly connectorId: string }
+  | {
+      readonly kind: "reconciled";
+      readonly connector: ReconciledFeishuCustomConnector;
+    };
 
 const FEISHU_SKILL_MARKDOWN = `Use Feishu OpenAPI as the connected user to find coworkers, collaborate in chats, work with cloud content, manage calendars, and organize tasks.
 
@@ -252,14 +269,15 @@ async function createFeishuCustomConnector(
   tx: DbTransaction,
   args: EnsureFeishuCustomConnectorArgs,
   installation: FeishuConnectorInstallation,
-  slug: string,
+  connectorId: string,
   signal: AbortSignal,
 ): Promise<ReconciledFeishuCustomConnector> {
   const [connector] = await tx
     .insert(orgCustomConnectors)
     .values({
+      id: connectorId,
       orgId: args.orgId,
-      slug,
+      slug: feishuCustomConnectorSlug(args.installationId),
       ...desiredConnectorDefinition(installation),
       createdBy: installation.ownerUserId ?? args.userId,
     })
@@ -275,7 +293,6 @@ async function createFeishuCustomConnector(
   signal.throwIfAborted();
   return {
     connectorId: connector.id,
-    displayName: feishuCustomConnectorDisplayName(installation.botName),
     definitionChanged: true,
     runtimeChanged: false,
   };
@@ -320,17 +337,49 @@ async function repairFeishuCustomConnector(
   signal.throwIfAborted();
   return {
     connectorId: existing.connector.id,
-    displayName: feishuCustomConnectorDisplayName(installation.botName),
     definitionChanged: true,
     runtimeChanged: true,
   };
 }
 
+async function preflightFeishuCustomConnectorId(
+  db: ReadonlyDb,
+  args: EnsureFeishuCustomConnectorArgs,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const [target] = await db
+    .select({
+      installationId: feishuOrgInstallations.id,
+      connectorId: orgCustomConnectors.id,
+    })
+    .from(feishuOrgInstallations)
+    .leftJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.orgId, feishuOrgInstallations.orgId),
+        eq(
+          orgCustomConnectors.slug,
+          feishuCustomConnectorSlug(args.installationId),
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(feishuOrgInstallations.id, args.installationId),
+        eq(feishuOrgInstallations.orgId, args.orgId),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return target ? (target.connectorId ?? randomUUID()) : null;
+}
+
 async function reconcileFeishuCustomConnector(
   tx: DbTransaction,
   args: EnsureFeishuCustomConnectorArgs,
+  prepared: PreparedFeishuCustomConnectorSkill,
   signal: AbortSignal,
-): Promise<ReconciledFeishuCustomConnector | null> {
+): Promise<FeishuCustomConnectorReconciliation> {
   await tx.execute(
     sql`SELECT pg_advisory_xact_lock(hashtextextended(${`feishu_custom_connector:${args.installationId}`}, 0))`,
   );
@@ -353,7 +402,7 @@ async function reconcileFeishuCustomConnector(
     .limit(1);
   signal.throwIfAborted();
   if (!installation) {
-    return null;
+    return { kind: "installation-missing" };
   }
 
   const slug = feishuCustomConnectorSlug(args.installationId);
@@ -379,34 +428,53 @@ async function reconcileFeishuCustomConnector(
     .for("update", { of: orgCustomConnectors })
     .limit(1);
   signal.throwIfAborted();
+  if (existing && existing.connector.id !== prepared.connectorId) {
+    return {
+      kind: "stale-target",
+      connectorId: existing.connector.id,
+    };
+  }
+
+  let connector: ReconciledFeishuCustomConnector;
   if (!existing) {
-    return await createFeishuCustomConnector(
+    connector = await createFeishuCustomConnector(
       tx,
       args,
       installation,
-      slug,
+      prepared.connectorId,
       signal,
     );
+  } else {
+    const needsRepair =
+      !connectorDefinitionMatches(existing.connector, installation) ||
+      !oauthConfigMatches(existing.oauthConfig, installation);
+    connector =
+      !args.configurationChanged && !needsRepair
+        ? {
+            connectorId: existing.connector.id,
+            definitionChanged: false,
+            runtimeChanged: false,
+          }
+        : await repairFeishuCustomConnector(
+            tx,
+            args,
+            installation,
+            existing,
+            signal,
+          );
   }
-
-  const needsRepair =
-    !connectorDefinitionMatches(existing.connector, installation) ||
-    !oauthConfigMatches(existing.oauthConfig, installation);
-  if (!args.configurationChanged && !needsRepair) {
-    return {
-      connectorId: existing.connector.id,
-      displayName: feishuCustomConnectorDisplayName(installation.botName),
-      definitionChanged: false,
-      runtimeChanged: false,
-    };
-  }
-  return await repairFeishuCustomConnector(
-    tx,
-    args,
-    installation,
-    existing,
+  await commitPreparedCustomConnectorSkillVolume(
+    {
+      db: tx,
+      connectorId: connector.connectorId,
+      volume: prepared.volume,
+    },
     signal,
   );
+  return {
+    kind: "reconciled",
+    connector,
+  };
 }
 
 export const ensureFeishuCustomConnector$ = command(
@@ -416,59 +484,72 @@ export const ensureFeishuCustomConnector$ = command(
     signal: AbortSignal,
   ): Promise<string | null> => {
     const db = set(writeDb$);
-    const reconciliation = db.transaction(async (tx) => {
-      return await reconcileFeishuCustomConnector(tx, args, signal);
-    });
-    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
-    const result = await commitConnectorRuntimeMutation(
-      reconciliation,
-      (connector) => {
-        return connector?.runtimeChanged
-          ? {
-              db,
-              scope: { orgId: args.orgId },
-              targets: [
-                {
-                  kind: "custom",
-                  customConnectorId: connector.connectorId,
-                },
-              ],
-            }
-          : undefined;
-      },
-    );
-    if (signal.aborted) {
-      postCommitAbort = { reason: signal.reason };
-    }
-    if (!result) {
-      signal.throwIfAborted();
-      return null;
-    }
-    if (result.definitionChanged) {
-      await publishCustomConnectorOrganizationInvalidationAfterCommit(
-        args.orgId,
-        get(clerk$).organizations,
+    let connectorId = await preflightFeishuCustomConnectorId(db, args, signal);
+    while (connectorId) {
+      const volume = await set(
+        prepareCustomConnectorSkillVolume$,
+        {
+          orgId: args.orgId,
+          connectorId,
+          connectorSlug: feishuCustomConnectorSlug(args.installationId),
+          displayName: FEISHU_DISPLAY_NAME,
+          skillMarkdown: FEISHU_SKILL_MARKDOWN,
+          skillName: FEISHU_SKILL_NAME,
+          skillDescription: FEISHU_SKILL_DESCRIPTION,
+        },
         signal,
-        postCommitAbort,
       );
-    } else {
       signal.throwIfAborted();
+      const prepared = { connectorId, volume };
+      const reconciliation = db.transaction(async (tx) => {
+        return await reconcileFeishuCustomConnector(tx, args, prepared, signal);
+      });
+      let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
+      const result = await commitConnectorRuntimeMutation(
+        reconciliation,
+        (attempt) => {
+          return attempt.kind === "reconciled" &&
+            attempt.connector.runtimeChanged
+            ? {
+                db,
+                scope: { orgId: args.orgId },
+                targets: [
+                  {
+                    kind: "custom",
+                    customConnectorId: attempt.connector.connectorId,
+                  },
+                ],
+              }
+            : undefined;
+        },
+      );
+      if (signal.aborted) {
+        postCommitAbort = { reason: signal.reason };
+      }
+      if (result.kind === "installation-missing") {
+        signal.throwIfAborted();
+        return null;
+      }
+      if (result.kind === "stale-target") {
+        signal.throwIfAborted();
+        connectorId = result.connectorId;
+        continue;
+      }
+
+      const connector = result.connector;
+      if (connector.definitionChanged) {
+        await publishCustomConnectorOrganizationInvalidationAfterCommit(
+          args.orgId,
+          get(clerk$).organizations,
+          signal,
+          postCommitAbort,
+        );
+      } else {
+        signal.throwIfAborted();
+      }
+      return connector.connectorId;
     }
-    await set(
-      syncCustomConnectorSkillVolume$,
-      {
-        orgId: args.orgId,
-        connectorId: result.connectorId,
-        connectorSlug: feishuCustomConnectorSlug(args.installationId),
-        displayName: result.displayName,
-        skillMarkdown: FEISHU_SKILL_MARKDOWN,
-        skillName: FEISHU_SKILL_NAME,
-        skillDescription: FEISHU_SKILL_DESCRIPTION,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    return result.connectorId;
+    return null;
   },
 );
 
@@ -519,18 +600,6 @@ export const deleteFeishuCustomConnector$ = command(
       signal,
       postCommitAbort,
     );
-    await set(
-      syncCustomConnectorSkillVolume$,
-      {
-        orgId: args.orgId,
-        connectorId: deleted.id,
-        connectorSlug: feishuCustomConnectorSlug(args.installationId),
-        displayName: FEISHU_DISPLAY_NAME,
-        skillMarkdown: null,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
   },
 );
 

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -45,7 +45,7 @@ export interface PrepareVolumeServerSideInput {
   readonly files: readonly VolumeFileInput[];
 }
 
-interface PreparedServerSideVolume {
+export interface PreparedServerSideVolume {
   readonly storageName: string;
   readonly version: PreparedStorageVersion;
   readonly updatedAt: Date;

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -68,7 +68,11 @@ import {
   type CustomConnectorCredentialAccess,
 } from "./custom-connector-credential-access.service";
 import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
-import { syncCustomConnectorSkillVolume$ } from "./custom-connector-skill-volume.service";
+import {
+  commitPreparedCustomConnectorSkillVolume,
+  prepareCustomConnectorSkillVolume$,
+} from "./custom-connector-skill-volume.service";
+import type { PreparedServerSideVolume } from "./storage-volume-publication.service";
 import {
   commitConnectorRuntimeMutation,
   publishConnectorRuntimeSyncWakeups,
@@ -1741,6 +1745,7 @@ async function findCustomConnectorPrefixConflict(
 async function persistCustomConnectorCreate(
   db: Db,
   args: {
+    readonly connectorId: string;
     readonly orgId: string;
     readonly userId: string;
     readonly slug: string;
@@ -1748,7 +1753,9 @@ async function persistCustomConnectorCreate(
     readonly storageVersion: number;
     readonly oauthConfigUpdate: ValidatedOAuthConfigUpdate;
     readonly encryptedClientSecret: string | null;
+    readonly preparedSkill: PreparedServerSideVolume | null;
   },
+  signal: AbortSignal,
 ): Promise<
   | {
       readonly row: CustomConnectorDefinitionRow;
@@ -1769,6 +1776,7 @@ async function persistCustomConnectorCreate(
     const [row] = await tx
       .insert(orgCustomConnectors)
       .values({
+        id: args.connectorId,
         orgId: args.orgId,
         slug: args.slug,
         displayName: args.definition.displayName,
@@ -1785,23 +1793,30 @@ async function persistCustomConnectorCreate(
     if (!row) {
       throw new Error("Expected insert to return a row");
     }
+    let oauthConfig: CustomConnectorOAuthConfigRow | null = null;
     if (
-      args.oauthConfigUpdate.kind !== "upsert" ||
-      !args.encryptedClientSecret
+      args.oauthConfigUpdate.kind === "upsert" &&
+      args.encryptedClientSecret
     ) {
-      return { row, oauthConfig: null };
+      const [insertedOAuthConfig] = await tx
+        .insert(orgCustomConnectorOauthConfigs)
+        .values({
+          connectorId: row.id,
+          orgId: args.orgId,
+          ...args.oauthConfigUpdate.config,
+          encryptedClientSecret: args.encryptedClientSecret,
+        })
+        .returning();
+      if (!insertedOAuthConfig) {
+        throw new Error("Expected OAuth config insert to return a row");
+      }
+      oauthConfig = insertedOAuthConfig;
     }
-    const [oauthConfig] = await tx
-      .insert(orgCustomConnectorOauthConfigs)
-      .values({
-        connectorId: row.id,
-        orgId: args.orgId,
-        ...args.oauthConfigUpdate.config,
-        encryptedClientSecret: args.encryptedClientSecret,
-      })
-      .returning();
-    if (!oauthConfig) {
-      throw new Error("Expected OAuth config insert to return a row");
+    if (args.preparedSkill) {
+      await commitPreparedCustomConnectorSkillVolume(
+        { db: tx, connectorId: row.id, volume: args.preparedSkill },
+        signal,
+      );
     }
     return { row, oauthConfig };
   });
@@ -1867,18 +1882,41 @@ export const createCustomConnector$ = command(
 
     const slugHost = hostSlugFromDefinition(v);
     const slug = v.slug ?? `_${slugHost}-${randomShortId()}`;
+    const connectorId = randomUUID();
     L.debug("creating custom connector", { orgId: args.orgId, slug });
 
+    const preparedSkill =
+      v.skillMarkdown === null
+        ? null
+        : await set(
+            prepareCustomConnectorSkillVolume$,
+            {
+              orgId: args.orgId,
+              connectorId,
+              connectorSlug: slug,
+              displayName: v.displayName,
+              skillMarkdown: v.skillMarkdown,
+            },
+            signal,
+          );
+    signal.throwIfAborted();
+
     let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
-    const created = await persistCustomConnectorCreate(writeDb, {
-      orgId: args.orgId,
-      userId: args.userId,
-      slug,
-      definition: v,
-      storageVersion: args.input.storageVersion ?? 1,
-      oauthConfigUpdate,
-      encryptedClientSecret,
-    });
+    const created = await persistCustomConnectorCreate(
+      writeDb,
+      {
+        connectorId,
+        orgId: args.orgId,
+        userId: args.userId,
+        slug,
+        definition: v,
+        storageVersion: args.input.storageVersion ?? 1,
+        oauthConfigUpdate,
+        encryptedClientSecret,
+        preparedSkill,
+      },
+      signal,
+    );
     if (signal.aborted) {
       postCommitAbort = { reason: signal.reason };
     }
@@ -1897,20 +1935,6 @@ export const createCustomConnector$ = command(
       signal,
       postCommitAbort,
     );
-    if (result.skillMarkdown !== null) {
-      await set(
-        syncCustomConnectorSkillVolume$,
-        {
-          orgId: result.orgId,
-          connectorId: result.id,
-          connectorSlug: result.slug,
-          displayName: result.displayName,
-          skillMarkdown: result.skillMarkdown,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-    }
     return result;
   },
 );
@@ -1978,11 +2002,13 @@ interface PersistCustomConnectorUpdateArgs {
   readonly encryptedClientSecret: string | null;
   readonly grantConfigurationChanged: boolean;
   readonly storageVersion: number;
+  readonly preparedSkill: PreparedServerSideVolume | null;
 }
 
 async function persistCustomConnectorUpdate(
   db: Db,
   args: PersistCustomConnectorUpdateArgs,
+  signal: AbortSignal,
 ): Promise<
   | {
       readonly row: CustomConnectorDefinitionRow;
@@ -2013,6 +2039,9 @@ async function persistCustomConnectorUpdate(
         queryInjections: [...args.definition.queryInjections],
         authMode: args.definition.authMode,
         skillMarkdown: args.definition.skillMarkdown,
+        ...(args.definition.skillMarkdown === null
+          ? { skillStorageVersionId: null }
+          : {}),
         storageVersion: args.storageVersion,
         updatedAt: nowDate(),
       })
@@ -2081,6 +2110,12 @@ async function persistCustomConnectorUpdate(
         .returning();
       storedOAuthConfig = upserted ?? null;
     }
+    if (args.preparedSkill) {
+      await commitPreparedCustomConnectorSkillVolume(
+        { db: tx, connectorId: updated.id, volume: args.preparedSkill },
+        signal,
+      );
+    }
     return { row: updated, oauthConfig: storedOAuthConfig };
   });
 }
@@ -2093,7 +2128,7 @@ async function persistCustomConnectorUpdateAndPublishRuntimeWakeup(
   readonly result: CustomConnectorRow | BadRequestResponse | null;
   readonly postCommitAbort?: CapturedConnectorClientInvalidationAbort;
 }> {
-  const result = await persistCustomConnectorUpdate(db, args);
+  const result = await persistCustomConnectorUpdate(db, args, signal);
   if (isBadRequest(result) || !result) {
     return {
       result,
@@ -2307,6 +2342,21 @@ export const updateCustomConnectorDefinition$ = command(
     if (isBadRequest(resolved)) {
       return resolved;
     }
+    const preparedSkill =
+      prepared.definition.skillMarkdown === null
+        ? null
+        : await set(
+            prepareCustomConnectorSkillVolume$,
+            {
+              orgId: args.orgId,
+              connectorId: existingConnector.id,
+              connectorSlug: existingConnector.slug,
+              displayName: prepared.definition.displayName,
+              skillMarkdown: prepared.definition.skillMarkdown,
+            },
+            signal,
+          );
+    signal.throwIfAborted();
     const { result: normalized, postCommitAbort } =
       await persistCustomConnectorUpdateAndPublishRuntimeWakeup(
         writeDb,
@@ -2319,6 +2369,7 @@ export const updateCustomConnectorDefinition$ = command(
           encryptedClientSecret,
           grantConfigurationChanged: resolved.grantConfigurationChanged,
           storageVersion: resolved.storageVersion,
+          preparedSkill,
         },
         signal,
       );
@@ -2332,23 +2383,6 @@ export const updateCustomConnectorDefinition$ = command(
       signal,
       postCommitAbort,
     );
-    if (
-      normalized.skillMarkdown !== null ||
-      args.input.skillMarkdown !== undefined
-    ) {
-      await set(
-        syncCustomConnectorSkillVolume$,
-        {
-          orgId: normalized.orgId,
-          connectorId: normalized.id,
-          connectorSlug: normalized.slug,
-          displayName: normalized.displayName,
-          skillMarkdown: normalized.skillMarkdown,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-    }
     return normalized;
   },
 );
@@ -2413,18 +2447,6 @@ export const deleteCustomConnector$ = command(
       signal,
       postCommitAbort,
     );
-    await set(
-      syncCustomConnectorSkillVolume$,
-      {
-        orgId: args.orgId,
-        connectorId: args.id,
-        connectorSlug: "_deleted",
-        displayName: "Deleted custom connector",
-        skillMarkdown: null,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
     L.debug("custom connector deleted", { orgId: args.orgId, id: args.id });
     return undefined;
   },


### PR DESCRIPTION
## Summary

- prepare and verify generated custom connector skill volumes before activating connector or OAuth state
- atomically commit the connector definition, immutable storage version, compatibility HEAD, and exact skill version pointer while preserving ordinary update CAS semantics and converging concurrent Feishu installation candidates
- retain historical skill storage when a skill is cleared or a custom connector is deleted

## Compatibility

- no public API schema, database schema, queue payload, or runner protocol changes
- existing runtime readers continue to resolve the compatibility HEAD
- follow-up cleanup remains tracked in #26137

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- targeted connector and Feishu integration tests (`81 passed`, `--maxWorkers=1`)
- `pnpm knip --workspace api`
- pre-commit full-workspace Knip and type checks

Closes #26134

Parent context: #26075
