### PR TITLE
refactor(connectors): dual-write custom credentials to shared storage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2918,6 +2918,29 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       hasSecret: true,
     });
     expectNoVisibleSecret(configured, "agent-created-secret");
+    const storage = await readCustomConnectorCredentialStorageParent(context, {
+      orgId: requiredOrgId(admin),
+      userId: admin.userId,
+      customConnectorId: created.body.id,
+    });
+    expect(storage.secrets).toStrictEqual([
+      {
+        name: "secret",
+        connector_id: storage.connector?.id,
+        encrypted_value: expect.any(String),
+        description: null,
+      },
+    ]);
+    expect(storage.legacy_custom_values).toStrictEqual([
+      {
+        kind: "secret",
+        key: "secret",
+        encrypted_value: storage.secrets?.[0]?.encrypted_value,
+      },
+    ]);
+    expect(storage.legacy_custom_secret_encrypted_value).toBe(
+      storage.secrets?.[0]?.encrypted_value,
+    );
 
     await connectorsApi.deleteCustomConnector(admin, created.body.id);
   });
@@ -2978,6 +3001,38 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       customConnectorId: created.id,
     });
     expect(parent.connector).toMatchObject({ storage_version: 1 });
+    if (!parent.connector) {
+      throw new Error("Expected a Custom connector credential parent");
+    }
+    expect(parent.secrets).toStrictEqual([
+      {
+        name: "api_key",
+        connector_id: parent.connector.id,
+        encrypted_value: expect.any(String),
+        description: null,
+      },
+    ]);
+    expect(parent.variables).toStrictEqual([
+      {
+        name: "subdomain",
+        connector_id: parent.connector.id,
+        value: "acme",
+      },
+    ]);
+    expect(parent.legacy_custom_values).toStrictEqual([
+      {
+        kind: "secret",
+        key: "api_key",
+        encrypted_value: parent.secrets?.[0]?.encrypted_value,
+      },
+      {
+        kind: "variable",
+        key: "subdomain",
+        encrypted_value: expect.any(String),
+      },
+    ]);
+    expect(parent.legacy_custom_secret_encrypted_value).toBeNull();
+
     await connectorsApi.setCustomConnectorValues(admin, created.id, [
       { key: "api_key", kind: "secret", value: "updated-secret" },
     ]);
@@ -2990,6 +3045,18 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       },
     );
     expect(updatedParent.connector).toStrictEqual(parent.connector);
+    expect(updatedParent.variables).toStrictEqual(parent.variables);
+    expect(updatedParent.secrets?.[0]?.encrypted_value).not.toBe(
+      parent.secrets?.[0]?.encrypted_value,
+    );
+    expect(updatedParent.legacy_custom_values).toStrictEqual([
+      {
+        kind: "secret",
+        key: "api_key",
+        encrypted_value: updatedParent.secrets?.[0]?.encrypted_value,
+      },
+      parent.legacy_custom_values?.[1],
+    ]);
 
     const listed = await connectorsApi.listCustomConnectors(admin);
     expect(
@@ -3042,7 +3109,13 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         userId: admin.userId,
         customConnectorId: created.id,
       }),
-    ).resolves.toMatchObject({ connector: null });
+    ).resolves.toMatchObject({
+      connector: null,
+      secrets: [],
+      variables: [],
+      legacy_custom_values: [],
+      legacy_custom_secret_encrypted_value: null,
+    });
     await expect(
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({
@@ -3061,7 +3134,15 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         userId: admin.userId,
         customConnectorId: created.id,
       }),
-    ).resolves.toMatchObject({ connector: { storage_version: 1 } });
+    ).resolves.toMatchObject({
+      connector: { storage_version: 1 },
+      secrets: [{ name: "api_key" }],
+      variables: [{ name: "subdomain", value: "reconnected" }],
+      legacy_custom_values: [
+        { kind: "secret", key: "api_key" },
+        { kind: "variable", key: "subdomain" },
+      ],
+    });
     await expect(
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({
@@ -3069,6 +3150,191 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       configuredFieldKeys: ["api_key", "subdomain"],
       missingRequiredFields: [],
     });
+
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("rejects an incomplete first manual value write without storing credentials", async () => {
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    const created = await connectorsApi.createCustomConnector(admin, {
+      displayName: "BDD Incomplete First Write",
+      prefixTemplates: ["https://incomplete-first-write.example.test/v1/"],
+      fields: [
+        {
+          key: "api_key",
+          label: "API key",
+          kind: "secret",
+          required: true,
+        },
+        {
+          key: "account",
+          label: "Account",
+          kind: "variable",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.api_key}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+    });
+
+    const rejected = await connectorsApi.requestSetCustomConnectorValues(
+      admin,
+      created.id,
+      [{ key: "api_key", kind: "secret", value: "incomplete-secret" }],
+      [400],
+    );
+    expectApiError(rejected.body);
+    expect(rejected.body.error.message).toContain(
+      "All required fields must be provided when connecting or restoring",
+    );
+    await expect(
+      readCustomConnectorCredentialStorageParent(context, {
+        orgId: requiredOrgId(admin),
+        userId: admin.userId,
+        customConnectorId: created.id,
+      }),
+    ).resolves.toMatchObject({
+      connector: null,
+      secrets: [],
+      variables: [],
+      legacy_custom_values: [],
+      legacy_custom_secret_encrypted_value: null,
+    });
+
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("isolates identical manual variable names by Custom connection", async () => {
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    const definition = {
+      fields: [
+        {
+          key: "region",
+          label: "Region",
+          kind: "variable" as const,
+          required: true,
+        },
+      ],
+      headerInjections: [],
+      queryInjections: [
+        { name: "region", valueTemplate: "{{variables.region}}" },
+      ],
+      authMode: "manual" as const,
+    };
+    const first = await connectorsApi.createCustomConnector(admin, {
+      ...definition,
+      displayName: "BDD Variable Isolation One",
+      prefixTemplates: ["https://variable-isolation-one.example.test/v1/"],
+    });
+    const second = await connectorsApi.createCustomConnector(admin, {
+      ...definition,
+      displayName: "BDD Variable Isolation Two",
+      prefixTemplates: ["https://variable-isolation-two.example.test/v1/"],
+    });
+
+    await connectorsApi.setCustomConnectorValues(admin, first.id, [
+      { key: "region", kind: "variable", value: "east" },
+    ]);
+    await connectorsApi.setCustomConnectorValues(admin, second.id, [
+      { key: "region", kind: "variable", value: "west" },
+    ]);
+    const firstState = await readCustomConnectorCredentialStorageParent(
+      context,
+      {
+        orgId: requiredOrgId(admin),
+        userId: admin.userId,
+        customConnectorId: first.id,
+      },
+    );
+    const secondState = await readCustomConnectorCredentialStorageParent(
+      context,
+      {
+        orgId: requiredOrgId(admin),
+        userId: admin.userId,
+        customConnectorId: second.id,
+      },
+    );
+    expect(firstState.variables).toStrictEqual([
+      {
+        name: "region",
+        connector_id: firstState.connector?.id,
+        value: "east",
+      },
+    ]);
+    expect(secondState.variables).toStrictEqual([
+      {
+        name: "region",
+        connector_id: secondState.connector?.id,
+        value: "west",
+      },
+    ]);
+    expect(firstState.connector?.id).not.toBe(secondState.connector?.id);
+
+    await connectorsApi.deleteCustomConnector(admin, first.id);
+    await connectorsApi.deleteCustomConnector(admin, second.id);
+  });
+
+  it("rolls back legacy and shared Custom values when a shared write fails", async () => {
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    const created = await connectorsApi.createCustomConnector(admin, {
+      displayName: "BDD Custom Value Rollback",
+      prefixTemplates: ["https://custom-value-rollback.example.test/v1/"],
+      fields: [
+        {
+          key: "api_key",
+          label: "API key",
+          kind: "secret",
+          required: true,
+        },
+        {
+          key: "note",
+          label: "Note",
+          kind: "variable",
+          required: false,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.api_key}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+    });
+    await connectorsApi.setCustomConnectorValues(admin, created.id, [
+      { key: "api_key", kind: "secret", value: "rollback-original" },
+    ]);
+    const storageBeforeFailure =
+      await readCustomConnectorCredentialStorageParent(context, {
+        orgId: requiredOrgId(admin),
+        userId: admin.userId,
+        customConnectorId: created.id,
+      });
+
+    const failed = await connectorsApi.requestSetCustomConnectorValues(
+      admin,
+      created.id,
+      [
+        { key: "api_key", kind: "secret", value: "rollback-replacement" },
+        { key: "note", kind: "variable", value: "invalid\u0000value" },
+      ],
+      [500],
+    );
+    expect(failed.status).toBe(500);
+    await expect(
+      readCustomConnectorCredentialStorageParent(context, {
+        orgId: requiredOrgId(admin),
+        userId: admin.userId,
+        customConnectorId: created.id,
+      }),
+    ).resolves.toStrictEqual(storageBeforeFailure);
 
     await connectorsApi.deleteCustomConnector(admin, created.id);
   });
@@ -3207,6 +3473,28 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         customConnectorId: created.id,
       }),
     ).resolves.toMatchObject({ connector: { storage_version: 4 } });
+    const replacementStorage = await readCustomConnectorCredentialStorageParent(
+      context,
+      {
+        orgId: requiredOrgId(admin),
+        userId: admin.userId,
+        customConnectorId: created.id,
+      },
+    );
+    expect(
+      replacementStorage.secrets?.map(({ name }) => {
+        return name;
+      }),
+    ).toStrictEqual(["api_key", "replacement"]);
+    expect(replacementStorage.variables).toStrictEqual([]);
+    expect(
+      replacementStorage.legacy_custom_values?.map(({ kind, key }) => {
+        return { kind, key };
+      }),
+    ).toStrictEqual([
+      { kind: "secret", key: "api_key" },
+      { kind: "secret", key: "replacement" },
+    ]);
 
     const semanticAdvance = await connectorsApi.updateCustomConnector(
       admin,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -3710,6 +3710,55 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connectorsApi.readAgentCustomConnectors(admin, agent.agentId),
     ).resolves.toStrictEqual([saved.connector.id]);
 
+    const emptyComplete = await connectorsApi.saveCustomConnectorProposal(
+      admin,
+      {
+        proposal: {
+          operation: "create",
+          displayName: "BDD Optional Proposal Value API",
+          prefixTemplates: [`https://optional-${rand}.example.test/v1/`],
+          fields: [
+            {
+              key: "api_key",
+              label: "API key",
+              kind: "secret",
+              required: false,
+            },
+          ],
+          headerInjections: [
+            {
+              name: "Authorization",
+              valueTemplate: "Bearer {{secrets.api_key}}",
+            },
+          ],
+          queryInjections: [],
+        },
+        values: [],
+        agentId: agent.agentId,
+      },
+    );
+    expect(emptyComplete.connector).toMatchObject({
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: [],
+    });
+    await expect(
+      readCustomConnectorCredentialStorageParent(context, {
+        orgId: requiredOrgId(admin),
+        userId: admin.userId,
+        customConnectorId: emptyComplete.connector.id,
+      }),
+    ).resolves.toMatchObject({
+      connector: { storage_version: 1 },
+      secrets: [],
+      variables: [],
+      legacy_custom_values: [],
+    });
+
+    await connectorsApi.deleteCustomConnector(
+      admin,
+      emptyComplete.connector.id,
+    );
     await connectorsApi.deleteCustomConnector(admin, saved.connector.id);
     await bdd.deleteAgent(admin, agent.agentId);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10722,9 +10722,16 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       }),
     );
 
-    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
-      { key: "api_key", kind: "secret", value: "recovered-key" },
-    ]);
+    const incompleteRecovery = await connectors.requestSetCustomConnectorValues(
+      actor,
+      saved.connector.id,
+      [{ key: "api_key", kind: "secret", value: "recovered-key" }],
+      [400],
+    );
+    expectApiError(incompleteRecovery.body);
+    expect(incompleteRecovery.body.error.message).toContain(
+      "All required fields must be provided when connecting or restoring",
+    );
     await api.requestCancelRun(actor, incompleteRun.runId, [200]);
 
     const longSubdomain = "a".repeat(55);

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -5,10 +5,12 @@ import {
 } from "@vm0/api-contracts/contracts/test-connector-credential-storage-state";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -149,6 +151,62 @@ async function readCustomParent(
     )
     .limit(1);
   signal.throwIfAborted();
+  const secretRows = connector
+    ? await db
+        .select({
+          name: secrets.name,
+          connectorId: secrets.connectorId,
+          encryptedValue: secrets.encryptedValue,
+          description: secrets.description,
+        })
+        .from(secrets)
+        .where(eq(secrets.connectorId, connector.id))
+        .orderBy(asc(secrets.name))
+    : [];
+  signal.throwIfAborted();
+  const variableRows = connector
+    ? await db
+        .select({
+          name: variables.name,
+          connectorId: variables.connectorId,
+          value: variables.value,
+        })
+        .from(variables)
+        .where(eq(variables.connectorId, connector.id))
+        .orderBy(asc(variables.name))
+    : [];
+  signal.throwIfAborted();
+  const legacyValueRows = await db
+    .select({
+      kind: orgCustomConnectorValues.kind,
+      key: orgCustomConnectorValues.key,
+      encryptedValue: orgCustomConnectorValues.encryptedValue,
+    })
+    .from(orgCustomConnectorValues)
+    .where(
+      and(
+        eq(orgCustomConnectorValues.orgId, body.org_id),
+        eq(orgCustomConnectorValues.userId, body.user_id),
+        eq(orgCustomConnectorValues.connectorId, body.custom_connector_id),
+      ),
+    )
+    .orderBy(
+      asc(orgCustomConnectorValues.kind),
+      asc(orgCustomConnectorValues.key),
+    );
+  signal.throwIfAborted();
+  const [legacySecret] = await db
+    .select({ encryptedValue: orgCustomConnectorSecrets.encryptedValue })
+    .from(orgCustomConnectorSecrets)
+    .where(
+      and(
+        eq(orgCustomConnectorSecrets.orgId, body.org_id),
+        eq(orgCustomConnectorSecrets.userId, body.user_id),
+        eq(orgCustomConnectorSecrets.connectorId, body.custom_connector_id),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
   return actionOk({
     connector: connector
       ? {
@@ -156,6 +214,29 @@ async function readCustomParent(
           storage_version: connector.storageVersion,
         }
       : null,
+    secrets: secretRows.map((row) => {
+      return {
+        name: row.name,
+        connector_id: requiredConnectorCredentialOwnerId(row.connectorId),
+        encrypted_value: row.encryptedValue,
+        description: row.description,
+      };
+    }),
+    variables: variableRows.map((row) => {
+      return {
+        name: row.name,
+        connector_id: requiredConnectorCredentialOwnerId(row.connectorId),
+        value: row.value,
+      };
+    }),
+    legacy_custom_values: legacyValueRows.map((row) => {
+      return {
+        kind: row.kind,
+        key: row.key,
+        encrypted_value: row.encryptedValue,
+      };
+    }),
+    legacy_custom_secret_encrypted_value: legacySecret?.encryptedValue ?? null,
   });
 }
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2105,7 +2105,7 @@ async function persistRefreshOutputValues(
           );
           await upsertConnectorOwnedSecret(args.db, {
             connectorId: prepared.connectorId,
-            method: prepared.runtimeMethod.method,
+            storage: prepared.runtimeMethod.method.storage,
             orgId: args.orgId,
             userId: context.secretUserId,
             name: target.name,
@@ -2124,7 +2124,7 @@ async function persistRefreshOutputValues(
         }
         await upsertConnectorOwnedVariable(args.db, {
           connectorId: prepared.connectorId,
-          method: prepared.runtimeMethod.method,
+          storage: prepared.runtimeMethod.method.storage,
           orgId: args.orgId,
           userId: context.secretUserId,
           name: target.name,

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -43,13 +43,16 @@ interface ConnectorCredentialWriteContext {
   readonly connectorId: string;
 }
 
-interface ReplaceConnectorConnectionArgs {
+export interface UpsertConnectorConnectionMetadataArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly authMethod: string;
   readonly storageVersion: number;
   readonly tokenExpiresAt: Date | null;
   readonly target: ConnectorConnectionTarget;
+}
+
+interface ReplaceConnectorConnectionArgs extends UpsertConnectorConnectionMetadataArgs {
   readonly writeCredentials: (
     context: ConnectorCredentialWriteContext,
     signal: AbortSignal,
@@ -73,9 +76,9 @@ function connectorConnectionSelection() {
   };
 }
 
-async function upsertConnectorConnection(
+export async function upsertConnectorConnectionMetadata(
   db: Tx,
-  args: Omit<ReplaceConnectorConnectionArgs, "writeCredentials">,
+  args: UpsertConnectorConnectionMetadataArgs,
 ): Promise<StoredConnectorConnectionRow> {
   const identityValues =
     args.target.kind === "builtin" && args.target.identity.kind === "external"
@@ -148,7 +151,7 @@ export async function replaceConnectorConnection(
   args: ReplaceConnectorConnectionArgs,
   signal: AbortSignal,
 ): Promise<StoredConnectorConnectionRow> {
-  const connection = await upsertConnectorConnection(db, args);
+  const connection = await upsertConnectorConnectionMetadata(db, args);
   signal.throwIfAborted();
 
   await deleteConnectorOwnedCredentialRows(

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -316,7 +316,7 @@ async function persistConnectorRefreshOutputs(
       const encryptedValue = await encryptStoredSecretValue(value);
       await upsertConnectorOwnedSecret(args.db, {
         connectorId: args.connection.connectorId,
-        method: args.connection.runtimeMethod.method,
+        storage: args.connection.runtimeMethod.method.storage,
         description: `Connector token output for ${args.connection.connectorSlug}: ${target.name}`,
         encryptedValue,
         name: target.name,
@@ -326,7 +326,7 @@ async function persistConnectorRefreshOutputs(
     } else {
       await upsertConnectorOwnedVariable(args.db, {
         connectorId: args.connection.connectorId,
-        method: args.connection.runtimeMethod.method,
+        storage: args.connection.runtimeMethod.method.storage,
         description: null,
         name: target.name,
         orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/connector-credential-storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-storage-write.service.ts
@@ -1,4 +1,3 @@
-import type { ConnectorAuthMethodRuntimeConfig } from "@vm0/connectors/connector-config";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
 import { variables } from "@vm0/db/schema/variable";
@@ -7,9 +6,14 @@ import { eq, isNotNull, sql, type SQL } from "drizzle-orm";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 
+export interface ConnectorCredentialStorageDeclaration {
+  readonly secrets: readonly string[];
+  readonly variables: readonly string[];
+}
+
 interface ConnectorOwnedCredentialWrite {
   readonly connectorId: string;
-  readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly storage: ConnectorCredentialStorageDeclaration;
   readonly name: string;
   readonly orgId: string;
   readonly userId: string;
@@ -41,13 +45,11 @@ interface ConnectorCredentialStorageDeleteConditions extends ConnectorOwnedCrede
 
 function requireDeclaredStorageName(args: {
   readonly kind: "secret" | "variable";
-  readonly method: ConnectorAuthMethodRuntimeConfig;
+  readonly storage: ConnectorCredentialStorageDeclaration;
   readonly name: string;
 }): void {
   const names =
-    args.kind === "secret"
-      ? args.method.storage.secrets
-      : args.method.storage.variables;
+    args.kind === "secret" ? args.storage.secrets : args.storage.variables;
   if (!names.includes(args.name)) {
     throw new Error(
       `Connector auth method does not declare ${args.kind} ${args.name}`,
@@ -64,7 +66,7 @@ export async function upsertConnectorOwnedSecret(
 ): Promise<void> {
   requireDeclaredStorageName({
     kind: "secret",
-    method: args.method,
+    storage: args.storage,
     name: args.name,
   });
   const [row] = await db
@@ -104,7 +106,7 @@ export async function upsertConnectorOwnedVariable(
 ): Promise<void> {
   requireDeclaredStorageName({
     kind: "variable",
-    method: args.method,
+    storage: args.storage,
     name: args.name,
   });
   const [row] = await db

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -4,10 +4,34 @@ import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-s
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 
 import type { Db } from "../external/db";
+import { nowDate } from "../../lib/time";
 import {
   deleteConnectorCredentialStorageConnection,
   type ConnectorOwnerScope,
+  type ConnectorCredentialStorageDeclaration,
+  upsertConnectorOwnedSecret,
+  upsertConnectorOwnedVariable,
 } from "./connector-credential-storage-write.service";
+
+const LEGACY_SECRET_KEY = "secret";
+
+export type PreparedCustomConnectorValue =
+  | {
+      readonly kind: "secret";
+      readonly key: string;
+      readonly encryptedValue: string;
+    }
+  | {
+      readonly kind: "variable";
+      readonly key: string;
+      readonly value: string;
+      readonly encryptedValue: string;
+    };
+
+interface CustomConnectorCredentialField {
+  readonly kind: "secret" | "variable";
+  readonly key: string;
+}
 
 interface CustomConnectorMemberConnection {
   readonly connectorId: string;
@@ -18,6 +42,105 @@ interface CustomConnectorMemberConnection {
 interface CustomConnectorStoredValueDeleteConditions {
   readonly legacySecret: SQL;
   readonly value: SQL;
+}
+
+function customConnectorStorageDeclaration(
+  fields: readonly CustomConnectorCredentialField[],
+): ConnectorCredentialStorageDeclaration {
+  return {
+    secrets: fields.flatMap((field) => {
+      return field.kind === "secret" ? [field.key] : [];
+    }),
+    variables: fields.flatMap((field) => {
+      return field.kind === "variable" ? [field.key] : [];
+    }),
+  };
+}
+
+export async function upsertCustomConnectorStoredValues(
+  db: Db,
+  args: {
+    readonly connectionId: string;
+    readonly customConnectorId: string;
+    readonly fields: readonly CustomConnectorCredentialField[];
+    readonly orgId: string;
+    readonly syncLegacySecret: boolean;
+    readonly userId: string;
+    readonly values: readonly PreparedCustomConnectorValue[];
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  const storage = customConnectorStorageDeclaration(args.fields);
+  for (const value of args.values) {
+    await db
+      .insert(orgCustomConnectorValues)
+      .values({
+        connectorId: args.customConnectorId,
+        userId: args.userId,
+        orgId: args.orgId,
+        kind: value.kind,
+        key: value.key,
+        encryptedValue: value.encryptedValue,
+      })
+      .onConflictDoUpdate({
+        target: [
+          orgCustomConnectorValues.connectorId,
+          orgCustomConnectorValues.userId,
+          orgCustomConnectorValues.kind,
+          orgCustomConnectorValues.key,
+        ],
+        set: { encryptedValue: value.encryptedValue, updatedAt: nowDate() },
+      });
+    signal.throwIfAborted();
+
+    if (
+      args.syncLegacySecret &&
+      value.kind === "secret" &&
+      value.key === LEGACY_SECRET_KEY
+    ) {
+      await db
+        .insert(orgCustomConnectorSecrets)
+        .values({
+          connectorId: args.customConnectorId,
+          userId: args.userId,
+          orgId: args.orgId,
+          encryptedValue: value.encryptedValue,
+        })
+        .onConflictDoUpdate({
+          target: [
+            orgCustomConnectorSecrets.connectorId,
+            orgCustomConnectorSecrets.userId,
+          ],
+          set: { encryptedValue: value.encryptedValue, updatedAt: nowDate() },
+        });
+      signal.throwIfAborted();
+    }
+
+    if (value.kind === "secret") {
+      await upsertConnectorOwnedSecret(db, {
+        connectorId: args.connectionId,
+        storage,
+        orgId: args.orgId,
+        userId: args.userId,
+        name: value.key,
+        encryptedValue: value.encryptedValue,
+        description: null,
+        updatedDescription: null,
+      });
+    } else {
+      await upsertConnectorOwnedVariable(db, {
+        connectorId: args.connectionId,
+        storage,
+        orgId: args.orgId,
+        userId: args.userId,
+        name: value.key,
+        value: value.value,
+        description: null,
+        updatedDescription: null,
+      });
+    }
+    signal.throwIfAborted();
+  }
 }
 
 async function deleteCustomConnectorStoredValuesWhere(

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -939,7 +939,7 @@ async function writeManualGrantCredentials(
   for (const field of args.encryptedSecrets) {
     await upsertConnectorOwnedSecret(db, {
       connectorId: args.connectorId,
-      method: args.method,
+      storage: args.method.storage,
       orgId: args.orgId,
       userId: args.userId,
       name: field.name,
@@ -953,7 +953,7 @@ async function writeManualGrantCredentials(
   for (const field of args.variableValues) {
     await upsertConnectorOwnedVariable(db, {
       connectorId: args.connectorId,
-      method: args.method,
+      storage: args.method.storage,
       orgId: args.orgId,
       userId: args.userId,
       name: field.name,
@@ -1510,7 +1510,7 @@ async function upsertConnectorTokenSecrets(
   for (const secret of args.secrets) {
     await upsertConnectorOwnedSecret(args.db, {
       connectorId: args.connectorId,
-      method: args.method,
+      storage: args.method.storage,
       orgId: args.orgId,
       userId: args.userId,
       name: secret.name,
@@ -1536,7 +1536,7 @@ async function upsertConnectorTokenVariables(
   for (const variable of args.variables) {
     await upsertConnectorOwnedVariable(args.db, {
       connectorId: args.connectorId,
-      method: args.method,
+      storage: args.method.storage,
       orgId: args.orgId,
       userId: args.userId,
       name: variable.name,

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -3580,7 +3580,12 @@ export const saveCustomConnectorProposal$ = command(
       return connector;
     }
 
-    if (args.values.length > 0) {
+    const missingRequiredProposalValues =
+      customConnectorMissingRequiredFieldKeys({
+        fields: proposalDefinition.fields,
+        markers: proposalValues,
+      });
+    if (args.values.length > 0 || missingRequiredProposalValues.length === 0) {
       const valueResult = await set(
         setCustomConnectorValues$,
         {

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -59,6 +59,8 @@ import {
 import {
   deleteCustomConnectorMemberConnection,
   deleteCustomConnectorStoredValues,
+  type PreparedCustomConnectorValue,
+  upsertCustomConnectorStoredValues,
 } from "./custom-connector-credential-storage.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 import {
@@ -85,7 +87,11 @@ import {
   type CapturedConnectorClientInvalidationAbort,
 } from "./connector-client-invalidation.service";
 import { isCustomConnectorMcpEnabled } from "./custom-connector-mcp-feature.service";
-import { replaceConnectorConnection } from "./connector-connection-write.service";
+import {
+  replaceConnectorConnection,
+  type UpsertConnectorConnectionMetadataArgs,
+  upsertConnectorConnectionMetadata,
+} from "./connector-connection-write.service";
 import type { Tx } from "../../lib/db-types";
 
 const L = logger("CustomConnectorService");
@@ -276,13 +282,6 @@ interface ValueMarker {
   readonly kind: CustomConnectorFieldKind;
   readonly key: string;
 }
-
-type EncryptedCustomConnectorValue = Omit<
-  CustomConnectorValueInput,
-  "value"
-> & {
-  readonly encryptedValue: string;
-};
 
 export class CustomConnectorRuntimePrefixError extends Error {
   constructor(connectorName: string | undefined) {
@@ -2606,19 +2605,28 @@ async function encryptCustomConnectorValues(
     readonly featureSwitchContext: FeatureSwitchContextArg;
   },
   signal: AbortSignal,
-): Promise<readonly EncryptedCustomConnectorValue[]> {
-  const encryptedValues: EncryptedCustomConnectorValue[] = [];
+): Promise<readonly PreparedCustomConnectorValue[]> {
+  const encryptedValues: PreparedCustomConnectorValue[] = [];
   for (const value of args.values) {
     const encryptedValue = await encryptStoredSecretValue(
       value.value,
       args.featureSwitchContext,
     );
     signal.throwIfAborted();
-    encryptedValues.push({
-      key: value.key,
-      kind: value.kind,
-      encryptedValue,
-    });
+    encryptedValues.push(
+      value.kind === "secret"
+        ? {
+            key: value.key,
+            kind: value.kind,
+            encryptedValue,
+          }
+        : {
+            key: value.key,
+            kind: value.kind,
+            value: value.value,
+            encryptedValue,
+          },
+    );
   }
   return encryptedValues;
 }
@@ -2633,8 +2641,8 @@ interface SetCustomConnectorValuesArgs {
 
 interface CustomConnectorValueWriteState {
   readonly connector: CustomConnectorRow;
+  readonly preservesStoredValues: boolean;
   readonly replacingStoredValues: boolean;
-  readonly establishesCurrentCredentials: boolean;
   readonly runtimeRecovered: boolean;
 }
 
@@ -2716,6 +2724,7 @@ async function prepareCustomConnectorValueWrite(args: {
 
   const [storedConnector] = await args.tx
     .select({
+      id: connectors.id,
       authMethod: connectors.authMethod,
       storageVersion: connectors.storageVersion,
     })
@@ -2733,6 +2742,13 @@ async function prepareCustomConnectorValueWrite(args: {
     fields: connector.fields,
     markers: currentValues,
   });
+  if (storedConnector === undefined && missingRequired.length > 0) {
+    return badRequestMessage(
+      `All required fields must be provided when connecting or restoring this connector: ${missingRequired.join(
+        ", ",
+      )}`,
+    );
+  }
   const replacingIncompatibleValues =
     storedConnector !== undefined &&
     (storedConnector.authMethod !== connector.authMode ||
@@ -2742,77 +2758,21 @@ async function prepareCustomConnectorValueWrite(args: {
     (await hasUnversionedCustomConnectorValues(args.tx, args.request));
   const replacingStoredValues =
     replacingIncompatibleValues || replacingUnversionedValues;
-  if (replacingStoredValues && missingRequired.length > 0) {
+  if (replacingIncompatibleValues && missingRequired.length > 0) {
     return badRequestMessage(
       `All required fields must be provided when restoring this connector: ${missingRequired.join(
         ", ",
       )}`,
     );
   }
-  const establishesCurrentCredentials =
-    storedConnector !== undefined || missingRequired.length === 0;
+  const preservesStoredValues =
+    storedConnector !== undefined && !replacingIncompatibleValues;
   return {
     connector,
+    preservesStoredValues,
     replacingStoredValues,
-    establishesCurrentCredentials,
-    runtimeRecovered:
-      replacingStoredValues ||
-      (storedConnector === undefined && establishesCurrentCredentials),
+    runtimeRecovered: !preservesStoredValues,
   };
-}
-
-async function upsertEncryptedCustomConnectorValues(
-  args: {
-    readonly tx: Tx;
-    readonly request: SetCustomConnectorValuesArgs;
-    readonly values: readonly EncryptedCustomConnectorValue[];
-  },
-  signal: AbortSignal,
-): Promise<void> {
-  for (const value of args.values) {
-    await args.tx
-      .insert(orgCustomConnectorValues)
-      .values({
-        connectorId: args.request.connectorId,
-        userId: args.request.userId,
-        orgId: args.request.orgId,
-        kind: value.kind,
-        key: value.key,
-        encryptedValue: value.encryptedValue,
-      })
-      .onConflictDoUpdate({
-        target: [
-          orgCustomConnectorValues.connectorId,
-          orgCustomConnectorValues.userId,
-          orgCustomConnectorValues.kind,
-          orgCustomConnectorValues.key,
-        ],
-        set: { encryptedValue: value.encryptedValue, updatedAt: nowDate() },
-      });
-    signal.throwIfAborted();
-
-    if (
-      args.request.syncLegacySecret &&
-      value.kind === "secret" &&
-      value.key === LEGACY_SECRET_KEY
-    ) {
-      await args.tx
-        .insert(orgCustomConnectorSecrets)
-        .values({
-          connectorId: args.request.connectorId,
-          userId: args.request.userId,
-          orgId: args.request.orgId,
-          encryptedValue: value.encryptedValue,
-        })
-        .onConflictDoUpdate({
-          target: [
-            orgCustomConnectorSecrets.connectorId,
-            orgCustomConnectorSecrets.userId,
-          ],
-          set: { encryptedValue: value.encryptedValue, updatedAt: nowDate() },
-        });
-    }
-  }
 }
 
 async function persistCustomConnectorValues(
@@ -2821,7 +2781,7 @@ async function persistCustomConnectorValues(
     readonly request: SetCustomConnectorValuesArgs;
     readonly expectedConnector: CustomConnectorRow;
     readonly expectedValues: readonly CustomConnectorValueInput[];
-    readonly encryptedValues: readonly EncryptedCustomConnectorValue[];
+    readonly encryptedValues: readonly PreparedCustomConnectorValue[];
   },
   signal: AbortSignal,
 ): Promise<
@@ -2840,42 +2800,59 @@ async function persistCustomConnectorValues(
   if (state.replacingStoredValues) {
     await deleteCustomConnectorStoredValues(args.tx, args.request, signal);
   }
-  const writeValues = async (tx: Tx, writeSignal: AbortSignal) => {
-    await upsertEncryptedCustomConnectorValues(
+  const writeValues = async (
+    tx: Tx,
+    connectionId: string,
+    writeSignal: AbortSignal,
+  ) => {
+    await upsertCustomConnectorStoredValues(
+      tx,
       {
-        tx,
-        request: args.request,
+        connectionId,
+        customConnectorId: args.request.connectorId,
+        fields: state.connector.fields,
+        orgId: args.request.orgId,
+        syncLegacySecret: args.request.syncLegacySecret === true,
+        userId: args.request.userId,
         values: args.encryptedValues,
       },
       writeSignal,
     );
   };
-  if (state.establishesCurrentCredentials) {
+  const connectionArgs: UpsertConnectorConnectionMetadataArgs = {
+    orgId: args.request.orgId,
+    userId: args.request.userId,
+    authMethod: "manual",
+    storageVersion: state.connector.storageVersion,
+    tokenExpiresAt: null,
+    target: {
+      kind: "custom",
+      customConnectorId: args.request.connectorId,
+    },
+  };
+  if (state.preservesStoredValues) {
+    const connection = await upsertConnectorConnectionMetadata(
+      args.tx,
+      connectionArgs,
+    );
+    signal.throwIfAborted();
+    await writeValues(args.tx, connection.id, signal);
+  } else {
     await replaceConnectorConnection(
       args.tx,
       {
-        orgId: args.request.orgId,
-        userId: args.request.userId,
-        authMethod: "manual",
-        storageVersion: state.connector.storageVersion,
-        tokenExpiresAt: null,
-        target: {
-          kind: "custom",
-          customConnectorId: args.request.connectorId,
-        },
-        writeCredentials: async ({ db }, writeSignal) => {
-          await writeValues(db, writeSignal);
+        ...connectionArgs,
+        writeCredentials: async ({ db, connectorId }, writeSignal) => {
+          await writeValues(db, connectorId, writeSignal);
         },
       },
       signal,
     );
-  } else {
-    await writeValues(args.tx, signal);
   }
   return {
     connector: state.connector,
     runtimeRecovered: state.runtimeRecovered,
-    usableConnection: state.establishesCurrentCredentials,
+    usableConnection: true,
   };
 }
 
@@ -3603,19 +3580,21 @@ export const saveCustomConnectorProposal$ = command(
       return connector;
     }
 
-    const valueResult = await set(
-      setCustomConnectorValues$,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        connectorId: connector.id,
-        values: args.values,
-        syncLegacySecret: true,
-      },
-      signal,
-    );
-    if ("status" in valueResult) {
-      return valueResult;
+    if (args.values.length > 0) {
+      const valueResult = await set(
+        setCustomConnectorValues$,
+        {
+          orgId: args.orgId,
+          userId: args.userId,
+          connectorId: connector.id,
+          values: args.values,
+          syncLegacySecret: true,
+        },
+        signal,
+      );
+      if ("status" in valueResult) {
+        return valueResult;
+      }
     }
 
     const authorizedAgentId = await set(

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -19,6 +19,13 @@ const secretStateSchema = z.object({
 const variableStateSchema = z.object({
   name: z.string(),
   connector_id: z.uuid(),
+  value: z.string().optional(),
+});
+
+const legacyCustomValueStateSchema = z.object({
+  kind: z.enum(["secret", "variable"]),
+  key: z.string(),
+  encrypted_value: z.string(),
 });
 
 const customOauthStateSchema = z.object({
@@ -121,6 +128,8 @@ export const testConnectorCredentialStorageStateActionResponseSchema = z.object(
     custom_oauth_state: customOauthStateSchema.nullable().optional(),
     secrets: z.array(secretStateSchema).optional(),
     variables: z.array(variableStateSchema).optional(),
+    legacy_custom_values: z.array(legacyCustomValueStateSchema).optional(),
+    legacy_custom_secret_encrypted_value: z.string().nullable().optional(),
   },
 );
 


### PR DESCRIPTION
## Summary

- dual-write accepted manual Custom connector credentials to legacy storage and connector-owned shared `secrets` / `variables` in one transaction
- preserve omitted fields for current same-version partial updates while keeping complete replacement for new or incompatible connections
- reuse the shared declared-storage writer for Builtin and Custom credentials without changing its SQL or ownership constraints
- reject parentless incomplete credential writes without creating storage state, while preserving empty proposal creation and authorization

## Compatibility and scope

- legacy Custom credential readers remain authoritative
- no schema, migration, reader cutover, feature switch, runner protocol, or storage-version change
- Custom OAuth storage and existing disconnect/owner cleanup paths remain unchanged
- #26233 commit `ed8a33ecc0` is confirmed in `api/production` via release `api-v1.423.1`; after this PR deploys, older non-dual API writers must drain before #26241 runs

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test` (27 files, 564 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts` (64 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-manual-grant-connect.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts` (76 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (158 tests)
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- `git diff --check`
- pre-commit hook: full Turbo Knip and `check-types` (14 tasks)

Closes #26240

Parent: #26080
