### PR TITLE
chore(rust): disallow tracing trace macro

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -709,9 +709,7 @@ async fn handle_message(
     close_rx: &mut CloseReceiver,
 ) -> LoopAction {
     match msg.action {
-        action::HEARTBEAT => {
-            tracing::trace!("Heartbeat received");
-        }
+        action::HEARTBEAT => {}
         action::MESSAGE => {
             if !message_targets_channel(&msg, &p.channel) {
                 return LoopAction::Continue;

--- a/crates/clippy.toml
+++ b/crates/clippy.toml
@@ -4,4 +4,5 @@ allow-panic-in-tests = true
 allow-indexing-slicing-in-tests = true
 disallowed-macros = [
     { path = "tracing::debug", reason = "DEBUG events have no configured production sink; remove the event or use an operationally visible level", allow-invalid = true },
+    { path = "tracing::trace", reason = "TRACE events have no configured production sink; remove the event or use an operationally visible level", allow-invalid = true },
 ]

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -229,7 +229,7 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::info!("local info");
         tracing::event!(tracing::Level::DEBUG, "local debug");
-        tracing::trace!("local trace");
+        tracing::event!(tracing::Level::TRACE, "local trace");
         tracing::warn!("local warn");
         tracing::warn!(target: INTERNAL_TARGET, dropped = 1_u64, "axiom channel full");
     }

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;
-use tracing::trace;
 
 use crate::process::ChildExitNotifier;
 
@@ -175,7 +174,6 @@ pub async fn exec_with_timeout(
     timeout: Duration,
 ) -> Result<String, CommandError> {
     let cmd_display = format_command_display(program, args);
-    trace!(command = %cmd_display, timeout_ms = timeout.as_millis() as u64, "exec_with_timeout");
 
     let output = command_output_with_timeout(program, args, timeout)
         .await
@@ -205,7 +203,6 @@ pub async fn exec_status_with_timeout(
     timeout: Duration,
 ) -> Result<(), CommandError> {
     let cmd_display = format_command_display(program, args);
-    trace!(command = %cmd_display, timeout_ms = timeout.as_millis() as u64, "exec_status_with_timeout");
 
     let output =
         command_output_with_policy(program, args, timeout, CommandOutputPolicy::status_only())
@@ -234,50 +231,23 @@ pub async fn exec_ignore_errors_with_timeout(
     args: &[&str],
     timeout: Duration,
 ) -> IgnoredCommandOutcome {
-    let cmd_display = format_command_display(program, args);
-    trace!(command = %cmd_display, timeout_ms = timeout.as_millis() as u64, "exec_ignore_errors_with_timeout");
-
     match command_output_with_policy(program, args, timeout, CommandOutputPolicy::status_only())
         .await
     {
         Ok(o) if o.status.success() => IgnoredCommandOutcome::Success,
-        Ok(o) => {
-            let stderr = o.stderr.to_lossy_trimmed_string();
-            trace!(command = %cmd_display, stderr = %stderr, "command failed (ignored)");
-            IgnoredCommandOutcome::NonZero
-        }
-        Err(CommandRunError::Timeout(ms)) => {
-            trace!(command = %cmd_display, timeout_ms = ms as u64, "command timed out (ignored)");
-            IgnoredCommandOutcome::Timeout
-        }
-        Err(CommandRunError::Wait(e)) => {
-            trace!(command = %cmd_display, error = %e, "command wait failed (ignored)");
-            IgnoredCommandOutcome::WaitError
-        }
-        Err(CommandRunError::PipeTask(e)) => {
-            trace!(command = %cmd_display, error = %e, "command pipe task failed (ignored)");
-            IgnoredCommandOutcome::PipeError
-        }
-        Err(CommandRunError::PipeRead(e)) => {
-            trace!(command = %cmd_display, error = %e, "command pipe read failed (ignored)");
-            IgnoredCommandOutcome::PipeError
-        }
-        Err(CommandRunError::PipeUnavailable(pipe)) => {
-            trace!(command = %cmd_display, pipe, "command pipe unavailable (ignored)");
-            IgnoredCommandOutcome::PipeError
-        }
-        Err(CommandRunError::OutputTooLarge { pipe, limit }) => {
-            trace!(command = %cmd_display, pipe, limit, "command output exceeded limit (ignored)");
-            IgnoredCommandOutcome::OutputTooLarge
-        }
+        Ok(_) => IgnoredCommandOutcome::NonZero,
+        Err(CommandRunError::Timeout(_)) => IgnoredCommandOutcome::Timeout,
+        Err(CommandRunError::Wait(_)) => IgnoredCommandOutcome::WaitError,
+        Err(
+            CommandRunError::PipeTask(_)
+            | CommandRunError::PipeRead(_)
+            | CommandRunError::PipeUnavailable(_),
+        ) => IgnoredCommandOutcome::PipeError,
+        Err(CommandRunError::OutputTooLarge { .. }) => IgnoredCommandOutcome::OutputTooLarge,
         Err(CommandRunError::Spawn(e)) if e.kind() == std::io::ErrorKind::NotFound => {
-            trace!(command = %cmd_display, error = %e, "command not found (ignored)");
             IgnoredCommandOutcome::NotFound
         }
-        Err(CommandRunError::Spawn(e)) => {
-            trace!(command = %cmd_display, error = %e, "command failed to spawn (ignored)");
-            IgnoredCommandOutcome::SpawnError
-        }
+        Err(CommandRunError::Spawn(_)) => IgnoredCommandOutcome::SpawnError,
     }
 }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -21,7 +21,7 @@ use sandbox::{
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, trace, warn};
+use tracing::{info, warn};
 use vsock_host::{
     ExecOutputEvent, ExecOwnedCapturedOutput, FencedExecError, FrameWriteObserver,
     NormalOperationFence, NormalOperationFenceRejection, SupervisedExecControl,
@@ -1593,9 +1593,8 @@ fn monitor_process_with_log_readers_and_exit_notifier(
             ProcessMonitorExit::Reaped(status) => (publish_process_monitor_exit(&context), status),
         };
 
-        match &status {
-            Ok(status) => trace!(id = %id, %status, "process monitor observed exit"),
-            Err(error) => warn!(id = %id, %error, "process monitor failed to wait for child"),
+        if let Err(error) = &status {
+            warn!(id = %id, %error, "process monitor failed to wait for child");
         }
         context.runtime_cancel.cancel();
 
@@ -3661,16 +3660,9 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     return SandboxParkOutcome::Reusable;
                 }
 
-                trace!(
-                    id = %log_id,
-                    actual = stats.actual_mib,
-                    target = target_mib,
-                    deficit_mib,
-                    tolerance_mib,
-                    observed_target_mib = stats.target_mib,
-                    sample_count = summary.sample_count,
-                    "waiting for balloon"
-                );
+                // Balloon timing tests advance paused time only after a completed stats sample.
+                #[cfg(test)]
+                tracing::event!(tracing::Level::TRACE, "waiting for balloon");
             }
             Ok(Err(e)) => {
                 let outcome = summary.park_outcome();


### PR DESCRIPTION
## Summary

- Disallow `tracing::trace!` through the shared Rust Clippy configuration.
- Remove all 15 production `trace!` calls instead of promoting diagnostics that have no operational sink.
- Preserve test-only TRACE semantics with generic `tracing::event!` calls where filtering and timing tests require them.

## Context

Production logging has no configured TRACE sink, so these events are not operationally visible. This extends the DEBUG enforcement introduced in #26324 to TRACE while leaving generic `event!` available for explicit test coverage.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p ably-subscriber` (200 tests and 1 doc test passed)
- `cargo test -p sandbox-fc` (793 unit tests and 1 integration test passed)
- `cargo test -p runner --bin runner axiom_filter_does_not_suppress_sibling_local_layers` reached final linking, but the local 3.8 GiB container killed `rustc` with SIGKILL; CI should run this test with normal build resources.

Follow-up to #26324.
