### PR TITLE
fix(runner): require exact dnsmasq executable matching

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -3603,6 +3603,22 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn report_warns_for_running_when_dnsmasq_name_only_suffix_matches() {
+        let suffix_collision_argv = ["not-dnsmasq", "--port", "5353"]
+            .map(str::to_string)
+            .to_vec();
+        let dns_procs = process::parse_dnsmasq_cmdline(&suffix_collision_argv)
+            .map(|port| dns_proc(888, port))
+            .into_iter()
+            .collect();
+
+        let report = build_test_runner_report("running", None, Some(5353), vec![], dns_procs).await;
+
+        assert!(has_dns_warning(&report));
+        assert_eq!(report.dns_pid, None);
+    }
+
     #[test]
     fn is_test_tld_matches_dot_test() {
         assert!(is_test_tld("https://not-a-real-server.test/api"));

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -12,6 +12,8 @@ mod types;
 
 pub use self::ancestry::{is_orphan, process_has_ancestor};
 pub(crate) use self::discovery::discover_all_with_status;
+#[cfg(test)]
+pub(crate) use self::discovery::parse_dnsmasq_cmdline;
 pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_id};
 pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -36,9 +36,9 @@ fn parse_mitmdump_cmdline(argv: &[String]) -> Option<u16> {
 /// Parse a dnsmasq argv for the listen port.
 ///
 /// Identifies dnsmasq by binary name and extracts the `--port` value.
-fn parse_dnsmasq_cmdline(argv: &[String]) -> Option<u16> {
+pub(crate) fn parse_dnsmasq_cmdline(argv: &[String]) -> Option<u16> {
     let binary = argv.first()?;
-    if !binary.ends_with("dnsmasq") {
+    if Path::new(binary).file_name().and_then(|name| name.to_str()) != Some("dnsmasq") {
         return None;
     }
     let pos = argv.iter().position(|t| t == "--port")?;
@@ -435,27 +435,55 @@ mod tests {
     }
 
     #[test]
-    fn parse_dnsmasq_port() {
-        let a = argv(&[
-            "dnsmasq",
-            "--no-daemon",
-            "--no-resolv",
-            "--port",
-            "5353",
-            "--server",
-            "8.8.8.8",
-        ]);
-        assert_eq!(parse_dnsmasq_cmdline(&a), Some(5353));
-    }
+    fn parse_dnsmasq_cmdline_matches_exact_basename_and_port() {
+        let cases: &[(&str, &[&str], Option<u16>)] = &[
+            (
+                "bare executable",
+                &[
+                    "dnsmasq",
+                    "--no-daemon",
+                    "--no-resolv",
+                    "--port",
+                    "5353",
+                    "--server",
+                    "8.8.8.8",
+                ],
+                Some(5353),
+            ),
+            (
+                "full executable path",
+                &["/usr/sbin/dnsmasq", "--port", "5354"],
+                Some(5354),
+            ),
+            ("empty argv", &[], None),
+            (
+                "unrelated executable",
+                &["mitmdump", "--port", "5353"],
+                None,
+            ),
+            ("missing port", &["dnsmasq", "--no-daemon"], None),
+            ("invalid port", &["dnsmasq", "--port", "invalid"], None),
+            ("out-of-range port", &["dnsmasq", "--port", "65536"], None),
+            (
+                "executable name prefix collision",
+                &["dnsmasq-wrapper", "--port", "5353"],
+                None,
+            ),
+            (
+                "executable name suffix collision",
+                &["not-dnsmasq", "--port", "5353"],
+                None,
+            ),
+            (
+                "full-path basename suffix collision",
+                &["/tmp/notdnsmasq", "--port", "5353"],
+                None,
+            ),
+        ];
 
-    #[test]
-    fn parse_dnsmasq_not_dnsmasq_returns_none() {
-        assert!(parse_dnsmasq_cmdline(&argv(&["mitmdump", "--port", "5353"])).is_none());
-    }
-
-    #[test]
-    fn parse_dnsmasq_no_port_returns_none() {
-        assert!(parse_dnsmasq_cmdline(&argv(&["dnsmasq", "--no-daemon"])).is_none());
+        for (name, parts, expected) in cases {
+            assert_eq!(parse_dnsmasq_cmdline(&argv(parts)), *expected, "{name}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require the exact `dnsmasq` executable basename during procfs command-line discovery
- cover bare paths, full paths, malformed ports, and filename collisions with table-driven parser cases
- verify a suffix-collision process cannot publish its PID or suppress the running-runner `NoDnsmasq` diagnostic

## Scope

- preserves the existing separate `--port` parsing and legitimate same-port diagnostic behavior
- adds no PPID or `/proc/<pid>/exe` provenance checks, procfs I/O, persisted state, protocol changes, or feature switch

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner process::discovery::tests::parse_dnsmasq_cmdline_matches_exact_basename_and_port`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::doctor::tests::report_warns_for_running_when_dnsmasq_name_only_suffix_matches`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`
- pre-commit workspace Rust formatting, Clippy, rustdoc, and file-size checks

Closes #26276
