### PR TITLE
test(e2e): restore runner firewall coverage

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -5,7 +5,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 WORKFLOW="${REPO_ROOT}/.github/workflows/turbo.yml"
 RUNNER_TESTS="${REPO_ROOT}/e2e/tests/03-runner"
-RUNNER_HELPER="${REPO_ROOT}/e2e/helpers/runner-chat.bash"
+RUNNER_HELPERS=(
+  "${REPO_ROOT}/e2e/helpers/runner-api.bash"
+  "${REPO_ROOT}/e2e/helpers/runner-chat.bash"
+)
 RUNNER_TOKEN="${REPO_ROOT}/e2e/playwright/runner-token.ts"
 
 fail() {
@@ -29,7 +32,7 @@ grep -Fq "RUNNER_GROUP: \${{ format('vm0/development-{0}', needs.prepare.outputs
 if grep -Fq 'playwright-staging' "$WORKFLOW"; then
   fail "main Playwright runs must not use a group outside the staging API default"
 fi
-if grep -R -Fq '/api/test/' "$RUNNER_TESTS" "$RUNNER_HELPER"; then
+if grep -R -Fq '/api/test/' "$RUNNER_TESTS" "${RUNNER_HELPERS[@]}"; then
   fail "runner E2E coverage must use supported public APIs"
 fi
 grep -Fq 'startVideoOnboardingCheckout' "$RUNNER_TOKEN" ||

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -57,12 +57,12 @@ unless consumer_step&.fetch("run", "")&.end_with?("runner-image-context.sh turbo
   raise "Turbo must restore the historical runner E2E consumer detector"
 end
 
-expected_indices = (1..12).to_a
 unless runner.dig("strategy", "fail-fast") == false
   raise "runner E2E shards must not fail fast"
 end
-unless runner.dig("strategy", "matrix", "index") == expected_indices
-  raise "runner E2E must preserve the historical twelve-shard matrix"
+expected_matrix = "${{ fromJSON(needs.cli-e2e-03-runner-prepare.outputs.runner-shard-matrix) }}"
+unless runner.dig("strategy", "matrix") == expected_matrix
+  raise "runner E2E must use the generated non-empty shard matrix"
 end
 
 expected_group = "cli-e2e-03-runner-${{ matrix.index }}-${{ needs.prepare.outputs.job-ref }}"
@@ -126,6 +126,22 @@ expected_organization_outputs.each do |job_output, step_output|
   unless account_prepare.dig("outputs", job_output) == expected
     raise "runner E2E account preparation must expose #{job_output}"
   end
+end
+unless account_prepare.dig("outputs", "runner-shard-matrix") ==
+    "${{ steps.shards.outputs.matrix }}"
+  raise "runner E2E preparation must expose the generated shard matrix"
+end
+
+shard_generation_step = account_prepare.fetch("steps").find do |step|
+  step["name"] == "Generate runner E2E shard matrix"
+end
+raise "missing runner E2E shard generation" unless shard_generation_step
+shard_generation_script = shard_generation_step.fetch("run")
+unless shard_generation_step["id"] == "shards" &&
+    shard_generation_script.include?("playwright/runner-shards.ts tests/03-runner") &&
+    shard_generation_script.include?('length > 0 and length <= 12') &&
+    shard_generation_script.include?('echo "matrix=$matrix" >> "$GITHUB_OUTPUT"')
+  raise "runner E2E shard generation must use the tested executable and reject empty matrices"
 end
 
 token_step = account_prepare.fetch("steps").find do |step|
@@ -218,21 +234,21 @@ shard_step = runner.fetch("steps").find do |step|
   step["name"] == "Initialize runner E2E shard"
 end
 raise "missing runner E2E shard scaffold" unless shard_step
+unless runner.dig("env", "E2E_RUNNER_TEST_FILES_JSON") == "${{ toJSON(matrix.files) }}" &&
+    runner.dig("env", "E2E_RUNNER_SHARD_TOTAL") == "${{ strategy.job-total }}"
+  raise "runner E2E shards must receive their exact file list and dynamic total"
+end
+
 run_step = runner.fetch("steps").find do |step|
   step.fetch("name", "").include?("Run runner E2E tests")
 end
-raise "missing runner E2E test execution" unless run_step
+raise "missing runner E2E BATS execution" unless run_step
 run_script = run_step.fetch("run")
-%w[
-  e2e/tests/03-runner
-  E2E_RUNNER_SHARD_INDEX
-  E2E_RUNNER_SHARD_TOTAL
-  BATS_TEST_TIMEOUT=240
-  ./e2e/test/libs/bats/bin/bats
-].each do |required_fragment|
-  unless run_script.include?(required_fragment)
-    raise "runner E2E test execution must include #{required_fragment}"
-  end
+unless run_script.include?('mapfile -t test_files') &&
+    run_script.include?('BATS_TEST_TIMEOUT=240 ./test/libs/bats/bin/bats') &&
+    run_script.include?('--report-formatter junit') &&
+    run_script.include?('"${test_files[@]}"')
+  raise "runner E2E must safely execute every matrix file with JUnit reporting"
 end
 unless run_step.dig("env", "VERCEL_AUTOMATION_BYPASS_SECRET") ==
     "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}"
@@ -243,6 +259,13 @@ unless runner.fetch("steps").any? do |step|
       step.dig("with", "name") == "e2e-tokens"
   end
   raise "every runner shard must download the token artifact"
+end
+unless runner.fetch("steps").any? do |step|
+    step["name"] == "Upload runner E2E JUnit XML" &&
+      step.dig("with", "name") == "e2e-runner-junit-${{ matrix.index }}" &&
+      step.dig("with", "retention-days") == 7
+  end
+  raise "every runner shard must upload its JUnit report"
 end
 
 cleanup_step = account_cleanup.fetch("steps").find do |step|

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2836,7 +2836,7 @@ jobs:
           fi
       - name: Upload runner E2E test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: e2e-runner
@@ -2844,7 +2844,7 @@ jobs:
           report_type: test_results
       - name: Upload runner E2E JUnit XML
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: e2e-runner-junit-${{ matrix.index }}
           path: e2e/results/runner-${{ matrix.index }}/

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2509,8 +2509,7 @@ jobs:
           RUNNER_START_SUCCEEDED=1
 
   # Prepare the runner identities and API credentials once, then fan runner
-  # coverage across the same twelve independent shards used by the retired
-  # runner suite.
+  # coverage across no more than twelve non-empty file-balanced shards.
   cli-e2e-03-runner-prepare:
     runs-on: ubuntu-latest
     timeout-minutes: 12
@@ -2533,6 +2532,7 @@ jobs:
       runner-email: ${{ steps.account.outputs.runner-email }}
       codex-email: ${{ steps.account.outputs.codex-email }}
       claude-email: ${{ steps.account.outputs.claude-email }}
+      runner-shard-matrix: ${{ steps.shards.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -2542,6 +2542,18 @@ jobs:
         run: corepack enable pnpm
       - name: Install E2E dependencies
         run: cd e2e && pnpm install --frozen-lockfile
+      - name: Generate runner E2E shard matrix
+        id: shards
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix="$(cd e2e && pnpm exec tsx playwright/runner-shards.ts tests/03-runner)"
+          jq -e '
+            .include | type == "array" and
+            length > 0 and length <= 12 and
+            all(.[]; (.files | type == "array" and length > 0))
+          ' <<<"$matrix" >/dev/null
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Prepare runner E2E accounts
         id: account
         run: cd e2e && pnpm exec tsx playwright/runner-account.ts prepare
@@ -2727,8 +2739,7 @@ jobs:
       needs.cli-e2e-03-runner-bootstrap.result == 'success'
     strategy:
       fail-fast: false
-      matrix:
-        index: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+      matrix: ${{ fromJSON(needs.cli-e2e-03-runner-prepare.outputs.runner-shard-matrix) }}
     env:
       E2E_CLERK_ORG_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.runner-organization-id }}
       E2E_RUNNER_CODEX_ORG_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.codex-organization-id }}
@@ -2737,7 +2748,8 @@ jobs:
       E2E_RUNNER_CODEX_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.codex-email }}
       E2E_RUNNER_CLAUDE_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.claude-email }}
       E2E_RUNNER_SHARD_INDEX: ${{ matrix.index }}
-      E2E_RUNNER_SHARD_TOTAL: 12
+      E2E_RUNNER_SHARD_TOTAL: ${{ strategy.job-total }}
+      E2E_RUNNER_TEST_FILES_JSON: ${{ toJSON(matrix.files) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -2782,37 +2794,61 @@ jobs:
           : "${E2E_RUNNER_CLAUDE_EMAIL:?runner Claude E2E account is required}"
           : "${E2E_API_TOKEN:?runner E2E API token is required}"
           : "${E2E_API_URL:?runner E2E API URL is required}"
-          echo "Runner E2E shard ${E2E_RUNNER_SHARD_INDEX}/${E2E_RUNNER_SHARD_TOTAL} is ready"
+          jq -e '
+            type == "array" and length > 0 and
+            all(.[]; type == "string" and length > 0)
+          ' <<<"$E2E_RUNNER_TEST_FILES_JSON" >/dev/null
+          test_count="$(jq 'length' <<<"$E2E_RUNNER_TEST_FILES_JSON")"
+          echo "Runner E2E shard ${E2E_RUNNER_SHARD_INDEX}/${E2E_RUNNER_SHARD_TOTAL} has ${test_count} file(s)"
       - name: Run runner E2E tests (shard ${{ matrix.index }})
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t runner_tests < <(
-            find e2e/tests/03-runner -maxdepth 1 -type f -name '*.bats' -print | LC_ALL=C sort
-          )
+          mapfile -t test_files < <(jq -er '.[]' <<<"$E2E_RUNNER_TEST_FILES_JSON")
+          if (( ${#test_files[@]} == 0 )); then
+            echo "::error::Runner E2E shard has no test files"
+            exit 1
+          fi
 
-          shard_tests=()
-          for test_index in "${!runner_tests[@]}"; do
-            assigned_shard=$((test_index % E2E_RUNNER_SHARD_TOTAL + 1))
-            if (( assigned_shard == E2E_RUNNER_SHARD_INDEX )); then
-              shard_tests+=("${runner_tests[$test_index]}")
+          cd e2e
+          for test_file in "${test_files[@]}"; do
+            if [[ ! -f "$test_file" ]]; then
+              echo "::error::Runner E2E test file does not exist: $test_file"
+              exit 1
             fi
           done
 
-          if (( ${#shard_tests[@]} == 0 )); then
-            echo "No runner E2E tests assigned to shard ${E2E_RUNNER_SHARD_INDEX}"
-            exit 0
-          fi
-
-          echo "Runner E2E shard ${E2E_RUNNER_SHARD_INDEX} files: ${shard_tests[*]}"
-          mkdir -p e2e/results
-          BATS_TEST_TIMEOUT=240 ./e2e/test/libs/bats/bin/bats \
+          result_directory="results/runner-${E2E_RUNNER_SHARD_INDEX}"
+          mkdir -p "$result_directory"
+          BATS_TEST_TIMEOUT=240 ./test/libs/bats/bin/bats \
             -T \
             --report-formatter junit \
-            --output e2e/results \
-            "${shard_tests[@]}"
+            --output "$result_directory" \
+            "${test_files[@]}"
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Print runner E2E trace log
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f /tmp/e2e-trace.log ]]; then
+            cat /tmp/e2e-trace.log
+          fi
+      - name: Upload runner E2E test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e-runner
+          files: e2e/results/runner-${{ matrix.index }}/*.xml
+          report_type: test_results
+      - name: Upload runner E2E JUnit XML
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-runner-junit-${{ matrix.index }}
+          path: e2e/results/runner-${{ matrix.index }}/
+          retention-days: 7
 
   cli-e2e-03-runner-cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2844,7 +2844,7 @@ jobs:
           report_type: test_results
       - name: Upload runner E2E JUnit XML
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-runner-junit-${{ matrix.index }}
           path: e2e/results/runner-${{ matrix.index }}/

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -14,6 +14,7 @@ use serde_json::{Value, json};
 use std::io::{self, Write};
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
+use std::process::Command;
 use std::thread;
 use uuid::Uuid;
 
@@ -31,6 +32,7 @@ const EVENT_DELIVERY_LARGE_EVENT_COUNT: usize = 10;
 const EVENT_DELIVERY_LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
 const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
 const SECONDARY_ITEM_STARTED_AT_MS: u64 = 1_700_000_000_000;
+const SHELL_PROMPT_PREFIX: &str = "@shell@\n";
 
 impl AppServerState {
     pub(super) fn handle_initialize<W: Write>(
@@ -293,7 +295,7 @@ impl AppServerState {
             },
             &inputs,
         )?;
-        let response_text = mock_response_text(inputs.iter().map(String::as_str));
+        let response_text = mock_response_text(inputs.iter().map(String::as_str))?;
         write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
         if self.scenario == Scenario::UnexpectedThreadOutputItemStarted {
             write_json_line(
@@ -466,7 +468,7 @@ impl AppServerState {
                 .iter()
                 .chain(&self.steered_inputs)
                 .map(String::as_str),
-        );
+        )?;
         if self.scenario == Scenario::RuntimeTurnCompleteBeforeSteerResponse {
             write_turn_completion_notifications(
                 output,
@@ -581,9 +583,28 @@ fn write_secondary_thread_notifications<W: Write>(
     write_json_line(output, &turn_completed_notification(thread_id, turn_id))
 }
 
-fn mock_response_text<'a>(inputs: impl IntoIterator<Item = &'a str>) -> String {
+fn mock_response_text<'a>(inputs: impl IntoIterator<Item = &'a str>) -> io::Result<String> {
     let prompt = inputs.into_iter().collect::<Vec<_>>().join(" ");
-    format!("guest-mock-codex app-server response: {prompt}")
+    let Some(script) = prompt.strip_prefix(SHELL_PROMPT_PREFIX) else {
+        return Ok(format!("guest-mock-codex app-server response: {prompt}"));
+    };
+
+    let output = Command::new("bash").args(["-c", script]).output()?;
+    let mut response = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.is_empty() {
+        if !response.is_empty() && !response.ends_with('\n') {
+            response.push('\n');
+        }
+        response.push_str(&stderr);
+    }
+    if !output.status.success() {
+        if !response.is_empty() && !response.ends_with('\n') {
+            response.push('\n');
+        }
+        response.push_str(&format!("mock shell exited with {}", output.status));
+    }
+    Ok(response)
 }
 
 fn validate_initialize_params(params: &Value) -> Result<(), &'static str> {

--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -454,6 +454,56 @@ fn app_server_shell_prompt_executes_inherited_environment() -> std::io::Result<(
 }
 
 #[test]
+fn app_server_shell_prompt_reports_stderr_and_failure() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("runtime-turn-complete"),
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.send(&json!({
+        "id": 2,
+        "method": "thread/start",
+        "params": { "cwd": "/tmp" }
+    }))?;
+    let thread_started = server.read_required()?;
+    assert_eq!(thread_started["method"], "thread/started");
+    let started = server.read_required()?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input(
+                "@shell@\nprintf stdout; printf stderr >&2; exit 7"
+            )]
+        }),
+    )?;
+
+    loop {
+        let notification = server.read_required()?;
+        if notification["method"] == "item/completed" {
+            assert_eq!(
+                notification["params"]["item"]["text"],
+                "stdout\nstderr\nmock shell exited with exit status: 7"
+            );
+        }
+        if notification["method"] == "turn/completed" {
+            break;
+        }
+    }
+
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_can_start_runtime_turn_before_steer_completion() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(

--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -405,6 +405,55 @@ fn app_server_turn_steer_can_complete_runtime_turn_after_success() -> std::io::R
 }
 
 #[test]
+fn app_server_shell_prompt_executes_inherited_environment() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server_with_env(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("runtime-turn-complete"),
+        &[("MOCK_SHELL_VALUE", "inherited-value")],
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.send(&json!({
+        "id": 2,
+        "method": "thread/start",
+        "params": { "cwd": "/tmp" }
+    }))?;
+    let thread_started = server.read_required()?;
+    assert_eq!(thread_started["method"], "thread/started");
+    let started = server.read_required()?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("@shell@\nprintf 'shell:%s' \"$MOCK_SHELL_VALUE\"")]
+        }),
+    )?;
+
+    loop {
+        let notification = server.read_required()?;
+        if notification["method"] == "item/completed" {
+            assert_eq!(
+                notification["params"]["item"]["text"],
+                "shell:inherited-value"
+            );
+        }
+        if notification["method"] == "turn/completed" {
+            break;
+        }
+    }
+
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_can_start_runtime_turn_before_steer_completion() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -9,7 +9,9 @@ entry points. The current suite covers:
   smoke checks;
 - Clerk sign-up and sign-in through the hosted form UI;
 - onboarding, chat submission, runner dispatch, and the assistant result through
-  the deployed web application.
+  the deployed web application;
+- connector firewall placeholder and authentication behavior through the
+  deployed preview API, runner, sandbox, and proxy.
 
 An E2E test must not call `/api/test/*`, mint a test-only API token, write the
 database directly, or use an internal fixture endpoint to construct or inspect
@@ -63,3 +65,19 @@ Push runner E2E changes to a branch and use the pull request pipeline to run
 and validate this suite. Do not treat a local `./e2e/run.sh` invocation as
 validation for `03-runner`; running the script without file arguments also
 selects the CI-only runner tests.
+
+## Adding runner BATS tests
+
+Runner BATS files live in `e2e/tests/03-runner`. They share the accounts and
+public device-flow tokens prepared by the runner E2E workflow, then create and
+clean up their own agents, threads, and connector connections through public
+`/api/zero/*` endpoints.
+
+Use a different organization-scoped connector slug in each file that can run in
+parallel. Assert sandbox-visible output and vm0-owned telemetry; do not treat an
+external provider's exact response status or body as the test oracle.
+
+The workflow discovers the checked-in BATS files, weighs each file by its test
+count, and assigns whole files to at most twelve non-empty shards. New files are
+included automatically. Keep setup and teardown self-contained within a file so
+the shard planner can move it without introducing cross-file ordering.

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 runner_e2e_require_environment() {
-    : "${E2E_API_TOKEN:?runner E2E API token is required}"
-    : "${E2E_API_URL:?runner E2E API URL is required}"
-    command -v curl >/dev/null
+    require_runner_api_credentials || return
+    command -v curl >/dev/null || return
     command -v jq >/dev/null
 }
 
@@ -23,45 +22,9 @@ runner_e2e_teardown_test() {
         runner_e2e_delete_chat_thread "$THREAD_ID" >/dev/null 2>&1 || true
     fi
     if [[ -n "${AGENT_ID:-}" ]]; then
-        runner_e2e_delete_agent "$AGENT_ID" >/dev/null 2>&1 || true
+        delete_runner_agent "$AGENT_ID" >/dev/null 2>&1 || true
     fi
     runner_e2e_delete_connector "$connector_slug" >/dev/null 2>&1 || true
-}
-
-runner_e2e_api_request() {
-    local method="$1"
-    local path="$2"
-    local body="${3-}"
-    local -a args=(
-        --fail-with-body
-        --silent
-        --show-error
-        --max-time 60
-        --request "$method"
-        --header "Authorization: Bearer ${E2E_API_TOKEN}"
-        --header "Accept: application/json"
-    )
-
-    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
-        args+=(--header "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
-    fi
-    if [[ $# -ge 3 ]]; then
-        args+=(--header "Content-Type: application/json" --data-binary "$body")
-    fi
-
-    curl "${args[@]}" "${E2E_API_URL%/}${path}"
-}
-
-runner_e2e_create_private_agent() {
-    local display_name="$1"
-    local payload
-    payload=$(jq -nc --arg displayName "$display_name" '{displayName: $displayName, visibility: "private"}')
-    runner_e2e_api_request POST "/api/zero/agents" "$payload"
-}
-
-runner_e2e_delete_agent() {
-    local agent_id="$1"
-    runner_e2e_api_request DELETE "/api/zero/agents/${agent_id}"
 }
 
 runner_e2e_connect_manual_connector() {
@@ -75,81 +38,32 @@ runner_e2e_connect_manual_connector() {
         --arg agentId "$agent_id" \
         --argjson values "$values" \
         '{authMethod: $authMethod, agentId: $agentId, authorizeAgent: true, values: $values}')
-    runner_e2e_api_request \
-        POST \
-        "/api/zero/connectors/${connector_slug}/manual-grant" \
-        "$payload"
+    runner_api_curl "/api/zero/connectors/${connector_slug}/manual-grant" \
+        -X POST \
+        -d "$payload"
 }
 
 runner_e2e_delete_connector() {
     local connector_slug="$1"
-    runner_e2e_api_request DELETE "/api/zero/connectors/${connector_slug}"
+    runner_api_curl "/api/zero/connectors/${connector_slug}" -X DELETE
 }
 
 runner_e2e_cancel_run() {
     local run_id="$1"
-    runner_e2e_api_request POST "/api/zero/runs/${run_id}/cancel"
+    runner_api_curl "/api/zero/runs/${run_id}/cancel" -X POST
 }
 
 runner_e2e_start_chat_run() {
     local agent_id="$1"
     local prompt="$2"
     local shell_prompt
-    local client_thread_id
-    local payload
     shell_prompt=$(printf '@shell@\n%s' "$prompt")
-    client_thread_id=$(cat /proc/sys/kernel/random/uuid)
-    payload=$(jq -nc \
-        --arg agentId "$agent_id" \
-        --arg clientThreadId "$client_thread_id" \
-        --arg model "deepseek-v4-flash" \
-        --arg prompt "$shell_prompt" \
-        '{
-            agentId: $agentId,
-            clientThreadId: $clientThreadId,
-            model: $model,
-            prompt: $prompt,
-            userMessage: {version: 1, parts: [{type: "text", text: $prompt}]},
-            hasTextContent: true
-        }')
-    runner_e2e_api_request POST "/api/zero/chat/events" "$payload"
+    runner_chat_send "$agent_id" "$shell_prompt" "" "deepseek-v4-flash"
 }
 
 runner_e2e_delete_chat_thread() {
     local thread_id="$1"
-    runner_e2e_api_request DELETE "/api/zero/chat-threads/${thread_id}"
-}
-
-runner_e2e_wait_for_run_completed() {
-    local run_id="$1"
-    local timeout_seconds="${2:-180}"
-    local started_at=$SECONDS
-    local last_response=""
-    local status=""
-
-    while ((SECONDS - started_at < timeout_seconds)); do
-        if last_response=$(runner_e2e_api_request GET "/api/zero/runs/${run_id}" 2>&1); then
-            status=$(jq -er '.status' <<<"$last_response") || {
-                echo "Runner E2E run returned an invalid status payload: $last_response" >&2
-                return 1
-            }
-            case "$status" in
-                completed)
-                    printf '%s\n' "$last_response"
-                    return 0
-                    ;;
-                failed | timeout | cancelled)
-                    echo "Runner E2E run ${run_id} reached ${status}: $last_response" >&2
-                    return 1
-                    ;;
-            esac
-        fi
-        sleep 2
-    done
-
-    echo "Timed out after ${timeout_seconds}s waiting for runner E2E run ${run_id}" >&2
-    echo "Last run response: ${last_response}" >&2
-    return 1
+    runner_api_curl "/api/zero/chat-threads/${thread_id}" -X DELETE
 }
 
 runner_e2e_agent_events() {
@@ -179,7 +93,7 @@ runner_e2e_collect_pages() {
             encoded_cursor=$(jq -rn --arg cursor "$cursor" '$cursor | @uri')
             query="${query}&cursor=${encoded_cursor}"
         fi
-        page=$(runner_e2e_api_request GET "${path}${query}") || return
+        page=$(runner_api_curl "${path}${query}") || return
         accumulated=$(jq -c \
             --arg collectionKey "$collection_key" \
             --argjson accumulated "$accumulated" \

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+
+runner_e2e_require_environment() {
+    : "${E2E_API_TOKEN:?runner E2E API token is required}"
+    : "${E2E_API_URL:?runner E2E API URL is required}"
+    command -v curl >/dev/null
+    command -v jq >/dev/null
+}
+
+runner_e2e_setup_test() {
+    TEST_ID="${E2E_RUNNER_SHARD_INDEX:-local}-$(date +%s)-$RANDOM"
+    AGENT_ID=""
+    THREAD_ID=""
+    RUN_ID=""
+}
+
+runner_e2e_teardown_test() {
+    local connector_slug="$1"
+    if [[ -n "${RUN_ID:-}" ]]; then
+        runner_e2e_cancel_run "$RUN_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${THREAD_ID:-}" ]]; then
+        runner_e2e_delete_chat_thread "$THREAD_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${AGENT_ID:-}" ]]; then
+        runner_e2e_delete_agent "$AGENT_ID" >/dev/null 2>&1 || true
+    fi
+    runner_e2e_delete_connector "$connector_slug" >/dev/null 2>&1 || true
+}
+
+runner_e2e_api_request() {
+    local method="$1"
+    local path="$2"
+    local body="${3-}"
+    local -a args=(
+        --fail-with-body
+        --silent
+        --show-error
+        --max-time 60
+        --request "$method"
+        --header "Authorization: Bearer ${E2E_API_TOKEN}"
+        --header "Accept: application/json"
+    )
+
+    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        args+=(--header "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+    fi
+    if [[ $# -ge 3 ]]; then
+        args+=(--header "Content-Type: application/json" --data-binary "$body")
+    fi
+
+    curl "${args[@]}" "${E2E_API_URL%/}${path}"
+}
+
+runner_e2e_create_private_agent() {
+    local display_name="$1"
+    local payload
+    payload=$(jq -nc --arg displayName "$display_name" '{displayName: $displayName, visibility: "private"}')
+    runner_e2e_api_request POST "/api/zero/agents" "$payload"
+}
+
+runner_e2e_delete_agent() {
+    local agent_id="$1"
+    runner_e2e_api_request DELETE "/api/zero/agents/${agent_id}"
+}
+
+runner_e2e_connect_manual_connector() {
+    local connector_slug="$1"
+    local auth_method="$2"
+    local agent_id="$3"
+    local values="$4"
+    local payload
+    payload=$(jq -nc \
+        --arg authMethod "$auth_method" \
+        --arg agentId "$agent_id" \
+        --argjson values "$values" \
+        '{authMethod: $authMethod, agentId: $agentId, authorizeAgent: true, values: $values}')
+    runner_e2e_api_request \
+        POST \
+        "/api/zero/connectors/${connector_slug}/manual-grant" \
+        "$payload"
+}
+
+runner_e2e_delete_connector() {
+    local connector_slug="$1"
+    runner_e2e_api_request DELETE "/api/zero/connectors/${connector_slug}"
+}
+
+runner_e2e_cancel_run() {
+    local run_id="$1"
+    runner_e2e_api_request POST "/api/zero/runs/${run_id}/cancel"
+}
+
+runner_e2e_start_chat_run() {
+    local agent_id="$1"
+    local prompt="$2"
+    local shell_prompt
+    local client_thread_id
+    local payload
+    shell_prompt=$(printf '@shell@\n%s' "$prompt")
+    client_thread_id=$(cat /proc/sys/kernel/random/uuid)
+    payload=$(jq -nc \
+        --arg agentId "$agent_id" \
+        --arg clientThreadId "$client_thread_id" \
+        --arg model "deepseek-v4-flash" \
+        --arg prompt "$shell_prompt" \
+        '{
+            agentId: $agentId,
+            clientThreadId: $clientThreadId,
+            model: $model,
+            prompt: $prompt,
+            userMessage: {version: 1, parts: [{type: "text", text: $prompt}]},
+            hasTextContent: true
+        }')
+    runner_e2e_api_request POST "/api/zero/chat/events" "$payload"
+}
+
+runner_e2e_delete_chat_thread() {
+    local thread_id="$1"
+    runner_e2e_api_request DELETE "/api/zero/chat-threads/${thread_id}"
+}
+
+runner_e2e_wait_for_run_completed() {
+    local run_id="$1"
+    local timeout_seconds="${2:-180}"
+    local started_at=$SECONDS
+    local last_response=""
+    local status=""
+
+    while ((SECONDS - started_at < timeout_seconds)); do
+        if last_response=$(runner_e2e_api_request GET "/api/zero/runs/${run_id}" 2>&1); then
+            status=$(jq -er '.status' <<<"$last_response") || {
+                echo "Runner E2E run returned an invalid status payload: $last_response" >&2
+                return 1
+            }
+            case "$status" in
+                completed)
+                    printf '%s\n' "$last_response"
+                    return 0
+                    ;;
+                failed | timeout | cancelled)
+                    echo "Runner E2E run ${run_id} reached ${status}: $last_response" >&2
+                    return 1
+                    ;;
+            esac
+        fi
+        sleep 2
+    done
+
+    echo "Timed out after ${timeout_seconds}s waiting for runner E2E run ${run_id}" >&2
+    echo "Last run response: ${last_response}" >&2
+    return 1
+}
+
+runner_e2e_agent_events() {
+    local run_id="$1"
+    runner_e2e_collect_pages "/api/zero/runs/${run_id}/telemetry/agent" events
+}
+
+runner_e2e_network_logs() {
+    local run_id="$1"
+    runner_e2e_collect_pages "/api/zero/runs/${run_id}/network" networkLogs
+}
+
+runner_e2e_collect_pages() {
+    local path="$1"
+    local collection_key="$2"
+    local accumulated='[]'
+    local cursor=""
+    local encoded_cursor
+    local has_more
+    local next_cursor
+    local page
+
+    local page_number
+    for ((page_number = 1; page_number <= 50; page_number += 1)); do
+        local query="?limit=100&order=asc"
+        if [[ -n "$cursor" ]]; then
+            encoded_cursor=$(jq -rn --arg cursor "$cursor" '$cursor | @uri')
+            query="${query}&cursor=${encoded_cursor}"
+        fi
+        page=$(runner_e2e_api_request GET "${path}${query}") || return
+        accumulated=$(jq -c \
+            --arg collectionKey "$collection_key" \
+            --argjson accumulated "$accumulated" \
+            '$accumulated + .[$collectionKey]' \
+            <<<"$page") || return
+        has_more=$(jq -r \
+            'if (.hasMore | type) == "boolean" then .hasMore else error("invalid hasMore") end' \
+            <<<"$page") || {
+            echo "Runner E2E telemetry returned an invalid page: $page" >&2
+            return 1
+        }
+        if [[ "$has_more" != "true" ]]; then
+            printf '%s\n' "$accumulated"
+            return 0
+        fi
+        next_cursor=$(jq -er '.nextCursor | select(type == "string" and length > 0)' <<<"$page") || {
+            echo "Runner E2E telemetry page is missing nextCursor: $page" >&2
+            return 1
+        }
+        cursor="$next_cursor"
+    done
+
+    echo "Runner E2E telemetry exceeded 50 pages for ${path}" >&2
+    return 1
+}
+
+runner_e2e_wait_for_agent_text() {
+    local run_id="$1"
+    local expected="$2"
+    local timeout_seconds="${3:-90}"
+    local started_at=$SECONDS
+    local last_events='[]'
+    local matched_text=""
+
+    while ((SECONDS - started_at < timeout_seconds)); do
+        if last_events=$(runner_e2e_agent_events "$run_id" 2>&1) &&
+            matched_text=$(jq -er --arg expected "$expected" '
+                [
+                    .[]
+                    | select(.eventType == "item.completed")
+                    | .eventData.item
+                    | select(.type == "agent_message")
+                    | .text
+                    | select(type == "string" and contains($expected))
+                ]
+                | last // empty
+            ' <<<"$last_events"); then
+            printf '%s\n' "$matched_text"
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "Timed out waiting for ${expected@Q} in agent telemetry for run ${run_id}" >&2
+    echo "Last agent telemetry: ${last_events}" >&2
+    return 1
+}
+
+runner_e2e_wait_for_firewall_log() {
+    local run_id="$1"
+    local firewall_name="$2"
+    local host="$3"
+    local expected_secrets="$4"
+    local expected_url_rewrite="${5:-ignore}"
+    local timeout_seconds="${6:-90}"
+    local started_at=$SECONDS
+    local last_logs='[]'
+
+    while ((SECONDS - started_at < timeout_seconds)); do
+        if last_logs=$(runner_e2e_network_logs "$run_id" 2>&1) &&
+            jq -e \
+                --arg firewallName "$firewall_name" \
+                --arg host "$host" \
+                --arg expectedUrlRewrite "$expected_url_rewrite" \
+                --argjson expectedSecrets "$expected_secrets" \
+                'any(.[];
+                    .firewall_name == $firewallName and
+                    .host == $host and
+                    .action == "ALLOW" and
+                    (((.auth_resolved_secrets // []) | sort) == ($expectedSecrets | sort)) and
+                    ($expectedUrlRewrite == "ignore" or
+                        .auth_url_rewrite == ($expectedUrlRewrite == "true")))' \
+                <<<"$last_logs" >/dev/null; then
+            printf '%s\n' "$last_logs"
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "Timed out waiting for firewall ${firewall_name@Q} on ${host@Q} for run ${run_id}" >&2
+    echo "Last network telemetry: ${last_logs}" >&2
+    return 1
+}

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -78,7 +78,7 @@ _runner_uuid() {
     tr -d '\n' < /proc/sys/kernel/random/uuid
 }
 
-_runner_chat_send() {
+runner_chat_send() {
     local agent_id="$1"
     local prompt="$2"
     local thread_id="$3"
@@ -119,7 +119,7 @@ _runner_chat_send() {
     runner_api_curl "/api/zero/chat/events" -X POST -d "$payload"
 }
 
-_wait_for_runner_run() {
+runner_wait_for_run() {
     local run_id="$1"
     local timeout="${2:-100}"
     local interval="${RUNNER_RUN_POLL_INTERVAL_SECONDS:-2}"
@@ -219,7 +219,7 @@ _runner_chat_execute() {
     local selected_model="$4"
     local send_response run_id resolved_thread_id run_response events_response
 
-    send_response="$(_runner_chat_send \
+    send_response="$(runner_chat_send \
         "$agent_id" \
         "$prompt" \
         "$thread_id" \
@@ -227,7 +227,7 @@ _runner_chat_execute() {
     run_id="$(jq -er '.runId | select(type == "string" and length > 0)' <<< "$send_response")" || return 1
     resolved_thread_id="$(jq -er '.threadId | select(type == "string" and length > 0)' <<< "$send_response")" || return 1
 
-    run_response="$(_wait_for_runner_run "$run_id")" || return 1
+    run_response="$(runner_wait_for_run "$run_id")" || return 1
     if ! jq -e '
         .status == "completed" and
         (.result.agentSessionId | type == "string" and length > 0)

--- a/e2e/playwright/lib/runner-shards.test.ts
+++ b/e2e/playwright/lib/runner-shards.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { test } from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+interface RunnerShard {
+  readonly files: readonly string[];
+  readonly index: number;
+  readonly weight: number;
+}
+
+interface RunnerShardMatrix {
+  readonly include: readonly RunnerShard[];
+}
+
+test("discovers and deterministically balances non-empty runner shards", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "runner-shards-test-"));
+  const testDirectory = join(testRoot, "03-runner");
+  await mkdir(testDirectory);
+  try {
+    const expectedFiles: string[] = [];
+    for (let index = 1; index <= 15; index += 1) {
+      const name = `runner-${String(index).padStart(2, "0")}.bats`;
+      const path = join(testDirectory, name);
+      const testCount = index === 1 ? 5 : index <= 4 ? 2 : 1;
+      const tests = Array.from(
+        { length: testCount },
+        (_, testIndex) => `@test "case ${testIndex + 1}" {\n  true\n}`,
+      ).join("\n\n");
+      await writeFile(path, `#!/usr/bin/env bats\n\n${tests}\n`, "utf8");
+      expectedFiles.push(relativeToWorkingDirectory(path));
+    }
+
+    const first = await runShardPlanner(testDirectory);
+    const second = await runShardPlanner(testDirectory);
+
+    assert.deepEqual(first, second);
+    assert.equal(first.include.length, 12);
+    assert.deepEqual(
+      first.include.map((shard) => shard.index),
+      Array.from({ length: 12 }, (_, index) => index + 1),
+    );
+    assert(first.include.every((shard) => shard.files.length > 0));
+    assert.deepEqual(
+      first.include.flatMap((shard) => shard.files).sort(),
+      expectedFiles.sort(),
+    );
+    assert.deepEqual(
+      first.include.map((shard) => shard.weight),
+      [5, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1],
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("rejects a runner test directory without executable BATS files", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "runner-shards-empty-test-"));
+  try {
+    await assert.rejects(runShardPlanner(testRoot), {
+      message: /No runner E2E test files found/u,
+    });
+
+    await writeFile(
+      join(testRoot, "empty.bats"),
+      "#!/usr/bin/env bats\n",
+      "utf8",
+    );
+    await assert.rejects(runShardPlanner(testRoot), {
+      message: /Runner E2E test file has no tests/u,
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+async function runShardPlanner(
+  testDirectory: string,
+): Promise<RunnerShardMatrix> {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", "playwright/runner-shards.ts", testDirectory],
+    { cwd: process.cwd() },
+  );
+  return parseMatrix(stdout);
+}
+
+function parseMatrix(output: string): RunnerShardMatrix {
+  const value: unknown = JSON.parse(output);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("include" in value) ||
+    !Array.isArray(value.include)
+  ) {
+    throw new Error("Runner shard planner returned an invalid matrix");
+  }
+  return { include: value.include.map(parseShard) };
+}
+
+function parseShard(value: unknown): RunnerShard {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("files" in value) ||
+    !Array.isArray(value.files) ||
+    !("index" in value) ||
+    typeof value.index !== "number" ||
+    !("weight" in value) ||
+    typeof value.weight !== "number"
+  ) {
+    throw new Error("Runner shard planner returned an invalid shard");
+  }
+  const files = value.files.map((file) => {
+    if (typeof file !== "string") {
+      throw new Error("Runner shard planner returned an invalid file path");
+    }
+    return file;
+  });
+  return { files, index: value.index, weight: value.weight };
+}
+
+function relativeToWorkingDirectory(path: string): string {
+  return relative(process.cwd(), path).split(sep).join("/");
+}

--- a/e2e/playwright/runner-shards.ts
+++ b/e2e/playwright/runner-shards.ts
@@ -1,0 +1,88 @@
+import { readdir, readFile } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
+
+const MAX_SHARDS = 12;
+
+interface WeightedTestFile {
+  readonly path: string;
+  readonly weight: number;
+}
+
+interface RunnerShard {
+  readonly files: string[];
+  readonly index: number;
+  weight: number;
+}
+
+async function main(): Promise<void> {
+  const testDirectory = resolve(process.argv[2] ?? "tests/03-runner");
+  const files = await discoverTestFiles(testDirectory);
+  const matrix = buildMatrix(files);
+  process.stdout.write(`${JSON.stringify(matrix)}\n`);
+}
+
+async function discoverTestFiles(
+  testDirectory: string,
+): Promise<readonly WeightedTestFile[]> {
+  const entries = await readdir(testDirectory, { withFileTypes: true });
+  const batsFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".bats"))
+    .map((entry) => resolve(testDirectory, entry.name))
+    .sort();
+
+  if (batsFiles.length === 0) {
+    throw new Error(`No runner E2E test files found in ${testDirectory}`);
+  }
+
+  return await Promise.all(
+    batsFiles.map(async (filePath) => {
+      const source = await readFile(filePath, "utf8");
+      const weight = source.match(/^\s*@test\b/gmu)?.length ?? 0;
+      if (weight === 0) {
+        throw new Error(`Runner E2E test file has no tests: ${filePath}`);
+      }
+      return {
+        path: relative(process.cwd(), filePath).split(sep).join("/"),
+        weight,
+      };
+    }),
+  );
+}
+
+function buildMatrix(files: readonly WeightedTestFile[]): {
+  readonly include: readonly RunnerShard[];
+} {
+  const shardCount = Math.min(MAX_SHARDS, files.length);
+  const shards: RunnerShard[] = Array.from(
+    { length: shardCount },
+    (_, index) => ({ files: [], index: index + 1, weight: 0 }),
+  );
+  const orderedFiles = [...files].sort((left, right) => {
+    if (left.weight !== right.weight) {
+      return right.weight - left.weight;
+    }
+    return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+  });
+
+  for (const file of orderedFiles) {
+    const shard = shards.reduce((lightest, candidate) => {
+      if (candidate.weight !== lightest.weight) {
+        return candidate.weight < lightest.weight ? candidate : lightest;
+      }
+      return candidate.index < lightest.index ? candidate : lightest;
+    });
+    shard.files.push(file.path);
+    shard.weight += file.weight;
+  }
+
+  for (const shard of shards) {
+    shard.files.sort();
+  }
+
+  return { include: shards };
+}
+
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/e2e/tests/03-runner/run-t01-firewall-agora.bats
+++ b/e2e/tests/03-runner/run-t01-firewall-agora.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load '../../helpers/setup'
+load '../../helpers/runner-chat'
 load '../../helpers/runner-api'
 
 setup() {
@@ -13,10 +14,10 @@ teardown() {
 }
 
 @test "runner firewall injects Agora placeholders and resolves Basic header auth" {
-    run runner_e2e_create_private_agent "runner-firewall-agora-${TEST_ID}"
+    run create_runner_agent "runner-firewall-agora-${TEST_ID}"
     echo "$output"
     assert_success
-    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+    AGENT_ID="$output"
 
     local values
     values=$(jq -nc \
@@ -43,7 +44,7 @@ EOF
     RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
     THREAD_ID=$(jq -er '.threadId' <<<"$output")
 
-    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    run runner_wait_for_run "$RUN_ID" 180
     echo "$output"
     assert_success
 

--- a/e2e/tests/03-runner/run-t01-firewall-agora.bats
+++ b/e2e/tests/03-runner/run-t01-firewall-agora.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test agora
+}
+
+@test "runner firewall injects Agora placeholders and resolves Basic header auth" {
+    run runner_e2e_create_private_agent "runner-firewall-agora-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+
+    local values
+    values=$(jq -nc \
+        --arg customerId "e2e-agora-customer-${TEST_ID}" \
+        --arg customerSecret "e2e-agora-secret-${TEST_ID}" \
+        --arg appId "e2e-agora-app-${TEST_ID}" \
+        '{customerId: $customerId, customerSecret: $customerSecret, appId: $appId}')
+    run runner_e2e_connect_manual_connector agora api-token "$AGENT_ID" "$values"
+    echo "$output"
+    assert_success
+
+    local prompt
+    prompt=$(cat <<'EOF'
+printf 'AGORA_CUSTOMER_ID=%s\n' "$AGORA_CUSTOMER_ID"
+printf 'AGORA_CUSTOMER_SECRET=%s\n' "$AGORA_CUSTOMER_SECRET"
+printf 'AGORA_APP_ID=%s\n' "$AGORA_APP_ID"
+curl --silent --show-error --max-time 5 --output /dev/null https://api.agora.io/dev/v1/projects || true
+printf 'AGORA_REQUEST_SENT\n'
+EOF
+)
+    run runner_e2e_start_chat_run "$AGENT_ID" "$prompt"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId' <<<"$output")
+
+    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_agent_text "$RUN_ID" AGORA_REQUEST_SENT
+    echo "$output"
+    assert_success
+    assert_output --partial "AGORA_CUSTOMER_ID=4259477b8362c0ffee5afe10ca1c0ff"
+    assert_output --partial "AGORA_CUSTOMER_SECRET=c0ffee5afe10ca1c0ffee5afe10ca1c"
+    assert_output --partial "AGORA_APP_ID=e2e-agora-app-${TEST_ID}"
+
+    run runner_e2e_wait_for_firewall_log \
+        "$RUN_ID" \
+        agora \
+        api.agora.io \
+        '["AGORA_CUSTOMER_ID","AGORA_CUSTOMER_SECRET"]'
+    echo "$output"
+    assert_success
+}

--- a/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
+++ b/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test discord-webhook
+}
+
+@test "runner firewall rewrites the Discord Webhook auth.base placeholder" {
+    run runner_e2e_create_private_agent "runner-firewall-discord-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+
+    local values
+    values=$(jq -nc \
+        --arg url "https://discord.com/api/webhooks/1234567890/e2e-${TEST_ID}" \
+        '{url: $url}')
+    run runner_e2e_connect_manual_connector discord-webhook api-token "$AGENT_ID" "$values"
+    echo "$output"
+    assert_success
+
+    local prompt
+    prompt=$(cat <<'EOF'
+printf 'DISCORD_WEBHOOK_URL=%s\n' "$DISCORD_WEBHOOK_URL"
+curl --silent --show-error --max-time 5 --output /dev/null "$DISCORD_WEBHOOK_URL" || true
+printf 'DISCORD_REQUEST_SENT\n'
+EOF
+)
+    run runner_e2e_start_chat_run "$AGENT_ID" "$prompt"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId' <<<"$output")
+
+    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_agent_text "$RUN_ID" DISCORD_REQUEST_SENT
+    echo "$output"
+    assert_success
+    assert_output --partial \
+        "DISCORD_WEBHOOK_URL=https://firewall-placeholder.vm3.ai/discord-webhook/hook"
+
+    run runner_e2e_wait_for_firewall_log \
+        "$RUN_ID" \
+        discord-webhook \
+        firewall-placeholder.vm3.ai \
+        '["DISCORD_WEBHOOK_URL"]' \
+        true
+    echo "$output"
+    assert_success
+}

--- a/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
+++ b/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load '../../helpers/setup'
+load '../../helpers/runner-chat'
 load '../../helpers/runner-api'
 
 setup() {
@@ -13,10 +14,10 @@ teardown() {
 }
 
 @test "runner firewall rewrites the Discord Webhook auth.base placeholder" {
-    run runner_e2e_create_private_agent "runner-firewall-discord-${TEST_ID}"
+    run create_runner_agent "runner-firewall-discord-${TEST_ID}"
     echo "$output"
     assert_success
-    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+    AGENT_ID="$output"
 
     local values
     values=$(jq -nc \
@@ -39,7 +40,7 @@ EOF
     RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
     THREAD_ID=$(jq -er '.threadId' <<<"$output")
 
-    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    run runner_wait_for_run "$RUN_ID" 180
     echo "$output"
     assert_success
 

--- a/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
+++ b/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load '../../helpers/setup'
+load '../../helpers/runner-chat'
 load '../../helpers/runner-api'
 
 setup() {
@@ -14,10 +15,10 @@ teardown() {
 
 @test "runner firewall resolves the Zendesk variable base and header auth" {
     local subdomain="e2e${RANDOM}${RANDOM}"
-    run runner_e2e_create_private_agent "runner-firewall-zendesk-${TEST_ID}"
+    run create_runner_agent "runner-firewall-zendesk-${TEST_ID}"
     echo "$output"
     assert_success
-    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+    AGENT_ID="$output"
 
     local values
     values=$(jq -nc \
@@ -45,7 +46,7 @@ EOF
     RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
     THREAD_ID=$(jq -er '.threadId' <<<"$output")
 
-    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    run runner_wait_for_run "$RUN_ID" 180
     echo "$output"
     assert_success
 

--- a/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
+++ b/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test zendesk
+}
+
+@test "runner firewall resolves the Zendesk variable base and header auth" {
+    local subdomain="e2e${RANDOM}${RANDOM}"
+    run runner_e2e_create_private_agent "runner-firewall-zendesk-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+
+    local values
+    values=$(jq -nc \
+        --arg apiToken "e2e-zendesk-token-${TEST_ID}" \
+        --arg email "runner-e2e@vm0.ai" \
+        --arg subdomain "$subdomain" \
+        '{apiToken: $apiToken, email: $email, subdomain: $subdomain}')
+    run runner_e2e_connect_manual_connector zendesk api-token "$AGENT_ID" "$values"
+    echo "$output"
+    assert_success
+
+    local prompt
+    prompt=$(cat <<'EOF'
+printf 'ZENDESK_API_TOKEN=%s\n' "$ZENDESK_API_TOKEN"
+printf 'ZENDESK_EMAIL=%s\n' "$ZENDESK_EMAIL"
+printf 'ZENDESK_SUBDOMAIN=%s\n' "$ZENDESK_SUBDOMAIN"
+curl --silent --show-error --max-time 5 --output /dev/null "https://__SUBDOMAIN__.zendesk.com/api/v2/users/me.json" || true
+printf 'ZENDESK_REQUEST_SENT\n'
+EOF
+)
+    prompt="${prompt//__SUBDOMAIN__/$subdomain}"
+    run runner_e2e_start_chat_run "$AGENT_ID" "$prompt"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId' <<<"$output")
+
+    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_agent_text "$RUN_ID" ZENDESK_REQUEST_SENT
+    echo "$output"
+    assert_success
+    assert_output --partial "ZENDESK_API_TOKEN=zkTkn_CoffeeSafeLocalCoffeeSafeLocalCoffeeSa"
+    assert_output --partial "ZENDESK_EMAIL=runner-e2e@vm0.ai"
+    assert_output --partial "ZENDESK_SUBDOMAIN=${subdomain}"
+
+    run runner_e2e_wait_for_firewall_log \
+        "$RUN_ID" \
+        zendesk \
+        "${subdomain}.zendesk.com" \
+        '["ZENDESK_API_TOKEN"]'
+    echo "$output"
+    assert_success
+}

--- a/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
+++ b/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load '../../helpers/setup'
+load '../../helpers/runner-chat'
 load '../../helpers/runner-api'
 
 setup() {
@@ -13,10 +14,10 @@ teardown() {
 }
 
 @test "runner firewall injects the SerpApi query authentication" {
-    run runner_e2e_create_private_agent "runner-firewall-serpapi-${TEST_ID}"
+    run create_runner_agent "runner-firewall-serpapi-${TEST_ID}"
     echo "$output"
     assert_success
-    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+    AGENT_ID="$output"
 
     local values
     values=$(jq -nc --arg apiKey "e2e-serpapi-token-${TEST_ID}" '{apiKey: $apiKey}')
@@ -37,7 +38,7 @@ EOF
     RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
     THREAD_ID=$(jq -er '.threadId' <<<"$output")
 
-    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    run runner_wait_for_run "$RUN_ID" 180
     echo "$output"
     assert_success
 

--- a/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
+++ b/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test serpapi
+}
+
+@test "runner firewall injects the SerpApi query authentication" {
+    run runner_e2e_create_private_agent "runner-firewall-serpapi-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID=$(jq -er '.agentId' <<<"$output")
+
+    local values
+    values=$(jq -nc --arg apiKey "e2e-serpapi-token-${TEST_ID}" '{apiKey: $apiKey}')
+    run runner_e2e_connect_manual_connector serpapi api-token "$AGENT_ID" "$values"
+    echo "$output"
+    assert_success
+
+    local prompt
+    prompt=$(cat <<'EOF'
+printf 'SERPAPI_TOKEN=%s\n' "$SERPAPI_TOKEN"
+curl --silent --show-error --max-time 5 --output /dev/null 'https://serpapi.com/search?q=vm0-e2e&engine=google' || true
+printf 'SERPAPI_REQUEST_SENT\n'
+EOF
+)
+    run runner_e2e_start_chat_run "$AGENT_ID" "$prompt"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId' <<<"$output")
+
+    run runner_e2e_wait_for_run_completed "$RUN_ID"
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_agent_text "$RUN_ID" SERPAPI_REQUEST_SENT
+    echo "$output"
+    assert_success
+    assert_output --partial "SERPAPI_TOKEN=CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCof"
+
+    run runner_e2e_wait_for_firewall_log \
+        "$RUN_ID" \
+        serpapi \
+        serpapi.com \
+        '["SERPAPI_TOKEN"]'
+    echo "$output"
+    assert_success
+}

--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -70,7 +70,7 @@ run_real_claude_chat() {
     local expected_output="$2"
     local send_response run_id thread_id run_response events_response
 
-    send_response="$(_runner_chat_send \
+    send_response="$(runner_chat_send \
         "$RUNNER_AGENT_ID" \
         "$prompt" \
         "" \
@@ -80,7 +80,7 @@ run_real_claude_chat() {
     thread_id="$(jq -er '.threadId | select(type == "string" and length > 0)' \
         <<< "$send_response")" || return 1
 
-    run_response="$(_wait_for_runner_run "$run_id" 150)" || return 1
+    run_response="$(runner_wait_for_run "$run_id" 150)" || return 1
     _wait_for_runner_chat_output \
         "$thread_id" \
         "$run_id" \


### PR DESCRIPTION
## Summary

- restore four deployed runner firewall authentication E2E scenarios through supported public APIs
- add a test-only mock Codex shell probe so assertions execute inside the sandbox without changing ordinary mock prompts
- replace fixed empty runner shards with a deterministic, tested matrix of at most twelve non-empty file-balanced shards and retain JUnit diagnostics

## Validation

- `cd crates && cargo fmt --check -p guest-mock-codex`
- `cd crates && cargo clippy -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc -p guest-mock-codex --all-features --no-deps`
- `cd crates && cargo test -p guest-mock-codex --all-targets --all-features`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm exec tsx --test playwright/lib/runner-shards.test.ts`
- Prettier, Bash syntax, and diff checks for the changed workflow, helper, tests, and documentation
- Live BATS/runner E2E is intentionally delegated to PR CI

Closes #26318

Parent: #26285
