### PR TITLE
feat(runner): enable durable active-input delivery

### DIFF
--- a/crates/api-contracts/src/generated/routes.rs
+++ b/crates/api-contracts/src/generated/routes.rs
@@ -203,6 +203,39 @@ pub mod runners {
                         }
                     }
                 }
+
+                /// Generated route bindings under `runners::runs::by_run_id::active_inputs::reserve`.
+                pub mod reserve {
+                    /// Reserve or retrieve pending active input for a run.
+                    /// Route contract: `POST /api/runners/runs/:runId/active-inputs/reserve`.
+                    pub const RESERVE: crate::RouteTemplate = crate::RouteTemplate {
+                        method: crate::Method::Post,
+                        path: "/api/runners/runs/:runId/active-inputs/reserve",
+                    };
+
+                    /// Path parameters for `POST /api/runners/runs/:runId/active-inputs/reserve`.
+                    #[derive(Debug, Clone, Copy)]
+                    pub struct Params<'a> {
+                        /// Value for the `:runId` path parameter.
+                        pub run_id: &'a str,
+                    }
+
+                    /// Build the concrete path for `POST /api/runners/runs/:runId/active-inputs/reserve`.
+                    /// Percent-encodes each path parameter as a URL path segment.
+                    #[must_use]
+                    pub fn path(params: Params<'_>) -> String {
+                        format!(
+                            "/api/runners/runs/{}/active-inputs/reserve",
+                            crate::route::encode_path_segment(params.run_id),
+                        )
+                    }
+
+                    /// Build a resolved route for `POST /api/runners/runs/:runId/active-inputs/reserve`.
+                    #[must_use]
+                    pub fn route(params: Params<'_>) -> crate::ResolvedRoute {
+                        crate::ResolvedRoute::new(RESERVE.method, path(params))
+                    }
+                }
             }
 
             /// Generated route bindings under `runners::runs::by_run_id::connector_runtime`.

--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -28,6 +28,58 @@ pub mod runners {
                     Rejected,
                 }
             }
+
+            /// DTOs for reserving or retrieving active-input delivery.
+            pub mod reserve {
+                /// Reason an active-input reservation was rejected.
+                #[derive(
+                    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+                )]
+                pub enum ResponseRejectedReason {
+                    /// The delivery-aware control payload exceeds the frame limit.
+                    #[serde(rename = "payload_too_large")]
+                    PayloadTooLarge,
+                    /// The target run is no longer running.
+                    #[serde(rename = "run_not_running")]
+                    RunNotRunning,
+                }
+
+                /// API outcome when reserving or retrieving active input.
+                #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+                #[serde(tag = "outcome", rename_all_fields = "camelCase")]
+                pub enum Response {
+                    /// A stable delivery batch is ready for Guest delivery.
+                    #[serde(rename = "reserved")]
+                    Reserved {
+                        /// Stable identity for the reserved delivery batch.
+                        delivery_id: String,
+                        /// Ordered source chat-event identities in the batch.
+                        event_ids: Vec<String>,
+                        /// Materialized prompt sent to the active Guest.
+                        prompt: String,
+                    },
+                    /// No pending active input is available.
+                    #[serde(rename = "empty")]
+                    Empty,
+                    /// The run is terminal and has no open delivery.
+                    #[serde(rename = "terminal")]
+                    Terminal,
+                    /// An open delivery remains held for a non-running run.
+                    #[serde(rename = "held")]
+                    Held {
+                        /// Stable identity for the reserved delivery batch.
+                        delivery_id: String,
+                        /// Ordered source chat-event identities in the batch.
+                        event_ids: Vec<String>,
+                    },
+                    /// Pending input cannot currently be reserved.
+                    #[serde(rename = "rejected")]
+                    Rejected {
+                        /// Reason the pending input could not be reserved.
+                        reason: ResponseRejectedReason,
+                    },
+                }
+            }
         }
     }
 

--- a/crates/guest-agent/src/active_input_receipts.rs
+++ b/crates/guest-agent/src/active_input_receipts.rs
@@ -176,6 +176,9 @@ async fn deliver_receipt(
     journal: &ReceiptJournal,
     rejected: &mut HashSet<String>,
 ) {
+    if !http.has_api() {
+        return;
+    }
     match http.post_active_input_receipt(run_id, delivery_id).await {
         Ok(Response::Delivered) => match journal.acknowledge(delivery_id) {
             Ok(()) => log_info!(

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use common::SystemLogOverrideGuard;
-use guest_agent::active_input::ActiveInputRuntime;
+use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
 use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
 use guest_agent::run_context::GuestRuntime;
@@ -104,6 +104,44 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     assert!(
         !complete_log.contains("Complete webhook failed"),
         "no-API complete path must return before touching the disabled HTTP client: {complete_log}"
+    );
+
+    let delivery_id = "60fca608-d174-4c1a-a1b2-57607b3adf46";
+    let receipt_log_path = tmp.path().join("active-input-receipt-system.log");
+    let receipt_log_guard = SystemLogOverrideGuard::set(&receipt_log_path);
+    let active_input = ActiveInputRuntime::new_with_receipts(
+        &runtime.config.run_id,
+        true,
+        &runtime.config.prompt,
+        tmp.path().join("active-input-receipts.json"),
+        http.clone(),
+    )?;
+    let active_input_controller = active_input.controller();
+    let mut active_input_writer = active_input.into_writer();
+    assert_eq!(
+        active_input_controller.handle_control_payload(&serde_json::to_vec(&json!({
+            "type": "active-input",
+            "deliveryId": delivery_id,
+            "text": "local follow-up",
+        }))?),
+        ActiveInputControlOutcome::Accepted,
+    );
+    let active_input_frame = active_input_writer
+        .next_frame()
+        .await
+        .expect("local active input should reach the CLI writer");
+    active_input_writer.mark_writing(&active_input_frame.uuid);
+    active_input_writer.mark_backend_accepted_without_replay(&active_input_frame)?;
+    active_input_controller.close_terminal();
+    assert_eq!(
+        active_input_controller.finalize_receipts().await?,
+        vec![delivery_id.to_string()],
+    );
+    drop(receipt_log_guard);
+    let receipt_log = std::fs::read_to_string(&receipt_log_path).unwrap_or_default();
+    assert!(
+        !receipt_log.contains("Active-input receipt attempt failed"),
+        "local active input must not attempt an API receipt: {receipt_log}",
     );
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(

--- a/crates/guest-contracts/src/active_input_receipts.rs
+++ b/crates/guest-contracts/src/active_input_receipts.rs
@@ -69,6 +69,26 @@ fn validate_journal(
     Ok(journal.delivery_ids)
 }
 
+/// Parse and validate a bounded active-input receipt journal snapshot.
+///
+/// This entry point is used when the caller already obtained bytes through a
+/// bounded sandbox file boundary. Local callers should prefer
+/// [`read_active_input_receipt_journal`] so private-file metadata is validated
+/// before parsing.
+pub fn parse_active_input_receipt_journal(
+    bytes: &[u8],
+    expected_run_id: &str,
+) -> io::Result<Vec<String>> {
+    if bytes.len() > MAX_ACTIVE_INPUT_RECEIPT_JOURNAL_BYTES {
+        return Err(invalid_data(format!(
+            "receipt journal exceeds {MAX_ACTIVE_INPUT_RECEIPT_JOURNAL_BYTES} bytes"
+        )));
+    }
+    let journal = serde_json::from_slice::<ActiveInputReceiptJournal>(bytes)
+        .map_err(|error| invalid_data(format!("invalid active-input receipt journal: {error}")))?;
+    validate_journal(journal, expected_run_id)
+}
+
 /// Read and validate the outstanding acceptance receipts for one run.
 ///
 /// A missing journal is equivalent to an empty outstanding set. The file is
@@ -83,9 +103,7 @@ pub fn read_active_input_receipt_journal(
         validate_run_id(expected_run_id)?;
         return Ok(Vec::new());
     };
-    let journal = serde_json::from_slice::<ActiveInputReceiptJournal>(&bytes)
-        .map_err(|error| invalid_data(format!("invalid active-input receipt journal: {error}")))?;
-    validate_journal(journal, expected_run_id)
+    parse_active_input_receipt_journal(&bytes, expected_run_id)
 }
 
 /// Atomically publish the outstanding acceptance receipts for one run.
@@ -227,6 +245,28 @@ mod tests {
             read_active_input_receipt_journal(&path, RUN_ID)
                 .unwrap_err()
                 .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn bounded_snapshot_parser_validates_sandbox_read_bytes() {
+        assert_eq!(
+            parse_active_input_receipt_journal(
+                format!(r#"{{"runId":"{RUN_ID}","deliveryIds":["{FIRST_ID}","{SECOND_ID}"]}}"#)
+                    .as_bytes(),
+                RUN_ID,
+            )
+            .unwrap(),
+            vec![FIRST_ID.to_owned(), SECOND_ID.to_owned()]
+        );
+        assert_eq!(
+            parse_active_input_receipt_journal(
+                &vec![b'x'; MAX_ACTIVE_INPUT_RECEIPT_JOURNAL_BYTES + 1],
+                RUN_ID,
+            )
+            .unwrap_err()
+            .kind(),
             io::ErrorKind::InvalidData
         );
     }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -41,7 +41,7 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 unicode-normalization = { workspace = true }
 url = { workspace = true }
-uuid = { workspace = true, features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "v5", "serde"] }
 sentry = { workspace = true, features = ["panic"] }
 which = { workspace = true }
 zstd = { workspace = true, features = ["zstdmt"] }

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -271,6 +271,10 @@ async fn read_api_active_input(
                 .await;
             match result {
                 Ok(ReserveActiveInputResult::RouteUnavailable) => {
+                    // A newly deployed Runner can reach an API version from before the
+                    // reserve route during the Runner/API rollout and rollback window
+                    // (up to two hours). Remove this legacy selection after that window
+                    // closes and production drain evidence satisfies #26061.
                     source.mode = ApiActiveInputMode::Legacy;
                     read_legacy_api_active_input(source).await
                 }

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -2,13 +2,20 @@ use std::io::{self, Write};
 use std::time::Duration;
 
 use tokio::sync::broadcast;
+use uuid::Uuid;
 
-use api_contracts::generated::constants::runners::ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES as ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES_U64;
+use api_contracts::generated::{
+    constants::runners::ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES as ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES_U64,
+    types::runners::runs::active_inputs::{
+        receipt::Response as ActiveInputReceiptResponse,
+        reserve::Response as ActiveInputReserveResponse,
+    },
+};
 
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
-use crate::provider::ApiClient;
+use crate::provider::{ApiClient, ReserveActiveInputResult};
 
 /// Exec-control payloads are bounded by the guest-side process-control IPC frame limit.
 pub(crate) const ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES: usize =
@@ -21,13 +28,16 @@ const _: () = assert!(
 pub(crate) struct ActiveInputPayload<'a> {
     #[serde(rename = "type")]
     payload_type: &'static str,
+    #[serde(rename = "deliveryId", skip_serializing_if = "Option::is_none")]
+    delivery_id: Option<&'a str>,
     text: &'a str,
 }
 
 impl<'a> ActiveInputPayload<'a> {
-    pub(crate) fn new(text: &'a str) -> Self {
+    pub(crate) fn new(delivery_id: Option<&'a str>, text: &'a str) -> Self {
         Self {
             payload_type: "active-input",
+            delivery_id,
             text,
         }
     }
@@ -62,10 +72,27 @@ impl Write for CountingWriter {
     }
 }
 
-pub(crate) fn active_input_payload_len(text: &str) -> Result<usize, serde_json::Error> {
+pub(crate) fn active_input_payload_len(
+    delivery_id: Option<&str>,
+    text: &str,
+) -> Result<usize, serde_json::Error> {
     let mut counter = CountingWriter::default();
-    serde_json::to_writer(&mut counter, &ActiveInputPayload::new(text))?;
+    serde_json::to_writer(&mut counter, &ActiveInputPayload::new(delivery_id, text))?;
     Ok(counter.len())
+}
+
+pub(crate) fn identified_active_input_payload_len(text: &str) -> Result<usize, serde_json::Error> {
+    let delivery_id = Uuid::nil().hyphenated().to_string();
+    active_input_payload_len(Some(&delivery_id), text)
+}
+
+pub(crate) fn local_active_input_delivery_id(run_id: RunId, sequence: u64) -> String {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("vm0:local-active-input:{run_id}:{sequence}").as_bytes(),
+    )
+    .hyphenated()
+    .to_string()
 }
 
 pub(crate) enum ActiveInputSource {
@@ -84,11 +111,27 @@ pub(crate) struct ApiActiveInputSource {
     run_id: RunId,
     sandbox_token: String,
     notifications: ActiveInputSubscription,
+    mode: ApiActiveInputMode,
+}
+
+#[derive(Clone)]
+pub(crate) struct ApiActiveInputRecovery {
+    api: ApiClient,
+    run_id: RunId,
+    sandbox_token: String,
+}
+
+#[derive(Clone, Copy)]
+enum ApiActiveInputMode {
+    Probe,
+    Reserve,
+    Legacy,
 }
 
 pub(crate) enum ActiveInputBatch {
     Local(Vec<ActiveInputEntry>),
-    Api {
+    ApiReserve(ActiveInputReserveResponse),
+    ApiLegacy {
         prompt: Option<String>,
         has_more: bool,
     },
@@ -156,10 +199,22 @@ impl ActiveInputSource {
             run_id,
             sandbox_token,
             notifications,
+            mode: ApiActiveInputMode::Probe,
         })
     }
 
-    pub(crate) async fn read(&self, min_sequence: u64) -> RunnerResult<ActiveInputBatch> {
+    pub(crate) fn api_recovery(&self) -> Option<ApiActiveInputRecovery> {
+        match self {
+            Self::LocalQueue(_) => None,
+            Self::Api(source) => Some(ApiActiveInputRecovery {
+                api: source.api.clone(),
+                run_id: source.run_id,
+                sandbox_token: source.sandbox_token.clone(),
+            }),
+        }
+    }
+
+    pub(crate) async fn read(&mut self, min_sequence: u64) -> RunnerResult<ActiveInputBatch> {
         match self {
             Self::LocalQueue(source) => {
                 let source = source.clone();
@@ -176,30 +231,7 @@ impl ActiveInputSource {
                 })?;
                 Ok(ActiveInputBatch::Local(entries))
             }
-            Self::Api(source) => {
-                let event_ids = source
-                    .api
-                    .list_active_input_event_ids(source.run_id, &source.sandbox_token)
-                    .await?;
-                let Some(event_id) = event_ids.first() else {
-                    return Ok(ActiveInputBatch::Api {
-                        prompt: None,
-                        has_more: false,
-                    });
-                };
-                let prompt = source
-                    .api
-                    .claim_active_inputs(
-                        source.run_id,
-                        &source.sandbox_token,
-                        std::slice::from_ref(event_id),
-                    )
-                    .await?;
-                Ok(ActiveInputBatch::Api {
-                    prompt: Some(prompt),
-                    has_more: event_ids.len() > 1,
-                })
-            }
+            Self::Api(source) => read_api_active_input(source).await,
         }
     }
 
@@ -216,6 +248,84 @@ impl ActiveInputSource {
     }
 }
 
+impl ApiActiveInputRecovery {
+    pub(crate) async fn record_delivery(
+        &self,
+        delivery_id: &str,
+    ) -> RunnerResult<ActiveInputReceiptResponse> {
+        self.api
+            .record_active_input_delivery(self.run_id, &self.sandbox_token, delivery_id)
+            .await
+    }
+}
+
+async fn read_api_active_input(
+    source: &mut ApiActiveInputSource,
+) -> RunnerResult<ActiveInputBatch> {
+    match source.mode {
+        ApiActiveInputMode::Legacy => read_legacy_api_active_input(source).await,
+        ApiActiveInputMode::Probe => {
+            let result = source
+                .api
+                .reserve_active_inputs(source.run_id, &source.sandbox_token)
+                .await;
+            match result {
+                Ok(ReserveActiveInputResult::RouteUnavailable) => {
+                    source.mode = ApiActiveInputMode::Legacy;
+                    read_legacy_api_active_input(source).await
+                }
+                Ok(ReserveActiveInputResult::Response(response)) => {
+                    source.mode = ApiActiveInputMode::Reserve;
+                    Ok(ActiveInputBatch::ApiReserve(response))
+                }
+                Err(error) => {
+                    source.mode = ApiActiveInputMode::Reserve;
+                    Err(error)
+                }
+            }
+        }
+        ApiActiveInputMode::Reserve => match source
+            .api
+            .reserve_active_inputs(source.run_id, &source.sandbox_token)
+            .await?
+        {
+            ReserveActiveInputResult::Response(response) => {
+                Ok(ActiveInputBatch::ApiReserve(response))
+            }
+            ReserveActiveInputResult::RouteUnavailable => Err(RunnerError::Api(
+                "reserve active inputs returned 404 after reserve support was selected".to_string(),
+            )),
+        },
+    }
+}
+
+async fn read_legacy_api_active_input(
+    source: &ApiActiveInputSource,
+) -> RunnerResult<ActiveInputBatch> {
+    let event_ids = source
+        .api
+        .list_active_input_event_ids(source.run_id, &source.sandbox_token)
+        .await?;
+    let Some(event_id) = event_ids.first() else {
+        return Ok(ActiveInputBatch::ApiLegacy {
+            prompt: None,
+            has_more: false,
+        });
+    };
+    let prompt = source
+        .api
+        .claim_active_inputs(
+            source.run_id,
+            &source.sandbox_token,
+            std::slice::from_ref(event_id),
+        )
+        .await?;
+    Ok(ActiveInputBatch::ApiLegacy {
+        prompt: Some(prompt),
+        has_more: event_ids.len() > 1,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,11 +338,16 @@ mod tests {
             "unicode café 你好 🚀".to_string(),
             "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES - 128),
         ];
+        let delivery_id = Uuid::new_v4().hyphenated().to_string();
 
         for text in texts {
-            let counted = active_input_payload_len(&text).unwrap();
-            let serialized = ActiveInputPayload::new(&text).to_vec().unwrap();
-            assert_eq!(counted, serialized.len(), "text len={}", text.len());
+            for candidate_delivery_id in [None, Some(delivery_id.as_str())] {
+                let counted = active_input_payload_len(candidate_delivery_id, &text).unwrap();
+                let serialized = ActiveInputPayload::new(candidate_delivery_id, &text)
+                    .to_vec()
+                    .unwrap();
+                assert_eq!(counted, serialized.len(), "text len={}", text.len());
+            }
         }
     }
 }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -15,7 +15,9 @@ use clap::Args;
 use tokio::signal::unix::{Signal, SignalKind, signal};
 use uuid::Uuid;
 
-use crate::active_input::{ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, active_input_payload_len};
+use crate::active_input::{
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, identified_active_input_payload_len,
+};
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::local_queue::{self, JobRequest, JobResponse};
@@ -470,7 +472,7 @@ impl SubmitPlan {
                 "invalid --active-input value: text must not contain NUL characters".to_string(),
             ));
         }
-        let payload_len = active_input_payload_len(text).map_err(|e| {
+        let payload_len = identified_active_input_payload_len(text).map_err(|e| {
             RunnerError::Internal(format!(
                 "serialize active-input payload for validation: {e}"
             ))

--- a/crates/runner/src/cmd/local/submit/tests/active_inputs.rs
+++ b/crates/runner/src/cmd/local/submit/tests/active_inputs.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 
 use super::super::{ActiveInputProducer, DelayedActiveInput, SubmitPlan, run_submit_with_home};
 use super::support::{submit_args_for_test, submit_queue_entry, write_queue_job_file};
-use crate::active_input::{ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, active_input_payload_len};
+use crate::active_input::{
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, identified_active_input_payload_len,
+};
 use crate::ids::RunId;
 use crate::local_queue::{self, JobRequest, JobResponse};
 use crate::paths::HomePaths;
@@ -136,7 +138,7 @@ fn rejects_invalid_active_input_specs() {
 
 #[test]
 fn accepts_active_input_payload_at_serialized_limit() {
-    let payload_overhead = active_input_payload_len("").unwrap();
+    let payload_overhead = identified_active_input_payload_len("").unwrap();
     let exact_limit_text = "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES - payload_overhead);
 
     let parsed = SubmitPlan::parse_active_inputs(
@@ -147,7 +149,7 @@ fn accepts_active_input_payload_at_serialized_limit() {
 
     assert_eq!(parsed.len(), 1);
     assert_eq!(
-        active_input_payload_len(&parsed[0].text).unwrap(),
+        identified_active_input_payload_len(&parsed[0].text).unwrap(),
         ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES
     );
 }

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -419,6 +419,7 @@ async fn complete_claimed_without_sandbox(
                 sandbox_id: None,
                 sandbox_reuse_result: reuse_result,
                 workspace_reuse_result: None,
+                active_input_delivery_ids: Vec::new(),
             },
             completion_auth,
         )

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1882,6 +1882,7 @@ async fn complete_claimed_failure(
                 sandbox_id: None,
                 sandbox_reuse_result: reuse_result,
                 workspace_reuse_result: None,
+                active_input_delivery_ids: Vec::new(),
             },
             completion_auth,
         )

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -129,6 +129,7 @@ pub(super) struct CompletionPayload {
     sandbox_id: SandboxId,
     reuse_result: SandboxReuseResult,
     workspace_reuse_result: Option<WorkspaceReuseResult>,
+    active_input_delivery_ids: Vec<String>,
     completion_auth: CompletionAuth,
 }
 
@@ -166,6 +167,7 @@ impl CompletionPayload {
             sandbox_id,
             reuse_result,
             workspace_reuse_result: None,
+            active_input_delivery_ids: Vec::new(),
             completion_auth,
         }
     }
@@ -178,6 +180,14 @@ impl CompletionPayload {
         self
     }
 
+    pub(super) fn with_active_input_delivery_ids(
+        mut self,
+        active_input_delivery_ids: Vec<String>,
+    ) -> Self {
+        self.active_input_delivery_ids = active_input_delivery_ids;
+        self
+    }
+
     pub(super) async fn report(self, provider: &dyn JobProvider) -> CompletionReportObservation {
         let Self {
             run_id,
@@ -186,6 +196,7 @@ impl CompletionPayload {
             sandbox_id,
             reuse_result,
             workspace_reuse_result,
+            active_input_delivery_ids,
             completion_auth,
         } = self;
         let provider_completion_started = Instant::now();
@@ -198,6 +209,7 @@ impl CompletionPayload {
                     sandbox_id: Some(sandbox_id),
                     sandbox_reuse_result: Some(reuse_result),
                     workspace_reuse_result,
+                    active_input_delivery_ids,
                 },
                 completion_auth,
             )
@@ -291,6 +303,7 @@ mod tests {
     }
     struct CompletionAuthProvider {
         auth_matches: Arc<AtomicBool>,
+        active_input_delivery_ids: Arc<std::sync::Mutex<Vec<String>>>,
     }
 
     #[async_trait]
@@ -308,6 +321,7 @@ mod tests {
                 completion_auth.matches_sandbox_token_for_test(request.run_id, "completion-token"),
                 Ordering::SeqCst,
             );
+            *self.active_input_delivery_ids.lock().unwrap() = request.active_input_delivery_ids;
         }
 
         async fn heartbeat(&self, _state: &HeartbeatState) {}
@@ -350,8 +364,10 @@ mod tests {
     #[tokio::test]
     async fn completion_payload_forwards_completion_auth() {
         let auth_matches = Arc::new(AtomicBool::new(false));
+        let active_input_delivery_ids = Arc::new(std::sync::Mutex::new(Vec::new()));
         let provider = CompletionAuthProvider {
             auth_matches: Arc::clone(&auth_matches),
+            active_input_delivery_ids: Arc::clone(&active_input_delivery_ids),
         };
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
@@ -364,12 +380,17 @@ mod tests {
             SandboxReuseResult::PoolMiss,
             CompletionAuth::sandbox_token(run_id, "completion-token".to_string()),
         )
+        .with_active_input_delivery_ids(vec!["b1e2ad6d-930a-4d51-aa40-7952d54f978b".to_string()])
         .report(&provider)
         .await;
 
         assert!(
             auth_matches.load(Ordering::SeqCst),
             "completion payload auth must be forwarded to provider.complete"
+        );
+        assert_eq!(
+            *active_input_delivery_ids.lock().unwrap(),
+            vec!["b1e2ad6d-930a-4d51-aa40-7952d54f978b".to_string()]
         );
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -224,6 +224,7 @@ impl ExecutorInvocation {
                 ExecutorPhaseOutcome {
                     outcome: executor::ExecuteOutcome {
                         failure: Some(failure),
+                        active_input_delivery_ids: Vec::new(),
                         sandbox_reuse_disposition: executor::SandboxReuseDisposition::default(),
                         sandbox: None,
                         source_ip: String::new(),
@@ -331,6 +332,7 @@ impl FinalizationPhase {
         } = executor_result;
         let executor::ExecuteOutcome {
             failure: _,
+            active_input_delivery_ids: _,
             sandbox_reuse_disposition,
             sandbox,
             source_ip,
@@ -768,6 +770,9 @@ pub(super) async fn run_job(
             reuse_result,
             completion_auth,
         )
+        .with_active_input_delivery_ids(std::mem::take(
+            &mut executor_result.outcome.active_input_delivery_ids,
+        ))
         .with_workspace_reuse_result(executor_result.outcome.workspace_reuse_result);
         // Structural guarantee: claim (in provider) is always paired with complete.
         signal_usage_flush(run_id, &usage_flush_tx);
@@ -1063,6 +1068,7 @@ mod tests {
         ExecutorPhaseOutcome {
             outcome: executor::ExecuteOutcome {
                 failure: None,
+                active_input_delivery_ids: Vec::new(),
                 sandbox_reuse_disposition: executor::SandboxReuseDisposition::Eligible(
                     executor::SandboxReuseTerminal::Success,
                 ),
@@ -1084,6 +1090,7 @@ mod tests {
         ExecutorPhaseOutcome {
             outcome: executor::ExecuteOutcome {
                 failure: None,
+                active_input_delivery_ids: Vec::new(),
                 sandbox_reuse_disposition: executor::SandboxReuseDisposition::default(),
                 sandbox: None,
                 source_ip: String::new(),

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -1,22 +1,35 @@
-//! Fire-and-forget active-input forwarding from a runner source to guest control.
+//! Durable active-input forwarding from a Runner source to Guest control.
 
 use std::time::Duration;
 
-use sandbox::GuestProcessControlHandle;
+use api_contracts::generated::types::runners::runs::active_inputs::{
+    receipt::Response as ActiveInputReceiptResponse,
+    reserve::{Response as ActiveInputReserveResponse, ResponseRejectedReason},
+};
+use sandbox::{
+    GuestProcessControlHandle, ProcessControlFailureKind, ProcessControlGuestStatus,
+    ProcessControlOutcome, ProcessControlWriteState, Sandbox,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use crate::active_input::{ActiveInputBatch, ActiveInputPayload, ActiveInputSource};
+use crate::active_input::{
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, ActiveInputBatch, ActiveInputPayload,
+    ActiveInputSource, ApiActiveInputRecovery, local_active_input_delivery_id,
+};
 use crate::ids::RunId;
 
 const ACTIVE_INPUT_READ_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
-const ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+const ACTIVE_INPUT_JOURNAL_READ_TIMEOUT: Duration = Duration::from_secs(5);
+const ACTIVE_INPUT_RECEIPT_RECOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 const FIRST_ACTIVE_INPUT_SEQUENCE: u64 = 1;
 
 pub(super) struct ActiveInputForwarder {
+    run_id: RunId,
     stop: CancellationToken,
     task: tokio::task::JoinHandle<()>,
+    recovery: Option<ApiActiveInputRecovery>,
 }
 
 impl ActiveInputForwarder {
@@ -29,26 +42,49 @@ impl ActiveInputForwarder {
         let (Some(source), Some(control)) = (source, control) else {
             return None;
         };
+        let recovery = source.api_recovery();
         let stop = CancellationToken::new();
         let stop_for_task = stop.clone();
         let task = tokio::spawn(async move {
             run_forwarder(run_id, source, control, job_cancel, stop_for_task).await;
         });
-        Some(Self { stop, task })
+        Some(Self {
+            run_id,
+            stop,
+            task,
+            recovery,
+        })
     }
 
-    pub(super) async fn stop(self) {
+    /// Stop live forwarding and recover Guest-persisted receipts while the
+    /// caller still owns the live sandbox.
+    pub(super) async fn stop(self, sandbox: &dyn Sandbox) -> Vec<String> {
         self.stop.cancel();
-        let mut task = self.task;
-        match tokio::time::timeout(ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT, &mut task).await {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => warn!(error = %error, "active-input forwarder task failed"),
-            Err(_) => {
-                task.abort();
-                let _ = task.await;
-            }
+        // A cancelled process-control future has an unknown write outcome. The
+        // provider already bounds each control call, so retain ownership until
+        // it resolves before reading the Guest receipt journal.
+        if let Err(error) = self.task.await {
+            warn!(error = %error, "active-input forwarder task failed");
         }
+        let Some(recovery) = self.recovery else {
+            return Vec::new();
+        };
+        recover_active_input_receipts(self.run_id, sandbox, &recovery).await
     }
+}
+
+#[derive(Clone, Copy)]
+enum DeliveryMode {
+    DurableApi,
+    Local,
+    Legacy,
+}
+
+enum ForwardDisposition {
+    Accepted,
+    Retry,
+    Suppress,
+    Stop,
 }
 
 async fn run_forwarder(
@@ -59,7 +95,10 @@ async fn run_forwarder(
     stop: CancellationToken,
 ) {
     let mut next_local_sequence = FIRST_ACTIVE_INPUT_SEQUENCE;
-    let mut delivery_sequence = 0_u64;
+    let mut legacy_delivery_sequence = 0_u64;
+    let mut suppressed_api_delivery_id: Option<String> = None;
+    let mut warned_source_read_failure = false;
+    let mut warned_payload_too_large = false;
     loop {
         let batch = tokio::select! {
             biased;
@@ -76,26 +115,117 @@ async fn run_forwarder(
                     if entry.sequence > next_local_sequence {
                         break;
                     }
-                    delivery_sequence = delivery_sequence.saturating_add(1);
-                    forward_text(run_id, delivery_sequence, &entry.text, &control).await;
-                    next_local_sequence = next_local_sequence.saturating_add(1);
+                    let delivery_id = local_active_input_delivery_id(run_id, entry.sequence);
+                    let disposition = forward_with_retry(
+                        run_id,
+                        Some(&delivery_id),
+                        &entry.text,
+                        DeliveryMode::Local,
+                        &control,
+                        &job_cancel,
+                        &stop,
+                    )
+                    .await;
+                    match disposition {
+                        ForwardDisposition::Accepted => {
+                            next_local_sequence = next_local_sequence.saturating_add(1);
+                        }
+                        ForwardDisposition::Suppress
+                        | ForwardDisposition::Retry
+                        | ForwardDisposition::Stop => return,
+                    }
                 }
                 (false, false)
             }
-            Ok(ActiveInputBatch::Api { prompt, has_more }) => {
+            Ok(ActiveInputBatch::ApiLegacy { prompt, has_more }) => {
                 let forwarded = if let Some(prompt) = prompt {
-                    delivery_sequence = delivery_sequence.saturating_add(1);
-                    forward_text(run_id, delivery_sequence, &prompt, &control).await
+                    legacy_delivery_sequence = legacy_delivery_sequence.saturating_add(1);
+                    let correlation_id =
+                        format!("active-input:{run_id}:{legacy_delivery_sequence}");
+                    matches!(
+                        forward_once(
+                            run_id,
+                            None,
+                            &correlation_id,
+                            &prompt,
+                            DeliveryMode::Legacy,
+                            &control,
+                            true,
+                        )
+                        .await,
+                        ForwardDisposition::Accepted
+                    )
                 } else {
                     false
                 };
                 (false, has_more && forwarded)
             }
+            Ok(ActiveInputBatch::ApiReserve(response)) => match response {
+                ActiveInputReserveResponse::Reserved {
+                    delivery_id,
+                    event_ids: _,
+                    prompt,
+                } => {
+                    warned_payload_too_large = false;
+                    if suppressed_api_delivery_id.as_deref() == Some(&delivery_id) {
+                        (false, false)
+                    } else {
+                        let disposition = forward_with_retry(
+                            run_id,
+                            Some(&delivery_id),
+                            &prompt,
+                            DeliveryMode::DurableApi,
+                            &control,
+                            &job_cancel,
+                            &stop,
+                        )
+                        .await;
+                        match disposition {
+                            ForwardDisposition::Accepted | ForwardDisposition::Suppress => {
+                                suppressed_api_delivery_id = Some(delivery_id);
+                                (false, false)
+                            }
+                            ForwardDisposition::Retry | ForwardDisposition::Stop => return,
+                        }
+                    }
+                }
+                ActiveInputReserveResponse::Empty => {
+                    suppressed_api_delivery_id = None;
+                    warned_payload_too_large = false;
+                    (false, false)
+                }
+                ActiveInputReserveResponse::Terminal => return,
+                ActiveInputReserveResponse::Held {
+                    delivery_id: _,
+                    event_ids: _,
+                } => return,
+                ActiveInputReserveResponse::Rejected { reason } => match reason {
+                    ResponseRejectedReason::PayloadTooLarge => {
+                        suppressed_api_delivery_id = None;
+                        if !warned_payload_too_large {
+                            warn!(
+                                run_id = %run_id,
+                                outcome = "payload_too_large",
+                                "active-input reserve rejected pending input"
+                            );
+                            warned_payload_too_large = true;
+                        }
+                        (false, false)
+                    }
+                    ResponseRejectedReason::RunNotRunning => return,
+                },
+            },
             Err(error) => {
-                warn!(run_id = %run_id, error = %error, "active-input source read failed");
+                if !warned_source_read_failure {
+                    warn!(run_id = %run_id, error = %error, "active-input source read failed; retrying");
+                    warned_source_read_failure = true;
+                }
                 (true, false)
             }
         };
+        if !retry_after_read_error {
+            warned_source_read_failure = false;
+        }
 
         tokio::select! {
             biased;
@@ -115,31 +245,321 @@ async fn run_forwarder(
     }
 }
 
-async fn forward_text(
+async fn forward_with_retry(
     run_id: RunId,
-    delivery_sequence: u64,
+    delivery_id: Option<&str>,
     text: &str,
+    mode: DeliveryMode,
     control: &GuestProcessControlHandle,
-) -> bool {
-    let payload = ActiveInputPayload::new(text);
-    let bytes = match payload.to_vec() {
-        Ok(bytes) => bytes,
+    job_cancel: &CancellationToken,
+    stop: &CancellationToken,
+) -> ForwardDisposition {
+    let correlation_id = delivery_id
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("active-input:{run_id}:legacy"));
+    let mut warn_retryable_failure = true;
+    loop {
+        let disposition = forward_once(
+            run_id,
+            delivery_id,
+            &correlation_id,
+            text,
+            mode,
+            control,
+            warn_retryable_failure,
+        )
+        .await;
+        if !matches!(disposition, ForwardDisposition::Retry) {
+            return disposition;
+        }
+        warn_retryable_failure = false;
+        tokio::select! {
+            biased;
+            () = stop.cancelled() => return ForwardDisposition::Stop,
+            () = job_cancel.cancelled() => return ForwardDisposition::Stop,
+            () = tokio::time::sleep(ACTIVE_INPUT_READ_RETRY_INTERVAL) => {}
+        }
+    }
+}
+
+async fn forward_once(
+    run_id: RunId,
+    delivery_id: Option<&str>,
+    correlation_id: &str,
+    text: &str,
+    mode: DeliveryMode,
+    control: &GuestProcessControlHandle,
+    warn_retryable_failure: bool,
+) -> ForwardDisposition {
+    let bytes = match ActiveInputPayload::new(delivery_id, text).to_vec() {
+        Ok(bytes) if bytes.len() <= ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES => bytes,
+        Ok(_) => {
+            warn!(
+                run_id = %run_id,
+                outcome = "payload_too_large",
+                "active-input control payload exceeds frame limit"
+            );
+            return ForwardDisposition::Stop;
+        }
         Err(error) => {
-            warn!(run_id = %run_id, error = %error, "failed to serialize active input");
-            return false;
+            warn!(
+                run_id = %run_id,
+                outcome = "serialization_error",
+                error = %error,
+                "failed to serialize active input"
+            );
+            return ForwardDisposition::Stop;
         }
     };
-    // Process control requires a request correlation key. It is deliberately
-    // runner-internal and has no active-input identity or deduplication semantics.
-    let correlation_id = format!("active-input:{run_id}:{delivery_sequence}");
-    match control
-        .control_owned(correlation_id, bytes, ACTIVE_INPUT_CONTROL_TIMEOUT)
-        .await
-    {
-        Ok(_) => true,
-        Err(error) => {
-            warn!(run_id = %run_id, error = %error, "active-input forward failed; dropping input");
-            false
+    let outcome = control
+        .control_owned_outcome(
+            correlation_id.to_owned(),
+            bytes,
+            ACTIVE_INPUT_CONTROL_TIMEOUT,
+        )
+        .await;
+    classify_control_outcome(run_id, mode, outcome, warn_retryable_failure)
+}
+
+fn classify_control_outcome(
+    run_id: RunId,
+    mode: DeliveryMode,
+    outcome: ProcessControlOutcome,
+    warn_retryable_failure: bool,
+) -> ForwardDisposition {
+    match outcome {
+        ProcessControlOutcome::Delivered(_) => ForwardDisposition::Accepted,
+        ProcessControlOutcome::GuestStatus { status, diagnostic } => match status {
+            ProcessControlGuestStatus::QueueFull | ProcessControlGuestStatus::SinkUnavailable => {
+                if warn_retryable_failure {
+                    warn!(
+                        run_id = %run_id,
+                        outcome = guest_status_label(status),
+                        diagnostic = %diagnostic,
+                        "active-input control will retry"
+                    );
+                }
+                identified_or_legacy(mode, ForwardDisposition::Retry)
+            }
+            ProcessControlGuestStatus::SinkTimeout | ProcessControlGuestStatus::SinkError => {
+                if warn_retryable_failure {
+                    warn!(
+                        run_id = %run_id,
+                        outcome = guest_status_label(status),
+                        diagnostic = %diagnostic,
+                        "active-input control acknowledgement is unknown"
+                    );
+                }
+                uncertain_disposition(mode)
+            }
+            ProcessControlGuestStatus::Inactive => ForwardDisposition::Stop,
+            ProcessControlGuestStatus::NonceMismatch
+            | ProcessControlGuestStatus::Unsupported
+            | ProcessControlGuestStatus::Rejected => {
+                warn!(
+                    run_id = %run_id,
+                    outcome = guest_status_label(status),
+                    diagnostic = %diagnostic,
+                    "active-input control stopped"
+                );
+                ForwardDisposition::Stop
+            }
+        },
+        ProcessControlOutcome::GuestError(error) => {
+            if warn_retryable_failure {
+                warn!(
+                    run_id = %run_id,
+                    outcome = "guest_error",
+                    error = %error,
+                    "active-input control acknowledgement is unknown"
+                );
+            }
+            uncertain_disposition(mode)
         }
+        ProcessControlOutcome::Failed {
+            kind,
+            write_state,
+            error,
+        } => {
+            let outcome = match (kind, write_state) {
+                (ProcessControlFailureKind::Operation, ProcessControlWriteState::NotWritten) => {
+                    "operation_not_written"
+                }
+                (
+                    ProcessControlFailureKind::Operation,
+                    ProcessControlWriteState::PossiblyWritten,
+                ) => "operation_possibly_written",
+                (
+                    ProcessControlFailureKind::BackendCrashed,
+                    ProcessControlWriteState::NotWritten,
+                ) => "backend_crashed_not_written",
+                (
+                    ProcessControlFailureKind::BackendCrashed,
+                    ProcessControlWriteState::PossiblyWritten,
+                ) => "backend_crashed_possibly_written",
+            };
+            if warn_retryable_failure {
+                warn!(
+                    run_id = %run_id,
+                    outcome,
+                    error = %error,
+                    "active-input control failed"
+                );
+            }
+            match (kind, write_state) {
+                (ProcessControlFailureKind::Operation, ProcessControlWriteState::NotWritten) => {
+                    identified_or_legacy(mode, ForwardDisposition::Retry)
+                }
+                (
+                    ProcessControlFailureKind::Operation,
+                    ProcessControlWriteState::PossiblyWritten,
+                ) => uncertain_disposition(mode),
+                (ProcessControlFailureKind::BackendCrashed, _) => {
+                    if matches!(
+                        (mode, write_state),
+                        (
+                            DeliveryMode::DurableApi,
+                            ProcessControlWriteState::PossiblyWritten
+                        )
+                    ) {
+                        ForwardDisposition::Suppress
+                    } else {
+                        ForwardDisposition::Stop
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn identified_or_legacy(mode: DeliveryMode, identified: ForwardDisposition) -> ForwardDisposition {
+    if matches!(mode, DeliveryMode::Legacy) {
+        ForwardDisposition::Accepted
+    } else {
+        identified
+    }
+}
+
+fn uncertain_disposition(mode: DeliveryMode) -> ForwardDisposition {
+    match mode {
+        DeliveryMode::DurableApi => ForwardDisposition::Suppress,
+        DeliveryMode::Local => ForwardDisposition::Retry,
+        DeliveryMode::Legacy => ForwardDisposition::Accepted,
+    }
+}
+
+fn guest_status_label(status: ProcessControlGuestStatus) -> &'static str {
+    match status {
+        ProcessControlGuestStatus::Inactive => "inactive",
+        ProcessControlGuestStatus::NonceMismatch => "nonce_mismatch",
+        ProcessControlGuestStatus::Unsupported => "unsupported",
+        ProcessControlGuestStatus::Rejected => "rejected",
+        ProcessControlGuestStatus::SinkUnavailable => "sink_unavailable",
+        ProcessControlGuestStatus::SinkTimeout => "sink_timeout",
+        ProcessControlGuestStatus::QueueFull => "queue_full",
+        ProcessControlGuestStatus::SinkError => "sink_error",
+    }
+}
+
+async fn recover_active_input_receipts(
+    run_id: RunId,
+    sandbox: &dyn Sandbox,
+    recovery: &ApiActiveInputRecovery,
+) -> Vec<String> {
+    let path = match super::guest_runtime_path(
+        run_id,
+        guest_contracts::runtime_paths::active_input_receipt_journal_file,
+    ) {
+        Ok(path) => path,
+        Err(error) => {
+            warn!(run_id = %run_id, error = %error, "failed to resolve active-input receipt journal");
+            return Vec::new();
+        }
+    };
+    let bytes = match read_active_input_receipt_journal(sandbox, run_id, &path).await {
+        Some(bytes) => bytes,
+        None => return Vec::new(),
+    };
+    let delivery_ids =
+        match guest_contracts::active_input_receipts::parse_active_input_receipt_journal(
+            &bytes,
+            &run_id.to_string(),
+        ) {
+            Ok(delivery_ids) => delivery_ids,
+            Err(error) => {
+                warn!(run_id = %run_id, error = %error, "invalid active-input receipt journal");
+                return Vec::new();
+            }
+        };
+
+    let deadline = tokio::time::Instant::now() + ACTIVE_INPUT_RECEIPT_RECOVERY_TIMEOUT;
+    let mut remaining = Vec::new();
+    let mut delivery_ids = delivery_ids.into_iter();
+    let mut warned_rejected = false;
+    let mut warned_failed = false;
+    while let Some(delivery_id) = delivery_ids.next() {
+        match tokio::time::timeout_at(deadline, recovery.record_delivery(&delivery_id)).await {
+            Ok(Ok(ActiveInputReceiptResponse::Delivered)) => {}
+            Ok(Ok(ActiveInputReceiptResponse::Rejected)) => {
+                if !warned_rejected {
+                    warn!(run_id = %run_id, "active-input recovery receipt was rejected");
+                    warned_rejected = true;
+                }
+            }
+            Ok(Err(error)) => {
+                if !warned_failed {
+                    warn!(run_id = %run_id, error = %error, "active-input recovery receipt failed");
+                    warned_failed = true;
+                }
+                remaining.push(delivery_id);
+            }
+            Err(_) => {
+                warn!(run_id = %run_id, "active-input recovery receipt deadline reached");
+                remaining.push(delivery_id);
+                remaining.extend(delivery_ids);
+                break;
+            }
+        }
+    }
+    remaining
+}
+
+async fn read_active_input_receipt_journal(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    path: &str,
+) -> Option<Vec<u8>> {
+    let deadline = tokio::time::Instant::now() + ACTIVE_INPUT_JOURNAL_READ_TIMEOUT;
+    let mut warned = false;
+    loop {
+        match tokio::time::timeout_at(
+            deadline,
+            sandbox.read_file(
+                path,
+                guest_contracts::active_input_receipts::MAX_ACTIVE_INPUT_RECEIPT_JOURNAL_BYTES
+                    as u64,
+            ),
+        )
+        .await
+        {
+            Ok(Ok(bytes)) => return bytes,
+            Ok(Err(error)) => {
+                if !warned {
+                    warn!(run_id = %run_id, error = %error, "failed to read active-input receipt journal; retrying");
+                    warned = true;
+                }
+            }
+            Err(_) => {
+                warn!(run_id = %run_id, "active-input receipt journal read timed out");
+                return None;
+            }
+        }
+
+        let retry_at = tokio::time::Instant::now() + ACTIVE_INPUT_READ_RETRY_INTERVAL;
+        if retry_at >= deadline {
+            warn!(run_id = %run_id, "active-input receipt journal read deadline reached");
+            return None;
+        }
+        tokio::time::sleep_until(retry_at).await;
     }
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -642,6 +642,7 @@ pub(super) struct AgentExecutionResult {
     pub(super) sandbox_reuse_disposition: SandboxReuseDisposition,
     pub(super) stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
     pub(super) reusable_session_identity: Option<RestoredSessionIdentity>,
+    pub(super) active_input_delivery_ids: Vec<String>,
 }
 
 impl AgentExecutionResult {
@@ -655,6 +656,7 @@ impl AgentExecutionResult {
             sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
             reusable_session_identity: None,
+            active_input_delivery_ids: Vec::new(),
         }
     }
 
@@ -668,7 +670,13 @@ impl AgentExecutionResult {
             sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
             reusable_session_identity: None,
+            active_input_delivery_ids: Vec::new(),
         }
+    }
+
+    pub(super) fn with_active_input_delivery_ids(mut self, delivery_ids: Vec<String>) -> Self {
+        self.active_input_delivery_ids = delivery_ids;
+        self
     }
 
     pub(super) fn with_stdout_stream_diagnostics(
@@ -2275,9 +2283,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // Stop locally owned post-spawn work before interpreting terminal process
     // state. Join active input and model prefetch; drain or abort stdout based
     // on the wait outcome.
-    if let Some(forwarder) = active_input_forwarder {
-        forwarder.stop().await;
-    }
+    let active_input_delivery_ids = match active_input_forwarder {
+        Some(forwarder) => forwarder.stop(sandbox).await,
+        None => Vec::new(),
+    };
     if let Some(forwarder) = pi_standby_forwarder {
         forwarder.stop().await;
     }
@@ -2330,7 +2339,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
                 return Ok(AgentExecutionResult::failure(1, error, None)
                     .with_resource_failure_kind(ResourceFailureKind::HostMemoryOomKilled)
-                    .with_stdout_stream_diagnostics(stdout_stream_diagnostics_on_wait_error));
+                    .with_stdout_stream_diagnostics(stdout_stream_diagnostics_on_wait_error)
+                    .with_active_input_delivery_ids(active_input_delivery_ids));
             }
             let error = e.to_string();
             telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
@@ -2349,6 +2359,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     ),
                     stdout_stream_diagnostics: stdout_stream_diagnostics_on_wait_error,
                     reusable_session_identity: None,
+                    active_input_delivery_ids,
                 });
             }
             let resource_diagnostics = if explicit_enospc_evidence([error.as_str()]) {
@@ -2365,7 +2376,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             };
             return Ok(AgentExecutionResult::failure_from_error(error)
                 .with_resource_diagnostics(resource_diagnostics)
-                .with_stdout_stream_diagnostics(stdout_stream_diagnostics_on_wait_error));
+                .with_stdout_stream_diagnostics(stdout_stream_diagnostics_on_wait_error)
+                .with_active_input_delivery_ids(active_input_delivery_ids));
         }
     };
     if exit.stream_overflowed {
@@ -2428,7 +2440,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 telemetry.record("agent_execute", t.elapsed(), false, Some(error));
                 return Ok(AgentExecutionResult::failure(1, error, None)
                     .with_resource_failure_kind(ResourceFailureKind::GuestMemoryOomKilled)
-                    .with_stdout_stream_diagnostics(stdout_stream_diagnostics));
+                    .with_stdout_stream_diagnostics(stdout_stream_diagnostics)
+                    .with_active_input_delivery_ids(active_input_delivery_ids));
             }
             Err(e) => {
                 warn!(run_id = %context.run_id, error = %e, "failed to exec dmesg for OOM check");
@@ -2594,12 +2607,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             sandbox_reuse_disposition,
             stdout_stream_diagnostics,
             reusable_session_identity: None,
+            active_input_delivery_ids,
         },
         None => AgentExecutionResult {
             failure: None,
             sandbox_reuse_disposition,
             stdout_stream_diagnostics,
             reusable_session_identity,
+            active_input_delivery_ids,
         },
     };
     telemetry.record(

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -344,6 +344,9 @@ pub(crate) enum SandboxReuseRejection {
 /// Outcome of a job execution and ownership of any sandbox still alive afterward.
 pub struct ExecuteOutcome {
     pub failure: Option<ExecutionFailure>,
+    /// Backend-accepted active-input deliveries not already confirmed through
+    /// the direct receipt route. Provider completion settles these IDs.
+    pub(crate) active_input_delivery_ids: Vec<String>,
     pub(crate) sandbox_reuse_disposition: SandboxReuseDisposition,
     /// Sandbox ownership after execution.
     ///
@@ -377,6 +380,7 @@ impl ExecuteOutcome {
     ) -> Self {
         Self {
             failure: Some(failure),
+            active_input_delivery_ids: Vec::new(),
             sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             sandbox: Some(sandbox),
             source_ip,
@@ -615,6 +619,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     ) {
         ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(error)),
+            active_input_delivery_ids: Vec::new(),
             sandbox_reuse_disposition: SandboxReuseDisposition::default(),
             sandbox: None,
             source_ip: String::new(),
@@ -645,6 +650,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             Ok(outcome) => outcome,
             Err(e) => ExecuteOutcome {
                 failure: Some(ExecutionFailure::from_error(e.to_string())),
+                active_input_delivery_ids: Vec::new(),
                 sandbox_reuse_disposition: SandboxReuseDisposition::default(),
                 sandbox: None,
                 source_ip: String::new(),

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1320,6 +1320,7 @@ pub(super) async fn execute_reused_sandbox(
             );
             return ExecuteOutcome {
                 failure: Some(ExecutionFailure::from_error(e.to_string())),
+                active_input_delivery_ids: Vec::new(),
                 sandbox_reuse_disposition: SandboxReuseDisposition::default(),
                 sandbox: Some(sandbox),
                 source_ip,
@@ -1484,6 +1485,7 @@ pub(super) async fn execute_prepared_sandbox_run_with_process_cancel_timeouts(
 
     ExecuteOutcome {
         failure: agent_result.failure,
+        active_input_delivery_ids: agent_result.active_input_delivery_ids,
         sandbox_reuse_disposition: agent_result.sandbox_reuse_disposition,
         sandbox: Some(sandbox),
         source_ip,

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -5,16 +5,20 @@ use tokio::net::{TcpListener, TcpStream};
 
 use crate::active_input::{
     API_ACTIVE_INPUT_RECHECK_INTERVAL, ActiveInputNotifications, ActiveInputSource,
+    local_active_input_delivery_id,
 };
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
 use crate::executor::tests::support::{
-    RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context, test_executor_config,
-    test_telemetry,
+    RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context,
+    sandbox_read_file_error, test_executor_config, test_telemetry,
 };
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::provider::ApiClient;
 use crate::types::SandboxReuseResult;
+
+const DELIVERY_ID: &str = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
+const EVENT_ID: &str = "e6bc287d-8c08-464e-831a-cad771610157";
 
 async fn read_http_request(socket: &mut TcpStream) -> String {
     let mut request = Vec::new();
@@ -62,8 +66,29 @@ fn http_request_body(request: &str) -> &str {
         .1
 }
 
+enum HttpServerAction {
+    Respond(String),
+    Disconnect,
+}
+
 async fn spawn_http_server(
     responses: Vec<String>,
+) -> (
+    String,
+    tokio::sync::mpsc::UnboundedReceiver<String>,
+    tokio::task::JoinHandle<()>,
+) {
+    spawn_http_server_with_actions(
+        responses
+            .into_iter()
+            .map(HttpServerAction::Respond)
+            .collect(),
+    )
+    .await
+}
+
+async fn spawn_http_server_with_actions(
+    actions: Vec<HttpServerAction>,
 ) -> (
     String,
     tokio::sync::mpsc::UnboundedReceiver<String>,
@@ -73,17 +98,41 @@ async fn spawn_http_server(
     let api_url = format!("http://{}", listener.local_addr().unwrap());
     let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
     let server = tokio::spawn(async move {
-        for response in responses {
+        for action in actions {
             let (mut socket, _) = listener.accept().await.unwrap();
             let request = read_http_request(&mut socket).await;
-            socket.write_all(response.as_bytes()).await.unwrap();
-            socket.shutdown().await.unwrap();
-            let mut closed = [0_u8; 1];
-            assert_eq!(socket.read(&mut closed).await.unwrap(), 0);
+            if let HttpServerAction::Respond(response) = action {
+                socket.write_all(response.as_bytes()).await.unwrap();
+                socket.shutdown().await.unwrap();
+                let mut closed = [0_u8; 1];
+                assert_eq!(socket.read(&mut closed).await.unwrap(), 0);
+            }
             request_tx.send(request).unwrap();
         }
     });
     (api_url, request_rx, server)
+}
+
+fn api_active_input_source(
+    api_url: String,
+    run_id: crate::ids::RunId,
+    notifications: &ActiveInputNotifications,
+    client_session_id: &str,
+) -> ActiveInputSource {
+    ActiveInputSource::api(
+        ApiClient::new(
+            HttpClient::new(HttpClientConfig {
+                api_url,
+                vercel_bypass: None,
+                client_session_id: client_session_id.to_string(),
+            })
+            .unwrap(),
+            "runner-token".to_string(),
+        ),
+        run_id,
+        "sandbox-token".to_string(),
+        notifications.subscribe(run_id),
+    )
 }
 
 #[tokio::test]
@@ -158,9 +207,9 @@ async fn run_in_sandbox_forwards_local_active_inputs_in_order() {
             .map(|call| call.message_id.as_str())
             .collect::<Vec<_>>(),
         vec![
-            format!("active-input:{run_id}:1"),
-            format!("active-input:{run_id}:2"),
-            format!("active-input:{run_id}:3"),
+            local_active_input_delivery_id(run_id, 1),
+            local_active_input_delivery_id(run_id, 2),
+            local_active_input_delivery_id(run_id, 3),
         ]
     );
     let payloads = calls
@@ -170,10 +219,22 @@ async fn run_in_sandbox_forwards_local_active_inputs_in_order() {
     assert_eq!(payloads[0]["text"], "first");
     assert_eq!(payloads[1]["text"], "duplicate");
     assert_eq!(payloads[2]["text"], "third");
+    assert_eq!(
+        payloads[0]["deliveryId"],
+        local_active_input_delivery_id(run_id, 1)
+    );
+    assert_eq!(
+        payloads[1]["deliveryId"],
+        local_active_input_delivery_id(run_id, 2)
+    );
+    assert_eq!(
+        payloads[2]["deliveryId"],
+        local_active_input_delivery_id(run_id, 3)
+    );
 }
 
 #[tokio::test]
-async fn run_in_sandbox_forwards_api_active_inputs_as_separate_messages() {
+async fn run_in_sandbox_forwards_legacy_api_active_inputs_as_separate_messages() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let wait_gate = Arc::new(tokio::sync::Notify::new());
@@ -187,6 +248,7 @@ async fn run_in_sandbox_forwards_api_active_inputs_as_separate_messages() {
     let claim_path = format!("{active_input_path}/claim");
 
     let (api_url, mut request_rx, server) = spawn_http_server(vec![
+        http_response("404 Not Found", r#"{"error":"not found"}"#),
         http_response("200 OK", r#"{"eventIds":["event-1","event-2"]}"#),
         http_response("200 OK", r#"{"prompt":"first message"}"#),
         http_response("200 OK", r#"{"eventIds":["event-2"]}"#),
@@ -250,17 +312,18 @@ async fn run_in_sandbox_forwards_api_active_inputs_as_separate_messages() {
     while let Some(request) = request_rx.recv().await {
         requests.push(request);
     }
-    assert_eq!(requests.len(), 4);
-    assert!(requests[0].starts_with(&format!("GET {active_input_path} ")));
-    assert!(requests[1].starts_with(&format!("POST {claim_path} ")));
+    assert_eq!(requests.len(), 5);
+    assert!(requests[0].starts_with(&format!("POST {active_input_path}/reserve ")));
+    assert!(requests[1].starts_with(&format!("GET {active_input_path} ")));
+    assert!(requests[2].starts_with(&format!("POST {claim_path} ")));
     assert_eq!(
-        serde_json::from_str::<serde_json::Value>(http_request_body(&requests[1])).unwrap(),
+        serde_json::from_str::<serde_json::Value>(http_request_body(&requests[2])).unwrap(),
         serde_json::json!({ "eventIds": ["event-1"] })
     );
-    assert!(requests[2].starts_with(&format!("GET {active_input_path} ")));
-    assert!(requests[3].starts_with(&format!("POST {claim_path} ")));
+    assert!(requests[3].starts_with(&format!("GET {active_input_path} ")));
+    assert!(requests[4].starts_with(&format!("POST {claim_path} ")));
     assert_eq!(
-        serde_json::from_str::<serde_json::Value>(http_request_body(&requests[3])).unwrap(),
+        serde_json::from_str::<serde_json::Value>(http_request_body(&requests[4])).unwrap(),
         serde_json::json!({ "eventIds": ["event-2"] })
     );
 
@@ -285,32 +348,23 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let active_input_path = format!("/api/runners/runs/{run_id}/active-inputs");
-    let claim_path = format!("{active_input_path}/claim");
+    let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
 
     let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("200 OK", r#"{"eventIds":[]}"#),
+        http_response("200 OK", r#"{"outcome":"empty"}"#),
         http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
-        http_response("200 OK", r#"{"eventIds":["event-1"]}"#),
-        http_response("200 OK", r#"{"prompt":"retry delivered"}"#),
+        http_response(
+            "200 OK",
+            &format!(
+                r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry delivered"}}"#,
+            ),
+        ),
     ])
     .await;
 
     let notifications = ActiveInputNotifications::new();
-    let source = ActiveInputSource::api(
-        ApiClient::new(
-            HttpClient::new(HttpClientConfig {
-                api_url,
-                vercel_bypass: None,
-                client_session_id: "active-input-retry-test".to_string(),
-            })
-            .unwrap(),
-            "runner-token".to_string(),
-        ),
-        run_id,
-        "sandbox-token".to_string(),
-        notifications.subscribe(run_id),
-    );
+    let source =
+        api_active_input_source(api_url, run_id, &notifications, "active-input-retry-test");
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
     let run_task = tokio::spawn(async move {
@@ -330,11 +384,11 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
         .await
     });
 
-    let initial_list = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
+    let initial_reserve = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
         .await
-        .expect("initial active-input list request should reach the server")
+        .expect("initial active-input reserve request should reach the server")
         .expect("active-input request channel should remain open");
-    assert!(initial_list.starts_with(&format!("GET {active_input_path} ")));
+    assert!(initial_reserve.starts_with(&format!("POST {reserve_path} ")));
     notifications.notify(run_id);
 
     assert!(
@@ -359,17 +413,16 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
     while let Some(request) = request_rx.recv().await {
         remaining_requests.push(request);
     }
-    assert_eq!(remaining_requests.len(), 3);
-    assert!(remaining_requests[0].starts_with(&format!("GET {active_input_path} ")));
-    assert!(remaining_requests[1].starts_with(&format!("GET {active_input_path} ")));
-    assert!(remaining_requests[2].starts_with(&format!("POST {claim_path} ")));
+    assert_eq!(remaining_requests.len(), 2);
+    assert!(remaining_requests[0].starts_with(&format!("POST {reserve_path} ")));
+    assert!(remaining_requests[1].starts_with(&format!("POST {reserve_path} ")));
 
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 1);
-    assert_eq!(
-        serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap()["text"],
-        "retry delivered"
-    );
+    assert_eq!(calls[0].message_id, DELIVERY_ID);
+    let payload = serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap();
+    assert_eq!(payload["deliveryId"], DELIVERY_ID);
+    assert_eq!(payload["text"], "retry delivered");
 }
 
 #[tokio::test]
@@ -383,30 +436,25 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let active_input_path = format!("/api/runners/runs/{run_id}/active-inputs");
-    let claim_path = format!("{active_input_path}/claim");
+    let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
 
     let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("200 OK", r#"{"eventIds":[]}"#),
-        http_response("200 OK", r#"{"eventIds":["event-1"]}"#),
-        http_response("200 OK", r#"{"prompt":"fallback delivered"}"#),
+        http_response("200 OK", r#"{"outcome":"empty"}"#),
+        http_response(
+            "200 OK",
+            &format!(
+                r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"fallback delivered"}}"#,
+            ),
+        ),
     ])
     .await;
 
     let notifications = ActiveInputNotifications::new();
-    let source = ActiveInputSource::api(
-        ApiClient::new(
-            HttpClient::new(HttpClientConfig {
-                api_url,
-                vercel_bypass: None,
-                client_session_id: "active-input-fallback-test".to_string(),
-            })
-            .unwrap(),
-            "runner-token".to_string(),
-        ),
+    let source = api_active_input_source(
+        api_url,
         run_id,
-        "sandbox-token".to_string(),
-        notifications.subscribe(run_id),
+        &notifications,
+        "active-input-fallback-test",
     );
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -427,11 +475,11 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
         .await
     });
 
-    let initial_list = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
+    let initial_reserve = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
         .await
-        .expect("initial active-input list request should reach the server")
+        .expect("initial active-input reserve request should reach the server")
         .expect("active-input request channel should remain open");
-    assert!(initial_list.starts_with(&format!("GET {active_input_path} ")));
+    assert!(initial_reserve.starts_with(&format!("POST {reserve_path} ")));
 
     tokio::time::pause();
     tokio::task::yield_now().await;
@@ -460,12 +508,12 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
     while let Some(request) = request_rx.recv().await {
         remaining_requests.push(request);
     }
-    assert_eq!(remaining_requests.len(), 2);
-    assert!(remaining_requests[0].starts_with(&format!("GET {active_input_path} ")));
-    assert!(remaining_requests[1].starts_with(&format!("POST {claim_path} ")));
+    assert_eq!(remaining_requests.len(), 1);
+    assert!(remaining_requests[0].starts_with(&format!("POST {reserve_path} ")));
 
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].message_id, DELIVERY_ID);
     assert_eq!(
         serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap()["text"],
         "fallback delivered"
@@ -473,7 +521,7 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_drops_active_input_after_control_error() {
+async fn run_in_sandbox_retries_local_active_input_with_same_id_after_uncertain_error() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let wait_gate = Arc::new(tokio::sync::Notify::new());
@@ -525,7 +573,7 @@ async fn run_in_sandbox_drops_active_input_after_control_error() {
 
     assert!(
         overrides
-            .wait_for_process_control_calls(2, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .wait_for_process_control_calls(3, RUN_IN_SANDBOX_TEST_TIMEOUT)
             .await
     );
     wait_gate.notify_one();
@@ -543,8 +591,591 @@ async fn run_in_sandbox_drops_active_input_after_control_error() {
             .map(|call| call.message_id.as_str())
             .collect::<Vec<_>>(),
         vec![
-            format!("active-input:{run_id}:1"),
-            format!("active-input:{run_id}:2"),
+            local_active_input_delivery_id(run_id, 1),
+            local_active_input_delivery_id(run_id, 1),
+            local_active_input_delivery_id(run_id, 2),
         ]
     );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_falls_back_when_first_reserve_request_is_unavailable() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let active_input_path = format!("/api/runners/runs/{run_id}/active-inputs");
+    let reserve_path = format!("{active_input_path}/reserve");
+    let claim_path = format!("{active_input_path}/claim");
+    let (api_url, mut request_rx, server) = spawn_http_server(vec![
+        http_response("404 Not Found", r#"{"error":"not found"}"#),
+        http_response("200 OK", &format!(r#"{{"eventIds":["{EVENT_ID}"]}}"#)),
+        http_response("200 OK", r#"{"prompt":"legacy delivered"}"#),
+    ])
+    .await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-legacy-fallback-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let mut requests = Vec::new();
+    while let Some(request) = request_rx.recv().await {
+        requests.push(request);
+    }
+    assert_eq!(requests.len(), 3);
+    assert!(requests[0].starts_with(&format!("POST {reserve_path} ")));
+    assert!(requests[1].starts_with(&format!("GET {active_input_path} ")));
+    assert!(requests[2].starts_with(&format!("POST {claim_path} ")));
+    let calls = overrides.process_control_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].message_id, format!("active-input:{run_id}:1"));
+    let payload = serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap();
+    assert!(payload.get("deliveryId").is_none());
+    assert_eq!(payload["text"], "legacy delivered");
+}
+
+#[tokio::test]
+async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
+    let reserved = http_response(
+        "200 OK",
+        &format!(
+            r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retrieved delivery"}}"#,
+        ),
+    );
+    let (api_url, mut request_rx, server) = spawn_http_server_with_actions(vec![
+        HttpServerAction::Disconnect,
+        HttpServerAction::Respond(reserved),
+    ])
+    .await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-lost-reserve-response-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    server.await.unwrap();
+
+    let mut requests = Vec::new();
+    while let Some(request) = request_rx.recv().await {
+        requests.push(request);
+    }
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.starts_with(&format!("POST {reserve_path} ")))
+    );
+    let calls = overrides.process_control_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].message_id, DELIVERY_ID);
+}
+
+#[tokio::test]
+async fn run_in_sandbox_does_not_fall_back_after_ambiguous_reserve_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
+    let (api_url, mut request_rx, server) = spawn_http_server(vec![
+        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
+        http_response("404 Not Found", r#"{"error":"not found"}"#),
+    ])
+    .await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-no-unsafe-fallback-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut requests = Vec::new();
+    while let Some(request) = request_rx.recv().await {
+        requests.push(request);
+    }
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.starts_with(&format!("POST {reserve_path} ")))
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    assert!(overrides.process_control_calls().is_empty());
+}
+
+#[tokio::test]
+async fn run_in_sandbox_stops_when_reserve_reports_terminal() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let (api_url, _request_rx, server) =
+        spawn_http_server(vec![http_response("200 OK", r#"{"outcome":"terminal"}"#)]).await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-terminal-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    server.await.unwrap();
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    assert!(overrides.process_control_calls().is_empty());
+}
+
+#[tokio::test]
+async fn run_in_sandbox_retries_not_written_delivery_with_same_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    overrides.push_process_control_outcome(sandbox::ProcessControlOutcome::Failed {
+        kind: sandbox::ProcessControlFailureKind::Operation,
+        write_state: sandbox::ProcessControlWriteState::NotWritten,
+        error: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "not written"),
+    });
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let (api_url, _request_rx, server) = spawn_http_server(vec![http_response(
+        "200 OK",
+        &format!(
+            r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry exact delivery"}}"#,
+        ),
+    )])
+    .await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-not-written-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(2, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    server.await.unwrap();
+    let calls = overrides.process_control_calls();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().all(|call| call.message_id == DELIVERY_ID));
+    assert_eq!(calls[0].payload, calls[1].payload);
+}
+
+#[tokio::test]
+async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    for status in [
+        sandbox::ProcessControlGuestStatus::QueueFull,
+        sandbox::ProcessControlGuestStatus::SinkUnavailable,
+    ] {
+        overrides.push_process_control_outcome(sandbox::ProcessControlOutcome::GuestStatus {
+            status,
+            diagnostic: "retryable guest backpressure".to_string(),
+        });
+    }
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let (api_url, _request_rx, server) = spawn_http_server(vec![http_response(
+        "200 OK",
+        &format!(
+            r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry guest backpressure"}}"#,
+        ),
+    )])
+    .await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-guest-backpressure-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(3, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    server.await.unwrap();
+    let calls = overrides.process_control_calls();
+    assert_eq!(calls.len(), 3);
+    assert!(calls.iter().all(|call| call.message_id == DELIVERY_ID));
+    assert!(
+        calls
+            .windows(2)
+            .all(|pair| pair[0].payload == pair[1].payload)
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_suppresses_possibly_written_delivery() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    overrides.push_process_control_io_error(
+        std::io::ErrorKind::TimedOut,
+        "delivery acknowledgement timed out",
+    );
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    let reserve = http_response(
+        "200 OK",
+        &format!(
+            r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"uncertain delivery"}}"#,
+        ),
+    );
+    let (api_url, mut request_rx, server) = spawn_http_server(vec![
+        reserve.clone(),
+        reserve,
+        http_response("200 OK", r#"{"outcome":"empty"}"#),
+    ])
+    .await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-possibly-written-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    request_rx.recv().await.unwrap();
+    notifications.notify(run_id);
+    request_rx.recv().await.unwrap();
+    notifications.notify(run_id);
+    request_rx.recv().await.unwrap();
+    assert_eq!(overrides.process_control_calls().len(), 1);
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    server.await.unwrap();
+    let calls = overrides.process_control_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].message_id, DELIVERY_ID);
+}
+
+#[tokio::test]
+async fn run_in_sandbox_carries_failed_journal_receipt_to_completion() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    let ctx = minimal_context();
+    let run_id = ctx.run_id;
+    overrides.push_read_file_result(Err(sandbox_read_file_error(
+        "transient guest file read failure",
+    )));
+    overrides.push_read_file_result(Ok(Some(
+        format!(r#"{{"runId":"{run_id}","deliveryIds":["{DELIVERY_ID}"]}}"#).into_bytes(),
+    )));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
+    let receipt_path =
+        format!("/api/runners/runs/{run_id}/active-inputs/deliveries/{DELIVERY_ID}/receipt");
+    let (api_url, mut request_rx, server) = spawn_http_server(vec![
+        http_response(
+            "200 OK",
+            &format!(
+                r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"recover receipt"}}"#,
+            ),
+        ),
+        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
+    ])
+    .await;
+    let notifications = ActiveInputNotifications::new();
+    let source = api_active_input_source(
+        api_url,
+        run_id,
+        &notifications,
+        "active-input-journal-recovery-test",
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    assert_eq!(
+        result.active_input_delivery_ids,
+        vec![DELIVERY_ID.to_string()]
+    );
+    server.await.unwrap();
+    let first_request = request_rx.recv().await.unwrap();
+    let second_request = request_rx.recv().await.unwrap();
+    assert!(first_request.starts_with(&format!("POST {reserve_path} ")));
+    assert!(second_request.starts_with(&format!("POST {receipt_path} ")));
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -13,6 +13,10 @@ use api_contracts::generated::{
         CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE, RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
     },
     routes,
+    types::runners::runs::active_inputs::{
+        receipt::Response as ActiveInputReceiptResponse,
+        reserve::Response as ActiveInputReserveResponse,
+    },
 };
 use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -973,6 +977,14 @@ pub(crate) struct ApiClient {
     token: String,
 }
 
+pub(crate) enum ReserveActiveInputResult {
+    RouteUnavailable,
+    Response(ActiveInputReserveResponse),
+}
+
+#[derive(Serialize)]
+struct EmptyRequest {}
+
 impl ApiClient {
     pub(crate) fn new(http: HttpClient, token: String) -> Self {
         Self { http, token }
@@ -1005,6 +1017,60 @@ impl ApiClient {
         let resp = check_api_status(resp, "list active inputs").await?;
         let body: ListResponse = decode_api_json(resp, "list active inputs").await?;
         Ok(body.event_ids)
+    }
+
+    pub(crate) async fn reserve_active_inputs(
+        &self,
+        run_id: RunId,
+        sandbox_token: &str,
+    ) -> RunnerResult<ReserveActiveInputResult> {
+        let run_id = run_id.to_string();
+        let resp = send_api(
+            self.http
+                .request_resolved_route(
+                    routes::runners::runs::by_run_id::active_inputs::reserve::route(
+                        routes::runners::runs::by_run_id::active_inputs::reserve::Params {
+                            run_id: run_id.as_str(),
+                        },
+                    ),
+                    sandbox_token,
+                )
+                .json(&EmptyRequest {}),
+            "reserve active inputs",
+        )
+        .await?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Ok(ReserveActiveInputResult::RouteUnavailable);
+        }
+        let resp = check_api_status(resp, "reserve active inputs").await?;
+        let body = decode_api_json(resp, "reserve active inputs").await?;
+        Ok(ReserveActiveInputResult::Response(body))
+    }
+
+    pub(crate) async fn record_active_input_delivery(
+        &self,
+        run_id: RunId,
+        sandbox_token: &str,
+        delivery_id: &str,
+    ) -> RunnerResult<ActiveInputReceiptResponse> {
+        let run_id = run_id.to_string();
+        let resp = send_api(
+            self.http
+                .request_resolved_route(
+                    routes::runners::runs::by_run_id::active_inputs::deliveries::by_delivery_id::receipt::route(
+                        routes::runners::runs::by_run_id::active_inputs::deliveries::by_delivery_id::receipt::Params {
+                            run_id: run_id.as_str(),
+                            delivery_id,
+                        },
+                    ),
+                    sandbox_token,
+                )
+                .json(&EmptyRequest {}),
+            "record active input delivery",
+        )
+        .await?;
+        let resp = check_api_status(resp, "record active input delivery").await?;
+        decode_api_json(resp, "record active input delivery").await
     }
 
     pub(crate) async fn claim_active_inputs(
@@ -2095,6 +2161,7 @@ mod tests {
             sandbox_id: None,
             sandbox_reuse_result: None,
             workspace_reuse_result: None,
+            active_input_delivery_ids: Vec::new(),
         }
     }
 
@@ -3865,6 +3932,7 @@ mod tests {
                     sandbox_id: None,
                     sandbox_reuse_result: None,
                     workspace_reuse_result: None,
+                    active_input_delivery_ids: Vec::new(),
                 },
             )
             .await
@@ -3908,6 +3976,7 @@ mod tests {
                 sandbox_id: None,
                 sandbox_reuse_result: Some(SandboxReuseResult::NoReuseKey),
                 workspace_reuse_result: Some(WorkspaceReuseResult::NoReuseKey),
+                active_input_delivery_ids: Vec::new(),
             },
         )
         .await

--- a/crates/runner/src/provider/local/tests/support.rs
+++ b/crates/runner/src/provider/local/tests/support.rs
@@ -49,6 +49,7 @@ pub(super) fn complete_request(
         sandbox_id: None,
         sandbox_reuse_result: None,
         workspace_reuse_result: None,
+        active_input_delivery_ids: Vec::new(),
     }
 }
 

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -14,7 +14,7 @@ mod local;
 #[cfg(test)]
 pub mod mock;
 
-pub(crate) use api::ApiClient;
+pub(crate) use api::{ApiClient, ReserveActiveInputResult};
 pub use api::{ApiProvider, ApiProviderConfig, BuiltinFirewallCatalogCachePaths};
 pub(crate) use connector_runtime_sync::{
     ConnectorRuntimeSyncHandle, ConnectorRuntimeSyncRegistration,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1730,6 +1730,10 @@ pub struct CompleteRequest {
     /// failed before the runner reached a reliable final decision.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_reuse_result: Option<WorkspaceReuseResult>,
+    /// Active-input deliveries observed in the guest receipt journal but not
+    /// confirmed through the direct receipt route before process exit.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub active_input_delivery_ids: Vec<String>,
 }
 
 /// Outcome of the sandbox-reuse decision made at job dispatch time. `Reused`
@@ -2210,6 +2214,7 @@ mod tests {
             sandbox_id: None,
             sandbox_reuse_result: None,
             workspace_reuse_result: None,
+            active_input_delivery_ids: Vec::new(),
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("runId").is_some());
@@ -2219,6 +2224,7 @@ mod tests {
         assert!(json.get("sandboxId").is_none());
         assert!(json.get("sandboxReuseResult").is_none());
         assert!(json.get("workspaceReuseResult").is_none());
+        assert!(json.get("activeInputDeliveryIds").is_none());
     }
 
     #[test]
@@ -2232,6 +2238,7 @@ mod tests {
             sandbox_id: None,
             sandbox_reuse_result: None,
             workspace_reuse_result: None,
+            active_input_delivery_ids: Vec::new(),
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["error"], "timeout");
@@ -2252,11 +2259,16 @@ mod tests {
             sandbox_id: Some(sid),
             sandbox_reuse_result: Some(SandboxReuseResult::Reused),
             workspace_reuse_result: Some(WorkspaceReuseResult::SandboxReused),
+            active_input_delivery_ids: vec!["aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee".to_string()],
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["sandboxId"], "11111111-2222-3333-4444-555555555555");
         assert_eq!(json["sandboxReuseResult"], "reused");
         assert_eq!(json["workspaceReuseResult"], "sandboxReused");
+        assert_eq!(
+            json["activeInputDeliveryIds"],
+            serde_json::json!(["aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"])
+        );
     }
 
     #[test]

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -159,8 +159,8 @@ pub(crate) struct ProcessOverrideState {
     pub(crate) process_control_calls: Mutex<Vec<ProcessControlCall>>,
     /// Wakes tests waiting for process-control calls to be recorded.
     pub(crate) process_control_notify: tokio::sync::Notify,
-    /// FIFO queue of process-control errors consumed by control handles.
-    pub(crate) process_control_errors: Mutex<VecDeque<(std::io::ErrorKind, String)>>,
+    /// FIFO queue of structured process-control outcomes consumed by control handles.
+    pub(crate) process_control_outcomes: Mutex<VecDeque<ProcessControlOutcome>>,
     /// Whether a successful process cancel releases the configured
     /// `wait_process` gate. Tests can disable this to exercise bounded wait
     /// timeout paths after cancel is sent.
@@ -190,7 +190,7 @@ impl Default for ProcessOverrideState {
             process_cancel_errors: Mutex::new(VecDeque::new()),
             process_control_calls: Mutex::new(Vec::new()),
             process_control_notify: tokio::sync::Notify::new(),
-            process_control_errors: Mutex::new(VecDeque::new()),
+            process_control_outcomes: Mutex::new(VecDeque::new()),
             process_cancel_releases_wait_gate: Mutex::new(true),
         }
     }
@@ -810,10 +810,19 @@ impl MockSandboxOverrides {
         kind: std::io::ErrorKind,
         message: impl Into<String>,
     ) {
+        self.push_process_control_outcome(ProcessControlOutcome::Failed {
+            kind: ProcessControlFailureKind::Operation,
+            write_state: ProcessControlWriteState::PossiblyWritten,
+            error: std::io::Error::new(kind, message.into()),
+        });
+    }
+
+    /// Queue a structured process-control outcome consumed by the next control handle.
+    pub fn push_process_control_outcome(&self, outcome: ProcessControlOutcome) {
         self.process
-            .process_control_errors
+            .process_control_outcomes
             .lock_ignoring_poison()
-            .push_back((kind, message.into()));
+            .push_back(outcome);
     }
 
     /// Configure whether successful process cancellation releases a configured

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -837,7 +837,7 @@ impl Sandbox for MockSandbox {
         let control = (request.control == ProcessControlMode::Enabled && process_control_supported)
             .then(|| {
                 let overrides = self.overrides.clone();
-                GuestProcessControlHandle::new(move |message_id, payload, timeout| {
+                GuestProcessControlHandle::new_with_outcome(move |message_id, payload, timeout| {
                     let overrides = overrides.clone();
                     Box::pin(async move {
                         if let Some(overrides) = overrides {
@@ -851,16 +851,16 @@ impl Sandbox for MockSandbox {
                                     timeout,
                                 });
                             overrides.process.process_control_notify.notify_waiters();
-                            if let Some((kind, message)) = overrides
+                            if let Some(outcome) = overrides
                                 .process
-                                .process_control_errors
+                                .process_control_outcomes
                                 .lock_ignoring_poison()
                                 .pop_front()
                             {
-                                return Err(std::io::Error::new(kind, message));
+                                return outcome;
                             }
                         }
-                        Ok(ProcessControlAck { message_id })
+                        ProcessControlOutcome::Delivered(ProcessControlAck { message_id })
                     })
                 })
             });

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -209,6 +209,42 @@ async fn queued_process_control_errors_are_consumed_fifo() {
 }
 
 #[tokio::test]
+async fn queued_structured_process_control_outcomes_are_preserved() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_process_control_outcome(ProcessControlOutcome::GuestStatus {
+        status: ProcessControlGuestStatus::QueueFull,
+        diagnostic: "guest queue is full".to_string(),
+    });
+    let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
+    let handle = sandbox
+        .start_process(&StartProcessRequest {
+            cmd: "agent",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+            control: ProcessControlMode::Enabled,
+        })
+        .await
+        .unwrap();
+    let control = handle
+        .control_handle()
+        .expect("enabled control should expose a handle");
+
+    let outcome = control
+        .control_outcome("msg-1", b"payload", Duration::from_secs(1))
+        .await;
+
+    assert!(matches!(
+        outcome,
+        ProcessControlOutcome::GuestStatus {
+            status: ProcessControlGuestStatus::QueueFull,
+            diagnostic,
+        } if diagnostic == "guest queue is full"
+    ));
+}
+
+#[tokio::test]
 async fn structured_process_control_distinguishes_timeout_write_state() {
     for write_state in [
         ProcessControlWriteState::NotWritten,

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -26,11 +26,12 @@ The delivery becomes settled through one of two proof-bearing paths:
 - A direct receipt confirms that the Guest accepted the batch. Each source is
   replaced by a run-attributed event and every item becomes `delivered`.
 - `/api/webhooks/agent/complete` proves that the Guest has quiesced, or that the
-  Runner observed process exit and completed sandbox teardown. Delivery IDs in
-  `activeInputDeliveryIds` become `delivered`. If the open delivery ID is not
-  present, prompt items become `released` and their original source events stay
-  pending; run-scoped budget items become `expired` and receive a
-  `control.revoke` event.
+  Runner observed process exit, stopped forwarding, and recovered the receipt
+  journal. Completion may overlap sandbox finalization after that boundary.
+  Delivery IDs in `activeInputDeliveryIds` become `delivered`. If the open
+  delivery ID is not present, prompt items become `released` and their original
+  source events stay pending; run-scoped budget items become `expired` and
+  receive a `control.revoke` event.
 
 All item and delivery transitions are monotonic. A late receipt for a released
 or expired delivery is rejected, while a repeated receipt for an already

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -38,12 +38,13 @@ delivered delivery is idempotent. Duplicate completion still processes an open
 delivery even when the run is already terminal.
 
 After the Guest process exits, the Runner reads the bounded run-scoped receipt
-journal while it still owns the sandbox. It retries those receipts for up to
-five seconds and includes unresolved IDs in the normal completion request. This
-uses completion's existing retry and idempotency boundary as the final recovery
-path. A successful direct receipt also reuses the existing Runner notification
-channel when settlement exposes another queued prompt; the 30-second poll
-remains notification-loss recovery rather than normal steering latency.
+journal while it still owns the sandbox. It attempts those receipts within one
+total five-second budget and includes unresolved IDs in the normal completion
+request. This uses completion's existing retry and idempotency boundary as the
+final recovery path. A successful direct receipt also reuses the existing
+Runner notification channel when settlement exposes another queued prompt; the
+30-second poll remains notification-loss recovery rather than normal steering
+latency.
 
 ## Terminal Status and Quiescence
 

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -14,6 +14,13 @@ it does not revoke or copy the source chat event. Retrying the reservation
 returns the same delivery ID, event ID, and materialized prompt while that
 delivery remains open.
 
+The Runner sends the delivery UUID with the Guest control payload. The Guest
+deduplicates that identity, persists it after the CLI backend accepts the
+follow-up, and attempts the direct receipt asynchronously. A delivered or
+acknowledgement-uncertain batch is not sent again while the API keeps returning
+the same reservation. Explicit pre-write failures and retryable Guest capacity
+statuses retry the same identity.
+
 The delivery becomes settled through one of two proof-bearing paths:
 
 - A direct receipt confirms that the Guest accepted the batch. Each source is
@@ -29,6 +36,14 @@ All item and delivery transitions are monotonic. A late receipt for a released
 or expired delivery is rejected, while a repeated receipt for an already
 delivered delivery is idempotent. Duplicate completion still processes an open
 delivery even when the run is already terminal.
+
+After the Guest process exits, the Runner reads the bounded run-scoped receipt
+journal while it still owns the sandbox. It retries those receipts for up to
+five seconds and includes unresolved IDs in the normal completion request. This
+uses completion's existing retry and idempotency boundary as the final recovery
+path. A successful direct receipt also reuses the existing Runner notification
+channel when settlement exposes another queued prompt; the 30-second poll
+remains notification-loss recovery rather than normal steering latency.
 
 ## Terminal Status and Quiescence
 
@@ -65,9 +80,30 @@ UUIDs, and carries no prompt content. Older callers can continue to omit it.
 Runs without durable delivery rows retain the legacy completion behavior; no
 protocol version or feature discriminator is persisted.
 
-The current server support is dormant until the Runner begins reserving active
-input. Runner journal recovery and activation are delivered separately in
-[#26060](https://github.com/vm0-ai/vm0/issues/26060).
+On its first active-input read, a Runner probes the reserve route. Only an
+immediate route-level `404` selects the legacy list/claim protocol for that run.
+Any response or ambiguous failure selects durable reserve mode permanently, so
+a committed reservation can never later fall through to destructive legacy
+claim. Legacy payloads omit the delivery UUID; durable API and local Runner
+payloads include a stable UUID. Older Runners continue to use the retained
+legacy routes against a newer API.
+
+The cutover Runner must run with a receipt-capable Guest from #26058. A legacy
+Guest treats process-control acceptance as queue admission and has no durable
+receipt, so it is not a compatible execution peer for a Runner that reserves a
+delivery. Deploy the Guest capability and drain any sandboxes that can still
+start that legacy Guest before enabling the cutover Runner. This is a rollout
+gate rather than a permanent protocol-negotiation branch.
+
+The browser remains event-oriented: optimistic input is reconciled by its chat
+event ID, and receipt/completion replacements use the existing realtime chat
+event projection. Delivery IDs remain internal to API, Runner, and Guest, so
+activation does not introduce a frontend protocol or deployment dependency.
+
+Durable delivery is active as of
+[#26060](https://github.com/vm0-ai/vm0/issues/26060). The legacy compatibility
+routes and optional Guest payload shape remain until the post-deployment
+contraction in [#26061](https://github.com/vm0-ai/vm0/issues/26061).
 
 During rollout, the legacy list/claim endpoint still accepts multiple event IDs
 for old Runners. Current Runners claim only the oldest listed event and

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1803,6 +1803,17 @@ describe("CHAT-02: queueing and recalling messages", () => {
       api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
     ).resolves.toStrictEqual(firstReservation);
 
+    const trailingEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        prompt: "third steer queued behind the open delivery",
+        clientEventId: trailingEventId,
+      },
+      [201],
+    );
     context.mocks.ably.publish.mockClear();
     const receipts = await Promise.all([
       api.recordRunnerActiveInputDelivery(
@@ -1825,6 +1836,14 @@ describe("CHAT-02: queueing and recalling messages", () => {
         return topic === `chatThreadMessageCreated:${active.threadId}`;
       }),
     ).toHaveLength(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("active-input", {
+      runId: active.runId,
+    });
+    expect(
+      context.mocks.ably.publish.mock.calls.filter(([topic]) => {
+        return topic === "active-input";
+      }),
+    ).toHaveLength(1);
     await expect(
       api.recordRunnerActiveInputDelivery(
         claimed.claim.sandboxToken,
@@ -1837,6 +1856,20 @@ describe("CHAT-02: queueing and recalling messages", () => {
         return topic === `chatThreadMessageCreated:${active.threadId}`;
       }),
     ).toHaveLength(1);
+
+    const trailingReservation = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (trailingReservation.outcome !== "reserved") {
+      throw new Error("Expected the trailing input to become reservable");
+    }
+    expect(trailingReservation.eventIds).toStrictEqual([trailingEventId]);
+    await api.recordRunnerActiveInputDelivery(
+      claimed.claim.sandboxToken,
+      active.runId,
+      trailingReservation.deliveryId,
+    );
 
     await expect(
       api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
@@ -1876,14 +1909,15 @@ describe("CHAT-02: queueing and recalling messages", () => {
       return (
         event.runId === active.runId &&
         (event.revokesEventId === firstEventId ||
-          event.revokesEventId === secondEventId)
+          event.revokesEventId === secondEventId ||
+          event.revokesEventId === trailingEventId)
       );
     });
     expect(
       replacements.map((event) => {
         return event.revokesEventId;
       }),
-    ).toStrictEqual([firstEventId, secondEventId]);
+    ).toStrictEqual([firstEventId, secondEventId, trailingEventId]);
     await cancelChatRun(actor, active.runId);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1803,17 +1803,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
       api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
     ).resolves.toStrictEqual(firstReservation);
 
-    const trailingEventId = randomUUID();
-    await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: active.threadId,
-        prompt: "third steer queued behind the open delivery",
-        clientEventId: trailingEventId,
-      },
-      [201],
-    );
     context.mocks.ably.publish.mockClear();
     const receipts = await Promise.all([
       api.recordRunnerActiveInputDelivery(
@@ -1857,20 +1846,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
       }),
     ).toHaveLength(1);
 
-    const trailingReservation = await api.reserveRunnerActiveInputs(
-      claimed.claim.sandboxToken,
-      active.runId,
-    );
-    if (trailingReservation.outcome !== "reserved") {
-      throw new Error("Expected the trailing input to become reservable");
-    }
-    expect(trailingReservation.eventIds).toStrictEqual([trailingEventId]);
-    await api.recordRunnerActiveInputDelivery(
-      claimed.claim.sandboxToken,
-      active.runId,
-      trailingReservation.deliveryId,
-    );
-
     await expect(
       api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
     ).resolves.toStrictEqual([secondEventId]);
@@ -1909,15 +1884,14 @@ describe("CHAT-02: queueing and recalling messages", () => {
       return (
         event.runId === active.runId &&
         (event.revokesEventId === firstEventId ||
-          event.revokesEventId === secondEventId ||
-          event.revokesEventId === trailingEventId)
+          event.revokesEventId === secondEventId)
       );
     });
     expect(
       replacements.map((event) => {
         return event.revokesEventId;
       }),
-    ).toStrictEqual([firstEventId, secondEventId, trailingEventId]);
+    ).toStrictEqual([firstEventId, secondEventId]);
     await cancelChatRun(actor, active.runId);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -96,6 +96,7 @@ import {
   reserveActiveInputDelivery,
 } from "../services/active-input-delivery.service";
 import { lockChatQueueThread } from "../services/chat-event-queue.service";
+import { notifyRunningChatRunOfPendingInput } from "../services/chat-thread-queue-drain.service";
 import { loadConnectorRuntimeSnapshot } from "../services/connector-catalog-runtime.service";
 import { loadConnectorRunnerFirewallCatalog } from "../services/connector-runner-firewall-catalog.service";
 import { resolveConnectorRuntimeTargets } from "../services/connector-runtime-sync.service";
@@ -3029,6 +3030,11 @@ const recordActiveInputDeliveryReceiptInner$ = command(
     if (result.replacementsAppended) {
       await publishChatThreadMessageCreatedSafely(
         auth.userId,
+        result.chatThreadId,
+      );
+      signal.throwIfAborted();
+      await notifyRunningChatRunOfPendingInput(
+        set(writeDb$),
         result.chatThreadId,
       );
       signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx
@@ -433,6 +433,100 @@ describe("chat lifecycle", () => {
     expect(screen.getAllByText(prompt)).toHaveLength(1);
   });
 
+  it("keeps a steered message singular when its delivery replacement syncs", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000735";
+    const runId = "d0000000-0000-4000-a000-000000000752";
+    const prompt = "Steer accepted by the running agent";
+    const initialUser = {
+      id: "00000000-0000-4000-8000-000000000760",
+      threadId,
+      eventType: "input.prompt" as const,
+      content: null,
+      userMessage: {
+        version: 1 as const,
+        parts: [{ type: "text" as const, text: "Start the active run" }],
+      },
+      createdAt: "2026-06-09T10:00:00.000Z",
+      seqId: 1,
+      runId,
+    } satisfies ChatEvent;
+    const activeReply = {
+      id: "00000000-0000-4000-8000-000000000761",
+      threadId,
+      eventType: "output.message" as const,
+      content: "Still working",
+      createdAt: "2026-06-09T10:00:01.000Z",
+      seqId: 2,
+      runId,
+    } satisfies ChatEvent;
+    const pendingSteer = {
+      id: "00000000-0000-4000-8000-000000000762",
+      threadId,
+      eventType: "input.prompt" as const,
+      content: null,
+      userMessage: {
+        version: 1 as const,
+        parts: [{ type: "text" as const, text: prompt }],
+      },
+      createdAt: "2026-06-09T10:00:02.000Z",
+      seqId: 3,
+    } satisfies ChatEvent;
+    const deliveredSteer = {
+      id: "00000000-0000-4000-8000-000000000763",
+      threadId,
+      eventType: "input.prompt" as const,
+      content: null,
+      userMessage: pendingSteer.userMessage,
+      createdAt: "2026-06-09T10:00:03.000Z",
+      seqId: 4,
+      runId,
+      revokesEventId: pendingSteer.id,
+    } satisfies ChatEvent;
+    let exposeReplacement = false;
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Durable steer projection",
+      activeRunIds: [runId],
+    });
+    context.mocks.api(chatThreadEventsContract.list, ({ query, respond }) => {
+      if (query.sinceSeqId === undefined) {
+        return respond(200, {
+          events: [initialUser, activeReply, pendingSteer].map(
+            chatEventResponse,
+          ),
+        });
+      }
+      if (query.sinceSeqId === pendingSteer.seqId) {
+        return respond(200, {
+          events: exposeReplacement ? [chatEventResponse(deliveredSteer)] : [],
+        });
+      }
+      if (query.sinceSeqId === deliveredSteer.seqId) {
+        return respond(200, { events: [] });
+      }
+      throw new Error(`Unexpected message cursor: ${JSON.stringify(query)}`);
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await waitFor(() => {
+      expect(screen.getAllByText(prompt)).toHaveLength(1);
+    });
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+    });
+
+    exposeReplacement = true;
+    context.mocks.ably.trigger(`chatThreadMessageCreated:${threadId}`);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(prompt)).toHaveLength(1);
+    });
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+  });
+
   it("renders synced messages when IndexedDB is unavailable", async () => {
     const threadId = "b0000000-0000-4000-a000-000000000732";
     const initialMessage = {

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
@@ -28,6 +28,18 @@ const expectedBindings = [
   },
   {
     method: "POST",
+    path: "/api/runners/runs/:runId/active-inputs/reserve",
+    rustModulePath: [
+      "runners",
+      "runs",
+      "by_run_id",
+      "active_inputs",
+      "reserve",
+    ],
+    rustConstName: "RESERVE",
+  },
+  {
+    method: "POST",
     path: "/api/runners/runs/:runId/active-inputs/deliveries/:deliveryId/receipt",
     rustModulePath: [
       "runners",

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -20,6 +20,11 @@ import {
 
 const expectedBindings = [
   {
+    rustModulePath: ["runners", "runs", "active_inputs", "reserve"],
+    rustTypeName: "Response",
+    direction: "response",
+  },
+  {
     rustModulePath: ["runners", "runs", "active_inputs", "receipt"],
     rustTypeName: "Response",
     direction: "response",
@@ -217,6 +222,9 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain(
       "pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,",
     );
+    expect(firstRender).toMatch(
+      /#\[derive\(\n\s+Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,\n\s+\)\]\n\s+pub enum ResponseRejectedReason \{/,
+    );
     expect(firstRender).toContain(
       "/// Request body for creating a recoverable agent checkpoint.",
     );
@@ -355,6 +363,75 @@ describe("Rust type bindings", () => {
     expect(rendered).toContain("Delivered,");
     expect(rendered).toContain('#[serde(rename = "rejected")]');
     expect(rendered).toContain("Rejected,");
+  });
+
+  it("renders internally tagged unions with variant fields", () => {
+    const rendered = renderExampleRustTypes([
+      validBinding({
+        schema: z.discriminatedUnion("outcome", [
+          z.object({
+            outcome: z.literal("reserved"),
+            deliveryId: z.uuid(),
+            eventIds: z.array(z.uuid()),
+          }),
+          z.object({ outcome: z.literal("empty") }),
+          z.object({
+            outcome: z.literal("rejected"),
+            reason: z.enum(["too_large", "not_running"]),
+          }),
+        ]),
+        rustTypeName: "Response",
+        declarations: [
+          {
+            rustTypeName: "Response",
+            rustDoc: ["Reserve response."],
+            fields: {
+              deliveryId: ["Delivery identity."],
+              eventIds: ["Source events."],
+              reason: ["Rejection reason."],
+            },
+            variants: {
+              reserved: ["Reserved."],
+              empty: ["Empty."],
+              rejected: ["Rejected."],
+            },
+          },
+          enumDeclaration("ResponseRejectedReason", {
+            too_large: ["Too large."],
+            not_running: ["Not running."],
+          }),
+        ],
+      }),
+    ]);
+
+    expect(rendered).toContain(
+      '#[serde(tag = "outcome", rename_all_fields = "camelCase")]',
+    );
+    expect(rendered).toContain("Reserved {");
+    expect(rendered).toContain("delivery_id: String,");
+    expect(rendered).toContain("event_ids: Vec<String>,");
+    expect(rendered).toContain("Empty,");
+    expect(rendered).toContain("Rejected {");
+    expect(rendered).toContain("reason: ResponseRejectedReason,");
+  });
+
+  it("rejects tagged variants with an ambiguous const discriminator", () => {
+    expect(() => {
+      renderExampleRustTypes([
+        validBinding({
+          schema: z.discriminatedUnion("outcome", [
+            z.object({
+              kind: z.literal("first"),
+              outcome: z.literal("reserved"),
+            }),
+            z.object({
+              kind: z.literal("second"),
+              outcome: z.literal("empty"),
+            }),
+          ]),
+        }),
+      ]);
+    }).toThrow("unsupported oneOf schema");
   });
 
   it("renders optional nullable fields without nested options", () => {

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -135,14 +135,15 @@ interface RustDeclaration {
   readonly lines: string[];
 }
 
-interface TaggedUnitUnion {
+interface TaggedUnion {
   readonly tag: string;
-  readonly values: readonly string[];
+  readonly variants: readonly TaggedUnionVariant[];
 }
 
-interface TaggedUnitVariant {
-  readonly tag: string;
+interface TaggedUnionVariant {
   readonly value: string;
+  readonly properties: JsonObject;
+  readonly required: readonly string[];
 }
 
 interface NormalizedTypeDeclarationDoc {
@@ -157,6 +158,9 @@ const rustModuleSegmentPattern = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
 const rustConstNamePattern = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$/;
 const rustTypeNamePattern = /^[A-Z][A-Za-z0-9]*$/;
 const routePathParamPattern = /^[A-Za-z][A-Za-z0-9_]*$/;
+// rustfmt expands this function-like attribute before the nominal 100-column
+// limit, so generated code must use the same effective width to remain stable.
+const rustfmtSingleLineDeriveMaxWidth = 96;
 const rustKeywords = new Set([
   "abstract",
   "as",
@@ -1144,9 +1148,9 @@ function rustTypeForSchema(
     return `Option<${rustTypeForSchema(nullable, typeName, context)}>`;
   }
 
-  const taggedUnitUnion = getTaggedUnitUnion(schema, context.label);
-  if (taggedUnitUnion !== null) {
-    return renderTaggedUnitEnum(taggedUnitUnion, typeName, context);
+  const taggedUnion = getTaggedUnion(schema, context.label);
+  if (taggedUnion !== null) {
+    return renderTaggedEnum(taggedUnion, typeName, context);
   }
 
   const enumValues = getStringArray(schema.enum);
@@ -1342,9 +1346,11 @@ function renderStructField(
   rustName: string,
   rustType: string,
   context: RenderTypeContext,
+  isPublic: boolean = true,
 ): string[] {
   const indent = "    ";
-  const singleLine = `${indent}pub ${rustName}: ${rustType},`;
+  const visibility = isPublic ? "pub " : "";
+  const singleLine = `${indent}${visibility}${rustName}: ${rustType},`;
   if (context.moduleIndentWidth + singleLine.length <= 100) {
     return [singleLine];
   }
@@ -1352,13 +1358,13 @@ function renderStructField(
   if (rustType.startsWith("Option<") && rustType.endsWith(">")) {
     const innerType = rustType.slice("Option<".length, -1);
     return [
-      `${indent}pub ${rustName}: Option<`,
+      `${indent}${visibility}${rustName}: Option<`,
       `${indent}    ${innerType},`,
       `${indent}>,`,
     ];
   }
 
-  return [`${indent}pub ${rustName}:`, `${indent}    ${rustType},`];
+  return [`${indent}${visibility}${rustName}:`, `${indent}    ${rustType},`];
 }
 
 function renderStringEnum(
@@ -1375,9 +1381,18 @@ function renderStringEnum(
   const declarationDoc = typeDeclarationDoc(context, typeName);
 
   const seenVariants = new Set<string>();
+  const derive =
+    "#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]";
   const lines = [
     ...renderOuterRustDoc(declarationDoc.rustDoc, ""),
-    "#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]",
+    ...(context.moduleIndentWidth + derive.length <=
+    rustfmtSingleLineDeriveMaxWidth
+      ? [derive]
+      : [
+          "#[derive(",
+          "    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,",
+          ")]",
+        ]),
     `pub enum ${typeName} {`,
   ];
 
@@ -1408,8 +1423,8 @@ function renderStringEnum(
   return typeName;
 }
 
-function renderTaggedUnitEnum(
-  union: TaggedUnitUnion,
+function renderTaggedEnum(
+  union: TaggedUnion,
   typeName: string,
   context: RenderTypeContext,
 ): string {
@@ -1420,19 +1435,30 @@ function renderTaggedUnitEnum(
   }
   context.declarationNames.add(typeName);
   const declarationDoc = typeDeclarationDoc(context, typeName);
+  const hasFields = union.variants.some((variant) => {
+    return Object.keys(variant.properties).length > 0;
+  });
 
   const seenVariants = new Set<string>();
   const lines = [
     ...renderOuterRustDoc(declarationDoc.rustDoc, ""),
-    "#[derive(",
-    "    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,",
-    ")]",
-    `#[serde(tag = ${rustStringLiteral(union.tag)})]`,
+    hasFields
+      ? "#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]"
+      : "#[derive(",
+    ...(hasFields
+      ? []
+      : [
+          "    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,",
+          ")]",
+        ]),
+    hasFields
+      ? `#[serde(tag = ${rustStringLiteral(union.tag)}, rename_all_fields = "camelCase")]`
+      : `#[serde(tag = ${rustStringLiteral(union.tag)})]`,
     `pub enum ${typeName} {`,
   ];
 
-  for (const value of union.values) {
-    const variant = toRustVariantName(value);
+  for (const taggedVariant of union.variants) {
+    const variant = toRustVariantName(taggedVariant.value);
     if (seenVariants.has(variant)) {
       throw new Error(
         `${context.label}.${typeName} has duplicate Rust enum variant: ${variant}`,
@@ -1441,12 +1467,82 @@ function renderTaggedUnitEnum(
     seenVariants.add(variant);
     lines.push(
       ...renderOuterRustDoc(
-        typeVariantDoc(context, typeName, value, declarationDoc),
+        typeVariantDoc(context, typeName, taggedVariant.value, declarationDoc),
         "    ",
       ),
     );
-    lines.push(`    #[serde(rename = ${rustStringLiteral(value)})]`);
-    lines.push(`    ${variant},`);
+    lines.push(
+      `    #[serde(rename = ${rustStringLiteral(taggedVariant.value)})]`,
+    );
+    if (Object.keys(taggedVariant.properties).length === 0) {
+      lines.push(`    ${variant},`);
+      continue;
+    }
+
+    lines.push(`    ${variant} {`);
+    const required = new Set(taggedVariant.required);
+    const seenRustFields = new Map<string, string>();
+    for (const [wireName, rawPropertySchema] of Object.entries(
+      taggedVariant.properties,
+    )) {
+      if (!isJsonObject(rawPropertySchema)) {
+        throw new Error(
+          `${context.label}.${typeName}.${variant}.${wireName} is not an object schema`,
+        );
+      }
+      const rustName = toRustFieldName(wireName);
+      const previousWireName = seenRustFields.get(rustName);
+      if (previousWireName !== undefined) {
+        throw new Error(
+          `${context.label}.${typeName}.${variant} maps both ${previousWireName} and ${wireName} to Rust field ${rustName}`,
+        );
+      }
+      seenRustFields.set(rustName, wireName);
+
+      const optional = !required.has(wireName);
+      const override = context.fieldTypeOverrides[wireName];
+      const rawType =
+        override ??
+        rustTypeForSchema(
+          rawPropertySchema,
+          nestedTypeNameForField(
+            `${typeName}${variant}`,
+            wireName,
+            rawPropertySchema,
+          ),
+          context,
+        );
+      const rustType =
+        optional && !isOptionType(rawType) ? `Option<${rawType}>` : rawType;
+      lines.push(
+        ...renderOuterRustDoc(
+          typeFieldDoc(context, typeName, wireName, declarationDoc),
+          "        ",
+        ),
+      );
+      for (const attribute of serdeFieldAttributes({
+        wireName,
+        rustName,
+        optional,
+      })) {
+        lines.push(`        ${attribute}`);
+      }
+      const fieldLines = renderStructField(
+        rustName,
+        rustType,
+        {
+          ...context,
+          moduleIndentWidth: context.moduleIndentWidth + 4,
+        },
+        false,
+      );
+      lines.push(
+        ...fieldLines.map((line) => {
+          return `    ${line}`;
+        }),
+      );
+    }
+    lines.push("    },");
   }
 
   lines.push("}");
@@ -1693,10 +1789,7 @@ function getJsonSchemaType(schema: JsonObject, label: string): string {
   return schema.type;
 }
 
-function getTaggedUnitUnion(
-  schema: JsonObject,
-  label: string,
-): TaggedUnitUnion | null {
+function getTaggedUnion(schema: JsonObject, label: string): TaggedUnion | null {
   const oneOf = schema.oneOf;
   if (oneOf === undefined) {
     return null;
@@ -1706,7 +1799,7 @@ function getTaggedUnitUnion(
   }
 
   const variants = oneOf.map((entry) => {
-    return getTaggedUnitVariant(entry, label);
+    return getTaggedVariant(entry, label);
   });
   const first = variants[0];
   if (first === undefined) {
@@ -1721,16 +1814,20 @@ function getTaggedUnitUnion(
   }
   return {
     tag: first.tag,
-    values: variants.map((variant) => {
-      return variant.value;
+    variants: variants.map(({ value, properties, required }) => {
+      return {
+        value,
+        properties,
+        required,
+      };
     }),
   };
 }
 
-function getTaggedUnitVariant(
+function getTaggedVariant(
   entry: unknown,
   label: string,
-): TaggedUnitVariant {
+): TaggedUnionVariant & { readonly tag: string } {
   if (!isJsonObject(entry) || entry.type !== "object") {
     throw new Error(`${label} uses unsupported oneOf schema`);
   }
@@ -1739,27 +1836,44 @@ function getTaggedUnitVariant(
   const required = getStringArray(entry.required);
   if (
     propertyEntries === null ||
-    propertyEntries.length !== 1 ||
+    propertyEntries.length === 0 ||
     required === null ||
-    required.length !== 1 ||
     entry.additionalProperties !== false
   ) {
     throw new Error(`${label} uses unsupported oneOf schema`);
   }
-  const propertyEntry = propertyEntries[0];
-  if (propertyEntry === undefined) {
+  const tagEntries = propertyEntries.filter(([, rawSchema]) => {
+    return isJsonObject(rawSchema) && typeof rawSchema.const === "string";
+  });
+  if (tagEntries.length !== 1) {
     throw new Error(`${label} uses unsupported oneOf schema`);
   }
-  const [tag, rawTagSchema] = propertyEntry;
+  const tagEntry = tagEntries[0];
+  if (tagEntry === undefined) {
+    throw new Error(`${label} uses unsupported oneOf schema`);
+  }
+  const [tag, rawTagSchema] = tagEntry;
   if (
-    required[0] !== tag ||
+    !required.includes(tag) ||
     !isJsonObject(rawTagSchema) ||
     rawTagSchema.type !== "string" ||
     typeof rawTagSchema.const !== "string"
   ) {
     throw new Error(`${label} uses unsupported oneOf schema`);
   }
-  return { tag, value: rawTagSchema.const };
+  const variantProperties = Object.fromEntries(
+    propertyEntries.filter(([wireName]) => {
+      return wireName !== tag;
+    }),
+  );
+  return {
+    tag,
+    value: rawTagSchema.const,
+    properties: variantProperties,
+    required: required.filter((wireName) => {
+      return wireName !== tag;
+    }),
+  };
 }
 
 function getOptionalObject(value: unknown): JsonObject | null {

--- a/turbo/packages/api-contracts/src/rust-bindings/routes.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/routes.ts
@@ -53,6 +53,17 @@ export const rustRouteBindings = [
     rustConstName: "CLAIM",
   },
   {
+    route: runnersActiveInputsContract.reserve,
+    rustModulePath: [
+      "runners",
+      "runs",
+      "by_run_id",
+      "active_inputs",
+      "reserve",
+    ],
+    rustConstName: "RESERVE",
+  },
+  {
     route: runnersActiveInputsContract.receipt,
     rustModulePath: [
       "runners",

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import {
+  activeInputDeliveryReserveResponseSchema,
   activeInputDeliveryReceiptResponseSchema,
   artifactMissingRootPolicySchema,
   storageMountEntrySchema,
@@ -61,6 +62,10 @@ export const rustTypeModuleDocs = [
     rustDoc: ["DTOs for durable active-input delivery."],
   },
   {
+    rustModulePath: ["runners", "runs", "active_inputs", "reserve"],
+    rustDoc: ["DTOs for reserving or retrieving active-input delivery."],
+  },
+  {
     rustModulePath: ["runners", "runs", "active_inputs", "receipt"],
     rustDoc: ["DTOs for recording active-input acceptance receipts."],
   },
@@ -97,6 +102,41 @@ export const rustTypeModuleDocs = [
 ] satisfies readonly RustTypeModuleDoc[];
 
 export const rustTypeBindings = [
+  {
+    schema: activeInputDeliveryReserveResponseSchema,
+    rustModulePath: ["runners", "runs", "active_inputs", "reserve"],
+    rustTypeName: "Response",
+    direction: "response",
+    declarations: [
+      {
+        rustTypeName: "Response",
+        rustDoc: ["API outcome when reserving or retrieving active input."],
+        fields: {
+          deliveryId: ["Stable identity for the reserved delivery batch."],
+          eventIds: ["Ordered source chat-event identities in the batch."],
+          prompt: ["Materialized prompt sent to the active Guest."],
+          reason: ["Reason the pending input could not be reserved."],
+        },
+        variants: {
+          reserved: ["A stable delivery batch is ready for Guest delivery."],
+          empty: ["No pending active input is available."],
+          terminal: ["The run is terminal and has no open delivery."],
+          held: ["An open delivery remains held for a non-running run."],
+          rejected: ["Pending input cannot currently be reserved."],
+        },
+      },
+      {
+        rustTypeName: "ResponseRejectedReason",
+        rustDoc: ["Reason an active-input reservation was rejected."],
+        variants: {
+          payload_too_large: [
+            "The delivery-aware control payload exceeds the frame limit.",
+          ],
+          run_not_running: ["The target run is no longer running."],
+        },
+      },
+    ],
+  },
   {
     schema: activeInputDeliveryReceiptResponseSchema,
     rustModulePath: ["runners", "runs", "active_inputs", "receipt"],


### PR DESCRIPTION
## Summary

- switch API-backed active input from destructive legacy claim to durable reserve, delivery, receipt, and settlement
- carry stable delivery identities through Runner, process control, Guest receipt recovery, completion, and local-runner execution
- preserve mixed-deployment compatibility by falling back only when an older API unambiguously lacks the reserve route
- keep Platform optimistic projection and replacement reconciliation correct across direct receipt settlement and completion recovery
- document the active-input delivery protocol, terminal behavior, and rollout boundary

## Scope

- Closes #26060
- Delivery parent: #26034
- Legacy route, payload, and fallback removal remains deferred to #26061 after the production drain gate
- The known upstream Codex turn/steer race is intentionally outside this slice; this PR uses successful `turn/steer` completion as the available acceptance boundary

## Fallbacks

- `crates/runner/src/active_input.rs:read_api_active_input` — when a newly deployed Runner receives an immediate route-level `404` from an API version that predates the additive reserve route, it selects the legacy list/claim path for that run. Surface: Runner/API rollout and rollback, up to 2 hours. Remove after old API and Runner versions have drained and production evidence satisfies the gate in #26061.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p api-contracts -p guest-agent -p guest-contracts -p runner -p sandbox-mock --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p api-contracts -p guest-agent -p guest-contracts -p runner -p sandbox-mock --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts -p guest-agent -p guest-contracts -p runner -p sandbox-mock --all-targets --all-features`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest run apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/platform/src/views/zero-page/__tests__/chat-history-navigation.test.tsx packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts packages/api-contracts/src/rust-bindings/__tests__/types.test.ts --maxWorkers=4 --silent=passed-only`
