### PR TITLE
feat(cli): add presentation template commands

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -177,6 +177,26 @@ describe("auth tokens", () => {
     );
   });
 
+  it("gates presentation template capabilities behind their feature switch", () => {
+    const defaultToken = generateZeroToken("user_zero", "run_zero", "org_zero");
+    const enabledToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      "org_zero",
+      { [FeatureSwitchKey.PresentationTemplates]: true },
+    );
+
+    const defaultCapabilities = verifyZeroToken(defaultToken)?.capabilities;
+    expect(defaultCapabilities).not.toContain("presentation-template:read");
+    expect(defaultCapabilities).not.toContain("presentation-template:write");
+    expect(verifyZeroToken(enabledToken)?.capabilities).toStrictEqual(
+      expect.arrayContaining([
+        "presentation-template:read",
+        "presentation-template:write",
+      ]),
+    );
+  });
+
   it("grants custom connector writes by default", () => {
     const token = generateZeroToken("user_zero", "run_zero", "org_zero");
 

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -128,16 +128,15 @@ const zeroAuth$ = command(
       return null;
     }
 
-    if (!options.acceptAnySandboxCapability) {
-      if (!options.requiredCapability) {
-        return null;
-      }
+    if (options.requiredCapability) {
       const hasCapability = zeroAuth.capabilities.some((capability) => {
         return capability === options.requiredCapability;
       });
       if (!hasCapability) {
         return null;
       }
+    } else if (!options.acceptAnySandboxCapability) {
+      return null;
     }
 
     const result: ZeroAuthContext = {

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -27,6 +27,8 @@ const SANDBOX_TOKEN_TTL_SECONDS = 3 * 60 * 60;
 
 const CONDITIONAL_CAPABILITIES = [
   ["banking:read", FeatureSwitchKey.Banking],
+  ["presentation-template:read", FeatureSwitchKey.PresentationTemplates],
+  ["presentation-template:write", FeatureSwitchKey.PresentationTemplates],
   ["seo:read", FeatureSwitchKey.SeoBuiltIn],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -601,7 +601,10 @@ describe("AUTH-01 sandbox and zero bearers", () => {
 
     const accepted = await cfg.probeAuth(
       { authorization: `Bearer ${sandbox.token}` },
-      { acceptAnySandboxCapability: "true" },
+      {
+        acceptAnySandboxCapability: "true",
+        requiredCapability: "file:read",
+      },
       [200],
     );
     expect(accepted.body).toStrictEqual({
@@ -615,7 +618,10 @@ describe("AUTH-01 sandbox and zero bearers", () => {
     cfg.mockMembership(zeroMember, "org:member");
     const memberProbe = await cfg.probeAuth(
       { authorization: `Bearer ${memberZero.token}` },
-      { acceptAnySandboxCapability: "true" },
+      {
+        acceptAnySandboxCapability: "true",
+        requiredCapability: "file:read",
+      },
       [200],
     );
     expect(memberProbe.body).toStrictEqual({
@@ -625,6 +631,20 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       orgRole: "member",
       runId: memberZero.runId,
       capabilities: ["file:read"],
+    });
+
+    const missingCapabilityProbe = await cfg.probeAuth(
+      { authorization: `Bearer ${memberZero.token}` },
+      {
+        acceptAnySandboxCapability: "true",
+        requiredCapability: "file:write",
+      },
+      [403],
+    );
+    expectApiError(missingCapabilityProbe.body);
+    expect(missingCapabilityProbe.body.error).toStrictEqual({
+      message: "Missing required capability: file:write",
+      code: "FORBIDDEN",
     });
 
     const adminZero = cfg.zeroBearer(zeroAdmin, ["file:read", "file:write"]);

--- a/turbo/apps/api/src/signals/routes/zero-presentation-templates.ts
+++ b/turbo/apps/api/src/signals/routes/zero-presentation-templates.ts
@@ -55,11 +55,20 @@ const templateWriteAuth = {
   requiredCapability: "agent:write",
 } as const;
 
-const templateRunAuth = {
+const templateRunReadAuth = {
   accept: ["zero", "sandbox"],
   acceptAnySandboxCapability: true,
   requireOrganization: true,
   missingOrganizationStatus: 401,
+  requiredCapability: "presentation-template:read",
+} as const;
+
+const templateRunWriteAuth = {
+  accept: ["zero", "sandbox"],
+  acceptAnySandboxCapability: true,
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "presentation-template:write",
 } as const;
 
 function templateNotFound(templateId: string) {
@@ -614,22 +623,22 @@ export const zeroPresentationTemplatesRoutes: readonly RouteEntry[] = [
   },
   {
     route: zeroPresentationTemplatesContract.source,
-    handler: authRoute(templateRunAuth, sourceInner$),
+    handler: authRoute(templateRunReadAuth, sourceInner$),
   },
   {
     route: zeroPresentationTemplatesContract.preparePages,
-    handler: authRoute(templateRunAuth, preparePagesInner$),
+    handler: authRoute(templateRunWriteAuth, preparePagesInner$),
   },
   {
     route: zeroPresentationTemplatesContract.commitPages,
-    handler: authRoute(templateRunAuth, commitPagesInner$),
+    handler: authRoute(templateRunWriteAuth, commitPagesInner$),
   },
   {
     route: zeroPresentationTemplatesContract.publishPackage,
-    handler: authRoute(templateRunAuth, packageInner$),
+    handler: authRoute(templateRunWriteAuth, packageInner$),
   },
   {
     route: zeroPresentationTemplatesContract.fail,
-    handler: authRoute(templateRunAuth, failInner$),
+    handler: authRoute(templateRunWriteAuth, failInner$),
   },
 ];

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -173,7 +173,6 @@ describe("registerZeroCommands", () => {
       "agent",
       "upgrade",
       "resource",
-      "presentation-template",
       "whoami",
       "generate",
       "web",
@@ -185,6 +184,7 @@ describe("registerZeroCommands", () => {
       "credit",
       "logs",
       "chat",
+      "presentation-template",
       "schedule",
       "github",
       "slack",
@@ -256,7 +256,6 @@ describe("registerZeroCommands", () => {
       "model-provider",
       "upgrade",
       "resource",
-      "presentation-template",
       "whoami",
       "generate",
       "web",
@@ -660,6 +659,35 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(hiddenCommandNames(prog)).toContain("banking");
+  });
+
+  it("should show presentation-template with either template capability", () => {
+    for (const capability of [
+      "presentation-template:read",
+      "presentation-template:write",
+    ]) {
+      const token = buildZeroToken({
+        scope: "zero",
+        capabilities: [capability],
+      });
+      vi.stubEnv("ZERO_TOKEN", token);
+
+      expect(visibleCommandNames(buildProgram())).toContain(
+        "presentation-template",
+      );
+    }
+  });
+
+  it("should hide presentation-template when its capabilities are missing", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["file:write"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    expect(hiddenCommandNames(buildProgram())).toContain(
+      "presentation-template",
+    );
   });
 
   it("should show goal when goal capabilities are present", () => {
@@ -1139,7 +1167,6 @@ describe("registerZeroCommands", () => {
       "mcp",
       "upgrade",
       "resource",
-      "presentation-template",
       "whoami",
       "generate",
       "web",

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -24,6 +24,7 @@ function buildCommands(): Command[] {
     new Command("logs"),
     new Command("chat"),
     new Command("resource"),
+    new Command("presentation-template"),
     new Command("schedule"),
     new Command("github"),
     new Command("slack"),
@@ -147,7 +148,12 @@ describe("registerZeroCommands", () => {
     vi.stubEnv("ZERO_TOKEN", undefined);
 
     const prog = buildProgram();
-    expect(hiddenCommandNames(prog)).toEqual(["mcp", "recognize", "translate"]);
+    expect(hiddenCommandNames(prog)).toEqual([
+      "mcp",
+      "presentation-template",
+      "recognize",
+      "translate",
+    ]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -167,6 +173,7 @@ describe("registerZeroCommands", () => {
       "agent",
       "upgrade",
       "resource",
+      "presentation-template",
       "whoami",
       "generate",
       "web",
@@ -206,7 +213,12 @@ describe("registerZeroCommands", () => {
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual(["mcp", "recognize", "translate"]);
+    expect(hiddenCommandNames(prog)).toEqual([
+      "mcp",
+      "presentation-template",
+      "recognize",
+      "translate",
+    ]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -220,7 +232,12 @@ describe("registerZeroCommands", () => {
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual(["mcp", "recognize", "translate"]);
+    expect(hiddenCommandNames(prog)).toEqual([
+      "mcp",
+      "presentation-template",
+      "recognize",
+      "translate",
+    ]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -239,6 +256,7 @@ describe("registerZeroCommands", () => {
       "model-provider",
       "upgrade",
       "resource",
+      "presentation-template",
       "whoami",
       "generate",
       "web",
@@ -1121,6 +1139,7 @@ describe("registerZeroCommands", () => {
       "mcp",
       "upgrade",
       "resource",
+      "presentation-template",
       "whoami",
       "generate",
       "web",

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -29,6 +29,7 @@ describe("zero CLI program", () => {
       "search",
       "chat",
       "resource",
+      "presentation-template",
       "workflow",
       "goal",
       "slack",
@@ -87,7 +88,7 @@ describe("zero CLI program", () => {
     expect(publicCommandNames).not.toContain("__agent-loop");
   });
 
-  it("should have exactly 40 public commands", () => {
-    expect(publicCommandNames).toHaveLength(40);
+  it("should have exactly 41 public commands", () => {
+    expect(publicCommandNames).toHaveLength(41);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/presentation-template/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/presentation-template/__tests__/index.test.ts
@@ -1,0 +1,444 @@
+import { createHash } from "node:crypto";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+import chalk from "chalk";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import { zeroPresentationTemplateCommand } from "../index";
+
+const TEMPLATE_ID = "00000000-0000-4000-8000-000000000123";
+const API_ROOT = `http://localhost:3000/api/zero/presentation-templates/${TEMPLATE_ID}`;
+const SOURCE_URL = "https://downloads.example.test/source.pptx";
+const PACKAGE_URL = "https://downloads.example.test/package.tar.gz";
+
+interface TarEntry {
+  readonly path: string;
+  readonly content: string;
+}
+
+function writeOctal(
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  buffer.write(
+    `${value.toString(8).padStart(length - 1, "0")}\0`,
+    offset,
+    length,
+    "ascii",
+  );
+}
+
+function tarHeader(entry: TarEntry): Buffer {
+  const content = Buffer.from(entry.content, "utf8");
+  const header = Buffer.alloc(512);
+  header.write(entry.path, 0, 100, "utf8");
+  writeOctal(header, 100, 8, 0o644);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, content.length);
+  writeOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header.write("0", 156, 1, "ascii");
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  const checksum = header.reduce((total, byte) => {
+    return total + byte;
+  }, 0);
+  header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii");
+  header[154] = 0;
+  header[155] = 0x20;
+  return header;
+}
+
+function tarGz(entries: readonly TarEntry[]): Buffer {
+  const chunks: Buffer[] = [];
+  for (const entry of entries) {
+    const content = Buffer.from(entry.content, "utf8");
+    chunks.push(tarHeader(entry), content);
+    const padding = (512 - (content.length % 512)) % 512;
+    if (padding > 0) chunks.push(Buffer.alloc(padding));
+  }
+  chunks.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(chunks));
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function png(): Buffer {
+  return Buffer.from("\x89PNG\r\n\x1a\n", "latin1");
+}
+
+describe("zero presentation-template", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  let testDir: string;
+
+  beforeEach(async () => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    testDir = await mkdtemp(
+      path.join(tmpdir(), "zero-presentation-template-test-"),
+    );
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("downloads the PPTX source to the requested path", async () => {
+    const source = Buffer.from("pptx-source", "utf8");
+    server.use(
+      http.get(`${API_ROOT}/source`, ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer test-zero-token",
+        );
+        return HttpResponse.json({
+          url: SOURCE_URL,
+          filename: "source.pptx",
+          contentType:
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          size: source.length,
+        });
+      }),
+      http.get(SOURCE_URL, () => {
+        return new HttpResponse(source);
+      }),
+    );
+    const outputPath = path.join(testDir, "nested", "source.pptx");
+
+    await zeroPresentationTemplateCommand.parseAsync([
+      "node",
+      "zero",
+      "source",
+      "--id",
+      TEMPLATE_ID,
+      "--out",
+      outputPath,
+    ]);
+
+    expect(await readFile(outputPath)).toEqual(source);
+  });
+
+  it("uploads PNG pages in numeric filename order and commits their keys", async () => {
+    const pagesDir = path.join(testDir, "pages");
+    await Promise.all([
+      writeFile(path.join(testDir, "page-1.png"), png()),
+      writeFile(path.join(testDir, "page-2.png"), png()),
+      writeFile(path.join(testDir, "page-10.png"), png()),
+    ]);
+    await mkdir(pagesDir);
+    await Promise.all([
+      rename(
+        path.join(testDir, "page-1.png"),
+        path.join(pagesDir, "page-1.png"),
+      ),
+      rename(
+        path.join(testDir, "page-2.png"),
+        path.join(pagesDir, "page-2.png"),
+      ),
+      rename(
+        path.join(testDir, "page-10.png"),
+        path.join(pagesDir, "page-10.png"),
+      ),
+    ]);
+    const uploaded: string[] = [];
+    server.use(
+      http.post(`${API_ROOT}/pages/prepare`, async ({ request }) => {
+        expect(await request.json()).toEqual({ count: 3 });
+        return HttpResponse.json({
+          uploads: [1, 2, 10].map((page) => {
+            return {
+              key: `page-key-${page.toString()}`,
+              uploadUrl: `https://uploads.example.test/${page.toString()}`,
+              uploadHeaders: { "x-amz-meta-page": page.toString() },
+            };
+          }),
+        });
+      }),
+      http.put(
+        "https://uploads.example.test/:page",
+        async ({ params, request }) => {
+          uploaded.push(String(params.page));
+          expect(request.headers.get("content-type")).toBe("image/png");
+          expect(request.headers.get("x-amz-meta-page")).toBe(
+            String(params.page),
+          );
+          expect(Buffer.from(await request.arrayBuffer())).toEqual(png());
+          return new HttpResponse(null, { status: 200 });
+        },
+      ),
+      http.post(`${API_ROOT}/pages/commit`, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          keys: ["page-key-1", "page-key-2", "page-key-10"],
+          aspectRatio: 16 / 9,
+        });
+        return HttpResponse.json({ id: TEMPLATE_ID, status: "processing" });
+      }),
+    );
+
+    await zeroPresentationTemplateCommand.parseAsync([
+      "node",
+      "zero",
+      "pages",
+      "upload",
+      "--id",
+      TEMPLATE_ID,
+      "--dir",
+      pagesDir,
+    ]);
+
+    expect(uploaded).toEqual(["1", "2", "10"]);
+  });
+
+  it("does not commit the page batch when one upload fails", async () => {
+    const pagesDir = path.join(testDir, "pages");
+    await mkdir(pagesDir);
+    await Promise.all([
+      writeFile(path.join(pagesDir, "page-1.png"), png()),
+      writeFile(path.join(pagesDir, "page-2.png"), png()),
+    ]);
+    let commitRequests = 0;
+    server.use(
+      http.post(`${API_ROOT}/pages/prepare`, () => {
+        return HttpResponse.json({
+          uploads: [1, 2].map((page) => {
+            return {
+              key: `page-key-${page.toString()}`,
+              uploadUrl: `https://uploads.example.test/${page.toString()}`,
+              uploadHeaders: {},
+            };
+          }),
+        });
+      }),
+      http.put("https://uploads.example.test/1", () => {
+        return new HttpResponse(null, { status: 200 });
+      }),
+      http.put("https://uploads.example.test/2", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+      http.post(`${API_ROOT}/pages/commit`, () => {
+        commitRequests += 1;
+        return HttpResponse.json({ id: TEMPLATE_ID, status: "processing" });
+      }),
+    );
+
+    await expect(
+      zeroPresentationTemplateCommand.parseAsync([
+        "node",
+        "zero",
+        "pages",
+        "upload",
+        "--id",
+        TEMPLATE_ID,
+        "--dir",
+        pagesDir,
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(commitRequests).toBe(0);
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Page upload failed for page-2.png: 500",
+    );
+  });
+
+  it("publishes exactly the three required package files", async () => {
+    const packageDir = path.join(testDir, "package");
+    await mkdir(packageDir);
+    await Promise.all([
+      writeFile(path.join(packageDir, "DESIGN_SYSTEM.md"), "design"),
+      writeFile(path.join(packageDir, "LAYOUTS.md"), "layouts"),
+      writeFile(path.join(packageDir, "tokens.json"), '{"colors":{}}'),
+    ]);
+    server.use(
+      http.post(`${API_ROOT}/package`, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          files: [
+            { path: "DESIGN_SYSTEM.md", content: "design" },
+            { path: "LAYOUTS.md", content: "layouts" },
+            { path: "tokens.json", content: '{"colors":{}}' },
+          ],
+        });
+        return HttpResponse.json({ id: TEMPLATE_ID, status: "ready" });
+      }),
+    );
+
+    await zeroPresentationTemplateCommand.parseAsync([
+      "node",
+      "zero",
+      "publish",
+      "--id",
+      TEMPLATE_ID,
+      "--dir",
+      packageDir,
+    ]);
+  });
+
+  it("reports a stable import failure", async () => {
+    server.use(
+      http.post(`${API_ROOT}/fail`, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          code: "render_failed",
+          message: "LibreOffice failed",
+        });
+        return HttpResponse.json({ id: TEMPLATE_ID, status: "failed" });
+      }),
+    );
+
+    await zeroPresentationTemplateCommand.parseAsync([
+      "node",
+      "zero",
+      "fail",
+      "--id",
+      TEMPLATE_ID,
+      "--code",
+      "render_failed",
+      "--message",
+      "LibreOffice failed",
+    ]);
+  });
+
+  it("downloads, verifies, and extracts a user template package", async () => {
+    const archive = tarGz([
+      { path: "DESIGN_SYSTEM.md", content: "design" },
+      { path: "LAYOUTS.md", content: "layouts" },
+      { path: "tokens.json", content: '{"colors":{}}' },
+    ]);
+    server.use(
+      http.get(`${API_ROOT}/package`, () => {
+        return HttpResponse.json({ url: PACKAGE_URL, sha256: sha256(archive) });
+      }),
+      http.get(PACKAGE_URL, () => {
+        return new HttpResponse(archive);
+      }),
+    );
+    const outputDir = path.join(testDir, "pulled");
+
+    await zeroPresentationTemplateCommand.parseAsync([
+      "node",
+      "zero",
+      "pull",
+      `user-template:${TEMPLATE_ID}`,
+      "--dir",
+      outputDir,
+    ]);
+
+    expect(
+      await readFile(path.join(outputDir, "DESIGN_SYSTEM.md"), "utf8"),
+    ).toBe("design");
+  });
+
+  it("rejects a package whose bytes do not match the API digest", async () => {
+    const archive = tarGz([{ path: "tokens.json", content: "{}" }]);
+    server.use(
+      http.get(`${API_ROOT}/package`, () => {
+        return HttpResponse.json({ url: PACKAGE_URL, sha256: sha256(archive) });
+      }),
+      http.get(PACKAGE_URL, () => {
+        return new HttpResponse(Buffer.from("wrong archive", "utf8"));
+      }),
+    );
+
+    await expect(
+      zeroPresentationTemplateCommand.parseAsync([
+        "node",
+        "zero",
+        "pull",
+        `user-template:${TEMPLATE_ID}`,
+        "--dir",
+        path.join(testDir, "digest-mismatch"),
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Presentation template package archive digest mismatch",
+    );
+  });
+
+  it("refuses package archive paths outside the destination", async () => {
+    const archive = tarGz([{ path: "../escape.txt", content: "escape" }]);
+    server.use(
+      http.get(`${API_ROOT}/package`, () => {
+        return HttpResponse.json({ url: PACKAGE_URL, sha256: sha256(archive) });
+      }),
+      http.get(PACKAGE_URL, () => {
+        return new HttpResponse(archive);
+      }),
+    );
+    const outputDir = path.join(testDir, "unsafe");
+
+    await expect(
+      zeroPresentationTemplateCommand.parseAsync([
+        "node",
+        "zero",
+        "pull",
+        `user-template:${TEMPLATE_ID}`,
+        "--dir",
+        outputDir,
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "contains unsafe path: ../escape.txt",
+    );
+    await expect(access(path.join(testDir, "escape.txt"))).rejects.toThrow();
+  });
+
+  it("surfaces API error messages without replacing them", async () => {
+    server.use(
+      http.get(`${API_ROOT}/source`, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "NOT_FOUND",
+              message: "Presentation template source is gone",
+            },
+          },
+          { status: 404 },
+        );
+      }),
+    );
+
+    await expect(
+      zeroPresentationTemplateCommand.parseAsync([
+        "node",
+        "zero",
+        "source",
+        "--id",
+        TEMPLATE_ID,
+        "--out",
+        path.join(testDir, "missing.pptx"),
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Presentation template source is gone",
+    );
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/presentation-template/index.ts
+++ b/turbo/apps/cli/src/commands/zero/presentation-template/index.ts
@@ -1,0 +1,283 @@
+import { createWriteStream } from "node:fs";
+import { mkdir, readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import {
+  MAX_PRESENTATION_TEMPLATE_PAGES,
+  PRESENTATION_TEMPLATE_PACKAGE_PATHS,
+  presentationTemplateIdSchema,
+  presentationTemplateImportErrorCodeSchema,
+} from "@vm0/api-contracts/contracts/zero-presentation-templates";
+import chalk from "chalk";
+import { Command, Option } from "commander";
+
+import {
+  commitPresentationTemplatePages,
+  failPresentationTemplateImport,
+  getPresentationTemplatePackage,
+  getPresentationTemplateSource,
+  preparePresentationTemplatePages,
+  publishPresentationTemplatePackage,
+} from "../../../lib/api/domains/zero-presentation-templates";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { pullTarArchive } from "../shared/pull-tar-archive";
+
+const USER_TEMPLATE_PREFIX = "user-template:";
+const PNG_CONTENT_TYPE = "image/png";
+const pageFilenameCollator = new Intl.Collator("en-US", { numeric: true });
+
+interface TemplateIdOptions {
+  readonly id: string;
+}
+
+interface SourceOptions extends TemplateIdOptions {
+  readonly out: string;
+}
+
+interface PagesUploadOptions extends TemplateIdOptions {
+  readonly dir: string;
+}
+
+interface PublishOptions extends TemplateIdOptions {
+  readonly dir: string;
+}
+
+interface FailOptions extends TemplateIdOptions {
+  readonly code: string;
+  readonly message: string;
+}
+
+interface PullOptions {
+  readonly dir: string;
+}
+
+interface PageFile {
+  readonly filename: string;
+  readonly path: string;
+}
+
+function parseTemplateId(value: string): string {
+  const parsed = presentationTemplateIdSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Invalid presentation template id: ${value}`);
+  }
+  return parsed.data;
+}
+
+function parseUserTemplateReference(value: string): string {
+  if (!value.startsWith(USER_TEMPLATE_PREFIX)) {
+    throw new Error(
+      `Presentation template reference must start with ${USER_TEMPLATE_PREFIX}`,
+    );
+  }
+  return parseTemplateId(value.slice(USER_TEMPLATE_PREFIX.length));
+}
+
+async function readPageFiles(directory: string): Promise<PageFile[]> {
+  const resolvedDirectory = path.resolve(directory);
+  const entries = await readdir(resolvedDirectory, { withFileTypes: true });
+  const filenames = entries
+    .filter((entry) => {
+      return (
+        entry.isFile() && path.extname(entry.name).toLowerCase() === ".png"
+      );
+    })
+    .map((entry) => {
+      return entry.name;
+    })
+    .sort((left, right) => {
+      return pageFilenameCollator.compare(left, right);
+    });
+  if (filenames.length === 0) {
+    throw new Error(`No PNG pages found in ${resolvedDirectory}`);
+  }
+  if (filenames.length > MAX_PRESENTATION_TEMPLATE_PAGES) {
+    throw new Error(
+      `Presentation template has ${filenames.length.toString()} pages; the maximum is ${MAX_PRESENTATION_TEMPLATE_PAGES.toString()}`,
+    );
+  }
+
+  return filenames.map((filename) => {
+    return { filename, path: path.join(resolvedDirectory, filename) };
+  });
+}
+
+async function downloadSource(url: string, destination: string): Promise<void> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Presentation template source download failed: ${response.status}`,
+    );
+  }
+  if (!response.body) {
+    throw new Error("Presentation template source download returned no body");
+  }
+  await mkdir(path.dirname(destination), { recursive: true });
+  await pipeline(
+    Readable.fromWeb(response.body as never),
+    createWriteStream(destination),
+  );
+}
+
+const sourceCommand = new Command()
+  .name("source")
+  .description("Download the uploaded PPTX source for an import run")
+  .requiredOption("--id <template-id>", "Presentation template UUID")
+  .requiredOption("--out <path>", "Destination path")
+  .action(
+    withErrorHandler(async (options: SourceOptions) => {
+      const templateId = parseTemplateId(options.id);
+      const source = await getPresentationTemplateSource(templateId);
+      const outputPath = path.resolve(options.out);
+      await downloadSource(source.url, outputPath);
+      const downloaded = await stat(outputPath);
+      if (downloaded.size !== source.size) {
+        throw new Error(
+          `Presentation template source size mismatch: expected ${source.size.toString()}, got ${downloaded.size.toString()}`,
+        );
+      }
+      console.log(chalk.green("✓ Downloaded presentation template source"));
+      console.log(chalk.dim(`  File: ${outputPath}`));
+    }),
+  );
+
+const pagesUploadCommand = new Command()
+  .name("upload")
+  .description("Upload and commit ordered PNG pages")
+  .requiredOption("--id <template-id>", "Presentation template UUID")
+  .requiredOption("--dir <path>", "Directory containing rendered PNG pages")
+  .action(
+    withErrorHandler(async (options: PagesUploadOptions) => {
+      const templateId = parseTemplateId(options.id);
+      const pages = await readPageFiles(options.dir);
+      const prepared = await preparePresentationTemplatePages(
+        templateId,
+        pages.length,
+      );
+      if (prepared.uploads.length !== pages.length) {
+        throw new Error(
+          `Expected ${pages.length.toString()} page upload targets, got ${prepared.uploads.length.toString()}`,
+        );
+      }
+
+      const keys: string[] = [];
+      for (const [index, upload] of prepared.uploads.entries()) {
+        const page = pages[index];
+        if (!page) {
+          throw new Error(`Missing page for upload index ${index.toString()}`);
+        }
+        const headers = new Headers(upload.uploadHeaders);
+        headers.set("content-type", PNG_CONTENT_TYPE);
+        const response = await fetch(upload.uploadUrl, {
+          method: "PUT",
+          headers,
+          body: await readFile(page.path),
+        });
+        if (!response.ok) {
+          throw new Error(
+            `Page upload failed for ${page.filename}: ${response.status}`,
+          );
+        }
+        keys.push(upload.key);
+      }
+
+      await commitPresentationTemplatePages(templateId, keys);
+      console.log(
+        chalk.green(`✓ Uploaded ${pages.length.toString()} presentation pages`),
+      );
+    }),
+  );
+
+const pagesCommand = new Command()
+  .name("pages")
+  .description("Manage rendered presentation template pages")
+  .addCommand(pagesUploadCommand);
+
+const publishCommand = new Command()
+  .name("publish")
+  .description("Publish the extracted presentation template package")
+  .requiredOption("--id <template-id>", "Presentation template UUID")
+  .requiredOption("--dir <path>", "Directory containing the package files")
+  .action(
+    withErrorHandler(async (options: PublishOptions) => {
+      const templateId = parseTemplateId(options.id);
+      const directory = path.resolve(options.dir);
+      const files = await Promise.all(
+        PRESENTATION_TEMPLATE_PACKAGE_PATHS.map(async (packagePath) => {
+          return {
+            path: packagePath,
+            content: await readFile(path.join(directory, packagePath), "utf8"),
+          };
+        }),
+      );
+      await publishPresentationTemplatePackage(templateId, files);
+      console.log(chalk.green("✓ Published presentation template package"));
+    }),
+  );
+
+const failCommand = new Command()
+  .name("fail")
+  .description("Report a presentation template import failure")
+  .requiredOption("--id <template-id>", "Presentation template UUID")
+  .addOption(
+    new Option("--code <code>", "Stable import failure code")
+      .choices([...presentationTemplateImportErrorCodeSchema.options])
+      .makeOptionMandatory(),
+  )
+  .requiredOption("--message <text>", "Failure message")
+  .action(
+    withErrorHandler(async (options: FailOptions) => {
+      const templateId = parseTemplateId(options.id);
+      const code = presentationTemplateImportErrorCodeSchema.parse(
+        options.code,
+      );
+      await failPresentationTemplateImport(templateId, code, options.message);
+      console.log(chalk.green("✓ Reported presentation template failure"));
+    }),
+  );
+
+const pullCommand = new Command()
+  .name("pull")
+  .description("Download and extract a ready presentation template package")
+  .argument("<template>", "Template reference in user-template:<uuid> form")
+  .option("--dir <path>", "Directory to extract into", "./generated/resources")
+  .action(
+    withErrorHandler(async (template: string, options: PullOptions) => {
+      const templateId = parseUserTemplateReference(template);
+      const download = await getPresentationTemplatePackage(templateId);
+      const outputDir = await pullTarArchive({
+        url: download.url,
+        expectedSha256: download.sha256,
+        outputDir: options.dir,
+        label: "Presentation template package archive",
+      });
+      console.log(chalk.green(`✓ Pulled ${template}`));
+      console.log(chalk.dim(`  Extracted to: ${outputDir}`));
+    }),
+  );
+
+export const zeroPresentationTemplateCommand = new Command()
+  .name("presentation-template")
+  .description("Import and pull user presentation templates")
+  .addCommand(sourceCommand)
+  .addCommand(pagesCommand)
+  .addCommand(publishCommand)
+  .addCommand(failCommand)
+  .addCommand(pullCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero presentation-template source --id <uuid> --out /tmp/source.pptx
+  zero presentation-template pages upload --id <uuid> --dir /tmp/pages
+  zero presentation-template publish --id <uuid> --dir /tmp/package
+  zero presentation-template fail --id <uuid> --code render_failed --message "LibreOffice failed"
+  zero presentation-template pull user-template:<uuid> --dir ./generated/resources
+
+Notes:
+  - Authenticates only through ZERO_TOKEN
+  - Source, page, publish, and fail commands are intended for template import runs
+  - Pull is intended for presentation generation runs`,
+  );

--- a/turbo/apps/cli/src/commands/zero/resource/index.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/index.ts
@@ -1,11 +1,7 @@
-import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { Command } from "commander";
 import chalk from "chalk";
-import * as tar from "tar";
 import {
   findColorSystem,
   findDesignSystem,
@@ -21,6 +17,7 @@ import {
 
 import { getRegistryResourceDownload } from "../../../lib/api/domains/registry-resources";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { pullTarArchive } from "../shared/pull-tar-archive";
 
 type PullableRegistryEntry = RegistryEntry | VideoTemplateRegistryEntry;
 
@@ -60,33 +57,6 @@ export function findRegistryResourceForPull(
     }
   }
   return undefined;
-}
-
-function isSafeTarPath(entryPath: string): boolean {
-  const normalized = entryPath.replace(/\\/gu, "/");
-  return (
-    !path.isAbsolute(normalized) &&
-    !normalized.split("/").some((segment) => {
-      return segment === "..";
-    })
-  );
-}
-
-async function downloadArchive(url: string): Promise<Buffer> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Resource archive download failed: ${response.status}`);
-  }
-  return Buffer.from(await response.arrayBuffer());
-}
-
-function verifyArchive(buffer: Buffer, expectedSha256: string): void {
-  const actual = createHash("sha256").update(buffer).digest("hex");
-  if (actual !== expectedSha256) {
-    throw new Error(
-      `Resource archive digest mismatch: expected ${expectedSha256}, got ${actual}`,
-    );
-  }
 }
 
 export const zeroResourceCommand = new Command()
@@ -130,25 +100,12 @@ export const zeroResourceCommand = new Command()
             );
           }
 
-          const buffer = await downloadArchive(download.url);
-          verifyArchive(buffer, archive.sha256);
-
-          const outputDir = path.resolve(options.dir);
-          const tmpDir = await mkdtemp(path.join(tmpdir(), "zero-resource-"));
-          const archivePath = path.join(tmpDir, "resource.tar.gz");
-          await mkdir(outputDir, { recursive: true });
-          await writeFile(archivePath, buffer);
-
-          try {
-            await tar.extract({
-              file: archivePath,
-              cwd: outputDir,
-              gzip: true,
-              filter: isSafeTarPath,
-            });
-          } finally {
-            await rm(tmpDir, { recursive: true, force: true });
-          }
+          const outputDir = await pullTarArchive({
+            url: download.url,
+            expectedSha256: archive.sha256,
+            outputDir: options.dir,
+            label: "Resource archive",
+          });
 
           console.log(chalk.green(`✓ Pulled ${entry.id}`));
           console.log(chalk.dim(`  Extracted to: ${outputDir}`));

--- a/turbo/apps/cli/src/commands/zero/shared/pull-tar-archive.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/pull-tar-archive.ts
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import * as tar from "tar";
+
+interface PullTarArchiveOptions {
+  readonly url: string;
+  readonly expectedSha256: string;
+  readonly outputDir: string;
+  readonly label: string;
+}
+
+function isSafeTarPath(entryPath: string): boolean {
+  const normalized = entryPath.replace(/\\/gu, "/");
+  return (
+    !path.isAbsolute(normalized) &&
+    !normalized.split("/").some((segment) => {
+      return segment === "..";
+    })
+  );
+}
+
+async function validateTarArchive(
+  archivePath: string,
+  label: string,
+): Promise<void> {
+  let unsafePath: string | undefined;
+  await tar.list({
+    file: archivePath,
+    gzip: true,
+    filter: (entryPath, entry) => {
+      if (
+        unsafePath === undefined &&
+        (!isSafeTarPath(entryPath) ||
+          !("type" in entry) ||
+          (entry.type !== "File" && entry.type !== "Directory"))
+      ) {
+        unsafePath = entryPath;
+      }
+      return false;
+    },
+  });
+  if (unsafePath !== undefined) {
+    throw new Error(`${label} contains unsafe path: ${unsafePath}`);
+  }
+}
+
+export async function pullTarArchive({
+  url,
+  expectedSha256,
+  outputDir,
+  label,
+}: PullTarArchiveOptions): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${label} download failed: ${response.status}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const actualSha256 = createHash("sha256").update(buffer).digest("hex");
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(
+      `${label} digest mismatch: expected ${expectedSha256}, got ${actualSha256}`,
+    );
+  }
+
+  const resolvedOutputDir = path.resolve(outputDir);
+  const tmpDir = await mkdtemp(path.join(tmpdir(), "zero-archive-"));
+  const archivePath = path.join(tmpDir, "archive.tar.gz");
+  await writeFile(archivePath, buffer);
+
+  try {
+    await validateTarArchive(archivePath, label);
+    await mkdir(resolvedOutputDir, { recursive: true });
+    await tar.extract({
+      file: archivePath,
+      cwd: resolvedOutputDir,
+      gzip: true,
+      filter: (entryPath, entry) => {
+        return (
+          isSafeTarPath(entryPath) &&
+          "type" in entry &&
+          (entry.type === "File" || entry.type === "Directory")
+        );
+      },
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  return resolvedOutputDir;
+}

--- a/turbo/apps/cli/src/lib/api/domains/zero-presentation-templates.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-presentation-templates.ts
@@ -1,0 +1,84 @@
+import {
+  type PresentationTemplateImportErrorCode,
+  type PresentationTemplatePackagePath,
+  zeroPresentationTemplatesContract,
+} from "@vm0/api-contracts/contracts/zero-presentation-templates";
+import { initClient } from "@vm0/api-contracts/contracts/trpc-contract";
+
+import { getClientConfig, handleError } from "../core/client-factory";
+
+interface PresentationTemplatePackageFile {
+  readonly path: PresentationTemplatePackagePath;
+  readonly content: string;
+}
+
+async function presentationTemplateClient() {
+  return initClient(zeroPresentationTemplatesContract, await getClientConfig());
+}
+
+export async function getPresentationTemplateSource(templateId: string) {
+  const client = await presentationTemplateClient();
+  const result = await client.source({ params: { templateId } });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to prepare presentation template source");
+}
+
+export async function preparePresentationTemplatePages(
+  templateId: string,
+  count: number,
+) {
+  const client = await presentationTemplateClient();
+  const result = await client.preparePages({
+    params: { templateId },
+    body: { count },
+  });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to prepare presentation template page uploads");
+}
+
+export async function commitPresentationTemplatePages(
+  templateId: string,
+  keys: string[],
+) {
+  const client = await presentationTemplateClient();
+  const result = await client.commitPages({
+    params: { templateId },
+    body: { keys, aspectRatio: 16 / 9 },
+  });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to commit presentation template pages");
+}
+
+export async function publishPresentationTemplatePackage(
+  templateId: string,
+  files: PresentationTemplatePackageFile[],
+) {
+  const client = await presentationTemplateClient();
+  const result = await client.publishPackage({
+    params: { templateId },
+    body: { files },
+  });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to publish presentation template package");
+}
+
+export async function failPresentationTemplateImport(
+  templateId: string,
+  code: PresentationTemplateImportErrorCode,
+  message: string,
+) {
+  const client = await presentationTemplateClient();
+  const result = await client.fail({
+    params: { templateId },
+    body: { code, message },
+  });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to report presentation template import failure");
+}
+
+export async function getPresentationTemplatePackage(templateId: string) {
+  const client = await presentationTemplateClient();
+  const result = await client.downloadPackage({ params: { templateId } });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to prepare presentation template package");
+}

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -47,6 +47,7 @@ const COMMAND_CAPABILITY_MAP: Record<
     "chat-thread:write",
   ],
   resource: null,
+  "presentation-template": null,
   github: ["github:read", "github:write"],
   slack: "slack:write",
   feishu: "feishu:write",
@@ -74,7 +75,12 @@ const COMMAND_CAPABILITY_MAP: Record<
   banking: "banking:read",
 };
 
-const RUN_ONLY_COMMANDS = new Set(["mcp", "recognize", "translate"]);
+const RUN_ONLY_COMMANDS = new Set([
+  "mcp",
+  "presentation-template",
+  "recognize",
+  "translate",
+]);
 
 const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
   {
@@ -221,6 +227,14 @@ const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
     description: "Pull registry resources from private R2-backed archives",
     load: async () => {
       return (await import("./commands/zero/resource")).zeroResourceCommand;
+    },
+  },
+  {
+    name: "presentation-template",
+    description: "Import and pull user presentation templates",
+    load: async () => {
+      return (await import("./commands/zero/presentation-template"))
+        .zeroPresentationTemplateCommand;
     },
   },
   {

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -47,7 +47,10 @@ const COMMAND_CAPABILITY_MAP: Record<
     "chat-thread:write",
   ],
   resource: null,
-  "presentation-template": null,
+  "presentation-template": [
+    "presentation-template:read",
+    "presentation-template:write",
+  ],
   github: ["github:read", "github:write"],
   slack: "slack:write",
   feishu: "feishu:write",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
@@ -40,8 +40,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 41 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(41);
+  it("should have exactly 43 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(43);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {
@@ -143,6 +143,11 @@ describe("ZERO_CAPABILITIES", () => {
 
   it("should include banking read capability", () => {
     expect(ZERO_CAPABILITIES).toContain("banking:read");
+  });
+
+  it("should include presentation template read and write capabilities", () => {
+    expect(ZERO_CAPABILITIES).toContain("presentation-template:read");
+    expect(ZERO_CAPABILITIES).toContain("presentation-template:write");
   });
 
   it("should include goal read and write capabilities", () => {

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -46,6 +46,8 @@ export const ZERO_CAPABILITIES = [
   "billing:read",
   "billing:write",
   "banking:read",
+  "presentation-template:read",
+  "presentation-template:write",
   "maps:read",
   "weather:read",
   "scrape:read",
@@ -155,6 +157,14 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     "banking:read": {
       group: "Banking",
       label: "Read enabled banking accounts",
+    },
+    "presentation-template:read": {
+      group: "Presentation Templates",
+      label: "Download presentation templates",
+    },
+    "presentation-template:write": {
+      group: "Presentation Templates",
+      label: "Process presentation template imports",
     },
     "maps:read": { group: "Maps", label: "Use managed maps services" },
     "weather:read": {

--- a/turbo/packages/api-contracts/src/contracts/zero-presentation-templates.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-presentation-templates.ts
@@ -10,6 +10,12 @@ export const MAX_PRESENTATION_TEMPLATE_PAGES = 100;
 export const PRESENTATION_TEMPLATE_CONVERSION_TIMEOUT_SECONDS = 10 * 60;
 export const MAX_PRESENTATION_TEMPLATE_PACKAGE_FILE_BYTES = 512 * 1024;
 
+export const PRESENTATION_TEMPLATE_PACKAGE_PATHS = [
+  "DESIGN_SYSTEM.md",
+  "LAYOUTS.md",
+  "tokens.json",
+] as const;
+
 export const presentationTemplateStatusSchema = z.enum([
   "pending",
   "processing",
@@ -55,8 +61,10 @@ const presentationTemplateDetailSchema =
     pageUrls: z.array(z.string().url()),
   });
 
+export const presentationTemplateIdSchema = z.uuid();
+
 const presentationTemplateIdParamsSchema = z.object({
-  templateId: z.uuid(),
+  templateId: presentationTemplateIdSchema,
 });
 
 const createPresentationTemplateBodySchema = z.object({
@@ -91,11 +99,7 @@ const commitPagesBodySchema = z.object({
   aspectRatio: z.number().positive().max(10),
 });
 
-const packagePathSchema = z.enum([
-  "DESIGN_SYSTEM.md",
-  "LAYOUTS.md",
-  "tokens.json",
-]);
+const packagePathSchema = z.enum(PRESENTATION_TEMPLATE_PACKAGE_PATHS);
 
 const packageFileSchema = z.object({
   path: packagePathSchema,
@@ -252,6 +256,22 @@ export const zeroPresentationTemplatesContract = c.router({
     },
     summary: "Publish a completed presentation template package",
   },
+  downloadPackage: {
+    method: "GET",
+    path: "/api/zero/presentation-templates/:templateId/package",
+    pathParams: presentationTemplateIdParamsSchema,
+    headers: authHeadersSchema,
+    responses: {
+      200: z.object({
+        url: z.string().url(),
+        sha256: z.string().regex(/^[a-f0-9]{64}$/u),
+      }),
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      ...commonErrors,
+    },
+    summary: "Prepare a presentation template package download",
+  },
   fail: {
     method: "POST",
     path: "/api/zero/presentation-templates/:templateId/fail",
@@ -273,3 +293,8 @@ export type ZeroPresentationTemplatesContract =
 export type PresentationTemplateSummary = z.infer<
   typeof presentationTemplateSummarySchema
 >;
+export type PresentationTemplateImportErrorCode = z.infer<
+  typeof presentationTemplateImportErrorCodeSchema
+>;
+export type PresentationTemplatePackagePath =
+  (typeof PRESENTATION_TEMPLATE_PACKAGE_PATHS)[number];

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -113,6 +113,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.JoggAiBuiltIn]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SeoBuiltIn]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConnectorDiscovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ConnectorCatalogCount]).toBe(true);
@@ -139,6 +140,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.StrapiIntegration]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.JoggAiBuiltIn]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SeoBuiltIn]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConcurrencyMemberUsage]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConnectorDiscovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConnectorCatalogCount]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -38,6 +38,7 @@ export enum FeatureSwitchKey {
   SpotifyConnector = "spotifyConnector",
   ZeroDebug = "zeroDebug",
   Banking = "banking",
+  PresentationTemplates = "presentationTemplates",
   Lab = "lab",
   NotionWorkflowAutomations = "notionWorkflowAutomations",
   GoogleFormsWorkflowAutomations = "googleFormsWorkflowAutomations",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -213,6 +213,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.PresentationTemplates]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Enable user-uploaded PPTX presentation templates and their ZERO_TOKEN capabilities.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.Lab]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the Lab page for toggling experimental features",


### PR DESCRIPTION
## Summary
- add zero presentation-template source, pages upload, publish, fail, and pull commands for PPTX template flows
- add the presentationTemplates feature switch, enabled for staff organizations by default, and gate the CLI through presentation-template:read and presentation-template:write ZERO_TOKEN capabilities
- require the corresponding ZERO_TOKEN capability on run-scoped API routes while continuing to accept raw sandbox callbacks
- authenticate commands through ZERO_TOKEN and preserve API error messages
- upload PNG pages in numeric filename order and commit only after the complete batch succeeds
- verify package SHA-256 digests and reject unsafe tar entries before extraction
- add the typed package-download contract and CLI client for the follow-up API implementation

## Stack
- Stacked on #26301
- The package-download handler lands in follow-up #26238; this PR adds its contract and CLI consumer
- This PR does not change the existing aspectRatio API or database schema and does not inspect page dimensions; it supplies the fixed 16:9 value required by the PR3 contract

## Verification
- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- bounded workspace, platform, and API type checks
- 8 targeted test files: 205 tests passed
- pnpm --filter @vm0/zero-cli build
- built dist/zero.js smoke: command hidden without presentation-template capabilities, visible with them, and source, pages upload, publish, fail, and pull help paths all exit 0

Closes #26237