### PR TITLE
fix(connectors): hide custom agent access while unavailable

### DIFF
--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -577,40 +577,7 @@ describe("team page navigation", () => {
     });
   });
 
-  it("authorizes a disconnected custom connector", async () => {
-    let updateCalls = 0;
-    mockTeamAPIs({
-      customConnector: {
-        ...createCustomConnector(),
-        connected: false,
-        missingRequiredFields: ["secret"],
-        configuredFieldKeys: [],
-        hasSecret: false,
-      },
-      onCustomConnectorUpdate: () => {
-        updateCalls += 1;
-      },
-    });
-
-    detachedSetupPage({ context, path: `/agents/${researchAgentId}` });
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Research Agent" }),
-      ).toBeInTheDocument();
-      expect(screen.getByText("Acme Search")).toBeInTheDocument();
-      expect(screen.getByText(/Not connected/)).toBeInTheDocument();
-    });
-
-    click(screen.getByLabelText("Grant Acme Search access"));
-    await waitFor(() => {
-      expect(updateCalls).toBe(1);
-      expect(screen.getByText("Custom connectors saved")).toBeInTheDocument();
-      expect(screen.getByLabelText("Revoke Acme Search access")).toBeChecked();
-    });
-  });
-
-  it("selects permissions before authorizing a disconnected custom connector", async () => {
+  it("hides unavailable custom connectors without loading agent access", async () => {
     const customConnector = {
       ...createCustomConnector(),
       connected: false,
@@ -619,92 +586,32 @@ describe("team page navigation", () => {
       hasSecret: false,
       permissionBundleRef: "builtin:feishu@1" as const,
     };
-    let capturedUpdate: AgentCustomConnectorUpdate | null = null;
+    let connectorListReads = 0;
+    let agentAccessReads = 0;
     mockTeamAPIs({ customConnector });
-    context.mocks.api(
-      zeroCustomConnectorByIdContract.permissions,
-      ({ params, respond }) => {
-        expect(params.id).toBe(customConnector.id);
-        return respond(200, {
-          ref: "builtin:feishu@1",
-          permissions: [
-            {
-              name: "standard:use",
-              description: "Use standard Feishu APIs with approval.",
-            },
-            {
-              name: "messages:send-as-user",
-              description: "Send or edit messages as the connected user.",
-            },
-            {
-              name: "resources:delete",
-              description: "Delete Feishu content.",
-            },
-          ],
-          defaultPolicies: {
-            "standard:use": "allow",
-            "messages:send-as-user": "deny",
-            "resources:delete": "deny",
-          },
-        });
-      },
-    );
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      connectorListReads += 1;
+      return respond(200, { connectors: [customConnector] });
+    });
     context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      agentAccessReads += 1;
       return respond(200, {
         enabledIds: [],
         grants: [],
       });
     });
-    context.mocks.api(
-      zeroAgentCustomConnectorsContract.update,
-      ({ body, respond }) => {
-        capturedUpdate = body;
-        return respond(200, {
-          enabledIds: [customConnector.id],
-          grants:
-            "grants" in body
-              ? body.grants
-              : [
-                  {
-                    customConnectorId: customConnector.id,
-                    permissionNames: [],
-                  },
-                ],
-        });
-      },
-    );
 
     detachedSetupPage({
       context,
       path: `/agents/${researchAgentId}`,
     });
 
-    await screen.findByText("Acme Search");
-    click(screen.getByLabelText("Grant Acme Search access"));
-
-    const messagePermission = await screen.findByText("messages:send-as-user");
-    const drawer = dialogForElement(messagePermission);
-    expect(within(drawer).queryByText("standard:use")).not.toBeInTheDocument();
-    expect(buttonByText("Apply", drawer)).toBeEnabled();
-    const messageRow = messagePermission.parentElement?.parentElement;
-    if (!(messageRow instanceof HTMLElement)) {
-      throw new Error("custom connector permission row not found");
-    }
-    click(buttonByText("Allow", messageRow));
-    click(buttonByText("Apply", drawer));
-
     await waitFor(() => {
-      expect(capturedUpdate).toStrictEqual({
-        grants: [
-          {
-            customConnectorId: customConnector.id,
-            permissionNames: ["messages:send-as-user"],
-          },
-        ],
-        operation: "add",
-      });
-      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      expect(connectorListReads).toBeGreaterThan(0);
+      expect(screen.getByText("@workspace")).toBeInTheDocument();
     });
+    expect(screen.queryByText("Acme Search")).not.toBeInTheDocument();
+    expect(agentAccessReads).toBe(0);
   });
 
   it("does not show a custom connector permission draft on another agent", async () => {

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -52,7 +52,6 @@ function JobCustomConnectorRow({
   readonly isLast: boolean;
   readonly onToggle: (id: string, checked: boolean) => void;
 }) {
-  const { t: tCommon } = useTranslation();
   const openPermissions = useSet(openCustomConnectorPermissions$);
   const permissionNames =
     grants?.find((grant) => {
@@ -82,16 +81,7 @@ function JobCustomConnectorRow({
         />
       }
       label={connector.displayName}
-      description={
-        <span className="font-mono">
-          {connector.prefixes[0]}
-          {!connector.connected
-            ? ` — ${tCommon(($) => {
-                return $.connectors.catalog.filters.notConnected;
-              })}`
-            : null}
-        </span>
-      }
+      description={<span className="font-mono">{connector.prefixes[0]}</span>}
       enabled={enabled}
       loading={
         loading || (Boolean(connector.permissionBundleRef) && grantsLoading)
@@ -121,9 +111,28 @@ function JobCustomConnectorRow({
 }
 
 export function JobCustomConnectorsSection() {
-  const { t } = useTranslation("agents");
   const connectors = useLastResolved(customConnectors$);
-  const httpConnectors = connectors?.filter(isHttpCustomConnectorResponse);
+  const connectedHttpConnectors = connectors
+    ?.filter(isHttpCustomConnectorResponse)
+    .filter((connector) => {
+      return connector.connected;
+    });
+
+  if (!connectedHttpConnectors || connectedHttpConnectors.length === 0) {
+    return null;
+  }
+
+  return (
+    <ConnectedJobCustomConnectorsSection connectors={connectedHttpConnectors} />
+  );
+}
+
+function ConnectedJobCustomConnectorsSection({
+  connectors,
+}: {
+  readonly connectors: readonly CustomConnectorHttpResponse[];
+}) {
+  const { t } = useTranslation("agents");
   const addedLoadable = useLastLoadable(agentAddedCustomConnectors$);
   const added = addedLoadable.state === "hasData" ? addedLoadable.data : [];
   const addedSet = new Set(added);
@@ -137,10 +146,6 @@ export function JobCustomConnectorsSection() {
   );
   const grantsLoadable = useLastLoadable(agentCustomConnectorGrants$);
   const detail = useLastResolved(agentDetail$);
-
-  if (!httpConnectors || httpConnectors.length === 0) {
-    return null;
-  }
 
   const handleToggle = (id: string, checked: boolean) => {
     if (saving) {
@@ -167,7 +172,7 @@ export function JobCustomConnectorsSection() {
       ? permissionDraft
       : null;
   const permissionTargetConnector = activePermissionDraft
-    ? httpConnectors.find((connector) => {
+    ? connectors.find((connector) => {
         return connector.id === activePermissionDraft.connectorId;
       })
     : undefined;
@@ -190,7 +195,7 @@ export function JobCustomConnectorsSection() {
           return $.authorization.customConnectors.description;
         })}
       </div>
-      {httpConnectors.map((connector, index) => {
+      {connectors.map((connector, index) => {
         return (
           <JobCustomConnectorRow
             key={connector.id}
@@ -202,7 +207,7 @@ export function JobCustomConnectorsSection() {
               grantsLoadable.state === "hasData" ? grantsLoadable.data : null
             }
             grantsLoading={grantsLoadable.state === "loading"}
-            isLast={index === httpConnectors.length - 1}
+            isLast={index === connectors.length - 1}
             onToggle={handleToggle}
           />
         );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -3488,7 +3488,7 @@ describe("connectors page", () => {
     ).toBeInTheDocument();
   });
 
-  it("manages agent access for a disconnected custom connector", async () => {
+  it("keeps a disconnected custom connector manageable without loading agent access", async () => {
     const researchAgentId = "c0000000-0000-4000-a000-000000000031";
     const supportAgentId = "c0000000-0000-4000-a000-000000000032";
     const connector = customConnector({});
@@ -3501,37 +3501,16 @@ describe("connectors page", () => {
       teamAgent(researchAgentId, "Research"),
       teamAgent(supportAgentId, "Support"),
     ]);
-    const enabledIdsByAgent = new Map<string, string[]>([
-      [researchAgentId, [connector.id]],
-      [supportAgentId, []],
-    ]);
+    let agentAccessReads = 0;
     context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
       return respond(200, { connectors: [connector] });
     });
     context.mocks.api(
       zeroAgentCustomConnectorsContract.get,
       ({ params, respond }) => {
+        agentAccessReads += 1;
         return respond(200, {
-          enabledIds: enabledIdsByAgent.get(params.id) ?? [],
-        });
-      },
-    );
-    context.mocks.api(
-      zeroAgentCustomConnectorsContract.update,
-      ({ params, body, respond }) => {
-        if (!("enabledIds" in body)) {
-          throw new Error("Expected custom connector ID authorization");
-        }
-        const current = enabledIdsByAgent.get(params.id) ?? [];
-        const next =
-          body.operation === "add"
-            ? Array.from(new Set([...current, ...body.enabledIds]))
-            : current.filter((id) => {
-                return !body.enabledIds.includes(id);
-              });
-        enabledIdsByAgent.set(params.id, next);
-        return respond(200, {
-          enabledIds: next,
+          enabledIds: params.id === researchAgentId ? [connector.id] : [],
         });
       },
     );
@@ -3545,41 +3524,28 @@ describe("connectors page", () => {
         within(card).getByText("https://api.acme.test/v1/"),
       ).toBeInTheDocument();
       expect(
-        within(card).getByTestId("connector-card-agent-access"),
-      ).toHaveTextContent("Used by Research");
-    });
-
-    click(
-      within(connectorCardByLabel("Acme Search")).getByLabelText(
-        "Manage Acme Search access",
-      ),
-    );
-    const dialog = await screen.findByRole("dialog", {
-      name: "Manage Acme Search access",
-    });
-    expect(within(dialog).getByText("Research")).toBeInTheDocument();
-    expect(within(dialog).getByText("Support")).toBeInTheDocument();
-
-    click(
-      within(dialog).getByLabelText("Authorize Acme Search access for Support"),
-    );
-    await waitFor(() => {
+        within(card).queryByTestId("connector-card-agent-access"),
+      ).not.toBeInTheDocument();
       expect(
-        within(dialog).getByLabelText("Revoke Acme Search access for Support"),
+        within(card).getByLabelText("Connect Acme Search"),
       ).toBeInTheDocument();
-      expect(
-        within(connectorCardByLabel("Acme Search")).getByTestId(
-          "connector-card-agent-access",
-        ),
-      ).toHaveTextContent("Used by Research, Support");
     });
-    expect(screen.queryByText("Connect Acme Search")).not.toBeInTheDocument();
+
+    click(screen.getByLabelText("More options"));
+    expect(menuItemByText("Connect")).toBeInTheDocument();
+    expect(menuItemByText("Edit")).toBeInTheDocument();
+    expect(menuItemByText("Delete")).toBeInTheDocument();
+    expect(agentAccessReads).toBe(0);
   });
 
   it("selects and edits permissions for a custom connector from settings", async () => {
     const researchAgentId = "c0000000-0000-4000-a000-000000000035";
     const supportAgentId = "c0000000-0000-4000-a000-000000000036";
     const connector = customConnector({
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      hasSecret: true,
       permissionBundleRef: "builtin:feishu@1",
     });
     const accessByAgentId = new Map<string, AgentCustomConnectorResponse>([
@@ -4018,6 +3984,7 @@ describe("connectors page", () => {
   it("reconnects a managed Feishu connector without replacing its grants", async () => {
     const defaultAgentId = "c0000000-0000-4000-a000-000000000044";
     let oauthStartCount = 0;
+    let authorizationReads = 0;
     let authorizationUpdates = 0;
     let connector = customConnector({
       slug: "_feishu-00000000-0000-4000-8000-000000000044",
@@ -4056,6 +4023,7 @@ describe("connectors page", () => {
       return respond(200, { connectors: [connector] });
     });
     context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      authorizationReads += 1;
       return respond(200, {
         enabledIds: [connector.id],
         grants: [
@@ -4113,6 +4081,12 @@ describe("connectors page", () => {
     const connectorButton = await waitFor(() => {
       return buttonByAriaLabel("Connect Feishu");
     });
+    expect(
+      within(connectorCardByLabel("Feishu")).queryByTestId(
+        "connector-card-agent-access",
+      ),
+    ).not.toBeInTheDocument();
+    expect(authorizationReads).toBe(0);
     click(connectorButton);
     expect(document.querySelector('[role="dialog"]')).not.toBeInTheDocument();
     await waitFor(() => {
@@ -4126,6 +4100,7 @@ describe("connectors page", () => {
         ),
       ).toHaveTextContent("Used by Zero");
     });
+    expect(authorizationReads).toBe(1);
     expect(authorizationUpdates).toBe(0);
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -4550,6 +4550,11 @@ describe("connectors page", () => {
 
     await waitFor(() => {
       expect(buttonByAriaLabel("Connect Acme Billing API")).toBeInTheDocument();
+      expect(
+        within(connectorCardByLabel("Acme Billing API")).queryByTestId(
+          "connector-card-agent-access",
+        ),
+      ).not.toBeInTheDocument();
     });
 
     click(screen.getByLabelText("More options"));

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -19,7 +19,6 @@ import {
   type CustomConnectorHttpResponse,
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import {
   disconnectCustomConnector$,
   closeCustomConnectorDialog$,
@@ -52,8 +51,6 @@ function connectsDirectlyWithOAuth(
 
 interface CustomConnectorRowProps {
   readonly connector: CustomConnectorResponse;
-  readonly authorizedAgents: readonly TeamComposeItem[];
-  readonly authorizedAgentsLoading: boolean;
   readonly isAdmin: boolean;
   readonly onConnect: () => void;
   readonly onDisconnect: () => void;
@@ -62,17 +59,38 @@ interface CustomConnectorRowProps {
   readonly onDelete: () => void;
 }
 
+function CustomConnectorAgentAccess({
+  connector,
+  onManageAccess,
+}: {
+  readonly connector: CustomConnectorHttpResponse;
+  readonly onManageAccess: () => void;
+}) {
+  const authorizedAgentsByIdLoadable = useLastLoadable(
+    customConnectorAuthorizedAgentsById$,
+  );
+  const authorizedAgents =
+    authorizedAgentsByIdLoadable.state === "hasData"
+      ? (authorizedAgentsByIdLoadable.data.get(connector.id) ?? [])
+      : [];
+
+  return (
+    <ConnectorAgentAccessButton
+      agents={authorizedAgents}
+      loading={authorizedAgentsByIdLoadable.state === "loading"}
+      connectorLabel={connector.displayName}
+      onClick={onManageAccess}
+    />
+  );
+}
+
 function CustomConnectorCardContent({
   connector,
-  authorizedAgents,
-  authorizedAgentsLoading,
   hasActions,
   onConnect,
   onManageAccess,
 }: {
   readonly connector: CustomConnectorResponse;
-  readonly authorizedAgents: readonly TeamComposeItem[];
-  readonly authorizedAgentsLoading: boolean;
   readonly hasActions: boolean;
   readonly onConnect: () => void;
   readonly onManageAccess: () => void;
@@ -157,12 +175,10 @@ function CustomConnectorCardContent({
             })}
           </span>
         ) : null}
-        {connector.kind === "http" ? (
-          <ConnectorAgentAccessButton
-            agents={authorizedAgents}
-            loading={authorizedAgentsLoading}
-            connectorLabel={connector.displayName}
-            onClick={onManageAccess}
+        {connector.kind === "http" && connector.connected ? (
+          <CustomConnectorAgentAccess
+            connector={connector}
+            onManageAccess={onManageAccess}
           />
         ) : null}
       </div>
@@ -172,8 +188,6 @@ function CustomConnectorCardContent({
 
 function CustomConnectorRow({
   connector,
-  authorizedAgents,
-  authorizedAgentsLoading,
   isAdmin,
   onConnect,
   onDisconnect,
@@ -191,8 +205,6 @@ function CustomConnectorRow({
   const cardContent = (
     <CustomConnectorCardContent
       connector={connector}
-      authorizedAgents={authorizedAgents}
-      authorizedAgentsLoading={authorizedAgentsLoading}
       hasActions={hasActions}
       onConnect={onConnect}
       onManageAccess={onManageAccess}
@@ -299,15 +311,6 @@ function CustomConnectorDialogs() {
 export function CustomConnectorsPanel() {
   const { t } = useTranslation();
   const connectors = useLastResolved(customConnectors$);
-  const authorizedAgentsByIdLoadable = useLastLoadable(
-    customConnectorAuthorizedAgentsById$,
-  );
-  const authorizedAgentsById =
-    authorizedAgentsByIdLoadable.state === "hasData"
-      ? authorizedAgentsByIdLoadable.data
-      : new Map<string, readonly TeamComposeItem[]>();
-  const authorizedAgentsLoading =
-    authorizedAgentsByIdLoadable.state === "loading";
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
   const openEdit = useSet(openCustomConnectorEditDialog$);
   const openAccess = useSet(openCustomConnectorAccessDialog$);
@@ -359,8 +362,6 @@ export function CustomConnectorsPanel() {
               <CustomConnectorRow
                 key={c.id}
                 connector={c}
-                authorizedAgents={authorizedAgentsById.get(c.id) ?? []}
-                authorizedAgentsLoading={authorizedAgentsLoading}
                 isAdmin={isAdmin}
                 onConnect={() => {
                   if (isHttpCustomConnectorResponse(c)) {


### PR DESCRIPTION
## Summary

- hide HTTP Custom connectors from agent authorization while their current connection is unavailable
- keep disconnected Custom settings cards available for connection and administration without exposing Agent Access
- mount per-agent authorization readers only for connected HTTP Custom surfaces, preserving shared authorization semantics and avoiding hidden fan-out
- keep durable grants visible again after reconnect without recreating them

## Scope

- Platform presentation and page-level integration coverage only
- no API, database, persisted-grant, runner, firewall, feature-switch, or deployment compatibility changes
- Builtin and MCP connector behavior remains unchanged

## Validation

- `pnpm prettier --write apps/platform/src/views/team-page/job-custom-connectors-section.tsx apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/team-page/__tests__/team-navigation.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/app`
- `lefthook run pre-commit`

Closes #26251

Parent: #25312
