### PR TITLE
test(connectors): fail fast in custom connector mocks

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -471,7 +471,10 @@ function mockCustomConnectorStory(): {
         };
         return updated;
       });
-      return respond(200, updated ?? customConnector({}));
+      if (!updated) {
+        throw new Error(`Expected custom connector ${params.id}`);
+      }
+      return respond(200, updated);
     },
   );
   context.mocks.api(
@@ -522,7 +525,10 @@ function mockCustomConnectorStory(): {
         };
         return updated;
       });
-      return respond(200, updated ?? customConnector({}));
+      if (!updated) {
+        throw new Error(`Expected custom connector ${params.id}`);
+      }
+      return respond(200, updated);
     },
   );
   context.mocks.api(


### PR DESCRIPTION
## Summary

- make the custom connector values mock fail when a request targets an unknown connector
- make the custom connector update mock fail under the same invalid setup
- prevent unrelated default fixtures from masking connector ID regressions

## Scope

This is a test-only change. It does not modify Platform production behavior, API contracts, or connector persistence.

## Validation

- `pnpm prettier --write apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx` (93 tests)
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- pre-commit Knip and repository-wide Turbo type checks
