### PR TITLE
fix(api): finalize active input deliveries on completion

### DIFF
--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -1,0 +1,71 @@
+# Active Input Delivery
+
+Active input delivery prevents a prompt accepted by a running Guest from being
+lost or executed twice when run completion, cancellation, and queue scheduling
+overlap.
+
+## Lifecycle
+
+The Runner reserves the current ordered active-input batch before sending it to
+the Guest. Reservation creates one `active_input_deliveries` row and ordered
+`active_input_delivery_items` rows, but it does not revoke or copy the source
+chat events. Retrying the reservation returns the same delivery ID, event IDs,
+and materialized prompt while that delivery remains open.
+
+The delivery becomes settled through one of two proof-bearing paths:
+
+- A direct receipt confirms that the Guest accepted the batch. Each source is
+  replaced by a run-attributed event and every item becomes `delivered`.
+- `/api/webhooks/agent/complete` proves that the Guest has quiesced, or that the
+  Runner observed process exit and completed sandbox teardown. Delivery IDs in
+  `activeInputDeliveryIds` become `delivered`. If the open delivery ID is not
+  present, prompt items become `released` and their original source events stay
+  pending; run-scoped budget items become `expired` and receive a
+  `control.revoke` event.
+
+All item and delivery transitions are monotonic. A late receipt for a released
+or expired delivery is rejected, while a repeated receipt for an already
+delivered delivery is idempotent. Duplicate completion still processes an open
+delivery even when the run is already terminal.
+
+## Terminal Status and Quiescence
+
+A terminal run status does not by itself prove that the old consumer is gone.
+Cancellation is visible immediately, and heartbeat timeout records an unknown
+consumer state, but neither path releases a reservation. Cooperative Guest
+completion and Runner post-exit completion are the existing quiescence signals.
+
+An open delivery is therefore a non-expiring thread-ordering barrier. The queue
+scheduler cannot skip its source events or launch later input on the same
+thread, even after cancellation recovery becomes stale. Once completion settles
+the delivery, released prompts return to their original FIFO position and the
+post-commit scheduler may create the successor run.
+
+## Transaction Boundary
+
+Reservation, direct receipt, and completion finalization serialize database
+state in this order:
+
+1. chat thread;
+2. agent run;
+3. delivery and delivery items;
+4. source and revoking chat events.
+
+Completion finalizes the delivery and applies or observes the terminal run
+state in one short transaction. Realtime publication, callbacks, usage work,
+and queue drain run only after commit. A first late finalization drains the
+thread without replaying the run's ordinary terminal callbacks or billing work.
+
+## Compatibility
+
+`activeInputDeliveryIds` is optional, contains at most 1,024 unique canonical
+UUIDs, and carries no prompt content. Older callers can continue to omit it.
+Runs without durable delivery rows retain the legacy completion behavior; no
+protocol version or feature discriminator is persisted.
+
+The current server support is dormant until the Runner begins reserving active
+input. Runner journal recovery and activation are delivered separately in
+[#26060](https://github.com/vm0-ai/vm0/issues/26060).
+
+Deleting a thread or run cascades its delivery state, so an abandoned delivery
+cannot block an unrelated thread.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -25,7 +25,10 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { isChatRunTerminalEventType } from "@vm0/api-contracts/contracts/chat-events";
 import { cronSteerRunTimeBudgetContract } from "@vm0/api-contracts/contracts/cron";
-import { ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
+import {
+  ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
+  CANCELLATION_RECOVERY_STALE_AFTER_MS,
+} from "@vm0/api-contracts/contracts/runners";
 import { zeroMailContract } from "@vm0/api-contracts/contracts/zero-mail";
 import {
   getModelProviderFirewall,
@@ -89,7 +92,9 @@ import {
   createUnassociatedThreadBoundZeroRunFixture,
 } from "../../../test-fixtures/thread-bound-run-admission";
 import {
+  completeRunWithoutCallbacksFixture,
   deleteAgentRunFixture,
+  holdCheckpointReadsFixture,
   deleteBddVm0ApiKey,
   holdChatEventFixture,
   holdChatEventQueueItemFixture,
@@ -103,6 +108,7 @@ import {
   replayPendingChatInputQueueEventFixture,
   replaceBddVm0ApiKey,
   replaceThreadSessionBindingFixture,
+  timeoutRunWithoutCallbacksFixture,
 } from "../../../test-fixtures/chat-events";
 import { cronSteerRunTimeBudgetRoutes } from "../cron-steer-run-time-budget";
 import { zeroChatEventsRoutes } from "../zero-chat-events";
@@ -666,7 +672,13 @@ async function waitForRunUserMessage(
 async function waitForRunStatus(
   actor: ApiTestUser,
   runId: string,
-  status: "cancelled" | "completed" | "failed" | "pending" | "running",
+  status:
+    | "cancelled"
+    | "completed"
+    | "failed"
+    | "pending"
+    | "running"
+    | "timeout",
 ): Promise<void> {
   await expect
     .poll(async () => {
@@ -726,6 +738,7 @@ async function completeChatRunOk(
   runId: string,
   sandboxHeaders: { readonly authorization: string },
   options: {
+    readonly activeInputDeliveryIds?: readonly string[];
     readonly cliAgentType?: "claude-code" | "codex";
     readonly lastEventSequence?: number;
   } = {},
@@ -754,6 +767,9 @@ async function completeChatRunOk(
     {
       runId,
       exitCode: 0,
+      ...(options.activeInputDeliveryIds === undefined
+        ? {}
+        : { activeInputDeliveryIds: [...options.activeInputDeliveryIds] }),
       ...(options.lastEventSequence === undefined
         ? stagedOutputEvents.length === 0
           ? {}
@@ -1848,6 +1864,551 @@ describe("CHAT-02: queueing and recalling messages", () => {
       }),
     ).toStrictEqual([firstEventId, secondEventId]);
     await cancelChatRun(actor, active.runId);
+  }, 90_000);
+
+  it("finalizes delivered input from completion receipts exactly once", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "complete a durable delivery",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const pendingEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "accepted before completion",
+        clientEventId: pendingEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected completion input to be reserved");
+    }
+
+    const history = `bdd chat session history ${active.runId}`;
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: active.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-cli-${active.runId}`,
+        cliAgentSessionHistoryHash: createHash("sha256")
+          .update(history)
+          .digest("hex"),
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    const checkpointGate = await holdCheckpointReadsFixture({
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      checkpointGate.release();
+      await checkpointGate.done;
+    });
+    const completion = webhooks.requestAgentComplete(
+      {
+        runId: active.runId,
+        exitCode: 0,
+        activeInputDeliveryIds: [reserved.deliveryId],
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    await expect
+      .poll(checkpointGate.blockedWaiterCount)
+      .toBeGreaterThanOrEqual(1);
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        active.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+    checkpointGate.release();
+    await checkpointGate.done;
+    await expect(completion).resolves.toMatchObject({
+      body: { success: true, status: "completed" },
+    });
+    await flushWaitUntilForTest();
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        active.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+
+    const duplicate = await webhooks.requestAgentComplete(
+      {
+        runId: active.runId,
+        exitCode: 1,
+        error: "late fallback completion",
+        activeInputDeliveryIds: [reserved.deliveryId],
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    expect(duplicate.body).toStrictEqual({
+      success: true,
+      status: "completed",
+    });
+    await flushWaitUntilForTest();
+
+    const events = await chat.listThreadEvents(actor, active.threadId);
+    expect(
+      events.events.filter((event) => {
+        return (
+          event.revokesEventId === pendingEventId &&
+          event.runId === active.runId
+        );
+      }),
+    ).toHaveLength(1);
+  }, 90_000);
+
+  it("finalizes a late receipt without replaying terminal callbacks", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "leave a legacy terminal delivery open",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const pendingEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "finalize after the terminal transition",
+        clientEventId: pendingEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected late completion input to be reserved");
+    }
+    await completeRunWithoutCallbacksFixture({ runId: active.runId });
+
+    const completed = await webhooks.requestAgentComplete(
+      {
+        runId: active.runId,
+        exitCode: 1,
+        error: "duplicate fallback",
+        activeInputDeliveryIds: [reserved.deliveryId],
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    expect(completed.body).toStrictEqual({
+      success: true,
+      status: "completed",
+    });
+    await flushWaitUntilForTest();
+
+    const events = await chat.listThreadEvents(actor, active.threadId);
+    expect(
+      events.events.filter((event) => {
+        return (
+          event.revokesEventId === pendingEventId &&
+          event.runId === active.runId
+        );
+      }),
+    ).toHaveLength(1);
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        active.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+  }, 90_000);
+
+  it("releases prompts and expires budget input before draining in FIFO order", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "finalize an unconfirmed delivery",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const releasedEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "released queue head",
+        clientEventId: releasedEventId,
+      },
+      [201],
+    );
+    await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
+    await runSteerRunTimeBudgetCron();
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected prompt and budget input to be reserved");
+    }
+    const budgetEventId = reserved.eventIds.find((eventId) => {
+      return eventId !== releasedEventId;
+    });
+    if (!budgetEventId) {
+      throw new Error("Expected a reserved budget input");
+    }
+    const laterEventId = randomUUID();
+    const later = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "later queue input",
+        clientEventId: laterEventId,
+      },
+      [201],
+    );
+    if (later.status !== 201) {
+      throw new Error("Expected later input to remain queued");
+    }
+    expect(later.body.runId).toBeNull();
+
+    await completeChatRunOk(active.runId, claimed.sandboxHeaders);
+    await flushWaitUntilForTest();
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        active.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "rejected" });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      active.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === releasedEventId &&
+            typeof message.runId === "string" &&
+            message.runId !== active.runId
+          );
+        });
+      },
+    );
+    const promoted = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === releasedEventId;
+    });
+    if (!promoted?.runId) {
+      throw new Error("Expected the released queue head to be promoted");
+    }
+    expect(
+      messages.events.filter((event) => {
+        return (
+          event.eventType === "control.revoke" &&
+          event.revokesEventId === budgetEventId &&
+          event.runId === active.runId
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      userMessages(messages.events).filter((message) => {
+        return message.revokesEventId === laterEventId;
+      }),
+    ).toHaveLength(0);
+
+    const successorClaim = await claimChatRun(runnerGroup, promoted.runId);
+    await expect(
+      api.listRunnerActiveInputs(
+        successorClaim.claim.sandboxToken,
+        promoted.runId,
+      ),
+    ).resolves.toStrictEqual([laterEventId]);
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        revokesEventId: laterEventId,
+      },
+      [201],
+    );
+    await cancelChatRun(actor, promoted.runId, successorClaim.sandboxHeaders);
+  }, 90_000);
+
+  it("keeps cancelled deliveries as barriers after recovery expiry", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "cancel with a held delivery",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const heldEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "accepted before cancellation",
+        clientEventId: heldEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected cancelled input to be reserved");
+    }
+    await api.requestCancelRun(actor, active.runId, [200]);
+    await waitForRunStatus(actor, active.runId, "cancelled");
+
+    mockNow(now() + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const laterEventId = randomUUID();
+    const later = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "wait behind stale cancellation recovery",
+        clientEventId: laterEventId,
+      },
+      [201],
+    );
+    if (later.status !== 201) {
+      throw new Error("Expected post-cancellation input to remain queued");
+    }
+    expect(later.body.runId).toBeNull();
+    const beforeCompletion = await chat.listThreadEvents(
+      actor,
+      active.threadId,
+    );
+    expect(
+      userMessages(beforeCompletion.events).filter((message) => {
+        return message.revokesEventId === laterEventId;
+      }),
+    ).toHaveLength(0);
+
+    await webhooks.requestAgentComplete(
+      {
+        runId: active.runId,
+        exitCode: 1,
+        error: "Run cancelled",
+        activeInputDeliveryIds: [reserved.deliveryId],
+      },
+      claimed.sandboxHeaders,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    clearMockNow();
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        active.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      active.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === laterEventId &&
+            typeof message.runId === "string" &&
+            message.runId !== active.runId
+          );
+        });
+      },
+    );
+    const successor = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === laterEventId;
+    })?.runId;
+    if (!successor) {
+      throw new Error("Expected the post-cancellation input to start a run");
+    }
+    expect(
+      userMessages(messages.events).filter((message) => {
+        return (
+          message.revokesEventId === heldEventId &&
+          message.runId === active.runId
+        );
+      }),
+    ).toHaveLength(1);
+    const successorClaim = await claimChatRun(runnerGroup, successor);
+    await cancelChatRun(actor, successor, successorClaim.sandboxHeaders);
+  }, 90_000);
+
+  it("keeps timed-out delivery input held until Runner completion", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "time out with an uncertain delivery",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const heldEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "release only after teardown completion",
+        clientEventId: heldEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected timeout input to be reserved");
+    }
+    await timeoutRunWithoutCallbacksFixture({ runId: active.runId });
+    await waitForRunStatus(actor, active.runId, "timeout");
+
+    const laterEventId = randomUUID();
+    const later = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "wait behind the timed-out delivery",
+        clientEventId: laterEventId,
+      },
+      [201],
+    );
+    if (later.status !== 201) {
+      throw new Error("Expected post-timeout input to remain queued");
+    }
+    expect(later.body.runId).toBeNull();
+
+    await failChatRun(
+      active.runId,
+      claimed.sandboxHeaders,
+      "Runner observed timed-out process exit",
+    );
+    await flushWaitUntilForTest();
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        active.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "rejected" });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      active.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === heldEventId &&
+            typeof message.runId === "string" &&
+            message.runId !== active.runId
+          );
+        });
+      },
+    );
+    const successor = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === heldEventId;
+    })?.runId;
+    if (!successor) {
+      throw new Error("Expected timed-out delivery input to be released");
+    }
+    expect(
+      userMessages(messages.events).filter((message) => {
+        return message.revokesEventId === laterEventId;
+      }),
+    ).toHaveLength(0);
+    const successorClaim = await claimChatRun(runnerGroup, successor);
+    await expect(
+      api.listRunnerActiveInputs(successorClaim.claim.sandboxToken, successor),
+    ).resolves.toStrictEqual([laterEventId]);
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        revokesEventId: laterEventId,
+      },
+      [201],
+    );
+    await cancelChatRun(actor, successor, successorClaim.sandboxHeaders);
+  }, 90_000);
+
+  it("cascades delivery state when its thread is deleted", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "delete a thread with reserved input",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "delete this reserved input",
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected deleted thread input to be reserved");
+    }
+
+    await chat.deleteThread(actor, active.threadId);
+    const missingDelivery = await api.requestRecordRunnerActiveInputDeliveryAs(
+      `Bearer ${claimed.claim.sandboxToken}`,
+      active.runId,
+      reserved.deliveryId,
+      [403],
+    );
+    expectApiError(missingDelivery.body);
+    await failChatRun(
+      active.runId,
+      claimed.sandboxHeaders,
+      "Thread deleted during execution",
+    );
+    await flushWaitUntilForTest();
+
+    const unrelated = await sendChatRun(actor, {
+      agentId,
+      prompt: "run after deleting another delivery thread",
+    });
+    const unrelatedClaim = await claimChatRun(runnerGroup, unrelated.runId);
+    await cancelChatRun(actor, unrelated.runId, unrelatedClaim.sandboxHeaders);
   }, 90_000);
 
   it("classifies delivery lifecycle and authorization without route-level 404", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1974,6 +1974,58 @@ describe("CHAT-02: queueing and recalling messages", () => {
     ).toHaveLength(1);
   }, 90_000);
 
+  it("settles delivered input with the terminal run transition", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "complete with a durable delivery",
+    });
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const pendingEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "settle with the terminal transition",
+        clientEventId: pendingEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected terminal input to be reserved");
+    }
+
+    await completeChatRunOk(active.runId, claimed.sandboxHeaders, {
+      activeInputDeliveryIds: [reserved.deliveryId],
+    });
+    await flushWaitUntilForTest();
+
+    expect((await api.readRun(actor, active.runId)).status).toBe("completed");
+    const events = await chat.listThreadEvents(actor, active.threadId);
+    expect(
+      events.events.filter((event) => {
+        return (
+          event.revokesEventId === pendingEventId &&
+          event.runId === active.runId
+        );
+      }),
+    ).toHaveLength(1);
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        active.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+  }, 90_000);
+
   it("finalizes a late receipt without replaying terminal callbacks", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
@@ -38,6 +38,16 @@ interface ActiveInputDeliveryReference {
   readonly eventIds: readonly string[];
 }
 
+interface ActiveInputDeliveryIdentity {
+  readonly runId: string;
+  readonly chatThreadId: string;
+}
+
+export interface FinalizeActiveInputDeliveryResult {
+  readonly finalized: boolean;
+  readonly chatEventsAppended: boolean;
+}
+
 type ReserveActiveInputDeliveryResult =
   | ({
       readonly outcome: "reserved";
@@ -188,7 +198,7 @@ async function prepareReservation(
 
 async function lockOpenDelivery(
   tx: ActiveInputDeliveryTransaction,
-  scope: ActiveInputDeliveryScope,
+  scope: ActiveInputDeliveryIdentity,
 ): Promise<ActiveInputDeliveryReference | null> {
   const [delivery] = await tx
     .select({
@@ -411,14 +421,7 @@ export async function replacePendingActiveInputEvent(
   ) {
     throw new Error("Pending active input has invalid event type");
   }
-  const target = {
-    id: event.id,
-    chatThreadId: event.chatThreadId,
-    createdAt: event.createdAt,
-    eventType: event.eventType,
-    contextType: event.contextType,
-    contextId: event.contextId,
-  };
+  const target = activeInputReplacementTarget(event);
   const replacement =
     event.eventType === "input.budget"
       ? await replaceLoadedChatEvent(tx, target, {
@@ -438,8 +441,42 @@ export async function replacePendingActiveInputEvent(
   }
 }
 
+type ActiveInputSourceRow = Awaited<
+  ReturnType<typeof activeInputRowsByIds>
+>[number];
+
+type ActiveInputReplacementTargetSource = Pick<
+  ActiveInputSourceRow,
+  | "id"
+  | "chatThreadId"
+  | "createdAt"
+  | "eventType"
+  | "contextType"
+  | "contextId"
+>;
+
+function activeInputReplacementTarget(
+  event: ActiveInputReplacementTargetSource,
+): {
+  readonly id: string;
+  readonly chatThreadId: string;
+  readonly createdAt: Date;
+  readonly eventType: ActiveInputSourceRow["eventType"];
+  readonly contextType: ActiveInputSourceRow["contextType"];
+  readonly contextId: ActiveInputSourceRow["contextId"];
+} {
+  return {
+    id: event.id,
+    chatThreadId: event.chatThreadId,
+    createdAt: event.createdAt,
+    eventType: event.eventType,
+    contextType: event.contextType,
+    contextId: event.contextId,
+  };
+}
+
 function sourceIsPendingForRun(
-  source: Awaited<ReturnType<typeof activeInputRowsByIds>>[number],
+  source: ActiveInputSourceRow,
   runId: string,
 ): boolean {
   if (source.runId !== null) {
@@ -461,6 +498,16 @@ interface LockedActiveInputDeliveryReceipt {
     readonly sourceEventId: string;
     readonly disposition: (typeof activeInputDeliveryItems.$inferSelect)["disposition"];
   }[];
+}
+
+interface ActiveInputDeliveryRevoker {
+  readonly eventType: (typeof chatEvents.$inferSelect)["eventType"];
+  readonly runId: string | null;
+}
+
+interface LockedActiveInputDeliverySources {
+  readonly sources: readonly ActiveInputSourceRow[];
+  readonly revokerBySource: ReadonlyMap<string, ActiveInputDeliveryRevoker>;
 }
 
 async function lockActiveInputDeliveryReceipt(
@@ -516,12 +563,11 @@ async function lockActiveInputDeliveryReceipt(
   return { status: delivery.status, items };
 }
 
-async function settleOpenActiveInputDeliveryReceipt(
+async function lockActiveInputDeliverySources(
   tx: ActiveInputDeliveryTransaction,
-  scope: ActiveInputDeliveryScope,
-  deliveryId: string,
+  scope: ActiveInputDeliveryIdentity,
   items: LockedActiveInputDeliveryReceipt["items"],
-): Promise<RecordActiveInputDeliveryReceiptResult> {
+): Promise<LockedActiveInputDeliverySources> {
   const eventIds = items.map((item) => {
     return item.sourceEventId;
   });
@@ -552,44 +598,62 @@ async function settleOpenActiveInputDeliveryReceipt(
       if (!revoker.revokesEventId) {
         throw new Error("Active input revoker is missing its source event");
       }
-      return [revoker.revokesEventId, revoker] as const;
+      return [
+        revoker.revokesEventId,
+        { eventType: revoker.eventType, runId: revoker.runId },
+      ] as const;
     }),
   );
-  const invalidSource = sources.some((source) => {
-    const revoker = revokerBySource.get(source.id);
+  return { sources, revokerBySource };
+}
+
+function activeInputDeliverySourcesAreDeliverable(
+  scope: ActiveInputDeliveryIdentity,
+  state: LockedActiveInputDeliverySources,
+): boolean {
+  return state.sources.every((source) => {
+    const revoker = state.revokerBySource.get(source.id);
     if (revoker) {
-      return !(
+      return (
         revoker.runId === scope.runId &&
         revoker.eventType === source.eventType &&
         (source.eventType === "input.prompt" ||
           source.eventType === "input.budget")
       );
     }
-    return !sourceIsPendingForRun(source, scope.runId);
+    return sourceIsPendingForRun(source, scope.runId);
   });
-  if (invalidSource) {
-    return { outcome: "rejected", replacementsAppended: false };
-  }
-  let replacementsAppended = false;
-  for (const source of sources) {
-    if (!revokerBySource.has(source.id)) {
-      await replacePendingActiveInputEvent(tx, source, scope.runId);
-      replacementsAppended = true;
-    }
+}
+
+async function settleActiveInputDeliveryItems(
+  tx: ActiveInputDeliveryTransaction,
+  deliveryId: string,
+  sourceEventIds: readonly string[],
+  disposition: "delivered" | "released" | "expired",
+): Promise<void> {
+  if (sourceEventIds.length === 0) {
+    return;
   }
   const updatedItems = await tx
     .update(activeInputDeliveryItems)
-    .set({ disposition: "delivered" })
+    .set({ disposition })
     .where(
       and(
         eq(activeInputDeliveryItems.deliveryId, deliveryId),
+        inArray(activeInputDeliveryItems.sourceEventId, sourceEventIds),
         isNull(activeInputDeliveryItems.disposition),
       ),
     )
     .returning({ sourceEventId: activeInputDeliveryItems.sourceEventId });
-  if (updatedItems.length !== items.length) {
+  if (updatedItems.length !== sourceEventIds.length) {
     throw new Error("Active input delivery item settlement was incomplete");
   }
+}
+
+async function settleActiveInputDelivery(
+  tx: ActiveInputDeliveryTransaction,
+  deliveryId: string,
+): Promise<void> {
   const [settled] = await tx
     .update(activeInputDeliveries)
     .set({ status: "settled" })
@@ -603,10 +667,94 @@ async function settleOpenActiveInputDeliveryReceipt(
   if (!settled) {
     throw new Error("Active input delivery settlement was incomplete");
   }
+}
+
+async function settleOpenActiveInputDeliveryAsDelivered(
+  tx: ActiveInputDeliveryTransaction,
+  scope: ActiveInputDeliveryIdentity,
+  deliveryId: string,
+  items: LockedActiveInputDeliveryReceipt["items"],
+): Promise<{ readonly replacementsAppended: boolean } | null> {
+  const state = await lockActiveInputDeliverySources(tx, scope, items);
+  if (!activeInputDeliverySourcesAreDeliverable(scope, state)) {
+    return null;
+  }
+  let replacementsAppended = false;
+  for (const source of state.sources) {
+    if (!state.revokerBySource.has(source.id)) {
+      await replacePendingActiveInputEvent(tx, source, scope.runId);
+      replacementsAppended = true;
+    }
+  }
+  await settleActiveInputDeliveryItems(
+    tx,
+    deliveryId,
+    items.map((item) => {
+      return item.sourceEventId;
+    }),
+    "delivered",
+  );
+  await settleActiveInputDelivery(tx, deliveryId);
+  return { replacementsAppended };
+}
+
+async function settleOpenActiveInputDeliveryAsUndelivered(
+  tx: ActiveInputDeliveryTransaction,
+  scope: ActiveInputDeliveryIdentity,
+  deliveryId: string,
+  items: LockedActiveInputDeliveryReceipt["items"],
+): Promise<FinalizeActiveInputDeliveryResult> {
+  const state = await lockActiveInputDeliverySources(tx, scope, items);
+  if (
+    state.sources.some((source) => {
+      return (
+        state.revokerBySource.has(source.id) ||
+        !sourceIsPendingForRun(source, scope.runId)
+      );
+    })
+  ) {
+    throw new Error("Undelivered active input source is no longer pending");
+  }
+  const promptEventIds: string[] = [];
+  const budgetEventIds: string[] = [];
+  for (const source of state.sources) {
+    if (source.eventType === "input.prompt") {
+      promptEventIds.push(source.id);
+      continue;
+    }
+    if (source.eventType !== "input.budget") {
+      throw new Error("Active input delivery has an invalid source type");
+    }
+    const revoked = await replaceLoadedChatEvent(
+      tx,
+      activeInputReplacementTarget(source),
+      {
+        chatThreadId: scope.chatThreadId,
+        eventType: "control.revoke",
+        runId: scope.runId,
+      },
+    );
+    if (!revoked) {
+      throw new Error("Active input budget expiry was not appended");
+    }
+    budgetEventIds.push(source.id);
+  }
+  await settleActiveInputDeliveryItems(
+    tx,
+    deliveryId,
+    promptEventIds,
+    "released",
+  );
+  await settleActiveInputDeliveryItems(
+    tx,
+    deliveryId,
+    budgetEventIds,
+    "expired",
+  );
+  await settleActiveInputDelivery(tx, deliveryId);
   return {
-    outcome: "delivered",
-    replacementsAppended,
-    chatThreadId: scope.chatThreadId,
+    finalized: true,
+    chatEventsAppended: budgetEventIds.length > 0,
   };
 }
 
@@ -647,12 +795,59 @@ async function recordActiveInputDeliveryReceiptTransition(
   ) {
     throw new Error("Open active input delivery has settled items");
   }
-  return await settleOpenActiveInputDeliveryReceipt(
+  const settlement = await settleOpenActiveInputDeliveryAsDelivered(
     tx,
     scope,
     deliveryId,
     delivery.items,
   );
+  if (!settlement) {
+    return { outcome: "rejected", replacementsAppended: false };
+  }
+  return {
+    outcome: "delivered",
+    replacementsAppended: settlement.replacementsAppended,
+    chatThreadId: scope.chatThreadId,
+  };
+}
+
+export async function finalizeActiveInputDeliveryForCompletion(
+  tx: ActiveInputDeliveryTransaction,
+  args: ActiveInputDeliveryIdentity & {
+    readonly deliveredDeliveryIds: ReadonlySet<string>;
+  },
+): Promise<FinalizeActiveInputDeliveryResult> {
+  const delivery = await lockOpenDelivery(tx, args);
+  if (!delivery) {
+    return {
+      finalized: false,
+      chatEventsAppended: false,
+    };
+  }
+  const items = delivery.eventIds.map((sourceEventId) => {
+    return { sourceEventId, disposition: null };
+  });
+  if (!args.deliveredDeliveryIds.has(delivery.deliveryId)) {
+    return await settleOpenActiveInputDeliveryAsUndelivered(
+      tx,
+      args,
+      delivery.deliveryId,
+      items,
+    );
+  }
+  const settlement = await settleOpenActiveInputDeliveryAsDelivered(
+    tx,
+    args,
+    delivery.deliveryId,
+    items,
+  );
+  if (!settlement) {
+    throw new Error("Delivered active input source is no longer valid");
+  }
+  return {
+    finalized: true,
+    chatEventsAppended: settlement.replacementsAppended,
+  };
 }
 
 export async function recordActiveInputDeliveryReceipt(

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -1,7 +1,11 @@
 import { command } from "ccstate";
 import type { z } from "zod";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
-import type { RunResult, RunStatus } from "@vm0/api-contracts/contracts/runs";
+import {
+  runStatusSchema,
+  type RunResult,
+  type RunStatus,
+} from "@vm0/api-contracts/contracts/runs";
 import { webhookCompleteContract } from "@vm0/api-contracts/contracts/webhooks";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -13,11 +17,13 @@ import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
+import type { Tx } from "../../lib/db-types";
 import type { SandboxAuth } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import {
   publishChatThreadDetailChangedSafely,
+  publishChatThreadMessageCreatedSafely,
   publishRunChangedForUserSafely,
 } from "../external/realtime";
 import { tapError } from "../utils";
@@ -27,6 +33,11 @@ import {
   dispatchRunCallbacks$,
 } from "./agent-run-callback.service";
 import { drainChatThreadQueueForRun$ } from "./chat-thread-queue-drain.service";
+import {
+  finalizeActiveInputDeliveryForCompletion,
+  type FinalizeActiveInputDeliveryResult,
+} from "./active-input-delivery.service";
+import { lockChatQueueThread } from "./chat-event-queue.service";
 import { projectLegacyCheckpointStorage } from "./storage-legacy-projection.service";
 import { maybeEmitRunUsageEvent$ } from "./zero-chat-usage-event.service";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
@@ -56,11 +67,21 @@ interface CancellationRecoverySideEffectsInput {
   readonly runId: string;
   readonly userId: string;
   readonly chatThreadId: string | null;
+  readonly chatEventsAppended: boolean;
+}
+
+interface DeliveryFinalizationSideEffectsInput {
+  readonly kind: "delivery-finalization";
+  readonly runId: string;
+  readonly userId: string;
+  readonly chatThreadId: string;
+  readonly chatEventsAppended: boolean;
 }
 
 type CompleteSideEffectsInput =
   | TerminalSideEffectsInput
-  | CancellationRecoverySideEffectsInput;
+  | CancellationRecoverySideEffectsInput
+  | DeliveryFinalizationSideEffectsInput;
 
 type DispatchCompleteSideEffectsInput = CompleteSideEffectsInput & {
   readonly apiStartTime?: number;
@@ -85,10 +106,31 @@ interface CompletionResponse {
 interface RunRecord {
   readonly cancellationRecoveryCompleted: boolean | null;
   readonly orgId: string;
-  readonly status: string;
+  readonly status: RunStatus;
   readonly userId: string;
   readonly chatThreadId: string | null;
 }
+
+interface PreparedCompletion {
+  readonly status: TerminalStatus;
+  readonly result?: RunResult;
+  readonly error?: string;
+  readonly failureKind?: "missing-checkpoint" | "reported";
+}
+
+interface CompletionCommit {
+  readonly run: RunRecord;
+  readonly transitioned: boolean;
+  readonly responseStatus: TerminalStatus;
+  readonly transitionError?: string;
+  readonly transitionFailureKind?: PreparedCompletion["failureKind"];
+  readonly finalization: FinalizeActiveInputDeliveryResult;
+}
+
+type CompletionTransactionResult =
+  | { readonly kind: "not-found" }
+  | { readonly kind: "retry"; readonly chatThreadId: string | null }
+  | { readonly kind: "committed"; readonly commit: CompletionCommit };
 
 const L = logger("webhook:complete");
 
@@ -121,7 +163,7 @@ function buildRunResult(
 }
 
 async function persistLastEventSequence(
-  db: Db,
+  db: Tx,
   runId: string,
   userId: string,
   lastEventSequence: number,
@@ -134,83 +176,11 @@ async function persistLastEventSequence(
     .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)));
 }
 
-async function transitionRunStatus(
-  db: Db,
-  runId: string,
-  update: {
-    readonly status: RunStatus;
-    readonly completedAt: Date;
-    readonly error?: string;
-    readonly result?: RunResult;
-    readonly sandboxId?: string;
-    readonly sandboxReuseResult?: WebhookCompleteBody["sandboxReuseResult"];
-    readonly workspaceReuseResult?: WebhookCompleteBody["workspaceReuseResult"];
-  },
-  allowedFromStatuses: readonly RunStatus[],
-): Promise<boolean> {
-  const [updated] = await db
-    .update(agentRuns)
-    .set(update)
-    .where(
-      and(
-        eq(agentRuns.id, runId),
-        inArray(agentRuns.status, [...allowedFromStatuses]),
-      ),
-    )
-    .returning({ id: agentRuns.id });
-  if (!updated) {
-    return false;
-  }
-  // Pi jobs can stay in the queue after a standby claim. Nothing consumes them
-  // once the run settles. Ordinary rows are already removed by the normal
-  // claim/expiry lifecycle, and deleting them here would change stale-claim
-  // errors.
-  await db
-    .delete(runnerJobQueue)
-    .where(
-      and(
-        eq(runnerJobQueue.runId, runId),
-        sql`${runnerJobQueue.executionContext}->>'piExecutionMode' = 'standby'`,
-      ),
-    );
-  recordSandboxOperation({
-    sandboxType: "runner",
-    actionType: "run_terminal_transition_committed",
-    durationMs: 0,
-    success: true,
-    runId,
-  });
-  return true;
-}
-
-function successResponse(
-  runId: string,
-  orgId: string,
-  status: TerminalStatus,
-  error?: string,
-): CompletionResponse {
-  return {
-    status: 200,
-    body: {
-      success: true,
-      status,
-    },
-    sideEffects: {
-      kind: "terminal",
-      runId,
-      orgId,
-      status,
-      ...(error ? { error } : {}),
-    },
-  };
-}
-
-async function handleLostTerminalTransition(
+async function loadCompletionRun(
   db: Db,
   input: CompleteAgentRunInput,
-  signal: AbortSignal,
-): Promise<CompletionResponse> {
-  const [currentRun] = await db
+): Promise<RunRecord | null> {
+  const [run] = await db
     .select({
       orgId: agentRuns.orgId,
       status: agentRuns.status,
@@ -227,27 +197,92 @@ async function handleLostTerminalTransition(
       ),
     )
     .limit(1);
-  signal.throwIfAborted();
-
-  if (currentRun?.status === "cancelled") {
-    return await handleCancelledCompletion(db, input, currentRun, signal);
+  if (!run) {
+    return null;
   }
+  return { ...run, status: runStatusSchema.parse(run.status) };
+}
 
+async function prepareCompletion(
+  db: Db,
+  input: CompleteAgentRunInput,
+  signal: AbortSignal,
+): Promise<PreparedCompletion> {
+  if (input.body.exitCode !== 0) {
+    return {
+      status: "failed",
+      error: input.body.error?.trim() || "Run failed without error message",
+      failureKind: "reported",
+    };
+  }
+  const [checkpoint] = await db
+    .select({
+      id: checkpoints.id,
+      conversationId: checkpoints.conversationId,
+      storageMounts: checkpoints.storageMounts,
+    })
+    .from(checkpoints)
+    .where(eq(checkpoints.runId, input.body.runId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!checkpoint) {
+    const allowCheckpointlessSuccess =
+      input.allowCheckpointlessSuccess ||
+      (await hasAcknowledgedTerminalPiMessage(db, input, signal));
+    if (allowCheckpointlessSuccess) {
+      return { status: "completed" };
+    }
+    return {
+      status: "failed",
+      error: "Checkpoint for run not found",
+      failureKind: "missing-checkpoint",
+    };
+  }
+  const [session] = await db
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(eq(agentSessions.conversationId, checkpoint.conversationId))
+    .limit(1);
+  signal.throwIfAborted();
   return {
-    status: 200,
-    body: {
-      success: true,
-      status: currentRun?.status === "completed" ? "completed" : "failed",
-    },
+    status: "completed",
+    result: buildRunResult(checkpoint, session?.id),
   };
 }
 
-async function handleCancelledCompletion(
-  db: Db,
+async function lockCompletionRun(
+  tx: Tx,
+  input: CompleteAgentRunInput,
+): Promise<RunRecord | null> {
+  const [run] = await tx
+    .select({
+      orgId: agentRuns.orgId,
+      status: agentRuns.status,
+      userId: agentRuns.userId,
+      cancellationRecoveryCompleted: agentRuns.cancellationRecoveryCompleted,
+      chatThreadId: zeroRuns.chatThreadId,
+    })
+    .from(agentRuns)
+    .leftJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+    .where(
+      and(
+        eq(agentRuns.id, input.body.runId),
+        eq(agentRuns.userId, input.auth.userId),
+      ),
+    )
+    .for("update", { of: agentRuns })
+    .limit(1);
+  if (!run) {
+    return null;
+  }
+  return { ...run, status: runStatusSchema.parse(run.status) };
+}
+
+async function applyCancelledCompletionMetadata(
+  tx: Tx,
   input: CompleteAgentRunInput,
   run: RunRecord,
-  signal: AbortSignal,
-): Promise<CompletionResponse> {
+): Promise<void> {
   // Guest and host completion may both arrive after cancellation. Preserve the
   // first terminal metadata just like the completed/failed transition paths.
   const update = {
@@ -271,7 +306,7 @@ async function handleCancelledCompletion(
       : {}),
   };
   if (Object.keys(update).length > 0) {
-    await db
+    await tx
       .update(agentRuns)
       .set(update)
       .where(
@@ -281,109 +316,184 @@ async function handleCancelledCompletion(
           eq(agentRuns.status, "cancelled"),
         ),
       );
-    signal.throwIfAborted();
   }
+}
 
+async function applyTerminalCompletion(
+  tx: Tx,
+  input: CompleteAgentRunInput,
+  prepared: PreparedCompletion,
+): Promise<void> {
+  const [updated] = await tx
+    .update(agentRuns)
+    .set({
+      status: prepared.status,
+      completedAt: nowDate(),
+      ...(prepared.error !== undefined ? { error: prepared.error } : {}),
+      ...(prepared.result !== undefined ? { result: prepared.result } : {}),
+      sandboxId: input.body.sandboxId,
+      sandboxReuseResult: input.body.sandboxReuseResult,
+      workspaceReuseResult: input.body.workspaceReuseResult,
+    })
+    .where(
+      and(
+        eq(agentRuns.id, input.body.runId),
+        eq(agentRuns.userId, input.auth.userId),
+        inArray(agentRuns.status, ["pending", "running", "timeout"]),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  if (!updated) {
+    throw new Error("Locked agent run lost its terminal transition");
+  }
+  // Pi jobs can stay in the queue after a standby claim. Nothing consumes them
+  // once the run settles. Ordinary rows are already removed by the normal
+  // claim/expiry lifecycle, and deleting them here would change stale-claim
+  // errors.
+  await tx
+    .delete(runnerJobQueue)
+    .where(
+      and(
+        eq(runnerJobQueue.runId, input.body.runId),
+        sql`${runnerJobQueue.executionContext}->>'piExecutionMode' = 'standby'`,
+      ),
+    );
+}
+
+function noActiveInputFinalization(): FinalizeActiveInputDeliveryResult {
+  return {
+    finalized: false,
+    chatEventsAppended: false,
+  };
+}
+
+async function completeAgentRunTransition(
+  tx: Tx,
+  input: CompleteAgentRunInput,
+  prepared: PreparedCompletion | null,
+  expectedChatThreadId: string | null,
+): Promise<CompletionTransactionResult> {
+  const threadLocked =
+    expectedChatThreadId === null
+      ? false
+      : await lockChatQueueThread(tx, expectedChatThreadId);
+  const run = await lockCompletionRun(tx, input);
+  if (!run) {
+    return { kind: "not-found" };
+  }
+  if (run.chatThreadId !== expectedChatThreadId) {
+    return { kind: "retry", chatThreadId: run.chatThreadId };
+  }
+  if (expectedChatThreadId !== null && !threadLocked) {
+    throw new Error("Agent run retained a missing chat thread");
+  }
+  if (input.body.lastEventSequence !== undefined) {
+    await persistLastEventSequence(
+      tx,
+      input.body.runId,
+      input.auth.userId,
+      input.body.lastEventSequence,
+    );
+  }
+  const finalization =
+    run.chatThreadId === null
+      ? noActiveInputFinalization()
+      : await finalizeActiveInputDeliveryForCompletion(tx, {
+          runId: input.body.runId,
+          chatThreadId: run.chatThreadId,
+          deliveredDeliveryIds: new Set(
+            input.body.activeInputDeliveryIds ?? [],
+          ),
+        });
+  const canTransition =
+    run.status === "pending" ||
+    run.status === "running" ||
+    run.status === "timeout";
+  if (canTransition) {
+    if (!prepared) {
+      throw new Error("Active agent run completion was not prepared");
+    }
+    await applyTerminalCompletion(tx, input, prepared);
+    return {
+      kind: "committed",
+      commit: {
+        run,
+        transitioned: true,
+        responseStatus: prepared.status,
+        transitionError: prepared.error,
+        transitionFailureKind: prepared.failureKind,
+        finalization,
+      },
+    };
+  }
+  if (run.status === "cancelled") {
+    await applyCancelledCompletionMetadata(tx, input, run);
+  }
+  return {
+    kind: "committed",
+    commit: {
+      run,
+      transitioned: false,
+      responseStatus: run.status === "completed" ? "completed" : "failed",
+      finalization,
+    },
+  };
+}
+
+function completionResponse(
+  runId: string,
+  commit: CompletionCommit,
+): CompletionResponse {
+  let sideEffects: CompleteSideEffectsInput | undefined;
+  if (commit.transitioned) {
+    sideEffects = {
+      kind: "terminal",
+      runId,
+      orgId: commit.run.orgId,
+      status: commit.responseStatus,
+      ...(commit.transitionError !== undefined
+        ? { error: commit.transitionError }
+        : {}),
+    };
+  } else if (
+    commit.run.status === "cancelled" &&
+    (commit.run.cancellationRecoveryCompleted !== null ||
+      commit.finalization.finalized)
+  ) {
+    sideEffects = {
+      kind: "cancellation-recovery",
+      runId,
+      userId: commit.run.userId,
+      chatThreadId: commit.run.chatThreadId,
+      chatEventsAppended: commit.finalization.chatEventsAppended,
+    };
+  } else if (
+    commit.finalization.finalized &&
+    commit.run.chatThreadId !== null
+  ) {
+    sideEffects = {
+      kind: "delivery-finalization",
+      runId,
+      userId: commit.run.userId,
+      chatThreadId: commit.run.chatThreadId,
+      chatEventsAppended: commit.finalization.chatEventsAppended,
+    };
+  }
+  return {
+    status: 200,
+    body: { success: true, status: commit.responseStatus },
+    ...(sideEffects ? { sideEffects } : {}),
+  };
+}
+
+function deletedRunCompletionResponse(run: RunRecord): CompletionResponse {
   return {
     status: 200,
     body: {
       success: true,
-      status: "failed",
+      status: run.status === "completed" ? "completed" : "failed",
     },
-    ...(run.cancellationRecoveryCompleted !== null
-      ? {
-          sideEffects: {
-            kind: "cancellation-recovery" as const,
-            runId: input.body.runId,
-            userId: run.userId,
-            chatThreadId: run.chatThreadId,
-          },
-        }
-      : {}),
   };
-}
-
-async function handleMissingCheckpoint(
-  db: Db,
-  input: CompleteAgentRunInput,
-  run: RunRecord,
-  signal: AbortSignal,
-): Promise<CompletionResponse> {
-  const error = "Checkpoint for run not found";
-  const completedAt = nowDate();
-  const transitioned = await transitionRunStatus(
-    db,
-    input.body.runId,
-    {
-      status: "failed",
-      completedAt,
-      error,
-      sandboxId: input.body.sandboxId,
-      sandboxReuseResult: input.body.sandboxReuseResult,
-      workspaceReuseResult: input.body.workspaceReuseResult,
-    },
-    ["pending", "running", "timeout"],
-  );
-  signal.throwIfAborted();
-
-  if (!transitioned) {
-    return await handleLostTerminalTransition(db, input, signal);
-  }
-
-  await publishRunChangedForUserSafely(run.userId, input.body.runId, {
-    status: "failed",
-  });
-  signal.throwIfAborted();
-
-  L.warn("Run failed because checkpoint was not found", {
-    runId: input.body.runId,
-    error,
-  });
-  return successResponse(input.body.runId, run.orgId, "failed", error);
-}
-
-async function handleSuccessfulCompletion(
-  db: Db,
-  input: CompleteAgentRunInput,
-  run: RunRecord,
-  signal: AbortSignal,
-): Promise<CompletionResponse> {
-  const [checkpoint] = await db
-    .select({
-      id: checkpoints.id,
-      conversationId: checkpoints.conversationId,
-      storageMounts: checkpoints.storageMounts,
-    })
-    .from(checkpoints)
-    .where(eq(checkpoints.runId, input.body.runId))
-    .limit(1);
-  signal.throwIfAborted();
-
-  if (!checkpoint) {
-    const allowCheckpointlessSuccess =
-      input.allowCheckpointlessSuccess ||
-      (await hasAcknowledgedTerminalPiMessage(db, input, signal));
-    if (allowCheckpointlessSuccess) {
-      return await persistSuccessfulCompletion(
-        db,
-        input,
-        run,
-        undefined,
-        signal,
-      );
-    }
-    return await handleMissingCheckpoint(db, input, run, signal);
-  }
-
-  const [session] = await db
-    .select({ id: agentSessions.id })
-    .from(agentSessions)
-    .where(eq(agentSessions.conversationId, checkpoint.conversationId))
-    .limit(1);
-  signal.throwIfAborted();
-
-  const result = buildRunResult(checkpoint, session?.id);
-  return await persistSuccessfulCompletion(db, input, run, result, signal);
 }
 
 async function hasAcknowledgedTerminalPiMessage(
@@ -420,118 +530,12 @@ async function hasAcknowledgedTerminalPiMessage(
   );
 }
 
-async function persistSuccessfulCompletion(
-  db: Db,
-  input: CompleteAgentRunInput,
-  run: RunRecord,
-  result: RunResult | undefined,
-  signal: AbortSignal,
-): Promise<CompletionResponse> {
-  const completedAt = nowDate();
-  const transitioned = await transitionRunStatus(
-    db,
-    input.body.runId,
-    {
-      status: "completed",
-      completedAt,
-      ...(result ? { result } : {}),
-      sandboxId: input.body.sandboxId,
-      sandboxReuseResult: input.body.sandboxReuseResult,
-      workspaceReuseResult: input.body.workspaceReuseResult,
-    },
-    ["pending", "running", "timeout"],
-  );
-  signal.throwIfAborted();
-
-  if (!transitioned) {
-    return await handleLostTerminalTransition(db, input, signal);
-  }
-
-  await publishRunChangedForUserSafely(run.userId, input.body.runId, {
-    status: "completed",
-  });
-  signal.throwIfAborted();
-
-  L.debug("Run completed successfully", { runId: input.body.runId });
-  return successResponse(input.body.runId, run.orgId, "completed");
-}
-
-async function handleFailedCompletion(
-  db: Db,
-  input: CompleteAgentRunInput,
-  run: RunRecord,
-  signal: AbortSignal,
-): Promise<CompletionResponse> {
-  const error = input.body.error?.trim() || "Run failed without error message";
-  const completedAt = nowDate();
-  const transitioned = await transitionRunStatus(
-    db,
-    input.body.runId,
-    {
-      status: "failed",
-      completedAt,
-      error,
-      sandboxId: input.body.sandboxId,
-      sandboxReuseResult: input.body.sandboxReuseResult,
-      workspaceReuseResult: input.body.workspaceReuseResult,
-    },
-    ["pending", "running", "timeout"],
-  );
-  signal.throwIfAborted();
-
-  if (!transitioned) {
-    return await handleLostTerminalTransition(db, input, signal);
-  }
-
-  await publishRunChangedForUserSafely(run.userId, input.body.runId, {
-    status: "failed",
-  });
-  signal.throwIfAborted();
-
-  L.warn("Run failed", {
-    runId: input.body.runId,
-    exitCode: input.body.exitCode,
-    error,
-  });
-  return successResponse(input.body.runId, run.orgId, "failed", error);
-}
-
-export const dispatchCompleteSideEffects$ = command(
+const dispatchTerminalCompleteSideEffects$ = command(
   async (
     { set },
-    input: DispatchCompleteSideEffectsInput,
+    input: TerminalSideEffectsInput & { readonly apiStartTime: number },
     signal: AbortSignal,
   ): Promise<void> => {
-    const apiStartTime = input.apiStartTime ?? now();
-    if (input.kind === "cancellation-recovery") {
-      if (input.chatThreadId !== null) {
-        await publishChatThreadDetailChangedSafely(
-          input.userId,
-          input.chatThreadId,
-        );
-        signal.throwIfAborted();
-      }
-      await tapError(
-        set(
-          drainChatThreadQueueForRun$,
-          {
-            runId: input.runId,
-            dispatchFailedCallbacks: dispatchFailedRunCallbacks,
-            apiStartTime,
-          },
-          signal,
-        ),
-        (error) => {
-          L.error("Failed to drain chat thread queue after recovery", {
-            runId: input.runId,
-            error,
-          });
-        },
-      );
-      signal.throwIfAborted();
-      return;
-    }
-
     const db = set(writeDb$);
     const callbackStatus =
       input.status === "completed" ? "completed" : "failed";
@@ -567,7 +571,7 @@ export const dispatchCompleteSideEffects$ = command(
           {
             runId: input.runId,
             dispatchFailedCallbacks: dispatchFailedRunCallbacks,
-            apiStartTime,
+            apiStartTime: input.apiStartTime,
           },
           signal,
         ),
@@ -610,6 +614,84 @@ export const dispatchCompleteSideEffects$ = command(
   },
 );
 
+export const dispatchCompleteSideEffects$ = command(
+  async (
+    { set },
+    input: DispatchCompleteSideEffectsInput,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const apiStartTime = input.apiStartTime ?? now();
+    if (input.kind === "cancellation-recovery") {
+      if (input.chatThreadId !== null) {
+        await publishChatThreadDetailChangedSafely(
+          input.userId,
+          input.chatThreadId,
+        );
+        signal.throwIfAborted();
+        if (input.chatEventsAppended) {
+          await publishChatThreadMessageCreatedSafely(
+            input.userId,
+            input.chatThreadId,
+          );
+          signal.throwIfAborted();
+        }
+      }
+      await tapError(
+        set(
+          drainChatThreadQueueForRun$,
+          {
+            runId: input.runId,
+            dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+            apiStartTime,
+          },
+          signal,
+        ),
+        (error) => {
+          L.error("Failed to drain chat thread queue after recovery", {
+            runId: input.runId,
+            error,
+          });
+        },
+      );
+      signal.throwIfAborted();
+      return;
+    }
+    if (input.kind === "delivery-finalization") {
+      if (input.chatEventsAppended) {
+        await publishChatThreadMessageCreatedSafely(
+          input.userId,
+          input.chatThreadId,
+        );
+        signal.throwIfAborted();
+      }
+      await tapError(
+        set(
+          drainChatThreadQueueForRun$,
+          {
+            runId: input.runId,
+            dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+            apiStartTime,
+          },
+          signal,
+        ),
+        (error) => {
+          L.error("Failed to drain chat thread queue after delivery", {
+            runId: input.runId,
+            error,
+          });
+        },
+      );
+      signal.throwIfAborted();
+      return;
+    }
+    await set(
+      dispatchTerminalCompleteSideEffects$,
+      { ...input, apiStartTime },
+      signal,
+    );
+  },
+);
+
 export const completeAgentRun$ = command(
   async (
     { set },
@@ -617,62 +699,81 @@ export const completeAgentRun$ = command(
     signal: AbortSignal,
   ): Promise<CompletionResponse> => {
     const db = set(writeDb$);
-    const [run] = await db
-      .select({
-        id: agentRuns.id,
-        orgId: agentRuns.orgId,
-        status: agentRuns.status,
-        userId: agentRuns.userId,
-        cancellationRecoveryCompleted: agentRuns.cancellationRecoveryCompleted,
-        chatThreadId: zeroRuns.chatThreadId,
-      })
-      .from(agentRuns)
-      .leftJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-      .where(
-        and(
-          eq(agentRuns.id, input.body.runId),
-          eq(agentRuns.userId, input.auth.userId),
-        ),
-      )
-      .limit(1);
+    const initialRun = await loadCompletionRun(db, input);
     signal.throwIfAborted();
-
-    if (!run) {
+    if (!initialRun) {
       return notFound("Agent run not found");
     }
+    const shouldPrepare =
+      initialRun.status === "pending" ||
+      initialRun.status === "running" ||
+      initialRun.status === "timeout";
+    const prepared = shouldPrepare
+      ? await prepareCompletion(db, input, signal)
+      : null;
+    signal.throwIfAborted();
 
-    if (input.body.lastEventSequence !== undefined) {
-      await persistLastEventSequence(
-        db,
+    let expectedChatThreadId = initialRun.chatThreadId;
+    let commit: CompletionCommit;
+    while (true) {
+      const result = await db.transaction(async (tx) => {
+        return await completeAgentRunTransition(
+          tx,
+          input,
+          prepared,
+          expectedChatThreadId,
+        );
+      });
+      signal.throwIfAborted();
+      if (result.kind === "retry") {
+        expectedChatThreadId = result.chatThreadId;
+        continue;
+      }
+      if (result.kind === "not-found") {
+        return deletedRunCompletionResponse(initialRun);
+      }
+      commit = result.commit;
+      break;
+    }
+
+    if (commit.transitioned) {
+      recordSandboxOperation({
+        sandboxType: "runner",
+        actionType: "run_terminal_transition_committed",
+        durationMs: 0,
+        success: true,
+        runId: input.body.runId,
+      });
+      await publishRunChangedForUserSafely(
+        commit.run.userId,
         input.body.runId,
-        input.auth.userId,
-        input.body.lastEventSequence,
+        { status: commit.responseStatus },
       );
       signal.throwIfAborted();
-    }
-
-    if (run.status === "completed" || run.status === "failed") {
-      L.debug("Skipping duplicate completion for terminal run", {
+      if (commit.responseStatus === "completed") {
+        L.debug("Run completed successfully", { runId: input.body.runId });
+      } else if (commit.transitionFailureKind === "missing-checkpoint") {
+        L.warn("Run failed because checkpoint was not found", {
+          runId: input.body.runId,
+          error: commit.transitionError,
+        });
+      } else {
+        L.warn("Run failed", {
+          runId: input.body.runId,
+          exitCode: input.body.exitCode,
+          error: commit.transitionError,
+        });
+      }
+    } else if (
+      commit.run.status === "completed" ||
+      commit.run.status === "failed"
+    ) {
+      L.debug("Processed duplicate completion for terminal run", {
         runId: input.body.runId,
-        status: run.status,
+        status: commit.run.status,
+        activeInputFinalized: commit.finalization.finalized,
       });
-      return {
-        status: 200,
-        body: {
-          success: true,
-          status: run.status === "completed" ? "completed" : "failed",
-        },
-      };
     }
-
-    if (run.status === "cancelled") {
-      return await handleCancelledCompletion(db, input, run, signal);
-    }
-
-    if (input.body.exitCode === 0) {
-      return await handleSuccessfulCompletion(db, input, run, signal);
-    }
-
-    return await handleFailedCompletion(db, input, run, signal);
+    return completionResponse(input.body.runId, commit);
   },
 );

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -1,6 +1,10 @@
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import {
+  activeInputDeliveries,
+  activeInputDeliveryItems,
+} from "@vm0/db/schema/active-input-delivery";
+import {
   and,
   asc,
   eq,
@@ -29,11 +33,29 @@ interface PendingChatQueueEvent {
 }
 
 function unrevokedQueueEventCondition(db: ChatQueueReadDb) {
-  return notExists(
-    db
-      .select({ id: queueEventRevoker.id })
-      .from(queueEventRevoker)
-      .where(eq(queueEventRevoker.revokesEventId, chatEvents.id)),
+  return and(
+    notExists(
+      db
+        .select({ id: queueEventRevoker.id })
+        .from(queueEventRevoker)
+        .where(eq(queueEventRevoker.revokesEventId, chatEvents.id)),
+    ),
+    notExists(
+      db
+        .select({ deliveryId: activeInputDeliveryItems.deliveryId })
+        .from(activeInputDeliveryItems)
+        .innerJoin(
+          activeInputDeliveries,
+          eq(activeInputDeliveries.id, activeInputDeliveryItems.deliveryId),
+        )
+        .where(
+          and(
+            eq(activeInputDeliveryItems.sourceEventId, chatEvents.id),
+            isNull(activeInputDeliveryItems.disposition),
+            eq(activeInputDeliveries.status, "open"),
+          ),
+        ),
+    ),
   );
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-active-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-active-run.service.ts
@@ -1,6 +1,7 @@
 import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@vm0/api-contracts/contracts/runners";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { activeInputDeliveries } from "@vm0/db/schema/active-input-delivery";
 import { chatEvents } from "@vm0/db/schema/chat-event";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -118,7 +119,7 @@ export async function cancellationRecoveryPendingForThread(
   return run !== undefined;
 }
 
-async function activeChatRunExists(
+async function chatThreadAdmissionBlockerExists(
   db: Pick<Db, "select">,
   args: {
     readonly threadId: string;
@@ -126,25 +127,50 @@ async function activeChatRunExists(
     readonly apiStartTime?: number;
   },
 ): Promise<boolean> {
-  const [run] = await db
-    .select({ id: zeroRuns.id })
-    .from(zeroRuns)
-    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+  const [thread] = await db
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
     .where(
       and(
-        eq(zeroRuns.chatThreadId, args.threadId),
-        args.excludeRunId === undefined
-          ? undefined
-          : ne(zeroRuns.id, args.excludeRunId),
+        eq(chatThreads.id, args.threadId),
         or(
-          activeChatRunCondition(db),
-          freshUnresolvedCancellationRecoveryCondition(db, args.apiStartTime),
+          exists(
+            db
+              .select({ id: zeroRuns.id })
+              .from(zeroRuns)
+              .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+              .where(
+                and(
+                  eq(zeroRuns.chatThreadId, args.threadId),
+                  args.excludeRunId === undefined
+                    ? undefined
+                    : ne(zeroRuns.id, args.excludeRunId),
+                  or(
+                    activeChatRunCondition(db),
+                    freshUnresolvedCancellationRecoveryCondition(
+                      db,
+                      args.apiStartTime,
+                    ),
+                  ),
+                ),
+              ),
+          ),
+          exists(
+            db
+              .select({ id: activeInputDeliveries.id })
+              .from(activeInputDeliveries)
+              .where(
+                and(
+                  eq(activeInputDeliveries.chatThreadId, args.threadId),
+                  eq(activeInputDeliveries.status, "open"),
+                ),
+              ),
+          ),
         ),
       ),
     )
     .limit(1);
-
-  return run !== undefined;
+  return thread !== undefined;
 }
 
 // A managed browser outlives the run that opened it and the next run simply
@@ -158,7 +184,7 @@ export async function chatThreadAdmissionBlocked(
     readonly apiStartTime?: number;
   },
 ): Promise<boolean> {
-  return await activeChatRunExists(db, args);
+  return await chatThreadAdmissionBlockerExists(db, args);
 }
 
 /** Pending queue threads whose cancellation recovery barrier has failed open. */

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -885,6 +885,28 @@ export async function completeRunWithoutCallbacksFixture(args: {
   }
 }
 
+/**
+ * Mark one claimed run timed out without completing its terminal side effects.
+ * This isolates the interval where cleanup has recorded uncertainty but the
+ * Runner has not yet reported process exit and teardown through `/complete`.
+ */
+export async function timeoutRunWithoutCallbacksFixture(args: {
+  readonly runId: string;
+}): Promise<void> {
+  const updated = await db()
+    .update(agentRuns)
+    .set({
+      status: "timeout",
+      completedAt: nowDate(),
+      error: "Run timed out (no heartbeat)",
+    })
+    .where(and(eq(agentRuns.id, args.runId), eq(agentRuns.status, "running")))
+    .returning({ id: agentRuns.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one running run to time out without callbacks");
+  }
+}
+
 /** Create a terminal source that predates runner-process identity tracking. */
 export async function completeRunWithoutRunnerIdentityFixture(args: {
   readonly runId: string;

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -7,6 +7,7 @@ import {
   storageManifestFilesSchema,
 } from "../storages";
 import {
+  ACTIVE_INPUT_DELIVERY_RECEIPT_MAX_IDS,
   webhookCompleteContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
@@ -129,6 +130,51 @@ describe("agent completion reuse outcomes", () => {
         webhookCompleteContract.complete.body.safeParse({
           ...baseBody,
           ...body,
+        }).success,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("agent completion active input receipts", () => {
+  const baseBody = {
+    runId: "00000000-0000-4000-8000-000000000000",
+    exitCode: 0,
+  };
+  const deliveryId = "00000000-0000-4000-8000-000000000001";
+
+  it("accepts optional unique canonical delivery IDs", () => {
+    expect(
+      webhookCompleteContract.complete.body.parse({
+        ...baseBody,
+        activeInputDeliveryIds: [deliveryId],
+      }),
+    ).toMatchObject({ activeInputDeliveryIds: [deliveryId] });
+    expect(
+      webhookCompleteContract.complete.body.safeParse(baseBody).success,
+    ).toBe(true);
+  });
+
+  it("rejects duplicate, malformed, non-canonical, and oversized IDs", () => {
+    const invalidLists = [
+      [deliveryId, deliveryId],
+      ["not-a-uuid"],
+      ["AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"],
+      Array.from(
+        { length: ACTIVE_INPUT_DELIVERY_RECEIPT_MAX_IDS + 1 },
+        (_, index) => {
+          return `00000000-0000-4000-8000-${index
+            .toString(16)
+            .padStart(12, "0")}`;
+        },
+      ),
+    ];
+
+    for (const activeInputDeliveryIds of invalidLists) {
+      expect(
+        webhookCompleteContract.complete.body.safeParse({
+          ...baseBody,
+          activeInputDeliveryIds,
         }).success,
       ).toBe(false);
     }

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -406,6 +406,32 @@ const currentSandboxReuseMissSchema = z.enum([
   "unparkFailed",
 ]);
 
+export const ACTIVE_INPUT_DELIVERY_RECEIPT_MAX_IDS = 1024;
+
+const activeInputDeliveryIdsSchema = z
+  .array(
+    z
+      .string()
+      .uuid()
+      .refine((id) => {
+        return id === id.toLowerCase();
+      }, "active input delivery IDs must use canonical lowercase UUIDs"),
+  )
+  .max(ACTIVE_INPUT_DELIVERY_RECEIPT_MAX_IDS)
+  .superRefine((ids, context) => {
+    const seen = new Set<string>();
+    ids.forEach((id, index) => {
+      if (seen.has(id)) {
+        context.addIssue({
+          code: "custom",
+          path: [index],
+          message: "active input delivery IDs must be unique",
+        });
+      }
+      seen.add(id);
+    });
+  });
+
 const webhookCompleteBodySchema = z
   .object({
     runId: z.string().min(1, "runId is required"),
@@ -418,6 +444,7 @@ const webhookCompleteBodySchema = z
     sandboxId: z.string().max(255).optional(),
     sandboxReuseResult: sandboxReuseResultSchema.optional(),
     workspaceReuseResult: workspaceReuseResultSchema.optional(),
+    activeInputDeliveryIds: activeInputDeliveryIdsSchema.optional(),
   })
   .superRefine((body, context) => {
     const workspaceResult = body.workspaceReuseResult;


### PR DESCRIPTION
## Summary

- accept bounded active-input delivery IDs on run completion and settle open deliveries under the thread-to-event lock order
- release unconfirmed prompts, expire unconfirmed run budgets, and keep open deliveries as non-expiring thread ordering barriers
- preserve duplicate, cancellation, timeout, deletion-race, and legacy no-delivery completion behavior while keeping external side effects after commit
- document the delivery lifecycle and add deterministic API coverage for receipt/completion races, terminal recovery, FIFO ordering, and deletion

## Compatibility

- `activeInputDeliveryIds` is optional, so existing Runner completion requests remain valid
- runs without durable delivery rows retain the existing completion behavior
- this PR does not add protocol negotiation, a migration, or Runner activation; the cutover remains in #26060

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts --silent=passed-only`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=2 --silent=passed-only`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts --maxWorkers=2 --silent=passed-only`
- `cd turbo && pnpm knip`

Closes #26059

Parent delivery issue: #26034
