### PR TITLE
feat: make okou.ai the default app domain

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -146,7 +146,7 @@ runs:
 
         if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
           web_url="${INPUT_WEB_URL:-https://www.vm0.ai}"
-          app_url="${INPUT_APP_URL:-https://app.vm0.ai}"
+          app_url="${INPUT_APP_URL:-https://app.okou.ai}"
           api_backend_url="$(first_non_empty "$INPUT_API_BACKEND_URL" "$(repo_var VM0_API_BACKEND_URL)")"
           axiom_dataset_suffix="prod"
           deploy_env="production"

--- a/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-pages-workflow-test.sh
@@ -85,11 +85,33 @@ require_fragments(
 if "WRANGLER_OUTPUT_FILE_PATH" not in preview_step.get("env", {}):
     raise RuntimeError("preview deployment no longer captures Wrangler output")
 
-require_fragments(release_step, ["curl -fsSL", '"$pages_url"', '"$production_url"'])
+require_fragments(
+    release_step,
+    [
+        "curl -fsSL",
+        'production_url="https://app.okou.ai"',
+        'legacy_production_url="https://app.vm0.ai"',
+        '"$pages_url"',
+        '"$production_url"',
+        '"$legacy_production_url"',
+    ],
+)
 require_fragments(
     rollback_step,
-    ["curl -fsSL", '"https://${CF_PAGES_PROJECT_NAME}.pages.dev"', '"https://app.vm0.ai"'],
+    [
+        "curl -fsSL",
+        '"https://${CF_PAGES_PROJECT_NAME}.pages.dev"',
+        '"https://app.okou.ai"',
+        '"https://app.vm0.ai"',
+    ],
 )
+
+for fragment in ("env_url: https://app.okou.ai", "<https://app.okou.ai|Open App>"):
+    if fragment not in release_source:
+        raise RuntimeError(f"release workflow is missing canonical Okou URL: {fragment}")
+
+if "env_url: https://app.okou.ai" not in rollback_source:
+    raise RuntimeError("rollback workflow is missing the canonical Okou environment URL")
 
 print("deploy-okou-pages workflow tests passed")
 PY

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -124,6 +124,7 @@ run_action() {
   local input_app="${3:-api}"
   local input_environment="${4:-preview}"
   local input_cli_pkg_url="${5-https://static.vm0.io/okou-cli/test-sha/package.tgz}"
+  local input_app_url="${6-https://pr-123-app.vm0.test}"
   local action_script="${test_dir}/web-api-env-action.sh"
   local github_output="${test_dir}/github-output"
   local repo_vars_json
@@ -141,7 +142,7 @@ run_action() {
     INPUT_DATABASE_URL="postgres://preview-db" \
     INPUT_JOB_REF="pr-123" \
     INPUT_WEB_URL="https://pr-123-www.vm0.test" \
-    INPUT_APP_URL="https://pr-123-app.vm0.test" \
+    INPUT_APP_URL="$input_app_url" \
     INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
     INPUT_CLI_PKG_URL="$input_cli_pkg_url" \
     REPO_VARS_JSON="$repo_vars_json" \
@@ -256,6 +257,7 @@ assert_env_value "$production_api_env_file" VM0_WEB_URL "https://pr-123-www.vm0.
 assert_env_value "$production_api_env_file" VM0_API_BACKEND_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" CLI_PKG_URL "https://static.vm0.io/okou-cli/test-sha/package.tgz"
+assert_env_value "$production_api_env_file" APP_URL "https://pr-123-app.vm0.test"
 assert_env_value "$production_api_env_file" ATOM_URL "https://atom.github.test"
 assert_env_value "$production_api_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
 assert_env_value "$production_api_env_file" JOGGAI_WEBHOOK_SECRET "github-joggai-webhook-secret"
@@ -276,6 +278,13 @@ assert_env_value "$production_api_env_file" STRIPE_WEBHOOK_SECRET "github-stripe
 assert_env_value "$production_api_env_file" STRIPE_AUTOMATION_WEBHOOK_SECRET "github-stripe-automation-webhook-secret"
 assert_env_absent_value "$production_api_env_file" "doppler-stripe-billing-webhook-secret"
 assert_env_absent_value "$production_api_env_file" "doppler-stripe-automation-webhook-secret"
+
+production_api_default_dir="$(mktemp -d)"
+TEMP_DIRS+=("$production_api_default_dir")
+production_api_default_output="$(run_action "$(build_doppler_secrets_json)" "$production_api_default_dir" api production "https://static.vm0.io/okou-cli/test-sha/package.tgz" "")"
+production_api_default_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${production_api_default_dir}/github-output")"
+assert_contains "$production_api_default_output" "Rendered"
+assert_env_value "$production_api_default_env_file" APP_URL "https://app.okou.ai"
 
 missing_dir="$(mktemp -d)"
 TEMP_DIRS+=("$missing_dir")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -962,7 +962,7 @@ jobs:
           environment: production
           database-url: ${{ steps.get-db-url.outputs.database-url }}
           web-url: https://www.vm0.ai
-          app-url: https://app.vm0.ai
+          app-url: https://app.okou.ai
           api-backend-url: ${{ vars.VM0_API_BACKEND_URL }}
           cli-pkg-url: ${{ steps.cli-artifact.outputs.package-url }}
         env:
@@ -1428,8 +1428,9 @@ jobs:
             "$ARTIFACT_SHA"
 
           pages_url="https://${CF_PAGES_PROJECT_NAME}.pages.dev"
-          production_url="https://app.vm0.ai"
-          for url in "$pages_url" "$production_url"; do
+          production_url="https://app.okou.ai"
+          legacy_production_url="https://app.vm0.ai"
+          for url in "$pages_url" "$production_url" "$legacy_production_url"; do
             curl -fsSL \
               --retry 12 \
               --retry-delay 5 \
@@ -1459,7 +1460,7 @@ jobs:
           token: ${{ github.token }}
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
-          env_url: https://app.vm0.ai
+          env_url: https://app.okou.ai
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Calculate duration
@@ -1487,7 +1488,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*App* ✅ Deployed to Cloudflare Pages\n📦 Version: `${{ needs.release-please.outputs.app_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🌐 <https://app.vm0.ai|Open App>\n🔄 <${{ github.server_url }}/${{ github.repository }}/issues/${{ vars.ROLLBACK_ISSUE_NUMBER }}|Rollback Dashboard>"
+                  text: "*App* ✅ Deployed to Cloudflare Pages\n📦 Version: `${{ needs.release-please.outputs.app_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🌐 <https://app.okou.ai|Open App>\n🔄 <${{ github.server_url }}/${{ github.repository }}/issues/${{ vars.ROLLBACK_ISSUE_NUMBER }}|Rollback Dashboard>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -206,7 +206,7 @@ jobs:
             production \
             "$TARGET_COMMIT"
 
-          for url in "https://${CF_PAGES_PROJECT_NAME}.pages.dev" "https://app.vm0.ai"; do
+          for url in "https://${CF_PAGES_PROJECT_NAME}.pages.dev" "https://app.okou.ai" "https://app.vm0.ai"; do
             curl -fsSL \
               --retry 12 \
               --retry-delay 5 \
@@ -224,7 +224,7 @@ jobs:
           token: ${{ github.token }}
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
-          env_url: https://app.vm0.ai
+          env_url: https://app.okou.ai
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Notify Slack - Success

--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -28,17 +28,17 @@ state creation inside React render.
 The body parser accepts platform links in common message forms:
 
 ```markdown
-https://app.vm0.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write
+https://app.okou.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write
 
-[Review permission](https://app.vm0.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write)
+[Review permission](https://app.okou.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write)
 
 /computer-use/authorize/request-token
 ```
 
-Absolute URLs must use an allowed VM0 platform origin. Relative paths resolve
-against the configured platform origin. A URL becomes a card only when its path
-and required parameters match a card parser exactly. An unrecognized or invalid
-link remains ordinary Markdown.
+Absolute URLs must use an allowed Okou or compatible VM0 platform origin.
+Relative paths resolve against the configured platform origin. A URL becomes a
+card only when its path and required parameters match a card parser exactly. An
+unrecognized or invalid link remains ordinary Markdown.
 
 Current link-backed card patterns include:
 

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -565,7 +565,7 @@ export function createAppWithRoutes({
 
   app.use("*", previewAutomationBypassMiddleware);
 
-  // Browser cross-origin requests (e.g. https://app.vm0.ai -> api.vm0.ai). Must
+  // Browser cross-origin requests (e.g. https://app.okou.ai -> api.vm0.ai). Must
   // run before the route handlers so OPTIONS preflight short-circuits without
   // matching a registered method, and so registered route responses receive
   // Access-Control-Allow-Origin without relying on the legacy web proxy.

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/check.test.ts
@@ -594,22 +594,27 @@ describe("zero connector check command", () => {
       {
         name: "production API",
         baseUrl: "https://api.vm0.ai",
-        platformOrigin: "https://app.vm0.ai",
+        platformOrigin: "https://app.okou.ai",
       },
       {
         name: "legacy production web",
         baseUrl: "https://www.vm0.ai",
-        platformOrigin: "https://app.vm0.ai",
+        platformOrigin: "https://app.okou.ai",
       },
       {
         name: "legacy production platform",
         baseUrl: "https://platform.vm0.ai",
-        platformOrigin: "https://app.vm0.ai",
+        platformOrigin: "https://app.okou.ai",
+      },
+      {
+        name: "legacy production app",
+        baseUrl: "https://app.vm0.ai",
+        platformOrigin: "https://app.okou.ai",
       },
       {
         name: "canonical production app",
-        baseUrl: "https://app.vm0.ai",
-        platformOrigin: "https://app.vm0.ai",
+        baseUrl: "https://app.okou.ai",
+        platformOrigin: "https://app.okou.ai",
       },
       {
         name: "staging API",

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
@@ -368,7 +368,7 @@ describe("zero connector permission-request command", () => {
     expect(logCalls).not.toContain("/agents/env-agent-123/permissions?");
   });
 
-  it("transforms www.vm0.ai to app.vm0.ai", async () => {
+  it("transforms the legacy production web origin to app.okou.ai", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://www.vm0.ai");
     vi.stubEnv("ZERO_AGENT_ID", "agent-1");
 
@@ -384,7 +384,7 @@ describe("zero connector permission-request command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain(
-      "https://app.vm0.ai/agents/agent-1/permissions?",
+      "https://app.okou.ai/agents/agent-1/permissions?",
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -310,7 +310,7 @@ describe("zero connector status command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain(
-        `[Authorize github](https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_UUID})`,
+        `[Authorize github](https://app.okou.ai/connectors/github/authorize?agentId=${AGENT_UUID})`,
       );
     });
 

--- a/turbo/apps/cli/src/commands/zero/doctor/platform-url.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/platform-url.ts
@@ -3,9 +3,10 @@ import { getApiUrl } from "../../../lib/api/config";
 /**
  * Transform the API host to the platform (app) host.
  *
- *   api.vm0.ai                    → app.vm0.ai
- *   www.vm0.ai                    → app.vm0.ai
- *   platform.vm0.ai               → app.vm0.ai
+ *   api.vm0.ai                    → app.okou.ai
+ *   www.vm0.ai                    → app.okou.ai
+ *   platform.vm0.ai               → app.okou.ai
+ *   app.vm0.ai                    → app.okou.ai
  *   staging-api.vm6.ai            → staging-app.omby.ai
  *   pr-123-api.vm6.ai             → pr-123-app.omby.ai
  *   tunnel-user-host-www.vm7.ai   → tunnel-user-host-app.vm7.ai
@@ -14,6 +15,16 @@ import { getApiUrl } from "../../../lib/api/config";
  */
 export function toPlatformUrl(apiUrl: string): URL {
   const parsed = new URL(apiUrl);
+  if (
+    parsed.hostname === "api.vm0.ai" ||
+    parsed.hostname === "www.vm0.ai" ||
+    parsed.hostname === "platform.vm0.ai" ||
+    parsed.hostname === "app.vm0.ai"
+  ) {
+    parsed.hostname = "app.okou.ai";
+    return parsed;
+  }
+
   const parts = parsed.hostname.split(".");
   const serviceLabel = parts[0]!;
   if (serviceLabel.endsWith("-www")) {

--- a/turbo/apps/cli/src/commands/zero/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/model-provider/__tests__/index.test.ts
@@ -115,6 +115,7 @@ describe("zero model-provider command", () => {
     );
     expect(helpText).toContain("top-left organization menu");
     expect(helpText).toContain("Preferences / Personal Models");
+    expect(helpText).toContain("https://app.okou.ai");
 
     await setCommand.parseAsync(["node", "cli"]);
 

--- a/turbo/apps/cli/src/commands/zero/model-provider/index.ts
+++ b/turbo/apps/cli/src/commands/zero/model-provider/index.ts
@@ -11,7 +11,7 @@ import {
 export const MODEL_PROVIDER_SET_GUIDANCE = [
   "Model provider routing is configured in the web app.",
   "",
-  "Organization admins: open https://app.vm0.ai, use the top-left organization menu, choose Manage, then add, delete, or adjust model providers.",
+  "Organization admins: open https://app.okou.ai, use the top-left organization menu, choose Manage, then add, delete, or adjust model providers.",
   "",
   "If an organization admin sets a model provider to subscription, members must use the bottom-left user menu, choose Preferences / Personal Models, and connect their personal subscription.",
 ].join("\n");

--- a/turbo/apps/cli/src/commands/zero/model/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/model/__tests__/index.test.ts
@@ -113,9 +113,9 @@ describe("zero model command", () => {
     );
   });
 
-  it("should point other environments at app.vm0.ai", () => {
+  it("should point other environments at app.okou.ai", () => {
     expect(getModelSwitchGuidance("schedule")).toContain(
-      "Open https://app.vm0.ai",
+      "Open https://app.okou.ai",
     );
   });
 });

--- a/turbo/apps/cli/src/commands/zero/model/index.ts
+++ b/turbo/apps/cli/src/commands/zero/model/index.ts
@@ -34,7 +34,7 @@ export function getModelSwitchGuidance(integration = getCurrentIntegration()) {
     return "Use /model in Telegram to switch models.";
   }
 
-  return "Open https://app.vm0.ai and switch models from the model selector next to the input box.";
+  return "Open https://app.okou.ai and switch models from the model selector next to the input box.";
 }
 
 const listCommand = new Command()

--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -2,9 +2,14 @@ const os = require("node:os");
 const path = require("node:path");
 
 const packageMetadata = require("./package.json");
+const desktopDomains = require("./src/desktop-domains.json");
 const desktopIdentities = require("./src/desktop-identities.json");
 
-const PRODUCTION_PLATFORM_HOSTNAME = "app.vm0.ai";
+const PRODUCTION_PLATFORM_HOSTNAMES = new Set(
+  desktopDomains.compatiblePlatformUrls.map((url) => new URL(url).hostname),
+);
+const DEFAULT_PLATFORM_HOSTNAME = new URL(desktopDomains.defaultPlatformUrl)
+  .hostname;
 const MINIMUM_MACOS_VERSION = "14.0";
 const DEFAULT_NOTARIZE_KEYCHAIN_PROFILE = "vm0-desktop-notary";
 const DEFAULT_NOTARIZE_KEYCHAIN = path.join(
@@ -57,13 +62,13 @@ function desktopNotarizeOptions() {
 
 function platformHostname(rawUrl) {
   if (!rawUrl || !rawUrl.trim()) {
-    return PRODUCTION_PLATFORM_HOSTNAME;
+    return DEFAULT_PLATFORM_HOSTNAME;
   }
   return new URL(rawUrl).hostname;
 }
 
 function desktopIdentityForPlatformUrl(rawUrl) {
-  if (platformHostname(rawUrl) === PRODUCTION_PLATFORM_HOSTNAME) {
+  if (PRODUCTION_PLATFORM_HOSTNAMES.has(platformHostname(rawUrl))) {
     return desktopIdentities.production;
   }
   return desktopIdentities.development;

--- a/turbo/apps/desktop/scripts/packaged-app-paths.js
+++ b/turbo/apps/desktop/scripts/packaged-app-paths.js
@@ -1,18 +1,23 @@
 const path = require("node:path");
 
+const desktopDomains = require("../src/desktop-domains.json");
 const desktopIdentities = require("../src/desktop-identities.json");
 
-const PRODUCTION_PLATFORM_HOSTNAME = "app.vm0.ai";
+const PRODUCTION_PLATFORM_HOSTNAMES = new Set(
+  desktopDomains.compatiblePlatformUrls.map((url) => new URL(url).hostname),
+);
+const DEFAULT_PLATFORM_HOSTNAME = new URL(desktopDomains.defaultPlatformUrl)
+  .hostname;
 
 function platformHostname(rawUrl) {
   if (!rawUrl || !rawUrl.trim()) {
-    return PRODUCTION_PLATFORM_HOSTNAME;
+    return DEFAULT_PLATFORM_HOSTNAME;
   }
   return new URL(rawUrl).hostname;
 }
 
 function desktopIdentityForPlatformUrl(rawUrl) {
-  if (platformHostname(rawUrl) === PRODUCTION_PLATFORM_HOSTNAME) {
+  if (PRODUCTION_PLATFORM_HOSTNAMES.has(platformHostname(rawUrl))) {
     return desktopIdentities.production;
   }
   return desktopIdentities.development;

--- a/turbo/apps/desktop/src/bootstrap-degraded.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.test.ts
@@ -73,6 +73,10 @@ function productionConfig(): DesktopConfig {
     },
     sessionPartition: "persist:desktop",
     allowedAppOrigins: new Set(["https://app.vm0.ai"]),
+    authCookieUrls: [
+      new URL("https://www.vm0.ai"),
+      new URL("https://app.vm0.ai"),
+    ],
   };
 }
 

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -1,9 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import desktopDomains from "./desktop-domains.json";
 import desktopIdentities from "./desktop-identities.json";
-import { rewriteDesktopServiceHostname } from "./desktop-api-base-url";
+import {
+  isProductionDesktopPlatformHostname,
+  rewriteDesktopServiceHostname,
+} from "./desktop-api-base-url";
 
-const PRODUCTION_PLATFORM_URL = "https://app.vm0.ai";
+const PRODUCTION_PLATFORM_URL = desktopDomains.defaultPlatformUrl;
 const DESKTOP_RUNTIME_CONFIG_FILE = "desktop-runtime-config.json";
 
 export type DesktopEnvironment = "production" | "staging" | "development";
@@ -26,6 +30,7 @@ export interface DesktopConfig {
   readonly identity: DesktopIdentity;
   readonly sessionPartition: string;
   readonly allowedAppOrigins: ReadonlySet<string>;
+  readonly authCookieUrls: readonly URL[];
 }
 
 function desktopRuntimeConfigPath(): string {
@@ -94,7 +99,10 @@ function environmentForPlatformUrl(
   platformUrl: URL,
   hasExplicitUrl: boolean,
 ): DesktopEnvironment {
-  if (!hasExplicitUrl || platformUrl.hostname === "app.vm0.ai") {
+  if (
+    !hasExplicitUrl ||
+    isProductionDesktopPlatformHostname(platformUrl.hostname)
+  ) {
     return "production";
   }
   if (platformUrl.hostname === "staging-app.omby.ai") {
@@ -124,11 +132,38 @@ function addDerivedOrigin(
   origins.add(deriveCompanionUrl(platformUrl, target).origin);
 }
 
-function allowedOriginsForPlatformUrl(platformUrl: URL): ReadonlySet<string> {
+function allowedOriginsForPlatformUrl(
+  platformUrl: URL,
+  environment: DesktopEnvironment,
+): ReadonlySet<string> {
   const origins = new Set<string>([platformUrl.origin]);
+  if (environment === "production") {
+    for (const compatiblePlatformUrl of desktopDomains.compatiblePlatformUrls) {
+      origins.add(new URL(compatiblePlatformUrl).origin);
+    }
+  }
   addDerivedOrigin(origins, platformUrl, "www");
   addDerivedOrigin(origins, platformUrl, "api");
   return origins;
+}
+
+function authCookieUrlsForPlatformUrl(
+  platformUrl: URL,
+  webUrl: URL,
+  environment: DesktopEnvironment,
+): readonly URL[] {
+  if (environment !== "production") {
+    return [webUrl, platformUrl];
+  }
+
+  const urls = [
+    webUrl,
+    ...desktopDomains.compatiblePlatformUrls
+      .map((url) => new URL(url))
+      .filter((url) => url.origin !== platformUrl.origin),
+    platformUrl,
+  ];
+  return [...new Map(urls.map((url) => [url.origin, url])).values()];
 }
 
 function deriveCompanionUrl(platformUrl: URL, target: "api" | "www"): URL {
@@ -151,13 +186,19 @@ export function resolveDesktopConfig(rawPlatformUrl?: string): DesktopConfig {
   const hasExplicitUrl = Boolean(platformUrlSource?.trim());
   const platformUrl = parsePlatformUrl(platformUrlSource);
   const environment = environmentForPlatformUrl(platformUrl, hasExplicitUrl);
+  const webUrl = deriveCompanionUrl(platformUrl, "www");
 
   return {
     platformUrl,
-    webUrl: deriveCompanionUrl(platformUrl, "www"),
+    webUrl,
     environment,
     identity: identityForEnvironment(environment),
     sessionPartition: `persist:vm0-desktop-${environment}`,
-    allowedAppOrigins: allowedOriginsForPlatformUrl(platformUrl),
+    allowedAppOrigins: allowedOriginsForPlatformUrl(platformUrl, environment),
+    authCookieUrls: authCookieUrlsForPlatformUrl(
+      platformUrl,
+      webUrl,
+      environment,
+    ),
   };
 }

--- a/turbo/apps/desktop/src/desktop-api-base-url.ts
+++ b/turbo/apps/desktop/src/desktop-api-base-url.ts
@@ -1,6 +1,16 @@
 // This module must stay loadable by the bootstrap entry: keep it free of
 // workspace (`@vm0/*`) and non-Electron package imports.
 
+import desktopDomains from "./desktop-domains.json";
+
+const PRODUCTION_PLATFORM_HOSTNAMES = new Set(
+  desktopDomains.compatiblePlatformUrls.map((url) => new URL(url).hostname),
+);
+
+export function isProductionDesktopPlatformHostname(hostname: string): boolean {
+  return PRODUCTION_PLATFORM_HOSTNAMES.has(hostname);
+}
+
 function replaceHostPrefix(hostname: string, target: "api" | "www"): string {
   return hostname.replace(/(^|-)(api|app|platform|www)\./, `$1${target}.`);
 }
@@ -11,6 +21,10 @@ export function rewriteDesktopServiceHostname(
   hostname: string,
   target: "api" | "www",
 ): string {
+  if (isProductionDesktopPlatformHostname(hostname)) {
+    return new URL(desktopDomains.productionServiceUrls[target]).hostname;
+  }
+
   const rewrittenHostname = replaceHostPrefix(hostname, target);
   if (target !== "api" || !CLOUDFLARE_PREVIEW_APP_HOSTNAME.test(hostname)) {
     return rewrittenHostname;

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -38,9 +38,8 @@ interface DesktopAuthSessionOptions {
   /** Pre-resolved API base URL (`resolveComputerUseApiBaseUrl(platformUrl)`). */
   readonly apiBaseUrl: string;
   /**
-   * Cookie-merge URLs for auth-state requests, in precedence order
-   * (`[webUrl, platformUrl]`). The per-request URL is appended internally so
-   * its cookies win last, matching the original `[webUrl, platformUrl, requestUrl]`.
+   * Cookie-merge URLs for auth-state requests, in precedence order. The
+   * per-request URL is appended internally so its cookies win last.
    */
   readonly cookieUrls: readonly URL[];
   readonly cookieSource: DesktopSessionCookieSource;

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -72,6 +72,10 @@ const productionConfig: DesktopConfig = {
   },
   sessionPartition: "persist:vm0-desktop-production",
   allowedAppOrigins: new Set(["https://app.vm0.ai"]),
+  authCookieUrls: [
+    new URL("https://www.vm0.ai"),
+    new URL("https://app.vm0.ai"),
+  ],
 };
 
 interface CapturedUpdateOptions {

--- a/turbo/apps/desktop/src/desktop-domains.json
+++ b/turbo/apps/desktop/src/desktop-domains.json
@@ -1,0 +1,8 @@
+{
+  "defaultPlatformUrl": "https://app.okou.ai",
+  "compatiblePlatformUrls": ["https://app.okou.ai", "https://app.vm0.ai"],
+  "productionServiceUrls": {
+    "api": "https://api.vm0.ai",
+    "www": "https://www.vm0.ai"
+  }
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -281,7 +281,7 @@ function getAuthSession(): DesktopAuthSession {
 
   authSession = new DesktopAuthSession({
     apiBaseUrl: desktopApiBaseUrl,
-    cookieUrls: [config.webUrl, config.platformUrl],
+    cookieUrls: config.authCookieUrls,
     cookieSource: session.fromPartition(config.sessionPartition),
     addClientHeaders: addDesktopClientHeaders,
     tokenUrl: desktopAuthTokenUrl,

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -187,7 +187,7 @@ describe("resolveDesktopConfig", () => {
   it("defaults to production", () => {
     const config = resolveDesktopConfig("");
 
-    expect(config.platformUrl.toString()).toBe("https://app.vm0.ai/");
+    expect(config.platformUrl.toString()).toBe("https://app.okou.ai/");
     expect(config.webUrl.toString()).toBe("https://www.vm0.ai/");
     expect(config.environment).toBe("production");
     expect(config.identity).toMatchObject({
@@ -198,8 +198,33 @@ describe("resolveDesktopConfig", () => {
     expect(config.sessionPartition).toBe("persist:vm0-desktop-production");
     expect([...config.allowedAppOrigins].sort()).toStrictEqual([
       "https://api.vm0.ai",
+      "https://app.okou.ai",
       "https://app.vm0.ai",
       "https://www.vm0.ai",
+    ]);
+    expect(config.authCookieUrls.map((url) => url.origin)).toStrictEqual([
+      "https://www.vm0.ai",
+      "https://app.vm0.ai",
+      "https://app.okou.ai",
+    ]);
+  });
+
+  it("keeps the legacy VM0 app origin in production", () => {
+    const config = resolveDesktopConfig("https://app.vm0.ai/");
+
+    expect(config.environment).toBe("production");
+    expect(config.webUrl.toString()).toBe("https://www.vm0.ai/");
+    expect(config.sessionPartition).toBe("persist:vm0-desktop-production");
+    expect([...config.allowedAppOrigins].sort()).toStrictEqual([
+      "https://api.vm0.ai",
+      "https://app.okou.ai",
+      "https://app.vm0.ai",
+      "https://www.vm0.ai",
+    ]);
+    expect(config.authCookieUrls.map((url) => url.origin)).toStrictEqual([
+      "https://www.vm0.ai",
+      "https://app.okou.ai",
+      "https://app.vm0.ai",
     ]);
   });
 
@@ -611,6 +636,9 @@ describe("desktop auth", () => {
 
 describe("computer use desktop runtime", () => {
   it("derives the API backend URL from platform URLs", () => {
+    expect(resolveComputerUseApiBaseUrl(new URL("https://app.okou.ai"))).toBe(
+      "https://api.vm0.ai",
+    );
     expect(resolveComputerUseApiBaseUrl(new URL("https://app.vm0.ai"))).toBe(
       "https://api.vm0.ai",
     );

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -95,6 +95,10 @@ const activeChatConnectorActionState$ = state<ActiveChatConnectorAction | null>(
   null,
 );
 
+function isCompatibleProductionAppOrigin(origin: string): boolean {
+  return origin === "https://app.okou.ai" || origin === "https://app.vm0.ai";
+}
+
 export const activeChatConnectorAction$ = computed((get) => {
   return get(activeChatConnectorActionState$);
 });
@@ -112,7 +116,14 @@ export function parseConnectorAuthorizeUrl(
     return null;
   }
   const url = new URL(value, appOrigin);
-  if (url.origin !== appOrigin && url.origin !== canonicalAppOrigin) {
+  const usesCompatibleProductionOrigin =
+    isCompatibleProductionAppOrigin(appOrigin) &&
+    isCompatibleProductionAppOrigin(url.origin);
+  if (
+    url.origin !== appOrigin &&
+    url.origin !== canonicalAppOrigin &&
+    !usesCompatibleProductionOrigin
+  ) {
     return null;
   }
 

--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -94,9 +94,11 @@ function hasExplicitUrlOrigin(value: string): boolean {
 }
 
 function isPlatformHostname(hostname: string): boolean {
-  const platformDomain = ["vm0.ai", "vm6.ai", "vm7.ai"].some((suffix) => {
-    return hostname === suffix || hostname.endsWith(`.${suffix}`);
-  });
+  const platformDomain = ["vm0.ai", "okou.ai", "vm6.ai", "vm7.ai"].some(
+    (suffix) => {
+      return hostname === suffix || hostname.endsWith(`.${suffix}`);
+    },
+  );
   return platformDomain && /(^|-)(platform|app|www|api)\./u.test(hostname);
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -90,9 +90,11 @@ function hasExplicitUrlOrigin(value: string): boolean {
 }
 
 function isPlatformPermissionHostname(hostname: string): boolean {
-  const isPlatformDomain = ["vm0.ai", "vm6.ai", "vm7.ai"].some((suffix) => {
-    return hostname === suffix || hostname.endsWith(`.${suffix}`);
-  });
+  const isPlatformDomain = ["vm0.ai", "okou.ai", "vm6.ai", "vm7.ai"].some(
+    (suffix) => {
+      return hostname === suffix || hostname.endsWith(`.${suffix}`);
+    },
+  );
   if (!isPlatformDomain) {
     return false;
   }

--- a/turbo/apps/platform/src/signals/chat-page/platform-action-url.ts
+++ b/turbo/apps/platform/src/signals/chat-page/platform-action-url.ts
@@ -54,9 +54,11 @@ function hasExplicitUrlOrigin(value: string): boolean {
 }
 
 function isPlatformHostname(hostname: string): boolean {
-  const isPlatformDomain = ["vm0.ai", "vm6.ai", "vm7.ai"].some((suffix) => {
-    return hostname === suffix || hostname.endsWith(`.${suffix}`);
-  });
+  const isPlatformDomain = ["vm0.ai", "okou.ai", "vm6.ai", "vm7.ai"].some(
+    (suffix) => {
+      return hostname === suffix || hostname.endsWith(`.${suffix}`);
+    },
+  );
   if (!isPlatformDomain) {
     return false;
   }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -909,7 +909,7 @@ describe("chat event action cards", () => {
   it("renders canonical user text literally and assistant actions on alternate origins", async () => {
     const previousUrl = window.location.href;
     const threadId = "e4000000-0000-4000-a000-000000000004";
-    window.location.href = `https://app.okou.ai/chats/${threadId}`;
+    window.location.href = `https://app.vm0.ai/chats/${threadId}`;
     context.signal.addEventListener(
       "abort",
       () => {
@@ -918,7 +918,7 @@ describe("chat event action cards", () => {
       { once: true },
     );
 
-    const canonicalUrl = `https://app.vm0.ai/connectors/slack/authorize?agentId=${AGENT_ID}`;
+    const canonicalUrl = `https://app.okou.ai/connectors/slack/authorize?agentId=${AGENT_ID}`;
     const untrustedUrl = `https://evil.example.test/connectors/slack/authorize?agentId=${AGENT_ID}`;
     mockConnectorCatalogStatus([
       publicConnectorStatusItem({
@@ -1533,7 +1533,7 @@ describe("chat event action cards", () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "c0000000-0000-4000-a000-000000000018";
     const mailDraftId = "c0000000-0000-4000-a000-000000000019";
-    const mailDraftUrl = `https://app.vm0.ai/mail/drafts/${mailDraftId}`;
+    const mailDraftUrl = `https://app.okou.ai/mail/drafts/${mailDraftId}`;
     const createdAt = "2026-07-14T10:00:00.000Z";
     let deleted = false;
     let draftRequests = 0;
@@ -1852,7 +1852,7 @@ describe("chat event action cards", () => {
     mockNow();
     const user = userEvent.setup({ delay: null });
     const connectorAuthorizeUrl = `${window.location.origin}/connectors/github/authorize?agentId=${AGENT_ID}`;
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=slack&ref=github&permission=catalog.analytics%3Aread&action=allow&expiresIn=24h`;
+    const permissionAuthorizeUrl = `https://app.okou.ai/agents/${AGENT_ID}/permissions?connectorSlug=slack&ref=github&permission=catalog.analytics%3Aread&action=allow&expiresIn=24h`;
     let capturedPermissionGrantBody: unknown = null;
 
     context.mocks.data.connectors([
@@ -3225,7 +3225,7 @@ describe("chat event action cards", () => {
 
   it("renders delegated computer use authorization links as action cards", async () => {
     const authorizationUrl =
-      "https://app.vm0.ai/computer-use/authorize/vm0_computer_use_authorization_request_test";
+      "https://app.okou.ai/computer-use/authorize/vm0_computer_use_authorization_request_test";
 
     mockChatLifecycle(context, {
       threadId: "e4000000-0000-4000-a000-000000000020",


### PR DESCRIPTION
## Summary

- make `https://app.okou.ai` the canonical production App URL in release workflows, API-generated links, and CLI guidance while retaining `https://app.vm0.ai` compatibility
- make Desktop default to Okou without changing its production identity, session partition, or VM0-backed auth/API service URLs
- accept trusted action links across both Okou and legacy VM0 production origins

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- workspace type checks for API, App, and all remaining packages
- targeted Desktop, Platform, and CLI tests
- GitHub workflow shell tests for deploy and API environment configuration
- `pnpm --filter @vm0/desktop run build:electron`
- production and preview Desktop identity assertions

## Deployment notes

- Clerk primary domain, `accounts.vm0.ai`, and `api.vm0.ai` are unchanged in this PR.
- Desktop auth and API traffic continue to use the existing VM0 technical domains; legacy auth cookies are checked before the new Okou App origin to preserve session continuity.
- Confirm the Telegram Login Widget/BotFather domain allows `app.okou.ai` before the production API release because the production `APP_URL` now defaults to Okou.
