### PR TITLE
test(runner): isolate workspace gc lock test from host discovery

### DIFF
--- a/crates/runner/src/cmd/gc/workspaces/tests.rs
+++ b/crates/runner/src/cmd/gc/workspaces/tests.rs
@@ -930,7 +930,16 @@ async fn gc_workspace_orphans_does_not_scan_mismatched_base_dir_lock_name() {
     let lock_path = locks_dir.join("base-dir-mismatch.lock");
     std::fs::write(&lock_path, base_dir.as_os_str().as_encoded_bytes()).unwrap();
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.base_dir_locks_removed, 1);


### PR DESCRIPTION
## Summary

- isolate the mismatched base-directory lock GC scenario from live host process discovery
- keep real lock candidate discovery, flock ownership, metadata validation, inode checks, and filesystem cleanup in the test
- preserve the production fail-closed behavior for uncertain process and live-runner discovery

## Problem

`gc_workspace_orphans_does_not_scan_mismatched_base_dir_lock_name` called the top-level workspace GC entry point even though the scenario only verifies malformed lock handling. The entry point intentionally returns an empty summary when live host discovery is uncertain, so concurrent CI process churn could prevent the malformed lock from being processed and make the expected removal count intermittently report zero.

The scenario now calls the existing candidate-processing seam with explicit complete discovery state. Its temporary lock and workspace still go through the real production candidate, locking, parsing, preservation, and removal logic.

## Exclusions

- no production runner behavior changes
- no timeout, retry, sleep, or skipped test
- no API, protocol, persisted state, migration, or deployment compatibility changes

## Validation

- `cargo fmt --all --check`
- exact mismatched-lock test: 50 consecutive passing runs
- `cargo test -p runner --bin runner --all-features cmd::gc::workspaces::tests::` (33 passed)
- `cargo test -p runner --bin runner --all-features` (3100 passed, 20 ignored)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- pre-commit hooks: workspace Cargo fmt, Clippy, docs, file-size check, and commitlint

Closes #26308
