### PR TITLE
perf(api): arm goal successor intent after admission

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -743,6 +743,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function immediateSuccessorIntentPublishCalls(args: {
+  readonly action: "arm" | "revoke";
+  readonly predecessorRunId: string;
+  readonly intentId: string;
+  readonly eventClass: "prompt" | "goal" | "automation";
+}): readonly unknown[][] {
+  return context.mocks.ably.publish.mock.calls.filter(([topic, payload]) => {
+    return (
+      topic === "immediate-successor-intent" &&
+      isRecord(payload) &&
+      payload.action === args.action &&
+      payload.predecessorRunId === args.predecessorRunId &&
+      payload.intentId === args.intentId &&
+      payload.eventClass === args.eventClass
+    );
+  });
+}
+
 function sandboxOperationEventsForRun(
   runId: string,
 ): readonly Record<string, unknown>[] {
@@ -1828,6 +1846,28 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
         expiresAt: expect.any(String),
       }),
     );
+    const goalArmCalls = immediateSuccessorIntentPublishCalls({
+      action: "arm",
+      predecessorRunId: first.runId,
+      intentId: goalContinuation.revokesEventId,
+      eventClass: "goal",
+    });
+    const goalIntentDecisions = sandboxOperationEventsForRun(
+      first.runId,
+    ).filter((event) => {
+      return (
+        event.op_type === "immediate_successor_intent_source_validation" &&
+        event.immediate_successor_action === "arm" &&
+        event.immediate_successor_event_class === "goal" &&
+        event.immediate_successor_outcome === "valid"
+      );
+    });
+    expect(goalIntentDecisions).toStrictEqual([
+      expect.objectContaining({
+        immediate_successor_decision_point: "queue_admission",
+      }),
+    ]);
+    expect(goalArmCalls).toHaveLength(1);
     await expectGoalDrainPreCreateTiming({
       runId: goalContinuation.runId,
       forbiddenValues: [
@@ -2065,6 +2105,16 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
         eventClass: "goal",
       }),
     );
+    for (const action of ["arm", "revoke"] as const) {
+      expect(
+        immediateSuccessorIntentPublishCalls({
+          action,
+          predecessorRunId: first.runId,
+          intentId: goalEventId,
+          eventClass: "goal",
+        }),
+      ).toHaveLength(1);
+    }
   }, 90_000);
 
   it("revokes a goal invalidated while a failing launch resolves", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -470,8 +470,13 @@ describe("zero goals", () => {
       objectiveBrief: "coalesce goal triggers",
     });
 
-    expect(first.kind).toBe("inserted");
-    expect(second).toStrictEqual({ kind: "coalesced" });
+    if (first.kind !== "inserted") {
+      throw new Error("Expected the first goal queue event to be inserted");
+    }
+    expect(second).toStrictEqual({
+      kind: "coalesced",
+      eventId: first.eventId,
+    });
     expect(kms.generateDataKeyCalls).toBe(0);
     const state = await readGoalQueueStateFixture(fixture.threadId);
     expect(state.eventIds).toHaveLength(1);

--- a/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-goal-queue.service.ts
@@ -32,7 +32,7 @@ const goalInputRevoker = alias(chatEvents, "goal_input_revoker");
 
 export type GoalQueueAdmission =
   | { readonly kind: "inserted"; readonly eventId: string }
-  | { readonly kind: "coalesced" };
+  | { readonly kind: "coalesced"; readonly eventId: string };
 
 export interface PendingGoalQueueEvent {
   readonly id: string;
@@ -61,10 +61,10 @@ type FailedGoalQueueSettlement =
   | { readonly kind: "stale" }
   | { readonly kind: "rejected"; readonly goalId: string };
 
-async function pendingGoalEventExists(
+async function pendingGoalEventId(
   db: Pick<Db, "select">,
   chatThreadId: string,
-): Promise<boolean> {
+): Promise<string | null> {
   const [event] = await db
     .select({ id: chatEvents.id })
     .from(chatEvents)
@@ -82,7 +82,7 @@ async function pendingGoalEventExists(
       ),
     )
     .limit(1);
-  return event !== undefined;
+  return event?.id ?? null;
 }
 
 /** Persist one coalesced goal continuation trigger without preparing its run. */
@@ -98,8 +98,9 @@ export async function admitGoalQueueEvent(
     if (!(await lockChatQueueThread(tx, args.chatThreadId))) {
       throw new Error("Goal chat thread no longer exists");
     }
-    if (await pendingGoalEventExists(tx, args.chatThreadId)) {
-      return { kind: "coalesced" };
+    const pendingEventId = await pendingGoalEventId(tx, args.chatThreadId);
+    if (pendingEventId) {
+      return { kind: "coalesced", eventId: pendingEventId };
     }
     const inserted = await insertChatEvent(tx, {
       chatThreadId: args.chatThreadId,

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -27,6 +27,7 @@ import { expiredCancellationRecoveryThreads } from "./zero-chat-active-run.servi
 import { drainGoalQueueForThread$ } from "./zero-goal-queue-drain.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 import { pendingActiveInputCondition } from "./chat-event-queue.service";
+import type { ImmediateSuccessorIntentHandle } from "./immediate-successor-intent.service";
 
 const DRAIN_SWEEP_LIMIT = 20;
 export const STALE_QUEUE_ITEM_AGE_MS = 5 * 60 * 1000;
@@ -47,6 +48,7 @@ type QueueDrainSweepCandidate =
 interface DrainChatThreadQueueInput {
   readonly apiStartTime?: number;
   readonly chatThreadId: string;
+  readonly goalImmediateSuccessorIntent?: ImmediateSuccessorIntentHandle;
   readonly immediateSuccessorPredecessorRunId?: string;
   readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
   readonly queueItemCreatedBefore?: Date;
@@ -149,6 +151,7 @@ export const drainChatThreadQueueForThread$ = command(
       {
         chatThreadId: input.chatThreadId,
         apiStartTime,
+        goalImmediateSuccessorIntent: input.goalImmediateSuccessorIntent,
         immediateSuccessorPredecessorRunId:
           input.immediateSuccessorPredecessorRunId,
         dispatchFailedCallbacks: input.dispatchFailedCallbacks,

--- a/turbo/apps/api/src/signals/services/immediate-successor-intent.service.ts
+++ b/turbo/apps/api/src/signals/services/immediate-successor-intent.service.ts
@@ -1,6 +1,7 @@
 import type { ImmediateSuccessorIntentSignal } from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { createStore, state } from "ccstate";
 import { eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
@@ -13,16 +14,33 @@ import { tapError } from "../utils";
 import { RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS } from "./runner-reuse-preference";
 
 const L = logger("ImmediateSuccessorIntent");
+const MAX_RETAINED_INTENT_HANDLES = 1024;
 
 type ImmediateSuccessorEventClass =
   ImmediateSuccessorIntentSignal["eventClass"];
+type ImmediateSuccessorIntentDecisionPoint = "queue_admission" | "queue_drain";
 
 interface ImmediateSuccessorIntentSource {
   readonly group: string;
   readonly signal: Omit<ImmediateSuccessorIntentSignal, "action">;
 }
 
+interface RetainedImmediateSuccessorIntentHandle {
+  readonly expiresAtMs: number;
+  readonly handle: ImmediateSuccessorIntentHandle;
+}
+
+// Concurrent completion drains can run in separate ccstate command trees in
+// one API process. Share only the short-lived advisory owner; runner receipt
+// idempotency remains the cross-process authority.
+const retainedIntentHandles$ = state<
+  ReadonlyMap<string, RetainedImmediateSuccessorIntentHandle>
+>(new Map());
+const intentHandleStore = createStore();
+
 export interface ImmediateSuccessorIntentHandle {
+  readonly intentId: string;
+  readonly eventClass: ImmediateSuccessorEventClass;
   revoke(): void;
 }
 
@@ -33,6 +51,7 @@ interface ScheduleImmediateSuccessorIntentArgs {
   readonly orgId: string;
   readonly intentId: string;
   readonly eventClass: ImmediateSuccessorEventClass;
+  readonly decisionPoint: ImmediateSuccessorIntentDecisionPoint;
 }
 
 type InvalidSourceReason =
@@ -50,13 +69,83 @@ type IntentOutcome =
   | "published"
   | "publish_failed";
 
+function intentHandleKey(args: {
+  readonly predecessorRunId: string;
+  readonly intentId: string;
+  readonly eventClass: ImmediateSuccessorEventClass;
+}): string {
+  return `${args.predecessorRunId}/${args.eventClass}/${args.intentId}`;
+}
+
+function retainedIntentHandle(
+  key: string,
+  decidedAtMs: number,
+): ImmediateSuccessorIntentHandle | undefined {
+  const retainedIntentHandles = intentHandleStore.get(retainedIntentHandles$);
+  const retained = retainedIntentHandles.get(key);
+  if (!retained) {
+    return undefined;
+  }
+  if (retained.expiresAtMs <= decidedAtMs) {
+    const next = new Map(retainedIntentHandles);
+    next.delete(key);
+    intentHandleStore.set(retainedIntentHandles$, next);
+    return undefined;
+  }
+  return retained.handle;
+}
+
+export function findImmediateSuccessorIntentHandle(args: {
+  readonly predecessorRunId: string | undefined;
+  readonly intentId: string;
+  readonly eventClass: ImmediateSuccessorEventClass;
+}): ImmediateSuccessorIntentHandle | undefined {
+  if (!args.predecessorRunId) {
+    return undefined;
+  }
+  return retainedIntentHandle(
+    intentHandleKey({
+      predecessorRunId: args.predecessorRunId,
+      intentId: args.intentId,
+      eventClass: args.eventClass,
+    }),
+    now(),
+  );
+}
+
+function retainIntentHandle(
+  key: string,
+  handle: ImmediateSuccessorIntentHandle,
+  decidedAtMs: number,
+): void {
+  const retainedIntentHandles = intentHandleStore.get(retainedIntentHandles$);
+  const next = new Map(retainedIntentHandles);
+  if (retainedIntentHandles.size >= MAX_RETAINED_INTENT_HANDLES) {
+    for (const [candidateKey, retained] of retainedIntentHandles) {
+      if (retained.expiresAtMs <= decidedAtMs) {
+        next.delete(candidateKey);
+      }
+    }
+  }
+  if (next.size >= MAX_RETAINED_INTENT_HANDLES) {
+    return;
+  }
+  next.set(key, {
+    expiresAtMs: decidedAtMs + RUNNER_FINALIZING_PREDECESSOR_PROTECTION_MS,
+    handle,
+  });
+  intentHandleStore.set(retainedIntentHandles$, next);
+}
+
 function intentDimensions(args: {
   readonly action: ImmediateSuccessorIntentSignal["action"];
+  readonly decisionPoint: ImmediateSuccessorIntentDecisionPoint;
   readonly eventClass: ImmediateSuccessorEventClass;
   readonly outcome: IntentOutcome;
 }): Record<string, string> {
   return {
     immediate_successor_action: args.action,
+    immediate_successor_decision_point: args.decisionPoint,
     immediate_successor_event_class: args.eventClass,
     immediate_successor_outcome: args.outcome,
   };
@@ -64,6 +153,7 @@ function intentDimensions(args: {
 
 function recordInvalidSource(args: {
   readonly predecessorRunId: string;
+  readonly decisionPoint: ImmediateSuccessorIntentDecisionPoint;
   readonly eventClass: ImmediateSuccessorEventClass;
   readonly decidedAtMs: number;
   readonly reason: InvalidSourceReason;
@@ -77,6 +167,7 @@ function recordInvalidSource(args: {
       runId: args.predecessorRunId,
       dimensions: intentDimensions({
         action: "arm",
+        decisionPoint: args.decisionPoint,
         eventClass: args.eventClass,
         outcome: args.reason,
       }),
@@ -87,6 +178,7 @@ function recordInvalidSource(args: {
 function invalidIntentSource(
   args: {
     readonly predecessorRunId: string;
+    readonly decisionPoint: ImmediateSuccessorIntentDecisionPoint;
     readonly eventClass: ImmediateSuccessorEventClass;
     readonly decidedAtMs: number;
   },
@@ -131,6 +223,7 @@ async function resolveIntentSource(
   const decidedAtMs = args.decidedAt.getTime();
   const invalidArgs = {
     predecessorRunId: args.predecessorRunId,
+    decisionPoint: args.decisionPoint,
     eventClass: args.eventClass,
     decidedAtMs,
   };
@@ -172,6 +265,7 @@ async function resolveIntentSource(
       runId: args.predecessorRunId,
       dimensions: intentDimensions({
         action: "arm",
+        decisionPoint: args.decisionPoint,
         eventClass: args.eventClass,
         outcome: "valid",
       }),
@@ -184,6 +278,7 @@ async function resolveIntentSource(
       runId: args.predecessorRunId,
       dimensions: intentDimensions({
         action: "arm",
+        decisionPoint: args.decisionPoint,
         eventClass: args.eventClass,
         outcome: "valid",
       }),
@@ -210,6 +305,7 @@ async function publishIntentAction(args: {
   readonly source: ImmediateSuccessorIntentSource | null;
   readonly action: ImmediateSuccessorIntentSignal["action"];
   readonly predecessorRunId: string;
+  readonly decisionPoint: ImmediateSuccessorIntentDecisionPoint;
   readonly eventClass: ImmediateSuccessorEventClass;
   readonly decidedAtMs: number;
 }): Promise<void> {
@@ -230,6 +326,7 @@ async function publishIntentAction(args: {
       runId: args.predecessorRunId,
       dimensions: intentDimensions({
         action: args.action,
+        decisionPoint: args.decisionPoint,
         eventClass: args.eventClass,
         outcome: "publish_started",
       }),
@@ -242,6 +339,7 @@ async function publishIntentAction(args: {
       runId: args.predecessorRunId,
       dimensions: intentDimensions({
         action: args.action,
+        decisionPoint: args.decisionPoint,
         eventClass: args.eventClass,
         outcome: published ? "published" : "publish_failed",
       }),
@@ -257,6 +355,15 @@ export function scheduleImmediateSuccessorIntent(
   }
   const predecessorRunId = args.predecessorRunId;
   const decidedAt = nowDate();
+  const key = intentHandleKey({
+    predecessorRunId,
+    intentId: args.intentId,
+    eventClass: args.eventClass,
+  });
+  const retained = retainedIntentHandle(key, decidedAt.getTime());
+  if (retained) {
+    return retained;
+  }
   const source = resolveIntentSource({
     ...args,
     predecessorRunId,
@@ -268,6 +375,7 @@ export function scheduleImmediateSuccessorIntent(
       source: resolved,
       action: "arm",
       predecessorRunId,
+      decisionPoint: args.decisionPoint,
       eventClass: args.eventClass,
       decidedAtMs: decidedAt.getTime(),
     });
@@ -275,8 +383,15 @@ export function scheduleImmediateSuccessorIntent(
   })();
   waitUntil(arm);
 
-  return {
+  let revoked = false;
+  const handle: ImmediateSuccessorIntentHandle = {
+    intentId: args.intentId,
+    eventClass: args.eventClass,
     revoke(): void {
+      if (revoked) {
+        return;
+      }
+      revoked = true;
       const revokeDecidedAtMs = now();
       waitUntil(
         (async () => {
@@ -285,6 +400,7 @@ export function scheduleImmediateSuccessorIntent(
             source: resolved,
             action: "revoke",
             predecessorRunId,
+            decisionPoint: args.decisionPoint,
             eventClass: args.eventClass,
             decidedAtMs: revokeDecidedAtMs,
           });
@@ -292,4 +408,6 @@ export function scheduleImmediateSuccessorIntent(
       );
     },
   };
+  retainIntentHandle(key, handle, decidedAt.getTime());
+  return handle;
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -3988,6 +3988,7 @@ async function prepareAutoSendQueuedMessageRunInput(
     orgId: agent.orgId,
     intentId: queuedMessage.id,
     eventClass: "prompt",
+    decisionPoint: "queue_drain",
   });
   const runInput = await measureChatCallbackPreCreateTiming(
     args.timing,

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -9,6 +9,7 @@ import { settle } from "../utils";
 import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import { admitGoalQueueEvent } from "./chat-goal-queue.service";
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
+import { scheduleImmediateSuccessorIntent } from "./immediate-successor-intent.service";
 import {
   loadActiveGoalForThread,
   pauseActiveGoalForThread,
@@ -117,10 +118,21 @@ const enqueueGoalContinuation$ = command(
       };
     }
 
+    const immediateSuccessorIntent = scheduleImmediateSuccessorIntent({
+      db: args.db,
+      predecessorRunId: args.immediateSuccessorPredecessorRunId,
+      chatThreadId: args.goal.threadId,
+      orgId: args.goal.orgId,
+      intentId: admission.value.eventId,
+      eventClass: "goal",
+      decisionPoint: "queue_admission",
+    });
+
     await set(
       drainChatThreadQueueForThread$,
       {
         chatThreadId: args.goal.threadId,
+        goalImmediateSuccessorIntent: immediateSuccessorIntent,
         immediateSuccessorPredecessorRunId:
           args.immediateSuccessorPredecessorRunId,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,

--- a/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-queue-drain.service.ts
@@ -22,6 +22,7 @@ import {
 } from "./chat-goal-queue.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
+  findImmediateSuccessorIntentHandle,
   scheduleImmediateSuccessorIntent,
   type ImmediateSuccessorIntentHandle,
 } from "./immediate-successor-intent.service";
@@ -441,6 +442,7 @@ export const drainGoalQueueForThread$ = command(
     args: {
       readonly chatThreadId: string;
       readonly apiStartTime: number;
+      readonly goalImmediateSuccessorIntent?: ImmediateSuccessorIntentHandle;
       readonly immediateSuccessorPredecessorRunId?: string;
       readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
       readonly queueItemCreatedBefore?: Date;
@@ -492,6 +494,16 @@ export const drainGoalQueueForThread$ = command(
         }),
       );
 
+      const prearmedImmediateSuccessorIntent =
+        args.goalImmediateSuccessorIntent?.eventClass === "goal" &&
+        args.goalImmediateSuccessorIntent.intentId === event.id
+          ? args.goalImmediateSuccessorIntent
+          : findImmediateSuccessorIntentHandle({
+              predecessorRunId: args.immediateSuccessorPredecessorRunId,
+              intentId: event.id,
+              eventClass: "goal",
+            });
+
       const goal = await timing.measure(
         "api_dispatch_pre_create_zero_goal_drain_load_target",
         "nested",
@@ -506,7 +518,9 @@ export const drainGoalQueueForThread$ = command(
           "api_dispatch_pre_create_zero_goal_drain_revoke_invalid_event",
           "nested",
           async () => {
-            return await revokeGoalEvent(db, event, signal);
+            return await revokeGoalEvent(db, event, signal, () => {
+              prearmedImmediateSuccessorIntent?.revoke();
+            });
           },
           phaseDimensions,
         );
@@ -514,14 +528,17 @@ export const drainGoalQueueForThread$ = command(
         continue;
       }
 
-      const immediateSuccessorIntent = scheduleImmediateSuccessorIntent({
-        db,
-        predecessorRunId: args.immediateSuccessorPredecessorRunId,
-        chatThreadId: event.chatThreadId,
-        orgId: goal.orgId,
-        intentId: event.id,
-        eventClass: "goal",
-      });
+      const immediateSuccessorIntent =
+        prearmedImmediateSuccessorIntent ??
+        scheduleImmediateSuccessorIntent({
+          db,
+          predecessorRunId: args.immediateSuccessorPredecessorRunId,
+          chatThreadId: event.chatThreadId,
+          orgId: goal.orgId,
+          intentId: event.id,
+          eventClass: "goal",
+          decisionPoint: "queue_drain",
+        });
 
       const result = await set(
         launchQueuedGoal$,

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -150,6 +150,7 @@ function prepareWorkflowImmediateSuccessor(args: {
     orgId: args.target.automation.orgId,
     intentId: args.event.id,
     eventClass: "automation",
+    decisionPoint: "queue_drain",
   });
   return { launchHint, intent };
 }


### PR DESCRIPTION
## Summary

- arm goal immediate-successor intent immediately after durable queue admission
- preserve the selected event ID for both inserted and coalesced goal admissions
- share one identity-bound, idempotent intent handle across concurrent same-process drains
- distinguish admission and drain fallback decisions in API telemetry

## Behavior

The goal queue transaction remains the durability boundary. Once it commits, the API starts the existing detached source validation and Ably publication using the exact predecessor, thread, organization, and durable event ID. The shared scheduler still applies prompt > goal > workflow priority, and run creation and runner claim remain the only execution authorities.

A hard-capped ccstate registry retains the advisory handle for at most the existing 1,500 ms usefulness window. Concurrent terminal-callback and delivery-finalization drains in one API process reuse the same arm and revoke owner. Cross-process duplicates remain compatible with existing runner idempotency.

This PR does not change the runner payload, sandbox lifecycle, claim behavior, database schema, or prepared-handoff rollout gate.

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-goals.test.ts src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/zero-workflow-queue.test.ts --maxWorkers=1 --silent=passed-only` (95 tests)
- pre-commit hook: Prettier, full Knip, full Turbo type checks, and file-size validation

Closes #26305

Parent context: #26069
