### PR TITLE
refactor: remove runless model annotation compatibility

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -962,53 +962,6 @@ describe("chat run queue", () => {
     expectTextBefore(MODEL_CHANGED_COPY, "Start the model B run");
   });
 
-  it("does not mistake a persisted steer model annotation for a new run", async () => {
-    mockChatLifecycle(context, {
-      threadId: THREAD_ID,
-      chatEvents: [
-        {
-          id: `${THREAD_ID}-active-user`,
-          role: "user",
-          content: "Start the model A run",
-          userMessage: modelAnnotatedMessage(
-            "Start the model A run",
-            "gpt-5.5",
-          ),
-          runId: "run-active",
-          createdAt: "2026-08-06T09:00:00Z",
-        },
-        {
-          id: `${THREAD_ID}-active-assistant`,
-          role: "assistant",
-          content: "Model A finished.",
-          runId: "run-active",
-          createdAt: "2026-08-06T09:00:01Z",
-        },
-        {
-          id: `${THREAD_ID}-persisted-steer`,
-          role: "user",
-          content: "Legacy persisted steer",
-          userMessage: modelAnnotatedMessage(
-            "Legacy persisted steer",
-            "claude-sonnet-4-6",
-          ),
-          runId: undefined,
-          createdAt: "2026-08-06T09:00:02Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({
-      context,
-      path: CHAT_PATH,
-    });
-
-    await expect(
-      screen.findByText("Legacy persisted steer"),
-    ).resolves.toBeInTheDocument();
-    expect(screen.queryByText(MODEL_CHANGED_COPY)).not.toBeInTheDocument();
-  });
-
   it.each([
     {
       name: "the models match",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -392,11 +392,7 @@ function modelChangeRunKey(
   if (inputEvent.runId !== undefined) {
     return `run:${inputEvent.runId}`;
   }
-  // Old web/app clients can persist model annotations on steer inputs for up
-  // to about two days. Keep persisted events from looking like run starts
-  // until their stored rows and snapshots are migrated; remove the seqId
-  // check after #25879 confirms no runless model annotations remain.
-  if (inputEvent.seqId === undefined && modelSelection !== undefined) {
+  if (modelSelection !== undefined) {
     return `event:${inputEvent.id}`;
   }
   return undefined;


### PR DESCRIPTION
## Summary

- remove the expired `seqId` guard from `modelChangeRunKey`
- treat current runless optimistic model selections as event-scoped run starts
- delete the integration test for legacy persisted steer model annotations

## Rollout window

PR #25907 retained this compatibility for old web/app clients that could persist model annotations on runless steer inputs. The documented maximum client-version skew was about two days. That window has now expired, so the old persisted-event branch and its dedicated test can be removed.

The normal `runId` key, optimistic event-ID key, permanent model-change dividers, next-run notice, Fast tier behavior, and their positive coverage remain unchanged.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-run-queue.test.tsx --maxWorkers=4 --silent=passed-only` (32 tests passed)
- `git diff --check`

No development server or full local Vitest suite was run, per repository instructions.
