### PR TITLE
test(e2e): cover active connector permission refresh

### DIFF
--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -6,6 +6,7 @@ use super::messages::{
     turn_completed_notification, turn_failed_notification, turn_started_notification,
     warning_notification, write_error, write_json_line, write_split_json_line_prefix,
     write_success, write_turn_completion_notifications, write_turn_notifications,
+    write_turn_start_notifications,
 };
 use super::persistence::{InputEventContext, persist_input_events};
 use super::scenario::Scenario;
@@ -33,6 +34,16 @@ const EVENT_DELIVERY_LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
 const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
 const SECONDARY_ITEM_STARTED_AT_MS: u64 = 1_700_000_000_000;
 const SHELL_PROMPT_PREFIX: &str = "@shell@\n";
+const CHECKPOINTED_SHELL_PROMPT_PREFIX: &str = "@shell-checkpoint@\n";
+const CHECKPOINTED_SHELL_SEPARATOR: &str = "\n@continue@\n";
+
+enum MockTurnOutput {
+    Complete(String),
+    Checkpoint {
+        checkpoint_text: String,
+        continuation_script: String,
+    },
+}
 
 impl AppServerState {
     pub(super) fn handle_initialize<W: Write>(
@@ -295,7 +306,14 @@ impl AppServerState {
             },
             &inputs,
         )?;
-        let response_text = mock_response_text(inputs.iter().map(String::as_str))?;
+        let turn_output = mock_turn_output(inputs.iter().map(String::as_str))?;
+        let response_text = match &turn_output {
+            MockTurnOutput::Complete(response_text)
+            | MockTurnOutput::Checkpoint {
+                checkpoint_text: response_text,
+                ..
+            } => response_text,
+        };
         write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
         if self.scenario == Scenario::UnexpectedThreadOutputItemStarted {
             write_json_line(
@@ -329,7 +347,7 @@ impl AppServerState {
             return Ok(ServerAction::Stop);
         }
         if self.scenario == Scenario::SecondaryThreadNotifications {
-            write_secondary_thread_notifications(output, &thread_id, &turn_id, &response_text)?;
+            write_secondary_thread_notifications(output, &thread_id, &turn_id, response_text)?;
             return Ok(ServerAction::Continue);
         }
         if self.scenario.writes_turn_started_before_steer() {
@@ -347,7 +365,37 @@ impl AppServerState {
             self.scenario,
             Scenario::RuntimeTurnComplete | Scenario::RuntimeTurnCompleteWithoutThreadStarted
         ) {
-            write_turn_notifications(output, &thread_id, &turn_id, &response_text)?;
+            match turn_output {
+                MockTurnOutput::Complete(response_text) => {
+                    write_turn_notifications(output, &thread_id, &turn_id, &response_text)?;
+                }
+                MockTurnOutput::Checkpoint {
+                    checkpoint_text,
+                    continuation_script,
+                } => {
+                    write_turn_start_notifications(output, &thread_id, &turn_id)?;
+                    write_json_line(
+                        output,
+                        &assistant_item_completed_notification(
+                            &thread_id,
+                            &turn_id,
+                            &checkpoint_text,
+                        ),
+                    )?;
+                    let response_text = shell_response_text(&continuation_script)?;
+                    write_turn_completion_notifications(
+                        output,
+                        &thread_id,
+                        &turn_id,
+                        &response_text,
+                    )?;
+                }
+            }
+        } else if matches!(turn_output, MockTurnOutput::Checkpoint { .. }) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "checkpointed shell prompts require a runtime turn-complete scenario",
+            ));
         }
         if self.scenario == Scenario::RuntimeTurnFailed {
             write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
@@ -584,11 +632,40 @@ fn write_secondary_thread_notifications<W: Write>(
 }
 
 fn mock_response_text<'a>(inputs: impl IntoIterator<Item = &'a str>) -> io::Result<String> {
-    let prompt = inputs.into_iter().collect::<Vec<_>>().join(" ");
-    let Some(script) = prompt.strip_prefix(SHELL_PROMPT_PREFIX) else {
-        return Ok(format!("guest-mock-codex app-server response: {prompt}"));
-    };
+    match mock_turn_output(inputs)? {
+        MockTurnOutput::Complete(response_text) => Ok(response_text),
+        MockTurnOutput::Checkpoint { .. } => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "checkpointed shell prompts are not supported for turn steering",
+        )),
+    }
+}
 
+fn mock_turn_output<'a>(inputs: impl IntoIterator<Item = &'a str>) -> io::Result<MockTurnOutput> {
+    let prompt = inputs.into_iter().collect::<Vec<_>>().join(" ");
+    if let Some(scripts) = prompt.strip_prefix(CHECKPOINTED_SHELL_PROMPT_PREFIX) {
+        let Some((checkpoint_script, continuation_script)) =
+            scripts.split_once(CHECKPOINTED_SHELL_SEPARATOR)
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "checkpointed shell prompt is missing @continue@ separator",
+            ));
+        };
+        return Ok(MockTurnOutput::Checkpoint {
+            checkpoint_text: shell_response_text(checkpoint_script)?,
+            continuation_script: continuation_script.to_string(),
+        });
+    }
+    if let Some(script) = prompt.strip_prefix(SHELL_PROMPT_PREFIX) {
+        return shell_response_text(script).map(MockTurnOutput::Complete);
+    }
+    Ok(MockTurnOutput::Complete(format!(
+        "guest-mock-codex app-server response: {prompt}"
+    )))
+}
+
+fn shell_response_text(script: &str) -> io::Result<String> {
     let output = Command::new("bash").args(["-c", script]).output()?;
     let mut response = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -215,6 +215,15 @@ pub(super) fn write_turn_notifications<W: Write>(
     turn_id: &str,
     response_text: &str,
 ) -> io::Result<()> {
+    write_turn_start_notifications(output, thread_id, turn_id)?;
+    write_turn_completion_notifications(output, thread_id, turn_id, response_text)
+}
+
+pub(super) fn write_turn_start_notifications<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+) -> io::Result<()> {
     write_json_line(output, &turn_started_notification(thread_id, turn_id))?;
     let started_at_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -243,7 +252,7 @@ pub(super) fn write_turn_notifications<W: Write>(
             ),
         )?;
     }
-    write_turn_completion_notifications(output, thread_id, turn_id, response_text)
+    Ok(())
 }
 
 pub(super) fn write_turn_completion_notifications<W: Write>(

--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -504,6 +504,65 @@ fn app_server_shell_prompt_reports_stderr_and_failure() -> std::io::Result<()> {
 }
 
 #[test]
+fn app_server_checkpointed_shell_emits_output_before_continuing() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let release_file = dir.path().join("continue-shell");
+    let release_file_value = release_file.to_string_lossy().into_owned();
+    let mut server = spawn_app_server_with_env(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("runtime-turn-complete"),
+        &[("MOCK_CHECKPOINT_RELEASE_FILE", &release_file_value)],
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.send(&json!({
+        "id": 2,
+        "method": "thread/start",
+        "params": { "cwd": "/tmp" }
+    }))?;
+    let thread_started = server.read_required()?;
+    assert_eq!(thread_started["method"], "thread/started");
+    let started = server.read_required()?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input(
+                "@shell-checkpoint@\nprintf checkpoint-ready\n@continue@\nwhile [[ ! -f \"$MOCK_CHECKPOINT_RELEASE_FILE\" ]]; do sleep 0.01; done\nprintf continuation-finished"
+            )]
+        }),
+    )?;
+
+    loop {
+        let notification = server.read_required()?;
+        if notification["method"] != "item/completed" {
+            continue;
+        }
+        assert_eq!(notification["params"]["item"]["text"], "checkpoint-ready");
+        break;
+    }
+
+    std::fs::write(release_file, "continue")?;
+    let completed_item = server.read_required()?;
+    let completed_turn = server.read_required()?;
+    assert_eq!(completed_item["method"], "item/completed");
+    assert_eq!(
+        completed_item["params"]["item"]["text"],
+        "continuation-finished"
+    );
+    assert_eq!(completed_turn["method"], "turn/completed");
+
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_can_start_runtime_turn_before_steer_completion() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -77,6 +77,11 @@ Use a different organization-scoped connector slug in each file that can run in
 parallel. Assert sandbox-visible output and vm0-owned telemetry; do not treat an
 external provider's exact response status or body as the test oracle.
 
+For active-run connector refresh cases, coordinate through a run-scoped output
+message in the public chat-events API. Network telemetry is uploaded after the
+run completes, so use it only as the final ordered policy assertion, not as a
+live synchronization point.
+
 The workflow discovers the checked-in BATS files, weighs each file by its test
 count, and assigns whole files to at most twelve non-empty shards. New files are
 included automatically. Keep setup and teardown self-contained within a file so

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -163,7 +163,7 @@ runner_e2e_wait_for_agent_text() {
     return 1
 }
 
-runner_e2e_wait_for_chat_text() {
+runner_e2e_wait_for_active_chat_text() {
     local thread_id="$1"
     local run_id="$2"
     local expected="$3"
@@ -204,7 +204,7 @@ runner_e2e_wait_for_chat_text() {
         sleep 2
     done
 
-    echo "Timed out waiting for ${expected@Q} in chat events for run ${run_id}" >&2
+    echo "Timed out waiting for active-run ${expected@Q} in chat events for run ${run_id}" >&2
     echo "Last chat events: ${last_events}" >&2
     echo "Last run response: ${last_run}" >&2
     return 1

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -61,6 +61,17 @@ runner_e2e_start_chat_run() {
     runner_chat_send "$agent_id" "$shell_prompt" "" "deepseek-v4-flash"
 }
 
+runner_e2e_start_checkpointed_chat_run() {
+    local agent_id="$1"
+    local checkpoint_script="$2"
+    local continuation_script="$3"
+    local shell_prompt
+    shell_prompt=$(printf '@shell-checkpoint@\n%s\n@continue@\n%s' \
+        "$checkpoint_script" \
+        "$continuation_script")
+    runner_chat_send "$agent_id" "$shell_prompt" "" "deepseek-v4-flash"
+}
+
 runner_e2e_delete_chat_thread() {
     local thread_id="$1"
     runner_api_curl "/api/zero/chat-threads/${thread_id}" -X DELETE
@@ -152,6 +163,53 @@ runner_e2e_wait_for_agent_text() {
     return 1
 }
 
+runner_e2e_wait_for_chat_text() {
+    local thread_id="$1"
+    local run_id="$2"
+    local expected="$3"
+    local timeout_seconds="${4:-90}"
+    local started_at=$SECONDS
+    local last_events='{}'
+    local last_run='{}'
+    local matched_text=""
+    local run_status=""
+
+    while ((SECONDS - started_at < timeout_seconds)); do
+        if last_events=$(runner_api_curl \
+            "/api/zero/chat-threads/${thread_id}/events?limit=50" 2>&1) &&
+            matched_text=$(jq -er --arg runId "$run_id" --arg expected "$expected" '
+                [
+                    .events[]?
+                    | select(.eventType == "output.message" and .runId == $runId)
+                    | .content
+                    | select(type == "string" and contains($expected))
+                ]
+                | last // empty
+            ' <<<"$last_events"); then
+            printf '%s\n' "$matched_text"
+            return 0
+        fi
+
+        if last_run=$(runner_api_curl "/api/zero/runs/${run_id}" 2>&1); then
+            run_status=$(jq -r '.status // empty' <<<"$last_run")
+            case "$run_status" in
+                completed|failed|timeout|cancelled)
+                    echo "Run ${run_id} reached terminal status ${run_status@Q} before ${expected@Q} was visible" >&2
+                    echo "Last chat events: ${last_events}" >&2
+                    echo "Last run response: ${last_run}" >&2
+                    return 1
+                    ;;
+            esac
+        fi
+        sleep 2
+    done
+
+    echo "Timed out waiting for ${expected@Q} in chat events for run ${run_id}" >&2
+    echo "Last chat events: ${last_events}" >&2
+    echo "Last run response: ${last_run}" >&2
+    return 1
+}
+
 runner_e2e_wait_for_firewall_log() {
     local run_id="$1"
     local firewall_name="$2"
@@ -184,6 +242,55 @@ runner_e2e_wait_for_firewall_log() {
     done
 
     echo "Timed out waiting for firewall ${firewall_name@Q} on ${host@Q} for run ${run_id}" >&2
+    echo "Last network telemetry: ${last_logs}" >&2
+    return 1
+}
+
+runner_e2e_wait_for_firewall_transition() {
+    local run_id="$1"
+    local firewall_name="$2"
+    local host="$3"
+    local method="$4"
+    local url="$5"
+    local permission="$6"
+    local timeout_seconds="${7:-90}"
+    local started_at=$SECONDS
+    local last_logs='[]'
+
+    while ((SECONDS - started_at < timeout_seconds)); do
+        if last_logs=$(runner_e2e_network_logs "$run_id" 2>&1) &&
+            jq -e \
+                --arg firewallName "$firewall_name" \
+                --arg host "$host" \
+                --arg method "$method" \
+                --arg url "$url" \
+                --arg permission "$permission" '
+                    [
+                        to_entries[]
+                        | select(
+                            .value.firewall_name == $firewallName and
+                            .value.host == $host and
+                            .value.method == $method and
+                            .value.url == $url and
+                            .value.firewall_permission == $permission
+                        )
+                    ] as $matching
+                    | any($matching[];
+                        . as $denied
+                        | $denied.value.action == "DENY" and
+                            $denied.value.status == 403 and
+                            any($matching[];
+                                .key > $denied.key and .value.action == "ALLOW"
+                            )
+                    )
+                ' <<<"$last_logs" >/dev/null; then
+            printf '%s\n' "$last_logs"
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "Timed out waiting for firewall transition ${firewall_name@Q} on ${url@Q} for run ${run_id}" >&2
     echo "Last network telemetry: ${last_logs}" >&2
     return 1
 }

--- a/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
+++ b/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test algolia
+}
+
+@test "runner refreshes connector permissions during an active run" {
+    run create_runner_agent "runner-firewall-permission-refresh-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    local values
+    values=$(jq -nc \
+        --arg applicationId "VM0E2E0001" \
+        --arg apiKey "00000000000000000000000000000000" \
+        '{applicationId: $applicationId, apiKey: $apiKey}')
+    run runner_e2e_connect_manual_connector algolia api-key "$AGENT_ID" "$values"
+    echo "$output"
+    assert_success
+
+    local request_url="https://firewall-placeholder.vm3.ai/algolia/write/1/indexes/vm0-e2e-${TEST_ID}"
+    local checkpoint_script
+    checkpoint_script=$(cat <<'EOF'
+set -euo pipefail
+response_file=$(mktemp)
+trap 'rm -f "$response_file"' EXIT
+status=$(curl --silent --show-error --max-time 5 \
+    --output "$response_file" \
+    --write-out '%{http_code}' \
+    --request POST \
+    --header 'content-type: application/json' \
+    --data '{"objectID":"vm0-e2e"}' \
+    '__REQUEST_URL__')
+test "$status" = 403
+grep -Eq '"error"[[:space:]]*:[[:space:]]*"permission_denied"' "$response_file"
+printf 'ALGOLIA_PERMISSION_DENIED\n'
+EOF
+)
+    checkpoint_script=${checkpoint_script//__REQUEST_URL__/$request_url}
+
+    local continuation_script
+    continuation_script=$(cat <<'EOF'
+set -euo pipefail
+response_file=$(mktemp)
+trap 'rm -f "$response_file"' EXIT
+deadline=$((SECONDS + 90))
+while ((SECONDS < deadline)); do
+    if curl --silent --show-error --max-time 5 \
+        --output "$response_file" \
+        --request POST \
+        --header 'content-type: application/json' \
+        --data '{"objectID":"vm0-e2e"}' \
+        '__REQUEST_URL__'; then
+        if ! grep -Eq '"error"[[:space:]]*:[[:space:]]*"permission_denied"' "$response_file"; then
+            printf 'ALGOLIA_PERMISSION_ALLOWED\n'
+            exit 0
+        fi
+    fi
+    sleep 1
+done
+cat "$response_file" >&2
+echo 'Timed out waiting for the Algolia permission refresh' >&2
+exit 1
+EOF
+)
+    continuation_script=${continuation_script//__REQUEST_URL__/$request_url}
+
+    run runner_e2e_start_checkpointed_chat_run \
+        "$AGENT_ID" \
+        "$checkpoint_script" \
+        "$continuation_script"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
+
+    run runner_e2e_wait_for_chat_text \
+        "$THREAD_ID" \
+        "$RUN_ID" \
+        ALGOLIA_PERMISSION_DENIED
+    echo "$output"
+    assert_success
+
+    run runner_api_curl "/api/zero/runs/${RUN_ID}"
+    echo "$output"
+    assert_success
+    run jq -e '.status == "running"' <<<"$output"
+    echo "$output"
+    assert_success
+
+    local grant_payload
+    grant_payload=$(jq -nc \
+        --arg agentId "$AGENT_ID" \
+        '{
+            agentId: $agentId,
+            connectorSlug: "algolia",
+            mode: "patch",
+            grants: [{
+                permission: "index-content.write",
+                action: "allow",
+                expiresIn: "1h"
+            }]
+        }')
+    run runner_api_curl "/api/zero/user-permission-grants/apply" \
+        -X PUT \
+        -d "$grant_payload"
+    echo "$output"
+    assert_success
+
+    run runner_wait_for_run "$RUN_ID" 180
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_chat_text \
+        "$THREAD_ID" \
+        "$RUN_ID" \
+        ALGOLIA_PERMISSION_ALLOWED
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_firewall_transition \
+        "$RUN_ID" \
+        algolia \
+        firewall-placeholder.vm3.ai \
+        POST \
+        "$request_url" \
+        index-content.write
+    echo "$output"
+    assert_success
+}

--- a/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
+++ b/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
@@ -55,6 +55,7 @@ response_file=$(mktemp)
 trap 'rm -f "$response_file"' EXIT
 deadline=$((SECONDS + 90))
 while ((SECONDS < deadline)); do
+    : > "$response_file"
     curl --silent --show-error --max-time 5 \
         --output "$response_file" \
         --request POST \

--- a/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
+++ b/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
@@ -55,16 +55,15 @@ response_file=$(mktemp)
 trap 'rm -f "$response_file"' EXIT
 deadline=$((SECONDS + 90))
 while ((SECONDS < deadline)); do
-    if curl --silent --show-error --max-time 5 \
+    curl --silent --show-error --max-time 5 \
         --output "$response_file" \
         --request POST \
         --header 'content-type: application/json' \
         --data '{"objectID":"vm0-e2e"}' \
-        '__REQUEST_URL__'; then
-        if ! grep -Eq '"error"[[:space:]]*:[[:space:]]*"permission_denied"' "$response_file"; then
-            printf 'ALGOLIA_PERMISSION_ALLOWED\n'
-            exit 0
-        fi
+        '__REQUEST_URL__' || true
+    if ! grep -Eq '"error"[[:space:]]*:[[:space:]]*"permission_denied"' "$response_file"; then
+        printf 'ALGOLIA_PERMISSION_ALLOWED\n'
+        exit 0
     fi
     sleep 1
 done

--- a/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
+++ b/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
@@ -84,7 +84,7 @@ EOF
     RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
     THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
 
-    run runner_e2e_wait_for_chat_text \
+    run runner_e2e_wait_for_active_chat_text \
         "$THREAD_ID" \
         "$RUN_ID" \
         ALGOLIA_PERMISSION_DENIED
@@ -121,10 +121,7 @@ EOF
     echo "$output"
     assert_success
 
-    run runner_e2e_wait_for_chat_text \
-        "$THREAD_ID" \
-        "$RUN_ID" \
-        ALGOLIA_PERMISSION_ALLOWED
+    run runner_e2e_wait_for_agent_text "$RUN_ID" ALGOLIA_PERMISSION_ALLOWED
     echo "$output"
     assert_success
 


### PR DESCRIPTION
## Summary

- add an opt-in checkpointed shell mode to the test-only mock Codex app server
- add a deployed runner E2E proving one active run changes Algolia `index-content.write` from denied to allowed after a public grant mutation
- use public chat events for live coordination and ordered post-run network telemetry for the final policy assertion
- document the active-run checkpoint and deferred telemetry boundary

## Scope

This does not change a production API, database schema, queue payload, runner protocol, connector catalog, or workflow. Existing mock prompts and `@shell@` behavior remain unchanged.

## Validation

- `cargo fmt -p guest-mock-codex -- --check`
- `cargo clippy -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-mock-codex --all-features --no-deps`
- `cargo test -p guest-mock-codex --all-targets --all-features`
- `bash -n e2e/helpers/runner-api.bash`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test`
- repository pre-commit hooks, including workspace Rust Clippy and documentation checks

The live runner BATS case is CI-only and was not executed locally.

Closes #26320

Parent: #26285
