### PR TITLE
fix: keep the prompt deep link through google one tap sign-in

### DIFF
--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -352,6 +352,37 @@ describe("app auth pages", () => {
       "data-clerk-force-redirect-url",
       redirectUrl,
     );
+    expect(screen.getByTestId("clerk-google-one-tap")).toHaveAttribute(
+      "data-sign-in-force-redirect-url",
+      redirectUrl,
+    );
+    expect(screen.getByTestId("clerk-google-one-tap")).toHaveAttribute(
+      "data-sign-up-force-redirect-url",
+      redirectUrl,
+    );
+  });
+
+  it("routes ad-attributed One Tap sign-ups through onboarding", async () => {
+    const path = "/sign-in?gclid=click-123&utm_campaign=summer";
+    setBrowserUrl(`https://app.vm0.ai${path}`);
+
+    detachedSetupPage({ context, path });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clerk-google-one-tap")).toBeInTheDocument();
+    });
+
+    const oneTap = screen.getByTestId("clerk-google-one-tap");
+    expect(oneTap.dataset.signInForceRedirectUrl).toBe("https://app.vm0.ai");
+
+    const signUpRedirectUrl = new URL(
+      oneTap.dataset.signUpForceRedirectUrl ?? "",
+    );
+    expect(signUpRedirectUrl.origin).toBe("https://app.vm0.ai");
+    expect(signUpRedirectUrl.pathname).toBe("/onboarding");
+    expect(signUpRedirectUrl.searchParams.get("gclid")).toBe("click-123");
+    expect(signUpRedirectUrl.searchParams.get("utm_campaign")).toBe("summer");
+    expect(signUpRedirectUrl.searchParams.get("vm0_source")).toBe("homepage");
   });
 
   it("allows sign-in redirects to okou.ai subdomains", async () => {

--- a/turbo/apps/platform/src/views/auth/auth-page.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-page.tsx
@@ -6,7 +6,6 @@ import { activeRoute$ } from "../../signals/active-route.ts";
 import {
   buildSignInRedirectUrl,
   buildSignupRedirectUrl,
-  resolveAppUrl,
 } from "../../signals/auth.ts";
 import { authPageMountRef$ } from "../../signals/auth-page-mount.ts";
 import { theme$ } from "../../signals/theme.ts";
@@ -43,15 +42,18 @@ export function AuthPage({ mode }: AuthPageProps) {
   const theme = useGet(theme$);
 
   if (mode === "sign-in") {
-    const appUrl = resolveAppUrl();
     const redirectUrl = buildSignInRedirectUrl(location.search);
+    const signUpRedirectUrl = buildSignupRedirectUrl(location.search);
 
     return (
       <>
+        {/* One Tap completes the sign-in without the card, so it needs the same
+            destination the card would use. Sending it to the bare app origin
+            drops the marketing `?prompt=` deep link and the ad attribution. */}
         {activeRoute === "signIn" && (
           <GoogleOneTap
-            signInForceRedirectUrl={appUrl}
-            signUpForceRedirectUrl={appUrl}
+            signInForceRedirectUrl={redirectUrl}
+            signUpForceRedirectUrl={signUpRedirectUrl}
           />
         )}
         <AuthLayout>


### PR DESCRIPTION
## Problem

Every template card on the marketing galleries (`/en/presentation`, `/en/report`, `/en/video`, `/en/web-design`) links to `app.vm0.ai/onboarding?prompt=/gen …` plus `vm0_source`, `gclid`, and `utm_*`. When the visitor is signed out, that becomes `/sign-in?redirect_url=<the onboarding URL>`.

`AuthPage` handed `GoogleOneTap` a bare `resolveAppUrl()` for both redirect props, so One Tap never read `redirect_url`. Both values are *force* redirects and no other prop carried the destination, so signing in through the One Tap prompt landed on the app root — the `?prompt=` deep link and the ad attribution were both dropped. The sign-in card rendered right next to it honoured them correctly.

Confirmed on production, where One Tap is live (`app.vm0.ai/sign-in` loads `accounts.google.com/gsi/client`). It does not render on staging, whose dev Clerk instance has One Tap unconfigured.

## Fix

Feed One Tap the same builders the card already uses:

- `signInForceRedirectUrl` → `buildSignInRedirectUrl(location.search)`
- `signUpForceRedirectUrl` → `buildSignupRedirectUrl(location.search)`

The two builders differ deliberately: `buildSignupRedirectUrl` also has the ad-traffic fallback that synthesizes an `/onboarding` entry URL when a paid click arrives without an explicit `redirect_url`, so a One Tap *sign-up* from an ad keeps its attribution instead of being credited to nothing.

## Tests

The only existing One Tap assertion loaded `/sign-in` **without** `redirect_url` and asserted the bare app origin, which pinned the buggy value rather than guarding it. That case stays valid (both builders fall back to the app URL with no `redirect_url` and no ad params), and two cases are added:

- `/sign-in?redirect_url=<onboarding URL>` → both One Tap props carry the onboarding URL
- `/sign-in?gclid=…&utm_campaign=…` → the sign-up prop is the synthesized `/onboarding` URL with `gclid`, `utm_campaign`, and `vm0_source=homepage`

## Not in scope

Verified separately and working, no change needed: email/password sign-up and sign-in, and the Google OAuth button (first-time users included) all carry the prompt through to `/onboarding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)