### PR TITLE
refactor(chat): cut over canonical event storage

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -23,6 +23,7 @@ const TEST_APP_ROUTES = Object.freeze([...healthRoutes, ...zeroMailRoutes]);
 
 const MINIMUM_WEB_CLIENT_VERSION =
   webClientCompatibility.minimumSupportedVersion;
+const PRE_CANONICAL_CHAT_EVENT_READER_VERSION = "0.721.0";
 
 // Derived so that raising the supported floor does not turn this fixture into
 // an unsupported version.
@@ -994,6 +995,27 @@ describe("createApp", () => {
   });
 
   describe("web client compatibility", () => {
+    it("force-upgrades app clients below the canonical chat event reader", async () => {
+      const app = createApp({
+        signal: context.signal,
+        routes: TEST_APP_ROUTES,
+      });
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: {
+          [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
+          [CLIENT_VERSION_HEADER]: PRE_CANONICAL_CHAT_EVENT_READER_VERSION,
+        },
+      });
+
+      expect(MINIMUM_WEB_CLIENT_VERSION).toBe("0.722.0");
+      expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: "Client update required",
+      });
+      expect(response.headers.get("cache-control")).toBe("no-store");
+    });
+
     it("rejects pre-MCP-reader app clients before custom connector route matching", async () => {
       const app = createApp({
         signal: context.signal,
@@ -1034,7 +1056,7 @@ describe("createApp", () => {
       expect(response.headers.get("cache-control")).toBe("no-store");
     });
 
-    it("allows current app clients", async () => {
+    it("allows the canonical chat event reader floor", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
@@ -1050,7 +1072,7 @@ describe("createApp", () => {
       expect(response.status).toBe(200);
     });
 
-    it("allows newer app clients", async () => {
+    it("allows app clients newer than the canonical reader floor", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.716.0"
+  "minimumSupportedVersion": "0.722.0"
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-canonical-storage.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-canonical-storage.test.ts
@@ -4,7 +4,7 @@ import { testContext } from "../../../__tests__/test-context";
 import {
   insertChatEventAgainstPrePayloadSchemaFixture,
   insertCanonicalChatEventWritesFixture,
-  isLegacyVisibleChatEventFixture,
+  isVisibleChatEventFixture,
   readCanonicalChatEventStorageFixture,
   readCanonicalRunIdCollisionSafetyFixture,
 } from "../../../test-fixtures/chat-events";
@@ -79,7 +79,7 @@ describe("canonical chat event storage", () => {
       interruptsRunId: fixture.single.interruptTargetRunId,
     });
     await expect(
-      isLegacyVisibleChatEventFixture(fixture.single.interruptId),
+      isVisibleChatEventFixture(fixture.single.interruptId),
     ).resolves.toBeFalsy();
     await expect(
       readCanonicalRunIdCollisionSafetyFixture({
@@ -133,22 +133,24 @@ describe("canonical chat event storage", () => {
       },
     });
 
-    const v3Rows = await chat.listThreadEventRows(actor, thread.id);
-    const v3Interrupt = v3Rows.find((candidate) => {
+    const v4Rows = await chat.listThreadEventRows(actor, thread.id);
+    const v4Interrupt = v4Rows.find((candidate) => {
       return candidate.id === fixture.single.interruptId;
     });
-    expect(v3Interrupt).toMatchObject({
-      runId: null,
-      interruptsRunId: fixture.single.interruptTargetRunId,
+    expect(v4Interrupt).toMatchObject({
+      runId: fixture.single.interruptTargetRunId,
+      payload: null,
     });
-    expect(v3Interrupt).not.toHaveProperty("payload");
-    const v3GoalOutput = v3Rows.find((candidate) => {
+    expect(v4Interrupt).not.toHaveProperty("interruptsRunId");
+    const v4GoalOutput = v4Rows.find((candidate) => {
       return candidate.id === fixture.single.goalContextEventId;
     });
-    expect(v3GoalOutput).toMatchObject({
-      contextType: null,
-      contextId: null,
+    expect(v4GoalOutput).toMatchObject({
+      contextType: "goal",
+      contextId: fixture.single.goalId,
+      payload: { content: "goal output" },
     });
+    expect(v4GoalOutput).not.toHaveProperty("runGroupId");
   });
 
   it("keeps central legacy writes legal before the payload column exists", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -226,7 +226,7 @@ describe("cron monitor chat event queue", () => {
     });
   });
 
-  it("does not alert for a paused goal continuation without a context pointer", async () => {
+  it("does not alert for a paused canonical goal continuation", async () => {
     const fixture = await trackFixture(seedFixture("paused-goal"));
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
+import { createDeferredPromise } from "../../utils";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { cronSnapshotChatEventsRoutes } from "../cron-snapshot-chat-events";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
@@ -17,6 +18,7 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
   installFakeChatEventR2,
+  readFakeChatEventObject,
   writeFakeChatEventObject,
   type RecordedChatEventPut,
 } from "./helpers/fake-chat-event-r2";
@@ -50,6 +52,15 @@ async function runSnapshotCron() {
     [200],
   );
   return response.body;
+}
+
+async function verifySnapshotConvergence() {
+  return await accept(
+    snapshotCronClient().verifyConvergence({
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    }),
+    [200, 409],
+  );
 }
 
 async function projectChatEventSearch(): Promise<void> {
@@ -88,25 +99,19 @@ interface ArchivedLine {
   readonly createdAt: string;
 }
 
-const ARCHIVE_V2_KEYS = [
+const ARCHIVE_V4_KEYS = [
   "chatThreadId",
-  "content",
   "contextId",
   "contextType",
   "createdAt",
-  "error",
   "eventType",
   "id",
-  "interruptsRunId",
+  "payload",
   "revokesEventId",
   "runEventId",
   "runEventSequenceNumber",
-  "runGroupId",
   "runId",
   "seqId",
-  "thinking",
-  "usagePayload",
-  "userMessage",
 ] as const;
 
 function archivedLines(body: Buffer): readonly ArchivedLine[] {
@@ -136,7 +141,7 @@ function expectArchiveInvariants(
   const lastLine = lines[lines.length - 1];
   expect(String(lastLine?.seqId)).toBe(match?.[2]);
   for (const [index, line] of lines.entries()) {
-    expect(Object.keys(line).sort()).toStrictEqual(ARCHIVE_V2_KEYS);
+    expect(Object.keys(line).sort()).toStrictEqual(ARCHIVE_V4_KEYS);
     expect(line.chatThreadId).toBe(threadId);
     expect(Number.isInteger(line.seqId)).toBeTruthy();
     expect(Number.isNaN(Date.parse(line.createdAt))).toBeFalsy();
@@ -177,7 +182,7 @@ describe("cron snapshot chat events", () => {
     });
   });
 
-  it("archives full-thread snapshots and extends them from the parent object", async () => {
+  it("rebuilds canonical full-thread snapshots from database rows", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {
       displayName: "Snapshot agent",
@@ -210,15 +215,15 @@ describe("cron snapshot chat events", () => {
     expect(firstRaw).toContain(`${marker} first`);
     expect(firstRaw).toContain(`${marker} second`);
     const firstHead = await readChatEventSnapshotHead(context, threadId);
-    expect(firstHead.archive_schema_version).toBe(3);
+    expect(firstHead.archive_schema_version).toBe(4);
     expect(firstHead.object_key).toBe(firstPut.key);
 
     // Nothing new to archive: the same pass again must not touch the thread.
     await runSnapshotCron();
     expect(putsForThread(threadId)).toHaveLength(1);
 
-    // A new Postgres tail beyond the projected watermark triggers a rebuild
-    // that verifies the canonical parent and appends only the new tail rows.
+    // A new Postgres tail beyond the projected watermark triggers another
+    // full canonical rebuild while preserving ordering and prior history.
     await sendNoCreditMessage(owner, {
       agentId: agent.agentId,
       threadId,
@@ -241,14 +246,14 @@ describe("cron snapshot chat events", () => {
     const secondRaw = gunzipSync(secondPut.body).toString("utf8");
     expect(secondRaw).toContain(`${marker} third`);
     const secondHead = await readChatEventSnapshotHead(context, threadId);
-    expect(secondHead.archive_schema_version).toBe(3);
+    expect(secondHead.archive_schema_version).toBe(4);
     expect(secondHead.object_key).toBe(secondPut.key);
 
     await runSnapshotCron();
     expect(putsForThread(threadId)).toHaveLength(2);
   }, 60_000);
 
-  it("fails the pass when a head carries an unsupported schema version", async () => {
+  it("rebuilds an idle retained v3 head and reports convergence", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {
       displayName: "Version-only snapshot agent",
@@ -265,48 +270,49 @@ describe("cron snapshot chat events", () => {
     if (firstPut === undefined) {
       throw new Error("Expected a first-generation snapshot object");
     }
-    const firstHead = await readChatEventSnapshotHead(context, threadId);
-    await setChatEventSnapshotHeadVersion(context, threadId, 2);
-
-    // An idle head on a retired version is never a candidate, so it cannot
-    // strand the globally scoped pass for every other thread.
-    const idle = await runSnapshotCron();
-    expect(idle.success).toBeTruthy();
-    expect(putsForThread(threadId)).toHaveLength(1);
-    const idleHead = await readChatEventSnapshotHead(context, threadId);
-    expect(idleHead.archive_schema_version).toBe(2);
-    expect(idleHead.object_key).toBe(firstPut.key);
-
-    // With a new tail the thread is a candidate again, and the retired rewrite
-    // fallback means it fails closed instead of republishing under v3.
-    await sendNoCreditMessage(owner, {
-      agentId: agent.agentId,
+    const legacyObjectKey = `chat-events/${threadId}/retained-v3-${randomUUID()}.ndjson.gz`;
+    writeFakeChatEventObject(legacyObjectKey, firstPut.body);
+    await setChatEventSnapshotHeadVersion(
+      context,
       threadId,
-      prompt: `version-only-tail-${randomUUID()}`,
-    });
-    await projectChatEventSearch();
-    await accept(
-      snapshotCronClient().snapshot({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
-      }),
-      [500],
+      3,
+      legacyObjectKey,
     );
-    expect(putsForThread(threadId)).toHaveLength(1);
-    const strandedHead = await readChatEventSnapshotHead(context, threadId);
-    expect(strandedHead.archive_schema_version).toBe(2);
-    expect(strandedHead.object_key).toBe(firstPut.key);
 
-    // Restore the supported version: the cron scope is global, so an
-    // unsupported head left behind would fail every later pass in the suite.
-    await setChatEventSnapshotHeadVersion(context, threadId, 3);
-    const recovered = await runSnapshotCron();
-    expect(recovered.success).toBeTruthy();
-    const recoveredHead = await readChatEventSnapshotHead(context, threadId);
-    expect(recoveredHead.last_seq_id).toBeGreaterThan(firstHead.last_seq_id);
-    expect(recoveredHead.object_key).not.toBe(firstPut.key);
+    const incomplete = await verifySnapshotConvergence();
+    expect(incomplete.status).toBe(409);
+    expect(incomplete.body).toMatchObject({
+      error: {
+        code: "CHAT_EVENT_SNAPSHOT_V4_CONVERGENCE_INCOMPLETE",
+      },
+      convergence: {
+        nonV4SnapshotHeads: 1,
+        snapshotHeadVersions: expect.arrayContaining([
+          { archiveSchemaVersion: 3, heads: 1 },
+        ]),
+      },
+    });
+
+    const rebuilt = await runSnapshotCron();
+    expect(rebuilt.success).toBeTruthy();
+    expect(rebuilt.nonV4SnapshotHeads).toBe(0);
+    expect(putsForThread(threadId)).toHaveLength(2);
+    const rebuiltHead = await readChatEventSnapshotHead(context, threadId);
+    expect(rebuiltHead.archive_schema_version).toBe(4);
+    expect(rebuiltHead.object_key).toBe(firstPut.key);
+
+    const converged = await verifySnapshotConvergence();
+    expect(converged.status).toBe(200);
+    expect(converged.body).toMatchObject({
+      success: true,
+      nonV4SnapshotHeads: 0,
+    });
+
+    await runSnapshotCron();
+    expect(putsForThread(threadId)).toHaveLength(2);
   }, 60_000);
 
-  it("fails the pass when a parent object no longer matches its content hash", async () => {
+  it("never reads or transforms an old R2 object during a rebuild", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {
       displayName: "Corruption agent",
@@ -337,19 +343,104 @@ describe("cron snapshot chat events", () => {
       prompt: `corruption-tail-${randomUUID()}`,
     });
     await projectChatEventSearch();
-    const failed = await accept(
-      snapshotCronClient().snapshot({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
-      }),
-      [500],
-    );
-    expect(failed.body).toStrictEqual({ error: "Internal server error" });
-    expect(putsForThread(threadId)).toHaveLength(1);
-
-    // Restoring the object bytes lets the next pass archive the thread again,
-    // and keeps the shared database healthy for the remaining tests.
-    writeFakeChatEventObject(headPut.key, headPut.body);
-    await runSnapshotCron();
+    const rebuilt = await runSnapshotCron();
+    expect(rebuilt.success).toBeTruthy();
     expect(putsForThread(threadId)).toHaveLength(2);
+    const rebuiltHead = await readChatEventSnapshotHead(context, threadId);
+    expect(rebuiltHead.object_key).not.toBe(headPut.key);
   }, 60_000);
+
+  it("resumes a bounded v3 rebuild until every head converges", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Resumable snapshot agent",
+    });
+    const threadIds = await Promise.all(
+      ["first", "second"].map(async (suffix) => {
+        return await sendNoCreditMessage(owner, {
+          agentId: agent.agentId,
+          prompt: `resumable-${suffix}-${randomUUID()}`,
+        });
+      }),
+    );
+    await projectChatEventSearch();
+    await runSnapshotCron();
+
+    for (const threadId of threadIds) {
+      const head = await readChatEventSnapshotHead(context, threadId);
+      const legacyObjectKey = `chat-events/${threadId}/retained-v3-${randomUUID()}.ndjson.gz`;
+      const body = readFakeChatEventObject(head.object_key);
+      if (body === undefined) {
+        throw new Error("Expected the v4 fixture object");
+      }
+      writeFakeChatEventObject(legacyObjectKey, body);
+      await setChatEventSnapshotHeadVersion(
+        context,
+        threadId,
+        3,
+        legacyObjectKey,
+      );
+    }
+
+    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_BATCH_SIZE", "1");
+    const firstPass = await runSnapshotCron();
+    expect(firstPass.nonV4SnapshotHeads).toBe(1);
+    const incomplete = await verifySnapshotConvergence();
+    expect(incomplete.status).toBe(409);
+
+    const secondPass = await runSnapshotCron();
+    expect(secondPass.nonV4SnapshotHeads).toBe(0);
+    const converged = await verifySnapshotConvergence();
+    expect(converged.status).toBe(200);
+    for (const threadId of threadIds) {
+      const head = await readChatEventSnapshotHead(context, threadId);
+      expect(head.archive_schema_version).toBe(4);
+    }
+  }, 90_000);
+
+  it("uses the exact parent metadata as a publication CAS", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Snapshot CAS agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `snapshot-cas-${randomUUID()}`,
+    });
+    await projectChatEventSearch();
+    await runSnapshotCron();
+    const parentHead = await readChatEventSnapshotHead(context, threadId);
+
+    await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      threadId,
+      prompt: `snapshot-cas-tail-${randomUUID()}`,
+    });
+    await projectChatEventSearch();
+
+    const publicationGate = createDeferredPromise<void>(context.signal);
+    let arrivals = 0;
+    installFakeChatEventR2(context, recordedPuts, async (put) => {
+      if (!put.key.startsWith(`chat-events/${threadId}/`)) {
+        return;
+      }
+      arrivals += 1;
+      if (arrivals === 2 && !publicationGate.settled()) {
+        publicationGate.resolve(undefined);
+      }
+      await publicationGate.promise;
+    });
+
+    const results = await Promise.all([runSnapshotCron(), runSnapshotCron()]);
+    expect(arrivals).toBe(2);
+    expect(
+      results.reduce((total, result) => {
+        return total + result.snapshots;
+      }, 0),
+    ).toBe(1);
+    const head = await readChatEventSnapshotHead(context, threadId);
+    expect(head.archive_schema_version).toBe(4);
+    expect(head.last_seq_id).toBeGreaterThan(parentHead.last_seq_id);
+    expect(head.object_key).not.toBe(parentHead.object_key);
+  }, 90_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-chat-event-r2.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-chat-event-r2.ts
@@ -88,20 +88,25 @@ function fakePutObject(
   record: FakeS3CommandRecord,
   key: string,
   recordedPuts?: RecordedChatEventPut[],
+  beforePut?: (put: RecordedChatEventPut) => Promise<void>,
 ) {
   const body = record.input?.Body;
   if (!Buffer.isBuffer(body)) {
     throw new Error("expected a Buffer body for chat-events puts");
   }
-  writeFakeChatEventObject(key, body);
-  recordedPuts?.push({
+  const put = {
     bucket: record.input?.Bucket ?? "",
     key,
     contentType: record.input?.ContentType,
     contentEncoding: record.input?.ContentEncoding,
     body,
-  });
-  return Promise.resolve({});
+  };
+  return (async () => {
+    await beforePut?.(put);
+    writeFakeChatEventObject(key, body);
+    recordedPuts?.push(put);
+    return {};
+  })();
 }
 
 function fakeGetObject(key: string) {
@@ -153,13 +158,14 @@ function fakeDeleteObjects(record: FakeS3CommandRecord) {
 function handleFakeS3Command(
   command: unknown,
   recordedPuts?: RecordedChatEventPut[],
+  beforePut?: (put: RecordedChatEventPut) => Promise<void>,
 ) {
   const record = command as FakeS3CommandRecord;
   const commandName = record.constructor.name;
   const key = record.input?.Key;
   if (key?.startsWith("chat-events/") === true) {
     if (commandName === "PutObjectCommand") {
-      return fakePutObject(record, key, recordedPuts);
+      return fakePutObject(record, key, recordedPuts, beforePut);
     }
     if (commandName === "GetObjectCommand") {
       return fakeGetObject(key);
@@ -177,11 +183,12 @@ function handleFakeS3Command(
 export function installFakeChatEventR2(
   context: TestContext,
   recordedPuts?: RecordedChatEventPut[],
+  beforePut?: (put: RecordedChatEventPut) => Promise<void>,
 ): void {
   // The suite-wide mock reset primes getSignedUrl in afterEach, so the first
   // test of a file starts unprimed; presigned downloads are part of this fake.
   context.mocks.s3.getSignedUrl.mockResolvedValue(FAKE_CHAT_EVENT_SNAPSHOT_URL);
   context.mocks.s3.send.mockImplementation((command: unknown) => {
-    return handleFakeS3Command(command, recordedPuts);
+    return handleFakeS3Command(command, recordedPuts, beforePut);
   });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -411,11 +411,13 @@ export async function setChatEventSnapshotHeadVersion(
   context: TestContext,
   threadId: string,
   archiveSchemaVersion: number,
+  objectKey?: string,
 ): Promise<void> {
   await postAction(context, {
     action: "set-chat-event-snapshot-head-version",
     thread_id: threadId,
     archive_schema_version: archiveSchemaVersion,
+    ...(objectKey === undefined ? {} : { object_key: objectKey }),
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { chatEventFromRow } from "@vm0/api-contracts/contracts/chat-event-row-projection";
-import {
-  canonicalChatEventRow,
-  chatEventRowSchema,
-} from "@vm0/api-contracts/contracts/chat-event-rows";
+import { chatEventRowV4Schema } from "@vm0/api-contracts/contracts/chat-event-rows";
 import { chatThreadEventsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   cronProjectChatEventSearchContract,
@@ -157,7 +154,7 @@ describe("chat event snapshot read endpoints", () => {
     );
     // The snapshot cron scope is global, so an unsupported head left behind
     // would fail every later pass in the suite.
-    await setChatEventSnapshotHeadVersion(context, threadId, 3);
+    await setChatEventSnapshotHeadVersion(context, threadId, 4);
 
     const stranger = bdd.user({ orgId: `org_${randomUUID()}` });
     const strangerResponse = await accept(
@@ -210,12 +207,17 @@ describe("chat event snapshot read endpoints", () => {
       [200],
     );
     for (const row of rows.body.rows) {
-      chatEventRowSchema.parse(row);
+      chatEventRowV4Schema.parse(row);
       expect(row.chatThreadId).toBe(threadId);
+      expect(row).not.toHaveProperty("content");
+      expect(row).not.toHaveProperty("userMessage");
+      expect(row).not.toHaveProperty("usagePayload");
+      expect(row).not.toHaveProperty("interruptsRunId");
+      expect(row).not.toHaveProperty("runGroupId");
     }
 
     const projected = rows.body.rows.map((row) => {
-      return chatEventFromRow(canonicalChatEventRow(row));
+      return chatEventFromRow(row);
     });
     const expected = events.body.events.filter((event) => {
       return event.seqId > firstSeqId;

--- a/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
@@ -2,7 +2,10 @@ import { cronSnapshotChatEventsContract } from "@vm0/api-contracts/contracts/cro
 import { command } from "ccstate";
 
 import type { RouteEntry } from "../route-entry";
-import { snapshotChatEvents$ } from "../services/cron-snapshot-chat-events.service";
+import {
+  snapshotChatEvents$,
+  verifyChatEventSnapshotConvergence$,
+} from "../services/cron-snapshot-chat-events.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
 const snapshotChatEventsRoute$ = command(
@@ -20,9 +23,40 @@ const snapshotChatEventsRoute$ = command(
   },
 );
 
+const verifyChatEventSnapshotConvergenceRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!get(hasValidCronSecret$)) {
+      return cronUnauthorized();
+    }
+
+    const convergence = await set(verifyChatEventSnapshotConvergence$, signal);
+    signal.throwIfAborted();
+    if (convergence.nonV4SnapshotHeads > 0) {
+      return {
+        status: 409 as const,
+        body: {
+          error: {
+            code: "CHAT_EVENT_SNAPSHOT_V4_CONVERGENCE_INCOMPLETE" as const,
+            message: `${convergence.nonV4SnapshotHeads.toString()} snapshot heads are not on archive schema v4`,
+          },
+          convergence,
+        },
+      };
+    }
+    return {
+      status: 200 as const,
+      body: { success: true as const, ...convergence },
+    };
+  },
+);
+
 export const cronSnapshotChatEventsRoutes: readonly RouteEntry[] = [
   {
     route: cronSnapshotChatEventsContract.snapshot,
     handler: snapshotChatEventsRoute$,
+  },
+  {
+    route: cronSnapshotChatEventsContract.verifyConvergence,
+    handler: verifyChatEventSnapshotConvergenceRoute$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -169,22 +169,18 @@ async function seedGoalFixture(
   if (!goal) {
     throw new Error("Failed to seed orphan monitor goal");
   }
-  const [goalInputEvent] = await tx
-    .insert(chatEvents)
-    .values({
-      chatThreadId: args.threadId,
-      contextType: "goal",
-      eventType: "input.goal",
-      runGroupId: goal.id,
-      userMessage: createUserMessageDocument({
-        text: null,
-        nonContentPart: { type: "goal", goalBrief: "orphan monitor goal" },
-      }),
-      runId: null,
-      createdAt: new Date(0),
-      seqId: 1,
-    })
-    .returning({ id: chatEvents.id });
+  const goalInputEvent = await insertChatEvent(tx, {
+    chatThreadId: args.threadId,
+    contextType: "goal",
+    eventType: "input.goal",
+    runGroupId: goal.id,
+    userMessage: createUserMessageDocument({
+      text: null,
+      nonContentPart: { type: "goal", goalBrief: "orphan monitor goal" },
+    }),
+    runId: null,
+    createdAt: new Date(0),
+  });
   if (args.fixtureKind === "orphaned-goal") {
     await tx.delete(threadGoals).where(eq(threadGoals.id, goal.id));
   }

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -1247,7 +1247,12 @@ async function chatEventSnapshotFixtureActionResponse(
   if (body.action === "set-chat-event-snapshot-head-version") {
     const updated = await db
       .update(chatEventSnapshots)
-      .set({ archiveSchemaVersion: body.archive_schema_version })
+      .set({
+        archiveSchemaVersion: body.archive_schema_version,
+        ...(body.object_key === undefined
+          ? {}
+          : { objectKey: body.object_key }),
+      })
       .where(
         and(
           eq(chatEventSnapshots.chatThreadId, body.thread_id),

--- a/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
@@ -17,6 +17,7 @@ import {
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
 import { pendingActiveInputCondition } from "./chat-event-queue.service";
+import { canonicalChatEventUserMessage } from "./canonical-chat-event-read.service";
 
 type ChatEventContextType = NonNullable<
   (typeof chatEvents.$inferSelect)["contextType"]
@@ -87,7 +88,7 @@ export function pendingActiveInputRows(
       eventType: chatEvents.eventType,
       contextType: chatEvents.contextType,
       contextId: chatEvents.contextId,
-      userMessage: chatEvents.userMessage,
+      userMessage: canonicalChatEventUserMessage(),
       seqId: chatEvents.seqId,
     })
     .from(chatEvents)
@@ -115,7 +116,7 @@ export function activeInputRowsByIds(
       eventType: chatEvents.eventType,
       contextType: chatEvents.contextType,
       contextId: chatEvents.contextId,
-      userMessage: chatEvents.userMessage,
+      userMessage: canonicalChatEventUserMessage(),
       seqId: chatEvents.seqId,
     })
     .from(chatEvents)

--- a/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
@@ -44,7 +44,7 @@ import {
 import { writeDb$, type Db } from "../external/db";
 import { publishArtifactCatalogChanged } from "./artifact-realtime.service";
 import { inferMimetype } from "./zero-chat-event-shared.service";
-import { legacyRunOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
+import { runOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
 
 const ARTIFACT_CATALOG_DEFAULT_LIMIT = 60;
 
@@ -218,7 +218,7 @@ async function resolveChatThreadId(
   const [event] = await db
     .select({ chatThreadId: chatEvents.chatThreadId })
     .from(chatEvents)
-    .where(legacyRunOwnedChatEventForRunCondition({ runId: row.runId }))
+    .where(runOwnedChatEventForRunCondition({ runId: row.runId }))
     .orderBy(asc(chatEvents.seqId))
     .limit(1);
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/artifact-realtime.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-realtime.service.ts
@@ -5,7 +5,7 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 
 import type { Db } from "../external/db";
 import { publishUserSignal } from "../external/realtime";
-import { legacyRunOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
+import { runOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
 
 /**
  * Fire the user-level "artifact catalog changed" signal. The artifacts page
@@ -53,7 +53,7 @@ export async function publishArtifactsChangedForRun(
     })
     .from(chatEvents)
     .innerJoin(chatThreads, eq(chatEvents.chatThreadId, chatThreads.id))
-    .where(legacyRunOwnedChatEventForRunCondition({ runId }))
+    .where(runOwnedChatEventForRunCondition({ runId }))
     .limit(1);
   signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/canonical-asset.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-asset.service.ts
@@ -668,8 +668,9 @@ export const materializeCanonicalSlackInputAssets$ = command(
  * Registers web chat input files as canonical assets.
  *
  * Web input events carry their own ordered attachment list in
- * `chat_events.user_message` (`type: "file"` parts with fileId, filename, and
- * content type), so this path only needs the canonical asset rows.
+ * `chat_events.payload.userMessage` (`type: "file"` parts with fileId,
+ * filename, and content type), so this path only needs the canonical asset
+ * rows.
  */
 export async function registerCanonicalWebInputAssets(
   db: Db,

--- a/turbo/apps/api/src/signals/services/canonical-chat-event-read.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-chat-event-read.service.ts
@@ -1,0 +1,40 @@
+import { chatEvents } from "@vm0/db/schema/chat-event";
+import { sql, type SQLWrapper } from "drizzle-orm";
+
+import { nullableDriverValueDecoder } from "../../lib/db-structured-result";
+
+/** Canonical payload leaves projected from chat_events.payload. */
+export function canonicalChatEventContent(
+  payload: SQLWrapper = chatEvents.payload,
+) {
+  return sql`${payload}->>'content'`.mapWith(
+    nullableDriverValueDecoder(chatEvents.content),
+  );
+}
+
+export function canonicalChatEventUserMessage(
+  payload: SQLWrapper = chatEvents.payload,
+) {
+  return sql`${payload}->'userMessage'`.mapWith(
+    nullableDriverValueDecoder(chatEvents.userMessage),
+  );
+}
+
+export function canonicalChatEventError(
+  payload: SQLWrapper = chatEvents.payload,
+) {
+  return sql`${payload}->>'error'`.mapWith(
+    nullableDriverValueDecoder(chatEvents.error),
+  );
+}
+
+/** Goal grouping exists only on the canonical goal context pointer. */
+export function canonicalChatEventGoalId(
+  contextType: SQLWrapper = chatEvents.contextType,
+  contextId: SQLWrapper = chatEvents.contextId,
+) {
+  return sql`CASE
+    WHEN ${contextType} = 'goal' THEN ${contextId}
+    ELSE NULL
+  END`.mapWith(nullableDriverValueDecoder(chatEvents.contextId));
+}

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -23,6 +23,10 @@ import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { appendGoalCloseMarker } from "./zero-chat-goal-marker.service";
 import { createUserMessageDocument } from "./zero-chat-user-message.service";
 import { lockGoalThread } from "./zero-goal-lock.service";
+import {
+  canonicalChatEventGoalId,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 
 const goalInputRevoker = alias(chatEvents, "goal_input_revoker");
 
@@ -148,7 +152,7 @@ export async function loadNextGoalQueueEvent(
         chatThreadId: chatEvents.chatThreadId,
         userId: chatThreads.userId,
         orgId: zeroAgents.orgId,
-        goalId: chatEvents.runGroupId,
+        goalId: canonicalChatEventGoalId(),
         createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)
@@ -190,6 +194,8 @@ export async function loadGoalQueueTarget(
       and(
         eq(chatEvents.id, event.id),
         eq(chatEvents.chatThreadId, threadGoals.chatThreadId),
+        eq(chatEvents.contextType, "goal"),
+        eq(chatEvents.contextId, threadGoals.id),
       ),
     )
     .where(
@@ -312,7 +318,7 @@ export async function settleFailedGoalQueueEvent(
 
     const [payload] = await tx
       .select({
-        userMessage: chatEvents.userMessage,
+        userMessage: canonicalChatEventUserMessage(),
         currentGoalObjectiveBrief: threadGoals.objectiveBrief,
       })
       .from(chatEvents)

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -171,7 +171,8 @@ function missingGoalRowCondition(db: Db) {
         .from(threadGoals)
         .where(
           and(
-            eq(threadGoals.id, chatEvents.runGroupId),
+            eq(chatEvents.contextType, "goal"),
+            eq(threadGoals.id, chatEvents.contextId),
             eq(threadGoals.chatThreadId, chatEvents.chatThreadId),
           ),
         ),

--- a/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
@@ -14,6 +14,10 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 
 interface ChatEventSearchProjectionStats {
   readonly threads: number;
@@ -96,8 +100,8 @@ async function projectThread(
       .select({
         id: chatEvents.id,
         eventType: chatEvents.eventType,
-        content: chatEvents.content,
-        userMessage: chatEvents.userMessage,
+        content: canonicalChatEventContent(),
+        userMessage: canonicalChatEventUserMessage(),
         revokesEventId: chatEvents.revokesEventId,
         seqId: chatEvents.seqId,
         createdAt: chatEvents.createdAt,

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -1,12 +1,24 @@
 import { createHash } from "node:crypto";
-import { gunzipSync, gzipSync } from "node:zlib";
+import { gzipSync } from "node:zlib";
 
 import {
-  chatEventRowSchema,
-  type ChatEventRow,
+  chatEventRowV4Schema,
+  type ChatEventRowV4,
 } from "@vm0/api-contracts/contracts/chat-event-rows";
 import { command, type Computed } from "ccstate";
-import { and, asc, eq, gt, inArray, lt, lte, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatEventSearchWatermarks } from "@vm0/db/schema/chat-event-search";
 import { chatEventSnapshots } from "@vm0/db/schema/chat-event-snapshot";
@@ -18,7 +30,6 @@ import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import {
   deleteS3Objects,
-  downloadS3Buffer,
   listS3ObjectsPage,
   putImmutableS3Object,
   type S3Object,
@@ -37,6 +48,20 @@ interface ChatEventSnapshotStats {
   readonly r2BytesDeleted: number;
   readonly r2GcShardsScanned: number;
   readonly r2GcSubpartitionedShards: number;
+  readonly snapshotHeads: number;
+  readonly nonV4SnapshotHeads: number;
+  readonly snapshotHeadVersions: readonly ChatEventSnapshotHeadVersion[];
+}
+
+interface ChatEventSnapshotHeadVersion {
+  readonly archiveSchemaVersion: number;
+  readonly heads: number;
+}
+
+interface ChatEventSnapshotConvergence {
+  readonly snapshotHeads: number;
+  readonly nonV4SnapshotHeads: number;
+  readonly snapshotHeadVersions: readonly ChatEventSnapshotHeadVersion[];
 }
 
 interface SnapshotCandidate {
@@ -50,11 +75,11 @@ interface SnapshotCandidate {
 
 /**
  * Version of the archive object contract. Bump it whenever the NDJSON line
- * shape (chatEventRowSchema) or the object encoding changes. v3 stores objects
- * with `Content-Encoding: gzip` metadata so browsers decompress snapshot
- * downloads transparently; readers only serve v3 heads.
+ * shape (chatEventRowV4Schema) or the object encoding changes. v4 is the
+ * canonical payload/run/context row shape and retains gzip content metadata
+ * so browser downloads are transparently decompressed.
  */
-export const ARCHIVE_SCHEMA_VERSION = 3;
+export const ARCHIVE_SCHEMA_VERSION = 4;
 const ARCHIVE_CONTENT_TYPE = "application/x-ndjson";
 const ARCHIVE_CONTENT_ENCODING = "gzip";
 /**
@@ -64,7 +89,6 @@ const ARCHIVE_CONTENT_ENCODING = "gzip";
  */
 const DEFAULT_THREAD_BATCH_SIZE = 500;
 const EVENT_PAGE_SIZE = 1000;
-const OBJECT_KEY_CONTENT_SHA256 = /-([0-9a-f]{64})\.ndjson\.gz$/;
 const DEFAULT_R2_GC_GRACE_HOURS = 24 * 7;
 const R2_GC_SHARDS_PER_RUN = 16;
 const R2_GC_SHARD_COUNT = 16 ** 3;
@@ -81,17 +105,11 @@ type ArchiveEventRow = Pick<
   | "id"
   | "chatThreadId"
   | "runId"
-  | "usagePayload"
   | "revokesEventId"
-  | "interruptsRunId"
-  | "runGroupId"
   | "eventType"
+  | "payload"
   | "contextType"
   | "contextId"
-  | "content"
-  | "userMessage"
-  | "thinking"
-  | "error"
   | "runEventSequenceNumber"
   | "runEventId"
   | "seqId"
@@ -142,96 +160,39 @@ function hoursBefore(now: Date, hours: number): Date {
   return new Date(now.getTime() - hours * 60 * 60 * 1000);
 }
 
-function encodeArchiveLine(line: ChatEventRow): Buffer {
+function encodeArchiveLine(line: ChatEventRowV4): Buffer {
   return Buffer.from(`${JSON.stringify(line)}\n`);
 }
 
 /**
- * One archived chat event, one NDJSON line. Fields are listed explicitly so
- * that a chat_events schema change forces a conscious decision here instead
- * of silently changing the persisted archive shape. Canonical interrupt and
- * goal pointers are masked back to the v3 contract for old web/app clients
- * (about two days) and existing R2 v3 archives; DB/API skew has an observed
- * maximum of about 102 minutes. Remove these masks only with the canonical
- * reader/v4 archive cutover. Follow-up: #26158.
+ * One canonical archived chat event, one NDJSON line. Fields are listed
+ * explicitly so a chat_events schema change cannot silently alter the durable
+ * wire shape. The legacy payload leaves and pointer columns remain in
+ * Postgres for rollback, but never enter a v4 object.
  */
-export function chatEventRowFromDbRow(row: ArchiveEventRow): ChatEventRow {
-  const hasCanonicalGoalContext =
-    row.contextType === "goal" && row.contextId !== null;
-  const legacyGoalInputContext =
-    row.runGroupId === null ||
-    row.eventType === "input.goal" ||
-    row.eventType === "input.prompt" ||
-    row.eventType === "input.rejected";
-  return {
+export function chatEventRowFromDbRow(row: ArchiveEventRow): ChatEventRowV4 {
+  return chatEventRowV4Schema.parse({
     id: row.id,
     chatThreadId: row.chatThreadId,
-    runId: row.eventType === "control.interrupt" ? null : row.runId,
-    usagePayload: row.usagePayload,
+    runId: row.runId,
     revokesEventId: row.revokesEventId,
-    interruptsRunId: row.interruptsRunId,
-    runGroupId: row.runGroupId,
     eventType: row.eventType,
-    contextType:
-      hasCanonicalGoalContext && !legacyGoalInputContext
-        ? null
-        : row.contextType,
-    contextId: hasCanonicalGoalContext ? null : row.contextId,
-    content: row.content,
-    userMessage: row.userMessage,
-    thinking: row.thinking,
-    error: row.error,
+    payload: row.payload,
+    contextType: row.contextType,
+    contextId: row.contextId,
     runEventSequenceNumber: row.runEventSequenceNumber,
     runEventId: row.runEventId,
     seqId: row.seqId,
     createdAt: row.createdAt.toISOString(),
-  };
+  });
 }
 
 function archiveLine(row: ArchiveEventRow): Buffer {
   return encodeArchiveLine(chatEventRowFromDbRow(row));
 }
 
-function parseArchiveLines(raw: Buffer): readonly unknown[] {
-  const text = raw.toString("utf8");
-  if (text.length === 0 || !text.endsWith("\n")) {
-    throw new Error(
-      "chat event snapshot must be non-empty newline-delimited JSON",
-    );
-  }
-  return text
-    .slice(0, -1)
-    .split("\n")
-    .map((line) => {
-      const parsed: unknown = JSON.parse(line);
-      return parsed;
-    });
-}
-
-function validatedArchiveRows(raw: Buffer): readonly ChatEventRow[] {
-  const lines = parseArchiveLines(raw);
-  return lines.map((line) => {
-    return chatEventRowSchema.parse(line);
-  });
-}
-
-function validatedArchiveRaw(raw: Buffer): Buffer {
-  validatedArchiveRows(raw);
-  return raw;
-}
-
 function sha256Hex(buffer: Buffer): string {
   return createHash("sha256").update(buffer).digest("hex");
-}
-
-function contentSha256FromObjectKey(objectKey: string): string {
-  const hash = OBJECT_KEY_CONTENT_SHA256.exec(objectKey)?.[1];
-  if (hash === undefined) {
-    throw new Error(
-      `chat event snapshot key is missing a content hash: ${objectKey}`,
-    );
-  }
-  return hash;
 }
 
 function chatEventSnapshotObjectKey(
@@ -242,18 +203,7 @@ function chatEventSnapshotObjectKey(
   return `chat-events/${chatThreadId}/${lastSeqId}-${contentSha256}.ndjson.gz`;
 }
 
-function verifiedArchiveRaw(objectKey: string, compressed: Buffer): Buffer {
-  const expected = contentSha256FromObjectKey(objectKey);
-  const actual = sha256Hex(compressed);
-  if (actual !== expected) {
-    throw new Error(
-      `chat event snapshot object ${objectKey} content hash mismatch: ${actual}`,
-    );
-  }
-  return gunzipSync(compressed);
-}
-
-async function readTailEvents(
+async function readCanonicalEvents(
   db: Db,
   candidate: SnapshotCandidate,
 ): Promise<{
@@ -262,7 +212,7 @@ async function readTailEvents(
   readonly lastSeqId: number;
 }> {
   const lines: Buffer[] = [];
-  let cursor = candidate.headLastSeqId ?? 0;
+  let cursor = 0;
   let count = 0;
   for (;;) {
     const rows = await db
@@ -270,17 +220,11 @@ async function readTailEvents(
         id: chatEvents.id,
         chatThreadId: chatEvents.chatThreadId,
         runId: chatEvents.runId,
-        usagePayload: chatEvents.usagePayload,
         revokesEventId: chatEvents.revokesEventId,
-        interruptsRunId: chatEvents.interruptsRunId,
-        runGroupId: chatEvents.runGroupId,
         eventType: chatEvents.eventType,
+        payload: chatEvents.payload,
         contextType: chatEvents.contextType,
         contextId: chatEvents.contextId,
-        content: chatEvents.content,
-        userMessage: chatEvents.userMessage,
-        thinking: chatEvents.thinking,
-        error: chatEvents.error,
         runEventSequenceNumber: chatEvents.runEventSequenceNumber,
         runEventId: chatEvents.runEventId,
         seqId: chatEvents.seqId,
@@ -305,6 +249,11 @@ async function readTailEvents(
       cursor = lastRow.seqId;
     }
     if (rows.length < EVENT_PAGE_SIZE) {
+      if (count === 0 || cursor !== candidate.indexedSeqId) {
+        throw new Error(
+          `chat event snapshot rebuild for ${candidate.chatThreadId} ended at ${cursor.toString()} instead of indexed seq ${candidate.indexedSeqId.toString()}`,
+        );
+      }
       return { lines, count, lastSeqId: cursor };
     }
   }
@@ -323,13 +272,27 @@ async function publishSnapshotHead(
 ): Promise<boolean> {
   return await db.transaction(async (tx) => {
     if (candidate.headId !== null) {
+      if (
+        candidate.headLastSeqId === null ||
+        candidate.headObjectKey === null ||
+        candidate.headArchiveSchemaVersion === null
+      ) {
+        throw new Error("chat event snapshot head metadata is incomplete");
+      }
       const demoted = await tx
         .update(chatEventSnapshots)
         .set({ isHead: false })
         .where(
           and(
             eq(chatEventSnapshots.id, candidate.headId),
+            eq(chatEventSnapshots.chatThreadId, candidate.chatThreadId),
             eq(chatEventSnapshots.isHead, true),
+            eq(
+              chatEventSnapshots.archiveSchemaVersion,
+              candidate.headArchiveSchemaVersion,
+            ),
+            eq(chatEventSnapshots.lastSeqId, candidate.headLastSeqId),
+            eq(chatEventSnapshots.objectKey, candidate.headObjectKey),
           ),
         )
         .returning({ id: chatEventSnapshots.id });
@@ -356,41 +319,15 @@ async function archiveThread(
   candidate: SnapshotCandidate,
   signal: AbortSignal,
 ): Promise<number | null> {
-  const tail = await readTailEvents(db, candidate);
+  const archive = await readCanonicalEvents(db, candidate);
   signal.throwIfAborted();
-  if (
-    candidate.headId !== null &&
-    candidate.headArchiveSchemaVersion !== ARCHIVE_SCHEMA_VERSION
-  ) {
-    throw new Error(
-      `unsupported chat event snapshot schema version: ${candidate.headArchiveSchemaVersion}`,
-    );
-  }
-  if (tail.count === 0) {
-    return null;
-  }
-
-  // The parent object supplies the archived prefix, so a rebuild only reads
-  // the Postgres tail past the head watermark. Re-reading the parent also
-  // re-verifies its hash.
-  let parentRaw: Buffer = Buffer.alloc(0);
-  if (candidate.headId !== null) {
-    if (candidate.headObjectKey === null) {
-      throw new Error("chat event snapshot head metadata is incomplete");
-    }
-    const parentCompressed = await get(
-      downloadS3Buffer(bucket, candidate.headObjectKey),
-    );
-    signal.throwIfAborted();
-    parentRaw = validatedArchiveRaw(
-      verifiedArchiveRaw(candidate.headObjectKey, parentCompressed),
-    );
-  }
-
-  const compressed = gzipSync(Buffer.concat([parentRaw, ...tail.lines]));
+  // Every generation is rebuilt from canonical Postgres rows. Retained v3 R2
+  // objects are immutable rollback/read-fallback inputs and are never
+  // transformed into a v4 object in place.
+  const compressed = gzipSync(Buffer.concat(archive.lines));
   const objectKey = chatEventSnapshotObjectKey(
     candidate.chatThreadId,
-    tail.lastSeqId,
+    archive.lastSeqId,
     sha256Hex(compressed),
   );
   await get(
@@ -405,7 +342,7 @@ async function archiveThread(
   // published this thread's next head (unique head/object key) are expected
   // races: skip the thread and leave the uploaded object orphaned.
   const published = await settle(
-    publishSnapshotHead(db, candidate, tail.lastSeqId, objectKey),
+    publishSnapshotHead(db, candidate, archive.lastSeqId, objectKey),
   );
   if (!published.ok) {
     if (
@@ -416,7 +353,34 @@ async function archiveThread(
     }
     return null;
   }
-  return published.value ? tail.count : null;
+  return published.value ? archive.count : null;
+}
+
+async function chatEventSnapshotConvergence(
+  db: Db,
+): Promise<ChatEventSnapshotConvergence> {
+  const versions = await db
+    .select({
+      archiveSchemaVersion: chatEventSnapshots.archiveSchemaVersion,
+      heads: count(),
+    })
+    .from(chatEventSnapshots)
+    .where(eq(chatEventSnapshots.isHead, true))
+    .groupBy(chatEventSnapshots.archiveSchemaVersion)
+    .orderBy(asc(chatEventSnapshots.archiveSchemaVersion));
+  const snapshotHeads = versions.reduce((total, version) => {
+    return total + version.heads;
+  }, 0);
+  const nonV4SnapshotHeads = versions.reduce((total, version) => {
+    return version.archiveSchemaVersion === ARCHIVE_SCHEMA_VERSION
+      ? total
+      : total + version.heads;
+  }, 0);
+  return {
+    snapshotHeads,
+    nonV4SnapshotHeads,
+    snapshotHeadVersions: versions,
+  };
 }
 
 interface R2GcStats {
@@ -593,15 +557,12 @@ async function collectR2SnapshotGarbage(
 }
 
 /**
- * Archives chat_events into immutable full-thread R2 snapshot objects, oldest
- * threads first. Each pass picks threads whose search watermark is ahead of
- * their head snapshot, rebuilds one full archive per thread (parent object +
- * Postgres tail up to the watermark), uploads it content-addressed, and
- * publishes it as the new head. The search watermark caps every snapshot so no
- * archived event outruns the search index. Ticks are idempotent: objects are
- * immutable, the head swap is
- * guarded by the expected parent, and a lost race only leaves an orphaned
- * object behind.
+ * Archives chat_events into immutable canonical full-thread R2 snapshots.
+ * Each bounded pass picks both retired-version heads and threads whose search
+ * watermark advanced. It rebuilds from Postgres through that watermark,
+ * uploads content-addressed v4 bytes, and publishes with an exact parent CAS.
+ * Existing v3 objects remain immutable. Repeated or interrupted ticks are
+ * idempotent; a lost race can only leave a collectable orphan object.
  */
 export const snapshotChatEvents$ = command(
   async (
@@ -631,16 +592,32 @@ export const snapshotChatEvents$ = command(
           eq(chatEventSnapshots.isHead, true),
         ),
       )
-      // Only threads with a new tail. An idle head on a retired archive
-      // version is left alone: the reader already treats it as missing, and
-      // selecting it here would abort the whole pass on the throw below.
+      // Retired heads are rebuilt even when idle; current v4 heads are picked
+      // only when the indexed tail advanced. Future versions fail closed and
+      // are reported by the convergence check instead of being overwritten.
       .where(
-        gt(
-          chatEventSearchWatermarks.indexedSeqId,
-          sql`COALESCE(${chatEventSnapshots.lastSeqId}, 0)`,
+        and(
+          or(
+            isNull(chatEventSnapshots.archiveSchemaVersion),
+            lte(
+              chatEventSnapshots.archiveSchemaVersion,
+              ARCHIVE_SCHEMA_VERSION,
+            ),
+          ),
+          or(
+            lt(chatEventSnapshots.archiveSchemaVersion, ARCHIVE_SCHEMA_VERSION),
+            gt(
+              chatEventSearchWatermarks.indexedSeqId,
+              sql`COALESCE(${chatEventSnapshots.lastSeqId}, 0)`,
+            ),
+          ),
         ),
       )
-      .orderBy(asc(chatThreads.lastMessageAt), asc(chatThreads.id))
+      .orderBy(
+        asc(chatEventSnapshots.archiveSchemaVersion),
+        asc(chatThreads.lastMessageAt),
+        asc(chatThreads.id),
+      )
       .limit(chatEventSnapshotThreadBatchSize());
     signal.throwIfAborted();
 
@@ -654,6 +631,8 @@ export const snapshotChatEvents$ = command(
         archivedEvents += archived;
       }
     }
+    const convergence = await chatEventSnapshotConvergence(db);
+    signal.throwIfAborted();
     const r2Gc = await collectR2SnapshotGarbage(get, db, bucket, signal);
     signal.throwIfAborted();
     return {
@@ -666,6 +645,15 @@ export const snapshotChatEvents$ = command(
       r2BytesDeleted: r2Gc.bytesDeleted,
       r2GcShardsScanned: r2Gc.shardsScanned,
       r2GcSubpartitionedShards: r2Gc.subpartitionedShards,
+      ...convergence,
     };
+  },
+);
+
+export const verifyChatEventSnapshotConvergence$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const convergence = await chatEventSnapshotConvergence(set(writeDb$));
+    signal.throwIfAborted();
+    return convergence;
   },
 );

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -42,7 +42,7 @@ import {
   type ConnectorCredentialConnection,
 } from "./connector-credential-runtime.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
-import { legacyRunOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
+import { runOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
 
 const GOOGLE_DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files";
 const GOOGLE_DRIVE_UPLOAD_URL =
@@ -614,7 +614,7 @@ async function loadArtifactFile(
               .select({ one: chatEvents.id })
               .from(chatEvents)
               .where(
-                legacyRunOwnedChatEventForRunCondition({
+                runOwnedChatEventForRunCondition({
                   runId: runUploadedFiles.runId,
                   chatThreadId: args.threadId,
                 }),

--- a/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts
@@ -25,6 +25,7 @@ import {
 } from "./agentphone-shared.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
 
 const L = logger("InternalCallbacksAgentPhoneChat");
 type AgentPhoneSendResult = Awaited<ReturnType<typeof sendAgentPhoneMessage>>;
@@ -171,7 +172,7 @@ async function loadAgentPhoneChatDeliveryContext(
   };
 
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
@@ -184,7 +185,7 @@ async function loadAgentPhoneChatDeliveryContext(
           "run.failed",
           "run.cancelled",
         ]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);
@@ -418,14 +419,14 @@ export async function deliverAgentPhoneChatAdmissionFailure(
   signal: AbortSignal,
 ): Promise<void> {
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
         eq(chatEvents.id, args.chatEventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         chatEventTypeIn(["output.error"]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -124,7 +124,7 @@ import type { ChatRunFinishedEvent } from "./chat-run-finished-event";
 import {
   insertAssistantEvents,
   insertAssistantEvents$,
-  runGroupIdForRun,
+  goalIdForRun,
   touchChatThreadLastMessageAt,
   type InsertAssistantEventsInput,
   visibleChatEventCondition,
@@ -180,6 +180,10 @@ import {
   chatEventTextCondition,
   chatEventTypeIn,
 } from "./zero-chat-event-type.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 import {
   loadSlackQueuedLaunchMaterial,
   type SlackQueuedLaunchMaterial,
@@ -949,7 +953,7 @@ async function latestEventBackedAssistantEvent(
 ): Promise<AssistantEventItem | null> {
   const [event] = await db
     .select({
-      content: chatEvents.content,
+      content: canonicalChatEventContent(),
       sequenceNumber: chatEvents.runEventSequenceNumber,
     })
     .from(chatEvents)
@@ -958,8 +962,8 @@ async function latestEventBackedAssistantEvent(
         eq(chatEvents.runId, runId),
         chatEventTypeIn(["output.message"]),
         isNotNull(chatEvents.runEventSequenceNumber),
-        isNotNull(chatEvents.content),
-        not(sql`${chatEvents.content} ~ '^[[:space:]]*$'`),
+        isNotNull(canonicalChatEventContent()),
+        not(sql`${canonicalChatEventContent()} ~ '^[[:space:]]*$'`),
         ...(options.maxSequenceNumber === undefined
           ? []
           : [
@@ -1409,7 +1413,7 @@ async function insertAssistantErrorEvent(args: {
   readonly sourceCallbackId?: string;
 }): Promise<FailedChatCallbackResult> {
   const displayErrorMessage = await args.getFormattedError();
-  const runGroupId = await runGroupIdForRun(args.db, args.runId);
+  const goalId = await goalIdForRun(args.db, args.runId);
   const inserted = await args.db.transaction(async (tx) => {
     const event = await insertChatEvent(
       tx,
@@ -1419,7 +1423,7 @@ async function insertAssistantErrorEvent(args: {
           args.lifecycleEvent === "failed" ? "run.failed" : "run.cancelled",
         content: displayErrorMessage,
         runId: args.runId,
-        runGroupId,
+        runGroupId: goalId,
         error: displayErrorMessage,
       },
       "run-lifecycle",
@@ -1553,7 +1557,7 @@ async function loadCanonicalDeliveryEvent(
       and(
         eq(chatEvents.runId, runId),
         chatEventTypeIn(["output.message"]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
         isNotNull(chatEvents.runEventSequenceNumber),
       ),
     )
@@ -1566,7 +1570,7 @@ async function insertIntegrationCompletionFallback(args: {
   readonly db: ChatCallbackTransaction;
   readonly runId: string;
   readonly threadId: string;
-  readonly runGroupId: string | null | undefined;
+  readonly goalId: string | null | undefined;
   readonly createdAt: Date;
 }): Promise<CanonicalDeliveryEvent> {
   const eventId = integrationCompletionFallbackEventIdForRun(args.runId);
@@ -1578,7 +1582,7 @@ async function insertIntegrationCompletionFallback(args: {
       eventType: "output.message",
       content: "Task completed successfully.",
       runId: args.runId,
-      runGroupId: args.runGroupId,
+      runGroupId: args.goalId,
       createdAt: args.createdAt,
     },
     "id",
@@ -1652,7 +1656,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
   readonly tx: ChatCallbackTransaction;
   readonly input: RunLifecycleMarkerArgs;
   readonly markerCreatedAt: Date;
-  readonly runGroupId: string | undefined;
+  readonly goalId: string | undefined;
 }): Promise<RunLifecycleDeliveryCallbacks | null> {
   const { input } = args;
   if (
@@ -1671,7 +1675,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
       db: args.tx,
       runId: input.runId,
       threadId: input.threadId,
-      runGroupId: args.runGroupId,
+      goalId: args.goalId,
       createdAt: args.markerCreatedAt,
     });
   }
@@ -1683,7 +1687,7 @@ async function insertRunLifecycleMarkerTransaction(args: {
         input.event === "completed" ? "run.completed" : "run.cancelled",
       content: null,
       runId: input.runId,
-      runGroupId: args.runGroupId,
+      runGroupId: args.goalId,
       createdAt: args.markerCreatedAt,
     },
     "run-lifecycle",
@@ -1773,13 +1777,13 @@ async function insertRunLifecycleMarker(
   | ({ readonly inserted: true } & RunLifecycleDeliveryCallbacks)
 > {
   const markerCreatedAt = nowDate();
-  const runGroupId = await runGroupIdForRun(args.db, args.runId);
+  const goalId = await goalIdForRun(args.db, args.runId);
   const inserted = await args.db.transaction(async (tx) => {
     return await insertRunLifecycleMarkerTransaction({
       tx,
       input: args,
       markerCreatedAt,
-      runGroupId,
+      goalId,
     });
   });
   if (!inserted) {
@@ -1805,7 +1809,7 @@ async function insertRecommendedFollowupsEvent(args: {
   readonly userId: string;
   readonly followups: readonly ChatRecommendedFollowup[];
 }): Promise<boolean> {
-  const runGroupId = await runGroupIdForRun(args.db, args.runId);
+  const goalId = await goalIdForRun(args.db, args.runId);
   const inserted = await args.db.transaction(async (tx) => {
     return await insertChatEvent(
       tx,
@@ -1815,7 +1819,7 @@ async function insertRecommendedFollowupsEvent(args: {
         eventType: "output.followups",
         content: serializeChatFollowupsContent(args.followups),
         runId: args.runId,
-        runGroupId,
+        runGroupId: goalId,
       },
       "id",
     );
@@ -2394,8 +2398,8 @@ async function getLatestRunsByThreadId(
     .select({
       runId: chatEvents.runId,
       eventType: chatEvents.eventType,
-      content: chatEvents.content,
-      userMessage: chatEvents.userMessage,
+      content: canonicalChatEventContent(),
+      userMessage: canonicalChatEventUserMessage(),
       createdAt: chatEvents.createdAt,
       sequenceNumber: chatEvents.runEventSequenceNumber,
     })
@@ -2741,9 +2745,9 @@ type LaunchLoader = (
 
 /**
  * Web is the only trigger source with no context table: the user typed the
- * message, so `chat_events.user_message` *is* the durable original fact rather
- * than a display copy of something stored elsewhere. This is the one place a
- * launch loader reads it, and it is deliberate.
+ * message, so `chat_events.payload.userMessage` is the durable original fact
+ * rather than a display copy of something stored elsewhere. This is the one
+ * place a launch loader reads it, and it is deliberate.
  */
 const loadWebQueuedLaunchMaterial: LaunchLoader = (_db, args) => {
   return Promise.resolve({

--- a/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts
@@ -25,6 +25,7 @@ import {
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveIntegrationAgentResponsePresentation } from "./integration-agent-response-presentation.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
 
 const L = logger("InternalCallbacksFeishuChat");
 
@@ -120,7 +121,7 @@ async function loadFeishuChatDeliveryContext(
   }
 
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
@@ -133,7 +134,7 @@ async function loadFeishuChatDeliveryContext(
           "run.failed",
           "run.cancelled",
         ]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);
@@ -209,14 +210,14 @@ async function loadFeishuAdmissionFailureContext(
 ): Promise<{ readonly messageContent: string }> {
   const [eventRows, bindingRows] = await Promise.all([
     args.db
-      .select({ content: chatEvents.content })
+      .select({ content: canonicalChatEventContent() })
       .from(chatEvents)
       .where(
         and(
           eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["output.error"]),
-          isNotNull(chatEvents.content),
+          isNotNull(canonicalChatEventContent()),
         ),
       )
       .limit(1),

--- a/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
@@ -25,6 +25,7 @@ import {
   removeGithubCommentReaction,
 } from "./github-issues-api.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
 import { resolveGithubAgentReplyFooterText } from "./zero-github-footer.service";
 
 const L = logger("InternalCallbacksGithubChat");
@@ -137,7 +138,7 @@ async function loadGitHubChatDeliveryContext(
   };
 
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
@@ -150,7 +151,7 @@ async function loadGitHubChatDeliveryContext(
           "run.failed",
           "run.cancelled",
         ]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);
@@ -402,14 +403,14 @@ export async function deliverGitHubChatAdmissionFailure(
   signal: AbortSignal,
 ): Promise<void> {
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
         eq(chatEvents.id, args.chatEventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         chatEventTypeIn(["output.error"]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts
@@ -16,6 +16,7 @@ import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import { createSlackClient } from "../external/slack-message-client";
 import { now, nowDate } from "../../lib/time";
@@ -119,7 +120,7 @@ async function loadSlackChatDeliveryContext(
   }
 
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
@@ -132,7 +133,7 @@ async function loadSlackChatDeliveryContext(
           "run.failed",
           "run.cancelled",
         ]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);
@@ -334,14 +335,14 @@ export async function deliverSlackChatAdmissionFailure(
 ): Promise<void> {
   const [eventRows, bindingRows] = await Promise.all([
     args.db
-      .select({ content: chatEvents.content })
+      .select({ content: canonicalChatEventContent() })
       .from(chatEvents)
       .where(
         and(
           eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["output.error"]),
-          isNotNull(chatEvents.content),
+          isNotNull(canonicalChatEventContent()),
         ),
       )
       .limit(1),

--- a/turbo/apps/api/src/signals/services/internal-teams-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-teams-chat-run-callback.service.ts
@@ -24,6 +24,7 @@ import { settleIncludingAbort } from "../utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveIntegrationAgentResponsePresentation } from "./integration-agent-response-presentation.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
 import {
   teamsChatCallbackPayloadSchema,
   type TeamsDeliveryTarget,
@@ -124,7 +125,7 @@ async function loadTeamsChatDeliveryContext(
   }
 
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
@@ -137,7 +138,7 @@ async function loadTeamsChatDeliveryContext(
           "run.failed",
           "run.cancelled",
         ]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);
@@ -416,14 +417,14 @@ async function loadTeamsAdmissionFailureContext(
 ): Promise<TeamsAdmissionFailureContext | undefined> {
   const [eventRows, bindingRows] = await Promise.all([
     args.db
-      .select({ content: chatEvents.content })
+      .select({ content: canonicalChatEventContent() })
       .from(chatEvents)
       .where(
         and(
           eq(chatEvents.id, args.chatEventId),
           eq(chatEvents.chatThreadId, args.chatThreadId),
           chatEventTypeIn(["output.error"]),
-          isNotNull(chatEvents.content),
+          isNotNull(canonicalChatEventContent()),
         ),
       )
       .limit(1),

--- a/turbo/apps/api/src/signals/services/internal-telegram-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-telegram-chat-run-callback.service.ts
@@ -39,6 +39,7 @@ import {
   type TelegramOwnerLink,
 } from "./telegram-chat-ingress.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
 import { storeTelegramBotMessage } from "./zero-telegram-callback-persistence.service";
 import { resolveTelegramAgentReplyFooterText } from "./zero-telegram-footer.service";
 
@@ -261,7 +262,7 @@ async function loadTelegramChatDeliveryContext(
   };
 
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
@@ -274,7 +275,7 @@ async function loadTelegramChatDeliveryContext(
           "run.failed",
           "run.cancelled",
         ]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);
@@ -632,14 +633,14 @@ export async function deliverTelegramChatAdmissionFailure(
   signal: AbortSignal,
 ): Promise<void> {
   const [event] = await args.db
-    .select({ content: chatEvents.content })
+    .select({ content: canonicalChatEventContent() })
     .from(chatEvents)
     .where(
       and(
         eq(chatEvents.id, args.chatEventId),
         eq(chatEvents.chatThreadId, args.chatThreadId),
         chatEventTypeIn(["output.error"]),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
       ),
     )
     .limit(1);

--- a/turbo/apps/api/src/signals/services/morning-brief-collect.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-collect.service.ts
@@ -29,6 +29,10 @@ import {
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
 import { chatEventTextCondition } from "./zero-chat-event-type.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 
 const GITHUB_API_BASE = "https://api.github.com";
 const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
@@ -605,8 +609,8 @@ async function collectUnreadChatThreads(args: {
     const messages = await args.db
       .select({
         eventType: chatEvents.eventType,
-        content: chatEvents.content,
-        userMessage: chatEvents.userMessage,
+        content: canonicalChatEventContent(),
+        userMessage: canonicalChatEventUserMessage(),
         createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)

--- a/turbo/apps/api/src/signals/services/shared-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/shared-thread.service.ts
@@ -19,6 +19,11 @@ import { visibleChatEventCondition } from "./zero-chat-event-shared.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { generateSharedThreadTitle } from "./zero-chat-title.service";
 import { projectUserMessageForPublicShare } from "./zero-chat-user-message.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventGoalId,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 
 const SHARED_THREAD_MAX_SERIALIZED_BYTES = 2 * 1024 * 1024;
 
@@ -82,10 +87,10 @@ export const createSharedThread$ = command(
     const rows = await database
       .select({
         eventType: chatEvents.eventType,
-        content: chatEvents.content,
-        userMessage: chatEvents.userMessage,
+        content: canonicalChatEventContent(),
+        userMessage: canonicalChatEventUserMessage(),
         runId: chatEvents.runId,
-        runGroupId: chatEvents.runGroupId,
+        runGroupId: canonicalChatEventGoalId(),
       })
       .from(chatEvents)
       .where(

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -69,6 +69,10 @@ import {
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
 import { chatEventTextCondition } from "./zero-chat-event-type.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 import { loadWorkflowVolumeFiles } from "./zero-workflow-volume.service";
 
 const RATE_LIMIT_MS = 24 * 60 * 60 * 1000;
@@ -763,8 +767,8 @@ async function collectConversationMessages(
     const rows = await runtime.db
       .select({
         eventType: chatEvents.eventType,
-        content: chatEvents.content,
-        userMessage: chatEvents.userMessage,
+        content: canonicalChatEventContent(),
+        userMessage: canonicalChatEventUserMessage(),
         createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -28,6 +28,7 @@ import type {
 } from "./workflow-automation-context.service";
 import type { Tx } from "../../lib/db-types";
 import { manualTriggerSource } from "./workflow-automation-trigger-source";
+import { canonicalChatEventUserMessage } from "./canonical-chat-event-read.service";
 
 const automationEventRevoker = alias(chatEvents, "automation_event_revoker");
 
@@ -269,7 +270,7 @@ async function loadAutomationRejectionPayload(
       automationId: chatAutomationContext.automationId,
       automationKind: zeroWorkflowAutomations.kind,
       triggerBrief: chatAutomationContext.triggerBrief,
-      userMessage: chatEvents.userMessage,
+      userMessage: canonicalChatEventUserMessage(),
       workflowId: zeroWorkflows.id,
       workflowName: zeroWorkflows.name,
     })

--- a/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
@@ -24,8 +24,9 @@ import { assistantEventIdForRunEvent } from "./assistant-event-id";
 import { insertChatEvents } from "./zero-chat-event.service";
 import {
   chatEventTypeIn,
-  legacyRunOwnedChatEventCondition,
+  runOwnedChatEventCondition,
 } from "./zero-chat-event-type.service";
+import { canonicalChatEventError } from "./canonical-chat-event-read.service";
 import { publishFirstAssistantEventCreatedSafely } from "./zero-chat-first-assistant-event-metric.service";
 import {
   appendChatThreadEvent,
@@ -121,9 +122,9 @@ export function visibleChatEventCondition(
     "control.interrupt",
     "control.revoke",
   ]);
-  const hasLegacyRunOwner = and(
+  const hasRunOwner = and(
     isNotNull(chatEvents.runId),
-    legacyRunOwnedChatEventCondition(),
+    runOwnedChatEventCondition(),
   );
   return and(
     not(chatEventTypeIn(["input.goal"])),
@@ -135,40 +136,36 @@ export function visibleChatEventCondition(
     ),
     or(
       not(isUserInputEvent),
-      hasLegacyRunOwner,
+      hasRunOwner,
       isNull(chatEvents.revokesEventId),
-      isNotNull(chatEvents.error),
+      isNotNull(canonicalChatEventError()),
     ),
-    or(
-      not(isUserInputEvent),
-      hasLegacyRunOwner,
-      isNull(chatEvents.interruptsRunId),
-    ),
+    not(chatEventTypeIn(["control.interrupt"])),
   );
 }
 
-export async function runGroupIdForRun(
+export async function goalIdForRun(
   db: Db,
   runId: string,
 ): Promise<string | undefined> {
   const [run] = await db
-    .select({ runGroupId: zeroRuns.runGroupId })
+    .select({ goalId: zeroRuns.goalId })
     .from(zeroRuns)
     .where(eq(zeroRuns.id, runId))
     .limit(1);
-  return run?.runGroupId ?? undefined;
+  return run?.goalId ?? undefined;
 }
 
 async function assistantEventRunContextForRun(
   db: ChatThreadEventTransaction,
   runId: string,
 ): Promise<{
-  readonly runGroupId: string | undefined;
+  readonly goalId: string | undefined;
   readonly shouldAttemptFirstAssistantEventClaim: boolean;
 }> {
   const [run] = await db
     .select({
-      runGroupId: zeroRuns.runGroupId,
+      goalId: zeroRuns.goalId,
       apiStartedAt: zeroRuns.apiStartedAt,
       firstAssistantEventAcknowledgedAt:
         zeroRuns.firstAssistantEventAcknowledgedAt,
@@ -177,7 +174,7 @@ async function assistantEventRunContextForRun(
     .where(eq(zeroRuns.id, runId))
     .limit(1);
   return {
-    runGroupId: run?.runGroupId ?? undefined,
+    goalId: run?.goalId ?? undefined,
     shouldAttemptFirstAssistantEventClaim:
       run !== undefined &&
       run.apiStartedAt !== null &&
@@ -212,7 +209,7 @@ export async function insertAssistantEventsInTransaction(
         id: assistantEventIdForRunEvent(args.runId, item.runEventId),
         chatThreadId: args.threadId,
         runId: args.runId,
-        runGroupId: runContext.runGroupId,
+        runGroupId: runContext.goalId,
         eventType: "output.message",
         content: item.content,
         runEventSequenceNumber: item.runEventSequenceNumber,

--- a/turbo/apps/api/src/signals/services/zero-chat-event-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-snapshot.service.ts
@@ -1,4 +1,4 @@
-import type { ChatEventRow } from "@vm0/api-contracts/contracts/chat-event-rows";
+import type { ChatEventRowV4 } from "@vm0/api-contracts/contracts/chat-event-rows";
 import { computed, type Computed } from "ccstate";
 import { and, asc, eq, gt } from "drizzle-orm";
 import { chatEvents } from "@vm0/db/schema/chat-event";
@@ -30,7 +30,7 @@ type ChatEventSnapshotDownload =
 type ChatEventRowsPage =
   | { readonly kind: "thread-not-found" }
   | { readonly kind: "expired" }
-  | { readonly kind: "ok"; readonly rows: readonly ChatEventRow[] };
+  | { readonly kind: "ok"; readonly rows: readonly ChatEventRowV4[] };
 
 const ownedThread = (threadId: string, userId: string) => {
   return and(eq(chatThreads.id, threadId), eq(chatThreads.userId, userId));
@@ -150,17 +150,11 @@ export function zeroChatThreadEventRows(args: {
         id: chatEvents.id,
         chatThreadId: chatEvents.chatThreadId,
         runId: chatEvents.runId,
-        usagePayload: chatEvents.usagePayload,
         revokesEventId: chatEvents.revokesEventId,
-        interruptsRunId: chatEvents.interruptsRunId,
-        runGroupId: chatEvents.runGroupId,
         eventType: chatEvents.eventType,
+        payload: chatEvents.payload,
         contextType: chatEvents.contextType,
         contextId: chatEvents.contextId,
-        content: chatEvents.content,
-        userMessage: chatEvents.userMessage,
-        thinking: chatEvents.thinking,
-        error: chatEvents.error,
         runEventSequenceNumber: chatEvents.runEventSequenceNumber,
         runEventId: chatEvents.runEventId,
         seqId: chatEvents.seqId,

--- a/turbo/apps/api/src/signals/services/zero-chat-event-type.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-type.service.ts
@@ -15,6 +15,11 @@ import {
   type SQLWrapper,
 } from "drizzle-orm";
 
+import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
+
 export function chatEventTypeIn(eventTypes: readonly ChatEventType[]): SQL {
   return inArray(chatEvents.eventType, [...eventTypes]);
 }
@@ -23,11 +28,11 @@ export function chatEventTextCondition(): SQL {
   return or(
     and(
       chatEventTypeIn(CHAT_EVENT_USER_MESSAGE_TEXT_TYPES),
-      isNotNull(chatEvents.userMessage),
+      isNotNull(canonicalChatEventUserMessage()),
     ),
     and(
       chatEventTypeIn(CHAT_EVENT_CONTENT_TEXT_TYPES),
-      isNotNull(chatEvents.content),
+      isNotNull(canonicalChatEventContent()),
     ),
   ) as SQL;
 }
@@ -55,19 +60,15 @@ export function chatInputPromptDispatchCondition(args: {
 }
 
 /**
- * During the canonical-schema rollout, control interrupts store their target
- * run in run_id. Legacy readers must not mistake that pointer for ordinary run
- * ownership until they switch to the canonical event-type-aware model. This
- * protects DB/API skew (observed maximum: about 102 minutes) and remains until
- * canonical readers replace run_id-as-ownership assumptions. Follow-up:
- * #26158.
+ * Canonical run_id is event-type-sensitive: on control.interrupt it is the
+ * target, while every other run-scoped event uses it as ownership.
  */
-export function legacyRunOwnedChatEventCondition(): SQL {
+export function runOwnedChatEventCondition(): SQL {
   return not(chatEventTypeIn(["control.interrupt"]));
 }
 
 /** Shared collision-safe run lookup for artifact and thread readers. */
-export function legacyRunOwnedChatEventForRunCondition(args: {
+export function runOwnedChatEventForRunCondition(args: {
   readonly runId: string | SQLWrapper;
   readonly chatThreadId?: string;
 }): SQL {
@@ -76,6 +77,6 @@ export function legacyRunOwnedChatEventForRunCondition(args: {
     args.chatThreadId === undefined
       ? undefined
       : eq(chatEvents.chatThreadId, args.chatThreadId),
-    legacyRunOwnedChatEventCondition(),
+    runOwnedChatEventCondition(),
   ) as SQL;
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -21,7 +21,7 @@ import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, ne } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -106,7 +106,15 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { registerCanonicalWebInputAssets } from "./canonical-asset.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
-import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import {
+  chatEventTypeIn,
+  runOwnedChatEventCondition,
+} from "./zero-chat-event-type.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventError,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 import {
   buildWebChatAppendSystemPrompt,
   type WebChatSessionPromptContext,
@@ -446,7 +454,6 @@ interface ExistingClientEventIdRow {
   readonly content: string | null;
   readonly runId: string | null;
   readonly revokesEventId: string | null;
-  readonly interruptsRunId: string | null;
   readonly error: string | null;
   readonly eventCreatedAt: Date;
   readonly runStatus: string | null;
@@ -486,8 +493,7 @@ function resolveExistingClientEventIdRow(
   if (
     row.chatThreadId !== params.threadId ||
     row.threadUserId !== params.userId ||
-    (row.eventType !== "input.prompt" && row.eventType !== "input.rejected") ||
-    row.interruptsRunId !== null
+    (row.eventType !== "input.prompt" && row.eventType !== "input.rejected")
   ) {
     return { kind: "conflict" };
   }
@@ -552,30 +558,35 @@ async function resolveClientEventId(
       chatThreadId: chatEvents.chatThreadId,
       threadUserId: chatThreads.userId,
       eventType: chatEvents.eventType,
-      content: chatEvents.content,
+      content: canonicalChatEventContent(),
       runId: chatEvents.runId,
       revokesEventId: chatEvents.revokesEventId,
-      interruptsRunId: chatEvents.interruptsRunId,
-      error: chatEvents.error,
+      error: canonicalChatEventError(),
       eventCreatedAt: chatEvents.createdAt,
       runStatus: agentRuns.status,
       runCreatedAt: agentRuns.createdAt,
       replacementEventId: replacementChatEvent.id,
       replacementRunId: replacementChatEvent.runId,
-      replacementError: replacementChatEvent.error,
+      replacementError: canonicalChatEventError(replacementChatEvent.payload),
       replacementRunStatus: replacementAgentRun.status,
       replacementRunCreatedAt: replacementAgentRun.createdAt,
     })
     .from(chatEvents)
     .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
-    .leftJoin(agentRuns, eq(agentRuns.id, chatEvents.runId))
+    .leftJoin(
+      agentRuns,
+      and(eq(agentRuns.id, chatEvents.runId), runOwnedChatEventCondition()),
+    )
     .leftJoin(
       replacementChatEvent,
       eq(replacementChatEvent.revokesEventId, chatEvents.id),
     )
     .leftJoin(
       replacementAgentRun,
-      eq(replacementAgentRun.id, replacementChatEvent.runId),
+      and(
+        eq(replacementAgentRun.id, replacementChatEvent.runId),
+        ne(replacementChatEvent.eventType, "control.interrupt"),
+      ),
     )
     .where(eq(chatEvents.id, params.clientEventId))
     .limit(1);
@@ -1466,30 +1477,35 @@ function appendUnassociatedUserMessage(params: {
         chatThreadId: chatEvents.chatThreadId,
         threadUserId: chatThreads.userId,
         eventType: chatEvents.eventType,
-        content: chatEvents.content,
+        content: canonicalChatEventContent(),
         runId: chatEvents.runId,
         revokesEventId: chatEvents.revokesEventId,
-        interruptsRunId: chatEvents.interruptsRunId,
-        error: chatEvents.error,
+        error: canonicalChatEventError(),
         eventCreatedAt: chatEvents.createdAt,
         runStatus: agentRuns.status,
         runCreatedAt: agentRuns.createdAt,
         replacementEventId: replacementChatEvent.id,
         replacementRunId: replacementChatEvent.runId,
-        replacementError: replacementChatEvent.error,
+        replacementError: canonicalChatEventError(replacementChatEvent.payload),
         replacementRunStatus: replacementAgentRun.status,
         replacementRunCreatedAt: replacementAgentRun.createdAt,
       })
       .from(chatEvents)
       .innerJoin(chatThreads, eq(chatThreads.id, chatEvents.chatThreadId))
-      .leftJoin(agentRuns, eq(agentRuns.id, chatEvents.runId))
+      .leftJoin(
+        agentRuns,
+        and(eq(agentRuns.id, chatEvents.runId), runOwnedChatEventCondition()),
+      )
       .leftJoin(
         replacementChatEvent,
         eq(replacementChatEvent.revokesEventId, chatEvents.id),
       )
       .leftJoin(
         replacementAgentRun,
-        eq(replacementAgentRun.id, replacementChatEvent.runId),
+        and(
+          eq(replacementAgentRun.id, replacementChatEvent.runId),
+          ne(replacementChatEvent.eventType, "control.interrupt"),
+        ),
       )
       .where(eq(chatEvents.id, explicitId))
       .limit(1);
@@ -1597,7 +1613,7 @@ function appendRecallChatEvent(params: {
     const [existingRevoker] = await tx
       .select({
         eventType: chatEvents.eventType,
-        content: chatEvents.content,
+        content: canonicalChatEventContent(),
         createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)
@@ -1623,7 +1639,7 @@ function appendRecallChatEvent(params: {
 
     const [target] = await tx
       .select({
-        error: chatEvents.error,
+        error: canonicalChatEventError(),
         revokesEventId: chatEvents.revokesEventId,
       })
       .from(chatEvents)
@@ -1686,8 +1702,8 @@ function appendRecallChatEvent(params: {
           eq(chatEvents.chatThreadId, params.threadId),
           eq(chatEvents.revokesEventId, params.revokesEventId),
           chatEventTypeIn(["control.revoke"]),
-          isNull(chatEvents.content),
-          isNull(chatEvents.error),
+          isNull(canonicalChatEventContent()),
+          isNull(canonicalChatEventError()),
         ),
       )
       .limit(1);
@@ -1713,7 +1729,7 @@ async function validateNormalRevocationTarget(params: {
   const [target] = await params.db
     .select({
       id: chatEvents.id,
-      content: chatEvents.content,
+      content: canonicalChatEventContent(),
     })
     .from(chatEvents)
     .where(
@@ -1755,14 +1771,15 @@ function appendInterruptUserMessage(params: {
     const [existingInterrupter] = await tx
       .select({
         eventType: chatEvents.eventType,
-        content: chatEvents.content,
+        content: canonicalChatEventContent(),
         createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)
       .where(
         and(
           eq(chatEvents.chatThreadId, params.threadId),
-          eq(chatEvents.interruptsRunId, params.interruptsRunId),
+          eq(chatEvents.runId, params.interruptsRunId),
+          chatEventTypeIn(["control.interrupt"]),
         ),
       )
       .limit(1);
@@ -1818,9 +1835,9 @@ function appendInterruptUserMessage(params: {
       .where(
         and(
           eq(chatEvents.chatThreadId, params.threadId),
-          eq(chatEvents.interruptsRunId, params.interruptsRunId),
+          eq(chatEvents.runId, params.interruptsRunId),
           chatEventTypeIn(["control.interrupt"]),
-          isNull(chatEvents.content),
+          isNull(canonicalChatEventContent()),
         ),
       )
       .limit(1);
@@ -2589,7 +2606,7 @@ async function appendQueueFirstInsufficientCreditsEvents(params: {
     }
     const [queuedMessage] = await tx
       .select({
-        userMessage: chatEvents.userMessage,
+        userMessage: canonicalChatEventUserMessage(),
         createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)

--- a/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-incomplete-context.service.ts
@@ -27,8 +27,10 @@ import type { Db } from "../external/db";
 import {
   chatEventTextCondition,
   chatEventTypeIn,
+  runOwnedChatEventCondition,
 } from "./zero-chat-event-type.service";
 import { visibleChatEventCondition } from "./zero-chat-event-shared.service";
+import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
 
 const INCOMPLETE_ROUND_LIMIT = 20;
 const INCOMPLETE_EVENT_CHAR_CAP = 4000;
@@ -120,6 +122,7 @@ async function selectIncompleteRoundFrontier(
         WHERE ${and(
           eq(chatEvents.chatThreadId, threadId),
           isNotNull(chatEvents.runId),
+          runOwnedChatEventCondition(),
           not(sql`${chatEvents.runId} = ANY(incomplete_frontier.seen_run_ids)`),
           visibleChatEventCondition(db),
           or(
@@ -216,7 +219,7 @@ async function loadSelectedIncompleteRounds(
     .select({
       runId: chatEvents.runId,
       eventType: chatEvents.eventType,
-      content: chatEvents.content,
+      content: canonicalChatEventContent(),
       agentPrompt: agentRuns.prompt,
     })
     .from(chatEvents)

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -21,7 +21,7 @@ import { publishUserSignal } from "../external/realtime";
 import { tapError } from "../utils";
 import { assistantEventIdForRunEvent } from "./assistant-event-id";
 import {
-  runGroupIdForRun,
+  goalIdForRun,
   visibleChatEventCondition,
 } from "./zero-chat-event-shared.service";
 import { insertChatEvent } from "./zero-chat-event.service";
@@ -31,6 +31,11 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventError,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 
 const log = logger("api:zero:chat-initial-thinking");
 
@@ -84,8 +89,8 @@ async function loadThinkingContextMessages(args: {
   const rows = await args.db
     .select({
       eventType: chatEvents.eventType,
-      content: chatEvents.content,
-      userMessage: chatEvents.userMessage,
+      content: canonicalChatEventContent(),
+      userMessage: canonicalChatEventUserMessage(),
       createdAt: chatEvents.createdAt,
       sequenceNumber: chatEvents.runEventSequenceNumber,
     })
@@ -102,11 +107,11 @@ async function loadThinkingContextMessages(args: {
         or(
           and(
             chatEventTypeIn(["input.prompt", "input.rejected"]),
-            isNotNull(chatEvents.userMessage),
+            isNotNull(canonicalChatEventUserMessage()),
           ),
           and(
             not(chatEventTypeIn(["input.prompt", "input.rejected"])),
-            isNotNull(chatEvents.content),
+            isNotNull(canonicalChatEventContent()),
           ),
         ),
         visibleChatEventCondition(args.db),
@@ -174,7 +179,10 @@ async function runCanReceiveThinkingMessage(args: {
           "run.failed",
           "run.cancelled",
         ]),
-        or(isNotNull(chatEvents.content), isNotNull(chatEvents.error)) as SQL,
+        or(
+          isNotNull(canonicalChatEventContent()),
+          isNotNull(canonicalChatEventError()),
+        ) as SQL,
       ),
     )
     .limit(1);
@@ -261,7 +269,7 @@ export async function generateAndPersistInitialThinkingMessage(args: {
     return false;
   }
 
-  const runGroupId = await runGroupIdForRun(args.db, args.runId);
+  const goalId = await goalIdForRun(args.db, args.runId);
   const inserted = await args.db.transaction(async (tx) => {
     return await insertChatEvent(
       tx,
@@ -272,7 +280,7 @@ export async function generateAndPersistInitialThinkingMessage(args: {
         ),
         chatThreadId: args.threadId,
         runId: args.runId,
-        runGroupId,
+        runGroupId: goalId,
         eventType: "output.thinking",
         content: null,
         thinking,

--- a/turbo/apps/api/src/signals/services/zero-chat-queue-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queue-marker.service.ts
@@ -6,6 +6,7 @@ import { alias } from "drizzle-orm/pg-core";
 import { revokeChatEvent, insertChatEvent } from "./zero-chat-event.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import type { Tx } from "../../lib/db-types";
+import { canonicalChatEventGoalId } from "./canonical-chat-event-read.service";
 
 type DbTransaction = Tx;
 
@@ -87,7 +88,7 @@ export async function revokeQueuedRunAssistantMarkers(
     .select({
       id: chatEvents.id,
       chatThreadId: chatEvents.chatThreadId,
-      runGroupId: chatEvents.runGroupId,
+      runGroupId: canonicalChatEventGoalId(),
     })
     .from(chatEvents)
     .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-queued-event.service.ts
@@ -54,6 +54,7 @@ import {
   createUserMessageDocument,
   withRunModelAnnotation,
 } from "./zero-chat-user-message.service";
+import { canonicalChatEventUserMessage } from "./canonical-chat-event-read.service";
 
 type DbTransaction = Tx;
 
@@ -265,7 +266,7 @@ export async function loadNextUnclaimedQueuedUserMessage(
     .select({
       id: chatEvents.id,
       createdAt: chatEvents.createdAt,
-      userMessage: chatEvents.userMessage,
+      userMessage: canonicalChatEventUserMessage(),
       modelProviderId: sql`NULL`.mapWith(pgNullDecoder),
       modelProviderType: sql`NULL`.mapWith(pgNullDecoder),
       modelProviderCredentialScope: sql`NULL`.mapWith(pgNullDecoder),
@@ -357,7 +358,7 @@ async function resolveUserQueueFirstClaimSnapshot(
   const [head] = await db
     .select({
       ...queueFirstReplacementTargetFields,
-      userMessage: chatEvents.userMessage,
+      userMessage: canonicalChatEventUserMessage(),
     })
     .from(chatEvents)
     .where(
@@ -408,7 +409,7 @@ async function resolveAutomationEventQueueFirstClaimSnapshot(
       ...queueFirstReplacementTargetFields,
       automationId: chatAutomationContext.automationId,
       automationKind: zeroWorkflowAutomations.kind,
-      userMessage: chatEvents.userMessage,
+      userMessage: canonicalChatEventUserMessage(),
     })
     .from(chatEvents)
     .leftJoin(
@@ -484,7 +485,8 @@ async function resolveGoalQueueFirstClaimSnapshot(
         eq(threadGoals.chatThreadId, chatEvents.chatThreadId),
         eq(threadGoals.orgId, args.orgId),
         eq(threadGoals.ownerUserId, args.userId),
-        eq(chatEvents.runGroupId, threadGoals.id),
+        eq(chatEvents.contextType, "goal"),
+        eq(chatEvents.contextId, threadGoals.id),
         // Match the lossless revision captured before run preparation.
         eq(sql`${threadGoals.updatedAt}::text`, args.goalStateRevision),
       ),
@@ -839,7 +841,7 @@ export async function failQueuedUserMessage(
 
     const [queued] = await tx
       .select({
-        userMessage: chatEvents.userMessage,
+        userMessage: canonicalChatEventUserMessage(),
         createdAt: chatEvents.createdAt,
       })
       .from(chatEvents)

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -4,7 +4,6 @@ import {
   type ChatEventType,
 } from "@vm0/api-contracts/contracts/chat-events";
 import {
-  chatEventResponse,
   type ChatSearchMessage,
   type ChatSearchResult,
   type ChatThreadDraft,
@@ -17,6 +16,8 @@ import {
   type UserMessageInputDocument,
   persistedAttachmentSchema,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { chatEventFromRow } from "@vm0/api-contracts/contracts/chat-event-row-projection";
+import type { ChatEventRowV4 } from "@vm0/api-contracts/contracts/chat-event-rows";
 import {
   modelProviderCredentialScopeSchema,
   modelProviderTypeSchema,
@@ -29,11 +30,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-host";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import {
-  chatEvents,
-  type ChatEventUsagePayload,
-  type ChatEventUserMessage,
-} from "@vm0/db/schema/chat-event";
+import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatEventSearchDocs } from "@vm0/db/schema/chat-event-search";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
@@ -73,6 +70,10 @@ import {
 } from "../../lib/db-structured-result";
 import { type Db, db$, type ReadonlyDb, writeDb$ } from "../external/db";
 import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
+import {
   inferMimetype,
   visibleChatEventCondition,
 } from "./zero-chat-event-shared.service";
@@ -89,29 +90,14 @@ import {
 } from "./zero-chat-user-message.service";
 import {
   chatEventTextCondition,
-  legacyRunOwnedChatEventForRunCondition,
+  runOwnedChatEventForRunCondition,
 } from "./zero-chat-event-type.service";
 import { cancellationRecoveryPendingForThread } from "./zero-chat-active-run.service";
 
 const matchedChatEvent = alias(chatEvents, "matched_chat_event");
 
-type ChatEventRow = {
-  readonly id: string;
-  readonly chatThreadId: string;
-  readonly eventType: ChatEventType;
-  readonly content: string | null;
-  readonly userMessage: ChatEventUserMessage | null;
-  readonly thinking: string | null;
-  readonly runId: string | null;
-  readonly runGroupId: string | null;
-  readonly usagePayload: ChatEventUsagePayload | null;
-  readonly runEventId: string | null;
-  readonly error: string | null;
-  readonly seqId: number;
-  readonly sequenceNumber: number | null;
+type ChatEventRow = Omit<ChatEventRowV4, "createdAt"> & {
   readonly createdAt: Date;
-  readonly revokesEventId: string | null;
-  readonly interruptsRunId: string | null;
 };
 
 type ChatSearchMessageRow = {
@@ -160,12 +146,9 @@ type ChatThreadDetailRow = {
   readonly lastReadAt: Date | null;
 };
 
-function effectiveChatEventRunId() {
-  // Keep the public v3 row contract on legacy interrupt semantics while the
-  // canonical storage pointer rolls out: DB/API skew has an observed maximum
-  // of about 102 minutes, and old web/app clients can remain for about two
-  // days. Remove this mask when canonical readers/versioned clients replace
-  // the v3 projection. Follow-up: #26158.
+function publicChatEventRunId() {
+  // Public ChatEvent responses preserve their established shape: an interrupt
+  // exposes its canonical target as interruptsRunId, never as run ownership.
   return sql`CASE
     WHEN ${chatEvents.eventType} = 'control.interrupt' THEN NULL
     ELSE ${chatEvents.runId}
@@ -178,19 +161,15 @@ const eventColumns = {
   id: chatEvents.id,
   chatThreadId: chatEvents.chatThreadId,
   eventType: chatEvents.eventType,
-  content: chatEvents.content,
-  userMessage: chatEvents.userMessage,
-  thinking: chatEvents.thinking,
-  runId: effectiveChatEventRunId(),
-  runGroupId: chatEvents.runGroupId,
-  usagePayload: chatEvents.usagePayload,
+  runId: chatEvents.runId,
+  payload: chatEvents.payload,
+  contextType: chatEvents.contextType,
+  contextId: chatEvents.contextId,
   runEventId: chatEvents.runEventId,
-  error: chatEvents.error,
   seqId: chatEvents.seqId,
-  sequenceNumber: chatEvents.runEventSequenceNumber,
+  runEventSequenceNumber: chatEvents.runEventSequenceNumber,
   createdAt: chatEvents.createdAt,
   revokesEventId: chatEvents.revokesEventId,
-  interruptsRunId: chatEvents.interruptsRunId,
 } as const;
 
 function selectChatEvents(db: Pick<Db, "select">) {
@@ -201,12 +180,12 @@ const searchMessageColumns = {
   messageId: chatEvents.id,
   chatThreadId: chatEvents.chatThreadId,
   eventType: chatEvents.eventType,
-  content: chatEvents.content,
-  userMessage: chatEvents.userMessage,
+  content: canonicalChatEventContent(),
+  userMessage: canonicalChatEventUserMessage(),
   createdAt: chatEvents.createdAt,
   seqId: chatEvents.seqId,
   sequenceNumber: chatEvents.runEventSequenceNumber,
-  runId: effectiveChatEventRunId(),
+  runId: publicChatEventRunId(),
 } as const;
 
 const searchContextMessageColumns = {
@@ -214,6 +193,8 @@ const searchContextMessageColumns = {
   eventType: sql`${chatEvents.eventType}`
     .mapWith(chatEvents.eventType)
     .as("context_event_type"),
+  content: canonicalChatEventContent().as("context_content"),
+  userMessage: canonicalChatEventUserMessage().as("context_user_message"),
 } as const;
 
 function parseHostedArtifactKind(
@@ -356,277 +337,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function normalizeUsagePayload(
-  value: ChatEventUsagePayload | null,
-): Extract<ChatEvent, { eventType: "usage.recorded" }>["usage"] | undefined {
-  if (value === null) {
-    return undefined;
-  }
-
-  return {
-    version: value.version,
-    totalCredits: value.totalCredits,
-    settledAt: value.settledAt,
-    breakdown: value.breakdown.map((kind) => {
-      return {
-        kind: kind.kind,
-        credits: kind.credits,
-        providers: kind.providers.map((provider) => {
-          return {
-            provider: provider.provider,
-            credits: provider.credits,
-          };
-        }),
-      };
-    }),
-  };
-}
-
-function requiredChatEventField<T>(
-  value: T | null,
-  eventType: ChatEventType,
-  field: string,
-): T {
-  if (value === null) {
-    throw new Error(`${eventType} chat event is missing ${field}`);
-  }
-  return value;
-}
-
-function baseChatEventFromRow(row: ChatEventRow, content: string | null) {
-  return {
-    id: row.id,
-    threadId: row.chatThreadId,
-    content,
-    runId: row.runId ?? undefined,
-    runGroupId: row.runGroupId ?? undefined,
-    runEventId: row.runEventId ?? undefined,
-    revokesEventId: row.revokesEventId ?? undefined,
-    seqId: row.seqId,
-    sequenceNumber: row.sequenceNumber,
-    createdAt: row.createdAt.toISOString(),
-  };
-}
-
-type ChatEventBase = ReturnType<typeof baseChatEventFromRow>;
-type ChatEventBuilder = (row: ChatEventRow, event: ChatEventBase) => ChatEvent;
-
-const chatEventBuilders = {
-  "input.prompt": (row, event) => {
-    return {
-      ...event,
-      eventType: "input.prompt",
-      content: null,
-      userMessage: requiredChatEventField(
-        row.userMessage,
-        row.eventType,
-        "userMessage",
-      ),
-    };
-  },
-  "input.automation": (row, event) => {
-    return {
-      ...event,
-      eventType: "input.automation",
-      content: null,
-      userMessage: row.userMessage ?? undefined,
-    };
-  },
-  "input.goal": (row, event) => {
-    return {
-      id: event.id,
-      threadId: event.threadId,
-      eventType: "input.goal",
-      content: null,
-      userMessage: requiredChatEventField(
-        row.userMessage,
-        row.eventType,
-        "userMessage",
-      ),
-      seqId: event.seqId,
-      createdAt: event.createdAt,
-    };
-  },
-  "input.budget": (row, event) => {
-    return {
-      ...event,
-      eventType: "input.budget",
-      content: null,
-      userMessage: requiredChatEventField(
-        row.userMessage,
-        row.eventType,
-        "userMessage",
-      ),
-    };
-  },
-  "input.rejected": (row, event) => {
-    return {
-      ...event,
-      eventType: "input.rejected",
-      content: null,
-      userMessage: requiredChatEventField(
-        row.userMessage,
-        row.eventType,
-        "userMessage",
-      ),
-      error: requiredChatEventField(row.error, row.eventType, "error"),
-    };
-  },
-  "output.message": (row, event) => {
-    return {
-      ...event,
-      eventType: "output.message",
-      content: requiredChatEventField(row.content, row.eventType, "content"),
-    };
-  },
-  "output.error": (row, event) => {
-    return {
-      ...event,
-      eventType: "output.error",
-      error: requiredChatEventField(row.error, row.eventType, "error"),
-    };
-  },
-  "output.thinking": (row, event) => {
-    return {
-      ...event,
-      eventType: "output.thinking",
-      content: null,
-      thinking: requiredChatEventField(row.thinking, row.eventType, "thinking"),
-    };
-  },
-  "output.followups": (row, event) => {
-    return {
-      ...event,
-      eventType: "output.followups",
-      content: requiredChatEventField(row.content, row.eventType, "content"),
-    };
-  },
-  "run.queued": (row, event) => {
-    return {
-      ...event,
-      eventType: "run.queued",
-      runId: requiredChatEventField(row.runId, row.eventType, "runId"),
-      content: requiredChatEventField(row.content, row.eventType, "content"),
-    };
-  },
-  "run.dequeued": (row, event) => {
-    return {
-      ...event,
-      eventType: "run.dequeued",
-      runId: requiredChatEventField(row.runId, row.eventType, "runId"),
-      content: null,
-      revokesEventId: requiredChatEventField(
-        row.revokesEventId,
-        row.eventType,
-        "revokesEventId",
-      ),
-    };
-  },
-  "run.completed": (row, event) => {
-    return {
-      ...event,
-      eventType: "run.completed",
-      runId: requiredChatEventField(row.runId, row.eventType, "runId"),
-      runLifecycleEvent: "completed",
-    };
-  },
-  "run.failed": (row, event) => {
-    return {
-      ...event,
-      eventType: "run.failed",
-      runId: requiredChatEventField(row.runId, row.eventType, "runId"),
-      error: row.error ?? undefined,
-      runLifecycleEvent: "failed",
-    };
-  },
-  "run.cancelled": (row, event) => {
-    return {
-      ...event,
-      eventType: "run.cancelled",
-      runId: requiredChatEventField(row.runId, row.eventType, "runId"),
-      error: row.error ?? undefined,
-      runLifecycleEvent: "cancelled",
-    };
-  },
-  "control.interrupt": (row, event) => {
-    return {
-      ...event,
-      eventType: "control.interrupt",
-      content: null,
-      interruptsRunId: requiredChatEventField(
-        row.interruptsRunId,
-        row.eventType,
-        "interruptsRunId",
-      ),
-    };
-  },
-  "control.revoke": (row, event) => {
-    return {
-      ...event,
-      eventType: "control.revoke",
-      content: null,
-      revokesEventId: requiredChatEventField(
-        row.revokesEventId,
-        row.eventType,
-        "revokesEventId",
-      ),
-    };
-  },
-  "browser.open": (_row, event) => {
-    return {
-      ...event,
-      eventType: "browser.open",
-      content: null,
-    };
-  },
-  "browser.close": (_row, event) => {
-    return {
-      ...event,
-      eventType: "browser.close",
-      content: null,
-    };
-  },
-  "goal.open": (row, event) => {
-    return {
-      id: event.id,
-      threadId: event.threadId,
-      eventType: "goal.open",
-      content: requiredChatEventField(row.content, row.eventType, "content"),
-      seqId: event.seqId,
-      createdAt: event.createdAt,
-    };
-  },
-  "goal.close": (_row, event) => {
-    return {
-      id: event.id,
-      threadId: event.threadId,
-      eventType: "goal.close",
-      content: null,
-      seqId: event.seqId,
-      createdAt: event.createdAt,
-    };
-  },
-  "usage.recorded": (row, event) => {
-    return {
-      ...event,
-      eventType: "usage.recorded",
-      runId: requiredChatEventField(row.runId, row.eventType, "runId"),
-      content: null,
-      usage: requiredChatEventField(
-        normalizeUsagePayload(row.usagePayload) ?? null,
-        row.eventType,
-        "usage",
-      ),
-    };
-  },
-} satisfies Record<ChatEvent["eventType"], ChatEventBuilder>;
-
 function toChatEvent(row: ChatEventRow): ChatEvent {
-  const event = chatEventBuilders[row.eventType](
-    row,
-    baseChatEventFromRow(row, row.content),
-  );
-  return chatEventResponse(event);
+  return chatEventFromRow({
+    ...row,
+    createdAt: row.createdAt.toISOString(),
+  });
 }
 
 const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
@@ -898,7 +613,7 @@ function loadZeroChatThreadArtifactRows(
               .select({ id: chatEvents.id })
               .from(chatEvents)
               .where(
-                legacyRunOwnedChatEventForRunCondition({
+                runOwnedChatEventForRunCondition({
                   runId: runUploadedFiles.runId,
                   chatThreadId: args.threadId,
                 }),

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -40,6 +40,10 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 
 const log = logger("api:zero:chat-title");
 const OPENROUTER_CHAT_COMPLETIONS_URL =
@@ -254,8 +258,8 @@ async function getLatestTitleContextMessages(
   const rows = await db
     .select({
       eventType: chatEvents.eventType,
-      content: chatEvents.content,
-      userMessage: chatEvents.userMessage,
+      content: canonicalChatEventContent(),
+      userMessage: canonicalChatEventUserMessage(),
       createdAt: chatEvents.createdAt,
       sequenceNumber: chatEvents.runEventSequenceNumber,
     })
@@ -430,8 +434,8 @@ async function getLatestFollowupContextMessages(
   const rows = await db
     .select({
       eventType: chatEvents.eventType,
-      content: chatEvents.content,
-      userMessage: chatEvents.userMessage,
+      content: canonicalChatEventContent(),
+      userMessage: canonicalChatEventUserMessage(),
       createdAt: chatEvents.createdAt,
       sequenceNumber: chatEvents.runEventSequenceNumber,
     })

--- a/turbo/apps/api/src/signals/services/zero-chat-usage-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-usage-event.service.ts
@@ -35,7 +35,7 @@ const TERMINAL_RUN_STATUSES = ["completed", "failed", "cancelled"] as const;
 const USAGE_CONTEXT_GROUP_BY_COLUMNS = [
   agentRuns.status,
   zeroRuns.chatThreadId,
-  zeroRuns.runGroupId,
+  zeroRuns.goalId,
   chatThreads.userId,
 ] as const;
 
@@ -74,7 +74,7 @@ async function loadUsageEventContext(tx: WriteTx, runId: string) {
     .select({
       status: agentRuns.status,
       chatThreadId: zeroRuns.chatThreadId,
-      runGroupId: zeroRuns.runGroupId,
+      goalId: zeroRuns.goalId,
       userId: chatThreads.userId,
       hasPending: exists(
         tx
@@ -184,7 +184,7 @@ export const maybeEmitRunUsageEvent$ = command(
         eventType: "usage.recorded",
         content: null,
         runId,
-        runGroupId: context.runGroupId,
+        runGroupId: context.goalId,
         usagePayload: payload,
         createdAt: new Date(payload.settledAt),
       });

--- a/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
@@ -34,6 +34,10 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
+import {
+  canonicalChatEventContent,
+  canonicalChatEventUserMessage,
+} from "./canonical-chat-event-read.service";
 
 const RECENT_CHAT_RUN_LIMIT = 10;
 const WEB_CHAT_PRIOR_MESSAGE_CHAR_CAP = 4000;
@@ -245,7 +249,7 @@ function lastRunMessageSeqIds(
       and(
         eq(chatEvents.chatThreadId, threadId),
         chatEventTypeIn(CHAT_EVENT_CONTENT_TEXT_TYPES),
-        isNotNull(chatEvents.content),
+        isNotNull(canonicalChatEventContent()),
         inArray(chatEvents.runId, [...runIds]),
         visibleChatEventCondition(db),
       ),
@@ -289,8 +293,8 @@ async function getLatestRunsByThreadId(
     .select({
       runId: chatEvents.runId,
       eventType: chatEvents.eventType,
-      content: chatEvents.content,
-      userMessage: chatEvents.userMessage,
+      content: canonicalChatEventContent(),
+      userMessage: canonicalChatEventUserMessage(),
     })
     .from(chatEvents)
     .where(

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -53,7 +53,7 @@ import {
 } from "../signals/services/zero-chat-event.service";
 import {
   chatInputPromptDispatchCondition,
-  legacyRunOwnedChatEventForRunCondition,
+  runOwnedChatEventForRunCondition,
 } from "../signals/services/zero-chat-event-type.service";
 import { visibleChatEventCondition } from "../signals/services/zero-chat-event-shared.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
@@ -2273,7 +2273,7 @@ export async function readCanonicalChatEventStorageFixture(
     .where(inArray(chatEvents.id, [...eventIds]));
 }
 
-export async function isLegacyVisibleChatEventFixture(
+export async function isVisibleChatEventFixture(
   eventId: string,
 ): Promise<boolean> {
   const database = db();
@@ -2412,7 +2412,7 @@ export async function readCanonicalRunIdCollisionSafetyFixture(args: {
       .where(
         and(
           eq(chatEvents.id, args.interruptEventId),
-          legacyRunOwnedChatEventForRunCondition({ runId: args.runId }),
+          runOwnedChatEventForRunCondition({ runId: args.runId }),
         ),
       )
       .limit(1),
@@ -2422,7 +2422,7 @@ export async function readCanonicalRunIdCollisionSafetyFixture(args: {
       .where(
         and(
           eq(chatEvents.id, args.interruptEventId),
-          legacyRunOwnedChatEventForRunCondition({
+          runOwnedChatEventForRunCondition({
             runId: args.runId,
             chatThreadId: args.chatThreadId,
           }),

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
@@ -100,7 +100,7 @@ interface ThreadFixture {
   readonly threadId: string;
   readonly promptEventRow: ChatEventRow;
   readonly assistantEventRow: ChatEventRow;
-  readonly tailEventRow: ChatEventRow;
+  readonly tailEventRow: ChatEventRowV4;
 }
 
 function threadFixture(): ThreadFixture {
@@ -109,7 +109,7 @@ function threadFixture(): ThreadFixture {
     threadId,
     promptEventRow: promptRow(threadId, 1, "snapshot prompt"),
     assistantEventRow: baseRow(threadId, 2),
-    tailEventRow: baseRow(threadId, 3),
+    tailEventRow: canonicalChatEventRow(baseRow(threadId, 3)),
   };
 }
 
@@ -356,7 +356,9 @@ describe("chat event snapshot read", () => {
     context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
       rowRequests.push(query.sinceSeqId);
       if (query.sinceSeqId === 0) {
-        return respond(200, { rows: [promptEventRow, assistantEventRow] });
+        return respond(200, {
+          rows: [promptEventRow, assistantEventRow].map(canonicalChatEventRow),
+        });
       }
       return respond(200, { rows: [] });
     });

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-event-row-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-event-row-data-source.ts
@@ -46,9 +46,9 @@ export const listRowsAfter$ = command(
       sinceSeqId,
       count: result.body.rows.length,
     });
-    // Normalize at the ingestion boundary: the tail serves v3 rows today and
-    // v4 rows after the canonical cutover; everything downstream, including
-    // the IndexedDB cache, holds only the canonical shape.
+    // Keep the canonical ingestion boundary explicit even though the tail
+    // contract is now v4-only. The snapshot parser below remains the retained
+    // v3/v4 compatibility reader for already-published archive objects.
     return { kind: "rows", rows: result.body.rows.map(canonicalChatEventRow) };
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { CHAT_EVENT_TYPES, type ChatEventType } from "../chat-events";
 import { chatEventFromRow } from "../chat-event-row-projection";
 import {
   canonicalChatEventRow,
   chatEventRowReadSchema,
+  chatEventRowV4Schema,
   type ChatEventRow,
   type ChatEventRowV4,
 } from "../chat-event-rows";
@@ -49,6 +51,65 @@ function v4Row(overrides: Partial<ChatEventRowV4>): ChatEventRowV4 {
     createdAt: CREATED_AT,
     ...overrides,
   };
+}
+
+function projectableV4Row(eventType: ChatEventType): ChatEventRowV4 {
+  const runId = "00000000-0000-4000-8000-000000000013";
+  const revokesEventId = "00000000-0000-4000-8000-000000000014";
+  const userMessage = {
+    version: 1,
+    parts: [{ type: "text", text: eventType }],
+  };
+  const variants: Record<ChatEventType, Partial<ChatEventRowV4>> = {
+    "input.prompt": { payload: { userMessage }, contextType: "web" },
+    "input.automation": {
+      payload: { userMessage },
+      contextType: "automation",
+      contextId: "00000000-0000-4000-8000-000000000015",
+    },
+    "input.goal": {
+      payload: { userMessage },
+      contextType: "goal",
+      contextId: "00000000-0000-4000-8000-000000000016",
+    },
+    "input.budget": { payload: { userMessage }, contextType: "web" },
+    "input.rejected": {
+      payload: { userMessage, error: "rejected" },
+      contextType: "web",
+    },
+    "output.message": { payload: { content: "message" } },
+    "output.error": {
+      payload: { content: "display error", error: "output error" },
+    },
+    "output.thinking": { payload: { thinking: "thinking" } },
+    "output.followups": { payload: { content: "followups" } },
+    "run.queued": { runId, payload: { content: "queued" } },
+    "run.dequeued": { runId, revokesEventId },
+    "run.completed": { runId },
+    "run.failed": {
+      runId,
+      payload: { content: "failed", error: "runner error" },
+    },
+    "run.cancelled": { runId, payload: { error: "cancelled" } },
+    "control.interrupt": { runId },
+    "control.revoke": { revokesEventId },
+    "browser.open": {},
+    "browser.close": {},
+    "goal.open": { payload: { content: "goal opened" } },
+    "goal.close": {},
+    "usage.recorded": {
+      runId,
+      payload: {
+        usage: {
+          version: 1,
+          totalCredits: 1,
+          settledAt: CREATED_AT,
+          breakdown: [],
+        },
+      },
+    },
+  };
+  return v4Row({ eventType, ...variants[eventType] });
 }
 
 describe("chat event row reader union", () => {
@@ -158,9 +219,50 @@ describe("chat event row reader union", () => {
     });
     expect(canonicalChatEventRow(canonical)).toBe(canonical);
   });
+
+  it("preserves canonical multi-leaf payloads and nested JSON nulls", () => {
+    const row = v4Row({
+      payload: {
+        content: "historical content",
+        userMessage: {
+          version: 1,
+          parts: [{ type: "text", text: "historical input" }],
+          compatibilityProbe: { nested: null },
+        },
+        thinking: "historical thinking",
+        error: "historical error",
+        usage: {
+          version: 1,
+          totalCredits: 4,
+          settledAt: CREATED_AT,
+          breakdown: [],
+        },
+      },
+    });
+    const parsed = chatEventRowV4Schema.parse(JSON.parse(JSON.stringify(row)));
+    expect(parsed).toStrictEqual(row);
+    expect(parsed.payload).toHaveProperty(
+      "userMessage.compatibilityProbe.nested",
+      null,
+    );
+    expect(parsed).not.toHaveProperty("content");
+    expect(parsed).not.toHaveProperty("interruptsRunId");
+    expect(parsed).not.toHaveProperty("runGroupId");
+  });
 });
 
 describe("canonical row projection keeps the v3 ChatEvent shape", () => {
+  it("serializes and projects every event type from canonical fields", () => {
+    expect(
+      CHAT_EVENT_TYPES.map((eventType) => {
+        const wireRow = JSON.parse(
+          JSON.stringify(projectableV4Row(eventType)),
+        ) as unknown;
+        return chatEventFromRow(chatEventRowV4Schema.parse(wireRow)).eventType;
+      }),
+    ).toStrictEqual([...CHAT_EVENT_TYPES]);
+  });
+
   it("emits the canonical interrupt run as interruptsRunId, never runId", () => {
     const target = "00000000-0000-4000-8000-000000000010";
     const projected = chatEventFromRow(

--- a/turbo/packages/api-contracts/src/contracts/chat-event-rows.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-event-rows.ts
@@ -6,12 +6,9 @@ const requiredJsonValueSchema = z.unknown().refine((value) => {
 }, "Expected a JSON value");
 
 /**
- * One raw chat_events row, exactly as archived into R2 snapshot objects and
- * served by the /event-rows tail endpoint. This is the persisted wire shape
- * behind the snapshot-read pipeline: clients cache these rows verbatim and
- * project them into ChatEvent at the read boundary. The archiver's
- * ARCHIVE_SCHEMA_VERSION tracks this shape; changing it requires a version
- * bump there.
+ * Retained v3 raw-row shape for already-published R2 snapshots. New archive
+ * objects and /event-rows responses use chatEventRowV4Schema, but rollout
+ * readers keep this strict schema until the retained v3 object window closes.
  */
 export const chatEventRowSchema = z
   .object({

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { chatEventRowReadSchema } from "./chat-event-rows";
+import { chatEventRowV4Schema } from "./chat-event-rows";
 import { CHAT_EVENT_TYPES } from "./chat-events";
 import { apiErrorSchema } from "./errors";
 import { requireUserMessageForDraftAttachments } from "./draft-user-message";
@@ -1500,7 +1500,7 @@ export const chatThreadEventsContract = c.router({
   },
   /**
    * Snapshot-read cold start: a presigned download for the thread's head
-   * archive object. The object is gzip NDJSON of chatEventRowSchema lines
+   * archive object. The object is gzip NDJSON of chatEventRowV4Schema lines
    * stored with `Content-Encoding: gzip`, so a browser fetch decompresses it
    * transparently. 404 also covers threads whose head has not reached the
    * current archive schema version yet.
@@ -1539,9 +1539,7 @@ export const chatThreadEventsContract = c.router({
     }),
     responses: {
       200: z.object({
-        // Reader union: the server emits v3 rows until the canonical (v4)
-        // cutover; clients normalize every row through canonicalChatEventRow.
-        rows: z.array(chatEventRowReadSchema),
+        rows: z.array(chatEventRowV4Schema),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -83,17 +83,37 @@ const cronProjectChatEventSearchResponseSchema = z.object({
   deletedDocs: z.number(),
 });
 
-const cronSnapshotChatEventsResponseSchema = z.object({
-  success: z.literal(true),
-  snapshots: z.number(),
-  archivedEvents: z.number(),
-  r2ObjectsScanned: z.number().int().nonnegative(),
-  r2ObjectsMeasured: z.number().int().nonnegative(),
-  r2ObjectsDeleted: z.number().int().nonnegative(),
-  r2BytesMeasured: z.number().int().nonnegative(),
-  r2BytesDeleted: z.number().int().nonnegative(),
-  r2GcShardsScanned: z.number().int().nonnegative(),
-  r2GcSubpartitionedShards: z.number().int().nonnegative(),
+const chatEventSnapshotConvergenceSchema = z.object({
+  snapshotHeads: z.number().int().nonnegative(),
+  nonV4SnapshotHeads: z.number().int().nonnegative(),
+  snapshotHeadVersions: z.array(
+    z.object({
+      archiveSchemaVersion: z.number().int().positive(),
+      heads: z.number().int().positive(),
+    }),
+  ),
+});
+
+const cronSnapshotChatEventsResponseSchema =
+  chatEventSnapshotConvergenceSchema.extend({
+    success: z.literal(true),
+    snapshots: z.number(),
+    archivedEvents: z.number(),
+    r2ObjectsScanned: z.number().int().nonnegative(),
+    r2ObjectsMeasured: z.number().int().nonnegative(),
+    r2ObjectsDeleted: z.number().int().nonnegative(),
+    r2BytesMeasured: z.number().int().nonnegative(),
+    r2BytesDeleted: z.number().int().nonnegative(),
+    r2GcShardsScanned: z.number().int().nonnegative(),
+    r2GcSubpartitionedShards: z.number().int().nonnegative(),
+  });
+
+const chatEventSnapshotConvergenceIncompleteSchema = z.object({
+  error: z.object({
+    code: z.literal("CHAT_EVENT_SNAPSHOT_V4_CONVERGENCE_INCOMPLETE"),
+    message: z.string(),
+  }),
+  convergence: chatEventSnapshotConvergenceSchema,
 });
 
 const cronCompactUsageEventsResponseSchema = z.object({
@@ -285,6 +305,19 @@ export const cronSnapshotChatEventsContract = c.router({
       500: z.object({ error: z.string() }),
     },
     summary: "Archive chat events into immutable full-thread R2 snapshots",
+  },
+  verifyConvergence: {
+    method: "GET",
+    path: "/api/cron/snapshot-chat-events/verify-convergence",
+    headers: authHeadersSchema,
+    responses: {
+      200: chatEventSnapshotConvergenceSchema.extend({
+        success: z.literal(true),
+      }),
+      401: apiErrorSchema,
+      409: chatEventSnapshotConvergenceIncompleteSchema,
+    },
+    summary: "Verify every chat event snapshot head uses archive schema v4",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -124,6 +124,7 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     action: z.literal("set-chat-event-snapshot-head-version"),
     thread_id: z.uuid(),
     archive_schema_version: z.int().positive(),
+    object_key: z.string().optional(),
   }),
   z.object({
     action: z.literal("clear-run-api-start"),

--- a/turbo/packages/db/src/schema/chat-event-snapshot.ts
+++ b/turbo/packages/db/src/schema/chat-event-snapshot.ts
@@ -17,11 +17,12 @@ import { chatThreads } from "./chat-thread";
  * Immutable R2 archive facts for the chat_events stream: one row per uploaded
  * full-thread snapshot object. Every snapshot covers seq_id (0, last_seq_id]
  * of its thread, so readers only ever need the head row plus the Postgres
- * tail. parent_snapshot_id records which snapshot object the archiver
- * replayed while building this one; a null parent is a first-generation
- * snapshot built entirely from Postgres. The object key embeds the gzip
- * content sha256, which makes objects content-addressed and lets readers
- * verify downloads without extra columns.
+ * tail. parent_snapshot_id records the exact head that was replaced by the
+ * compare-and-swap publication; every object generation is rebuilt from
+ * Postgres rather than replaying that parent object. A null parent is a
+ * first-generation snapshot. The object key embeds the gzip content sha256,
+ * which makes objects content-addressed and lets readers verify downloads
+ * without extra columns.
  */
 export const chatEventSnapshots = pgTable(
   "chat_event_snapshots",


### PR DESCRIPTION
## Summary

- raise the single App/Platform compatibility floor to **App 0.722.0** and reject older clients before canonical-only event reads are exposed
- cut API and server read semantics over to canonical `payload`, `run_id`, `context_type`, and `context_id` storage while retaining every legacy write and rollback column
- emit strict canonical v4 raw rows, publish archive schema v4, and retain the v3 snapshot reader during the rollout fallback window
- rebuild each snapshot from the complete canonical PostgreSQL event history and publish immutable R2 objects through an exact snapshot-head compare-and-swap
- expose bounded, resumable rebuild progress and a production convergence endpoint that remains non-successful while any snapshot head is not v4

## Minimum App / Platform version

The minimum version is **App 0.722.0**.

- immutable tag [`app-v0.722.0`](https://github.com/vm0-ai/vm0/releases/tag/app-v0.722.0) resolves to release commit [`d46ae412fabd4288743f2e5138429b2f2edb1ad2`](https://github.com/vm0-ai/vm0/commit/d46ae412fabd4288743f2e5138429b2f2edb1ad2)
- release PR [#26177](https://github.com/vm0-ai/vm0/pull/26177) records PR2 commit [`ec855a7283afd2701b2f2cc109135267e837a2a3`](https://github.com/vm0-ai/vm0/commit/ec855a7283afd2701b2f2cc109135267e837a2a3) in App 0.722.0
- release run [31404752899](https://github.com/vm0-ai/vm0/actions/runs/31404752899) completed successfully, including successful [`promote-app-production`](https://github.com/vm0-ai/vm0/actions/runs/31404752899/job/93539178457)
- `ec855a7283afd2701b2f2cc109135267e837a2a3` is an ancestor of `app-v0.722.0`; no newer App tag existed when this PR was finalized

The established web-client compatibility gate now returns `426` with `Cache-Control: no-store` below 0.722.0. Exact 0.722.0 and newer clients proceed.

## Canonical read cutover

Canonical storage now drives:

- API event-row reads and event projection
- search indexing, result context windows, title extraction, initial thinking, active/incomplete prompt context, and web-session prompt reconstruction
- queue selection, queue markers, revoke/interrupt handling, and run ownership checks
- goal grouping through `context_type = 'goal'` plus `context_id`
- shared-thread visibility and event-type-safe ownership
- web, Slack, Feishu, Teams, Telegram, GitHub, and AgentPhone callback paths
- artifact catalog/realtime projection, Google Drive artifact sync, canonical asset reads, user export, usage reads, and morning-brief collection

Payload variants are discriminated by `event_type`. `control.interrupt` reads its target from `run_id`; goals read their grouping from canonical context fields. Both `seq_id` and `run_event_sequence_number` remain, and persisted `run_event_id` remains in the canonical row contract.

## v4 wire and archive contract

New raw event-row responses and snapshot NDJSON lines use the strict v4 envelope:

- canonical `payload`, `runId`, `contextType`, and `contextId`
- retained `seqId`, `runEventSequenceNumber`, and `runEventId`
- no top-level legacy payload leaves, `usagePayload`, `interruptsRunId`, or `runGroupId`

The reader remains a strict v3/v4 union and normalizes retained v3 rows into v4, including nested JSON null preservation and historical multi-leaf payloads. This PR does not remove the v3 reader.

## Full PostgreSQL rebuild and R2 publication

- every selected thread is rebuilt from canonical PostgreSQL rows from sequence 1 through its search watermark; the final sequence is asserted exactly
- existing R2 snapshot contents are never read or transformed in place
- the gzip NDJSON body is content-addressed and written as an immutable object
- head publication compares the exact prior head identity, version, last sequence, and object key; a concurrent append/rebuild causes the CAS to lose instead of overwriting newer progress
- unique/FK races on first-head publication are treated as lost CAS races, leaving any orphaned immutable object for the existing grace-period R2 collector
- bounded batches prioritize retained non-v4 heads and make repeated runs idempotent and resumable

`GET /api/cron/snapshot-chat-events/verify-convergence` enumerates every current snapshot head and reports counts by archive schema version. It returns `409` while `nonV4SnapshotHeads > 0` (including unknown future versions) and returns `200` only when every head is v4. The regular snapshot cron response includes the same convergence evidence.

Expected production evidence before the fallback is removed: run the rebuild until the convergence endpoint reports every head under version 4 and `nonV4SnapshotHeads: 0`, then retain that result through the planned fallback window.

## Rollback compatibility retained

- all writers continue dual-writing canonical and legacy columns
- all legacy columns, indexes, bridge triggers, uniqueness constraints, append-only protections, and pre-payload deployed-writer compatibility remain
- `run_event_id`, the v3 snapshot reader, and all API/DB rollback storage remain
- no canonical-only write, column/index/trigger removal, migration contraction, PR1/PR2 fallback cleanup, or PR4 work is included

A later, separate PR4 may remove these fallbacks only after the DB/API rollback and client-skew windows have closed, deployed writers/readers no longer require them, production convergence remains at zero non-v4 heads, and the retained v3 snapshot fallback window has elapsed.

## Verification

Completed locally against a fresh PostgreSQL database with the full current migration chain applied:

- `pnpm format`
- `pnpm lint`
- `pnpm knip`
- workspace staged type checks, plus final `pnpm --filter api run check-types`
- `turbo/apps/api/src/__tests__/app-factory.test.ts` — 46 passed
- `turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts` — 10 passed
- `turbo/packages/db/src/__tests__/chat-event.test.ts` — 3 passed
- `turbo/apps/api/src/signals/routes/__tests__/chat-event-canonical-storage.test.ts` — 2 passed
- `turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts` — 6 passed
- `turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts` — 3 passed
- `turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts` — 7 passed
- `turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts` — 9 passed
- `turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts` — 15 passed
- focused `chat-threads.bdd.test.ts` canonical context-window case — 1 passed
- `git diff --check` and staged diff checks

Focused coverage includes the version floor, every canonical payload projection, nested JSON nulls, historical multi-leaf v3 payloads, interrupts, goals, foreign contexts, dual-write rollback storage, retained v3 snapshot plus v4 tail ordering, full DB rebuilds, idle v3-head rebuilding, resumability, deterministic CAS races, and convergence `409 -> 200` reporting.

Broader BDD runs also exposed two unchanged baseline failures and were not used as PR3 pass claims: runner-claim scenarios return the same queue `404` on latest `origin/main`, and the chat-search `since` boundary assertion reproduces unchanged on latest `origin/main`. The broad callback BDD file was stopped after its existing deferred runner setup made no progress. No full Vitest suite or local development server was run.
