### PR TITLE
docs: retire remaining workflow event wording

### DIFF
--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -715,7 +715,7 @@ const {
 });
 
 /**
- * Raw event for the workflow-events ingress, which zod-parses the payload
+ * Raw event for the automation-event ingress, which zod-parses the payload
  * itself rather than branching on Stripe's union.
  */
 export function constructStripeWebhookEvent(

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -103,7 +103,7 @@ async function setupScenario(
     throw new Error("Expected an organization-scoped workflow owner");
   }
   const { agentId } = await workflows.createAgent(actor, {
-    displayName: "Stripe Workflow Event Agent",
+    displayName: "Stripe Automation Event Agent",
   });
   const workflowId = await workflows.createWorkflow(actor, {
     agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -582,7 +582,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     const listedRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
     const admittedRunId = listedRuns.runs[0]?.id;
     if (!admittedRunId || listedRuns.runs.length !== 1) {
-      throw new Error("Expected an admitted workflow event run");
+      throw new Error("Expected an admitted automation event run");
     }
     await runsApi.claimRunnerJob(admittedRunId);
 
@@ -736,7 +736,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     const claim = await runsApi.claimRunnerJob(runId);
     const zeroToken = claim.environment?.ZERO_TOKEN;
     if (!zeroToken) {
-      throw new Error("Expected the workflow event run to expose ZERO_TOKEN");
+      throw new Error("Expected the automation event run to expose ZERO_TOKEN");
     }
     expect(verifyZeroToken(zeroToken)?.capabilities).toContain(
       "goal:user-control:write",

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
@@ -239,13 +239,13 @@ function eventContextFromPrompt(
   const marker = "# This run's event\n";
   const markerIndex = appendSystemPrompt.indexOf(marker);
   if (markerIndex === -1) {
-    throw new Error("Expected workflow event payload in appendSystemPrompt");
+    throw new Error("Expected automation event payload in appendSystemPrompt");
   }
   const parsed = JSON.parse(
     appendSystemPrompt.slice(markerIndex + marker.length),
   ) as unknown;
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new Error("Expected workflow event payload object");
+    throw new Error("Expected automation event payload object");
   }
   return parsed as Record<string, unknown>;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -312,7 +312,7 @@ async function expectAcceptedRunId(
     .toHaveLength(1);
   const [claimedRunId] = await workflowRunIds(threadId);
   if (!claimedRunId) {
-    throw new Error("Expected the accepted workflow event to create a run");
+    throw new Error("Expected the accepted automation event to create a run");
   }
   return claimedRunId;
 }
@@ -595,7 +595,7 @@ describe("workflow queue", () => {
     await runsApi.requestCancelRun(scenario.actor, user.body.runId, [200]);
   });
 
-  it("runs a pending goal continuation before a newer workflow event on the same thread", async () => {
+  it("runs a pending goal continuation before a newer automation event on the same thread", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const goal = await createActiveGoalQueueEventFixture({
@@ -603,8 +603,8 @@ describe("workflow queue", () => {
       orgId: scenario.orgId,
       userId: scenario.userId,
       agentId: scenario.agentId,
-      objective: "finish before the workflow event",
-      objectiveBrief: "Finish before the workflow event",
+      objective: "finish before the automation event",
+      objectiveBrief: "Finish before the automation event",
     });
 
     expectAcceptedWithoutRun(
@@ -625,7 +625,7 @@ describe("workflow queue", () => {
     await runsApi.requestCancelRun(scenario.actor, goalRunId, [200]);
   });
 
-  it("lets a goal continuation preempt a workflow event during final queue claim", async () => {
+  it("lets a goal continuation preempt an automation event during final queue claim", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const admissionLock = await holdOrgAdmissionLockFixture({
@@ -648,8 +648,8 @@ describe("workflow queue", () => {
       orgId: scenario.orgId,
       userId: scenario.userId,
       agentId: scenario.agentId,
-      objective: "preempt the preparing workflow event",
-      objectiveBrief: "Preempt the preparing workflow event",
+      objective: "preempt the preparing automation event",
+      objectiveBrief: "Preempt the preparing automation event",
     });
     const goalDrain = drainChatThreadQueueFixture({
       threadId: automation.threadId,
@@ -710,7 +710,7 @@ describe("workflow queue", () => {
     await runsApi.requestCancelRun(scenario.actor, workflowRunId, [200]);
   });
 
-  it("does not let the stale sweep race a newly admitted workflow event", async () => {
+  it("does not let the stale sweep race a newly admitted automation event", async () => {
     mockNow(Date.UTC(2020, 0, 1));
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
@@ -727,7 +727,7 @@ describe("workflow queue", () => {
     await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
     const event = (await pendingAutomationEvents(automation.threadId))[0];
     if (!event) {
-      throw new Error("Expected a pending workflow event");
+      throw new Error("Expected a pending automation event");
     }
 
     // The business assertion: the stale sweep must not race the freshly
@@ -744,7 +744,7 @@ describe("workflow queue", () => {
     ]);
   });
 
-  it("does not let the stale sweep drain a fresh user message ahead of a stale workflow event", async () => {
+  it("does not let the stale sweep drain a fresh user message ahead of a stale automation event", async () => {
     mockNow(Date.UTC(2020, 0, 1));
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
@@ -761,7 +761,7 @@ describe("workflow queue", () => {
     await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
     const event = (await pendingAutomationEvents(automation.threadId))[0];
     if (!event) {
-      throw new Error("Expected a pending workflow event");
+      throw new Error("Expected a pending automation event");
     }
     await setWorkflowQueueEventCreatedAtFixture({
       eventId: event.id,
@@ -796,7 +796,7 @@ describe("workflow queue", () => {
     await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(2);
 
     // The business assertion: the stale sweep must leave the fresh user message
-    // queued and must not drain it ahead of the stale workflow event that is
+    // queued and must not drain it ahead of the stale automation event that is
     // still blocked on org admission.
     await cleanupSandboxes();
     await expectSweepLeftQueueUntouched(automation.threadId, [event.id]);
@@ -811,7 +811,7 @@ describe("workflow queue", () => {
     expect(userResult.status).toBe(201);
   });
 
-  it("recovers a stale workflow event after its terminal callback is missed", async () => {
+  it("recovers a stale automation event after its terminal callback is missed", async () => {
     mockNow(Date.UTC(2020, 0, 1));
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
@@ -824,7 +824,7 @@ describe("workflow queue", () => {
     );
     const event = (await pendingAutomationEvents(automation.threadId))[0];
     if (!event) {
-      throw new Error("Expected a pending workflow event");
+      throw new Error("Expected a pending automation event");
     }
     await setWorkflowQueueEventCreatedAtFixture({
       eventId: event.id,
@@ -1071,7 +1071,7 @@ describe("workflow queue", () => {
     );
     const [queuedEvent] = await pendingAutomationEvents(automation.threadId);
     if (!queuedEvent) {
-      throw new Error("Expected a queued workflow event");
+      throw new Error("Expected a queued automation event");
     }
 
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
@@ -1110,7 +1110,7 @@ describe("workflow queue", () => {
     );
     const [queuedEvent] = await pendingAutomationEvents(automation.threadId);
     if (!queuedEvent) {
-      throw new Error("Expected a queued workflow event");
+      throw new Error("Expected a queued automation event");
     }
 
     await runsApi.heartbeatRunner(scenario.runnerGroup);
@@ -1213,7 +1213,7 @@ describe("workflow queue", () => {
     await runsApi.requestCancelRun(scenario.actor, blockerRunId, [200]);
   });
 
-  it("keeps workflow events queued until cancellation recovery completes", async () => {
+  it("keeps automation events queued until cancellation recovery completes", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const firstRunId = await expectAcceptedRunId(
@@ -1476,13 +1476,13 @@ describe("workflow queue", () => {
   it("uses full PostgreSQL timestamp precision for workflow queue FIFO", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
-    const firstBrief = "First precise workflow event";
+    const firstBrief = "First precise automation event";
     const firstEventId = await admitWorkflowAutomationEventFixture({
       automationId: automation.automationId,
       chatThreadId: automation.threadId,
       triggerBrief: firstBrief,
     });
-    const secondBrief = "Second precise workflow event";
+    const secondBrief = "Second precise automation event";
     const secondEventId = await admitWorkflowAutomationEventFixture({
       automationId: automation.automationId,
       chatThreadId: automation.threadId,
@@ -1538,13 +1538,13 @@ describe("workflow queue", () => {
     ).toContain(databaseSecond.id);
   });
 
-  it("retries when an earlier workflow event becomes queue head during launch", async () => {
+  it("retries when an earlier automation event becomes queue head during launch", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const originalEventId = await admitWorkflowAutomationEventFixture({
       automationId: automation.automationId,
       chatThreadId: automation.threadId,
-      triggerBrief: "Original queued workflow event",
+      triggerBrief: "Original queued automation event",
     });
     await setWorkflowQueueEventCreatedAtFixture({
       eventId: originalEventId,
@@ -1566,7 +1566,7 @@ describe("workflow queue", () => {
     );
     await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
 
-    const preemptingBrief = "Earlier workflow event admitted during launch";
+    const preemptingBrief = "Earlier automation event admitted during launch";
     const preemptingEventId = await admitWorkflowAutomationEventFixture({
       automationId: automation.automationId,
       chatThreadId: automation.threadId,
@@ -1618,7 +1618,7 @@ describe("workflow queue", () => {
       },
     );
     if (!claimedEvent) {
-      throw new Error("Expected the workflow event to be claimed");
+      throw new Error("Expected the automation event to be claimed");
     }
     const contextBeforeDelete = await readChatEventContextFixture(
       claimedEvent.id,
@@ -1829,7 +1829,7 @@ describe("workflow queue", () => {
     expect(drained.nextRunAt).toBeNull();
   });
 
-  it("drains user chat before workflow events in one canonical session", async () => {
+  it("drains user chat before automation events in one canonical session", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     // The queued-message auto-send runs inside the terminal chat callback,
@@ -1877,7 +1877,7 @@ describe("workflow queue", () => {
     );
     expect(queued.body.runId).toBeNull();
 
-    // Terminal run: the user message drains first, the workflow event waits.
+    // Terminal run: the user message drains first, the automation event waits.
     await completeRunThroughSandbox(scenario, firstRunId);
     await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(1);
     const messages = await wf.readThreadEvents(automation.threadId);
@@ -1900,7 +1900,7 @@ describe("workflow queue", () => {
       run_session_id: firstBinding.agent_session_id,
     });
 
-    // The workflow event drains only after the user's run finishes.
+    // The automation event drains only after the user's run finishes.
     const userClaim = await completeRunThroughSandbox(
       scenario,
       userMessage.runId,
@@ -1912,7 +1912,7 @@ describe("workflow queue", () => {
     expect(runIds).toHaveLength(2);
     const secondWorkflowRunId = runIds[1];
     if (!secondWorkflowRunId) {
-      throw new Error("Expected the queued workflow event to drain");
+      throw new Error("Expected the queued automation event to drain");
     }
     const workflowBinding = await readThreadSessionBinding(
       context,
@@ -2006,7 +2006,7 @@ describe("workflow queue", () => {
     await completeRunThroughSandbox(scenario, userResult.body.runId);
     const [workflowRunId] = await workflowRunIds(automation.threadId);
     if (!workflowRunId) {
-      throw new Error("Expected the competing workflow event to drain");
+      throw new Error("Expected the competing automation event to drain");
     }
     const workflowBinding = await readThreadSessionBinding(
       context,
@@ -2032,7 +2032,7 @@ describe("workflow queue", () => {
     const before = await pendingAutomationEvents(automation.threadId);
     const target = before[0];
     if (!target) {
-      throw new Error("Expected a pending workflow event");
+      throw new Error("Expected a pending automation event");
     }
     const clientEventId = randomUUID();
     await accept(

--- a/turbo/apps/api/src/signals/services/github-label-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/github-label-automation-event.service.ts
@@ -694,7 +694,7 @@ export const dispatchGithubLabelWorkflowAutomations$ = command(
     );
     signal.throwIfAborted();
     if (!installationRecord) {
-      log.debug("Ignoring GitHub workflow event for unbound installation", {
+      log.debug("Ignoring GitHub automation event for unbound installation", {
         action,
         installationId: String(installation.id),
         repo: repository.full_name,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -4038,7 +4038,7 @@ function autoSendAdmissionBlocked(
 /**
  * User-message half of the per-thread scheduler: when the thread has no
  * in-flight run, dispatch the oldest queued user message — whoever sent it.
- * The shared thread scheduler calls this before attempting the workflow-event
+ * The shared thread scheduler calls this before attempting the automation-event
  * half, preserving user-message priority.
  */
 async function autoSendQueuedMessageForThread(

--- a/turbo/apps/api/src/signals/services/strapi-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/strapi-automation-event.service.ts
@@ -730,7 +730,7 @@ async function executeDueStrapiAutomationEvents(
       if (result.error instanceof StrapiPendingEventChangedError) {
         continue;
       }
-      log.error("Failed to process Strapi workflow event", {
+      log.error("Failed to process Strapi automation event", {
         automationId: pending.automationId,
         pendingEventId: pending.id,
         error: result.error,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -18,7 +18,7 @@ import type {
 } from "./zero-workflow-automation-launch.service";
 
 /**
- * Durable workflow-event ingress. Every event enters the chat thread queue
+ * Durable automation-event ingress. Every event enters the chat thread queue
  * before the shared scheduler prepares a run; the run persistence transaction
  * later owns the authoritative queue claim.
  */

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -2280,7 +2280,7 @@ async function createNotionEventAutomationForWorkflow(
           )
         : {
             kind: "bad-request",
-            message: "Unsupported Notion workflow event config",
+            message: "Unsupported Notion automation event config",
           };
   } else if (args.input.eventType === "notion-database-item-created") {
     preparedConfig =
@@ -2305,7 +2305,7 @@ async function createNotionEventAutomationForWorkflow(
           )
         : {
             kind: "bad-request",
-            message: "Unsupported Notion workflow event config",
+            message: "Unsupported Notion automation event config",
           };
   } else {
     preparedConfig =
@@ -2338,7 +2338,7 @@ async function createNotionEventAutomationForWorkflow(
           )
         : {
             kind: "bad-request",
-            message: "Unsupported Notion workflow event config",
+            message: "Unsupported Notion automation event config",
           };
   }
   signal.throwIfAborted();
@@ -2669,7 +2669,7 @@ const createEventAutomationForWorkflow$ = command(
     }
     return {
       kind: "bad-request",
-      message: "Unsupported workflow event automation type",
+      message: "Unsupported event automation type",
     };
   },
 );

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -810,7 +810,7 @@ export async function replayPendingChatInputQueueEventFixture(args: {
 }
 
 /**
- * Move one exact workflow event into historical state without waiting for real
+ * Move one exact automation event into historical state without waiting for real
  * time to pass. A string preserves PostgreSQL precision beyond JavaScript
  * milliseconds. Product APIs cannot construct an already-stale queue item.
  */

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -443,7 +443,7 @@ function ComposerQueueGlyph() {
   );
 }
 
-// A single strip row — a queued message, workflow event, or active goal. All
+// A single strip row — a queued message, automation event, or active goal. All
 // share one layout so they read as the same kind of pending item; only the
 // leading icon distinguishes them. Goals open a modal because their full
 // objective is fetched lazily by thread.
@@ -733,7 +733,7 @@ function PendingItemsStrip({ signals }: { signals: ComposerSignals }) {
             />
           );
         })}
-        {/* The active goal sits last — below queued messages and workflow events
+        {/* The active goal sits last — below queued messages and automation events
             — because it only runs once the queue drains. Like other pending
             items it can be cancelled from the strip. */}
         {activeGoal ? (


### PR DESCRIPTION
## Summary

- replace the final 46 human-readable `workflow event` references with automation vocabulary
- update comments, operator logs, API error messages, test titles/errors, and descriptive fixture briefs
- preserve identifiers, enum values, trigger sources, assertions, and dispatch-timing strings

## Validation

- target TypeScript/TSX grep returns no matches outside historical migrations
- full epic grep returns no unexpected matches outside historical migrations and `CHANGELOG.md`
- `workflow-automation` / `workflow_automation` / `WorkflowAutomation` count remains 7,638
- `git diff --check`
- local test suite not run per issue scope; PR CI is the verification gate

Closes #26265