### PR TITLE
test(api): isolate threadless trigger source cases

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -615,12 +615,14 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     });
   });
 
-  it("processes every non-test trigger source when the run is threadless", async () => {
-    mockNow(THREADLESS_TEST_NOW_MS);
-    const fixtures: RunFixture[] = [];
-    for (const triggerSource of NON_TEST_TRIGGER_SOURCES) {
-      fixtures.push(
-        await trackRun(
+  // Each source owns a separate lifecycle budget because the suite shares its
+  // cleanup lock with past-clock export tests running in another worker.
+  describe.each(NON_TEST_TRIGGER_SOURCES)(
+    "when the trigger source is %s",
+    (triggerSource) => {
+      it("processes the threadless run", async () => {
+        mockNow(THREADLESS_TEST_NOW_MS);
+        const fixture = await trackRun(
           insertRunFixture({
             status: "completed",
             createdAt: new Date(THREADLESS_FORWARD_CUTOFF_MS + 1),
@@ -630,25 +632,21 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
             threadless: true,
             triggerSource,
           }),
-        ),
-      );
-    }
+        );
 
-    const response = await accept(
-      apiClient().cleanup({ headers: cronHeaders() }),
-      [200],
-    );
+        const response = await accept(
+          apiClient().cleanup({ headers: cronHeaders() }),
+          [200],
+        );
 
-    expect(response.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(
-      NON_TEST_TRIGGER_SOURCES.length,
-    );
-    expect(response.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(
-      NON_TEST_TRIGGER_SOURCES.length,
-    );
-    for (const fixture of fixtures) {
-      await expect(findRun(fixture.runId)).resolves.toBeNull();
-    }
-  });
+        expect(response.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(
+          1,
+        );
+        expect(response.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(1);
+        await expect(findRun(fixture.runId)).resolves.toBeNull();
+      });
+    },
+  );
 
   it("waits through the quiet window and deletes at its exact boundary", async () => {
     const completedAt = new Date(THREADLESS_TEST_NOW_MS);


### PR DESCRIPTION
## Summary

- split the enum-derived non-test trigger-source matrix into one API integration case per source
- keep every case under the existing advisory-lock fixture and verify discovery, deletion, and direct run absence
- leave production cleanup behavior, timeouts, retries, sleeps, skips, and cleanup semantics unchanged

## Root cause

The original test gave one 5-second lifecycle budget to 13 sequential database fixture setups, one cleanup request, and 13 deletion checks. That lifecycle also included waiting for the shared `threadless-run-cleanup-integration-test` advisory lock, which serializes these tests against past-clock export tests running in another worker.

In the failed shard, the case took 5,698 ms while the same code took 637 ms on the PR head. The concurrent locked `ops-logs.bdd.test.ts` suite took 20.5 seconds in the failed shard versus 6.3 seconds in the passing comparison. The target test, lock fixture, cleanup service, and competing suite have identical Git object hashes at the passing head, failed main SHA, and current main. Fourteen sampled nearby main runs passed this case in 491-1,776 ms; the 5,698 ms observation was the sole timeout.

The nondeterminism is therefore the mismatch between one coarse test owner and 13 independent database lifecycles under cross-worker lock/database contention. `describe.each` preserves dynamic coverage of every non-test enum value while giving each source its own fixture, cleanup request, assertions, and existing timeout budget.

## Evidence

- Failed run: https://github.com/vm0-ai/vm0/actions/runs/31470251534
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/31470251534/job/93712129711
- Passing comparison: https://github.com/vm0-ai/vm0/actions/runs/31466672807/job/93700946477
- Failure SHA: `f2ed156c69dceac9cbbc5557203174cc30effeec`
- Current base: `c107fa2be08e003be782a58ade09eb1458982e80`
- No open PR modifies the target file. The similarly named remote branch belongs to merged PR #26297 and changes only `integrations.bdd.test.ts`.

## Verification

- `pnpm format`
- targeted Prettier on the final file
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- target-file type-aware Oxlint and ESLint after rebasing onto current main
- `git diff --check`

The five local targeted repetitions were not run because this API integration test requires PostgreSQL and no local service was already available; the repair constraints prohibit starting a local service. The PR pipeline's `test-api (4)` job is the authoritative runtime verification.

Preview browser verification is not applicable: this is a test-only change for an internal cron API integration invariant with no browser acceptance surface.
