### PR TITLE
fix(e2e): restore codex runner coverage

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 WORKFLOW="${REPO_ROOT}/.github/workflows/turbo.yml"
+RUNNER_TESTS="${REPO_ROOT}/e2e/tests/03-runner"
+RUNNER_HELPER="${REPO_ROOT}/e2e/helpers/runner-chat.bash"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -25,6 +27,9 @@ grep -Fq "RUNNER_GROUP: \${{ format('vm0/development-{0}', needs.prepare.outputs
   fail "runner group must match the deployed API default group"
 if grep -Fq 'playwright-staging' "$WORKFLOW"; then
   fail "main Playwright runs must not use a group outside the staging API default"
+fi
+if grep -R -Fq '/api/test/' "$RUNNER_TESTS" "$RUNNER_HELPER"; then
+  fail "runner E2E coverage must use supported public APIs"
 fi
 
 ruby -ryaml - "$WORKFLOW" <<'RUBY'
@@ -183,8 +188,25 @@ shard_step = runner.fetch("steps").find do |step|
   step["name"] == "Initialize runner E2E shard"
 end
 raise "missing runner E2E shard scaffold" unless shard_step
-if runner.fetch("steps").any? { |step| step.fetch("name", "").include?("Run runner E2E tests") }
-  raise "runner E2E scaffold must not add test coverage yet"
+run_step = runner.fetch("steps").find do |step|
+  step.fetch("name", "").include?("Run runner E2E tests")
+end
+raise "missing runner E2E test execution" unless run_step
+run_script = run_step.fetch("run")
+%w[
+  e2e/tests/03-runner
+  E2E_RUNNER_SHARD_INDEX
+  E2E_RUNNER_SHARD_TOTAL
+  BATS_TEST_TIMEOUT=240
+  ./e2e/test/libs/bats/bin/bats
+].each do |required_fragment|
+  unless run_script.include?(required_fragment)
+    raise "runner E2E test execution must include #{required_fragment}"
+  end
+end
+unless run_step.dig("env", "VERCEL_AUTOMATION_BYPASS_SECRET") ==
+    "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}"
+  raise "runner E2E tests must receive the preview bypass secret"
 end
 unless runner.fetch("steps").any? do |step|
     step["name"] == "Download runner E2E API tokens" &&

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2508,9 +2508,9 @@ jobs:
 
           RUNNER_START_SUCCEEDED=1
 
-  # Prepare the runner identities and API credentials once, then fan future
-  # runner coverage across the same twelve independent shards used by the
-  # retired runner suite.
+  # Prepare the runner identities and API credentials once, then fan runner
+  # coverage across the same twelve independent shards used by the retired
+  # runner suite.
   cli-e2e-03-runner-prepare:
     runs-on: ubuntu-latest
     timeout-minutes: 8
@@ -2719,6 +2719,36 @@ jobs:
           : "${E2E_API_TOKEN:?runner E2E API token is required}"
           : "${E2E_API_URL:?runner E2E API URL is required}"
           echo "Runner E2E shard ${E2E_RUNNER_SHARD_INDEX}/${E2E_RUNNER_SHARD_TOTAL} is ready"
+      - name: Run runner E2E tests (shard ${{ matrix.index }})
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t runner_tests < <(
+            find e2e/tests/03-runner -maxdepth 1 -type f -name '*.bats' -print | LC_ALL=C sort
+          )
+
+          shard_tests=()
+          for test_index in "${!runner_tests[@]}"; do
+            assigned_shard=$((test_index % E2E_RUNNER_SHARD_TOTAL + 1))
+            if (( assigned_shard == E2E_RUNNER_SHARD_INDEX )); then
+              shard_tests+=("${runner_tests[$test_index]}")
+            fi
+          done
+
+          if (( ${#shard_tests[@]} == 0 )); then
+            echo "No runner E2E tests assigned to shard ${E2E_RUNNER_SHARD_INDEX}"
+            exit 0
+          fi
+
+          echo "Runner E2E shard ${E2E_RUNNER_SHARD_INDEX} files: ${shard_tests[*]}"
+          mkdir -p e2e/results
+          BATS_TEST_TIMEOUT=240 ./e2e/test/libs/bats/bin/bats \
+            -T \
+            --report-formatter junit \
+            --output e2e/results \
+            "${shard_tests[@]}"
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
   cli-e2e-03-runner-cleanup:
     runs-on: ubuntu-latest

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+
+runner_api_token() {
+    if [[ -z "${E2E_API_TOKEN:-}" ]]; then
+        echo "E2E_API_TOKEN is required" >&2
+        return 1
+    fi
+    printf '%s' "$E2E_API_TOKEN"
+}
+
+runner_api_url() {
+    if [[ -z "${E2E_API_URL:-}" ]]; then
+        echo "E2E_API_URL is required" >&2
+        return 1
+    fi
+    printf '%s' "${E2E_API_URL%/}"
+}
+
+require_runner_api_credentials() {
+    runner_api_token >/dev/null && runner_api_url >/dev/null
+}
+
+runner_api_curl() {
+    local path="$1"
+    shift
+
+    local token base
+    token="$(runner_api_token)" || return 1
+    base="$(runner_api_url)" || return 1
+
+    local -a headers=(
+        -H "Authorization: Bearer $token"
+        -H "Content-Type: application/json"
+    )
+    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        headers+=(
+            -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET"
+        )
+    fi
+
+    curl -fsS \
+        --connect-timeout "${E2E_CURL_CONNECT_TIMEOUT_SECONDS:-10}" \
+        --max-time "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
+        "${headers[@]}" \
+        "$@" \
+        "$base$path"
+}
+
+create_runner_agent() {
+    local display_name="$1"
+    local payload response
+
+    payload="$(jq -nc \
+        --arg displayName "$display_name" \
+        '{displayName: $displayName, visibility: "private"}')"
+    response="$(runner_api_curl "/api/zero/agents" -X POST -d "$payload")" || return 1
+    jq -er '.agentId | select(type == "string" and length > 0)' <<< "$response"
+}
+
+set_runner_agent_instructions() {
+    local agent_id="$1"
+    local content="$2"
+    local payload
+
+    payload="$(jq -nc --arg content "$content" '{content: $content}')"
+    runner_api_curl "/api/zero/agents/$agent_id/instructions" \
+        -X PUT \
+        -d "$payload" \
+        >/dev/null
+}
+
+delete_runner_agent() {
+    local agent_id="$1"
+    runner_api_curl "/api/zero/agents/$agent_id" -X DELETE >/dev/null
+}
+
+_runner_uuid() {
+    tr -d '\n' < /proc/sys/kernel/random/uuid
+}
+
+_runner_chat_send() {
+    local agent_id="$1"
+    local prompt="$2"
+    local thread_id="$3"
+    local selected_model="$4"
+    local client_event_id payload
+
+    client_event_id="$(_runner_uuid)"
+    if [[ -n "$thread_id" ]]; then
+        payload="$(jq -nc \
+            --arg agentId "$agent_id" \
+            --arg prompt "$prompt" \
+            --arg threadId "$thread_id" \
+            --arg clientEventId "$client_event_id" \
+            '{
+                agentId: $agentId,
+                prompt: $prompt,
+                threadId: $threadId,
+                clientEventId: $clientEventId,
+                userMessage: {version: 1, parts: [{type: "text", text: $prompt}]},
+                hasTextContent: true
+            }')"
+    else
+        payload="$(jq -nc \
+            --arg agentId "$agent_id" \
+            --arg prompt "$prompt" \
+            --arg model "$selected_model" \
+            --arg clientEventId "$client_event_id" \
+            '{
+                agentId: $agentId,
+                prompt: $prompt,
+                model: $model,
+                clientEventId: $clientEventId,
+                userMessage: {version: 1, parts: [{type: "text", text: $prompt}]},
+                hasTextContent: true
+            }')"
+    fi
+
+    runner_api_curl "/api/zero/chat/events" -X POST -d "$payload"
+}
+
+_wait_for_runner_run() {
+    local run_id="$1"
+    local timeout="${2:-100}"
+    local interval="${RUNNER_RUN_POLL_INTERVAL_SECONDS:-2}"
+    local start=$SECONDS
+    local response="" run_status=""
+
+    while (( SECONDS - start < timeout )); do
+        if response="$(runner_api_curl "/api/zero/runs/$run_id" 2>&1)"; then
+            run_status="$(jq -r '.status // empty' <<< "$response")"
+            case "$run_status" in
+                completed)
+                    printf '%s\n' "$response"
+                    return 0
+                    ;;
+                failed|timeout|cancelled)
+                    echo "# Run $run_id reached terminal status: $run_status" >&2
+                    echo "# Run response: $response" >&2
+                    return 1
+                    ;;
+            esac
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for run $run_id" >&2
+    echo "# Last run response: $response" >&2
+    return 1
+}
+
+_wait_for_runner_chat_output() {
+    local thread_id="$1"
+    local run_id="$2"
+    local prompt="$3"
+    local timeout="${4:-30}"
+    local interval="${RUNNER_CHAT_EVENT_POLL_INTERVAL_SECONDS:-2}"
+    local start=$SECONDS
+    local response=""
+
+    while (( SECONDS - start < timeout )); do
+        if response="$(runner_api_curl "/api/zero/chat-threads/$thread_id/events?limit=50" 2>&1)"; then
+            if jq -e --arg runId "$run_id" --arg prompt "$prompt" '
+                any(.events[]?;
+                    .eventType == "output.message" and
+                    .runId == $runId and
+                    (.content | contains($prompt))
+                ) and
+                any(.events[]?;
+                    .eventType == "run.completed" and .runId == $runId
+                )
+            ' <<< "$response" >/dev/null; then
+                return 0
+            fi
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for chat output for run $run_id" >&2
+    echo "# Last chat event response: $response" >&2
+    return 1
+}
+
+_wait_for_runner_codex_events() {
+    local run_id="$1"
+    local prompt="$2"
+    local timeout="${3:-30}"
+    local interval="${RUNNER_EVENT_POLL_INTERVAL_SECONDS:-2}"
+    local start=$SECONDS
+    local response=""
+
+    while (( SECONDS - start < timeout )); do
+        if response="$(runner_api_curl "/api/zero/runs/$run_id/telemetry/agent?limit=100&order=asc" 2>&1)"; then
+            if jq -e --arg prompt "$prompt" '
+                [.events[]?.eventData |
+                    if type == "string" then . else tojson end
+                ] as $payloads |
+                .framework == "codex" and
+                any($payloads[]; contains("thread.started")) and
+                any($payloads[]; contains("turn.completed")) and
+                any($payloads[]; contains($prompt))
+            ' <<< "$response" >/dev/null; then
+                printf '%s\n' "$response"
+                return 0
+            fi
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for Codex events for run $run_id" >&2
+    echo "# Last event response: $response" >&2
+    return 1
+}
+
+_runner_chat_execute() {
+    local agent_id="$1"
+    local prompt="$2"
+    local thread_id="$3"
+    local selected_model="$4"
+    local send_response run_id resolved_thread_id run_response events_response
+
+    send_response="$(_runner_chat_send \
+        "$agent_id" \
+        "$prompt" \
+        "$thread_id" \
+        "$selected_model")" || return 1
+    run_id="$(jq -er '.runId | select(type == "string" and length > 0)' <<< "$send_response")" || return 1
+    resolved_thread_id="$(jq -er '.threadId | select(type == "string" and length > 0)' <<< "$send_response")" || return 1
+
+    run_response="$(_wait_for_runner_run "$run_id")" || return 1
+    if ! jq -e '
+        .status == "completed" and
+        (.result.agentSessionId | type == "string" and length > 0)
+    ' <<< "$run_response" >/dev/null; then
+        echo "# Completed run did not contain a session id: $run_response" >&2
+        return 1
+    fi
+
+    _wait_for_runner_chat_output \
+        "$resolved_thread_id" \
+        "$run_id" \
+        "$prompt" || return 1
+    events_response="$(_wait_for_runner_codex_events "$run_id" "$prompt")" || return 1
+
+    jq -cn \
+        --arg runId "$run_id" \
+        --arg threadId "$resolved_thread_id" \
+        --arg sessionId "$(jq -er '.result.agentSessionId' <<< "$run_response")" \
+        --arg framework "$(jq -er '.framework' <<< "$events_response")" \
+        '{
+            runId: $runId,
+            threadId: $threadId,
+            sessionId: $sessionId,
+            framework: $framework,
+            status: "completed"
+        }'
+    jq -r '.events[].eventData |
+        if type == "string" then . else tojson end
+    ' <<< "$events_response"
+}
+
+runner_chat_start() {
+    local agent_id="$1"
+    local prompt="$2"
+    _runner_chat_execute "$agent_id" "$prompt" "" "deepseek-v4-flash"
+}
+
+runner_chat_continue() {
+    local agent_id="$1"
+    local thread_id="$2"
+    local prompt="$3"
+    _runner_chat_execute "$agent_id" "$prompt" "$thread_id" ""
+}
+
+runner_chat_field() {
+    local captured_output="$1"
+    local filter="$2"
+    sed -n '1p' <<< "$captured_output" | jq -er "$filter"
+}

--- a/e2e/tests/03-runner/t-codex-resume.bats
+++ b/e2e/tests/03-runner/t-codex-resume.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+# Codex resume test through two supported sends on the same chat thread.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+
+setup_file() {
+    require_runner_api_credentials
+
+    export RUNNER_AGENT_ID
+    RUNNER_AGENT_ID="$(create_runner_agent \
+        "e2e-codex-resume-$(date +%s%3N)-$RANDOM")"
+    set_runner_agent_instructions \
+        "$RUNNER_AGENT_ID" \
+        "Codex resume test instructions."
+}
+
+teardown_file() {
+    if [[ -n "${RUNNER_AGENT_ID:-}" ]]; then
+        delete_runner_agent "$RUNNER_AGENT_ID"
+    fi
+}
+
+@test "t-codex-resume-1: second chat turn resumes the codex session" {
+    run runner_chat_start "$RUNNER_AGENT_ID" "first turn"
+
+    assert_success
+    assert_output --partial '"type":"thread.started"'
+    assert_output --partial "first turn"
+    assert_output --partial '"type":"turn.completed"'
+
+    local first_output="$output"
+    local thread_id first_session_id
+    thread_id="$(runner_chat_field "$first_output" '.threadId')"
+    first_session_id="$(runner_chat_field "$first_output" '.sessionId')"
+
+    run runner_chat_continue "$RUNNER_AGENT_ID" "$thread_id" "second turn"
+
+    assert_success
+    assert_output --partial '"type":"thread.started"'
+    assert_output --partial "second turn"
+    assert_output --partial '"type":"turn.completed"'
+
+    local second_thread_id second_session_id
+    second_thread_id="$(runner_chat_field "$output" '.threadId')"
+    second_session_id="$(runner_chat_field "$output" '.sessionId')"
+    [[ "$second_thread_id" == "$thread_id" ]]
+    [[ "$second_session_id" == "$first_session_id" ]]
+}

--- a/e2e/tests/03-runner/t-codex-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-smoke.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# Codex smoke test through the supported agent and chat APIs.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+
+setup_file() {
+    require_runner_api_credentials
+
+    export RUNNER_AGENT_ID
+    RUNNER_AGENT_ID="$(create_runner_agent \
+        "e2e-codex-smoke-$(date +%s%3N)-$RANDOM")"
+    set_runner_agent_instructions \
+        "$RUNNER_AGENT_ID" \
+        "Codex smoke test instructions."
+}
+
+teardown_file() {
+    if [[ -n "${RUNNER_AGENT_ID:-}" ]]; then
+        delete_runner_agent "$RUNNER_AGENT_ID"
+    fi
+}
+
+@test "t-codex-smoke-1: basic codex chat run returns structured events" {
+    run runner_chat_start "$RUNNER_AGENT_ID" "echo from codex"
+
+    assert_success
+    assert_output --partial '"framework":"codex"'
+    assert_output --partial '"type":"thread.started"'
+    assert_output --partial "echo from codex"
+    assert_output --partial '"type":"turn.completed"'
+    [[ -n "$(runner_chat_field "$output" '.runId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.sessionId')" ]]
+}


### PR DESCRIPTION
## Summary

- restore `t-codex-smoke` and `t-codex-resume` through the supported agent and chat APIs
- verify user-visible output, Codex lifecycle telemetry, and session reuse across turns
- execute runner BATS files across the existing 12-shard e2e-03 scaffold

## Test plan

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/turbo.yml`
- `bats --count e2e/tests/03-runner/t-codex-smoke.bats e2e/tests/03-runner/t-codex-resume.bats`

The PR pipeline will run the restored tests against the e2e-03 preview and runner.
