### PR TITLE
fix(chat): load every attachment preview from a presigned url

### DIFF
--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -20,13 +20,12 @@ function isAuthenticatedAttachmentUrl(url: string): boolean {
 
 /**
  * Persisted chat attachments live in a private bucket behind an authenticated
- * API route, and `<img src>` cannot carry an Authorization header. Exchange the
- * canonical API URL for a short-lived presigned object URL the browser can load
- * on its own; the API still runs the ownership check before signing.
+ * API route, and a bare `src` attribute cannot carry an Authorization header.
+ * Exchange the canonical API URL for a short-lived presigned object URL the
+ * browser can load on its own; the API still runs the ownership check before
+ * signing.
  */
-export function createAttachmentResourceUrl$(
-  url: string,
-): Computed<Promise<string>> {
+function createAttachmentResourceUrl$(url: string): Computed<Promise<string>> {
   return computed(async (get) => {
     if (!isAuthenticatedAttachmentUrl(url)) {
       return url;
@@ -50,3 +49,22 @@ export function createAttachmentResourceUrl$(
     return response.body.url;
   });
 }
+
+/**
+ * Every preview kind resolves through this resolver, so a component can ask for
+ * a loadable URL during render: the computed it hands back is memoized per
+ * source URL and therefore stable across renders, instead of signing the same
+ * attachment again on every pass.
+ */
+export const attachmentResourceUrlResolver$ = computed(() => {
+  const resourceUrlByUrl = new Map<string, Computed<Promise<string>>>();
+  return (url: string): Computed<Promise<string>> => {
+    const existing = resourceUrlByUrl.get(url);
+    if (existing) {
+      return existing;
+    }
+    const resourceUrl$ = createAttachmentResourceUrl$(url);
+    resourceUrlByUrl.set(url, resourceUrl$);
+    return resourceUrl$;
+  };
+});

--- a/turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts
@@ -7,7 +7,7 @@ import {
   createTextPreviewComputed,
   isTextPreviewKind,
 } from "../text-preview.ts";
-import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
+import { attachmentResourceUrlResolver$ } from "../attachment-resource-url.ts";
 
 export type ArtifactKind =
   | "image"
@@ -47,7 +47,9 @@ function createArtifactSignals(
   descriptor: ArtifactDescriptor,
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
 ): ArtifactSignals {
-  const resourceUrl$ = createAttachmentResourceUrl$(descriptor.url);
+  const resourceUrl$ = computed((get) => {
+    return get(get(attachmentResourceUrlResolver$)(descriptor.url));
+  });
   const previewImageUrl$ = computed(async (get) => {
     if (descriptor.kind !== "html" && descriptor.kind !== "video") {
       return undefined;

--- a/turbo/apps/platform/src/signals/text-preview.ts
+++ b/turbo/apps/platform/src/signals/text-preview.ts
@@ -1,4 +1,5 @@
 import { computed, type Computed } from "ccstate";
+import { attachmentResourceUrlResolver$ } from "./attachment-resource-url.ts";
 
 export type TextPreviewKind = "markdown" | "text" | "json" | "csv";
 export type TextPreviewComputed = Computed<Promise<string>>;
@@ -62,8 +63,11 @@ export async function fetchPreviewText(url: string): Promise<string> {
 }
 
 export function createTextPreviewComputed(url: string): TextPreviewComputed {
-  return computed((_get) => {
-    return fetchPreviewText(url);
+  return computed(async (get) => {
+    // The canonical attachment URL needs an Authorization header this fetch
+    // does not carry, so read the presigned object URL instead.
+    const resolveResourceUrl = get(attachmentResourceUrlResolver$);
+    return fetchPreviewText(await get(resolveResourceUrl(url)));
   });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -419,6 +419,38 @@ describe("thread-owned utility sidebar", () => {
     expect(requestedThreadIds).toContain(THREAD_ID);
   });
 
+  it("previews a public catalog document through the resolved resource url", async () => {
+    const htmlUrl = "https://catalog-document.sites.vm7.io";
+    const summary = catalogArtifact({ title: "launch-site.html" });
+    setupArtifactCatalog(
+      [summary],
+      new Map([
+        [
+          summary.id,
+          catalogFileDetail({
+            contentType: "text/html",
+            filename: "launch-site.html",
+            fileId: "f0000000-0000-4000-a000-000000000003",
+            summary,
+            url: htmlUrl,
+          }),
+        ],
+      ]),
+    );
+
+    setupChatThread();
+    await openCatalogArtifact("launch-site.html");
+
+    // A public URL resolves to itself, so the same path that presigns a private
+    // attachment leaves a hosted site untouched.
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "src",
+        htmlUrl,
+      );
+    });
+  });
+
   it("shows an unavailable artifact detail with a way back to the list", async () => {
     context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1388,20 +1388,42 @@ describe("zero attachment chips", () => {
     );
     expect(iframe).toHaveClass("h-full", "min-h-0", "border-0");
 
-    click(screen.getByLabelText("Close"));
+    // The split view reads the same document, so it must resolve the same
+    // loadable URL rather than falling back to the canonical route.
+    click(screen.getByLabelText("Open in split view"));
 
     await waitFor(() => {
       expect(
         screen.queryByTestId("attachment-lightbox"),
       ).not.toBeInTheDocument();
+      expect(screen.getByTestId("artifact-sidebar-body-pdf")).toHaveAttribute(
+        "src",
+        `${presignedFileUrl("attachment-pdf")}#navpanes=0`,
+      );
+    });
+
+    click(screen.getByLabelText("Close artifact"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
     });
 
     click(screen.getByLabelText("Open html preview for launch-site.html"));
 
     await waitFor(() => {
-      expect(
-        screen.getByTestId("artifact-dialog-body-html"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("artifact-dialog-body-html")).toHaveAttribute(
+        "src",
+        presignedFileUrl("attachment-html"),
+      );
+    });
+
+    click(screen.getByLabelText("Open in split view"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "src",
+        presignedFileUrl("attachment-html"),
+      );
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -29,6 +29,9 @@ function presignedFileUrl(fileId: string): string {
   return `https://r2.example.com/artifacts/${fileId}?sig=test`;
 }
 
+/** Matches presignedFileUrl so a preview body can be served from that URL. */
+const PRESIGNED_FILE_PATTERN = "https://r2.example.com/artifacts/:fileId";
+
 function artifactFile(
   url: string,
   overrides: Partial<ChatThreadArtifactFile> = {},
@@ -1198,10 +1201,8 @@ describe("zero attachment chips", () => {
   });
 
   it("opens persisted canonical audio, video, and document attachments", async () => {
-    context.mocks.http.get("/api/zero/web/download-file", ({ request }) => {
-      expect(new URL(request.url).searchParams.get("file_id")).toBe(
-        "attachment-json",
-      );
+    context.mocks.http.get(PRESIGNED_FILE_PATTERN, ({ params }) => {
+      expect(params.fileId).toBe("attachment-json");
       return new Response(JSON.stringify({ status: "ready" }), {
         headers: { "Content-Type": "application/json" },
       });
@@ -1297,10 +1298,8 @@ describe("zero attachment chips", () => {
   });
 
   it("opens persisted canonical csv, pdf, and html document previews", async () => {
-    context.mocks.http.get("/api/zero/web/download-file", ({ request }) => {
-      expect(new URL(request.url).searchParams.get("file_id")).toBe(
-        "attachment-csv",
-      );
+    context.mocks.http.get(PRESIGNED_FILE_PATTERN, ({ params }) => {
+      expect(params.fileId).toBe("attachment-csv");
       return new Response("metric,value\nsignups,42\nactivation,87", {
         headers: { "Content-Type": "text/csv" },
       });
@@ -1385,7 +1384,7 @@ describe("zero attachment chips", () => {
     expect(documentFrame).toHaveClass("h-full", "min-h-0");
     expect(iframe).toHaveAttribute(
       "src",
-      `${canonicalUserMessageFileUrl("attachment-pdf")}#navpanes=0`,
+      `${presignedFileUrl("attachment-pdf")}#navpanes=0`,
     );
     expect(iframe).toHaveClass("h-full", "min-h-0", "border-0");
 
@@ -2802,8 +2801,8 @@ describe("zero attachment chips", () => {
   it("opens canonical markdown and text previews, shares a document link, and reports download failures", async () => {
     const releaseNotesUrl = canonicalUserMessageFileUrl("attachment-markdown");
     context.mocks.browser.clipboardWriteText();
-    context.mocks.http.get("/api/zero/web/download-file", ({ request }) => {
-      const fileId = new URL(request.url).searchParams.get("file_id");
+    context.mocks.http.get(PRESIGNED_FILE_PATTERN, ({ params }) => {
+      const fileId = params.fileId;
       if (fileId === "attachment-markdown") {
         return new Response("# Release notes\n\nThe rollout is ready.", {
           headers: { "Content-Type": "text/markdown" },
@@ -2814,6 +2813,11 @@ describe("zero attachment chips", () => {
           headers: { "Content-Type": "text/plain" },
         });
       }
+      return new Response(null, { status: 500 });
+    });
+    // A download reads the canonical route directly, so it keeps its own
+    // failure path independent of the presigned preview URL.
+    context.mocks.http.get("/api/zero/web/download-file", () => {
       return new Response(null, { status: 500 });
     });
     mockChatLifecycle(context, {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -32,6 +32,7 @@ import {
   TextPreviewLoader,
 } from "./zero-attachment-chips.tsx";
 import { publicAttachmentUrl } from "./zero-attachment-url";
+import { useResolvedAttachmentUrl } from "./zero-attachment-resource";
 import { artifactPreviewUrlsMatch } from "./zero-attachment-url.ts";
 import { lightboxDialogVisible$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import { Markdown } from "../components/markdown.tsx";
@@ -1152,6 +1153,11 @@ function ArtifactImageBody({
   filename: string;
 }) {
   const modalOpen = useGet(lightboxDialogVisible$);
+  const resourceUrl = useResolvedAttachmentUrl(url);
+
+  if (resourceUrl === null) {
+    return <ArtifactSpinner />;
+  }
 
   return (
     <ArtifactStageShell flush scrollable={false}>
@@ -1163,7 +1169,7 @@ function ArtifactImageBody({
             navigation={imageNavigation}
           />
           <ZoomableArtifactImageCanvas
-            src={publicAttachmentUrl(url)}
+            src={resourceUrl}
             alt={filename}
             zoomKey={zoomableArtifactImageKey(
               "artifact-sidebar",
@@ -1305,25 +1311,28 @@ function ArtifactVideoBody({
   filename: string;
 }) {
   const { t } = useTranslation();
+  const resourceUrl = useResolvedAttachmentUrl(url);
   return (
     <ArtifactStageShell centered>
       <div
         className="w-full overflow-hidden rounded-xl border border-border/70 bg-black shadow-sm"
         data-testid="artifact-sidebar-video-stage"
       >
-        <video
-          src={publicAttachmentUrl(url)}
-          controls
-          playsInline
-          className="block aspect-video w-full bg-black object-contain"
-          aria-label={t(
-            ($) => {
-              return $.artifacts.preview.videoLabel;
-            },
-            { filename },
-          )}
-          data-testid="artifact-sidebar-body-video"
-        />
+        {resourceUrl !== null && (
+          <video
+            src={resourceUrl}
+            controls
+            playsInline
+            className="block aspect-video w-full bg-black object-contain"
+            aria-label={t(
+              ($) => {
+                return $.artifacts.preview.videoLabel;
+              },
+              { filename },
+            )}
+            data-testid="artifact-sidebar-body-video"
+          />
+        )}
       </div>
     </ArtifactStageShell>
   );
@@ -1337,23 +1346,26 @@ function ArtifactAudioBody({
   filename: string;
 }) {
   const { t } = useTranslation();
+  const resourceUrl = useResolvedAttachmentUrl(url);
   return (
     <ArtifactStageShell centered>
       <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
         <p className="text-sm text-muted-foreground">{filename}</p>
-        <audio
-          src={publicAttachmentUrl(url)}
-          controls
-          preload="metadata"
-          className="w-full"
-          aria-label={t(
-            ($) => {
-              return $.artifacts.preview.audioLabel;
-            },
-            { filename },
-          )}
-          data-testid="artifact-sidebar-body-audio"
-        />
+        {resourceUrl !== null && (
+          <audio
+            src={resourceUrl}
+            controls
+            preload="metadata"
+            className="w-full"
+            aria-label={t(
+              ($) => {
+                return $.artifacts.preview.audioLabel;
+              },
+              { filename },
+            )}
+            data-testid="artifact-sidebar-body-audio"
+          />
+        )}
       </div>
     </ArtifactStageShell>
   );
@@ -1373,20 +1385,26 @@ function ArtifactIframeBody({
   fullscreen: boolean;
 }) {
   const { t } = useTranslation();
+  const resourceUrl = useResolvedAttachmentUrl(url);
   // PDF Open Parameters: #navpanes=0 hides Chromium's built-in left rail
   // (thumbnails / bookmarks) so the embedded preview shows just the page
   // and toolbar by default. Firefox/PDF.js silently ignores it.
-  const publicUrl = publicAttachmentUrl(url);
-  const src = kind === "pdf" ? `${publicUrl}#navpanes=0` : publicUrl;
+  const src =
+    resourceUrl !== null && kind === "pdf"
+      ? `${resourceUrl}#navpanes=0`
+      : resourceUrl;
   const isPresentationHtml =
     kind === "html" && artifactKind === "presentation-html";
+  if (resourceUrl === null || src === null) {
+    return <ArtifactSpinner />;
+  }
   if (kind === "html") {
     return (
       <div className="h-full w-full">
         <AutoFocusedArtifactIframe
-          focusKey={`${publicUrl}:${fullscreen ? "fullscreen" : "sidebar"}`}
+          focusKey={`${resourceUrl}:${fullscreen ? "fullscreen" : "sidebar"}`}
           focusOnMount={fullscreen && !isPresentationHtml}
-          src={publicUrl}
+          src={resourceUrl}
           title={t(
             ($) => {
               return $.artifacts.preview.dialogLabel;

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1588,6 +1588,49 @@ export function PreviewableAudioAttachmentChip({
 // AttachmentChip — chip shown in the composer before the message is sent
 // ---------------------------------------------------------------------------
 
+/**
+ * A restored attachment carries the canonical API URL, so the thumbnail needs
+ * the same presigned exchange the sent message uses. Kept in its own component
+ * so the surrounding button stays one DOM node across the pending-to-uploaded
+ * transition, and the load key stays on the canonical URL, which is stable
+ * across re-signing.
+ */
+function ComposerImagePreviewImage({
+  imageLoadKey,
+  loaded,
+  url,
+}: {
+  imageLoadKey: string;
+  loaded: boolean;
+  url: string;
+}) {
+  const imageLoadStatusRef = useSet(imageLoadStatusRef$);
+  const setImageLoadStatus = useSet(setImageLoadStatus$);
+  const resolvedUrl = useResolvedAttachmentUrl(url);
+
+  if (resolvedUrl === null) {
+    return null;
+  }
+
+  return (
+    <img
+      key={imageLoadKey}
+      ref={imageLoadStatusRef}
+      src={resolvedUrl}
+      alt=""
+      data-image-load-key={imageLoadKey}
+      loading="lazy"
+      onLoad={() => {
+        setImageLoadStatus(imageLoadKey, "loaded");
+      }}
+      onError={() => {
+        setImageLoadStatus(imageLoadKey, "error");
+      }}
+      className={`h-full w-full object-cover ${loaded ? "" : "opacity-0"}`}
+    />
+  );
+}
+
 function ComposerImagePreviewButton({
   filename,
   openImageLightbox,
@@ -1598,8 +1641,14 @@ function ComposerImagePreviewButton({
   url: string | undefined;
 }) {
   const { t } = useTranslation();
+  const imageLoadStatuses = useGet(imageLoadStatusByKey$);
+  const imageLoadKey = url ? `composer-image:${url}` : null;
 
-  if (!url) {
+  const currentImageStatus = imageLoadKey
+    ? (imageLoadStatuses[imageLoadKey] ?? "loading")
+    : "loading";
+
+  if (!url || !imageLoadKey) {
     return (
       <button
         type="button"
@@ -1619,35 +1668,6 @@ function ComposerImagePreviewButton({
       </button>
     );
   }
-
-  return (
-    <ComposerImagePreviewThumbnail
-      filename={filename}
-      openImageLightbox={openImageLightbox}
-      url={url}
-    />
-  );
-}
-
-function ComposerImagePreviewThumbnail({
-  filename,
-  openImageLightbox,
-  url,
-}: {
-  filename: string;
-  openImageLightbox: (url: string) => void;
-  url: string;
-}) {
-  const { t } = useTranslation();
-  const imageLoadStatuses = useGet(imageLoadStatusByKey$);
-  const imageLoadStatusRef = useSet(imageLoadStatusRef$);
-  const setImageLoadStatus = useSet(setImageLoadStatus$);
-  // A restored attachment carries the canonical API URL, so the thumbnail needs
-  // the same presigned exchange the sent message uses. The load key stays on the
-  // canonical URL, which is stable across re-signing.
-  const resolvedUrl = useResolvedAttachmentUrl(url);
-  const imageLoadKey = `composer-image:${url}`;
-  const currentImageStatus = imageLoadStatuses[imageLoadKey] ?? "loading";
 
   return (
     <button
@@ -1678,25 +1698,11 @@ function ComposerImagePreviewThumbnail({
           )}
         </span>
       )}
-      {resolvedUrl !== null && (
-        <img
-          key={imageLoadKey}
-          ref={imageLoadStatusRef}
-          src={resolvedUrl}
-          alt=""
-          data-image-load-key={imageLoadKey}
-          loading="lazy"
-          onLoad={() => {
-            setImageLoadStatus(imageLoadKey, "loaded");
-          }}
-          onError={() => {
-            setImageLoadStatus(imageLoadKey, "error");
-          }}
-          className={`h-full w-full object-cover ${
-            currentImageStatus === "loaded" ? "" : "opacity-0"
-          }`}
-        />
-      )}
+      <ComposerImagePreviewImage
+        imageLoadKey={imageLoadKey}
+        loaded={currentImageStatus === "loaded"}
+        url={url}
+      />
       <span className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/image-preview:bg-black/30">
         <Image
           size={18}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,5 +1,4 @@
 import type { MouseEvent, ReactNode } from "react";
-import type { Computed } from "ccstate";
 import {
   useGet,
   useLastLoadable,
@@ -62,8 +61,8 @@ import {
   artifactPreviewUrlsMatch,
   attachmentFilenameFromUrl,
   downloadAttachmentUrl,
-  publicAttachmentUrl,
 } from "./zero-attachment-url.ts";
+import { useResolvedAttachmentUrl } from "./zero-attachment-resource.ts";
 import {
   ArtifactActionSeparator,
   ArtifactDownloadMenu,
@@ -784,14 +783,12 @@ function ArtifactDialogImageBody({
   filename,
   imageNavigation,
   preview,
-  resourceUrl$,
 }: {
   filename: string;
   imageNavigation?: ArtifactImageNavigationActions;
   preview: Extract<AttachmentLightboxState, { kind: "image" }>;
-  resourceUrl$: Computed<Promise<string>>;
 }) {
-  const resourceUrl = useLastResolved(resourceUrl$) ?? null;
+  const resourceUrl = useResolvedAttachmentUrl(preview.url);
   return (
     <ArtifactDialogImageStage
       filename={filename}
@@ -802,45 +799,25 @@ function ArtifactDialogImageBody({
   );
 }
 
-function ArtifactDialogBody({
-  imageResourceUrl$,
-  imageNavigation,
+function ArtifactDialogVideoBody({
+  filename,
   preview,
 }: {
-  imageResourceUrl$?: Computed<Promise<string>>;
-  imageNavigation?: ArtifactImageNavigationActions;
+  filename: string;
   preview: AttachmentLightboxState;
 }) {
   const { t } = useTranslation();
-  const filename = artifactDialogFilename(preview);
+  const resourceUrl = useResolvedAttachmentUrl(preview.url);
 
-  if (preview.kind === "image") {
-    return imageResourceUrl$ ? (
-      <ArtifactDialogImageBody
-        filename={filename}
-        imageNavigation={imageNavigation}
-        preview={preview}
-        resourceUrl$={imageResourceUrl$}
-      />
-    ) : (
-      <ArtifactDialogImageStage
-        filename={filename}
-        imageNavigation={imageNavigation}
-        preview={preview}
-        resourceUrl={publicAttachmentUrl(preview.url)}
-      />
-    );
-  }
-
-  if (preview.kind === "video") {
-    return (
-      <ArtifactDialogStage centered>
-        <div
-          className="w-full overflow-hidden rounded-xl border border-border/70 bg-black shadow-sm"
-          data-testid="artifact-dialog-video-stage"
-        >
+  return (
+    <ArtifactDialogStage centered>
+      <div
+        className="w-full overflow-hidden rounded-xl border border-border/70 bg-black shadow-sm"
+        data-testid="artifact-dialog-video-stage"
+      >
+        {resourceUrl !== null && (
           <video
-            src={publicAttachmentUrl(preview.url)}
+            src={resourceUrl}
             controls
             autoPlay
             playsInline
@@ -853,23 +830,34 @@ function ArtifactDialogBody({
               { filename },
             )}
           />
-        </div>
-      </ArtifactDialogStage>
-    );
-  }
+        )}
+      </div>
+    </ArtifactDialogStage>
+  );
+}
 
-  if (preview.kind === "audio") {
-    return (
-      <ArtifactDialogStage centered>
-        <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
-          <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/70 bg-muted/50 text-muted-foreground">
-            <FileMusic size={28} />
-          </span>
-          <p className="max-w-full truncate text-sm text-muted-foreground">
-            {filename}
-          </p>
+function ArtifactDialogAudioBody({
+  filename,
+  preview,
+}: {
+  filename: string;
+  preview: AttachmentLightboxState;
+}) {
+  const { t } = useTranslation();
+  const resourceUrl = useResolvedAttachmentUrl(preview.url);
+
+  return (
+    <ArtifactDialogStage centered>
+      <div className="flex w-full max-w-[520px] flex-col items-center gap-4 rounded-xl border border-border/70 bg-background p-6 shadow-sm">
+        <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/70 bg-muted/50 text-muted-foreground">
+          <FileMusic size={28} />
+        </span>
+        <p className="max-w-full truncate text-sm text-muted-foreground">
+          {filename}
+        </p>
+        {resourceUrl !== null && (
           <audio
-            src={publicAttachmentUrl(preview.url)}
+            src={resourceUrl}
             controls
             autoPlay
             preload="metadata"
@@ -882,9 +870,77 @@ function ArtifactDialogBody({
             )}
             data-testid="artifact-dialog-audio"
           />
-        </div>
-      </ArtifactDialogStage>
+        )}
+      </div>
+    </ArtifactDialogStage>
+  );
+}
+
+function ArtifactDialogDocumentFrameBody({
+  filename,
+  preview,
+}: {
+  filename: string;
+  preview: AttachmentLightboxState;
+}) {
+  const { t } = useTranslation();
+  const resourceUrl = useResolvedAttachmentUrl(preview.url);
+  // PDF Open Parameters: #navpanes=0 hides Chromium's built-in left rail so the
+  // embedded preview shows just the page and toolbar by default.
+  const src =
+    resourceUrl !== null && preview.kind === "pdf"
+      ? `${resourceUrl}#navpanes=0`
+      : resourceUrl;
+
+  return (
+    <ArtifactDialogStage scrollable={false}>
+      <div
+        className="flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
+        data-testid="artifact-dialog-document-frame"
+      >
+        {src !== null && (
+          <iframe
+            src={src}
+            title={t(
+              ($) => {
+                return $.artifacts.preview.dialogLabel;
+              },
+              { filename },
+            )}
+            scrolling="yes"
+            className="block h-full min-h-0 w-full border-0 bg-background"
+          />
+        )}
+      </div>
+    </ArtifactDialogStage>
+  );
+}
+
+function ArtifactDialogBody({
+  imageNavigation,
+  preview,
+}: {
+  imageNavigation?: ArtifactImageNavigationActions;
+  preview: AttachmentLightboxState;
+}) {
+  const filename = artifactDialogFilename(preview);
+
+  if (preview.kind === "image") {
+    return (
+      <ArtifactDialogImageBody
+        filename={filename}
+        imageNavigation={imageNavigation}
+        preview={preview}
+      />
     );
+  }
+
+  if (preview.kind === "video") {
+    return <ArtifactDialogVideoBody filename={filename} preview={preview} />;
+  }
+
+  if (preview.kind === "audio") {
+    return <ArtifactDialogAudioBody filename={filename} preview={preview} />;
   }
 
   if (
@@ -900,28 +956,8 @@ function ArtifactDialogBody({
     return <ArtifactDialogHtmlBody filename={filename} preview={preview} />;
   }
 
-  const publicUrl = publicAttachmentUrl(preview.url);
-  const src = preview.kind === "pdf" ? `${publicUrl}#navpanes=0` : publicUrl;
-
   return (
-    <ArtifactDialogStage scrollable={false}>
-      <div
-        className="flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
-        data-testid="artifact-dialog-document-frame"
-      >
-        <iframe
-          src={src}
-          title={t(
-            ($) => {
-              return $.artifacts.preview.dialogLabel;
-            },
-            { filename },
-          )}
-          scrolling="yes"
-          className="block h-full min-h-0 w-full border-0 bg-background"
-        />
-      </div>
-    </ArtifactDialogStage>
+    <ArtifactDialogDocumentFrameBody filename={filename} preview={preview} />
   );
 }
 
@@ -934,9 +970,18 @@ function ArtifactDialogHtmlBody({
 }) {
   const { t } = useTranslation();
   const fullscreen = useGet(lightboxDialogFullscreen$);
-  const src = publicAttachmentUrl(preview.url);
+  const src = useResolvedAttachmentUrl(preview.url);
   const isPresentationHtml =
     preview.artifact?.artifactKind === "presentation-html";
+
+  if (src === null) {
+    return (
+      <div
+        className="h-full w-full bg-background"
+        data-testid="artifact-dialog-site-frame"
+      />
+    );
+  }
 
   return (
     <div
@@ -1045,10 +1090,6 @@ function ArtifactPreviewDialogThreadResolver({
   });
   const navigateImageLightbox = useSet(navigateImageLightbox$);
   const reloadArtifacts = useSet(thread.reloadArtifacts$);
-  const imageResourceUrl$ =
-    preview.kind === "image"
-      ? thread.artifactSignalsForUrl(preview.url)?.resourceUrl$
-      : undefined;
   const item =
     loadable.state === "hasData"
       ? findArtifactDialogItemForUrl(loadable.data, preview.url)
@@ -1110,7 +1151,6 @@ function ArtifactPreviewDialogThreadResolver({
           onNext: imageNavigationAction(imageNavigation.next),
           onPrevious: imageNavigationAction(imageNavigation.previous),
         }}
-        imageResourceUrl$={imageResourceUrl$}
         preview={preview}
       />
     );
@@ -1135,7 +1175,6 @@ function ArtifactPreviewDialogThreadResolver({
         onNext: imageNavigationAction(imageNavigation.next),
         onPrevious: imageNavigationAction(imageNavigation.previous),
       }}
-      imageResourceUrl$={imageResourceUrl$}
       preview={preview}
     />
   );
@@ -1254,12 +1293,10 @@ function ArtifactPreviewDialogActions({
 function ArtifactPreviewDialogContent({
   artifact,
   imageNavigation,
-  imageResourceUrl$,
   preview,
 }: {
   artifact: AttachmentArtifactMetadata | undefined;
   imageNavigation?: ArtifactImageNavigationActions;
-  imageResourceUrl$?: Computed<Promise<string>>;
   preview: AttachmentLightboxState;
 }) {
   const { t } = useTranslation();
@@ -1330,7 +1367,6 @@ function ArtifactPreviewDialogContent({
         </div>
         <div className="min-h-0 flex-1 bg-background">
           <ArtifactDialogBody
-            imageResourceUrl$={imageResourceUrl$}
             imageNavigation={imageNavigation}
             preview={preview}
           />
@@ -1562,16 +1598,8 @@ function ComposerImagePreviewButton({
   url: string | undefined;
 }) {
   const { t } = useTranslation();
-  const imageLoadStatuses = useGet(imageLoadStatusByKey$);
-  const imageLoadStatusRef = useSet(imageLoadStatusRef$);
-  const setImageLoadStatus = useSet(setImageLoadStatus$);
-  const imageLoadKey = url ? `composer-image:${url}` : null;
 
-  const currentImageStatus = imageLoadKey
-    ? (imageLoadStatuses[imageLoadKey] ?? "loading")
-    : "loading";
-
-  if (!url || !imageLoadKey) {
+  if (!url) {
     return (
       <button
         type="button"
@@ -1591,6 +1619,35 @@ function ComposerImagePreviewButton({
       </button>
     );
   }
+
+  return (
+    <ComposerImagePreviewThumbnail
+      filename={filename}
+      openImageLightbox={openImageLightbox}
+      url={url}
+    />
+  );
+}
+
+function ComposerImagePreviewThumbnail({
+  filename,
+  openImageLightbox,
+  url,
+}: {
+  filename: string;
+  openImageLightbox: (url: string) => void;
+  url: string;
+}) {
+  const { t } = useTranslation();
+  const imageLoadStatuses = useGet(imageLoadStatusByKey$);
+  const imageLoadStatusRef = useSet(imageLoadStatusRef$);
+  const setImageLoadStatus = useSet(setImageLoadStatus$);
+  // A restored attachment carries the canonical API URL, so the thumbnail needs
+  // the same presigned exchange the sent message uses. The load key stays on the
+  // canonical URL, which is stable across re-signing.
+  const resolvedUrl = useResolvedAttachmentUrl(url);
+  const imageLoadKey = `composer-image:${url}`;
+  const currentImageStatus = imageLoadStatuses[imageLoadKey] ?? "loading";
 
   return (
     <button
@@ -1621,23 +1678,25 @@ function ComposerImagePreviewButton({
           )}
         </span>
       )}
-      <img
-        key={imageLoadKey}
-        ref={imageLoadStatusRef}
-        src={url}
-        alt=""
-        data-image-load-key={imageLoadKey}
-        loading="lazy"
-        onLoad={() => {
-          setImageLoadStatus(imageLoadKey, "loaded");
-        }}
-        onError={() => {
-          setImageLoadStatus(imageLoadKey, "error");
-        }}
-        className={`h-full w-full object-cover ${
-          currentImageStatus === "loaded" ? "" : "opacity-0"
-        }`}
-      />
+      {resolvedUrl !== null && (
+        <img
+          key={imageLoadKey}
+          ref={imageLoadStatusRef}
+          src={resolvedUrl}
+          alt=""
+          data-image-load-key={imageLoadKey}
+          loading="lazy"
+          onLoad={() => {
+            setImageLoadStatus(imageLoadKey, "loaded");
+          }}
+          onError={() => {
+            setImageLoadStatus(imageLoadKey, "error");
+          }}
+          className={`h-full w-full object-cover ${
+            currentImageStatus === "loaded" ? "" : "opacity-0"
+          }`}
+        />
+      )}
       <span className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/image-preview:bg-black/30">
         <Image
           size={18}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-resource.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-resource.ts
@@ -1,0 +1,16 @@
+import { useGet, useLastResolved } from "ccstate-react";
+import { attachmentResourceUrlResolver$ } from "../../signals/attachment-resource-url.ts";
+import { publicAttachmentUrl } from "./zero-attachment-url";
+
+/**
+ * Resolves the URL a browser element can actually load, or null while that is
+ * still in flight. Persisted attachments live behind an authenticated API
+ * route, and a `src` attribute on `<img>`, `<video>`, `<audio>` or `<iframe>`
+ * cannot carry an Authorization header, so every preview renders from the
+ * presigned object URL. Public CDN URLs resolve to themselves, so a caller does
+ * not need to know which form it holds.
+ */
+export function useResolvedAttachmentUrl(url: string): string | null {
+  const resolveResourceUrl = useGet(attachmentResourceUrlResolver$);
+  return useLastResolved(resolveResourceUrl(publicAttachmentUrl(url))) ?? null;
+}


### PR DESCRIPTION
## Summary

Fixes #26258 and #26259. Depends on #26326 (revert of #26293) — merge that first.

Persisted chat attachments live in a private bucket behind an authenticated API route (`/api/zero/web/download-file`, `file:read`). A bare `src` attribute cannot carry an `Authorization` header, so only images did the right thing: they exchanged the canonical URL for a short-lived presigned object URL. Every other preview path handed the auth-gated URL to an element that could never load it.

This routes all preview kinds through that one exchange.

## What changed

**Signals**

- `attachment-resource-url.ts` — the exchange is reached through `attachmentResourceUrlResolver$`, a computed that hands back a per-URL memoized signal, so a component can resolve during render without re-signing on every pass. Memoized inside a computed rather than package scope, per `ccstate/no-package-variable`.
- `text-preview.ts` — `createTextPreviewComputed` resolves the presigned URL before fetching. Its `fetch` carries no `Authorization` header, so markdown/text/json/csv previews of uploaded files were failing.
- `artifact-card-signals.ts` — `resourceUrl$` reads through the shared resolver, so the message list and the lightbox reuse one signature per file.

**Views**

- New `useResolvedAttachmentUrl` hook (`zero-attachment-resource.ts`) composes the CDN rewrite with the presigned exchange, so a caller does not need to know which URL form it holds. Public CDN URLs (`/f/…`, `/artifacts/…`) resolve to themselves — unchanged for hosted sites, presentations, and public catalog artifacts.
- Lightbox: video, audio, PDF/document-frame and HTML bodies are extracted into their own components and resolve before rendering. The `imageResourceUrl$` prop threading is gone — the image body resolves through the same hook, so the prop was redundant.
- Sidebar: image, video, audio and iframe bodies resolve the same way.
- Composer chip: the thumbnail renders from the resolved URL, and lives in `ComposerImagePreviewImage` so the surrounding button stays one DOM node across the pending-to-uploaded transition. This is the #26258 fix — a chip restored from a copied message carries the canonical API URL, which the old code passed straight to `<img>`.

`fileInfo$.url` deliberately stays canonical, so re-sending a restored attachment persists the canonical URL rather than an expiring presigned one.

## Relationship to #26293

#26293 fixed the PDF and HTML iframes by threading a `resourceUrl$` signal through `ArtifactRef`, the lightbox state and the catalog. This PR reaches the same result by resolving at the leaf, which needs no threading and also covers the composer chip (where no ref exists), the sidebar image, video, audio and text previews. #26326 reverts it so only one mechanism ships. The split-view and public-catalog assertions #26293 added are kept here.

## Tests

- `zero-attachment-chips.test.tsx` — 42 passed
- `thread-sidebar.test.tsx` — 21 passed
- `chat-composer-model-selection-and-providers.test.tsx` — 49 passed
- `check-types`, `oxlint`, `eslint`, `knip` — clean

The full app suite is left to CI.

## Verify in preview

Text previews fetch the presigned R2 URL with a `Range` header. R2 bucket CORS lives outside this repo — the browser upload path already PUTs directly to the same bucket, but please confirm a ranged cross-origin GET is allowed when checking the preview deployment. This cannot regress uploaded files (that fetch fails today), and public CDN URLs are untouched.

## Out of scope

- Copying a message by native text selection still drops images: the paste fallback only handles `clipboardData.items` of `kind === "file"` and ignores `<img>` tags in pasted HTML. Noted in #26258.
- Office documents, archives and other types with no preview branch at all need server-side conversion or a third-party viewer — tracked in #26259.
- `.markdown`/`.mdx` mapping and the `heic/tiff/psd`-as-image misclassification ship in #26277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
