### PR TITLE
feat(platform): unify avatar and workspace logo thumbnails

### DIFF
--- a/turbo/apps/platform/src/views/components/avatar.tsx
+++ b/turbo/apps/platform/src/views/components/avatar.tsx
@@ -1,0 +1,100 @@
+import { cn } from "@vm0/ui";
+
+/**
+ * Shared thumbnail scale for the two identity marks in the app chrome: the
+ * person behind the session (`UserAvatar`) and the workspace they are in
+ * (`WorkspaceLogo`). Both draw from the same size and stroke vocabulary so a
+ * user avatar and a workspace logo sitting in the same column line up.
+ */
+const THUMBNAIL_SIZE = {
+  sm: "h-6 w-6",
+  md: "h-8 w-8",
+  lg: "h-10 w-10",
+  xl: "h-12 w-12",
+} as const;
+
+const THUMBNAIL_INITIAL_TEXT = {
+  sm: "text-[11px]",
+  md: "text-xs",
+  lg: "text-sm",
+  xl: "text-base",
+} as const;
+
+type ThumbnailSize = keyof typeof THUMBNAIL_SIZE;
+
+// `zero-thumb-border` is the 0.5px hairline every thumbnail carries so its
+// bounds stay readable against the sidebar, cards, and menus alike — including
+// avatars whose artwork fades out at the edge.
+const THUMBNAIL_BASE = "shrink-0 zero-thumb-border";
+
+/**
+ * A person: always a circle, so it never reads as a workspace or an app icon.
+ * Falls back to the name's initial when the account has no picture.
+ */
+export function UserAvatar({
+  imageUrl,
+  name,
+  initial,
+  size = "md",
+}: {
+  imageUrl: string | null | undefined;
+  name: string;
+  initial: string;
+  size?: ThumbnailSize;
+}) {
+  const base = cn(THUMBNAIL_BASE, THUMBNAIL_SIZE[size], "rounded-full");
+
+  if (imageUrl) {
+    return (
+      <img src={imageUrl} alt={name} className={cn(base, "object-cover")} />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        base,
+        "flex items-center justify-center bg-muted font-medium text-muted-foreground",
+        THUMBNAIL_INITIAL_TEXT[size],
+      )}
+    >
+      {initial}
+    </div>
+  );
+}
+
+/**
+ * A workspace: a rounded square, the shape brands are drawn for. Kept visually
+ * distinct from `UserAvatar` on purpose — the shape is what tells the two
+ * sidebar rows apart once they share a size.
+ */
+export function WorkspaceLogo({
+  name,
+  imageUrl,
+  size = "sm",
+}: {
+  name: string;
+  imageUrl?: string | null;
+  size?: ThumbnailSize;
+}) {
+  const radius = size === "sm" || size === "md" ? "rounded-md" : "rounded-xl";
+  const base = cn(THUMBNAIL_BASE, THUMBNAIL_SIZE[size], radius);
+
+  if (imageUrl) {
+    return (
+      <img src={imageUrl} alt={name} className={cn(base, "object-cover")} />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        base,
+        "flex items-center justify-center bg-[hsl(var(--gray-200))] font-bold text-[hsl(var(--primary-700))]",
+        THUMBNAIL_INITIAL_TEXT[size],
+      )}
+    >
+      {name.charAt(0).toUpperCase()}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -524,6 +524,12 @@ body {
   border-top: 0.7px dashed hsl(var(--gray-400));
 }
 
+/* Avatar / logo thumbnails: a hairline lighter than zero-border, so the edge of
+   a picture stays readable without the stroke reading as a frame. */
+.zero-thumb-border {
+  border: 0.5px solid hsl(var(--gray-400));
+}
+
 /* Role / status badge: pill with 0.7px border on neutral background */
 .zero-badge {
   border: 0.7px solid hsl(var(--gray-400));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -813,15 +813,19 @@ describe("zero sidebar account menu", () => {
     click(within(menu).getByText("Settings"));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("dialog", { name: "Settings" }),
-      ).toBeInTheDocument();
+      const dialog = screen.getByRole("dialog", { name: "Settings" });
+      expect(dialog).toBeInTheDocument();
       expect(
         screen.getByRole("heading", { name: "Preference" }),
       ).toBeInTheDocument();
-      expect(screen.getByText("Account & Security")).toBeInTheDocument();
-      expect(screen.getByText("Alex Rivera")).toBeInTheDocument();
-      expect(screen.getByText("alex.rivera@example.test")).toBeInTheDocument();
+      // Scoped to the dialog: the sidebar account row also carries the name.
+      expect(
+        within(dialog).getByText("Account & Security"),
+      ).toBeInTheDocument();
+      expect(within(dialog).getByText("Alex Rivera")).toBeInTheDocument();
+      expect(
+        within(dialog).getByText("alex.rivera@example.test"),
+      ).toBeInTheDocument();
     });
 
     const openedSettingsDialog = screen.getByRole("dialog", {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -86,6 +86,7 @@ import {
 } from "../../../../signals/zero-page/settings/workspace-settings-state.ts";
 import { openSettingsMemberUsagePacks$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import { formatUsd } from "../../../../i18n/format.ts";
+import { UserAvatar } from "../../../components/avatar.tsx";
 import {
   parseUsagePackOption,
   usagePackOptionLabel,
@@ -562,7 +563,7 @@ function MemberRow({
   return (
     <div className={cn(memberRowGrid(showUsagePack), "py-3 px-5")}>
       <div className="flex items-center gap-3 min-w-0">
-        <MemberAvatar
+        <UserAvatar
           imageUrl={member.imageUrl}
           initial={initial}
           name={name || member.email}
@@ -983,7 +984,7 @@ function PendingInvitationRow({
   return (
     <div className={cn(memberRowGrid(showUsagePack), "py-3 px-5")}>
       <div className="flex items-center gap-3 min-w-0">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-xs font-medium text-muted-foreground border border-dashed border-border">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted/50 text-xs font-medium text-muted-foreground border border-dashed border-border">
           {initial}
         </div>
         <div className="min-w-0">
@@ -1136,7 +1137,7 @@ function MembershipRequestRow({
   return (
     <div className={cn(memberRowGrid(showUsagePack), "py-3 px-5")}>
       <div className="flex items-center gap-3 min-w-0">
-        <MemberAvatar
+        <UserAvatar
           imageUrl={request.imageUrl}
           initial={initial}
           name={name || request.email}
@@ -1192,36 +1193,13 @@ function MembershipRequestRow({
   );
 }
 
-function MemberAvatar({
-  imageUrl,
-  initial,
-  name,
-}: {
-  imageUrl: string;
-  initial: string;
-  name: string;
-}) {
-  if (imageUrl) {
-    return (
-      <div className="h-8 w-8 shrink-0 rounded-lg overflow-hidden">
-        <img src={imageUrl} alt={name} className="h-full w-full object-cover" />
-      </div>
-    );
-  }
-  return (
-    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-xs font-medium text-muted-foreground">
-      {initial}
-    </div>
-  );
-}
-
 function MemberRowSkeleton({ showUsagePack }: { showUsagePack: boolean }) {
   return (
     <div
       className={cn(memberRowGrid(showUsagePack), "py-3 px-5 animate-pulse")}
     >
       <div className="flex items-center gap-3">
-        <div className="h-8 w-8 shrink-0 rounded-lg bg-muted/50" />
+        <div className="h-8 w-8 shrink-0 rounded-full bg-muted/50" />
         <div className="flex flex-col gap-1">
           <div className="h-4 w-24 rounded bg-muted/50" />
           <div className="h-3 w-36 rounded bg-muted/30" />

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -14,6 +14,7 @@ import {
 import { billingStatusAsync$ } from "../../../../signals/zero-page/billing.ts";
 import { currentLocale, i18n } from "../../../../i18n/index.ts";
 import { formatLocalizedNumber } from "../../../../i18n/format.ts";
+import { UserAvatar } from "../../../components/avatar.tsx";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -685,29 +686,6 @@ export function CreditBalanceCard({
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function MemberAvatar({
-  imageUrl,
-  initial,
-  name,
-}: {
-  imageUrl: string;
-  initial: string;
-  name: string;
-}) {
-  if (imageUrl) {
-    return (
-      <div className="h-8 w-8 shrink-0 rounded-lg overflow-hidden">
-        <img src={imageUrl} alt={name} className="h-full w-full object-cover" />
-      </div>
-    );
-  }
-  return (
-    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-xs font-medium text-muted-foreground">
-      {initial}
-    </div>
-  );
-}
-
 export function MemberUsageTable({
   members,
   memberMap,
@@ -742,7 +720,7 @@ export function MemberUsageTable({
             <div className="h-0 zero-border-t mx-5" />
             <div className="grid grid-cols-[1fr_7rem] gap-x-4 items-center px-5 py-3">
               <div className="flex items-center gap-3 min-w-0">
-                <MemberAvatar
+                <UserAvatar
                   imageUrl={orgMember?.imageUrl ?? ""}
                   initial={initial}
                   name={label}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/account-section.tsx
@@ -7,6 +7,7 @@ import {
   currentUserInfo$,
   resolveClerkSatelliteConfig,
 } from "../../../../../signals/auth.ts";
+import { UserAvatar } from "../../../../components/avatar.tsx";
 
 // Clerk satellite domains do not receive their own hosted Account Portal.
 const CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
@@ -26,17 +27,12 @@ export function AccountSection() {
 
   return (
     <div className="flex items-center gap-4 bg-card rounded-xl zero-border p-5">
-      {user?.imageUrl ? (
-        <img
-          src={user.imageUrl}
-          alt=""
-          className="h-12 w-12 rounded-xl object-cover shrink-0"
-        />
-      ) : (
-        <div className="h-12 w-12 rounded-xl bg-muted flex items-center justify-center text-sm font-medium text-muted-foreground shrink-0">
-          {initial}
-        </div>
-      )}
+      <UserAvatar
+        imageUrl={user?.imageUrl}
+        name={displayName}
+        initial={initial}
+        size="xl"
+      />
       <div className="flex-1 min-w-0">
         {displayName && (
           <div className="text-sm font-medium text-foreground truncate">

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -31,39 +31,7 @@ import {
   acceptingInvitationId$,
   setAcceptingInvitationId$,
 } from "../../signals/select-org/org-switcher-ui.ts";
-
-function OrgAvatar({
-  name,
-  imageUrl,
-  size = "sm",
-}: {
-  name: string;
-  imageUrl?: string | null;
-  size?: "sm" | "lg";
-}) {
-  const dim = size === "lg" ? "h-10 w-10" : "h-6 w-6";
-  const radius = size === "lg" ? "rounded-xl" : "rounded-md";
-  const textSize = size === "lg" ? "text-base" : "text-[11px]";
-  const initial = name.charAt(0).toUpperCase();
-
-  if (imageUrl) {
-    return (
-      <img
-        src={imageUrl}
-        alt={name}
-        className={`${dim} ${radius} object-cover shrink-0`}
-      />
-    );
-  }
-
-  return (
-    <div
-      className={`${dim} ${radius} bg-[hsl(var(--gray-200))] text-[hsl(var(--primary-700))] flex items-center justify-center ${textSize} font-bold shrink-0`}
-    >
-      {initial}
-    </div>
-  );
-}
+import { WorkspaceLogo } from "../components/avatar.tsx";
 
 function InvitationRow({
   invitation,
@@ -99,7 +67,7 @@ function InvitationRow({
 
   return (
     <div className="flex min-w-0 items-center gap-3 overflow-hidden px-3 py-2.5">
-      <OrgAvatar
+      <WorkspaceLogo
         name={invitation.publicOrganizationData.name}
         imageUrl={invitation.publicOrganizationData.imageUrl}
       />
@@ -202,7 +170,7 @@ function OtherMembershipsList() {
             }}
             className="min-w-0 gap-3 px-3 py-2.5"
           >
-            <OrgAvatar
+            <WorkspaceLogo
               name={membership.organization.name}
               imageUrl={membership.organization.imageUrl}
             />
@@ -250,7 +218,11 @@ function OrgDropdownContent() {
       }}
     >
       <div className="flex min-w-0 shrink-0 items-center gap-3 px-2 py-1.5">
-        <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} size="lg" />
+        <WorkspaceLogo
+          name={orgName}
+          imageUrl={currentOrg?.imageUrl}
+          size="lg"
+        />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold leading-tight truncate text-foreground">
             {orgName}
@@ -324,7 +296,7 @@ export function ZeroOrgSwitcherCompact() {
           size="icon"
           className="relative"
         >
-          <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} />
+          <WorkspaceLogo name={orgName} imageUrl={currentOrg?.imageUrl} />
           <PendingInvitationsBadge />
         </Button>
       </DropdownMenuTrigger>
@@ -354,7 +326,7 @@ export function ZeroOrgSwitcher() {
             className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-state-hover text-sidebar-foreground transition-colors"
           >
             <span className="relative shrink-0">
-              <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} />
+              <WorkspaceLogo name={orgName} imageUrl={currentOrg?.imageUrl} />
               <PendingInvitationsBadge />
             </span>
             <span className="min-w-0 flex-1 text-left text-sm font-semibold leading-tight truncate">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -66,6 +66,7 @@ import {
   useSubscriptionUsageRows,
 } from "./zero-sidebar-subscriptions.tsx";
 import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
+import { UserAvatar } from "../components/avatar.tsx";
 import { formatLocalizedNumber } from "../../i18n/format.ts";
 import { i18n } from "../../i18n/index.ts";
 
@@ -87,35 +88,6 @@ function formatCreditBalance(credits: number): string {
       count: credits,
       value: formatLocalizedNumber(credits),
     },
-  );
-}
-
-function AccountAvatar({
-  imageUrl,
-  name,
-  initial,
-  size = "sm",
-}: {
-  imageUrl: string | undefined;
-  name: string;
-  initial: string;
-  size?: "sm" | "md";
-}) {
-  const dim = size === "md" ? "h-9 w-9" : "h-8 w-8";
-  const textSize = size === "md" ? "text-sm" : "text-xs";
-  if (imageUrl) {
-    return (
-      <div className={`${dim} shrink-0 rounded-xl overflow-hidden`}>
-        <img src={imageUrl} alt={name} className="h-full w-full object-cover" />
-      </div>
-    );
-  }
-  return (
-    <div
-      className={`${dim} rounded-xl bg-orange-200/95 dark:bg-orange-300/80 flex items-center justify-center text-orange-900 dark:text-orange-950 ${textSize} font-medium shrink-0`}
-    >
-      {initial}
-    </div>
   );
 }
 
@@ -189,31 +161,40 @@ function accountDisplayFrom(
 }
 
 function renderAccountTrigger(display: AccountDisplay, collapsed: boolean) {
+  if (collapsed) {
+    return (
+      <Button
+        type="button"
+        variant="quiet"
+        size="icon"
+        className="shrink-0 p-0"
+      >
+        <UserAvatar
+          imageUrl={display.imageUrl}
+          name={display.name}
+          initial={display.initial}
+          size="sm"
+        />
+      </Button>
+    );
+  }
+  // Geometry mirrors ZeroOrgSwitcher's trigger so the workspace row at the top
+  // of the sidebar and the account row at the bottom read as one pair.
   return (
-    <Button
+    <button
       type="button"
-      variant="ghost"
-      size={collapsed ? "icon-sm" : "default"}
-      className={`font-normal text-sidebar-foreground duration-200 ${
-        collapsed ? "shrink-0 p-0" : "h-auto w-full justify-start p-2 text-left"
-      }`}
+      className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-state-hover text-sidebar-foreground transition-colors"
     >
-      <AccountAvatar
+      <UserAvatar
         imageUrl={display.imageUrl}
         name={display.name}
         initial={display.initial}
+        size="sm"
       />
-      {!collapsed && (
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium leading-tight truncate text-sidebar-foreground">
-            {display.name}
-          </p>
-          <p className="text-xs leading-tight truncate mt-px text-sidebar-foreground opacity-70">
-            {display.email}
-          </p>
-        </div>
-      )}
-    </Button>
+      <span className="min-w-0 flex-1 text-left text-sm font-medium leading-tight truncate">
+        {display.name}
+      </span>
+    </button>
   );
 }
 
@@ -231,11 +212,11 @@ function CurrentAccountHeader({
     <>
       <div className="px-3 py-3">
         <div className="flex items-center gap-3">
-          <AccountAvatar
+          <UserAvatar
             imageUrl={display.imageUrl}
             name={display.name}
             initial={display.initial}
-            size="md"
+            size="lg"
           />
           <div className="flex-1 min-w-0">
             <div className="text-sm font-medium text-foreground truncate">
@@ -723,7 +704,7 @@ function AccountManagementGroup({
               }}
               className="gap-3 px-3 py-2.5"
             >
-              <AccountAvatar
+              <UserAvatar
                 imageUrl={account.imageUrl}
                 name={account.name}
                 initial={account.initial}


### PR DESCRIPTION
## What

Aligns the sidebar's two switcher rows and gives every identity thumbnail one shared treatment.

**1. Sidebar rows now match**
- Removed the email from the sidebar account row — it was the only reason that row was taller than the workspace row.
- The account trigger now mirrors `ZeroOrgSwitcher`'s geometry exactly: `w-full · px-2 py-2 · gap-2.5 · rounded-lg · hover:bg-state-hover`, with a 24px mark. Both rows are 40px tall with their marks on the same left edge.
- Collapsed rail: the account button moves from `icon-sm` to `icon` so it matches `ZeroOrgSwitcherCompact`.

**2. Avatars are circles, from one component**
There was no shared avatar component — four hand-rolled copies had drifted to `rounded-xl`, `rounded-lg`, and three different fallback fills. New `views/components/avatar.tsx` exports `UserAvatar` (always a circle) and `WorkspaceLogo` (rounded square), sharing one size scale. Replaced every copy in the sidebar account menu, org members tab, org usage tab, and account settings.

Workspace logos deliberately stay rounded squares: once the two marks share a size, shape is what tells "a person" apart from "a workspace".

**3. 0.5px hairline on every thumbnail**
New `.zero-thumb-border` utility (`0.5px solid hsl(var(--gray-400))`), a touch lighter than the existing `.zero-border`. Both `UserAvatar` and `WorkspaceLogo` carry it, so a picture that fades out at its edge still shows its true bounds.

## Checks

`pnpm format` · `pnpm check-types` · `pnpm -F @vm0/app lint` · `pnpm knip --workspace apps/platform` — all clean.
Tests: `zero-sidebar-account-menu`, `zero-org-switcher`, `zero-sidebar`, `org-members-tab`, `org-usage-tab` — 88 passed.

One assertion in `zero-sidebar-account-menu.test.tsx` was scoped to the settings dialog with `within(dialog)`: the sidebar row and the dialog both legitimately render the account name, so the unscoped `screen.getByText` was ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)