### PR TITLE
fix(runner): restrict model usage to supported operations

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -31,7 +31,7 @@ Request context
 - ``SUPPRESS_REQUEST_BODY_CAPTURE``: ``bool`` written by auth.base request-size
   handling. Read by body capture to mark oversized request bodies truncated.
 - ``CLI_AGENT_TYPE``: ``str`` copied from registry VM info, defaulting to
-  ``"claude-code"``. Read by model-provider usage protocol selection.
+  ``"claude-code"``. Read by provider output-timing instrumentation.
 - ``BROWSER_USER_AGENT``: ``bool`` written during request classification when
   the request matches the short-term browser passthrough User-Agent heuristic.
   Read by request dispatch to skip connector firewall handling and managed

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -19,7 +19,7 @@ import tempfile
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NoReturn
+from typing import Literal, NoReturn, assert_never
 
 from mitmproxy import connection, ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
@@ -55,6 +55,7 @@ import http_local_responses
 import http_network_log
 import matching
 import mitmproxy_compat
+import model_usage_eligibility
 import platform_api
 import registry
 import request_classification
@@ -1009,7 +1010,11 @@ async def _try_firewall_request_stream_from_headers(
         fall_back()
         return
 
-    _maybe_normalize_accept_encoding_for_body_inspection(flow, allow, vm_info)
+    model_usage_candidate = _maybe_normalize_accept_encoding_for_body_inspection(
+        flow,
+        allow,
+        vm_info,
+    )
     _start_request_timing(flow)
     expected_run_id = flow_metadata.run_id(flow.metadata)
     admitted_server = flow.server_conn
@@ -1042,6 +1047,7 @@ async def _try_firewall_request_stream_from_headers(
         is_billable_firewall(allow.name, vm_info),
         _is_model_provider_usage_observable(allow.name, vm_info),
     )
+    model_usage_eligibility.record_provider_continuation(flow, model_usage_candidate)
     try:
         request_classification.cache_classification(flow, classification)
         flow.metadata[_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS] = True
@@ -1400,7 +1406,11 @@ async def request(flow: http.HTTPFlow) -> None:
                     error=host_policy_error,
                 )
                 return
-            _maybe_normalize_accept_encoding_for_body_inspection(flow, allow, vm_info)
+            model_usage_candidate = _maybe_normalize_accept_encoding_for_body_inspection(
+                flow,
+                allow,
+                vm_info,
+            )
             terminal_usage.track_flow_if_needed(
                 flow,
                 is_billable_firewall(allow.name, vm_info),
@@ -1430,6 +1440,10 @@ async def request(flow: http.HTTPFlow) -> None:
                 auth_base_forwarder.release_forward_request_admission_from_flow(flow)
                 terminal_usage.release_tracked_flow(flow)
             elif auth_result is FirewallAuthHandlingResult.CONTINUE_UPSTREAM:
+                model_usage_eligibility.record_provider_continuation(
+                    flow,
+                    model_usage_candidate,
+                )
                 await _prepare_codex_catalog_request_with_upstream_revalidation(
                     flow,
                     allow,
@@ -1437,6 +1451,11 @@ async def request(flow: http.HTTPFlow) -> None:
                     admitted_server=admitted_server,
                     require_connected=require_connected,
                     request_end_stream=True,
+                )
+            elif auth_result is FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE:
+                model_usage_eligibility.record_provider_continuation(
+                    flow,
+                    model_usage_candidate,
                 )
             return
 
@@ -1459,6 +1478,7 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         aws_sigv4_body_admission.release_from_flow(flow)
+        model_usage_eligibility.release_flow_state(flow)
         terminal_usage.release_tracked_flow(flow)
         raise
     finally:
@@ -1480,26 +1500,43 @@ def _maybe_normalize_accept_encoding_for_body_inspection(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     vm_info: dict,
-) -> None:
-    if _is_websocket_upgrade_request(flow):
+) -> model_usage_eligibility.ModelUsageRequest | None:
+    websocket_upgrade_request = _is_websocket_upgrade_request(flow)
+    if websocket_upgrade_request:
         flow.metadata[metadata_keys.WEBSOCKET_UPGRADE_REQUEST] = True
-    if _expects_http_response_body_usage_inspection(flow, allow, vm_info):
+    model_usage_candidate = None
+    if _is_model_provider_usage_observable(allow.name, vm_info):
+        model_usage_candidate = model_usage_eligibility.classify_request_candidate(
+            flow,
+            websocket_upgrade_request=websocket_upgrade_request,
+        )
+    if _expects_http_response_body_usage_inspection(
+        flow,
+        allow,
+        vm_info,
+        model_usage_candidate=model_usage_candidate,
+        websocket_upgrade_request=websocket_upgrade_request,
+    ):
         response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
             flow.request.headers
         )
+    return model_usage_candidate
 
 
 def _expects_http_response_body_usage_inspection(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     vm_info: dict,
+    *,
+    model_usage_candidate: model_usage_eligibility.ModelUsageRequest | None,
+    websocket_upgrade_request: bool,
 ) -> bool:
     if flow.request.method.upper() in _HTTP_RESPONSE_BODYLESS_METHODS:
         return False
-    if _is_websocket_upgrade_request(flow):
+    if websocket_upgrade_request:
         return False
     if _is_model_provider_usage_observable(allow.name, vm_info):
-        return True
+        return model_usage_candidate is not None
     return is_billable_firewall(allow.name, vm_info) and usage.has_connector_response_parser(
         allow.name
     )
@@ -1570,19 +1607,16 @@ def websocket_message(flow: http.HTTPFlow) -> None:
 
     message = flow.websocket.messages[-1]
     websocket_retention.schedule_message_trim(flow)
-    if not response_streaming.is_model_websocket_usage_enabled(flow):
+    if not model_usage_eligibility.is_websocket_active(flow):
         return
-    uses_openai_responses = response_streaming.model_usage_protocol(flow) == "openai_responses"
     if getattr(message, "from_client", False):
-        if uses_openai_responses:
-            body = message.content.encode() if isinstance(message.content, str) else message.content
-            event_type = usage.inspect_openai_responses_event_type_json(body)
-            codex_output_timing.observe_client_event(flow, event_type, message.timestamp)
+        body = message.content.encode() if isinstance(message.content, str) else message.content
+        event_type = usage.inspect_openai_responses_event_type_json(body)
+        codex_output_timing.observe_client_event(flow, event_type, message.timestamp)
         return
     body = message.content.encode() if isinstance(message.content, str) else message.content
     event = usage.inspect_openai_responses_event_json(body)
-    if uses_openai_responses:
-        codex_output_timing.observe_server_event(flow, event.event_type)
+    codex_output_timing.observe_server_event(flow, event.event_type)
     response_streaming.feed_model_websocket_usage(flow, event)
 
 
@@ -1619,6 +1653,7 @@ def _release_terminal_flow_state(
     if release_tracking:
         websocket_retention.release_terminal_messages(flow)
         terminal_usage.release_model_websocket_terminal_state(flow)
+        model_usage_eligibility.release_flow_state(flow)
     request_classification.pop_cached_classification(flow)
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     flow.metadata.pop(metadata_keys.FIREWALL_AUTH_PROBE_FAILURE, None)
@@ -1639,7 +1674,7 @@ def websocket_end(flow: http.HTTPFlow) -> None:
     """Report model-provider usage extracted from a WebSocket-upgraded response."""
     try:
         run_id = flow_metadata.run_id(flow.metadata)
-        if run_id:
+        if run_id and model_usage_eligibility.is_websocket_active(flow):
             terminal_usage.report_model_provider_usage_once(flow, run_id)
     finally:
         _release_terminal_flow_state(flow, release_tracking=True)
@@ -1660,7 +1695,7 @@ def response(flow: http.HTTPFlow) -> Awaitable[None] | None:
 
     release_tracking = True
     try:
-        release_tracking = not response_streaming.is_model_websocket_usage_enabled(flow)
+        release_tracking = not model_usage_eligibility.is_websocket_active(flow)
     finally:
         _release_terminal_flow_state(
             flow,
@@ -1677,7 +1712,7 @@ async def _complete_response(
     release_tracking = True
     try:
         await continuation
-        release_tracking = not response_streaming.is_model_websocket_usage_enabled(flow)
+        release_tracking = not model_usage_eligibility.is_websocket_active(flow)
     finally:
         _release_terminal_flow_state(
             flow,
@@ -1785,13 +1820,14 @@ def _finish_response_handling(
     # For non-streaming responses, fall back to extracting usage from the
     # buffered JSON body only for legacy/test flows that did not pass through
     # responseheaders() and therefore have no incremental extractor.
+    model_protocol = model_usage_eligibility.activated_protocol(flow)
     if (
-        not flow.metadata.get(metadata_keys.MODEL_JSON_USAGE_FINALIZED)
+        model_protocol is not None
+        and not flow.metadata.get(metadata_keys.MODEL_JSON_USAGE_FINALIZED)
         and not flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
         and stream_buf
         and response_streaming.uses_model_json_fallback(flow)
     ):
-        model_protocol = response_streaming.model_usage_protocol(flow)
         if model_protocol == "openai_responses":
             json_usage, json_error = usage.extract_openai_responses_usage_with_error_from_json(
                 bytes(stream_buf),
@@ -1804,11 +1840,13 @@ def _finish_response_handling(
                     flow.response.headers if flow.response else None,
                 )
             )
-        else:
+        elif model_protocol == "anthropic_messages":
             json_usage, json_error = usage.extract_anthropic_messages_usage_with_error_from_json(
                 bytes(stream_buf),
                 flow.response.headers if flow.response else None,
             )
+        else:
+            assert_never(model_protocol)
         if json_usage:
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = json_usage
         elif json_error is not None:

--- a/crates/runner/mitm-addon/src/model_usage_eligibility.py
+++ b/crates/runner/mitm-addon/src/model_usage_eligibility.py
@@ -1,0 +1,110 @@
+"""Model-provider request eligibility across mitmproxy hook phases.
+
+Lifecycle:
+- Request handling classifies a candidate from the stable original request and
+  keeps it local while firewall auth resolves.
+- Successful provider continuation records the candidate on the flow. HTTP
+  candidates are active immediately; WebSocket candidates remain pending.
+- Response-header handling activates a pending WebSocket candidate only after
+  validating the provider's 101 upgrade response.
+- Model response parsers, WebSocket extraction, and terminal reporting read the
+  activated protocol through this module.
+- Terminal flow cleanup releases all state owned here.
+
+The private metadata keys intentionally stay in this module. Other modules use
+the transition and read APIs so candidacy cannot be mistaken for activation.
+"""
+
+from typing import Literal, NamedTuple
+
+from mitmproxy import http
+
+import flow_metadata
+from runtime_url_parsing import split_runtime_url
+
+type ModelUsageProtocol = Literal[
+    "anthropic_messages",
+    "openai_chat_completions",
+    "openai_responses",
+]
+type ModelUsageTransport = Literal["http", "websocket"]
+
+_PROVIDER_REQUEST = "_model_usage_provider_request"
+_WEBSOCKET_ACTIVE = "_model_usage_websocket_active"
+
+
+class ModelUsageRequest(NamedTuple):
+    protocol: ModelUsageProtocol
+    transport: ModelUsageTransport
+
+
+def classify_request_candidate(
+    flow: http.HTTPFlow,
+    *,
+    websocket_upgrade_request: bool,
+) -> ModelUsageRequest | None:
+    """Return the supported model operation represented by the request."""
+    request_target = flow_metadata.original_url(flow.metadata) or flow.request.path
+    request_path = split_runtime_url(request_target).path.rstrip("/")
+    request_method = flow.request.method.upper()
+
+    if request_method == "POST":
+        if request_path.endswith("/chat/completions"):
+            return ModelUsageRequest("openai_chat_completions", "http")
+        if request_path.endswith("/responses"):
+            return ModelUsageRequest("openai_responses", "http")
+        if request_path.endswith("/messages"):
+            return ModelUsageRequest("anthropic_messages", "http")
+        return None
+
+    if (
+        request_method == "GET"
+        and websocket_upgrade_request
+        and request_path.endswith("/responses")
+    ):
+        return ModelUsageRequest("openai_responses", "websocket")
+    return None
+
+
+def record_provider_continuation(
+    flow: http.HTTPFlow,
+    candidate: ModelUsageRequest | None,
+) -> None:
+    """Record a supported request only after auth confirms provider continuation."""
+    if candidate is not None:
+        flow.metadata[_PROVIDER_REQUEST] = candidate
+
+
+def activate_confirmed_websocket(flow: http.HTTPFlow) -> None:
+    """Activate a provider-confirmed WebSocket request after its valid 101 response."""
+    candidate = flow.metadata.get(_PROVIDER_REQUEST)
+    if isinstance(candidate, ModelUsageRequest) and candidate.transport == "websocket":
+        flow.metadata[_WEBSOCKET_ACTIVE] = True
+
+
+def activated_request(flow: http.HTTPFlow) -> ModelUsageRequest | None:
+    """Return the provider-confirmed request when model usage is active."""
+    candidate = flow.metadata.get(_PROVIDER_REQUEST)
+    if not isinstance(candidate, ModelUsageRequest):
+        return None
+    if candidate.transport == "http" or flow.metadata.get(_WEBSOCKET_ACTIVE) is True:
+        return candidate
+    return None
+
+
+def activated_protocol(flow: http.HTTPFlow) -> ModelUsageProtocol | None:
+    """Return the single protocol selected for active model usage consumers."""
+    request = activated_request(flow)
+    return request.protocol if request is not None else None
+
+
+def is_websocket_active(flow: http.HTTPFlow) -> bool:
+    """Return whether a confirmed model-provider WebSocket owns terminal usage."""
+    request = activated_request(flow)
+    return request is not None and request.transport == "websocket"
+
+
+def release_flow_state(flow: http.HTTPFlow) -> None:
+    """Release provider-continuation and WebSocket activation state."""
+    flow.metadata.pop(_PROVIDER_REQUEST, None)
+    flow.metadata.pop(_WEBSOCKET_ACTIVE, None)

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -18,7 +18,7 @@ Lifecycle:
 """
 
 from collections.abc import Callable
-from typing import Literal, NamedTuple
+from typing import NamedTuple, assert_never
 
 from mitmproxy import http
 from wsproto.utilities import generate_accept_token
@@ -28,7 +28,7 @@ import body_decoding
 import claude_output_timing
 import flow_metadata
 import flow_metadata_keys as metadata_keys
-import runtime_url_parsing
+import model_usage_eligibility
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from logging_utils import log_proxy_entry
@@ -43,7 +43,6 @@ _HTTP_STATUS_NOT_MODIFIED = 304
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
-_MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
 _CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
 _CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION = "connector_response_report_on_interruption"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
@@ -54,12 +53,6 @@ _OPENAI_CHAT_COMPLETIONS_SSE_PROTOCOL = "openai_chat_completions_sse"
 _OPENAI_RESPONSES_SSE_PROTOCOL = "openai_responses_sse"
 _ANTHROPIC_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 _ANTHROPIC_MESSAGE_STOP_EVENT = "message_stop"
-
-ModelUsageProtocol = Literal[
-    "anthropic_messages",
-    "openai_chat_completions",
-    "openai_responses",
-]
 
 _ResponseChunkParser = Callable[[bytes], None]
 _SseUsageParseErrorLogger = Callable[[str, str], None]
@@ -90,17 +83,6 @@ class _ResponseUsageStreamSetup(NamedTuple):
     needs_buffered_fallback: bool
 
 
-def model_usage_protocol(flow: http.HTTPFlow) -> ModelUsageProtocol:
-    """Classify model usage from the observed request and CLI fallback."""
-    request_target = flow_metadata.original_url(flow.metadata) or flow.request.path
-    request_path = runtime_url_parsing.strip_url_query_and_fragment(request_target).rstrip("/")
-    if request_path.endswith("/chat/completions"):
-        return "openai_chat_completions"
-    if flow_metadata.cli_agent_type(flow.metadata) == "codex":
-        return "openai_responses"
-    return "anthropic_messages"
-
-
 def _response_has_event_stream_media_type(response: http.Response) -> bool:
     content_type = response.headers.get("content-type", "")
     media_type = content_type.partition(";")[0].strip(_HTTP_OWS_CHARS).lower()
@@ -113,28 +95,12 @@ def uses_model_json_fallback(flow: http.HTTPFlow) -> bool:
     if (
         response is None
         or not _response_can_have_body(flow, response)
-        or not usage.is_model_provider_usage_observable(flow)
+        or model_usage_eligibility.activated_protocol(flow) is None
     ):
         return False
     if _response_has_event_stream_media_type(response):
         return False
     return not _is_confirmed_websocket_upgrade_response(flow)
-
-
-def is_model_websocket_usage_enabled(flow: http.HTTPFlow) -> bool:
-    """Return whether model-provider WebSocket usage extraction is active.
-
-    Read-only predicate used by ``websocket_message()`` feeding and terminal
-    response cleanup. Reads ``_MODEL_WEBSOCKET_USAGE_ENABLED``; true means an
-    HTTP 101 response is not terminal for tracked usage and reporting must wait
-    for ``websocket_end()``.
-    """
-    return bool(flow.metadata.get(_MODEL_WEBSOCKET_USAGE_ENABLED, False))
-
-
-def release_model_websocket_usage_state(flow: http.HTTPFlow) -> None:
-    """Disable WebSocket usage extraction after a terminal websocket/error hook."""
-    flow.metadata.pop(_MODEL_WEBSOCKET_USAGE_ENABLED, None)
 
 
 def _make_response_decode_session(
@@ -235,20 +201,16 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
     # and the incremental response parsers used for connector billing payload
     # extraction. Model-provider usage reporting is gated separately.
     is_billable_flow = flow_metadata.is_firewall_billable(flow.metadata)
-    is_observable_model_provider = usage.is_model_provider_usage_observable(flow)
-    model_protocol = model_usage_protocol(flow) if is_observable_model_provider else None
-    if (
-        is_observable_model_provider
-        and model_protocol == "openai_responses"
-        and _is_confirmed_websocket_upgrade_response(flow)
-    ):
+    if _is_confirmed_websocket_upgrade_response(flow):
+        model_usage_eligibility.activate_confirmed_websocket(flow)
+    model_protocol = model_usage_eligibility.activated_protocol(flow)
+    if model_usage_eligibility.is_websocket_active(flow):
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {}
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
-        flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return _ResponseUsageStreamSetup(None, False)
     if not _response_can_have_body(flow, response):
         return _ResponseUsageStreamSetup(None, False)
-    if is_observable_model_provider:
+    if model_protocol is not None:
         if _response_has_event_stream_media_type(response):
             lifecycle_observer: _AnthropicLifecycleObserver | None = None
             anthropic_accounting_events: set[str] = set()
@@ -279,7 +241,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                 parser_fn, usage_dict = usage.create_openai_chat_completions_sse_usage_extractor(
                     on_parse_error=log_parse_error,
                 )
-            else:
+            elif model_protocol == "anthropic_messages":
                 usage_protocol = _ANTHROPIC_MESSAGES_SSE_PROTOCOL
                 log_parse_error = _make_model_sse_parse_error_logger(
                     flow,
@@ -291,6 +253,8 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
                     on_lifecycle_event=lifecycle_observer,
                     on_accounting_event=anthropic_accounting_events.add,
                 )
+            else:
+                assert_never(model_protocol)
             decode_session = _make_response_decode_session(parser_fn, response.headers)
             if decode_session is None:
                 _maybe_log_response_encoding_inspection_risk(flow, response)
@@ -336,8 +300,10 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
             extractor = usage.create_openai_responses_json_usage_extractor()
         elif model_protocol == "openai_chat_completions":
             extractor = usage.create_openai_chat_completions_json_usage_extractor()
-        else:
+        elif model_protocol == "anthropic_messages":
             extractor = usage.create_anthropic_messages_json_usage_extractor()
+        else:
+            assert_never(model_protocol)
         decode_session = _make_response_decode_session(
             extractor.feed,
             response.headers,
@@ -582,15 +548,15 @@ def feed_model_websocket_usage(
     """Merge model-provider usage from one server WebSocket frame.
 
     Called from ``websocket_message()`` only for server-originated frames after
-    provider event inspection. Reads ``_MODEL_WEBSOCKET_USAGE_ENABLED`` via
-    ``is_model_websocket_usage_enabled()`` and temporarily writes per-response sources to
+    provider event inspection. Reads the activated eligibility state and
+    temporarily writes per-response sources to
     ``metadata_keys.MODEL_PROVIDER_USAGE_SOURCES`` while attempting a
     source-preserving report, then releases them from flow metadata. Frames
     without a response id fall back to ``metadata_keys.MODEL_PROVIDER_USAGE``.
     This helper is not idempotent for the same frame; callers must feed each
     server frame once.
     """
-    if not is_model_websocket_usage_enabled(flow):
+    if not model_usage_eligibility.is_websocket_active(flow):
         return
     usage_result, inspection_error = usage.extract_openai_responses_usage_from_event(event)
     if inspection_error is not None:

--- a/crates/runner/mitm-addon/src/terminal_usage.py
+++ b/crates/runner/mitm-addon/src/terminal_usage.py
@@ -3,7 +3,7 @@
 from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
-import response_streaming
+import model_usage_eligibility
 import usage
 
 _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
@@ -35,6 +35,8 @@ def release_tracked_flow(flow: http.HTTPFlow) -> None:
 
 def report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
     """Avoid duplicate usage webhook enqueue if response/error both fire."""
+    if model_usage_eligibility.activated_protocol(flow) is None:
+        return
     if flow.metadata.get(_MODEL_PROVIDER_USAGE_REPORTED, False):
         return
     reported_usage = usage.report_model_provider_usage(flow, run_id)
@@ -44,7 +46,6 @@ def report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
 
 
 def release_model_websocket_terminal_state(flow: http.HTTPFlow) -> None:
-    if response_streaming.is_model_websocket_usage_enabled(flow):
+    if model_usage_eligibility.is_websocket_active(flow):
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
         usage.release_model_provider_usage_tiers(flow)
-        response_streaming.release_model_websocket_usage_state(flow)

--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -8,6 +8,9 @@ from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import http_network_log
+import model_usage_eligibility
+import usage
+from runtime_url_parsing import split_runtime_url
 from tests.flow_helpers import header_map
 
 RealFlowFactory = Callable[..., http.HTTPFlow]
@@ -62,8 +65,8 @@ def make_model_provider_flow(
     host: str,
     original_url: str,
     firewall_name: str,
-    path: str = "/",
-    method: str = "GET",
+    path: str | None = None,
+    method: str = "POST",
     run_id: str = "run-abc-123",
     network_log_path: Path | str | None = None,
     proxy_log_path: Path | str | None = None,
@@ -73,7 +76,8 @@ def make_model_provider_flow(
     cli_agent_type: str | None = None,
     model_usage_provider: str | None = None,
 ) -> http.HTTPFlow:
-    flow = real_flow(with_response=False, host=host, path=path, method=method)
+    request_path = split_runtime_url(original_url).path if path is None else path
+    flow = real_flow(with_response=False, host=host, path=request_path, method=method)
     flow.metadata[metadata_keys.VM_RUN_ID] = run_id
     flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(
         network_log_path if network_log_path is not None else tmp_path / "network.jsonl"
@@ -98,7 +102,28 @@ def make_model_provider_flow(
         flow.metadata[metadata_keys.CLI_AGENT_TYPE] = cli_agent_type
     if model_usage_provider is not None:
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = model_usage_provider
+    if usage.is_model_provider_usage_observable(flow):
+        candidate = model_usage_eligibility.classify_request_candidate(
+            flow,
+            websocket_upgrade_request=False,
+        )
+        model_usage_eligibility.record_provider_continuation(flow, candidate)
     return flow
+
+
+def record_model_provider_continuation(
+    flow: http.HTTPFlow,
+    *,
+    websocket_upgrade_request: bool = False,
+) -> None:
+    """Establish the production provider-continuation transition for a test flow."""
+    assert usage.is_model_provider_usage_observable(flow)
+    candidate = model_usage_eligibility.classify_request_candidate(
+        flow,
+        websocket_upgrade_request=websocket_upgrade_request,
+    )
+    assert candidate is not None
+    model_usage_eligibility.record_provider_continuation(flow, candidate)
 
 
 def make_openai_responses_websocket_flow(
@@ -111,11 +136,14 @@ def make_openai_responses_websocket_flow(
         host="api.openai.com",
         original_url="https://api.openai.com/v1/responses",
         firewall_name="model-provider:openai-api-key",
+        path="/v1/responses",
+        method="GET",
         cli_agent_type="codex",
         model_usage_provider="gpt-5.5",
     )
     flow.request.headers = _openai_responses_websocket_request_headers()
     flow.metadata[metadata_keys.WEBSOCKET_UPGRADE_REQUEST] = True
+    record_model_provider_continuation(flow, websocket_upgrade_request=True)
     flow.response = tutils.tresp(
         status_code=101,
         headers=make_openai_responses_websocket_response_headers(),

--- a/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
@@ -14,6 +14,8 @@ import flow_metadata_keys as metadata_keys
 import http_network_log
 import mitm_addon
 import usage
+from runtime_url_parsing import split_runtime_url
+from tests.model_provider_flow_helpers import record_model_provider_continuation
 
 
 @dataclass(frozen=True)
@@ -382,7 +384,12 @@ def model_provider_flow(
     proxy_log_path: Path | None = None,
     run_id: str = "run-abc-123",
 ):
-    flow = real_flow(with_response=False, host=provider_case.host)
+    flow = real_flow(
+        with_response=False,
+        host=provider_case.host,
+        path=split_runtime_url(provider_case.original_url).path,
+        method="POST",
+    )
     set_model_provider_metadata(
         flow,
         tmp_path,
@@ -392,4 +399,6 @@ def model_provider_flow(
         proxy_log_path=proxy_log_path,
         run_id=run_id,
     )
+    if observable:
+        record_model_provider_continuation(flow)
     return flow

--- a/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
@@ -9,7 +9,7 @@ from wsproto.frame_protocol import Opcode
 
 import deferred_callbacks
 import mitm_addon
-import response_streaming
+import model_usage_eligibility
 
 _WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
 ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
@@ -91,7 +91,7 @@ def set_websocket_message(
 
 
 def _assert_model_websocket_usage_started(flow: http.HTTPFlow) -> None:
-    assert response_streaming.is_model_websocket_usage_enabled(flow)
+    assert model_usage_eligibility.is_websocket_active(flow)
 
 
 def feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -200,6 +200,7 @@ def _write_codex_registry(tmp_path: Path, *, capture: bool, billable: bool = Fal
             vm_fields={
                 "captureNetworkBodies": capture,
                 "cliAgentType": "codex",
+                "modelUsageProvider": "gpt-5.5",
             },
         ),
     )
@@ -380,6 +381,9 @@ async def test_catalog_wait_revalidates_only_provider_continuation(
                 assert follower.metadata.get(metadata_keys.FIREWALL_ERROR) is None
 
             mitm_addon.responseheaders(follower)
+            assert metadata_keys.MODEL_PROVIDER_USAGE not in follower.metadata
+            assert "model_json_usage_finish" not in follower.metadata
+            assert "model_sse_usage_finish" not in follower.metadata
             mitm_addon.response(follower)
     finally:
         if follower_task is not None:

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -28,6 +28,7 @@ from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
 )
+from tests.model_provider_flow_helpers import record_model_provider_continuation
 from tests.request_handler_helpers import (
     _single_firewall_vm,
     _vm_without_firewalls,
@@ -769,7 +770,12 @@ class TestErrorHandler:
 
         Verifies that error() hook delivers partial usage through loopback HTTP.
         """
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-int-002"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
@@ -789,6 +795,7 @@ class TestErrorHandler:
             "model": "claude-sonnet-4-6",
             "tokens.input": 80,
         }
+        record_model_provider_continuation(flow)
         flow.error = Error("connection reset by peer")
 
         with usage_webhook_api() as webhook:

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -10,6 +10,7 @@ import mitm_addon
 import response_streaming
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import jsonl_exists_after_flush
+from tests.model_provider_flow_helpers import record_model_provider_continuation
 from tests.x_flow_helpers import make_x_response_flow
 
 
@@ -24,7 +25,12 @@ class TestResponseHeadersModelJsonParser:
         ],
     )
     def test_non_sse_media_type_uses_json_parser(self, real_flow, content_type):
-        flow = real_flow(with_response=False, host="api.openai.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.openai.com",
+            path="/v1/responses",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": content_type}),
@@ -33,6 +39,7 @@ class TestResponseHeadersModelJsonParser:
         flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -51,7 +58,12 @@ class TestResponseHeadersModelJsonParser:
         }
 
     def test_brotli_model_json_skips_incremental_parser(self, real_flow, mitm_ctx):
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json", "content-encoding": "br"}),
@@ -59,6 +71,7 @@ class TestResponseHeadersModelJsonParser:
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        record_model_provider_continuation(flow)
 
         with mitm_ctx() as log:
             mitm_addon.responseheaders(flow)
@@ -79,15 +92,15 @@ class TestBodylessModelResponseParserAdmission:
     @pytest.mark.parametrize(
         ("request_method", "response_status", "content_type", "content_encoding"),
         [
-            pytest.param("GET", 103, "application/json", "", id="informational"),
-            pytest.param("GET", 204, "application/json", "", id="no-content"),
-            pytest.param("GET", 205, "application/json", "", id="reset-content"),
-            pytest.param("GET", 304, "application/json", "", id="not-modified"),
+            pytest.param("POST", 103, "application/json", "", id="informational"),
+            pytest.param("POST", 204, "application/json", "", id="no-content"),
+            pytest.param("POST", 205, "application/json", "", id="reset-content"),
+            pytest.param("POST", 304, "application/json", "", id="not-modified"),
             pytest.param("HEAD", 200, "application/json", "", id="head"),
             pytest.param("CONNECT", 200, "application/json", "", id="successful-connect"),
-            pytest.param("GET", 204, "application/json", "gzip", id="gzip"),
-            pytest.param("GET", 204, "application/json", "deflate", id="deflate"),
-            pytest.param("GET", 204, "text/event-stream", "", id="sse"),
+            pytest.param("POST", 204, "application/json", "gzip", id="gzip"),
+            pytest.param("POST", 204, "application/json", "deflate", id="deflate"),
+            pytest.param("POST", 204, "text/event-stream", "", id="sse"),
         ],
     )
     def test_bodyless_response_skips_usage_parser_and_keeps_byte_accounting(
@@ -122,6 +135,8 @@ class TestBodylessModelResponseParserAdmission:
                 metadata_keys.MODEL_USAGE_PROVIDER: "claude-sonnet-4-6",
             }
         )
+        if request_method == "POST":
+            record_model_provider_continuation(flow)
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
@@ -148,13 +163,19 @@ class TestResponseHeadersSseParser:
     """Tests for SSE parser setup in responseheaders()."""
 
     def test_sets_up_sse_parser_for_model_provider(self, real_flow, headers):
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -174,7 +195,12 @@ class TestResponseHeadersSseParser:
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.input"] == 42
 
     def test_sets_up_sse_parser_with_case_insensitive_content_type(self, real_flow):
-        flow = real_flow(with_response=False, host="api.openai.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.openai.com",
+            path="/v1/responses",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "Text/Event-Stream; Charset=UTF-8"}),
@@ -183,6 +209,7 @@ class TestResponseHeadersSseParser:
         flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -197,7 +224,12 @@ class TestResponseHeadersSseParser:
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.output"] == 5
 
     def test_finalizes_sse_parser_for_trailing_event_without_blank_line(self, real_flow):
-        flow = real_flow(with_response=False, host="api.openai.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.openai.com",
+            path="/v1/responses",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
@@ -206,6 +238,7 @@ class TestResponseHeadersSseParser:
         flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -223,7 +256,12 @@ class TestResponseHeadersSseParser:
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.output"] == 7
 
     def test_sets_up_openai_sse_parser_for_openai_model_provider(self, real_flow, headers):
-        flow = real_flow(with_response=False, host="api.openai.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.openai.com",
+            path="/v1/responses",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
@@ -232,6 +270,7 @@ class TestResponseHeadersSseParser:
         flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -248,7 +287,12 @@ class TestResponseHeadersSseParser:
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.cache_read"] == 12
 
     def test_codex_oauth_model_provider_uses_openai_sse_parser(self, real_flow):
-        flow = real_flow(with_response=False, host="chatgpt.com")
+        flow = real_flow(
+            with_response=False,
+            host="chatgpt.com",
+            path="/backend-api/codex/responses",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
@@ -257,6 +301,7 @@ class TestResponseHeadersSseParser:
         flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -272,18 +317,26 @@ class TestResponseHeadersSseParser:
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.input"] == 30
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.cache_read"] == 12
 
-    @pytest.mark.parametrize("cli_agent_type", [None, ""])
-    def test_default_cli_agent_type_uses_anthropic_sse_parser(self, real_flow, cli_agent_type):
-        flow = real_flow(with_response=False, host="chatgpt.com")
+    @pytest.mark.parametrize("cli_agent_type", [None, "", "codex"])
+    def test_messages_route_uses_anthropic_parser_independent_of_cli(
+        self, real_flow, cli_agent_type
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
         )
-        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:codex-oauth-token"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         if cli_agent_type is not None:
             flow.metadata[metadata_keys.CLI_AGENT_TYPE] = cli_agent_type
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -299,7 +352,12 @@ class TestResponseHeadersSseParser:
 
     def test_decompresses_gzip_sse_before_parsing(self, real_flow, headers):
         """Compressed SSE streams must be decompressed before usage extraction."""
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -312,6 +370,7 @@ class TestResponseHeadersSseParser:
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -346,12 +405,18 @@ class TestResponseHeadersSseParser:
         assert "model_sse_usage_finish" not in flow.metadata
 
     def test_no_sse_parser_for_non_sse_response(self, real_flow, headers):
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 
@@ -359,7 +424,12 @@ class TestResponseHeadersSseParser:
         assert "model_sse_usage_finish" not in flow.metadata
 
     def test_no_sse_parser_without_model_usage_provider(self, real_flow, headers):
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
@@ -373,13 +443,19 @@ class TestResponseHeadersSseParser:
     def test_sets_up_sse_parser_for_non_billable_observable_model_provider(
         self, real_flow, headers
     ):
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        record_model_provider_continuation(flow)
 
         mitm_addon.responseheaders(flow)
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -7,6 +7,7 @@ from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import model_usage_eligibility
 import response_streaming
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import jsonl_exists_after_flush
@@ -143,7 +144,7 @@ class TestBodylessModelResponseParserAdmission:
 
             assert "model_json_usage_finish" not in flow.metadata
             assert "model_sse_usage_finish" not in flow.metadata
-            assert "model_websocket_usage_enabled" not in flow.metadata
+            assert not model_usage_eligibility.is_websocket_active(flow)
             assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
             unexpected_wire_bytes = b"bodyless-response-wire-bytes"

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -14,6 +14,7 @@ from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
+from tests.model_provider_flow_helpers import record_model_provider_continuation
 from tests.usage_helpers import compact_observation_quantities
 
 
@@ -797,7 +798,12 @@ class TestModelProviderResponseHookUsage:
 
         Verifies wiring between all intermediate layers through loopback HTTP.
         """
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-int-001"
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
@@ -818,6 +824,7 @@ class TestModelProviderResponseHookUsage:
             "tokens.input": 100,
             "tokens.output": 500,
         }
+        record_model_provider_continuation(flow)
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
@@ -9,6 +9,7 @@ from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
 import mitm_addon
+import model_usage_eligibility
 import usage
 from tests.model_provider_flow_helpers import (
     make_openai_responses_websocket_request_flow,
@@ -87,7 +88,9 @@ class TestModelProviderWebSocketLifecycle:
                 headers=make_openai_responses_websocket_response_headers(),
             )
             mitm_addon.responseheaders(flow)
+            assert model_usage_eligibility.is_websocket_active(flow)
             mitm_addon.response(flow)
+            assert model_usage_eligibility.is_websocket_active(flow)
             usage.write_pending_snapshot(flush_request_id="after-response")
             assert_pending(
                 pending_path,
@@ -115,6 +118,7 @@ class TestModelProviderWebSocketLifecycle:
                 ).encode(),
             )
             mitm_addon.websocket_end(flow)
+            assert not model_usage_eligibility.is_websocket_active(flow)
             usage.flush_usage_events(trigger="test")
 
         events = usage_webhook_server.usage_events()
@@ -163,6 +167,7 @@ class TestModelProviderWebSocketLifecycle:
             fake_firewall_headers(),
         ):
             await mitm_addon.request(flow)
+            assert model_usage_eligibility.activated_protocol(flow) is None
             usage.write_pending_snapshot(flush_request_id="before-response")
             assert_pending(
                 pending_path,
@@ -177,6 +182,7 @@ class TestModelProviderWebSocketLifecycle:
                 headers=http.Headers(upgrade="h2c"),
             )
             mitm_addon.responseheaders(flow)
+            assert not model_usage_eligibility.is_websocket_active(flow)
             mitm_addon.response(flow)
             usage.write_pending_snapshot(flush_request_id="after-response")
 
@@ -189,17 +195,25 @@ class TestModelProviderWebSocketLifecycle:
         )
 
     @pytest.mark.parametrize(
-        "response_headers",
+        ("status_code", "response_headers"),
         [
             pytest.param(
+                400,
+                make_openai_responses_websocket_response_headers(),
+                id="non-switching-response",
+            ),
+            pytest.param(
+                101,
                 make_openai_responses_websocket_response_headers(upgrade="h2c"),
                 id="non-websocket-upgrade",
             ),
             pytest.param(
+                101,
                 make_openai_responses_websocket_response_headers(connection=None),
                 id="missing-connection-upgrade",
             ),
             pytest.param(
+                101,
                 make_openai_responses_websocket_response_headers(accept="wrong"),
                 id="wrong-accept",
             ),
@@ -211,9 +225,10 @@ class TestModelProviderWebSocketLifecycle:
         real_flow,
         mitm_ctx,
         fake_firewall_headers,
+        status_code: int,
         response_headers: http.Headers,
     ):
-        """A malformed 101 WebSocket response must not wait for websocket_end()."""
+        """A failed WebSocket response must not wait for websocket_end()."""
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
         reg_path = _write_openai_model_websocket_registry(tmp_path)
@@ -225,6 +240,7 @@ class TestModelProviderWebSocketLifecycle:
             fake_firewall_headers(),
         ):
             await mitm_addon.request(flow)
+            assert model_usage_eligibility.activated_protocol(flow) is None
             usage.write_pending_snapshot(flush_request_id="before-response")
             assert_pending(
                 pending_path,
@@ -234,9 +250,11 @@ class TestModelProviderWebSocketLifecycle:
                 flush_request_id="before-response",
             )
 
-            flow.response = tutils.tresp(status_code=101, headers=response_headers)
+            flow.response = tutils.tresp(status_code=status_code, headers=response_headers)
             mitm_addon.responseheaders(flow)
+            assert not model_usage_eligibility.is_websocket_active(flow)
             mitm_addon.response(flow)
+            assert model_usage_eligibility.activated_protocol(flow) is None
             usage.write_pending_snapshot(flush_request_id="after-response")
 
         assert_pending(
@@ -273,6 +291,7 @@ class TestModelProviderWebSocketLifecycle:
                 headers=make_openai_responses_websocket_response_headers(),
             )
             mitm_addon.responseheaders(flow)
+            assert model_usage_eligibility.is_websocket_active(flow)
             mitm_addon.response(flow)
             usage.write_pending_snapshot(flush_request_id="after-response")
             assert_pending(
@@ -301,6 +320,7 @@ class TestModelProviderWebSocketLifecycle:
             )
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
+            assert not model_usage_eligibility.is_websocket_active(flow)
             usage.flush_usage_events(trigger="test")
 
         events = usage_webhook_server.usage_events()

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -10,6 +10,7 @@ from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import model_usage_eligibility
 import usage
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import (
@@ -203,7 +204,7 @@ class TestModelProviderWebSocketUsage:
         """Codex Responses WebSocket frames should bill like SSE events."""
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
-        assert flow.metadata["model_websocket_usage_enabled"] is True
+        assert model_usage_eligibility.is_websocket_active(flow)
         assert "model_json_usage_finish" not in flow.metadata
         assert "model_sse_usage_finish" not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_model_usage_eligibility.py
+++ b/crates/runner/mitm-addon/tests/test_model_usage_eligibility.py
@@ -1,0 +1,604 @@
+"""Public-hook coverage for model-usage operation eligibility."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mitmproxy import http
+from mitmproxy.test import tutils
+
+import auth
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import model_usage_eligibility
+import response_streaming
+import usage
+from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.flow_helpers import header_map, response_stream
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.requestheaders_helpers import await_requestheaders_result
+
+type HookPhase = Literal["request", "requestheaders"]
+
+
+def _write_model_provider_registry(
+    tmp_path: Path,
+    *,
+    host: str,
+    firewall_name: str,
+    model_usage_provider: str,
+    billable: bool = True,
+    capture_network_bodies: bool = False,
+    auth_config: dict[str, object] | None = None,
+    allow_operation: bool = True,
+) -> Path:
+    vm_fields: dict[str, object] = {
+        "cliAgentType": "codex",
+        "modelUsageProvider": model_usage_provider,
+    }
+    if capture_network_bodies:
+        vm_fields["captureNetworkBodies"] = True
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            run_id="run-model-eligibility",
+            sandbox_marker="tok-model-eligibility",
+            firewall_name=firewall_name,
+            api_entry={
+                "base": f"https://{host}",
+                "auth": auth_config
+                if auth_config is not None
+                else {"headers": {"Authorization": "Bearer test"}},
+                "permissions": [
+                    {
+                        "name": "model-provider-api",
+                        "rules": ["ANY /{path+}"],
+                    }
+                ],
+            },
+            network_policy={
+                "allow": ["model-provider-api"] if allow_operation else [],
+                "deny": [] if allow_operation else ["model-provider-api"],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            billable_firewalls=[firewall_name] if billable else None,
+            vm_fields=vm_fields,
+        ),
+    )
+
+
+def _model_request_flow(
+    real_flow: Callable[..., http.HTTPFlow],
+    *,
+    host: str,
+    path: str,
+    method: str,
+    capture_request_body: bool = False,
+) -> http.HTTPFlow:
+    request_body = b'{"model":"test"}' if capture_request_body else None
+    return real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host=host,
+        path=path,
+        method=method,
+        request_headers=header_map(
+            {
+                "Host": host,
+                "Accept-Encoding": "gzip, zstd, br",
+            }
+        ),
+        request_body=request_body,
+    )
+
+
+async def _run_request_hook(flow: http.HTTPFlow, hook_phase: HookPhase) -> None:
+    if hook_phase == "requestheaders":
+        await await_requestheaders_result(mitm_addon.requestheaders(flow))
+        assert flow.metadata[mitm_addon._FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS] is True
+    await mitm_addon.request(flow)
+
+
+@pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
+@pytest.mark.parametrize(
+    (
+        "host",
+        "path",
+        "firewall_name",
+        "model_usage_provider",
+        "expected_protocol",
+        "content_type",
+        "body",
+    ),
+    [
+        pytest.param(
+            "api.anthropic.com",
+            "/proxy/v1/messages/?trace=1#retained-fragment",
+            "model-provider:anthropic-api-key",
+            "claude-sonnet-4-6",
+            "anthropic_messages",
+            "application/json",
+            b'{"id":"msg_1","model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":12,"output_tokens":7}}',
+            id="anthropic-json-prefixed-query-trailing-slash",
+        ),
+        pytest.param(
+            "api.openai.com",
+            "/compatible/v1/chat/completions?trace=1",
+            "model-provider:openai-api-key",
+            "gpt-5.5",
+            "openai_chat_completions",
+            "text/event-stream",
+            b'data: {"id":"chatcmpl_1","model":"gpt-5.5","choices":[],'
+            b'"usage":{"prompt_tokens":12,"completion_tokens":7}}\n\n'
+            b"data: [DONE]\n\n",
+            id="chat-completions-sse-prefixed-query",
+        ),
+        pytest.param(
+            "chatgpt.com",
+            "/backend-api/codex/responses/?trace=1",
+            "model-provider:codex-oauth-token",
+            "gpt-5.5",
+            "openai_responses",
+            "text/event-stream",
+            b"event: response.completed\n"
+            b'data: {"type":"response.completed","response":{"id":"resp_1",'
+            b'"model":"gpt-5.5","usage":{"input_tokens":12,"output_tokens":7}}}\n\n',
+            id="responses-sse-prefixed-query-trailing-slash",
+        ),
+    ],
+)
+async def test_supported_http_operations_activate_and_report_from_both_auth_phases(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+    usage_webhook_server,
+    sync_usage_executor,
+    hook_phase: HookPhase,
+    host: str,
+    path: str,
+    firewall_name: str,
+    model_usage_provider: str,
+    expected_protocol: model_usage_eligibility.ModelUsageProtocol,
+    content_type: str,
+    body: bytes,
+) -> None:
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name=firewall_name,
+        model_usage_provider=model_usage_provider,
+        capture_network_bodies=hook_phase == "requestheaders",
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=host,
+        path=path,
+        method="POST",
+        capture_request_body=hook_phase == "requestheaders",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+        fake_firewall_headers(),
+    ):
+        await _run_request_hook(flow, hook_phase)
+        assert model_usage_eligibility.activated_protocol(flow) == expected_protocol
+        assert flow.request.headers["Accept-Encoding"] == "gzip"
+
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": content_type}),
+        )
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(body) == body
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+
+    assert {
+        event["category"]: event["quantity"] for event in usage_webhook_server.usage_events()
+    } == {
+        "tokens.input": 12,
+        "tokens.output": 7,
+    }
+    assert model_usage_eligibility.activated_protocol(flow) is None
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        pytest.param("GET", "/v1/models", id="model-catalog"),
+        pytest.param("GET", "/v1/account/usage", id="account-usage"),
+        pytest.param("POST", "/v1/images/generations", id="images"),
+        pytest.param("POST", "/v1/batches", id="batches"),
+        pytest.param("GET", "/v1/responses/resp_1", id="response-retrieval"),
+        pytest.param("POST", "/v1/responses/compact", id="response-compact"),
+        pytest.param("POST", "/v1/messages/count_tokens", id="message-subresource"),
+        pytest.param(
+            "POST",
+            "/v1/models?hint=/v1/responses",
+            id="endpoint-text-in-query",
+        ),
+        pytest.param("GET", "/v1/responses?hint=/v1/responses", id="ordinary-responses-get"),
+        pytest.param("PUT", "/v1/responses", id="wrong-method"),
+        pytest.param("POST", "/v1/notresponses", id="sibling-name"),
+    ],
+)
+async def test_unsupported_operations_keep_generic_streaming_without_model_usage(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+    usage_webhook_server,
+    sync_usage_executor,
+    method: str,
+    path: str,
+) -> None:
+    host = "api.openai.com"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name="model-provider:openai-api-key",
+        model_usage_provider="gpt-5.5",
+    )
+    flow = _model_request_flow(real_flow, host=host, path=path, method=method)
+    usage_shaped_body = (
+        b'{"id":"resp_unrelated","model":"gpt-5.5","usage":{"input_tokens":100,"output_tokens":50}}'
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+        assert model_usage_eligibility.activated_protocol(flow) is None
+        assert flow.request.headers["Accept-Encoding"] == "gzip, zstd, br"
+
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+        mitm_addon.responseheaders(flow)
+        assert "model_json_usage_finish" not in flow.metadata
+        assert "model_sse_usage_finish" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert response_stream(flow)(usage_shaped_body) == usage_shaped_body
+        assert response_streaming.streamed_response_size(flow) == len(usage_shaped_body)
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+
+    assert usage_webhook_server.usage_events() == []
+    assert usage_webhook_server.model_usage_observation_events() == []
+
+
+async def test_local_auth_response_on_supported_path_stays_inactive(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    usage_webhook_server,
+    sync_usage_executor,
+) -> None:
+    host = "api.anthropic.com"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name="model-provider:anthropic-api-key",
+        model_usage_provider="claude-sonnet-4-6",
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=host,
+        path="/v1/messages",
+        method="POST",
+    )
+    auth_fetch = AsyncMock(side_effect=RuntimeError("auth backend unavailable"))
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+        patch.object(auth, "get_firewall_headers", auth_fetch),
+    ):
+        await mitm_addon.request(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert model_usage_eligibility.activated_protocol(flow) is None
+
+        usage_shaped_body = (
+            b'{"id":"msg_local","model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":100,"output_tokens":50}}'
+        )
+        flow.response.raw_content = usage_shaped_body
+        flow.response.headers = header_map({"content-type": "application/json"})
+        mitm_addon.responseheaders(flow)
+        assert "model_json_usage_finish" not in flow.metadata
+        assert response_stream(flow)(usage_shaped_body) == usage_shaped_body
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+
+    auth_fetch.assert_awaited_once()
+    assert usage_webhook_server.usage_events() == []
+    assert usage_webhook_server.model_usage_observation_events() == []
+
+
+async def test_local_firewall_response_on_supported_path_stays_inactive(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    usage_webhook_server,
+    sync_usage_executor,
+) -> None:
+    host = "api.anthropic.com"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name="model-provider:anthropic-api-key",
+        model_usage_provider="claude-sonnet-4-6",
+        allow_operation=False,
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=host,
+        path="/v1/messages",
+        method="POST",
+    )
+    usage_shaped_body = (
+        b'{"id":"msg_blocked","model":"claude-sonnet-4-6",'
+        b'"usage":{"input_tokens":100,"output_tokens":50}}'
+    )
+
+    with mitm_ctx(
+        registry_path=str(reg_path),
+        api_url=usage_webhook_server.api_url,
+    ):
+        await mitm_addon.request(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        assert model_usage_eligibility.activated_protocol(flow) is None
+
+        flow.response.raw_content = usage_shaped_body
+        flow.response.headers = header_map({"content-type": "application/json"})
+        mitm_addon.responseheaders(flow)
+        assert "model_json_usage_finish" not in flow.metadata
+        assert response_stream(flow)(usage_shaped_body) == usage_shaped_body
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+
+    assert usage_webhook_server.usage_events() == []
+    assert usage_webhook_server.model_usage_observation_events() == []
+
+
+async def test_unsupported_operation_preserves_configured_body_capture(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    host = "api.openai.com"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name="model-provider:openai-api-key",
+        model_usage_provider="gpt-5.5",
+        capture_network_bodies=True,
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=host,
+        path="/v1/models",
+        method="GET",
+    )
+    body = b'{"data":[{"id":"gpt-5.5"}]}'
+
+    with (
+        mitm_ctx(registry_path=str(reg_path)),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+        assert model_usage_eligibility.activated_protocol(flow) is None
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(body) == body
+        assert bytes(flow.metadata[metadata_keys.STREAM_BUFFER]) == body
+        mitm_addon.response(flow)
+
+    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_entry["response_body"] == body.decode()
+    assert metadata_keys.STREAM_BUFFER not in flow.metadata
+
+
+async def test_custom_surface_supported_path_preserves_existing_non_observable_boundary(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    host = "gateway.example.com"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name="model-provider-surface:custom",
+        model_usage_provider="gpt-5.5",
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=host,
+        path="/v1/responses",
+        method="POST",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path)),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert model_usage_eligibility.activated_protocol(flow) is None
+    assert flow.request.headers["Accept-Encoding"] == "gzip, zstd, br"
+
+
+async def test_provider_error_with_input_only_usage_remains_reportable(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+    usage_webhook_server,
+    sync_usage_executor,
+) -> None:
+    host = "api.anthropic.com"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name="model-provider:anthropic-api-key",
+        model_usage_provider="claude-sonnet-4-6",
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=host,
+        path="/v1/messages",
+        method="POST",
+    )
+    body = (
+        b'{"id":"msg_failed","model":"claude-sonnet-4-6",'
+        b'"usage":{"input_tokens":17,"output_tokens":0}}'
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+        flow.response = tutils.tresp(
+            status_code=429,
+            headers=header_map({"content-type": "application/json"}),
+        )
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(body) == body
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+
+    assert [
+        (event["category"], event["quantity"]) for event in usage_webhook_server.usage_events()
+    ] == [("tokens.input", 17)]
+
+
+async def test_non_billable_supported_request_emits_observation_only(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+    usage_webhook_server,
+    sync_usage_executor,
+) -> None:
+    host = "api.openai.com"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=host,
+        firewall_name="model-provider:openai-api-key",
+        model_usage_provider="gpt-5.5",
+        billable=False,
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=host,
+        path="/v1/responses",
+        method="POST",
+    )
+    body = b'{"id":"resp_observed","model":"gpt-5.5","usage":{"input_tokens":9,"output_tokens":3}}'
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+        mitm_addon.responseheaders(flow)
+        assert response_stream(flow)(body) == body
+        mitm_addon.response(flow)
+        usage.flush_usage_events(trigger="test")
+
+    assert usage_webhook_server.usage_events() == []
+    assert len(usage_webhook_server.model_usage_observation_events()) == 1
+
+
+async def test_successful_auth_base_provider_response_activates_usage(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    usage_webhook_server,
+    sync_usage_executor,
+) -> None:
+    placeholder_host = "placeholder.example.com"
+    firewall_name = "model-provider:anthropic-api-key"
+    reg_path = _write_model_provider_registry(
+        tmp_path,
+        host=placeholder_host,
+        firewall_name=firewall_name,
+        model_usage_provider="claude-sonnet-4-6",
+        auth_config={"base": "${{ secrets.ANTHROPIC_URL }}"},
+    )
+    flow = _model_request_flow(
+        real_flow,
+        host=placeholder_host,
+        path="/v1/messages",
+        method="POST",
+    )
+    body = (
+        b'{"id":"msg_inline","model":"claude-sonnet-4-6",'
+        b'"usage":{"input_tokens":8,"output_tokens":2}}'
+    )
+    auth_result = {
+        "headers": {},
+        "base": "https://api.anthropic.com/v1/messages",
+        "resolved_secrets": ["ANTHROPIC_URL"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url=usage_webhook_server.api_url),
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=auth_result)),
+    ):
+        with fake_forwarder_upstream(
+            body=body,
+            headers=[("Content-Type", "application/json")],
+        ):
+            await mitm_addon.request(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 200
+        assert model_usage_eligibility.activated_protocol(flow) == "anthropic_messages"
+        assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is True
+        assert flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] == "claude-sonnet-4-6"
+        assert flow.metadata[metadata_keys.VM_RUN_ID] == "run-model-eligibility"
+        assert flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] == "tok-model-eligibility"
+
+        mitm_addon.responseheaders(flow)
+        assert "model_json_usage_finish" in flow.metadata
+        assert response_stream(flow)(body) == body
+        mitm_addon.response(flow)
+        parsed_usage = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
+        assert parsed_usage["tokens.input"] == 8
+        assert parsed_usage["tokens.output"] == 2
+        usage.flush_usage_events(trigger="test")
+
+    assert {request.path for request in usage_webhook_server.requests} == {
+        "/api/webhooks/agent/usage-event",
+        "/api/webhooks/agent/model-usage-observation",
+    }
+    assert {
+        event["category"]: event["quantity"] for event in usage_webhook_server.usage_events()
+    } == {
+        "tokens.input": 8,
+        "tokens.output": 2,
+    }

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -391,7 +391,7 @@ async def test_registry_change_during_auth_blocks_old_authorization(
     else:
         assert flow.request.headers.get("Host") == "api.github.com"
         assert flow.request.headers.get("Content-Length") == str(STREAM_BUFFER_LIMIT + 1)
-        assert flow.request.headers.get("Accept-Encoding") == "identity"
+        assert flow.request.headers.get("Accept-Encoding") is None
     assert flow.request.path == original_path
     assert flow.request.headers.get("Authorization") is None
     _assert_current_denial(flow, registry_mutation)
@@ -501,7 +501,7 @@ async def test_different_same_run_allow_decision_fails_closed_without_old_creden
     auth_fetch.assert_awaited_once()
     assert flow.request.headers.get("Host") == "api.github.com"
     assert flow.request.headers.get("Content-Length") == str(STREAM_BUFFER_LIMIT + 1)
-    assert flow.request.headers.get("Accept-Encoding") == "identity"
+    assert flow.request.headers.get("Accept-Encoding") is None
     assert flow.request.path == original_path
     assert flow.response is not None
     assert flow.response.status_code == 409

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -8,6 +8,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
+from tests.model_provider_flow_helpers import record_model_provider_continuation
 from tests.x_flow_helpers import make_x_pipeline_flow
 
 
@@ -21,6 +22,7 @@ class TestResponseEncodingInspectionRisk:
         *,
         content_encoding: str,
         content_type: str = "application/json",
+        activate: bool = True,
     ) -> http.HTTPFlow:
         flow = real_flow(
             with_response=False,
@@ -46,6 +48,8 @@ class TestResponseEncodingInspectionRisk:
                 metadata_keys.MODEL_USAGE_PROVIDER: "claude-sonnet-4-6",
             }
         )
+        if activate:
+            record_model_provider_continuation(flow)
         return flow
 
     @pytest.mark.parametrize(
@@ -132,7 +136,12 @@ class TestResponseEncodingInspectionRisk:
     def test_non_observable_model_response_does_not_log_encoding_risk(
         self, real_flow, tmp_path, mitm_ctx
     ) -> None:
-        flow = self._model_flow(real_flow, tmp_path, content_encoding="zstd")
+        flow = self._model_flow(
+            real_flow,
+            tmp_path,
+            content_encoding="zstd",
+            activate=False,
+        )
         flow.metadata.pop(metadata_keys.MODEL_USAGE_PROVIDER)
 
         with mitm_ctx():
@@ -145,10 +154,10 @@ class TestResponseEncodingInspectionRisk:
     @pytest.mark.parametrize(
         ("request_method", "response_status"),
         [
-            pytest.param("GET", 101, id="informational"),
-            pytest.param("GET", 204, id="no-content"),
-            pytest.param("GET", 205, id="reset-content"),
-            pytest.param("GET", 304, id="not-modified"),
+            pytest.param("POST", 101, id="informational"),
+            pytest.param("POST", 204, id="no-content"),
+            pytest.param("POST", 205, id="reset-content"),
+            pytest.param("POST", 304, id="not-modified"),
             pytest.param("HEAD", 200, id="head"),
             pytest.param("CONNECT", 200, id="successful-connect"),
         ],
@@ -161,8 +170,15 @@ class TestResponseEncodingInspectionRisk:
         request_method: str,
         response_status: int,
     ) -> None:
-        flow = self._model_flow(real_flow, tmp_path, content_encoding="zstd")
+        flow = self._model_flow(
+            real_flow,
+            tmp_path,
+            content_encoding="zstd",
+            activate=False,
+        )
         flow.request.method = request_method
+        if request_method == "POST":
+            record_model_provider_continuation(flow)
         assert flow.response is not None
         flow.response.status_code = response_status
 

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -236,6 +236,9 @@ def _model_provider_registry(
     model_usage_provider: object = "claude-sonnet-4-6",
     capture_network_bodies: bool = False,
     rule_method: str = "POST",
+    firewall_name: str = _MODEL_PROVIDER_FIREWALL_NAME,
+    host: str = _MODEL_PROVIDER_HOST,
+    path: str = _MODEL_PROVIDER_PATH,
 ) -> Path:
     vm_fields: dict[str, object] = {}
     if model_usage_provider is not None:
@@ -247,16 +250,14 @@ def _model_provider_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
             tmp_path,
-            firewall_name=_MODEL_PROVIDER_FIREWALL_NAME,
+            firewall_name=firewall_name,
             api_entry={
-                "base": f"https://{_MODEL_PROVIDER_HOST}",
+                "base": f"https://{host}",
                 "auth": {"headers": {"x-api-key": "test-key"}},
-                "permissions": [
-                    {"name": "messages", "rules": [f"{rule_method} {_MODEL_PROVIDER_PATH}"]}
-                ],
+                "permissions": [{"name": "operation", "rules": [f"{rule_method} {path}"]}],
             },
             network_policy={
-                "allow": ["messages"],
+                "allow": ["operation"],
                 "deny": [],
                 "ask": [],
                 "unknownPolicy": "deny",
@@ -794,7 +795,7 @@ async def test_response_bodyless_usage_inspected_methods_keep_accept_encoding(
         ),
     ],
 )
-async def test_invalid_websocket_upgrade_normalizes_accept_encoding(
+async def test_invalid_websocket_upgrade_keeps_accept_encoding(
     tmp_path: Path,
     real_flow: Callable[..., http.HTTPFlow],
     headers: Callable[..., http.Headers],
@@ -802,12 +803,21 @@ async def test_invalid_websocket_upgrade_normalizes_accept_encoding(
     fake_firewall_headers,
     extra_headers: tuple[tuple[str, str], ...],
 ) -> None:
-    reg_path = _model_provider_registry(tmp_path, rule_method="GET")
+    host = "api.openai.com"
+    path = "/v1/responses"
+    reg_path = _model_provider_registry(
+        tmp_path,
+        rule_method="GET",
+        firewall_name="model-provider:openai-api-key",
+        host=host,
+        path=path,
+        model_usage_provider="gpt-5.5",
+    )
     flow = _request_flow(
         real_flow,
         headers,
-        host=_MODEL_PROVIDER_HOST,
-        path=_MODEL_PROVIDER_PATH,
+        host=host,
+        path=path,
         method="GET",
         accept_encoding="gzip, zstd, br",
         extra_headers=extra_headers,
@@ -819,7 +829,7 @@ async def test_invalid_websocket_upgrade_normalizes_accept_encoding(
     ):
         await mitm_addon.request(flow)
 
-    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
 
 
 async def test_invalid_websocket_upgrade_method_normalizes_accept_encoding(
@@ -855,7 +865,7 @@ async def test_invalid_websocket_upgrade_method_normalizes_accept_encoding(
 
 
 @pytest.mark.parametrize("http_version", ["HTTP/1.0", "HTTP/2.0", "HTTP/3"])
-async def test_invalid_websocket_upgrade_http_version_normalizes_accept_encoding(
+async def test_invalid_websocket_upgrade_http_version_keeps_accept_encoding(
     tmp_path: Path,
     real_flow: Callable[..., http.HTTPFlow],
     headers: Callable[..., http.Headers],
@@ -863,12 +873,21 @@ async def test_invalid_websocket_upgrade_http_version_normalizes_accept_encoding
     fake_firewall_headers,
     http_version: str,
 ) -> None:
-    reg_path = _model_provider_registry(tmp_path, rule_method="GET")
+    host = "api.openai.com"
+    path = "/v1/responses"
+    reg_path = _model_provider_registry(
+        tmp_path,
+        rule_method="GET",
+        firewall_name="model-provider:openai-api-key",
+        host=host,
+        path=path,
+        model_usage_provider="gpt-5.5",
+    )
     flow = _request_flow(
         real_flow,
         headers,
-        host=_MODEL_PROVIDER_HOST,
-        path=_MODEL_PROVIDER_PATH,
+        host=host,
+        path=path,
         method="GET",
         accept_encoding="gzip, zstd, br",
         extra_headers=(
@@ -886,7 +905,7 @@ async def test_invalid_websocket_upgrade_http_version_normalizes_accept_encoding
     ):
         await mitm_addon.request(flow)
 
-    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
 
 
 async def test_browser_passthrough_keeps_accept_encoding_for_parser_connector(

--- a/crates/runner/mitm-addon/tests/test_response_handler_cleanup.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_cleanup.py
@@ -9,6 +9,7 @@ import http_network_log
 import mitm_addon
 import request_streaming
 from tests.flow_helpers import header_map, response_stream
+from tests.model_provider_flow_helpers import record_model_provider_continuation
 
 
 def test_pops_start_time_even_when_run_id_absent(real_flow, mitm_ctx):
@@ -118,11 +119,17 @@ def test_response_does_not_clear_replaced_request_stream_callback(real_flow):
 
 def test_response_without_run_id_releases_sse_streaming_state(real_flow):
     """Early-returning SSE flows should not retain parser closures."""
-    flow = real_flow(with_response=False, host="api.openai.com")
+    flow = real_flow(
+        with_response=False,
+        host="api.openai.com",
+        path="/v1/responses",
+        method="POST",
+    )
     flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
     flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
     flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
     flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+    record_model_provider_continuation(flow)
     flow.response = tutils.tresp(
         status_code=200,
         headers=header_map({"content-type": "text/event-stream"}),

--- a/crates/runner/mitm-addon/tests/test_response_stream_state_release.py
+++ b/crates/runner/mitm-addon/tests/test_response_stream_state_release.py
@@ -7,6 +7,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_streaming
 from tests.flow_helpers import header_map, response_stream
+from tests.model_provider_flow_helpers import record_model_provider_continuation
 
 
 class TestReleaseResponseStreamState:
@@ -38,6 +39,7 @@ class TestReleaseResponseStreamState:
         (
             "host",
             "path",
+            "request_method",
             "response_content_type",
             "metadata",
             "finish_key",
@@ -47,6 +49,7 @@ class TestReleaseResponseStreamState:
             pytest.param(
                 "api.anthropic.com",
                 "/v1/messages",
+                "POST",
                 "application/json",
                 {
                     metadata_keys.FIREWALL_NAME: "model-provider:anthropic-api-key",
@@ -60,6 +63,7 @@ class TestReleaseResponseStreamState:
             pytest.param(
                 "api.openai.com",
                 "/v1/responses",
+                "POST",
                 "text/event-stream",
                 {
                     metadata_keys.FIREWALL_NAME: "model-provider:openai-api-key",
@@ -74,6 +78,7 @@ class TestReleaseResponseStreamState:
             pytest.param(
                 "api.x.com",
                 "/2/tweets",
+                "GET",
                 "application/json",
                 {
                     metadata_keys.FIREWALL_NAME: "x",
@@ -87,6 +92,7 @@ class TestReleaseResponseStreamState:
             pytest.param(
                 "api.x.com",
                 "/2/tweets/search/stream",
+                "GET",
                 "application/json",
                 {
                     metadata_keys.FIREWALL_NAME: "x",
@@ -104,13 +110,21 @@ class TestReleaseResponseStreamState:
         real_flow,
         host,
         path,
+        request_method,
         response_content_type,
         metadata,
         finish_key,
         reports_on_interruption,
     ):
-        flow = real_flow(with_response=False, host=host, path=path)
+        flow = real_flow(
+            with_response=False,
+            host=host,
+            path=path,
+            method=request_method,
+        )
         flow.metadata.update(metadata)
+        if finish_key.startswith("model_"):
+            record_model_provider_continuation(flow)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": response_content_type}),
@@ -163,10 +177,16 @@ class TestReleaseResponseStreamState:
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_release_after_response_is_removed_still_drops_metadata(self, real_flow):
-        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        record_model_provider_continuation(flow)
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -38,6 +38,7 @@ class TestUsageReportingIdempotency:
             original_url="https://api.openai.com/v1/responses",
             firewall_name="model-provider:openai-api-key",
             cli_agent_type="codex",
+            model_usage_provider="gpt-5.5",
         )
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "gpt-5.5",
@@ -71,10 +72,10 @@ class TestUsageReportingIdempotency:
                 for entry in entries
             )
 
-    def test_empty_model_usage_does_not_block_later_error_usage(
+    def test_terminal_response_does_not_accept_late_error_usage(
         self, tmp_path, real_flow, mitm_ctx, usage_webhook_api
     ):
-        """A no-event response pass must not mark the flow reported."""
+        """Usage added after terminal response cleanup must not be reported."""
         flow = make_model_provider_flow(
             real_flow,
             tmp_path,
@@ -82,6 +83,7 @@ class TestUsageReportingIdempotency:
             original_url="https://api.openai.com/v1/responses",
             firewall_name="model-provider:openai-api-key",
             cli_agent_type="codex",
+            model_usage_provider="gpt-5.5",
         )
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "gpt-5.5",
@@ -101,8 +103,7 @@ class TestUsageReportingIdempotency:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
 
-        events = webhook.usage_events()
-        assert [event["category"] for event in events] == ["tokens.output"]
+        assert webhook.usage_events() == []
 
     def test_reports_usage_without_provider_message_id(
         self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api

--- a/crates/runner/mitm-addon/tests/test_websocket_retention.py
+++ b/crates/runner/mitm-addon/tests/test_websocket_retention.py
@@ -7,6 +7,7 @@ from mitmproxy.flow import Error
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import model_usage_eligibility
 import usage
 from tests.model_provider_flow_helpers import (
     make_openai_responses_websocket_flow,
@@ -163,7 +164,7 @@ class TestModelProviderWebSocketRetentionWithUsageDelivery:
         )
         assert flow.websocket is not None
         assert flow.websocket.messages == []
-        assert "model_websocket_usage_enabled" not in flow.metadata
+        assert not model_usage_eligibility.is_websocket_active(flow)
 
         run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
         assert flow.websocket.messages == []
@@ -197,7 +198,7 @@ class TestModelProviderWebSocketRetentionWithUsageDelivery:
         )
         assert flow.websocket is not None
         assert flow.websocket.messages == []
-        assert "model_websocket_usage_enabled" not in flow.metadata
+        assert not model_usage_eligibility.is_websocket_active(flow)
 
         run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
         assert flow.websocket.messages == []


### PR DESCRIPTION
## Summary

- replace CLI-wide model usage protocol fallback with one request-scoped eligibility lifecycle
- activate supported HTTP operations only after provider continuation and Responses WebSockets only after a validated `101` handshake
- gate JSON, SSE, buffered fallback, WebSocket, observation, and billing consumers on the same activated decision
- preserve generic response byte accounting, configured body capture, connector parsing, and Codex model catalog behavior for unsupported operations

## Supported operations

- `POST */messages`
- `POST */chat/completions`
- `POST */responses`
- validated WebSocket `GET */responses`

All other model-provider operations remain outside model usage extraction, including response retrieval and subresources, `/responses/compact`, models, images, batches, account usage, and message subresources.

## Lifecycle safety

- local auth, firewall, admission, diagnostic, and cache responses cannot activate model usage
- failed or malformed WebSocket upgrades remain inactive and release terminal tracking
- valid input-only provider usage remains observable and billable
- `model-provider-surface:*` custom gateway behavior is unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`5309 passed`)

## Exclusions

- no API, database schema, persisted-data migration, or runner/guest protocol change
- no new accounting support for `/responses/compact` or other unsupported operations
- no change to custom gateway observation policy
- no attribution or historical repair for the reconciliation discrepancy tracked by the parent issue

Closes #26330

Parent context: #26303
