### PR TITLE
test(api): verify retained managed key resolution

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4617,7 +4617,9 @@ describe("CHAT-02: model-first provider policies", () => {
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const keyFixtureId = randomUUID();
-    const apiKey = `vm0-key-bdd-dev-seed-${keyFixtureId}`;
+    const requestedApiKey = `vm0-key-bdd-dev-seed-${keyFixtureId}`;
+    await seedVm0ManagedModelKey("glm-5.2");
+
     let runId: string | null = null;
 
     onTestFinished(async () => {
@@ -4627,11 +4629,12 @@ describe("CHAT-02: model-first provider policies", () => {
       ]);
     });
 
-    await acquireBddVm0ApiKey({
+    const acquiredApiKey = await acquireBddVm0ApiKey({
       fixtureId: keyFixtureId,
       vendor: "zai",
-      apiKey,
+      apiKey: requestedApiKey,
     });
+    expect(acquiredApiKey === requestedApiKey).toBeFalsy();
 
     await api.updateOrgModelPolicies(actor, [
       {
@@ -4680,7 +4683,9 @@ describe("CHAT-02: model-first provider policies", () => {
       throw new Error("Expected vm0 firewall auth to resolve");
     }
     const authorization = resolved.body.headers.Authorization;
-    expect(authorization).toBe(`Bearer ${apiKey}`);
+    expect(authorization?.startsWith("Bearer ")).toBeTruthy();
+    expect(authorization?.length ?? 0).toBeGreaterThan("Bearer ".length);
+    expect(authorization === `Bearer ${acquiredApiKey}`).toBeTruthy();
   }, 90_000);
   it("rejects legacy blank OpenRouter provider secrets during firewall auth", async () => {
     const fw = createFirewallApi(context);

--- a/turbo/apps/api/src/signals/services/test-vm0-managed-model-key-fixture.service.ts
+++ b/turbo/apps/api/src/signals/services/test-vm0-managed-model-key-fixture.service.ts
@@ -50,9 +50,10 @@ export async function acquireVm0ManagedModelKeyFixture(
   db: Db,
   fixtureId: string,
   rows: readonly Vm0ManagedModelKeyRow[],
-): Promise<void> {
+): Promise<readonly Vm0ManagedModelKeyRow[]> {
+  const acquiredRows: Vm0ManagedModelKeyRow[] = [];
   for (const value of rows) {
-    await db.transaction(async (tx) => {
+    const apiKey = await db.transaction(async (tx) => {
       const [row] = await tx
         .insert(vm0ApiKeys)
         .values({
@@ -66,14 +67,18 @@ export async function acquireVm0ManagedModelKeyFixture(
           // window where the previous fixture owner can delete the row.
           set: { vendor: value.vendor },
         })
-        .returning({ id: vm0ApiKeys.id, label: vm0ApiKeys.label });
+        .returning({
+          id: vm0ApiKeys.id,
+          apiKey: vm0ApiKeys.apiKey,
+          label: vm0ApiKeys.label,
+        });
       if (!row) {
         throw new Error(`Expected VM0 managed key for vendor: ${value.vendor}`);
       }
 
       const fixtureLabel = parseVm0ManagedModelKeyFixtureLabel(row.label);
       if (fixtureLabel?.fixtureIds.includes(fixtureId)) {
-        return;
+        return row.apiKey;
       }
       const fixtureIds = fixtureLabel
         ? [...fixtureLabel.fixtureIds, fixtureId]
@@ -90,8 +95,11 @@ export async function acquireVm0ManagedModelKeyFixture(
           updatedAt: nowDate(),
         })
         .where(eq(vm0ApiKeys.id, row.id));
+      return row.apiKey;
     });
+    acquiredRows.push({ vendor: value.vendor, apiKey });
   }
+  return acquiredRows;
 }
 
 /** Releases only one fixture's ownership, deleting the row at the last owner. */

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -12,6 +12,7 @@ import type {
 } from "@vm0/db/jsonb-contracts/chat-slack-context";
 import type { ChatTeamsMessageFiles } from "@vm0/db/jsonb-contracts/chat-teams-context";
 import type { JsonObject } from "@vm0/db/jsonb-contracts/shared";
+import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -1266,7 +1267,7 @@ export async function acquireBddVm0ApiKey(args: {
   readonly fixtureId: string;
   readonly vendor: string;
   readonly apiKey: string;
-}): Promise<void> {
+}): Promise<string> {
   const scoped = VM0_BDD_API_KEY_PREFIXES.some((prefix) => {
     return args.apiKey.length > prefix.length && args.apiKey.startsWith(prefix);
   });
@@ -1281,6 +1282,15 @@ export async function acquireBddVm0ApiKey(args: {
       apiKey: args.apiKey,
     },
   ]);
+  const [acquired] = await db()
+    .select({ apiKey: vm0ApiKeys.apiKey })
+    .from(vm0ApiKeys)
+    .where(eq(vm0ApiKeys.vendor, args.vendor))
+    .limit(1);
+  if (!acquired) {
+    throw new Error(`Expected VM0 managed key for vendor: ${args.vendor}`);
+  }
+  return acquired.apiKey;
 }
 
 /** Releases only this bdd fixture's ownership of its vendor key. */

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -12,7 +12,6 @@ import type {
 } from "@vm0/db/jsonb-contracts/chat-slack-context";
 import type { ChatTeamsMessageFiles } from "@vm0/db/jsonb-contracts/chat-teams-context";
 import type { JsonObject } from "@vm0/db/jsonb-contracts/shared";
-import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
@@ -1276,17 +1275,16 @@ export async function acquireBddVm0ApiKey(args: {
       `acquireBddVm0ApiKey: api key must start with one of ${VM0_BDD_API_KEY_PREFIXES.join(", ")}`,
     );
   }
-  await acquireVm0ManagedModelKeyFixture(db(), args.fixtureId, [
-    {
-      vendor: args.vendor,
-      apiKey: args.apiKey,
-    },
-  ]);
-  const [acquired] = await db()
-    .select({ apiKey: vm0ApiKeys.apiKey })
-    .from(vm0ApiKeys)
-    .where(eq(vm0ApiKeys.vendor, args.vendor))
-    .limit(1);
+  const [acquired] = await acquireVm0ManagedModelKeyFixture(
+    db(),
+    args.fixtureId,
+    [
+      {
+        vendor: args.vendor,
+        apiKey: args.apiKey,
+      },
+    ],
+  );
   if (!acquired) {
     throw new Error(`Expected VM0 managed key for vendor: ${args.vendor}`);
   }


### PR DESCRIPTION
## Summary

- build on #26287 by returning the actual vendor key retained by ownership arbitration
- make the ZAI route scenario hold an overlapping runtime owner and prove a later BDD owner does not replace its key
- preserve exact firewall key-resolution coverage while ensuring failed assertions cannot print the resolved credential

## Problem

The ownership service intentionally keeps an existing vendor key when another fixture owner acquires the same unique row. After #26287, `acquireBddVm0ApiKey` returned no value, so the ZAI scenario still compared firewall output with the newly requested key. That works in a clean CI database but fails when a runtime fixture or local development seed already owns the vendor row.

The shared acquisition service now returns the key selected by the same atomic `INSERT ... ON CONFLICT ... RETURNING` arbitration. The BDD helper exposes that retained key without a second database query. The test deterministically creates the overlapping-owner state, proves the requested key was not substituted, and compares firewall output with the retained key through assertions that cannot reveal the credential on failure.

## Exclusions

- no production managed-key selection behavior changes
- no database schema, migration, or API contract changes

## Validation

- `scripts/prepare.sh`
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/pi-edge-loop.test.ts src/signals/routes/__tests__/test-runtime-state.test.ts --maxWorkers=3 --reporter=dot --silent=passed-only` (104 tests)
- pre-commit hooks: repository Prettier, Knip, full type checks, file-size check, and commitlint

Closes #26283
