### PR TITLE
refactor(connectors): write canonical runtime target fields

### DIFF
--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -90,7 +90,7 @@ fn proxy_register_failure_warns_with_error() {
 }
 
 #[tokio::test]
-async fn proxy_registration_prefers_complete_connector_candidates_with_legacy_fallback() {
+async fn proxy_registration_accepts_rollout_candidates_and_canonical_targets() {
     let candidate_dir = tempfile::tempdir().unwrap();
     let candidate_config = test_executor_config(candidate_dir.path()).await;
     let mut candidate_context = minimal_context();
@@ -150,26 +150,57 @@ async fn proxy_registration_prefers_complete_connector_candidates_with_legacy_fa
         serde_json::json!({"ZENDESK_SUBDOMAIN": "münich"})
     );
 
-    let legacy_dir = tempfile::tempdir().unwrap();
-    let legacy_config = test_executor_config(legacy_dir.path()).await;
-    let mut legacy_context = minimal_context();
-    legacy_context.firewalls = None;
-    legacy_context.connector_runtime_targets = vec![ConnectorRuntimeTargetRegistration::Builtin {
-        connector_slug: "zendesk".to_string(),
-        base_url_vars: None,
-    }];
-    legacy_context.connector_runtime_candidate_targets = None;
+    let canonical_dir = tempfile::tempdir().unwrap();
+    let canonical_config = test_executor_config(canonical_dir.path()).await;
+    let mut canonical_context = minimal_context();
+    let canonical_routing_variables =
+        HashMap::from([("ZENDESK_SUBDOMAIN".to_string(), "xn--mnich-kva".to_string())]);
+    canonical_context.firewalls = Some(vec![FirewallEntry::Builtin {
+        name: "zendesk".to_string(),
+        base_url_vars: Some(canonical_routing_variables.clone()),
+    }]);
+    canonical_context.connector_runtime_targets =
+        vec![ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "zendesk".to_string(),
+            base_url_vars: Some(canonical_routing_variables),
+        }];
+    canonical_context.connector_runtime_candidate_targets = None;
+    canonical_context.vars = Some(HashMap::from([(
+        "ZENDESK_SUBDOMAIN".to_string(),
+        "münich".to_string(),
+    )]));
 
-    let _legacy_session = register_proxy(&legacy_config, &legacy_context, "10.200.0.3")
+    let _canonical_session = register_proxy(&canonical_config, &canonical_context, "10.200.0.3")
         .await
         .unwrap();
-    let legacy_registry: serde_json::Value = serde_json::from_str(
-        &tokio::fs::read_to_string(legacy_dir.path().join("proxy-registry.json"))
+    let canonical_registry: serde_json::Value = serde_json::from_str(
+        &tokio::fs::read_to_string(canonical_dir.path().join("proxy-registry.json"))
             .await
             .unwrap(),
     )
     .unwrap();
-    assert!(legacy_registry["vms"]["10.200.0.3"]["firewalls"].is_null());
+    let canonical_vm = &canonical_registry["vms"]["10.200.0.3"];
+    assert_eq!(
+        canonical_vm["firewalls"],
+        serde_json::json!([{
+            "kind": "builtin",
+            "name": "zendesk",
+            "baseUrlVars": {
+                "ZENDESK_SUBDOMAIN": "xn--mnich-kva"
+            }
+        }])
+    );
+    assert_eq!(
+        canonical_vm["connectorRuntimeTargets"],
+        serde_json::json!([{
+            "kind": "builtin",
+            "connectorSlug": "zendesk"
+        }])
+    );
+    assert_eq!(
+        canonical_vm["connectorRoutingVariables"]["builtin:zendesk"],
+        serde_json::json!({"ZENDESK_SUBDOMAIN": "münich"})
+    );
 }
 
 #[tokio::test]

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -287,7 +287,7 @@ export async function mutateRunnerJobConnectorPermissionBaseline(
   context: TestContext,
   runId: string,
   mode:
-    | "legacy-targets"
+    | "rollout-targets"
     | "remove"
     | "malformed"
     | "capability-mismatch"

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8153,7 +8153,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
 });
 
 describe("RUN-02: custom connectors, grants, and network policies", () => {
-  it("keeps overlapping connector candidates behind the legacy runner view", async () => {
+  it("admits overlapping custom and built-in connector targets", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -8191,26 +8191,26 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
     const internalName = `custom_connector_${custom.id.replaceAll("-", "")}`;
-    expect(findFirewallEntry(claim.firewalls, "figma")).toBeUndefined();
+    expect(findFirewallEntry(claim.firewalls, "figma")).toMatchObject({
+      kind: "builtin",
+      name: "figma",
+    });
     expect(inlineFirewallApis(claim.firewalls, internalName)).toMatchObject([
       {
         base: "https://api.figma.com/",
       },
     ]);
-    expect(claim.connectorRuntimeTargets).not.toContainEqual({
+    expect(claim.connectorRuntimeTargets).toContainEqual({
       kind: "builtin",
       connectorSlug: "figma",
     });
-    expect(claim.connectorRuntimeCandidateTargets).toContainEqual({
-      kind: "builtin",
-      connectorSlug: "figma",
-    });
-    expect(claim.connectorRuntimeCandidateTargets).toContainEqual(
+    expect(claim.connectorRuntimeTargets).toContainEqual(
       expect.objectContaining({
         kind: "custom",
         customConnectorId: custom.id,
       }),
     );
+    expect(claim).not.toHaveProperty("connectorRuntimeCandidateTargets");
     expect(claim.networkPolicies).toHaveProperty("figma");
     expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("allow");
 
@@ -8270,10 +8270,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       kind: "builtin",
       connectorSlug: "figma",
     });
-    expect(claim.connectorRuntimeCandidateTargets).toContainEqual({
-      kind: "builtin",
-      connectorSlug: "figma",
-    });
+    expect(claim).not.toHaveProperty("connectorRuntimeCandidateTargets");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     expect((await api.readRun(actor, run.runId)).status).toBe("cancelled");
@@ -10676,11 +10673,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       name: "zendesk",
       baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
     });
-    expect(claim.connectorRuntimeCandidateTargets).toContainEqual({
+    expect(claim.connectorRuntimeTargets).toContainEqual({
       kind: "builtin",
       connectorSlug: "zendesk",
       baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
     });
+    expect(claim).not.toHaveProperty("connectorRuntimeCandidateTargets");
     expect(customApis[0]?.base).toBe("https://internal.example.com/api/");
 
     await api.requestCancelRun(actor, run.runId, [200]);
@@ -10802,7 +10800,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("falls back for old, invalid, and incompatible permission baselines", async () => {
+  it("handles rollout, missing, invalid, and incompatible permission baselines", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const fw = createFirewallApi(context);
@@ -10820,7 +10818,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     const cases = [
       {
-        mode: "legacy-targets",
+        mode: "rollout-targets",
         path: "baseline",
       },
       {
@@ -10853,6 +10851,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       },
     ] as const;
 
+    const slackTargets = expect.arrayContaining([
+      { kind: "builtin", connectorSlug: "slack" },
+    ]);
+
     for (const fallbackCase of cases) {
       const run = await api.createRun(actor, {
         agentId: agent.agentId,
@@ -10866,6 +10868,13 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       );
       const claim = await api.claimRunnerJob(run.runId);
 
+      const isRolloutContext = fallbackCase.mode === "rollout-targets";
+      expect(claim.connectorRuntimeTargets).toStrictEqual(
+        isRolloutContext ? [] : slackTargets,
+      );
+      expect(claim.connectorRuntimeCandidateTargets).toStrictEqual(
+        isRolloutContext ? slackTargets : undefined,
+      );
       expect(claim.networkPolicies?.slack?.allow).toContain(
         "conversations:read",
       );
@@ -10875,7 +10884,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expectClaimRouteResponseTimingActions({
         runId: run.runId,
         expectedActionTypes:
-          fallbackCase.mode === "legacy-targets" ||
+          fallbackCase.mode === "rollout-targets" ||
           fallbackCase.mode === "catalog-mismatch"
             ? [
                 "claim_route_response_network_policy_refresh",

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -555,8 +555,18 @@ async function mutateRunnerJobConnectorPermissionBaseline(
 ): Promise<void> {
   let executionContext: SQL;
   switch (body.mode) {
-    case "legacy-targets": {
-      executionContext = sql`${runnerJobQueue.executionContext} - 'connectorRuntimeCandidateTargets'`;
+    case "rollout-targets": {
+      executionContext = sql`jsonb_set(
+        jsonb_set(
+          ${runnerJobQueue.executionContext},
+          '{connectorRuntimeCandidateTargets}',
+          ${runnerJobQueue.executionContext}->'connectorRuntimeTargets',
+          true
+        ),
+        '{connectorRuntimeTargets}',
+        '[]'::jsonb,
+        true
+      )`;
       break;
     }
     case "remove": {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -69,7 +69,6 @@ import {
   type NetworkPolicies,
   type NetworkPolicy,
   canonicalizeFirewallBaseUrl,
-  normalizeFirewallFixedHost,
   validateBaseUrlHostPolicy,
 } from "@vm0/connectors/firewall-types";
 import {
@@ -744,7 +743,6 @@ interface PermissionManifest {
   readonly firewalls: ExecutionFirewalls;
   readonly networkPolicies: NetworkPolicies;
   readonly builtinRuntimeTargets?: readonly BuiltinRuntimeTargetRegistration[];
-  readonly builtinRuntimeCandidateTargets?: readonly BuiltinRuntimeTargetRegistration[];
   readonly connectorPermissionBaseline?: StoredConnectorPermissionBaseline;
   readonly environmentSecretPlaceholders:
     | Readonly<Record<string, string>>
@@ -4858,81 +4856,6 @@ interface BuiltinConnectorManifestSource {
   readonly permissionIndex: ConnectorServerFirewallPermissionIndex;
 }
 
-interface FixedFirewallBaseParts {
-  readonly protocol: string;
-  readonly authority: string;
-  readonly pathPrefix: string;
-}
-
-function fixedFirewallBaseParts(base: string): FixedFirewallBaseParts | null {
-  const schemeEnd = base.indexOf("://");
-  if (schemeEnd === -1) {
-    return null;
-  }
-  const authorityStart = schemeEnd + 3;
-  const authorityEnd = base.indexOf("/", authorityStart);
-  const rawAuthority = base.slice(
-    authorityStart,
-    authorityEnd === -1 ? base.length : authorityEnd,
-  );
-  if (/[${}*]/u.test(rawAuthority)) {
-    return null;
-  }
-  const parsed = safeSync(() => {
-    return new URL(base);
-  });
-  if ("error" in parsed) {
-    return null;
-  }
-  const authority = normalizeFirewallFixedHost(parsed.ok.host);
-  if (!authority) {
-    return null;
-  }
-  const pathname = parsed.ok.pathname.endsWith("/")
-    ? parsed.ok.pathname
-    : `${parsed.ok.pathname}/`;
-  return {
-    protocol: parsed.ok.protocol.toLowerCase(),
-    authority,
-    pathPrefix: pathname,
-  };
-}
-
-function customFirewallCoversBuiltinBase(
-  customBase: string,
-  builtinBase: string,
-): boolean {
-  const custom = fixedFirewallBaseParts(customBase);
-  const builtin = fixedFirewallBaseParts(builtinBase);
-  return (
-    custom !== null &&
-    builtin !== null &&
-    custom.protocol === builtin.protocol &&
-    custom.authority === builtin.authority &&
-    builtin.pathPrefix.startsWith(custom.pathPrefix)
-  );
-}
-
-function builtinConnectorOverriddenByCustomFirewalls(args: {
-  readonly snapshot: ConnectorRuntimeSnapshot;
-  readonly connectorSlug: ConnectorSlug;
-  readonly customFirewalls: readonly ExpandedFirewallConfig[];
-}): boolean {
-  const metadata = args.snapshot.serverFirewalls.getRoutingIndexMetadata(
-    args.connectorSlug,
-  );
-  if (!metadata) {
-    return false;
-  }
-  return metadata.apis.some((builtinApi) => {
-    return args.customFirewalls.some((customFirewall) => {
-      return customFirewall.apis.some((customApi) => {
-        return customFirewallCoversBuiltinBase(customApi.base, builtinApi.base);
-      });
-    });
-  });
-}
-
 function buildConnectorPermissionBaseline(
   snapshot: ConnectorRuntimeSnapshot,
   sources: readonly BuiltinConnectorManifestSource[],
@@ -5045,21 +4968,13 @@ function mergePermissionManifests(args: {
   >;
   readonly providerManifest: PermissionManifest | undefined;
   readonly customConnectorFirewalls: readonly ExpandedFirewallConfig[];
-  readonly legacyBuiltinConnectorSlugs: ReadonlySet<ConnectorSlug>;
 }): PermissionManifest | undefined {
-  const builtinRuntimeCandidateTargets = args.connectorManifest.firewalls.map(
+  const builtinRuntimeTargets = args.connectorManifest.firewalls.map(
     builtinRuntimeTargetRegistration,
   );
   const firewalls = [
     ...(args.providerManifest?.firewalls ?? []),
-    ...args.connectorManifest.firewalls.filter((firewall) => {
-      return (
-        firewall.kind !== "builtin" ||
-        args.legacyBuiltinConnectorSlugs.has(
-          connectorSlugSchema.parse(firewall.name),
-        )
-      );
-    }),
+    ...args.connectorManifest.firewalls,
     ...args.customConnectorManifest.firewalls,
   ];
 
@@ -5069,10 +4984,7 @@ function mergePermissionManifests(args: {
 
   return {
     firewalls,
-    builtinRuntimeTargets: builtinRuntimeCandidateTargets.filter((target) => {
-      return args.legacyBuiltinConnectorSlugs.has(target.connectorSlug);
-    }),
-    builtinRuntimeCandidateTargets,
+    builtinRuntimeTargets,
     connectorPermissionBaseline: buildConnectorPermissionBaseline(
       args.connectorCatalogSnapshot,
       args.builtinSources,
@@ -5120,18 +5032,6 @@ async function buildPermissionManifest(
   const builtinConnectorSlugs = connectorSlugs.filter((connectorSlug) => {
     return args.connectorCatalogSnapshot.serverFirewalls.has(connectorSlug);
   });
-  // Previous runners cannot reconcile overlapping candidates. Keep their
-  // firewall and target view filtered until that runner generation drains;
-  // candidate-aware runners receive the complete membership separately.
-  const legacyBuiltinConnectorSlugs = new Set(
-    builtinConnectorSlugs.filter((connectorSlug) => {
-      return !builtinConnectorOverriddenByCustomFirewalls({
-        snapshot: args.connectorCatalogSnapshot,
-        connectorSlug,
-        customFirewalls: customConnectorFirewalls,
-      });
-    }),
-  );
 
   const builtinSources = await measureApiDispatchTiming(
     args.timing,
@@ -5217,7 +5117,6 @@ async function buildPermissionManifest(
           customConnectorManifest,
           providerManifest,
           customConnectorFirewalls,
-          legacyBuiltinConnectorSlugs,
         }),
       );
     },
@@ -5901,23 +5800,14 @@ async function insertLaunchRunRows(
   return { createdAt };
 }
 
-function storedConnectorRuntimeTargetViews(args: {
+function storedConnectorRuntimeTargets(args: {
   readonly permissionManifest: PermissionManifest | undefined;
   readonly customTargets: readonly ConnectorRuntimeTargetRegistration[];
-}): {
-  readonly legacy: ConnectorRuntimeTargetRegistration[];
-  readonly candidates: ConnectorRuntimeTargetRegistration[];
-} {
-  return {
-    legacy: [
-      ...(args.permissionManifest?.builtinRuntimeTargets ?? []),
-      ...args.customTargets,
-    ],
-    candidates: [
-      ...(args.permissionManifest?.builtinRuntimeCandidateTargets ?? []),
-      ...args.customTargets,
-    ],
-  };
+}): ConnectorRuntimeTargetRegistration[] {
+  return [
+    ...(args.permissionManifest?.builtinRuntimeTargets ?? []),
+    ...args.customTargets,
+  ];
 }
 
 async function buildStoredExecutionContextDraft(args: {
@@ -5953,13 +5843,13 @@ async function buildStoredExecutionContextDraft(args: {
   const secretValues = executionSecrets.secrets
     ? Object.values(executionSecrets.secrets)
     : [];
-  const connectorRuntimeTargets = storedConnectorRuntimeTargetViews({
+  const connectorRuntimeTargets = storedConnectorRuntimeTargets({
     permissionManifest: permissions,
     customTargets: args.customConnectorContext.targets,
   });
   const customConnectorIds = [
     ...new Set(
-      connectorRuntimeTargets.candidates.flatMap((target) => {
+      connectorRuntimeTargets.flatMap((target) => {
         return target.kind === "custom" ? [target.customConnectorId] : [];
       }),
     ),
@@ -6009,8 +5899,7 @@ async function buildStoredExecutionContextDraft(args: {
       userTimezone: args.userTimezone,
       firewalls: permissions?.firewalls,
       networkPolicies: permissions?.networkPolicies,
-      connectorRuntimeTargets: connectorRuntimeTargets.legacy,
-      connectorRuntimeCandidateTargets: connectorRuntimeTargets.candidates,
+      connectorRuntimeTargets,
       connectorPermissionBaseline: permissions?.connectorPermissionBaseline,
       disallowedTools: args.body.disallowedTools,
       tools: args.body.tools,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -325,11 +325,30 @@ describe("connector runtime synchronization contract", () => {
     ).toBe(true);
   });
 
-  it("preserves complete candidate targets and pinned built-in routing values", () => {
+  it("preserves canonical built-in targets and pinned routing values", () => {
     const fixture = executionContextSchema.parse(
       loadRunnerClaimResponseFixture(),
     );
-    const candidateTarget = {
+    const target = {
+      kind: "builtin" as const,
+      connectorSlug: "zendesk",
+      baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
+    };
+
+    const execution = executionContextSchema.parse({
+      ...fixture,
+      connectorRuntimeTargets: [target],
+    });
+
+    expect(execution.connectorRuntimeTargets).toEqual([target]);
+    expect(execution.connectorRuntimeCandidateTargets).toBeUndefined();
+  });
+
+  it("preserves complete targets from rollout contexts", () => {
+    const fixture = executionContextSchema.parse(
+      loadRunnerClaimResponseFixture(),
+    );
+    const target = {
       kind: "builtin" as const,
       connectorSlug: "zendesk",
       baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
@@ -338,18 +357,11 @@ describe("connector runtime synchronization contract", () => {
     const execution = executionContextSchema.parse({
       ...fixture,
       connectorRuntimeTargets: [],
-      connectorRuntimeCandidateTargets: [candidateTarget],
-    });
-    const legacy = executionContextSchema.parse({
-      ...fixture,
-      connectorRuntimeTargets: [],
+      connectorRuntimeCandidateTargets: [target],
     });
 
     expect(execution.connectorRuntimeTargets).toEqual([]);
-    expect(execution.connectorRuntimeCandidateTargets).toEqual([
-      candidateTarget,
-    ]);
-    expect(legacy.connectorRuntimeCandidateTargets).toBeUndefined();
+    expect(execution.connectorRuntimeCandidateTargets).toEqual([target]);
   });
 
   it("requires stable API identities on available custom firewalls", () => {

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -75,7 +75,7 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     action: z.literal("mutate-runner-job-connector-permission-baseline"),
     run_id: z.uuid(),
     mode: z.enum([
-      "legacy-targets",
+      "rollout-targets",
       "remove",
       "malformed",
       "capability-mismatch",


### PR DESCRIPTION
## Summary

- collapse new run contexts onto one complete Builtin and Custom runtime target view
- include every admitted Builtin and currently available Custom firewall, and stop writing `connectorRuntimeCandidateTargets`
- retain rollout-context readers and cover both rollout and canonical inputs across API contracts and runner registration

## Compatibility

- keeps the optional TypeScript and Rust candidate readers, API claim handling, and runner synthesis path for already persisted rollout contexts
- introduces no database migration, JSONB rewrite, context version, proxy registry change, or runtime synchronization change
- relies on the Gate 0 production evidence recorded on #26260 and #26185; all job-admitting production runners and the supported rollback release include the candidate-aware reader

## Testing

- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm knip`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -q -p runner proxy_registration_accepts_rollout_candidates_and_canonical_targets`

Closes #26260
Relates to #26185
