### PR TITLE
fix(ci): restore runner e2e gate policy

### DIFF
--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'USAGE'
-Usage: runner-image-context.sh <resolve|playwright-consumer|crates-consumer|image-inputs|needed|artifact-name>
+Usage: runner-image-context.sh <resolve|turbo-consumer|playwright-consumer|crates-consumer|image-inputs|needed|artifact-name>
 
 resolve:
   Computes release skip, canonical job ref, and head SHA from GitHub event env.
@@ -14,6 +14,10 @@ resolve:
 needed:
   Computes runner image consumer demand and current-image selection from
   explicit workflow selection booleans.
+
+turbo-consumer:
+  Computes whether Turbo runner E2E is a runner image consumer from the same
+  change booleans used by turbo.yml.
 
 playwright-consumer:
   Computes whether Playwright needs a dedicated runner.
@@ -178,6 +182,12 @@ needed() {
     has_metal_hosts="true"
   fi
 
+  local turbo_consumer
+  turbo_consumer=$(bool "${TURBO_RUNNER_CONSUMER_NEEDED:-false}")
+  if [ "$EVENT_NAME" = "push" ]; then
+    turbo_consumer="false"
+  fi
+
   local playwright_consumer
   playwright_consumer=$(bool "${PLAYWRIGHT_RUNNER_CONSUMER_NEEDED:-false}")
 
@@ -196,17 +206,20 @@ needed() {
   local reason="no-runner-image-consumer"
 
   if [ "$release_skip" = "true" ]; then
+    turbo_consumer="false"
     playwright_consumer="false"
     crates_consumer="false"
     image_inputs_changed="false"
     reason="release-skip"
   elif [ "$has_metal_hosts" != "true" ]; then
+    turbo_consumer="false"
     playwright_consumer="false"
     crates_consumer="false"
     image_inputs_changed="false"
     reason="no-metal-hosts"
   else
-    if [ "$playwright_consumer" = "true" ] ||
+    if [ "$turbo_consumer" = "true" ] ||
+      [ "$playwright_consumer" = "true" ] ||
       [ "$crates_consumer" = "true" ]; then
       runner_consumer="true"
     fi
@@ -228,6 +241,7 @@ needed() {
   fi
 
   emit "has-metal-hosts" "$has_metal_hosts"
+  emit "turbo-runner-consumer-needed" "$turbo_consumer"
   emit "playwright-runner-consumer-needed" "$playwright_consumer"
   emit "crates-runner-consumer-needed" "$crates_consumer"
   emit "runner-image-consumer-needed" "$runner_consumer"
@@ -235,6 +249,24 @@ needed() {
   emit "current-runner-image-needed" "$current_image_needed"
   emit "stable-runner-image-allowed" "$stable_image_allowed"
   emit "image-selection-reason" "$reason"
+}
+
+turbo_consumer() {
+  require_env EVENT_NAME
+
+  local consumer="false"
+  if [ "$EVENT_NAME" != "push" ] && {
+    is_true "${WEB_CHANGED:-false}" ||
+    is_true "${API_CHANGED:-false}" ||
+    is_true "${CLI_CHANGED:-false}" ||
+    is_true "${CRATES_CHANGED:-false}" ||
+    is_true "${CI_CHANGED:-false}" ||
+    is_true "${E2E_CHANGED:-false}"
+  }; then
+    consumer="true"
+  fi
+
+  emit "turbo-runner-consumer-needed" "$consumer"
 }
 
 playwright_consumer() {
@@ -297,6 +329,7 @@ artifact_name() {
 cmd="${1:-}"
 case "$cmd" in
   resolve) resolve ;;
+  turbo-consumer) turbo_consumer ;;
   playwright-consumer) playwright_consumer ;;
   crates-consumer) crates_consumer ;;
   image-inputs) image_inputs ;;

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -93,6 +93,30 @@ assert_contains "$out" "release-skip=true"
 assert_contains "$out" "skip-reason=release-please-push"
 assert_contains "$out" "job-ref="
 
+assert_fails "turbo-consumer requires EVENT_NAME" \
+  WEB_CHANGED=true \
+  "$CONTEXT" turbo-consumer
+
+for flag in WEB_CHANGED API_CHANGED CLI_CHANGED CRATES_CHANGED CI_CHANGED E2E_CHANGED; do
+  out=$(run_clean \
+    EVENT_NAME=pull_request \
+    "${flag}=true" \
+    "$CONTEXT" turbo-consumer)
+  assert_contains "$out" "turbo-runner-consumer-needed=true"
+done
+
+out=$(run_clean \
+  EVENT_NAME=merge_group \
+  API_CHANGED=true \
+  "$CONTEXT" turbo-consumer)
+assert_contains "$out" "turbo-runner-consumer-needed=true"
+
+out=$(run_clean \
+  EVENT_NAME=push \
+  WEB_CHANGED=true \
+  "$CONTEXT" turbo-consumer)
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+
 out=$(run_clean "$CONTEXT" playwright-consumer)
 assert_contains "$out" "playwright-runner-consumer-needed=false"
 
@@ -219,6 +243,18 @@ assert_contains "$out" "current-runner-image-needed=false"
 assert_contains "$out" "stable-runner-image-allowed=false"
 assert_contains "$out" "image-selection-reason=no-runner-image-consumer"
 
+out=$(assert_needed_case "Turbo runner E2E consumer" \
+  EVENT_NAME=pull_request \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=false)
+assert_contains "$out" "turbo-runner-consumer-needed=true"
+assert_contains "$out" "playwright-runner-consumer-needed=false"
+assert_contains "$out" "runner-image-consumer-needed=true"
+assert_contains "$out" "stable-runner-image-allowed=true"
+assert_contains "$out" "current-runner-image-needed=true"
+
 out=$(assert_needed_case "crates ci-only consumer before stable reuse" \
   EVENT_NAME=pull_request \
   RELEASE_SKIP=false \
@@ -260,6 +296,16 @@ assert_contains "$out" "runner-image-inputs-changed=true"
 assert_contains "$out" "stable-runner-image-allowed=false"
 assert_contains "$out" "current-runner-image-needed=true"
 assert_contains "$out" "image-selection-reason=runner-image-inputs-changed"
+
+out=$(assert_needed_case "Turbo runner E2E ignored on push" \
+  EVENT_NAME=push \
+  RELEASE_SKIP=false \
+  METAL_HOSTS=dev-1 \
+  TURBO_RUNNER_CONSUMER_NEEDED=true \
+  RUNNER_IMAGE_INPUTS_CHANGED=false)
+assert_contains "$out" "turbo-runner-consumer-needed=false"
+assert_contains "$out" "runner-image-consumer-needed=false"
+assert_contains "$out" "current-runner-image-needed=false"
 
 out=$(assert_needed_case "guest input" \
   EVENT_NAME=pull_request \

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -14,18 +14,23 @@ command -v yq >/dev/null || fail "yq is required"
 workflow_json=$(yq -o=json '.' "$WORKFLOW")
 
 jq -e '
+  .jobs.prepare.outputs["turbo-runner-consumer-needed"] ==
+    "${{ steps.needed.outputs.turbo-runner-consumer-needed }}" and
   .jobs.prepare.outputs["playwright-runner-consumer-needed"] ==
     "${{ steps.needed.outputs.playwright-runner-consumer-needed }}" and
   any(.jobs.prepare.steps[];
-    .id == "playwright" and
+    .id == "turbo" and
+    (.run | contains(".github/scripts/runner-image-context.sh turbo-consumer")) and
     (.run | contains(".github/scripts/runner-image-context.sh playwright-consumer"))
   ) and
   any(.jobs.prepare.steps[];
     .id == "needed" and
+    .env.TURBO_RUNNER_CONSUMER_NEEDED ==
+      "${{ steps.turbo.outputs.turbo-runner-consumer-needed }}" and
     .env.PLAYWRIGHT_RUNNER_CONSUMER_NEEDED ==
-      "${{ steps.playwright.outputs.playwright-runner-consumer-needed }}"
+      "${{ steps.turbo.outputs.playwright-runner-consumer-needed }}"
   )
-' <<<"$workflow_json" >/dev/null || fail "Playwright dedicated-runner demand must reach runner image selection"
+' <<<"$workflow_json" >/dev/null || fail "Turbo and Playwright runner demand must reach runner image selection"
 
 jq -e '
   .jobs["cancel-superseded"].name == "Cancel superseded merge-group CI" and

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -30,9 +30,21 @@ fi
 ruby -ryaml - "$WORKFLOW" <<'RUBY'
 workflow = YAML.load_file(ARGV.fetch(0))
 jobs = workflow.fetch("jobs")
+prepare = jobs.fetch("prepare")
 account_prepare = jobs.fetch("cli-e2e-03-runner-prepare")
 runner = jobs.fetch("cli-e2e-03-runner")
 account_cleanup = jobs.fetch("cli-e2e-03-runner-cleanup")
+
+unless prepare.dig("outputs", "turbo-runner-consumer-needed") ==
+    "${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}"
+  raise "Turbo must expose the historical runner E2E consumer decision"
+end
+consumer_step = prepare.fetch("steps").find do |step|
+  step["id"] == "runner-e2e"
+end
+unless consumer_step&.fetch("run", "")&.end_with?("runner-image-context.sh turbo-consumer")
+  raise "Turbo must restore the historical runner E2E consumer detector"
+end
 
 expected_indices = (1..12).to_a
 unless runner.dig("strategy", "fail-fast") == false
@@ -56,6 +68,21 @@ required_needs = %w[
 ]
 unless required_needs.all? { |job_name| Array(runner["needs"]).include?(job_name) }
   raise "runner E2E shards must wait for accounts, API, and runner deployment"
+end
+
+unless account_prepare.fetch("if").include?("turbo-runner-consumer-needed == 'true'")
+  raise "runner E2E account preparation must use the runner E2E consumer"
+end
+unless runner.fetch("if").include?("turbo-runner-consumer-needed == 'true'")
+  raise "runner E2E shards must use the runner E2E consumer"
+end
+
+%w[deploy-runner-prepare deploy-runner-start].each do |job_name|
+  condition = jobs.fetch(job_name).fetch("if")
+  unless condition.include?("turbo-runner-consumer-needed == 'true'") &&
+      condition.include?("playwright-runner-consumer-needed == 'true'")
+    raise "#{job_name} must serve both runner E2E and Playwright consumers"
+  end
 end
 
 prepare_step = account_prepare.fetch("steps").find do |step|
@@ -95,6 +122,24 @@ gate_needs = Array(jobs.fetch("ci-gate-turbo")["needs"])
   cli-e2e-03-runner-cleanup
 ].each do |job_name|
   raise "CI gate must include #{job_name}" unless gate_needs.include?(job_name)
+end
+
+gate_step = jobs.fetch("ci-gate-turbo").fetch("steps").find do |step|
+  step["name"] == "Validate CI results"
+end
+raise "missing Turbo CI gate validation" unless gate_step
+gate_script = gate_step.fetch("run")
+unless gate_script.include?("RUNNER_E2E_SKIP_ALLOWED=\"true\"") &&
+    gate_script.include?("needs.prepare.outputs.turbo-runner-consumer-needed")
+  raise "CI gate must restore the runner-specific E2E skip policy"
+end
+%w[
+  cli-e2e-03-runner-prepare
+  cli-e2e-03-runner
+  cli-e2e-03-runner-cleanup
+].each do |job_name|
+  expected = "check_result \"#{job_name}\" \"${{ needs.#{job_name}.result }}\" \"$RUNNER_E2E_SKIP_ALLOWED\""
+  raise "CI gate must check #{job_name} with RUNNER_E2E_SKIP_ALLOWED" unless gate_script.include?(expected)
 end
 RUBY
 

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -57,6 +57,7 @@ jobs:
       source-head-sha: ${{ steps.identity.outputs.source-head-sha }}
       pr-number: ${{ steps.identity.outputs.pr-number }}
       pr-head-ref: ${{ steps.identity.outputs.pr-head-ref }}
+      turbo-runner-consumer-needed: ${{ steps.needed.outputs.turbo-runner-consumer-needed }}
       playwright-runner-consumer-needed: ${{ steps.needed.outputs.playwright-runner-consumer-needed }}
       crates-runner-consumer-needed: ${{ steps.needed.outputs.crates-runner-consumer-needed }}
       runner-image-consumer-needed: ${{ steps.needed.outputs.runner-image-consumer-needed }}
@@ -102,17 +103,24 @@ jobs:
           echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
           echo "Base ref: ${BASE_REF}"
 
-      - name: Detect Playwright runner image consumer
-        id: playwright
+      - name: Detect Turbo and Playwright runner image consumers
+        id: turbo
         if: steps.identity.outputs.release-skip != 'true'
         env:
           BASE_REF: ${{ steps.base.outputs.base-ref }}
         run: |
           set -euo pipefail
           CHANGES_JSON=$(./scripts/changed.sh "$BASE_REF")
+          web_changed=$(echo "$CHANGES_JSON" | jq -r '."web" // false')
           platform_changed=$(echo "$CHANGES_JSON" | jq -r '."@vm0/app" // false')
           api_changed=$(echo "$CHANGES_JSON" | jq -r '."api" // false')
           cli_changed=$(echo "$CHANGES_JSON" | jq -r '."@vm0/zero-cli" // false')
+
+          if git diff --name-only "$BASE_REF" HEAD | grep -q "^crates/"; then
+            crates_changed=true
+          else
+            crates_changed=false
+          fi
 
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
             ci_changed=true
@@ -125,6 +133,15 @@ jobs:
           else
             e2e_changed=false
           fi
+
+          EVENT_NAME="${{ github.event_name }}" \
+          WEB_CHANGED="$web_changed" \
+          API_CHANGED="$api_changed" \
+          CLI_CHANGED="$cli_changed" \
+          CRATES_CHANGED="$crates_changed" \
+          CI_CHANGED="$ci_changed" \
+          E2E_CHANGED="$e2e_changed" \
+          .github/scripts/runner-image-context.sh turbo-consumer
 
           API_CHANGED="$api_changed" \
           PLATFORM_CHANGED="$platform_changed" \
@@ -214,7 +231,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_SKIP: ${{ steps.identity.outputs.release-skip }}
           RUNNER_HOST_GROUPS_CONFIGURED: ${{ steps.host-group-presence.outputs.configured }}
-          PLAYWRIGHT_RUNNER_CONSUMER_NEEDED: ${{ steps.playwright.outputs.playwright-runner-consumer-needed }}
+          TURBO_RUNNER_CONSUMER_NEEDED: ${{ steps.turbo.outputs.turbo-runner-consumer-needed }}
+          PLAYWRIGHT_RUNNER_CONSUMER_NEEDED: ${{ steps.turbo.outputs.playwright-runner-consumer-needed }}
           CRATES_RUNNER_CONSUMER_NEEDED: ${{ steps.crates.outputs.crates-runner-consumer-needed }}
           RUNNER_IMAGE_INPUTS_CHANGED: ${{ steps.image-inputs.outputs.runner-image-inputs-changed }}
         run: .github/scripts/runner-image-context.sh needed

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -171,6 +171,7 @@ jobs:
       crates-changed: ${{ steps.detect.outputs.crates-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       e2e-changed: ${{ steps.detect.outputs.e2e-changed }}
+      turbo-runner-consumer-needed: ${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}
       playwright-runner-consumer-needed: ${{ steps.playwright-runner.outputs.playwright-runner-consumer-needed }}
       base-ref: ${{ steps.detect.outputs.base-ref }}
     steps:
@@ -252,6 +253,17 @@ jobs:
             echo "No E2E test changes"
             echo "e2e-changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Select runner E2E consumer
+        id: runner-e2e
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          API_CHANGED: ${{ steps.detect.outputs.api-changed }}
+          CLI_CHANGED: ${{ steps.detect.outputs.cli-changed }}
+          CRATES_CHANGED: ${{ steps.detect.outputs.crates-changed }}
+          CI_CHANGED: ${{ steps.detect.outputs.ci-changed }}
+          E2E_CHANGED: ${{ steps.detect.outputs.e2e-changed }}
+        run: .github/scripts/runner-image-context.sh turbo-consumer
 
       - name: Select Playwright runner consumer
         id: playwright-runner
@@ -1779,7 +1791,10 @@ jobs:
       needs.deploy-app.result == 'success' &&
       (github.event_name == 'push' || needs.deploy-stripe-listener.result == 'success') &&
       (
-        needs.prepare.outputs.playwright-runner-consumer-needed != 'true' ||
+        (
+          needs.prepare.outputs.turbo-runner-consumer-needed != 'true' &&
+          needs.prepare.outputs.playwright-runner-consumer-needed != 'true'
+        ) ||
         needs.deploy-runner-start.result == 'success'
       )
     steps:
@@ -2195,7 +2210,10 @@ jobs:
     if: |
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+      (
+        needs.prepare.outputs.turbo-runner-consumer-needed == 'true' ||
+        needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+      )
     outputs:
       bin-dir: ${{ steps.manifest.outputs.bin-dir }}
       runner-dir: ${{ steps.manifest.outputs.runner-dir }}
@@ -2241,7 +2259,10 @@ jobs:
     if: |
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+      (
+        needs.prepare.outputs.turbo-runner-consumer-needed == 'true' ||
+        needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+      )
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -2499,7 +2520,7 @@ jobs:
     if: |
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
+      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
     outputs:
       organization-id: ${{ steps.account.outputs.organization-id }}
       runner-email: ${{ steps.account.outputs.runner-email }}
@@ -2535,9 +2556,8 @@ jobs:
       - cli-e2e-03-runner-prepare
     if: |
       always() &&
-      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.job-ref != '' &&
-      needs.prepare.outputs.playwright-runner-consumer-needed == 'true' &&
+      needs.prepare.outputs.turbo-runner-consumer-needed == 'true' &&
       needs.deploy-api.result == 'success' &&
       needs.deploy-runner-prepare.result == 'success' &&
       needs.deploy-runner-start.result == 'success' &&
@@ -2743,14 +2763,20 @@ jobs:
             TS_CHECK_SKIP_ALLOWED="skipped"
           fi
           RUNNER_DEPLOY_SKIP_ALLOWED="true"
-          if [ "${{ needs.prepare.outputs.playwright-runner-consumer-needed }}" = "true" ]; then
+          if [ "${{ needs.prepare.outputs.turbo-runner-consumer-needed }}" = "true" ] ||
+            [ "${{ needs.prepare.outputs.playwright-runner-consumer-needed }}" = "true" ]; then
             RUNNER_DEPLOY_SKIP_ALLOWED=""
+          fi
+          RUNNER_E2E_SKIP_ALLOWED="true"
+          if [ "${{ needs.prepare.outputs.turbo-runner-consumer-needed }}" = "true" ]; then
+            RUNNER_E2E_SKIP_ALLOWED=""
           fi
           CF_APP_SKIP_ALLOWED=""
           if [ "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}" = "true" ]; then
             # External fork PRs cannot access runner infra secrets, so their
-            # runner deployment jobs are expected to skip.
+            # runner deployment and runner E2E jobs are expected to skip.
             RUNNER_DEPLOY_SKIP_ALLOWED="true"
+            RUNNER_E2E_SKIP_ALLOWED="true"
             CF_APP_SKIP_ALLOWED="true"
           fi
           if [ "${{ github.actor == 'dependabot[bot]' }}" = "true" ]; then
@@ -2803,9 +2829,9 @@ jobs:
           check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-02-playwright" "${{ needs.cli-e2e-02-playwright.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
-          check_result "cli-e2e-03-runner-prepare" "${{ needs.cli-e2e-03-runner-prepare.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
-          check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
-          check_result "cli-e2e-03-runner-cleanup" "${{ needs.cli-e2e-03-runner-cleanup.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
+          check_result "cli-e2e-03-runner-prepare" "${{ needs.cli-e2e-03-runner-prepare.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
+          check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
+          check_result "cli-e2e-03-runner-cleanup" "${{ needs.cli-e2e-03-runner-cleanup.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "$RUNNER_DEPLOY_SKIP_ALLOWED"
 


### PR DESCRIPTION
## Summary

- restore the historical Turbo runner E2E consumer decision
- keep runner deployment shared by Turbo E2E and Playwright consumers
- gate runner account preparation, twelve shards, and cleanup with RUNNER_E2E_SKIP_ALLOWED
- add regression coverage for the restored consumer and gate behavior

Follow-up to #26230.

## Validation

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged package type checks
- .github/scripts/tests/runner-image-context-test.sh
- .github/scripts/tests/turbo-playwright-runner-workflow-test.sh
- .github/scripts/tests/runner-image-workflow-test.sh