### PR TITLE
revert: use signed urls for document previews (#26293)

### DIFF
--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -25,10 +25,9 @@ function isAuthenticatedAttachmentUrl(url: string): boolean {
  * on its own; the API still runs the ownership check before signing.
  */
 export function createAttachmentResourceUrl$(
-  source: string | Computed<Promise<string>>,
+  url: string,
 ): Computed<Promise<string>> {
   return computed(async (get) => {
-    const url = typeof source === "string" ? source : await get(source);
     if (!isAuthenticatedAttachmentUrl(url)) {
       return url;
     }

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
@@ -14,7 +14,6 @@ import type {
   ArtifactRefInput,
   ThreadSidebarTarget,
 } from "./thread-sidebar.ts";
-import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
 import { createObjectUrlResource } from "../object-url-resource.ts";
 
 // ---------------------------------------------------------------------------
@@ -136,7 +135,6 @@ export function artifactRefFromUrl(url: string): ArtifactRef {
     url,
     kind: classifyChatAttachment(attachment),
     filename: attachment.filename,
-    resourceUrl$: createAttachmentResourceUrl$(url),
   };
 }
 
@@ -156,8 +154,6 @@ function materializeArtifactRef(
         url: input.url,
       }),
       filename: input.filename,
-      resourceUrl$:
-        input.resourceUrl$ ?? createAttachmentResourceUrl$(input.url),
       ...(input.shareAvailable === undefined
         ? {}
         : { shareAvailable: input.shareAvailable }),
@@ -172,7 +168,6 @@ function materializeArtifactRef(
       url: resource.url,
     }),
     filename: input.file.name,
-    resourceUrl$: createAttachmentResourceUrl$(resource.url),
     releaseObjectUrl: resource.release,
     ...(input.shareAvailable === undefined
       ? {}

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
@@ -5,7 +5,6 @@ import {
   type ArtifactCatalogSignals,
 } from "../artifacts-page/create-artifact-catalog-signals.ts";
 import { artifactDetailPreview } from "../artifacts-page/artifact-catalog-signals.ts";
-import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
 import { fetchPreviewText, isTextPreviewKind } from "../text-preview.ts";
 import { resetSignal } from "../utils.ts";
 
@@ -39,7 +38,6 @@ export type ArtifactRef = {
   readonly url: string;
   readonly kind: ArtifactPreviewKind;
   readonly filename: string;
-  readonly resourceUrl$: Computed<Promise<string>>;
   readonly shareAvailable?: boolean;
   readonly releaseObjectUrl?: () => void;
 };
@@ -54,7 +52,6 @@ export type ArtifactMetadataRef = {
   readonly url: string;
   readonly filename: string;
   readonly contentType?: string;
-  readonly resourceUrl$?: Computed<Promise<string>>;
   readonly shareAvailable?: boolean;
 };
 
@@ -102,7 +99,6 @@ export interface ThreadSidebarSignals {
    * with the thread signals themselves on a thread switch.
    */
   readonly artifactCatalog: ArtifactCatalogSignals;
-  readonly selectedArtifactResourceUrl$: Computed<Promise<string>>;
   readonly selectedArtifactText$: Computed<Promise<string>>;
   /**
    * Session resources for an open artifacts list: refresh the first page in
@@ -134,20 +130,12 @@ export function createThreadSidebarSignals(
   const artifactCatalog = createArtifactCatalogSignals({
     chatThreadId: threadId,
   });
-  const selectedArtifactPreview$ = computed(async (get) => {
+  const selectedArtifactText$ = computed(async (get): Promise<string> => {
     const detail = await get(artifactCatalog.selectedArtifactDetail$);
     if (!detail) {
       throw new Error("Selected artifact is unavailable");
     }
-    return artifactDetailPreview(detail);
-  });
-  const selectedArtifactUrl$ = computed(async (get): Promise<string> => {
-    return (await get(selectedArtifactPreview$)).url;
-  });
-  const selectedArtifactResourceUrl$ =
-    createAttachmentResourceUrl$(selectedArtifactUrl$);
-  const selectedArtifactText$ = computed(async (get): Promise<string> => {
-    const preview = await get(selectedArtifactPreview$);
+    const preview = artifactDetailPreview(detail);
     if (!isTextPreviewKind(preview.kind)) {
       throw new Error("Selected artifact is not a text preview");
     }
@@ -234,7 +222,6 @@ export function createThreadSidebarSignals(
       });
     }),
     artifactCatalog,
-    selectedArtifactResourceUrl$,
     selectedArtifactText$,
     setupArtifactsSession$,
   };

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import { timeout } from "signal-timers";
 import { openArtifactInOpenSidebar$ } from "../chat-page/thread-sidebar-coordinator.ts";
 import type { ArtifactRefInput } from "../chat-page/thread-sidebar.ts";
@@ -15,7 +15,6 @@ import {
   type ObjectUrlResource,
 } from "../object-url-resource.ts";
 import { rootSignal$ } from "../root-signal.ts";
-import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
 
 // ---------------------------------------------------------------------------
 // Lightbox state — tracks which attachment is open in the global preview UI
@@ -56,11 +55,6 @@ type AttachmentFramedDocumentLightboxInput = AttachmentDocumentLightboxBase & {
   readonly kind: "html" | "pdf";
 };
 
-type AttachmentFramedDocumentLightboxState =
-  AttachmentFramedDocumentLightboxInput & {
-    readonly resourceUrl$: Computed<Promise<string>>;
-  };
-
 type AttachmentDocumentLightboxInput =
   | AttachmentTextDocumentLightboxInput
   | AttachmentFramedDocumentLightboxInput;
@@ -81,7 +75,7 @@ export type AttachmentDocumentLightboxState =
       readonly kind: TextPreviewKind;
       readonly text$: TextPreviewComputed;
     })
-  | AttachmentFramedDocumentLightboxState;
+  | AttachmentFramedDocumentLightboxInput;
 
 function isAttachmentTextDocumentLightboxInput(
   value: AttachmentDocumentLightboxInput,
@@ -205,7 +199,6 @@ type AttachmentSidebarPreviewInput = {
   readonly file?: File;
   readonly filename?: string;
   readonly contentType?: string;
-  readonly resourceUrl$?: Computed<Promise<string>>;
   readonly shareAvailable?: boolean;
   readonly splitViewAvailable?: boolean;
 };
@@ -217,9 +210,6 @@ export function attachmentSidebarRef(
     value.shareAvailable === undefined
       ? {}
       : { shareAvailable: value.shareAvailable };
-  const resource = value.resourceUrl$
-    ? { resourceUrl$: value.resourceUrl$ }
-    : {};
   if (value.file) {
     return { file: value.file, url: value.url, ...share };
   }
@@ -231,7 +221,6 @@ export function attachmentSidebarRef(
       url: value.url,
       filename: value.filename,
       ...(contentType ? { contentType } : {}),
-      ...resource,
       ...share,
     };
   }
@@ -311,17 +300,7 @@ export const navigateImageLightbox$ = command(
 
 export const openDocumentLightbox$ = command(
   ({ set }, value: AttachmentDocumentLightboxInput) => {
-    const preview: AttachmentDocumentLightboxState =
-      isAttachmentTextDocumentLightboxInput(value)
-        ? {
-            ...value,
-            text$: value.text$ ?? createTextPreviewComputed(value.url),
-          }
-        : {
-            ...value,
-            resourceUrl$: createAttachmentResourceUrl$(value.url),
-          };
-    if (set(routeToOpenArtifactSidebar$, preview)) {
+    if (set(routeToOpenArtifactSidebar$, value)) {
       return;
     }
     set(internalLightboxDialogCloseToken$, (value) => {
@@ -329,7 +308,14 @@ export const openDocumentLightbox$ = command(
     });
     set(internalLightboxDialogVisible$, true);
     set(internalLightboxDialogFullscreen$, false);
-    set(internalLightboxState$, preview);
+    if (isAttachmentTextDocumentLightboxInput(value)) {
+      set(internalLightboxState$, {
+        ...value,
+        text$: value.text$ ?? createTextPreviewComputed(value.url),
+      });
+      return;
+    }
+    set(internalLightboxState$, value);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -419,36 +419,6 @@ describe("thread-owned utility sidebar", () => {
     expect(requestedThreadIds).toContain(THREAD_ID);
   });
 
-  it("previews a public catalog document through its resource URL signal", async () => {
-    const htmlUrl = "https://catalog-document.sites.vm7.io";
-    const summary = catalogArtifact({ title: "launch-site.html" });
-    setupArtifactCatalog(
-      [summary],
-      new Map([
-        [
-          summary.id,
-          catalogFileDetail({
-            contentType: "text/html",
-            filename: "launch-site.html",
-            fileId: "f0000000-0000-4000-a000-000000000003",
-            summary,
-            url: htmlUrl,
-          }),
-        ],
-      ]),
-    );
-
-    setupChatThread();
-    await openCatalogArtifact("launch-site.html");
-
-    await waitFor(() => {
-      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
-        "src",
-        htmlUrl,
-      );
-    });
-  });
-
   it("shows an unavailable artifact detail with a way back to the list", async () => {
     context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1385,44 +1385,24 @@ describe("zero attachment chips", () => {
     expect(documentFrame).toHaveClass("h-full", "min-h-0");
     expect(iframe).toHaveAttribute(
       "src",
-      `${presignedFileUrl("attachment-pdf")}#navpanes=0`,
+      `${canonicalUserMessageFileUrl("attachment-pdf")}#navpanes=0`,
     );
     expect(iframe).toHaveClass("h-full", "min-h-0", "border-0");
 
-    click(screen.getByLabelText("Open in split view"));
+    click(screen.getByLabelText("Close"));
 
     await waitFor(() => {
       expect(
         screen.queryByTestId("attachment-lightbox"),
       ).not.toBeInTheDocument();
-      expect(screen.getByTestId("artifact-sidebar-body-pdf")).toHaveAttribute(
-        "src",
-        `${presignedFileUrl("attachment-pdf")}#navpanes=0`,
-      );
-    });
-
-    click(screen.getByLabelText("Close artifact"));
-
-    await waitFor(() => {
-      expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
     });
 
     click(screen.getByLabelText("Open html preview for launch-site.html"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("artifact-dialog-body-html")).toHaveAttribute(
-        "src",
-        presignedFileUrl("attachment-html"),
-      );
-    });
-
-    click(screen.getByLabelText("Open in split view"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
-        "src",
-        presignedFileUrl("attachment-html"),
-      );
+      expect(
+        screen.getByTestId("artifact-dialog-body-html"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
@@ -355,7 +355,6 @@ function ThreadArtifactDetail({
         url: preview.url,
         kind: preview.kind,
         filename: preview.filename,
-        resourceUrl$: sidebar.selectedArtifactResourceUrl$,
       }}
       thread={thread}
       text$={sidebar.selectedArtifactText$}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import type { Computed } from "ccstate";
 import {
   ArrowLeft,
   Maximize2,
@@ -311,7 +310,6 @@ function ArtifactSidebarResolvedContent({
           artifactKind={display.artifactKind}
           imageNavigation={imageNavigation}
           fullscreen={fullscreen}
-          resourceUrl$={display.resourceUrl$}
           text$={text$}
         />
       </div>
@@ -454,7 +452,6 @@ interface ArtifactDisplay {
   filename: string;
   subtitle: string;
   shareAvailable: boolean;
-  resourceUrl$: Computed<Promise<string>>;
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
 }
 
@@ -514,7 +511,6 @@ function resolveArtifactDisplay(
       filename: item.file.filename,
       subtitle: artifactTitleSubtitle(ref.kind, item.file),
       shareAvailable: ref.shareAvailable ?? true,
-      resourceUrl$: ref.resourceUrl$,
       artifactKind: item.file.artifactKind,
     };
   }
@@ -524,7 +520,6 @@ function resolveArtifactDisplay(
     filename: ref.filename,
     subtitle: artifactFallbackSubtitle(ref.kind, ref.filename),
     shareAvailable: ref.shareAvailable ?? true,
-    resourceUrl$: ref.resourceUrl$,
   };
 }
 
@@ -808,7 +803,6 @@ function ArtifactBody({
   artifactKind,
   imageNavigation,
   fullscreen,
-  resourceUrl$,
   text$,
 }: {
   url: string;
@@ -817,7 +811,6 @@ function ArtifactBody({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   imageNavigation?: ArtifactImageNavigationActions;
   fullscreen: boolean;
-  resourceUrl$: Computed<Promise<string>>;
   text$?: TextPreviewComputed;
 }) {
   const { t } = useTranslation();
@@ -872,8 +865,8 @@ function ArtifactBody({
   }
   if (kind === "html" || kind === "pdf") {
     return (
-      <ArtifactIframeResourceBody
-        resourceUrl$={resourceUrl$}
+      <ArtifactIframeBody
+        url={url}
         kind={kind}
         filename={filename}
         artifactKind={artifactKind}
@@ -882,34 +875,6 @@ function ArtifactBody({
     );
   }
   return <ArtifactGenericBody filename={filename} />;
-}
-
-function ArtifactIframeResourceBody({
-  resourceUrl$,
-  kind,
-  filename,
-  artifactKind,
-  fullscreen,
-}: {
-  resourceUrl$: Computed<Promise<string>>;
-  kind: "html" | "pdf";
-  filename: string;
-  artifactKind?: ChatThreadArtifactFile["artifactKind"];
-  fullscreen: boolean;
-}) {
-  const resourceUrl = useLastResolved(resourceUrl$);
-  if (!resourceUrl) {
-    return <ArtifactSpinner />;
-  }
-  return (
-    <ArtifactIframeBody
-      url={resourceUrl}
-      kind={kind}
-      filename={filename}
-      artifactKind={artifactKind}
-      fullscreen={fullscreen}
-    />
-  );
 }
 
 function ArtifactSpinner() {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -896,46 +896,12 @@ function ArtifactDialogBody({
     return <ArtifactDialogTextBody kind={preview.kind} text$={preview.text$} />;
   }
 
-  if (preview.kind === "html" || preview.kind === "pdf") {
-    return <ArtifactDialogFramedBody filename={filename} preview={preview} />;
-  }
-
-  return null;
-}
-
-type ArtifactDialogFramedPreview = Extract<
-  AttachmentLightboxState,
-  { readonly kind: "html" | "pdf" }
->;
-
-function ArtifactDialogFramedBody({
-  filename,
-  preview,
-}: {
-  filename: string;
-  preview: ArtifactDialogFramedPreview;
-}) {
-  const { t } = useTranslation();
-  const resourceUrl = useLastResolved(preview.resourceUrl$);
-  if (!resourceUrl) {
-    return (
-      <ArtifactDialogStage centered>
-        <Loader2 className="animate-spin text-muted-foreground" />
-      </ArtifactDialogStage>
-    );
-  }
-
   if (preview.kind === "html") {
-    return (
-      <ArtifactDialogHtmlBody
-        filename={filename}
-        preview={preview}
-        src={publicAttachmentUrl(resourceUrl)}
-      />
-    );
+    return <ArtifactDialogHtmlBody filename={filename} preview={preview} />;
   }
 
-  const src = `${publicAttachmentUrl(resourceUrl)}#navpanes=0`;
+  const publicUrl = publicAttachmentUrl(preview.url);
+  const src = preview.kind === "pdf" ? `${publicUrl}#navpanes=0` : publicUrl;
 
   return (
     <ArtifactDialogStage scrollable={false}>
@@ -962,14 +928,13 @@ function ArtifactDialogFramedBody({
 function ArtifactDialogHtmlBody({
   filename,
   preview,
-  src,
 }: {
   filename: string;
-  preview: ArtifactDialogFramedPreview;
-  src: string;
+  preview: AttachmentLightboxState;
 }) {
   const { t } = useTranslation();
   const fullscreen = useGet(lightboxDialogFullscreen$);
+  const src = publicAttachmentUrl(preview.url);
   const isPresentationHtml =
     preview.artifact?.artifactKind === "presentation-html";
 


### PR DESCRIPTION
## Summary

Reverts #26293 so the unified fix in #26275 can land as a single mechanism.

#26293 presigns the PDF and HTML iframes by threading a `resourceUrl$` signal through `ArtifactRef`, the lightbox state, and the artifact catalog. #26275 resolves the same URL at the leaf component instead, which needs no threading and also covers the paths #26293 does not reach: the composer thumbnail restored from a copied message (#26258), the sidebar image body, video, audio, and text previews.

Keeping both would leave two mechanisms for the same job, so this reverts first and #26275 lands the single one.

## Interim state

PDF and HTML previews of private attachments go back to loading the authenticated API URL, i.e. the #26259 behavior, until #26275 merges. Accepted as a short window because the feature is behind a switch.

## Verification

- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/thread-sidebar.test.tsx` — 62 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
