### PR TITLE
test(connectors): cover canonical custom connector grant regressions

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/index.test.ts
@@ -4,10 +4,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CustomConnectorMcpResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 
 import { server } from "../../../../../mocks/server";
-import { customConnector } from "../../../__tests__/helpers/custom-connectors";
+import {
+  customConnector,
+  stubAgentCustomConnectors,
+  stubCustomConnectors,
+} from "../../../__tests__/helpers/custom-connectors";
 import { customConnectorCommand } from "../index";
 
 const CONNECTOR_ID = "33333333-3333-4333-8333-333333333333";
+const AGENT_ID = "44444444-4444-4444-8444-444444444444";
 
 describe("zero connector custom readers", () => {
   const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -39,6 +44,46 @@ describe("zero connector custom readers", () => {
     expect(output).toContain("KIND");
     expect(output).toContain("Acme Search");
     expect(output).toContain("http");
+  });
+
+  it("renders grant-based authorization for an agent", async () => {
+    const connector = customConnector();
+    server.use(
+      stubCustomConnectors([connector]),
+      http.get(`http://localhost:3000/api/zero/agents/${AGENT_ID}`, () => {
+        return HttpResponse.json({
+          agentId: AGENT_ID,
+          ownerId: "owner-1",
+          description: null,
+          displayName: "Maya",
+          sound: null,
+          avatarUrl: null,
+        });
+      }),
+      stubAgentCustomConnectors([
+        {
+          customConnectorId: connector.id,
+          permissionNames: ["chat:write"],
+        },
+      ]),
+    );
+
+    await customConnectorCommand.parseAsync([
+      "node",
+      "zero",
+      "list",
+      "--agent",
+      AGENT_ID,
+    ]);
+
+    const output = consoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("AUTHORIZED FOR Maya");
+    const connectorRow = (consoleLog.mock.calls.flat() as string[]).find(
+      (line) => {
+        return line.startsWith(connector.id);
+      },
+    );
+    expect(connectorRow).toMatch(/✓$/u);
   });
 
   it("keeps HTTP routing details in status for an older kind-less response", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3139,6 +3139,64 @@ describe("chat event action cards", () => {
     expect(within(card).queryByText("Authorized")).not.toBeInTheDocument();
   });
 
+  it("keeps a connected permissioned custom connector unauthorized without a selection", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e4000000-0000-4000-a000-000000000318";
+    const callbackPrompt = "Continue after authorizing Acme Internal API";
+    const connector = customConnector({
+      connected: true,
+      hasSecret: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      permissionBundleRef: "builtin:feishu@1",
+    });
+    const connectUrl = `${window.location.origin}/connectors/${connector.slug}/connect?agentId=${AGENT_ID}&threadId=${threadId}&callbackPrompt=${encodeURIComponent(callbackPrompt)}`;
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledIds: [], grants: [] });
+    });
+    context.mocks.api(zeroAgentCustomConnectorsContract.update, () => {
+      throw new Error(
+        "A permissioned custom connector requires an explicit selection",
+      );
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Connected permissioned custom connector card",
+      chatEvents: [
+        {
+          id: "msg-user-connected-permissioned-custom-connector",
+          role: "user",
+          content: "Authorize the connected permissioned custom connector",
+          runId: "run-connected-permissioned-custom-connector",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-assistant-connected-permissioned-custom-connector-card",
+          role: "assistant",
+          content: connectUrl,
+          runId: "run-connected-permissioned-custom-connector",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+      onSendRequest: () => {
+        throw new Error("The chat must not resume without authorization");
+      },
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const card = await screen.findByTestId("connector-action-card");
+    await user.click(await waitForButtonByText("Authorize", card));
+
+    await waitFor(() => {
+      expect(within(card).getByText("Authorize")).toBeInTheDocument();
+      expect(within(card).queryByText("Authorized")).not.toBeInTheDocument();
+    });
+  });
+
   it("leaves legacy custom connector proposal links as markdown", async () => {
     const proposalUrl = `${window.location.origin}/connectors/custom/proposal?p=legacy`;
     mockChatLifecycle(context, {


### PR DESCRIPTION
## Summary

- cover `zero connector custom list --agent` reading canonical Custom connector grants through the CLI entry point
- cover an already connected permissioned Custom connector action remaining unauthorized until permissions are selected
- assert the guarded action neither writes an empty grant nor resumes the chat callback

## Scope

- tests only; no production behavior, API contract, database, runner, or deployment changes
- follow-up regression coverage for #26250
- relates to #26211

## Validation

- `pnpm exec prettier --write apps/cli/src/commands/zero/connector/custom/__tests__/index.test.ts apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx`
- `pnpm -F @vm0/zero-cli exec vitest run src/commands/zero/connector/custom/__tests__/index.test.ts --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx --silent=passed-only`
- `pnpm turbo run lint check-types --filter=@vm0/app --filter=@vm0/zero-cli`
- `pnpm knip`
