### PR TITLE
fix(api): seed canonical chat event payload in benchmark

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -634,6 +634,7 @@ async function seedTargetThreadRuns(
     eventType: "input.prompt" | "output.message";
     contextType?: "web";
     content?: string;
+    payload: { content: string } | { userMessage: UserMessageDocument };
     sequenceNumber: number;
     seqId: number;
     userMessage?: UserMessageDocument;
@@ -663,6 +664,8 @@ async function seedTargetThreadRuns(
           ? targetAttachmentId(i - latestAttachmentStart)
           : undefined;
       const content = markdownLorem(i, m);
+      const userMessage =
+        m === 0 ? benchUserMessage(content, attachmentId) : undefined;
       eventRows.push({
         chatThreadId: fixture.threadId,
         runId,
@@ -671,12 +674,13 @@ async function seedTargetThreadRuns(
         seqId: i * TARGET_MESSAGES_PER_RUN + m + 1,
         // Input events carry their text in user_message only; chat_events
         // rejects a non-null content projection for them.
-        ...(m === 0
+        ...(userMessage !== undefined
           ? {
               contextType: "web",
-              userMessage: benchUserMessage(content, attachmentId),
+              userMessage,
+              payload: { userMessage },
             }
-          : { content }),
+          : { content, payload: { content } }),
         createdAt: new Date(now + i * 1000 + m),
       });
     }


### PR DESCRIPTION
## Summary

- seed canonical `payload.userMessage` and `payload.content` alongside the benchmark legacy leaves
- mirror the central chat-event writer dual-write contract without changing production reads, writes, or validation

## Root cause

[PR #26197](https://github.com/vm0-ai/vm0/pull/26197) cut `GET /api/zero/chat-threads/:threadId/events` over to the canonical row projection. The benchmark fixture bulk-inserts `chat_events` rows directly, bypassing `insertChatEvent(s)`, and only populated the legacy `user_message` and `content` columns. Canonical `payload` was therefore null, so the strict projection correctly raised `output.message chat event is missing content` and the route returned 500.

The production writer still dual-writes legacy leaves and canonical payload at the central persistence boundary. This PR changes only the benchmark fixture and keeps the strict reader validation intact. The later `no samples` summary error is downstream of the route failure.

## Regression evidence

- [First failure](https://github.com/vm0-ai/vm0/actions/runs/31443438124/job/93632767178)
- [Repeated failure](https://github.com/vm0-ai/vm0/actions/runs/31443541451/job/93633762181)
- [Latest failure on `ad8a55617e1749da061af9dafb0ea0cd8c308235`](https://github.com/vm0-ai/vm0/actions/runs/31446718477/job/93642508155)

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `git diff --check origin/main...HEAD`
- [PR `bench-api`](https://github.com/vm0-ai/vm0/actions/runs/31448276300/job/93647171856) passed; no local service or benchmark run per repository guidance
