### PR TITLE
fix(connectors): repair custom skill version associations

### DIFF
--- a/turbo/apps/api/src/__tests__/vercel-crons.test.ts
+++ b/turbo/apps/api/src/__tests__/vercel-crons.test.ts
@@ -8,6 +8,7 @@ import {
   cronCompactUsageEventsContract,
   cronCleanupSandboxesContract,
   cronConnectorCatalogContract,
+  cronCustomConnectorSkillRepairContract,
   cronConnectorOauthStateCleanupContract,
   cronComputerUseScreenshotCleanupContract,
   cronDrainEmailOutboxContract,
@@ -114,6 +115,10 @@ const expectedVercelCrons = [
   },
   {
     path: cronConnectorCatalogContract.sync.path,
+    schedule: "* * * * *",
+  },
+  {
+    path: cronCustomConnectorSkillRepairContract.repair.path,
     schedule: "* * * * *",
   },
   {

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -8,6 +8,7 @@ import { cronSnapshotChatEventsRoutes } from "./routes/cron-snapshot-chat-events
 import { cronCompactUsageEventsRoutes } from "./routes/cron-compact-usage-events";
 import { cronCleanupSandboxesRoutes } from "./routes/cron-cleanup-sandboxes";
 import { cronConnectorCatalogRoutes } from "./routes/cron-connector-catalog";
+import { cronCustomConnectorSkillRepairRoutes } from "./routes/cron-custom-connector-skill-repair";
 import { cronConnectorOauthStateCleanupRoutes } from "./routes/cron-connector-oauth-state-cleanup";
 import { cronDrainEmailOutboxRoutes } from "./routes/cron-drain-email-outbox";
 import { cronExecuteMorningBriefsRoutes } from "./routes/cron-execute-morning-briefs";
@@ -229,6 +230,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronCompactUsageEventsRoutes,
   ...cronCleanupSandboxesRoutes,
   ...cronConnectorCatalogRoutes,
+  ...cronCustomConnectorSkillRepairRoutes,
   ...cronConnectorOauthStateCleanupRoutes,
   ...cronDrainEmailOutboxRoutes,
   ...cronExecuteMorningBriefsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-custom-connector-skill-repair.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-custom-connector-skill-repair.test.ts
@@ -1,0 +1,687 @@
+import { randomUUID } from "node:crypto";
+
+import { cronCustomConnectorSkillRepairContract } from "@vm0/api-contracts/contracts/cron";
+import { testCustomConnectorSkillRepairStateContract } from "@vm0/api-contracts/contracts/test-custom-connector-skill-repair-state";
+import type { CustomConnectorHttpResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { getCustomConnectorSkillName } from "@vm0/core/storage-names";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { extractFileFromTarGz } from "../../../lib/tar";
+import { createDeferredPromise } from "../../utils";
+import { cronCustomConnectorSkillRepairRoutes } from "../cron-custom-connector-skill-repair";
+import { testCustomConnectorSkillRepairStateRoutes } from "../test-custom-connector-skill-repair-state";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const connectorsApi = createConnectorBddApi(context);
+const CRON_SECRET = "custom-connector-skill-repair-test-secret";
+
+function cronClient() {
+  return setupApp({
+    context,
+    routes: cronCustomConnectorSkillRepairRoutes,
+  })(cronCustomConnectorSkillRepairContract);
+}
+
+function stateClient() {
+  return setupApp({
+    context,
+    routes: testCustomConnectorSkillRepairStateRoutes,
+  })(testCustomConnectorSkillRepairStateContract);
+}
+
+function cronHeaders(secret = CRON_SECRET) {
+  return { authorization: `Bearer ${secret}` };
+}
+
+function uniqueSlug(): string {
+  return `_repair-${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+}
+
+async function createConnector(
+  actor: ApiTestUser,
+  skillMarkdown: string | null,
+): Promise<CustomConnectorHttpResponse> {
+  const slug = uniqueSlug();
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+    { data: [{ publicUserData: { userId: actor.userId } }] },
+  );
+  const connector = await connectorsApi.createCustomConnector(actor, {
+    displayName: `Repair ${slug}`,
+    slug,
+    prefixes: [`https://${slug.slice(1)}.example.test/v1/`],
+    headerName: "Authorization",
+    headerTemplate: "Bearer {{secret}}",
+    skillMarkdown,
+  });
+  if (connector.kind !== "http") {
+    throw new Error("Expected an HTTP custom connector");
+  }
+  return connector;
+}
+
+async function createOauthConnector(
+  actor: ApiTestUser,
+  skillMarkdown: string,
+): Promise<CustomConnectorHttpResponse> {
+  const slug = uniqueSlug();
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+    { data: [{ publicUserData: { userId: actor.userId } }] },
+  );
+  const connector = await connectorsApi.createCustomConnector(actor, {
+    displayName: `Managed repair ${slug}`,
+    slug,
+    prefixTemplates: [`https://${slug.slice(1)}.example.test/v1/`],
+    fields: [],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{oauth.access_token}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "oauth",
+    oauthConfig: {
+      providerAdapter: "standard",
+      clientId: `client-${randomUUID()}`,
+      clientSecret: "repair-test-client-secret",
+      authorizationUrl: "https://oauth.example.test/authorize",
+      tokenUrl: "https://oauth.example.test/token",
+      tokenEndpointAuthMethod: "client_secret_post",
+      pkceMethod: "none",
+      scopes: ["read"],
+      authorizationParams: {},
+    },
+    skillMarkdown,
+  });
+  if (connector.kind !== "http") {
+    throw new Error("Expected an HTTP custom connector");
+  }
+  return connector;
+}
+
+async function updateSkill(
+  actor: ApiTestUser,
+  connector: CustomConnectorHttpResponse,
+  skillMarkdown: string,
+): Promise<CustomConnectorHttpResponse> {
+  const response = await connectorsApi.requestUpdateCustomConnector(
+    actor,
+    connector.id,
+    {
+      displayName: connector.displayName,
+      prefixTemplates: connector.prefixTemplates,
+      fields: connector.fields,
+      headerInjections: connector.headerInjections,
+      queryInjections: connector.queryInjections,
+      authMode: connector.authMode ?? "manual",
+      permissionBundleRef: connector.permissionBundleRef,
+      skillMarkdown,
+      storageVersion: connector.storageVersion,
+    },
+    [200],
+  );
+  if (response.status !== 200) {
+    throw new Error("Expected the custom connector update to succeed");
+  }
+  if (response.body.kind !== "http") {
+    throw new Error("Expected an HTTP custom connector");
+  }
+  return response.body;
+}
+
+async function readState(connectorId: string) {
+  const response = await accept(
+    stateClient().action({
+      body: { action: "read", connectorId },
+    }),
+    [200],
+  );
+  return response.body.state;
+}
+
+async function setConnectorState(
+  connectorId: string,
+  values: {
+    readonly skillMarkdown?: string | null;
+    readonly skillStorageVersionId?: string | null;
+  },
+) {
+  const response = await accept(
+    stateClient().action({
+      body: { action: "set-connector", connectorId, ...values },
+    }),
+    [200],
+  );
+  return response.body.state;
+}
+
+async function setHead(connectorId: string, headVersionId: string | null) {
+  const response = await accept(
+    stateClient().action({
+      body: { action: "set-head", connectorId, headVersionId },
+    }),
+    [200],
+  );
+  return response.body.state;
+}
+
+async function setManagedFeishuInstallation(
+  connectorId: string,
+  installationId: string,
+  defaultComposeId: string,
+) {
+  const response = await accept(
+    stateClient().action({
+      body: {
+        action: "set-managed-feishu-installation",
+        connectorId,
+        installationId,
+        defaultComposeId,
+      },
+    }),
+    [200],
+  );
+  return response.body.state;
+}
+
+async function setProviderAdapter(
+  connectorId: string,
+  providerAdapter: "standard" | "feishu",
+) {
+  const response = await accept(
+    stateClient().action({
+      body: {
+        action: "set-provider-adapter",
+        connectorId,
+        providerAdapter,
+      },
+    }),
+    [200],
+  );
+  return response.body.state;
+}
+
+async function clearManagedFeishuInstallation(
+  connectorId: string,
+  installationId: string,
+) {
+  const response = await accept(
+    stateClient().action({
+      body: {
+        action: "clear-managed-feishu-installation",
+        connectorId,
+        installationId,
+      },
+    }),
+    [200, 404],
+  );
+  return response.body;
+}
+
+async function repair() {
+  return await accept(cronClient().repair({ headers: cronHeaders() }), [200]);
+}
+
+async function status() {
+  const response = await accept(
+    cronClient().status({ headers: cronHeaders() }),
+    [200],
+  );
+  return response.body;
+}
+
+function requireVersionId(versionId: string | null, message: string): string {
+  if (!versionId) {
+    throw new Error(message);
+  }
+  return versionId;
+}
+
+function commandName(command: unknown): string | undefined {
+  return typeof command === "object" && command !== null
+    ? command.constructor.name
+    : undefined;
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function s3PutCalls(): readonly unknown[][] {
+  return context.mocks.s3.send.mock.calls.filter(([command]) => {
+    return commandName(command) === "PutObjectCommand";
+  });
+}
+
+function uploadedSkillMarkdown(): string {
+  for (const [command] of s3PutCalls()) {
+    const input = commandInput(command);
+    if (
+      String(input.Key).endsWith("/archive.tar.gz") &&
+      Buffer.isBuffer(input.Body)
+    ) {
+      const skillMarkdown = extractFileFromTarGz(input.Body, "SKILL.md");
+      if (skillMarkdown !== null) {
+        return skillMarkdown;
+      }
+    }
+  }
+  throw new Error("Expected a repaired SKILL.md upload");
+}
+
+beforeEach(() => {
+  mockEnv("CRON_SECRET", CRON_SECRET);
+  bdd.acceptAgentStorageWrites();
+});
+
+describe.sequential("custom connector skill repair cron", () => {
+  const createdConnectors: {
+    actor: ApiTestUser;
+    connectorId: string;
+  }[] = [];
+
+  async function createTrackedConnector(
+    actor: ApiTestUser,
+    skillMarkdown: string | null,
+  ): Promise<CustomConnectorHttpResponse> {
+    const connector = await createConnector(actor, skillMarkdown);
+    createdConnectors.push({ actor, connectorId: connector.id });
+    return connector;
+  }
+
+  async function createTrackedOauthConnector(
+    actor: ApiTestUser,
+    skillMarkdown: string,
+  ): Promise<CustomConnectorHttpResponse> {
+    const connector = await createOauthConnector(actor, skillMarkdown);
+    createdConnectors.push({ actor, connectorId: connector.id });
+    return connector;
+  }
+
+  const managedFeishuInstallations: {
+    connectorId: string;
+    installationId: string;
+  }[] = [];
+
+  afterEach(async () => {
+    for (const { connectorId, installationId } of managedFeishuInstallations
+      .splice(0)
+      .reverse()) {
+      await clearManagedFeishuInstallation(connectorId, installationId);
+    }
+    for (const { actor, connectorId } of createdConnectors
+      .splice(0)
+      .reverse()) {
+      await connectorsApi.deleteCustomConnector(actor, connectorId, [204, 404]);
+    }
+  });
+
+  it("protects repair and status with the cron secret", async () => {
+    const repairResponse = await accept(
+      cronClient().repair({ headers: cronHeaders("wrong") }),
+      [401],
+    );
+    const statusResponse = await accept(
+      cronClient().status({ headers: {} }),
+      [401],
+    );
+
+    expect(repairResponse.body.error.code).toBe("UNAUTHORIZED");
+    expect(statusResponse.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("reports mutually exclusive semantic reasons without calling S3", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const baseline = await status();
+
+    const missingStorage = await createTrackedConnector(actor, null);
+    await setConnectorState(missingStorage.id, {
+      skillMarkdown: "Missing canonical storage",
+    });
+
+    const missingExpected = await createTrackedConnector(
+      actor,
+      "Registered v1",
+    );
+    await setConnectorState(missingExpected.id, {
+      skillMarkdown: "Unregistered v2",
+    });
+
+    const missingAssociation = await createTrackedConnector(
+      actor,
+      "Missing association",
+    );
+    await setConnectorState(missingAssociation.id, {
+      skillStorageVersionId: null,
+    });
+
+    const wrongStorage = await createTrackedConnector(actor, "Wrong storage A");
+    const otherStorage = await createTrackedConnector(actor, "Wrong storage B");
+    const otherVersionId = requireVersionId(
+      (await readState(otherStorage.id)).connector.skillStorageVersionId,
+      "Expected the other connector version",
+    );
+    await setConnectorState(wrongStorage.id, {
+      skillStorageVersionId: otherVersionId,
+    });
+
+    const staleAssociation = await createTrackedConnector(actor, "Stale v1");
+    const staleVersionId = requireVersionId(
+      (await readState(staleAssociation.id)).connector.skillStorageVersionId,
+      "Expected the stale connector version",
+    );
+    await updateSkill(actor, staleAssociation, "Stale v2");
+    await setConnectorState(staleAssociation.id, {
+      skillStorageVersionId: staleVersionId,
+    });
+
+    const headMismatch = await createTrackedConnector(actor, "HEAD v1");
+    const previousHeadId = requireVersionId(
+      (await readState(headMismatch.id)).storage?.headVersionId ?? null,
+      "Expected the previous HEAD",
+    );
+    await updateSkill(actor, headMismatch, "HEAD v2");
+    await setHead(headMismatch.id, previousHeadId);
+
+    const inverseInvalid = await createTrackedConnector(
+      actor,
+      "Remove this skill",
+    );
+    await setConnectorState(inverseInvalid.id, { skillMarkdown: null });
+
+    context.mocks.s3.send.mockClear();
+    const result = await status();
+
+    expect(result.reasons).toMatchObject({
+      inverseInvalid: baseline.reasons.inverseInvalid + 1,
+      missingStorage: baseline.reasons.missingStorage + 1,
+      missingExpectedVersion: baseline.reasons.missingExpectedVersion + 1,
+      missingAssociation: baseline.reasons.missingAssociation + 1,
+      wrongStorage: baseline.reasons.wrongStorage + 1,
+      staleAssociation: baseline.reasons.staleAssociation + 1,
+      headMismatch: baseline.reasons.headMismatch + 1,
+    });
+    expect(result.verified + result.unresolved).toBe(result.total);
+    expect(
+      Object.values(result.reasons).reduce((sum, count) => {
+        return sum + count;
+      }, 0),
+    ).toBe(result.unresolved);
+    expect(result.complete).toBeFalsy();
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+  });
+
+  it("repairs an existing exact version without uploading", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const connector = await createTrackedConnector(
+      actor,
+      "Exact registered skill",
+    );
+    const before = await readState(connector.id);
+    const expectedVersionId = requireVersionId(
+      before.connector.skillStorageVersionId,
+      "Expected the registered version",
+    );
+    await setConnectorState(connector.id, { skillStorageVersionId: null });
+    context.mocks.s3.send.mockClear();
+
+    const result = await repair();
+    const repairedState = await readState(connector.id);
+
+    expect(result.body).toMatchObject({
+      success: true,
+      attempted: 1,
+      repaired: 1,
+      conflicts: 0,
+    });
+    expect(repairedState.connector.skillStorageVersionId).toBe(
+      expectedVersionId,
+    );
+    expect(repairedState.storage?.headVersionId).toBe(expectedVersionId);
+    expect(s3PutCalls()).toHaveLength(0);
+  });
+
+  it("keeps user-created Feishu adapters on ordinary skill metadata", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const connector = await createTrackedOauthConnector(
+      actor,
+      "Custom Feishu adapter v1",
+    );
+    await setProviderAdapter(connector.id, "feishu");
+    await setConnectorState(connector.id, {
+      skillMarkdown: "Custom Feishu adapter v2",
+    });
+    context.mocks.s3.send.mockClear();
+
+    const result = await repair();
+    const repairedState = await readState(connector.id);
+    const repairedSkill = uploadedSkillMarkdown();
+
+    expect(result.body).toMatchObject({ attempted: 1, repaired: 1 });
+    expect(repairedState.connector).toMatchObject({
+      oauthProviderAdapter: "feishu",
+      managedFeishuInstallationId: null,
+    });
+    expect(repairedState.storage?.headVersionId).toBe(
+      repairedState.connector.skillStorageVersionId,
+    );
+    expect(repairedSkill).toContain(
+      `name: ${getCustomConnectorSkillName(connector.slug, connector.id)}`,
+    );
+    expect(repairedSkill).toContain(`description: ${connector.displayName}`);
+    expect(repairedSkill).toContain("Custom Feishu adapter v2");
+  });
+
+  it("uses the live managed Feishu skill metadata during repair", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Managed Feishu repair agent",
+    });
+    const installationId = randomUUID();
+    const connector = await createTrackedOauthConnector(
+      actor,
+      "Managed Feishu repair instruction",
+    );
+    const initialVersionId = requireVersionId(
+      (await readState(connector.id)).connector.skillStorageVersionId,
+      "Expected the initial ordinary version",
+    );
+    await setManagedFeishuInstallation(
+      connector.id,
+      installationId,
+      agent.agentId,
+    );
+    managedFeishuInstallations.push({
+      connectorId: connector.id,
+      installationId,
+    });
+    context.mocks.s3.send.mockClear();
+
+    const result = await repair();
+    const repairedState = await readState(connector.id);
+    const repairedSkill = uploadedSkillMarkdown();
+
+    expect(result.body).toMatchObject({ attempted: 1, repaired: 1 });
+    expect(repairedState.connector).toMatchObject({
+      oauthProviderAdapter: "standard",
+      managedFeishuInstallationId: installationId,
+    });
+    expect(repairedState.connector.skillStorageVersionId).not.toBe(
+      initialVersionId,
+    );
+    expect(repairedState.storage?.headVersionId).toBe(
+      repairedState.connector.skillStorageVersionId,
+    );
+    expect(repairedSkill).toContain("---\nname: feishu\n");
+    expect(repairedSkill).toContain(
+      "description: Feishu OpenAPI for user-authorized messaging, people search, cloud",
+    );
+    expect(repairedSkill).not.toContain(connector.displayName);
+    expect(repairedSkill).not.toContain(connector.id);
+  });
+
+  it("aligns stale HEAD and clears inverse-invalid pointers without uploading", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const headConnector = await createTrackedConnector(actor, "HEAD old");
+    const previousHeadId = requireVersionId(
+      (await readState(headConnector.id)).storage?.headVersionId ?? null,
+      "Expected an old HEAD",
+    );
+    await updateSkill(actor, headConnector, "HEAD current");
+    const expectedHeadId = requireVersionId(
+      (await readState(headConnector.id)).connector.skillStorageVersionId,
+      "Expected the current version",
+    );
+    await setHead(headConnector.id, previousHeadId);
+
+    const noSkillConnector = await createTrackedConnector(
+      actor,
+      "Temporary skill",
+    );
+    const noSkillBefore = await readState(noSkillConnector.id);
+    await setConnectorState(noSkillConnector.id, { skillMarkdown: null });
+    context.mocks.s3.send.mockClear();
+
+    const result = await repair();
+    const repairedHead = await readState(headConnector.id);
+    const repairedNoSkill = await readState(noSkillConnector.id);
+
+    expect(result.body).toMatchObject({ attempted: 2, repaired: 2 });
+    expect(repairedHead.connector.skillStorageVersionId).toBe(expectedHeadId);
+    expect(repairedHead.storage?.headVersionId).toBe(expectedHeadId);
+    expect(repairedNoSkill.connector).toMatchObject({
+      skillMarkdown: null,
+      skillStorageVersionId: null,
+    });
+    expect(repairedNoSkill.storage).toStrictEqual(noSkillBefore.storage);
+    expect(s3PutCalls()).toHaveLength(0);
+  });
+
+  it("bounds each mutation invocation to five unresolved connectors", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const connectors: CustomConnectorHttpResponse[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      const connector = await createTrackedConnector(actor, null);
+      await setConnectorState(connector.id, {
+        skillMarkdown: `Backfilled skill ${index}`,
+      });
+      connectors.push(connector);
+    }
+
+    const first = await repair();
+    const firstStates = await Promise.all(
+      connectors.map(({ id }) => {
+        return readState(id);
+      }),
+    );
+    const firstRepaired = firstStates.filter((state) => {
+      return (
+        state.connector.skillStorageVersionId !== null &&
+        state.storage?.headVersionId === state.connector.skillStorageVersionId
+      );
+    });
+
+    expect(first.body).toMatchObject({ attempted: 5, repaired: 5 });
+    expect(firstRepaired).toHaveLength(5);
+
+    const second = await repair();
+    const secondStates = await Promise.all(
+      connectors.map(({ id }) => {
+        return readState(id);
+      }),
+    );
+    expect(second.body).toMatchObject({ attempted: 1, repaired: 1 });
+    expect(
+      secondStates.every((state) => {
+        return (
+          state.connector.skillStorageVersionId !== null &&
+          state.storage?.headVersionId === state.connector.skillStorageVersionId
+        );
+      }),
+    ).toBeTruthy();
+  });
+
+  it("leaves a failed upload unresolved and repairs it on retry", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const connector = await createTrackedConnector(actor, "Upload v1");
+    const initial = await readState(connector.id);
+    await setConnectorState(connector.id, { skillMarkdown: "Upload v2" });
+    context.mocks.s3.send.mockResolvedValue({ ContentLength: 1024 });
+    context.mocks.s3.send.mockRejectedValueOnce(
+      new Error("Injected repair upload failure"),
+    );
+
+    await accept(cronClient().repair({ headers: cronHeaders() }), [500]);
+    const failedState = await readState(connector.id);
+    expect(failedState.connector.skillStorageVersionId).toBe(
+      initial.connector.skillStorageVersionId,
+    );
+    expect(failedState.storage?.headVersionId).toBe(
+      initial.storage?.headVersionId,
+    );
+
+    context.mocks.s3.send.mockResolvedValue({ ContentLength: 1024 });
+    const retried = await repair();
+    const repairedState = await readState(connector.id);
+    expect(retried.body).toMatchObject({ attempted: 1, repaired: 1 });
+    expect(repairedState.connector.skillStorageVersionId).not.toBe(
+      initial.connector.skillStorageVersionId,
+    );
+    expect(repairedState.storage?.headVersionId).toBe(
+      repairedState.connector.skillStorageVersionId,
+    );
+  });
+
+  it("does not bind a prepared artifact after authoritative source changes", async () => {
+    const actor = bdd.user({ orgRole: "org:admin" });
+    const connector = await createTrackedConnector(actor, "Concurrent v1");
+    const initial = await readState(connector.id);
+    await setConnectorState(connector.id, { skillMarkdown: "Concurrent v2" });
+    const uploadReached = createDeferredPromise<void>(context.signal);
+    const uploadRelease = createDeferredPromise<unknown>(context.signal);
+    let heldUpload = false;
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (!heldUpload && commandName(command) === "PutObjectCommand") {
+        heldUpload = true;
+        uploadReached.resolve();
+        return uploadRelease.promise;
+      }
+      return Promise.resolve({ ContentLength: 1024 });
+    });
+
+    const pendingRepair = cronClient().repair({ headers: cronHeaders() });
+    await uploadReached.promise;
+    await setConnectorState(connector.id, { skillMarkdown: "Concurrent v3" });
+    uploadRelease.resolve({});
+    const result = await accept(pendingRepair, [200]);
+    const finalState = await readState(connector.id);
+
+    expect(result.body).toMatchObject({
+      attempted: 1,
+      repaired: 0,
+      conflicts: 1,
+    });
+    expect(finalState.connector).toMatchObject({
+      skillMarkdown: "Concurrent v3",
+      skillStorageVersionId: initial.connector.skillStorageVersionId,
+    });
+    expect(finalState.storage?.headVersionId).toBe(
+      initial.storage?.headVersionId,
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-custom-connector-skill-repair.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-custom-connector-skill-repair.test.ts
@@ -456,7 +456,7 @@ describe.sequential("custom connector skill repair cron", () => {
     expect(s3PutCalls()).toHaveLength(0);
   });
 
-  it("keeps user-created Feishu adapters on ordinary skill metadata", async () => {
+  it("does not infer managed Feishu identity from the adapter alone", async () => {
     const actor = bdd.user({ orgRole: "org:admin" });
     const connector = await createTrackedOauthConnector(
       actor,

--- a/turbo/apps/api/src/signals/routes/cron-custom-connector-skill-repair.ts
+++ b/turbo/apps/api/src/signals/routes/cron-custom-connector-skill-repair.ts
@@ -1,0 +1,44 @@
+import { cronCustomConnectorSkillRepairContract } from "@vm0/api-contracts/contracts/cron";
+import { command } from "ccstate";
+
+import type { RouteEntry } from "../route-entry";
+import {
+  customConnectorSkillRepairStatus$,
+  repairCustomConnectorSkillVersions$,
+} from "../services/cron-custom-connector-skill-repair.service";
+import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
+
+const repairRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!get(hasValidCronSecret$)) {
+    return cronUnauthorized();
+  }
+  const result = await set(repairCustomConnectorSkillVersions$, signal);
+  signal.throwIfAborted();
+  return {
+    status: 200 as const,
+    body: { success: true as const, ...result },
+  };
+});
+
+const statusRoute$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!get(hasValidCronSecret$)) {
+    return cronUnauthorized();
+  }
+  const result = await set(customConnectorSkillRepairStatus$, signal);
+  signal.throwIfAborted();
+  return {
+    status: 200 as const,
+    body: { success: true as const, ...result },
+  };
+});
+
+export const cronCustomConnectorSkillRepairRoutes: readonly RouteEntry[] = [
+  {
+    route: cronCustomConnectorSkillRepairContract.repair,
+    handler: repairRoute$,
+  },
+  {
+    route: cronCustomConnectorSkillRepairContract.status,
+    handler: statusRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/test-custom-connector-skill-repair-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-custom-connector-skill-repair-state.ts
@@ -1,0 +1,210 @@
+import { testCustomConnectorSkillRepairStateContract } from "@vm0/api-contracts/contracts/test-custom-connector-skill-repair-state";
+import {
+  getCustomConnectorSkillStorageName,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
+import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
+import { orgCustomConnectorOauthConfigs } from "@vm0/db/schema/org-custom-connector-oauth-config";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { storages } from "@vm0/db/schema/storage";
+import { command } from "ccstate";
+import { and, eq } from "drizzle-orm";
+
+import { notFound } from "../../lib/error";
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import { writeDb$, type Db } from "../external/db";
+import type { RouteEntry } from "../route-entry";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+import { getFeishuCustomConnectorSlug } from "../services/feishu-custom-connector-skill-metadata";
+
+const actionBody$ = bodyResultOf(
+  testCustomConnectorSkillRepairStateContract.action,
+);
+
+async function readConnectorIdentity(
+  db: Db,
+  connectorId: string,
+  signal: AbortSignal,
+) {
+  const [connector] = await db
+    .select({
+      id: orgCustomConnectors.id,
+      orgId: orgCustomConnectors.orgId,
+      slug: orgCustomConnectors.slug,
+    })
+    .from(orgCustomConnectors)
+    .where(eq(orgCustomConnectors.id, connectorId))
+    .limit(1);
+  signal.throwIfAborted();
+  return connector;
+}
+
+async function readState(db: Db, connectorId: string, signal: AbortSignal) {
+  const [connector] = await db
+    .select({
+      id: orgCustomConnectors.id,
+      orgId: orgCustomConnectors.orgId,
+      slug: orgCustomConnectors.slug,
+      skillMarkdown: orgCustomConnectors.skillMarkdown,
+      skillStorageVersionId: orgCustomConnectors.skillStorageVersionId,
+      oauthProviderAdapter: orgCustomConnectorOauthConfigs.providerAdapter,
+    })
+    .from(orgCustomConnectors)
+    .leftJoin(
+      orgCustomConnectorOauthConfigs,
+      and(
+        eq(orgCustomConnectorOauthConfigs.connectorId, orgCustomConnectors.id),
+        eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
+      ),
+    )
+    .where(eq(orgCustomConnectors.id, connectorId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!connector) {
+    return undefined;
+  }
+  const [storage] = await db
+    .select({ id: storages.id, headVersionId: storages.headVersionId })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, connector.orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, getCustomConnectorSkillStorageName(connector.id)),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  const installations = await db
+    .select({ id: feishuOrgInstallations.id })
+    .from(feishuOrgInstallations)
+    .where(eq(feishuOrgInstallations.orgId, connector.orgId));
+  signal.throwIfAborted();
+  const managedFeishuInstallation = installations.find((installation) => {
+    return getFeishuCustomConnectorSlug(installation.id) === connector.slug;
+  });
+  return {
+    connector: {
+      skillMarkdown: connector.skillMarkdown,
+      skillStorageVersionId: connector.skillStorageVersionId,
+      oauthProviderAdapter: connector.oauthProviderAdapter,
+      managedFeishuInstallationId: managedFeishuInstallation?.id ?? null,
+    },
+    storage: storage ?? null,
+  };
+}
+
+const action$ = command(async ({ get, set }, signal: AbortSignal) => {
+  if (!isTestEndpointAllowed(get(request$))) {
+    return testEndpointNotFoundResponse();
+  }
+  const bodyResult = await get(actionBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const db = set(writeDb$);
+  const body = bodyResult.data;
+  if (body.action === "set-connector") {
+    const values: {
+      skillMarkdown?: string | null;
+      skillStorageVersionId?: string | null;
+    } = {};
+    if (body.skillMarkdown !== undefined) {
+      values.skillMarkdown = body.skillMarkdown;
+    }
+    if (body.skillStorageVersionId !== undefined) {
+      values.skillStorageVersionId = body.skillStorageVersionId;
+    }
+    await db
+      .update(orgCustomConnectors)
+      .set(values)
+      .where(eq(orgCustomConnectors.id, body.connectorId));
+    signal.throwIfAborted();
+  } else if (body.action === "set-provider-adapter") {
+    const [oauthConfig] = await db
+      .update(orgCustomConnectorOauthConfigs)
+      .set({ providerAdapter: body.providerAdapter })
+      .where(eq(orgCustomConnectorOauthConfigs.connectorId, body.connectorId))
+      .returning({ connectorId: orgCustomConnectorOauthConfigs.connectorId });
+    signal.throwIfAborted();
+    if (!oauthConfig) {
+      return notFound("Custom connector repair fixture OAuth config not found");
+    }
+  } else if (body.action === "set-managed-feishu-installation") {
+    const connector = await readConnectorIdentity(db, body.connectorId, signal);
+    if (!connector) {
+      return notFound("Custom connector repair fixture target not found");
+    }
+    await db
+      .update(orgCustomConnectors)
+      .set({ slug: getFeishuCustomConnectorSlug(body.installationId) })
+      .where(eq(orgCustomConnectors.id, connector.id));
+    signal.throwIfAborted();
+    await db
+      .insert(feishuOrgInstallations)
+      .values({
+        id: body.installationId,
+        orgId: connector.orgId,
+        appId: `repair-test-${body.installationId}`,
+        encryptedAppSecret: "repair-test-app-secret",
+        encryptedVerificationToken: "repair-test-verification-token",
+        encryptedEncryptKey: "repair-test-encrypt-key",
+        defaultComposeId: body.defaultComposeId,
+      })
+      .onConflictDoNothing();
+    signal.throwIfAborted();
+  } else if (body.action === "clear-managed-feishu-installation") {
+    const connector = await readConnectorIdentity(db, body.connectorId, signal);
+    if (!connector) {
+      return notFound("Custom connector repair fixture target not found");
+    }
+    await db
+      .delete(feishuOrgInstallations)
+      .where(
+        and(
+          eq(feishuOrgInstallations.id, body.installationId),
+          eq(feishuOrgInstallations.orgId, connector.orgId),
+        ),
+      );
+    signal.throwIfAborted();
+  } else if (body.action === "set-head") {
+    const connector = await readConnectorIdentity(db, body.connectorId, signal);
+    if (!connector) {
+      return notFound("Custom connector repair fixture target not found");
+    }
+    const [storage] = await db
+      .update(storages)
+      .set({ headVersionId: body.headVersionId })
+      .where(
+        and(
+          eq(storages.orgId, connector.orgId),
+          eq(storages.userId, VOLUME_ORG_USER_ID),
+          eq(storages.name, getCustomConnectorSkillStorageName(connector.id)),
+        ),
+      )
+      .returning({ id: storages.id });
+    signal.throwIfAborted();
+    if (!storage) {
+      return notFound("Custom connector repair fixture storage not found");
+    }
+  }
+
+  const state = await readState(db, body.connectorId, signal);
+  if (!state) {
+    return notFound("Custom connector repair fixture target not found");
+  }
+  return { status: 200 as const, body: { ok: true as const, state } };
+});
+
+export const testCustomConnectorSkillRepairStateRoutes: readonly RouteEntry[] =
+  [
+    {
+      route: testCustomConnectorSkillRepairStateContract.action,
+      handler: action$,
+    },
+  ];

--- a/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
@@ -33,6 +33,11 @@ type CustomConnectorSkillRepairReason =
   | "staleAssociation"
   | "headMismatch";
 
+type SkillConnectorRepairReason = Exclude<
+  CustomConnectorSkillRepairReason,
+  "inverseInvalid"
+>;
+
 interface CustomConnectorSkillRepairReasonCounts {
   readonly inverseInvalid: number;
   readonly missingStorage: number;
@@ -86,7 +91,14 @@ type CustomConnectorSkillClassification =
   | {
       readonly kind: "unresolved";
       readonly connector: CustomConnectorSkillScanRow;
-      readonly reason: CustomConnectorSkillRepairReason;
+      readonly reason: "inverseInvalid";
+    }
+  | {
+      readonly kind: "unresolved";
+      readonly connector: CustomConnectorSkillScanRow & {
+        readonly skillMarkdown: string;
+      };
+      readonly reason: SkillConnectorRepairReason;
     };
 
 function storageKey(orgId: string, storageName: string): string {
@@ -280,50 +292,72 @@ function classifyConnector(
       ? { kind: "verified", connector }
       : { kind: "unresolved", connector, reason: "inverseInvalid" };
   }
+  const skillConnector = {
+    ...connector,
+    skillMarkdown: connector.skillMarkdown,
+  };
 
   const storage = canonicalStorageByKey.get(
     storageKey(
-      connector.orgId,
-      getCustomConnectorSkillStorageName(connector.id),
+      skillConnector.orgId,
+      getCustomConnectorSkillStorageName(skillConnector.id),
     ),
   );
   if (!storage) {
-    return { kind: "unresolved", connector, reason: "missingStorage" };
+    return {
+      kind: "unresolved",
+      connector: skillConnector,
+      reason: "missingStorage",
+    };
   }
   const expectedVersionId = computeCustomConnectorSkillVersionId(
     storage.id,
-    skillContentInput({ ...connector, skillMarkdown: connector.skillMarkdown }),
+    skillContentInput(skillConnector),
   );
   if (!versionById.has(expectedVersionId)) {
     return {
       kind: "unresolved",
-      connector,
+      connector: skillConnector,
       reason: "missingExpectedVersion",
     };
   }
-  if (connector.skillStorageVersionId === null) {
+  if (skillConnector.skillStorageVersionId === null) {
     return {
       kind: "unresolved",
-      connector,
+      connector: skillConnector,
       reason: "missingAssociation",
     };
   }
-  const associatedVersion = versionById.get(connector.skillStorageVersionId);
+  const associatedVersion = versionById.get(
+    skillConnector.skillStorageVersionId,
+  );
   if (!associatedVersion) {
     throw new Error(
-      `Custom connector ${connector.id} points to missing storage version ${connector.skillStorageVersionId}`,
+      `Custom connector ${skillConnector.id} points to missing storage version ${skillConnector.skillStorageVersionId}`,
     );
   }
   if (associatedVersion.storageId !== storage.id) {
-    return { kind: "unresolved", connector, reason: "wrongStorage" };
+    return {
+      kind: "unresolved",
+      connector: skillConnector,
+      reason: "wrongStorage",
+    };
   }
-  if (connector.skillStorageVersionId !== expectedVersionId) {
-    return { kind: "unresolved", connector, reason: "staleAssociation" };
+  if (skillConnector.skillStorageVersionId !== expectedVersionId) {
+    return {
+      kind: "unresolved",
+      connector: skillConnector,
+      reason: "staleAssociation",
+    };
   }
   if (storage.headVersionId !== expectedVersionId) {
-    return { kind: "unresolved", connector, reason: "headMismatch" };
+    return {
+      kind: "unresolved",
+      connector: skillConnector,
+      reason: "headMismatch",
+    };
   }
-  return { kind: "verified", connector };
+  return { kind: "verified", connector: skillConnector };
 }
 
 async function classifyConnectorPage(
@@ -546,18 +580,19 @@ export const repairCustomConnectorSkillVersions$ = command(
           return true;
         }
         attempted += 1;
-        const connector = classification.connector;
         const didRepair =
           classification.reason === "inverseInvalid"
-            ? await repairInverseInvalidConnector(db, connector.id, signal)
-            : connector.skillMarkdown === null
-              ? false
-              : await repairSkillConnector(
-                  set,
-                  db,
-                  { ...connector, skillMarkdown: connector.skillMarkdown },
-                  signal,
-                );
+            ? await repairInverseInvalidConnector(
+                db,
+                classification.connector.id,
+                signal,
+              )
+            : await repairSkillConnector(
+                set,
+                db,
+                classification.connector,
+                signal,
+              );
         if (didRepair) {
           repaired += 1;
         } else {

--- a/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, type Setter } from "ccstate";
 import {
   getCustomConnectorSkillStorageName,
   VOLUME_ORG_USER_ID,
@@ -88,8 +88,6 @@ type CustomConnectorSkillClassification =
       readonly connector: CustomConnectorSkillScanRow;
       readonly reason: CustomConnectorSkillRepairReason;
     };
-
-type CommandSet = Parameters<Parameters<typeof command>[0]>[0]["set"];
 
 function storageKey(orgId: string, storageName: string): string {
   return `${orgId}\u0000${storageName}`;
@@ -430,7 +428,7 @@ async function readLockedConnector(
 }
 
 async function repairSkillConnector(
-  set: CommandSet,
+  set: Setter,
   db: Db,
   connector: CustomConnectorSkillScanRow & { readonly skillMarkdown: string },
   signal: AbortSignal,

--- a/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
@@ -1,4 +1,4 @@
-import { command, type Setter } from "ccstate";
+import { command } from "ccstate";
 import {
   getCustomConnectorSkillStorageName,
   VOLUME_ORG_USER_ID,
@@ -461,54 +461,61 @@ async function readLockedConnector(
   };
 }
 
-async function repairSkillConnector(
-  set: Setter,
-  db: Db,
-  connector: CustomConnectorSkillScanRow & { readonly skillMarkdown: string },
-  signal: AbortSignal,
-): Promise<boolean> {
-  const volume = await set(
-    prepareCustomConnectorSkillVolume$,
-    {
-      orgId: connector.orgId,
-      ...skillContentInput(connector),
+const repairSkillConnector$ = command(
+  async (
+    { set },
+    db: Db,
+    connector: CustomConnectorSkillScanRow & {
+      readonly skillMarkdown: string;
     },
-    signal,
-  );
-  signal.throwIfAborted();
-
-  return await db.transaction(async (tx) => {
-    const current = await readLockedConnector(tx, connector.id, signal);
-    if (
-      !current ||
-      current.orgId !== connector.orgId ||
-      current.skillMarkdown === null ||
-      computeCustomConnectorSkillVersionId(
-        volume.version.storageId,
-        skillContentInput({ ...current, skillMarkdown: current.skillMarkdown }),
-      ) !== volume.version.versionId
-    ) {
-      return false;
-    }
-    const [storage] = await tx
-      .select({ headVersionId: storages.headVersionId })
-      .from(storages)
-      .where(eq(storages.id, volume.version.storageId))
-      .limit(1);
-    signal.throwIfAborted();
-    if (
-      current.skillStorageVersionId === volume.version.versionId &&
-      storage?.headVersionId === volume.version.versionId
-    ) {
-      return false;
-    }
-    await commitPreparedCustomConnectorSkillVolume(
-      { db: tx, connectorId: connector.id, volume },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const volume = await set(
+      prepareCustomConnectorSkillVolume$,
+      {
+        orgId: connector.orgId,
+        ...skillContentInput(connector),
+      },
       signal,
     );
-    return true;
-  });
-}
+    signal.throwIfAborted();
+
+    return await db.transaction(async (tx) => {
+      const current = await readLockedConnector(tx, connector.id, signal);
+      if (
+        !current ||
+        current.orgId !== connector.orgId ||
+        current.skillMarkdown === null ||
+        computeCustomConnectorSkillVersionId(
+          volume.version.storageId,
+          skillContentInput({
+            ...current,
+            skillMarkdown: current.skillMarkdown,
+          }),
+        ) !== volume.version.versionId
+      ) {
+        return false;
+      }
+      const [storage] = await tx
+        .select({ headVersionId: storages.headVersionId })
+        .from(storages)
+        .where(eq(storages.id, volume.version.storageId))
+        .limit(1);
+      signal.throwIfAborted();
+      if (
+        current.skillStorageVersionId === volume.version.versionId &&
+        storage?.headVersionId === volume.version.versionId
+      ) {
+        return false;
+      }
+      await commitPreparedCustomConnectorSkillVolume(
+        { db: tx, connectorId: connector.id, volume },
+        signal,
+      );
+      return true;
+    });
+  },
+);
 
 async function repairInverseInvalidConnector(
   db: Db,
@@ -587,8 +594,8 @@ export const repairCustomConnectorSkillVersions$ = command(
                 classification.connector.id,
                 signal,
               )
-            : await repairSkillConnector(
-                set,
+            : await set(
+                repairSkillConnector$,
                 db,
                 classification.connector,
                 signal,

--- a/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-custom-connector-skill-repair.service.ts
@@ -1,0 +1,573 @@
+import { command } from "ccstate";
+import {
+  getCustomConnectorSkillStorageName,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
+import { feishuOrgInstallations } from "@vm0/db/schema/feishu-org-installation";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { and, asc, eq, gt, inArray } from "drizzle-orm";
+
+import type { Tx } from "../../lib/db-types";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import {
+  commitPreparedCustomConnectorSkillVolume,
+  computeCustomConnectorSkillVersionId,
+  prepareCustomConnectorSkillVolume$,
+  type CustomConnectorSkillContentInput,
+} from "./custom-connector-skill-volume.service";
+import {
+  FEISHU_CUSTOM_CONNECTOR_SKILL_METADATA,
+  getFeishuCustomConnectorSlug,
+} from "./feishu-custom-connector-skill-metadata";
+
+const SCAN_PAGE_SIZE = 100;
+const REPAIR_LIMIT = 5;
+
+type CustomConnectorSkillRepairReason =
+  | "inverseInvalid"
+  | "missingStorage"
+  | "missingExpectedVersion"
+  | "missingAssociation"
+  | "wrongStorage"
+  | "staleAssociation"
+  | "headMismatch";
+
+interface CustomConnectorSkillRepairReasonCounts {
+  readonly inverseInvalid: number;
+  readonly missingStorage: number;
+  readonly missingExpectedVersion: number;
+  readonly missingAssociation: number;
+  readonly wrongStorage: number;
+  readonly staleAssociation: number;
+  readonly headMismatch: number;
+}
+
+interface CustomConnectorSkillRepairStatus {
+  readonly total: number;
+  readonly verified: number;
+  readonly unresolved: number;
+  readonly reasons: CustomConnectorSkillRepairReasonCounts;
+  readonly complete: boolean;
+}
+
+interface CustomConnectorSkillRepairResult {
+  readonly scanned: number;
+  readonly attempted: number;
+  readonly repaired: number;
+  readonly conflicts: number;
+}
+
+interface CustomConnectorSkillScanRow {
+  readonly id: string;
+  readonly orgId: string;
+  readonly slug: string;
+  readonly displayName: string;
+  readonly skillMarkdown: string | null;
+  readonly skillStorageVersionId: string | null;
+  readonly isManagedFeishu: boolean;
+}
+
+interface CanonicalStorageState {
+  readonly id: string;
+  readonly headVersionId: string | null;
+}
+
+interface StorageVersionState {
+  readonly id: string;
+  readonly storageId: string;
+}
+
+type CustomConnectorSkillClassification =
+  | {
+      readonly kind: "verified";
+      readonly connector: CustomConnectorSkillScanRow;
+    }
+  | {
+      readonly kind: "unresolved";
+      readonly connector: CustomConnectorSkillScanRow;
+      readonly reason: CustomConnectorSkillRepairReason;
+    };
+
+type CommandSet = Parameters<Parameters<typeof command>[0]>[0]["set"];
+
+function storageKey(orgId: string, storageName: string): string {
+  return `${orgId}\u0000${storageName}`;
+}
+
+function skillContentInput(
+  connector: CustomConnectorSkillScanRow & { readonly skillMarkdown: string },
+): CustomConnectorSkillContentInput {
+  const managedMetadata = connector.isManagedFeishu
+    ? FEISHU_CUSTOM_CONNECTOR_SKILL_METADATA
+    : undefined;
+  return {
+    connectorId: connector.id,
+    connectorSlug: connector.slug,
+    displayName: connector.displayName,
+    skillMarkdown: connector.skillMarkdown,
+    skillName: managedMetadata?.name,
+    skillDescription: managedMetadata?.description,
+  };
+}
+
+async function readConnectorPage(
+  db: ReadonlyDb,
+  afterId: string | undefined,
+  signal: AbortSignal,
+): Promise<readonly CustomConnectorSkillScanRow[]> {
+  const rows = await db
+    .select({
+      id: orgCustomConnectors.id,
+      orgId: orgCustomConnectors.orgId,
+      slug: orgCustomConnectors.slug,
+      displayName: orgCustomConnectors.displayName,
+      skillMarkdown: orgCustomConnectors.skillMarkdown,
+      skillStorageVersionId: orgCustomConnectors.skillStorageVersionId,
+    })
+    .from(orgCustomConnectors)
+    .where(
+      afterId === undefined ? undefined : gt(orgCustomConnectors.id, afterId),
+    )
+    .orderBy(asc(orgCustomConnectors.id))
+    .limit(SCAN_PAGE_SIZE);
+  signal.throwIfAborted();
+  const feishuOrgIds = [
+    ...new Set(
+      rows.map((row) => {
+        return row.orgId;
+      }),
+    ),
+  ];
+  if (feishuOrgIds.length === 0) {
+    return rows.map((row) => {
+      return { ...row, isManagedFeishu: false };
+    });
+  }
+  const installations = await db
+    .select({
+      id: feishuOrgInstallations.id,
+      orgId: feishuOrgInstallations.orgId,
+    })
+    .from(feishuOrgInstallations)
+    .where(inArray(feishuOrgInstallations.orgId, feishuOrgIds));
+  signal.throwIfAborted();
+  const managedConnectorKeys = new Set(
+    installations.map((installation) => {
+      return storageKey(
+        installation.orgId,
+        getFeishuCustomConnectorSlug(installation.id),
+      );
+    }),
+  );
+  return rows.map((row) => {
+    return {
+      ...row,
+      isManagedFeishu: managedConnectorKeys.has(
+        storageKey(row.orgId, row.slug),
+      ),
+    };
+  });
+}
+
+async function readCanonicalStorages(
+  db: ReadonlyDb,
+  connectors: readonly CustomConnectorSkillScanRow[],
+  signal: AbortSignal,
+): Promise<ReadonlyMap<string, CanonicalStorageState>> {
+  const skillConnectors = connectors.filter(
+    (
+      connector,
+    ): connector is CustomConnectorSkillScanRow & {
+      readonly skillMarkdown: string;
+    } => {
+      return connector.skillMarkdown !== null;
+    },
+  );
+  if (skillConnectors.length === 0) {
+    return new Map();
+  }
+
+  const orgIds = [
+    ...new Set(
+      skillConnectors.map(({ orgId }) => {
+        return orgId;
+      }),
+    ),
+  ];
+  const storageNames = skillConnectors.map(({ id }) => {
+    return getCustomConnectorSkillStorageName(id);
+  });
+  const rows = await db
+    .select({
+      id: storages.id,
+      orgId: storages.orgId,
+      name: storages.name,
+      headVersionId: storages.headVersionId,
+    })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        inArray(storages.orgId, orgIds),
+        inArray(storages.name, storageNames),
+      ),
+    );
+  signal.throwIfAborted();
+  return new Map(
+    rows.map((row) => {
+      return [storageKey(row.orgId, row.name), row] as const;
+    }),
+  );
+}
+
+async function readRelevantVersions(
+  db: ReadonlyDb,
+  connectors: readonly CustomConnectorSkillScanRow[],
+  canonicalStorageByKey: ReadonlyMap<string, CanonicalStorageState>,
+  signal: AbortSignal,
+): Promise<ReadonlyMap<string, StorageVersionState>> {
+  const ids = new Set<string>();
+  for (const connector of connectors) {
+    if (
+      connector.skillMarkdown !== null &&
+      connector.skillStorageVersionId !== null
+    ) {
+      ids.add(connector.skillStorageVersionId);
+    }
+    if (connector.skillMarkdown === null) {
+      continue;
+    }
+    const storage = canonicalStorageByKey.get(
+      storageKey(
+        connector.orgId,
+        getCustomConnectorSkillStorageName(connector.id),
+      ),
+    );
+    if (storage) {
+      ids.add(
+        computeCustomConnectorSkillVersionId(
+          storage.id,
+          skillContentInput({
+            ...connector,
+            skillMarkdown: connector.skillMarkdown,
+          }),
+        ),
+      );
+    }
+  }
+  if (ids.size === 0) {
+    return new Map();
+  }
+
+  const rows = await db
+    .select({ id: storageVersions.id, storageId: storageVersions.storageId })
+    .from(storageVersions)
+    .where(inArray(storageVersions.id, [...ids]));
+  signal.throwIfAborted();
+  return new Map(
+    rows.map((row) => {
+      return [row.id, row] as const;
+    }),
+  );
+}
+
+function classifyConnector(
+  connector: CustomConnectorSkillScanRow,
+  canonicalStorageByKey: ReadonlyMap<string, CanonicalStorageState>,
+  versionById: ReadonlyMap<string, StorageVersionState>,
+): CustomConnectorSkillClassification {
+  if (connector.skillMarkdown === null) {
+    return connector.skillStorageVersionId === null
+      ? { kind: "verified", connector }
+      : { kind: "unresolved", connector, reason: "inverseInvalid" };
+  }
+
+  const storage = canonicalStorageByKey.get(
+    storageKey(
+      connector.orgId,
+      getCustomConnectorSkillStorageName(connector.id),
+    ),
+  );
+  if (!storage) {
+    return { kind: "unresolved", connector, reason: "missingStorage" };
+  }
+  const expectedVersionId = computeCustomConnectorSkillVersionId(
+    storage.id,
+    skillContentInput({ ...connector, skillMarkdown: connector.skillMarkdown }),
+  );
+  if (!versionById.has(expectedVersionId)) {
+    return {
+      kind: "unresolved",
+      connector,
+      reason: "missingExpectedVersion",
+    };
+  }
+  if (connector.skillStorageVersionId === null) {
+    return {
+      kind: "unresolved",
+      connector,
+      reason: "missingAssociation",
+    };
+  }
+  const associatedVersion = versionById.get(connector.skillStorageVersionId);
+  if (!associatedVersion) {
+    throw new Error(
+      `Custom connector ${connector.id} points to missing storage version ${connector.skillStorageVersionId}`,
+    );
+  }
+  if (associatedVersion.storageId !== storage.id) {
+    return { kind: "unresolved", connector, reason: "wrongStorage" };
+  }
+  if (connector.skillStorageVersionId !== expectedVersionId) {
+    return { kind: "unresolved", connector, reason: "staleAssociation" };
+  }
+  if (storage.headVersionId !== expectedVersionId) {
+    return { kind: "unresolved", connector, reason: "headMismatch" };
+  }
+  return { kind: "verified", connector };
+}
+
+async function classifyConnectorPage(
+  db: ReadonlyDb,
+  connectors: readonly CustomConnectorSkillScanRow[],
+  signal: AbortSignal,
+): Promise<readonly CustomConnectorSkillClassification[]> {
+  const canonicalStorages = await readCanonicalStorages(db, connectors, signal);
+  const versions = await readRelevantVersions(
+    db,
+    connectors,
+    canonicalStorages,
+    signal,
+  );
+  return connectors.map((connector) => {
+    return classifyConnector(connector, canonicalStorages, versions);
+  });
+}
+
+async function walkClassifications(
+  db: ReadonlyDb,
+  signal: AbortSignal,
+  visit: (
+    classification: CustomConnectorSkillClassification,
+  ) => boolean | Promise<boolean>,
+): Promise<number> {
+  let afterId: string | undefined;
+  let scanned = 0;
+  while (true) {
+    const connectors = await readConnectorPage(db, afterId, signal);
+    if (connectors.length === 0) {
+      return scanned;
+    }
+    const classifications = await classifyConnectorPage(db, connectors, signal);
+    for (const classification of classifications) {
+      scanned += 1;
+      if (!(await visit(classification))) {
+        return scanned;
+      }
+      signal.throwIfAborted();
+    }
+    if (connectors.length < SCAN_PAGE_SIZE) {
+      return scanned;
+    }
+    afterId = connectors.at(-1)?.id;
+  }
+}
+
+function emptyReasonCounts(): CustomConnectorSkillRepairReasonCounts {
+  return {
+    inverseInvalid: 0,
+    missingStorage: 0,
+    missingExpectedVersion: 0,
+    missingAssociation: 0,
+    wrongStorage: 0,
+    staleAssociation: 0,
+    headMismatch: 0,
+  };
+}
+
+function incrementReason(
+  counts: CustomConnectorSkillRepairReasonCounts,
+  reason: CustomConnectorSkillRepairReason,
+): CustomConnectorSkillRepairReasonCounts {
+  return { ...counts, [reason]: counts[reason] + 1 };
+}
+
+async function readLockedConnector(
+  tx: Tx,
+  connectorId: string,
+  signal: AbortSignal,
+): Promise<CustomConnectorSkillScanRow | undefined> {
+  const [connector] = await tx
+    .select({
+      id: orgCustomConnectors.id,
+      orgId: orgCustomConnectors.orgId,
+      slug: orgCustomConnectors.slug,
+      displayName: orgCustomConnectors.displayName,
+      skillMarkdown: orgCustomConnectors.skillMarkdown,
+      skillStorageVersionId: orgCustomConnectors.skillStorageVersionId,
+    })
+    .from(orgCustomConnectors)
+    .where(eq(orgCustomConnectors.id, connectorId))
+    .for("update")
+    .limit(1);
+  signal.throwIfAborted();
+  if (!connector) {
+    return undefined;
+  }
+  const installations = await tx
+    .select({ id: feishuOrgInstallations.id })
+    .from(feishuOrgInstallations)
+    .where(eq(feishuOrgInstallations.orgId, connector.orgId))
+    .for("key share");
+  signal.throwIfAborted();
+  return {
+    ...connector,
+    isManagedFeishu: installations.some((installation) => {
+      return getFeishuCustomConnectorSlug(installation.id) === connector.slug;
+    }),
+  };
+}
+
+async function repairSkillConnector(
+  set: CommandSet,
+  db: Db,
+  connector: CustomConnectorSkillScanRow & { readonly skillMarkdown: string },
+  signal: AbortSignal,
+): Promise<boolean> {
+  const volume = await set(
+    prepareCustomConnectorSkillVolume$,
+    {
+      orgId: connector.orgId,
+      ...skillContentInput(connector),
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return await db.transaction(async (tx) => {
+    const current = await readLockedConnector(tx, connector.id, signal);
+    if (
+      !current ||
+      current.orgId !== connector.orgId ||
+      current.skillMarkdown === null ||
+      computeCustomConnectorSkillVersionId(
+        volume.version.storageId,
+        skillContentInput({ ...current, skillMarkdown: current.skillMarkdown }),
+      ) !== volume.version.versionId
+    ) {
+      return false;
+    }
+    const [storage] = await tx
+      .select({ headVersionId: storages.headVersionId })
+      .from(storages)
+      .where(eq(storages.id, volume.version.storageId))
+      .limit(1);
+    signal.throwIfAborted();
+    if (
+      current.skillStorageVersionId === volume.version.versionId &&
+      storage?.headVersionId === volume.version.versionId
+    ) {
+      return false;
+    }
+    await commitPreparedCustomConnectorSkillVolume(
+      { db: tx, connectorId: connector.id, volume },
+      signal,
+    );
+    return true;
+  });
+}
+
+async function repairInverseInvalidConnector(
+  db: Db,
+  connectorId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  return await db.transaction(async (tx) => {
+    const current = await readLockedConnector(tx, connectorId, signal);
+    if (
+      !current ||
+      current.skillMarkdown !== null ||
+      current.skillStorageVersionId === null
+    ) {
+      return false;
+    }
+    await tx
+      .update(orgCustomConnectors)
+      .set({ skillStorageVersionId: null })
+      .where(eq(orgCustomConnectors.id, connectorId));
+    signal.throwIfAborted();
+    return true;
+  });
+}
+
+export const customConnectorSkillRepairStatus$ = command(
+  async (
+    { get },
+    signal: AbortSignal,
+  ): Promise<CustomConnectorSkillRepairStatus> => {
+    let verified = 0;
+    let reasons = emptyReasonCounts();
+    const total = await walkClassifications(
+      get(db$),
+      signal,
+      (classification) => {
+        if (classification.kind === "verified") {
+          verified += 1;
+        } else {
+          reasons = incrementReason(reasons, classification.reason);
+        }
+        return true;
+      },
+    );
+    const unresolved = total - verified;
+    return {
+      total,
+      verified,
+      unresolved,
+      reasons,
+      complete: unresolved === 0,
+    };
+  },
+);
+
+export const repairCustomConnectorSkillVersions$ = command(
+  async (
+    { set },
+    signal: AbortSignal,
+  ): Promise<CustomConnectorSkillRepairResult> => {
+    const db = set(writeDb$);
+    let attempted = 0;
+    let repaired = 0;
+    let conflicts = 0;
+    const scanned = await walkClassifications(
+      db,
+      signal,
+      async (classification) => {
+        if (classification.kind === "verified") {
+          return true;
+        }
+        attempted += 1;
+        const connector = classification.connector;
+        const didRepair =
+          classification.reason === "inverseInvalid"
+            ? await repairInverseInvalidConnector(db, connector.id, signal)
+            : connector.skillMarkdown === null
+              ? false
+              : await repairSkillConnector(
+                  set,
+                  db,
+                  { ...connector, skillMarkdown: connector.skillMarkdown },
+                  signal,
+                );
+        if (didRepair) {
+          repaired += 1;
+        } else {
+          conflicts += 1;
+        }
+        return attempted < REPAIR_LIMIT;
+      },
+    );
+    return { scanned, attempted, repaired, conflicts };
+  },
+);

--- a/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
@@ -13,16 +13,55 @@ import {
   prepareVolumeServerSide$,
   type PreparedServerSideVolume,
 } from "./storage-volume-publication.service";
+import {
+  computeContentHashFromHashes,
+  hashFileContent,
+} from "./storage-content-hash.service";
 import { SKILL_FILENAME } from "./zero-workflow-volume.service";
 
-interface PrepareCustomConnectorSkillVolumeInput {
-  readonly orgId: string;
+export interface CustomConnectorSkillContentInput {
   readonly connectorId: string;
   readonly connectorSlug: string;
   readonly displayName: string;
   readonly skillMarkdown: string;
   readonly skillName?: string;
   readonly skillDescription?: string;
+}
+
+interface PrepareCustomConnectorSkillVolumeInput extends CustomConnectorSkillContentInput {
+  readonly orgId: string;
+}
+
+function buildCustomConnectorSkillFiles(
+  args: CustomConnectorSkillContentInput,
+): readonly { readonly path: string; readonly content: string }[] {
+  return [
+    {
+      path: SKILL_FILENAME,
+      content: synthesizeSkillMd({
+        name:
+          args.skillName ??
+          getCustomConnectorSkillName(args.connectorSlug, args.connectorId),
+        description: args.skillDescription ?? args.displayName,
+        instruction: args.skillMarkdown,
+      }),
+    },
+  ];
+}
+
+export function computeCustomConnectorSkillVersionId(
+  storageId: string,
+  args: CustomConnectorSkillContentInput,
+): string {
+  const files = buildCustomConnectorSkillFiles(args).map((file) => {
+    const content = Buffer.from(file.content, "utf8");
+    return {
+      path: file.path,
+      hash: hashFileContent(content),
+      size: content.length,
+    };
+  });
+  return computeContentHashFromHashes(storageId, files);
 }
 
 export const prepareCustomConnectorSkillVolume$ = command(
@@ -36,21 +75,7 @@ export const prepareCustomConnectorSkillVolume$ = command(
       {
         orgId: args.orgId,
         storageName: getCustomConnectorSkillStorageName(args.connectorId),
-        files: [
-          {
-            path: SKILL_FILENAME,
-            content: synthesizeSkillMd({
-              name:
-                args.skillName ??
-                getCustomConnectorSkillName(
-                  args.connectorSlug,
-                  args.connectorId,
-                ),
-              description: args.skillDescription ?? args.displayName,
-              instruction: args.skillMarkdown,
-            }),
-          },
-        ],
+        files: buildCustomConnectorSkillFiles(args),
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector-skill-metadata.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector-skill-metadata.ts
@@ -1,0 +1,9 @@
+export const FEISHU_CUSTOM_CONNECTOR_SKILL_METADATA = {
+  name: "feishu",
+  description:
+    "Feishu OpenAPI for user-authorized messaging, people search, cloud documents, calendars, and tasks. Use when the user asks to work with Feishu.",
+} as const;
+
+export function getFeishuCustomConnectorSlug(installationId: string): string {
+  return `_feishu-${installationId}`;
+}

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -20,6 +20,10 @@ import {
   commitPreparedCustomConnectorSkillVolume,
   prepareCustomConnectorSkillVolume$,
 } from "./custom-connector-skill-volume.service";
+import {
+  FEISHU_CUSTOM_CONNECTOR_SKILL_METADATA,
+  getFeishuCustomConnectorSlug,
+} from "./feishu-custom-connector-skill-metadata";
 import { commitConnectorRuntimeMutation } from "./connector-runtime-wakeup.service";
 import {
   customConnectorDefinitionSelection,
@@ -34,9 +38,6 @@ const FEISHU_AUTHORIZATION_URL =
 const FEISHU_TOKEN_URL =
   "https://open.feishu.cn/open-apis/authen/v2/oauth/token";
 const FEISHU_DISPLAY_NAME = "Feishu";
-const FEISHU_SKILL_NAME = "feishu";
-const FEISHU_SKILL_DESCRIPTION =
-  "Feishu OpenAPI for user-authorized messaging, people search, cloud documents, calendars, and tasks. Use when the user asks to work with Feishu.";
 const FEISHU_AUTHORIZATION_HEADER = "Authorization";
 const FEISHU_AUTHORIZATION_TEMPLATE = "Bearer {{oauth.access_token}}";
 
@@ -178,10 +179,6 @@ curl -sS -X POST \
 7. Consult the current Feishu API reference when an endpoint, payload, supported token type, or resource-specific limitation is uncertain.
 `;
 
-function feishuCustomConnectorSlug(installationId: string): string {
-  return `_feishu-${installationId}`;
-}
-
 function feishuCustomConnectorDisplayName(botName: string | null): string {
   return botName ? `${FEISHU_DISPLAY_NAME}-${botName}` : FEISHU_DISPLAY_NAME;
 }
@@ -277,7 +274,7 @@ async function createFeishuCustomConnector(
     .values({
       id: connectorId,
       orgId: args.orgId,
-      slug: feishuCustomConnectorSlug(args.installationId),
+      slug: getFeishuCustomConnectorSlug(args.installationId),
       ...desiredConnectorDefinition(installation),
       createdBy: installation.ownerUserId ?? args.userId,
     })
@@ -359,7 +356,7 @@ async function preflightFeishuCustomConnectorId(
         eq(orgCustomConnectors.orgId, feishuOrgInstallations.orgId),
         eq(
           orgCustomConnectors.slug,
-          feishuCustomConnectorSlug(args.installationId),
+          getFeishuCustomConnectorSlug(args.installationId),
         ),
       ),
     )
@@ -405,7 +402,7 @@ async function reconcileFeishuCustomConnector(
     return { kind: "installation-missing" };
   }
 
-  const slug = feishuCustomConnectorSlug(args.installationId);
+  const slug = getFeishuCustomConnectorSlug(args.installationId);
   const [existing] = await tx
     .select({
       connector: customConnectorDefinitionSelection(),
@@ -491,11 +488,11 @@ export const ensureFeishuCustomConnector$ = command(
         {
           orgId: args.orgId,
           connectorId,
-          connectorSlug: feishuCustomConnectorSlug(args.installationId),
+          connectorSlug: getFeishuCustomConnectorSlug(args.installationId),
           displayName: FEISHU_DISPLAY_NAME,
           skillMarkdown: FEISHU_SKILL_MARKDOWN,
-          skillName: FEISHU_SKILL_NAME,
-          skillDescription: FEISHU_SKILL_DESCRIPTION,
+          skillName: FEISHU_CUSTOM_CONNECTOR_SKILL_METADATA.name,
+          skillDescription: FEISHU_CUSTOM_CONNECTOR_SKILL_METADATA.description,
         },
         signal,
       );
@@ -569,7 +566,7 @@ export const deleteFeishuCustomConnector$ = command(
           eq(orgCustomConnectors.orgId, args.orgId),
           eq(
             orgCustomConnectors.slug,
-            feishuCustomConnectorSlug(args.installationId),
+            getFeishuCustomConnectorSlug(args.installationId),
           ),
         ),
       )
@@ -635,7 +632,7 @@ export async function hasFeishuCustomConnectorOAuthConnection(
         eq(orgCustomConnectors.orgId, args.orgId),
         eq(
           orgCustomConnectors.slug,
-          feishuCustomConnectorSlug(args.installationId),
+          getFeishuCustomConnectorSlug(args.installationId),
         ),
         eq(connectors.userId, args.userId),
         eq(connectors.authMethod, "oauth"),
@@ -663,7 +660,7 @@ export async function disconnectFeishuCustomConnectorOAuthConnection(
         eq(orgCustomConnectors.orgId, args.orgId),
         eq(
           orgCustomConnectors.slug,
-          feishuCustomConnectorSlug(args.installationId),
+          getFeishuCustomConnectorSlug(args.installationId),
         ),
       ),
     )

--- a/turbo/apps/api/vercel.json
+++ b/turbo/apps/api/vercel.json
@@ -73,6 +73,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/repair-custom-connector-skill-versions",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/process-usage-events",
       "schedule": "* * * * *"
     },

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -188,6 +188,33 @@ const cronSyncSkillsResponseSchema = z.object({
   total: z.number(),
 });
 
+const customConnectorSkillRepairReasonCountsSchema = z.object({
+  inverseInvalid: z.number().int().nonnegative(),
+  missingStorage: z.number().int().nonnegative(),
+  missingExpectedVersion: z.number().int().nonnegative(),
+  missingAssociation: z.number().int().nonnegative(),
+  wrongStorage: z.number().int().nonnegative(),
+  staleAssociation: z.number().int().nonnegative(),
+  headMismatch: z.number().int().nonnegative(),
+});
+
+const cronCustomConnectorSkillRepairResponseSchema = z.object({
+  success: z.literal(true),
+  scanned: z.number().int().nonnegative(),
+  attempted: z.number().int().nonnegative(),
+  repaired: z.number().int().nonnegative(),
+  conflicts: z.number().int().nonnegative(),
+});
+
+const cronCustomConnectorSkillRepairStatusResponseSchema = z.object({
+  success: z.literal(true),
+  total: z.number().int().nonnegative(),
+  verified: z.number().int().nonnegative(),
+  unresolved: z.number().int().nonnegative(),
+  reasons: customConnectorSkillRepairReasonCountsSchema,
+  complete: z.boolean(),
+});
+
 const connectorCatalogSyncResponseSchema =
   connectorCatalogDiagnosticsSchema.extend({
     outcome: z.enum(["accepted", "unchanged", "rejected"]),
@@ -504,6 +531,31 @@ export const cronSyncSkillsContract = c.router({
   },
 });
 
+export const cronCustomConnectorSkillRepairContract = c.router({
+  repair: {
+    method: "GET",
+    path: "/api/cron/repair-custom-connector-skill-versions",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronCustomConnectorSkillRepairResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Repair custom connector skill version associations",
+  },
+  status: {
+    method: "GET",
+    path: "/api/cron/repair-custom-connector-skill-versions/status",
+    headers: authHeadersSchema,
+    responses: {
+      200: cronCustomConnectorSkillRepairStatusResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Report custom connector skill repair completion",
+  },
+});
+
 export const cronConnectorCatalogContract = c.router({
   sync: {
     method: "GET",
@@ -590,6 +642,8 @@ export type CronComputerUseScreenshotCleanupContract =
 export type CronBrowserReconcileContract = typeof cronBrowserReconcileContract;
 export type CronDrainEmailOutboxContract = typeof cronDrainEmailOutboxContract;
 export type CronSyncSkillsContract = typeof cronSyncSkillsContract;
+export type CronCustomConnectorSkillRepairContract =
+  typeof cronCustomConnectorSkillRepairContract;
 export type CronConnectorCatalogContract = typeof cronConnectorCatalogContract;
 export type CronRenewGmailWatchesContract =
   typeof cronRenewGmailWatchesContract;

--- a/turbo/packages/api-contracts/src/contracts/test-custom-connector-skill-repair-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-custom-connector-skill-repair-state.ts
@@ -71,7 +71,3 @@ export const testCustomConnectorSkillRepairStateContract = c.router({
     summary: "Mutate custom connector skill repair test state",
   },
 });
-
-export type TestCustomConnectorSkillRepairStateAction = z.infer<
-  typeof actionBodySchema
->;

--- a/turbo/packages/api-contracts/src/contracts/test-custom-connector-skill-repair-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-custom-connector-skill-repair-state.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const actionBodySchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("read"),
+    connectorId: z.string().uuid(),
+  }),
+  z.object({
+    action: z.literal("set-connector"),
+    connectorId: z.string().uuid(),
+    skillMarkdown: z.string().nullable().optional(),
+    skillStorageVersionId: z.string().nullable().optional(),
+  }),
+  z.object({
+    action: z.literal("set-head"),
+    connectorId: z.string().uuid(),
+    headVersionId: z.string().nullable(),
+  }),
+  z.object({
+    action: z.literal("set-provider-adapter"),
+    connectorId: z.string().uuid(),
+    providerAdapter: z.enum(["standard", "feishu"]),
+  }),
+  z.object({
+    action: z.literal("set-managed-feishu-installation"),
+    connectorId: z.string().uuid(),
+    installationId: z.string().uuid(),
+    defaultComposeId: z.string().uuid(),
+  }),
+  z.object({
+    action: z.literal("clear-managed-feishu-installation"),
+    connectorId: z.string().uuid(),
+    installationId: z.string().uuid(),
+  }),
+]);
+
+const stateSchema = z.object({
+  connector: z.object({
+    skillMarkdown: z.string().nullable(),
+    skillStorageVersionId: z.string().nullable(),
+    oauthProviderAdapter: z.enum(["standard", "feishu"]).nullable(),
+    managedFeishuInstallationId: z.string().uuid().nullable(),
+  }),
+  storage: z
+    .object({
+      id: z.string().uuid(),
+      headVersionId: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+const actionResponseSchema = z.object({
+  ok: z.literal(true),
+  state: stateSchema,
+});
+
+export const testCustomConnectorSkillRepairStateContract = c.router({
+  action: {
+    method: "POST",
+    path: "/api/test/custom-connector-skill-repair-state/action",
+    body: actionBodySchema,
+    responses: {
+      200: actionResponseSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Mutate custom connector skill repair test state",
+  },
+});
+
+export type TestCustomConnectorSkillRepairStateAction = z.infer<
+  typeof actionBodySchema
+>;


### PR DESCRIPTION
## Summary

- add CRON-secret-protected mutation and status endpoints that semantically verify every Custom connector skill association
- repair at most five unresolved connectors per invocation by preparing artifacts outside the transaction and atomically binding the exact version plus compatibility HEAD after re-reading authoritative state
- share live skill synthesis/version identity, including managed Feishu detection from persisted organization and installation identity
- schedule the temporary repair every minute now that the atomic writer release is deployed and drained

## Compatibility and scope

- no database schema, public API, runner protocol, or runtime reader changes
- verified status scans perform database reads and hashing only; they do not call S3
- no-skill rows only clear inverse-invalid pointers; artifact cleanup and exact runtime reads remain deferred to the parent rollout

## Validation

- `pnpm exec prettier --check <changed files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-custom-connector-skill-repair.test.ts src/signals/routes/__tests__/zero-feishu-integration.test.ts src/__tests__/vercel-crons.test.ts --maxWorkers=1 --silent=passed-only` (38 tests)
- `pnpm -F @vm0/api-contracts test -- --maxWorkers=1 --silent=passed-only` (557 tests)
- pre-commit hook: full Turbo Knip and type checks

The local all-file API Vitest command also exposed pre-existing shared-database cross-file pollution in chat snapshot tests and concurrent global `vm0_api_keys` fixtures. The affected snapshot files pass in isolation on consistent state, and none of those paths are changed here.

Closes #26135

Parent: #26075
