### PR TITLE
fix: tighten tooltip vertical padding for balanced optical spacing

### DIFF
--- a/turbo/packages/ui/src/components/ui/tooltip.tsx
+++ b/turbo/packages/ui/src/components/ui/tooltip.tsx
@@ -21,7 +21,7 @@ const TooltipContent = React.forwardRef<
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 overflow-hidden rounded-md p-2 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 overflow-hidden rounded-md px-2 py-1 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         style={{


### PR DESCRIPTION
## Problem

`TooltipContent` uses `p-2`. Combined with `text-xs` (12px font / 16px line box), that renders a **32px** tall tooltip.

The vertical padding is measured to the **line box**, not to the glyphs. The 16px line box is 7px taller than the 9px ink of a cap-height string, so it contributes 3.5px of half-leading on each side. The result is asymmetric optical spacing:

| | optical gap |
|---|---|
| left / right | 8.5px |
| top / bottom | **11.5px** |

Vertically 35% looser than horizontally, which reads as a fat tooltip.

Measured from a 2x screenshot of the production UI, then reproduced pixel-for-pixel (108x32 box, 6px corner radius, 9px ink height, 8.5/8.5 and 11.5/11.5 gaps) to confirm the decomposition is `8 + 16 + 8`.

## Change

`p-2` -> `px-2 py-1`. Horizontal padding is unchanged at 8px; vertical padding drops to 4px.

| | before | after |
|---|---|---|
| height | 32px | **24px** |
| optical gap, left / right | 8.5px | 8.5px |
| optical gap, top / bottom | 11.5px | **7.5px** |
| horizontal / vertical ratio | 0.74 | **1.13** |

The horizontal gap stays slightly larger than the vertical one, which is the correct relationship for a text label - text extends horizontally, so equal numeric padding reads as horizontally tight. 24px also lands on the 4px grid.

Candidate heights were rendered and measured side by side before picking 24px; 26px gives strictly equal 8.5/8.5 gaps but reads square, and 22px starts to look cramped.

## Blast radius

- 141 `TooltipContent` call sites inherit the new padding.
- The three call sites that override padding (`agents-page-tabs.tsx`, `workflow-detail-page.tsx`, `workflows-page.tsx`, all `p-3` rich panels) are **unaffected**: `cn()` runs `tailwind-merge`, which drops `px-2`/`py-1` in favour of the `p-` shorthand.
- No other call site overrides padding, and no test asserts the tooltip class string.

## Tests

No test added. This is a Tailwind class change on a presentational primitive with no behavioral surface; asserting the class string would be a unit test on internals, which the repo's testing guidelines rule out. Verified by measuring the rendered box instead.

## Verification

- [x] `prettier@3.8.1 --check` on the touched file passes
- [ ] CI (lint / check-types / test / deploy)