### PR TITLE
refactor: remove tiktok ads connector feature switch

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -43,7 +43,6 @@ const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
   "test-oauth\0oauth": FeatureSwitchKey.TestOauthConnector,
   "test-oauth-device\0api": FeatureSwitchKey.TestOauthConnector,
   "test-oauth-device\0oauth": FeatureSwitchKey.TestOauthConnector,
-  "tiktok-ads\0oauth": FeatureSwitchKey.TikTokAdsConnector,
   "webflow\0oauth": FeatureSwitchKey.WebflowConnector,
   "workday\0api-token": FeatureSwitchKey.WorkdayConnector,
   "zapier\0api-token": FeatureSwitchKey.ZapierConnector,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -29,7 +29,6 @@ export enum FeatureSwitchKey {
   WebflowConnector = "webflowConnector",
   CloseConnector = "closeConnector",
   MetaAdsConnector = "metaAdsConnector",
-  TikTokAdsConnector = "tiktokAdsConnector",
   PosthogConnector = "posthogConnector",
   PayPalConnector = "payPalConnector",
   RampConnector = "rampConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -165,11 +165,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Meta Ads Manager connector",
     enabled: false,
   },
-  [FeatureSwitchKey.TikTokAdsConnector]: {
-    maintainer: "yuma@vm0.ai",
-    description: "Enable the TikTok Ads Manager connector",
-    enabled: false,
-  },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the PostHog analytics connector",


### PR DESCRIPTION
## Summary

Remove the `tiktokAdsConnector` feature switch and make the TikTok Ads OAuth connector permanently available through connector discovery.

## Terminal state

**Fully rolled out.** The user explicitly requested a full rollout in this cleanup request.

## History and behavior comparison

- Introducing commit: `5e0824bb25` (`feat: add TikTok Ads connector (#17148)`).
- Its parent had no TikTok Ads connector. The commit added the connector implementation and a disabled discovery gate together.
- `11071e0563` later moved the switch key into `@vm0/core`; `6670ff6f17` later moved the auth-method rollout association into the API-owned mapping.
- `b1d81d84ea` subsequently made the connector use TikTok's long-lived access tokens; that current connector behavior is retained.
- On current `main`, the disabled path hides `tiktok-ads\0oauth` from discovery. Connector authorization and execution do not use this rollout switch.
- For the fully rolled-out state, this PR keeps the enabled connector behavior and removes only the discovery gate and its registry/type artifacts.

## What changed

Removed:

- `FeatureSwitchKey.TikTokAdsConnector`
- The `tiktokAdsConnector` registry entry
- The `"tiktok-ads\0oauth" -> TikTokAdsConnector` rollout association

Kept:

- TikTok Ads catalog metadata and Platform fixture
- OAuth authorization and long-lived access-token exchange
- Provider registration, environment wiring, firewall behavior, icon/resources, skill metadata, and connector tests

Tests:

- No TikTok Ads true/false switch matrix, override fixture, or feature-specific fallback test existed to remove.
- Existing catalog rollout coverage verifies that auth methods without a vm0-owned rollout association remain visible.
- No negative test was added to assert that the removed key or source strings are absent.

## Cross-repository check

- `vm0-ai/vm0-connectors` owns the current TikTok Ads connector source and artifacts but delegates rollout policy to `vm0`.
- Its current `connectors/tiktok-ads/connector.yaml` declares the OAuth method as `visible: true` and contains no feature-switch key.
- No companion repository change is required.

## Search audit

- Exact and naming-variant searches covered `TikTokAdsConnector`, `tiktokAdsConnector`, snake/kebab variants, and TikTok Ads plus feature-switch associations; no live switch references remain.
- The only broad phrase matches are historical changelog entries recording the connector's introduction.
- The semantic follow-up covered `tiktok-ads`, `TikTok Ads`, `TIKTOK_ADS`, OAuth/provider names, fixtures, tests, environment wiring, resources, and changelogs. Remaining matches are retained enabled-product behavior or historical records.

## Knip

- Baseline: `pnpm knip` exited successfully with 42 existing configuration hints and no unused-code findings.
- After cleanup: `pnpm knip` exited successfully with the same 42 configuration hints and no new orphaned files, exports, types, or dependencies.

## Verification

Passed locally:

- Prettier on all changed files
- `pnpm --filter @vm0/core lint`
- `pnpm --filter api lint` (exit 0; emitted existing unrelated test warnings)
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter api check-types`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` - 24/24 passed
- `pnpm --filter @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/tiktok-ads.test.ts` - 6/6 passed
- `git diff --check`
- Exact-key, association, and semantic follow-up searches described above

Environment-blocked local check:

- The targeted database-backed API catalog test could not start locally because no PostgreSQL listener is available at `localhost:5432` (`ECONNREFUSED ::1:5432` and `ECONNREFUSED 127.0.0.1:5432`); all 107 tests in that file were skipped during setup.
- The PR pipeline owns this database-backed coverage and the repository's full required checks.
