### PR TITLE
feat: name the hovered emoji and tighten the picker section titles

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1636,6 +1636,7 @@
       "openBrowser": "Browser öffnen",
       "openNamedAgent": "Agent {{name}} öffnen",
       "openNamedChat": "Chat {{title}} öffnen",
+      "pickEmoji": "Ein Emoji auswählen",
       "scrollToBottom": "Nach unten scrollen",
       "searchEmoji": "Emoji suchen"
     },

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1636,6 +1636,7 @@
       "openBrowser": "Open browser",
       "openNamedAgent": "Open agent {{name}}",
       "openNamedChat": "Open chat {{title}}",
+      "pickEmoji": "Pick an emoji",
       "scrollToBottom": "Scroll to bottom",
       "searchEmoji": "Search emoji"
     },

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1676,6 +1676,7 @@
       "openBrowser": "Abrir navegador",
       "openNamedAgent": "Abrir agente {{name}}",
       "openNamedChat": "Abrir chat {{title}}",
+      "pickEmoji": "Elige un emoji",
       "scrollToBottom": "Desplázate hasta abajo",
       "searchEmoji": "Buscar emoji"
     },

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1676,6 +1676,7 @@
       "openBrowser": "Ouvrir le navigateur",
       "openNamedAgent": "Ouvrir l'agent {{name}}",
       "openNamedChat": "Ouvrir le chat {{title}}",
+      "pickEmoji": "Choisissez un emoji",
       "scrollToBottom": "Faire défiler vers le bas",
       "searchEmoji": "Rechercher un emoji"
     },

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1636,6 +1636,7 @@
       "openBrowser": "खुला ब्राउज़र",
       "openNamedAgent": "ओपन एजेंट {{name}}",
       "openNamedChat": "चैट {{title}} खोलें",
+      "pickEmoji": "एक इमोजी चुनें",
       "scrollToBottom": "नीचे स्क्रॉल करें",
       "searchEmoji": "इमोजी खोजें"
     },

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1635,6 +1635,7 @@
       "openBrowser": "Buka browser",
       "openNamedAgent": "Buka agen {{name}}",
       "openNamedChat": "Buka chat {{title}}",
+      "pickEmoji": "Pilih emoji",
       "scrollToBottom": "Gulir ke bawah",
       "searchEmoji": "Cari emoji"
     },

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1676,6 +1676,7 @@
       "openBrowser": "Apri il browser",
       "openNamedAgent": "Apri agente {{name}}",
       "openNamedChat": "Apri la chat {{title}}",
+      "pickEmoji": "Scegli un'emoji",
       "scrollToBottom": "Scorri fino in fondo",
       "searchEmoji": "Cerca emoji"
     },

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1635,6 +1635,7 @@
       "openBrowser": "ブラウザを開く",
       "openNamedAgent": "エージェント {{name}} を開く",
       "openNamedChat": "チャットを開く {{title}}",
+      "pickEmoji": "絵文字を選択",
       "scrollToBottom": "一番下までスクロール",
       "searchEmoji": "絵文字を検索"
     },

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1635,6 +1635,7 @@
       "openBrowser": "브라우저 열기",
       "openNamedAgent": "에이전트 {{name}} 열기",
       "openNamedChat": "채팅 {{title}} 열기",
+      "pickEmoji": "이모지 선택",
       "scrollToBottom": "맨 아래로 스크롤",
       "searchEmoji": "이모지 검색"
     },

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1676,6 +1676,7 @@
       "openBrowser": "Abrir navegador",
       "openNamedAgent": "Abrir agente {{name}}",
       "openNamedChat": "Abrir conversa {{title}}",
+      "pickEmoji": "Escolha um emoji",
       "scrollToBottom": "Rolar até o final",
       "searchEmoji": "Buscar emoji"
     },

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
@@ -71,6 +71,25 @@ export const setChatThreadEmojiPendingJump$ = command(
   },
 );
 
+// The emoji the pointer or keyboard is currently on, named in the preview bar
+// under the grid. Held in a signal so pointing at a new emoji re-renders that
+// bar alone rather than the whole grid it sits under.
+const internalChatThreadEmojiPreview$ = state<ChatThreadEmojiItem | null>(null);
+
+export const chatThreadEmojiPreview$ = computed((get) => {
+  return get(internalChatThreadEmojiPreview$);
+});
+
+export const setChatThreadEmojiPreview$ = command(
+  ({ get, set }, value: ChatThreadEmojiItem | null) => {
+    // Pointing at one emoji fires repeatedly as the pointer moves across it.
+    if (get(internalChatThreadEmojiPreview$)?.emoji === value?.emoji) {
+      return;
+    }
+    set(internalChatThreadEmojiPreview$, value);
+  },
+);
+
 export function filterChatThreadEmojiGroups(
   groups: ChatThreadEmojiGroup[],
   query: string,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-emoji-category-rail.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-emoji-category-rail.test.tsx
@@ -61,6 +61,15 @@ function selectedCategoryLabel(): string | null {
 // jsdom has no layout, so every section reports offsetTop 0. Scrolling away
 // from 0 is therefore the only way to tell a rail that is following the feed
 // from one still waiting for a jump that will never land.
+function previewBarText(): string {
+  const feed = document.querySelector("[data-chat-thread-emoji-feed]");
+  const bar = feed?.nextElementSibling;
+  if (!(bar instanceof HTMLElement)) {
+    throw new Error("Expected the emoji name bar under the feed");
+  }
+  return bar.textContent ?? "";
+}
+
 function scrollEmojiFeed(scrollTop: number): void {
   const feed = document.querySelector("[data-chat-thread-emoji-feed]");
   if (!(feed instanceof HTMLElement)) {
@@ -153,6 +162,22 @@ describe("chat thread emoji category rail", () => {
     await waitFor(() => {
       expect(screen.getByText(":watermelon:")).toBeInTheDocument();
     });
+  });
+
+  it("names a frequently used emoji by its product label, not as a shortcode", async () => {
+    setupChatWithRail(true);
+    await openEmojiPicker();
+    await waitForCategories();
+
+    // These nine are named by translated product labels rather than by the
+    // emoji dataset, so wrapping them in shortcode colons would claim a
+    // shortcode that does not exist — ":Done:" in en-US, ":完了:" in ja-JP.
+    fireEvent.mouseOver(await screen.findByLabelText("Done"));
+
+    await waitFor(() => {
+      expect(previewBarText()).toContain("Done");
+    });
+    expect(previewBarText()).not.toContain(":Done:");
   });
 
   it("leaves the search results when a category is picked", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-emoji-category-rail.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thread-emoji-category-rail.test.tsx
@@ -133,6 +133,28 @@ describe("chat thread emoji category rail", () => {
     expect(categoryTab("Frequently used")).toHaveAttribute("tabindex", "-1");
   });
 
+  it("names the emoji the pointer is on", async () => {
+    setupChatWithRail(true);
+    await openEmojiPicker();
+    await waitForCategories();
+
+    expect(screen.getByText("Pick an emoji")).toBeInTheDocument();
+
+    const grinningFace = await screen.findByLabelText("grinning face");
+    fireEvent.mouseOver(grinningFace);
+
+    await waitFor(() => {
+      expect(screen.getByText(":grinning_face:")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Pick an emoji")).toBeNull();
+
+    fireEvent.mouseOver(await screen.findByLabelText("watermelon"));
+
+    await waitFor(() => {
+      expect(screen.getByText(":watermelon:")).toBeInTheDocument();
+    });
+  });
+
   it("leaves the search results when a category is picked", async () => {
     setupChatWithRail(true);
     await openEmojiPicker();
@@ -157,5 +179,6 @@ describe("chat thread emoji category rail", () => {
     await screen.findByText("Frequently used");
 
     expect(categoryTabs()).toHaveLength(0);
+    expect(screen.queryByText("Pick an emoji")).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -286,10 +286,12 @@ import {
   chatThreadEmojiActiveCategory$,
   chatThreadEmojiGroups$,
   chatThreadEmojiPendingJump$,
+  chatThreadEmojiPreview$,
   chatThreadEmojiQuery$,
   filterChatThreadEmojiGroups,
   setChatThreadEmojiActiveCategory$,
   setChatThreadEmojiPendingJump$,
+  setChatThreadEmojiPreview$,
   setChatThreadEmojiQuery$,
   type ChatThreadEmojiItem,
 } from "../../signals/chat-page/chat-thread-emoji.ts";
@@ -884,6 +886,7 @@ function ChatThreadEmojiMenuButton({
   const setEmojiQuery = useSet(setChatThreadEmojiQuery$);
   const setEmojiActiveCategory = useSet(setChatThreadEmojiActiveCategory$);
   const setEmojiPendingJump = useSet(setChatThreadEmojiPendingJump$);
+  const setEmojiPreview = useSet(setChatThreadEmojiPreview$);
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -894,6 +897,7 @@ function ChatThreadEmojiMenuButton({
             setEmojiQuery("");
             setEmojiActiveCategory(null);
             setEmojiPendingJump(null);
+            setEmojiPreview(null);
             openChatThreadEmojiMenu({ threadId, title });
           } else {
             closeMenu();
@@ -1241,7 +1245,15 @@ function ChatThreadEmojiPicker({
           onSelect={jumpToCategory}
         />
       )}
-      <div className="flex items-center gap-2 p-2">
+      <div
+        className={cn(
+          "flex items-center gap-2 px-2 pt-2",
+          // Pull the first section title up towards the search field. The title
+          // keeps its own box height so the fade under it is unchanged; only
+          // the gap above it closes.
+          railEnabled ? "pb-1" : "pb-2",
+        )}
+      >
         <div className="relative flex-1">
           <Search
             size={15}
@@ -1281,6 +1293,35 @@ function ChatThreadEmojiPicker({
         onSelect={onSelect}
         railEnabled={railEnabled}
       />
+      {railEnabled && <ChatThreadEmojiPreview />}
+    </div>
+  );
+}
+
+// Names whichever emoji the pointer or keyboard is on, so the grid stays a
+// grid of glyphs and the reader still gets a label for the one in question.
+function ChatThreadEmojiPreview() {
+  const { t } = useTranslation();
+  const preview = useGet(chatThreadEmojiPreview$);
+
+  return (
+    <div className="flex h-10 shrink-0 items-center gap-2 border-t border-border px-3">
+      {preview ? (
+        <>
+          <span aria-hidden="true" className="zero-emoji text-lg leading-none">
+            {preview.emoji}
+          </span>
+          <span className="truncate text-xs font-medium text-muted-foreground">
+            {`:${preview.name.replace(/\s+/g, "_")}:`}
+          </span>
+        </>
+      ) : (
+        <span className="text-xs text-muted-foreground/70">
+          {t(($) => {
+            return $.chat.thread.pickEmoji;
+          })}
+        </span>
+      )}
     </div>
   );
 }
@@ -1300,6 +1341,19 @@ function ChatThreadEmojiFeed({
   const setActiveCategory = useSet(setChatThreadEmojiActiveCategory$);
   const pendingJump = useGet(chatThreadEmojiPendingJump$);
   const setPendingJump = useSet(setChatThreadEmojiPendingJump$);
+  const setPreview = useSet(setChatThreadEmojiPreview$);
+
+  // One delegated listener on the feed rather than a pair on each of the ~1,900
+  // buttons. Pointer and keyboard both report through it.
+  function previewEmojiUnder(target: EventTarget): void {
+    if (!(target instanceof Element)) {
+      return;
+    }
+    const button = target.closest<HTMLElement>("[data-chat-thread-emoji]");
+    const emoji = button?.dataset.chatThreadEmoji;
+    const name = button?.getAttribute("aria-label");
+    setPreview(emoji && name ? { emoji, name } : null);
+  }
 
   function handleScroll(event: ReactUIEvent<HTMLDivElement>): void {
     const feed = event.currentTarget;
@@ -1338,6 +1392,27 @@ function ChatThreadEmojiFeed({
       onWheel={railEnabled ? releasePendingJump : undefined}
       onTouchStart={railEnabled ? releasePendingJump : undefined}
       onPointerDown={railEnabled ? releasePendingJump : undefined}
+      onMouseOver={
+        railEnabled
+          ? (event) => {
+              previewEmojiUnder(event.target);
+            }
+          : undefined
+      }
+      onFocus={
+        railEnabled
+          ? (event) => {
+              previewEmojiUnder(event.target);
+            }
+          : undefined
+      }
+      onMouseLeave={
+        railEnabled
+          ? () => {
+              setPreview(null);
+            }
+          : undefined
+      }
     >
       {searchResults !== null ? (
         searchResults.length > 0 ? (
@@ -1402,8 +1477,11 @@ function ChatThreadEmojiSection({
           "flex items-baseline justify-between gap-2 px-1 pb-1 pt-2",
           // Fade to transparent at the lower edge so emoji dissolve as they
           // scroll under the pinned title instead of colliding with it.
+          // pt-1/pb-3 shifts the label up towards the search field while
+          // keeping the box — and so the painted fade — the same 32px tall as
+          // the pt-2/pb-2 it replaces.
           pinnedTitle &&
-            "sticky top-0 z-10 bg-gradient-to-b from-popover from-60% to-transparent pb-2",
+            "sticky top-0 z-10 bg-gradient-to-b from-popover from-60% to-transparent pb-3 pt-1",
         )}
       >
         <span className="text-xs font-medium text-muted-foreground">
@@ -1459,6 +1537,7 @@ function ChatThreadEmojiGrid({
             key={`${item.name}-${item.emoji}`}
             type="button"
             aria-label={item.name}
+            data-chat-thread-emoji={item.emoji}
             title={shortcutLabel}
             className="relative flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-state-hover"
             onClick={() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1032,6 +1032,17 @@ interface ChatThreadEmojiCategory {
   icon: LucideIcon;
   items: ChatThreadEmojiItem[];
   showShortcutDigits: boolean;
+  // The emoji dataset names an emoji the way a shortcode does; the frequently
+  // used row names it the way this product does ("Done", "Urgent"), which is
+  // translated and must not be dressed up as a shortcode.
+  shortcodeNames: boolean;
+}
+
+function chatThreadEmojiDisplayName(
+  name: string,
+  shortcodeNames: boolean,
+): string {
+  return shortcodeNames ? `:${name.replace(/\s+/g, "_")}:` : name;
 }
 
 function chatThreadEmojiSectionId(key: string): string {
@@ -1092,6 +1103,7 @@ function chatThreadEmojiCategories(
       icon: Clock,
       items: frequentItems,
       showShortcutDigits: true,
+      shortcodeNames: false,
     },
     ...(groups ?? []).map((group) => {
       return {
@@ -1100,6 +1112,7 @@ function chatThreadEmojiCategories(
         icon: chatThreadEmojiCategoryIcon(group.name),
         items: group.emojis,
         showShortcutDigits: false,
+        shortcodeNames: true,
       };
     }),
   ];
@@ -1312,7 +1325,7 @@ function ChatThreadEmojiPreview() {
             {preview.emoji}
           </span>
           <span className="truncate text-xs font-medium text-muted-foreground">
-            {`:${preview.name.replace(/\s+/g, "_")}:`}
+            {preview.name}
           </span>
         </>
       ) : (
@@ -1351,7 +1364,7 @@ function ChatThreadEmojiFeed({
     }
     const button = target.closest<HTMLElement>("[data-chat-thread-emoji]");
     const emoji = button?.dataset.chatThreadEmoji;
-    const name = button?.getAttribute("aria-label");
+    const name = button?.dataset.chatThreadEmojiName;
     setPreview(emoji && name ? { emoji, name } : null);
   }
 
@@ -1434,6 +1447,7 @@ function ChatThreadEmojiFeed({
               items={category.items}
               onSelect={onSelect}
               showShortcutDigits={category.showShortcutDigits}
+              shortcodeNames={category.shortcodeNames}
               pinnedTitle={railEnabled}
             />
           );
@@ -1449,6 +1463,7 @@ function ChatThreadEmojiSection({
   items,
   onSelect,
   showShortcutDigits = false,
+  shortcodeNames = true,
   pinnedTitle = false,
 }: {
   categoryKey: string;
@@ -1456,6 +1471,7 @@ function ChatThreadEmojiSection({
   items: ChatThreadEmojiItem[];
   onSelect: (emoji: string) => void;
   showShortcutDigits?: boolean;
+  shortcodeNames?: boolean;
   pinnedTitle?: boolean;
 }) {
   const { t } = useTranslation();
@@ -1497,6 +1513,7 @@ function ChatThreadEmojiSection({
         items={items}
         onSelect={onSelect}
         showShortcutDigits={showShortcutDigits}
+        shortcodeNames={shortcodeNames}
       />
     </div>
   );
@@ -1513,10 +1530,12 @@ function ChatThreadEmojiGrid({
   items,
   onSelect,
   showShortcutDigits = false,
+  shortcodeNames = true,
 }: {
   items: ChatThreadEmojiItem[];
   onSelect: (emoji: string) => void;
   showShortcutDigits?: boolean;
+  shortcodeNames?: boolean;
 }) {
   // Nine columns so the nine frequently-used digit shortcuts sit on a single
   // row; every other emoji group uses the same width to stay aligned.
@@ -1538,6 +1557,10 @@ function ChatThreadEmojiGrid({
             type="button"
             aria-label={item.name}
             data-chat-thread-emoji={item.emoji}
+            data-chat-thread-emoji-name={chatThreadEmojiDisplayName(
+              item.name,
+              shortcodeNames,
+            )}
             title={shortcutLabel}
             className="relative flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-state-hover"
             onClick={() => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -351,7 +351,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.EmojiPickerCategoryRail]: {
     maintainer: "tongx@vm0.ai",
     description:
-      "Add a category icon rail, pinned section titles, and jump-to-category scrolling to the thread emoji picker.",
+      "Add a category icon rail, pinned section titles, jump-to-category scrolling, and a hovered-emoji name bar to the thread emoji picker.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
Follow-up to #26342, from review of the shipped rail.

## What

**A name bar under the grid.** The rail landed without one, so the grid gave no way to read an emoji's name. A bar under the feed now names whichever emoji the pointer or keyboard is on, rendered as `:grinning_face:`, and shows a short hint when nothing is under the pointer.

**A tighter gap under the search field.** The first section title sat 16px below the search field, which read as a gap rather than a grouping. It is now 8px.

## Why it is built this way

- **One delegated listener, not ~1,900 pairs.** The hover source is a single `onMouseOver`/`onFocus` on the feed that resolves the emoji from `event.target.closest("[data-chat-thread-emoji]")`. Each button carries its glyph in that attribute because its `textContent` also contains the shortcut digit for the first nine frequently-used entries.
- **The preview lives in a signal, read only by the bar.** Pointing at a new emoji re-renders the name bar alone rather than the grid above it — the same reason the active category moved into the rail in #26342. The command also drops repeat writes, since moving across one emoji fires `mouseover` repeatedly.
- **The gap closes without touching the fade.** 4px comes off the search row's bottom padding, and the label shifts up inside its own box via `pt-1 pb-3` replacing `pt-2 pb-2`. Both add to 32px, so the box the gradient paints into is the same height as before. Measured in a browser against the real utility classes: title box 33px before and after, input-bottom-to-label 16px → 8px.
- **4px is the floor for the search row.** `Input` uses `focus:ring-[3px]` and the field is `autoFocus`, so a smaller bottom padding would put the focus ring over the first row of the feed.

## Verification

- `pnpm format`, `pnpm turbo run lint` (13/13), `pnpm check-types` (14/14), `pnpm knip --workspace apps/platform` — all clean
- `chat-thread-emoji-category-rail.test.tsx` — 6 passed, including a new case that hovers two emoji and asserts the bar names each one, and the idle hint appearing and disappearing
- `chat-history-navigation.test.tsx` — 34 passed
- The switch-off case now also asserts the bar is absent

The spacing itself has no automated coverage: jsdom has no layout, so any assertion on the gap would pass without proving anything. It was measured in a browser instead, against a reproduction using the same utility classes.

## Feature switch

Both changes sit behind the existing `emojiPickerCategoryRail` switch, still `enabled: false` and staff-only, so this stays one rollout unit with the rail rather than adding a second switch for the same redesign. Its description is updated to cover the name bar.