### PR TITLE
fix(connectors): align custom oauth state lifecycle

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2140,7 +2140,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await connectorsApi.deleteCustomConnector(admin, created.id);
   });
 
-  it("keeps OAuth callback state scoped to its Builtin or Custom target", async () => {
+  it("keeps OAuth state target-scoped and aligns Custom lifecycle with Builtin", async () => {
     mockEnv("APP_URL", "https://app.vm0.test");
     mockGitHubConnectorOAuth();
     const provider = mockCustomConnectorOAuth2Provider(context, {
@@ -2194,6 +2194,16 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       message: "Invalid state - please try again",
     });
 
+    const customMissingCode =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        state: customState,
+      });
+    expect(customMissingCode.body).toStrictEqual({
+      status: "error",
+      message: "Missing authorization code",
+    });
+    expect(provider.tokenBodies).toHaveLength(0);
+
     const customSuccess =
       await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
         code: "custom-success-code",
@@ -2203,6 +2213,8 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       status: "success",
       username: null,
     });
+    expect(provider.tokenBodies).toHaveLength(1);
+    expect(provider.tokenBodies[0]?.get("code")).toBe("custom-success-code");
     const ownerConnectors = await connectorsApi.listCustomConnectors(owner);
     expect(
       ownerConnectors.find((candidate) => {
@@ -2225,6 +2237,31 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       status: "error",
       message: "Invalid OAuth state - please try again",
     });
+    expect(provider.tokenBodies).toHaveLength(1);
+
+    const deniedAuthorizationUrl =
+      await connectorsApi.startCustomConnectorOAuth2(owner, connector.id);
+    const deniedState = stateFromAuthorizationUrl(deniedAuthorizationUrl);
+    const denied =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        error: "access_denied",
+        error_description: "Provider denied access",
+        state: deniedState,
+      });
+    expect(denied.body).toStrictEqual({
+      status: "error",
+      message: "Provider denied access",
+    });
+    const deniedReplay =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "custom-denied-replay-code",
+        state: deniedState,
+      });
+    expect(deniedReplay.body).toStrictEqual({
+      status: "error",
+      message: "Invalid OAuth state - please try again",
+    });
+    expect(provider.tokenBodies).toHaveLength(1);
 
     const builtinAuthorization = await connectorsApi.startOauth(
       peer,
@@ -2236,7 +2273,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     );
     const wrongCustomCallback =
       await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
-        code: "wrong-custom-source-code",
         state: builtinState,
       });
     expect(wrongCustomCallback.body).toStrictEqual({
@@ -2262,16 +2298,25 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       await connectorsApi.startCustomConnectorOAuth2(peer, connector.id);
     const expiringState = stateFromAuthorizationUrl(expiringAuthorizationUrl);
     mockNow(now() + 16 * 60 * 1000);
-    const expired =
+    const expiredStatus =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        state: expiringState,
+      });
+    const expiredClaim =
       await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
         code: "expired-custom-code",
         state: expiringState,
       });
     clearMockNow();
-    expect(expired.body).toStrictEqual({
+    expect(expiredStatus.body).toStrictEqual({
       status: "error",
       message: "Invalid OAuth state - please try again",
     });
+    expect(expiredClaim.body).toStrictEqual({
+      status: "error",
+      message: "Invalid OAuth state - please try again",
+    });
+    expect(provider.tokenBodies).toHaveLength(1);
     const peerAfterExpiry = await connectorsApi.listCustomConnectors(peer);
     expect(
       peerAfterExpiry.find((candidate) => {

--- a/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
@@ -343,7 +343,10 @@ async function rejectInvalidStoredOAuthStateForCallback(
 ): Promise<Response | undefined> {
   const status = await getConnectorOAuthStateStatus(
     args.db,
-    { state: args.state, connectorSlug: args.connectorSlug },
+    {
+      state: args.state,
+      target: { kind: "builtin", connectorSlug: args.connectorSlug },
+    },
     signal,
   );
   if (status.kind === "usable") {

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts
@@ -11,6 +11,7 @@ import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import {
   claimConnectorOAuthState,
+  getConnectorOAuthStateStatus,
   type StoredCustomConnectorOAuthState,
 } from "../services/connector-oauth-state.service";
 import { validateConnectorAuthorizationTarget$ } from "../services/connected-connector-authorization.service";
@@ -203,29 +204,49 @@ async function persistCustomConnectorOAuth2Connection(
   await publishCustomUserInvalidation(args.userId, signal);
 }
 
+async function codeLessCustomOAuthCallbackResponse(
+  args: { readonly db: Db; readonly origin: string; readonly state: string },
+  signal: AbortSignal,
+): Promise<Response> {
+  const status = await getConnectorOAuthStateStatus(
+    args.db,
+    { state: args.state, target: { kind: "custom" } },
+    signal,
+  );
+  signal.throwIfAborted();
+  return status.kind === "usable"
+    ? callbackError(args.origin, "Missing authorization code")
+    : callbackError(args.origin, "Invalid OAuth state - please try again");
+}
+
 const completeOAuth2Callback$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<Response> => {
     const query = get(queryOf(zeroCustomConnectorOAuth2Contract.callback));
     const origin = new URL(env("APP_URL")).origin;
-    if (!query.state) {
+    const oauthState = query.state;
+    const authorizationCode = query.code ?? "";
+    const providerError = query.error;
+    if (!oauthState) {
       return callbackError(origin, "Missing OAuth state");
+    }
+    if (!providerError && !authorizationCode) {
+      return await codeLessCustomOAuthCallbackResponse(
+        { db: set(writeDb$), origin, state: oauthState },
+        signal,
+      );
     }
     const claimed = await claimConnectorOAuthState(
       set(writeDb$),
-      { state: query.state, target: { kind: "custom" } },
+      { state: oauthState, target: { kind: "custom" } },
       signal,
     );
     signal.throwIfAborted();
     if (claimed.kind !== "usable") {
       return callbackError(origin, "Invalid OAuth state - please try again");
     }
-    if (query.error) {
-      return callbackError(origin, query.error_description ?? query.error);
+    if (providerError) {
+      return callbackError(origin, query.error_description ?? providerError);
     }
-    if (!query.code) {
-      return callbackError(origin, "Missing authorization code");
-    }
-    const authorizationCode = query.code;
     const state = validateClaimedState(claimed.state);
     if (!state.ok) {
       return callbackError(origin, "Invalid OAuth state - please try again");

--- a/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-state.service.ts
@@ -160,14 +160,10 @@ export async function getConnectorOAuthStateStatus(
   db: Db,
   args: {
     readonly state: string;
-    readonly connectorSlug: ConnectorSlug;
+    readonly target: OAuthStateTarget;
   },
   signal: AbortSignal,
 ): Promise<ConnectorOAuthStateStatus> {
-  const target: BuiltinOAuthStateTarget = {
-    kind: "builtin",
-    connectorSlug: args.connectorSlug,
-  };
   const [storedState] = await db
     .select({
       connectorSlug: connectorOauthStates.connectorSlug,
@@ -185,7 +181,7 @@ export async function getConnectorOAuthStateStatus(
   }
 
   if (
-    !matchesOAuthStateTarget(storedState, target) ||
+    !matchesOAuthStateTarget(storedState, args.target) ||
     storedState.consumedAt ||
     storedState.expiresAt <= nowDate()
   ) {


### PR DESCRIPTION
## Summary

- make the shared OAuth state status check target-aware for Builtin and Custom connectors
- keep valid Custom OAuth state reusable when a callback has neither a code nor a provider error
- preserve atomic terminal claims for provider errors and authorization codes
- cover missing-code reuse, provider-error replay, target isolation, and expiry through public API routes

## Correctness and performance

- successful code callbacks still perform one atomic `DELETE ... RETURNING` claim before token exchange
- provider-error callbacks remain terminal and consume valid state
- code-less callbacks use one narrow status query and never authorize a connection
- Builtin callback ordering and public responses are unchanged

## Exclusions

- no schema, migration, persisted-state, API contract, feature-switch, frontend, runner, or queue changes
- no changes to provider-specific token exchange, credential persistence, connector validation, MCP gating, or agent authorization

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/connector-oauth-state.service.ts apps/api/src/signals/routes/connectors-slug-callback.ts apps/api/src/signals/routes/zero-custom-connectors-oauth2.ts apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm knip --workspace api`
- pre-commit full-workspace Knip and TypeScript checks
- `git diff --check`

Closes #26164

Parent objective: #25312
