### PR TITLE
fix(platform): restore chat scroll after react commit

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -18,6 +18,7 @@ import type { EditorDocumentSnapshot } from "../zero-page/user-message-document-
 import type { ArtifactSignals } from "./artifact-card-signals.ts";
 import type {
   createChatThreadScrollSignals,
+  ReadyScrollAfterRenderRequest,
   ThreadScrollPosition,
 } from "./chat-thread-scroll.ts";
 import type { AssistantErrorRecovery } from "./assistant-error-recovery.ts";
@@ -62,6 +63,9 @@ export interface MessageListSignals {
   readonly latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
   readonly visibleRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>;
   readonly visibleRenderedChatGroupsReady$: Computed<Promise<boolean>>;
+  readonly readyScrollAfterRenderRequest$: Computed<
+    Promise<ReadyScrollAfterRenderRequest | null>
+  >;
   readonly chatSkeletonVisible$: Computed<boolean>;
   readonly assistantErrorRecovery$: Computed<
     Promise<AssistantErrorRecovery | null>
@@ -139,6 +143,13 @@ export interface ChatPanelSignals {
   readonly scrollContentOnRef$: Command<
     (() => void) | undefined,
     [HTMLElement | null]
+  >;
+  readonly scrollCommitOnRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
+  >;
+  readonly readyScrollAfterRenderRequest$: Computed<
+    Promise<ReadyScrollAfterRenderRequest | null>
   >;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly scrollTo$: Command<void, [ThreadScrollPosition]>;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -6,15 +6,22 @@ import { onRef } from "../utils.ts";
 const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD_PX = 10;
 const SCROLL_ANCHOR_ATTRIBUTE = "data-chat-scroll-anchor-event-id";
+const SCROLL_COMMIT_REVISION_ATTRIBUTE = "data-chat-scroll-commit-revision";
+const SCROLL_COMMIT_TO_TAIL_ATTRIBUTE = "data-chat-scroll-commit-to-tail";
 
 export interface ThreadScrollPosition {
   readonly targetEventId: string;
   readonly viewportOffsetTop: number;
 }
 
-interface ScrollAfterRenderRequest {
+export interface ScrollAfterRenderRequest {
   readonly revision: number;
   readonly position: ThreadScrollPosition | null;
+}
+
+export interface ReadyScrollAfterRenderRequest {
+  readonly request: ScrollAfterRenderRequest;
+  readonly renderedEventKeys: readonly string[];
 }
 
 export interface ChatThreadScrollSignals {
@@ -26,6 +33,11 @@ export interface ChatThreadScrollSignals {
     (() => void) | undefined,
     [HTMLElement | null]
   >;
+  readonly scrollCommitOnRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
+  >;
+  readonly pendingScrollAfterRenderRequest$: Computed<ScrollAfterRenderRequest | null>;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
   readonly readRenderedThreadScrollPosition$: Command<
@@ -67,6 +79,23 @@ function scrollAnchorForEvent(
   return container.querySelector<HTMLElement>(
     `[${SCROLL_ANCHOR_ATTRIBUTE}="${eventId}"]`,
   );
+}
+
+function scrollContainerForCommitMarker(marker: HTMLElement): HTMLElement {
+  const container = marker.closest("[data-scroll-container]");
+  if (!(container instanceof HTMLElement)) {
+    throw new Error("Chat scroll commit marker has no scroll container");
+  }
+  return container;
+}
+
+function scrollRenderRevision(marker: HTMLElement): number {
+  const value = marker.getAttribute(SCROLL_COMMIT_REVISION_ATTRIBUTE);
+  const revision = Number(value);
+  if (value === null || revision < 1 || !Number.isSafeInteger(revision)) {
+    throw new Error("Chat scroll commit marker has no valid revision");
+  }
+  return revision;
 }
 
 function applyScrollTop(
@@ -256,6 +285,7 @@ function createScrollNavigationSignals(
   threadId: string,
   scroll: InternalScrollSignals,
   runtime: ScrollRuntime,
+  pendingScrollAfterRenderRequest$: Computed<ScrollAfterRenderRequest | null>,
 ) {
   const scrollTo$ = command(({ get }, position: ThreadScrollPosition) => {
     const container = get(scroll.scrollContainer$);
@@ -308,22 +338,26 @@ function createScrollNavigationSignals(
     if (!container) {
       throw new Error("Chat scroll container is not mounted");
     }
-    if (position && scrollToPosition(runtime, container, position)) {
-      runtime.initialized = true;
-      return;
+    if (position) {
+      if (scrollToPosition(runtime, container, position)) {
+        runtime.initialized = true;
+        return;
+      }
+      if (get(pendingScrollAfterRenderRequest$) !== null) {
+        // Event rendering can replace the content between ResizeObserver's
+        // notification and this restore. The commit marker owns that pending
+        // batch, so keep the anchor until React acknowledges its final DOM.
+        L.debug("resize scroll restore waiting for render commit", {
+          threadId,
+          targetEventId: position.targetEventId,
+        });
+        return;
+      }
+      L.debug("resize scroll restore target no longer rendered", {
+        threadId,
+        targetEventId: position.targetEventId,
+      });
     }
-    // Either the thread is following the tail, or the event it anchors to has
-    // left the DOM — a queued message moves into the thinking indicator, which
-    // renders no anchor. Holding a position nothing renders would freeze the
-    // thread where it stands and every later resize would try again, so the
-    // thread goes back to following the tail.
-    L.debug("resize scroll restore fell back to the tail", {
-      threadId,
-      targetEventId: position?.targetEventId ?? null,
-      anchorRendered:
-        position !== null &&
-        scrollAnchorForEvent(container, position.targetEventId) !== null,
-    });
     set(scrollToBottom$);
   });
 
@@ -374,61 +408,65 @@ function createScrollNavigationSignals(
   };
 }
 
-/**
- * Commits the scroll that belongs to a rendered batch of events: one frame
- * after the events change, either back to the bottom or onto the anchor the
- * reader is holding.
- */
+/** Commits scroll only when React acknowledges the matching event batch. */
 function createRenderScrollSignals(
   threadId: string,
   scroll: InternalScrollSignals,
   runtime: ScrollRuntime,
 ) {
-  const commitScrollAfterRender$ = command(
-    ({ get, set }, request: ScrollAfterRenderRequest): void => {
-      if (request.revision !== runtime.latestRenderRequestRevision) {
-        L.debug("stale render scroll ignored", {
-          revision: request.revision,
-          currentRevision: runtime.latestRenderRequestRevision,
-        });
-        return;
+  const internalPendingRequest$ = state<ScrollAfterRenderRequest | null>(null);
+  const pendingScrollAfterRenderRequest$ = computed((get) => {
+    return get(internalPendingRequest$);
+  });
+  const clearPendingRequest$ = command(
+    ({ get, set }, revision: number): void => {
+      if (get(internalPendingRequest$)?.revision === revision) {
+        set(internalPendingRequest$, null);
       }
-      const container = get(scroll.scrollContainer$);
-      if (!container) {
-        L.debug("render scroll skipped without container", {
+    },
+  );
+  const scrollCommitOnRef$ = onRef(
+    command(({ get, set }, marker: HTMLElement, signal: AbortSignal): void => {
+      signal.throwIfAborted();
+      const revision = scrollRenderRevision(marker);
+      const request = get(pendingScrollAfterRenderRequest$);
+      if (!request || request.revision !== revision) {
+        L.debug("stale render scroll commit ignored", {
           threadId,
-          revision: request.revision,
+          revision,
+          currentRevision: request?.revision ?? null,
         });
         return;
       }
+      const container = scrollContainerForCommitMarker(marker);
       if (scrollAnchors(container).length === 0) {
-        L.debug("render scroll skipped without messages", {
+        L.debug("render scroll commit waiting for messages", {
           threadId,
-          revision: request.revision,
+          revision,
         });
         return;
       }
-      if (
+      if (marker.hasAttribute(SCROLL_COMMIT_TO_TAIL_ATTRIBUTE)) {
+        set(scroll.clearThreadScrollPosition$);
+        applyScrollTop(runtime, container, container.scrollHeight);
+      } else if (
         !request.position ||
         !scrollToPosition(runtime, container, request.position)
       ) {
-        // The batch either follows the tail, or it carries a position whose
-        // event this render does not show: sending while a run is active
-        // queues the message, and a queued message moves into the thinking
-        // indicator, which renders no anchor. Nothing can hold that position,
-        // so the thread follows the tail rather than staying put.
-        set(scroll.clearThreadScrollPosition$);
-        applyScrollTop(runtime, container, container.scrollHeight);
+        throw new Error(
+          `Chat scroll target is not rendered: ${request.position?.targetEventId ?? "none"}`,
+        );
       }
       runtime.initialized = true;
+      set(clearPendingRequest$, revision);
       L.debug("render scroll committed", {
         threadId,
-        revision: request.revision,
+        revision,
         targetEventId: request.position?.targetEventId ?? null,
         viewportOffsetTop: request.position?.viewportOffsetTop ?? null,
         scrollTop: container.scrollTop,
       });
-    },
+    }),
   );
   const autoScroll$ = command(
     (
@@ -451,17 +489,16 @@ function createRenderScrollSignals(
         targetEventId: position?.targetEventId ?? null,
         viewportOffsetTop: position?.viewportOffsetTop ?? null,
       });
-      animationFrame(
-        () => {
-          set(commitScrollAfterRender$, request);
-        },
-        { signal },
-      );
+      set(internalPendingRequest$, request);
       return Promise.resolve();
     },
   );
 
-  return { autoScroll$ };
+  return {
+    autoScroll$,
+    pendingScrollAfterRenderRequest$,
+    scrollCommitOnRef$,
+  };
 }
 
 type ScrollNavigationSignals = ReturnType<typeof createScrollNavigationSignals>;
@@ -586,8 +623,13 @@ export function createChatThreadScrollSignals(
     programmaticScrollTop: null,
   };
   const scroll = createInternalScrollSignals(threadId);
-  const navigation = createScrollNavigationSignals(threadId, scroll, runtime);
   const render = createRenderScrollSignals(threadId, scroll, runtime);
+  const navigation = createScrollNavigationSignals(
+    threadId,
+    scroll,
+    runtime,
+    render.pendingScrollAfterRenderRequest$,
+  );
   const scrollContainerOnRef$ = createScrollContainerOnRef(
     threadId,
     scroll,
@@ -599,6 +641,8 @@ export function createChatThreadScrollSignals(
   return {
     scrollContainerOnRef$,
     scrollContentOnRef$,
+    scrollCommitOnRef$: render.scrollCommitOnRef$,
+    pendingScrollAfterRenderRequest$: render.pendingScrollAfterRenderRequest$,
     threadScrollPosition$: scroll.threadScrollPosition$,
     awayFromBottom$: scroll.awayFromBottom$,
     readRenderedThreadScrollPosition$: scroll.readRenderedThreadScrollPosition$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -22,6 +22,7 @@ import { activeThreadSidebar$ } from "./thread-sidebar-coordinator.ts";
 import { CHAT_THREAD_SIDEBAR_SPLIT_VIEW_MEDIA_QUERY } from "./chat-thread-sidebar-layout.ts";
 import {
   createChatThreadScrollSignals,
+  type ReadyScrollAfterRenderRequest,
   type ThreadScrollPosition,
 } from "./chat-thread-scroll.ts";
 import {
@@ -2118,6 +2119,29 @@ function createChatThreadMessagePipeline({
     chatEvents,
     visibleRenderedChatGroups$: renderWindow.visibleRenderedChatGroups$,
   });
+  const readyScrollAfterRenderRequest$ = computed(
+    async (get): Promise<ReadyScrollAfterRenderRequest | null> => {
+      const request = get(effects.scroll.pendingScrollAfterRenderRequest$);
+      if (request === null) {
+        return null;
+      }
+      const renderedGroups = await get(renderWindow.visibleRenderedChatGroups$);
+      const currentRequest = get(
+        effects.scroll.pendingScrollAfterRenderRequest$,
+      );
+      if (currentRequest?.revision !== request.revision) {
+        return null;
+      }
+      return {
+        request,
+        renderedEventKeys: renderedGroups.flatMap((group) => {
+          return group.events.map((event) => {
+            return `${event.id}:${event.isQueued ? "queued" : "active"}`;
+          });
+        }),
+      };
+    },
+  );
 
   const loadMoreRenderedChatGroups$ = command(
     async ({ set }, signal: AbortSignal): Promise<boolean> => {
@@ -2145,6 +2169,7 @@ function createChatThreadMessagePipeline({
     ...projections,
     ...resources.publicSignals,
     ...renderWindow,
+    readyScrollAfterRenderRequest$,
     loadMoreRenderedChatGroups$,
   };
 }
@@ -3518,6 +3543,7 @@ function publicChatThreadEventSignals(events: MessageListSignals) {
     latestAssistantTextCreatedAt$: events.latestAssistantTextCreatedAt$,
     visibleRenderedChatGroups$: events.visibleRenderedChatGroups$,
     visibleRenderedChatGroupsReady$: events.visibleRenderedChatGroupsReady$,
+    readyScrollAfterRenderRequest$: events.readyScrollAfterRenderRequest$,
     chatSkeletonVisible$: events.chatSkeletonVisible$,
     assistantErrorRecovery$: events.assistantErrorRecovery$,
     retryAssistantError$: events.retryAssistantError$,
@@ -3796,6 +3822,7 @@ function createChatPanelSignalsWithDraft(
     threadSettledInServer$,
     scrollContainerOnRef$: messages.scroll.scrollContainerOnRef$,
     scrollContentOnRef$: messages.scroll.scrollContentOnRef$,
+    scrollCommitOnRef$: messages.scroll.scrollCommitOnRef$,
     threadScrollPosition$: messages.scroll.threadScrollPosition$,
     awayFromBottom$: messages.scroll.awayFromBottom$,
     scrollTo$: messages.scroll.scrollTo$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -612,34 +612,74 @@ function mockKeyboardThreadScrollLayout({
   currentScrollHeight = () => {
     return 1200;
   },
+  includeCurrentLeadingEvent = false,
 }: {
   readonly currentThreadTop: () => number;
   readonly currentScrollHeight?: () => number;
-}): void {
+  readonly includeCurrentLeadingEvent?: boolean;
+}): {
+  readonly beginPartialCurrentThreadReturn: () => void;
+  readonly publishCurrentThreadTarget: () => Promise<void>;
+} {
   mockKeyboardNavigationThreads();
+  let partialCurrentThreadReturn = false;
+  let currentThreadTargetPublished = true;
+  const currentThreadEvents = normalizeMockChatEvents([
+    ...(includeCurrentLeadingEvent
+      ? [
+          {
+            id: `${KEYBOARD_CURRENT_THREAD_ID}-cached-leading-message`,
+            threadId: KEYBOARD_CURRENT_THREAD_ID,
+            role: "assistant" as const,
+            content: "Current thread cached leading note",
+            createdAt: "2026-05-31T23:59:00Z",
+          },
+        ]
+      : []),
+    {
+      id: `${KEYBOARD_CURRENT_THREAD_ID}-message`,
+      threadId: KEYBOARD_CURRENT_THREAD_ID,
+      role: "assistant",
+      content: "Current thread launch note",
+      createdAt: "2026-06-01T00:00:00Z",
+    },
+  ]);
+  const previousThreadEvents = normalizeMockChatEvents([
+    {
+      id: `${KEYBOARD_PREV_THREAD_ID}-message`,
+      threadId: KEYBOARD_PREV_THREAD_ID,
+      role: "assistant",
+      content: "Previous thread launch note",
+      createdAt: "2026-06-01T00:00:00Z",
+    },
+  ]);
+  const eventsByThreadId = new Map<string, readonly ChatEvent[]>([
+    [KEYBOARD_CURRENT_THREAD_ID, currentThreadEvents],
+    [KEYBOARD_PREV_THREAD_ID, previousThreadEvents],
+  ]);
   context.mocks.api(
     chatThreadEventsContract.list,
     ({ params, query, respond }) => {
-      if (query.beforeSeqId !== undefined || query.sinceSeqId !== undefined) {
-        return respond(200, { events: [] });
-      }
-      const contentByThreadId = new Map([
-        [KEYBOARD_CURRENT_THREAD_ID, "Current thread launch note"],
-        [KEYBOARD_PREV_THREAD_ID, "Previous thread launch note"],
-      ]);
-      const content = contentByThreadId.get(params.threadId);
+      const events = eventsByThreadId.get(params.threadId) ?? [];
+      const filteredEvents = events.filter((event) => {
+        if (
+          params.threadId === KEYBOARD_CURRENT_THREAD_ID &&
+          partialCurrentThreadReturn &&
+          event.id === `${KEYBOARD_CURRENT_THREAD_ID}-message` &&
+          !currentThreadTargetPublished
+        ) {
+          return false;
+        }
+        if (query.beforeSeqId !== undefined) {
+          return event.seqId < query.beforeSeqId;
+        }
+        if (query.sinceSeqId !== undefined) {
+          return event.seqId > query.sinceSeqId;
+        }
+        return true;
+      });
       return respond(200, {
-        events: content
-          ? normalizeMockChatEvents([
-              {
-                id: `${params.threadId}-message`,
-                threadId: params.threadId,
-                role: "assistant",
-                content,
-                createdAt: "2026-06-01T00:00:00Z",
-              },
-            ]).map(chatEventResponse)
-          : [],
+        events: filteredEvents.map(chatEventResponse),
       });
     },
   );
@@ -677,6 +717,21 @@ function mockKeyboardThreadScrollLayout({
       ],
     ]),
   );
+  return {
+    beginPartialCurrentThreadReturn: () => {
+      partialCurrentThreadReturn = true;
+      currentThreadTargetPublished = false;
+    },
+    publishCurrentThreadTarget: async () => {
+      await waitFor(() => {
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+      });
+      currentThreadTargetPublished = true;
+      context.mocks.ably.trigger(
+        `chatThreadMessageCreated:${KEYBOARD_CURRENT_THREAD_ID}`,
+      );
+    },
+  };
 }
 
 describe("chat scroll position", () => {
@@ -1486,6 +1541,67 @@ describe("chat scroll position", () => {
     ).resolves.toBeInTheDocument();
 
     click(linkByText("Current keyboard thread"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      expect(viewportOffsetTop(`${KEYBOARD_CURRENT_THREAD_ID}-message`)).toBe(
+        -20,
+      );
+      expect(chatScrollContainer().scrollTop).toBe(420);
+    });
+  });
+
+  it("waits for the returned thread DOM to commit before restoring its anchor", async () => {
+    installImmediateAnimationFrames();
+    const { beginPartialCurrentThreadReturn, publishCurrentThreadTarget } =
+      mockKeyboardThreadScrollLayout({
+        currentThreadTop: () => {
+          return 400;
+        },
+        includeCurrentLeadingEvent: true,
+      });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${KEYBOARD_CURRENT_THREAD_ID}`,
+    });
+
+    const currentContainer = await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      return chatScrollContainer();
+    });
+    await waitFor(() => {
+      expect(currentContainer.scrollTop).toBe(900);
+    });
+    scrollTo(currentContainer, 420);
+    expect(viewportOffsetTop(`${KEYBOARD_CURRENT_THREAD_ID}-message`)).toBe(
+      -20,
+    );
+    await waitFor(() => {
+      expect(document.querySelector("[data-scroll-to-bottom]")).not.toBeNull();
+    });
+
+    click(linkByText("Previous keyboard thread"));
+    await expect(
+      screen.findByText("Previous thread launch note"),
+    ).resolves.toBeInTheDocument();
+
+    beginPartialCurrentThreadReturn();
+    click(linkByText("Current keyboard thread"));
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread cached leading note"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Current thread launch note"),
+      ).not.toBeInTheDocument();
+      expect(document.querySelector("[data-scroll-to-bottom]")).not.toBeNull();
+    });
+    await publishCurrentThreadTarget();
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2793,15 +2793,101 @@ const CHAT_THREAD_CONTENT_MAIN_CLASS =
   "items-center py-4 pl-4 pr-4 sm:pl-6 sm:pr-6 @container";
 const CHAT_RENDER_LOAD_MORE_TOP_THRESHOLD_PX = 100;
 
+function renderedChatEventKeys(
+  groups: readonly ChatEventGroup[],
+): readonly string[] {
+  return groups.flatMap((group) => {
+    return group.events.map((event) => {
+      return `${event.id}:${event.isQueued ? "queued" : "active"}`;
+    });
+  });
+}
+
+function chatGroupsContainEvent(
+  groups: readonly ChatEventGroup[],
+  eventId: string | undefined,
+): boolean {
+  return groups.some((group) => {
+    return group.events.some((event) => {
+      return event.id === eventId;
+    });
+  });
+}
+
+function ChatThreadScrollCommitMarker({
+  thread,
+  renderedGroups,
+}: {
+  thread: ChatPanelSignals;
+  renderedGroups: ChatEventGroup[] | undefined;
+}) {
+  const readyScrollRequestLoadable = useLoadable(
+    thread.readyScrollAfterRenderRequest$,
+  );
+  const commitScroll = useSet(thread.scrollCommitOnRef$);
+  if (
+    renderedGroups === undefined ||
+    readyScrollRequestLoadable.state !== "hasData" ||
+    readyScrollRequestLoadable.data === null
+  ) {
+    return null;
+  }
+
+  const readyScrollRequest = readyScrollRequestLoadable.data;
+  if (
+    !equalArrays(
+      readyScrollRequest.renderedEventKeys,
+      renderedChatEventKeys(renderedGroups),
+    )
+  ) {
+    return null;
+  }
+
+  const { activeGroups, queuedGroups } =
+    splitQueuedEventsForThinkingIndicator(renderedGroups);
+  const { request } = readyScrollRequest;
+  const targetEventId = request.position?.targetEventId;
+  const activeTargetRendered = chatGroupsContainEvent(
+    activeGroups,
+    targetEventId,
+  );
+  const targetMovedToQueue = chatGroupsContainEvent(
+    queuedGroups,
+    targetEventId,
+  );
+  const activeEventsRendered = activeGroups.some((group) => {
+    return group.events.length > 0;
+  });
+  if (
+    !activeEventsRendered ||
+    (request.position !== null && !activeTargetRendered && !targetMovedToQueue)
+  ) {
+    return null;
+  }
+
+  const commitToTail = request.position === null || targetMovedToQueue;
+  return (
+    <span
+      key={request.revision}
+      ref={commitScroll}
+      data-chat-scroll-commit-revision={request.revision}
+      data-chat-scroll-commit-to-tail={commitToTail ? "" : undefined}
+      aria-hidden
+      className="hidden"
+    />
+  );
+}
+
 function ChatThreadRenderedEventGroups({
   thread,
 }: {
   thread: ChatPanelSignals;
 }) {
-  const renderedGroups =
-    useLastResolved(thread.visibleRenderedChatGroups$, {
-      equalityFn: equalArrays,
-    }) ?? [];
+  const resolvedRenderedGroups = useLastResolved(
+    thread.visibleRenderedChatGroups$,
+    { equalityFn: equalArrays },
+  );
+  const renderedGroups = resolvedRenderedGroups ?? [];
   const { activeGroups: renderedActiveGroups } =
     splitQueuedEventsForThinkingIndicator(renderedGroups);
   const modelChanges = modelChangesByEventId(renderedActiveGroups);
@@ -2829,16 +2915,22 @@ function ChatThreadRenderedEventGroups({
     completedWorkFolding?.visibleGroups ?? runGroupVisibleGroups;
 
   return (
-    <ChatThreadEventGroups
-      thread={thread}
-      groups={visibleGroups}
-      modelChanges={modelChanges}
-      runGroupFolding={runGroupFolding}
-      onToggleRunGroup={toggleRunGroupExpanded}
-      completedWorkFolding={completedWorkFolding}
-      completedWorkExpandedKeys={effectiveCompletedWorkExpandedKeys}
-      onToggleCompletedWork={toggleCompletedWorkExpanded}
-    />
+    <>
+      <ChatThreadEventGroups
+        thread={thread}
+        groups={visibleGroups}
+        modelChanges={modelChanges}
+        runGroupFolding={runGroupFolding}
+        onToggleRunGroup={toggleRunGroupExpanded}
+        completedWorkFolding={completedWorkFolding}
+        completedWorkExpandedKeys={effectiveCompletedWorkExpandedKeys}
+        onToggleCompletedWork={toggleCompletedWorkExpanded}
+      />
+      <ChatThreadScrollCommitMarker
+        thread={thread}
+        renderedGroups={resolvedRenderedGroups}
+      />
+    </>
   );
 }
 
@@ -3953,7 +4045,7 @@ function ChatThreadEventsPane({ thread }: { thread: ChatPanelSignals }) {
           standalonePwa && "overscroll-contain",
         )}
       >
-        <ChatThreadEventsMain thread={thread} />
+        <ChatThreadEventsMain key={thread.threadId} thread={thread} />
       </div>
       <ChatThreadSkeletonOverlay
         key={`skeleton:${thread.threadId}`}


### PR DESCRIPTION
## Summary

- replace the render-time animation-frame guess with a revisioned scroll request acknowledged by a React callback ref
- bind the acknowledgement to the exact rendered event batch so stale or partial thread DOM cannot consume the saved anchor
- preserve pending anchors across resize notifications and reset thread-local retained render state when switching threads
- add a regression test where the restored target arrives only after the returned thread first commits a partial batch

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-scroll-position.test.tsx --reporter=dot` (23 tests)