### PR TITLE
fix(test): arbitrate chat managed key fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -92,10 +92,10 @@ import {
   createUnassociatedThreadBoundZeroRunFixture,
 } from "../../../test-fixtures/thread-bound-run-admission";
 import {
+  acquireBddVm0ApiKey,
   completeRunWithoutCallbacksFixture,
   deleteAgentRunFixture,
   holdCheckpointReadsFixture,
-  deleteBddVm0ApiKey,
   holdChatEventFixture,
   holdChatEventQueueItemFixture,
   holdChatThreadRowLockFixture,
@@ -105,8 +105,8 @@ import {
   holdThreadSessionConversationClearFixture,
   readCanonicalChatEventStorageFixture,
   readChatEventContextFixture,
+  releaseBddVm0ApiKey,
   replayPendingChatInputQueueEventFixture,
-  replaceBddVm0ApiKey,
   replaceThreadSessionBindingFixture,
   timeoutRunWithoutCallbacksFixture,
 } from "../../../test-fixtures/chat-events";
@@ -4555,12 +4555,15 @@ describe("CHAT-02: model-first provider policies", () => {
 
   it("routes vm0 Kimi through Moonshot attachment-disabled env bindings", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
-    const keySuffix = randomUUID();
+    const keyFixtureId = randomUUID();
 
-    await replaceBddVm0ApiKey({
+    // Keep a second Moonshot fixture owner alive to cover vendor-unique row
+    // arbitration instead of relying on another test file's scheduling.
+    await seedVm0ManagedModelKey("kimi-k2.7-code");
+    await acquireBddVm0ApiKey({
+      fixtureId: keyFixtureId,
       vendor: "moonshot",
-      apiKey: `vm0-key-bdd-dev-seed-${keySuffix}`,
-      label: "dev-seed",
+      apiKey: `vm0-key-bdd-dev-seed-${keyFixtureId}`,
     });
 
     let runId: string | null = null;
@@ -4569,11 +4572,11 @@ describe("CHAT-02: model-first provider policies", () => {
         await api.requestCancelRun(actor, runId, [200]);
       }
     };
-    const deleteVm0KimiKeys = async () => {
-      await deleteBddVm0ApiKey({ vendor: "moonshot" });
+    const releaseVm0KimiKey = async () => {
+      await releaseBddVm0ApiKey({ fixtureId: keyFixtureId });
     };
     const cleanupRunAndKeys = async () => {
-      await Promise.all([deleteVm0KimiKeys(), cancelRunIfCreated()]);
+      await Promise.all([releaseVm0KimiKey(), cancelRunIfCreated()]);
     };
 
     await (async () => {
@@ -4613,21 +4616,21 @@ describe("CHAT-02: model-first provider policies", () => {
   it("selects a vm0 managed key by vendor", async () => {
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledChatActor();
-    const keySuffix = randomUUID();
-    const apiKey = `vm0-key-bdd-dev-seed-${keySuffix}`;
+    const keyFixtureId = randomUUID();
+    const apiKey = `vm0-key-bdd-dev-seed-${keyFixtureId}`;
     let runId: string | null = null;
 
     onTestFinished(async () => {
       await Promise.all([
-        deleteBddVm0ApiKey({ vendor: "zai" }),
+        releaseBddVm0ApiKey({ fixtureId: keyFixtureId }),
         ...(runId ? [api.requestCancelRun(actor, runId, [200])] : []),
       ]);
     });
 
-    await replaceBddVm0ApiKey({
+    await acquireBddVm0ApiKey({
+      fixtureId: keyFixtureId,
       vendor: "zai",
       apiKey,
-      label: "dev-seed",
     });
 
     await api.updateOrgModelPolicies(actor, [

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -12,7 +12,6 @@ import type {
 } from "@vm0/db/jsonb-contracts/chat-slack-context";
 import type { ChatTeamsMessageFiles } from "@vm0/db/jsonb-contracts/chat-teams-context";
 import type { JsonObject } from "@vm0/db/jsonb-contracts/shared";
-import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -29,17 +28,7 @@ import { chatEvents } from "@vm0/db/schema/chat-event";
 import { checkpoints } from "@vm0/db/schema/checkpoint";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { threadGoals } from "@vm0/db/schema/thread-goal";
-import {
-  and,
-  count,
-  eq,
-  inArray,
-  isNull,
-  like,
-  or,
-  sql,
-  type SQL,
-} from "drizzle-orm";
+import { and, count, eq, inArray, isNull, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
@@ -55,6 +44,10 @@ import {
   chatInputPromptDispatchCondition,
   runOwnedChatEventForRunCondition,
 } from "../signals/services/zero-chat-event-type.service";
+import {
+  acquireVm0ManagedModelKeyFixture,
+  releaseVm0ManagedModelKeyFixture,
+} from "../signals/services/test-vm0-managed-model-key-fixture.service";
 import { visibleChatEventCondition } from "../signals/services/zero-chat-event-shared.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { buildFeishuChatOpenUrl } from "../signals/services/feishu-config";
@@ -62,9 +55,8 @@ import { createUserMessageDocument } from "../signals/services/zero-chat-user-me
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
- * BDD-scoped vm0 managed key prefixes. Fixture writes below only ever touch
- * rows whose api_key carries one of these prefixes, so concurrent test files
- * cannot clobber real seed data or each other's non-bdd rows.
+ * BDD-scoped vm0 managed key prefixes. Fixture acquisition below only accepts
+ * keys carrying one of these prefixes.
  */
 const VM0_BDD_API_KEY_PREFIXES = [
   "vm0-key-bdd-fake-",
@@ -1259,57 +1251,43 @@ async function pidIsBlocked(waiterPid: number): Promise<boolean> {
   return rows[0]?.blocked ?? false;
 }
 
-function bddVm0ApiKeyFilter(vendor: string) {
-  const [fakePrefix, devSeedPrefix] = VM0_BDD_API_KEY_PREFIXES;
-  return and(
-    eq(vm0ApiKeys.vendor, vendor),
-    or(
-      like(vm0ApiKeys.apiKey, `${fakePrefix}%`),
-      like(vm0ApiKeys.apiKey, `${devSeedPrefix}%`),
-    ),
-  );
-}
-
 /**
- * Replaces the bdd-scoped row of the platform-managed vm0 API key pool for one
- * vendor.
+ * Acquires bdd-scoped ownership of the platform-managed vm0 API key pool for
+ * one vendor.
  *
  * Why product APIs cannot construct this state: vm0_api_keys is a
  * platform-operations table with no product write surface — keys are
  * provisioned out of band. Keys passed here must carry a
- * VM0_BDD_API_KEY_PREFIXES prefix so only bdd rows are touched.
+ * VM0_BDD_API_KEY_PREFIXES prefix. The shared fixture service atomically
+ * arbitrates the vendor-unique row and prevents one test owner from deleting
+ * another owner's key.
  */
-export async function replaceBddVm0ApiKey(args: {
+export async function acquireBddVm0ApiKey(args: {
+  readonly fixtureId: string;
   readonly vendor: string;
   readonly apiKey: string;
-  readonly label: string;
 }): Promise<void> {
   const scoped = VM0_BDD_API_KEY_PREFIXES.some((prefix) => {
     return args.apiKey.length > prefix.length && args.apiKey.startsWith(prefix);
   });
   if (!scoped) {
     throw new Error(
-      `replaceBddVm0ApiKey: api key must start with one of ${VM0_BDD_API_KEY_PREFIXES.join(", ")}`,
+      `acquireBddVm0ApiKey: api key must start with one of ${VM0_BDD_API_KEY_PREFIXES.join(", ")}`,
     );
   }
-  await db().transaction(async (tx) => {
-    await tx.delete(vm0ApiKeys).where(bddVm0ApiKeyFilter(args.vendor));
-    await tx.insert(vm0ApiKeys).values({
+  await acquireVm0ManagedModelKeyFixture(db(), args.fixtureId, [
+    {
       vendor: args.vendor,
       apiKey: args.apiKey,
-      label: args.label,
-    });
-  });
+    },
+  ]);
 }
 
-/**
- * Deletes the bdd-scoped row of the platform-managed vm0 API key pool for one
- * vendor. See replaceBddVm0ApiKey for why no product API exists.
- */
-export async function deleteBddVm0ApiKey(args: {
-  readonly vendor: string;
+/** Releases only this bdd fixture's ownership of its vendor key. */
+export async function releaseBddVm0ApiKey(args: {
+  readonly fixtureId: string;
 }): Promise<void> {
-  await db().delete(vm0ApiKeys).where(bddVm0ApiKeyFilter(args.vendor));
+  await releaseVm0ManagedModelKeyFixture(db(), args.fixtureId);
 }
 
 /**


### PR DESCRIPTION
## Summary

- route the chat-events VM0 managed-key fixture through the existing row-locked ownership service for vendor-unique keys
- release only the calling fixture's UUID ownership instead of deleting a shared vendor row
- make the Kimi/Moonshot regression keep a second owner alive while retaining the original runner environment assertions

## Root cause

[Turbo run 31463169470](https://github.com/vm0-ai/vm0/actions/runs/31463169470) failed in [`test-api (6)`](https://github.com/vm0-ai/vm0/actions/runs/31463169470/job/93690669799) before `routes vm0 Kimi through Moonshot attachment-disabled env bindings` reached its business assertions.

`replaceBddVm0ApiKey` deleted the BDD-scoped `vendor=moonshot` row and inserted its replacement as two statements inside a transaction. Other API test fixtures use the same persisted, vendor-unique `vm0_api_keys` table. A concurrent owner could create or retain the Moonshot row after the delete statement's snapshot, so PostgreSQL rejected the later insert with `23505` on `idx_vm0_api_keys_vendor` (`Key (vendor)=(moonshot) already exists`). This is persisted test-state isolation nondeterminism, not a product failure.

PR #26246 does not change the failed test or fixture. The same `test-api (6)` shard passed on [the represented PR run](https://github.com/vm0-ai/vm0/actions/runs/31462842829/job/93689712046), and base `fc0f2bc38441c9b1695986d53d28a4af76e4cd8d` passed both [merge-group](https://github.com/vm0-ai/vm0/actions/runs/31462305566) and [main push](https://github.com/vm0-ai/vm0/actions/runs/31462569809) Turbo runs. `ci-gate-turbo` was only the aggregate consequence; fail-fast cancellation and expected warning/error logging were not causal.

## Fix

Use the existing `acquireVm0ManagedModelKeyFixture` / `releaseVm0ManagedModelKeyFixture` boundary with a unique fixture UUID. Its single `ON CONFLICT DO UPDATE ... RETURNING` statement lets PostgreSQL arbitrate and lock the vendor row atomically, records overlapping owners, preserves an existing managed key, and deletes the row only after the final tracked owner releases it.

The Kimi test now deliberately seeds an overlapping Moonshot owner first. The old delete-then-insert implementation deterministically encounters the same unique-vendor conflict in that setup; the repaired fixture shares ownership while the original Moonshot environment-binding assertions remain unchanged. The unique-vendor product contract and the Z.AI exact key-resolution assertion are preserved.

No retries, sleeps, timeouts, skipped tests, weakened assertions, swallowed errors, or manual detached cleanup are included.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

The targeted API test was not run locally because it requires PostgreSQL and the repair contract prohibits starting local services or running service-backed tests. The PR pipeline provides the database-backed `test-api` validation. Deployment-preview and staging-browser validation are not applicable because this change only affects test fixtures and test code.
