### PR TITLE
refactor(connectors): use canonical custom connector grants

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -737,12 +737,16 @@ describe("AGENT-01 and AGENT-02", () => {
       publicAgent.agentId,
       [connector.id],
     );
-    expect(enabled.enabledIds).toStrictEqual([connector.id]);
+    expect(enabled.grants).toStrictEqual([
+      { customConnectorId: connector.id, permissionNames: [] },
+    ]);
     const readEnabled = await api.readAgentCustomConnectors(
       admin,
       publicAgent.agentId,
     );
-    expect(readEnabled.enabledIds).toStrictEqual([connector.id]);
+    expect(readEnabled.grants).toStrictEqual([
+      { customConnectorId: connector.id, permissionNames: [] },
+    ]);
 
     const otherAgent = await api.createAgent(otherAdmin, {
       displayName: "Other Org Agent",
@@ -762,7 +766,7 @@ describe("AGENT-01 and AGENT-02", () => {
       publicAgent.agentId,
       [],
     );
-    expect(cleared.enabledIds).toStrictEqual([]);
+    expect(cleared.grants).toStrictEqual([]);
 
     await api.disconnectCustomConnector(admin, connector.id);
     const afterDisconnect = await api.listCustomConnectors(admin);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -1775,6 +1775,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       ],
       queryInjections: [],
       authMode: "oauth" as const,
+      permissionBundleRef: "builtin:slack@1",
       oauthConfig: {
         providerAdapter: "standard" as const,
         clientId,
@@ -1817,6 +1818,16 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connected: false,
     });
     expectNoVisibleSecret(created, clientSecret);
+    const expectedGrant = {
+      customConnectorId: created.id,
+      permissionNames: ["chat:write"],
+    };
+    await connectorsApi.requestUpdateAgentCustomConnectorGrants(
+      member,
+      agent.agentId,
+      [expectedGrant],
+      [200],
+    );
 
     const authorizationUrl = await connectorsApi.startCustomConnectorOAuth2(
       member,
@@ -1923,6 +1934,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await expect(
       connectorsApi.readAgentCustomConnectors(member, agent.agentId),
     ).resolves.toContain(created.id);
+    await expect(
+      connectorsApi.readAgentCustomConnectorGrants(member, agent.agentId),
+    ).resolves.toContainEqual(expectedGrant);
 
     const replacementUrl = await connectorsApi.startCustomConnectorOAuth2(
       member,
@@ -1946,6 +1960,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expect(provider.tokenBodies[1]?.get("code")).toBe(
       "bdd-custom-oauth-replacement-code",
     );
+    await expect(
+      connectorsApi.readAgentCustomConnectorGrants(member, agent.agentId),
+    ).resolves.toContainEqual(expectedGrant);
 
     await setCustomConnectorCredentialStorageState(context, {
       orgId: requiredOrgId(member),
@@ -1963,12 +1980,14 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connected: false,
       missingRequiredFields: ["oauth"],
     });
-    const durableGrant = await connectorsApi.requestUpdateAgentCustomConnectors(
-      member,
-      agent.agentId,
-      [created.id],
-      [200],
-    );
+    const durableGrant =
+      await connectorsApi.requestLegacyAgentCustomConnectorIdsUpdate(
+        member,
+        agent.agentId,
+        [created.id],
+        [200],
+        "add",
+      );
     expect(durableGrant.body).toMatchObject({
       enabledIds: expect.arrayContaining([created.id]),
     });
@@ -1977,7 +1996,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     }
     expect(durableGrant.body.grants).toContainEqual({
       customConnectorId: created.id,
-      permissionNames: [],
+      permissionNames: ["chat:write"],
     });
     await expect(
       connectorsApi.readAgentCustomConnectors(member, agent.agentId),
@@ -3282,6 +3301,69 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expectNoVisibleSecret(listed, "proposal-secret");
 
     await connectorsApi.deleteCustomConnector(admin, saved.connector.id);
+    await bdd.deleteAgent(admin, agent.agentId);
+  });
+
+  it("preserves selected permissions when a proposal reauthorizes an existing connector", async () => {
+    const bdd = createBddApi(context);
+    bdd.acceptAgentStorageWrites();
+    const admin = bdd.user({ orgRole: "org:admin" });
+    const agent = await bdd.createAgent(admin, {
+      displayName: "BDD Permissioned Proposal Agent",
+    });
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+    const connector = await connectorsApi.createCustomConnector(admin, {
+      displayName: "BDD Permissioned Proposal API",
+      prefixTemplates: [`https://${rand}.permissioned-proposal.test/v1/`],
+      fields: [
+        {
+          key: "api_key",
+          label: "API key",
+          kind: "secret",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.api_key}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+      permissionBundleRef: "builtin:slack@1",
+    });
+    const grant = {
+      customConnectorId: connector.id,
+      permissionNames: ["chat:write"],
+    };
+    await connectorsApi.requestUpdateAgentCustomConnectorGrants(
+      admin,
+      agent.agentId,
+      [grant],
+      [200],
+    );
+
+    const saved = await connectorsApi.saveCustomConnectorProposal(admin, {
+      proposal: {
+        operation: "update",
+        connectorId: connector.id,
+        displayName: connector.displayName,
+        prefixTemplates: connector.prefixTemplates,
+        fields: connector.fields,
+        headerInjections: connector.headerInjections,
+        queryInjections: connector.queryInjections,
+      },
+      values: [{ key: "api_key", kind: "secret", value: "proposal-secret" }],
+      agentId: agent.agentId,
+    });
+
+    expect(saved.authorizedAgentId).toBe(agent.agentId);
+    await expect(
+      connectorsApi.readAgentCustomConnectorGrants(admin, agent.agentId),
+    ).resolves.toStrictEqual([grant]);
+
+    await connectorsApi.deleteCustomConnector(admin, connector.id);
     await bdd.deleteAgent(admin, agent.agentId);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -30,7 +30,7 @@ import {
 import { authContract } from "@vm0/api-contracts/contracts/auth";
 import {
   zeroAgentCustomConnectorsContract,
-  type AgentCustomConnectorEnabledIds,
+  type AgentCustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroAgentsByIdContract,
@@ -1587,7 +1587,7 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
     async readAgentCustomConnectors(
       actor: ApiTestUser,
       agentId: string,
-    ): Promise<AgentCustomConnectorEnabledIds> {
+    ): Promise<AgentCustomConnectorResponse> {
       const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
         zeroAgentCustomConnectorsContract,
       );
@@ -1604,8 +1604,8 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
     async updateAgentCustomConnectors(
       actor: ApiTestUser,
       agentId: string,
-      enabledIds: readonly string[],
-    ): Promise<AgentCustomConnectorEnabledIds> {
+      connectorIds: readonly string[],
+    ): Promise<AgentCustomConnectorResponse> {
       const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
         zeroAgentCustomConnectorsContract,
       );
@@ -1613,7 +1613,11 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
         client.update({
           headers: authenticate(actor),
           params: { id: agentId },
-          body: { enabledIds: [...enabledIds] },
+          body: {
+            grants: connectorIds.map((customConnectorId) => {
+              return { customConnectorId, permissionNames: [] };
+            }),
+          },
         }),
         [200],
       );
@@ -1623,7 +1627,7 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
     async requestUpdateAgentCustomConnectors(
       actor: ApiTestUser | null,
       agentId: string,
-      enabledIds: readonly string[],
+      connectorIds: readonly string[],
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
     ) {
       const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
@@ -1633,7 +1637,11 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
         client.update({
           headers: authenticate(actor),
           params: { id: agentId },
-          body: { enabledIds: [...enabledIds] },
+          body: {
+            grants: connectorIds.map((customConnectorId) => {
+              return { customConnectorId, permissionNames: [] };
+            }),
+          },
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -2187,7 +2187,9 @@ export function createConnectorBddApi(context: TestContext) {
         [200],
       );
       expectStatus(response, 200);
-      return response.body.enabledIds;
+      return response.body.grants.map((grant) => {
+        return grant.customConnectorId;
+      });
     },
 
     async readAgentCustomConnectorGrants(
@@ -2200,10 +2202,43 @@ export function createConnectorBddApi(context: TestContext) {
         [200],
       );
       expectStatus(response, 200);
-      return response.body.grants ?? [];
+      return response.body.grants;
     },
 
     async requestUpdateAgentCustomConnectors(
+      actor: ApiTestUser | null,
+      agentId: string,
+      connectorIds: readonly string[],
+      statuses: readonly (200 | 400 | 401 | 403 | 404)[],
+      operation?: "replace" | "add" | "remove",
+    ) {
+      const client = setupApp({ context, routes: zeroAgentsRoutes })(
+        zeroAgentCustomConnectorsContract,
+      );
+      const body =
+        operation === undefined
+          ? {
+              grants: connectorIds.map((customConnectorId) => {
+                return { customConnectorId, permissionNames: [] };
+              }),
+            }
+          : {
+              grants: connectorIds.map((customConnectorId) => {
+                return { customConnectorId, permissionNames: [] };
+              }),
+              operation,
+            };
+      return await accept(
+        client.update({
+          params: { id: agentId },
+          headers: authenticate(actor),
+          body,
+        }),
+        statuses,
+      );
+    },
+
+    async requestLegacyAgentCustomConnectorIdsUpdate(
       actor: ApiTestUser | null,
       agentId: string,
       enabledIds: readonly string[],
@@ -2230,18 +2265,20 @@ export function createConnectorBddApi(context: TestContext) {
     async updateAgentCustomConnectors(
       actor: ApiTestUser,
       agentId: string,
-      enabledIds: readonly string[],
+      connectorIds: readonly string[],
       operation?: "replace" | "add" | "remove",
     ): Promise<readonly string[]> {
       const response = await api.requestUpdateAgentCustomConnectors(
         actor,
         agentId,
-        enabledIds,
+        connectorIds,
         [200],
         operation,
       );
       expectStatus(response, 200);
-      return response.body.enabledIds;
+      return response.body.grants.map((grant) => {
+        return grant.customConnectorId;
+      });
     },
 
     async requestUpdateAgentCustomConnectorGrants(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -2,10 +2,12 @@ import { randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
+import { mockEnv } from "../../../lib/env";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
@@ -321,12 +323,13 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
       "permission-required",
     );
 
-    const response = await connectors.requestUpdateAgentCustomConnectors(
-      actor,
-      agent.agentId,
-      [connector.id],
-      [400],
-    );
+    const response =
+      await connectors.requestLegacyAgentCustomConnectorIdsUpdate(
+        actor,
+        agent.agentId,
+        [connector.id],
+        [400],
+      );
 
     expect(response.body).toStrictEqual({
       error: {
@@ -386,6 +389,132 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     ).resolves.toStrictEqual([grant]);
   });
 
+  it("replaces an existing permission selection with an explicit empty grant", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, {
+      displayName: "Empty Permission Agent",
+    });
+    const connector = await createPermissionedCustomConnector(
+      actor,
+      "empty-permission-selection",
+    );
+
+    await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agent.agentId,
+      [
+        {
+          customConnectorId: connector.id,
+          permissionNames: ["chat:write"],
+        },
+      ],
+      [200],
+    );
+    const emptied = await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agent.agentId,
+      [{ customConnectorId: connector.id, permissionNames: [] }],
+      [200],
+      "add",
+    );
+
+    expect(emptied.body).toStrictEqual({
+      enabledIds: [connector.id],
+      grants: [{ customConnectorId: connector.id, permissionNames: [] }],
+    });
+  });
+
+  it("preserves existing permissions for a legacy idempotent add", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, {
+      displayName: "Legacy Permission Agent",
+    });
+    const connector = await createPermissionedCustomConnector(
+      actor,
+      "legacy-permission-preservation",
+    );
+    const grant = {
+      customConnectorId: connector.id,
+      permissionNames: ["chat:write"],
+    };
+    await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agent.agentId,
+      [grant],
+      [200],
+    );
+
+    const repeated =
+      await connectors.requestLegacyAgentCustomConnectorIdsUpdate(
+        actor,
+        agent.agentId,
+        [connector.id],
+        [200],
+        "add",
+      );
+
+    expect(repeated.body).toStrictEqual({
+      enabledIds: [connector.id],
+      grants: [grant],
+    });
+  });
+
+  it("writes empty HTTP and MCP grants without accepted catalog state", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, {
+      displayName: "Catalog Independent Agent",
+    });
+    const httpConnector = await createUnconfiguredCustomConnector(
+      actor,
+      "catalog-independent-http",
+    );
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const mcpConnector = await connectors.createCustomConnector(actor, {
+      kind: "mcp",
+      displayName: "Catalog Independent MCP",
+      endpoint: "https://catalog-independent-mcp.example.test/server",
+      transport: "streamable-http",
+      fields: [
+        {
+          key: "secret",
+          label: "API token",
+          kind: "secret",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.secret}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+    });
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `missing-connector-catalog-${randomUUID()}`,
+    );
+    const grants = [
+      { customConnectorId: httpConnector.id, permissionNames: [] },
+      { customConnectorId: mcpConnector.id, permissionNames: [] },
+    ];
+
+    const response = await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agent.agentId,
+      grants,
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      enabledIds: [httpConnector.id, mcpConnector.id],
+      grants,
+    });
+  });
+
   it("persists disconnected custom connectors through legacy id selection", async () => {
     const actor = bdd.user();
     const agent = await createAgent(actor, { displayName: "Test Agent" });
@@ -394,12 +523,13 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
       "missing-secret",
     );
 
-    const response = await connectors.requestUpdateAgentCustomConnectors(
-      actor,
-      agent.agentId,
-      [connector.id],
-      [200],
-    );
+    const response =
+      await connectors.requestLegacyAgentCustomConnectorIdsUpdate(
+        actor,
+        agent.agentId,
+        [connector.id],
+        [200],
+      );
 
     expect(response.body).toStrictEqual({
       enabledIds: [connector.id],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -2471,6 +2471,34 @@ describe("Feishu integration", () => {
         );
       }),
     ).toBeFalsy();
+    const managedConnector = requireValue(
+      (await authOrgApi.listCustomConnectors(actor)).connectors.find(
+        (connector) => {
+          return connector.permissionBundleRef === "builtin:feishu@1";
+        },
+      ),
+      "Expected managed Feishu custom connector",
+    );
+    const agentAccessClient = setupApp({ context, routes: zeroAgentsRoutes })(
+      zeroAgentCustomConnectorsContract,
+    );
+    const selectedPermissions = ["messages:send-as-user"];
+    await accept(
+      agentAccessClient.update({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { id: defaultAgentId },
+        body: {
+          grants: [
+            {
+              customConnectorId: managedConnector.id,
+              permissionNames: selectedPermissions,
+            },
+          ],
+          operation: "add",
+        },
+      }),
+      [200],
+    );
     const retryConnectResponse = await connectApp.request(
       "/api/zero/feishu/connect",
       {
@@ -2485,6 +2513,17 @@ describe("Feishu integration", () => {
     const retryAuthorizationUrl =
       await feishuAuthorizationUrlFromResponse(retryConnectResponse);
     await completeFeishuAuthorization(retryAuthorizationUrl, "ou_feishu_user");
+    const preservedAccess = await accept(
+      agentAccessClient.get({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { id: defaultAgentId },
+      }),
+      [200],
+    );
+    expect(preservedAccess.body.grants).toContainEqual({
+      customConnectorId: managedConnector.id,
+      permissionNames: selectedPermissions,
+    });
     await flushWaitUntilForTest();
     const welcome = outboundMessages.find((message) => {
       return (

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -761,21 +761,22 @@ const updateAgentCustomConnectorsInner$ = command(
     }
 
     const writeDb = set(writeDb$);
-    const grants = "grants" in body.data ? body.data.grants : undefined;
-    const enabledIds =
-      "enabledIds" in body.data
-        ? Array.from(new Set(body.data.enabledIds))
-        : body.data.grants.map((grant) => {
-            return grant.customConnectorId;
-          });
+    const canonicalRequest = "grants" in body.data;
+    const grants = canonicalRequest
+      ? body.data.grants
+      : Array.from(new Set(body.data.enabledIds)).map((customConnectorId) => {
+          return { customConnectorId, permissionNames: [] };
+        });
     const operation = body.data.operation ?? "replace";
 
     const updated = await updateUserCustomConnectors(writeDb, {
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
-      enabledIds,
-      ...(grants !== undefined ? { grants } : {}),
+      grants,
+      permissionIntent: canonicalRequest
+        ? "exact"
+        : "preserveExistingOrDefault",
       operation,
     });
     signal.throwIfAborted();
@@ -808,7 +809,9 @@ const updateAgentCustomConnectorsInner$ = command(
     return {
       status: 200 as const,
       body: {
-        enabledIds: [...updated.enabledIds],
+        enabledIds: updated.grants.map((grant) => {
+          return grant.customConnectorId;
+        }),
         grants: [...updated.grants],
       },
     };

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -38,7 +38,6 @@ type UserConnectorUpdateOperation = "replace" | "add" | "remove";
 type UpdateUserCustomConnectorsResult =
   | {
       readonly status: "updated";
-      readonly enabledIds: readonly string[];
       readonly grants: readonly AgentCustomConnectorGrant[];
     }
   | { readonly status: "agentNotFound" }
@@ -57,6 +56,7 @@ type UpdateUserCustomConnectorsResult =
   | { readonly status: "mcpFeatureDisabled" };
 
 type UserCustomConnectorUpdateOperation = "replace" | "add" | "remove";
+type CustomConnectorPermissionIntent = "exact" | "preserveExistingOrDefault";
 type DbTransaction = Tx;
 
 interface UserCustomConnectorTransactionResult {
@@ -68,8 +68,8 @@ interface UpdateUserCustomConnectorsArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
-  readonly enabledIds: readonly string[];
-  readonly grants?: readonly AgentCustomConnectorGrant[];
+  readonly grants: readonly AgentCustomConnectorGrant[];
+  readonly permissionIntent: CustomConnectorPermissionIntent;
   readonly operation?: UserCustomConnectorUpdateOperation;
 }
 
@@ -175,10 +175,10 @@ async function lockCustomConnectorDefinitionsForGrant(
   db: Pick<Db, "select">,
   args: {
     readonly orgId: string;
-    readonly enabledIds: readonly string[];
+    readonly connectorIds: readonly string[];
   },
 ): Promise<LockedCustomConnectorDefinitions> {
-  if (args.enabledIds.length === 0) {
+  if (args.connectorIds.length === 0) {
     return {
       missingIds: [],
       mcpConnectorIds: new Set(),
@@ -186,7 +186,7 @@ async function lockCustomConnectorDefinitionsForGrant(
     };
   }
 
-  const sortedIds = [...args.enabledIds].sort();
+  const sortedIds = [...args.connectorIds].sort();
   const lockedRows: LockedCustomConnectorRow[] = [];
   for (const id of sortedIds) {
     const [locked] = await db
@@ -234,7 +234,7 @@ async function lockCustomConnectorDefinitionsForGrant(
       return row.mcpTransport === null ? [] : [row.id];
     }),
   );
-  const missingIds = args.enabledIds.filter((id) => {
+  const missingIds = args.connectorIds.filter((id) => {
     return !lockedIds.has(id);
   });
   if (missingIds.length > 0) {
@@ -347,7 +347,7 @@ export async function updateUserConnectors(
 }
 
 interface NormalizedCustomConnectorGrantRequest {
-  readonly enabledIds: readonly string[];
+  readonly grants: readonly AgentCustomConnectorGrant[];
   readonly grantByConnectorId: ReadonlyMap<string, readonly string[]>;
 }
 
@@ -366,13 +366,13 @@ type PermissionSelectionError = Extract<
 >;
 
 function normalizeCustomConnectorGrantRequest(args: {
-  readonly enabledIds: readonly string[];
-  readonly grants?: readonly AgentCustomConnectorGrant[];
+  readonly grants: readonly AgentCustomConnectorGrant[];
 }):
   | NormalizedCustomConnectorGrantRequest
   | InvalidCustomConnectorPermissionsResult {
   const grantByConnectorId = new Map<string, readonly string[]>();
-  for (const grant of args.grants ?? []) {
+  const grants: AgentCustomConnectorGrant[] = [];
+  for (const grant of args.grants) {
     if (grantByConnectorId.has(grant.customConnectorId)) {
       return {
         status: "invalidCustomConnectorPermissions",
@@ -386,17 +386,18 @@ function normalizeCustomConnectorGrantRequest(args: {
         message: `Duplicate permission names for custom connector ${grant.customConnectorId}`,
       };
     }
-    grantByConnectorId.set(grant.customConnectorId, [...uniquePermissionNames]);
+    const permissionNames = [...uniquePermissionNames];
+    grantByConnectorId.set(grant.customConnectorId, permissionNames);
+    grants.push({
+      customConnectorId: grant.customConnectorId,
+      permissionNames,
+    });
   }
-  const enabledIds =
-    args.grants !== undefined
-      ? [...grantByConnectorId.keys()]
-      : Array.from(new Set(args.enabledIds));
-  return { enabledIds, grantByConnectorId };
+  return { grants, grantByConnectorId };
 }
 
 async function validateExplicitPermissionNames(args: {
-  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly snapshot: ConnectorRuntimeSnapshot | null;
   readonly connectorId: string;
   readonly permissionNames: readonly string[];
   readonly permissionBundleRef: string | null;
@@ -407,16 +408,20 @@ async function validateExplicitPermissionNames(args: {
       readonly error: InvalidCustomConnectorPermissionsResult;
     }
 > {
+  if (args.permissionNames.length === 0) {
+    return { ok: true, permissionNames: [] };
+  }
   if (args.permissionBundleRef === null) {
-    return args.permissionNames.length === 0
-      ? { ok: true, permissionNames: [] }
-      : {
-          ok: false,
-          error: {
-            status: "invalidCustomConnectorPermissions",
-            message: `Custom connector ${args.connectorId} has no permission bundle`,
-          },
-        };
+    return {
+      ok: false,
+      error: {
+        status: "invalidCustomConnectorPermissions",
+        message: `Custom connector ${args.connectorId} has no permission bundle`,
+      },
+    };
+  }
+  if (!args.snapshot) {
+    throw new Error("Expected connector catalog snapshot");
   }
 
   const bundle = await loadCustomConnectorPermissionBundle({
@@ -448,10 +453,14 @@ async function validateExplicitPermissionNames(args: {
       };
 }
 
-async function validateCustomConnectorPermissionSelection(args: {
-  readonly enabledIds: readonly string[];
-  readonly explicitGrants: boolean;
+async function resolveCustomConnectorPermissionSelection(args: {
+  readonly connectorIds: readonly string[];
+  readonly permissionIntent: CustomConnectorPermissionIntent;
   readonly grantByConnectorId: ReadonlyMap<string, readonly string[]>;
+  readonly previousPermissionNamesByConnectorId: ReadonlyMap<
+    string,
+    readonly string[]
+  >;
   readonly permissionBundleRefs: ReadonlyMap<string, string | null>;
   readonly snapshot: ConnectorRuntimeSnapshot | null;
 }): Promise<
@@ -464,8 +473,11 @@ async function validateCustomConnectorPermissionSelection(args: {
     }
   | { readonly ok: false; readonly error: PermissionSelectionError }
 > {
-  if (!args.explicitGrants) {
-    const connectorIds = args.enabledIds.filter((connectorId) => {
+  if (args.permissionIntent === "preserveExistingOrDefault") {
+    const selectionRequiredIds = args.connectorIds.filter((connectorId) => {
+      if (args.previousPermissionNamesByConnectorId.has(connectorId)) {
+        return false;
+      }
       const permissionBundleRef =
         args.permissionBundleRefs.get(connectorId) ?? null;
       return (
@@ -473,12 +485,16 @@ async function validateCustomConnectorPermissionSelection(args: {
         permissionBundleRef !== FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF
       );
     });
-    return connectorIds.length === 0
+    return selectionRequiredIds.length === 0
       ? {
           ok: true,
           permissionNamesByConnectorId: new Map(
-            args.enabledIds.map((connectorId) => {
-              return [connectorId, []] as const;
+            args.connectorIds.map((connectorId) => {
+              return [
+                connectorId,
+                args.previousPermissionNamesByConnectorId.get(connectorId) ??
+                  [],
+              ] as const;
             }),
           ),
         }
@@ -486,16 +502,13 @@ async function validateCustomConnectorPermissionSelection(args: {
           ok: false,
           error: {
             status: "customConnectorPermissionSelectionRequired",
-            connectorIds,
+            connectorIds: selectionRequiredIds,
           },
         };
   }
-  if (!args.snapshot) {
-    throw new Error("Expected connector catalog snapshot");
-  }
 
   const permissionNamesByConnectorId = new Map<string, readonly string[]>();
-  for (const connectorId of args.enabledIds) {
+  for (const connectorId of args.connectorIds) {
     const result = await validateExplicitPermissionNames({
       snapshot: args.snapshot,
       connectorId,
@@ -516,14 +529,13 @@ async function persistUserCustomConnectorUpdate(
     readonly orgId: string;
     readonly userId: string;
     readonly agentId: string;
-    readonly enabledIds: readonly string[];
+    readonly grants: readonly AgentCustomConnectorGrant[];
     readonly operation: UserCustomConnectorUpdateOperation;
-    readonly permissionNamesByConnectorId: ReadonlyMap<
-      string,
-      readonly string[]
-    >;
   },
 ): Promise<Extract<UpdateUserCustomConnectorsResult, { status: "updated" }>> {
+  const connectorIds = args.grants.map((grant) => {
+    return grant.customConnectorId;
+  });
   const connectorScope = and(
     eq(userCustomConnectors.orgId, args.orgId),
     eq(userCustomConnectors.userId, args.userId),
@@ -531,31 +543,28 @@ async function persistUserCustomConnectorUpdate(
   );
   if (args.operation === "replace") {
     await tx.delete(userCustomConnectors).where(connectorScope);
-  } else if (args.operation === "remove" && args.enabledIds.length > 0) {
+  } else if (args.operation === "remove" && connectorIds.length > 0) {
     await tx
       .delete(userCustomConnectors)
       .where(
         and(
           connectorScope,
-          inArray(userCustomConnectors.customConnectorId, args.enabledIds),
+          inArray(userCustomConnectors.customConnectorId, connectorIds),
         ),
       );
   }
 
-  if (args.operation !== "remove" && args.enabledIds.length > 0) {
+  if (args.operation !== "remove" && args.grants.length > 0) {
     await tx
       .insert(userCustomConnectors)
       .values(
-        args.enabledIds.map((customConnectorId) => {
+        args.grants.map((grant) => {
           return {
             orgId: args.orgId,
             userId: args.userId,
             agentId: args.agentId,
-            customConnectorId,
-            permissionNames: [
-              ...(args.permissionNamesByConnectorId.get(customConnectorId) ??
-                []),
-            ],
+            customConnectorId: grant.customConnectorId,
+            permissionNames: [...grant.permissionNames],
           };
         }),
       )
@@ -575,15 +584,7 @@ async function persistUserCustomConnectorUpdate(
   if (args.operation === "replace") {
     return {
       status: "updated",
-      enabledIds: args.enabledIds,
-      grants: args.enabledIds.map((customConnectorId) => {
-        return {
-          customConnectorId,
-          permissionNames: [
-            ...(args.permissionNamesByConnectorId.get(customConnectorId) ?? []),
-          ],
-        };
-      }),
+      grants: args.grants,
     };
   }
   const rows = await tx
@@ -603,9 +604,6 @@ async function persistUserCustomConnectorUpdate(
     .orderBy(userCustomConnectors.customConnectorId);
   return {
     status: "updated",
-    enabledIds: rows.map((row) => {
-      return row.customConnectorId;
-    }),
     grants: rows.map((row) => {
       return {
         customConnectorId: row.customConnectorId,
@@ -618,7 +616,7 @@ async function persistUserCustomConnectorUpdate(
 async function persistUserCustomConnectorTransaction(args: {
   readonly tx: DbTransaction;
   readonly request: UpdateUserCustomConnectorsArgs;
-  readonly enabledIds: readonly string[];
+  readonly grants: readonly AgentCustomConnectorGrant[];
   readonly grantByConnectorId: ReadonlyMap<string, readonly string[]>;
   readonly operation: UserCustomConnectorUpdateOperation;
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot | null;
@@ -631,7 +629,10 @@ async function persistUserCustomConnectorTransaction(args: {
     return { result: { status: "agentNotFound" }, previousIds: [] };
   }
   const previousRows = await args.tx
-    .select({ customConnectorId: userCustomConnectors.customConnectorId })
+    .select({
+      customConnectorId: userCustomConnectors.customConnectorId,
+      permissionNames: userCustomConnectors.permissionNames,
+    })
     .from(userCustomConnectors)
     .where(
       and(
@@ -644,21 +645,25 @@ async function persistUserCustomConnectorTransaction(args: {
   const previousIds = previousRows.map((row) => {
     return row.customConnectorId;
   });
+  const connectorIds = args.grants.map((grant) => {
+    return grant.customConnectorId;
+  });
 
   if (args.operation === "remove") {
     return {
       result: await persistUserCustomConnectorUpdate(args.tx, {
-        ...args.request,
-        enabledIds: args.enabledIds,
+        orgId: args.request.orgId,
+        userId: args.request.userId,
+        agentId: args.request.agentId,
+        grants: args.grants,
         operation: args.operation,
-        permissionNamesByConnectorId: new Map(),
       }),
       previousIds,
     };
   }
   const definitions = await lockCustomConnectorDefinitionsForGrant(args.tx, {
     orgId: args.request.orgId,
-    enabledIds: args.enabledIds,
+    connectorIds,
   });
   if (definitions.missingIds.length > 0) {
     return {
@@ -670,7 +675,7 @@ async function persistUserCustomConnectorTransaction(args: {
     };
   }
   const previousIdSet = new Set(previousIds);
-  const addsMcpConnector = args.enabledIds.some((connectorId) => {
+  const addsMcpConnector = connectorIds.some((connectorId) => {
     return (
       !previousIdSet.has(connectorId) &&
       definitions.mcpConnectorIds.has(connectorId)
@@ -689,10 +694,15 @@ async function persistUserCustomConnectorTransaction(args: {
       };
     }
   }
-  const permissionSelection = await validateCustomConnectorPermissionSelection({
-    enabledIds: args.enabledIds,
-    explicitGrants: args.request.grants !== undefined,
+  const permissionSelection = await resolveCustomConnectorPermissionSelection({
+    connectorIds,
+    permissionIntent: args.request.permissionIntent,
     grantByConnectorId: args.grantByConnectorId,
+    previousPermissionNamesByConnectorId: new Map(
+      previousRows.map((row) => {
+        return [row.customConnectorId, row.permissionNames] as const;
+      }),
+    ),
     permissionBundleRefs: definitions.permissionBundleRefs,
     snapshot: args.connectorCatalogSnapshot,
   });
@@ -701,11 +711,20 @@ async function persistUserCustomConnectorTransaction(args: {
   }
   return {
     result: await persistUserCustomConnectorUpdate(args.tx, {
-      ...args.request,
-      enabledIds: args.enabledIds,
+      orgId: args.request.orgId,
+      userId: args.request.userId,
+      agentId: args.request.agentId,
+      grants: connectorIds.map((customConnectorId) => {
+        return {
+          customConnectorId,
+          permissionNames: [
+            ...(permissionSelection.permissionNamesByConnectorId.get(
+              customConnectorId,
+            ) ?? []),
+          ],
+        };
+      }),
       operation: args.operation,
-      permissionNamesByConnectorId:
-        permissionSelection.permissionNamesByConnectorId,
     }),
     previousIds,
   };
@@ -720,10 +739,14 @@ export async function updateUserCustomConnectors(
   if ("status" in normalized) {
     return normalized;
   }
-  const { enabledIds, grantByConnectorId } = normalized;
+  const { grants, grantByConnectorId } = normalized;
   const operation = args.operation ?? "replace";
   const connectorCatalogSnapshot =
-    args.grants !== undefined && operation !== "remove"
+    args.permissionIntent === "exact" &&
+    operation !== "remove" &&
+    grants.some((grant) => {
+      return grant.permissionNames.length > 0;
+    })
       ? await loadConnectorRuntimeSnapshot(db)
       : null;
 
@@ -731,7 +754,7 @@ export async function updateUserCustomConnectors(
     return await persistUserCustomConnectorTransaction({
       tx,
       request: args,
-      enabledIds,
+      grants,
       grantByConnectorId,
       operation,
       connectorCatalogSnapshot,
@@ -750,8 +773,12 @@ export async function updateUserCustomConnectors(
       },
       targets: [
         ...committed.previousIds,
-        ...committed.result.enabledIds,
-        ...enabledIds,
+        ...committed.result.grants.map((grant) => {
+          return grant.customConnectorId;
+        }),
+        ...grants.map((grant) => {
+          return grant.customConnectorId;
+        }),
       ].map((customConnectorId) => {
         return { kind: "custom" as const, customConnectorId };
       }),
@@ -776,7 +803,13 @@ export async function addUserCustomConnector(
       orgId: args.orgId,
       userId: args.userId,
       agentId: args.agentId,
-      enabledIds: [args.customConnectorId],
+      grants: [
+        {
+          customConnectorId: args.customConnectorId,
+          permissionNames: [],
+        },
+      ],
+      permissionIntent: "preserveExistingOrDefault",
       operation: "add",
     },
     options,

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
@@ -4,6 +4,7 @@ import type {
   CustomConnectorMcpResponse,
   CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 
 export function customConnector(
   overrides: Partial<CustomConnectorHttpResponse> = {},
@@ -90,10 +91,15 @@ export function stubCustomConnectors(
 }
 
 export function stubAgentCustomConnectors(
-  enabledIds: readonly string[],
+  grants: readonly AgentCustomConnectorGrant[],
   origin = "http://localhost:3000",
 ) {
   return http.get(`${origin}/api/zero/agents/:id/custom-connectors`, () => {
-    return HttpResponse.json({ enabledIds });
+    return HttpResponse.json({
+      enabledIds: grants.map((grant) => {
+        return grant.customConnectorId;
+      }),
+      grants,
+    });
   });
 }

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -319,7 +319,9 @@ describe("zero connector list command", () => {
         stubCustomConnectors([connector]),
         stubAgent(AGENT_UUID, "maya"),
         stubUserConnectors(AGENT_UUID, []),
-        stubAgentCustomConnectors([connector.id]),
+        stubAgentCustomConnectors([
+          { customConnectorId: connector.id, permissionNames: [] },
+        ]),
       );
 
       await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -413,7 +413,9 @@ describe("zero connector search command", () => {
         stubCustomConnectors([connector]),
         stubAgent(AGENT_UUID, "maya"),
         stubUserConnectors(AGENT_UUID, []),
-        stubAgentCustomConnectors([connector.id]),
+        stubAgentCustomConnectors([
+          { customConnectorId: connector.id, permissionNames: [] },
+        ]),
       );
 
       await searchCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/connector/agent-context.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/agent-context.ts
@@ -1,6 +1,6 @@
 import {
   getZeroAgent,
-  getZeroAgentCustomConnectors,
+  getZeroAgentCustomConnectorGrants,
   getZeroAgentUserConnectors,
 } from "../../../lib/api/domains/zero-agents";
 
@@ -38,17 +38,21 @@ export async function resolveConnectorDiscoveryAgentContext(
   const agentId = flagAgentId ?? process.env.ZERO_AGENT_ID;
   if (!agentId) return null;
 
-  const [agent, enabledConnectorSlugs, enabledCustomConnectorIds] =
+  const [agent, enabledConnectorSlugs, customConnectorGrants] =
     await Promise.all([
       getZeroAgent(agentId),
       getZeroAgentUserConnectors(agentId),
-      getZeroAgentCustomConnectors(agentId),
+      getZeroAgentCustomConnectorGrants(agentId),
     ]);
 
   return {
     agentId: agent.agentId,
     displayName: agent.displayName ?? agent.agentId,
     authorizedConnectorSlugs: new Set(enabledConnectorSlugs),
-    authorizedCustomConnectorIds: new Set(enabledCustomConnectorIds),
+    authorizedCustomConnectorIds: new Set(
+      customConnectorGrants.map((grant) => {
+        return grant.customConnectorId;
+      }),
+    ),
   };
 }

--- a/turbo/apps/cli/src/commands/zero/connector/custom/index.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import {
   getZeroAgent,
-  getZeroAgentCustomConnectors,
+  getZeroAgentCustomConnectorGrants,
 } from "../../../../lib/api/domains/zero-agents";
 import {
   getZeroCustomConnector,
@@ -36,14 +36,18 @@ async function resolveCustomAgentContext(agentId: string | undefined): Promise<{
   if (!resolvedAgentId) {
     return null;
   }
-  const [agent, enabledIds] = await Promise.all([
+  const [agent, grants] = await Promise.all([
     getZeroAgent(resolvedAgentId),
-    getZeroAgentCustomConnectors(resolvedAgentId),
+    getZeroAgentCustomConnectorGrants(resolvedAgentId),
   ]);
   return {
     agentId: agent.agentId,
     displayName: agent.displayName ?? agent.agentId,
-    authorizedIds: new Set(enabledIds),
+    authorizedIds: new Set(
+      grants.map((grant) => {
+        return grant.customConnectorId;
+      }),
+    ),
   };
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
@@ -13,7 +13,10 @@ import {
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { getClientConfig, handleError } from "../core/client-factory";
 
 export type ZeroUserPermissionGrant = UserPermissionGrantResponse;
@@ -88,13 +91,13 @@ export async function getZeroAgentUserConnectors(
   );
 }
 
-export async function getZeroAgentCustomConnectors(
+export async function getZeroAgentCustomConnectorGrants(
   id: string,
-): Promise<string[]> {
+): Promise<AgentCustomConnectorGrant[]> {
   const config = await getClientConfig();
   const client = initClient(zeroAgentCustomConnectorsContract, config);
   const result = await client.get({ params: { id } });
-  if (result.status === 200) return result.body.enabledIds;
+  if (result.status === 200) return result.body.grants;
   handleError(
     result,
     `Failed to get custom connector permissions for zero agent "${id}"`,

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -2,7 +2,10 @@ import {
   zeroTeamContract,
   type TeamComposeItem,
 } from "@vm0/api-contracts/contracts/zero-team";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { zeroComposesListContract } from "@vm0/api-contracts/contracts/zero-composes";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import {
@@ -61,7 +64,10 @@ const DEFAULT_COMPOSES_LIST: ComposeListItem[] = [
 
 let mockComposesList: ComposeListItem[] = [...DEFAULT_COMPOSES_LIST];
 const mockEnabledConnectorSlugsByAgent = new Map<string, string[]>();
-const mockEnabledCustomConnectorIdsByAgent = new Map<string, string[]>();
+const mockCustomConnectorGrantsByAgent = new Map<
+  string,
+  AgentCustomConnectorGrant[]
+>();
 
 export function setMockComposesList(composes: ComposeListItem[]): void {
   mockComposesList = composes;
@@ -73,7 +79,7 @@ export function resetMockComposesList(): void {
 
 export function resetMockUserConnectors(): void {
   mockEnabledConnectorSlugsByAgent.clear();
-  mockEnabledCustomConnectorIdsByAgent.clear();
+  mockCustomConnectorGrantsByAgent.clear();
 }
 
 function mockConnectorUpdateResponse(
@@ -87,6 +93,35 @@ function mockConnectorUpdateResponse(
   if (operation === "remove") {
     return current.filter((value) => {
       return !requested.includes(value);
+    });
+  }
+  return [...requested];
+}
+
+function mockCustomConnectorGrantUpdateResponse(
+  current: readonly AgentCustomConnectorGrant[],
+  requested: readonly AgentCustomConnectorGrant[],
+  operation: "replace" | "add" | "remove" | undefined,
+): AgentCustomConnectorGrant[] {
+  if (operation === "add") {
+    const byConnectorId = new Map(
+      current.map((grant) => {
+        return [grant.customConnectorId, grant] as const;
+      }),
+    );
+    for (const grant of requested) {
+      byConnectorId.set(grant.customConnectorId, grant);
+    }
+    return [...byConnectorId.values()];
+  }
+  if (operation === "remove") {
+    const removedIds = new Set(
+      requested.map((grant) => {
+        return grant.customConnectorId;
+      }),
+    );
+    return current.filter((grant) => {
+      return !removedIds.has(grant.customConnectorId);
     });
   }
   return [...requested];
@@ -114,8 +149,12 @@ export const apiAgentsHandlers = [
 
   // GET /api/zero/agents/:id/custom-connectors
   mockApi(zeroAgentCustomConnectorsContract.get, ({ params, respond }) => {
+    const grants = mockCustomConnectorGrantsByAgent.get(params.id) ?? [];
     return respond(200, {
-      enabledIds: mockEnabledCustomConnectorIdsByAgent.get(params.id) ?? [],
+      enabledIds: grants.map((grant) => {
+        return grant.customConnectorId;
+      }),
+      grants,
     });
   }),
 
@@ -136,19 +175,29 @@ export const apiAgentsHandlers = [
   mockApi(
     zeroAgentCustomConnectorsContract.update,
     ({ body, params, respond }) => {
-      const requestedIds =
-        "enabledIds" in body
-          ? body.enabledIds
-          : body.grants.map((grant) => {
-              return grant.customConnectorId;
+      const current = mockCustomConnectorGrantsByAgent.get(params.id) ?? [];
+      const requestedGrants =
+        "grants" in body
+          ? body.grants
+          : body.enabledIds.map((customConnectorId) => {
+              return (
+                current.find((grant) => {
+                  return grant.customConnectorId === customConnectorId;
+                }) ?? { customConnectorId, permissionNames: [] }
+              );
             });
-      const enabledIds = mockConnectorUpdateResponse(
-        mockEnabledCustomConnectorIdsByAgent.get(params.id) ?? [],
-        requestedIds,
+      const grants = mockCustomConnectorGrantUpdateResponse(
+        current,
+        requestedGrants,
         body.operation,
       );
-      mockEnabledCustomConnectorIdsByAgent.set(params.id, enabledIds);
-      return respond(200, { enabledIds });
+      mockCustomConnectorGrantsByAgent.set(params.id, grants);
+      return respond(200, {
+        enabledIds: grants.map((grant) => {
+          return grant.customConnectorId;
+        }),
+        grants,
+      });
     },
   ),
 

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -364,15 +364,24 @@ function createCustomConnectorSignals(
       return;
     }
     if (connector.connected) {
-      await set(
-        setCustomConnectorAgentAuthorization$,
-        {
-          agentId: descriptor.agentId,
-          connectorId: connector.id,
-          authorized: true,
-        },
-        signal,
-      );
+      const alreadyAuthorized = await get(authorized$);
+      signal.throwIfAborted();
+      const authorized =
+        alreadyAuthorized ||
+        (await set(
+          setCustomConnectorAgentAuthorization$,
+          {
+            agentId: descriptor.agentId,
+            connectorId: connector.id,
+            permissionBundleRef: connector.permissionBundleRef ?? null,
+            authorized: true,
+          },
+          signal,
+        ));
+      signal.throwIfAborted();
+      if (!authorized) {
+        return;
+      }
       await set(runConnectorActionCallback$, descriptor, signal);
       return;
     }

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
@@ -2,7 +2,6 @@ import { command, computed, state } from "ccstate";
 import {
   zeroAgentCustomConnectorsContract,
   type AgentCustomConnectorGrant,
-  type AgentCustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { zeroClient$ } from "../../api-client.ts";
 import { withCleanup } from "../../utils.ts";
@@ -26,36 +25,38 @@ const reloadAgentCustomConnectors$ = command(({ set }) => {
   });
 });
 
-const seededCustomConnectorAccess$ = computed(
-  async (get): Promise<AgentCustomConnectorResponse> => {
+const seededCustomConnectorGrants$ = computed(
+  async (get): Promise<readonly AgentCustomConnectorGrant[]> => {
     get(internalReload$);
     get(customConnectorAuthorizationReloadVersion$);
     const detail = await get(agentDetail$);
     if (!detail?.agentId) {
-      return { enabledIds: [], grants: [] };
+      return [];
     }
     const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
     const result = await accept(
       client.get({ params: { id: detail.agentId } }),
       [200],
     );
-    return result.body;
+    return result.body.grants;
   },
 );
 
-const seededCustomConnectors$ = computed(async (get): Promise<string[]> => {
-  return (await get(seededCustomConnectorAccess$)).enabledIds;
+const seededCustomConnectorIds$ = computed(async (get): Promise<string[]> => {
+  return (await get(seededCustomConnectorGrants$)).map((grant) => {
+    return grant.customConnectorId;
+  });
 });
 
 export const agentCustomConnectorGrants$ = computed(
   async (get): Promise<readonly AgentCustomConnectorGrant[]> => {
-    return (await get(seededCustomConnectorAccess$)).grants ?? [];
+    return await get(seededCustomConnectorGrants$);
   },
 );
 
 type CustomConnectorsDraft = {
   readonly agentId: string;
-  readonly enabledIds: readonly string[];
+  readonly connectorIds: readonly string[];
 };
 
 const internalAdded$ = state<CustomConnectorsDraft | null>(null);
@@ -69,9 +70,9 @@ export const agentAddedCustomConnectors$ = computed(
     }
     const local = get(internalAdded$);
     if (local?.agentId === detail.agentId) {
-      return [...local.enabledIds];
+      return [...local.connectorIds];
     }
-    return await get(seededCustomConnectors$);
+    return await get(seededCustomConnectorIds$);
   },
 );
 
@@ -96,10 +97,10 @@ const setAgentCustomConnectorDraft$ = command(
     const current = get(internalAdded$);
     const base =
       current?.agentId === detail.agentId
-        ? current.enabledIds
-        : await get(seededCustomConnectors$);
+        ? current.connectorIds
+        : await get(seededCustomConnectorIds$);
     signal.throwIfAborted();
-    const enabledIds =
+    const connectorIds =
       args.operation === "add"
         ? Array.from(new Set([...base, args.id]))
         : base.filter((s) => {
@@ -107,7 +108,7 @@ const setAgentCustomConnectorDraft$ = command(
           });
     set(internalAdded$, {
       agentId: detail.agentId,
-      enabledIds,
+      connectorIds,
     });
   },
 );
@@ -155,7 +156,10 @@ const saveAgentCustomConnectors$ = command(
         await accept(
           client.update({
             params: { id: detail.agentId },
-            body: { enabledIds: [id], operation },
+            body: {
+              grants: [{ customConnectorId: id, permissionNames: [] }],
+              operation,
+            },
             fetchOptions: { signal },
           }),
           [200],

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -255,15 +255,19 @@ const isCustomConnectorAuthorizedForTarget$ = command(
     if (args.target.kind === "visible-agents") {
       return false;
     }
-    const agentId = args.target.agentId;
-    const authorizedAgentsByConnectorId = await get(
-      customConnectorAuthorizedAgentsById$,
+    const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
+    const result = await accept(
+      client.get({
+        params: { id: args.target.agentId },
+        fetchOptions: { signal },
+      }),
+      [200, 404],
     );
-    signal.throwIfAborted();
-    return (authorizedAgentsByConnectorId.get(args.connectorId) ?? []).some(
-      (agent) => {
-        return agent.id === agentId;
-      },
+    return (
+      result.status === 200 &&
+      result.body.grants.some((grant) => {
+        return grant.customConnectorId === args.connectorId;
+      })
     );
   },
 );
@@ -492,25 +496,8 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
     }
     authWindow.opener = null;
     let navigated = false;
-    const targetAlreadyAuthorized = await withCleanup(
+    await withCleanup(
       (async () => {
-        const connectorBeforeConnection = (await get(customConnectors$)).find(
-          (candidate) => {
-            return candidate.id === args.id;
-          },
-        );
-        signal.throwIfAborted();
-        const authorized = connectorBeforeConnection?.permissionBundleRef
-          ? await set(
-              isCustomConnectorAuthorizedForTarget$,
-              {
-                connectorId: connectorBeforeConnection.id,
-                target: args.authorizationTarget,
-              },
-              signal,
-            )
-          : false;
-        signal.throwIfAborted();
         const createClient = get(zeroClient$);
         const client = createClient(zeroCustomConnectorOAuth2Contract, {
           apiBase: "api",
@@ -526,7 +513,6 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
         signal.throwIfAborted();
         authWindow.location.href = result.body.authorizationUrl;
         navigated = true;
-        return authorized;
       })(),
       () => {
         if (!navigated) {
@@ -549,21 +535,29 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
     const connector = connectors.find((candidate) => {
       return candidate.id === args.id;
     });
-    if (connector?.connected && !connector.permissionBundleRef) {
-      await set(
-        authorizeCustomConnectorForTarget$,
-        {
-          connectorId: args.id,
-          target: args.authorizationTarget,
-        },
-        signal,
-      );
+    let targetAuthorized = false;
+    if (connector?.connected) {
+      if (!connector.permissionBundleRef) {
+        await set(
+          authorizeCustomConnectorForTarget$,
+          {
+            connectorId: args.id,
+            target: args.authorizationTarget,
+          },
+          signal,
+        );
+        targetAuthorized = true;
+      } else {
+        targetAuthorized = await set(
+          isCustomConnectorAuthorizedForTarget$,
+          { connectorId: connector.id, target: args.authorizationTarget },
+          signal,
+        );
+      }
     }
     return {
       connected: connector?.connected ?? false,
-      targetAuthorized:
-        connector?.connected === true &&
-        (!connector.permissionBundleRef || targetAlreadyAuthorized),
+      targetAuthorized,
     };
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -263,6 +263,7 @@ const isCustomConnectorAuthorizedForTarget$ = command(
       }),
       [200, 404],
     );
+    signal.throwIfAborted();
     return (
       result.status === 200 &&
       result.body.grants.some((grant) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/custom-connectors.ts
@@ -110,10 +110,11 @@ export const customConnectorAuthorizedAgentsById$ = computed(
     const rows = await get(customConnectorAgentAuthorizations$);
     const agentsByConnectorId = new Map<string, TeamComposeItem[]>();
     for (const row of rows) {
-      for (const connectorId of row.access.enabledIds) {
-        const authorizedAgents = agentsByConnectorId.get(connectorId) ?? [];
+      for (const grant of row.access.grants) {
+        const authorizedAgents =
+          agentsByConnectorId.get(grant.customConnectorId) ?? [];
         authorizedAgents.push(row.agent);
-        agentsByConnectorId.set(connectorId, authorizedAgents);
+        agentsByConnectorId.set(grant.customConnectorId, authorizedAgents);
       }
     }
     return agentsByConnectorId;
@@ -132,17 +133,26 @@ export const setCustomConnectorAgentAuthorization$ = command(
     args: {
       readonly agentId: string;
       readonly connectorId: string;
+      readonly permissionBundleRef: string | null;
       readonly authorized: boolean;
     },
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
+    if (args.authorized && args.permissionBundleRef) {
+      return false;
+    }
     const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
     await withCleanup(
       accept(
         client.update({
           params: { id: args.agentId },
           body: {
-            enabledIds: [args.connectorId],
+            grants: [
+              {
+                customConnectorId: args.connectorId,
+                permissionNames: [],
+              },
+            ],
             operation: args.authorized ? "add" : "remove",
           },
           fetchOptions: { signal },
@@ -154,6 +164,7 @@ export const setCustomConnectorAgentAuthorization$ = command(
       },
     );
     signal.throwIfAborted();
+    return true;
   },
 );
 
@@ -209,7 +220,15 @@ const authorizeCustomConnectorForTarget$ = command(
           await accept(
             client.update({
               params: { id: agentId },
-              body: { enabledIds: [args.connectorId], operation: "add" },
+              body: {
+                grants: [
+                  {
+                    customConnectorId: args.connectorId,
+                    permissionNames: [],
+                  },
+                ],
+                operation: "add",
+              },
               fetchOptions: { signal },
             }),
             args.target.kind === "agent" ? [200] : [200, 404],
@@ -224,18 +243,15 @@ const authorizeCustomConnectorForTarget$ = command(
   },
 );
 
-const shouldWriteLegacyAuthorizationAfterConnection$ = command(
+const isCustomConnectorAuthorizedForTarget$ = command(
   async (
     { get },
     args: {
-      readonly connector: CustomConnectorClientResponse;
+      readonly connectorId: string;
       readonly target: CustomConnectorAuthorizationTarget;
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
-    if (!args.connector.permissionBundleRef) {
-      return true;
-    }
     if (args.target.kind === "visible-agents") {
       return false;
     }
@@ -244,13 +260,18 @@ const shouldWriteLegacyAuthorizationAfterConnection$ = command(
       customConnectorAuthorizedAgentsById$,
     );
     signal.throwIfAborted();
-    return !(authorizedAgentsByConnectorId.get(args.connector.id) ?? []).some(
+    return (authorizedAgentsByConnectorId.get(args.connectorId) ?? []).some(
       (agent) => {
         return agent.id === agentId;
       },
     );
   },
 );
+
+interface CustomConnectorConnectionResult {
+  readonly connected: boolean;
+  readonly targetAuthorized: boolean;
+}
 
 export const createCustomConnector$ = command(
   async (
@@ -344,7 +365,7 @@ const setCustomConnectorValuesForTarget$ = command(
       readonly authorizationTarget: CustomConnectorAuthorizationTarget;
     },
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<CustomConnectorConnectionResult> => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroCustomConnectorValuesContract);
     const result = await accept(
@@ -359,23 +380,25 @@ const setCustomConnectorValuesForTarget$ = command(
     const connector = customConnectorClientResponseSchema.parse(result.body);
     set(bumpReload$);
     if (!connector.connected) {
-      return false;
+      return { connected: false, targetAuthorized: false };
     }
-    const writeLegacyAuthorization = await set(
-      shouldWriteLegacyAuthorizationAfterConnection$,
-      { connector, target: args.authorizationTarget },
-      signal,
-    );
-    signal.throwIfAborted();
-    if (writeLegacyAuthorization) {
+    let targetAuthorized: boolean;
+    if (connector.permissionBundleRef) {
+      targetAuthorized = await set(
+        isCustomConnectorAuthorizedForTarget$,
+        { connectorId: connector.id, target: args.authorizationTarget },
+        signal,
+      );
+    } else {
       await set(
         authorizeCustomConnectorForTarget$,
         {
-          connectorId: args.id,
+          connectorId: connector.id,
           target: args.authorizationTarget,
         },
         signal,
       );
+      targetAuthorized = true;
     }
     signal.throwIfAborted();
     toast.success(
@@ -383,7 +406,7 @@ const setCustomConnectorValuesForTarget$ = command(
         return $.connectors.custom.toasts.connected;
       }),
     );
-    return true;
+    return { connected: true, targetAuthorized };
   },
 );
 
@@ -395,7 +418,7 @@ export const setCustomConnectorValues$ = command(
       readonly values: readonly CustomConnectorValueInput[];
     },
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<CustomConnectorConnectionResult> => {
     return await set(
       setCustomConnectorValuesForTarget$,
       {
@@ -416,7 +439,7 @@ export const setCustomConnectorValuesForAgent$ = command(
       readonly agentId: string;
     },
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<CustomConnectorConnectionResult> => {
     return await set(
       setCustomConnectorValuesForTarget$,
       {
@@ -458,7 +481,7 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
       readonly authorizationTarget: CustomConnectorAuthorizationTarget;
     },
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<CustomConnectorConnectionResult> => {
     const authWindow = window.open(
       "about:blank",
       "_blank",
@@ -469,8 +492,25 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
     }
     authWindow.opener = null;
     let navigated = false;
-    await withCleanup(
+    const targetAlreadyAuthorized = await withCleanup(
       (async () => {
+        const connectorBeforeConnection = (await get(customConnectors$)).find(
+          (candidate) => {
+            return candidate.id === args.id;
+          },
+        );
+        signal.throwIfAborted();
+        const authorized = connectorBeforeConnection?.permissionBundleRef
+          ? await set(
+              isCustomConnectorAuthorizedForTarget$,
+              {
+                connectorId: connectorBeforeConnection.id,
+                target: args.authorizationTarget,
+              },
+              signal,
+            )
+          : false;
+        signal.throwIfAborted();
         const createClient = get(zeroClient$);
         const client = createClient(zeroCustomConnectorOAuth2Contract, {
           apiBase: "api",
@@ -486,6 +526,7 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
         signal.throwIfAborted();
         authWindow.location.href = result.body.authorizationUrl;
         navigated = true;
+        return authorized;
       })(),
       () => {
         if (!navigated) {
@@ -508,15 +549,7 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
     const connector = connectors.find((candidate) => {
       return candidate.id === args.id;
     });
-    const writeLegacyAuthorization = connector
-      ? await set(
-          shouldWriteLegacyAuthorizationAfterConnection$,
-          { connector, target: args.authorizationTarget },
-          signal,
-        )
-      : false;
-    signal.throwIfAborted();
-    if (connector?.connected && writeLegacyAuthorization) {
+    if (connector?.connected && !connector.permissionBundleRef) {
       await set(
         authorizeCustomConnectorForTarget$,
         {
@@ -526,12 +559,21 @@ const connectCustomConnectorOAuth2ForTarget$ = command(
         signal,
       );
     }
-    return connector?.connected ?? false;
+    return {
+      connected: connector?.connected ?? false,
+      targetAuthorized:
+        connector?.connected === true &&
+        (!connector.permissionBundleRef || targetAlreadyAuthorized),
+    };
   },
 );
 
 export const connectCustomConnectorOAuth2$ = command(
-  async ({ set }, id: string, signal: AbortSignal): Promise<boolean> => {
+  async (
+    { set },
+    id: string,
+    signal: AbortSignal,
+  ): Promise<CustomConnectorConnectionResult> => {
     return await set(
       connectCustomConnectorOAuth2ForTarget$,
       {
@@ -548,7 +590,7 @@ export const connectCustomConnectorOAuth2ForAgent$ = command(
     { set },
     args: { readonly id: string; readonly agentId: string },
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<CustomConnectorConnectionResult> => {
     return await set(
       connectCustomConnectorOAuth2ForTarget$,
       {

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -1,7 +1,10 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
@@ -26,7 +29,7 @@ import {
 export interface ComposerConnectorAuthorizationState {
   readonly agentId: string;
   readonly enabledConnectorSlugs: readonly ConnectorSlug[];
-  readonly enabledCustomConnectorIds: readonly string[];
+  readonly customConnectorGrants: readonly AgentCustomConnectorGrant[];
 }
 
 export type ComposerConnectorAuthorizationTarget =
@@ -37,6 +40,7 @@ export type ComposerConnectorAuthorizationTarget =
   | {
       readonly kind: "custom";
       readonly connectorId: string;
+      readonly permissionBundleRef: string | null;
     };
 
 export interface ComposerConnectorUiState {
@@ -96,12 +100,12 @@ interface AgentCustomConnectorAuthorizationRequestBroker {
     readonly createClient: ZeroClientFactory;
     readonly agentId: string;
     readonly reloadGeneration: number;
-  }): Promise<readonly string[]>;
+  }): Promise<readonly AgentCustomConnectorGrant[]>;
 }
 
 interface ResolvedAgentCustomConnectorAuthorizationRequest {
   readonly key: string;
-  readonly value: readonly string[];
+  readonly value: readonly AgentCustomConnectorGrant[];
 }
 
 function agentCustomConnectorAuthorizationRequestKey(params: {
@@ -114,7 +118,7 @@ function agentCustomConnectorAuthorizationRequestKey(params: {
 function createAgentCustomConnectorAuthorizationRequestBroker(): AgentCustomConnectorAuthorizationRequestBroker {
   const pendingRequestsByClient = new WeakMap<
     ZeroClientFactory,
-    Map<string, Promise<readonly string[]>>
+    Map<string, Promise<readonly AgentCustomConnectorGrant[]>>
   >();
   const latestRequestedKeyByClient = new WeakMap<ZeroClientFactory, string>();
   const latestResolvedByClient = new WeakMap<
@@ -140,13 +144,13 @@ function createAgentCustomConnectorAuthorizationRequestBroker(): AgentCustomConn
         return pendingRequest;
       }
 
-      const load = async (): Promise<readonly string[]> => {
+      const load = async (): Promise<readonly AgentCustomConnectorGrant[]> => {
         const client = params.createClient(zeroAgentCustomConnectorsContract);
         const result = await accept(
           client.get({ params: { id: params.agentId } }),
           [200],
         );
-        const value = result.body.enabledIds;
+        const value = result.body.grants;
         if (latestRequestedKeyByClient.get(params.createClient) === key) {
           latestResolvedByClient.set(params.createClient, { key, value });
         }
@@ -197,14 +201,14 @@ function createConnectorAuthorizationSignal(
   });
 
   return computed(async (get): Promise<ComposerConnectorAuthorizationState> => {
-    const [authorizations, enabledCustomConnectorIds] = await Promise.all([
+    const [authorizations, customConnectorGrants] = await Promise.all([
       get(authorizations$),
       get(customAuthorizations$),
     ]);
     return {
       agentId: authorizations.agentId,
       enabledConnectorSlugs: authorizations.enabledConnectorSlugs,
-      enabledCustomConnectorIds,
+      customConnectorGrants,
     };
   });
 }
@@ -261,7 +265,12 @@ function createCustomConnectorAuthorizationCommand(
           client.update({
             params: { id: agentId },
             body: {
-              enabledIds: [connectorId],
+              grants: [
+                {
+                  customConnectorId: connectorId,
+                  permissionNames: [],
+                },
+              ],
               operation: authorized ? "add" : "remove",
             },
             fetchOptions: { signal },
@@ -297,6 +306,9 @@ function createConnectorAuthorizationCommand(
           authorized,
           signal,
         );
+        return;
+      }
+      if (authorized && target.permissionBundleRef) {
         return;
       }
       await set(

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -15,6 +15,7 @@ import {
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import {
   zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
   type AgentCustomConnectorUpdate,
 } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
@@ -85,24 +86,41 @@ function applyUserConnectorUpdate(
 }
 
 function applyCustomConnectorUpdate(
-  current: readonly string[],
+  current: readonly AgentCustomConnectorGrant[],
   body: AgentCustomConnectorUpdate,
-): string[] {
-  const enabledIds =
-    "enabledIds" in body
-      ? body.enabledIds
-      : body.grants.map((grant) => {
-          return grant.customConnectorId;
+): AgentCustomConnectorGrant[] {
+  const requested =
+    "grants" in body
+      ? body.grants
+      : body.enabledIds.map((customConnectorId) => {
+          return (
+            current.find((grant) => {
+              return grant.customConnectorId === customConnectorId;
+            }) ?? { customConnectorId, permissionNames: [] }
+          );
         });
   if (body.operation === "add") {
-    return Array.from(new Set([...current, ...enabledIds]));
+    const byConnectorId = new Map(
+      current.map((grant) => {
+        return [grant.customConnectorId, grant] as const;
+      }),
+    );
+    for (const grant of requested) {
+      byConnectorId.set(grant.customConnectorId, grant);
+    }
+    return [...byConnectorId.values()];
   }
   if (body.operation === "remove") {
-    return current.filter((id) => {
-      return !enabledIds.includes(id);
+    const removedIds = new Set(
+      requested.map((grant) => {
+        return grant.customConnectorId;
+      }),
+    );
+    return current.filter((grant) => {
+      return !removedIds.has(grant.customConnectorId);
     });
   }
-  return [...enabledIds];
+  return [...requested];
 }
 
 function createAgent(id: string, displayName: string): TeamComposeItem {
@@ -390,7 +408,10 @@ function mockTeamAPIs({
     createConnector("slack", "ops"),
   ]);
   const enabledConnectorSlugsByAgent = new Map<string, string[]>();
-  const enabledCustomConnectorIdsByAgent = new Map<string, string[]>();
+  const customConnectorGrantsByAgent = new Map<
+    string,
+    AgentCustomConnectorGrant[]
+  >();
   context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
     return respond(200, {
       enabledConnectorSlugs: enabledConnectorSlugsByAgent.get(params.id) ?? [],
@@ -413,8 +434,12 @@ function mockTeamAPIs({
   context.mocks.api(
     zeroAgentCustomConnectorsContract.get,
     ({ params, respond }) => {
+      const grants = customConnectorGrantsByAgent.get(params.id) ?? [];
       return respond(200, {
-        enabledIds: enabledCustomConnectorIdsByAgent.get(params.id) ?? [],
+        enabledIds: grants.map((grant) => {
+          return grant.customConnectorId;
+        }),
+        grants,
       });
     },
   );
@@ -422,15 +447,17 @@ function mockTeamAPIs({
     zeroAgentCustomConnectorsContract.update,
     ({ body, params, respond }) => {
       onCustomConnectorUpdate?.();
-      const enabledCustomConnectorIds = applyCustomConnectorUpdate(
-        enabledCustomConnectorIdsByAgent.get(params.id) ?? [],
+      const grants = applyCustomConnectorUpdate(
+        customConnectorGrantsByAgent.get(params.id) ?? [],
         body,
       );
-      enabledCustomConnectorIdsByAgent.set(
-        params.id,
-        enabledCustomConnectorIds,
-      );
-      return respond(200, { enabledIds: enabledCustomConnectorIds });
+      customConnectorGrantsByAgent.set(params.id, grants);
+      return respond(200, {
+        enabledIds: grants.map((grant) => {
+          return grant.customConnectorId;
+        }),
+        grants,
+      });
     },
   );
   context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -9,7 +9,10 @@ import {
   zeroCustomConnectorsContract,
   type CustomConnectorHttpResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import {
   zeroConnectorNoAuthGrantContract,
@@ -204,12 +207,12 @@ describe("chat composer connector connection", () => {
     context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
       return respond(200, { connectors: [connector] });
     });
-    let enabledIds: string[] = [];
+    let grants: AgentCustomConnectorGrant[] = [];
     context.mocks.api(
       zeroAgentCustomConnectorsContract.get,
       ({ params, respond }) => {
         expect(params.id).toBe(AGENT_ID);
-        return respond(200, { enabledIds });
+        return respond(200, { enabledIds: [], grants });
       },
     );
     let updateCount = 0;
@@ -219,11 +222,11 @@ describe("chat composer connector connection", () => {
         updateCount += 1;
         expect(params.id).toBe(AGENT_ID);
         expect(body).toStrictEqual({
-          enabledIds: [connector.id],
+          grants: [{ customConnectorId: connector.id, permissionNames: [] }],
           operation: "add",
         });
-        enabledIds = [connector.id];
-        return respond(200, { enabledIds });
+        grants = [{ customConnectorId: connector.id, permissionNames: [] }];
+        return respond(200, { enabledIds: [connector.id], grants });
       },
     );
 
@@ -241,6 +244,47 @@ describe("chat composer connector connection", () => {
     await waitFor(() => {
       expect(updateCount).toBe(1);
       expect(screen.getByLabelText("Remove Acme Search")).toBeInTheDocument();
+    });
+  });
+
+  it("does not create an empty grant for a permissioned custom connector", async () => {
+    const user = userEvent.setup({ delay: null });
+    const connector = customConnector({
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      hasSecret: true,
+      permissionBundleRef: "builtin:feishu@1",
+    });
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledIds: [], grants: [] });
+    });
+    let updateCount = 0;
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ respond }) => {
+        updateCount += 1;
+        return respond(200, { enabledIds: [], grants: [] });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    await user.click(within(composer).getByLabelText("Connectors"));
+    await user.click(await screen.findByLabelText("Add Acme Search"));
+
+    await waitFor(() => {
+      expect(updateCount).toBe(0);
+      expect(screen.getByLabelText("Add Acme Search")).toBeInTheDocument();
     });
   });
 
@@ -291,11 +335,14 @@ describe("chat composer connector connection", () => {
       zeroAgentCustomConnectorsContract.update,
       ({ body, params, respond }) => {
         expect(body).toStrictEqual({
-          enabledIds: [connector.id],
+          grants: [{ customConnectorId: connector.id, permissionNames: [] }],
           operation: "add",
         });
         updatedAgentIds.push(params.id);
-        return respond(200, { enabledIds: [connector.id] });
+        return respond(200, {
+          enabledIds: [connector.id],
+          grants: [{ customConnectorId: connector.id, permissionNames: [] }],
+        });
       },
     );
     detachedSetupPage({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -2619,7 +2619,7 @@ describe("chat composer models", () => {
       return respond(200, { enabledConnectorSlugs: ["github"] });
     });
     context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
-      return respond(200, { enabledIds: [] });
+      return respond(200, { enabledIds: [], grants: [] });
     });
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
@@ -2726,7 +2726,7 @@ describe("chat composer models", () => {
         if (customAuthorizationRequestCount > 1) {
           await withSignal(unexpectedCustomReload.promise);
         }
-        return respond(200, { enabledIds: [] });
+        return respond(200, { enabledIds: [], grants: [] });
       },
     );
     context.mocks.api(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -17,7 +17,10 @@ import {
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
@@ -2831,7 +2834,7 @@ describe("chat event action cards", () => {
   it("connects and authorizes a custom connector from its action card", async () => {
     const user = userEvent.setup({ delay: null });
     let connected = false;
-    let enabledIds: string[] = [];
+    let grants: AgentCustomConnectorGrant[] = [];
     let submittedValues: readonly {
       readonly key: string;
       readonly kind: "secret" | "variable";
@@ -2867,16 +2870,26 @@ describe("chat event action cards", () => {
       },
     );
     context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
-      return respond(200, { enabledIds });
+      return respond(200, {
+        enabledIds: grants.map((grant) => {
+          return grant.customConnectorId;
+        }),
+        grants,
+      });
     });
     context.mocks.api(
       zeroAgentCustomConnectorsContract.update,
       ({ body, respond }) => {
-        if (!("enabledIds" in body)) {
-          throw new Error("Expected custom connector ID authorization");
+        if (!("grants" in body)) {
+          throw new Error("Expected canonical custom connector grants");
         }
-        enabledIds = Array.from(new Set([...enabledIds, ...body.enabledIds]));
-        return respond(200, { enabledIds });
+        grants = body.grants;
+        return respond(200, {
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
+        });
       },
     );
 
@@ -2924,7 +2937,9 @@ describe("chat event action cards", () => {
       expect(submittedValues).toStrictEqual([
         { key: "secret", kind: "secret", value: "acme-secret" },
       ]);
-      expect(enabledIds).toStrictEqual([connector.id]);
+      expect(grants).toStrictEqual([
+        { customConnectorId: connector.id, permissionNames: [] },
+      ]);
       expect(within(card).getByText("Authorized")).toBeInTheDocument();
     });
   });
@@ -2984,7 +2999,15 @@ describe("chat event action cards", () => {
       zeroAgentCustomConnectorsContract.update,
       ({ respond }) => {
         authorizationUpdates += 1;
-        return respond(200, { enabledIds: [connector.id] });
+        return respond(200, {
+          enabledIds: [connector.id],
+          grants: [
+            {
+              customConnectorId: connector.id,
+              permissionNames: ["messages:send-as-user"],
+            },
+          ],
+        });
       },
     );
 
@@ -3029,6 +3052,85 @@ describe("chat event action cards", () => {
       expect(within(card).getByText("Authorized")).toBeInTheDocument();
     });
     expect(authorizationUpdates).toBe(0);
+  });
+
+  it("does not complete a new permissioned custom connector action without a selection", async () => {
+    const user = userEvent.setup({ delay: null });
+    let connected = false;
+    let authorizationUpdates = 0;
+    const connector = customConnector({
+      permissionBundleRef: "builtin:feishu@1",
+    });
+    const connectUrl = `${window.location.origin}/connectors/${connector.slug}/connect?agentId=${AGENT_ID}`;
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          {
+            ...connector,
+            connected,
+            hasSecret: connected,
+            missingRequiredFields: connected ? [] : ["secret"],
+            configuredFieldKeys: connected ? ["secret"] : [],
+          },
+        ],
+      });
+    });
+    context.mocks.api(zeroCustomConnectorSecretContract.set, ({ respond }) => {
+      connected = true;
+      return respond(204);
+    });
+    context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledIds: [], grants: [] });
+    });
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ respond }) => {
+        authorizationUpdates += 1;
+        return respond(200, { enabledIds: [], grants: [] });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId: "e4000000-0000-4000-a000-000000000218",
+      threadTitle: "New permissioned custom connector card",
+      chatEvents: [
+        {
+          id: "msg-user-new-permissioned-custom-connector",
+          role: "user",
+          content: "Connect the permissioned custom connector",
+          runId: "run-new-permissioned-custom-connector",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-assistant-new-permissioned-custom-connector-card",
+          role: "assistant",
+          content: connectUrl,
+          runId: "run-new-permissioned-custom-connector",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/e4000000-0000-4000-a000-000000000218",
+    });
+
+    const card = await screen.findByTestId("connector-action-card");
+    await user.click(await waitForButtonByText("Connect", card));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Connect Acme Internal API",
+    });
+    await user.type(within(dialog).getByLabelText("Secret"), "acme-secret");
+    await user.click(buttonByText("Save", dialog));
+
+    await waitFor(() => {
+      expect(connected).toBeTruthy();
+      expect(
+        screen.queryByRole("dialog", { name: "Connect Acme Internal API" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(authorizationUpdates).toBe(0);
+    expect(within(card).queryByText("Authorized")).not.toBeInTheDocument();
   });
 
   it("leaves legacy custom connector proposal links as markdown", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3075,9 +3075,15 @@ describe("chat event action cards", () => {
         ],
       });
     });
-    context.mocks.api(zeroCustomConnectorSecretContract.set, ({ respond }) => {
+    context.mocks.api(zeroCustomConnectorValuesContract.set, ({ respond }) => {
       connected = true;
-      return respond(204);
+      return respond(200, {
+        ...connector,
+        connected: true,
+        hasSecret: true,
+        missingRequiredFields: [],
+        configuredFieldKeys: ["secret"],
+      });
     });
     context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
       return respond(200, { enabledIds: [], grants: [] });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -4168,7 +4168,7 @@ describe("connectors page", () => {
       readonly agentId: string;
       readonly body: AgentCustomConnectorUpdate;
     }[] = [];
-    const enabledIdsByAgent = new Map<string, string[]>([
+    const grantsByAgentId = new Map<string, AgentCustomConnectorGrant[]>([
       [researchAgentId, []],
       [supportAgentId, []],
     ]);
@@ -4271,29 +4271,41 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroAgentCustomConnectorsContract.get,
       ({ params, respond }) => {
+        const grants = grantsByAgentId.get(params.id) ?? [];
         return respond(200, {
-          enabledIds: enabledIdsByAgent.get(params.id) ?? [],
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
         });
       },
     );
     context.mocks.api(
       zeroAgentCustomConnectorsContract.update,
       ({ params, body, respond }) => {
-        if (!("enabledIds" in body)) {
-          throw new Error("Expected custom connector ID authorization");
+        if (!("grants" in body)) {
+          throw new Error("Expected canonical custom connector grants");
         }
         authorizationUpdates.push({ agentId: params.id, body });
-        const current = enabledIdsByAgent.get(params.id) ?? [];
-        const next =
-          body.operation === "add"
-            ? Array.from(new Set([...current, ...body.enabledIds]))
-            : body.operation === "remove"
-              ? current.filter((id) => {
-                  return !body.enabledIds.includes(id);
-                })
-              : [...body.enabledIds];
-        enabledIdsByAgent.set(params.id, next);
-        return respond(200, { enabledIds: next });
+        const current = grantsByAgentId.get(params.id) ?? [];
+        const requestedIds = new Set(
+          body.grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+        );
+        const grants =
+          body.operation === "remove"
+            ? current.filter((grant) => {
+                return !requestedIds.has(grant.customConnectorId);
+              })
+            : body.grants;
+        grantsByAgentId.set(params.id, grants);
+        return respond(200, {
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
+        });
       },
     );
 
@@ -4413,7 +4425,7 @@ describe("connectors page", () => {
       authorizationUpdates.some(({ agentId, body }) => {
         return (
           agentId === supportAgentId &&
-          "enabledIds" in body &&
+          "grants" in body &&
           body.operation === "remove"
         );
       }),
@@ -4649,8 +4661,16 @@ describe("connectors page", () => {
       connected: true,
       hasSecret: true,
     });
-    const enabledIdsByAgent = new Map<string, string[]>([
-      [researchAgentId, [connector.id]],
+    const grantsByAgentId = new Map<string, AgentCustomConnectorGrant[]>([
+      [
+        researchAgentId,
+        [
+          {
+            customConnectorId: connector.id,
+            permissionNames: [],
+          },
+        ],
+      ],
       [supportAgentId, []],
     ]);
     const authorizationUpdates: AgentCustomConnectorUpdate[] = [];
@@ -4670,23 +4690,38 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroAgentCustomConnectorsContract.get,
       ({ params, respond }) => {
+        const grants = grantsByAgentId.get(params.id) ?? [];
         return respond(200, {
-          enabledIds: enabledIdsByAgent.get(params.id) ?? [],
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
         });
       },
     );
     context.mocks.api(
       zeroAgentCustomConnectorsContract.update,
       ({ params, body, respond }) => {
-        if (!("enabledIds" in body) || body.operation !== "remove") {
+        if (!("grants" in body) || body.operation !== "remove") {
           throw new Error("Expected only MCP authorization removal");
         }
         authorizationUpdates.push(body);
-        const next = (enabledIdsByAgent.get(params.id) ?? []).filter((id) => {
-          return !body.enabledIds.includes(id);
+        const requestedIds = new Set(
+          body.grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+        );
+        const current = grantsByAgentId.get(params.id) ?? [];
+        const grants = current.filter((grant) => {
+          return !requestedIds.has(grant.customConnectorId);
         });
-        enabledIdsByAgent.set(params.id, next);
-        return respond(200, { enabledIds: next });
+        grantsByAgentId.set(params.id, grants);
+        return respond(200, {
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
+        });
       },
     );
     context.mocks.api(
@@ -4749,7 +4784,12 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(authorizationUpdates).toStrictEqual([
         {
-          enabledIds: [connector.id],
+          grants: [
+            {
+              customConnectorId: connector.id,
+              permissionNames: [],
+            },
+          ],
           operation: "remove",
         },
       ]);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -4092,14 +4092,22 @@ describe("connectors page", () => {
       context.mocks.api(
         zeroAgentCustomConnectorsContract.get,
         ({ respond }) => {
-          return respond(200, { enabledIds: [] });
+          return respond(200, { enabledIds: [], grants: [] });
         },
       );
       context.mocks.api(
         zeroAgentCustomConnectorsContract.update,
         ({ respond }) => {
           authorizationUpdates += 1;
-          return respond(200, { enabledIds: [connector.id] });
+          return respond(200, {
+            enabledIds: [connector.id],
+            grants: [
+              {
+                customConnectorId: connector.id,
+                permissionNames: [],
+              },
+            ],
+          });
         },
       );
       context.mocks.api(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
   type AgentCustomConnectorResponse,
   type AgentCustomConnectorUpdate,
 } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
@@ -3590,8 +3591,15 @@ describe("connectors page", () => {
       zeroAgentCustomConnectorsContract.get,
       ({ params, respond }) => {
         agentAccessReads += 1;
+        const grants: AgentCustomConnectorGrant[] =
+          params.id === researchAgentId
+            ? [{ customConnectorId: connector.id, permissionNames: [] }]
+            : [];
         return respond(200, {
-          enabledIds: params.id === researchAgentId ? [connector.id] : [],
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
         });
       },
     );
@@ -3691,23 +3699,33 @@ describe("connectors page", () => {
         };
         let next: AgentCustomConnectorResponse;
         if ("grants" in body) {
-          next = {
-            enabledIds: body.grants.map((grant) => {
+          const requestedIds = new Set(
+            body.grants.map((grant) => {
               return grant.customConnectorId;
             }),
-            grants: body.grants,
-          };
-        } else if (body.operation === "remove") {
+          );
           next = {
-            enabledIds: current.enabledIds.filter((connectorId) => {
-              return !body.enabledIds.includes(connectorId);
-            }),
-            grants: (current.grants ?? []).filter((grant) => {
-              return !body.enabledIds.includes(grant.customConnectorId);
-            }),
+            grants:
+              body.operation === "remove"
+                ? current.grants.filter((grant) => {
+                    return !requestedIds.has(grant.customConnectorId);
+                  })
+                : body.grants,
+            enabledIds:
+              body.operation === "remove"
+                ? current.grants
+                    .filter((grant) => {
+                      return !requestedIds.has(grant.customConnectorId);
+                    })
+                    .map((grant) => {
+                      return grant.customConnectorId;
+                    })
+                : body.grants.map((grant) => {
+                    return grant.customConnectorId;
+                  }),
           };
         } else {
-          throw new Error("Expected explicit grants or direct removal");
+          throw new Error("Expected canonical custom connector grants");
         }
         accessByAgentId.set(params.id, next);
         return respond(200, next);
@@ -3818,7 +3836,7 @@ describe("connectors page", () => {
       expect(updates[2]).toStrictEqual({
         agentId: supportAgentId,
         body: {
-          enabledIds: [connector.id],
+          grants: [{ customConnectorId: connector.id, permissionNames: [] }],
           operation: "remove",
         },
       });
@@ -3881,7 +3899,15 @@ describe("connectors page", () => {
       zeroAgentCustomConnectorsContract.update,
       ({ respond }) => {
         authorizationUpdates += 1;
-        return respond(200, { enabledIds: [connector.id] });
+        return respond(200, {
+          enabledIds: [connector.id],
+          grants: [
+            {
+              customConnectorId: connector.id,
+              permissionNames: ["messages:send-as-user"],
+            },
+          ],
+        });
       },
     );
     context.mocks.api(
@@ -4807,7 +4833,10 @@ describe("connectors page", () => {
       return respond(200, { connectors: [connector] });
     });
     context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
-      return respond(200, { enabledIds: [connector.id] });
+      return respond(200, {
+        enabledIds: [connector.id],
+        grants: [{ customConnectorId: connector.id, permissionNames: [] }],
+      });
     });
 
     detachedSetupPage({
@@ -4922,7 +4951,7 @@ describe("connectors page", () => {
       },
     );
     const authWindow = createMockAuthWindow();
-    context.mocks.browser.open(authWindow);
+    const browserOpen = context.mocks.browser.open(authWindow);
     context.mocks.api(
       zeroCustomConnectorOAuth2Contract.start,
       ({ params, respond }) => {
@@ -4960,6 +4989,7 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
     expect(authorizationReads).toBe(0);
     click(connectorButton);
+    expect(browserOpen.calls).toHaveLength(1);
     expect(document.querySelector('[role="dialog"]')).not.toBeInTheDocument();
     await waitFor(() => {
       expect(authWindow.location.href).toBe(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -6,7 +6,10 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import { chatEventsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import {
+  zeroAgentCustomConnectorsContract,
+  type AgentCustomConnectorGrant,
+} from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroCustomConnectorOAuth2Contract,
   zeroCustomConnectorValuesContract,
@@ -346,7 +349,7 @@ function getButtonByText(text: string): HTMLElement {
 describe("directed connector connect page", () => {
   it("connects and authorizes a manual custom connector", async () => {
     let connected = false;
-    let enabledIds: string[] = [];
+    let grants: AgentCustomConnectorGrant[] = [];
     let submittedValues: readonly {
       readonly key: string;
       readonly kind: "secret" | "variable";
@@ -385,11 +388,16 @@ describe("directed connector connect page", () => {
       zeroAgentCustomConnectorsContract.update,
       ({ body, params, respond }) => {
         expect(params.id).toBe(AGENT_ID);
-        if (!("enabledIds" in body)) {
-          throw new Error("Expected custom connector ID authorization");
+        if (!("grants" in body)) {
+          throw new Error("Expected canonical custom connector grants");
         }
-        enabledIds = Array.from(new Set([...enabledIds, ...body.enabledIds]));
-        return respond(200, { enabledIds });
+        grants = body.grants;
+        return respond(200, {
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
+        });
       },
     );
 
@@ -411,14 +419,16 @@ describe("directed connector connect page", () => {
       expect(submittedValues).toStrictEqual([
         { key: "secret", kind: "secret", value: "acme-secret" },
       ]);
-      expect(enabledIds).toStrictEqual([connector.id]);
+      expect(grants).toStrictEqual([
+        { customConnectorId: connector.id, permissionNames: [] },
+      ]);
       expect(screen.getByText("Acme API connected")).toBeInTheDocument();
     });
   });
 
   it("starts OAuth and authorizes an OAuth custom connector", async () => {
     let connected = false;
-    let enabledIds: string[] = [];
+    let grants: AgentCustomConnectorGrant[] = [];
     const connector = customConnector({
       slug: "_acme-oauth",
       displayName: "Acme OAuth",
@@ -461,11 +471,16 @@ describe("directed connector connect page", () => {
       zeroAgentCustomConnectorsContract.update,
       ({ body, params, respond }) => {
         expect(params.id).toBe(AGENT_ID);
-        if (!("enabledIds" in body)) {
-          throw new Error("Expected custom connector ID authorization");
+        if (!("grants" in body)) {
+          throw new Error("Expected canonical custom connector grants");
         }
-        enabledIds = Array.from(new Set([...enabledIds, ...body.enabledIds]));
-        return respond(200, { enabledIds });
+        grants = body.grants;
+        return respond(200, {
+          enabledIds: grants.map((grant) => {
+            return grant.customConnectorId;
+          }),
+          grants,
+        });
       },
     );
     const authWindow = context.mocks.browser.authWindow();
@@ -491,7 +506,9 @@ describe("directed connector connect page", () => {
       expect(authWindow.location.href).toBe(
         "https://acme.test/oauth/authorize",
       );
-      expect(enabledIds).toStrictEqual([connector.id]);
+      expect(grants).toStrictEqual([
+        { customConnectorId: connector.id, permissionNames: [] },
+      ]);
       expect(screen.getByText("Acme OAuth connected")).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -513,6 +513,107 @@ describe("directed connector connect page", () => {
     });
   });
 
+  it("starts permissioned OAuth before checking the target grant", async () => {
+    let connected = false;
+    let authorizationUpdates = 0;
+    const authorizationRequested = context.mocks.deferred<void>();
+    const releaseAuthorization = context.mocks.deferred<void>();
+    const connector = customConnector({
+      slug: "_acme-permissioned-oauth",
+      displayName: "Acme Permissioned OAuth",
+      authMode: "oauth",
+      fields: [],
+      missingRequiredFields: ["oauth"],
+      permissionBundleRef: "builtin:feishu@1",
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      oauthConfig: {
+        providerAdapter: "standard",
+        clientId: "client-id",
+        authorizationUrl: "https://acme.test/oauth/authorize",
+        tokenUrl: "https://acme.test/oauth/token",
+        tokenEndpointAuthMethod: "client_secret_post",
+        pkceMethod: "S256",
+        scopes: ["read"],
+        authorizationParams: {},
+      },
+    });
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, {
+        connectors: [{ ...connector, connected, hasSecret: connected }],
+      });
+    });
+    context.mocks.api(
+      zeroCustomConnectorOAuth2Contract.start,
+      ({ params, respond }) => {
+        expect(params.id).toBe(connector.id);
+        connected = true;
+        return respond(200, {
+          authorizationUrl: "https://acme.test/oauth/authorize",
+        });
+      },
+    );
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.get,
+      async ({ params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        authorizationRequested.resolve();
+        await releaseAuthorization.promise;
+        const grants = [
+          {
+            customConnectorId: connector.id,
+            permissionNames: ["messages:send-as-user"],
+          },
+        ];
+        return respond(200, { enabledIds: [connector.id], grants });
+      },
+    );
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ respond }) => {
+        authorizationUpdates += 1;
+        return respond(200, { enabledIds: [], grants: [] });
+      },
+    );
+    const authWindow = context.mocks.browser.authWindow();
+    authWindow.closed = true;
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/${connector.slug}/connect?agentId=${AGENT_ID}`,
+    });
+
+    await screen.findByText("Zero needs Acme Permissioned OAuth to proceed");
+    click(getButtonByText("Connect"));
+    await screen.findByRole("dialog", {
+      name: "Connect Acme Permissioned OAuth",
+    });
+    click(getButtonByText("Continue"));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://acme.test/oauth/authorize",
+      );
+    });
+    await authorizationRequested.promise;
+    releaseAuthorization.resolve();
+    await waitFor(() => {
+      expect(
+        screen.getByText("Acme Permissioned OAuth connected"),
+      ).toBeInTheDocument();
+    });
+    expect(authorizationUpdates).toBe(0);
+  });
+
   it("starts an OAuth flow from a directed link", async () => {
     let startedAgentId: string | undefined;
     let authorizeAgent: true | undefined;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -552,7 +552,9 @@ function customConnectorAccessRows(
   return authorizations.map(({ agent, access }) => {
     return {
       agent,
-      authorized: access.enabledIds.includes(connectorId),
+      authorized: access.grants.some((grant) => {
+        return grant.customConnectorId === connectorId;
+      }),
       grants: [],
     };
   });
@@ -566,7 +568,7 @@ function customConnectorPermissionNamesByAgentId(
     authorizations.map(({ agent, access }) => {
       return [
         agent.id,
-        access.grants?.find((grant) => {
+        access.grants.find((grant) => {
           return grant.customConnectorId === connectorId;
         })?.permissionNames ?? [],
       ] as const;
@@ -643,6 +645,7 @@ function useCustomConnectorAuthorization(
             {
               agentId: row.agent.id,
               connectorId: connector.id,
+              permissionBundleRef: connector.permissionBundleRef ?? null,
               authorized,
             },
             pageSignal,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -231,17 +231,19 @@ function ConnectDialogFooter({
   );
 }
 
+interface CustomConnectorConnectDialogProps {
+  readonly connector: CustomConnectorClientResponse;
+  readonly agentId?: string;
+  readonly onClose?: () => void;
+  readonly onSuccess?: () => void | Promise<void>;
+}
+
 export function CustomConnectorConnectDialog({
   connector,
   agentId,
   onClose,
   onSuccess,
-}: {
-  readonly connector: CustomConnectorClientResponse;
-  readonly agentId?: string;
-  readonly onClose?: () => void;
-  readonly onSuccess?: () => void | Promise<void>;
-}) {
+}: CustomConnectorConnectDialogProps) {
   const { t } = useTranslation();
   const form = useGet(customConnectorConnectForm$);
   const setField = useSet(setCustomConnectorConnectField$);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-connect-dialog.tsx
@@ -32,6 +32,11 @@ import { sanitizeTokenInputRecord } from "../../../../signals/zero-page/settings
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { CustomConnectorIcon } from "./custom-connector-icon.tsx";
 
+interface CustomConnectorConnectionSubmission {
+  readonly connected: boolean;
+  readonly targetAuthorized: boolean;
+}
+
 function formValue(
   values: Readonly<Record<string, string>>,
   key: string,
@@ -153,7 +158,7 @@ function useCustomConnectorConnectionSubmitters(agentId: string | undefined) {
       readonly values: readonly CustomConnectorValueInput[];
     },
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<CustomConnectorConnectionSubmission> => {
     if (agentId) {
       return await submitAgentValues({ ...args, agentId }, signal);
     }
@@ -162,7 +167,7 @@ function useCustomConnectorConnectionSubmitters(agentId: string | undefined) {
   const submitOAuth = async (
     connectorId: string,
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<CustomConnectorConnectionSubmission> => {
     if (agentId) {
       return await submitAgentOAuth2({ id: connectorId, agentId }, signal);
     }
@@ -280,13 +285,15 @@ export function CustomConnectorConnectDialog({
     }
     detach(
       (async () => {
-        const connected = oauth
+        const result = oauth
           ? await submitOAuth(connector.id, signal)
           : await submitDeclaredValues({ id: connector.id, values }, signal);
-        if (!connected) {
+        if (!result.connected) {
           return;
         }
-        await onSuccess?.();
+        if (result.targetAuthorized) {
+          await onSuccess?.();
+        }
         close();
       })(),
       Reason.DomCallback,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -144,6 +144,7 @@ import {
   type CustomConnectorClientResponse,
   type CustomConnectorHttpClientResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
   ModelProviderPicker,
@@ -7555,7 +7556,27 @@ function equalComposerConnectorAuthorizationState(
   return (
     left.agentId === right.agentId &&
     equalArrays(left.enabledConnectorSlugs, right.enabledConnectorSlugs) &&
-    equalArrays(left.enabledCustomConnectorIds, right.enabledCustomConnectorIds)
+    equalCustomConnectorGrants(
+      left.customConnectorGrants,
+      right.customConnectorGrants,
+    )
+  );
+}
+
+function equalCustomConnectorGrants(
+  left: readonly AgentCustomConnectorGrant[],
+  right: readonly AgentCustomConnectorGrant[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((grant, index) => {
+      const other = right[index];
+      return (
+        other !== undefined &&
+        grant.customConnectorId === other.customConnectorId &&
+        equalArrays(grant.permissionNames, other.permissionNames)
+      );
+    })
   );
 }
 
@@ -7589,17 +7610,17 @@ function matchingAuthorizedConnectorSlugs(
   return authorization.data.enabledConnectorSlugs;
 }
 
-function matchingAuthorizedCustomConnectorIds(
+function matchingCustomConnectorGrants(
   agentId: string,
   authorization: Loadable<ComposerConnectorAuthorizationState>,
-): readonly string[] | null {
+): readonly AgentCustomConnectorGrant[] | null {
   if (authorization.state !== "hasData") {
     return null;
   }
   if (authorization.data.agentId !== agentId) {
     return null;
   }
-  return authorization.data.enabledCustomConnectorIds;
+  return authorization.data.customConnectorGrants;
 }
 
 interface ResolvedComposerConnectorCollections {
@@ -7622,7 +7643,7 @@ function resolveComposerConnectorCollections({
   addDialogCatalogItems,
   customConnectors,
   authorizedConnectorSlugs,
-  authorizedCustomConnectorIds,
+  customConnectorGrants,
   optimisticConnected,
   selectedCustomConnectorId,
 }: {
@@ -7632,7 +7653,7 @@ function resolveComposerConnectorCollections({
   >;
   customConnectors: Loadable<readonly CustomConnectorClientResponse[]>;
   authorizedConnectorSlugs: readonly ConnectorSlug[] | null;
-  authorizedCustomConnectorIds: readonly string[] | null;
+  customConnectorGrants: readonly AgentCustomConnectorGrant[] | null;
   optimisticConnected: ReadonlySet<ConnectorSlug>;
   selectedCustomConnectorId: string | null;
 }): ResolvedComposerConnectorCollections {
@@ -7645,7 +7666,11 @@ function resolveComposerConnectorCollections({
       ? customConnectors.data.filter(isHttpCustomConnectorClientResponse)
       : [];
   const authorizedSet = new Set(authorizedConnectorSlugs ?? []);
-  const authorizedCustomSet = new Set(authorizedCustomConnectorIds ?? []);
+  const authorizedCustomSet = new Set(
+    customConnectorGrants?.map((grant) => {
+      return grant.customConnectorId;
+    }) ?? [],
+  );
   const connectorMap = new Map(
     [...resolvedRelatedCatalogItems, ...resolvedAddDialogCatalogItems].map(
       (connector) => {
@@ -7831,7 +7856,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     agentRecordId,
     authorizationLoadable,
   );
-  const authorizedCustomConnectors = matchingAuthorizedCustomConnectorIds(
+  const customConnectorGrants = matchingCustomConnectorGrants(
     agentRecordId,
     authorizationLoadable,
   );
@@ -7840,7 +7865,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     relatedCatalogItemsLoadable.state !== "hasData" ||
     customConnectorsLoadable.state !== "hasData" ||
     authorizedConnectors === null ||
-    authorizedCustomConnectors === null;
+    customConnectorGrants === null;
 
   const {
     authorizedSet,
@@ -7855,7 +7880,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     addDialogCatalogItems: addDialogCatalogItemsLoadable,
     customConnectors: customConnectorsLoadable,
     authorizedConnectorSlugs: authorizedConnectors,
-    authorizedCustomConnectorIds: authorizedCustomConnectors,
+    customConnectorGrants,
     optimisticConnected,
     selectedCustomConnectorId,
   });
@@ -7996,10 +8021,20 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   };
 
   const handleCustomToggle = async (connectorId: string, checked: boolean) => {
+    const connector = agentCustomConnectors.find((candidate) => {
+      return candidate.id === connectorId;
+    });
+    if (checked && connector?.permissionBundleRef) {
+      return;
+    }
     updateConnectorUi({ savingCustomConnectorId: connectorId });
     await bestEffort(
       setConnectorAuthorization(
-        { kind: "custom", connectorId },
+        {
+          kind: "custom",
+          connectorId,
+          permissionBundleRef: connector?.permissionBundleRef ?? null,
+        },
         checked,
         pageSignal,
       ),

--- a/turbo/packages/api-contracts/src/contracts/zero-agent-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agent-custom-connectors.ts
@@ -33,7 +33,7 @@ export type AgentCustomConnectorGrants = z.infer<
 
 export const agentCustomConnectorResponseSchema =
   agentCustomConnectorEnabledIdsSchema.extend({
-    grants: z.array(agentCustomConnectorGrantSchema).optional(),
+    grants: z.array(agentCustomConnectorGrantSchema),
   });
 export type AgentCustomConnectorResponse = z.infer<
   typeof agentCustomConnectorResponseSchema
@@ -81,7 +81,7 @@ export const zeroAgentCustomConnectorsContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Get enabled custom connector ids for user on agent",
+    summary: "Get custom connector grants for user on agent",
   },
   update: {
     method: "PUT",
@@ -96,7 +96,7 @@ export const zeroAgentCustomConnectorsContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Update enabled custom connector ids for user on agent",
+    summary: "Update custom connector grants for user on agent",
   },
 });
 export type ZeroAgentCustomConnectorsContract =


### PR DESCRIPTION
## Summary

- make Custom connector grants the canonical API service, Platform, and CLI representation while deriving connector IDs only where membership or compatibility projection needs them
- preserve existing permission selections for idempotent authorization flows and keep explicit grant updates, including empty permission lists, exact
- avoid accepted-catalog reads for empty permission updates and prevent Platform surfaces without permission selection UI from creating empty permission-bundled grants
- retain the legacy `enabledIds` request adapter and response projection at the public route boundary for independently deployed clients

## Compatibility and exclusions

- old App and CLI clients remain supported through the route-only compatibility adapter
- the current App and CLI remain compatible with the previous API, which already accepts and returns grants
- no database migration, persisted-data rewrite, runner protocol, Builtin connector, feature switch, or deployment configuration change

## Validation

- `pnpm format`
- `pnpm turbo run lint --filter=@vm0/api-contracts --filter=api --filter=@vm0/app --filter=@vm0/zero-cli --output-logs=errors-only`
- `pnpm check-types`
- `pnpm knip`
- `pnpm --filter @vm0/api-contracts run build:runtime-api-schema`
- focused API integration tests for Custom connector grants, OAuth, Feishu, proposal authorization, agent access, and run lifecycle
- focused Platform integration tests for settings, agent detail, composer, connector actions, and directed connection
- focused CLI Commander tests for Custom connector list and search
- full Vitest run: 600 files and 8,147 tests passed; local environment failures were independently reproduced as a fixed `/home/user` permission mismatch, root Vitest collecting a Node test suite, and concurrently scanned snapshot test state; the affected snapshot suites passed serially (9/9)

Closes #26211

Parent: #26082
