### PR TITLE
refactor: remove expired client rollout fallbacks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -297,7 +297,6 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
 
     const initialList = await connectorsApi.listConnectors(actor);
     expect(initialList.connectors).toStrictEqual([]);
-    expect(initialList.configuredConnectorSlugs).toStrictEqual([]);
     expect(initialList.connectorProvidedBindings).toStrictEqual([]);
 
     const search = await connectorsApi.searchConnectors(actor, "OPENAI");

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -4358,9 +4358,6 @@ describe("connector catalog valid lifecycle", () => {
       new URL(callbackLocation ?? "https://invalid.example").pathname,
     ).toBe("/connector/success");
     const hiddenConnectedList = await connectorsApi.listConnectors(actor);
-    expect(hiddenConnectedList.configuredConnectorSlugs).not.toContain(
-      "datadog",
-    );
     expect(hiddenConnectedList.connectors).toContainEqual(
       expect.objectContaining({ slug: "datadog", authMethod: "oauth" }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -1192,7 +1192,7 @@ export function createBddIntegrationApi(context: TestContext) {
     async updateUserModelPreference(
       actor: ApiTestUser,
       selectedModel: SupportedRunModel | null,
-      serviceTier?: "priority" | null,
+      serviceTier: "priority" | null = null,
     ): Promise<void> {
       const client = setupApp({
         context,

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -311,6 +311,7 @@ describe("AUTH-03 user model preference", () => {
 
     const updated = await cfg.updateModelPreference(admin, {
       selectedModel: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+      serviceTier: null,
     });
     expect(updated.selectedModel).toBe(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL);
     expect(updated.serviceTier).toBeNull();
@@ -320,6 +321,7 @@ describe("AUTH-03 user model preference", () => {
 
     const cleared = await cfg.updateModelPreference(admin, {
       selectedModel: null,
+      serviceTier: null,
     });
     expect(cleared).toStrictEqual({
       selectedModel: null,
@@ -347,7 +349,7 @@ describe("AUTH-03 user model preference", () => {
 
     const removedModel = await cfg.rawUpdateModelPreference(
       admin,
-      { selectedModel: "claude-haiku-4-5" },
+      { selectedModel: "claude-haiku-4-5", serviceTier: null },
       [400],
     );
     expectApiError(removedModel.body);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -91,23 +91,7 @@ describe("GET /api/zero/connectors", () => {
     );
 
     expect(response.body.connectors).toStrictEqual([]);
-    expect(response.body.configuredConnectorSlugs).toStrictEqual([]);
     expect(Array.isArray(response.body.connectorProvidedBindings)).toBeTruthy();
-  });
-
-  it("does not return the connector catalog through the deprecated field", async () => {
-    const fixture = seedAuthenticatedFixture();
-    seededFixtures.push(fixture);
-    mocks.clerk.session(fixture.userId, fixture.orgId);
-
-    const client = setupApp({ context, routes: zeroConnectorsRoutes })(
-      zeroConnectorsMainContract,
-    );
-    const nonStaff = await accept(
-      client.list({ headers: authHeaders() }),
-      [200],
-    );
-    expect(nonStaff.body.configuredConnectorSlugs).toStrictEqual([]);
   });
 
   it("returns connectors created through the connector API", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -458,7 +458,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
     await accept(
       preferenceClient.update({
         headers: authHeaders(),
-        body: { selectedModel: removedModel },
+        body: { selectedModel: removedModel, serviceTier: null },
       }),
       [200],
     );
@@ -511,7 +511,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
     await accept(
       preferenceClient.update({
         headers: authHeaders(),
-        body: { selectedModel: keptModel },
+        body: { selectedModel: keptModel, serviceTier: null },
       }),
       [200],
     );
@@ -1024,15 +1024,6 @@ describe("GET/PUT /api/zero/model-policies", () => {
       (await accept(preferenceClient.get({ headers: authHeaders() }), [200]))
         .body.serviceTier,
     ).toBe("priority");
-
-    const legacyUpdate = await accept(
-      preferenceClient.update({
-        headers: authHeaders(),
-        body: { selectedModel: "gpt-5.6-sol" },
-      }),
-      [200],
-    );
-    expect(legacyUpdate.body.serviceTier).toBeNull();
   });
 
   it("allows compatible member OAuth provider routes", async () => {

--- a/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agentphone.service.ts
@@ -1322,7 +1322,7 @@ const handleModelCommand$ = command(
       {
         orgId: args.orgId,
         userId: args.userId,
-        preference: { selectedModel: option.model },
+        preference: { selectedModel: option.model, serviceTier: null },
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -461,10 +461,6 @@ export function zeroConnectorList(args: {
       connectors: connectorList.map((connector) => {
         return connector.response;
       }),
-      // Old web/app clients may require this response field for up to ~2 days.
-      // Keep it empty during PR #26142's version-skew window, then remove it
-      // together with connectorListResponseSchema through #26165.
-      configuredConnectorSlugs: [],
       connectorProvidedBindings,
     };
   });

--- a/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-feishu-dispatch.service.ts
@@ -1045,7 +1045,7 @@ const handleModelCommand$ = command(
       {
         orgId: args.installation.orgId,
         userId: args.connection.vm0UserId,
-        preference: { selectedModel: selected.model },
+        preference: { selectedModel: selected.model, serviceTier: null },
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1947,7 +1947,7 @@ const handleModelPickerSubmit$ = command(
       {
         orgId: ctx.orgId,
         userId: ctx.connection.vm0UserId,
-        preference: { selectedModel: option.model },
+        preference: { selectedModel: option.model, serviceTier: null },
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -2117,7 +2117,7 @@ const connectedTeamsCardAction$ = command(
       {
         orgId: args.installation.orgId,
         userId: args.connection.vm0UserId,
-        preference: { selectedModel: option.model },
+        preference: { selectedModel: option.model, serviceTier: null },
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-post.service.ts
@@ -2108,7 +2108,7 @@ const handleModelCommand$ = command(
       {
         orgId: args.orgId,
         userId: args.userId,
-        preference: { selectedModel: option.model },
+        preference: { selectedModel: option.model, serviceTier: null },
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -336,7 +336,7 @@ export const updateUserModelPreference$ = command(
     }
 
     const updatedAt = nowDate();
-    const serviceTier = args.preference.serviceTier ?? null;
+    const serviceTier = args.preference.serviceTier;
     await writeDb
       .insert(orgMembersMetadata)
       .values({

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -328,7 +328,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["github", "google"],
             connectorProvidedBindings: [],
           });
         }),
@@ -390,7 +389,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["slack"],
             connectorProvidedBindings: [],
           });
         }),
@@ -469,7 +467,6 @@ describe("zero whoami command", () => {
         http.get("http://localhost:3000/api/zero/connectors", () => {
           return HttpResponse.json({
             connectors: [],
-            configuredConnectorSlugs: [],
             connectorProvidedBindings: [],
           });
         }),
@@ -521,7 +518,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["github"],
             connectorProvidedBindings: [],
           });
         }),
@@ -586,7 +582,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["slack"],
             connectorProvidedBindings: [],
           });
         }),
@@ -681,7 +676,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["server-only"],
             connectorProvidedBindings: [],
           });
         }),
@@ -748,7 +742,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["github"],
             connectorProvidedBindings: [],
           });
         }),
@@ -807,7 +800,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["github"],
             connectorProvidedBindings: [],
           });
         }),
@@ -885,7 +877,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["github"],
             connectorProvidedBindings: [],
           });
         }),
@@ -958,7 +949,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["github"],
             connectorProvidedBindings: [],
           });
         }),
@@ -1045,7 +1035,6 @@ describe("zero whoami command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
-            configuredConnectorSlugs: ["github", "axiom"],
             connectorProvidedBindings: [],
           });
         }),

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -44,14 +44,10 @@ const defaultPermissionDetails = [
   }),
 ];
 
-function mockConnectorListHandler(
-  connectors: Record<string, unknown>[] = [],
-  configuredConnectorSlugs: string[] = [],
-) {
+function mockConnectorListHandler(connectors: Record<string, unknown>[] = []) {
   return http.get("http://localhost:3000/api/zero/connectors", () => {
     return HttpResponse.json({
       connectors,
-      configuredConnectorSlugs,
       connectorProvidedBindings: [],
     });
   });
@@ -457,7 +453,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledConnectorSlugs: ["github"] });
           },
         ),
-        mockConnectorListHandler([makeConnector()], ["github"]),
+        mockConnectorListHandler([makeConnector()]),
       );
 
       await viewCommand.parseAsync(["node", "cli", "my-agent"]);
@@ -477,7 +473,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledConnectorSlugs: ["github"] });
           },
         ),
-        mockConnectorListHandler([makeConnector()], ["github"]),
+        mockConnectorListHandler([makeConnector()]),
       );
 
       await viewCommand.parseAsync([
@@ -528,16 +524,13 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledConnectorSlugs: ["github"] });
           },
         ),
-        mockConnectorListHandler(
-          [
-            makeConnector({
-              authMethod: "api-token",
-              externalUsername: null,
-              externalEmail: null,
-            }),
-          ],
-          ["github"],
-        ),
+        mockConnectorListHandler([
+          makeConnector({
+            authMethod: "api-token",
+            externalUsername: null,
+            externalEmail: null,
+          }),
+        ]),
       );
 
       await viewCommand.parseAsync([
@@ -562,10 +555,9 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledConnectorSlugs: ["github"] });
           },
         ),
-        mockConnectorListHandler(
-          [makeConnector({ connectionStatus: "reconnect-required" })],
-          ["github"],
-        ),
+        mockConnectorListHandler([
+          makeConnector({ connectionStatus: "reconnect-required" }),
+        ]),
       );
 
       await viewCommand.parseAsync([
@@ -591,15 +583,12 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledConnectorSlugs: ["github"] });
           },
         ),
-        mockConnectorListHandler(
-          [
-            makeConnector({
-              externalUsername: null,
-              externalEmail: "user@example.com",
-            }),
-          ],
-          ["github"],
-        ),
+        mockConnectorListHandler([
+          makeConnector({
+            externalUsername: null,
+            externalEmail: "user@example.com",
+          }),
+        ]),
       );
 
       await viewCommand.parseAsync(["node", "cli", "my-agent"]);

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -56,7 +56,7 @@ function connector(
 }
 
 function stubConnectors(connectors: Array<Record<string, unknown>>) {
-  return stubConnectorsWithConfiguredSlugs(connectors, [
+  return stubConnectorsWithCatalogSlugs(connectors, [
     "fal",
     "luma",
     "luma-ai",
@@ -66,9 +66,9 @@ function stubConnectors(connectors: Array<Record<string, unknown>>) {
   ]);
 }
 
-function stubConnectorsWithConfiguredSlugs(
+function stubConnectorsWithCatalogSlugs(
   connectors: Array<Record<string, unknown>>,
-  configuredConnectorSlugs: string[],
+  catalogConnectorSlugs: string[],
 ) {
   const connectedBySlug = new Map(
     connectors.map((item) => {
@@ -95,7 +95,7 @@ function stubConnectorsWithConfiguredSlugs(
     }),
   );
   const visibleConnectorSlugs = new Set([
-    ...configuredConnectorSlugs,
+    ...catalogConnectorSlugs,
     ...connectedBySlug.keys(),
   ]);
   return stubConnectorCatalogStatus(
@@ -347,7 +347,7 @@ describe("zero generate lister", () => {
 
   it("suggests the built-in video command when no video connector is ready", async () => {
     server.use(
-      stubConnectorsWithConfiguredSlugs([], ["fal", "luma-ai", "runway"]),
+      stubConnectorsWithCatalogSlugs([], ["fal", "luma-ai", "runway"]),
       stubUserConnectors([]),
     );
 
@@ -382,7 +382,7 @@ describe("zero generate lister", () => {
 
   it("reflects built-in and connector choices for avatar video", async () => {
     server.use(
-      stubConnectorsWithConfiguredSlugs(
+      stubConnectorsWithCatalogSlugs(
         [connector("joggai", "jogg-user")],
         ["joggai"],
       ),
@@ -411,7 +411,7 @@ describe("zero generate lister", () => {
 
   it("marks built-in video models as plan-restricted before generation", async () => {
     server.use(
-      stubConnectorsWithConfiguredSlugs([], ["fal", "luma-ai", "runway"]),
+      stubConnectorsWithCatalogSlugs([], ["fal", "luma-ai", "runway"]),
       stubUserConnectors([]),
       stubBillingStatus(false),
     );
@@ -428,10 +428,7 @@ describe("zero generate lister", () => {
   });
 
   it("suggests the built-in presentation command", async () => {
-    server.use(
-      stubConnectorsWithConfiguredSlugs([], []),
-      stubUserConnectors([]),
-    );
+    server.use(stubConnectorsWithCatalogSlugs([], []), stubUserConnectors([]));
 
     await generateCommand.parseAsync(["node", "cli", "presentation"]);
 
@@ -451,10 +448,7 @@ describe("zero generate lister", () => {
   });
 
   it("suggests the built-in website command", async () => {
-    server.use(
-      stubConnectorsWithConfiguredSlugs([], []),
-      stubUserConnectors([]),
-    );
+    server.use(stubConnectorsWithCatalogSlugs([], []), stubUserConnectors([]));
 
     await generateCommand.parseAsync(["node", "cli", "website"]);
 
@@ -496,10 +490,7 @@ describe("zero generate lister", () => {
       "Built-in mobile app design generation",
     ],
   ])("suggests the built-in %s command", async (type, label, commandLabel) => {
-    server.use(
-      stubConnectorsWithConfiguredSlugs([], []),
-      stubUserConnectors([]),
-    );
+    server.use(stubConnectorsWithCatalogSlugs([], []), stubUserConnectors([]));
 
     await generateCommand.parseAsync(["node", "cli", type]);
 
@@ -514,7 +505,7 @@ describe("zero generate lister", () => {
 
   it("suggests the built-in voice command when no voice connector is ready", async () => {
     server.use(
-      stubConnectorsWithConfiguredSlugs(
+      stubConnectorsWithCatalogSlugs(
         [],
         ["elevenlabs", "hume", "minimax", "openai"],
       ),
@@ -542,7 +533,7 @@ describe("zero generate lister", () => {
 
   it("also shows the built-in voice provider when a voice connector is ready", async () => {
     server.use(
-      stubConnectorsWithConfiguredSlugs(
+      stubConnectorsWithCatalogSlugs(
         [connector("openai", "openai-user")],
         ["elevenlabs", "hume", "minimax", "openai"],
       ),
@@ -565,7 +556,7 @@ describe("zero generate lister", () => {
 
   it("lists music as the public audio connector-backed subtype", async () => {
     server.use(
-      stubConnectorsWithConfiguredSlugs(
+      stubConnectorsWithCatalogSlugs(
         [connector("elevenlabs", "elevenlabs-user")],
         ["elevenlabs", "minimax"],
       ),

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -222,7 +222,6 @@ export const apiHandlers = [
     return HttpResponse.json(
       {
         connectors: [],
-        configuredConnectorSlugs: [],
         connectorProvidedBindings: [],
       },
       { status: 200 },
@@ -232,7 +231,6 @@ export const apiHandlers = [
     return HttpResponse.json(
       {
         connectors: [],
-        configuredConnectorSlugs: [],
         connectorProvidedBindings: [],
       },
       { status: 200 },

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -33,7 +33,6 @@ import {
   testConnectorCatalogCategoryMetadata,
   testConnectorCatalogDefinitions,
   testConnectorPermissionDetails,
-  testConnectorSlugs,
   type TestConnectorCatalogDefinition,
 } from "./connector-catalog-fixtures.ts";
 
@@ -310,7 +309,6 @@ export const apiConnectorsHandlers = [
   mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
     return respond(200, {
       connectors: mockConnectors,
-      configuredConnectorSlugs: [...testConnectorSlugs],
       connectorProvidedBindings: [],
     });
   }),

--- a/turbo/apps/platform/src/mocks/handlers/api-user-model-preference.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-model-preference.ts
@@ -32,7 +32,7 @@ export const apiUserModelPreferenceHandlers = [
   mockApi(zeroUserModelPreferenceContract.update, ({ body, respond }) => {
     mockUserModelPreference = {
       selectedModel: body.selectedModel,
-      serviceTier: body.serviceTier ?? null,
+      serviceTier: body.serviceTier,
       updatedAt: nowDate().toISOString(),
     };
     return respond(200, mockUserModelPreference);

--- a/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
+++ b/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
@@ -776,12 +776,6 @@ export const testConnectorCatalogCategoryMetadata = {
   groups: [{ id: "ai", label: "AI", menuLabel: "AI" }],
 } satisfies PublicConnectorCatalogCategoryMetadata;
 
-export const testConnectorSlugs = testConnectorCatalogDefinitions.map(
-  (definition) => {
-    return definition.connectorSlug;
-  },
-);
-
 export const composerOverflowConnectorSlugs = [
   "asana",
   "box",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -133,7 +133,11 @@ describe("chat composer models", () => {
     });
     context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
       preferenceRequestCount += 1;
-      return respond(200, { selectedModel: null, updatedAt: null });
+      return respond(200, {
+        selectedModel: null,
+        serviceTier: null,
+        updatedAt: null,
+      });
     });
     mockAgent();
 
@@ -188,7 +192,11 @@ describe("chat composer models", () => {
         if (blockModelRequests) {
           await withSignal(pendingModelRequests.promise);
         }
-        return respond(200, { selectedModel: null, updatedAt: null });
+        return respond(200, {
+          selectedModel: null,
+          serviceTier: null,
+          updatedAt: null,
+        });
       },
     );
     mockAgent();
@@ -232,6 +240,7 @@ describe("chat composer models", () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     context.mocks.data.userModelPreference({
       selectedModel: "claude-opus-4-7",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockAgent();
@@ -248,6 +257,7 @@ describe("chat composer models", () => {
     const user = userEvent.setup({ delay: null });
     let preference: UserModelPreferenceResponse = {
       selectedModel: "kimi-k2.7-code",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     };
     const updatedModels: UserModelPreferenceResponse["selectedModel"][] = [];
@@ -264,6 +274,7 @@ describe("chat composer models", () => {
         await preferenceUpdate.promise;
         preference = {
           selectedModel: body.selectedModel,
+          serviceTier: body.serviceTier,
           updatedAt: "2026-03-10T00:01:00Z",
         };
         return respond(200, preference);
@@ -394,7 +405,7 @@ describe("chat composer models", () => {
           updatedPreference = body;
           return respond(200, {
             selectedModel: body.selectedModel,
-            serviceTier: body.serviceTier ?? null,
+            serviceTier: body.serviceTier,
             updatedAt: "2026-03-10T00:01:00Z",
           });
         },
@@ -481,7 +492,7 @@ describe("chat composer models", () => {
         updatedPreference = body;
         return respond(200, {
           selectedModel: body.selectedModel,
-          serviceTier: body.serviceTier ?? null,
+          serviceTier: body.serviceTier,
           updatedAt: "2026-03-10T00:01:00Z",
         });
       },
@@ -530,6 +541,7 @@ describe("chat composer models", () => {
         updatedModel = body.selectedModel;
         return respond(200, {
           selectedModel: body.selectedModel,
+          serviceTier: body.serviceTier,
           updatedAt: "2026-03-10T00:01:00Z",
         });
       },
@@ -1445,7 +1457,11 @@ describe("chat composer models", () => {
           preferenceReloadStarted = true;
           await withSignal(pendingPreferenceReload.promise);
         }
-        return respond(200, { selectedModel: null, updatedAt: null });
+        return respond(200, {
+          selectedModel: null,
+          serviceTier: null,
+          updatedAt: null,
+        });
       },
     );
     mockAgent();
@@ -1490,6 +1506,7 @@ describe("chat composer models", () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     context.mocks.data.userModelPreference({
       selectedModel: "claude-opus-4-7",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockAgent();
@@ -1526,6 +1543,7 @@ describe("chat composer models", () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     context.mocks.data.userModelPreference({
       selectedModel: "claude-opus-4-7",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockAgent();
@@ -1552,6 +1570,7 @@ describe("chat composer models", () => {
       preferenceRequestStarted = true;
       return respond(200, {
         selectedModel: "claude-opus-4-7",
+        serviceTier: null,
         updatedAt: "2026-03-10T00:00:00Z",
       });
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -121,6 +121,7 @@ function textarea(): HTMLElement {
 function mockAgentChatPage(agentId: string): void {
   context.mocks.data.userModelPreference({
     selectedModel: "claude-sonnet-4-6",
+    serviceTier: null,
     updatedAt: "2026-03-10T00:00:00Z",
   });
   context.mocks.api(zeroTeamContract.list, ({ respond }) => {
@@ -492,6 +493,7 @@ describe("chat drafts", () => {
   it("preserves per-thread text drafts while navigating", async () => {
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -525,6 +527,7 @@ describe("chat drafts", () => {
     const note = "Name the responsible team";
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -580,6 +583,7 @@ describe("chat drafts", () => {
   it("restores a saved server draft with attachments on first thread open", async () => {
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -928,6 +932,7 @@ describe("chat drafts", () => {
 
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -1086,6 +1091,7 @@ describe("chat drafts", () => {
 
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -1154,6 +1160,7 @@ describe("chat drafts", () => {
 
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -1256,6 +1263,7 @@ describe("chat drafts", () => {
 
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -1347,6 +1355,7 @@ describe("chat drafts", () => {
 
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -1432,6 +1441,7 @@ describe("chat drafts", () => {
 
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();
@@ -1494,6 +1504,7 @@ describe("chat drafts", () => {
 
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     mockThreadDetails();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -507,6 +507,7 @@ describe("chat lifecycle", () => {
     let sentUserMessage: UserMessageDocument | undefined;
     context.mocks.data.userModelPreference({
       selectedModel: "glm-5.1",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     context.mocks.data.orgModelPolicies([
@@ -589,6 +590,7 @@ describe("chat lifecycle", () => {
     let sentUserMessage: UserMessageDocument | undefined;
     context.mocks.data.userModelPreference({
       selectedModel: "glm-5.1",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     context.mocks.data.orgModelPolicies([
@@ -666,6 +668,7 @@ describe("chat lifecycle", () => {
     let sentUserMessage: UserMessageDocument | undefined;
     context.mocks.data.userModelPreference({
       selectedModel: "claude-sonnet-4-6",
+      serviceTier: null,
       updatedAt: "2026-03-10T00:00:00Z",
     });
     context.mocks.data.orgModelPolicies([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -646,6 +646,7 @@ describe("chat run queue", () => {
     });
     context.mocks.data.userModelPreference({
       selectedModel: "gpt-5.5",
+      serviceTier: null,
       updatedAt: "2026-08-06T09:00:00Z",
     });
     context.mocks.data.orgModelPolicies([
@@ -858,6 +859,7 @@ describe("chat run queue", () => {
     });
     context.mocks.data.userModelPreference({
       selectedModel: "gpt-5.5",
+      serviceTier: null,
       updatedAt: "2026-08-06T09:00:00Z",
     });
     context.mocks.data.orgModelPolicies([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -122,6 +122,7 @@ function setupHostedSiteArtifactPreview({
 beforeEach(() => {
   context.mocks.data.userModelPreference({
     selectedModel: "claude-sonnet-4-6",
+    serviceTier: null,
     updatedAt: "2026-03-10T00:00:00Z",
   });
   context.mocks.browser.blobDownload();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -2325,7 +2325,6 @@ describe("connectors page", () => {
       }
       return respond(200, {
         connectors: listedConnectors,
-        configuredConnectorSlugs: ["stripe"],
         connectorProvidedBindings: [],
       });
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1849,9 +1849,7 @@ describe("zero sidebar", () => {
               sequenceNumber: null,
               runId: null,
             },
-            // The first result deliberately models an older API response so
-            // the rollout fallback is exercised through the rendered page.
-            ...(index === 0 ? {} : { matchedRanges: [{ start: 11, end: 17 }] }),
+            matchedRanges: [{ start: 11, end: 17 }],
             contextBefore: [],
             contextAfter: [],
           };

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -692,7 +692,7 @@ function avoidSplitSurrogateEnd(content: string, end: number): number {
 
 function chatMessageSnippetParts(
   content: string,
-  ranges: NonNullable<ChatSearchResult["matchedRanges"]>,
+  ranges: ChatSearchResult["matchedRanges"],
 ): ChatMessageSnippetPart[] {
   const validRanges = ranges.filter((range) => {
     return (
@@ -748,10 +748,7 @@ function ChatMessageSnippet({
   readonly message: ChatSearchResult;
 }) {
   const content = message.matchedMessage.content;
-  // Keep a new client compatible with an older API during PR #25901's at-most
-  // 2-day web/app-to-API rollout window. Remove with #25913 after that window
-  // and the API rollback window have closed.
-  const parts = chatMessageSnippetParts(content, message.matchedRanges ?? []);
+  const parts = chatMessageSnippetParts(content, message.matchedRanges);
   return (
     <span
       className="block truncate text-xs text-muted-foreground"

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   chatThreadByIdContract,
+  chatSearchContract,
   chatEventsContract,
   chatThreadEventsContract,
   chatThreadComputerUseHostContract,
@@ -175,6 +176,45 @@ describe("chat event pagination request compatibility", () => {
       success: true,
       data: { sinceSeqId: 42, limit: 20 },
     });
+  });
+});
+
+describe("chat search response contract", () => {
+  it("rejects results without matched ranges", () => {
+    const resultWithoutMatchedRanges = {
+      chatThreadId: "thread-1",
+      agentName: "test-agent",
+      matchedMessage: {
+        messageId: "message-1",
+        chatThreadId: "thread-1",
+        role: "user",
+        content: "find this",
+        createdAt: "2026-08-11T00:00:00.000Z",
+        seqId: 1,
+        sequenceNumber: null,
+        runId: null,
+      },
+      contextBefore: [],
+      contextAfter: [],
+    };
+
+    expect(
+      chatSearchContract.search.responses[200].safeParse({
+        results: [
+          {
+            ...resultWithoutMatchedRanges,
+            matchedRanges: [{ start: 0, end: 4 }],
+          },
+        ],
+        hasMore: false,
+      }).success,
+    ).toBe(true);
+    expect(
+      chatSearchContract.search.responses[200].safeParse({
+        results: [resultWithoutMatchedRanges],
+        hasMore: false,
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   chatThreadByIdContract,
-  chatSearchContract,
   chatEventsContract,
   chatThreadEventsContract,
   chatThreadComputerUseHostContract,
@@ -176,45 +175,6 @@ describe("chat event pagination request compatibility", () => {
       success: true,
       data: { sinceSeqId: 42, limit: 20 },
     });
-  });
-});
-
-describe("chat search response contract", () => {
-  it("rejects results without matched ranges", () => {
-    const resultWithoutMatchedRanges = {
-      chatThreadId: "thread-1",
-      agentName: "test-agent",
-      matchedMessage: {
-        messageId: "message-1",
-        chatThreadId: "thread-1",
-        role: "user",
-        content: "find this",
-        createdAt: "2026-08-11T00:00:00.000Z",
-        seqId: 1,
-        sequenceNumber: null,
-        runId: null,
-      },
-      contextBefore: [],
-      contextAfter: [],
-    };
-
-    expect(
-      chatSearchContract.search.responses[200].safeParse({
-        results: [
-          {
-            ...resultWithoutMatchedRanges,
-            matchedRanges: [{ start: 0, end: 4 }],
-          },
-        ],
-        hasMore: false,
-      }).success,
-    ).toBe(true);
-    expect(
-      chatSearchContract.search.responses[200].safeParse({
-        results: [resultWithoutMatchedRanges],
-        hasMore: false,
-      }).success,
-    ).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -78,7 +78,6 @@ describe("connector client response contracts", () => {
     expect(
       connectorListResponseSchema.parse({
         connectors: [connector],
-        configuredConnectorSlugs: ["github"],
         connectorProvidedBindings: [
           {
             connectorSlug: "github",
@@ -90,7 +89,11 @@ describe("connector client response contracts", () => {
           },
         ],
       }),
-    ).toMatchObject({ configuredConnectorSlugs: ["github"] });
+    ).toMatchObject({
+      connectorProvidedBindings: [
+        { connectorSlug: "github", name: "GITHUB_TOKEN" },
+      ],
+    });
     expect(
       connectorOauthDeviceAuthSessionStartResponseSchema.parse({
         sessionId: "00000000-0000-4000-a000-000000000003",

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1410,13 +1410,7 @@ const chatSearchResultSchema = z.object({
   chatThreadId: z.string(),
   agentName: z.string(),
   matchedMessage: chatSearchMessageSchema,
-  /**
-   * Rollout compatibility for a new web/app client reading an older API
-   * response that predates match ranges. The web/app-to-API skew window is at
-   * most 2 days. After PR #25901 has been deployed for that window and the API
-   * rollback window has closed, make this required; tracked by #25913.
-   */
-  matchedRanges: z.array(chatSearchMatchRangeSchema).optional(),
+  matchedRanges: z.array(chatSearchMatchRangeSchema),
   contextBefore: z.array(chatSearchMessageSchema),
   contextAfter: z.array(chatSearchMessageSchema),
 });

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -102,9 +102,6 @@ export function guaranteedConnectorProvidedBindingNames(args: {
  */
 export const connectorListResponseSchema = z.object({
   connectors: z.array(connectorResponseSchema),
-  configuredConnectorSlugs: z
-    .array(connectorSlugSchema)
-    .describe("Deprecated rollout compatibility field; always empty"),
   connectorProvidedBindings: z
     .array(connectorProvidedBindingSchema)
     .default([]),

--- a/turbo/packages/api-contracts/src/contracts/zero-user-model-preference.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-model-preference.ts
@@ -6,17 +6,9 @@ import { chatThreadServiceTierSchema } from "./chat-threads";
 
 const c = initContract();
 
-// PR #26028 rollout compatibility: old web/app clients omit serviceTier in
-// requests, while new clients can still receive responses from an old API that
-// omits it. Keep the field optional for the ~2-day client-skew window; remove
-// after #26028 has been live in production for two days. Follow-up: #26042.
-const rolloutCompatibleServiceTierSchema = chatThreadServiceTierSchema
-  .nullable()
-  .optional();
-
 export const userModelPreferenceResponseSchema = z.object({
   selectedModel: supportedRunModelSchema.nullable(),
-  serviceTier: rolloutCompatibleServiceTierSchema,
+  serviceTier: chatThreadServiceTierSchema.nullable(),
   updatedAt: z.string().nullable(),
 });
 
@@ -26,7 +18,7 @@ export type UserModelPreferenceResponse = z.infer<
 
 export const updateUserModelPreferenceRequestSchema = z.object({
   selectedModel: supportedRunModelSchema.nullable(),
-  serviceTier: rolloutCompatibleServiceTierSchema,
+  serviceTier: chatThreadServiceTierSchema.nullable(),
 });
 
 export type UpdateUserModelPreferenceRequest = z.infer<


### PR DESCRIPTION
## Summary

- remove the deprecated `configuredConnectorSlugs` field from the connector list contract, API response, and client fixtures
- require nullable `serviceTier` in user model preference requests and responses, with every caller now sending an explicit value
- require `matchedRanges` in chat search results and remove the App rendering fallback
- close #26170 without duplicating its database work, which already landed in #26199

## Rollout evidence

- App `0.722.0` is the forced minimum version through #26197
- the `app-v0.722.0` release contains the source changes from #26142, #26028, and #25901
- #26199 already removed `insights_daily` and `usage_daily` after verifying #26154 was deployed, the previous API had drained, and the tables had no remaining writers
- no compatibility fallback is introduced by this cleanup

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- targeted API contracts tests: `connector-client-contract.test.ts`, `chat-threads.test.ts`
- targeted App tests: `zero-sidebar.test.tsx`, `chat-composer-model-selection-and-providers.test.tsx`, `zero-connectors-page.test.tsx`
- targeted CLI tests: `whoami.test.ts`, `view.test.ts`, `lister.test.ts`
- targeted API tests: `zero-connectors-list.test.ts`, `user-config.bdd.test.ts`, `zero-model-policies.test.ts`

Closes #26165
Closes #26042
Closes #25913
Closes #26170
