### PR TITLE
fix(platform): overlap chat composer bottom gap with pwa safe-area inset

### DIFF
--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -92,6 +92,9 @@ describe("platform entrypoint safe area behavior", () => {
       /@media\s*\(display-mode:\s*standalone\)\s*{[\s\S]*\[data-chat-composer\]\s+\.zero-composer\s*{\s*scroll-margin-block-end:\s*16px;\s*}/,
     );
     expect(globalCss).toMatch(
+      /\[data-chat-composer\]\s*{\s*padding-bottom:\s*max\(0\.5rem\s*-\s*var\(--sab\),\s*0px\);\s*}/,
+    );
+    expect(globalCss).toMatch(
       /#root::after\s*{[\s\S]*height:\s*var\(--zero-keyboard-scroll-reserve,\s*0px\);[\s\S]*pointer-events:\s*none;/,
     );
     expect(globalCss).not.toContain("data-keyboard-inset-page");

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -150,6 +150,15 @@ body {
   }
 }
 
+/* The chat composer footer keeps 8px of breathing room below the card but
+   overlaps it with the root-owned bottom inset instead of stacking on top of
+   it, so the gap to the screen edge is max(0.5rem, inset) rather than
+   0.5rem + inset. While the keyboard is open --sab is 0px and the full 8px
+   returns above the keyboard. */
+[data-chat-composer] {
+  padding-bottom: max(0.5rem - var(--sab), 0px);
+}
+
 .zero-sidebar-header {
   padding-top: 0.375rem;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4557,7 +4557,7 @@ function ChatThreadComposer({ thread }: { thread: ChatPanelSignals }) {
   return (
     <footer
       data-chat-composer
-      className="relative shrink-0 bg-[hsl(var(--background))] pb-2"
+      className="relative shrink-0 bg-[hsl(var(--background))]"
     >
       <div className="pointer-events-none absolute inset-x-0 -top-5 h-[21px] bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
       <div


### PR DESCRIPTION
## Summary

Fix lever 2 from #26229: in standalone PWA mode, the gap below the chat composer card is 50px because the thread footer's bottom paddings stack on top of the root-owned `safe-area-inset-bottom` (8px inner + 8px footer + 34px inset). #20976 replaced the footer's original `max(0.5rem, var(--sab))` overlap semantics with a plain `pb-2`, which is where the stacking began.

This PR restores the overlap at the footer layer:

- `[data-chat-composer]` now gets `padding-bottom: max(0.5rem - var(--sab), 0px)` in the shared safe-area CSS block, replacing the footer's `pb-2` utility.
- Gap below the card becomes `8px + max(8px, inset)`: **42px in iPhone standalone PWA (was 50px)**, unchanged 16px in browser/desktop where the inset is 0.
- Keyboard behavior is unchanged: `--sab` is already zeroed while the keyboard is open, so the full 8px returns above the keyboard and the keyboard-reserve measurements see the same footer height as before.
- The inner scroll container's `pb-2` is deliberately kept: it is the clip headroom for the card's shadow/focus veil inside the `overflow-y-auto` wrapper.

Added a regex assertion for the new rule in `entrypoint-safe-area.test.ts`, next to the existing safe-area contract assertions.

Part of #26229 (lever 1, the 68px editor min-height, is a separate change).

## Verification

- Formatting via Prettier on the three changed files.
- Relying on the PR pipeline for lint, type checks, and the `entrypoint-safe-area` vitest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
