### PR TITLE
fix(runner): bound workspace copy subprocess cleanup

### DIFF
--- a/crates/runner/src/bounded_command.rs
+++ b/crates/runner/src/bounded_command.rs
@@ -1,0 +1,399 @@
+use std::io;
+use std::process::{ExitStatus, Output, Stdio};
+use std::time::Duration;
+
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
+const COMMAND_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug)]
+pub(crate) enum BoundedCommandOutcome<T> {
+    Exited(T),
+    TimedOut,
+}
+
+#[derive(Debug)]
+pub(crate) enum BoundedCommandError {
+    Spawn(io::Error),
+    Wait(io::Error),
+    Lifecycle(String),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum CommandOutputCapture {
+    Stderr,
+    StdoutAndStderr,
+}
+
+pub(crate) async fn run_bounded(
+    mut command: Command,
+    program: &str,
+    timeout: Duration,
+) -> Result<BoundedCommandOutcome<ExitStatus>, BoundedCommandError> {
+    command.kill_on_drop(true);
+    let mut child = command.spawn().map_err(BoundedCommandError::Spawn)?;
+
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => Ok(BoundedCommandOutcome::Exited(status)),
+        Ok(Err(error)) => {
+            kill_and_reap_child(program, &mut child)
+                .await
+                .map_err(BoundedCommandError::Lifecycle)?;
+            Err(BoundedCommandError::Wait(error))
+        }
+        Err(_) => {
+            kill_and_reap_child(program, &mut child)
+                .await
+                .map_err(BoundedCommandError::Lifecycle)?;
+            Ok(BoundedCommandOutcome::TimedOut)
+        }
+    }
+}
+
+pub(crate) async fn run_output_bounded(
+    mut command: Command,
+    program: &str,
+    capture: CommandOutputCapture,
+    timeout: Duration,
+) -> Result<BoundedCommandOutcome<Output>, BoundedCommandError> {
+    match capture {
+        CommandOutputCapture::Stderr => {
+            command.stdout(Stdio::null()).stderr(Stdio::piped());
+        }
+        CommandOutputCapture::StdoutAndStderr => {
+            command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        }
+    }
+    command.kill_on_drop(true);
+
+    let mut child = command.spawn().map_err(BoundedCommandError::Spawn)?;
+    let mut output_tasks = match ChildOutputTasks::from_child(&mut child, capture) {
+        Ok(output_tasks) => output_tasks,
+        Err(stream) => {
+            return match kill_and_reap_child(program, &mut child).await {
+                Ok(()) => Err(BoundedCommandError::Lifecycle(format!(
+                    "{program} {stream} pipe unavailable"
+                ))),
+                Err(cleanup_error) => Err(BoundedCommandError::Lifecycle(format!(
+                    "{program} {stream} pipe unavailable and failed to stop child: {cleanup_error}"
+                ))),
+            };
+        }
+    };
+
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(error)) => {
+            let cleanup_result = kill_and_reap_child(program, &mut child).await;
+            output_tasks.abort();
+            cleanup_result.map_err(BoundedCommandError::Lifecycle)?;
+            return Err(BoundedCommandError::Wait(error));
+        }
+        Err(_) => {
+            let cleanup_result = kill_and_reap_child(program, &mut child).await;
+            output_tasks.abort();
+            cleanup_result.map_err(BoundedCommandError::Lifecycle)?;
+            return Ok(BoundedCommandOutcome::TimedOut);
+        }
+    };
+
+    let (stdout, stderr) = output_tasks.collect(program).await?;
+    Ok(BoundedCommandOutcome::Exited(Output {
+        status,
+        stdout,
+        stderr,
+    }))
+}
+
+enum ChildOutputTasks {
+    Stderr(JoinHandle<io::Result<Vec<u8>>>),
+    StdoutAndStderr {
+        stdout: JoinHandle<io::Result<Vec<u8>>>,
+        stderr: JoinHandle<io::Result<Vec<u8>>>,
+    },
+}
+
+impl ChildOutputTasks {
+    fn from_child(
+        child: &mut tokio::process::Child,
+        capture: CommandOutputCapture,
+    ) -> Result<Self, &'static str> {
+        match capture {
+            CommandOutputCapture::Stderr => {
+                let stderr = child.stderr.take().ok_or("stderr")?;
+                Ok(Self::Stderr(tokio::spawn(read_child_output(stderr))))
+            }
+            CommandOutputCapture::StdoutAndStderr => {
+                let stdout = child.stdout.take().ok_or("stdout")?;
+                let stderr = child.stderr.take().ok_or("stderr")?;
+                Ok(Self::StdoutAndStderr {
+                    stdout: tokio::spawn(read_child_output(stdout)),
+                    stderr: tokio::spawn(read_child_output(stderr)),
+                })
+            }
+        }
+    }
+
+    async fn collect(&mut self, program: &str) -> Result<(Vec<u8>, Vec<u8>), BoundedCommandError> {
+        let deadline = Instant::now() + COMMAND_CLEANUP_TIMEOUT;
+        match self {
+            Self::Stderr(stderr_task) => {
+                let result = tokio::time::timeout_at(
+                    deadline,
+                    wait_child_output_task(program, "stderr", stderr_task),
+                )
+                .await;
+                match result {
+                    Ok(stderr) => Ok((Vec::new(), stderr?)),
+                    Err(_) => {
+                        stderr_task.abort();
+                        Err(output_task_timeout(program, "stderr"))
+                    }
+                }
+            }
+            Self::StdoutAndStderr {
+                stdout: stdout_task,
+                stderr: stderr_task,
+            } => {
+                let result = tokio::time::timeout_at(deadline, async {
+                    tokio::try_join!(
+                        wait_child_output_task(program, "stdout", stdout_task),
+                        wait_child_output_task(program, "stderr", stderr_task),
+                    )
+                })
+                .await;
+                match result {
+                    Ok(Ok(output)) => Ok(output),
+                    Ok(Err(error)) => {
+                        stdout_task.abort();
+                        stderr_task.abort();
+                        Err(error)
+                    }
+                    Err(_) => {
+                        let stream = if stdout_task.is_finished() {
+                            "stderr"
+                        } else {
+                            "stdout"
+                        };
+                        stdout_task.abort();
+                        stderr_task.abort();
+                        Err(output_task_timeout(program, stream))
+                    }
+                }
+            }
+        }
+    }
+
+    fn abort(&self) {
+        match self {
+            Self::Stderr(stderr) => stderr.abort(),
+            Self::StdoutAndStderr { stdout, stderr } => {
+                stdout.abort();
+                stderr.abort();
+            }
+        }
+    }
+}
+
+async fn read_child_output<R>(mut reader: R) -> io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+async fn wait_child_output_task(
+    program: &str,
+    stream: &str,
+    task: &mut JoinHandle<io::Result<Vec<u8>>>,
+) -> Result<Vec<u8>, BoundedCommandError> {
+    child_output_task_result(program, stream, task.await)
+}
+
+fn child_output_task_result(
+    program: &str,
+    stream: &str,
+    result: Result<io::Result<Vec<u8>>, tokio::task::JoinError>,
+) -> Result<Vec<u8>, BoundedCommandError> {
+    match result {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(error)) => Err(BoundedCommandError::Lifecycle(format!(
+            "read {program} {stream}: {error}"
+        ))),
+        Err(error) => Err(BoundedCommandError::Lifecycle(format!(
+            "{program} {stream} task failed: {error}"
+        ))),
+    }
+}
+
+fn output_task_timeout(program: &str, stream: &str) -> BoundedCommandError {
+    BoundedCommandError::Lifecycle(format!(
+        "{program} {stream} task did not finish within {}ms after child exit",
+        COMMAND_CLEANUP_TIMEOUT.as_millis()
+    ))
+}
+
+async fn kill_and_reap_child(
+    program: &str,
+    child: &mut tokio::process::Child,
+) -> Result<(), String> {
+    let kill_error = child.start_kill().err();
+    let deadline = Instant::now() + COMMAND_CLEANUP_TIMEOUT;
+    match tokio::time::timeout_at(deadline, child.wait()).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(error)) => Err(format!("wait killed {program}: {error}")),
+        Err(_) => {
+            let kill_detail = kill_error
+                .map(|error| format!("; kill failed first: {error}"))
+                .unwrap_or_default();
+            Err(format!(
+                "killed {program} did not exit within {}ms{kill_detail}",
+                COMMAND_CLEANUP_TIMEOUT.as_millis()
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    use crate::process::read_process_stat;
+
+    #[tokio::test]
+    async fn status_command_times_out_after_reaping_child() {
+        let mut command = Command::new("sleep");
+        command.arg("60");
+
+        let outcome = run_bounded(command, "sleep", Duration::from_millis(1))
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, BoundedCommandOutcome::TimedOut));
+    }
+
+    #[tokio::test]
+    async fn output_command_times_out_after_reaping_child() {
+        let mut command = Command::new("sleep");
+        command.arg("60");
+
+        let outcome = run_output_bounded(
+            command,
+            "sleep",
+            CommandOutputCapture::StdoutAndStderr,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(outcome, BoundedCommandOutcome::TimedOut));
+    }
+
+    #[tokio::test]
+    async fn output_command_captures_requested_streams() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "printf stdout; printf stderr >&2"]);
+
+        let outcome = run_output_bounded(
+            command,
+            "sh",
+            CommandOutputCapture::StdoutAndStderr,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let BoundedCommandOutcome::Exited(output) = outcome else {
+            panic!("command unexpectedly timed out");
+        };
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"stdout");
+        assert_eq!(output.stderr, b"stderr");
+
+        let mut command = Command::new("sh");
+        command.args(["-c", "printf stdout; printf stderr >&2"]);
+        let outcome = run_output_bounded(
+            command,
+            "sh",
+            CommandOutputCapture::Stderr,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let BoundedCommandOutcome::Exited(output) = outcome else {
+            panic!("command unexpectedly timed out");
+        };
+
+        assert!(output.status.success());
+        assert!(output.stdout.is_empty());
+        assert_eq!(output.stderr, b"stderr");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn kill_and_reap_child_reaps_running_child() {
+        let mut child = Command::new("sleep")
+            .arg("60")
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap();
+        let starttime = read_process_stat(pid)
+            .await
+            .unwrap_or_else(|| panic!("read initial process stat for pid {pid}"))
+            .starttime;
+
+        kill_and_reap_child("sleep", &mut child).await.unwrap();
+
+        let observed = read_process_stat(pid).await;
+        assert!(
+            !matches!(&observed, Some(stat) if stat.starttime == starttime),
+            "killed child pid {pid} was not reaped: {observed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn output_tasks_share_one_cleanup_deadline() {
+        let stdout = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(1_500)).await;
+            Ok(Vec::new())
+        });
+        let stderr = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(Vec::new())
+        });
+        let mut tasks = ChildOutputTasks::StdoutAndStderr { stdout, stderr };
+        let started_at = Instant::now();
+
+        let error = tasks.collect("test-command").await.unwrap_err();
+
+        assert_eq!(Instant::now() - started_at, COMMAND_CLEANUP_TIMEOUT);
+        assert!(
+            matches!(error, BoundedCommandError::Lifecycle(message) if message.contains("stderr task did not finish"))
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn output_task_failure_is_not_masked_by_open_sibling() {
+        let stdout = tokio::spawn(async { Err(io::Error::other("read failed")) });
+        let stderr = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(Vec::new())
+        });
+        let mut tasks = ChildOutputTasks::StdoutAndStderr { stdout, stderr };
+        let started_at = Instant::now();
+
+        let error = tasks.collect("test-command").await.unwrap_err();
+
+        assert_eq!(Instant::now() - started_at, Duration::ZERO);
+        assert!(
+            matches!(error, BoundedCommandError::Lifecycle(message) if message.contains("read test-command stdout: read failed"))
+        );
+    }
+}

--- a/crates/runner/src/cmd/service/signal.rs
+++ b/crates/runner/src/cmd/service/signal.rs
@@ -7,7 +7,7 @@ use crate::error::{RunnerError, RunnerResult};
 
 use super::diagnostic::status_field_preview;
 use super::systemctl::{
-    has_service_main_process, has_service_main_process_bounded, run_command_output_bounded,
+    has_service_main_process, has_service_main_process_bounded, run_systemctl_output_bounded,
 };
 use super::target::RunnerServiceUnit;
 
@@ -70,8 +70,7 @@ pub(super) async fn signal_service_main_bounded(
 ) -> RunnerResult<ServiceSignalOutcome> {
     let deadline = Instant::now() + duration;
     let signal_arg = format!("--signal={}", signal.as_str());
-    let output = run_command_output_bounded(
-        "systemctl",
+    let output = run_systemctl_output_bounded(
         &[
             "kill",
             "--kill-whom=main",

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -1,17 +1,18 @@
 use std::collections::BTreeMap;
-use std::process::{ExitStatus, Output, Stdio};
+use std::process::{ExitStatus, Output};
 use std::time::Duration;
 
+use crate::bounded_command::{
+    BoundedCommandError, BoundedCommandOutcome, CommandOutputCapture, run_bounded,
+    run_output_bounded,
+};
 use crate::error::{RunnerError, RunnerResult};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
-use tokio::io::AsyncReadExt;
-use tokio::task::JoinHandle;
 
 use super::diagnostic::status_field_preview;
 use super::target::RunnerServiceUnit;
 
-const BOUNDED_COMMAND_KILL_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 const SYSTEMCTL_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(super) fn journalctl_logs_status(svc: &str, status: ExitStatus) -> RunnerResult<()> {
@@ -66,172 +67,52 @@ pub(super) async fn run_systemctl_bounded(
     args: &[&str],
     duration: Duration,
 ) -> RunnerResult<BoundedSystemctlOutcome> {
-    run_command_bounded("systemctl", args, duration).await
-}
-
-async fn run_command_bounded(
-    program: &str,
-    args: &[&str],
-    duration: Duration,
-) -> RunnerResult<BoundedSystemctlOutcome> {
-    let mut child = tokio::process::Command::new(program)
-        .args(args)
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| RunnerError::Internal(format!("spawn {program}: {e}")))?;
-
-    match tokio::time::timeout(duration, child.wait()).await {
-        Ok(Ok(status)) if status.success() => Ok(BoundedSystemctlOutcome::Success),
-        Ok(Ok(status)) => Ok(BoundedSystemctlOutcome::Failed(status)),
-        Ok(Err(e)) => Err(RunnerError::Internal(format!("wait {program}: {e}"))),
-        Err(_) => {
-            kill_and_reap_child(program, &mut child).await?;
-            Ok(BoundedSystemctlOutcome::TimedOut)
+    let mut command = tokio::process::Command::new("systemctl");
+    command.args(args);
+    match run_bounded(command, "systemctl", duration)
+        .await
+        .map_err(|error| bounded_command_error("systemctl", error))?
+    {
+        BoundedCommandOutcome::Exited(status) if status.success() => {
+            Ok(BoundedSystemctlOutcome::Success)
         }
+        BoundedCommandOutcome::Exited(status) => Ok(BoundedSystemctlOutcome::Failed(status)),
+        BoundedCommandOutcome::TimedOut => Ok(BoundedSystemctlOutcome::TimedOut),
     }
 }
 
-pub(super) async fn run_command_output_bounded(
-    program: &str,
+pub(super) async fn run_systemctl_output_bounded(
     args: &[&str],
     duration: Duration,
 ) -> RunnerResult<Output> {
-    let mut child = tokio::process::Command::new(program)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| RunnerError::Internal(format!("spawn {program}: {e}")))?;
-
-    let Some(stdout) = child.stdout.take() else {
-        if let Err(e) = kill_and_reap_child(program, &mut child).await {
-            return Err(RunnerError::Internal(format!(
-                "{program} stdout pipe unavailable and failed to stop child: {e}"
-            )));
-        }
-        return Err(RunnerError::Internal(format!(
-            "{program} stdout pipe unavailable"
-        )));
-    };
-    let Some(stderr) = child.stderr.take() else {
-        if let Err(e) = kill_and_reap_child(program, &mut child).await {
-            return Err(RunnerError::Internal(format!(
-                "{program} stderr pipe unavailable and failed to stop child: {e}"
-            )));
-        }
-        return Err(RunnerError::Internal(format!(
-            "{program} stderr pipe unavailable"
-        )));
-    };
-    let stdout_task = tokio::spawn(read_child_output(stdout));
-    let stderr_task = tokio::spawn(read_child_output(stderr));
-
-    let status = match tokio::time::timeout(duration, child.wait()).await {
-        Ok(Ok(status)) => status,
-        Ok(Err(e)) => {
-            if let Err(kill_error) = kill_and_reap_child(program, &mut child).await {
-                abort_child_output_tasks(stdout_task, stderr_task).await;
-                return Err(kill_error);
-            }
-            abort_child_output_tasks(stdout_task, stderr_task).await;
-            return Err(RunnerError::Internal(format!("wait {program}: {e}")));
-        }
-        Err(_) => {
-            if let Err(e) = kill_and_reap_child(program, &mut child).await {
-                abort_child_output_tasks(stdout_task, stderr_task).await;
-                return Err(e);
-            }
-            abort_child_output_tasks(stdout_task, stderr_task).await;
-            return Err(RunnerError::Internal(format!(
-                "{program} timed out after {}ms",
-                duration.as_millis()
-            )));
-        }
-    };
-    let (stdout, stderr) = collect_child_output_tasks(program, stdout_task, stderr_task).await?;
-
-    Ok(Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
-
-async fn read_child_output<R>(mut reader: R) -> std::io::Result<Vec<u8>>
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
-    let mut output = Vec::new();
-    reader.read_to_end(&mut output).await?;
-    Ok(output)
-}
-
-async fn collect_child_output_tasks(
-    program: &str,
-    mut stdout_task: JoinHandle<std::io::Result<Vec<u8>>>,
-    mut stderr_task: JoinHandle<std::io::Result<Vec<u8>>>,
-) -> RunnerResult<(Vec<u8>, Vec<u8>)> {
-    let stdout = match wait_child_output_task(program, "stdout", &mut stdout_task).await {
-        Ok(output) => output,
-        Err(e) => {
-            stderr_task.abort();
-            let _ = stderr_task.await;
-            return Err(e);
-        }
-    };
-    let stderr = wait_child_output_task(program, "stderr", &mut stderr_task).await?;
-    Ok((stdout, stderr))
-}
-
-async fn wait_child_output_task(
-    program: &str,
-    stream: &str,
-    task: &mut JoinHandle<std::io::Result<Vec<u8>>>,
-) -> RunnerResult<Vec<u8>> {
-    match tokio::time::timeout(BOUNDED_COMMAND_KILL_WAIT_TIMEOUT, &mut *task).await {
-        Ok(Ok(Ok(output))) => Ok(output),
-        Ok(Ok(Err(e))) => Err(RunnerError::Internal(format!(
-            "read {program} {stream}: {e}"
+    let mut command = tokio::process::Command::new("systemctl");
+    command.args(args);
+    match run_output_bounded(
+        command,
+        "systemctl",
+        CommandOutputCapture::StdoutAndStderr,
+        duration,
+    )
+    .await
+    .map_err(|error| bounded_command_error("systemctl", error))?
+    {
+        BoundedCommandOutcome::Exited(output) => Ok(output),
+        BoundedCommandOutcome::TimedOut => Err(RunnerError::Internal(format!(
+            "systemctl timed out after {}ms",
+            duration.as_millis()
         ))),
-        Ok(Err(e)) => Err(RunnerError::Internal(format!(
-            "{program} {stream} task failed: {e}"
-        ))),
-        Err(_) => {
-            task.abort();
-            let _ = task.await;
-            Err(RunnerError::Internal(format!(
-                "{program} {stream} task did not finish within {}ms after child exit",
-                BOUNDED_COMMAND_KILL_WAIT_TIMEOUT.as_millis()
-            )))
-        }
     }
 }
 
-async fn abort_child_output_tasks(
-    stdout_task: JoinHandle<std::io::Result<Vec<u8>>>,
-    stderr_task: JoinHandle<std::io::Result<Vec<u8>>>,
-) {
-    stdout_task.abort();
-    stderr_task.abort();
-    let _ = stdout_task.await;
-    let _ = stderr_task.await;
-}
-
-async fn kill_and_reap_child(program: &str, child: &mut tokio::process::Child) -> RunnerResult<()> {
-    let kill_error = child.start_kill().err();
-    match tokio::time::timeout(BOUNDED_COMMAND_KILL_WAIT_TIMEOUT, child.wait()).await {
-        Ok(Ok(_)) => Ok(()),
-        Ok(Err(e)) => Err(RunnerError::Internal(format!("wait killed {program}: {e}"))),
-        Err(_) => {
-            let kill_detail = kill_error
-                .map(|e| format!("; kill failed first: {e}"))
-                .unwrap_or_default();
-            Err(RunnerError::Internal(format!(
-                "killed {program} did not exit within {}ms{kill_detail}",
-                BOUNDED_COMMAND_KILL_WAIT_TIMEOUT.as_millis()
-            )))
+fn bounded_command_error(program: &str, error: BoundedCommandError) -> RunnerError {
+    match error {
+        BoundedCommandError::Spawn(error) => {
+            RunnerError::Internal(format!("spawn {program}: {error}"))
         }
+        BoundedCommandError::Wait(error) => {
+            RunnerError::Internal(format!("wait {program}: {error}"))
+        }
+        BoundedCommandError::Lifecycle(message) => RunnerError::Internal(message),
     }
 }
 
@@ -473,12 +354,9 @@ fn service_unit_state_from_output(
 /// Read the fragment and drop-ins selected by the running systemd manager.
 pub(super) async fn cat_unit_content(unit: &RunnerServiceUnit) -> RunnerResult<String> {
     let svc = unit.service_name();
-    let output = run_command_output_bounded(
-        "systemctl",
-        &["--no-pager", "cat", "--", svc],
-        SYSTEMCTL_QUERY_TIMEOUT,
-    )
-    .await?;
+    let output =
+        run_systemctl_output_bounded(&["--no-pager", "cat", "--", svc], SYSTEMCTL_QUERY_TIMEOUT)
+            .await?;
     unit_content_from_systemctl_cat(svc, &output)
 }
 
@@ -600,7 +478,7 @@ async fn read_unit_enablement_bounded(
     duration: Duration,
 ) -> RunnerResult<SystemdUnitEnablement> {
     let svc = unit.service_name();
-    let output = run_command_output_bounded("systemctl", &["is-enabled", svc], duration).await?;
+    let output = run_systemctl_output_bounded(&["is-enabled", svc], duration).await?;
     unit_enablement_from_systemctl_is_enabled(svc, &output.status, &output.stdout, &output.stderr)
 }
 
@@ -674,7 +552,7 @@ async fn run_systemctl_show_bounded(
         args.push(format!("--property={property}"));
     }
     let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-    run_command_output_bounded("systemctl", &arg_refs, duration).await
+    run_systemctl_output_bounded(&arg_refs, duration).await
 }
 
 fn parse_systemctl_show_output(
@@ -1077,9 +955,6 @@ fn systemctl_show_status_error(
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(target_os = "linux")]
-    use crate::process::read_process_stat;
-
     fn systemctl_show_output(status: ExitStatus, stdout: &[u8], stderr: &[u8]) -> Output {
         Output {
             status,
@@ -1116,24 +991,6 @@ mod tests {
         let status = ExitStatus::from_raw(libc::SIGPIPE);
 
         assert!(journalctl_logs_status("vm0-runner-test.service", status).is_ok());
-    }
-
-    #[tokio::test]
-    async fn run_command_bounded_times_out() {
-        let outcome = run_command_bounded("sleep", &["60"], Duration::from_millis(1))
-            .await
-            .unwrap();
-
-        assert!(matches!(outcome, BoundedSystemctlOutcome::TimedOut));
-    }
-
-    #[tokio::test]
-    async fn run_command_output_bounded_times_out() {
-        let err = run_command_output_bounded("sleep", &["60"], Duration::from_millis(1))
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("timed out"));
     }
 
     #[test]
@@ -1196,44 +1053,6 @@ mod tests {
 
         assert!(message.contains("non-UTF-8 output"));
         assert!(!message.contains("secret"));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn kill_and_reap_child_reaps_running_child() {
-        let mut child = tokio::process::Command::new("sleep")
-            .arg("60")
-            .kill_on_drop(true)
-            .spawn()
-            .unwrap();
-        let pid = child.id().unwrap();
-        let starttime = read_process_stat(pid)
-            .await
-            .unwrap_or_else(|| panic!("read initial process stat for pid {pid}"))
-            .starttime;
-
-        kill_and_reap_child("sleep", &mut child).await.unwrap();
-
-        let observed = read_process_stat(pid).await;
-        assert!(
-            !matches!(&observed, Some(stat) if stat.starttime == starttime),
-            "killed child pid {pid} was not reaped: {observed:?}"
-        );
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn collect_child_output_tasks_times_out_when_reader_stays_open() {
-        let stdout_task = tokio::spawn(async {
-            tokio::time::sleep(Duration::from_secs(60)).await;
-            Ok(Vec::new())
-        });
-        let stderr_task = tokio::spawn(async { Ok(Vec::new()) });
-
-        let err = collect_child_output_tasks("systemctl", stdout_task, stderr_task)
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("stdout task did not finish"));
     }
 
     #[test]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,6 +1,7 @@
 // Trigger another runner release on 2026-07-31.
 mod active_input;
 mod axiom_layer;
+mod bounded_command;
 mod ca;
 mod child_cleanup;
 mod cmd;

--- a/crates/runner/src/workspace_image_cache/fs.rs
+++ b/crates/runner/src/workspace_image_cache/fs.rs
@@ -1,15 +1,16 @@
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::time::Duration;
 
 #[cfg(not(test))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
 use tokio::fs;
-use tokio::io::AsyncReadExt;
 
 use chrono::SecondsFormat;
 
+use crate::bounded_command::{
+    BoundedCommandError, BoundedCommandOutcome, CommandOutputCapture, run_output_bounded,
+};
 use crate::error::{RunnerError, RunnerResult};
 
 use super::WorkspaceImageCache;
@@ -158,32 +159,13 @@ pub(super) async fn sparse_copy_with_timeout(
         .arg("--no-dereference")
         .arg("--")
         .arg(src)
-        .arg(dst)
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    let mut child = command
-        .spawn()
-        .map_err(|e| RunnerError::Internal(format!("exec cp: {e}")))?;
-    let Some(stderr) = child.stderr.take() else {
-        let _ = child.start_kill();
-        let _ = child.wait().await;
-        return Err(RunnerError::Internal("cp stderr pipe unavailable".into()));
-    };
-    let stderr_task = tokio::spawn(read_child_output(stderr));
-
-    let status = match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(Ok(status)) => status,
-        Ok(Err(e)) => {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            let _ = stderr_task.await;
-            return Err(RunnerError::Internal(format!("wait cp: {e}")));
-        }
-        Err(_) => {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            let _ = stderr_task.await;
+        .arg(dst);
+    let output = match run_output_bounded(command, "cp", CommandOutputCapture::Stderr, timeout)
+        .await
+        .map_err(cp_command_error)?
+    {
+        BoundedCommandOutcome::Exited(output) => output,
+        BoundedCommandOutcome::TimedOut => {
             return Err(RunnerError::Internal(format!(
                 "cp --sparse=always --no-dereference {} {} timed out after {}ms",
                 src.display(),
@@ -192,14 +174,10 @@ pub(super) async fn sparse_copy_with_timeout(
             )));
         }
     };
-    let stderr = stderr_task
-        .await
-        .map_err(|e| RunnerError::Internal(format!("cp stderr task failed: {e}")))?
-        .map_err(|e| RunnerError::Internal(format!("read cp stderr: {e}")))?;
-    if status.success() {
+    if output.status.success() {
         return Ok(());
     }
-    let stderr = String::from_utf8_lossy(&stderr);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     Err(RunnerError::Internal(format!(
         "cp --sparse=always --no-dereference {} {} failed: {}",
         src.display(),
@@ -208,13 +186,12 @@ pub(super) async fn sparse_copy_with_timeout(
     )))
 }
 
-pub(super) async fn read_child_output<R>(mut output: R) -> std::io::Result<Vec<u8>>
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
-    let mut bytes = Vec::new();
-    output.read_to_end(&mut bytes).await?;
-    Ok(bytes)
+fn cp_command_error(error: BoundedCommandError) -> RunnerError {
+    match error {
+        BoundedCommandError::Spawn(error) => RunnerError::Internal(format!("exec cp: {error}")),
+        BoundedCommandError::Wait(error) => RunnerError::Internal(format!("wait cp: {error}")),
+        BoundedCommandError::Lifecycle(message) => RunnerError::Internal(message),
+    }
 }
 
 #[cfg(not(test))]

--- a/crates/runner/src/workspace_image_cache/tests/storage.rs
+++ b/crates/runner/src/workspace_image_cache/tests/storage.rs
@@ -154,6 +154,49 @@ async fn sparse_copy_times_out_when_copy_blocks() {
     let err = sparse_copy_with_timeout(&source, &destination, std::time::Duration::ZERO)
         .await
         .unwrap_err();
+    let message = err.to_string();
 
-    assert!(err.to_string().contains("timed out after"));
+    assert!(message.contains("timed out after"));
+    assert!(message.contains(&source.display().to_string()));
+    assert!(message.contains(&destination.display().to_string()));
+}
+
+#[tokio::test]
+async fn sparse_copy_reports_failed_command_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("missing.ext4");
+    let destination = dir.path().join("out.ext4");
+
+    let err = sparse_copy_with_timeout(&source, &destination, std::time::Duration::from_secs(1))
+        .await
+        .unwrap_err();
+    let message = err.to_string();
+    let (_, stderr) = message.split_once(" failed: ").unwrap();
+
+    assert!(message.contains("cp --sparse=always --no-dereference"));
+    assert!(message.contains(&source.display().to_string()));
+    assert!(message.contains(&destination.display().to_string()));
+    assert!(!stderr.trim().is_empty());
+}
+
+#[tokio::test]
+async fn sparse_copy_preserves_non_utf8_paths() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir
+        .path()
+        .join(OsString::from_vec(b"source-\xff.ext4".to_vec()));
+    let destination = dir
+        .path()
+        .join(OsString::from_vec(b"destination-\xff.ext4".to_vec()));
+    let content = b"workspace image";
+    tokio::fs::write(&source, content).await.unwrap();
+
+    sparse_copy_with_timeout(&source, &destination, std::time::Duration::from_secs(1))
+        .await
+        .unwrap();
+
+    assert_eq!(tokio::fs::read(destination).await.unwrap(), content);
 }


### PR DESCRIPTION
## Summary

- add a neutral runner boundary for bounded one-shot host commands using prepared `tokio::process::Command` values
- enforce one execution timeout plus a fixed, aggregate cleanup grace for explicit child reaping and output-reader completion
- migrate bounded systemctl execution and sparse workspace-image copy to the shared lifecycle while preserving domain diagnostics and native paths
- cover real child reaping, stuck and failed readers, stream capture modes, workspace timeout/failure mapping, and non-UTF-8 copy paths

## Scope

- runner-internal process lifecycle only
- no API, protocol, queue payload, schema, migration, persisted-data, configuration, feature-switch, dependency, or deployment-order change
- long-lived managed processes and synchronous drop cleanup remain separate lifecycle owners

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner bounded_command -- --nocapture` (6 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner sparse_copy -- --nocapture` (4 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner systemctl -- --nocapture` (56 passed, 2 existing ignored child fixtures)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3,105 passed, 20 existing ignored; guest inventory passed)
- pre-commit: cargo fmt, Clippy, rustdoc, file-size, and commitlint
- `git diff --check`

Closes #26278
