### PR TITLE
fix: complete custom mcp ui and simplify firewall policies

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8874,22 +8874,19 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     const [mcpApi] = inlineFirewallApis(claim.firewalls, mcpInternalName);
     expect(mcpApi).toMatchObject({
-      base: "https://mcp-runtime.example.test",
+      base: "https://mcp-runtime.example.test/api/mcp",
       hostPolicy: { kind: "publicDestination" },
-      permissions: [
-        {
-          name: "mcp-endpoint",
-          rules: ["POST /api/mcp", "GET /api/mcp", "DELETE /api/mcp"],
-        },
-      ],
+      permissions: [],
     });
     const mcpSecretKey = `CUSTOM_${mcp.id.replaceAll("-", "")}_S_SECRET`;
     expect(mcpApi?.auth.headers?.Authorization).toBe(
       `Bearer \${{ secrets.${mcpSecretKey} }}`,
     );
-    expect(claim.networkPolicies?.[mcpInternalName]).toMatchObject({
-      allow: ["mcp-endpoint"],
-      unknownPolicy: "deny",
+    expect(claim.networkPolicies?.[mcpInternalName]).toStrictEqual({
+      allow: [],
+      deny: [],
+      ask: [],
+      unknownPolicy: "allow",
     });
     expect(claim.secretValues).not.toContain("mcp-runtime-token");
     expect(
@@ -8909,6 +8906,15 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       targets: [target],
     });
     const initialRuntime = availableCustomConnectorRuntime(initialResult);
+    expect(initialRuntime.firewall.firewall.apis[0]?.permissions).toStrictEqual(
+      [],
+    );
+    expect(initialRuntime.networkPolicy).toStrictEqual({
+      allow: [],
+      deny: [],
+      ask: [],
+      unknownPolicy: "allow",
+    });
     const { body: initialAuthBody } = customConnectorRuntimeAuthBody(
       initialRuntime,
       fw.encryptedSecretsBody({}),
@@ -8947,13 +8953,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     const movedRuntime = availableCustomConnectorRuntime(movedResult);
     expect(movedRuntime.firewall.firewall.apis[0]).toMatchObject({
-      base: "https://mcp-runtime.example.test",
-      permissions: [
-        {
-          name: "mcp-endpoint",
-          rules: ["POST /v2/mcp/", "GET /v2/mcp/", "DELETE /v2/mcp/"],
-        },
-      ],
+      base: "https://mcp-runtime.example.test/v2/mcp/",
+      permissions: [],
+    });
+    expect(movedRuntime.networkPolicy).toStrictEqual({
+      allow: [],
+      deny: [],
+      ask: [],
+      unknownPolicy: "allow",
     });
 
     await connectors.disconnectCustomConnector(actor, mcp.id);
@@ -9942,13 +9949,8 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     const internalName = `custom_connector_${mcp.id.replaceAll("-", "")}`;
     expect(inlineFirewallApis(claim.firewalls, internalName)[0]).toMatchObject({
-      base: "https://mcp-oauth.example.test",
-      permissions: [
-        {
-          name: "mcp-endpoint",
-          rules: ["POST /oauth/mcp", "GET /oauth/mcp", "DELETE /oauth/mcp"],
-        },
-      ],
+      base: "https://mcp-oauth.example.test/oauth/mcp",
+      permissions: [],
     });
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
       targets: [

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4054,7 +4054,7 @@ function buildCustomConnectorRuntimeApis(args: {
         serviceName: "MCP custom connector",
         hostPolicy: { kind: "publicDestination" },
       });
-      return endpoint;
+      return canonicalEndpoint;
     });
     if ("error" in endpointResult) {
       args.stats.recordInvalidPrefix();
@@ -4062,24 +4062,13 @@ function buildCustomConnectorRuntimeApis(args: {
       return [];
     }
     const endpoint = endpointResult.ok;
-    const endpointPath = endpoint.pathname;
     args.stats.recordRenderedApi();
     args.stats.recordPhaseDuration("renderPrefixes", prefixStartedAt);
     return [
       {
-        base: endpoint.origin,
+        base: endpoint,
         hostPolicy: { kind: "publicDestination" },
         auth: { headers: args.headers, query: args.query },
-        permissions: [
-          {
-            name: "mcp-endpoint",
-            rules: [
-              `POST ${endpointPath}`,
-              `GET ${endpointPath}`,
-              `DELETE ${endpointPath}`,
-            ],
-          },
-        ],
       },
     ];
   }
@@ -4374,18 +4363,12 @@ async function buildCustomConnectorRuntimeRow(args: {
       description: args.row.connector.displayName,
       apis,
     },
-    permissionPolicy:
-      args.row.connector.kind === "mcp"
-        ? {
-            policies: { "mcp-endpoint": "allow" },
-            unknownPolicy: "deny",
-          }
-        : permissionBundle
-          ? buildCustomConnectorPermissionPolicy({
-              bundle: permissionBundle,
-              selectedPermissionNames: args.selectedPermissionNames,
-            })
-          : undefined,
+    permissionPolicy: permissionBundle
+      ? buildCustomConnectorPermissionPolicy({
+          bundle: permissionBundle,
+          selectedPermissionNames: args.selectedPermissionNames,
+        })
+      : undefined,
   };
 }
 

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1940,6 +1940,7 @@
       "emptyAdmin": "Noch keine benutzerdefinierten Integrationen. Erstellen Sie eine, um eine API zu registrieren, die jedes Mitglied verwenden kann.",
       "emptyMember": "Ihre Organisation hat noch keine benutzerdefinierten Integrationen registriert.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "Weitere Optionen",
       "statusConnected": "Verbunden",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1940,6 +1940,7 @@
       "emptyAdmin": "No custom connectors yet. Create one to register an API for every member to use.",
       "emptyMember": "Your org hasn't registered any custom connectors yet.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "More options",
       "statusConnected": "Connected",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1980,6 +1980,7 @@
       "emptyAdmin": "Todavía no hay conectores personalizados. Crea uno para registrar una API para que cada miembro la use.",
       "emptyMember": "Tu organización aún no ha registrado ningún conector personalizado.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "Más opciones",
       "statusConnected": "Conectado",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1980,6 +1980,7 @@
       "emptyAdmin": "Pas encore de connecteurs personnalisés. Créez-en un pour enregistrer une API que tous les membres pourront utiliser.",
       "emptyMember": "Votre organisation n'a pas encore enregistré de connecteurs personnalisés.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "Plus d'options",
       "statusConnected": "Connecté",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1940,6 +1940,7 @@
       "emptyAdmin": "अभी तक कोई कस्टम कनेक्टर नहीं. प्रत्येक सदस्य के उपयोग के लिए एक API पंजीकृत करने के लिए एक बनाएं।",
       "emptyMember": "आपके संगठन ने अभी तक कोई कस्टम कनेक्टर पंजीकृत नहीं किया है.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "अधिक विकल्प",
       "statusConnected": "जुड़े हुए",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1939,6 +1939,7 @@
       "emptyAdmin": "Belum ada konektor kustom. Buat satu untuk mendaftarkan API agar bisa digunakan semua anggota.",
       "emptyMember": "Org Anda belum mendaftarkan konektor kustom apa pun.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "Opsi lainnya",
       "statusConnected": "Terhubung",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1980,6 +1980,7 @@
       "emptyAdmin": "Nessun connettore personalizzato ancora. Creane uno per registrare un API affinché ogni membro possa utilizzarlo.",
       "emptyMember": "La tua organizzazione non ha ancora registrato alcun connettore personalizzato.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "Più opzioni",
       "statusConnected": "Connesso",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1939,6 +1939,7 @@
       "emptyAdmin": "カスタム コネクタはまだありません。すべてのメンバーが使用する API を登録するために作成します。",
       "emptyMember": "組織はまだカスタム コネクタを登録していません。",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "その他のオプション",
       "statusConnected": "接続済み",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1939,6 +1939,7 @@
       "emptyAdmin": "아직 커스텀 커넥터가 없습니다. 모든 멤버가 사용할 API를 등록하려면 새로 만드세요.",
       "emptyMember": "조직에 등록된 커스텀 커넥터가 없습니다.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "추가 옵션",
       "statusConnected": "연결됨",
       "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1980,6 +1980,7 @@
       "emptyAdmin": "Ainda não há conectores personalizados. Crie um para registrar uma API que todos os membros possam usar.",
       "emptyMember": "Sua organização ainda não registrou conectores personalizados.",
       "mcpStreamableHttp": "MCP · Streamable HTTP",
+      "mcpType": "MCP",
       "moreOptions": "Mais opções",
       "statusConnected": "Conectado",
       "toasts": {

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -72,6 +72,10 @@ export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
   );
 });
 
+export const customConnectorMcpEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.CustomConnectorMcp] ?? false;
+});
+
 export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const clerk = await get(clerk$);

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -37,8 +37,10 @@ import {
   zeroCustomConnectorByIdContract,
   zeroCustomConnectorsContract,
   type CustomConnectorHttpResponse,
+  type CustomConnectorMcpResponse,
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { describe, expect, it } from "vitest";
@@ -251,6 +253,42 @@ function createCustomConnector(): CustomConnectorHttpResponse {
     hasSecret: true,
     createdAt: "2026-02-01T00:00:00Z",
     updatedAt: "2026-02-01T00:00:00Z",
+  };
+}
+
+function createMcpCustomConnector(): CustomConnectorMcpResponse {
+  return {
+    kind: "mcp",
+    id: "44444444-4444-4444-8444-444444444444",
+    storageVersion: 1,
+    slug: "_deepwiki",
+    displayName: "DeepWiki",
+    endpoint: "https://mcp.deepwiki.com/mcp",
+    transport: "streamable-http",
+    prefixTemplates: [],
+    fields: [
+      {
+        key: "secret",
+        label: "Secret",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "X-VM0-Test-Token",
+        valueTemplate: "{{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "manual",
+    permissionBundleRef: null,
+    connected: true,
+    missingRequiredFields: [],
+    configuredFieldKeys: ["secret"],
+    hasSecret: true,
+    createdAt: "2026-08-11T00:00:00Z",
+    updatedAt: "2026-08-11T00:00:00Z",
   };
 }
 
@@ -580,6 +618,34 @@ describe("team page navigation", () => {
         screen.queryByText("Custom connectors saved"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("shows and authorizes connected MCP custom connectors", async () => {
+    const connector = createMcpCustomConnector();
+    mockTeamAPIs({ customConnector: connector });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("DeepWiki")).toBeInTheDocument();
+      expect(
+        screen.getByText("https://mcp.deepwiki.com/mcp"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByLabelText("Manage DeepWiki permissions"),
+    ).not.toBeInTheDocument();
+
+    click(screen.getByLabelText("Grant DeepWiki access"));
+    await waitFor(() => {
+      expect(screen.getByText("Custom connectors saved")).toBeInTheDocument();
+      expect(screen.getByLabelText("Revoke DeepWiki access")).toBeChecked();
+    });
+    toast.dismiss();
   });
 
   it("hides unavailable custom connectors without loading agent access", async () => {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -648,6 +648,52 @@ describe("team page navigation", () => {
     toast.dismiss();
   });
 
+  it("keeps authorized MCP custom connectors revocable while disabled", async () => {
+    const connector = createMcpCustomConnector();
+    let grants: AgentCustomConnectorGrant[] = [
+      { customConnectorId: connector.id, permissionNames: [] },
+    ];
+    let updateCount = 0;
+    mockTeamAPIs({ customConnector: connector });
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.get,
+      ({ params, respond }) => {
+        expect(params.id).toBe(researchAgentId);
+        return respond(200, { grants });
+      },
+    );
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(researchAgentId);
+        expect(body).toStrictEqual({
+          grants: [{ customConnectorId: connector.id, permissionNames: [] }],
+          operation: "remove",
+        });
+        updateCount += 1;
+        grants = [];
+        return respond(200, { grants });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: false },
+    });
+
+    await screen.findByText("DeepWiki");
+    expect(
+      screen.queryByLabelText("Grant DeepWiki access"),
+    ).not.toBeInTheDocument();
+    click(screen.getByLabelText("Revoke DeepWiki access"));
+
+    await waitFor(() => {
+      expect(updateCount).toBe(1);
+      expect(screen.queryByText("DeepWiki")).not.toBeInTheDocument();
+    });
+  });
+
   it("hides unavailable custom connectors without loading agent access", async () => {
     const customConnector = {
       ...createCustomConnector(),

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -8,10 +8,7 @@ import {
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import {
-  isHttpCustomConnectorClientResponse,
-  type CustomConnectorHttpClientResponse,
-} from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { CustomConnectorClientResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { customConnectors$ } from "../../signals/zero-page/settings/custom-connectors.ts";
 import {
@@ -32,6 +29,8 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { CustomConnectorIcon } from "../zero-page/components/settings/custom-connector-icon.tsx";
 import { ConnectorPermissionRow } from "../zero-page/components/settings/connector-permission-row.tsx";
 import { CustomConnectorPermissionsDrawer } from "../zero-page/components/settings/custom-connector-permissions-drawer.tsx";
+import { customConnectorTarget } from "../zero-page/components/settings/custom-connector-display.ts";
+import { customConnectorMcpEnabled$ } from "../../signals/external/feature-switch.ts";
 
 function JobCustomConnectorRow({
   connector,
@@ -43,7 +42,7 @@ function JobCustomConnectorRow({
   isLast,
   onToggle,
 }: {
-  readonly connector: CustomConnectorHttpClientResponse;
+  readonly connector: CustomConnectorClientResponse;
   readonly enabled: boolean;
   readonly loading: boolean;
   readonly agentId: string | undefined;
@@ -53,6 +52,8 @@ function JobCustomConnectorRow({
   readonly onToggle: (id: string, checked: boolean) => void;
 }) {
   const openPermissions = useSet(openCustomConnectorPermissions$);
+  const hasPermissionBundle =
+    connector.kind === "http" && Boolean(connector.permissionBundleRef);
   const permissionNames =
     grants?.find((grant) => {
       return grant.customConnectorId === connector.id;
@@ -82,22 +83,20 @@ function JobCustomConnectorRow({
       }
       label={connector.displayName}
       description={
-        <span className="font-mono">{connector.prefixTemplates[0]}</span>
+        <span className="font-mono">{customConnectorTarget(connector)}</span>
       }
       enabled={enabled}
-      loading={
-        loading || (Boolean(connector.permissionBundleRef) && grantsLoading)
-      }
-      disabled={Boolean(connector.permissionBundleRef) && grants === null}
+      loading={loading || (hasPermissionBundle && grantsLoading)}
+      disabled={hasPermissionBundle && grants === null}
       showManage={
         enabled &&
-        Boolean(connector.permissionBundleRef) &&
+        hasPermissionBundle &&
         grants !== null &&
         agentId !== undefined
       }
       isLast={isLast}
       onToggle={(checked) => {
-        if (checked && connector.permissionBundleRef) {
+        if (checked && hasPermissionBundle) {
           if (grants !== null && agentId) {
             openPermissionDrawer(false);
           }
@@ -114,27 +113,26 @@ function JobCustomConnectorRow({
 
 export function JobCustomConnectorsSection() {
   const connectors = useLastResolved(customConnectors$);
-  const connectedHttpConnectors = connectors
-    ?.filter(isHttpCustomConnectorClientResponse)
-    .filter((connector) => {
-      return connector.connected;
-    });
+  const connectedConnectors = connectors?.filter((connector) => {
+    return connector.connected;
+  });
 
-  if (!connectedHttpConnectors || connectedHttpConnectors.length === 0) {
+  if (!connectedConnectors || connectedConnectors.length === 0) {
     return null;
   }
 
   return (
-    <ConnectedJobCustomConnectorsSection connectors={connectedHttpConnectors} />
+    <ConnectedJobCustomConnectorsSection connectors={connectedConnectors} />
   );
 }
 
 function ConnectedJobCustomConnectorsSection({
   connectors,
 }: {
-  readonly connectors: readonly CustomConnectorHttpClientResponse[];
+  readonly connectors: readonly CustomConnectorClientResponse[];
 }) {
   const { t } = useTranslation("agents");
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const addedLoadable = useLastLoadable(agentAddedCustomConnectors$);
   const added = addedLoadable.state === "hasData" ? addedLoadable.data : [];
   const addedSet = new Set(added);
@@ -148,6 +146,11 @@ function ConnectedJobCustomConnectorsSection({
   );
   const grantsLoadable = useLastLoadable(agentCustomConnectorGrants$);
   const detail = useLastResolved(agentDetail$);
+  const visibleConnectors = connectors.filter((connector) => {
+    return (
+      connector.kind === "http" || mcpEnabled || addedSet.has(connector.id)
+    );
+  });
 
   const handleToggle = (id: string, checked: boolean) => {
     if (saving) {
@@ -190,6 +193,10 @@ function ConnectedJobCustomConnectorsSection({
       ? permissionBundleLoadable.data
       : null;
 
+  if (visibleConnectors.length === 0) {
+    return null;
+  }
+
   return (
     <div className="zero-card">
       <div className="px-5 pt-4 pb-3 text-sm text-muted-foreground border-b border-border/50">
@@ -197,7 +204,7 @@ function ConnectedJobCustomConnectorsSection({
           return $.authorization.customConnectors.description;
         })}
       </div>
-      {connectors.map((connector, index) => {
+      {visibleConnectors.map((connector, index) => {
         return (
           <JobCustomConnectorRow
             key={connector.id}
@@ -209,7 +216,7 @@ function ConnectedJobCustomConnectorsSection({
               grantsLoadable.state === "hasData" ? grantsLoadable.data : null
             }
             grantsLoading={grantsLoadable.state === "loading"}
-            isLast={index === connectors.length - 1}
+            isLast={index === visibleConnectors.length - 1}
             onToggle={handleToggle}
           />
         );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -8,6 +8,7 @@ import {
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
   type CustomConnectorHttpResponse,
+  type CustomConnectorMcpResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   zeroAgentCustomConnectorsContract,
@@ -116,6 +117,45 @@ function customConnector(
   };
 }
 
+function mcpCustomConnector(
+  overrides: Partial<CustomConnectorMcpResponse> = {},
+): CustomConnectorMcpResponse {
+  return {
+    kind: "mcp",
+    id: "44444444-4444-4444-8444-444444444444",
+    storageVersion: 1,
+    slug: "_deepwiki",
+    displayName: "DeepWiki",
+    endpoint: "https://mcp.deepwiki.com/mcp",
+    transport: "streamable-http",
+    prefixTemplates: [],
+    fields: [
+      {
+        key: "secret",
+        label: "Secret",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "X-VM0-Test-Token",
+        valueTemplate: "{{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "manual",
+    permissionBundleRef: null,
+    connected: false,
+    missingRequiredFields: ["secret"],
+    configuredFieldKeys: [],
+    hasSecret: false,
+    createdAt: "2026-08-11T00:00:00.000Z",
+    updatedAt: "2026-08-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
 function mockCatalog(
   connectors: readonly PublicConnectorCatalogStatusItem[],
 ): void {
@@ -196,9 +236,9 @@ describe("chat composer connector connection", () => {
     });
   });
 
-  it("shows connected custom connectors and toggles agent access", async () => {
+  it("shows connected MCP custom connectors and toggles agent access", async () => {
     const user = userEvent.setup({ delay: null });
-    const connector = customConnector({
+    const connector = mcpCustomConnector({
       connected: true,
       missingRequiredFields: [],
       configuredFieldKeys: ["secret"],
@@ -233,17 +273,18 @@ describe("chat composer connector connection", () => {
     detachedSetupPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
     });
 
     const composer = composerElementFrom(
       await screen.findByPlaceholderText(PLACEHOLDER),
     );
     await user.click(within(composer).getByLabelText("Connectors"));
-    await user.click(await screen.findByLabelText("Add Acme Search"));
+    await user.click(await screen.findByLabelText("Add DeepWiki"));
 
     await waitFor(() => {
       expect(updateCount).toBe(1);
-      expect(screen.getByLabelText("Remove Acme Search")).toBeInTheDocument();
+      expect(screen.getByLabelText("Remove DeepWiki")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -288,6 +288,60 @@ describe("chat composer connector connection", () => {
     });
   });
 
+  it("keeps authorized MCP custom connectors removable while disabled", async () => {
+    const user = userEvent.setup({ delay: null });
+    const connector = mcpCustomConnector({
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      hasSecret: true,
+    });
+    let grants: AgentCustomConnectorGrant[] = [
+      { customConnectorId: connector.id, permissionNames: [] },
+    ];
+    let updateCount = 0;
+    context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.get,
+      ({ params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        return respond(200, { grants });
+      },
+    );
+    context.mocks.api(
+      zeroAgentCustomConnectorsContract.update,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        expect(body).toStrictEqual({
+          grants: [{ customConnectorId: connector.id, permissionNames: [] }],
+          operation: "remove",
+        });
+        updateCount += 1;
+        grants = [];
+        return respond(200, { grants });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: false },
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    await user.click(within(composer).getByLabelText("Connectors"));
+    await user.click(await screen.findByLabelText("Remove DeepWiki"));
+
+    await waitFor(() => {
+      expect(updateCount).toBe(1);
+      expect(screen.queryByText("DeepWiki")).not.toBeInTheDocument();
+    });
+  });
+
   it("does not create an empty grant for a permissioned custom connector", async () => {
     const user = userEvent.setup({ delay: null });
     const connector = customConnector({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -25,6 +25,7 @@ import {
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
   type CustomConnectorHttpResponse,
+  type CustomConnectorMcpResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   zeroUserPermissionGrantsContract,
@@ -222,6 +223,42 @@ function customConnector(
     createdAt: "2026-06-09T10:00:00Z",
     updatedAt: "2026-06-09T10:00:00Z",
     ...overrides,
+  };
+}
+
+function mcpCustomConnector(): CustomConnectorMcpResponse {
+  return {
+    kind: "mcp",
+    id: "44444444-4444-4444-8444-444444444444",
+    storageVersion: 1,
+    slug: "_deepwiki",
+    displayName: "DeepWiki",
+    endpoint: "https://mcp.deepwiki.com/mcp",
+    transport: "streamable-http",
+    prefixTemplates: [],
+    fields: [
+      {
+        key: "secret",
+        label: "Secret",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "X-VM0-Test-Token",
+        valueTemplate: "{{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "manual",
+    permissionBundleRef: null,
+    connected: false,
+    missingRequiredFields: ["secret"],
+    configuredFieldKeys: [],
+    hasSecret: false,
+    createdAt: "2026-08-11T00:00:00Z",
+    updatedAt: "2026-08-11T00:00:00Z",
   };
 }
 
@@ -2831,7 +2868,7 @@ describe("chat event action cards", () => {
     expect(queryButtonByText("Confirm", permissionCard)).toBeNull();
   });
 
-  it("connects and authorizes a custom connector from its action card", async () => {
+  it("connects and authorizes an MCP custom connector from its action card", async () => {
     const user = userEvent.setup({ delay: null });
     let connected = false;
     let grants: AgentCustomConnectorGrant[] = [];
@@ -2840,7 +2877,7 @@ describe("chat event action cards", () => {
       readonly kind: "secret" | "variable";
       readonly value: string;
     }[] = [];
-    const connector = customConnector();
+    const connector = mcpCustomConnector();
     const connectUrl = `${window.location.origin}/connectors/${connector.slug}/connect?agentId=${AGENT_ID}`;
     context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
       return respond(200, {
@@ -2904,10 +2941,11 @@ describe("chat event action cards", () => {
     detachedSetupPage({
       context,
       path: "/chats/e4000000-0000-4000-a000-000000000018",
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
     });
 
     const card = await screen.findByTestId("connector-action-card");
-    expect(within(card).getByText("Acme Internal API")).toBeInTheDocument();
+    expect(within(card).getByText("DeepWiki")).toBeInTheDocument();
     expect(
       within(card).getByText(
         "Review, connect, and authorize this custom connector for the agent.",
@@ -2915,7 +2953,7 @@ describe("chat event action cards", () => {
     ).toBeInTheDocument();
     await user.click(await waitForButtonByText("Connect", card));
     const dialog = await screen.findByRole("dialog", {
-      name: "Connect Acme Internal API",
+      name: "Connect DeepWiki",
     });
     await user.type(within(dialog).getByLabelText("Secret"), "acme-secret");
     await user.click(buttonByText("Save", dialog));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -3603,6 +3603,7 @@ describe("connectors page", () => {
 
     await waitFor(() => {
       const card = connectorCardByLabel("Acme Search");
+      expect(within(card).getByText("HTTP API")).toBeInTheDocument();
       expect(within(card).getByText("Not connected")).toBeInTheDocument();
       expect(
         within(card).getByText("https://api.acme.test/v1/"),
@@ -4311,7 +4312,12 @@ describe("connectors page", () => {
     click(buttonByText("Create", createDialog));
 
     await waitFor(() => {
-      expect(connectorCardByLabel("Acme MCP")).toBeInTheDocument();
+      const card = connectorCardByLabel("Acme MCP");
+      expect(within(card).getByText("MCP")).toBeInTheDocument();
+      expect(
+        within(card).getByText("https://mcp.acme.test/server"),
+      ).toBeInTheDocument();
+      expect(within(card).getByText("Not connected")).toBeInTheDocument();
     });
     expect(createBodies).toStrictEqual([
       {
@@ -4355,6 +4361,9 @@ describe("connectors page", () => {
           "connector-card-agent-access",
         ),
       ).toHaveTextContent("Used by Research, Support");
+      expect(
+        within(connectorCardByLabel("Acme MCP")).getByText("Connected"),
+      ).toBeInTheDocument();
     });
 
     click(
@@ -4710,10 +4719,11 @@ describe("connectors page", () => {
     const card = await waitFor(() => {
       return connectorCardByLabel("Acme MCP");
     });
-    expect(within(card).getByText("MCP · Streamable HTTP")).toBeInTheDocument();
+    expect(within(card).getByText("MCP")).toBeInTheDocument();
     expect(
       within(card).getByText("https://mcp.acme.test/server"),
     ).toBeInTheDocument();
+    expect(within(card).getByText("Connected")).toBeInTheDocument();
     expect(screen.queryByLabelText("Connect Acme MCP")).not.toBeInTheDocument();
     expect(
       within(card).getByTestId("connector-card-agent-access"),
@@ -5418,8 +5428,10 @@ describe("connectors page", () => {
       ),
     ).toHaveAttribute("title", "Zero, Research, Support");
     expect(
-      screen.queryByText("https://api.acme.test/v1/"),
-    ).not.toBeInTheDocument();
+      within(connectorCardByLabel("Acme API")).getByText(
+        "https://api.acme.test/v1/",
+      ),
+    ).toBeInTheDocument();
 
     click(screen.getByLabelText("More options"));
     click(await screen.findByText("Edit"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -15,7 +15,9 @@ import {
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
   type CustomConnectorHttpResponse,
+  type CustomConnectorMcpResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   zeroConnectorCatalogContract,
@@ -243,6 +245,42 @@ function customConnector(
   };
 }
 
+function mcpCustomConnector(): CustomConnectorMcpResponse {
+  return {
+    kind: "mcp",
+    id: "44444444-4444-4444-8444-444444444444",
+    storageVersion: 1,
+    slug: "_deepwiki",
+    displayName: "DeepWiki",
+    endpoint: "https://mcp.deepwiki.com/mcp",
+    transport: "streamable-http",
+    prefixTemplates: [],
+    fields: [
+      {
+        key: "secret",
+        label: "Secret",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "X-VM0-Test-Token",
+        valueTemplate: "{{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "manual",
+    permissionBundleRef: null,
+    connected: false,
+    missingRequiredFields: ["secret"],
+    configuredFieldKeys: [],
+    hasSecret: false,
+    createdAt: "2026-08-11T00:00:00Z",
+    updatedAt: "2026-08-11T00:00:00Z",
+  };
+}
+
 function steamOpenIdConnectorStatus(): PublicConnectorCatalogStatusItem {
   return {
     slug: "steam",
@@ -347,7 +385,7 @@ function getButtonByText(text: string): HTMLElement {
 }
 
 describe("directed connector connect page", () => {
-  it("connects and authorizes a manual custom connector", async () => {
+  it("connects and authorizes a manual MCP custom connector", async () => {
     let connected = false;
     let grants: AgentCustomConnectorGrant[] = [];
     let submittedValues: readonly {
@@ -355,7 +393,7 @@ describe("directed connector connect page", () => {
       readonly kind: "secret" | "variable";
       readonly value: string;
     }[] = [];
-    const connector = customConnector();
+    const connector = mcpCustomConnector();
     context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
       return respond(200, {
         connectors: [
@@ -396,13 +434,14 @@ describe("directed connector connect page", () => {
     detachedSetupPage({
       context,
       path: `/connectors/${connector.slug}/connect?agentId=${AGENT_ID}`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
     });
 
-    const heading = await screen.findByText("Zero needs Acme API to proceed");
+    const heading = await screen.findByText("Zero needs DeepWiki to proceed");
     expect(heading).toBeInTheDocument();
     click(getButtonByText("Connect"));
     const dialog = await screen.findByRole("dialog", {
-      name: "Connect Acme API",
+      name: "Connect DeepWiki",
     });
     await fill(within(dialog).getByLabelText("Secret"), "acme-secret");
     click(getButtonByText("Save"));
@@ -414,7 +453,7 @@ describe("directed connector connect page", () => {
       expect(grants).toStrictEqual([
         { customConnectorId: connector.id, permissionNames: [] },
       ]);
-      expect(screen.getByText("Acme API connected")).toBeInTheDocument();
+      expect(screen.getByText("DeepWiki connected")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -6,7 +6,6 @@ import type {
   CustomConnectorClientResponse,
   UpdateCustomConnectorBody,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   Button,
   CopyButton,
@@ -32,7 +31,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 
 import { resolveApiBaseForTarget } from "../../../../signals/api-base.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
+import { customConnectorMcpEnabled$ } from "../../../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   addCustomConnectorAuthMethod$,
@@ -1202,8 +1201,7 @@ export function CustomConnectorCreateDialog({
 }) {
   const { t } = useTranslation();
   const form = useGet(customConnectorCreateForm$);
-  const mcpEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.CustomConnectorMcp] ?? false;
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const setField = useSet(setCustomConnectorCreateField$);
   const setKind = useSet(setCustomConnectorCreateKind$);
   const addAuthMethod = useSet(addCustomConnectorAuthMethod$);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-display.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-display.ts
@@ -1,0 +1,9 @@
+import type { CustomConnectorClientResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+
+export function customConnectorTarget(
+  connector: CustomConnectorClientResponse,
+): string {
+  return connector.kind === "mcp"
+    ? connector.endpoint
+    : connector.prefixTemplates.join(", ");
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connectors-panel.tsx
@@ -15,7 +15,6 @@ import {
   DropdownMenuTrigger,
 } from "@vm0/ui";
 import type { CustomConnectorClientResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   disconnectCustomConnector$,
   closeCustomConnectorDialog$,
@@ -29,7 +28,7 @@ import {
   openCustomConnectorEditDialog$,
 } from "../../../../signals/zero-page/settings/custom-connectors.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
+import { customConnectorMcpEnabled$ } from "../../../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { CustomConnectorIcon } from "./custom-connector-icon.tsx";
@@ -40,6 +39,7 @@ import { CustomConnectorAccessManagementDialog } from "./connector-access-manage
 import { ConnectorAgentAccessButton } from "./connector-agent-access-button.tsx";
 import { DropdownMenuModalItem } from "../../../components/dropdown-menu-modal-item.tsx";
 import { noConnectorImg } from "../../platform-assets.ts";
+import { customConnectorTarget } from "./custom-connector-display.ts";
 
 function connectsDirectlyWithOAuth(
   connector: CustomConnectorClientResponse,
@@ -105,6 +105,15 @@ function CustomConnectorCardContent({
   readonly onManageAccess: () => void;
 }) {
   const { t } = useTranslation();
+  const connectorType =
+    connector.kind === "mcp"
+      ? t(($) => {
+          return $.connectors.custom.mcpType;
+        })
+      : t(($) => {
+          return $.connectors.custom.create.httpType;
+        });
+  const connectorTarget = customConnectorTarget(connector);
   const headerContent = (
     <>
       <CustomConnectorIcon
@@ -119,20 +128,16 @@ function CustomConnectorCardContent({
         >
           {connector.displayName}
         </span>
-        {connector.kind === "mcp" ? (
-          <span className="block truncate text-xs text-muted-foreground">
-            {t(($) => {
-              return $.connectors.custom.mcpStreamableHttp;
-            })}
-          </span>
-        ) : !connector.connected ? (
+        <span className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
+          <span className="shrink-0">{connectorType}</span>
+          <span aria-hidden="true">·</span>
           <span
-            className="block truncate font-mono text-xs text-muted-foreground/60"
-            title={connector.prefixTemplates[0]}
+            className="min-w-0 truncate font-mono text-muted-foreground/60"
+            title={connectorTarget}
           >
-            {connector.prefixTemplates[0]}
+            {connectorTarget}
           </span>
-        ) : null}
+        </span>
       </span>
     </>
   );
@@ -162,28 +167,20 @@ function CustomConnectorCardContent({
           hasActions ? "pr-12" : "pr-2"
         }`}
       >
-        {connector.kind === "mcp" ? (
+        <span className="flex shrink-0 items-center gap-2 truncate text-xs text-muted-foreground">
           <span
-            className="min-w-0 truncate font-mono text-xs text-muted-foreground/60"
-            title={connector.endpoint}
-          >
-            {connector.endpoint}
-          </span>
-        ) : connector.connected ? (
-          <span className="flex shrink-0 items-center gap-2 truncate text-xs text-muted-foreground">
-            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
-            {t(($) => {
-              return $.connectors.custom.statusConnected;
-            })}
-          </span>
-        ) : connector.kind === "http" ? (
-          <span className="flex shrink-0 items-center gap-2 truncate text-xs text-muted-foreground">
-            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
-            {t(($) => {
-              return $.connectors.catalog.filters.notConnected;
-            })}
-          </span>
-        ) : null}
+            className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+              connector.connected ? "bg-emerald-500" : "bg-muted-foreground/50"
+            }`}
+          />
+          {connector.connected
+            ? t(($) => {
+                return $.connectors.custom.statusConnected;
+              })
+            : t(($) => {
+                return $.connectors.catalog.filters.notConnected;
+              })}
+        </span>
         {connector.connected ? (
           <CustomConnectorAgentAccess
             connector={connector}
@@ -327,8 +324,7 @@ export function CustomConnectorsPanel() {
   const { t } = useTranslation();
   const connectors = useLastResolved(customConnectors$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
-  const mcpEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.CustomConnectorMcp] ?? false;
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const openEdit = useSet(openCustomConnectorEditDialog$);
   const openAccess = useSet(openCustomConnectorAccessDialog$);
   const openConnect = useSet(openCustomConnectorConnectDialog$);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -139,11 +139,7 @@ import {
 import { r2ImageTransformUrl } from "@vm0/core/r2-image-transform";
 import type { ConnectorSlug } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
-import {
-  isHttpCustomConnectorClientResponse,
-  type CustomConnectorClientResponse,
-  type CustomConnectorHttpClientResponse,
-} from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { CustomConnectorClientResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
@@ -153,6 +149,7 @@ import {
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectorCard } from "./components/settings/connector-card.tsx";
 import { CustomConnectorIcon } from "./components/settings/custom-connector-icon.tsx";
+import { customConnectorTarget } from "./components/settings/custom-connector-display.ts";
 import { CustomConnectorConnectDialog } from "./components/settings/custom-connector-connect-dialog.tsx";
 import type { ConnectorConnectHandlers } from "./components/settings/launch-connector-connect.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
@@ -181,6 +178,7 @@ import {
 import {
   codexFastModeEnabled$,
   composerConnectorPermissionsEnabled$,
+  customConnectorMcpEnabled$,
   avatarTemplatesEnabled$,
   imageRecognitionAvailable$,
 } from "../../signals/external/feature-switch.ts";
@@ -342,7 +340,7 @@ type ComposerConnectorItem = PlatformConnectorCatalogStatusItem & {
   readonly authorized: boolean;
 };
 
-type ComposerCustomConnectorItem = CustomConnectorHttpClientResponse & {
+type ComposerCustomConnectorItem = CustomConnectorClientResponse & {
   readonly authorized: boolean;
 };
 
@@ -5933,7 +5931,7 @@ function ConnectorTriggerIcons({
 
 function matchesCustomConnectorSearch(
   search: string,
-  connector: CustomConnectorHttpClientResponse,
+  connector: CustomConnectorClientResponse,
 ): boolean {
   const normalizedSearch = search.trim().toLowerCase();
   if (!normalizedSearch) {
@@ -5942,7 +5940,7 @@ function matchesCustomConnectorSearch(
   return [
     connector.displayName,
     connector.slug,
-    ...connector.prefixTemplates,
+    customConnectorTarget(connector),
   ].some((value) => {
     return value.toLowerCase().includes(normalizedSearch);
   });
@@ -5952,7 +5950,7 @@ function CustomConnectorCatalogCard({
   connector,
   onConnect,
 }: {
-  connector: CustomConnectorHttpClientResponse;
+  connector: CustomConnectorClientResponse;
   onConnect: () => void;
 }) {
   const { t } = useTranslation();
@@ -5992,9 +5990,21 @@ function CustomConnectorCatalogCard({
       <span className="block px-5 pb-4 pt-1">
         <span
           data-testid="connector-help-text"
-          className="line-clamp-2 text-xs text-muted-foreground"
+          className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground"
         >
-          {connector.prefixTemplates[0]}
+          <span className="shrink-0">
+            {connector.kind === "mcp"
+              ? t(($) => {
+                  return $.connectors.custom.mcpType;
+                })
+              : t(($) => {
+                  return $.connectors.custom.create.httpType;
+                })}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span className="min-w-0 truncate font-mono text-muted-foreground/60">
+            {customConnectorTarget(connector)}
+          </span>
         </span>
       </span>
     </button>
@@ -6012,12 +6022,12 @@ function AddConnectorsDialog({
 }: {
   signals: ComposerSignals;
   unconnected: PlatformConnectorCatalogStatusItem[];
-  unconnectedCustom: CustomConnectorHttpClientResponse[];
+  unconnectedCustom: CustomConnectorClientResponse[];
   busyConnectorSlug: ConnectorSlug | null;
   connectHandlers: (
     connector: PlatformConnectorCatalogStatusItem,
   ) => ConnectorConnectHandlers;
-  onConnectCustom: (connector: CustomConnectorHttpClientResponse) => void;
+  onConnectCustom: (connector: CustomConnectorClientResponse) => void;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
@@ -7639,12 +7649,10 @@ interface ResolvedComposerConnectorCollections {
     PlatformConnectorCatalogStatusItem
   >;
   readonly unconnectedConnectors: PlatformConnectorCatalogStatusItem[];
-  readonly unconnectedCustomConnectors: CustomConnectorHttpClientResponse[];
+  readonly unconnectedCustomConnectors: CustomConnectorClientResponse[];
   readonly agentConnectors: ComposerConnectorItem[];
   readonly agentCustomConnectors: ComposerCustomConnectorItem[];
-  readonly selectedCustomConnector:
-    | CustomConnectorHttpClientResponse
-    | undefined;
+  readonly selectedCustomConnector: CustomConnectorClientResponse | undefined;
 }
 
 function resolveComposerConnectorCollections({
@@ -7655,6 +7663,7 @@ function resolveComposerConnectorCollections({
   customConnectorGrants,
   optimisticConnected,
   selectedCustomConnectorId,
+  mcpEnabled,
 }: {
   relatedCatalogItems: Loadable<readonly PlatformConnectorCatalogStatusItem[]>;
   addDialogCatalogItems: Loadable<
@@ -7665,21 +7674,28 @@ function resolveComposerConnectorCollections({
   customConnectorGrants: readonly AgentCustomConnectorGrant[] | null;
   optimisticConnected: ReadonlySet<ConnectorSlug>;
   selectedCustomConnectorId: string | null;
+  mcpEnabled: boolean;
 }): ResolvedComposerConnectorCollections {
   const resolvedRelatedCatalogItems =
     relatedCatalogItems.state === "hasData" ? relatedCatalogItems.data : [];
   const resolvedAddDialogCatalogItems =
     addDialogCatalogItems.state === "hasData" ? addDialogCatalogItems.data : [];
-  const resolvedCustomConnectors =
-    customConnectors.state === "hasData"
-      ? customConnectors.data.filter(isHttpCustomConnectorClientResponse)
-      : [];
   const authorizedSet = new Set(authorizedConnectorSlugs ?? []);
   const authorizedCustomSet = new Set(
     customConnectorGrants?.map((grant) => {
       return grant.customConnectorId;
     }) ?? [],
   );
+  const resolvedCustomConnectors =
+    customConnectors.state === "hasData"
+      ? customConnectors.data.filter((connector) => {
+          return (
+            connector.kind === "http" ||
+            mcpEnabled ||
+            authorizedCustomSet.has(connector.id)
+          );
+        })
+      : [];
   const connectorMap = new Map(
     [...resolvedRelatedCatalogItems, ...resolvedAddDialogCatalogItems].map(
       (connector) => {
@@ -7694,7 +7710,7 @@ function resolveComposerConnectorCollections({
   );
   const unconnectedCustomConnectors = resolvedCustomConnectors.filter(
     (connector) => {
-      return !connector.connected;
+      return !connector.connected && (connector.kind === "http" || mcpEnabled);
     },
   );
   const agentConnectors = resolvedRelatedCatalogItems
@@ -7789,6 +7805,7 @@ function ComposerAttachments({ signals }: { signals: ComposerSignals }) {
 
 function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
   const { t } = useTranslation();
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const connectorReadState = useComposerConnectorReadState(signals);
   const agents = useLastResolved(agents$) ?? [];
   const connectorUi = useGet(signals.connector.connectorUiState$);
@@ -7892,6 +7909,7 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
     customConnectorGrants,
     optimisticConnected,
     selectedCustomConnectorId,
+    mcpEnabled,
   });
   const selectedConnector = selectedConnectorSlug
     ? connectorMap.get(selectedConnectorSlug)

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -83,7 +83,6 @@ import {
   BrandSlack,
 } from "@vm0/ui";
 import { RUN_ERROR_GUIDANCE } from "@vm0/api-contracts/contracts/errors";
-import { isHttpCustomConnectorClientResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type {
   ChatEventUsagePayload,
   ChatRecommendedFollowup,
@@ -120,6 +119,7 @@ import { isMobileTextInputDevice } from "../../lib/visual-viewport-keyboard.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
+  customConnectorMcpEnabled$,
   featureSwitch$,
   videoTemplateOptionsEnabled$,
 } from "../../signals/external/feature-switch.ts";
@@ -6135,6 +6135,7 @@ function PermissionActionCard({ signals }: { signals: PermissionSignals }) {
 
 function ChatConnectorActionConnectModal() {
   const active = useGet(activeChatConnectorAction$);
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const close = useSet(closeChatConnectorActionConnectDialog$);
   const runCallback = useSet(runChatActionCallback$);
   const pageSignal = useGet(pageSignal$);
@@ -6158,11 +6159,12 @@ function ChatConnectorActionConnectModal() {
   };
 
   if (active.kind === "custom") {
-    const connector = customConnectors
-      ?.filter(isHttpCustomConnectorClientResponse)
-      .find((candidate) => {
-        return candidate.slug === active.connectorSlug;
-      });
+    const connector = customConnectors?.find((candidate) => {
+      return (
+        candidate.slug === active.connectorSlug &&
+        (candidate.kind === "http" || mcpEnabled)
+      );
+    });
     return connector ? (
       <CustomConnectorConnectDialog
         connector={connector}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -6,11 +6,9 @@ import {
   type ConnectorSlug,
 } from "@vm0/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogAuthMethodDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import {
-  isHttpCustomConnectorClientResponse,
-  type CustomConnectorClientResponse,
-  type CustomConnectorHttpClientResponse,
-  type CustomConnectorSlug,
+import type {
+  CustomConnectorClientResponse,
+  CustomConnectorSlug,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { Input } from "@vm0/ui/components/ui/input";
@@ -79,6 +77,8 @@ import {
 } from "../../signals/zero-page/settings/custom-connectors.ts";
 import { CustomConnectorIcon } from "./components/settings/custom-connector-icon.tsx";
 import { CustomConnectorConnectDialog } from "./components/settings/custom-connector-connect-dialog.tsx";
+import { customConnectorTarget } from "./components/settings/custom-connector-display.ts";
+import { customConnectorMcpEnabled$ } from "../../signals/external/feature-switch.ts";
 
 function runDirectedConnect(
   params: {
@@ -745,12 +745,14 @@ function DirectedConnectCard() {
 function customConnectorForSlug(
   connectors: readonly CustomConnectorClientResponse[],
   connectorSlug: CustomConnectorSlug,
-): CustomConnectorHttpClientResponse | undefined {
-  return connectors
-    .filter(isHttpCustomConnectorClientResponse)
-    .find((connector) => {
-      return connector.slug === connectorSlug;
-    });
+  mcpEnabled: boolean,
+): CustomConnectorClientResponse | undefined {
+  return connectors.find((connector) => {
+    return (
+      connector.slug === connectorSlug &&
+      (connector.kind === "http" || mcpEnabled)
+    );
+  });
 }
 
 function CustomDirectedConnectCard({
@@ -761,6 +763,7 @@ function CustomDirectedConnectCard({
   const agentId = useGet(directedConnectAgentId$);
   const agentNameLoadable = useLastLoadable(directedConnectAgentName$);
   const connectorsLoadable = useLastLoadable(customConnectors$);
+  const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const dialogKey = useGet(directedConnectCustomDialogKey$);
   const setDialogKey = useSet(setDirectedConnectCustomDialogKey$);
   const resetConnectInput = useSet(resetCustomConnectorConnectInput$);
@@ -769,7 +772,11 @@ function CustomDirectedConnectCard({
   const signal = useGet(pageSignal$);
   const connectors =
     connectorsLoadable.state === "hasData" ? connectorsLoadable.data : [];
-  const connector = customConnectorForSlug(connectors, connectorSlug);
+  const connector = customConnectorForSlug(
+    connectors,
+    connectorSlug,
+    mcpEnabled,
+  );
   const dialogOpen =
     dialogKey?.connectorSlug === connectorSlug &&
     dialogKey.agentId === agentId &&
@@ -814,7 +821,7 @@ function CustomDirectedConnectCard({
           ) : null
         }
         connectorLabel={connector?.displayName ?? connectorSlug}
-        connectorDescription={connector?.prefixTemplates[0] ?? ""}
+        connectorDescription={connector ? customConnectorTarget(connector) : ""}
         agentName={agentName}
         isLoading={connectorsLoadable.state === "loading"}
         isConnected={connector?.connected ?? false}

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -2689,32 +2689,27 @@
       }
     },
     {
-      "name": "MCP origin base allows exact POST endpoint path",
+      "name": "MCP endpoint base allows permissionless POST",
       "firewalls": [
         {
           "name": "custom_connector_00000000000040008000000000000001",
           "customConnectorId": "00000000-0000-4000-8000-000000000001",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "hostPolicy": { "kind": "publicDestination" },
               "auth": { "headers": { "Authorization": "Bearer token" } },
-              "permissions": [
-                {
-                  "name": "mcp-endpoint",
-                  "rules": ["POST /api/mcp", "GET /api/mcp", "DELETE /api/mcp"]
-                }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "custom_connector_00000000000040008000000000000001": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -2728,37 +2723,30 @@
       "expected": {
         "kind": "allow",
         "firewallName": "custom_connector_00000000000040008000000000000001",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/mcp",
-        "permission": "mcp-endpoint",
-        "rule": "POST /api/mcp"
+        "base": "https://mcp.example.com/api/mcp",
+        "relativePath": "/"
       }
     },
     {
-      "name": "MCP origin base allows compatibility GET endpoint path",
+      "name": "MCP endpoint base allows permissionless GET",
       "firewalls": [
         {
           "name": "mcp",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": {},
-              "permissions": [
-                {
-                  "name": "mcp-endpoint",
-                  "rules": ["GET /api/mcp", "DELETE /api/mcp"]
-                }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "mcp": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -2768,37 +2756,30 @@
       "expected": {
         "kind": "allow",
         "firewallName": "mcp",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/mcp",
-        "permission": "mcp-endpoint",
-        "rule": "GET /api/mcp"
+        "base": "https://mcp.example.com/api/mcp",
+        "relativePath": "/"
       }
     },
     {
-      "name": "MCP origin base allows compatibility DELETE endpoint path",
+      "name": "MCP endpoint base allows permissionless DELETE",
       "firewalls": [
         {
           "name": "mcp",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": {},
-              "permissions": [
-                {
-                  "name": "mcp-endpoint",
-                  "rules": ["GET /api/mcp", "DELETE /api/mcp"]
-                }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "mcp": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -2808,34 +2789,30 @@
       "expected": {
         "kind": "allow",
         "firewallName": "mcp",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/mcp",
-        "permission": "mcp-endpoint",
-        "rule": "DELETE /api/mcp"
+        "base": "https://mcp.example.com/api/mcp",
+        "relativePath": "/"
       }
     },
     {
-      "name": "MCP exact endpoint denies a distinct trailing slash",
+      "name": "MCP endpoint base allows a trailing slash",
       "firewalls": [
         {
           "name": "mcp",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": {},
-              "permissions": [
-                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "mcp": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -2843,36 +2820,32 @@
         "url": "https://mcp.example.com/api/mcp/"
       },
       "expected": {
-        "kind": "block",
+        "kind": "allow",
         "firewallName": "mcp",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/mcp/",
-        "reason": "unknown_endpoint",
-        "permissions": []
+        "base": "https://mcp.example.com/api/mcp",
+        "relativePath": "/"
       }
     },
     {
-      "name": "MCP exact endpoint denies a child path",
+      "name": "MCP endpoint base allows a child path",
       "firewalls": [
         {
           "name": "mcp",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": {},
-              "permissions": [
-                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "mcp": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -2880,36 +2853,32 @@
         "url": "https://mcp.example.com/api/mcp/child"
       },
       "expected": {
-        "kind": "block",
+        "kind": "allow",
         "firewallName": "mcp",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/mcp/child",
-        "reason": "unknown_endpoint",
-        "permissions": []
+        "base": "https://mcp.example.com/api/mcp",
+        "relativePath": "/child"
       }
     },
     {
-      "name": "MCP exact endpoint denies an unsupported method",
+      "name": "MCP endpoint base allows any method",
       "firewalls": [
         {
           "name": "mcp",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": {},
-              "permissions": [
-                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "mcp": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -2917,50 +2886,39 @@
         "url": "https://mcp.example.com/api/mcp"
       },
       "expected": {
-        "kind": "block",
+        "kind": "allow",
         "firewallName": "mcp",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/mcp",
-        "reason": "unknown_endpoint",
-        "permissions": []
+        "base": "https://mcp.example.com/api/mcp",
+        "relativePath": "/"
       }
     },
     {
-      "name": "MCP exact endpoint denies a sibling path",
+      "name": "MCP endpoint base does not match a sibling path",
       "firewalls": [
         {
           "name": "mcp",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": {},
-              "permissions": [
-                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "mcp": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
         "method": "POST",
         "url": "https://mcp.example.com/api/other"
       },
-      "expected": {
-        "kind": "block",
-        "firewallName": "mcp",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/other",
-        "reason": "unknown_endpoint",
-        "permissions": []
-      }
+      "expected": { "kind": "no_match" }
     },
     {
       "name": "MCP exact endpoint does not match another host",
@@ -2969,21 +2927,19 @@
           "name": "mcp",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": {},
-              "permissions": [
-                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "mcp": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -2993,18 +2949,16 @@
       "expected": { "kind": "no_match" }
     },
     {
-      "name": "MCP shared exact endpoint uses stable custom connector intent",
+      "name": "MCP shared endpoint uses stable custom connector intent",
       "firewalls": [
         {
           "name": "custom_connector_00000000000040008000000000000001",
           "customConnectorId": "00000000-0000-4000-8000-000000000001",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": { "headers": { "Authorization": "Bearer first" } },
-              "permissions": [
-                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
-              ]
+              "permissions": []
             }
           ]
         },
@@ -3013,27 +2967,25 @@
           "customConnectorId": "00000000-0000-4000-8000-000000000002",
           "apis": [
             {
-              "base": "https://mcp.example.com",
+              "base": "https://mcp.example.com/api/mcp",
               "auth": { "headers": { "Authorization": "Bearer second" } },
-              "permissions": [
-                { "name": "mcp-endpoint", "rules": ["POST /api/mcp"] }
-              ]
+              "permissions": []
             }
           ]
         }
       ],
       "networkPolicies": {
         "custom_connector_00000000000040008000000000000001": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         },
         "custom_connector_00000000000040008000000000000002": {
-          "allow": ["mcp-endpoint"],
+          "allow": [],
           "deny": [],
           "ask": [],
-          "unknownPolicy": "deny"
+          "unknownPolicy": "allow"
         }
       },
       "request": {
@@ -3047,10 +2999,8 @@
       "expected": {
         "kind": "allow",
         "firewallName": "custom_connector_00000000000040008000000000000002",
-        "base": "https://mcp.example.com",
-        "relativePath": "/api/mcp",
-        "permission": "mcp-endpoint",
-        "rule": "POST /api/mcp"
+        "base": "https://mcp.example.com/api/mcp",
+        "relativePath": "/"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- align Custom HTTP and MCP connector cards and expose MCP connectors in Agent Authorization, composer, action-card, and directed-connect flows
- keep custom MCP authorization connector-scoped without fine-grained permission controls
- send permissionless custom MCP firewall data to runners with the configured endpoint and authentication injection intact

## Behavior

- MCP cards use the same name, type/target, connection state, agent-access, and action layout as HTTP custom connectors
- the MCP feature switch gates access-increasing flows, while already-authorized MCP connectors remain visible so access can be revoked
- runner firewall payloads use the canonical MCP endpoint as `base`, an empty `permissions` list, and `{ "allow": [], "deny": [], "ask": [], "unknownPolicy": "allow" }`
- MCP endpoint child paths are allowed by the shared custom-connector firewall semantics; sibling paths and other hosts do not match

## Exclusions

- no database schema or persisted-data changes
- no MCP tool-level or URL-rule allowlist
- no production feature-switch rollout change

## Validation

- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm knip --workspace @vm0/app`
- `pnpm -F @vm0/app exec vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx src/views/zero-page/__tests__/chat-event-action-cards.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/app exec vitest run src/views/team-page/__tests__/team-navigation.test.tsx src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-semantics-contract.test.ts --maxWorkers=1 --silent=passed-only`
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/`

Relates to #25031
