### PR TITLE
test(pi-agent-runtime): isolate skill fixtures from guest path

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/runtime.test.ts
@@ -1,10 +1,16 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
 
 import {
   PI_SKILLS_ROOT,
   type RunSkillSnapshot,
 } from "@vm0/api-contracts/contracts/runners";
+import type {
+  FileError,
+  FileInfo,
+  Result,
+} from "@earendil-works/pi-agent-core";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
@@ -26,6 +32,72 @@ const ZERO_USAGE = {
   totalTokens: 0,
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
+
+class GuestSkillsExecutionEnv extends NodeExecutionEnv {
+  constructor(private readonly hostSkillsRoot: string) {
+    super({ cwd: "/home/user/workspace" });
+  }
+
+  private hostPath(path: string): string {
+    const suffix =
+      path === PI_SKILLS_ROOT ? "" : path.slice(`${PI_SKILLS_ROOT}/`.length);
+    return join(this.hostSkillsRoot, suffix);
+  }
+
+  private guestPath(path: string): string {
+    const suffix = relative(this.hostSkillsRoot, path);
+    return suffix ? join(PI_SKILLS_ROOT, suffix) : PI_SKILLS_ROOT;
+  }
+
+  private guestFileInfo(info: FileInfo): FileInfo {
+    return { ...info, path: this.guestPath(info.path) };
+  }
+
+  override readTextFile(
+    path: string,
+    abortSignal?: AbortSignal,
+  ): Promise<Result<string, FileError>> {
+    return super.readTextFile(this.hostPath(path), abortSignal);
+  }
+
+  override readBinaryFile(
+    path: string,
+    abortSignal?: AbortSignal,
+  ): Promise<Result<Uint8Array, FileError>> {
+    return super.readBinaryFile(this.hostPath(path), abortSignal);
+  }
+
+  override async fileInfo(path: string): Promise<Result<FileInfo, FileError>> {
+    const result = await super.fileInfo(this.hostPath(path));
+    return result.ok
+      ? { ok: true, value: this.guestFileInfo(result.value) }
+      : result;
+  }
+
+  override async listDir(
+    path: string,
+    abortSignal?: AbortSignal,
+  ): Promise<Result<FileInfo[], FileError>> {
+    const result = await super.listDir(this.hostPath(path), abortSignal);
+    return result.ok
+      ? {
+          ok: true,
+          value: result.value.map((info) => {
+            return this.guestFileInfo(info);
+          }),
+        }
+      : result;
+  }
+
+  override async canonicalPath(
+    path: string,
+  ): Promise<Result<string, FileError>> {
+    const result = await super.canonicalPath(this.hostPath(path));
+    return result.ok
+      ? { ok: true, value: this.guestPath(result.value) }
+      : result;
+  }
+}
 
 function assistantToolCall(name: string): AssistantMessage {
   return {
@@ -78,46 +150,48 @@ describe("Pi run Skill runtime", () => {
   });
 
   it("loads only snapshot Skills and preserves prompt and read semantics", async () => {
-    await mkdir(PI_SKILLS_ROOT, { recursive: true });
-    const testRoot = await mkdtemp(join(PI_SKILLS_ROOT, "vm0-runtime-test-"));
-    const skillDirectory = join(testRoot, "pinned-skill");
-    const ambientDirectory = join(testRoot, "ambient-skill");
+    const hostSkillsRoot = await mkdtemp(join(tmpdir(), "vm0-runtime-test-"));
+    const skillDirectory = join(PI_SKILLS_ROOT, "pinned-skill");
     const referencePath = join(skillDirectory, "references", "answer.txt");
-    await writeSkill(
-      skillDirectory,
-      "pinned-skill",
-      "Use for pinned runtime tests.",
-      "Read references/answer.txt before answering.",
-    );
-    await mkdir(join(skillDirectory, "references"), { recursive: true });
-    await writeFile(referencePath, "snapshot bytes\n");
-    await writeSkill(
-      ambientDirectory,
-      "ambient-skill",
-      "Must remain invisible.",
-      "ambient body",
-    );
-
-    const snapshot: RunSkillSnapshot = {
-      schemaVersion: 1,
-      policyVersion: 1,
-      root: PI_SKILLS_ROOT,
-      digest: SHA256_ZERO,
-      entries: [
-        {
-          logicalDir: skillDirectory,
-          skillFile: join(skillDirectory, "SKILL.md"),
-          orgId: "org_test",
-          userId: "user_test",
-          storageName: "pinned-skill",
-          storageId: "storage_test",
-          versionId: "version_test",
-        },
-      ],
-    };
-    const env = new NodeExecutionEnv({ cwd: "/home/user/workspace" });
+    const hostSkillDirectory = join(hostSkillsRoot, "pinned-skill");
+    const env = new GuestSkillsExecutionEnv(hostSkillsRoot);
 
     try {
+      await writeSkill(
+        hostSkillDirectory,
+        "pinned-skill",
+        "Use for pinned runtime tests.",
+        "Read references/answer.txt before answering.",
+      );
+      await mkdir(join(hostSkillDirectory, "references"), { recursive: true });
+      await writeFile(
+        join(hostSkillDirectory, "references", "answer.txt"),
+        "snapshot bytes\n",
+      );
+      await writeSkill(
+        join(hostSkillsRoot, "ambient-skill"),
+        "ambient-skill",
+        "Must remain invisible.",
+        "ambient body",
+      );
+
+      const snapshot: RunSkillSnapshot = {
+        schemaVersion: 1,
+        policyVersion: 1,
+        root: PI_SKILLS_ROOT,
+        digest: SHA256_ZERO,
+        entries: [
+          {
+            logicalDir: skillDirectory,
+            skillFile: join(skillDirectory, "SKILL.md"),
+            orgId: "org_test",
+            userId: "user_test",
+            storageName: "pinned-skill",
+            storageId: "storage_test",
+            versionId: "version_test",
+          },
+        ],
+      };
       const resources = await loadPiRunSkills(env, snapshot);
       expect(resources.diagnostics).toEqual([]);
       expect(
@@ -170,7 +244,7 @@ describe("Pi run Skill runtime", () => {
       ]);
     } finally {
       await env.cleanup();
-      await rm(testRoot, { recursive: true, force: true });
+      await rm(hostSkillsRoot, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

- keep Pi Skill snapshots, prompts, and tool reads on the canonical guest path
- store test fixture bytes under a unique writable host temporary directory
- translate filesystem results through a test-only `NodeExecutionEnv` subclass so the integration test still exercises real filesystem behavior

## Scope

- test-only change in `@vm0/pi-agent-runtime`
- no production runtime, API, protocol, schema, dependency, or deployment behavior changes

## Validation

- `pnpm -F @vm0/pi-agent-runtime exec vitest run src/runtime.test.ts`
- `pnpm -F @vm0/pi-agent-runtime test`
- `pnpm -F @vm0/pi-agent-runtime lint`
- `pnpm -F @vm0/pi-agent-runtime check-types`
- `pnpm -F @vm0/pi-agent-runtime build`
- `pnpm knip --workspace @vm0/pi-agent-runtime`
- pre-commit repository checks: Prettier, Knip, and `pnpm check-types`

Closes #26356
