### PR TITLE
fix: prevent workflows from watching their own thread

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -285,6 +285,39 @@ describe("chat-run-finished workflow automations", () => {
     expect(foreignThread.body.error.message).toContain("Chat thread not found");
   });
 
+  it("prevents a workflow from watching its own chat thread", async () => {
+    const fixture = await setupChatAutomationFixture();
+    const workflowThread = await chat.createThread(fixture.actor, {
+      agentId: fixture.agentId,
+      model: "claude-sonnet-5",
+    });
+    const workflowId = await wf.createWorkflow(fixture.actor, {
+      agentId: fixture.agentId,
+      name: `self-watching-${randomUUID().slice(0, 8)}`,
+      chatThreadId: workflowThread.id,
+    });
+
+    const response = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: {
+          kind: "event",
+          eventType: "chat-run-finished",
+          eventConfig: {
+            provider: "chat",
+            event: "run_finished",
+            chatThreadId: workflowThread.id,
+          },
+        },
+      }),
+      [400],
+    );
+    expect(response.body.error.message).toBe(
+      "A workflow cannot watch run-finished events from its own chat thread",
+    );
+  });
+
   it(
     "fires claimable matching automations when a watched run completes",
     { timeout: 30_000 },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
@@ -172,6 +172,7 @@ export function createWorkflowsBddApi(context: TestContext) {
       options: {
         readonly agentId: string;
         readonly name: string;
+        readonly chatThreadId?: string;
         readonly visibility?: "public" | "private";
       },
     ): Promise<string> {
@@ -184,6 +185,9 @@ export function createWorkflowsBddApi(context: TestContext) {
           body: {
             agentId: options.agentId,
             name: options.name,
+            ...(options.chatThreadId
+              ? { chatThreadId: options.chatThreadId }
+              : {}),
             visibility: options.visibility ?? "public",
           },
         }),

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -2525,6 +2525,22 @@ async function createChatRunFinishedEventAutomationForWorkflow(args: {
     };
   }
 
+  const automationThreadId = await loadWorkflowUserAutomationThreadId(
+    args.context.db,
+    {
+      orgId: args.input.orgId,
+      userId: args.input.member.userId,
+      workflowId: args.context.workflowId,
+    },
+  );
+  if (automationThreadId === args.input.eventConfig.chatThreadId) {
+    return {
+      kind: "bad-request",
+      message:
+        "A workflow cannot watch run-finished events from its own chat thread",
+    };
+  }
+
   const summary = await insertEventAutomation(args.context.db, {
     input: args.input,
     workflowId: args.context.workflowId,

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation.service.ts
@@ -2501,15 +2501,18 @@ const createStripeInvoicePaidEventAutomation$ = command(
   },
 );
 
-async function createChatRunFinishedEventAutomationForWorkflow(args: {
-  readonly context: {
-    readonly db: Db;
-    readonly workflowId: string;
-    readonly agentId: string;
-    readonly workflowTitle: string;
-  };
-  readonly input: CreateChatRunFinishedEventAutomationInput;
-}): Promise<AutomationResult> {
+async function createChatRunFinishedEventAutomationForWorkflow(
+  args: {
+    readonly context: {
+      readonly db: Db;
+      readonly workflowId: string;
+      readonly agentId: string;
+      readonly workflowTitle: string;
+    };
+    readonly input: CreateChatRunFinishedEventAutomationInput;
+  },
+  signal: AbortSignal,
+): Promise<AutomationResult> {
   // The watched thread must belong to the automation owner: the run's final
   // output is surfaced to the workflow run, so cross-user watching would leak
   // another user's conversation.
@@ -2518,6 +2521,7 @@ async function createChatRunFinishedEventAutomationForWorkflow(args: {
     .from(chatThreads)
     .where(eq(chatThreads.id, args.input.eventConfig.chatThreadId))
     .limit(1);
+  signal.throwIfAborted();
   if (!thread || thread.userId !== args.input.member.userId) {
     return {
       kind: "bad-request",
@@ -2533,6 +2537,7 @@ async function createChatRunFinishedEventAutomationForWorkflow(args: {
       workflowId: args.context.workflowId,
     },
   );
+  signal.throwIfAborted();
   if (automationThreadId === args.input.eventConfig.chatThreadId) {
     return {
       kind: "bad-request",
@@ -2548,6 +2553,7 @@ async function createChatRunFinishedEventAutomationForWorkflow(args: {
     workflowTitle: args.context.workflowTitle,
     currentTime: nowDate(),
   });
+  signal.throwIfAborted();
   return { kind: "ok", summary };
 }
 
@@ -2565,10 +2571,13 @@ const createEventAutomationForWorkflow$ = command(
   ): Promise<AutomationResult> => {
     const { input } = args;
     if (automationCreateInputIsChatRunFinished(input)) {
-      return await createChatRunFinishedEventAutomationForWorkflow({
-        context: args,
-        input,
-      });
+      return await createChatRunFinishedEventAutomationForWorkflow(
+        {
+          context: args,
+          input,
+        },
+        signal,
+      );
     }
 
     if (input.eventType === "webhook-received") {


### PR DESCRIPTION
## Summary

- Reject `chat-run-finished` automations when the watched thread is the workflow's bound automation thread.
- Enforce the invariant in the shared workflow automation service so every creation surface is covered.
- Add API BDD coverage for the self-watch rejection.

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts -t "prevents a workflow from watching its own chat thread"`

## Local baseline note

Running the entire target test file leaves three existing runner-claim scenarios at HTTP 404 in this local environment. The same failures reproduce on `origin/main`; the new regression test passes.