### PR TITLE
build(runner): add libreoffice and poppler to the sandbox rootfs

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -353,6 +353,7 @@ install_packages() {
   apt-get install -y \
     procps wget git ripgrep jq file iproute2 sudo ffmpeg \
     fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
+    libreoffice-impress poppler-utils \
     libnss3 p11-kit-modules unzip \
     nodejs \
     python3 python3-pip \

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -302,6 +302,12 @@ check_bin "/usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf" "Noto Sans
 check_bin "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc" "Noto Sans CJK"
 check_bin "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf" "Noto Color Emoji"
 
+# Document conversion: office decks reach PDF through LibreOffice, and PDF pages
+# are rasterised with Poppler.
+check_bin "/usr/lib/libreoffice/program/soffice.bin" "LibreOffice soffice.bin"
+check_required_executable "/usr/bin/pdftoppm" "pdftoppm"
+check_required_executable "/usr/bin/pdfinfo" "pdfinfo"
+
 # Browser automation relies on the native vm0 fork binary.
 check_required_executable "/usr/local/bin/agent-browser" "agent-browser CLI"
 

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -593,6 +593,33 @@ wait
     }
 
     #[test]
+    fn template_installs_and_verifies_document_conversion_tools() {
+        for package in ["libreoffice-impress", "poppler-utils"] {
+            assert!(
+                template_build_installs_apt_package(package),
+                "build-template.sh should install {package} so uploaded decks can be converted \
+                 to per-page images inside the sandbox"
+            );
+        }
+
+        assert!(
+            VERIFY_SCRIPT
+                .contains(r#"check_bin "/usr/lib/libreoffice/program/soffice.bin" "LibreOffice"#),
+            "verify-rootfs.sh should verify LibreOffice is present in sandbox images"
+        );
+        for (path, name) in [
+            ("/usr/bin/pdftoppm", "pdftoppm"),
+            ("/usr/bin/pdfinfo", "pdfinfo"),
+        ] {
+            let check = format!(r#"check_required_executable "{path}" "{name}""#);
+            assert!(
+                VERIFY_SCRIPT.contains(&check),
+                "verify-rootfs.sh should verify {name} is present in sandbox images"
+            );
+        }
+    }
+
+    #[test]
     fn template_installs_and_verifies_noto_fonts() {
         for package in [
             "fonts-noto-core",


### PR DESCRIPTION
Closes #26234. Part of #21350.

Uploaded presentation templates are converted to per-page images inside the sandbox. Neither tool that does it exists in the image today, so this PR adds them and asserts they are present.

## What changes

- `build-template.sh` apt block: `libreoffice-impress` and `poppler-utils`.
- `verify-rootfs.sh`: assertions for `soffice.bin`, `pdftoppm` and `pdfinfo`, next to the existing font and binary assertions.
- `scripts.rs`: a guard test in the same shape as the ffmpeg and Noto ones, so the package list and the verifier can't drift apart.

## Why these two

- `poppler-utils` (~2 MB) → `pdftoppm -png -r 150` renders PDF pages to PNG, and `pdfinfo` rejects encrypted or corrupt files before any rendering work. `pdffonts` and `pdftocairo -svg` additionally give exact fonts and fill colours, so the extraction step does not have to sample pixels.
- `libreoffice-impress` → `soffice --headless --convert-to pdf` is the only server-side way to open `.pptx`. It is used to reach PDF, never to render the final artifact.

Fonts are **not** added here: #26113 already installed `fonts-noto-core`, `fonts-noto-cjk` and `fonts-noto-color-emoji`. They are load-bearing for this change — LibreOffice re-lays out text with system fonts, so a CJK deck would convert to tofu boxes without them. Nothing font-related may be removed from the image while this pipeline exists.

Chromium (already pinned in the image) covers the single-page HTML input, and ImageMagick is not needed because `pdftoppm` writes PNG directly.

## Cost

@seven332 simulated the install against the current Noble sandbox package set:

- 73 new packages, ~95.7 MB download, ~337 MB on disk.
- Current rootfs baseline ~5.8 GiB of the 8 GiB image, so the space is there.
- Cold start should be largely unaffected: the rootfs logical size stays 8 GiB and the snapshot does not pre-warm LibreOffice. The real costs are template cache-miss/build downloads, higher actual disk per retained rootfs per host, and old/new hash coexistence during rollout. GC keeps the latest 6.

The apt list is hashed into `template_hash`, so `rootfs_hash` and `snapshot_hash` change and CI recomputes `DEFAULT_ROOTFS_HASH`.

**Measured on real runner hosts (was: still to capture before merge).** Taken from this PR's own Runner Image builds, which run `runner build --profile vm0/default` on metal for both architecture groups. Baseline is #26113, the previous template change, measured on the same two hosts one day earlier — the last run before this one that also missed the template cache and rebuilt from `debootstrap`.

| Metric | arm64 (`dev-1.aws`) | x86_64 (`dev-11.gcp`) |
| --- | --- | --- |
| `rootfs_disk` before → after | 5.8 GiB → **6.1 GiB** | 6.1 GiB → **6.4 GiB** |
| Δ actual disk | **+0.3 GiB** | **+0.3 GiB** |
| `rootfs_logical` | 8.0 GiB → 8.0 GiB | 8.0 GiB → 8.0 GiB |
| Template build (cache miss) before → after | 4m54s → **6m16s** (+1m22s) | 4m00s → **5m01s** (+1m01s) |
| `snapshot_disk` | 12.0 KiB → 12.0 KiB | 28.0 KiB → 28.0 KiB |
| `memory_disk` | 4.0 GiB → 4.0 GiB | 4.0 GiB → 4.0 GiB |
| `cow_disk` | 524.0 KiB → 556.0 KiB | 560.0 KiB → 560.0 KiB |

The measured +0.3 GiB matches the ~337 MB predicted by the simulation above. Logical size and snapshot/memory artefacts are unchanged, so restore cost is unaffected.

Startup: `runner benchmark` on this head (x86_64) reports `boot_ms=76/76`, `guest_restore_ms=40/49`. Those cluster by benchmark host, not by branch — five unrelated same-day runs give 38–42 / 7–8 on `dev-1.aws` and 76–99 / 40–61 on `dev-11.gcp`, including a `main` run at `boot_ms=94/99`. This PR sits at the fast end of its host's band, so no startup regression is attributable to it.

The new `verify-rootfs.sh` assertions ran inside the built image and passed identically on both architectures: `LibreOffice soffice.bin: found`, `pdftoppm: found`, `pdfinfo: found`.

Evidence: [Runner Image](https://github.com/vm0-ai/vm0/actions/runs/31458477128) and [Crates](https://github.com/vm0-ai/vm0/actions/runs/31458477130) for this PR; [Runner Image](https://github.com/vm0-ai/vm0/actions/runs/31374542506) and [Crates](https://github.com/vm0-ai/vm0/actions/runs/31374542169) for the #26113 baseline.

## Rejected alternative

Installing these packages on demand inside the import run. `sudo` and `apt-get` do work in the sandbox today, but every import would re-download and unpack them, upstream repository contents drift so imports stop being reproducible, and apt writes land in the rootfs COW layer while the existing idle-reuse cleanup only clears runner runtime directories, never `/usr`.

## Verification

- `cargo fmt -p runner` clean.
- The new guard test's assertions were verified against the two scripts by replicating the test's parser: both packages are found inside the apt block, and all three verifier strings are present. The Rust test itself did not run locally — compiling the runner test binary OOMs in this 4 GB sandbox — so CI is the first place it executes.

