### PR TITLE
fix: keep scroll-to-bottom button opaque on hover

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4265,7 +4265,7 @@ function ScrollToBottomButton({ thread }: { thread: ChatPanelSignals }) {
       onClick={() => {
         scrollToBottom();
       }}
-      className="absolute bottom-4 left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-md transition-colors hover:bg-state-hover hover:text-foreground"
+      className="absolute bottom-4 left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-md transition-colors hover:bg-background-hover hover:text-foreground"
     >
       <ArrowDown size={18} />
     </button>

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -149,6 +149,11 @@
   );
   --color-state-pressed: hsl(var(--state-layer) / var(--state-pressed-alpha));
 
+  --color-background-hover: color-mix(
+    in srgb,
+    hsl(var(--background)),
+    hsl(var(--state-layer)) var(--state-hover-alpha)
+  );
   --color-card-hover: color-mix(
     in srgb,
     hsl(var(--card)),


### PR DESCRIPTION
## Problem

The chat scroll-to-bottom button turns nearly invisible on hover — the disc goes see-through and the chat text underneath shows straight through it, while the border, shadow and arrow stay put.

## Root cause

`ScrollToBottomButton` used `bg-background hover:bg-state-hover`.

`--color-state-hover` is a **5% translucent state layer**, not a solid colour. Both classes set `background-color`, so on hover it **replaces** the opaque `bg-background` fill rather than sitting on top of it, leaving the button 95% transparent. Because the button is `absolute`-positioned over the message list, what shows through is the conversation.

The design system already calls this out in `globals.css`:

> Elements that do carry an opaque fill cannot use a translucent layer (the layer would replace the fill instead of sitting on it), so each fill gets its own pre-mixed pair below.

`card`, `input` and `secondary` all have pre-mixed `-hover` pairs — `background` was the one surface missing one.

## Fix

Add the missing `--color-background-hover` token using the exact same `color-mix` form as its siblings, and point the button at it.

## Verification

Compiled the token through Tailwind v4 in isolation:

- `hover:bg-background-hover` emits `background-color: var(--color-background-hover)`; no name collision with the existing `--color-background-50`
- Light: `rgb(250,251,252)` → `rgb(238,240,244)` — **fully opaque**, ~12/255 darkening, a clear but restrained hover
- Dark: `rgb(25,25,26)` → `rgb(40,40,42)` — inverts to lighter automatically
- Tailwind also emits a `@supports` fallback (`hsl(var(--background))`) for engines without `color-mix`, which is likewise opaque — worst case is no hover effect, never a transparent button

No tests referenced the old class.

## Note for reviewers

Four other floating controls share this root cause but use `bg-background/90 + backdrop-blur`, so they are *intentionally* translucent and the correct hover treatment is a design call rather than a mechanical swap. Left untouched here:

- `zero-artifact-sidebar.tsx:1210,1226` and `zero-attachment-chips.tsx:564,580` — carousel arrows
- `agent-chat-page.tsx:302` — attachment remove badge

The many other `bg-background hover:bg-state-hover` sites in the codebase render correctly today because they sit directly on the page background, so the 5% layer composites over the same colour it was mixed against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)