### PR TITLE
fix(chat): classify attachment kinds by what a browser can render

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -243,10 +243,20 @@ const CHAT_KIND_BY_CONTENT_TYPE: Readonly<Record<string, BodyPreviewKind>> = {
   "text/csv": "csv",
   "application/pdf": "pdf",
   "text/html": "html",
+  // Image types no browser decodes in `<img>`. Claiming an image preview for
+  // them renders a broken frame, so they stay download-only files.
+  "image/heic": "file",
+  "image/heic-sequence": "file",
+  "image/heif": "file",
+  "image/heif-sequence": "file",
+  "image/tiff": "file",
+  "image/vnd.adobe.photoshop": "file",
 } as const;
 
 const CHAT_KIND_BY_EXTENSION: Readonly<Record<string, BodyPreviewKind>> = {
   md: "markdown",
+  markdown: "markdown",
+  mdx: "markdown",
   txt: "text",
   log: "text",
   xml: "text",
@@ -266,11 +276,6 @@ const CHAT_KIND_BY_EXTENSION: Readonly<Record<string, BodyPreviewKind>> = {
   svg: "image",
   bmp: "image",
   avif: "image",
-  heic: "image",
-  heif: "image",
-  tif: "image",
-  tiff: "image",
-  psd: "image",
   mp4: "video",
   webm: "video",
   mov: "video",
@@ -305,15 +310,20 @@ export function classifyChatAttachment(
 ): ChatAttachmentKind {
   const type = normalizeType(attachment.contentType);
   const ext = fileExt(attachment.filename);
-  const mediaKind = mediaKindFromContentType(type);
 
+  // An exact content type wins over the media prefix, so a type the browser
+  // cannot render is not claimed as a preview by its `image/` prefix alone.
+  const exactKind = CHAT_KIND_BY_CONTENT_TYPE[type];
+  if (exactKind) {
+    return exactKind;
+  }
+
+  const mediaKind = mediaKindFromContentType(type);
   if (mediaKind) {
     return mediaKind;
   }
 
-  return (
-    CHAT_KIND_BY_CONTENT_TYPE[type] ?? CHAT_KIND_BY_EXTENSION[ext] ?? "file"
-  );
+  return CHAT_KIND_BY_EXTENSION[ext] ?? "file";
 }
 
 function filenameFromUrl(url: string): string {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1200,6 +1200,56 @@ describe("zero attachment chips", () => {
     ).toBe(docChip);
   });
 
+  it("keeps undecodable image formats downloadable and previews every markdown extension", async () => {
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-attachment-kinds",
+          role: "user",
+          content: "Review these formats",
+          fileParts: [
+            {
+              type: "file",
+              fileId: "attachment-heic",
+              filenameSnapshot: "capture.heic",
+              contentType: "image/heic",
+            },
+            {
+              type: "file",
+              fileId: "attachment-psd",
+              filenameSnapshot: "poster.psd",
+              contentType: "image/vnd.adobe.photoshop",
+            },
+            {
+              type: "file",
+              fileId: "attachment-mdx",
+              filenameSnapshot: "guide.mdx",
+              contentType: "application/octet-stream",
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() => {
+      expect(screen.getByText("Review these formats")).toBeInTheDocument();
+    });
+
+    // A browser cannot decode either format in `<img>`, so neither claims an
+    // image preview.
+    expect(screen.getByLabelText("Download capture.heic")).toBeInTheDocument();
+    expect(screen.getByLabelText("Download poster.psd")).toBeInTheDocument();
+    expect(screen.queryByAltText("capture.heic")).toBeNull();
+    expect(screen.queryByAltText("poster.psd")).toBeNull();
+    expect(
+      screen.getByLabelText("Open markdown preview for guide.mdx"),
+    ).toBeInTheDocument();
+  });
+
   it("opens persisted canonical audio, video, and document attachments", async () => {
     context.mocks.http.get(PRESIGNED_FILE_PATTERN, ({ params }) => {
       expect(params.fileId).toBe("attachment-json");

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -32,6 +32,7 @@ import {
   currentRightThread$,
 } from "../../signals/chat-page/chat-thread-panes.ts";
 import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
+import { classifyChatAttachment } from "../../signals/chat-page/parse-body-blocks.ts";
 import {
   imageLoadStatusByKey$,
   imageLoadStatusRef$,
@@ -1726,7 +1727,14 @@ function AttachmentChip({
   const url =
     infoLoadable.state === "hasData" ? infoLoadable.data?.url : undefined;
   const openImageLightbox = useSet(openImageLightbox$);
-  const isImage = attachment.contentType.startsWith("image/");
+  // Classified rather than prefix-matched, so an image format the browser
+  // cannot decode gets a file chip instead of a broken thumbnail.
+  const isImage =
+    classifyChatAttachment({
+      contentType: attachment.contentType,
+      filename: attachment.filename,
+      url: url ?? "",
+    }) === "image";
   return (
     <div
       className="relative inline-flex items-center"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6173,10 +6173,10 @@ function ChatConnectorActionConnectModal() {
   );
 }
 
+// Only formats a browser decodes in `<img>`. An undecodable image format
+// renders a broken thumbnail, so it stays a downloadable file chip.
 function isImageFilename(filename: string): boolean {
-  return /\.(png|jpe?g|gif|webp|svg|bmp|avif|heic|heif|tiff?|psd)$/i.test(
-    filename,
-  );
+  return /\.(png|jpe?g|gif|webp|svg|bmp|avif)$/i.test(filename);
 }
 
 const CREDITS_PER_DOLLAR = 1000;


### PR DESCRIPTION
## Summary

Follow-up to #26275, covering the two classification problems the #26259 audit turned up. Independent of that PR — this one is about which kind an attachment is assigned, not which URL the preview loads from.

## What changed

**`.markdown` and `.mdx` had no preview**

`CHAT_KIND_BY_EXTENSION` only carried `md`, so both fell through to the download-only file chip even though the markdown preview handles them fine. Both are mapped now.

**Undecodable image formats claimed an image preview**

`heic`, `heif`, `tif`/`tiff` and `psd` were classified as images and handed to `<img>`, which no browser decodes — the user got a broken thumbnail instead of a file they could download. They are files now.

Fixing that meant three places, because the "is this an image" decision was duplicated:

1. `parse-body-blocks.ts` — the undecodable content types map to `file`, and an exact content type is consulted before the `image/` prefix so the mapping is reachable. No existing entry overlaps a media prefix, so the reorder changes nothing else.
2. `zero-chat-thread-page.tsx` `isImageFilename` — an independent regex that ORs with the classified kind, so it re-promoted the same formats. Narrowed to the renderable set.
3. `zero-attachment-chips.tsx` — the composer chip prefix-matched `image/` directly; it now uses `classifyChatAttachment`, so composer and message list agree.

Uploading these formats is still allowed, and the file-icon accent (`psd` → artwork) is unchanged. `isVisualAttachment` in `resolve-draft-attachments.ts` is deliberately untouched: it decides what gets sent to a model that does not accept images, which is a different question from what a browser can paint.

## Tests

New case in `zero-attachment-chips.test.tsx`: a message carrying `capture.heic`, `poster.psd` and `guide.mdx` renders download chips for the first two, no `<img>` for either, and a markdown preview for the third.

- `zero-attachment-chips.test.tsx` — 43 passed
- `chat-user-messages`, `thread-sidebar`, `chat-draft`, `chat-lifecycle` — 82 passed
- `check-types`, `oxlint`, `eslint`, `knip` — clean

The full app suite was left to CI.

## Not included

Office documents, archives and databases still have no preview branch at all. That needs server-side conversion or a third-party viewer and should be its own product decision — tracked in #26259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
