### PR TITLE
fix: use signed urls for document previews

### DIFF
--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -25,9 +25,10 @@ function isAuthenticatedAttachmentUrl(url: string): boolean {
  * on its own; the API still runs the ownership check before signing.
  */
 export function createAttachmentResourceUrl$(
-  url: string,
+  source: string | Computed<Promise<string>>,
 ): Computed<Promise<string>> {
   return computed(async (get) => {
+    const url = typeof source === "string" ? source : await get(source);
     if (!isAuthenticatedAttachmentUrl(url)) {
       return url;
     }

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
@@ -14,6 +14,7 @@ import type {
   ArtifactRefInput,
   ThreadSidebarTarget,
 } from "./thread-sidebar.ts";
+import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
 import { createObjectUrlResource } from "../object-url-resource.ts";
 
 // ---------------------------------------------------------------------------
@@ -135,6 +136,7 @@ export function artifactRefFromUrl(url: string): ArtifactRef {
     url,
     kind: classifyChatAttachment(attachment),
     filename: attachment.filename,
+    resourceUrl$: createAttachmentResourceUrl$(url),
   };
 }
 
@@ -154,7 +156,8 @@ function materializeArtifactRef(
         url: input.url,
       }),
       filename: input.filename,
-      ...(input.resourceUrl$ ? { resourceUrl$: input.resourceUrl$ } : {}),
+      resourceUrl$:
+        input.resourceUrl$ ?? createAttachmentResourceUrl$(input.url),
       ...(input.shareAvailable === undefined
         ? {}
         : { shareAvailable: input.shareAvailable }),
@@ -169,6 +172,7 @@ function materializeArtifactRef(
       url: resource.url,
     }),
     filename: input.file.name,
+    resourceUrl$: createAttachmentResourceUrl$(resource.url),
     releaseObjectUrl: resource.release,
     ...(input.shareAvailable === undefined
       ? {}

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
@@ -154,6 +154,7 @@ function materializeArtifactRef(
         url: input.url,
       }),
       filename: input.filename,
+      ...(input.resourceUrl$ ? { resourceUrl$: input.resourceUrl$ } : {}),
       ...(input.shareAvailable === undefined
         ? {}
         : { shareAvailable: input.shareAvailable }),

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
@@ -38,6 +38,7 @@ export type ArtifactRef = {
   readonly url: string;
   readonly kind: ArtifactPreviewKind;
   readonly filename: string;
+  readonly resourceUrl$?: Computed<Promise<string>>;
   readonly shareAvailable?: boolean;
   readonly releaseObjectUrl?: () => void;
 };
@@ -52,6 +53,7 @@ export type ArtifactMetadataRef = {
   readonly url: string;
   readonly filename: string;
   readonly contentType?: string;
+  readonly resourceUrl$?: Computed<Promise<string>>;
   readonly shareAvailable?: boolean;
 };
 

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
@@ -5,6 +5,7 @@ import {
   type ArtifactCatalogSignals,
 } from "../artifacts-page/create-artifact-catalog-signals.ts";
 import { artifactDetailPreview } from "../artifacts-page/artifact-catalog-signals.ts";
+import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
 import { fetchPreviewText, isTextPreviewKind } from "../text-preview.ts";
 import { resetSignal } from "../utils.ts";
 
@@ -38,7 +39,7 @@ export type ArtifactRef = {
   readonly url: string;
   readonly kind: ArtifactPreviewKind;
   readonly filename: string;
-  readonly resourceUrl$?: Computed<Promise<string>>;
+  readonly resourceUrl$: Computed<Promise<string>>;
   readonly shareAvailable?: boolean;
   readonly releaseObjectUrl?: () => void;
 };
@@ -101,6 +102,7 @@ export interface ThreadSidebarSignals {
    * with the thread signals themselves on a thread switch.
    */
   readonly artifactCatalog: ArtifactCatalogSignals;
+  readonly selectedArtifactResourceUrl$: Computed<Promise<string>>;
   readonly selectedArtifactText$: Computed<Promise<string>>;
   /**
    * Session resources for an open artifacts list: refresh the first page in
@@ -132,12 +134,20 @@ export function createThreadSidebarSignals(
   const artifactCatalog = createArtifactCatalogSignals({
     chatThreadId: threadId,
   });
-  const selectedArtifactText$ = computed(async (get): Promise<string> => {
+  const selectedArtifactPreview$ = computed(async (get) => {
     const detail = await get(artifactCatalog.selectedArtifactDetail$);
     if (!detail) {
       throw new Error("Selected artifact is unavailable");
     }
-    const preview = artifactDetailPreview(detail);
+    return artifactDetailPreview(detail);
+  });
+  const selectedArtifactUrl$ = computed(async (get): Promise<string> => {
+    return (await get(selectedArtifactPreview$)).url;
+  });
+  const selectedArtifactResourceUrl$ =
+    createAttachmentResourceUrl$(selectedArtifactUrl$);
+  const selectedArtifactText$ = computed(async (get): Promise<string> => {
+    const preview = await get(selectedArtifactPreview$);
     if (!isTextPreviewKind(preview.kind)) {
       throw new Error("Selected artifact is not a text preview");
     }
@@ -224,6 +234,7 @@ export function createThreadSidebarSignals(
       });
     }),
     artifactCatalog,
+    selectedArtifactResourceUrl$,
     selectedArtifactText$,
     setupArtifactsSession$,
   };

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 import { timeout } from "signal-timers";
 import { openArtifactInOpenSidebar$ } from "../chat-page/thread-sidebar-coordinator.ts";
 import type { ArtifactRefInput } from "../chat-page/thread-sidebar.ts";
@@ -15,6 +15,7 @@ import {
   type ObjectUrlResource,
 } from "../object-url-resource.ts";
 import { rootSignal$ } from "../root-signal.ts";
+import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
 
 // ---------------------------------------------------------------------------
 // Lightbox state — tracks which attachment is open in the global preview UI
@@ -55,6 +56,11 @@ type AttachmentFramedDocumentLightboxInput = AttachmentDocumentLightboxBase & {
   readonly kind: "html" | "pdf";
 };
 
+type AttachmentFramedDocumentLightboxState =
+  AttachmentFramedDocumentLightboxInput & {
+    readonly resourceUrl$: Computed<Promise<string>>;
+  };
+
 type AttachmentDocumentLightboxInput =
   | AttachmentTextDocumentLightboxInput
   | AttachmentFramedDocumentLightboxInput;
@@ -75,7 +81,7 @@ export type AttachmentDocumentLightboxState =
       readonly kind: TextPreviewKind;
       readonly text$: TextPreviewComputed;
     })
-  | AttachmentFramedDocumentLightboxInput;
+  | AttachmentFramedDocumentLightboxState;
 
 function isAttachmentTextDocumentLightboxInput(
   value: AttachmentDocumentLightboxInput,
@@ -199,6 +205,7 @@ type AttachmentSidebarPreviewInput = {
   readonly file?: File;
   readonly filename?: string;
   readonly contentType?: string;
+  readonly resourceUrl$?: Computed<Promise<string>>;
   readonly shareAvailable?: boolean;
   readonly splitViewAvailable?: boolean;
 };
@@ -210,6 +217,9 @@ export function attachmentSidebarRef(
     value.shareAvailable === undefined
       ? {}
       : { shareAvailable: value.shareAvailable };
+  const resource = value.resourceUrl$
+    ? { resourceUrl$: value.resourceUrl$ }
+    : {};
   if (value.file) {
     return { file: value.file, url: value.url, ...share };
   }
@@ -221,6 +231,7 @@ export function attachmentSidebarRef(
       url: value.url,
       filename: value.filename,
       ...(contentType ? { contentType } : {}),
+      ...resource,
       ...share,
     };
   }
@@ -300,7 +311,17 @@ export const navigateImageLightbox$ = command(
 
 export const openDocumentLightbox$ = command(
   ({ set }, value: AttachmentDocumentLightboxInput) => {
-    if (set(routeToOpenArtifactSidebar$, value)) {
+    const preview: AttachmentDocumentLightboxState =
+      isAttachmentTextDocumentLightboxInput(value)
+        ? {
+            ...value,
+            text$: value.text$ ?? createTextPreviewComputed(value.url),
+          }
+        : {
+            ...value,
+            resourceUrl$: createAttachmentResourceUrl$(value.url),
+          };
+    if (set(routeToOpenArtifactSidebar$, preview)) {
       return;
     }
     set(internalLightboxDialogCloseToken$, (value) => {
@@ -308,14 +329,7 @@ export const openDocumentLightbox$ = command(
     });
     set(internalLightboxDialogVisible$, true);
     set(internalLightboxDialogFullscreen$, false);
-    if (isAttachmentTextDocumentLightboxInput(value)) {
-      set(internalLightboxState$, {
-        ...value,
-        text$: value.text$ ?? createTextPreviewComputed(value.url),
-      });
-      return;
-    }
-    set(internalLightboxState$, value);
+    set(internalLightboxState$, preview);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -419,6 +419,36 @@ describe("thread-owned utility sidebar", () => {
     expect(requestedThreadIds).toContain(THREAD_ID);
   });
 
+  it("previews a public catalog document through its resource URL signal", async () => {
+    const htmlUrl = "https://catalog-document.sites.vm7.io";
+    const summary = catalogArtifact({ title: "launch-site.html" });
+    setupArtifactCatalog(
+      [summary],
+      new Map([
+        [
+          summary.id,
+          catalogFileDetail({
+            contentType: "text/html",
+            filename: "launch-site.html",
+            fileId: "f0000000-0000-4000-a000-000000000003",
+            summary,
+            url: htmlUrl,
+          }),
+        ],
+      ]),
+    );
+
+    setupChatThread();
+    await openCatalogArtifact("launch-site.html");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "src",
+        htmlUrl,
+      );
+    });
+  });
+
   it("shows an unavailable artifact detail with a way back to the list", async () => {
     context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1385,24 +1385,44 @@ describe("zero attachment chips", () => {
     expect(documentFrame).toHaveClass("h-full", "min-h-0");
     expect(iframe).toHaveAttribute(
       "src",
-      `${canonicalUserMessageFileUrl("attachment-pdf")}#navpanes=0`,
+      `${presignedFileUrl("attachment-pdf")}#navpanes=0`,
     );
     expect(iframe).toHaveClass("h-full", "min-h-0", "border-0");
 
-    click(screen.getByLabelText("Close"));
+    click(screen.getByLabelText("Open in split view"));
 
     await waitFor(() => {
       expect(
         screen.queryByTestId("attachment-lightbox"),
       ).not.toBeInTheDocument();
+      expect(screen.getByTestId("artifact-sidebar-body-pdf")).toHaveAttribute(
+        "src",
+        `${presignedFileUrl("attachment-pdf")}#navpanes=0`,
+      );
+    });
+
+    click(screen.getByLabelText("Close artifact"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
     });
 
     click(screen.getByLabelText("Open html preview for launch-site.html"));
 
     await waitFor(() => {
-      expect(
-        screen.getByTestId("artifact-dialog-body-html"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("artifact-dialog-body-html")).toHaveAttribute(
+        "src",
+        presignedFileUrl("attachment-html"),
+      );
+    });
+
+    click(screen.getByLabelText("Open in split view"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "src",
+        presignedFileUrl("attachment-html"),
+      );
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
@@ -355,6 +355,7 @@ function ThreadArtifactDetail({
         url: preview.url,
         kind: preview.kind,
         filename: preview.filename,
+        resourceUrl$: sidebar.selectedArtifactResourceUrl$,
       }}
       thread={thread}
       text$={sidebar.selectedArtifactText$}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { Computed } from "ccstate";
 import {
   ArrowLeft,
   Maximize2,
@@ -310,6 +311,7 @@ function ArtifactSidebarResolvedContent({
           artifactKind={display.artifactKind}
           imageNavigation={imageNavigation}
           fullscreen={fullscreen}
+          resourceUrl$={display.resourceUrl$}
           text$={text$}
         />
       </div>
@@ -452,6 +454,7 @@ interface ArtifactDisplay {
   filename: string;
   subtitle: string;
   shareAvailable: boolean;
+  resourceUrl$?: Computed<Promise<string>>;
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
 }
 
@@ -511,6 +514,7 @@ function resolveArtifactDisplay(
       filename: item.file.filename,
       subtitle: artifactTitleSubtitle(ref.kind, item.file),
       shareAvailable: ref.shareAvailable ?? true,
+      ...(ref.resourceUrl$ ? { resourceUrl$: ref.resourceUrl$ } : {}),
       artifactKind: item.file.artifactKind,
     };
   }
@@ -520,6 +524,7 @@ function resolveArtifactDisplay(
     filename: ref.filename,
     subtitle: artifactFallbackSubtitle(ref.kind, ref.filename),
     shareAvailable: ref.shareAvailable ?? true,
+    ...(ref.resourceUrl$ ? { resourceUrl$: ref.resourceUrl$ } : {}),
   };
 }
 
@@ -803,6 +808,7 @@ function ArtifactBody({
   artifactKind,
   imageNavigation,
   fullscreen,
+  resourceUrl$,
   text$,
 }: {
   url: string;
@@ -811,6 +817,7 @@ function ArtifactBody({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   imageNavigation?: ArtifactImageNavigationActions;
   fullscreen: boolean;
+  resourceUrl$?: Computed<Promise<string>>;
   text$?: TextPreviewComputed;
 }) {
   const { t } = useTranslation();
@@ -864,7 +871,15 @@ function ArtifactBody({
     return <ArtifactAudioBody url={url} filename={filename} />;
   }
   if (kind === "html" || kind === "pdf") {
-    return (
+    return resourceUrl$ ? (
+      <ArtifactIframeResourceBody
+        resourceUrl$={resourceUrl$}
+        kind={kind}
+        filename={filename}
+        artifactKind={artifactKind}
+        fullscreen={fullscreen}
+      />
+    ) : (
       <ArtifactIframeBody
         url={url}
         kind={kind}
@@ -875,6 +890,34 @@ function ArtifactBody({
     );
   }
   return <ArtifactGenericBody filename={filename} />;
+}
+
+function ArtifactIframeResourceBody({
+  resourceUrl$,
+  kind,
+  filename,
+  artifactKind,
+  fullscreen,
+}: {
+  resourceUrl$: Computed<Promise<string>>;
+  kind: "html" | "pdf";
+  filename: string;
+  artifactKind?: ChatThreadArtifactFile["artifactKind"];
+  fullscreen: boolean;
+}) {
+  const resourceUrl = useLastResolved(resourceUrl$);
+  if (!resourceUrl) {
+    return <ArtifactSpinner />;
+  }
+  return (
+    <ArtifactIframeBody
+      url={resourceUrl}
+      kind={kind}
+      filename={filename}
+      artifactKind={artifactKind}
+      fullscreen={fullscreen}
+    />
+  );
 }
 
 function ArtifactSpinner() {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -454,7 +454,7 @@ interface ArtifactDisplay {
   filename: string;
   subtitle: string;
   shareAvailable: boolean;
-  resourceUrl$?: Computed<Promise<string>>;
+  resourceUrl$: Computed<Promise<string>>;
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
 }
 
@@ -514,7 +514,7 @@ function resolveArtifactDisplay(
       filename: item.file.filename,
       subtitle: artifactTitleSubtitle(ref.kind, item.file),
       shareAvailable: ref.shareAvailable ?? true,
-      ...(ref.resourceUrl$ ? { resourceUrl$: ref.resourceUrl$ } : {}),
+      resourceUrl$: ref.resourceUrl$,
       artifactKind: item.file.artifactKind,
     };
   }
@@ -524,7 +524,7 @@ function resolveArtifactDisplay(
     filename: ref.filename,
     subtitle: artifactFallbackSubtitle(ref.kind, ref.filename),
     shareAvailable: ref.shareAvailable ?? true,
-    ...(ref.resourceUrl$ ? { resourceUrl$: ref.resourceUrl$ } : {}),
+    resourceUrl$: ref.resourceUrl$,
   };
 }
 
@@ -817,7 +817,7 @@ function ArtifactBody({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   imageNavigation?: ArtifactImageNavigationActions;
   fullscreen: boolean;
-  resourceUrl$?: Computed<Promise<string>>;
+  resourceUrl$: Computed<Promise<string>>;
   text$?: TextPreviewComputed;
 }) {
   const { t } = useTranslation();
@@ -871,17 +871,9 @@ function ArtifactBody({
     return <ArtifactAudioBody url={url} filename={filename} />;
   }
   if (kind === "html" || kind === "pdf") {
-    return resourceUrl$ ? (
+    return (
       <ArtifactIframeResourceBody
         resourceUrl$={resourceUrl$}
-        kind={kind}
-        filename={filename}
-        artifactKind={artifactKind}
-        fullscreen={fullscreen}
-      />
-    ) : (
-      <ArtifactIframeBody
-        url={url}
         kind={kind}
         filename={filename}
         artifactKind={artifactKind}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -896,12 +896,46 @@ function ArtifactDialogBody({
     return <ArtifactDialogTextBody kind={preview.kind} text$={preview.text$} />;
   }
 
-  if (preview.kind === "html") {
-    return <ArtifactDialogHtmlBody filename={filename} preview={preview} />;
+  if (preview.kind === "html" || preview.kind === "pdf") {
+    return <ArtifactDialogFramedBody filename={filename} preview={preview} />;
   }
 
-  const publicUrl = publicAttachmentUrl(preview.url);
-  const src = preview.kind === "pdf" ? `${publicUrl}#navpanes=0` : publicUrl;
+  return null;
+}
+
+type ArtifactDialogFramedPreview = Extract<
+  AttachmentLightboxState,
+  { readonly kind: "html" | "pdf" }
+>;
+
+function ArtifactDialogFramedBody({
+  filename,
+  preview,
+}: {
+  filename: string;
+  preview: ArtifactDialogFramedPreview;
+}) {
+  const { t } = useTranslation();
+  const resourceUrl = useLastResolved(preview.resourceUrl$);
+  if (!resourceUrl) {
+    return (
+      <ArtifactDialogStage centered>
+        <Loader2 className="animate-spin text-muted-foreground" />
+      </ArtifactDialogStage>
+    );
+  }
+
+  if (preview.kind === "html") {
+    return (
+      <ArtifactDialogHtmlBody
+        filename={filename}
+        preview={preview}
+        src={publicAttachmentUrl(resourceUrl)}
+      />
+    );
+  }
+
+  const src = `${publicAttachmentUrl(resourceUrl)}#navpanes=0`;
 
   return (
     <ArtifactDialogStage scrollable={false}>
@@ -928,13 +962,14 @@ function ArtifactDialogBody({
 function ArtifactDialogHtmlBody({
   filename,
   preview,
+  src,
 }: {
   filename: string;
-  preview: AttachmentLightboxState;
+  preview: ArtifactDialogFramedPreview;
+  src: string;
 }) {
   const { t } = useTranslation();
   const fullscreen = useGet(lightboxDialogFullscreen$);
-  const src = publicAttachmentUrl(preview.url);
   const isPresentationHtml =
     preview.artifact?.artifactKind === "presentation-html";
 


### PR DESCRIPTION
## Summary

- exchange authenticated PDF and HTML attachment URLs for short-lived signed resource URLs before mounting preview iframes
- require every artifact sidebar reference to carry a resource URL signal, including public catalog artifacts
- preserve the resource signal when moving a document preview from the dialog into the thread sidebar
- keep the iframe unmounted behind a loading state until the signed URL is available
- cover persisted PDF and HTML attachments plus public catalog documents through the unified path

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/thread-sidebar.test.tsx --maxWorkers=1` (63 passed)
- `pnpm -F @vm0/app check-types`
- scoped ESLint, Oxlint, and type-aware Oxlint on all changed platform files
- Prettier 3.8.1 check on all changed files
