### PR TITLE
perf(runner): report completion during sandbox finalization

### DIFF
--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -88,16 +88,16 @@ impl ActiveBudgetLease {
     }
 }
 
-/// Budget ownership after sandbox finalization but before completion is reported.
+/// Budget ownership after sandbox finalization but before runner-local settlement.
 ///
-/// This distinguishes a lease that completion must release from one already
+/// This distinguishes a lease that settlement must release from one already
 /// transferred to an accepted idle-pool entry.
 #[must_use]
 pub(super) enum BudgetOwnership {
-    /// The active job retains the lease through provider completion and active-status
-    /// removal, after which completion releases it.
+    /// The active job retains the lease until provider completion and active-status
+    /// settlement have both finished, after which settlement releases it.
     Active(ActiveBudgetLease),
-    /// The idle pool accepted the sandbox and its lease, so completion performs no
+    /// The idle pool accepted the sandbox and its lease, so settlement performs no
     /// release. Reuse transfers the lease; idle destruction drops it.
     IdleOwned,
 }

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -157,49 +157,9 @@ impl CompletionPayload {
         self.workspace_reuse_result = workspace_reuse_result;
         self
     }
-}
 
-/// Sandbox cleanup/parking has finished; completion can now be reported.
-#[must_use]
-pub(super) struct CompletionReady {
-    payload: CompletionPayload,
-    budget: BudgetOwnership,
-    reuse_state_changed: bool,
-}
-
-impl CompletionReady {
-    pub(super) fn new(payload: CompletionPayload, budget: BudgetOwnership) -> Self {
-        Self {
-            payload,
-            budget,
-            reuse_state_changed: false,
-        }
-    }
-
-    pub(super) fn with_reuse_state_changed(mut self) -> Self {
-        self.reuse_state_changed = true;
-        self
-    }
-
-    pub(super) fn reuse_state_changed(&self) -> bool {
-        self.reuse_state_changed
-    }
-
-    #[cfg(test)]
-    pub(super) fn result_for_test(&self) -> (i32, Option<&str>) {
-        (self.payload.exit_code, self.payload.error.as_deref())
-    }
-
-    pub(super) async fn complete_and_release(
-        self,
-        provider: &dyn JobProvider,
-        ownership: &OwnershipTransitions<'_>,
-        cleanup_state: &RunCleanupState,
-    ) -> Duration {
+    pub(super) async fn report(self, provider: &dyn JobProvider) -> Duration {
         let Self {
-            payload, budget, ..
-        } = self;
-        let CompletionPayload {
             run_id,
             exit_code,
             error,
@@ -207,8 +167,7 @@ impl CompletionReady {
             reuse_result,
             workspace_reuse_result,
             completion_auth,
-        } = payload;
-
+        } = self;
         let provider_completion_started = Instant::now();
         provider
             .complete(
@@ -223,13 +182,43 @@ impl CompletionReady {
                 completion_auth,
             )
             .await;
-        let provider_completion_duration = provider_completion_started.elapsed();
-        ownership
-            .active_completed(RunSandbox::new(run_id, sandbox_id))
-            .await;
+        provider_completion_started.elapsed()
+    }
+}
+
+/// Sandbox finalization has resolved resource ownership.
+#[must_use]
+pub(super) struct FinalizationReady {
+    budget: BudgetOwnership,
+    reuse_state_changed: bool,
+}
+
+impl FinalizationReady {
+    pub(super) fn new(budget: BudgetOwnership) -> Self {
+        Self {
+            budget,
+            reuse_state_changed: false,
+        }
+    }
+
+    pub(super) fn with_reuse_state_changed(mut self) -> Self {
+        self.reuse_state_changed = true;
+        self
+    }
+
+    pub(super) fn reuse_state_changed(&self) -> bool {
+        self.reuse_state_changed
+    }
+
+    pub(super) async fn settle(
+        self,
+        completed_run: RunSandbox,
+        ownership: &OwnershipTransitions<'_>,
+        cleanup_state: &RunCleanupState,
+    ) {
+        ownership.active_completed(completed_run).await;
         cleanup_state.mark_status_removed();
-        budget.release();
-        provider_completion_duration
+        self.budget.release();
     }
 }
 
@@ -237,7 +226,7 @@ impl CompletionReady {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use async_trait::async_trait;
     use sandbox::SandboxId;
@@ -255,17 +244,6 @@ mod tests {
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
         (budget, lease)
     }
-    fn test_completion_payload(run_id: RunId, sandbox_id: SandboxId) -> CompletionPayload {
-        CompletionPayload::new(
-            run_id,
-            0,
-            None,
-            sandbox_id,
-            SandboxReuseResult::PoolMiss,
-            CompletionAuth::local(),
-        )
-    }
-
     async fn status_active_run_count(path: &std::path::Path) -> usize {
         let raw = tokio::fs::read_to_string(path).await.unwrap();
         let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -288,39 +266,8 @@ mod tests {
         records.sort_unstable();
         records
     }
-    struct CompletionOrderProvider {
-        budget: Arc<ResourceBudget>,
-        budget_count_at_complete: Arc<AtomicUsize>,
-        active_runs_at_complete: Arc<AtomicUsize>,
-        status_path: std::path::PathBuf,
-    }
-
     struct CompletionAuthProvider {
         auth_matches: Arc<AtomicBool>,
-    }
-
-    #[async_trait]
-    impl JobProvider for CompletionOrderProvider {
-        async fn discover(&self) -> Option<JobCandidate> {
-            None
-        }
-
-        async fn claim(&self, _candidate: JobCandidate) -> Option<ClaimedJob> {
-            None
-        }
-
-        async fn complete(&self, _request: CompleteRequest, _completion_auth: CompletionAuth) {
-            self.budget_count_at_complete
-                .store(self.budget.allocated().2, Ordering::SeqCst);
-            self.active_runs_at_complete.store(
-                status_active_run_count(&self.status_path).await,
-                Ordering::SeqCst,
-            );
-        }
-
-        async fn heartbeat(&self, _state: &HeartbeatState) {}
-
-        async fn shutdown(&self) {}
     }
 
     #[async_trait]
@@ -346,42 +293,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completion_ready_complete_and_release_orders_completion_status_and_budget() {
+    async fn finalization_ready_settles_active_status_and_budget() {
         let (budget, lease) = test_budget_lease();
-        let budget_count_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
-        let active_runs_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
         let ownership = OwnershipTransitions::new(&status);
-        let provider = CompletionOrderProvider {
-            budget: Arc::clone(&budget),
-            budget_count_at_complete: Arc::clone(&budget_count_at_complete),
-            active_runs_at_complete: Arc::clone(&active_runs_at_complete),
-            status_path: status_path.clone(),
-        };
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        let _ = CompletionReady::new(
-            test_completion_payload(run_id, sandbox_id),
-            BudgetOwnership::active(ActiveBudgetLease::new(lease)),
-        )
-        .complete_and_release(&provider, &ownership, &cleanup_state)
-        .await;
+        FinalizationReady::new(BudgetOwnership::active(ActiveBudgetLease::new(lease)))
+            .settle(
+                RunSandbox::new(run_id, sandbox_id),
+                &ownership,
+                &cleanup_state,
+            )
+            .await;
 
-        assert_eq!(
-            budget_count_at_complete.load(Ordering::SeqCst),
-            1,
-            "active budget must still be held while provider.complete runs",
-        );
-        assert_eq!(
-            active_runs_at_complete.load(Ordering::SeqCst),
-            1,
-            "active status removal must happen after provider.complete",
-        );
         assert_eq!(
             status_active_run_count(&status_path).await,
             0,
@@ -395,32 +325,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completion_ready_forwards_completion_auth() {
-        let (_budget, lease) = test_budget_lease();
+    async fn completion_payload_forwards_completion_auth() {
         let auth_matches = Arc::new(AtomicBool::new(false));
-        let dir = tempfile::tempdir().unwrap();
-        let status = StatusTracker::new(dir.path().join("status.json"), 4, None, None);
-        let ownership = OwnershipTransitions::new(&status);
         let provider = CompletionAuthProvider {
             auth_matches: Arc::clone(&auth_matches),
         };
-        let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        status.add_run(run_id, sandbox_id).await;
 
-        let _ = CompletionReady::new(
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::sandbox_token(run_id, "completion-token".to_string()),
-            ),
-            BudgetOwnership::active(ActiveBudgetLease::new(lease)),
+        let _ = CompletionPayload::new(
+            run_id,
+            0,
+            None,
+            sandbox_id,
+            SandboxReuseResult::PoolMiss,
+            CompletionAuth::sandbox_token(run_id, "completion-token".to_string()),
         )
-        .complete_and_release(&provider, &ownership, &cleanup_state)
+        .report(&provider)
         .await;
 
         assert!(
@@ -430,32 +351,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completion_ready_idle_owned_does_not_release_idle_park_budget() {
+    async fn finalization_ready_idle_owned_does_not_release_idle_park_budget() {
         let (budget, lease) = test_budget_lease();
         let idle_park_lease = ActiveBudgetLease::new(lease).into_idle_park_lease();
-        let budget_count_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
-        let active_runs_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
         let ownership = OwnershipTransitions::new(&status);
-        let provider = CompletionOrderProvider {
-            budget: Arc::clone(&budget),
-            budget_count_at_complete,
-            active_runs_at_complete,
-            status_path,
-        };
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        let _ = CompletionReady::new(
-            test_completion_payload(run_id, sandbox_id),
-            BudgetOwnership::idle_owned(),
-        )
-        .complete_and_release(&provider, &ownership, &cleanup_state)
-        .await;
+        FinalizationReady::new(BudgetOwnership::idle_owned())
+            .settle(
+                RunSandbox::new(run_id, sandbox_id),
+                &ownership,
+                &cleanup_state,
+            )
+            .await;
 
         assert_eq!(
             budget.allocated().2,
@@ -471,20 +385,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completion_ready_does_not_remove_reinserted_active_run() {
+    async fn finalization_ready_does_not_remove_reinserted_active_run() {
         let (budget, lease) = test_budget_lease();
-        let budget_count_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
-        let active_runs_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
         let ownership = OwnershipTransitions::new(&status);
-        let provider = CompletionOrderProvider {
-            budget: Arc::clone(&budget),
-            budget_count_at_complete,
-            active_runs_at_complete,
-            status_path: status_path.clone(),
-        };
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let completed_sandbox_id = SandboxId::new_v4();
@@ -492,12 +398,13 @@ mod tests {
         status.add_run(run_id, completed_sandbox_id).await;
         status.add_run(run_id, current_sandbox_id).await;
 
-        let _ = CompletionReady::new(
-            test_completion_payload(run_id, completed_sandbox_id),
-            BudgetOwnership::active(ActiveBudgetLease::new(lease)),
-        )
-        .complete_and_release(&provider, &ownership, &cleanup_state)
-        .await;
+        FinalizationReady::new(BudgetOwnership::active(ActiveBudgetLease::new(lease)))
+            .settle(
+                RunSandbox::new(run_id, completed_sandbox_id),
+                &ownership,
+                &cleanup_state,
+            )
+            .await;
 
         assert_eq!(
             status_active_run_records(&status_path).await,
@@ -511,37 +418,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejected_park_budget_is_recovered_as_active_and_released_after_completion() {
+    async fn rejected_park_budget_is_recovered_as_active_and_released_after_settlement() {
         let (budget, lease) = test_budget_lease();
-        let budget_count_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
-        let active_runs_at_complete = Arc::new(AtomicUsize::new(usize::MAX));
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
         let ownership = OwnershipTransitions::new(&status);
-        let provider = CompletionOrderProvider {
-            budget: Arc::clone(&budget),
-            budget_count_at_complete: Arc::clone(&budget_count_at_complete),
-            active_runs_at_complete,
-            status_path,
-        };
         let cleanup_state = RunCleanupState::new();
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         status.add_run(run_id, sandbox_id).await;
 
-        let _ = CompletionReady::new(
-            test_completion_payload(run_id, sandbox_id),
-            BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(lease)),
+        FinalizationReady::new(BudgetOwnership::active(
+            ActiveBudgetLease::from_idle_park_lease(lease),
+        ))
+        .settle(
+            RunSandbox::new(run_id, sandbox_id),
+            &ownership,
+            &cleanup_state,
         )
-        .complete_and_release(&provider, &ownership, &cleanup_state)
         .await;
 
-        assert_eq!(
-            budget_count_at_complete.load(Ordering::SeqCst),
-            1,
-            "rejected park must retain active budget through provider.complete",
-        );
         assert_eq!(budget.allocated().2, 0);
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -38,7 +38,7 @@ use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_logs;
-use crate::provider::{ClaimedJob, JobProvider};
+use crate::provider::{ClaimedJob, CompletionReportTiming, JobProvider};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{
     RunCancellationHandle, RunCancellationRegistration, RunCancellationSignals,
@@ -771,10 +771,18 @@ pub(super) async fn run_job(
         .with_workspace_reuse_result(executor_result.outcome.workspace_reuse_result);
         // Structural guarantee: claim (in provider) is always paired with complete.
         signal_usage_flush(run_id, &usage_flush_tx);
-        let (provider_completion_duration, finalized) = tokio::join!(
-            completion_payload.report(provider.as_ref()),
-            finalization.finalize(executor_result),
-        );
+        let (provider_completion_duration, finalized) = match provider.completion_report_timing() {
+            CompletionReportTiming::ConcurrentWithFinalization => tokio::join!(
+                completion_payload.report(provider.as_ref()),
+                finalization.finalize(executor_result),
+            ),
+            CompletionReportTiming::AfterFinalization => {
+                let finalized = finalization.finalize(executor_result).await;
+                let provider_completion_duration =
+                    completion_payload.report(provider.as_ref()).await;
+                (provider_completion_duration, finalized)
+            }
+        };
         let FinalizedJob {
             finalization_ready,
             mut telemetry,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -750,7 +750,7 @@ pub(super) async fn run_job(
         #[cfg(test)]
         maybe_panic_outer_job(outer_job_panic, OuterJobPanicPoint::ActiveOrUnknown, run_id);
 
-        let executor_result = executor.execute().await;
+        let mut executor_result = executor.execute().await;
         let cancelled_for_log = job_cancel.is_cancelled();
         log_terminal_job_outcome(
             run_id,
@@ -763,7 +763,7 @@ pub(super) async fn run_job(
         let completion_payload = CompletionPayload::new(
             run_id,
             executor_result.exit_code,
-            executor_result.err.clone(),
+            executor_result.err.take(),
             sandbox_id,
             reuse_result,
             completion_auth,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -19,7 +19,7 @@ use super::factory_lifecycle::SharedFactory;
 use super::heartbeat::WorkspaceCacheStateSnapshot;
 use super::idle_lifecycle::SharedIdlePool;
 use super::job_lifecycle::{
-    ActiveBudgetLease, CompletionPayload, CompletionReady, RunCleanupDisposition, RunCleanupState,
+    ActiveBudgetLease, CompletionPayload, FinalizationReady, RunCleanupDisposition, RunCleanupState,
 };
 use super::job_terminal_log::log_terminal_job_outcome;
 use super::orphan_reap::OrphanedActiveRuns;
@@ -38,7 +38,7 @@ use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_logs;
-use crate::provider::{ClaimedJob, CompletionAuth, JobProvider};
+use crate::provider::{ClaimedJob, JobProvider};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{
     RunCancellationHandle, RunCancellationRegistration, RunCancellationSignals,
@@ -246,7 +246,6 @@ struct FinalizationPhase {
     run_id: RunId,
     sandbox_id: SandboxId,
     runner_id: String,
-    completion_auth: CompletionAuth,
     active_lease: BudgetLease,
     reuse_result: SandboxReuseResult,
     workspace_disk_mb: u32,
@@ -274,7 +273,7 @@ struct FinalizationPhase {
 }
 
 struct FinalizedJob {
-    completion_ready: CompletionReady,
+    finalization_ready: FinalizationReady,
     telemetry: JobTelemetry,
     immediate_successor_receipt: Option<ImmediateSuccessorReceiptTelemetry>,
 }
@@ -299,7 +298,6 @@ impl FinalizationPhase {
             run_id,
             sandbox_id,
             runner_id,
-            completion_auth,
             active_lease,
             reuse_result,
             workspace_disk_mb,
@@ -328,7 +326,7 @@ impl FinalizationPhase {
         let ExecutorPhaseOutcome {
             outcome,
             exit_code,
-            err,
+            err: _,
             mut telemetry,
         } = executor_result;
         let executor::ExecuteOutcome {
@@ -338,7 +336,7 @@ impl FinalizationPhase {
             source_ip,
             network_log_session,
             workspace_image,
-            workspace_reuse_result,
+            workspace_reuse_result: _,
             discovered_cli_agent_session_id,
             restored_session_identity,
         } = outcome;
@@ -349,15 +347,6 @@ impl FinalizationPhase {
             should_track_immediate_successor_intents(reuse_key.as_deref());
         let cleanup_state_after_finalize = cleanup_state.clone();
 
-        let completion_payload = CompletionPayload::new(
-            run_id,
-            exit_code,
-            err,
-            sandbox_id,
-            reuse_result,
-            completion_auth,
-        )
-        .with_workspace_reuse_result(workspace_reuse_result);
         // Cancellation can arrive after terminal logging or while
         // `sandbox.park()` is in flight. Pass the live handle so finalization
         // can synchronize the final idle-pool ownership transfer.
@@ -368,10 +357,9 @@ impl FinalizationPhase {
             true,
             None,
         );
-        let completion_ready = finalize_sandbox_for_completion_with_telemetry(
+        let finalization_ready = finalize_sandbox_for_completion_with_telemetry(
             sandbox,
             ActiveBudgetLease::new(active_lease),
-            completion_payload,
             &mut telemetry,
             FinalizeContext {
                 run_id,
@@ -415,7 +403,7 @@ impl FinalizationPhase {
         }
         let finalization_duration = finalization_started.elapsed();
         let disposition = cleanup_state_after_finalize.disposition();
-        let reuse_state_changed = completion_ready.reuse_state_changed();
+        let reuse_state_changed = finalization_ready.reuse_state_changed();
         if had_sandbox {
             telemetry.record(
                 sandbox_reuse_disposition.telemetry_action(),
@@ -454,7 +442,7 @@ impl FinalizationPhase {
         );
 
         FinalizedJob {
-            completion_ready,
+            finalization_ready,
             telemetry,
             immediate_successor_receipt: track_immediate_successor_intents.then_some(
                 ImmediateSuccessorReceiptTelemetry {
@@ -482,38 +470,32 @@ fn record_session_history_identity_park_telemetry(
     telemetry.record(action_type, Duration::ZERO, true, None);
 }
 
-struct CompletionPhase {
+struct CompletionSettlementPhase {
     run_id: RunId,
-    provider: Arc<dyn JobProvider>,
+    sandbox_id: SandboxId,
     status: Arc<StatusTracker>,
-    usage_flush_tx: mpsc::Sender<()>,
     active_run_guard: ActiveRunGuard,
     cleanup_state: RunCleanupState,
 }
 
-impl CompletionPhase {
-    async fn complete(self, completion_ready: CompletionReady, telemetry: &mut JobTelemetry) {
+impl CompletionSettlementPhase {
+    async fn settle(self, finalization_ready: FinalizationReady, telemetry: &mut JobTelemetry) {
         let Self {
             run_id,
-            provider,
+            sandbox_id,
             status,
-            usage_flush_tx,
             active_run_guard,
             cleanup_state,
         } = self;
 
-        // Structural guarantee: claim (in provider) is always paired with complete.
-        signal_usage_flush(run_id, &usage_flush_tx);
         let ownership = OwnershipTransitions::new(status.as_ref());
-        let provider_completion_duration = completion_ready
-            .complete_and_release(provider.as_ref(), &ownership, &cleanup_state)
+        finalization_ready
+            .settle(
+                RunSandbox::new(run_id, sandbox_id),
+                &ownership,
+                &cleanup_state,
+            )
             .await;
-        telemetry.record(
-            "runner_host_completion_fallback",
-            provider_completion_duration,
-            true,
-            None,
-        );
         if active_run_guard.release() {
             telemetry.record(
                 "runner_active_reuse_key_released",
@@ -590,11 +572,11 @@ impl DeferredUploadPhase {
 /// active, and a reuse key is available. Park failure, hard cancellation before
 /// idle-pool transfer, or pool rejection falls back to destruction.
 ///
-/// The completion state returned by finalization carries
+/// The ownership state returned by finalization carries
 /// [`BudgetOwnership`](super::job_lifecycle::BudgetOwnership). Non-accepted paths
-/// keep the active lease through provider completion and active-status removal,
-/// then release it. An accepted idle entry owns and retains the lease until reuse
-/// or destruction.
+/// keep the active lease until provider completion and active-status settlement
+/// have both finished, then release it. An accepted idle entry owns and retains
+/// the lease until reuse or destruction.
 pub(super) fn spawn_job(
     mut request: SpawnJobRequest,
     ctx: &SpawnContext,
@@ -723,7 +705,6 @@ pub(super) async fn run_job(
         run_id,
         sandbox_id,
         runner_id,
-        completion_auth,
         active_lease,
         reuse_result,
         workspace_disk_mb,
@@ -749,6 +730,13 @@ pub(super) async fn run_job(
         #[cfg(test)]
         test_observer,
     };
+    let completion_settlement = CompletionSettlementPhase {
+        run_id,
+        sandbox_id,
+        status,
+        active_run_guard,
+        cleanup_state: cleanup_state_for_body,
+    };
     let deferred_upload = DeferredUploadPhase {
         run_id,
         sandbox_token,
@@ -772,21 +760,35 @@ pub(super) async fn run_job(
             executor_result.outcome.failure.as_ref(),
         );
 
+        let completion_payload = CompletionPayload::new(
+            run_id,
+            executor_result.exit_code,
+            executor_result.err.clone(),
+            sandbox_id,
+            reuse_result,
+            completion_auth,
+        )
+        .with_workspace_reuse_result(executor_result.outcome.workspace_reuse_result);
+        // Structural guarantee: claim (in provider) is always paired with complete.
+        signal_usage_flush(run_id, &usage_flush_tx);
+        let (provider_completion_duration, finalized) = tokio::join!(
+            completion_payload.report(provider.as_ref()),
+            finalization.finalize(executor_result),
+        );
         let FinalizedJob {
-            completion_ready,
+            finalization_ready,
             mut telemetry,
             immediate_successor_receipt,
-        } = finalization.finalize(executor_result).await;
-        CompletionPhase {
-            run_id,
-            provider,
-            status,
-            usage_flush_tx,
-            active_run_guard,
-            cleanup_state: cleanup_state_for_body,
-        }
-        .complete(completion_ready, &mut telemetry)
-        .await;
+        } = finalized;
+        telemetry.record(
+            "runner_host_completion_fallback",
+            provider_completion_duration,
+            true,
+            None,
+        );
+        completion_settlement
+            .settle(finalization_ready, &mut telemetry)
+            .await;
         // The API acknowledges `/complete` before its detached terminal
         // callback publishes the advisory signal. Start the bounded settlement
         // window only after completion has been acknowledged, otherwise a
@@ -1013,7 +1015,6 @@ mod tests {
                 run_id,
                 sandbox_id,
                 runner_id: "runner-test".into(),
-                completion_auth: CompletionAuth::local(),
                 active_lease,
                 reuse_result: SandboxReuseResult::PoolMiss,
                 workspace_disk_mb: 0,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -21,7 +21,7 @@ use super::idle_lifecycle::{
     SharedIdlePool, destroy_idle_jobs_and_wait, destroy_idle_payload_and_wait,
 };
 use super::job_lifecycle::{
-    ActiveBudgetLease, BudgetOwnership, CompletionPayload, CompletionReady, RunCleanupState,
+    ActiveBudgetLease, BudgetOwnership, FinalizationReady, RunCleanupState,
 };
 use super::ownership::OwnershipTransitions;
 #[cfg(test)]
@@ -38,8 +38,6 @@ use crate::immediate_successor_intent::{
 };
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogSession;
-#[cfg(test)]
-use crate::provider::CompletionAuth;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
@@ -176,13 +174,13 @@ fn local_completed_at() -> String {
 }
 
 fn mark_reuse_state_refresh(
-    completion_ready: CompletionReady,
+    finalization_ready: FinalizationReady,
     reuse_state_changed: bool,
-) -> CompletionReady {
+) -> FinalizationReady {
     if reuse_state_changed {
-        completion_ready.with_reuse_state_changed()
+        finalization_ready.with_reuse_state_changed()
     } else {
-        completion_ready
+        finalization_ready
     }
 }
 
@@ -252,10 +250,9 @@ pub(super) struct FinalizeContext {
 pub(super) async fn finalize_sandbox_for_completion_with_telemetry(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,
-    completion_payload: CompletionPayload,
     telemetry: &mut JobTelemetry,
     ctx: FinalizeContext,
-) -> CompletionReady {
+) -> FinalizationReady {
     let immediate_successor_intents = ctx.immediate_successor_intents.clone();
     let track_immediate_successor_intents =
         should_track_immediate_successor_intents(ctx.reuse_key.as_deref());
@@ -263,7 +260,6 @@ pub(super) async fn finalize_sandbox_for_completion_with_telemetry(
     finalize_sandbox_for_completion_inner(
         sandbox,
         active_lease,
-        completion_payload,
         FinalizationTelemetry::new(
             telemetry,
             immediate_successor_intents,
@@ -279,9 +275,8 @@ pub(super) async fn finalize_sandbox_for_completion_with_telemetry(
 async fn finalize_sandbox_for_completion(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,
-    completion_payload: CompletionPayload,
     ctx: FinalizeContext,
-) -> CompletionReady {
+) -> FinalizationReady {
     let immediate_successor_intents = ctx.immediate_successor_intents.clone();
     let track_immediate_successor_intents =
         should_track_immediate_successor_intents(ctx.reuse_key.as_deref());
@@ -289,7 +284,6 @@ async fn finalize_sandbox_for_completion(
     finalize_sandbox_for_completion_inner(
         sandbox,
         active_lease,
-        completion_payload,
         FinalizationTelemetry::disabled(
             immediate_successor_intents,
             track_immediate_successor_intents,
@@ -303,12 +297,11 @@ async fn finalize_sandbox_for_completion(
 async fn finalize_sandbox_for_completion_inner(
     sandbox: Option<Box<dyn Sandbox>>,
     active_lease: ActiveBudgetLease,
-    completion_payload: CompletionPayload,
     mut telemetry: FinalizationTelemetry<'_>,
     ctx: FinalizeContext,
-) -> CompletionReady {
+) -> FinalizationReady {
     let Some(sandbox) = sandbox else {
-        return CompletionReady::new(completion_payload, BudgetOwnership::active(active_lease));
+        return FinalizationReady::new(BudgetOwnership::active(active_lease));
     };
 
     let FinalizeContext {
@@ -473,12 +466,9 @@ async fn finalize_sandbox_for_completion_inner(
                     );
                     record_destroy_result(destroy_result.outcome, destroy_bookkeeping);
                     return mark_reuse_state_refresh(
-                        CompletionReady::new(
-                            completion_payload,
-                            BudgetOwnership::active(ActiveBudgetLease::from_idle_park_lease(
-                                budget_lease,
-                            )),
-                        ),
+                        FinalizationReady::new(BudgetOwnership::active(
+                            ActiveBudgetLease::from_idle_park_lease(budget_lease),
+                        )),
                         workspace_cache_promoted,
                     );
                 }
@@ -518,7 +508,7 @@ async fn finalize_sandbox_for_completion_inner(
                         destroy_result.workspace_cache_promoted,
                     );
                     return mark_reuse_state_refresh(
-                        CompletionReady::new(completion_payload, destroy_result.budget),
+                        FinalizationReady::new(destroy_result.budget),
                         workspace_cache_promoted,
                     );
                 }
@@ -683,7 +673,7 @@ async fn finalize_sandbox_for_completion_inner(
                             destroy_result.workspace_cache_promoted,
                         );
                         return mark_reuse_state_refresh(
-                            CompletionReady::new(completion_payload, destroy_result.budget),
+                            FinalizationReady::new(destroy_result.budget),
                             workspace_cache_promoted,
                         );
                     }
@@ -717,7 +707,7 @@ async fn finalize_sandbox_for_completion_inner(
                         destroy_result.workspace_cache_promoted,
                     );
                     return mark_reuse_state_refresh(
-                        CompletionReady::new(completion_payload, destroy_result.budget),
+                        FinalizationReady::new(destroy_result.budget),
                         workspace_cache_promoted,
                     );
                 }
@@ -864,10 +854,7 @@ async fn finalize_sandbox_for_completion_inner(
         BudgetOwnership::active(active_lease)
     };
 
-    mark_reuse_state_refresh(
-        CompletionReady::new(completion_payload, budget),
-        reuse_state_changed,
-    )
+    mark_reuse_state_refresh(FinalizationReady::new(budget), reuse_state_changed)
 }
 
 #[derive(Clone, Copy)]
@@ -1069,9 +1056,7 @@ mod tests {
 
     use super::super::active_runs::ActiveRuns;
     use super::super::idle_lifecycle::SharedIdlePool;
-    use super::super::job_lifecycle::{
-        ActiveBudgetLease, CompletionPayload, RunCleanupDisposition, RunCleanupState,
-    };
+    use super::super::job_lifecycle::{ActiveBudgetLease, RunCleanupDisposition, RunCleanupState};
     use crate::idle_pool::{
         IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult, ParkingGate,
         RestoreReservedIdleResult, test_support::ParkedIdleCandidateBuilder,
@@ -1494,19 +1479,11 @@ mod tests {
         );
         context.guest_timezone_intent = GuestTimezoneIntent::Configured("Asia/Shanghai".into());
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
                 "network-log-park",
             ))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -1579,22 +1556,11 @@ mod tests {
         context.runner_id = "runner-attribution-test".into();
         context.reuse_result = SandboxReuseResult::Reused;
 
-        let (completion_ready, events) = capture_async_log_events(finalize_sandbox_for_completion(
-            Some(sandbox),
-            ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::Reused,
-                CompletionAuth::local(),
-            ),
-            context,
-        ))
+        let (_finalization_ready, events) = capture_async_log_events(
+            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context),
+        )
         .await;
 
-        assert_eq!(completion_ready.result_for_test(), (0, None));
         assert_eq!(overrides.destroy_call_count(), 1);
         assert_eq!(fixture.idle_pool.lock().await.len(), 0);
         let matching_events: Vec<_> = events
@@ -1744,22 +1710,10 @@ mod tests {
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
 
-        let completion_ready = finalize_sandbox_for_completion(
-            Some(sandbox),
-            ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
-            context,
-        )
-        .await;
+        let _finalization_ready =
+            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context)
+                .await;
 
-        assert_eq!(completion_ready.result_for_test(), (0, None));
         assert_eq!(overrides.park_call_count(), 1);
         assert_eq!(overrides.unpark_call_count(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
@@ -1801,19 +1755,11 @@ mod tests {
         );
         context.test_observer = observer.clone();
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
                 "finalizer-redaction",
             ))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -1842,19 +1788,11 @@ mod tests {
         );
         context.cleanup_state = cleanup_state.clone();
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
                 "cancel-after-transfer",
             ))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -2163,19 +2101,11 @@ mod tests {
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
                 "guest-session-promotion",
             ))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -2233,20 +2163,9 @@ mod tests {
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64 + 1;
 
-        let _completion_ready = finalize_sandbox_for_completion(
-            Some(sandbox),
-            ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
-            context,
-        )
-        .await;
+        let _finalization_ready =
+            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context)
+                .await;
 
         assert_eq!(
             overrides.park_call_count(),
@@ -2378,20 +2297,9 @@ mod tests {
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
 
-        let _completion_ready = finalize_sandbox_for_completion(
-            Some(sandbox),
-            ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                1,
-                Some("rotation failed before session discovery".into()),
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
-            context,
-        )
-        .await;
+        let _finalization_ready =
+            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context)
+                .await;
 
         assert_eq!(overrides.park_call_count(), 0);
         assert_eq!(overrides.destroy_call_count(), 1);
@@ -2533,17 +2441,9 @@ mod tests {
         context.workspace_image_size_bytes = b"image".len() as u64;
         context.parking_gate.close();
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(sandbox)),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -2627,17 +2527,9 @@ mod tests {
         context.workspace_image_size_bytes = b"image".len() as u64;
         let workspace_cache_snapshot = context.workspace_cache_snapshot.clone();
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(MockSandbox::new("reuse-key-promotion"))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                1,
-                Some("invalid resume session".into()),
-                sandbox_id,
-                SandboxReuseResult::Reused,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -2714,20 +2606,9 @@ mod tests {
         context.workspace_image_size_bytes = b"image".len() as u64;
         let workspace_cache_snapshot = context.workspace_cache_snapshot.clone();
 
-        let _completion_ready = finalize_sandbox_for_completion(
-            Some(sandbox),
-            ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                1,
-                Some("simulated agent failure".into()),
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
-            context,
-        )
-        .await;
+        let _finalization_ready =
+            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context)
+                .await;
 
         assert_eq!(overrides.park_call_count(), 0);
         assert_eq!(overrides.destroy_call_count(), 1);
@@ -2797,20 +2678,9 @@ mod tests {
         context.workspace_image_size_bytes = b"image".len() as u64;
         let workspace_cache_snapshot = context.workspace_cache_snapshot.clone();
 
-        let _completion_ready = finalize_sandbox_for_completion(
-            Some(sandbox),
-            ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                1,
-                Some("simulated failure".into()),
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
-            context,
-        )
-        .await;
+        let _finalization_ready =
+            finalize_sandbox_for_completion(Some(sandbox), ActiveBudgetLease::new(lease), context)
+                .await;
 
         let exec_calls = overrides.exec_calls();
         assert_eq!(exec_calls.len(), 1);
@@ -2877,19 +2747,11 @@ mod tests {
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
                 "rejected-workspace-promotion",
             ))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -2998,14 +2860,6 @@ mod tests {
                 "replacement-sandbox",
             ))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                new_run_id,
-                0,
-                None,
-                new_sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         ));
 
@@ -3019,7 +2873,7 @@ mod tests {
         );
 
         destroy_gate.release_one();
-        let _completion_ready = finalize_task.await.expect("finalizer task should join");
+        let _finalization_ready = finalize_task.await.expect("finalizer task should join");
         assert!(
             reuse_state_notify.notified().now_or_never().is_some(),
             "replaced idle workspace cache promotion should notify after destroy"
@@ -3044,17 +2898,9 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(MockSandbox::new("network-log-cancel"))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             fixture.finalize_context(
                 run_id,
                 sandbox_id,
@@ -3096,19 +2942,11 @@ mod tests {
         context.restored_session_identity = Some(identity.clone());
         context.cleanup_state = cleanup_state.clone();
 
-        let _completion_ready = finalize_sandbox_for_completion(
+        let _finalization_ready = finalize_sandbox_for_completion(
             Some(Box::new(mock_sandbox_ready_for_idle_reuse(
                 "late-cooperative-cancel",
             ))),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                137,
-                Some("cancelled by user".into()),
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         )
         .await;
@@ -3166,14 +3004,6 @@ mod tests {
         let finalize_task = tokio::spawn(finalize_sandbox_for_completion(
             Some(sandbox),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         ));
 
@@ -3206,7 +3036,7 @@ mod tests {
         );
 
         destroy_gate.release_one();
-        let _completion_ready = finalize_task.await.expect("finalizer task should join");
+        let _finalization_ready = finalize_task.await.expect("finalizer task should join");
         assert_eq!(overrides.park_call_count(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
         assert_eq!(
@@ -3248,14 +3078,6 @@ mod tests {
         let finalize_task = tokio::spawn(finalize_sandbox_for_completion(
             Some(sandbox),
             ActiveBudgetLease::new(lease),
-            CompletionPayload::new(
-                run_id,
-                0,
-                None,
-                sandbox_id,
-                SandboxReuseResult::PoolMiss,
-                CompletionAuth::local(),
-            ),
             context,
         ));
 
@@ -3283,7 +3105,7 @@ mod tests {
         );
 
         destroy_gate.release_one();
-        let _completion_ready = finalize_task.await.expect("finalizer task should join");
+        let _finalization_ready = finalize_task.await.expect("finalizer task should join");
         assert_eq!(overrides.park_call_count(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
         assert_eq!(

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -4,7 +4,7 @@ use super::support::{
     mock_run_config_with_overrides, push_job, seed_idle_pool, seed_idle_pool_expired,
     seed_idle_pool_with_timing, shutdown, status_idle_reuse_keys, test_profiles, two_profiles,
     wait_budget_count, wait_cancel_token, wait_discover_entered,
-    wait_idle_cleanup_processed_with_expired_entries,
+    wait_idle_cleanup_processed_with_expired_entries, wait_status_idle_reuse_keys_and_active_runs,
 };
 
 // -----------------------------------------------------------------------
@@ -396,11 +396,13 @@ async fn idle_vm_is_reclaimed_only_after_candidate_discovery() {
         1,
         "idle VM should be retained"
     );
-    assert_eq!(
-        status_idle_reuse_keys(&status_path).await,
-        vec!["sess-pressure-status".to_string()],
-        "status.json should retain the reusable idle VM"
-    );
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &["sess-pressure-status"],
+        &[],
+        Duration::from_secs(5),
+    )
+    .await;
 
     let generic_run_id = RunId::new_v4();
     push_job(

--- a/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
@@ -4,7 +4,7 @@ use super::super::support::{
     test_profiles, wait_budget_count, wait_cancel_token, wait_cancel_token_removed,
     wait_idle_pool_len, wait_status_idle_reuse_keys_and_active_runs,
 };
-use super::support::assert_no_completion_for_run;
+use super::support::{assert_no_completion_for_run, assert_successful_completion_for_run};
 
 use sandbox_mock::MockLifecycleGate;
 
@@ -40,11 +40,12 @@ async fn outer_job_panic_after_idle_pool_owned_cleans_token_and_active_status() 
         Duration::from_secs(5),
     )
     .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "outer job panic must not synthesize provider completion",
-    );
+        "host completion should report before idle-pool finalization panics",
+    )
+    .await;
 
     shutdown(&env, run_handle).await;
 }
@@ -86,7 +87,7 @@ async fn outer_job_panic_active_unknown_reconciles_on_shutdown_final_scan() {
     assert_no_completion_for_run(
         &env,
         run_id,
-        "outer job panic must not synthesize provider completion",
+        "outer job panic before executor completion must not synthesize provider completion",
     );
 }
 
@@ -134,20 +135,22 @@ async fn outer_job_panic_after_active_stop_panic_preserves_status_for_reconcilia
         Duration::from_secs(5),
     )
     .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "outer job panic must not synthesize provider completion",
-    );
+        "host completion should report before destroy bookkeeping panics",
+    )
+    .await;
 
     shutdown(&env, run_handle).await;
     wait_status_idle_reuse_keys_and_active_runs(&status_path, &[], &[], Duration::from_secs(5))
         .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "orphan reconciliation must not synthesize provider completion",
-    );
+        "orphan reconciliation must not duplicate host completion",
+    )
+    .await;
 }
 
 #[tokio::test(start_paused = true)]
@@ -178,11 +181,12 @@ async fn outer_job_panic_after_destroy_completed_cleans_token_and_active_status(
     wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(5)).await;
     wait_status_idle_reuse_keys_and_active_runs(&status_path, &[], &[], Duration::from_secs(5))
         .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "outer job panic must not synthesize provider completion",
-    );
+        "host completion should report before completed destroy bookkeeping panics",
+    )
+    .await;
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -1,10 +1,10 @@
 use super::super::super::*;
 use super::super::support::{
-    MockRunEnv, context_with_session, mock_run_config_with_overrides, push_job, seed_idle_pool,
-    shutdown, test_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
+    context_with_session, mock_run_config_with_overrides, push_job, seed_idle_pool, shutdown,
+    test_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
     wait_status_idle_reuse_keys_and_active_runs, wait_workspace_cache_reuse_keys,
 };
-use super::support::assert_no_completion_for_run;
+use super::support::assert_successful_completion_for_run;
 
 use crate::idle_pool::ParkingState;
 use crate::paths::RunnerPaths;
@@ -270,19 +270,13 @@ async fn non_reusable_park_keeps_budget_until_destroy_and_never_enters_idle_stat
         Duration::from_secs(5),
     )
     .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "provider.complete must wait until non-reusable VM destroy finishes",
-    );
-
-    release_destroy_and_wait_for_successful_completion(
-        &env,
-        &destroy_gate,
-        run_id,
-        "successful job should complete after non-reusable VM destroy finishes",
+        "host completion should report while non-reusable VM destroy is blocked",
     )
     .await;
+    destroy_gate.release_one();
 
     assert_post_destroy_cleanup(&budget, &idle_pool, None, run_id, 0, 0).await;
     wait_status_idle_reuse_keys_and_active_runs(&status_path, &[], &[], Duration::from_secs(5))
@@ -389,25 +383,6 @@ async fn assert_idle_pool_len(idle_pool: &SharedIdlePool, expected_len: usize, m
     assert_eq!(idle_pool.lock().await.len(), expected_len, "{message}");
 }
 
-async fn release_destroy_and_wait_for_successful_completion(
-    env: &MockRunEnv,
-    destroy_gate: &MockLifecycleGate,
-    run_id: RunId,
-    completion_message: &str,
-) {
-    destroy_gate.release_one();
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await
-        .expect(completion_message);
-    assert_eq!(completion.exit_code, 0);
-    assert!(
-        completion.error.is_none(),
-        "parking cleanup should not rewrite job result"
-    );
-}
-
 async fn assert_post_destroy_cleanup(
     budget: &ResourceBudget,
     idle_pool: &SharedIdlePool,
@@ -509,19 +484,13 @@ async fn assert_workspace_cache_after_late_cancellation(
         "cancelled VM should be sent to destroy exactly once",
         "cancelled VM must retain budget while destroy is in-flight",
     );
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "provider.complete must wait until cancelled VM destroy finishes",
-    );
-
-    release_destroy_and_wait_for_successful_completion(
-        &env,
-        &destroy_gate,
-        run_id,
-        "job should complete after destroy finishes",
+        "host completion should report while cancelled VM destroy is blocked",
     )
     .await;
+    destroy_gate.release_one();
 
     assert_post_destroy_cleanup(&budget, &idle_pool, Some(&cancel_tokens), run_id, 0, 0).await;
     wait_workspace_cache_reuse_keys(&workspace_cache, &[session_id], Duration::from_secs(2)).await;
@@ -599,19 +568,13 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
         "rejected VM should be sent to destroy",
         "rejected active VM must retain its budget while destroy is in-flight",
     );
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "provider.complete must wait until rejected VM destroy finishes",
-    );
-
-    release_destroy_and_wait_for_successful_completion(
-        &env,
-        &destroy_gate,
-        run_id,
-        "job should complete after rejected VM destroy",
+        "host completion should report while rejected VM destroy is blocked",
     )
     .await;
+    destroy_gate.release_one();
 
     wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
     let pool = idle_pool.lock().await;
@@ -670,19 +633,13 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
         "closed gate must reject the candidate instead of parking it",
     )
     .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "provider.complete must wait until rejected VM destroy finishes",
-    );
-
-    release_destroy_and_wait_for_successful_completion(
-        &env,
-        &destroy_gate,
-        run_id,
-        "job should complete after destroy finishes",
+        "host completion should report while rejected VM destroy is blocked",
     )
     .await;
+    destroy_gate.release_one();
 
     assert_post_destroy_cleanup(&budget, &idle_pool, None, run_id, 0, 0).await;
 
@@ -740,19 +697,13 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
         "cancelled VM must not enter the idle pool after waiting for the lock",
     )
     .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "provider.complete must wait until cancelled VM destroy finishes",
-    );
-
-    release_destroy_and_wait_for_successful_completion(
-        &env,
-        &destroy_gate,
-        run_id,
-        "job should complete after destroy finishes",
+        "host completion should report while cancelled VM destroy is blocked",
     )
     .await;
+    destroy_gate.release_one();
 
     assert_post_destroy_cleanup(&budget, &idle_pool, Some(&cancel_tokens), run_id, 0, 0).await;
 
@@ -808,19 +759,13 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
         "cancelled VM must not enter the idle pool after park returns",
     )
     .await;
-    assert_no_completion_for_run(
+    assert_successful_completion_for_run(
         &env,
         run_id,
-        "provider.complete must wait until cancelled VM destroy finishes",
-    );
-
-    release_destroy_and_wait_for_successful_completion(
-        &env,
-        &destroy_gate,
-        run_id,
-        "job should complete after destroy finishes",
+        "host completion should report while cancelled VM destroy is blocked",
     )
     .await;
+    destroy_gate.release_one();
 
     assert_post_destroy_cleanup(&budget, &idle_pool, Some(&cancel_tokens), run_id, 0, 0).await;
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/support.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/support.rs
@@ -1,5 +1,7 @@
 use super::super::support::MockRunEnv;
 
+use std::time::Duration;
+
 use crate::ids::RunId;
 
 pub(super) fn assert_no_completion_for_run(env: &MockRunEnv, run_id: RunId, reason: &str) {
@@ -9,5 +11,28 @@ pub(super) fn assert_no_completion_for_run(env: &MockRunEnv, run_id: RunId, reas
             .iter()
             .any(|completion| completion.run_id == run_id),
         "{reason}"
+    );
+}
+
+pub(super) async fn assert_successful_completion_for_run(
+    env: &MockRunEnv,
+    run_id: RunId,
+    reason: &str,
+) {
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect(reason);
+    assert_eq!(completion.exit_code, 0);
+    assert!(completion.error.is_none(), "{reason}");
+    let completions = env.handle.completions.lock().unwrap();
+    assert_eq!(
+        completions
+            .iter()
+            .filter(|completion| completion.run_id == run_id)
+            .count(),
+        1,
+        "host completion must be reported exactly once",
     );
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -306,6 +306,53 @@ async fn sandbox_finalization_progresses_while_completion_report_is_blocked() {
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test]
+async fn provider_can_require_finalization_before_completion_is_observable() {
+    let park_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_park_lifecycle_gate(park_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let status_path = env._temp_dir.path().join("status.json");
+    env.handle.require_finalization_before_completion();
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    let reuse_key = "thread:completion-after-park";
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.into());
+    push_job(&env, run_id, "vm0/default", Some(context));
+
+    park_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("sandbox park should reach the lifecycle gate");
+    assert!(
+        env.handle
+            .wait_completion(run_id, Duration::ZERO)
+            .await
+            .is_none(),
+        "provider completion must remain hidden until sandbox finalization finishes",
+    );
+    wait_status_idle_empty_with_active_run(&status_path, run_id, Duration::from_secs(5)).await;
+
+    park_gate.release_one();
+    env.handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("provider completion should be reported after sandbox finalization");
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &[reuse_key],
+        &[],
+        Duration::from_secs(5),
+    )
+    .await;
+
+    shutdown(&env, run_handle).await;
+}
+
 // -----------------------------------------------------------------------
 // Test 11: Job without a reuse key destroys its sandbox (no parking)
 // -----------------------------------------------------------------------

--- a/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/parking.rs
@@ -3,7 +3,7 @@ use super::super::support::{
     context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
     push_job, seed_idle_pool, shutdown, test_profiles, wait_budget_count, wait_discover_entered,
     wait_idle_pool_reuse_keys, wait_sandbox_lifecycle_counts,
-    wait_status_idle_reuse_keys_and_active_runs,
+    wait_status_idle_empty_with_active_run, wait_status_idle_reuse_keys_and_active_runs,
 };
 
 use crate::types::SandboxReuseResult;
@@ -205,6 +205,103 @@ async fn successful_job_parks_in_idle_pool() {
     }
     let (_, _, count) = budget.allocated();
     assert_eq!(count, 1, "parked VM should hold budget");
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn completion_report_starts_while_sandbox_park_is_blocked() {
+    let park_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_park_lifecycle_gate(park_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    let reuse_key = "thread:completion-before-park";
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.into());
+    push_job(&env, run_id, "vm0/default", Some(context));
+
+    park_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("sandbox park should reach the lifecycle gate");
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("host completion should be reported before park finishes");
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(budget.allocated().2, 1, "active budget must remain held");
+    assert_eq!(idle_pool.lock().await.len(), 0);
+    wait_status_idle_empty_with_active_run(&status_path, run_id, Duration::from_secs(5)).await;
+
+    park_gate.release_one();
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &[reuse_key],
+        &[],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(budget.allocated().2, 1, "idle sandbox must own the budget");
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn sandbox_finalization_progresses_while_completion_report_is_blocked() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let status_path = env._temp_dir.path().join("status.json");
+    env.handle.block_completions();
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    let reuse_key = "thread:park-before-completion";
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.into());
+    push_job(&env, run_id, "vm0/default", Some(context));
+
+    env.handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("blocked host completion should record its request");
+    assert_eq!(env.handle.completion_in_flight(), 1);
+    wait_idle_pool_reuse_keys(&idle_pool, &[reuse_key], Duration::from_secs(5)).await;
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &[reuse_key],
+        &[run_id.to_string()],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "finalization must transfer budget ownership without releasing it",
+    );
+
+    env.handle.unblock_completions();
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &[reuse_key],
+        &[],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(env.handle.completion_in_flight(), 0);
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "idle sandbox must retain the budget"
+    );
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -914,18 +914,11 @@ async fn finalizing_successor_starts_before_replaced_sandbox_cleanup_finishes() 
         .wait_entered(2, Duration::from_secs(5))
         .await
         .expect("successor should activate the published sandbox before cleanup finishes");
-    assert!(
-        env.handle
-            .wait_completion(history_generation_run_id, Duration::ZERO)
-            .await
-            .is_none(),
-        "predecessor completion must still be blocked on replaced sandbox cleanup"
-    );
-    destroy_gate.release_one();
     env.handle
         .wait_completion(history_generation_run_id, Duration::from_secs(5))
         .await
-        .expect("predecessor should complete after replaced sandbox cleanup");
+        .expect("predecessor should report completion while replaced sandbox cleanup is blocked");
+    destroy_gate.release_one();
     wait_status_idle_reuse_keys_and_active_runs(
         &status_path,
         &[],

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -30,8 +30,9 @@ use super::builtin_firewall_catalog::{
 };
 use super::connector_runtime_sync::ConnectorRuntimeSyncHandle;
 use super::{
-    ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
-    RunnerPreference, RunnerPreferenceClaimState, parse_runner_preference,
+    ClaimedJob, CompletionAuth, CompletionAuthError, CompletionReportTiming, JobCandidate,
+    JobDiscoverySource, JobProvider, RunnerPreference, RunnerPreferenceClaimState,
+    parse_runner_preference,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
 use crate::duration::duration_ms;
@@ -764,6 +765,10 @@ impl JobProvider for ApiProvider {
         }
         self.connector_runtime_sync.shutdown().await;
         self.builtin_firewall_catalog_refresh.shutdown().await;
+    }
+
+    fn completion_report_timing(&self) -> CompletionReportTiming {
+        CompletionReportTiming::ConcurrentWithFinalization
     }
 
     async fn complete(&self, request: CompleteRequest, completion_auth: CompletionAuth) {

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider};
+use super::{ClaimedJob, CompletionAuth, CompletionReportTiming, JobCandidate, JobProvider};
 use crate::local_queue::{LocalClaimResult, LocalDiscoveredJob, LocalQueue};
 use crate::run_cancellation::RunCancellationRegistry;
 use crate::types::{CompleteRequest, ExecutionContext, HeartbeatState};
@@ -227,6 +227,12 @@ impl JobProvider for LocalProvider {
                 None
             }
         }
+    }
+
+    fn completion_report_timing(&self) -> CompletionReportTiming {
+        // Writing the result unblocks `runner local submit`, whose next turn
+        // may immediately depend on the finalized sandbox being reusable.
+        CompletionReportTiming::AfterFinalization
     }
 
     async fn complete(&self, request: CompleteRequest, _completion_auth: CompletionAuth) {

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -26,7 +26,7 @@ use tokio::sync::{Mutex, Notify, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider};
+use super::{ClaimedJob, CompletionAuth, CompletionReportTiming, JobCandidate, JobProvider};
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::types::{
@@ -95,6 +95,7 @@ pub struct MockJobProvider {
     heartbeat_control: Arc<MockHeartbeatControl>,
     claim_control: Arc<MockClaimControl>,
     completion_control: Arc<MockCompletionControl>,
+    completion_after_finalization: Arc<AtomicBool>,
 }
 
 /// Test-side handle for driving the mock provider.
@@ -118,6 +119,7 @@ pub struct MockProviderHandle {
     heartbeat_control: Arc<MockHeartbeatControl>,
     claim_control: Arc<MockClaimControl>,
     completion_control: Arc<MockCompletionControl>,
+    completion_after_finalization: Arc<AtomicBool>,
 }
 
 #[derive(Clone)]
@@ -336,6 +338,7 @@ impl MockJobProvider {
         let heartbeat_control = Arc::new(MockHeartbeatControl::default());
         let claim_control = Arc::new(MockClaimControl::default());
         let completion_control = Arc::new(MockCompletionControl::default());
+        let completion_after_finalization = Arc::new(AtomicBool::new(false));
         let provider = Arc::new(Self {
             startup_readiness: Arc::clone(&startup_readiness),
             discovery: Mutex::new(rx),
@@ -355,6 +358,7 @@ impl MockJobProvider {
             heartbeat_control: Arc::clone(&heartbeat_control),
             claim_control: Arc::clone(&claim_control),
             completion_control: Arc::clone(&completion_control),
+            completion_after_finalization: Arc::clone(&completion_after_finalization),
         });
         let handle = MockProviderHandle {
             startup_readiness,
@@ -372,6 +376,7 @@ impl MockJobProvider {
             heartbeat_control,
             claim_control,
             completion_control,
+            completion_after_finalization,
         };
         (provider, handle)
     }
@@ -436,6 +441,11 @@ impl MockProviderHandle {
 
     pub fn completion_in_flight(&self) -> usize {
         self.completion_control.in_flight.load(Ordering::SeqCst)
+    }
+
+    pub fn require_finalization_before_completion(&self) {
+        self.completion_after_finalization
+            .store(true, Ordering::SeqCst);
     }
 
     pub fn discover_started_count(&self) -> usize {
@@ -684,6 +694,14 @@ impl JobProvider for MockJobProvider {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .pop_front()
+    }
+
+    fn completion_report_timing(&self) -> CompletionReportTiming {
+        if self.completion_after_finalization.load(Ordering::SeqCst) {
+            CompletionReportTiming::AfterFinalization
+        } else {
+            CompletionReportTiming::ConcurrentWithFinalization
+        }
     }
 
     async fn complete(&self, request: CompleteRequest, _completion_auth: CompletionAuth) {

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -94,6 +94,7 @@ pub struct MockJobProvider {
     heartbeat_notify: Arc<Notify>,
     heartbeat_control: Arc<MockHeartbeatControl>,
     claim_control: Arc<MockClaimControl>,
+    completion_control: Arc<MockCompletionControl>,
 }
 
 /// Test-side handle for driving the mock provider.
@@ -116,6 +117,7 @@ pub struct MockProviderHandle {
     heartbeat_notify: Arc<Notify>,
     heartbeat_control: Arc<MockHeartbeatControl>,
     claim_control: Arc<MockClaimControl>,
+    completion_control: Arc<MockCompletionControl>,
 }
 
 #[derive(Clone)]
@@ -148,6 +150,13 @@ struct MockClaimControl {
     in_flight: AtomicUsize,
     release: Notify,
     state_changed: Notify,
+}
+
+#[derive(Default)]
+struct MockCompletionControl {
+    blocked: AtomicBool,
+    in_flight: AtomicUsize,
+    release: Notify,
 }
 
 impl MockHeartbeatControl {
@@ -185,12 +194,32 @@ impl MockClaimControl {
     }
 }
 
+impl MockCompletionControl {
+    fn enter(&self) -> MockCompletionInFlight<'_> {
+        self.in_flight.fetch_add(1, Ordering::SeqCst);
+        MockCompletionInFlight { control: self }
+    }
+
+    fn block(&self) {
+        self.blocked.store(true, Ordering::SeqCst);
+    }
+
+    fn unblock(&self) {
+        self.blocked.store(false, Ordering::SeqCst);
+        self.release.notify_waiters();
+    }
+}
+
 struct MockHeartbeatInFlight<'a> {
     control: &'a MockHeartbeatControl,
 }
 
 struct MockClaimInFlight<'a> {
     control: &'a MockClaimControl,
+}
+
+struct MockCompletionInFlight<'a> {
+    control: &'a MockCompletionControl,
 }
 
 impl Drop for MockHeartbeatInFlight<'_> {
@@ -204,6 +233,12 @@ impl Drop for MockClaimInFlight<'_> {
     fn drop(&mut self) {
         self.control.in_flight.fetch_sub(1, Ordering::SeqCst);
         self.control.state_changed.notify_waiters();
+    }
+}
+
+impl Drop for MockCompletionInFlight<'_> {
+    fn drop(&mut self) {
+        self.control.in_flight.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -300,6 +335,7 @@ impl MockJobProvider {
         let heartbeat_notify = Arc::new(Notify::new());
         let heartbeat_control = Arc::new(MockHeartbeatControl::default());
         let claim_control = Arc::new(MockClaimControl::default());
+        let completion_control = Arc::new(MockCompletionControl::default());
         let provider = Arc::new(Self {
             startup_readiness: Arc::clone(&startup_readiness),
             discovery: Mutex::new(rx),
@@ -318,6 +354,7 @@ impl MockJobProvider {
             heartbeat_notify: Arc::clone(&heartbeat_notify),
             heartbeat_control: Arc::clone(&heartbeat_control),
             claim_control: Arc::clone(&claim_control),
+            completion_control: Arc::clone(&completion_control),
         });
         let handle = MockProviderHandle {
             startup_readiness,
@@ -334,6 +371,7 @@ impl MockJobProvider {
             heartbeat_notify,
             heartbeat_control,
             claim_control,
+            completion_control,
         };
         (provider, handle)
     }
@@ -384,6 +422,20 @@ impl MockProviderHandle {
 
     pub fn startup_readiness_calls(&self) -> usize {
         self.startup_readiness.calls()
+    }
+
+    /// Block completion calls after recording their request payload.
+    pub fn block_completions(&self) {
+        self.completion_control.block();
+    }
+
+    /// Release blocked completion calls and allow later calls to return.
+    pub fn unblock_completions(&self) {
+        self.completion_control.unblock();
+    }
+
+    pub fn completion_in_flight(&self) -> usize {
+        self.completion_control.in_flight.load(Ordering::SeqCst)
     }
 
     pub fn discover_started_count(&self) -> usize {
@@ -635,6 +687,10 @@ impl JobProvider for MockJobProvider {
     }
 
     async fn complete(&self, request: CompleteRequest, _completion_auth: CompletionAuth) {
+        let release = self.completion_control.release.notified();
+        tokio::pin!(release);
+        release.as_mut().enable();
+        let _in_flight = self.completion_control.enter();
         self.completions
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -649,6 +705,9 @@ impl JobProvider for MockJobProvider {
         // Wake all pending `wait_completion` waiters — they re-scan the vec
         // and return if their run_id is now present.
         self.completion_notify.notify_waiters();
+        if self.completion_control.blocked.load(Ordering::SeqCst) {
+            release.await;
+        }
     }
 
     async fn heartbeat(&self, state: &HeartbeatState) {

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -212,6 +212,12 @@ pub(crate) enum JobDiscoverySource {
     Poll,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CompletionReportTiming {
+    ConcurrentWithFinalization,
+    AfterFinalization,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RunnerPreferenceContext {
     runner_preference: RunnerPreference,
@@ -798,6 +804,17 @@ pub trait JobProvider: Send + Sync {
     /// inside a `select!` branch handler) to guarantee that a successful
     /// claim is always paired with a later [`complete()`](JobProvider::complete).
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob>;
+
+    /// Controls when reporting completion may make the terminal result
+    /// externally observable.
+    ///
+    /// API-backed providers can report while finalization runs because the API
+    /// coordinates immediate successors with finalizing runner state. Providers
+    /// whose completion result directly releases a local caller can require
+    /// finalization first so a following reuse-dependent submission is safe.
+    fn completion_report_timing(&self) -> CompletionReportTiming {
+        CompletionReportTiming::AfterFinalization
+    }
 
     /// Report job completion. Called concurrently from spawned executor tasks.
     ///


### PR DESCRIPTION
## Summary

- report immutable API completion while sandbox finalization runs
- keep active status, budget, and reuse-key ownership settlement behind both operations
- preserve local submit's finalization-before-result contract so an immediate next turn can reuse the parked sandbox
- cover concurrent and finalization-first provider behavior with deterministic lifecycle barriers

## Scope

- preserves the existing completion request and runner/API protocol
- preserves sandbox parking, destruction, workspace promotion, and fallback behavior
- keeps completion reporting inside the supervised job task
- uses a conservative finalization-first default; the API provider explicitly opts into concurrent reporting

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (3,105 passed, 20 ignored)
- repository pre-commit and commit-message hooks

Closes #26171

Parent: #26069
