### PR TITLE
feat: roll out avatar to all users

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
@@ -97,9 +97,9 @@ async function seedAvatarVideoFixture(options?: {
     { ...fixture, role: "admin" },
     context.signal,
   );
-  if (options?.featureEnabled ?? true) {
+  if (options?.featureEnabled !== undefined) {
     await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.JoggAiBuiltIn]: true,
+      [FeatureSwitchKey.JoggAiBuiltIn]: options.featureEnabled,
     });
   }
   if (options?.withPricing ?? true) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -664,6 +664,8 @@ describe("chat composer templates", () => {
     const user = userEvent.setup({ delay: null });
     const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
     const videoTemplate = VIDEO_TEMPLATE_ITEMS[0]!;
+    mockAvatarCatalog();
+    mockVoiceCatalog();
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
     detachedSetupPage({
@@ -688,11 +690,7 @@ describe("chat composer templates", () => {
     expect(tabByText("Illustration")).toBeInTheDocument();
     expect(tabByText("Video")).toBeInTheDocument();
     expect(tabByText("Website")).toBeInTheDocument();
-    expect(
-      queryAllByRoleFast("tab").some((tab) => {
-        return tab.textContent === "Avatar";
-      }),
-    ).toBeFalsy();
+    expect(tabByText("Avatar")).toBeInTheDocument();
     expect(document.activeElement).not.toBe(tabByText("Presentation"));
     expect(tabByText("Presentation")).toHaveAttribute("aria-selected", "true");
     const categorySelect = screen.getByRole("combobox", {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -15,6 +15,7 @@ describe("isFeatureEnabled", () => {
       true,
     );
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -26,7 +27,6 @@ describe("isFeatureEnabled", () => {
   it("should return false for disabled switch without context", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.SeoBuiltIn, {})).toBe(false);
   });
 
@@ -111,7 +111,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.JoggAiBuiltIn]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SeoBuiltIn]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConnectorDiscovery]).toBe(true);
@@ -137,7 +136,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.JoggAiBuiltIn]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SeoBuiltIn]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConnectorDiscovery]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -111,8 +111,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.JoggAiBuiltIn]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable vm0-managed JoggAI talking-avatar video generation",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.SeoBuiltIn]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- enable the `joggAiBuiltIn` feature switch globally
- remove the staff-org rollout restriction
- update core feature-switch coverage for the global rollout

## Behavior

Avatar templates and vm0-managed JoggAI talking-avatar video generation become available to all workspaces. Existing Pro, Team, or Custom plan eligibility, credit, and provider-configuration checks remain unchanged.

## Validation

- `corepack pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `corepack pnpm --filter @vm0/core lint`
- `corepack pnpm --filter @vm0/core check-types`
- `corepack pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 tests passed)
- `git diff --check`