### PR TITLE
test(e2e): restore parallel runner scaffold

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -27,4 +27,75 @@ if grep -Fq 'playwright-staging' "$WORKFLOW"; then
   fail "main Playwright runs must not use a group outside the staging API default"
 fi
 
+ruby -ryaml - "$WORKFLOW" <<'RUBY'
+workflow = YAML.load_file(ARGV.fetch(0))
+jobs = workflow.fetch("jobs")
+account_prepare = jobs.fetch("cli-e2e-03-runner-prepare")
+runner = jobs.fetch("cli-e2e-03-runner")
+account_cleanup = jobs.fetch("cli-e2e-03-runner-cleanup")
+
+expected_indices = (1..12).to_a
+unless runner.dig("strategy", "fail-fast") == false
+  raise "runner E2E shards must not fail fast"
+end
+unless runner.dig("strategy", "matrix", "index") == expected_indices
+  raise "runner E2E must preserve the historical twelve-shard matrix"
+end
+
+expected_group = "cli-e2e-03-runner-${{ matrix.index }}-${{ needs.prepare.outputs.job-ref }}"
+unless runner.dig("concurrency", "group") == expected_group
+  raise "each runner E2E shard must keep its independent concurrency group"
+end
+
+required_needs = %w[
+  prepare
+  deploy-api
+  deploy-runner-prepare
+  deploy-runner-start
+  cli-e2e-03-runner-prepare
+]
+unless required_needs.all? { |job_name| Array(runner["needs"]).include?(job_name) }
+  raise "runner E2E shards must wait for accounts, API, and runner deployment"
+end
+
+prepare_step = account_prepare.fetch("steps").find do |step|
+  step["name"] == "Prepare runner E2E accounts"
+end
+raise "missing runner E2E account preparation" unless prepare_step
+unless prepare_step.fetch("run").end_with?("runner-account.ts prepare")
+  raise "runner E2E account preparation must use the shared lifecycle entry point"
+end
+
+shard_step = runner.fetch("steps").find do |step|
+  step["name"] == "Initialize runner E2E shard"
+end
+raise "missing runner E2E shard scaffold" unless shard_step
+if runner.fetch("steps").any? { |step| step.fetch("name", "").include?("Run runner E2E tests") }
+  raise "runner E2E scaffold must not add test coverage yet"
+end
+
+cleanup_step = account_cleanup.fetch("steps").find do |step|
+  step["name"] == "Cleanup runner E2E accounts"
+end
+raise "missing runner E2E account cleanup" unless cleanup_step
+unless account_cleanup.fetch("if").include?("always()")
+  raise "runner E2E account cleanup must run after shard failures"
+end
+unless Array(account_cleanup["needs"]).include?("cli-e2e-03-runner")
+  raise "runner E2E account cleanup must wait for every shard"
+end
+unless cleanup_step.fetch("run").end_with?("runner-account.ts cleanup")
+  raise "runner E2E account cleanup must use the shared lifecycle entry point"
+end
+
+gate_needs = Array(jobs.fetch("ci-gate-turbo")["needs"])
+%w[
+  cli-e2e-03-runner-prepare
+  cli-e2e-03-runner
+  cli-e2e-03-runner-cleanup
+].each do |job_name|
+  raise "CI gate must include #{job_name}" unless gate_needs.include?(job_name)
+end
+RUBY
+
 echo "turbo-playwright-runner-workflow-test: ok"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2489,6 +2489,122 @@ jobs:
 
           RUNNER_START_SUCCEEDED=1
 
+  # Prepare the shared Clerk identities once, then fan future runner coverage
+  # across the same twelve independent shards used by the retired runner suite.
+  cli-e2e-03-runner-prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: cli-e2e-03-runner-prepare-${{ needs.prepare.outputs.job-ref }}
+      cancel-in-progress: true
+    needs: [prepare]
+    if: |
+      needs.prepare.outputs.job-ref != '' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+    outputs:
+      organization-id: ${{ steps.account.outputs.organization-id }}
+      runner-email: ${{ steps.account.outputs.runner-email }}
+      codex-email: ${{ steps.account.outputs.codex-email }}
+      claude-email: ${{ steps.account.outputs.claude-email }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install pnpm
+        run: corepack enable pnpm
+      - name: Install E2E dependencies
+        run: cd e2e && pnpm install --frozen-lockfile
+      - name: Prepare runner E2E accounts
+        id: account
+        run: cd e2e && pnpm exec tsx playwright/runner-account.ts prepare
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+
+  cli-e2e-03-runner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: cli-e2e-03-runner-${{ matrix.index }}-${{ needs.prepare.outputs.job-ref }}
+      cancel-in-progress: true
+    needs:
+      - prepare
+      - deploy-api
+      - deploy-runner-prepare
+      - deploy-runner-start
+      - cli-e2e-03-runner-prepare
+    if: |
+      always() &&
+      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      needs.prepare.outputs.job-ref != '' &&
+      needs.prepare.outputs.playwright-runner-consumer-needed == 'true' &&
+      needs.deploy-api.result == 'success' &&
+      needs.deploy-runner-prepare.result == 'success' &&
+      needs.deploy-runner-start.result == 'success' &&
+      needs.cli-e2e-03-runner-prepare.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        index: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    env:
+      E2E_CLERK_ORG_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.organization-id }}
+      E2E_RUNNER_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.runner-email }}
+      E2E_RUNNER_CODEX_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.codex-email }}
+      E2E_RUNNER_CLAUDE_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.claude-email }}
+      E2E_RUNNER_SHARD_INDEX: ${{ matrix.index }}
+      E2E_RUNNER_SHARD_TOTAL: 12
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install pnpm
+        run: corepack enable pnpm
+      - name: Install E2E dependencies
+        run: cd e2e && pnpm install --frozen-lockfile
+      - name: Initialize runner E2E shard
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${E2E_CLERK_ORG_ID:?runner E2E organization is required}"
+          : "${E2E_RUNNER_EMAIL:?runner E2E account is required}"
+          : "${E2E_RUNNER_CODEX_EMAIL:?runner Codex E2E account is required}"
+          : "${E2E_RUNNER_CLAUDE_EMAIL:?runner Claude E2E account is required}"
+          echo "Runner E2E shard ${E2E_RUNNER_SHARD_INDEX}/${E2E_RUNNER_SHARD_TOTAL} is ready"
+
+  cli-e2e-03-runner-cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - prepare
+      - cli-e2e-03-runner-prepare
+      - cli-e2e-03-runner
+    if: |
+      always() &&
+      needs.prepare.outputs.job-ref != '' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      needs.cli-e2e-03-runner-prepare.result != 'skipped' &&
+      needs.cli-e2e-03-runner-prepare.result != 'cancelled'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install pnpm
+        run: corepack enable pnpm
+      - name: Install E2E dependencies
+        run: cd e2e && pnpm install --frozen-lockfile
+      - name: Cleanup runner E2E accounts
+        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          E2E_RUNNER_ORGANIZATION_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.organization-id }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+
   lint-runtime-api-compat:
     runs-on: ubuntu-latest
     timeout-minutes: 8
@@ -2587,6 +2703,9 @@ jobs:
       - cli-e2e-02-browser
       - cli-e2e-02-playwright
       - cli-e2e-01-serial
+      - cli-e2e-03-runner-prepare
+      - cli-e2e-03-runner
+      - cli-e2e-03-runner-cleanup
       - deploy-runner-prepare
       - deploy-runner-start
     # Always run so the gate reports an explicit result (not "skipped").
@@ -2686,6 +2805,9 @@ jobs:
           check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-02-playwright" "${{ needs.cli-e2e-02-playwright.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
+          check_result "cli-e2e-03-runner-prepare" "${{ needs.cli-e2e-03-runner-prepare.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
+          check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
+          check_result "cli-e2e-03-runner-cleanup" "${{ needs.cli-e2e-03-runner-cleanup.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
 

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -8,9 +8,12 @@ import { test } from "node:test";
 
 import {
   createOrganization,
+  createOrganizationMembership,
   createUser,
+  deleteOrganizationById,
   deleteStaleTestUsers,
   deleteUserByEmail,
+  runnerTestAccounts,
 } from "./clerk-api";
 
 interface ObservedRequest {
@@ -90,6 +93,77 @@ test("retries an idempotent membership role update", async () => {
           "PATCH",
           "/v1/organizations/org_test/memberships/user_test",
         ),
+        2,
+      );
+    },
+  );
+});
+
+test("creates runner accounts with the historical three email names", () => {
+  const previousJobRef = process.env.JOB_REF;
+  process.env.JOB_REF = "pr-123";
+  try {
+    assert.deepEqual(runnerTestAccounts(), {
+      runner: "pr-123+clerk_test+runner@vm0-e2e.ai",
+      codex: "pr-123+clerk_test+runner-real-codex@vm0-e2e.ai",
+      claude: "pr-123+clerk_test+runner-real-claude@vm0-e2e.ai",
+    });
+  } finally {
+    restoreEnvironmentVariable("JOB_REF", previousJobRef);
+  }
+});
+
+test("creates an organization member without replaying the POST", async () => {
+  await withClerkServer(
+    (request, response) => {
+      if (
+        request.method === "POST" &&
+        request.url === "/v1/organizations/org_test/memberships"
+      ) {
+        sendJson(response, 200, { role: "org:member" });
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      await createOrganizationMembership("org_test", "user_member");
+      assert.equal(
+        countRequests(
+          requests,
+          "POST",
+          "/v1/organizations/org_test/memberships",
+        ),
+        1,
+      );
+    },
+  );
+});
+
+test("retries organization cleanup and accepts not found", async () => {
+  await withClerkServer(
+    (request, response, requests) => {
+      if (
+        request.method === "DELETE" &&
+        request.url === "/v1/organizations/org_cleanup"
+      ) {
+        const deleteCount = countRequests(
+          requests,
+          "DELETE",
+          "/v1/organizations/org_cleanup",
+        );
+        if (deleteCount === 1) {
+          sendJson(response, 503, { errors: [] }, { "retry-after": "0" });
+        } else {
+          sendJson(response, 404, { errors: [] });
+        }
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      await deleteOrganizationById("org_cleanup");
+      assert.equal(
+        countRequests(requests, "DELETE", "/v1/organizations/org_cleanup"),
         2,
       );
     },

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -17,6 +17,12 @@ interface RetryableClerkRequestInit extends RequestInit {
   readonly method: "GET" | "DELETE" | "PATCH";
 }
 
+export interface RunnerTestAccounts {
+  readonly runner: string;
+  readonly codex: string;
+  readonly claude: string;
+}
+
 function getClerkApiBase(): string {
   const testApiBase = process.env.CLERK_API_TEST_BASE_URL;
   if (!testApiBase) {
@@ -45,6 +51,15 @@ export function generateTestEmail(): string {
   const jobRef = process.env.JOB_REF ?? "local";
   const randHex = randomBytes(4).toString("hex");
   return `${jobRef}+clerk_test@e2e-browser-${randHex}.ai`;
+}
+
+export function runnerTestAccounts(): RunnerTestAccounts {
+  const jobRef = process.env.JOB_REF ?? "local";
+  return {
+    runner: `${jobRef}+clerk_test+runner@vm0-e2e.ai`,
+    codex: `${jobRef}+clerk_test+runner-real-codex@vm0-e2e.ai`,
+    claude: `${jobRef}+clerk_test+runner-real-claude@vm0-e2e.ai`,
+  };
 }
 
 export async function createUser(email: string): Promise<string> {
@@ -87,6 +102,30 @@ export async function createOrganization(
   }
   await updateOrganizationMembershipRole(data.id, createdByUserId, "org:admin");
   return data.id;
+}
+
+export async function createOrganizationMembership(
+  organizationId: string,
+  userId: string,
+): Promise<void> {
+  const response = await requestClerk(
+    "create Clerk organization membership",
+    `/organizations/${organizationId}/memberships`,
+    {
+      method: "POST",
+      headers: getClerkHeaders(),
+      body: JSON.stringify({ user_id: userId, role: "org:member" }),
+    },
+  );
+  const data = await readClerkJson(
+    response,
+    "create Clerk organization membership",
+  );
+  if (!hasStringProperty(data, "role") || data.role !== "org:member") {
+    throw new Error(
+      `create Clerk organization membership returned an unexpected role: ${formatClerkResponseSummary(response)}`,
+    );
+  }
 }
 
 async function updateOrganizationMembershipRole(
@@ -155,6 +194,22 @@ export async function deleteStaleTestUsers(): Promise<void> {
         "Failed to delete a stale Clerk test user; continuing stale cleanup",
       );
     }
+  }
+}
+
+export async function deleteOrganizationById(
+  organizationId: string,
+): Promise<void> {
+  const response = await requestClerkWithRetry(
+    "delete Clerk test organization",
+    `/organizations/${organizationId}`,
+    { method: "DELETE", headers: getClerkHeaders() },
+  );
+  await response.body?.cancel();
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      `delete Clerk test organization failed with ${formatClerkResponseSummary(response)}`,
+    );
   }
 }
 

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -52,12 +52,10 @@ async function prepareRunnerAccounts(
   await createOrganizationMembership(organizationId, codexUserId);
   await createOrganizationMembership(organizationId, claudeUserId);
 
-  console.log(
-    `Prepared runner E2E accounts in organization ${organizationId}:`,
-    runnerAccounts.runner,
-    runnerAccounts.codex,
-    runnerAccounts.claude,
-  );
+  console.log("Prepared runner E2E accounts", {
+    organizationId,
+    ...runnerAccounts,
+  });
 }
 
 async function cleanupRunnerAccounts(

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -10,22 +10,25 @@ import {
   type RunnerTestAccounts,
 } from "./lib/clerk-api";
 
-const command = process.argv[2];
-if (command !== "prepare" && command !== "cleanup") {
-  throw new Error("Usage: runner-account.ts <prepare|cleanup>");
-}
+async function main(): Promise<void> {
+  const command = process.argv[2];
+  if (command !== "prepare" && command !== "cleanup") {
+    throw new Error("Usage: runner-account.ts <prepare|cleanup>");
+  }
 
-const jobRef = requiredEnvironmentVariable("JOB_REF");
-const accounts = runnerTestAccounts();
+  const jobRef = requiredEnvironmentVariable("JOB_REF");
+  const accounts = runnerTestAccounts();
 
-if (command === "prepare") {
-  await prepareRunnerAccounts(accounts);
-} else {
-  await cleanupRunnerAccounts(accounts);
+  if (command === "prepare") {
+    await prepareRunnerAccounts(accounts, jobRef);
+  } else {
+    await cleanupRunnerAccounts(accounts);
+  }
 }
 
 async function prepareRunnerAccounts(
   runnerAccounts: RunnerTestAccounts,
+  jobRef: string,
 ): Promise<void> {
   await deleteRunnerUsers(runnerAccounts);
 
@@ -85,3 +88,8 @@ function requiredEnvironmentVariable(name: string): string {
   }
   return value;
 }
+
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -1,0 +1,89 @@
+import { appendFile } from "node:fs/promises";
+
+import {
+  createOrganization,
+  createOrganizationMembership,
+  createUser,
+  deleteOrganizationById,
+  deleteUserByEmail,
+  runnerTestAccounts,
+  type RunnerTestAccounts,
+} from "./lib/clerk-api";
+
+const command = process.argv[2];
+if (command !== "prepare" && command !== "cleanup") {
+  throw new Error("Usage: runner-account.ts <prepare|cleanup>");
+}
+
+const jobRef = requiredEnvironmentVariable("JOB_REF");
+const accounts = runnerTestAccounts();
+
+if (command === "prepare") {
+  await prepareRunnerAccounts(accounts);
+} else {
+  await cleanupRunnerAccounts(accounts);
+}
+
+async function prepareRunnerAccounts(
+  runnerAccounts: RunnerTestAccounts,
+): Promise<void> {
+  await deleteRunnerUsers(runnerAccounts);
+
+  const runnerUserId = await createUser(runnerAccounts.runner);
+  const codexUserId = await createUser(runnerAccounts.codex);
+  const claudeUserId = await createUser(runnerAccounts.claude);
+  const organizationId = await createOrganization(
+    `Runner E2E ${jobRef}`,
+    runnerUserId,
+  );
+
+  await appendFile(
+    requiredEnvironmentVariable("GITHUB_OUTPUT"),
+    [
+      `organization-id=${organizationId}`,
+      `runner-email=${runnerAccounts.runner}`,
+      `codex-email=${runnerAccounts.codex}`,
+      `claude-email=${runnerAccounts.claude}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  await createOrganizationMembership(organizationId, codexUserId);
+  await createOrganizationMembership(organizationId, claudeUserId);
+
+  console.log(
+    `Prepared runner E2E accounts in organization ${organizationId}:`,
+    runnerAccounts.runner,
+    runnerAccounts.codex,
+    runnerAccounts.claude,
+  );
+}
+
+async function cleanupRunnerAccounts(
+  runnerAccounts: RunnerTestAccounts,
+): Promise<void> {
+  const organizationId = process.env.E2E_RUNNER_ORGANIZATION_ID;
+  if (organizationId) {
+    await deleteOrganizationById(organizationId);
+  }
+
+  await deleteRunnerUsers(runnerAccounts);
+  console.log("Cleaned up runner E2E accounts");
+}
+
+async function deleteRunnerUsers(
+  runnerAccounts: RunnerTestAccounts,
+): Promise<void> {
+  for (const email of Object.values(runnerAccounts)) {
+    await deleteUserByEmail(email);
+  }
+}
+
+function requiredEnvironmentVariable(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} environment variable is required`);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- restore a dedicated runner E2E account lifecycle that creates the historical runner, runner-real-codex, and runner-real-claude Clerk identities once in a shared organization
- preserve the retired runner suite's 12-shard matrix, fail-fast behavior, and per-shard concurrency groups
- keep every shard intentionally test-free for this baseline; each shard only installs the E2E toolchain and validates the prepared account outputs
- always clean up the shared organization and all three users after the shard matrix, including when a shard fails
- make account preparation, the shard matrix, and account cleanup blocking CI-gate inputs

## Timing comparison

The linked current run (https://github.com/vm0-ai/vm0/actions/runs/31452572489/job/93660093752) spent about 5 seconds creating the three Clerk users and organization, then about 33 seconds in serial browser sign-in and workspace/API initialization before the tests could proceed.

A successful run before the old suite was removed (https://github.com/vm0-ai/vm0/actions/runs/31020908290) spent 5 seconds provisioning E2E accounts, 3 seconds generating API credentials, and used a separate 8-second bootstrap job before starting 12 runner shards together. The main difference is therefore lifecycle placement and pre-generated authentication, not raw Clerk provisioning time.

This PR restores that lifecycle and parallel topology without restoring any deleted runner test case or deprecated test-only API route.

## Validation

- exact repository Prettier formatting for all changed files
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (9 passed)
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- Ruby YAML parse for `.github/workflows/turbo.yml`
- `git diff --check`
- `scripts/check-file-size.sh` for all changed files

The local shell-compatibility and checkout-depth helpers require `shellcheck` and `yq`, which are not installed in this environment; the PR pipeline will run those checks.
