### PR TITLE
fix(ci): retry transient cloudflare pages deployments

### DIFF
--- a/.github/scripts/deploy-okou-pages.sh
+++ b/.github/scripts/deploy-okou-pages.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 4 )); then
+  echo "usage: $0 <pages-dist> <project-name> <branch> <commit-sha>" >&2
+  exit 1
+fi
+
+pages_dist="$1"
+project_name="$2"
+branch="$3"
+commit_sha="$4"
+
+: "${project_name:?Cloudflare Pages project name is required}"
+: "${branch:?Cloudflare Pages branch is required}"
+: "${commit_sha:?Cloudflare Pages commit SHA is required}"
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+
+if [[ ! -d "$pages_dist" ]]; then
+  echo "Cloudflare Pages distribution directory does not exist: $pages_dist" >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+retry_delays_seconds=(5 10)
+max_attempts=$((${#retry_delays_seconds[@]} + 1))
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if [[ -n "${WRANGLER_OUTPUT_FILE_PATH:-}" ]]; then
+    : >"$WRANGLER_OUTPUT_FILE_PATH"
+  fi
+
+  if pnpm --dir "${repo_root}/turbo" \
+    --filter @vm0/host-worker \
+    exec wrangler pages deploy "$pages_dist" \
+    --project-name "$project_name" \
+    --branch "$branch" \
+    --commit-hash "$commit_sha" \
+    --commit-dirty=false; then
+    exit 0
+  else
+    status=$?
+  fi
+
+  if (( attempt == max_attempts )); then
+    echo "::error::Cloudflare Pages deployment failed after ${max_attempts} attempts" >&2
+    exit "$status"
+  fi
+
+  retry_delay_seconds="${retry_delays_seconds[$((attempt - 1))]}"
+  echo "::warning title=Retrying Cloudflare Pages deployment::Attempt ${attempt}/${max_attempts} failed with exit ${status}; retrying in ${retry_delay_seconds}s" >&2
+  sleep "$retry_delay_seconds"
+done

--- a/.github/scripts/tests/deploy-okou-pages-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/deploy-okou-pages.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+pages_dist="${tmp_dir}/pages dist"
+mkdir -p "$pages_dist" "${tmp_dir}/bin"
+
+cat >"${tmp_dir}/bin/pnpm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_args=(
+  --dir "${MOCK_REPO_ROOT}/turbo"
+  --filter @vm0/host-worker
+  exec wrangler pages deploy "$EXPECTED_PAGES_DIST"
+  --project-name "$EXPECTED_PROJECT_NAME"
+  --branch "$EXPECTED_BRANCH"
+  --commit-hash "$EXPECTED_COMMIT_SHA"
+  --commit-dirty=false
+)
+
+if (( $# != ${#expected_args[@]} )); then
+  echo "unexpected pnpm argument count: $#" >&2
+  exit 2
+fi
+for ((index = 0; index < ${#expected_args[@]}; index++)); do
+  position=$((index + 1))
+  if [[ "${!position}" != "${expected_args[$index]}" ]]; then
+    echo "unexpected pnpm argument ${position}" >&2
+    exit 2
+  fi
+done
+
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID was not forwarded}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN was not forwarded}"
+
+attempt="$(<"$MOCK_PNPM_STATE_FILE")"
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" >"$MOCK_PNPM_STATE_FILE"
+
+if [[ -n "${WRANGLER_OUTPUT_FILE_PATH:-}" ]]; then
+  printf '{"type":"wrangler-session","attempt":%s}\n' "$attempt" \
+    >>"$WRANGLER_OUTPUT_FILE_PATH"
+fi
+
+if (( attempt <= MOCK_PNPM_FAILURES )); then
+  if [[ -n "${WRANGLER_OUTPUT_FILE_PATH:-}" ]]; then
+    printf '{"type":"command-failed","attempt":%s}\n' "$attempt" \
+      >>"$WRANGLER_OUTPUT_FILE_PATH"
+  fi
+  exit 17
+fi
+
+if [[ -n "${WRANGLER_OUTPUT_FILE_PATH:-}" ]]; then
+  printf '{"type":"pages-deploy-detailed","attempt":%s}\n' "$attempt" \
+    >>"$WRANGLER_OUTPUT_FILE_PATH"
+fi
+EOF
+
+cat >"${tmp_dir}/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${1:?sleep delay is required}" >>"$MOCK_SLEEP_LOG"
+EOF
+
+chmod +x "${tmp_dir}/bin/pnpm" "${tmp_dir}/bin/sleep"
+
+export PATH="${tmp_dir}/bin:${PATH}"
+export CLOUDFLARE_ACCOUNT_ID="test-account"
+export CLOUDFLARE_API_TOKEN="test-token"
+export EXPECTED_BRANCH="pr-26218-app"
+export EXPECTED_COMMIT_SHA="0123456789abcdef0123456789abcdef01234567"
+export EXPECTED_PAGES_DIST="$pages_dist"
+export EXPECTED_PROJECT_NAME="okou-app"
+export MOCK_PNPM_STATE_FILE="${tmp_dir}/pnpm-state"
+export MOCK_REPO_ROOT="$repo_root"
+export MOCK_SLEEP_LOG="${tmp_dir}/sleep.log"
+
+reset_attempts() {
+  printf '0\n' >"$MOCK_PNPM_STATE_FILE"
+  : >"$MOCK_SLEEP_LOG"
+}
+
+run_deploy() {
+  bash "$script" \
+    "$pages_dist" \
+    "$EXPECTED_PROJECT_NAME" \
+    "$EXPECTED_BRANCH" \
+    "$EXPECTED_COMMIT_SHA"
+}
+
+reset_attempts
+MOCK_PNPM_FAILURES=0 run_deploy >/dev/null
+[[ "$(<"$MOCK_PNPM_STATE_FILE")" == "1" ]]
+[[ ! -s "$MOCK_SLEEP_LOG" ]]
+
+reset_attempts
+output_file="${tmp_dir}/wrangler-output.ndjson"
+printf '{"type":"stale"}\n' >"$output_file"
+WRANGLER_OUTPUT_FILE_PATH="$output_file" \
+  MOCK_PNPM_FAILURES=2 \
+  run_deploy >/dev/null 2>&1
+[[ "$(<"$MOCK_PNPM_STATE_FILE")" == "3" ]]
+grep -Fxq '5' "$MOCK_SLEEP_LOG"
+grep -Fxq '10' "$MOCK_SLEEP_LOG"
+[[ "$(wc -l <"$MOCK_SLEEP_LOG")" == "2" ]]
+grep -Fq '"type":"pages-deploy-detailed","attempt":3' "$output_file"
+if grep -Eq 'stale|command-failed|"attempt":[12]' "$output_file"; then
+  echo "Wrangler output retained a previous attempt" >&2
+  exit 1
+fi
+
+reset_attempts
+printf '{"type":"stale"}\n' >"$output_file"
+if WRANGLER_OUTPUT_FILE_PATH="$output_file" \
+  MOCK_PNPM_FAILURES=99 \
+  run_deploy >/dev/null 2>"${tmp_dir}/exhausted.stderr"; then
+  echo "expected an exhausted deployment to fail" >&2
+  exit 1
+else
+  status=$?
+fi
+[[ "$status" == "17" ]]
+[[ "$(<"$MOCK_PNPM_STATE_FILE")" == "3" ]]
+[[ "$(wc -l <"$MOCK_SLEEP_LOG")" == "2" ]]
+grep -Fq '"type":"command-failed","attempt":3' "$output_file"
+if grep -Eq 'stale|"attempt":[12]' "$output_file"; then
+  echo "final Wrangler output retained an earlier attempt" >&2
+  exit 1
+fi
+grep -Fq 'failed after 3 attempts' "${tmp_dir}/exhausted.stderr"
+
+if bash "$script" "$pages_dist" okou-app production >/dev/null 2>&1; then
+  echo "expected a missing argument to fail" >&2
+  exit 1
+fi
+
+if bash "$script" \
+  "${tmp_dir}/missing" \
+  okou-app \
+  production \
+  "$EXPECTED_COMMIT_SHA" >/dev/null 2>&1; then
+  echo "expected a missing distribution to fail" >&2
+  exit 1
+fi
+
+if (
+  unset CLOUDFLARE_API_TOKEN
+  run_deploy >/dev/null 2>&1
+); then
+  echo "expected a missing Cloudflare token to fail" >&2
+  exit 1
+fi
+
+echo "deploy-okou-pages tests passed"

--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+python3 - \
+  "${repo_root}/.github/workflows/turbo.yml" \
+  "${repo_root}/.github/workflows/release-please.yml" \
+  "${repo_root}/.github/workflows/rollback-production.yml" <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+
+def load_workflow(path: str) -> tuple[dict[str, object], str]:
+    source = Path(path).read_text()
+    return yaml.safe_load(source), source
+
+
+def find_step(job: dict[str, object], name: str) -> dict[str, object]:
+    steps = job["steps"]
+    if not isinstance(steps, list):
+        raise RuntimeError(f"job steps are not a list: {name}")
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == name:
+            return step
+    raise RuntimeError(f"missing workflow step: {name}")
+
+
+def require_fragments(step: dict[str, object], fragments: list[str]) -> str:
+    source = step.get("run")
+    if not isinstance(source, str):
+        raise RuntimeError(f"step has no run source: {step.get('name')}")
+    for fragment in fragments:
+        if fragment not in source:
+            raise RuntimeError(
+                f"step {step.get('name')} is missing deployment input: {fragment}"
+            )
+    return source
+
+
+turbo, turbo_source = load_workflow(sys.argv[1])
+release, release_source = load_workflow(sys.argv[2])
+rollback, rollback_source = load_workflow(sys.argv[3])
+
+turbo_job = turbo["jobs"]["deploy-app"]
+release_job = release["jobs"]["promote-app-production"]
+rollback_job = rollback["jobs"]["rollback-app"]
+
+preview_step = find_step(turbo_job, "Deploy Cloudflare Pages preview")
+release_step = find_step(release_job, "Deploy Cloudflare Pages production")
+rollback_step = find_step(rollback_job, "Deploy App to Cloudflare Pages production")
+
+shared_script = "bash .github/scripts/deploy-okou-pages.sh"
+require_fragments(
+    preview_step,
+    [shared_script, '"$PAGES_DIST"', '"$CF_PAGES_PROJECT_NAME"', '"$PAGES_BRANCH"', '"$ARTIFACT_SHA"'],
+)
+require_fragments(
+    release_step,
+    [shared_script, '"$PAGES_DIST"', '"$CF_PAGES_PROJECT_NAME"', "production", '"$ARTIFACT_SHA"'],
+)
+require_fragments(
+    rollback_step,
+    [shared_script, '"$PAGES_DIST"', '"$CF_PAGES_PROJECT_NAME"', "production", '"$TARGET_COMMIT"'],
+)
+
+for step in (preview_step, release_step, rollback_step):
+    if "working-directory" in step:
+        raise RuntimeError(f"shared Pages deployment must run from the repository root: {step['name']}")
+
+for path, source in (
+    (sys.argv[1], turbo_source),
+    (sys.argv[2], release_source),
+    (sys.argv[3], rollback_source),
+):
+    if "wrangler pages deploy" in source:
+        raise RuntimeError(f"direct Pages deployment remains in {path}")
+
+require_fragments(
+    preview_step,
+    ["pages-deploy-detailed", "deployment_url", "deployment_commit"],
+)
+if "WRANGLER_OUTPUT_FILE_PATH" not in preview_step.get("env", {}):
+    raise RuntimeError("preview deployment no longer captures Wrangler output")
+
+require_fragments(release_step, ["curl -fsSL", '"$pages_url"', '"$production_url"'])
+require_fragments(
+    rollback_step,
+    ["curl -fsSL", '"https://${CF_PAGES_PROJECT_NAME}.pages.dev"', '"https://app.vm0.ai"'],
+)
+
+print("deploy-okou-pages workflow tests passed")
+PY

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1419,17 +1419,13 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
           PAGES_DIST: ${{ steps.pages-production.outputs.pages-dist }}
-        working-directory: turbo
         run: |
           set -euo pipefail
-          : "${CF_PAGES_PROJECT_NAME:?CF_PAGES_PROJECT_NAME variable is required}"
-          : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
-          : "${CLOUDFLARE_API_TOKEN:?CF_PAGES_DEPLOY_API_TOKEN secret is required}"
-          pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
-            --project-name "$CF_PAGES_PROJECT_NAME" \
-            --branch production \
-            --commit-hash "$ARTIFACT_SHA" \
-            --commit-dirty=false
+          bash .github/scripts/deploy-okou-pages.sh \
+            "$PAGES_DIST" \
+            "$CF_PAGES_PROJECT_NAME" \
+            production \
+            "$ARTIFACT_SHA"
 
           pages_url="https://${CF_PAGES_PROJECT_NAME}.pages.dev"
           production_url="https://app.vm0.ai"

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -197,15 +197,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_DEPLOY_API_TOKEN }}
           PAGES_DIST: ${{ steps.app.outputs.pages_dist }}
           TARGET_COMMIT: ${{ needs.resolve-target.outputs.target_commit }}
-        working-directory: turbo
         run: |
           set -euo pipefail
 
-          pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
-            --project-name "$CF_PAGES_PROJECT_NAME" \
-            --branch production \
-            --commit-hash "$TARGET_COMMIT" \
-            --commit-dirty=false
+          bash .github/scripts/deploy-okou-pages.sh \
+            "$PAGES_DIST" \
+            "$CF_PAGES_PROJECT_NAME" \
+            production \
+            "$TARGET_COMMIT"
 
           for url in "https://${CF_PAGES_PROJECT_NAME}.pages.dev" "https://app.vm0.ai"; do
             curl -fsSL \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -225,6 +225,7 @@ jobs:
             .github/scripts/cloudflare-ssh-command.sh \
             .github/scripts/cloudflare-ssh-diagnostics.sh \
             .github/scripts/cloudflare-ssh-preconnect.sh \
+            .github/scripts/deploy-okou-pages.sh \
             .github/scripts/fetch-okou-desktop-artifact.sh \
             .github/scripts/pass-release-pr-ci-gates.sh \
             .github/scripts/resolve-desktop-version-change.sh \
@@ -239,6 +240,8 @@ jobs:
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
             .github/scripts/tests/cloudflare-ssh-proxy-test.sh \
             .github/scripts/tests/deploy-desktop-workflow-test.sh \
+            .github/scripts/tests/deploy-okou-pages-test.sh \
+            .github/scripts/tests/deploy-okou-pages-workflow-test.sh \
             .github/scripts/tests/fetch-okou-desktop-artifact-test.sh \
             .github/scripts/tests/okou-desktop-artifact-test.sh \
             .github/scripts/tests/resolve-desktop-version-change-test.sh \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1405,15 +1405,13 @@ jobs:
           PAGES_BRANCH: ${{ steps.pages-branch.outputs.branch }}
           PAGES_DIST: ${{ steps.pages-preview.outputs.dist }}
           WRANGLER_OUTPUT_FILE_PATH: /tmp/wrangler-pages-output.ndjson
-        working-directory: turbo
         run: |
           set -euo pipefail
-          : "${CLOUDFLARE_API_TOKEN:?CF_PAGES_DEPLOY_API_TOKEN secret is required}"
-          pnpm --filter @vm0/host-worker exec wrangler pages deploy "$PAGES_DIST" \
-            --project-name "$CF_PAGES_PROJECT_NAME" \
-            --branch "$PAGES_BRANCH" \
-            --commit-hash "$ARTIFACT_SHA" \
-            --commit-dirty=false
+          bash .github/scripts/deploy-okou-pages.sh \
+            "$PAGES_DIST" \
+            "$CF_PAGES_PROJECT_NAME" \
+            "$PAGES_BRANCH" \
+            "$ARTIFACT_SHA"
 
           deployment="$(
             jq --slurp --compact-output \


### PR DESCRIPTION
## Summary

- centralize Cloudflare Pages publication in a shared deployment script
- retry failed Wrangler deployments up to three times with bounded 5-second and 10-second backoff
- reset Wrangler's NDJSON output before each attempt so preview validation reads only the successful or final attempt
- use the same retry behavior for preview, production release, and production rollback workflows

## Validation

- `bash .github/scripts/tests/deploy-okou-pages-test.sh`
- `bash .github/scripts/tests/deploy-okou-pages-workflow-test.sh`
- `bash .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- all `.github/scripts/tests/*.sh`
- ShellCheck for the new deployment script and tests
- actionlint for all workflows
- workflow shell compatibility checks
- Prettier checks for the four changed workflow files
- `git diff --check`

## Scope

This keeps the existing deployment identity validation and post-deployment reachability gates unchanged. It does not add provider-state reconciliation or weaken terminal failures: the final Wrangler exit status still fails the job.

Closes #26218
