### PR TITLE
perf(api): raise chat event snapshot batch to 1000

### DIFF
--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -83,11 +83,11 @@ export const ARCHIVE_SCHEMA_VERSION = 4;
 const ARCHIVE_CONTENT_TYPE = "application/x-ndjson";
 const ARCHIVE_CONTENT_ENCODING = "gzip";
 /**
- * At the 10-minute cron cadence this cap permits 72k changed threads per day.
+ * At the 10-minute cron cadence this cap permits 144k changed threads per day.
  * Normal traffic re-archives roughly 700 active threads per day, so the cap
  * leaves ample room for bursts while keeping each invocation bounded.
  */
-const DEFAULT_THREAD_BATCH_SIZE = 500;
+const DEFAULT_THREAD_BATCH_SIZE = 1000;
 const EVENT_PAGE_SIZE = 1000;
 const DEFAULT_R2_GC_GRACE_HOURS = 24 * 7;
 const R2_GC_SHARDS_PER_RUN = 16;


### PR DESCRIPTION
## Summary

- raise the default chat-event snapshot thread batch from 500 to 1000
- update the documented daily capacity from 72k to 144k threads
- keep the 10-minute cadence, 300-second function limit, sequential processing, and environment override unchanged

## Production sizing

- the latest 40 full v4 batches at size 500 all returned HTTP 200
- measured p95 was about 114 seconds, with a maximum below 115 seconds
- a linear 1000-thread estimate is about 229 seconds, retaining roughly 71 seconds of headroom under the 300-second limit
- the sizing snapshot had 57,808 remaining v3 heads, giving an estimated convergence time of about 9.6 hours at 6,000 heads per hour

## Safety

- snapshot writes remain idempotent and exact-CAS guarded
- threads are still processed sequentially within each invocation
- CHAT_EVENT_SNAPSHOT_BATCH_SIZE remains available for an immediate operational override
- no cadence, timeout, schema, or PR4 behavior changes are included

## Verification

- npx --yes prettier@3.6.2 --check turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
- git diff --check
- confirmed existing integration coverage pins CHAT_EVENT_SNAPSHOT_BATCH_SIZE explicitly, so this default-only change does not alter those test paths

Full local Vitest and a local dev server were not run; the PR pipeline will run the repository checks.

## Fallbacks

None added. The existing environment override is retained.