### PR TITLE
fix(desktop): defer active background updates

### DIFF
--- a/turbo/apps/desktop/src/bootstrap-degraded.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
     },
     autoUpdater: {
       quitAndInstall: vi.fn(),
+      on: vi.fn(),
       once: vi.fn(),
       removeListener: vi.fn(),
     },

--- a/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS,
-  shouldNotifyUserForDesktopUpdate,
+  shouldDeferDesktopUpdate,
 } from "./desktop-auto-update-policy";
 import type {
   ComputerUseHostRuntimeState,
@@ -51,12 +51,12 @@ function hostState(
 
 describe("desktop auto-update policy", () => {
   it("allows silent restart when there is no command activity", () => {
-    expect(shouldNotifyUserForDesktopUpdate(hostState({}), now)).toBe(false);
+    expect(shouldDeferDesktopUpdate(hostState({}), now)).toBe(false);
   });
 
   it("allows silent restart when the last command is older than 30 minutes", () => {
     expect(
-      shouldNotifyUserForDesktopUpdate(
+      shouldDeferDesktopUpdate(
         hostState({
           lastCommandAt: isoAgo(DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS + 1),
         }),
@@ -65,9 +65,9 @@ describe("desktop auto-update policy", () => {
     ).toBe(false);
   });
 
-  it("notifies when the last command completed within 30 minutes", () => {
+  it("defers when the last command completed within 30 minutes", () => {
     expect(
-      shouldNotifyUserForDesktopUpdate(
+      shouldDeferDesktopUpdate(
         hostState({
           lastCommandAt: isoAgo(DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS - 1),
         }),
@@ -76,9 +76,9 @@ describe("desktop auto-update policy", () => {
     ).toBe(true);
   });
 
-  it("notifies when a local command log entry completed within 30 minutes", () => {
+  it("defers when a local command log entry completed within 30 minutes", () => {
     expect(
-      shouldNotifyUserForDesktopUpdate(
+      shouldDeferDesktopUpdate(
         hostState({
           localCommandLog: [
             commandEntry({
@@ -92,9 +92,9 @@ describe("desktop auto-update policy", () => {
     ).toBe(true);
   });
 
-  it("notifies while a command is still running", () => {
+  it("defers while a command is still running", () => {
     expect(
-      shouldNotifyUserForDesktopUpdate(
+      shouldDeferDesktopUpdate(
         hostState({
           localCommandLog: [
             commandEntry({
@@ -111,7 +111,7 @@ describe("desktop auto-update policy", () => {
 
   it("ignores malformed timestamps", () => {
     expect(
-      shouldNotifyUserForDesktopUpdate(
+      shouldDeferDesktopUpdate(
         hostState({
           lastCommandAt: "not-a-date",
           localCommandLog: [

--- a/turbo/apps/desktop/src/desktop-auto-update-policy.ts
+++ b/turbo/apps/desktop/src/desktop-auto-update-policy.ts
@@ -18,7 +18,7 @@ function isRecentTimestamp(value: string | null, nowMs: number): boolean {
   );
 }
 
-export function shouldNotifyUserForDesktopUpdate(
+export function shouldDeferDesktopUpdate(
   hostState: ComputerUseHostRuntimeState,
   nowMs = Date.now(),
 ): boolean {

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -11,6 +11,7 @@ import {
 const mocks = vi.hoisted(() => {
   type AutoUpdaterListener = (...args: readonly unknown[]) => void;
   const autoUpdaterListeners = new Map<string, Set<AutoUpdaterListener>>();
+  const autoUpdaterOnceListeners = new Map<string, Set<AutoUpdaterListener>>();
 
   function addAutoUpdaterListener(
     eventName: string,
@@ -21,11 +22,21 @@ const mocks = vi.hoisted(() => {
     autoUpdaterListeners.set(eventName, listeners);
   }
 
+  function addAutoUpdaterOnceListener(
+    eventName: string,
+    listener: AutoUpdaterListener,
+  ): void {
+    const listeners = autoUpdaterOnceListeners.get(eventName) ?? new Set();
+    listeners.add(listener);
+    autoUpdaterOnceListeners.set(eventName, listeners);
+  }
+
   function removeAutoUpdaterListener(
     eventName: string,
     listener: AutoUpdaterListener,
   ): void {
     autoUpdaterListeners.get(eventName)?.delete(listener);
+    autoUpdaterOnceListeners.get(eventName)?.delete(listener);
   }
 
   return {
@@ -33,10 +44,12 @@ const mocks = vi.hoisted(() => {
     autoUpdater: {
       checkForUpdates: vi.fn<() => void>(),
       quitAndInstall: vi.fn(),
-      once: vi.fn(addAutoUpdaterListener),
+      on: vi.fn(addAutoUpdaterListener),
+      once: vi.fn(addAutoUpdaterOnceListener),
       removeListener: vi.fn(removeAutoUpdaterListener),
     },
     autoUpdaterListeners,
+    autoUpdaterOnceListeners,
     dialog: {
       showMessageBox: vi.fn<() => Promise<{ response: number }>>(),
     },
@@ -131,8 +144,11 @@ function emitAutoUpdaterEvent(
   ...args: readonly unknown[]
 ): void {
   const listeners = [...(mocks.autoUpdaterListeners.get(eventName) ?? [])];
-  mocks.autoUpdaterListeners.delete(eventName);
-  listeners.forEach((listener) => {
+  const onceListeners = [
+    ...(mocks.autoUpdaterOnceListeners.get(eventName) ?? []),
+  ];
+  mocks.autoUpdaterOnceListeners.delete(eventName);
+  [...listeners, ...onceListeners].forEach((listener) => {
     listener(...args);
   });
 }
@@ -146,6 +162,7 @@ describe("desktop auto-updates", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.autoUpdaterListeners.clear();
+    mocks.autoUpdaterOnceListeners.clear();
     mocks.app.isPackaged = true;
     mocks.dialog.showMessageBox.mockResolvedValue({ response: 1 });
     stubDesktopAutoUpdatePlatform();
@@ -236,7 +253,7 @@ describe("desktop auto-updates", () => {
     consoleError.mockRestore();
   });
 
-  it("prompts instead of silently restarting during recent command activity", async () => {
+  it("defers without prompting during recent command activity", async () => {
     const { updateOptions, prepareForQuitAndInstall } =
       installAndCaptureUpdateOptions(() => ({
         ...OFFLINE_COMPUTER_USE_HOST_STATE,
@@ -246,20 +263,66 @@ describe("desktop auto-updates", () => {
     updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
     await flushDownloadedUpdateCallback();
 
-    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Zero 1.2.3",
-      }),
-    );
+    expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
     expect(prepareForQuitAndInstall).not.toHaveBeenCalled();
     expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
   });
 
-  it("prompts when Computer Use activity inspection fails", async () => {
+  it("installs a deferred update on the next check after activity stops", async () => {
+    let hostState: ComputerUseHostRuntimeState = {
+      ...OFFLINE_COMPUTER_USE_HOST_STATE,
+      lastCommandAt: new Date().toISOString(),
+    };
+    const { updateOptions, prepareForQuitAndInstall } =
+      installAndCaptureUpdateOptions(() => hostState);
+
+    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    await flushDownloadedUpdateCallback();
+
+    hostState = OFFLINE_COMPUTER_USE_HOST_STATE;
+    emitAutoUpdaterEvent("checking-for-update");
+
+    await vi.waitFor(() => {
+      expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+      expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("keeps a downloaded update pending across active checks", async () => {
+    let hostState: ComputerUseHostRuntimeState = {
+      ...OFFLINE_COMPUTER_USE_HOST_STATE,
+      lastCommandAt: new Date().toISOString(),
+    };
+    const { updateOptions, prepareForQuitAndInstall } =
+      installAndCaptureUpdateOptions(() => hostState);
+
+    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    emitAutoUpdaterEvent("checking-for-update");
+    emitAutoUpdaterEvent("checking-for-update");
+    await flushDownloadedUpdateCallback();
+
+    expect(prepareForQuitAndInstall).not.toHaveBeenCalled();
+    expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+
+    hostState = OFFLINE_COMPUTER_USE_HOST_STATE;
+    emitAutoUpdaterEvent("checking-for-update");
+
+    await vi.waitFor(() => {
+      expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+      expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("defers when Computer Use activity inspection fails", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let inspectionFails = true;
     const { updateOptions, prepareForQuitAndInstall } =
       installAndCaptureUpdateOptions(() => {
-        throw new Error("state unavailable");
+        if (inspectionFails) {
+          throw new Error("state unavailable");
+        }
+        return OFFLINE_COMPUTER_USE_HOST_STATE;
       });
 
     updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
@@ -269,14 +332,52 @@ describe("desktop auto-updates", () => {
       "Unable to inspect Computer Use activity for update",
       expect.any(Error),
     );
-    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Zero 1.2.3",
-      }),
-    );
+    expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
     expect(prepareForQuitAndInstall).not.toHaveBeenCalled();
     expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
 
+    inspectionFails = false;
+    emitAutoUpdaterEvent("checking-for-update");
+
+    await vi.waitFor(() => {
+      expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+      expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
     warn.mockRestore();
+  });
+
+  it("starts only one install while an update restart is in progress", async () => {
+    const { updateOptions, prepareForQuitAndInstall } =
+      installAndCaptureUpdateOptions(() => OFFLINE_COMPUTER_USE_HOST_STATE);
+    let finishPreparation: (() => void) | undefined;
+    prepareForQuitAndInstall.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPreparation = resolve;
+        }),
+    );
+
+    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    await vi.waitFor(() => {
+      expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    emitAutoUpdaterEvent("checking-for-update");
+    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    await flushDownloadedUpdateCallback();
+
+    expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+    expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+
+    finishPreparation?.();
+    await vi.waitFor(() => {
+      expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    emitAutoUpdaterEvent("checking-for-update");
+    await flushDownloadedUpdateCallback();
+    expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+    expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
   });
 });

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -1,12 +1,8 @@
 import { app, autoUpdater, dialog } from "electron";
-import {
-  UpdateSourceType,
-  updateElectronApp,
-  type IUpdateInfo,
-} from "update-electron-app";
+import { UpdateSourceType, updateElectronApp } from "update-electron-app";
 
 import type { DesktopConfig } from "./config";
-import { shouldNotifyUserForDesktopUpdate } from "./desktop-auto-update-policy";
+import { shouldDeferDesktopUpdate } from "./desktop-auto-update-policy";
 import {
   desktopUpdateFeedBaseUrl,
   shouldInstallDesktopAutoUpdates,
@@ -25,28 +21,6 @@ async function restartForUpdate(
 ): Promise<void> {
   await prepareForQuitAndInstall();
   autoUpdater.quitAndInstall();
-}
-
-async function promptToRestartForUpdate(
-  info: IUpdateInfo,
-  prepareForQuitAndInstall: () => Promise<void>,
-): Promise<void> {
-  const result = await dialog.showMessageBox({
-    type: "info",
-    buttons: ["Restart", "Later"],
-    defaultId: 0,
-    cancelId: 1,
-    title: "Update Ready",
-    message: info.releaseName,
-    detail:
-      "A new version has been downloaded. Restart Zero Computer Use to install it.",
-  });
-
-  if (result.response !== 0) {
-    return;
-  }
-
-  await restartForUpdate(prepareForQuitAndInstall);
 }
 
 async function notifyNoDesktopUpdatesFound(): Promise<void> {
@@ -71,27 +45,15 @@ async function notifyDesktopUpdateCheckFailed(error: unknown): Promise<void> {
   });
 }
 
-function shouldPromptForDownloadedUpdate(
+function shouldDeferDownloadedUpdate(
   getComputerUseHostState: () => ComputerUseHostRuntimeState,
 ): boolean {
   try {
-    return shouldNotifyUserForDesktopUpdate(getComputerUseHostState());
+    return shouldDeferDesktopUpdate(getComputerUseHostState());
   } catch (error) {
     console.warn("Unable to inspect Computer Use activity for update", error);
     return true;
   }
-}
-
-async function handleDownloadedUpdate(
-  info: IUpdateInfo,
-  options: DesktopAutoUpdateOptions,
-): Promise<void> {
-  if (shouldPromptForDownloadedUpdate(options.getComputerUseHostState)) {
-    await promptToRestartForUpdate(info, options.prepareForQuitAndInstall);
-    return;
-  }
-
-  await restartForUpdate(options.prepareForQuitAndInstall);
 }
 
 export function installDesktopAutoUpdates(
@@ -114,6 +76,35 @@ export function installDesktopAutoUpdates(
     return false;
   }
 
+  let downloadedUpdatePending = false;
+  let updateInstallationInProgress = false;
+
+  const installPendingUpdateWhenInactive = async (): Promise<void> => {
+    if (
+      !downloadedUpdatePending ||
+      updateInstallationInProgress ||
+      shouldDeferDownloadedUpdate(options.getComputerUseHostState)
+    ) {
+      return;
+    }
+
+    updateInstallationInProgress = true;
+    try {
+      await restartForUpdate(options.prepareForQuitAndInstall);
+      downloadedUpdatePending = false;
+    } finally {
+      updateInstallationInProgress = false;
+    }
+  };
+
+  const tryInstallPendingUpdate = (): void => {
+    void installPendingUpdateWhenInactive().catch((error) => {
+      console.error("Desktop update install failed", error);
+    });
+  };
+
+  autoUpdater.on("checking-for-update", tryInstallPendingUpdate);
+
   updateElectronApp({
     updateSource: {
       type: UpdateSourceType.StaticStorage,
@@ -121,10 +112,9 @@ export function installDesktopAutoUpdates(
     },
     updateInterval: "30 minutes",
     notifyUser: true,
-    onNotifyUser: (info) => {
-      void handleDownloadedUpdate(info, options).catch((error) => {
-        console.error("Desktop update restart prompt failed", error);
-      });
+    onNotifyUser: () => {
+      downloadedUpdatePending = true;
+      tryInstallPendingUpdate();
     },
   });
   return true;


### PR DESCRIPTION
## Summary

- remove the background update restart prompt when Computer Use is active
- retain downloaded updates as pending and re-evaluate them on subsequent updater checks
- fail closed when activity inspection fails and prevent concurrent install flows
- preserve user-initiated update-check status and error dialogs

## Why

The existing policy correctly avoided a silent restart during recent Computer Use activity, but replaced that interruption with an `Update Ready` dialog. Background updates should wait for an inactive period without interrupting the user.

## User impact

Downloaded Desktop updates now install silently only when the existing Computer Use activity policy considers the host inactive. Active users see no update prompt; the app retries the pending update on later checks.

## Validation

- `pnpm -F @vm0/desktop test` — 35 files, 311 tests passed
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop build:electron` — includes the bootstrap bundle guard
- Prettier on all changed files
- `pnpm knip --workspace @vm0/desktop` — reports the existing `@sentry/cli` finding from the unchanged Desktop package; the dependency is used by `scripts/upload-sentry-artifacts.js`
- `pnpm knip` — reports the repository's existing unused files, exports, and configuration hints

Closes #26351