### PR TITLE
test(api): isolate stripe lifecycle delivery checks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -42,6 +42,11 @@ const cronResultSchema = z.object({
   executed: z.number().int().nonnegative(),
   skipped: z.number().int().nonnegative(),
 });
+const TERMINALLY_SKIPPED_EXECUTION = {
+  success: true,
+  executed: 0,
+  skipped: 1,
+} as const;
 
 interface Scenario {
   readonly actor: ApiTestUser;
@@ -379,6 +384,22 @@ async function readStripeAutomation(scenario: Scenario) {
     throw new Error("Expected a Stripe invoice-paid automation summary");
   }
   return summary;
+}
+
+async function setupPendingLifecycleDelivery(label: string): Promise<{
+  readonly accountId: string;
+  readonly scenario: Scenario;
+}> {
+  const accountId = `acct_stripe_lifecycle_${label}_${randomUUID()}`;
+  const scenario = await setupScenario({ accountId });
+  await postStripeAutomationEvent(invoicePaidEvent({ accountId }));
+  return { accountId, scenario };
+}
+
+async function executeLifecycleDelivery(scenario: Scenario) {
+  const execution = await executeAutomation(scenario);
+  const inputEvents = await automationInputEvents(scenario);
+  return { execution: execution.body, inputEvents };
 }
 
 beforeEach(() => {
@@ -916,45 +937,74 @@ describe("Stripe automation event webhook", () => {
     });
   });
 
-  it("terminally skips persisted deliveries after every public lifecycle binding change", async () => {
-    const disabled = await setupScenario();
-    const deleted = await setupScenario();
-    const changedAccount = await setupScenario();
-    const testMode = await setupScenario();
-    const deletedConnector = await setupScenario();
-    await postStripeAutomationEvent(
-      invoicePaidEvent({ eventId: "evt_lifecycle_changes" }),
-    );
-
-    await setAutomationEnabled(disabled, false);
-    await deleteAutomation(deleted);
-    const changed = await connectStripeOAuth(
-      changedAccount.actor,
-      "acct_stripe_changed_after_receipt",
-    );
-    expect(changed.id).toBe(changedAccount.connector.id);
-    const testConnection = await connectStripeOAuth(
-      testMode.actor,
-      STRIPE_ACCOUNT_ID,
-      false,
-    );
-    expect(testConnection.id).toBe(testMode.connector.id);
-    await connectors.deleteConnectorBySlug(deletedConnector.actor, "stripe");
-
-    expect((await executeCron()).skipped).toBeGreaterThanOrEqual(5);
-    for (const scenario of [
-      disabled,
-      changedAccount,
-      testMode,
-      deletedConnector,
-    ]) {
+  describe("terminally skips persisted deliveries after public lifecycle binding changes", () => {
+    it("when the automation is disabled", async () => {
+      const { scenario } = await setupPendingLifecycleDelivery("disabled");
+      await setAutomationEnabled(scenario, false);
+      const result = await executeLifecycleDelivery(scenario);
+      expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
       expect((await readStripeAutomation(scenario)).health).toMatchObject({
         lastDeliveryStatus: "skipped",
         warning: null,
       });
-      await expect(automationInputEvents(scenario)).resolves.toHaveLength(0);
-    }
-    await expect(automationInputEvents(deleted)).resolves.toHaveLength(0);
+      expect(result.inputEvents).toHaveLength(0);
+    });
+
+    it("when the automation is deleted", async () => {
+      const { scenario } = await setupPendingLifecycleDelivery("deleted");
+      await deleteAutomation(scenario);
+      const result = await executeLifecycleDelivery(scenario);
+      expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
+      expect(result.inputEvents).toHaveLength(0);
+    });
+
+    it("when the connected account changes", async () => {
+      const { scenario } =
+        await setupPendingLifecycleDelivery("changed_account");
+      const changed = await connectStripeOAuth(
+        scenario.actor,
+        `acct_stripe_changed_${randomUUID()}`,
+      );
+      expect(changed.id).toBe(scenario.connector.id);
+      const result = await executeLifecycleDelivery(scenario);
+      expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
+      expect((await readStripeAutomation(scenario)).health).toMatchObject({
+        lastDeliveryStatus: "skipped",
+        warning: null,
+      });
+      expect(result.inputEvents).toHaveLength(0);
+    });
+
+    it("when the connection changes from live mode to test mode", async () => {
+      const { accountId, scenario } =
+        await setupPendingLifecycleDelivery("test_mode");
+      const testConnection = await connectStripeOAuth(
+        scenario.actor,
+        accountId,
+        false,
+      );
+      expect(testConnection.id).toBe(scenario.connector.id);
+      const result = await executeLifecycleDelivery(scenario);
+      expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
+      expect((await readStripeAutomation(scenario)).health).toMatchObject({
+        lastDeliveryStatus: "skipped",
+        warning: null,
+      });
+      expect(result.inputEvents).toHaveLength(0);
+    });
+
+    it("when the connector is deleted", async () => {
+      const { scenario } =
+        await setupPendingLifecycleDelivery("deleted_connector");
+      await connectors.deleteConnectorBySlug(scenario.actor, "stripe");
+      const result = await executeLifecycleDelivery(scenario);
+      expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
+      expect((await readStripeAutomation(scenario)).health).toMatchObject({
+        lastDeliveryStatus: "skipped",
+        warning: null,
+      });
+      expect(result.inputEvents).toHaveLength(0);
+    });
   });
 
   it("marks only the exact deauthorized account for reconnect and terminally skips its pending delivery", async () => {


### PR DESCRIPTION
## Summary

- split the Stripe lifecycle-binding matrix into five scenario-sized tests
- give every scenario a unique Stripe account and event fixture
- execute only the delivery owned by each automation through the existing test-only scoped endpoint
- retain exact coverage for automation disable/delete, account change, Live-to-test mode change, and connector deletion

## Root cause

The first causal failure in [Turbo run 31463216508](https://github.com/vm0-ai/vm0/actions/runs/31463216508) was the named Stripe lifecycle test reaching the fixed 5000 ms boundary at 5003 ms in [test-api (8)](https://github.com/vm0-ai/vm0/actions/runs/31463216508/job/93690800412). There was no assertion mismatch, early unhandled rejection, or teardown failure.

The test put five independent lifecycle scenarios in one `it()` and then called the global workflow-automation cron route. That route scans unrelated schedule, Notion, Strapi, and Stripe work from the persistent shared test database. The test therefore owned both all five setups and nondeterministic shared backlog under one 5-second budget.

The same unchanged test passed in adjacent runs at 1531 ms, 1485 ms, 1594 ms, and 1586 ms:

- [PR run 31462229281](https://github.com/vm0-ai/vm0/actions/runs/31462229281/job/93687961469)
- [previous merge-group run 31462693251](https://github.com/vm0-ai/vm0/actions/runs/31462693251/job/93689274968)
- [main run 31462569809](https://github.com/vm0-ai/vm0/actions/runs/31462569809/job/93689684364)
- [merge-group run 31462305566](https://github.com/vm0-ai/vm0/actions/runs/31462305566/job/93688170980)

The failing file took 15523 ms versus roughly 9600-10700 ms in those passing runs. PR #26250 does not modify this test file. Its connector-grants type/UI failures are a separate deterministic contract problem; cancelled jobs and `ci-gate-turbo` are downstream noise. Expected provider, queue-admission, and Telegram MSW logs from neighboring tests are also not causal.

## Fix

Each public lifecycle change now has its own test budget and unique account/event fixture. Each test uses the scoped automation execution endpoint introduced by #26190, so it can process only its own persisted delivery. The assertions are stricter than the previous aggregate `skipped >= 5`: every scenario must return exactly `{ success: true, executed: 0, skipped: 1 }`, produce no automation input event, and retain skipped health where the automation still exists.

This does not add retries, sleeps, timeout changes, skipped tests, cleanup workarounds, or weaker assertions.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'` (12/12 tasks)
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- targeted Prettier, Oxlint, type-aware Oxlint, and ESLint for `stripe-automation-events.test.ts`
- `git diff --check origin/main...HEAD`

The focused API integration file requires the real PostgreSQL test service. This environment has no configured or running PostgreSQL, and the repair contract forbids starting a backend/service, so local five-run Vitest repetition was intentionally not performed. The PR CI API shard is the runtime validator.

`staging-browser` validation is not applicable: this change touches only a test file and uses a test-only API endpoint that is gated outside the test environment. There is no user-visible app/API preview flow for this invariant.
