### PR TITLE
fix: remove nested hover surface on the composer goal row

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -521,20 +521,23 @@ function ComposerStripRow({
       className="group flex items-center gap-2 rounded-md pl-2 pr-1 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-state-hover"
     >
       {isGoal && onOpenDetail ? (
+        // This target spans almost the whole row, so it deliberately paints no
+        // background of its own — the row's hover carries the highlight and a
+        // second, near-coextensive surface would read as a box inside a box.
+        // Its icon sits in the same p-1 slot the other rows' leading button
+        // uses, keeping every row's glyph and text on one column.
         <button
           type="button"
-          className="-ml-1 flex min-w-0 flex-1 items-center gap-2 rounded-md p-1 text-left transition-colors hover:bg-state-selected-hover hover:text-sidebar-foreground focus-visible:bg-state-selected-hover focus-visible:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           onClick={onOpenDetail}
           aria-label={t(($) => {
             return $.chat.queue.openGoalDetails;
           })}
         >
-          <Target
-            size={16}
-            className="shrink-0 text-emerald-800"
-            aria-hidden="true"
-          />
-          <span className="min-w-0 flex-1 truncate">{text}</span>
+          <span className="flex shrink-0 p-1 text-emerald-800">
+            <Target size={16} aria-hidden="true" />
+          </span>
+          <span className="min-w-0 flex-1 truncate py-1">{text}</span>
         </button>
       ) : (
         <>


### PR DESCRIPTION
## Problem

The active-goal row in the composer's pending-items strip painted two state layers at the same time:

- the row (`ComposerStripRow`) with `hover:bg-state-hover` — state layer at 5%
- the open-details button inside it with `hover:bg-state-selected-hover` — state layer at 11.5%

That button is `flex-1`, so it covers almost the entire row. Hovering the goal text hit both rules at once and composited 5% + 11.5%, drawing a second rounded rectangle inside the row highlight — a visible box-inside-a-box.

Queued and automation rows never showed this, because their hover surface lives only on the 16px leading icon button, where a small chip nested in a row highlight is the expected icon-button behaviour. Only the goal row also made a full-width target its own surface.

## Change

The open-details target now paints no background of its own; the row hover carries the highlight, and the target signals itself with the existing `hover:text-sidebar-foreground` shift plus the focus ring for keyboard users. One surface per row.

Removing the inner box exposed a second-order issue: the button's `-ml-1 p-1` placed the goal's target glyph 4px left of the queued rows' glyph, which the box had been hiding. The icon now sits in the same `p-1` slot the other rows' leading button uses, so every row's glyph and text line up on one column.

## Verification

Rendered against the repo's real design tokens (`packages/ui/src/styles/globals.css` compiled with Tailwind 4.3.3) and checked with a real pointer hover in light and dark themes: hovering the goal text, the row, or the close button now produces exactly one highlight surface, and the close button keeps its own small chip consistent with the other rows.

No behaviour change — click handlers, `aria-label`s, and roles are untouched, so the existing goal-row tests continue to assert the same contract.