### PR TITLE
fix(runner): validate h1 absolute-form authorities

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -44,6 +44,7 @@ ruby -ryaml - "$WORKFLOW" <<'RUBY'
 workflow = YAML.load_file(ARGV.fetch(0))
 jobs = workflow.fetch("jobs")
 prepare = jobs.fetch("prepare")
+stripe_listener = jobs.fetch("deploy-stripe-listener")
 account_prepare = jobs.fetch("cli-e2e-03-runner-prepare")
 bootstrap = jobs.fetch("cli-e2e-03-runner-bootstrap")
 runner = jobs.fetch("cli-e2e-03-runner")
@@ -58,6 +59,15 @@ consumer_step = prepare.fetch("steps").find do |step|
 end
 unless consumer_step&.fetch("run", "")&.end_with?("runner-image-context.sh turbo-consumer")
   raise "Turbo must restore the historical runner E2E consumer detector"
+end
+
+stripe_listener_condition = stripe_listener.fetch("if")
+unless stripe_listener_condition.include?(
+    "turbo-runner-consumer-needed == 'true'"
+  ) && stripe_listener_condition.include?(
+    "playwright-runner-consumer-needed == 'true'"
+  )
+  raise "Stripe forwarding must run for every deployed E2E consumer"
 end
 
 unless runner.dig("strategy", "fail-fast") == false

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -62,11 +62,12 @@ unless consumer_step&.fetch("run", "")&.end_with?("runner-image-context.sh turbo
 end
 
 stripe_listener_condition = stripe_listener.fetch("if")
-unless stripe_listener_condition.include?(
-    "turbo-runner-consumer-needed == 'true'"
-  ) && stripe_listener_condition.include?(
-    "playwright-runner-consumer-needed == 'true'"
-  )
+stripe_listener_lines = stripe_listener_condition.lines.map(&:strip)
+expected_stripe_listener_consumers = [
+  "needs.prepare.outputs.turbo-runner-consumer-needed == 'true' ||",
+  "needs.prepare.outputs.playwright-runner-consumer-needed == 'true'",
+]
+unless stripe_listener_lines.each_cons(2).include?(expected_stripe_listener_consumers)
   raise "Stripe forwarding must run for every deployed E2E consumer"
 end
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1636,21 +1636,19 @@ jobs:
     concurrency:
       group: deploy-stripe-listener-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
-    # Runs in parallel with deploy-api: the forward URL is the deterministic
+    # Runs in parallel with deploy-api whenever a deployed E2E consumer may
+    # exercise a payment flow. The forward URL is the deterministic
     # prepare.outputs.api-preview-url (a stable alias, not a deploy-api output),
-    # and Stripe webhooks only fire during e2e payment tests, which run after
-    # deploy-api has succeeded — so the listener never forwards to a dead API.
+    # and Stripe webhooks only fire after deploy-api has succeeded — so the
+    # listener never forwards to a dead API.
     needs: [prepare]
     if: |
       always() &&
       github.event_name != 'push' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.prepare.outputs.job-ref != '' && (
-        needs.prepare.outputs.api-changed == 'true' ||
-        needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.platform-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true' ||
-        needs.prepare.outputs.e2e-changed == 'true'
+        needs.prepare.outputs.turbo-runner-consumer-needed == 'true' ||
+        needs.prepare.outputs.playwright-runner-consumer-needed == 'true'
       )
     steps:
       - uses: actions/checkout@v7.0.1

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -40,6 +40,7 @@ _PERCENT_DECODED_HOST_SYNTAX_CHARS = frozenset("{}.\u3002\uff0e\uff61,")
 _URL_PATH_SAFE_CHARS = "/%:@!$&'()*+,;="
 _URL_QUERY_SAFE_CHARS = "/?%:@!$&'()*+,;="
 _VALID_AUTH_BASE_SCHEME = "https"
+_DEFAULT_HTTPS_PORT = 443
 
 
 @dataclass(frozen=True)
@@ -77,10 +78,12 @@ class AuthorityValidationError(Exception):
     - ``missing_sni``: the HTTPS request had no TLS SNI.
     - ``invalid_sni``: the TLS SNI failed hostname normalization.
     - ``missing_authority``: the HTTPS request had no Host/``:authority``.
-    - ``invalid_authority``: Host/``:authority`` was ambiguous or failed
+    - ``invalid_authority``: an asserted HTTP authority was ambiguous or failed
       parsing or normalization.
-    - ``authority_mismatch``: the Host hostname did not match TLS SNI.
-    - ``authority_port_mismatch``: the Host port did not match destination port.
+    - ``authority_mismatch``: an asserted authority hostname did not match TLS
+      SNI.
+    - ``authority_port_mismatch``: an asserted authority port did not match the
+      destination port.
     """
 
     def __init__(
@@ -255,18 +258,20 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
             fallback_url=trusted_url,
         )
 
-    authorities = [host_header]
+    authority_assertions: list[tuple[str, int | None]] = [(host_header, None)]
     if flow.request.authority:
         if flow.request.is_http2 or flow.request.is_http3:
             if raw_host_headers:
-                authorities.append(raw_host_headers[0])
+                authority_assertions.append((raw_host_headers[0], None))
         else:
-            authorities.append(flow.request.authority)
+            # Unlike a Host field, an absolute HTTPS URI with no explicit port
+            # identifies the default 443 origin.
+            authority_assertions.append((flow.request.authority, _DEFAULT_HTTPS_PORT))
 
-    for authority in authorities:
+    for authority, implicit_port in authority_assertions:
         try:
-            header_host, header_port = _parse_host_authority(authority)
-            normalized_header_host = _normalize_hostname(header_host)
+            parsed_host, explicit_port = _parse_host_authority(authority)
+            normalized_authority_host = _normalize_hostname(parsed_host)
         except (UnicodeError, ValueError):
             raise _authority_validation_error(
                 "invalid_authority",
@@ -274,14 +279,15 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
                 fallback_url=trusted_url,
             ) from None
 
-        if normalized_header_host != normalized_sni:
+        if normalized_authority_host != normalized_sni:
             raise _authority_validation_error(
                 "authority_mismatch",
                 message="Request blocked: Host authority does not match TLS SNI",
                 fallback_url=trusted_url,
             )
 
-        if header_port is not None and header_port != port:
+        effective_port = explicit_port if explicit_port is not None else implicit_port
+        if effective_port is not None and effective_port != port:
             raise _authority_validation_error(
                 "authority_port_mismatch",
                 message="Request blocked: Host authority port does not match destination port",

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -46,7 +46,7 @@ _VALID_AUTH_BASE_SCHEME = "https"
 class TrustedAuthority:
     """Authority components trusted by firewall/auth decisions.
 
-    For HTTPS, ``host`` is the normalized TLS SNI after Host/``:authority``
+    For HTTPS, ``host`` is the normalized TLS SNI after HTTP request authority
     validation. For non-HTTPS traffic, ``host`` is the transparent destination
     because there is no SNI binding. ``url`` is the reconstructed URL used by
     firewall matching and credential injection.
@@ -182,11 +182,11 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
 
     In transparent mode, mitmproxy's request host is the ``SO_ORIGINAL_DST``
     destination. For HTTPS, the TLS SNI is the domain authority used for
-    upstream TLS, while Host/``:authority`` values are only client assertions.
-    Require every HTTP authority to agree with SNI before using the URL for
-    firewall matching or credential injection. For non-HTTPS traffic there is
-    no SNI binding, so use the transparent destination host and do not trust
-    Host.
+    upstream TLS, while Host, HTTP/1 request-target authority, and HTTP/2/3
+    ``:authority`` values are only client assertions. Require every HTTP
+    authority to agree with SNI before using the URL for firewall matching or
+    credential injection. For non-HTTPS traffic there is no SNI binding, so use
+    the transparent destination host and do not trust Host.
 
     HTTPS validation failures raise ``AuthorityValidationError`` with one of
     the documented ``AuthorityValidationReason`` values.
@@ -256,12 +256,12 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
         )
 
     authorities = [host_header]
-    if (
-        (flow.request.is_http2 or flow.request.is_http3)
-        and flow.request.authority
-        and raw_host_headers
-    ):
-        authorities.append(raw_host_headers[0])
+    if flow.request.authority:
+        if flow.request.is_http2 or flow.request.is_http3:
+            if raw_host_headers:
+                authorities.append(raw_host_headers[0])
+        else:
+            authorities.append(flow.request.authority)
 
     for authority in authorities:
         try:

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -14,6 +14,7 @@ from h2.connection import H2Connection
 from mitmproxy import connection, http
 from mitmproxy.addons.proxyserver import Proxyserver
 from mitmproxy.flow import Error
+from mitmproxy.net.http import http1
 from mitmproxy.proxy import commands, events
 from mitmproxy.proxy.context import Context
 from mitmproxy.proxy.layers.http import (
@@ -159,6 +160,9 @@ def _start_http_layer(
     *,
     alpn: bytes,
     host: str = _PLACEHOLDER_HOST,
+    server_host: str | None = None,
+    server_port: int = 443,
+    mode: HTTPMode = HTTPMode.regular,
 ) -> tuple[connection.Client, HttpLayer]:
     client = connection.Client(
         peername=(_CLIENT_IP, 12345),
@@ -169,8 +173,10 @@ def _start_http_layer(
         sni=host,
     )
     context = Context(client, addon_context.options)
-    context.server.address = (host, 443)
-    http_layer = HttpLayer(context, HTTPMode.regular)
+    context.server.address = (server_host or host, server_port)
+    if mode is HTTPMode.transparent:
+        context.server.tls = True
+    http_layer = HttpLayer(context, mode)
     list(http_layer.handle_event(events.Start()))
     return client, http_layer
 
@@ -246,6 +252,38 @@ def _start_http1_request(
             events.DataReceived(
                 client,
                 f"{method} / HTTP/1.1\r\nHost: placeholder.example.com\r\n\r\n".encode(),
+            )
+        )
+    )
+    request_headers_hook = next(
+        command for command in commands if isinstance(command, HttpRequestHeadersHook)
+    )
+    return http_layer, request_headers_hook
+
+
+def _start_transparent_http1_absolute_request(
+    addon_context: taddons.context,
+    *,
+    authority: str,
+    host: str = "api.github.com",
+    original_host: str = "203.0.113.10",
+    port: int = 443,
+    path: str = "/repos",
+) -> tuple[HttpLayer, HttpRequestHeadersHook]:
+    client, http_layer = _start_http_layer(
+        addon_context,
+        alpn=b"http/1.1",
+        host=host,
+        server_host=original_host,
+        server_port=port,
+        mode=HTTPMode.transparent,
+    )
+
+    commands = list(
+        http_layer.handle_event(
+            events.DataReceived(
+                client,
+                f"GET https://{authority}{path} HTTP/1.1\r\nHost: {host}\r\n\r\n".encode(),
             )
         )
     )
@@ -457,6 +495,119 @@ async def test_http2_duplicate_host_is_rejected_before_auth_or_http1_downgrade(
         and isinstance(command.connection, connection.Server)
         for command in request_commands
     )
+
+
+async def test_http1_absolute_form_authority_is_rejected_before_auth_or_forwarding(
+    tmp_path: Path,
+    fake_firewall_headers,
+) -> None:
+    registry_path = _write_github_firewall_registry(
+        tmp_path,
+        base="https://api.github.com",
+        vm_fields={"captureNetworkBodies": True},
+    )
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        http_layer, request_headers_hook = _start_transparent_http1_absolute_request(
+            addon_context,
+            authority="attacker.example",
+        )
+        flow = request_headers_hook.flow
+        original_head = http1.assemble_request_head(flow.request)
+
+        assert flow.request.scheme == "https"
+        assert flow.request.host == "203.0.113.10"
+        assert flow.request.port == 443
+        assert flow.request.host_header == "api.github.com"
+        assert flow.request.authority == "attacker.example"
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+
+        get_headers.assert_not_awaited()
+        assert http1.assemble_request_head(flow.request) == original_head
+
+        header_commands = list(
+            http_layer.handle_event(events.HookCompleted(request_headers_hook, None))
+        )
+        request_hook = next(
+            command for command in header_commands if isinstance(command, HttpRequestHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+
+        request_commands = list(http_layer.handle_event(events.HookCompleted(request_hook, None)))
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.response.content is not None
+    assert json.loads(flow.response.content)["error"] == "authority_mismatch"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "authority_mismatch"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert http1.assemble_request_head(flow.request) == original_head
+    assert "Authorization" not in flow.request.headers
+    get_headers.assert_not_awaited()
+    assert not any(
+        isinstance(command, (commands.OpenConnection, commands.SendData))
+        and isinstance(command.connection, connection.Server)
+        for command in request_commands
+    )
+
+
+async def test_matching_http1_absolute_form_authority_is_forwardable_with_auth(
+    tmp_path: Path,
+    fake_firewall_headers,
+) -> None:
+    registry_path = _write_github_firewall_registry(
+        tmp_path,
+        base="https://api.github.com",
+        vm_fields={"captureNetworkBodies": True},
+    )
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        http_layer, request_headers_hook = _start_transparent_http1_absolute_request(
+            addon_context,
+            authority="API.GITHUB.COM.:443",
+        )
+        flow = request_headers_hook.flow
+
+        assert flow.request.host == "203.0.113.10"
+        assert flow.request.host_header == "api.github.com"
+        assert flow.request.authority == "API.GITHUB.COM.:443"
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+        header_commands = list(
+            http_layer.handle_event(events.HookCompleted(request_headers_hook, None))
+        )
+        request_hook = next(
+            command for command in header_commands if isinstance(command, HttpRequestHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+        list(http_layer.handle_event(events.HookCompleted(request_hook, None)))
+
+    assert flow.response is None
+    assert flow.request.authority == "API.GITHUB.COM.:443"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert flow.request.headers["Authorization"] == "Bearer managed-secret"
+    assert get_headers.await_count == 1
+    forwarded_head = http1.assemble_request_head(flow.request)
+    assert forwarded_head.startswith(b"GET https://API.GITHUB.COM.:443/repos HTTP/1.1\r\n")
+    assert b"Host: api.github.com\r\n" in forwarded_head
+    assert b"Authorization: Bearer managed-secret\r\n" in forwarded_head
 
 
 async def test_http2_fresh_catalog_hit_completes_without_provider_connection(

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -573,7 +573,7 @@ async def test_matching_http1_absolute_form_authority_is_forwardable_with_auth(
     with (
         patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
         taddons.context(Proxyserver(), mitm_addon) as addon_context,
-        fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
+        fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}),
     ):
         addon_context.options.update(
             vm0_api_url="https://api.vm0.ai",
@@ -603,7 +603,6 @@ async def test_matching_http1_absolute_form_authority_is_forwardable_with_auth(
     assert flow.request.authority == "API.GITHUB.COM.:443"
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
     assert flow.request.headers["Authorization"] == "Bearer managed-secret"
-    assert get_headers.await_count == 1
     forwarded_head = http1.assemble_request_head(flow.request)
     assert forwarded_head.startswith(b"GET https://API.GITHUB.COM.:443/repos HTTP/1.1\r\n")
     assert b"Host: api.github.com\r\n" in forwarded_head

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_framing.py
@@ -497,13 +497,37 @@ async def test_http2_duplicate_host_is_rejected_before_auth_or_http1_downgrade(
     )
 
 
+@pytest.mark.parametrize(
+    ("port", "authority", "expected_reason", "expected_original_url"),
+    [
+        pytest.param(
+            443,
+            "attacker.example",
+            "authority_mismatch",
+            "https://api.github.com/repos",
+            id="host-mismatch",
+        ),
+        pytest.param(
+            8443,
+            "api.github.com",
+            "authority_port_mismatch",
+            "https://api.github.com:8443/repos",
+            id="implicit-default-port-mismatch",
+        ),
+    ],
+)
 async def test_http1_absolute_form_authority_is_rejected_before_auth_or_forwarding(
     tmp_path: Path,
     fake_firewall_headers,
+    port: int,
+    authority: str,
+    expected_reason: str,
+    expected_original_url: str,
 ) -> None:
+    firewall_base = "https://api.github.com" if port == 443 else f"https://api.github.com:{port}"
     registry_path = _write_github_firewall_registry(
         tmp_path,
-        base="https://api.github.com",
+        base=firewall_base,
         vm_fields={"captureNetworkBodies": True},
     )
 
@@ -518,16 +542,17 @@ async def test_http1_absolute_form_authority_is_rejected_before_auth_or_forwardi
         )
         http_layer, request_headers_hook = _start_transparent_http1_absolute_request(
             addon_context,
-            authority="attacker.example",
+            authority=authority,
+            port=port,
         )
         flow = request_headers_hook.flow
         original_head = http1.assemble_request_head(flow.request)
 
         assert flow.request.scheme == "https"
         assert flow.request.host == "203.0.113.10"
-        assert flow.request.port == 443
+        assert flow.request.port == port
         assert flow.request.host_header == "api.github.com"
-        assert flow.request.authority == "attacker.example"
+        assert flow.request.authority == authority
 
         await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
 
@@ -547,9 +572,9 @@ async def test_http1_absolute_form_authority_is_rejected_before_auth_or_forwardi
     assert flow.response is not None
     assert flow.response.status_code == 403
     assert flow.response.content is not None
-    assert json.loads(flow.response.content)["error"] == "authority_mismatch"
-    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "authority_mismatch"
-    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert json.loads(flow.response.content)["error"] == expected_reason
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_reason
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     assert http1.assemble_request_head(flow.request) == original_head
     assert "Authorization" not in flow.request.headers
     get_headers.assert_not_awaited()

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -352,22 +352,35 @@ async def test_rejects_disagreement_between_pseudo_authority_and_host(
 
 
 @pytest.mark.parametrize(
-    ("request_authority", "expected_reason"),
+    ("request_port", "request_authority", "expected_reason", "expected_original_url"),
     [
         pytest.param(
+            443,
             "attacker.example.com",
             "authority_mismatch",
+            "https://api.github.com/repos",
             id="host-mismatch",
         ),
         pytest.param(
+            443,
             "api.github.com:bad",
             "invalid_authority",
+            "https://api.github.com/repos",
             id="malformed-port",
         ),
         pytest.param(
+            443,
             "api.github.com:444",
             "authority_port_mismatch",
+            "https://api.github.com/repos",
             id="port-mismatch",
+        ),
+        pytest.param(
+            8443,
+            "api.github.com",
+            "authority_port_mismatch",
+            "https://api.github.com:8443/repos",
+            id="implicit-default-port-mismatch",
         ),
     ],
 )
@@ -377,14 +390,17 @@ async def test_rejects_invalid_http1_request_target_authority_before_firewall_au
     mitm_ctx,
     fake_firewall_headers,
     headers,
+    request_port,
     request_authority,
     expected_reason,
+    expected_original_url,
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host="203.0.113.10",
+        port=request_port,
         sni="api.github.com",
         path="/repos",
         request_headers=headers(("Host", "api.github.com")),
@@ -406,7 +422,7 @@ async def test_rejects_invalid_http1_request_target_authority_before_firewall_au
     assert body["host_header"] == "api.github.com"
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_reason
-    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     assert tuple(flow.request.headers.fields) == original_headers
     assert flow.request.authority == request_authority
     auth_fetch.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -235,6 +235,65 @@ async def test_valid_pseudo_authority_allows_firewall_auth(
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
+@pytest.mark.parametrize(
+    ("request_port", "request_authority", "expected_original_url"),
+    [
+        pytest.param(
+            443,
+            "API.GITHUB.COM.",
+            "https://api.github.com/repos",
+            id="normalized-host",
+        ),
+        pytest.param(
+            8443,
+            "api.github.com:8443",
+            "https://api.github.com:8443/repos",
+            id="matching-port",
+        ),
+    ],
+)
+async def test_valid_http1_request_target_authority_allows_firewall_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    request_port,
+    request_authority,
+    expected_original_url,
+):
+    firewall_base = (
+        "https://api.github.com"
+        if request_port == 443
+        else f"https://api.github.com:{request_port}"
+    )
+    reg_path = _write_github_firewall_registry(tmp_path, base=firewall_base)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        port=request_port,
+        sni="api.github.com",
+        path="/repos",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+    flow.request.authority = request_authority
+    bind_flow_upstream(flow, port=request_port)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.http_version == "HTTP/1.1"
+    assert flow.request.authority == request_authority
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == firewall_base
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
+    assert flow.request.headers["Authorization"] == "Bearer x"
+
+
 @pytest.mark.parametrize("http_version", ["HTTP/2.0", "HTTP/3"])
 @pytest.mark.parametrize(
     ("pseudo_authority", "regular_host"),
@@ -288,6 +347,68 @@ async def test_rejects_disagreement_between_pseudo_authority_and_host(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "authority_mismatch"
     assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    auth_fetch.assert_not_called()
+    assert "Authorization" not in flow.request.headers
+
+
+@pytest.mark.parametrize(
+    ("request_authority", "expected_reason"),
+    [
+        pytest.param(
+            "attacker.example.com",
+            "authority_mismatch",
+            id="host-mismatch",
+        ),
+        pytest.param(
+            "api.github.com:bad",
+            "invalid_authority",
+            id="malformed-port",
+        ),
+        pytest.param(
+            "api.github.com:444",
+            "authority_port_mismatch",
+            id="port-mismatch",
+        ),
+    ],
+)
+async def test_rejects_invalid_http1_request_target_authority_before_firewall_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    request_authority,
+    expected_reason,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.github.com",
+        path="/repos",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+    flow.request.authority = request_authority
+    original_headers = tuple(flow.request.headers.fields)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == expected_reason
+    assert body["sni"] == "api.github.com"
+    assert body["host_header"] == "api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_reason
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.authority == request_authority
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 

--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority.py
@@ -187,6 +187,55 @@ class TestTrustedAuthoritySuccess:
         assert trusted.url == "https://api.github.com:8443/repos"
 
     @pytest.mark.parametrize(
+        ("request_port", "request_authority", "expected_url"),
+        [
+            pytest.param(
+                443,
+                "API.GITHUB.COM.",
+                "https://api.github.com/repos",
+                id="normalized-host",
+            ),
+            pytest.param(
+                443,
+                "api.github.com:000443",
+                "https://api.github.com/repos",
+                id="explicit-default-port",
+            ),
+            pytest.param(
+                8443,
+                "api.github.com:8443",
+                "https://api.github.com:8443/repos",
+                id="matching-nondefault-port",
+            ),
+        ],
+    )
+    def test_accepts_matching_http1_request_target_authority(
+        self,
+        real_flow,
+        headers,
+        request_port,
+        request_authority,
+        expected_url,
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="203.0.113.10",
+            port=request_port,
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+        flow.request.authority = request_authority
+
+        trusted = get_trusted_authority(flow)
+
+        assert flow.request.http_version == "HTTP/1.1"
+        assert flow.request.authority == request_authority
+        assert trusted.host == "api.github.com"
+        assert trusted.port == request_port
+        assert trusted.url == expected_url
+
+    @pytest.mark.parametrize(
         "host_header",
         [
             pytest.param("[2001:db8::1]", id="ipv6-without-port"),

--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
@@ -500,22 +500,40 @@ class TestTrustedAuthorityRejection:
         )
 
     @pytest.mark.parametrize(
-        ("request_authority", "expected_reason"),
+        (
+            "request_port",
+            "request_authority",
+            "expected_reason",
+            "expected_fallback_url",
+        ),
         [
             pytest.param(
+                443,
                 "attacker.example.com",
                 "authority_mismatch",
+                "https://api.github.com/repos",
                 id="host-mismatch",
             ),
             pytest.param(
+                443,
                 "api.github.com:bad",
                 "invalid_authority",
+                "https://api.github.com/repos",
                 id="malformed-port",
             ),
             pytest.param(
+                443,
                 "api.github.com:444",
                 "authority_port_mismatch",
+                "https://api.github.com/repos",
                 id="port-mismatch",
+            ),
+            pytest.param(
+                8443,
+                "api.github.com",
+                "authority_port_mismatch",
+                "https://api.github.com:8443/repos",
+                id="implicit-default-port-mismatch",
             ),
         ],
     )
@@ -523,12 +541,15 @@ class TestTrustedAuthorityRejection:
         self,
         real_flow,
         headers,
+        request_port,
         request_authority,
         expected_reason,
+        expected_fallback_url,
     ):
         flow = real_flow(
             with_response=False,
             host="203.0.113.10",
+            port=request_port,
             sni="api.github.com",
             path="/repos",
             request_headers=headers(("Host", "api.github.com")),
@@ -546,6 +567,6 @@ class TestTrustedAuthorityRejection:
             sni="api.github.com",
             request_host="203.0.113.10",
             host_header="api.github.com",
-            request_port=443,
-            fallback_url="https://api.github.com/repos",
+            request_port=request_port,
+            fallback_url=expected_fallback_url,
         )

--- a/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
+++ b/crates/runner/mitm-addon/tests/test_url_utils_trusted_authority_rejection.py
@@ -498,3 +498,54 @@ class TestTrustedAuthorityRejection:
             request_port=request_port,
             fallback_url=expected_fallback_url,
         )
+
+    @pytest.mark.parametrize(
+        ("request_authority", "expected_reason"),
+        [
+            pytest.param(
+                "attacker.example.com",
+                "authority_mismatch",
+                id="host-mismatch",
+            ),
+            pytest.param(
+                "api.github.com:bad",
+                "invalid_authority",
+                id="malformed-port",
+            ),
+            pytest.param(
+                "api.github.com:444",
+                "authority_port_mismatch",
+                id="port-mismatch",
+            ),
+        ],
+    )
+    def test_rejects_invalid_http1_request_target_authority(
+        self,
+        real_flow,
+        headers,
+        request_authority,
+        expected_reason,
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=headers(("Host", "api.github.com")),
+        )
+        flow.request.authority = request_authority
+
+        with pytest.raises(AuthorityValidationError) as exc_info:
+            get_trusted_authority(flow)
+
+        assert flow.request.http_version == "HTTP/1.1"
+        assert flow.request.authority == request_authority
+        _assert_authority_error(
+            exc_info,
+            reason=expected_reason,
+            sni="api.github.com",
+            request_host="203.0.113.10",
+            host_header="api.github.com",
+            request_port=443,
+            fallback_url="https://api.github.com/repos",
+        )

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -133,7 +133,7 @@ suites before committing the upgrade.
 | `test_request_headers_api_admission.py`                 | Requestheaders platform API destination admission and binding                                                        |
 | `test_request_headers_connector_admission.py`           | Requestheaders connector destination admission, TLS evidence, and binding                                            |
 | `test_request_headers_firewall_auth.py`                 | Requestheaders stream-safe firewall auth, connector intent, fallback, and cancellation cleanup                       |
-| `test_mitmproxy_request_framing.py`                     | HTTP/2 request framing through mitmproxy's state machine and real addon hook dispatch                                |
+| `test_mitmproxy_request_framing.py`                     | HTTP/1 and HTTP/2 request framing through mitmproxy's state machine and real addon hook dispatch                     |
 | `test_mitmproxy_websocket_framing.py`                   | Decoded WebSocket message bounds through mitmproxy's state machine and real addon hook dispatch                      |
 | `test_request_handler_usage_tracking.py`                | Request-hook billable usage tracking lifecycle                                                                       |
 | `test_response_headers_handler.py`                      | Response-header hook stream setup                                                                                    |

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -117,7 +117,7 @@ suites before committing the upgrade.
 | `test_codex_model_catalog_cache_lifecycle.py`           | Codex catalog partitioning, expiry, ETag invalidation, and stored-entry eviction                                     |
 | `test_codex_model_catalog_cache_responses.py`           | Codex catalog response cacheability, decoding, framing, validation, and replay                                       |
 | `test_request_handler_passthrough.py`                   | Request-hook ordinary and browser user-agent passthrough decisions                                                   |
-| `test_request_handler_authority_validation.py`          | Request-hook Host/SNI/`:authority` validation and denial effects                                                     |
+| `test_request_handler_authority_validation.py`          | Request-hook SNI and asserted HTTP authority validation and denial effects                                           |
 | `test_request_handler_builtin_host_policy.py`           | Request-hook runtime built-in host-policy enforcement and compiled-policy reuse                                      |
 | `test_request_handler_connector_admission.py`           | Request-hook connector destination admission, TLS evidence, test-endpoint bypass, and API binding interaction        |
 | `test_request_handler_api_admission.py`                 | Request-hook platform API auto-allow, port scoping, registry gate, and destination binding                           |


### PR DESCRIPTION
## Summary

- validate non-empty HTTPS HTTP/1 absolute-form request-target authorities alongside `Host`, TLS SNI, and the destination port
- interpret an omitted absolute-form HTTPS port as 443, preventing a non-default transparent destination from being trusted as a different URI origin
- fail closed before firewall matching or managed auth for malformed, host-mismatched, and explicit or implicit port-mismatched targets
- cover direct validation, request-hook auth ordering, and real transparent-mode mitmproxy parsing and forwarding while preserving matching absolute-form traffic
- start per-PR Stripe forwarding from the deployed E2E consumer selections so crates-only runner changes still execute runner E2E instead of being skipped by a stale file-category gate

## Scope

- reuses the existing authority parser, normalization, denial reasons, and response/log contracts
- does not rewrite request targets or change mitmproxy, dependencies, lockfiles, auth APIs, registry formats, persisted state, or rollout behavior
- preserves existing origin-form, asterisk-form, HTTP/2, HTTP/3, and regular `Host` behavior
- keeps Stripe listener failure blocking for deployed E2E while allowing it to remain skipped when neither runner nor Playwright E2E is selected

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_url_utils_trusted_authority.py tests/test_url_utils_trusted_authority_rejection.py tests/test_request_handler_authority_validation.py tests/test_mitmproxy_request_framing.py` (`219 passed`)
- `uv run --no-sync python -m pytest tests/` (`5283 passed`)
- `pnpm exec prettier --check ../docs/testing/mitm-addon-testing.md`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/runner-image-context-test.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `bash .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml`
- `shellcheck .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `actionlint .github/workflows/turbo.yml`
- `pnpm exec prettier --check ../.github/workflows/turbo.yml`

Closes #26288
