### PR TITLE
refactor(connectors): remove runtime candidate compatibility readers

### DIFF
--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -46,9 +46,7 @@ use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::storage_cache::PreparedFreshStorage;
 use crate::storage_plan::build_storage_plan;
 use crate::telemetry::JobTelemetry;
-use crate::types::{
-    ConnectorRuntimeTargetRegistration, ExecutionContext, FirewallEntry, WorkspaceReuseResult,
-};
+use crate::types::{ExecutionContext, WorkspaceReuseResult};
 use crate::workspace_image_cache::{
     WorkspaceCacheCheckoutResult, WorkspaceImageLease, WorkspaceImageLeaseIdentity,
     WorkspaceImagePrepareRequest,
@@ -1528,57 +1526,6 @@ fn normalize_guest_cli_agent_session_id(
 }
 
 /// Register a VM in the proxy registry and network log manager.
-fn candidate_firewalls(
-    context: &ExecutionContext,
-    targets: &[ConnectorRuntimeTargetRegistration],
-) -> RunnerResult<Option<Vec<FirewallEntry>>> {
-    if context.connector_runtime_candidate_targets.is_none() {
-        return Ok(context.firewalls.clone());
-    }
-
-    let mut firewalls = context.firewalls.clone();
-    for target in targets {
-        let ConnectorRuntimeTargetRegistration::Builtin {
-            connector_slug,
-            base_url_vars,
-        } = target
-        else {
-            continue;
-        };
-        let existing = firewalls
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .find(|entry| match entry {
-                FirewallEntry::Builtin { name, .. } => name == connector_slug,
-                FirewallEntry::Inline { firewall, .. } => firewall.name == *connector_slug,
-            });
-        match existing {
-            Some(FirewallEntry::Builtin {
-                base_url_vars: existing_base_url_vars,
-                ..
-            }) if existing_base_url_vars == base_url_vars => {}
-            Some(FirewallEntry::Builtin { .. }) => {
-                return Err(RunnerError::Internal(format!(
-                    "builtin connector {connector_slug} has conflicting pinned routing variables"
-                )));
-            }
-            Some(FirewallEntry::Inline { .. }) => {
-                return Err(RunnerError::Internal(format!(
-                    "builtin connector {connector_slug} conflicts with an inline firewall"
-                )));
-            }
-            None => firewalls
-                .get_or_insert_with(Vec::new)
-                .push(FirewallEntry::Builtin {
-                    name: connector_slug.clone(),
-                    base_url_vars: base_url_vars.clone(),
-                }),
-        }
-    }
-    Ok(firewalls)
-}
-
 pub(super) async fn register_proxy(
     config: &ExecutorConfig,
     context: &ExecutionContext,
@@ -1588,20 +1535,15 @@ pub(super) async fn register_proxy(
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
     let cli_agent_type = normalized_cli_agent_type(&context.cli_agent_type);
-    let connector_runtime_targets = context
-        .connector_runtime_candidate_targets
-        .as_deref()
-        .unwrap_or(&context.connector_runtime_targets);
-    let firewalls = candidate_firewalls(context, connector_runtime_targets)?;
     let registration = proxy::VmRegistration {
         run_id: &run_id_str,
         cli_agent_type,
         sandbox_token: &context.sandbox_token,
         network_log_path: &network_log_path,
         proxy_log_path: &proxy_log_path,
-        firewalls: firewalls.as_deref(),
+        firewalls: context.firewalls.as_deref(),
         network_policies: context.network_policies.as_ref(),
-        connector_runtime_targets: Some(connector_runtime_targets),
+        connector_runtime_targets: Some(&context.connector_runtime_targets),
         encrypted_secrets: context.encrypted_secrets.as_deref(),
         secret_connector_map: context.secret_connector_map.as_ref(),
         secret_connector_metadata_map: context.secret_connector_metadata_map.as_ref(),
@@ -1625,7 +1567,7 @@ pub(super) async fn register_proxy(
                 run_id: context.run_id,
                 source_ip,
                 registry: config.registry.clone(),
-                targets: connector_runtime_targets,
+                targets: &context.connector_runtime_targets,
                 refreshes: context.network_policy_refreshes.as_ref(),
             })
             .await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -44,8 +44,7 @@ use crate::ids::RunId;
 use crate::paths::{RunnerPaths, scoped_workspace_image_cache_key};
 use crate::storage_manifest::StorageManifest;
 use crate::types::{
-    ConnectorRuntimeTargetRegistration, Firewall, FirewallApi, FirewallAuth, FirewallEntry,
-    ResumeSession, SandboxReuseResult,
+    ConnectorRuntimeTargetRegistration, FirewallEntry, ResumeSession, SandboxReuseResult,
 };
 use crate::workspace_image_cache::{
     WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageCache,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -90,66 +90,7 @@ fn proxy_register_failure_warns_with_error() {
 }
 
 #[tokio::test]
-async fn proxy_registration_accepts_rollout_candidates_and_canonical_targets() {
-    let candidate_dir = tempfile::tempdir().unwrap();
-    let candidate_config = test_executor_config(candidate_dir.path()).await;
-    let mut candidate_context = minimal_context();
-    candidate_context.firewalls = Some(vec![FirewallEntry::Builtin {
-        name: "model-provider:anthropic-api-key".to_string(),
-        base_url_vars: None,
-    }]);
-    candidate_context.connector_runtime_targets = Vec::new();
-    candidate_context.connector_runtime_candidate_targets =
-        Some(vec![ConnectorRuntimeTargetRegistration::Builtin {
-            connector_slug: "zendesk".to_string(),
-            base_url_vars: Some(HashMap::from([(
-                "ZENDESK_SUBDOMAIN".to_string(),
-                "xn--mnich-kva".to_string(),
-            )])),
-        }]);
-    candidate_context.vars = Some(HashMap::from([(
-        "ZENDESK_SUBDOMAIN".to_string(),
-        "münich".to_string(),
-    )]));
-
-    let _candidate_session = register_proxy(&candidate_config, &candidate_context, "10.200.0.2")
-        .await
-        .unwrap();
-    let candidate_registry: serde_json::Value = serde_json::from_str(
-        &tokio::fs::read_to_string(candidate_dir.path().join("proxy-registry.json"))
-            .await
-            .unwrap(),
-    )
-    .unwrap();
-    let candidate_vm = &candidate_registry["vms"]["10.200.0.2"];
-    assert_eq!(
-        candidate_vm["firewalls"],
-        serde_json::json!([
-            {
-                "kind": "builtin",
-                "name": "model-provider:anthropic-api-key"
-            },
-            {
-                "kind": "builtin",
-                "name": "zendesk",
-                "baseUrlVars": {
-                    "ZENDESK_SUBDOMAIN": "xn--mnich-kva"
-                }
-            }
-        ])
-    );
-    assert_eq!(
-        candidate_vm["connectorRuntimeTargets"],
-        serde_json::json!([{
-            "kind": "builtin",
-            "connectorSlug": "zendesk"
-        }])
-    );
-    assert_eq!(
-        candidate_vm["connectorRoutingVariables"]["builtin:zendesk"],
-        serde_json::json!({"ZENDESK_SUBDOMAIN": "münich"})
-    );
-
+async fn proxy_registration_accepts_canonical_targets() {
     let canonical_dir = tempfile::tempdir().unwrap();
     let canonical_config = test_executor_config(canonical_dir.path()).await;
     let mut canonical_context = minimal_context();
@@ -164,7 +105,6 @@ async fn proxy_registration_accepts_rollout_candidates_and_canonical_targets() {
             connector_slug: "zendesk".to_string(),
             base_url_vars: Some(canonical_routing_variables),
         }];
-    canonical_context.connector_runtime_candidate_targets = None;
     canonical_context.vars = Some(HashMap::from([(
         "ZENDESK_SUBDOMAIN".to_string(),
         "münich".to_string(),
@@ -200,76 +140,6 @@ async fn proxy_registration_accepts_rollout_candidates_and_canonical_targets() {
     assert_eq!(
         canonical_vm["connectorRoutingVariables"]["builtin:zendesk"],
         serde_json::json!({"ZENDESK_SUBDOMAIN": "münich"})
-    );
-}
-
-#[tokio::test]
-async fn proxy_registration_rejects_conflicting_builtin_candidate_sources() {
-    let routing_variables =
-        HashMap::from([("ZENDESK_SUBDOMAIN".to_string(), "xn--mnich-kva".to_string())]);
-
-    let routing_dir = tempfile::tempdir().unwrap();
-    let routing_config = test_executor_config(routing_dir.path()).await;
-    let mut routing_context = minimal_context();
-    routing_context.firewalls = Some(vec![FirewallEntry::Builtin {
-        name: "zendesk".to_string(),
-        base_url_vars: None,
-    }]);
-    routing_context.connector_runtime_candidate_targets =
-        Some(vec![ConnectorRuntimeTargetRegistration::Builtin {
-            connector_slug: "zendesk".to_string(),
-            base_url_vars: Some(routing_variables),
-        }]);
-
-    let routing_error = match register_proxy(&routing_config, &routing_context, "10.200.0.4").await
-    {
-        Ok(_) => panic!("conflicting pinned routing variables must fail registration"),
-        Err(error) => error,
-    };
-    assert!(
-        routing_error
-            .to_string()
-            .contains("zendesk has conflicting pinned routing variables"),
-        "unexpected error: {routing_error}"
-    );
-
-    let ownership_dir = tempfile::tempdir().unwrap();
-    let ownership_config = test_executor_config(ownership_dir.path()).await;
-    let mut ownership_context = minimal_context();
-    ownership_context.firewalls = Some(vec![FirewallEntry::Inline {
-        firewall: Firewall {
-            name: "zendesk".to_string(),
-            apis: vec![FirewallApi {
-                id: "custom-zendesk:0".to_string(),
-                base: "https://custom.example.test/".to_string(),
-                auth: FirewallAuth {
-                    headers: HashMap::new(),
-                    base: None,
-                    query: None,
-                    aws_sigv4: None,
-                },
-                host_policy: None,
-                permissions: None,
-            }],
-        },
-        custom_connector_id: None,
-    }]);
-    ownership_context.connector_runtime_candidate_targets =
-        Some(vec![ConnectorRuntimeTargetRegistration::Builtin {
-            connector_slug: "zendesk".to_string(),
-            base_url_vars: None,
-        }]);
-
-    let ownership_error =
-        match register_proxy(&ownership_config, &ownership_context, "10.200.0.5").await {
-            Ok(_) => panic!("inline ownership conflicts must fail registration"),
-            Err(error) => error,
-        };
-    assert!(
-        ownership_error
-            .to_string()
-            .contains("zendesk conflicts with an inline firewall"),
-        "unexpected error: {ownership_error}"
     );
 }
 

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -189,7 +189,6 @@ impl JobProvider for LocalProvider {
             network_policies: None,
             network_policy_refreshes: None,
             connector_runtime_targets: Vec::new(),
-            connector_runtime_candidate_targets: None,
             disallowed_tools: None,
             tools: None,
             settings: None,

--- a/crates/runner/src/test_fixtures/execution_context.rs
+++ b/crates/runner/src/test_fixtures/execution_context.rs
@@ -26,7 +26,6 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
         network_policies: None,
         network_policy_refreshes: None,
         connector_runtime_targets: Vec::new(),
-        connector_runtime_candidate_targets: None,
         disallowed_tools: None,
         tools: None,
         settings: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -130,10 +130,6 @@ pub struct ExecutionContext {
     #[serde(default)]
     pub network_policy_refreshes: Option<std::collections::HashMap<String, NetworkPolicyRefresh>>,
     pub connector_runtime_targets: Vec<ConnectorRuntimeTargetRegistration>,
-    /// Complete target membership written by candidate-aware APIs. During
-    /// rollout, connector_runtime_targets remains the previous runner view.
-    #[serde(default)]
-    pub connector_runtime_candidate_targets: Option<Vec<ConnectorRuntimeTargetRegistration>>,
     #[serde(default)]
     pub disallowed_tools: Option<Vec<String>>,
     #[serde(default)]
@@ -1963,46 +1959,6 @@ mod tests {
         assert_eq!(snapshot.entries[0].version_id, "version-1");
         let serialized = serde_json::to_string(snapshot).unwrap();
         assert!(!serialized.contains("url"));
-    }
-
-    #[test]
-    fn execution_context_preserves_optional_connector_candidate_targets() {
-        let mut json = serde_json::json!({
-            "runId": "11111111-1111-4111-8111-111111111111",
-            "prompt": "hello",
-            "sandboxToken": "tok",
-            "cliAgentType": "claude-code",
-            "connectorRuntimeTargets": [],
-            "connectorRuntimeCandidateTargets": [{
-                "kind": "builtin",
-                "connectorSlug": "zendesk",
-                "baseUrlVars": {
-                    "ZENDESK_SUBDOMAIN": "xn--mnich-kva"
-                }
-            }]
-        });
-
-        let context: ExecutionContext = serde_json::from_value(json.clone()).unwrap();
-        let candidate = context
-            .connector_runtime_candidate_targets
-            .as_deref()
-            .and_then(|targets| targets.first())
-            .expect("candidate target should be preserved");
-        assert!(matches!(
-            candidate,
-            ConnectorRuntimeTargetRegistration::Builtin {
-                connector_slug,
-                base_url_vars: Some(base_url_vars),
-            } if connector_slug == "zendesk"
-                && base_url_vars.get("ZENDESK_SUBDOMAIN")
-                    .is_some_and(|value| value == "xn--mnich-kva")
-        ));
-
-        json.as_object_mut()
-            .unwrap()
-            .remove("connectorRuntimeCandidateTargets");
-        let legacy: ExecutionContext = serde_json::from_value(json).unwrap();
-        assert!(legacy.connector_runtime_candidate_targets.is_none());
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -287,7 +287,6 @@ export async function mutateRunnerJobConnectorPermissionBaseline(
   context: TestContext,
   runId: string,
   mode:
-    | "rollout-targets"
     | "remove"
     | "malformed"
     | "capability-mismatch"

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8210,7 +8210,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         customConnectorId: custom.id,
       }),
     );
-    expect(claim).not.toHaveProperty("connectorRuntimeCandidateTargets");
     expect(claim.networkPolicies).toHaveProperty("figma");
     expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("allow");
 
@@ -8270,7 +8269,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       kind: "builtin",
       connectorSlug: "figma",
     });
-    expect(claim).not.toHaveProperty("connectorRuntimeCandidateTargets");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     expect((await api.readRun(actor, run.runId)).status).toBe("cancelled");
@@ -10727,7 +10725,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       connectorSlug: "zendesk",
       baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
     });
-    expect(claim).not.toHaveProperty("connectorRuntimeCandidateTargets");
     expect(customApis[0]?.base).toBe("https://internal.example.com/api/");
 
     await api.requestCancelRun(actor, run.runId, [200]);
@@ -10849,7 +10846,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("handles rollout, missing, invalid, and incompatible permission baselines", async () => {
+  it("handles missing, invalid, and incompatible permission baselines", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const fw = createFirewallApi(context);
@@ -10866,10 +10863,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.heartbeatRunner(runnerGroup);
 
     const cases = [
-      {
-        mode: "rollout-targets",
-        path: "baseline",
-      },
       {
         mode: "remove",
         path: "full_missing_baseline",
@@ -10917,13 +10910,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       );
       const claim = await api.claimRunnerJob(run.runId);
 
-      const isRolloutContext = fallbackCase.mode === "rollout-targets";
-      expect(claim.connectorRuntimeTargets).toStrictEqual(
-        isRolloutContext ? [] : slackTargets,
-      );
-      expect(claim.connectorRuntimeCandidateTargets).toStrictEqual(
-        isRolloutContext ? slackTargets : undefined,
-      );
+      expect(claim.connectorRuntimeTargets).toStrictEqual(slackTargets);
       expect(claim.networkPolicies?.slack?.allow).toContain(
         "conversations:read",
       );
@@ -10933,7 +10920,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expectClaimRouteResponseTimingActions({
         runId: run.runId,
         expectedActionTypes:
-          fallbackCase.mode === "rollout-targets" ||
           fallbackCase.mode === "catalog-mismatch"
             ? [
                 "claim_route_response_network_policy_refresh",

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import { connectorSlugSchema } from "@vm0/api-contracts/contracts/connector-identity";
 import {
   compatibleStoredExecutionContextSchema,
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
@@ -1398,16 +1397,9 @@ function connectorPermissionBaselineMatchesStoredContext(
 ): boolean {
   const baselineConnectorSlugs = Object.keys(baseline.connectors);
   const storedBuiltinConnectorSlugs = new Set(
-    storedContext.connectorRuntimeCandidateTargets === undefined
-      ? (storedContext.firewalls ?? []).flatMap((firewall) => {
-          return firewall.kind === "builtin" &&
-            connectorSlugSchema.safeParse(firewall.name).success
-            ? [firewall.name]
-            : [];
-        })
-      : storedContext.connectorRuntimeCandidateTargets.flatMap((target) => {
-          return target.kind === "builtin" ? [target.connectorSlug] : [];
-        }),
+    storedContext.connectorRuntimeTargets.flatMap((target) => {
+      return target.kind === "builtin" ? [target.connectorSlug] : [];
+    }),
   );
   const storedNetworkPolicies = storedContext.networkPolicies ?? {};
   return (

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -555,20 +555,6 @@ async function mutateRunnerJobConnectorPermissionBaseline(
 ): Promise<void> {
   let executionContext: SQL;
   switch (body.mode) {
-    case "rollout-targets": {
-      executionContext = sql`jsonb_set(
-        jsonb_set(
-          ${runnerJobQueue.executionContext},
-          '{connectorRuntimeCandidateTargets}',
-          ${runnerJobQueue.executionContext}->'connectorRuntimeTargets',
-          true
-        ),
-        '{connectorRuntimeTargets}',
-        '[]'::jsonb,
-        true
-      )`;
-      break;
-    }
     case "remove": {
       executionContext = sql`${runnerJobQueue.executionContext} - 'connectorPermissionBaseline'`;
       break;

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -341,27 +341,6 @@ describe("connector runtime synchronization contract", () => {
     });
 
     expect(execution.connectorRuntimeTargets).toEqual([target]);
-    expect(execution.connectorRuntimeCandidateTargets).toBeUndefined();
-  });
-
-  it("preserves complete targets from rollout contexts", () => {
-    const fixture = executionContextSchema.parse(
-      loadRunnerClaimResponseFixture(),
-    );
-    const target = {
-      kind: "builtin" as const,
-      connectorSlug: "zendesk",
-      baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
-    };
-
-    const execution = executionContextSchema.parse({
-      ...fixture,
-      connectorRuntimeTargets: [],
-      connectorRuntimeCandidateTargets: [target],
-    });
-
-    expect(execution.connectorRuntimeTargets).toEqual([]);
-    expect(execution.connectorRuntimeCandidateTargets).toEqual([target]);
   });
 
   it("requires stable API identities on available custom firewalls", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -853,10 +853,6 @@ const storedExecutionContextObjectSchema = z.object({
   // Stable connector targets pinned for this run. The runner owns this list
   // after claim independently of whether each target is currently available.
   connectorRuntimeTargets: connectorRuntimeTargetsSchema,
-  // Complete target membership for candidate-aware runners. During rollout,
-  // connectorRuntimeTargets remains the filtered compatibility view consumed
-  // by previous runners. Remove this field after that runner generation drains.
-  connectorRuntimeCandidateTargets: connectorRuntimeTargetsSchema.optional(),
   // API-only catalog-derived permission defaults for claim-time grant refresh.
   connectorPermissionBaseline:
     storedConnectorPermissionBaselineSchema.optional(),
@@ -959,9 +955,6 @@ const executionContextObjectSchema = z.object({
   // Stable connector targets pinned for this run. The runner owns this list
   // after claim independently of whether each target is currently available.
   connectorRuntimeTargets: connectorRuntimeTargetsSchema,
-  // Complete target membership for candidate-aware runners. Missing means the
-  // filtered connectorRuntimeTargets list is authoritative.
-  connectorRuntimeCandidateTargets: connectorRuntimeTargetsSchema.optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -75,7 +75,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     action: z.literal("mutate-runner-job-connector-permission-baseline"),
     run_id: z.uuid(),
     mode: z.enum([
-      "rollout-targets",
       "remove",
       "malformed",
       "capability-mismatch",


### PR DESCRIPTION
## Summary

- remove the rollout-only `connectorRuntimeCandidateTargets` field from the TypeScript and Rust execution-context contracts
- make API permission-baseline validation and Runner proxy/runtime synchronization consume the canonical `connectorRuntimeTargets` and `firewalls` fields directly
- remove rollout-only mutations, fallback synthesis, conflict branches, fixtures, and tests while preserving canonical connector runtime coverage

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --reporter=dot` (154 passed)
- `pnpm knip`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner --bin runner` (3099 passed, 20 ignored)
- mitm addon: `uv lock --check`, `uv sync --locked`, Ruff format/lint, basedpyright, and pytest (5265 passed)
- exact repository scan confirms no active `connectorRuntimeCandidateTargets`, `connector_runtime_candidate_targets`, or `rollout-targets` references remain

## Deployment compatibility

- no database migration or persisted-context rewrite is included
- the canonical-writer release is already deployed, but the remaining production evidence in #26261 is still a merge-only gate
- **do not merge while #26261 remains labeled `deferred` or before every production gate is recorded**

Closes #26261
Relates to #26185
