### PR TITLE
fix(app): simplify personal provider account rows

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -315,6 +315,7 @@ describe("personal model providers settings", () => {
     expect(within(rowB).getByText("account-b@example.com")).toBeInTheDocument();
     expect(within(rowA).getByText("Active")).toBeInTheDocument();
     expect(within(rowB).queryByText("Active")).not.toBeInTheDocument();
+    expect(within(rowB).queryByText("Use")).not.toBeInTheDocument();
     expect(
       queryAllByRoleFast("button").filter((button) => {
         return button.textContent?.trim() === "Add account";
@@ -329,7 +330,7 @@ describe("personal model providers settings", () => {
     ).toBeFalsy();
     click(within(rowA).getByLabelText("More options"));
 
-    click(buttonByText("Use", rowB));
+    click(buttonByLabel("Use", rowB));
     await waitFor(() => {
       expect(within(rowB).getByText("Active")).toBeInTheDocument();
       expect(within(rowA).queryByText("Active")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -321,12 +321,9 @@ function OAuthAccountRow({
       },
       { number: fallbackIndex },
     );
-  const details = [
-    account.workspaceName === identity ? null : account.workspaceName,
-    formatSubscriptionPlan(account),
-  ].filter((value): value is string => {
-    return Boolean(value);
-  });
+  const plan = formatSubscriptionPlan(account);
+  const detail =
+    account.workspaceName === identity ? null : account.workspaceName;
   return (
     <div
       data-testid={`oauth-account-${account.id}`}
@@ -353,7 +350,12 @@ function OAuthAccountRow({
         </button>
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-2">
-            <p className="truncate text-sm font-medium text-foreground">
+            {plan ? (
+              <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                {plan}
+              </span>
+            ) : null}
+            <p className="min-w-0 truncate text-sm font-medium text-foreground">
               {identity}
             </p>
             {account.isActive ? (
@@ -364,31 +366,16 @@ function OAuthAccountRow({
               </span>
             ) : null}
           </div>
-          <p className="mt-0.5 truncate text-xs text-muted-foreground">
-            {account.needsReconnect
-              ? t(($) => {
-                  return $.settings.models.personal.status.stale;
-                })
-              : details.join(" · ") ||
-                t(($) => {
-                  return $.settings.models.personal.status.connected;
-                })}
-          </p>
+          {account.needsReconnect || detail ? (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {account.needsReconnect
+                ? t(($) => {
+                    return $.settings.models.personal.status.stale;
+                  })
+                : detail}
+            </p>
+          ) : null}
         </div>
-        {!account.isActive ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-8 shrink-0 rounded-lg"
-            disabled={actionPending}
-            onClick={onActivate}
-          >
-            {t(($) => {
-              return $.settings.models.personal.useAccount;
-            })}
-          </Button>
-        ) : null}
         <OAuthAccountMenu
           account={account}
           actionPending={actionPending}


### PR DESCRIPTION
## Summary

- show each personal provider subscription plan as a compact badge before the account identity
- remove the redundant visible `Use` action while retaining the radio selection control and its accessible label
- omit the empty secondary status line when an account has no distinct workspace or reconnect detail

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/personal-providers-tab.test.tsx` (13 tests passed)
