### PR TITLE
fix(connectors): pin custom skills to admitted versions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -17,6 +17,7 @@ import {
   type CreateCustomConnectorBody,
   ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { testCustomConnectorSkillRepairStateContract } from "@vm0/api-contracts/contracts/test-custom-connector-skill-repair-state";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   getCustomConnectorSkillStorageName,
@@ -34,7 +35,8 @@ import { v5 as uuidv5 } from "uuid";
 
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now, nowDate } from "../../../lib/time";
-import { testContext } from "../../../__tests__/test-context";
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
@@ -124,6 +126,7 @@ import {
   type SecretKmsDataKey,
   type SecretKmsGenerateDataKeyRequest,
 } from "../../../lib/secret-kms-client";
+import { testCustomConnectorSkillRepairStateRoutes } from "../test-custom-connector-skill-repair-state";
 
 /**
  * RUN-01..04 and CHAIN-RUN: successful run dispatch and lifecycle.
@@ -9045,6 +9048,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const api = createRunsApi(context);
     createBddApi(context).acceptAgentStorageWrites();
     const connectors = createConnectorBddApi(context);
+    const storages = createStoragesBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const slug = `_bdd-permission-skill-${randomUUID().slice(0, 8)}`;
     const custom = await connectors.createCustomConnector(actor, {
@@ -9072,6 +9076,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       permissionBundleRef: "builtin:slack@1",
       skillMarkdown: "Use the selected Slack-compatible operations only.",
     });
+    const initialSkill = await storages.downloadStorage(actor, {
+      name: getCustomConnectorSkillStorageName(custom.id),
+      owner: "organization",
+    });
     const grant = {
       customConnectorId: custom.id,
       permissionNames: ["chat:write"],
@@ -9094,6 +9102,22 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       prompt: "use the disconnected custom connector skill",
       modelProvider: "anthropic-api-key",
     });
+    await connectors.updateCustomConnector(actor, custom.id, {
+      displayName: custom.displayName,
+      prefixTemplates: custom.prefixTemplates,
+      fields: custom.fields,
+      headerInjections: custom.headerInjections,
+      queryInjections: custom.queryInjections,
+      authMode: custom.authMode ?? "manual",
+      permissionBundleRef: custom.permissionBundleRef,
+      skillMarkdown: "Use the updated Slack-compatible operations only.",
+      storageVersion: custom.storageVersion,
+    });
+    const updatedSkill = await storages.downloadStorage(actor, {
+      name: getCustomConnectorSkillStorageName(custom.id),
+      owner: "organization",
+    });
+    expect(updatedSkill.versionId).not.toBe(initialSkill.versionId);
     await api.heartbeatRunner(runnerGroup);
     const disconnectedClaim = await api.claimRunnerJob(disconnectedRun.runId);
     expect(
@@ -9116,6 +9140,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(disconnectedSkillMount?.mountPath).toBe(
       `/home/user/.claude/skills/custom-${slug.slice(1, 49)}-${custom.id.replaceAll("-", "").slice(0, 8)}`,
     );
+    expect(disconnectedSkillMount?.versionId).toBe(initialSkill.versionId);
 
     await connectors.setCustomConnectorValues(actor, custom.id, [
       { key: "workspace", kind: "variable", value: "restored" },
@@ -9163,8 +9188,118 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(restoredSkillMount?.mountPath).toBe(
       disconnectedSkillMount?.mountPath,
     );
+    expect(restoredSkillMount?.versionId).toBe(updatedSkill.versionId);
 
     await api.requestCancelRun(actor, restoredRun.runId, [200]);
+  });
+
+  it("fails closed when a custom skill exact association is invalid", async () => {
+    const api = createRunsApi(context);
+    const bdd = createBddApi(context);
+    bdd.acceptAgentStorageWrites();
+    const connectors = createConnectorBddApi(context);
+    const storages = createStoragesBddApi(context);
+    const stateClient = setupApp({
+      context,
+      routes: testCustomConnectorSkillRepairStateRoutes,
+    })(testCustomConnectorSkillRepairStateContract);
+    const { actor, agentId } = await entitledRunActor();
+    const suffix = randomUUID().slice(0, 8);
+    const target = await connectors.createCustomConnector(actor, {
+      displayName: "BDD Exact Skill Target",
+      prefixTemplates: [`https://exact-target-${suffix}.example.test/api/`],
+      fields: [
+        {
+          key: "secret",
+          label: "API token",
+          kind: "secret",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.secret}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+      skillMarkdown: "Use only the target connector skill.",
+    });
+    const other = await connectors.createCustomConnector(actor, {
+      displayName: "BDD Exact Skill Other",
+      prefixTemplates: [`https://exact-other-${suffix}.example.test/api/`],
+      fields: [
+        {
+          key: "secret",
+          label: "API token",
+          kind: "secret",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.secret}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+      skillMarkdown: "Use only the other connector skill.",
+    });
+    onTestFinished(async () => {
+      await connectors.deleteCustomConnector(actor, target.id);
+      await connectors.deleteCustomConnector(actor, other.id);
+    });
+    await connectors.updateAgentCustomConnectors(actor, agentId, [target.id]);
+    const otherSkill = await storages.downloadStorage(actor, {
+      name: getCustomConnectorSkillStorageName(other.id),
+      owner: "organization",
+    });
+
+    await accept(
+      stateClient.action({
+        body: {
+          action: "set-connector",
+          connectorId: target.id,
+          skillStorageVersionId: otherSkill.versionId,
+        },
+      }),
+      [200],
+    );
+    const wrongStorageRun = await api.createRun(actor, {
+      agentId,
+      prompt: "reject the wrong custom skill storage owner",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(wrongStorageRun).toMatchObject({
+      status: "failed",
+      error: "Custom connector skill registration is unavailable",
+    });
+
+    const missingAssociationState = await accept(
+      stateClient.action({
+        body: {
+          action: "set-connector",
+          connectorId: target.id,
+          skillStorageVersionId: null,
+        },
+      }),
+      [200],
+    );
+    expect(missingAssociationState.body.state.connector).toMatchObject({
+      skillMarkdown: "Use only the target connector skill.",
+      skillStorageVersionId: null,
+    });
+    await expect(
+      api.createRun(actor, {
+        agentId,
+        prompt: "reject the missing custom skill association",
+        modelProvider: "anthropic-api-key",
+      }),
+    ).rejects.toThrow(
+      "Unknown response status 500 for POST /api/test/zero-run-fixture",
+    );
   });
 
   it("admits an unrefreshable custom OAuth token only until it expires", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -2775,6 +2775,10 @@ describe("Feishu integration", () => {
       connectorList.body.connectors[0],
       "Expected connected Feishu custom connector",
     );
+    const managedSkill = await storagesApi.downloadStorage(actor, {
+      name: getCustomConnectorSkillStorageName(managedConnector.id),
+      owner: "organization",
+    });
     const customConnectorGrants = await accept(
       setupApp({ context, routes: zeroAgentsRoutes })(
         zeroAgentCustomConnectorsContract,
@@ -2935,16 +2939,14 @@ describe("Feishu integration", () => {
         permissionNames: ["messages:send-as-user"],
       },
     ]);
-    expect(
-      expectCanonicalStorageManifest(claim.storageManifest)?.storageMounts.some(
-        (storage) => {
-          return (
-            storage.name ===
-            getCustomConnectorSkillStorageName(managedConnector.id)
-          );
-        },
-      ),
-    ).toBeTruthy();
+    const managedSkillMount = expectCanonicalStorageManifest(
+      claim.storageManifest,
+    )?.storageMounts.find((storage) => {
+      return (
+        storage.name === getCustomConnectorSkillStorageName(managedConnector.id)
+      );
+    });
+    expect(managedSkillMount?.versionId).toBe(managedSkill.versionId);
     expect(claim.prompt).toContain(feishuFilePrompt);
     expect(claim.prompt).toContain("   [MESSAGE_ID] om_file_message");
     expect(claim.prompt).toContain("   [TYPE] file");

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -901,6 +901,7 @@ interface CustomConnectorRuntimeContext {
   readonly skills: readonly {
     readonly connectorId: string;
     readonly connectorSlug: string;
+    readonly versionId: string;
   }[];
 }
 
@@ -972,6 +973,28 @@ function skillMountPath(skillsRoot: string, skillName: string): string {
   return `${skillsRoot}/${skillName}`;
 }
 
+type ConnectorSkillVolumeSource = Extract<
+  StorageManifestSource,
+  "connector_skill" | "custom_connector_skill"
+>;
+
+function buildExactConnectorSkillVolume(args: {
+  readonly name: string;
+  readonly version: string;
+  readonly mountPath: string;
+  readonly source: ConnectorSkillVolumeSource;
+}): PreparedAdditionalVolume {
+  return {
+    volume: {
+      name: args.name,
+      version: args.version,
+      mountPath: args.mountPath,
+      ...(args.source === "connector_skill" ? { system: true } : {}),
+    },
+    source: args.source,
+  };
+}
+
 // Legacy CLI runs use the framework resolved from the model provider, never
 // the framework declared in the compose. Eligible Pi runs instead receive the
 // fixed Pi root before Storage resolves any versions or overlays.
@@ -1008,15 +1031,12 @@ function buildConnectorSkillVolumes(
     if (connector.skill.kind === "none") {
       return [];
     }
-    const prepared: PreparedAdditionalVolume = {
-      volume: {
-        name: connector.skill.storageName,
-        version: connector.skill.versionId,
-        mountPath: skillMountPath(skillsRoot, connectorSlug),
-        system: true,
-      },
+    const prepared = buildExactConnectorSkillVolume({
+      name: connector.skill.storageName,
+      version: connector.skill.versionId,
+      mountPath: skillMountPath(skillsRoot, connectorSlug),
       source: "connector_skill",
-    };
+    });
     return [prepared];
   });
 }
@@ -1043,16 +1063,15 @@ function buildCustomConnectorSkillVolumes(
   skillsRoot: string,
 ): readonly PreparedAdditionalVolume[] {
   return skills.map((skill) => {
-    return {
-      volume: {
-        name: getCustomConnectorSkillStorageName(skill.connectorId),
-        mountPath: skillMountPath(
-          skillsRoot,
-          getCustomConnectorSkillName(skill.connectorSlug, skill.connectorId),
-        ),
-      },
+    return buildExactConnectorSkillVolume({
+      name: getCustomConnectorSkillStorageName(skill.connectorId),
+      version: skill.versionId,
+      mountPath: skillMountPath(
+        skillsRoot,
+        getCustomConnectorSkillName(skill.connectorSlug, skill.connectorId),
+      ),
       source: "custom_connector_skill",
-    };
+    });
   });
 }
 
@@ -4178,12 +4197,18 @@ interface BuiltCustomConnectorRuntimeRow {
 function customConnectorRuntimeSkill(
   row: CustomConnectorRuntimeDataRows[number],
 ): CustomConnectorRuntimeContext["skills"][number] | undefined {
-  return row.connector.skillMarkdown === null
-    ? undefined
-    : {
-        connectorId: row.connector.id,
-        connectorSlug: row.connector.slug,
-      };
+  const { skillMarkdown, skillStorageVersionId } = row.connector;
+  if (skillMarkdown === null && skillStorageVersionId === null) {
+    return undefined;
+  }
+  if (skillMarkdown === null || skillStorageVersionId === null) {
+    throw new Error("Custom connector skill registration is unavailable");
+  }
+  return {
+    connectorId: row.connector.id,
+    connectorSlug: row.connector.slug,
+    versionId: skillStorageVersionId,
+  };
 }
 
 function customConnectorRuntimeCredentialsAreComplete(
@@ -4369,6 +4394,7 @@ export async function buildCustomConnectorRuntimeContext(
   const skills: {
     connectorId: string;
     connectorSlug: string;
+    versionId: string;
   }[] = [];
   const grantByConnectorId = new Map(
     (args.grants ?? []).map((grant) => {

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1703,8 +1703,14 @@ async function resolveAdditionalStorageInput(args: {
   readonly volume: AdditionalVolume;
   readonly source: StorageManifestSource;
 }): Promise<ResolvedManifestStorageInput | null> {
-  if (args.source === "connector_skill") {
-    return resolveConnectorSkillStorageInput(args);
+  const { source } = args;
+  if (source === "connector_skill" || source === "custom_connector_skill") {
+    return resolveConnectorSkillStorageInput({
+      index: args.index,
+      runtimeOrgId: args.runtimeOrgId,
+      volume: args.volume,
+      source,
+    });
   }
   const resolvedResult = await settle(
     resolveVolumeStorage({
@@ -1734,42 +1740,60 @@ async function resolveAdditionalStorageInput(args: {
 
 const CONNECTOR_SKILL_REGISTRATION_ERROR =
   "Connector skill registration is unavailable";
+const CUSTOM_CONNECTOR_SKILL_REGISTRATION_ERROR =
+  "Custom connector skill registration is unavailable";
 
-function connectorSkillRegistrationError(): Error {
-  return new Error(CONNECTOR_SKILL_REGISTRATION_ERROR);
+type ConnectorSkillStorageSource = Extract<
+  StorageManifestSource,
+  "connector_skill" | "custom_connector_skill"
+>;
+
+function connectorSkillRegistrationError(
+  source: ConnectorSkillStorageSource,
+): Error {
+  return new Error(
+    source === "connector_skill"
+      ? CONNECTOR_SKILL_REGISTRATION_ERROR
+      : CUSTOM_CONNECTOR_SKILL_REGISTRATION_ERROR,
+  );
 }
 
 function resolveConnectorSkillStorageInput(args: {
   readonly index: StorageIndex;
+  readonly runtimeOrgId: string;
   readonly volume: AdditionalVolume;
+  readonly source: ConnectorSkillStorageSource;
 }): ResolvedManifestStorageInput {
   const version = args.volume.version;
   if (
-    !args.volume.system ||
+    (args.source === "connector_skill") !== (args.volume.system === true) ||
     version === undefined ||
     !/^[a-f0-9]{64}$/u.test(version)
   ) {
-    throw connectorSkillRegistrationError();
+    throw connectorSkillRegistrationError(args.source);
   }
 
-  const lookup = volumeStorageLookup(SYSTEM_ORG_ID, args.volume);
+  const ownerOrgId =
+    args.source === "connector_skill" ? SYSTEM_ORG_ID : args.runtimeOrgId;
+  const lookup = volumeStorageLookup(ownerOrgId, args.volume);
   const storage = args.index.get(
     storageIndexKey(lookup.orgId, lookup.userId, lookup.name),
   );
   if (!storage) {
-    throw connectorSkillRegistrationError();
+    throw connectorSkillRegistrationError(args.source);
   }
   const resolved = resolvePreloadedExactVersion(storage, lookup, version);
   if (!resolved) {
-    throw connectorSkillRegistrationError();
+    throw connectorSkillRegistrationError(args.source);
   }
 
-  const expectedPrefix = `${SYSTEM_ORG_ID}/volume/${args.volume.name}`;
+  const expectedKey = `${resolved.s3Prefix}/${version}`;
   if (
-    resolved.s3Prefix !== expectedPrefix ||
-    resolved.s3Key !== `${expectedPrefix}/${version}`
+    resolved.s3Key !== expectedKey ||
+    (args.source === "connector_skill" &&
+      resolved.s3Prefix !== `${SYSTEM_ORG_ID}/volume/${args.volume.name}`)
   ) {
-    throw connectorSkillRegistrationError();
+    throw connectorSkillRegistrationError(args.source);
   }
 
   return {
@@ -2320,12 +2344,16 @@ function storageManifestRequests(args: {
   }
   for (const [index, volume] of (args.additionalVolumes ?? []).entries()) {
     const version = volumeVersion(volume);
-    if (
-      additionalVolumeSourceAt(args.additionalVolumeSources, index) ===
-      "connector_skill"
-    ) {
+    const source = additionalVolumeSourceAt(
+      args.additionalVolumeSources,
+      index,
+    );
+    if (source === "connector_skill" || source === "custom_connector_skill") {
       requests.push({
-        lookup: volumeStorageLookup(SYSTEM_ORG_ID, volume),
+        lookup: volumeStorageLookup(
+          source === "connector_skill" ? SYSTEM_ORG_ID : args.runtimeOrgId,
+          volume,
+        ),
         version,
       });
       continue;

--- a/turbo/apps/api/src/signals/services/custom-connector-definition-selection.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-definition-selection.ts
@@ -16,6 +16,7 @@ export function customConnectorDefinitionSelection() {
     mcpEndpoint: orgCustomConnectors.mcpEndpoint,
     mcpTransport: orgCustomConnectors.mcpTransport,
     skillMarkdown: orgCustomConnectors.skillMarkdown,
+    skillStorageVersionId: orgCustomConnectors.skillStorageVersionId,
     storageVersion: orgCustomConnectors.storageVersion,
     createdBy: orgCustomConnectors.createdBy,
     createdAt: orgCustomConnectors.createdAt,

--- a/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-skill-volume.service.ts
@@ -92,7 +92,7 @@ export async function commitPreparedCustomConnectorSkillVolume(
   },
   signal: AbortSignal,
 ): Promise<void> {
-  await commitPreparedVolumeServerSide(
+  await commitPreparedCustomConnectorSkillStorage(
     { db: args.db, volume: args.volume },
     signal,
   );
@@ -101,4 +101,17 @@ export async function commitPreparedCustomConnectorSkillVolume(
     .set({ skillStorageVersionId: args.volume.version.versionId })
     .where(eq(orgCustomConnectors.id, args.connectorId));
   signal.throwIfAborted();
+}
+
+export async function commitPreparedCustomConnectorSkillStorage(
+  args: {
+    readonly db: Db;
+    readonly volume: PreparedServerSideVolume;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await commitPreparedVolumeServerSide(
+    { db: args.db, volume: args.volume },
+    signal,
+  );
 }

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -17,7 +17,7 @@ import {
 } from "./connector-client-invalidation.service";
 import { deleteCustomConnectorMemberConnection } from "./custom-connector-credential-storage.service";
 import {
-  commitPreparedCustomConnectorSkillVolume,
+  commitPreparedCustomConnectorSkillStorage,
   prepareCustomConnectorSkillVolume$,
 } from "./custom-connector-skill-volume.service";
 import {
@@ -220,6 +220,7 @@ function desiredOAuthConfig(installation: FeishuConnectorInstallation) {
 function connectorDefinitionMatches(
   connector: CustomConnectorDefinitionRow,
   installation: FeishuConnectorInstallation,
+  skillStorageVersionId: string,
 ): boolean {
   const desired = desiredConnectorDefinition(installation);
   return (
@@ -231,7 +232,8 @@ function connectorDefinitionMatches(
     connector.authMode === desired.authMode &&
     connector.enabled === desired.enabled &&
     connector.permissionBundleRef === desired.permissionBundleRef &&
-    connector.skillMarkdown === desired.skillMarkdown
+    connector.skillMarkdown === desired.skillMarkdown &&
+    connector.skillStorageVersionId === skillStorageVersionId
   );
 }
 
@@ -260,16 +262,17 @@ async function createFeishuCustomConnector(
   tx: DbTransaction,
   args: EnsureFeishuCustomConnectorArgs,
   installation: FeishuConnectorInstallation,
-  connectorId: string,
+  prepared: PreparedFeishuCustomConnectorSkill,
   signal: AbortSignal,
 ): Promise<ReconciledFeishuCustomConnector> {
   const [connector] = await tx
     .insert(orgCustomConnectors)
     .values({
-      id: connectorId,
+      id: prepared.connectorId,
       orgId: args.orgId,
       slug: getFeishuCustomConnectorSlug(args.installationId),
       ...desiredConnectorDefinition(installation),
+      skillStorageVersionId: prepared.volume.version.versionId,
       createdBy: installation.ownerUserId ?? args.userId,
     })
     .returning({ id: orgCustomConnectors.id });
@@ -291,9 +294,9 @@ async function createFeishuCustomConnector(
 
 async function repairFeishuCustomConnector(
   tx: DbTransaction,
-  args: EnsureFeishuCustomConnectorArgs,
   installation: FeishuConnectorInstallation,
   existing: ExistingFeishuCustomConnector,
+  skillStorageVersionId: string,
   signal: AbortSignal,
 ): Promise<ReconciledFeishuCustomConnector> {
   const credentialContractChanged =
@@ -304,6 +307,7 @@ async function repairFeishuCustomConnector(
     .update(orgCustomConnectors)
     .set({
       ...desiredConnectorDefinition(installation),
+      skillStorageVersionId,
       storageVersion: credentialContractChanged
         ? existing.connector.storageVersion + 1
         : existing.connector.storageVersion,
@@ -426,19 +430,28 @@ async function reconcileFeishuCustomConnector(
     };
   }
 
+  await commitPreparedCustomConnectorSkillStorage(
+    { db: tx, volume: prepared.volume },
+    signal,
+  );
+  const skillStorageVersionId = prepared.volume.version.versionId;
+
   let connector: ReconciledFeishuCustomConnector;
   if (!existing) {
     connector = await createFeishuCustomConnector(
       tx,
       args,
       installation,
-      prepared.connectorId,
+      prepared,
       signal,
     );
   } else {
     const needsRepair =
-      !connectorDefinitionMatches(existing.connector, installation) ||
-      !oauthConfigMatches(existing.oauthConfig, installation);
+      !connectorDefinitionMatches(
+        existing.connector,
+        installation,
+        skillStorageVersionId,
+      ) || !oauthConfigMatches(existing.oauthConfig, installation);
     connector =
       !args.configurationChanged && !needsRepair
         ? {
@@ -448,20 +461,12 @@ async function reconcileFeishuCustomConnector(
           }
         : await repairFeishuCustomConnector(
             tx,
-            args,
             installation,
             existing,
+            skillStorageVersionId,
             signal,
           );
   }
-  await commitPreparedCustomConnectorSkillVolume(
-    {
-      db: tx,
-      connectorId: connector.connectorId,
-      volume: prepared.volume,
-    },
-    signal,
-  );
   return {
     kind: "reconciled",
     connector,

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -71,7 +71,7 @@ import {
 } from "./custom-connector-credential-access.service";
 import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
 import {
-  commitPreparedCustomConnectorSkillVolume,
+  commitPreparedCustomConnectorSkillStorage,
   prepareCustomConnectorSkillVolume$,
 } from "./custom-connector-skill-volume.service";
 import type { PreparedServerSideVolume } from "./storage-volume-publication.service";
@@ -187,6 +187,7 @@ interface CustomConnectorSharedRow {
   readonly oauthConfig: CustomConnectorOAuthConfigRow | null;
   readonly enabled: boolean;
   readonly skillMarkdown: string | null;
+  readonly skillStorageVersionId: string | null;
   readonly storageVersion: number;
   readonly createdBy: string;
   readonly createdAt: Date;
@@ -463,6 +464,7 @@ export function normaliseCustomConnectorRow(
     oauthConfig,
     enabled: row.enabled,
     skillMarkdown: row.skillMarkdown,
+    skillStorageVersionId: row.skillStorageVersionId,
     storageVersion: row.storageVersion,
     createdBy: row.createdBy,
     createdAt: row.createdAt,
@@ -1745,6 +1747,12 @@ async function persistCustomConnectorCreate(
         return prefixConflict;
       }
     }
+    if (args.preparedSkill) {
+      await commitPreparedCustomConnectorSkillStorage(
+        { db: tx, volume: args.preparedSkill },
+        signal,
+      );
+    }
     const [row] = await tx
       .insert(orgCustomConnectors)
       .values({
@@ -1758,6 +1766,7 @@ async function persistCustomConnectorCreate(
         queryInjections: [...args.definition.queryInjections],
         authMode: args.definition.authMode,
         skillMarkdown: args.definition.skillMarkdown,
+        skillStorageVersionId: args.preparedSkill?.version.versionId ?? null,
         storageVersion: args.storageVersion,
         createdBy: args.userId,
       })
@@ -1783,12 +1792,6 @@ async function persistCustomConnectorCreate(
         throw new Error("Expected OAuth config insert to return a row");
       }
       oauthConfig = insertedOAuthConfig;
-    }
-    if (args.preparedSkill) {
-      await commitPreparedCustomConnectorSkillVolume(
-        { db: tx, connectorId: row.id, volume: args.preparedSkill },
-        signal,
-      );
     }
     return { row, oauthConfig };
   });
@@ -1997,23 +2000,9 @@ async function persistCustomConnectorUpdate(
         return prefixConflict;
       }
     }
-    const kindColumns = protocolColumns(args.definition);
-    const [updated] = await tx
-      .update(orgCustomConnectors)
-      .set({
-        displayName: args.definition.displayName,
-        ...kindColumns,
-        fields: [...args.definition.fields],
-        headerInjections: [...args.definition.headerInjections],
-        queryInjections: [...args.definition.queryInjections],
-        authMode: args.definition.authMode,
-        skillMarkdown: args.definition.skillMarkdown,
-        ...(args.definition.skillMarkdown === null
-          ? { skillStorageVersionId: null }
-          : {}),
-        storageVersion: args.storageVersion,
-        updatedAt: nowDate(),
-      })
+    const [locked] = await tx
+      .select({ id: orgCustomConnectors.id })
+      .from(orgCustomConnectors)
       .where(
         and(
           eq(orgCustomConnectors.id, args.id),
@@ -2026,8 +2015,9 @@ async function persistCustomConnectorUpdate(
           ),
         ),
       )
-      .returning(customConnectorDefinitionSelection());
-    if (!updated) {
+      .for("update", { of: orgCustomConnectors })
+      .limit(1);
+    if (!locked) {
       const [current] = await tx
         .select({ id: orgCustomConnectors.id })
         .from(orgCustomConnectors)
@@ -2043,6 +2033,37 @@ async function persistCustomConnectorUpdate(
             "Custom connector changed while the definition was being saved; retry",
           )
         : null;
+    }
+    if (args.preparedSkill) {
+      await commitPreparedCustomConnectorSkillStorage(
+        { db: tx, volume: args.preparedSkill },
+        signal,
+      );
+    }
+    const kindColumns = protocolColumns(args.definition);
+    const [updated] = await tx
+      .update(orgCustomConnectors)
+      .set({
+        displayName: args.definition.displayName,
+        ...kindColumns,
+        fields: [...args.definition.fields],
+        headerInjections: [...args.definition.headerInjections],
+        queryInjections: [...args.definition.queryInjections],
+        authMode: args.definition.authMode,
+        skillMarkdown: args.definition.skillMarkdown,
+        skillStorageVersionId: args.preparedSkill?.version.versionId ?? null,
+        storageVersion: args.storageVersion,
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          eq(orgCustomConnectors.id, args.id),
+          eq(orgCustomConnectors.orgId, args.orgId),
+        ),
+      )
+      .returning(customConnectorDefinitionSelection());
+    if (!updated) {
+      throw new Error("Expected locked custom connector to be updated");
     }
     let storedOAuthConfig: CustomConnectorOAuthConfigRow | null = null;
     if (args.oauthConfigUpdate.kind === "none") {
@@ -2078,12 +2099,6 @@ async function persistCustomConnectorUpdate(
         })
         .returning();
       storedOAuthConfig = upserted ?? null;
-    }
-    if (args.preparedSkill) {
-      await commitPreparedCustomConnectorSkillVolume(
-        { db: tx, connectorId: updated.id, volume: args.preparedSkill },
-        signal,
-      );
     }
     return { row: updated, oauthConfig: storedOAuthConfig };
   });


### PR DESCRIPTION
## Summary

- carry each Custom connector's persisted skill storage version into run admission
- resolve Builtin and Custom connector skills through shared fail-closed exact-version mechanics with fixed system and organization ownership
- make ordinary and managed Feishu writers write skill markdown and its exact version together, preparing the next release for the nullable-pair database constraint

## Behavior

Runs now mount the exact Custom connector skill version admitted with the connector definition. Updating a connector after run admission no longer moves that run to the new storage HEAD. Missing, mixed, malformed, wrong-storage, or unavailable Custom associations fail closed instead of omitting the mount or following HEAD.

Builtin connector skill behavior remains unchanged. Public Custom connector responses, credential `storageVersion`, run manifests, queue payloads, and runner contracts are unchanged.

## Rollout

This PR intentionally contains no database migration. Existing and new API versions can overlap while the exact reader cuts over. After this API version is deployed and the previous writer drains, #26137 will recheck production state, add the immediate nullable-pair CHECK, and remove the temporary repair/status surfaces and bounded artifacts.

## Validation

- `pnpm -F @vm0/db db:reset`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/zero-feishu-integration.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/cron-custom-connector-skill-repair.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts --maxWorkers=4 --silent=passed-only` (356 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit full-repository Prettier, Knip, and TypeScript checks

Closes #26136

Parent: #26075
