### PR TITLE
test(api): isolate slack ingress from cron cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -5,13 +5,14 @@ import type { ChatEvent } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { createStore } from "ccstate";
-import { describe, expect, it } from "vitest";
+import { describe, expect, test as vitestTest } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
 import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
+import { withThreadlessRunCleanupTestLockFixture } from "../../../test-fixtures/run-deletion";
 import { readChatEventContextFixture } from "../../../test-fixtures/chat-events";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -386,6 +387,29 @@ async function pollSlackRun(runnerGroup: string): Promise<string> {
   return await pollRunnerRun(
     runnerGroup,
     "Expected a Slack-triggered run in the runner queue",
+  );
+}
+
+function it(name: string, test: () => Promise<void>, timeout?: number): void {
+  vitestTest(
+    name,
+    async () => {
+      if (
+        name ===
+        "delivers canonical Slack callbacks for progress, audit footers, failures, and Slack errors"
+      ) {
+        // The cron cleanup suite runs the global canonical-ingress sweep from
+        // another worker. Share its lock so it cannot claim this test's fresh
+        // Slack ingress outside the owning provider-mock lifetime.
+        await withThreadlessRunCleanupTestLockFixture({
+          signal: context.signal,
+          run: test,
+        });
+        return;
+      }
+      await test();
+    },
+    timeout,
   );
 }
 


### PR DESCRIPTION
## Summary

- serialize the affected canonical Slack callback test with the same advisory lock used by the cron cleanup fixture
- keep fresh Slack ingress processing inside the owning test worker and its Slack provider mocks
- preserve the callback, run-creation, failure, audit-footer, assertion, and timeout behavior

## Flake evidence

- Trigger: https://github.com/vm0-ai/vm0/actions/runs/31463746793
- Failed shard: https://github.com/vm0-ai/vm0/actions/runs/31463746793/job/93692328148
- Exact SHA passed the merge-group `test-api (4)` shard: https://github.com/vm0-ai/vm0/actions/runs/31463454030/job/93691481550
- The failure log first shows the affected canonical ingress becoming incomplete. The same ingress ID is then retried while `cron-cleanup-sandboxes.test.ts` cases are active, where `getMessagePermalink` receives the other worker mock state and returns no `permalink`. The Slack test later times out waiting for the run that ingress should create.
- `cron-cleanup-sandboxes.test.ts` invokes a global canonical-ingress sweep from a parallel Vitest worker. Its fixture already owns an advisory test lock; the affected Slack test now participates in that same deterministic isolation boundary.
- The merged connector change did not touch this test, and the same SHA passed the equivalent shard, so this is test isolation rather than a deterministic product regression.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm --filter api exec eslint src/signals/routes/__tests__/integrations.bdd.test.ts --max-warnings 0`
- `git diff --check`

The changed BDD file is service-backed and requires the API test database, so it was not run locally under the flaky-test repair constraints. The PR `test-api (4)` shard is the applicable regression check because it recreates the original cross-file worker concurrency.

Browser preview validation is not applicable: this is a test-only isolation fixture with no production or UI behavior change.
