### PR TITLE
test(api): isolate snapshot publication cas assertion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -431,14 +431,12 @@ describe("cron snapshot chat events", () => {
       await publicationGate.promise;
     });
 
-    const results = await Promise.all([runSnapshotCron(), runSnapshotCron()]);
+    await Promise.all([runSnapshotCron(), runSnapshotCron()]);
     expect(arrivals).toBe(2);
-    expect(
-      results.reduce((total, result) => {
-        return total + result.snapshots;
-      }, 0),
-    ).toBe(1);
     const head = await readChatEventSnapshotHead(context, threadId);
+    // Cron result counts cover every candidate in the shared test database;
+    // the persisted generation count scopes the CAS assertion to this thread.
+    expect(head.snapshot_count).toBe(parentHead.snapshot_count + 1);
     expect(head.archive_schema_version).toBe(4);
     expect(head.last_seq_id).toBeGreaterThan(parentHead.last_seq_id);
     expect(head.object_key).not.toBe(parentHead.object_key);

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -24,7 +24,7 @@ import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { zeroWorkflowAutomations } from "@vm0/db/schema/zero-workflow";
-import { and, desc, eq, sql, type SQL } from "drizzle-orm";
+import { and, count, desc, eq, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 import { closeDbPool } from "../../lib/db";
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -1302,20 +1302,26 @@ async function chatEventSnapshotFixtureActionResponse(
     }
     return { status: 200 as const, body: { ok: true as const } };
   }
-  const [head] = await db
-    .select({
-      archiveSchemaVersion: chatEventSnapshots.archiveSchemaVersion,
-      lastSeqId: chatEventSnapshots.lastSeqId,
-      objectKey: chatEventSnapshots.objectKey,
-    })
-    .from(chatEventSnapshots)
-    .where(
-      and(
-        eq(chatEventSnapshots.chatThreadId, body.thread_id),
-        eq(chatEventSnapshots.isHead, true),
-      ),
-    )
-    .limit(1);
+  const [[head], [snapshotCount]] = await Promise.all([
+    db
+      .select({
+        archiveSchemaVersion: chatEventSnapshots.archiveSchemaVersion,
+        lastSeqId: chatEventSnapshots.lastSeqId,
+        objectKey: chatEventSnapshots.objectKey,
+      })
+      .from(chatEventSnapshots)
+      .where(
+        and(
+          eq(chatEventSnapshots.chatThreadId, body.thread_id),
+          eq(chatEventSnapshots.isHead, true),
+        ),
+      )
+      .limit(1),
+    db
+      .select({ value: count() })
+      .from(chatEventSnapshots)
+      .where(eq(chatEventSnapshots.chatThreadId, body.thread_id)),
+  ]);
   signal.throwIfAborted();
   return {
     status: 200 as const,
@@ -1326,6 +1332,7 @@ async function chatEventSnapshotFixtureActionResponse(
             archive_schema_version: head.archiveSchemaVersion,
             last_seq_id: head.lastSeqId,
             object_key: head.objectKey,
+            snapshot_count: snapshotCount?.value ?? 0,
           }
         : null,
     },

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -1327,6 +1327,9 @@ async function chatEventSnapshotFixtureActionResponse(
       .where(eq(chatEventSnapshots.chatThreadId, body.thread_id)),
   ]);
   signal.throwIfAborted();
+  if (!snapshotCount) {
+    throw new Error("read-chat-event-snapshot-head missing snapshot count");
+  }
   return {
     status: 200 as const,
     body: {
@@ -1336,7 +1339,7 @@ async function chatEventSnapshotFixtureActionResponse(
             archive_schema_version: head.archiveSchemaVersion,
             last_seq_id: head.lastSeqId,
             object_key: head.objectKey,
-            snapshot_count: snapshotCount?.value ?? 0,
+            snapshot_count: snapshotCount.value,
           }
         : null,
     },

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -216,6 +216,7 @@ export const testRuntimeStateActionResponseSchema = z.object({
       archive_schema_version: z.int().positive(),
       last_seq_id: z.int().positive(),
       object_key: z.string(),
+      snapshot_count: z.int().positive(),
     })
     .nullable()
     .optional(),


### PR DESCRIPTION
## Summary

- scope the snapshot publication CAS assertion to its unique chat thread
- expose the target thread's persisted snapshot generation count through the existing test-only runtime-state fixture
- preserve the two-request publication gate and the exact head metadata assertions

## Root cause

The failing assertion in [Turbo run 31449986269](https://github.com/vm0-ai/vm0/actions/runs/31449986269), [`test-api (8)`](https://github.com/vm0-ai/vm0/actions/runs/31449986269/job/93652211270), summed `snapshots` from both cron responses and expected `1`.

That response field is a database-wide count for every candidate handled by the cron pass. API test files run in parallel against shared persisted PostgreSQL state, `testContext()` does not roll rows back, and this file raises the batch size to `10000`. An unrelated candidate created by another test file can therefore contribute a second successful publication even though the target thread's exact-parent CAS still admits only one new generation. The same SHA passed the corresponding shard in [merge-group run 31449679371](https://github.com/vm0-ai/vm0/actions/runs/31449679371), [`test-api (8)`](https://github.com/vm0-ai/vm0/actions/runs/31449679371/job/93651304995).

The repair keeps both target uploads synchronized at the publication boundary, then verifies that only one snapshot row was added for the target thread. It does not change production publication behavior or weaken the CAS invariant.

The other API shards in the triggering run were fail-fast cancellations, and `ci-gate-turbo` was downstream aggregate noise.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts` — 5 consecutive runs, 6/6 passed each run
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts` — 1/1 passed
- `git diff --check`

Preview/browser validation is not applicable because this PR changes only test code and a test-only runtime-state contract; no production app or API behavior is changed.

<!-- turbo-flaky-repair -->
TURBO_FLAKY_KEY: test-api-cron-snapshot-chat-events-publication-cas-duplicate-snapshot
