### PR TITLE
chore(rust): disallow tracing debug macro

### DIFF
--- a/crates/clippy.toml
+++ b/crates/clippy.toml
@@ -2,3 +2,6 @@ allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true
 allow-indexing-slicing-in-tests = true
+disallowed-macros = [
+    { path = "tracing::debug", reason = "DEBUG events have no configured production sink; remove the event or use an operationally visible level", allow-invalid = true },
+]

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -228,7 +228,7 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::info!("local info");
-        tracing::debug!("local debug");
+        tracing::event!(tracing::Level::DEBUG, "local debug");
         tracing::trace!("local trace");
         tracing::warn!("local warn");
         tracing::warn!(target: INTERNAL_TARGET, dropped = 1_u64, "axiom channel full");

--- a/crates/runner/src/child_cleanup.rs
+++ b/crates/runner/src/child_cleanup.rs
@@ -1,5 +1,5 @@
 use tokio::runtime::Handle;
-use tracing::{debug, warn};
+use tracing::warn;
 
 /// Kill a child from a synchronous drop fallback and reap it on the active runtime.
 ///
@@ -16,15 +16,7 @@ pub(crate) fn kill_and_reap_child_on_drop(
     let pid = child.id();
 
     match child.try_wait() {
-        Ok(Some(status)) => {
-            debug!(
-                label,
-                ?pid,
-                code = status.code(),
-                "child already exited during drop cleanup"
-            );
-            return;
-        }
+        Ok(Some(_)) => return,
         Ok(None) => {}
         Err(error) => {
             warn!(label, ?pid, error = %error, "failed to check child status during drop cleanup");
@@ -36,15 +28,7 @@ pub(crate) fn kill_and_reap_child_on_drop(
     }
 
     match child.try_wait() {
-        Ok(Some(status)) => {
-            debug!(
-                label,
-                ?pid,
-                code = status.code(),
-                "child exited during drop cleanup"
-            );
-            return;
-        }
+        Ok(Some(_)) => return,
         Ok(None) => {}
         Err(error) => {
             warn!(label, ?pid, error = %error, "failed to recheck child status during drop cleanup");

--- a/crates/runner/src/cmd/gc/filesystem.rs
+++ b/crates/runner/src/cmd/gc/filesystem.rs
@@ -164,7 +164,6 @@ async fn collect_dir_stats_with_reader(
         let current_meta = match tokio::fs::symlink_metadata(&current).await {
             Ok(metadata) => metadata,
             Err(_) => {
-                tracing::debug!("dir_stats: cannot stat {}", current.display());
                 complete = false;
                 continue;
             }
@@ -176,8 +175,7 @@ async fn collect_dir_stats_with_reader(
 
         let mut entries = match tokio::fs::read_dir(&current).await {
             Ok(rd) => rd,
-            Err(e) => {
-                tracing::debug!("dir_stats: cannot read {}: {e}", current.display());
+            Err(_) => {
                 complete = false;
                 continue;
             }
@@ -198,7 +196,6 @@ async fn collect_dir_stats_with_reader(
             let meta = match tokio::fs::symlink_metadata(&path).await {
                 Ok(metadata) => metadata,
                 Err(_) => {
-                    tracing::debug!("dir_stats: cannot stat {}", entry.path().display());
                     complete = false;
                     continue;
                 }

--- a/crates/runner/src/cmd/gc/nbd.rs
+++ b/crates/runner/src/cmd/gc/nbd.rs
@@ -25,12 +25,11 @@ where
     Scan: FnOnce() -> (u32, Vec<(u32, u32)>) + Send + 'static,
     Disconnect: Fn(u32, u32) -> NbdOrphanDisconnect + Clone + Send + 'static,
 {
-    let (max_devs, orphans) = tokio::task::spawn_blocking(scan)
+    let (_, orphans) = tokio::task::spawn_blocking(scan)
         .await
         .map_err(|e| RunnerError::Internal(format!("nbd orphan scan task failed: {e}")))?;
 
     if orphans.is_empty() {
-        tracing::debug!("nbd: scanned {max_devs} devices, no orphans");
         return Ok(GcReport::default());
     }
 

--- a/crates/runner/src/cmd/gc/workspaces.rs
+++ b/crates/runner/src/cmd/gc/workspaces.rs
@@ -242,7 +242,6 @@ pub(super) async fn gc_workspace_orphans(
     .map_err(|e| RunnerError::Internal(format!("discover base-dir locks task failed: {e}")))?;
 
     if candidates.is_empty() {
-        tracing::debug!("workspace gc: no initially-free base-dir locks discovered");
         return Ok(WorkspaceGcSummary::default());
     }
 
@@ -326,7 +325,6 @@ async fn gc_workspace_orphans_with_candidates_and_remove(
 
     let active = active_workspace_paths(firecrackers);
     let mut summary = WorkspaceGcSummary::default();
-    let candidate_count = candidates.len();
 
     for candidate in candidates {
         let lease =
@@ -390,11 +388,6 @@ async fn gc_workspace_orphans_with_candidates_and_remove(
             "workspace orphans: {} cleaned ({})",
             summary.workspaces_cleaned,
             human_bytes(summary.bytes_freed)
-        );
-    } else {
-        tracing::debug!(
-            "workspace gc: no orphans found across {} base-dir lock candidates",
-            candidate_count
         );
     }
 
@@ -499,11 +492,6 @@ async fn gc_workspace_orphans_in_base_dir(
             .and_then(|mtime| workspace_age_reference.duration_since(mtime).ok())
             .unwrap_or_default();
         if age < GC_MIN_AGE {
-            tracing::debug!(
-                "workspace gc: {} too recent ({}s), skipping",
-                path.display(),
-                age.as_secs()
-            );
             preserve_lock = true;
             continue;
         }

--- a/crates/runner/src/cmd/service/reload.rs
+++ b/crates/runner/src/cmd/service/reload.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
@@ -135,10 +135,6 @@ async fn coordinate_systemd_reload_with_ops(
     };
 
     if !should_reload {
-        debug!(
-            unit = %unit.unit_name(),
-            "systemd reload skipped because the unit mutation is already effective"
-        );
         return Ok(false);
     }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use futures_util::future::BoxFuture;
-use tracing::{debug, info};
+use tracing::info;
 
 use super::active_runs::ActiveRuns;
 use crate::config::ProfileConfig;
@@ -361,11 +361,6 @@ pub(super) async fn send_heartbeat(
         reusable_sandboxes = state.held_sandbox_states.len(),
         workspace_states = state.held_workspace_states.len(),
         "heartbeat"
-    );
-    debug!(
-        reusable_sandboxes = state.held_sandbox_states.len(),
-        workspace_states = state.held_workspace_states.len(),
-        "heartbeat held reusable states"
     );
     hb.provider.heartbeat(&state).await;
 }
@@ -926,16 +921,17 @@ mod tests {
         let ((), events) =
             capture_heartbeat_events(send_heartbeat(&hb, RunnerMode::Running, 42)).await;
 
-        let debug_event = captured_event(&events, "heartbeat held reusable states");
+        let heartbeat_event = captured_event(&events, "heartbeat");
+        assert_eq!(heartbeat_event.level, tracing::Level::INFO);
         assert_eq!(
-            debug_event
+            heartbeat_event
                 .fields
                 .get("reusable_sandboxes")
                 .map(String::as_str),
             Some("0")
         );
         assert_eq!(
-            debug_event
+            heartbeat_event
                 .fields
                 .get("workspace_states")
                 .map(String::as_str),

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use sandbox::GuestProcessControlHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::active_input::{ActiveInputBatch, ActiveInputPayload, ActiveInputSource};
 use crate::ids::RunId;
@@ -127,13 +127,10 @@ async fn forward_text(
     // Process control requires a request correlation key. It is deliberately
     // runner-internal and has no active-input identity or deduplication semantics.
     let correlation_id = format!("active-input:{run_id}:{delivery_sequence}");
-    match control
+    if let Err(error) = control
         .control_owned(correlation_id, bytes, ACTIVE_INPUT_CONTROL_TIMEOUT)
         .await
     {
-        Ok(_) => debug!(run_id = %run_id, "forwarded active input"),
-        Err(error) => {
-            warn!(run_id = %run_id, error = %error, "active-input forward failed; dropping input")
-        }
+        warn!(run_id = %run_id, error = %error, "active-input forward failed; dropping input");
     }
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -21,7 +21,7 @@ use sandbox::{
 };
 use shell_quote::quote_shell_arg;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use super::codex_model_catalog_prefetch::{
     StartedCodexModelCatalogPrefetch, is_eligible as is_codex_model_catalog_prefetch_eligible,
@@ -467,24 +467,12 @@ async fn verify_restored_session_identity_for_reuse(
     identity: RestoredSessionIdentity,
 ) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
     let Some(requested_identity) = RestoredSessionIdentity::from_context(context) else {
-        debug!(
-            run_id = %context.run_id,
-            "restored session identity cannot be verified without a valid hash-backed resume request"
-        );
         return Err(SessionHistoryIdentityReason::VerifyRequestMissing);
     };
     if identity != requested_identity {
-        debug!(
-            run_id = %context.run_id,
-            "restored session identity invalidated because it does not match the resume request"
-        );
         return Err(SessionHistoryIdentityReason::VerifyRequestMismatch);
     }
     let Some(verification) = identity.final_metadata_verification() else {
-        debug!(
-            run_id = %context.run_id,
-            "restored session identity cannot be verified without a final metadata verifier"
-        );
         return Err(SessionHistoryIdentityReason::VerifyMissingVerifier);
     };
     if !identity.is_verified_match_for_request(&requested_identity) {
@@ -511,12 +499,11 @@ async fn verify_restored_session_identity_for_reuse(
         history_hash,
         history_size_bytes,
     );
-    verify_final_identity_metadata(sandbox, context, identity, command, &runtime_dir).await
+    verify_final_identity_metadata(sandbox, identity, command, &runtime_dir).await
 }
 
 async fn verify_final_identity_metadata(
     sandbox: &dyn Sandbox,
-    context: &ExecutionContext,
     identity: RestoredSessionIdentity,
     command: String,
     runtime_dir: &str,
@@ -539,21 +526,8 @@ async fn verify_final_identity_metadata(
         .await
     {
         Ok(result) if helper_exec_succeeded(&result) => Ok(identity),
-        Ok(result) => {
-            debug!(
-                run_id = %context.run_id,
-                termination = %helper_exec_termination_label(&result),
-                "restored session identity final metadata verification failed"
-            );
-            Err(session_history_identity_reason_from_helper_result(&result))
-        }
-        Err(_) => {
-            debug!(
-                run_id = %context.run_id,
-                "restored session identity final metadata verification errored"
-            );
-            Err(SessionHistoryIdentityReason::VerifyHelperExecError)
-        }
+        Ok(result) => Err(session_history_identity_reason_from_helper_result(&result)),
+        Err(_) => Err(SessionHistoryIdentityReason::VerifyHelperExecError),
     }
 }
 
@@ -626,23 +600,13 @@ async fn read_final_session_history_identity(
         guest_contracts::runtime_paths::final_session_history_identity_file,
     ) {
         Ok(path) => path,
-        Err(error) => {
-            debug!(
-                run_id = %context.run_id,
-                error = %error,
-                "final session history identity path could not be resolved"
-            );
+        Err(_) => {
             return Err(SessionHistoryIdentityReason::FinalizeMetadataPathUnresolved);
         }
     };
     let runtime_dir = match guest_runtime_dir(context.run_id) {
         Ok(path) => path,
-        Err(error) => {
-            debug!(
-                run_id = %context.run_id,
-                error = %error,
-                "guest runtime dir could not be resolved for final session history identity"
-            );
+        Err(_) => {
             return Err(SessionHistoryIdentityReason::FinalizeRuntimeDirUnresolved);
         }
     };
@@ -652,22 +616,11 @@ async fn read_final_session_history_identity(
     {
         Ok(Some(bytes)) => bytes,
         Ok(None) => return Err(SessionHistoryIdentityReason::FinalizeMissingMetadata),
-        Err(_) => {
-            debug!(
-                run_id = %context.run_id,
-                "final session history identity metadata read failed"
-            );
-            return Err(SessionHistoryIdentityReason::FinalizeMetadataReadFailed);
-        }
+        Err(_) => return Err(SessionHistoryIdentityReason::FinalizeMetadataReadFailed),
     };
     let metadata = match FinalSessionHistoryIdentity::from_json_slice(&bytes) {
         Ok(metadata) => metadata,
         Err(error) => {
-            debug!(
-                run_id = %context.run_id,
-                error = %error,
-                "final session history identity metadata was invalid"
-            );
             return Err(SessionHistoryIdentityReason::from_final_metadata_error(
                 error,
             ));

--- a/crates/runner/src/executor/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/codex_model_catalog_prefetch.rs
@@ -8,7 +8,7 @@ use sandbox::{
     ProcessControlMode, ProcessExit, ProcessOutputMode, Sandbox, StartProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::warn;
 
 use super::cli_framework::EffectiveCliFramework;
 use super::effective_cli_framework;
@@ -257,10 +257,7 @@ impl<'a> CodexModelCatalogPrefetch<'a> {
                 ExecTermination::StartFailed => (false, Some("process_start_failed")),
                 ExecTermination::WaitFailed => (false, Some("process_wait_failed")),
             },
-            Err(error) => {
-                debug!(error = %error, "Codex model catalog prefetch wait failed");
-                (false, Some("wait_failed"))
-            }
+            Err(_) => (false, Some("wait_failed")),
         };
         self.outcome = Some(PrefetchOutcome {
             duration,

--- a/crates/runner/src/executor/pi_standby.rs
+++ b/crates/runner/src/executor/pi_standby.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use sandbox::GuestProcessControlHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::ids::RunId;
 use crate::pi_standby::{PiStandbySignal, PiStandbySubscription};
@@ -46,14 +46,11 @@ impl PiStandbyForwarder {
                 PiStandbySignal::Release => br#"{"type":"pi-standby-release"}"#.as_slice(),
             };
             let correlation_id = format!("pi-standby:{run_id}");
-            match control
+            if let Err(error) = control
                 .control(&correlation_id, payload, PI_STANDBY_CONTROL_TIMEOUT)
                 .await
             {
-                Ok(_) => debug!(run_id = %run_id, ?signal, "forwarded Pi standby control"),
-                Err(error) => {
-                    warn!(run_id = %run_id, ?signal, error = %error, "Pi standby control forward failed")
-                }
+                warn!(run_id = %run_id, ?signal, error = %error, "Pi standby control forward failed");
             }
         });
         Some(Self { stop, task })

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -317,14 +317,14 @@ async fn read_record_with_liveness(
         Ok(Some(content)) => content,
         Ok(None) => return Ok(RecordRead::Missing),
         Err(e) => {
-            tracing::debug!(path = %path.display(), error = %e, "ignoring unreadable live runner instance record");
+            tracing::info!(path = %path.display(), error = %e, "ignoring unreadable live runner instance record");
             return Ok(RecordRead::InvalidFile);
         }
     };
     let record: LiveRunnerInstanceRecord = match serde_json::from_str(&content) {
         Ok(record) => record,
         Err(e) => {
-            tracing::debug!(path = %path.display(), error = %e, "ignoring malformed live runner instance record");
+            tracing::info!(path = %path.display(), error = %e, "ignoring malformed live runner instance record");
             return Ok(RecordRead::InvalidFile);
         }
     };
@@ -340,7 +340,7 @@ async fn remove_stale_records(home: &HomePaths) {
     let mut entries = match tokio::fs::read_dir(&dir).await {
         Ok(entries) => entries,
         Err(e) => {
-            tracing::debug!(path = %dir.display(), error = %e, "cannot scan live runner instances");
+            tracing::info!(path = %dir.display(), error = %e, "cannot scan live runner instances");
             return;
         }
     };
@@ -351,7 +351,7 @@ async fn remove_stale_records(home: &HomePaths) {
             Ok(Some(entry)) => entry,
             Ok(None) => break,
             Err(e) => {
-                tracing::debug!(path = %dir.display(), error = %e, "cannot read live runner instance entry");
+                tracing::info!(path = %dir.display(), error = %e, "cannot read live runner instance entry");
                 break;
             }
         };
@@ -360,7 +360,7 @@ async fn remove_stale_records(home: &HomePaths) {
         if let Some(identity) = stable_record_identity_from_file_name(&file_name) {
             match read_record_for_identity(&path, identity, &liveness).await {
                 Err(e) => {
-                    tracing::debug!(
+                    tracing::info!(
                         path = %path.display(),
                         error = %e,
                         "preserving live runner instance record after liveness check failed"
@@ -395,7 +395,7 @@ async fn read_record_for_identity(
     if record.pid == identity.pid && record.starttime == identity.starttime {
         Ok(RecordForIdentity::Valid(record))
     } else {
-        tracing::debug!(
+        tracing::info!(
             path = %path.display(),
             record_pid = record.pid,
             record_starttime = record.starttime,
@@ -429,7 +429,7 @@ async fn remove_stale_tmp_file(
             remove_stale_file(path, "stale live runner instance tmp file").await;
         }
         Err(e) => {
-            tracing::debug!(
+            tracing::info!(
                 path = %path.display(),
                 error = %e,
                 "preserving live runner instance tmp file after liveness check failed"
@@ -440,12 +440,10 @@ async fn remove_stale_tmp_file(
 
 async fn remove_stale_file(path: &Path, reason: &'static str) {
     match tokio::fs::remove_file(path).await {
-        Ok(()) => {
-            tracing::debug!(path = %path.display(), reason, "removed stale live runner instance file");
-        }
+        Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {
-            tracing::debug!(path = %path.display(), reason, error = %e, "cannot remove stale live runner instance file");
+            tracing::info!(path = %path.display(), reason, error = %e, "cannot remove stale live runner instance file");
         }
     }
 }

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use nix::fcntl::Flock;
 use nix::sys::signal::Signal;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::process::{ProcessStat, ProcessStatRead, process_stat_is_live};
@@ -393,17 +393,9 @@ fn is_launch_path(root: &Path, path: &Path) -> bool {
 }
 
 fn log_process_snapshot(target: &Path, snapshot: &ProcessSnapshot) {
-    let elapsed_ms = snapshot.elapsed.as_millis();
-    let matched = snapshot.processes.len();
-    debug!(
-        target = %target.display(),
-        elapsed_ms,
-        examined = snapshot.examined,
-        same_uid = snapshot.same_uid,
-        matched,
-        "scanned for mitmdump runtime owners"
-    );
     if snapshot.elapsed >= PROCESS_EXIT_TIMEOUT {
+        let elapsed_ms = snapshot.elapsed.as_millis();
+        let matched = snapshot.processes.len();
         warn!(
             target = %target.display(),
             elapsed_ms,

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -5,8 +5,6 @@ use std::time::{Duration, Instant};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use nix::fcntl::Flock;
 use tokio::fs;
-#[cfg(test)]
-use tracing::debug;
 use tracing::{info, warn};
 
 use crate::duration::duration_ms;
@@ -1109,10 +1107,6 @@ impl WorkspaceImageLease {
             completed_at,
             storage_fingerprints: storage_fingerprints.clone(),
         }) else {
-            debug!(
-                run_id = %run_id,
-                "workspace image cache promotion skipped: checkout result is not promotable"
-            );
             return Ok(false);
         };
         let outcome = promotion.promote().await?;


### PR DESCRIPTION
## Summary

- disallow `tracing::debug!` through the shared Clippy configuration
- remove normal-path, duplicate, no-work, and structured-outcome DEBUG diagnostics
- promote eight swallowed live-runner-registry failures to local `INFO`
- preserve the Axiom sibling-layer DEBUG coverage with `tracing::event!`

This does not enable `RUST_LOG`, change the runner's `INFO+` local threshold, or change Axiom's `WARN+` ingestion threshold.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner --bin runner` (3102 passed, 20 ignored)
- imported-and-renamed macro negative probe: Clippy rejected an aliased `tracing::debug!` invocation with the configured reason
- pre-commit Rust formatting, Clippy, documentation, file-size, and commit-message checks

Closes #26324
