### PR TITLE
refactor: reduce fallback slop in ui helpers

### DIFF
--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
@@ -489,6 +489,63 @@ describe("zero chat messages command", () => {
     expect(output).not.toContain("(no message text)");
   });
 
+  it("renders every feedback note part from the contract", async () => {
+    server.use(
+      http.get(EVENTS_URL, () => {
+        return HttpResponse.json({
+          events: [
+            {
+              id: "00000000-0000-4000-8000-000000000031",
+              threadId: THREAD_ID,
+              eventType: "input.prompt",
+              content: null,
+              userMessage: {
+                version: 1,
+                parts: [
+                  {
+                    type: "feedback",
+                    quote: "Original answer",
+                    note: [
+                      { type: "text", text: "Compare " },
+                      {
+                        type: "chat_thread",
+                        threadId: SOURCE_THREAD_ID,
+                        titleSnapshot: "Source thread",
+                      },
+                      {
+                        type: "agent",
+                        agentId: "00000000-0000-4000-8000-000000000032",
+                        nameSnapshot: "Iris",
+                      },
+                      {
+                        type: "template",
+                        titleSnapshot: "Launch deck",
+                        template: {
+                          type: "illustration",
+                          selection: { illustrationStyleId: "editorial" },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              runId: RUN_ID,
+              seqId: 1,
+              createdAt: "2026-07-29T10:00:00.000Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(
+      '[Feedback on "Original answer"] Compare [Chat thread: Source thread][Agent: Iris][Template: Launch deck]',
+    );
+  });
+
   it("guides to send when the thread has no messages", async () => {
     server.use(
       http.get(EVENTS_URL, () => {

--- a/turbo/apps/cli/src/commands/zero/chat/messages.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/messages.ts
@@ -34,6 +34,11 @@ interface ChatMessage {
   readonly text: string;
 }
 
+type FeedbackNotePart = Extract<
+  UserMessagePart,
+  { readonly type: "feedback" }
+>["note"][number];
+
 /**
  * Parts that read as one sentence with their neighbours, so they concatenate
  * without a separator the way the chat UI renders them inline.
@@ -49,6 +54,23 @@ function inlinePartText(part: UserMessagePart): string | null {
     return `[Agent: ${part.nameSnapshot}]`;
   }
   return null;
+}
+
+function feedbackNotePartText(part: FeedbackNotePart): string {
+  switch (part.type) {
+    case "text": {
+      return part.text;
+    }
+    case "chat_thread": {
+      return `[Chat thread: ${part.titleSnapshot}]`;
+    }
+    case "agent": {
+      return `[Agent: ${part.nameSnapshot}]`;
+    }
+    case "template": {
+      return `[Template: ${part.titleSnapshot}]`;
+    }
+  }
 }
 
 /**
@@ -72,12 +94,7 @@ function blockPartText(part: UserMessagePart): string | null {
     return `[Morning brief: ${part.briefDate}]`;
   }
   if (part.type === "feedback") {
-    const note = part.note
-      .map((notePart) => {
-        return inlinePartText(notePart) ?? blockPartText(notePart) ?? "";
-      })
-      .join("")
-      .trim();
+    const note = part.note.map(feedbackNotePartText).join("").trim();
     return `[Feedback on "${part.quote}"] ${note}`.trim();
   }
   return null;

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -570,6 +570,34 @@ describe("Desktop renderer bridge integration", () => {
     expect(developerTools.subscribe).toHaveBeenCalled();
   });
 
+  it("opens runtime error details from the first captured error", async () => {
+    const baseState = createComputerUseState({ status: "error" });
+    installDesktopBridges({
+      computerUseState: {
+        ...baseState,
+        host: {
+          ...baseState.host,
+          errorLog: [
+            {
+              id: "runtime-error-1",
+              source: "heartbeat",
+              message: "Heartbeat failed",
+              occurredAt: "2026-06-22T00:00:00.000Z",
+              hostId: "host_test",
+              status: "error",
+            },
+          ],
+        },
+      },
+      developerToolsState: { available: true, enabled: true },
+    });
+    renderDesktopApp();
+
+    fireEvent.click(await screen.findByLabelText("Show error details"));
+
+    expect(await screen.findAllByText("Heartbeat failed")).toHaveLength(2);
+  });
+
   it("delegates signed-out account actions to the auth bridge", async () => {
     const { auth } = installDesktopBridges({
       authState: signedOutAuthState,

--- a/turbo/apps/desktop/src/renderer/command-log/index.tsx
+++ b/turbo/apps/desktop/src/renderer/command-log/index.tsx
@@ -78,9 +78,11 @@ export function RuntimePanel({
   const stopDisabled =
     (state.host.status !== "online" && state.host.status !== "recovering") ||
     stopLoadable.state === "loading";
+  const latestError =
+    state.host.lastError ?? state.host.errorLog.at(0)?.message;
   const hasErrorDetails =
     (state.host.status === "error" || state.host.status === "recovering") &&
-    (state.host.lastError !== null || state.host.errorLog.length > 0);
+    latestError !== undefined;
 
   return (
     <Panel title="Runtime" icon={<Activity size={18} />}>
@@ -159,8 +161,9 @@ export function RuntimePanel({
           Refresh
         </IconButton>
       </div>
-      {errorDetailsOpen && hasErrorDetails && (
+      {errorDetailsOpen && hasErrorDetails && latestError !== undefined && (
         <RuntimeErrorDetailsModal
+          latestError={latestError}
           state={state}
           onClose={() => {
             setErrorDetailsOpen(false);

--- a/turbo/apps/desktop/src/renderer/modals/index.tsx
+++ b/turbo/apps/desktop/src/renderer/modals/index.tsx
@@ -18,9 +18,11 @@ const RUNTIME_ERROR_SOURCE_LABELS = {
 } as const satisfies Record<RuntimeErrorEntry["source"], string>;
 
 export function RuntimeErrorDetailsModal({
+  latestError,
   onClose,
   state,
 }: {
+  readonly latestError: string;
   readonly onClose: () => void;
   readonly state: DesktopComputerUseState;
 }) {
@@ -36,8 +38,6 @@ export function RuntimeErrorDetailsModal({
     };
   }, [onClose]);
 
-  const latestError =
-    state.host.lastError ?? state.host.errorLog[0]?.message ?? "Unknown error";
   const rawDiagnostics = {
     status: state.host.status,
     hostId: state.host.hostId,

--- a/turbo/apps/platform/src/i18n/format.ts
+++ b/turbo/apps/platform/src/i18n/format.ts
@@ -1,8 +1,7 @@
-import { i18n } from "./index.ts";
-import { DEFAULT_LOCALE } from "./resources.ts";
+import { currentLocale } from "./index.ts";
 
 export function resolvedAppLocale(): string {
-  return i18n.resolvedLanguage ?? i18n.language ?? DEFAULT_LOCALE;
+  return currentLocale();
 }
 
 export function formatAppNumber(

--- a/turbo/apps/platform/src/i18n/index.ts
+++ b/turbo/apps/platform/src/i18n/index.ts
@@ -10,8 +10,9 @@ import {
 
 export const i18n = createInstance().use(initReactI18next);
 
+// bootstrap$ awaits initializeI18n before rendering production callers.
 export function currentLocale(): string {
-  return i18n.resolvedLanguage ?? i18n.language ?? DEFAULT_LOCALE;
+  return i18n.resolvedLanguage ?? i18n.language;
 }
 
 export async function initializeI18n(

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   zeroBillingStatusContract,
   type BillingStatusResponse,
@@ -42,7 +43,6 @@ import {
   setMockGithubIntegration,
 } from "../../../mocks/handlers/api-integrations-github.ts";
 import { i18n } from "../../../i18n/index.ts";
-import { labelInitials } from "../workflow-shared.tsx";
 
 const context = testContext();
 const CURRENT_USER_ID = "test-user-123";
@@ -67,17 +67,6 @@ type WorkflowDetailTestTab = "automations" | "instructions" | "info";
 
 afterEach(() => {
   toast.dismiss();
-});
-
-describe("workflow label initials", () => {
-  it("uses the first two non-empty words", () => {
-    expect(labelInitials("  Research   Assistant  ")).toBe("RA");
-  });
-
-  it("uses up to two characters for a single word", () => {
-    expect(labelInitials("Zero")).toBe("ZE");
-    expect(labelInitials(" ")).toBe("??");
-  });
 });
 
 function workflowDetailPath(tab: WorkflowDetailTestTab): string {
@@ -1397,6 +1386,7 @@ async function openCopyDialog(): Promise<HTMLElement> {
 
 describe("workflows routes", () => {
   it("renders the workspace workflows index", async () => {
+    const user = userEvent.setup();
     mockWorkflowApis([salesResearch()]);
 
     detachedSetupPage({
@@ -1411,6 +1401,10 @@ describe("workflows routes", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText("Sales Research")).toBeInTheDocument();
+
+    await user.hover(linkByAriaLabel("Open Sales Research"));
+    const tooltip = await screen.findByRole("tooltip");
+    expect(within(tooltip).getByText("TU")).toBeInTheDocument();
   });
 
   it("labels existing Stripe automations on the workspace workflows index", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -42,6 +42,7 @@ import {
   setMockGithubIntegration,
 } from "../../../mocks/handlers/api-integrations-github.ts";
 import { i18n } from "../../../i18n/index.ts";
+import { labelInitials } from "../workflow-shared.tsx";
 
 const context = testContext();
 const CURRENT_USER_ID = "test-user-123";
@@ -66,6 +67,17 @@ type WorkflowDetailTestTab = "automations" | "instructions" | "info";
 
 afterEach(() => {
   toast.dismiss();
+});
+
+describe("workflow label initials", () => {
+  it("uses the first two non-empty words", () => {
+    expect(labelInitials("  Research   Assistant  ")).toBe("RA");
+  });
+
+  it("uses up to two characters for a single word", () => {
+    expect(labelInitials("Zero")).toBe("ZE");
+    expect(labelInitials(" ")).toBe("??");
+  });
 });
 
 function workflowDetailPath(tab: WorkflowDetailTestTab): string {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
@@ -23,6 +23,20 @@ export function workflowTitle(workflow: {
   return workflow.displayName ?? workflow.name;
 }
 
+export function labelInitials(label: string): string {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length >= 2) {
+    return words
+      .slice(0, 2)
+      .map((word) => {
+        return word.charAt(0);
+      })
+      .join("")
+      .toUpperCase();
+  }
+  return (words[0]?.slice(0, 2) || "??").toUpperCase();
+}
+
 export function isMarkdownPath(path: string): boolean {
   return /\.(md|markdown|mdx)$/i.test(path);
 }

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -63,7 +63,11 @@ import {
   automationTypeLabel,
   WorkflowAutomationEnabledSwitch,
 } from "../zero-page/workflow-automations-page.tsx";
-import { agentLabel, workflowTitle } from "./workflow-shared.tsx";
+import {
+  agentLabel,
+  labelInitials,
+  workflowTitle,
+} from "./workflow-shared.tsx";
 import { WorkflowWebhookUpgradeDialog } from "./workflow-webhook-upgrade-dialog.tsx";
 
 type WorkflowAutomationEntryMap = ReadonlyMap<
@@ -85,14 +89,6 @@ function workflowAutomationEntryMap(
 
 function ownerLabel(workflow: ZeroWorkflowSummary): string {
   return workflow.ownerUserDisplayName?.trim() || workflow.ownerUserId;
-}
-
-function initials(label: string): string {
-  const words = label.trim().split(/\s+/).filter(Boolean);
-  if (words.length >= 2) {
-    return `${words[0]?.[0] ?? ""}${words[1]?.[0] ?? ""}`.toUpperCase();
-  }
-  return (words[0]?.slice(0, 2) || "??").toUpperCase();
 }
 
 function automationDotClass(entry: WorkflowAutomationEntry): string {
@@ -176,7 +172,7 @@ function MemberAvatar({
   }
   return (
     <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border/60 bg-gray-50 text-[10px] font-semibold text-muted-foreground">
-      {initials(label)}
+      {labelInitials(label)}
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-icon.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-icon.tsx
@@ -23,7 +23,7 @@ function initial(name: string): string {
   // Prefer the first alphabetic char, else fall back to the first grapheme
   // (emoji / digit / non-latin) so we never render a blank avatar.
   const firstLetter = trimmed.match(/\p{L}/u)?.[0];
-  return (firstLetter ?? trimmed[0] ?? "?").toUpperCase();
+  return (firstLetter ?? trimmed.charAt(0)).toUpperCase();
 }
 
 export function CustomConnectorIcon({

--- a/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
@@ -73,6 +73,7 @@ import {
   githubAutomationFilterValueLabel,
   gmailAutomationSummary,
   gmailAutomationTitle,
+  labelInitials,
   workflowTitle,
 } from "../workflows-page/workflow-shared.tsx";
 import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "../../signals/chat-page/workflow-prompt-action";
@@ -604,14 +605,6 @@ export function automationTypeLabel(
   });
 }
 
-function agentInitials(label: string): string {
-  const words = label.trim().split(/\s+/).filter(Boolean);
-  if (words.length >= 2) {
-    return `${words[0]?.[0] ?? ""}${words[1]?.[0] ?? ""}`.toUpperCase();
-  }
-  return (words[0]?.slice(0, 2) || "??").toUpperCase();
-}
-
 function WorkflowAgentAvatar({
   agent,
   label,
@@ -633,7 +626,7 @@ function WorkflowAgentAvatar({
   }
   return (
     <span className={cn("inline-flex items-center justify-center", className)}>
-      {agentInitials(label)}
+      {labelInitials(label)}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

- centralize the initialized app locale resolver and remove the unreachable default-locale tail
- replace guarded index fallback chains with a shared workflow-label initials helper and a non-empty connector initial
- require the desktop runtime error modal to receive a caller-validated error instead of fabricating an unknown error
- exhaustively render the four feedback-note contract variants in the CLI

## Why this is safe

- platform bootstrap awaits i18n initialization before rendering, and the i18next language field is required after initialization
- the initials helpers run after explicit non-empty or two-word guards, so the removed empty values were unreachable
- the desktop modal has one caller, which now derives and checks the latest error before rendering it
- the feedback note schema is a closed union of text, chat thread, agent, and template parts; the new renderer handles all four explicitly
- external API compatibility chains, database null contracts, and intentional presentational defaults were left unchanged

## Scanner

- base: b3b96986bef87df70de60a279bfbe20d33237773
- high-confidence production actionable: 228 -> 216 (-12; required minimum 12)
- all actionable: 4635 -> 4618 (-17)

## Verification

- Prettier on all changed files
- targeted Oxlint and ESLint on all changed files
- CLI chat messages: 11 passed
- desktop renderer App: 9 passed
- workflow label initials: 2 passed
- initialized locale formatting: 1 passed
- CLI, desktop, and platform package type checks
- final scanner re-run and git diff check
