### PR TITLE
fix(runner): preserve completion telemetry timestamp

### DIFF
--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -1,7 +1,9 @@
-use sandbox::SandboxId;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use sandbox::SandboxId;
 
 use crate::ids::RunId;
 use crate::provider::{CompletionAuth, JobProvider};
@@ -130,6 +132,24 @@ pub(super) struct CompletionPayload {
     completion_auth: CompletionAuth,
 }
 
+#[must_use]
+pub(super) struct CompletionReportObservation {
+    duration: Duration,
+    completed_at: DateTime<Utc>,
+}
+
+impl CompletionReportObservation {
+    pub(super) fn record(self, telemetry: &mut crate::telemetry::JobTelemetry) {
+        telemetry.record_at(
+            "runner_host_completion_fallback",
+            self.duration,
+            true,
+            None,
+            self.completed_at,
+        );
+    }
+}
+
 impl CompletionPayload {
     pub(super) fn new(
         run_id: RunId,
@@ -158,7 +178,7 @@ impl CompletionPayload {
         self
     }
 
-    pub(super) async fn report(self, provider: &dyn JobProvider) -> Duration {
+    pub(super) async fn report(self, provider: &dyn JobProvider) -> CompletionReportObservation {
         let Self {
             run_id,
             exit_code,
@@ -182,7 +202,10 @@ impl CompletionPayload {
                 completion_auth,
             )
             .await;
-        provider_completion_started.elapsed()
+        CompletionReportObservation {
+            duration: provider_completion_started.elapsed(),
+            completed_at: Utc::now(),
+        }
     }
 }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -771,16 +771,15 @@ pub(super) async fn run_job(
         .with_workspace_reuse_result(executor_result.outcome.workspace_reuse_result);
         // Structural guarantee: claim (in provider) is always paired with complete.
         signal_usage_flush(run_id, &usage_flush_tx);
-        let (provider_completion_duration, finalized) = match provider.completion_report_timing() {
+        let (completion_report, finalized) = match provider.completion_report_timing() {
             CompletionReportTiming::ConcurrentWithFinalization => tokio::join!(
                 completion_payload.report(provider.as_ref()),
                 finalization.finalize(executor_result),
             ),
             CompletionReportTiming::AfterFinalization => {
                 let finalized = finalization.finalize(executor_result).await;
-                let provider_completion_duration =
-                    completion_payload.report(provider.as_ref()).await;
-                (provider_completion_duration, finalized)
+                let completion_report = completion_payload.report(provider.as_ref()).await;
+                (completion_report, finalized)
             }
         };
         let FinalizedJob {
@@ -788,12 +787,7 @@ pub(super) async fn run_job(
             mut telemetry,
             immediate_successor_receipt,
         } = finalized;
-        telemetry.record(
-            "runner_host_completion_fallback",
-            provider_completion_duration,
-            true,
-            None,
-        );
+        completion_report.record(&mut telemetry);
         completion_settlement
             .settle(finalization_ready, &mut telemetry)
             .await;

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::time::{Duration, Instant};
 
 use api_contracts::generated::routes;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::task::JoinHandle;
 use tracing::warn;
@@ -95,6 +95,28 @@ impl JobTelemetry {
         error: Option<&str>,
     ) {
         self.record_inner(action_type, duration, success, error, None);
+    }
+
+    /// Record a timed operation using the timestamp captured when it completed.
+    ///
+    /// This preserves event timing when a concurrently polled operation cannot
+    /// be added to this mutable buffer until another operation also finishes.
+    pub(crate) fn record_at(
+        &mut self,
+        action_type: &str,
+        duration: Duration,
+        success: bool,
+        error: Option<&str>,
+        completed_at: DateTime<Utc>,
+    ) {
+        self.push_operation(sandbox_op_at(
+            action_type,
+            duration,
+            success,
+            error,
+            None,
+            completed_at,
+        ));
     }
 
     pub(crate) fn record_api_to_spawn(
@@ -339,8 +361,19 @@ fn sandbox_op(
     error: Option<&str>,
     metadata: Option<SessionHistoryTelemetryMetadata>,
 ) -> SandboxOp {
+    sandbox_op_at(action_type, duration, success, error, metadata, Utc::now())
+}
+
+fn sandbox_op_at(
+    action_type: &str,
+    duration: Duration,
+    success: bool,
+    error: Option<&str>,
+    metadata: Option<SessionHistoryTelemetryMetadata>,
+    completed_at: DateTime<Utc>,
+) -> SandboxOp {
     SandboxOp {
-        ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        ts: completed_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         action_type: action_type.to_string(),
         duration_ms: duration_ms(duration),
         success,
@@ -646,6 +679,43 @@ mod tests {
 
         assert_eq!(telemetry.pending_ops_snapshot().len(), 2);
         assert!(telemetry.oldest_pending.is_some());
+    }
+
+    #[tokio::test]
+    async fn telemetry_flush_preserves_captured_operation_timestamp() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start_async().await;
+        let telemetry_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .body_includes(r#""ts":"2026-08-11T10:20:30.456Z""#)
+                    .body_includes(r#""action_type":"concurrent_operation""#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"success":true,"id":"ok"}"#);
+            })
+            .await;
+        let mut telemetry = JobTelemetry::new(
+            http_client_for_api_url(&server.base_url()),
+            RunId::nil(),
+            "tok".to_string(),
+        );
+        let completed_at = DateTime::parse_from_rfc3339("2026-08-11T10:20:30.456Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        telemetry.record_at(
+            "concurrent_operation",
+            Duration::from_millis(25),
+            true,
+            None,
+            completed_at,
+        );
+        telemetry.flush().await;
+
+        telemetry_mock.assert_calls_async(1).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- preserve the provider completion timestamp when completion reporting overlaps sandbox finalization
- serialize the captured timestamp after the shared telemetry buffer becomes available
- verify explicit operation timestamps at the telemetry HTTP boundary

## Scope

- does not change completion or finalization ordering
- does not add tasks, HTTP requests, locks, or protocol fields

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (3,107 passed, 20 ignored; additional inventory test passed)
