### PR TITLE
refactor(connectors): unify connector connection writes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -54,6 +54,8 @@ import {
   readConnectorCredentialStorageState,
   readCustomConnectorCredentialStorageParent,
   readCustomConnectorOAuthStorageState,
+  seedConnectorStorageRow,
+  setConnectorVariableOwner,
   setCustomConnectorCredentialStorageState,
 } from "./helpers/connector-credential-storage-state";
 import { zeroCustomConnectorsRoutes } from "../zero-custom-connectors";
@@ -5100,6 +5102,148 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       }),
     );
     expectNoVisibleSecret(apiListed, "bdd-test-oauth-api-access-token");
+
+    await connectorsApi.deleteConnectorBySlug(actor, "test-oauth");
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("rolls back failed OAuth-to-manual credential replacement before a successful retry", async () => {
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+    mockTestOAuthAuthCodeProvider({
+      refreshToken: "bdd-rollback-refresh-token",
+    });
+
+    const initial = await connectorsApi.connectManualGrant(
+      actor,
+      "test-oauth",
+      "api-token",
+      {
+        apiToken: "bdd-rollback-manual-token",
+        inputVariable: "bdd-rollback-input",
+        tenantId: "bdd-rollback-manual-tenant",
+      },
+    );
+    const conflictOwnerId = await seedConnectorStorageRow(context, {
+      orgId: requiredOrgId(actor),
+      userId: actor.userId,
+      connectorSlug: uniqueSlug("credential-conflict"),
+      authMethod: "fixture",
+      storageVersion: 1,
+    });
+    await setConnectorVariableOwner(context, {
+      connectorId: conflictOwnerId,
+      name: "TEST_OAUTH_API_TOKEN_INPUT_VAR",
+      orgId: requiredOrgId(actor),
+      userId: actor.userId,
+    });
+
+    const oauthStart = await connectorsApi.startOauth(
+      actor,
+      "test-oauth",
+      "oauth",
+    );
+    await connectorsApi.completeOauthCallback("test-oauth", {
+      code: "bdd-rollback-oauth-code",
+      state: stateFromAuthorizationUrl(oauthStart.authorizationUrl),
+    });
+    const oauthConnector = await connectorsApi.readConnectorBySlug(
+      actor,
+      "test-oauth",
+    );
+    expect(oauthConnector).toMatchObject({
+      id: initial.id,
+      authMethod: "oauth",
+      externalId: "bdd-test-oauth-user",
+      oauthScopes: ["read"],
+    });
+    const storageQuery = {
+      orgId: requiredOrgId(actor),
+      userId: actor.userId,
+      connectorSlug: "test-oauth",
+      secretNames: [
+        "TEST_OAUTH_TOKEN",
+        "TEST_OAUTH_ACCESS_TOKEN",
+        "TEST_OAUTH_REFRESH_TOKEN",
+      ],
+      variableNames: [
+        "TEST_OAUTH_API_TOKEN_INPUT_VAR",
+        "TEST_OAUTH_API_TENANT_ID",
+      ],
+    };
+    const storageBeforeFailure = await readConnectorCredentialStorageState(
+      context,
+      storageQuery,
+    );
+
+    const failed = await connectorsApi.requestManualGrant(
+      actor,
+      "test-oauth",
+      "api-token",
+      {
+        apiToken: "bdd-failed-replacement-token",
+        inputVariable: "bdd-failed-replacement-input",
+        tenantId: "bdd-failed-replacement-tenant",
+      },
+      { statuses: [500] },
+    );
+    expect(failed.status).toBe(500);
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "test-oauth"),
+    ).resolves.toStrictEqual(oauthConnector);
+    await expect(
+      readConnectorCredentialStorageState(context, storageQuery),
+    ).resolves.toStrictEqual(storageBeforeFailure);
+
+    await setConnectorVariableOwner(context, {
+      connectorId: oauthConnector.id,
+      name: "TEST_OAUTH_API_TOKEN_INPUT_VAR",
+      orgId: requiredOrgId(actor),
+      userId: actor.userId,
+    });
+    const manual = await connectorsApi.connectManualGrant(
+      actor,
+      "test-oauth",
+      "api-token",
+      {
+        apiToken: "bdd-successful-replacement-token",
+        inputVariable: "bdd-successful-replacement-input",
+        tenantId: "bdd-successful-replacement-tenant",
+      },
+    );
+    expect(manual).toMatchObject({
+      id: oauthConnector.id,
+      authMethod: "api-token",
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      oauthScopes: null,
+      tokenExpiresAt: null,
+    });
+    const manualStorage = await readConnectorCredentialStorageState(
+      context,
+      storageQuery,
+    );
+    expect(
+      manualStorage.secrets?.map(({ name }) => {
+        return name;
+      }),
+    ).toStrictEqual(["TEST_OAUTH_TOKEN"]);
+    expect(
+      manualStorage.variables
+        ?.map(({ name }) => {
+          return name;
+        })
+        .sort((left, right) => {
+          return left.localeCompare(right);
+        }),
+    ).toStrictEqual([
+      "TEST_OAUTH_API_TENANT_ID",
+      "TEST_OAUTH_API_TOKEN_INPUT_VAR",
+    ]);
 
     await connectorsApi.deleteConnectorBySlug(actor, "test-oauth");
     await connectorsApi.deleteFeatureSwitches(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -5127,6 +5127,8 @@ describe("CONN-02: test-oauth auth-code journey", () => {
         tenantId: "bdd-rollback-manual-tenant",
       },
     );
+    // Production APIs cannot move a connector variable to another connection;
+    // this fixture creates the storage conflict needed to exercise rollback.
     const conflictOwnerId = await seedConnectorStorageRow(context, {
       orgId: requiredOrgId(actor),
       userId: actor.userId,

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -23,10 +23,15 @@ type ConnectorConnectionTarget =
   | {
       readonly kind: "builtin";
       readonly connectorSlug: string;
-      readonly externalId: string;
-      readonly externalUsername: string | null;
-      readonly externalEmail: string | null;
-      readonly oauthScopes: readonly string[];
+      readonly identity:
+        | { readonly kind: "local" }
+        | {
+            readonly kind: "external";
+            readonly externalId: string;
+            readonly externalUsername: string | null;
+            readonly externalEmail: string | null;
+            readonly oauthScopes: readonly string[];
+          };
     }
   | {
       readonly kind: "custom";
@@ -72,85 +77,68 @@ async function upsertConnectorConnection(
   db: Tx,
   args: Omit<ReplaceConnectorConnectionArgs, "writeCredentials">,
 ): Promise<StoredConnectorConnectionRow> {
-  if (args.target.kind === "builtin") {
-    const [row] = await db
-      .insert(connectors)
-      .values({
-        userId: args.userId,
-        connectorSlug: args.target.connectorSlug,
-        authMethod: args.authMethod,
-        storageVersion: args.storageVersion,
-        externalId: args.target.externalId,
-        externalUsername: args.target.externalUsername,
-        externalEmail: args.target.externalEmail,
-        oauthScopes: JSON.stringify(args.target.oauthScopes),
-        tokenExpiresAt: args.tokenExpiresAt,
-        needsReconnect: false,
-        reconnectReason: null,
-        orgId: args.orgId,
-      })
-      .onConflictDoUpdate({
-        target: [connectors.orgId, connectors.userId, connectors.connectorSlug],
-        targetWhere: isNotNull(connectors.connectorSlug),
-        set: {
-          authMethod: args.authMethod,
-          storageVersion: args.storageVersion,
-          externalId: args.target.externalId,
-          externalUsername: args.target.externalUsername,
-          externalEmail: args.target.externalEmail,
-          oauthScopes: JSON.stringify(args.target.oauthScopes),
-          tokenExpiresAt: args.tokenExpiresAt,
-          needsReconnect: false,
-          reconnectReason: null,
-          updatedAt: sql`clock_timestamp()`,
-        },
-      })
-      .returning(connectorConnectionSelection());
-    if (!row) {
-      throw new Error("Failed to upsert Builtin connector connection");
-    }
-    return row;
-  }
+  const identityValues =
+    args.target.kind === "builtin" && args.target.identity.kind === "external"
+      ? {
+          externalId: args.target.identity.externalId,
+          externalUsername: args.target.identity.externalUsername,
+          externalEmail: args.target.identity.externalEmail,
+          oauthScopes: JSON.stringify(args.target.identity.oauthScopes),
+        }
+      : {
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+        };
+  const targetValues =
+    args.target.kind === "builtin"
+      ? {
+          connectorSlug: args.target.connectorSlug,
+          customConnectorId: null,
+        }
+      : {
+          connectorSlug: null,
+          customConnectorId: args.target.customConnectorId,
+        };
+  const replacementValues = {
+    authMethod: args.authMethod,
+    storageVersion: args.storageVersion,
+    ...identityValues,
+    tokenExpiresAt: args.tokenExpiresAt,
+    needsReconnect: false,
+    reconnectReason: null,
+  };
+  const conflictTarget =
+    args.target.kind === "builtin"
+      ? [connectors.orgId, connectors.userId, connectors.connectorSlug]
+      : [connectors.orgId, connectors.userId, connectors.customConnectorId];
+  const conflictTargetWhere =
+    args.target.kind === "builtin"
+      ? isNotNull(connectors.connectorSlug)
+      : isNotNull(connectors.customConnectorId);
 
   const [row] = await db
     .insert(connectors)
     .values({
-      customConnectorId: args.target.customConnectorId,
-      authMethod: args.authMethod,
-      storageVersion: args.storageVersion,
-      externalId: null,
-      externalUsername: null,
-      externalEmail: null,
-      oauthScopes: null,
-      tokenExpiresAt: args.tokenExpiresAt,
-      needsReconnect: false,
-      reconnectReason: null,
-      userId: args.userId,
       orgId: args.orgId,
+      userId: args.userId,
+      ...targetValues,
+      ...replacementValues,
     })
     .onConflictDoUpdate({
-      target: [
-        connectors.orgId,
-        connectors.userId,
-        connectors.customConnectorId,
-      ],
-      targetWhere: isNotNull(connectors.customConnectorId),
+      target: conflictTarget,
+      targetWhere: conflictTargetWhere,
       set: {
-        authMethod: args.authMethod,
-        storageVersion: args.storageVersion,
-        externalId: null,
-        externalUsername: null,
-        externalEmail: null,
-        oauthScopes: null,
-        tokenExpiresAt: args.tokenExpiresAt,
-        needsReconnect: false,
-        reconnectReason: null,
+        ...replacementValues,
         updatedAt: sql`clock_timestamp()`,
       },
     })
     .returning(connectorConnectionSelection());
   if (!row) {
-    throw new Error("Failed to upsert Custom connector connection");
+    throw new Error(
+      `Failed to upsert ${args.target.kind === "builtin" ? "Builtin" : "Custom"} connector connection`,
+    );
   }
   return row;
 }

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -60,7 +60,6 @@ import {
 import { publishBuiltinConnectorInvalidationAfterCommit } from "./connector-client-invalidation.service";
 import {
   deleteConnectorCredentialStorageConnection,
-  deleteConnectorOwnedCredentialRows,
   upsertConnectorOwnedSecret,
   upsertConnectorOwnedVariable,
 } from "./connector-credential-storage-write.service";
@@ -816,70 +815,6 @@ export const deleteZeroConnectorLocalState$ = command(
   },
 );
 
-async function upsertLocalConnectorRow(
-  db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly connectorSlug: string;
-    readonly authMethod: string;
-    readonly storageVersion: number;
-  },
-): Promise<StoredConnectorRow> {
-  const [row] = await db
-    .insert(connectors)
-    .values({
-      orgId: args.orgId,
-      userId: args.userId,
-      connectorSlug: args.connectorSlug,
-      authMethod: args.authMethod,
-      storageVersion: args.storageVersion,
-      externalId: null,
-      externalUsername: null,
-      externalEmail: null,
-      oauthScopes: null,
-      tokenExpiresAt: null,
-      needsReconnect: false,
-      reconnectReason: null,
-    })
-    .onConflictDoUpdate({
-      target: [connectors.orgId, connectors.userId, connectors.connectorSlug],
-      targetWhere: isNotNull(connectors.connectorSlug),
-      set: {
-        authMethod: args.authMethod,
-        storageVersion: args.storageVersion,
-        externalId: null,
-        externalUsername: null,
-        externalEmail: null,
-        oauthScopes: null,
-        tokenExpiresAt: null,
-        needsReconnect: false,
-        reconnectReason: null,
-        updatedAt: sql`clock_timestamp()`,
-      },
-    })
-    .returning({
-      id: connectors.id,
-      authMethod: connectors.authMethod,
-      externalId: connectors.externalId,
-      externalUsername: connectors.externalUsername,
-      externalEmail: connectors.externalEmail,
-      oauthScopes: connectors.oauthScopes,
-      needsReconnect: connectors.needsReconnect,
-      reconnectReason: connectors.reconnectReason,
-      storageVersion: connectors.storageVersion,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-      createdAt: connectors.createdAt,
-      updatedAt: connectors.updatedAt,
-    });
-
-  if (!row) {
-    throw new Error("Failed to upsert local connector");
-  }
-
-  return row;
-}
-
 async function deleteUserSecretNames(
   db: Db,
   args: {
@@ -928,7 +863,7 @@ async function deleteVariableNames(
   }
 }
 
-async function cleanupExistingStoredConnectorForLocalConnect(
+async function loadPendingConnectorTokenRevokeForLocalConnect(
   db: Db,
   args: {
     readonly orgId: string;
@@ -985,14 +920,6 @@ async function cleanupExistingStoredConnectorForLocalConnect(
       signal,
     );
   }
-
-  await deleteConnectorOwnedCredentialRows(
-    db,
-    {
-      connectorId: existing.id,
-    },
-    signal,
-  );
 
   return pendingTokenRevoke;
 }
@@ -1084,7 +1011,7 @@ export const connectManualGrantConnector$ = command(
       });
       signal.throwIfAborted();
 
-      pendingTokenRevoke = await cleanupExistingStoredConnectorForLocalConnect(
+      pendingTokenRevoke = await loadPendingConnectorTokenRevokeForLocalConnect(
         tx,
         {
           orgId: args.orgId,
@@ -1096,24 +1023,33 @@ export const connectManualGrantConnector$ = command(
         signal,
       );
 
-      connectorRow = await upsertLocalConnectorRow(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
-        connectorSlug: args.runtimeMethod.connectorSlug,
-        authMethod: args.runtimeMethod.authMethodId,
-        storageVersion: args.runtimeMethod.method.storage.version,
-      });
-      signal.throwIfAborted();
-
-      await writeManualGrantCredentials(
+      connectorRow = await replaceConnectorConnection(
         tx,
         {
-          connectorId: connectorRow.id,
-          encryptedSecrets,
-          method: args.runtimeMethod.method,
           orgId: args.orgId,
           userId: args.userId,
-          variableValues: preparedResult.prepared.variableValues,
+          authMethod: args.runtimeMethod.authMethodId,
+          storageVersion: args.runtimeMethod.method.storage.version,
+          tokenExpiresAt: null,
+          target: {
+            kind: "builtin",
+            connectorSlug: args.runtimeMethod.connectorSlug,
+            identity: { kind: "local" },
+          },
+          writeCredentials: async ({ db, connectorId }, writeSignal) => {
+            await writeManualGrantCredentials(
+              db,
+              {
+                connectorId,
+                encryptedSecrets,
+                method: args.runtimeMethod.method,
+                orgId: args.orgId,
+                userId: args.userId,
+                variableValues: preparedResult.prepared.variableValues,
+              },
+              writeSignal,
+            );
+          },
         },
         signal,
       );
@@ -1196,7 +1132,7 @@ export const connectNoAuthConnector$ = command(
       });
       signal.throwIfAborted();
 
-      pendingTokenRevoke = await cleanupExistingStoredConnectorForLocalConnect(
+      pendingTokenRevoke = await loadPendingConnectorTokenRevokeForLocalConnect(
         tx,
         {
           orgId: args.orgId,
@@ -1208,14 +1144,25 @@ export const connectNoAuthConnector$ = command(
         signal,
       );
 
-      connectorRow = await upsertLocalConnectorRow(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
-        connectorSlug: args.runtimeMethod.connectorSlug,
-        authMethod: args.runtimeMethod.authMethodId,
-        storageVersion: args.runtimeMethod.method.storage.version,
-      });
-      signal.throwIfAborted();
+      connectorRow = await replaceConnectorConnection(
+        tx,
+        {
+          orgId: args.orgId,
+          userId: args.userId,
+          authMethod: args.runtimeMethod.authMethodId,
+          storageVersion: args.runtimeMethod.method.storage.version,
+          tokenExpiresAt: null,
+          target: {
+            kind: "builtin",
+            connectorSlug: args.runtimeMethod.connectorSlug,
+            identity: { kind: "local" },
+          },
+          writeCredentials: () => {
+            return Promise.resolve();
+          },
+        },
+        signal,
+      );
     });
     if (signal.aborted) {
       postCommitAbort ??= signal.reason;
@@ -1759,10 +1706,13 @@ async function commitConnectorTokenConnection(
       target: {
         kind: "builtin",
         connectorSlug: args.runtimeMethod.connectorSlug,
-        externalId: args.userInfo.id,
-        externalUsername: args.userInfo.username,
-        externalEmail: args.userInfo.email,
-        oauthScopes: args.oauthScopes,
+        identity: {
+          kind: "external",
+          externalId: args.userInfo.id,
+          externalUsername: args.userInfo.username,
+          externalEmail: args.userInfo.email,
+          oauthScopes: args.oauthScopes,
+        },
       },
       writeCredentials: async ({ db, connectorId }, writeSignal) => {
         await upsertPreparedConnectorTokenState(


### PR DESCRIPTION
## Summary

- route Builtin manual and retained no-auth connection replacement through the same transactional boundary used by Builtin OAuth and Custom connectors
- consolidate the shared Builtin/Custom connection upsert while keeping their partial unique conflict targets explicit
- add an API integration regression test proving a failed OAuth-to-manual credential write rolls back the connection and storage before a successful retry

## Scope

- preserves source-specific locking, token revocation, legacy credential cleanup, post-commit invalidation, wakeups, and abort handling
- keeps refresh and reconnect mutations outside the replacement primitive
- does not change schemas, persisted formats, public APIs, catalog artifacts, feature switches, or runner protocols

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/connector-connection-write.service.ts apps/api/src/signals/services/zero-connector-data.service.ts apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api check-types:tests`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=1 --silent=passed-only` (59 tests)
- `pnpm -F api exec vitest run --maxWorkers=1 --silent=passed-only` (187 files, 2,842 tests)
- pre-commit `pnpm check-types` (14 Turbo tasks)

Closes #26086
Relates to #25312
