### PR TITLE
feat: open a read-only spec dialog from sent video template chips

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/sent-template-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/sent-template-detail.ts
@@ -1,0 +1,29 @@
+import { command, computed, state } from "ccstate";
+import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+
+/**
+ * The sent-message template chip the user tapped, held at page level so a
+ * single dialog instance serves every message in the thread. Touch viewports
+ * hide the chip's inline parameter echo, so this dialog is the only way a
+ * phone can read back what a sent video used.
+ */
+interface SentTemplateDetail {
+  readonly titleSnapshot: string;
+  readonly template: GenerationTemplateRequest;
+}
+
+const internalSentTemplateDetail$ = state<SentTemplateDetail | null>(null);
+
+export const sentTemplateDetail$ = computed((get) => {
+  return get(internalSentTemplateDetail$);
+});
+
+export const openSentTemplateDetail$ = command(
+  ({ set }, detail: SentTemplateDetail) => {
+    set(internalSentTemplateDetail$, detail);
+  },
+);
+
+export const closeSentTemplateDetail$ = command(({ set }) => {
+  set(internalSentTemplateDetail$, null);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -116,6 +116,7 @@ describe("user messages", () => {
   });
 
   it("echoes the video parameters a sent template used", async () => {
+    const user = userEvent.setup({ delay: null });
     const threadId = "b0000000-0000-4000-a000-000000000750";
     const templateItem = VIDEO_TEMPLATE_ITEMS[0]!;
     mockChatLifecycle(context, {
@@ -169,6 +170,31 @@ describe("user messages", () => {
     expect(reference).toHaveTextContent(
       "Seedance 2.0 fast \u00b7 9:16 \u00b7 8s \u00b7 720p \u00b7 Audio",
     );
+
+    // Touch viewports hide the inline echo and have no hover, so the chip
+    // doubles as a button that opens a read-only detail dialog.
+    expect(reference.tagName).toBe("BUTTON");
+    await user.click(reference);
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText(templateItem.title)).toBeInTheDocument();
+    expect(dialog.querySelector("img")).toBeInstanceOf(HTMLImageElement);
+    const rows = [
+      ["Model", "Seedance 2.0 fast"],
+      ["Ratio", "9:16"],
+      ["Duration", "8s"],
+      ["Resolution", "720p"],
+      ["Generate audio", "Audio"],
+    ] as const;
+    for (const [label, value] of rows) {
+      expect(within(dialog).getByText(label).parentElement).toHaveTextContent(
+        value,
+      );
+    }
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
   });
 
   it("renders ordered canonical snapshots with literal Markdown text", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-user-messages.test.tsx
@@ -160,21 +160,28 @@ describe("user messages", () => {
       },
     });
 
-    // The hover title repeats the spec because narrow viewports hide the
-    // inline echo.
+    // Wide viewports keep a static record: the inline echo plus a hover
+    // title that repeats the spec. No dialog opens from this variant.
     const reference = await screen.findByTitle(
       `Video \u00b7 ${templateItem.title} \u00b7 ` +
         "Seedance 2.0 fast \u00b7 9:16 \u00b7 8s \u00b7 720p \u00b7 Audio",
     );
+    expect(reference.tagName).toBe("SPAN");
     // Every parameter is echoed, not only the one the user changed.
     expect(reference).toHaveTextContent(
       "Seedance 2.0 fast \u00b7 9:16 \u00b7 8s \u00b7 720p \u00b7 Audio",
     );
 
-    // Touch viewports hide the inline echo and have no hover, so the chip
-    // doubles as a button that opens a read-only detail dialog.
-    expect(reference.tagName).toBe("BUTTON");
     await user.click(reference);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // Touch-width viewports hide the inline echo and have no hover, so only
+    // there the chip swaps to a button that opens a read-only detail dialog.
+    const chipButton = queryAllByRoleFast("button").find((element) => {
+      return element.textContent === templateItem.title;
+    });
+    expect(chipButton).toBeInstanceOf(HTMLButtonElement);
+    await user.click(chipButton!);
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText(templateItem.title)).toBeInTheDocument();
     expect(dialog.querySelector("img")).toBeInstanceOf(HTMLImageElement);

--- a/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
@@ -115,8 +115,9 @@ function SentVideoTemplateDetail({
 
 /**
  * Read-only echo of a sent video template, opened by tapping the message
- * chip. Docks to the bottom edge on touch-width viewports — where the chip
- * hides its inline spec — and floats as a small centered dialog elsewhere.
+ * chip — a button only on touch-width viewports, where the chip hides its
+ * inline spec. Docks to the bottom edge; the sm: styles only cover a dialog
+ * kept open while the viewport is resized past the breakpoint.
  */
 export function SentTemplateDetailDialog() {
   const { t } = useTranslation();

--- a/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
@@ -140,7 +140,11 @@ export function SentTemplateDetailDialog() {
         closeLabel={t(($) => {
           return $.artifacts.actions.close;
         })}
-        className="bottom-0 left-0 right-0 top-auto max-w-none translate-x-0 translate-y-0 gap-3 rounded-b-none rounded-t-2xl p-4 pb-[calc(1rem+var(--sab))] sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:max-w-sm sm:translate-x-[-50%] sm:translate-y-[-50%] sm:gap-4 sm:rounded-xl sm:p-6"
+        // The kit's close button (size-9 box around a 20px glyph at right-4
+        // top-4) lines its glyph up with a p-6 content box; this sheet uses
+        // p-4, so shift it to keep the glyph on the content edge, centered
+        // on the title row.
+        className="bottom-0 left-0 right-0 top-auto max-w-none translate-x-0 translate-y-0 gap-3 rounded-b-none rounded-t-2xl p-4 pb-[calc(1rem+var(--sab))] [&>button]:right-2 [&>button]:top-1.5 sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:max-w-sm sm:translate-x-[-50%] sm:translate-y-[-50%] sm:gap-4 sm:rounded-xl sm:p-6 sm:[&>button]:right-4 sm:[&>button]:top-4"
       >
         <SentVideoTemplateDetail
           titleSnapshot={detail.titleSnapshot}

--- a/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
@@ -1,0 +1,151 @@
+import { useGet, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+import { SwatchBook } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import { findVideoTemplateItem, r2ImageTransformUrl } from "@vm0/core";
+import {
+  VIDEO_MODEL_CONFIGS,
+  resolveVideoGenerationOptions,
+} from "@vm0/core/video-model-catalog";
+import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  closeSentTemplateDetail$,
+  sentTemplateDetail$,
+} from "../../signals/zero-page/sent-template-detail.ts";
+
+function SentVideoTemplateDetail({
+  titleSnapshot,
+  template,
+}: {
+  readonly titleSnapshot: string;
+  readonly template: Extract<GenerationTemplateRequest, { type: "video" }>;
+}) {
+  const { t } = useTranslation();
+  const item = findVideoTemplateItem(template.selection.stylePresetId);
+  const resolved = resolveVideoGenerationOptions(
+    template.selection.videoOptions,
+  );
+  const config = VIDEO_MODEL_CONFIGS[resolved.model];
+  const audio = resolved.generateAudio
+    ? t(($) => {
+        return $.chat.templates.videoSpecAudioOn;
+      })
+    : t(($) => {
+        return $.chat.templates.videoSpecAudioOff;
+      });
+  const rows: readonly { label: string; value: string }[] = [
+    {
+      label: t(($) => {
+        return $.chat.templates.videoOptionsModel;
+      }),
+      value: config.label,
+    },
+    {
+      label: t(($) => {
+        return $.chat.templates.videoOptionsRatio;
+      }),
+      value: resolved.aspectRatio,
+    },
+    {
+      label: t(($) => {
+        return $.chat.templates.videoOptionsDuration;
+      }),
+      value: resolved.duration,
+    },
+    {
+      label: t(($) => {
+        return $.chat.templates.videoOptionsResolution;
+      }),
+      value: resolved.resolution,
+    },
+    ...(config.supportsGenerateAudio
+      ? [
+          {
+            label: t(($) => {
+              return $.chat.templates.videoOptionsAudio;
+            }),
+            value: audio,
+          },
+        ]
+      : []),
+  ];
+  return (
+    <>
+      <DialogHeader className="text-left">
+        <DialogTitle className="flex min-w-0 items-center gap-1.5 pr-8 text-base">
+          <SwatchBook
+            size={15}
+            className="shrink-0 text-orange-600 dark:text-orange-300"
+          />
+          <span className="min-w-0 truncate">{titleSnapshot}</span>
+        </DialogTitle>
+      </DialogHeader>
+      {item && (
+        <img
+          src={r2ImageTransformUrl(item.cardPreviewImage ?? item.previewImage, {
+            width: 768,
+            height: 432,
+          })}
+          alt=""
+          aria-hidden="true"
+          className="aspect-video w-full rounded-lg bg-muted object-cover"
+        />
+      )}
+      <div className="flex flex-col">
+        {rows.map((row) => {
+          return (
+            <div
+              key={row.label}
+              className="flex items-center justify-between gap-3 py-1.5"
+            >
+              <span className="text-sm text-muted-foreground">{row.label}</span>
+              <span className="text-sm">{row.value}</span>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+/**
+ * Read-only echo of a sent video template, opened by tapping the message
+ * chip. Docks to the bottom edge on touch-width viewports — where the chip
+ * hides its inline spec — and floats as a small centered dialog elsewhere.
+ */
+export function SentTemplateDetailDialog() {
+  const { t } = useTranslation();
+  const detail = useGet(sentTemplateDetail$);
+  const close = useSet(closeSentTemplateDetail$);
+  if (detail === null || detail.template.type !== "video") {
+    return null;
+  }
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+        }
+      }}
+    >
+      <DialogContent
+        aria-describedby={undefined}
+        closeLabel={t(($) => {
+          return $.artifacts.actions.close;
+        })}
+        className="bottom-0 left-0 right-0 top-auto max-w-none translate-x-0 translate-y-0 gap-3 rounded-b-none rounded-t-2xl p-4 pb-[calc(1rem+var(--sab))] sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:max-w-sm sm:translate-x-[-50%] sm:translate-y-[-50%] sm:gap-4 sm:rounded-xl sm:p-6"
+      >
+        <SentVideoTemplateDetail
+          titleSnapshot={detail.titleSnapshot}
+          template={detail.template}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sent-template-detail-dialog.tsx
@@ -144,7 +144,7 @@ export function SentTemplateDetailDialog() {
         // top-4) lines its glyph up with a p-6 content box; this sheet uses
         // p-4, so shift it to keep the glyph on the content edge, centered
         // on the title row.
-        className="bottom-0 left-0 right-0 top-auto max-w-none translate-x-0 translate-y-0 gap-3 rounded-b-none rounded-t-2xl p-4 pb-[calc(1rem+var(--sab))] [&>button]:right-2 [&>button]:top-1.5 sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:max-w-sm sm:translate-x-[-50%] sm:translate-y-[-50%] sm:gap-4 sm:rounded-xl sm:p-6 sm:[&>button]:right-4 sm:[&>button]:top-4"
+        className="bottom-0 left-0 right-0 top-auto max-w-none translate-x-0 translate-y-0 gap-3 rounded-b-none rounded-t-2xl p-4 pb-[calc(1rem+var(--sab))] [&>button]:right-2 [&>button]:top-2.5 sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:max-w-sm sm:translate-x-[-50%] sm:translate-y-[-50%] sm:gap-4 sm:rounded-xl sm:p-6 sm:[&>button]:right-4 sm:[&>button]:top-4"
       >
         <SentVideoTemplateDetail
           titleSnapshot={detail.titleSnapshot}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -128,6 +128,8 @@ import {
   videoTemplateSpecText,
   type VideoTemplateSpec,
 } from "../../signals/zero-page/video-template-spec.ts";
+import { openSentTemplateDetail$ } from "../../signals/zero-page/sent-template-detail.ts";
+import { SentTemplateDetailDialog } from "./sent-template-detail-dialog.tsx";
 import { isStandalonePwa } from "../../lib/keyboard-dismiss-gesture.ts";
 import {
   captureRecommendedFollowupSelected,
@@ -2766,6 +2768,7 @@ export function ZeroChatThreadPage() {
         <ChatThreadArea leftPane={leftPane} rightPane={rightPane} />
       </ChatThreadSidebarShell>
       {lightboxUrl && <AttachmentLightbox />}
+      <SentTemplateDetailDialog />
       <ChatConnectorActionConnectModal />
     </>
   );
@@ -7499,11 +7502,12 @@ const STRUCTURED_INLINE_REFERENCE_BASE_CLASS =
   "gap-1.5 rounded-md bg-orange-500/10 px-2 align-middle text-[13px] " +
   "font-medium text-orange-600 dark:bg-orange-400/15 dark:text-orange-300";
 const STRUCTURED_INLINE_REFERENCE_CLASS = `${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} max-w-[240px]`;
-const STRUCTURED_INLINE_LINK_REFERENCE_CLASS =
-  `${STRUCTURED_INLINE_REFERENCE_CLASS} transition-colors ` +
-  "hover:bg-orange-500/15 focus-visible:outline-none focus-visible:ring-2 " +
-  "focus-visible:ring-orange-500/30 active:bg-orange-500/20 " +
-  "dark:hover:bg-orange-400/20 dark:active:bg-orange-400/25";
+const STRUCTURED_INLINE_INTERACTIVE_CLASS =
+  "transition-colors hover:bg-orange-500/15 focus-visible:outline-none " +
+  "focus-visible:ring-2 focus-visible:ring-orange-500/30 " +
+  "active:bg-orange-500/20 dark:hover:bg-orange-400/20 " +
+  "dark:active:bg-orange-400/25";
+const STRUCTURED_INLINE_LINK_REFERENCE_CLASS = `${STRUCTURED_INLINE_REFERENCE_CLASS} ${STRUCTURED_INLINE_INTERACTIVE_CLASS}`;
 
 /**
  * Read-only echo of the parameters a sent video used. Narrow viewports hide
@@ -7520,8 +7524,10 @@ function SentVideoTemplateSpec({ spec }: { readonly spec: VideoTemplateSpec }) {
 }
 
 /**
- * A sent template is a record of what the message used, not a control. It
- * renders as static text so the history stays read-only.
+ * A sent template is a record of what the message used, not an editing
+ * control. Templates without a spec render as static text; a spec-bearing
+ * video chip is a button that opens the read-only detail dialog, because
+ * narrow viewports hide the inline spec and touch has no hover title.
  */
 function UserMessageTemplateReference({
   part,
@@ -7530,26 +7536,41 @@ function UserMessageTemplateReference({
 }) {
   const typeLabel = generationTemplateTypeLabel(part.template);
   const videoOptionsEnabled = useGet(videoTemplateOptionsEnabled$);
+  const openDetail = useSet(openSentTemplateDetail$);
   const spec = videoOptionsEnabled ? videoTemplateSpec(part.template) : null;
   const label = `${typeLabel ?? part.template.type} · ${part.titleSnapshot}`;
+  if (spec === null) {
+    return (
+      <span
+        data-structured-template-reference=""
+        className={STRUCTURED_INLINE_REFERENCE_CLASS}
+        title={label}
+      >
+        <SwatchBook size={13} className="shrink-0" />
+        <span className="min-w-0 truncate">{part.titleSnapshot}</span>
+      </span>
+    );
+  }
   return (
-    <span
+    <button
+      type="button"
       data-structured-template-reference=""
       // The spec is as wide as the chip's old fixed cap on its own, so a
       // spec-bearing chip trades the cap for the full message width.
-      className={
-        spec === null
-          ? STRUCTURED_INLINE_REFERENCE_CLASS
-          : `${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} max-w-full`
-      }
-      title={
-        spec === null ? label : `${label} · ${videoTemplateSpecText(spec)}`
-      }
+      className={`${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} max-w-full ${STRUCTURED_INLINE_INTERACTIVE_CLASS}`}
+      title={`${label} · ${videoTemplateSpecText(spec)}`}
+      aria-haspopup="dialog"
+      onClick={() => {
+        openDetail({
+          titleSnapshot: part.titleSnapshot,
+          template: part.template,
+        });
+      }}
     >
       <SwatchBook size={13} className="shrink-0" />
       <span className="min-w-0 truncate">{part.titleSnapshot}</span>
-      {spec !== null && <SentVideoTemplateSpec spec={spec} />}
-    </span>
+      <SentVideoTemplateSpec spec={spec} />
+    </button>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -7497,10 +7497,13 @@ function AgentRunSourceMessageAnnotation({
 // File chips carry their own border, so they need more breathing room from the
 // surrounding sentence than a borderless inline mention does.
 const INLINE_FILE_REFERENCE_SPACING_CLASS = "mx-1";
-const STRUCTURED_INLINE_REFERENCE_BASE_CLASS =
-  "relative -top-px mx-0.5 inline-flex h-7 items-center " +
+// Layout without a display class so the spec-bearing chip can pick its own
+// responsive display (hidden sm:inline-flex / sm:hidden) per variant.
+const STRUCTURED_INLINE_REFERENCE_LAYOUT_CLASS =
+  "relative -top-px mx-0.5 h-7 items-center " +
   "gap-1.5 rounded-md bg-orange-500/10 px-2 align-middle text-[13px] " +
   "font-medium text-orange-600 dark:bg-orange-400/15 dark:text-orange-300";
+const STRUCTURED_INLINE_REFERENCE_BASE_CLASS = `inline-flex ${STRUCTURED_INLINE_REFERENCE_LAYOUT_CLASS}`;
 const STRUCTURED_INLINE_REFERENCE_CLASS = `${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} max-w-[240px]`;
 const STRUCTURED_INLINE_INTERACTIVE_CLASS =
   "transition-colors hover:bg-orange-500/15 focus-visible:outline-none " +
@@ -7510,14 +7513,12 @@ const STRUCTURED_INLINE_INTERACTIVE_CLASS =
 const STRUCTURED_INLINE_LINK_REFERENCE_CLASS = `${STRUCTURED_INLINE_REFERENCE_CLASS} ${STRUCTURED_INLINE_INTERACTIVE_CLASS}`;
 
 /**
- * Read-only echo of the parameters a sent video used. Narrow viewports hide
- * the spec entirely — the chip's hover title still carries it — so the
- * template title keeps the room it needs; wide viewports show every
- * parameter in full.
+ * Read-only echo of the parameters a sent video used. Rendered only inside
+ * the wide-viewport chip variant, which owns the responsive visibility.
  */
 function SentVideoTemplateSpec({ spec }: { readonly spec: VideoTemplateSpec }) {
   return (
-    <span className="hidden shrink-0 text-[12px] font-normal text-orange-600/70 dark:text-orange-300/70 sm:inline">
+    <span className="shrink-0 text-[12px] font-normal text-orange-600/70 dark:text-orange-300/70">
       {videoTemplateSpecText(spec)}
     </span>
   );
@@ -7525,9 +7526,11 @@ function SentVideoTemplateSpec({ spec }: { readonly spec: VideoTemplateSpec }) {
 
 /**
  * A sent template is a record of what the message used, not an editing
- * control. Templates without a spec render as static text; a spec-bearing
- * video chip is a button that opens the read-only detail dialog, because
- * narrow viewports hide the inline spec and touch has no hover title.
+ * control. Templates without a spec render as static text. A spec-bearing
+ * video chip stays a static record on wide viewports too — the inline echo
+ * and hover title already carry the spec there — and only the touch-width
+ * variant is a button opening the read-only detail dialog, because narrow
+ * viewports hide the inline echo and touch has no hover title.
  */
 function UserMessageTemplateReference({
   part,
@@ -7552,25 +7555,34 @@ function UserMessageTemplateReference({
     );
   }
   return (
-    <button
-      type="button"
-      data-structured-template-reference=""
-      // The spec is as wide as the chip's old fixed cap on its own, so a
-      // spec-bearing chip trades the cap for the full message width.
-      className={`${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} max-w-full ${STRUCTURED_INLINE_INTERACTIVE_CLASS}`}
-      title={`${label} · ${videoTemplateSpecText(spec)}`}
-      aria-haspopup="dialog"
-      onClick={() => {
-        openDetail({
-          titleSnapshot: part.titleSnapshot,
-          template: part.template,
-        });
-      }}
-    >
-      <SwatchBook size={13} className="shrink-0" />
-      <span className="min-w-0 truncate">{part.titleSnapshot}</span>
-      <SentVideoTemplateSpec spec={spec} />
-    </button>
+    <>
+      <span
+        data-structured-template-reference=""
+        // The spec is as wide as the chip's old fixed cap on its own, so a
+        // spec-bearing chip trades the cap for the full message width.
+        className={`hidden max-w-full sm:inline-flex ${STRUCTURED_INLINE_REFERENCE_LAYOUT_CLASS}`}
+        title={`${label} · ${videoTemplateSpecText(spec)}`}
+      >
+        <SwatchBook size={13} className="shrink-0" />
+        <span className="min-w-0 truncate">{part.titleSnapshot}</span>
+        <SentVideoTemplateSpec spec={spec} />
+      </span>
+      <button
+        type="button"
+        data-structured-template-reference=""
+        className={`max-w-full sm:hidden ${STRUCTURED_INLINE_REFERENCE_BASE_CLASS} ${STRUCTURED_INLINE_INTERACTIVE_CLASS}`}
+        aria-haspopup="dialog"
+        onClick={() => {
+          openDetail({
+            titleSnapshot: part.titleSnapshot,
+            template: part.template,
+          });
+        }}
+      >
+        <SwatchBook size={13} className="shrink-0" />
+        <span className="min-w-0 truncate">{part.titleSnapshot}</span>
+      </button>
+    </>
   );
 }
 


### PR DESCRIPTION
## Why

On phone-width viewports the sent video template chip hides its inline parameter echo entirely and falls back to the chip's hover `title` — which touch devices cannot show. So after sending, a phone user had no way to read back which model, ratio, duration, resolution, or audio setting a video message used.

## What

- On `sm`-and-wider viewports the sent chip is unchanged: a static record with the inline parameter echo and hover title. No dialog opens there.
- Below the `sm` breakpoint — where the inline echo is hidden and touch has no hover — the chip renders as a `button` that opens a read-only detail dialog docked to the bottom edge (safe-area padded), showing the template preview image plus every resolved parameter (model, ratio, duration, resolution, audio), mirroring the composer options popover rows.
- Templates without a spec (illustration, website, presentation, avatar) keep rendering as static text; nothing changes with the `VideoTemplateOptions` switch off.
- Open state lives in a page-level ccstate signal (same pattern as the attachment lightbox) so one dialog instance serves the whole thread.

## Test plan

- Extended `chat-user-messages.test.tsx`: the wide-viewport chip stays a static span whose click opens nothing, while the touch-width button variant opens the dialog with the preview image and all five label/value rows, and Escape closes it.
- `chat-workflows-and-goals.test.tsx` still asserts the flag-off chip stays a non-button record.
- Ran platform `tsc`, `lint`, and the affected test files locally; verified both widths on the PR preview in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)