### PR TITLE
fix(chat): download private attachments from signed urls

### DIFF
--- a/turbo/apps/platform/src/signals/artifacts-page/artifact-catalog-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifact-catalog-signals.ts
@@ -1,10 +1,8 @@
 import { command, computed } from "ccstate";
 import type { ArtifactDetail } from "@vm0/api-contracts/contracts/artifact-catalog";
 
-import {
-  downloadAttachmentUrl,
-  publicAttachmentUrl,
-} from "../../views/zero-page/zero-attachment-url.ts";
+import { publicAttachmentUrl } from "../../views/zero-page/zero-attachment-url.ts";
+import { downloadAttachment$ } from "../attachment-download.ts";
 import { fetchPreviewText, isTextPreviewKind } from "../text-preview.ts";
 import {
   classifyChatAttachment,
@@ -118,7 +116,11 @@ export const openArtifact$ = command(
       return;
     }
     if (preview.kind === "file") {
-      await downloadAttachmentUrl(preview.url, signal, preview.filename);
+      await set(
+        downloadAttachment$,
+        { filename: preview.filename, url: preview.url },
+        signal,
+      );
       signal.throwIfAborted();
       return;
     }

--- a/turbo/apps/platform/src/signals/attachment-download.ts
+++ b/turbo/apps/platform/src/signals/attachment-download.ts
@@ -1,0 +1,30 @@
+import { command } from "ccstate";
+import { downloadAttachmentUrl } from "../views/zero-page/zero-attachment-url.ts";
+import { attachmentResourceUrlResolver$ } from "./attachment-resource-url.ts";
+
+type AttachmentDownload = {
+  readonly filename: string;
+  readonly url: string;
+};
+
+/**
+ * Resolve private uploaded files through the authenticated signing endpoint
+ * before fetching their bytes. Public artifact URLs pass through unchanged.
+ */
+export const downloadAttachment$ = command(
+  async (
+    { get },
+    attachment: AttachmentDownload,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const resolveResourceUrl = get(attachmentResourceUrlResolver$);
+    await downloadAttachmentUrl(
+      attachment.url,
+      signal,
+      attachment.filename,
+      (url) => {
+        return get(resolveResourceUrl(url));
+      },
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/attachment-download.ts
+++ b/turbo/apps/platform/src/signals/attachment-download.ts
@@ -1,5 +1,8 @@
 import { command } from "ccstate";
-import { downloadAttachmentUrl } from "../views/zero-page/zero-attachment-url.ts";
+import {
+  downloadAttachmentUrl,
+  publicAttachmentUrl,
+} from "../views/zero-page/zero-attachment-url.ts";
 import { attachmentResourceUrlResolver$ } from "./attachment-resource-url.ts";
 
 type AttachmentDownload = {
@@ -18,13 +21,10 @@ export const downloadAttachment$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const resolveResourceUrl = get(attachmentResourceUrlResolver$);
-    await downloadAttachmentUrl(
-      attachment.url,
-      signal,
-      attachment.filename,
-      (url) => {
-        return get(resolveResourceUrl(url));
-      },
+    const resourceUrl = await get(
+      resolveResourceUrl(publicAttachmentUrl(attachment.url)),
     );
+    signal.throwIfAborted();
+    await downloadAttachmentUrl(resourceUrl, signal, attachment.filename);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2820,8 +2820,9 @@ describe("zero attachment chips", () => {
     expect(screen.queryByAltText("1280x720")).toBeNull();
   });
 
-  it("opens canonical markdown and text previews, shares a document link, and reports download failures", async () => {
+  it("opens canonical text previews and downloads a private presentation from its presigned url", async () => {
     const releaseNotesUrl = canonicalUserMessageFileUrl("attachment-markdown");
+    const browser = context.mocks.browser.blobDownload();
     context.mocks.browser.clipboardWriteText();
     context.mocks.http.get(PRESIGNED_FILE_PATTERN, ({ params }) => {
       const fileId = params.fileId;
@@ -2835,10 +2836,18 @@ describe("zero attachment chips", () => {
           headers: { "Content-Type": "text/plain" },
         });
       }
+      if (fileId === "attachment-presentation") {
+        return new Response("presentation bytes", {
+          headers: {
+            "Content-Type":
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          },
+        });
+      }
       return new Response(null, { status: 500 });
     });
-    // A download reads the canonical route directly, so it keeps its own
-    // failure path independent of the presigned preview URL.
+    // Guard against regressing to the canonical route, which needs an
+    // Authorization header that the download fetch does not carry.
     context.mocks.http.get("/api/zero/web/download-file", () => {
       return new Response(null, { status: 500 });
     });
@@ -2864,9 +2873,10 @@ describe("zero attachment chips", () => {
             },
             {
               type: "file",
-              fileId: "attachment-file",
-              filenameSnapshot: "archive.bin",
-              contentType: "application/octet-stream",
+              fileId: "attachment-presentation",
+              filenameSnapshot: "quarterly-plan.pptx",
+              contentType:
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             },
           ],
           createdAt: "2026-03-10T00:00:00Z",
@@ -2886,7 +2896,9 @@ describe("zero attachment chips", () => {
       expect(
         screen.getByLabelText("Open text preview for transcript.txt"),
       ).toBeInTheDocument();
-      expect(screen.getByLabelText("Download archive.bin")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Download quarterly-plan.pptx"),
+      ).toBeInTheDocument();
     });
 
     click(screen.getByLabelText("Open markdown preview for release-notes.md"));
@@ -2929,10 +2941,15 @@ describe("zero attachment chips", () => {
       ).not.toBeInTheDocument();
     });
 
-    click(screen.getByLabelText("Download archive.bin"));
+    click(screen.getByLabelText("Download quarterly-plan.pptx"));
 
     await waitFor(() => {
-      expect(screen.getByText("Download failed")).toBeInTheDocument();
+      expect(browser.downloads).toHaveLength(1);
     });
+    expect(browser.downloads[0]).toMatchObject({
+      filename: "quarterly-plan.pptx",
+      blob: expect.any(Blob),
+    });
+    expect(screen.queryByText("Download failed")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -23,6 +23,7 @@ import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { accept } from "../../lib/accept.ts";
 import { i18n } from "../../i18n/index.ts";
+import { downloadAttachment$ } from "../../signals/attachment-download.ts";
 import {
   OAUTH_API_BASE,
   zeroClient$,
@@ -53,7 +54,6 @@ import {
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import {
   copyAttachmentLinkToClipboard,
-  downloadAttachmentUrl,
   publicAttachmentUrl,
 } from "./zero-attachment-url.ts";
 
@@ -672,6 +672,7 @@ export function ArtifactDownloadMenu({
   const closeMenu = useSet(closeArtifactDownloadMenu$);
   const startArtifactDownload = useSet(startArtifactDownload$);
   const finishArtifactDownload = useSet(finishArtifactDownload$);
+  const downloadAttachment = useSet(downloadAttachment$);
   const pageSignal = useGet(pageSignal$);
   const open = openKey === `${menuInstanceKey}:${artifactDownloadKey}`;
   const downloadPending = pendingKey === artifactDownloadKey;
@@ -730,7 +731,10 @@ export function ArtifactDownloadMenu({
             startArtifactDownloadWithCleanup({
               closeMenu,
               operation: "artifact download",
-              download: downloadAttachmentUrl(url, pageSignal, downloadName),
+              download: downloadAttachment(
+                { filename: downloadName, url },
+                pageSignal,
+              ),
               downloadKey: artifactDownloadKey,
               finish: finishArtifactDownload,
               start: startArtifactDownload,

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -27,6 +27,7 @@ import type {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ZeroChatAttachment } from "../../signals/zero-page/chat-draft";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
+import { downloadAttachment$ } from "../../signals/attachment-download.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import {
   currentLeftThread$,
@@ -61,7 +62,6 @@ import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 import {
   artifactPreviewUrlsMatch,
   attachmentFilenameFromUrl,
-  downloadAttachmentUrl,
 } from "./zero-attachment-url.ts";
 import { useResolvedAttachmentUrl } from "./zero-attachment-resource.ts";
 import {
@@ -1437,12 +1437,14 @@ export function FileAttachmentChip({
   url: string;
 }) {
   const { t } = useTranslation();
+  const downloadAttachment = useSet(downloadAttachment$);
+  const rootSignal = useGet(rootSignal$);
   return (
     <button
       type="button"
       onClick={() => {
         detach(
-          downloadAttachmentUrl(url, undefined, filename),
+          downloadAttachment({ filename, url }, rootSignal),
           Reason.DomCallback,
           "attachment download",
         );

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -28,6 +28,7 @@ import type {
 import type { ZeroChatAttachment } from "../../signals/zero-page/chat-draft";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
 import { downloadAttachment$ } from "../../signals/attachment-download.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import {
   currentLeftThread$,
@@ -1438,13 +1439,13 @@ export function FileAttachmentChip({
 }) {
   const { t } = useTranslation();
   const downloadAttachment = useSet(downloadAttachment$);
-  const rootSignal = useGet(rootSignal$);
+  const pageSignal = useGet(pageSignal$);
   return (
     <button
       type="button"
       onClick={() => {
         detach(
-          downloadAttachment({ filename, url }, rootSignal),
+          downloadAttachment({ filename, url }, pageSignal),
           Reason.DomCallback,
           "attachment download",
         );

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -2,6 +2,8 @@ import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { Download, Eye, FileMusic, Play, Video } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
+import { downloadAttachment$ } from "../../signals/attachment-download.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import type { TextPreviewComputed } from "../../signals/text-preview.ts";
 import {
@@ -15,10 +17,7 @@ import {
   FilePreviewIcon,
   getFilePreviewAccentClass,
 } from "./zero-file-preview-icon.tsx";
-import {
-  downloadAttachmentUrl,
-  publicAttachmentUrl,
-} from "./zero-attachment-url";
+import { publicAttachmentUrl } from "./zero-attachment-url";
 import { ArtifactThumbnailImage } from "./zero-artifact-thumbnail.tsx";
 
 interface ChatAttachmentDescriptor {
@@ -410,16 +409,17 @@ function FileThumbnailPreview({
 }) {
   const { t } = useTranslation();
   const accentClass = getFilePreviewAccentClass(filename, contentType);
+  const downloadAttachment = useSet(downloadAttachment$);
+  const pageSignal = useGet(pageSignal$);
 
   return (
     <button
       type="button"
       onClick={() => {
         detach(
-          downloadAttachmentUrl(
-            normalizePlatformFileUrl(url),
-            undefined,
-            filename,
+          downloadAttachment(
+            { filename, url: normalizePlatformFileUrl(url) },
+            pageSignal,
           ),
           Reason.DomCallback,
           "attachment download",

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
@@ -230,12 +230,14 @@ function triggerBlobDownload(blob: Blob, filename: string): void {
 async function fetchBlobForDownload(
   url: string,
   signal: AbortSignal,
+  resolveResourceUrl: (url: string) => Promise<string>,
 ): Promise<Blob | null> {
-  const fetchUrl = publicAttachmentUrl(url);
   // The catch branch reports network/CORS failures without falling back to
   // cross-origin anchor navigation, which would open images instead.
   // eslint-disable-next-line no-restricted-syntax -- fetch/CORS failures should surface as download failures
   try {
+    const fetchUrl = await resolveResourceUrl(publicAttachmentUrl(url));
+    signal.throwIfAborted();
     const res = await fetch(fetchUrl, {
       cache: "reload",
       mode: "cors",
@@ -261,8 +263,11 @@ export async function downloadAttachmentUrl(
   url: string,
   signal: AbortSignal = AbortSignal.any([]),
   filename = attachmentFilenameFromUrl(url),
+  resolveResourceUrl: (url: string) => Promise<string> = (resourceUrl) => {
+    return Promise.resolve(resourceUrl);
+  },
 ): Promise<void> {
-  const blob = await fetchBlobForDownload(url, signal);
+  const blob = await fetchBlobForDownload(url, signal, resolveResourceUrl);
   if (blob !== null) {
     triggerBlobDownload(blob, filename);
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
@@ -230,14 +230,12 @@ function triggerBlobDownload(blob: Blob, filename: string): void {
 async function fetchBlobForDownload(
   url: string,
   signal: AbortSignal,
-  resolveResourceUrl: (url: string) => Promise<string>,
 ): Promise<Blob | null> {
+  const fetchUrl = publicAttachmentUrl(url);
   // The catch branch reports network/CORS failures without falling back to
   // cross-origin anchor navigation, which would open images instead.
   // eslint-disable-next-line no-restricted-syntax -- fetch/CORS failures should surface as download failures
   try {
-    const fetchUrl = await resolveResourceUrl(publicAttachmentUrl(url));
-    signal.throwIfAborted();
     const res = await fetch(fetchUrl, {
       cache: "reload",
       mode: "cors",
@@ -263,11 +261,8 @@ export async function downloadAttachmentUrl(
   url: string,
   signal: AbortSignal = AbortSignal.any([]),
   filename = attachmentFilenameFromUrl(url),
-  resolveResourceUrl: (url: string) => Promise<string> = (resourceUrl) => {
-    return Promise.resolve(resourceUrl);
-  },
 ): Promise<void> {
-  const blob = await fetchBlobForDownload(url, signal, resolveResourceUrl);
+  const blob = await fetchBlobForDownload(url, signal);
   if (blob !== null) {
     triggerBlobDownload(blob, filename);
   }


### PR DESCRIPTION
## Summary

- Resolve private web-uploaded attachments through the existing authenticated signing endpoint before fetching their bytes.
- Route every attachment download entry point through one command: message chips, body file cards, preview/sidebar menus, and the artifact catalog.
- Keep public artifact and CDN URLs unchanged.

## Root cause

Persisted web uploads use a canonical `/api/zero/web/download-file` URL protected by `file:read`. The download path called bare `fetch` on that URL, so the request carried no Authorization header and failed before a blob could be created. The recent preview fix presigned renderer URLs but did not cover downloads; one integration test explicitly preserved the failing raw-route behavior.

The new command reuses `attachmentResourceUrlResolver$`, so private files are exchanged for a short-lived object URL after the ownership check, while public files pass through. Resolution is inside the existing download error boundary, so signing and fetch failures both keep the current Download failed toast.

## Tests

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for non-app/API packages, app, and API
- `zero-attachment-chips.test.tsx`
- `artifact-catalog-page.test.tsx`
- `thread-sidebar.test.tsx`

The attachment integration coverage now downloads a private `.pptx` from the presigned URL while the canonical download route is forced to return 500.