### PR TITLE
feat: add server-authored mcp connector discovery

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -104,6 +104,7 @@ import { zeroImageShareXRoutes } from "./routes/zero-image-share-x";
 import { zeroLogsRoutes } from "./routes/zero-logs";
 import { zeroMailRoutes } from "./routes/zero-mail";
 import { zeroMapsRoutes } from "./routes/zero-maps";
+import { zeroMcpConnectorsRoutes } from "./routes/zero-mcp-connectors";
 import { zeroWeatherRoutes } from "./routes/zero-weather";
 import { zeroModelPoliciesRoutes } from "./routes/zero-model-policies";
 import { zeroModelProviderGatewayRoutes } from "./routes/zero-model-provider-gateways";
@@ -300,6 +301,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroLogsRoutes,
   ...zeroMailRoutes,
   ...zeroMapsRoutes,
+  ...zeroMcpConnectorsRoutes,
   ...zeroWeatherRoutes,
   ...zeroScrapeRoutes,
   ...zeroPeopleSearchRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mcp-connectors.test.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from "node:crypto";
+
+import type { CreateCustomConnectorBody } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { zeroMcpConnectorsContract } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { mockClerkMembership } from "./helpers/api-bdd-clerk";
+import {
+  createConnectorBddApi,
+  manualHttpCustomConnectorCreateBody,
+} from "./helpers/api-bdd-connectors";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { zeroMcpConnectorsRoutes } from "../zero-mcp-connectors";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const connectors = createConnectorBddApi(context);
+const runs = createRunsApi(context);
+const mocks = createZeroRouteMocks(context);
+
+type McpCreateBody = Extract<
+  CreateCustomConnectorBody,
+  { readonly kind: "mcp" }
+>;
+
+function manualMcpConnectorBody(args: {
+  readonly slug: string;
+  readonly displayName: string;
+  readonly endpoint: string;
+}): McpCreateBody {
+  return {
+    kind: "mcp",
+    slug: args.slug,
+    displayName: args.displayName,
+    endpoint: args.endpoint,
+    transport: "streamable-http",
+    fields: [
+      {
+        key: "secret",
+        label: "API token",
+        kind: "secret",
+        required: true,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+    authMode: "manual",
+  };
+}
+
+function client() {
+  return setupApp({ context, routes: zeroMcpConnectorsRoutes })(
+    zeroMcpConnectorsContract,
+  );
+}
+
+function headers(token: string): { readonly authorization: string } {
+  return { authorization: `Bearer ${token}` };
+}
+
+async function createRunForAgent(actor: ApiTestUser, agentId: string) {
+  return await runs.createDirectRun(actor, {
+    agentComposeId: agentId,
+    prompt: "Discover MCP connectors",
+    modelProviderType: "anthropic-api-key",
+    vars: { ZERO_AGENT_ID: agentId },
+    secrets: { ZERO_TOKEN: "mcp-discovery-zero-token" },
+  });
+}
+
+describe("GET /api/zero/mcp-connectors", () => {
+  it("returns only the current Agent's MCP grants", async () => {
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "MCP Discovery Agent",
+    });
+    const otherAgent = await bdd.createAgent(actor, {
+      displayName: "Other Agent",
+    });
+    const run = await createRunForAgent(actor, agent.agentId);
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const disconnected = await connectors.createCustomConnector(
+      actor,
+      manualMcpConnectorBody({
+        slug: "_alpha-mcp",
+        displayName: "Alpha MCP",
+        endpoint: "https://alpha-mcp.example.test/server",
+      }),
+    );
+    const connected = await connectors.createCustomConnector(
+      actor,
+      manualMcpConnectorBody({
+        slug: "_zulu-mcp",
+        displayName: "Zulu MCP",
+        endpoint: "https://zulu-mcp.example.test/server",
+      }),
+    );
+    await connectors.setCustomConnectorSecret(
+      actor,
+      connected.id,
+      "zulu-secret",
+    );
+    const ungranted = await connectors.createCustomConnector(
+      actor,
+      manualMcpConnectorBody({
+        slug: "_ungranted-mcp",
+        displayName: "Ungranted MCP",
+        endpoint: "https://ungranted-mcp.example.test/server",
+      }),
+    );
+    const otherAgentConnector = await connectors.createCustomConnector(
+      actor,
+      manualMcpConnectorBody({
+        slug: "_other-agent-mcp",
+        displayName: "Other Agent MCP",
+        endpoint: "https://other-agent-mcp.example.test/server",
+      }),
+    );
+    const httpConnector = await connectors.createCustomConnector(
+      actor,
+      manualHttpCustomConnectorCreateBody({
+        slug: "_http-connector",
+        displayName: "HTTP Connector",
+        prefixTemplates: ["https://http-connector.example.test/v1/"],
+      }),
+    );
+    await connectors.updateAgentCustomConnectors(actor, agent.agentId, [
+      disconnected.id,
+      connected.id,
+      httpConnector.id,
+    ]);
+    await connectors.updateAgentCustomConnectors(actor, otherAgent.agentId, [
+      otherAgentConnector.id,
+    ]);
+    mockClerkMembership(context, actor, "org:admin");
+
+    const response = await accept(
+      client().list({
+        headers: headers(
+          runs.zeroTokenForRunWithCapabilities(actor, run.runId, [
+            "connector:read",
+          ]),
+        ),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      connectors: [
+        {
+          id: disconnected.id,
+          slug: "_alpha-mcp",
+          displayName: "Alpha MCP",
+          transport: "streamable-http",
+          endpoint: "https://alpha-mcp.example.test/server",
+          connected: false,
+        },
+        {
+          id: connected.id,
+          slug: "_zulu-mcp",
+          displayName: "Zulu MCP",
+          transport: "streamable-http",
+          endpoint: "https://zulu-mcp.example.test/server",
+          connected: true,
+        },
+      ],
+    });
+    expect(response.body.connectors).not.toContainEqual(
+      expect.objectContaining({ id: ungranted.id }),
+    );
+  });
+
+  it("returns an empty authoritative result when the token run is absent", async () => {
+    const actor = bdd.user();
+    mockClerkMembership(context, actor, "org:admin");
+
+    const response = await accept(
+      client().list({
+        headers: headers(
+          runs.zeroTokenForRunWithCapabilities(actor, randomUUID(), [
+            "connector:read",
+          ]),
+        ),
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ connectors: [] });
+  });
+
+  it("requires Zero authentication with connector read capability", async () => {
+    const actor = bdd.user();
+    mockClerkMembership(context, actor, "org:admin");
+    const runId = randomUUID();
+
+    const unauthenticated = await accept(client().list({ headers: {} }), [401]);
+    const missingCapability = await accept(
+      client().list({
+        headers: headers(
+          runs.zeroTokenForRunWithCapabilities(actor, runId, []),
+        ),
+      }),
+      [403],
+    );
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+    const session = await accept(
+      client().list({ headers: headers("clerk-session") }),
+      [403],
+    );
+
+    expect(unauthenticated.status).toBe(401);
+    expect(missingCapability.status).toBe(403);
+    expect(session.status).toBe(403);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mcp-connectors.test.ts
@@ -186,6 +186,32 @@ describe("GET /api/zero/mcp-connectors", () => {
     expect(response.body.connectors).not.toContainEqual(
       expect.objectContaining({ id: ungranted.id }),
     );
+    const peer = bdd.user({ orgId: actor.orgId });
+    const peerResponse = await accept(
+      client().list({
+        headers: headers(
+          runs.zeroTokenForRunWithCapabilities(peer, run.runId, [
+            "connector:read",
+          ]),
+        ),
+      }),
+      [200],
+    );
+    const foreign = bdd.user();
+    mockClerkMembership(context, foreign, "org:admin");
+    const foreignResponse = await accept(
+      client().list({
+        headers: headers(
+          runs.zeroTokenForRunWithCapabilities(foreign, run.runId, [
+            "connector:read",
+          ]),
+        ),
+      }),
+      [200],
+    );
+
+    expect(peerResponse.body).toStrictEqual({ connectors: [] });
+    expect(foreignResponse.body).toStrictEqual({ connectors: [] });
   });
 
   it("returns an empty authoritative result when the token run is absent", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-mcp-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-mcp-connectors.ts
@@ -1,0 +1,37 @@
+import { computed } from "ccstate";
+import { zeroMcpConnectorsContract } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import type { RouteEntry } from "../route-entry";
+import { zeroRunMcpConnectorList } from "../services/zero-run-mcp-connectors.service";
+
+const listRunMcpConnectorsInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  if (auth.tokenType !== "zero") {
+    throw new Error("Run MCP connector route requires Zero authentication");
+  }
+  const connectors = await get(
+    zeroRunMcpConnectorList({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      runId: auth.runId,
+    }),
+  );
+  return { status: 200 as const, body: { connectors: [...connectors] } };
+});
+
+export const zeroMcpConnectorsRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroMcpConnectorsContract.list,
+    handler: authRoute(
+      {
+        accept: ["zero"],
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "connector:read",
+      },
+      listRunMcpConnectorsInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-run-mcp-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-mcp-connectors.service.ts
@@ -1,0 +1,105 @@
+import { computed, type Computed } from "ccstate";
+import type { ZeroMcpConnector } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
+import {
+  agentRuns,
+  agentSessions,
+} from "@vm0/db/schema/agent-run-session-conversation";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
+import { and, eq } from "drizzle-orm";
+
+import { db$ } from "../external/db";
+import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
+import {
+  customConnectorDefinitionHasUsableConnection,
+  loadCurrentCustomConnectorValueMarkers,
+  loadUsableCustomConnectorConnections,
+} from "./custom-connector-credential-access.service";
+import {
+  normaliseCustomConnectorRow,
+  serialiseCustomConnector,
+} from "./zero-custom-connector.service";
+
+export function zeroRunMcpConnectorList(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId: string;
+}): Computed<Promise<readonly ZeroMcpConnector[]>> {
+  return computed(async (get): Promise<readonly ZeroMcpConnector[]> => {
+    const db = get(db$);
+    const rows = await db
+      .select({ connector: customConnectorDefinitionSelection() })
+      .from(agentRuns)
+      .innerJoin(
+        agentSessions,
+        and(
+          eq(agentSessions.id, agentRuns.sessionId),
+          eq(agentSessions.orgId, args.orgId),
+          eq(agentSessions.userId, args.userId),
+        ),
+      )
+      .innerJoin(
+        userCustomConnectors,
+        and(
+          eq(userCustomConnectors.agentId, agentSessions.agentComposeId),
+          eq(userCustomConnectors.orgId, args.orgId),
+          eq(userCustomConnectors.userId, args.userId),
+        ),
+      )
+      .innerJoin(
+        orgCustomConnectors,
+        and(
+          eq(orgCustomConnectors.id, userCustomConnectors.customConnectorId),
+          eq(orgCustomConnectors.orgId, args.orgId),
+        ),
+      )
+      .where(
+        and(
+          eq(agentRuns.id, args.runId),
+          eq(agentRuns.orgId, args.orgId),
+          eq(agentRuns.userId, args.userId),
+          eq(orgCustomConnectors.enabled, true),
+          eq(orgCustomConnectors.mcpTransport, "streamable-http"),
+        ),
+      )
+      .orderBy(orgCustomConnectors.slug);
+
+    const connectorIds = rows.map(({ connector }) => {
+      return connector.id;
+    });
+    const [valueMarkers, usableConnections] = await Promise.all([
+      loadCurrentCustomConnectorValueMarkers(db, {
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorIds,
+      }),
+      loadUsableCustomConnectorConnections(db, {
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorIds,
+      }),
+    ]);
+
+    return rows.map(({ connector }) => {
+      const response = serialiseCustomConnector({
+        row: normaliseCustomConnectorRow(connector),
+        valueMarkers,
+        usableConnection: customConnectorDefinitionHasUsableConnection({
+          usableConnections,
+          definition: connector,
+        }),
+      });
+      if (response.kind !== "mcp") {
+        throw new Error("Run MCP connector query returned a non-MCP connector");
+      }
+      return {
+        id: response.id,
+        slug: response.slug,
+        displayName: response.displayName,
+        transport: response.transport,
+        endpoint: response.endpoint,
+        connected: response.connected,
+      };
+    });
+  });
+}

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
@@ -4,6 +4,7 @@ import type {
   CustomConnectorMcpResponse,
   CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { ZeroMcpConnector } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 
 export function customConnector(
@@ -87,6 +88,45 @@ export function stubCustomConnectors(
 ) {
   return http.get(`${origin}/api/zero/custom-connectors`, () => {
     return HttpResponse.json({ connectors });
+  });
+}
+
+export function runMcpConnector(
+  overrides: Partial<ZeroMcpConnector> = {},
+): ZeroMcpConnector {
+  return {
+    id: "44444444-4444-4444-8444-444444444444",
+    slug: "_acme-mcp",
+    displayName: "Acme MCP",
+    transport: "streamable-http",
+    endpoint: "https://mcp.example.test/server",
+    connected: true,
+    ...overrides,
+  };
+}
+
+export function stubRunMcpConnectors(
+  connectors: readonly ZeroMcpConnector[],
+  origin = "http://localhost:3000",
+) {
+  return http.get(`${origin}/api/zero/mcp-connectors`, () => {
+    return HttpResponse.json({ connectors });
+  });
+}
+
+export function stubRunMcpConnectorsUnavailable(
+  origin = "http://localhost:3000",
+) {
+  return http.get(`${origin}/api/zero/mcp-connectors`, () => {
+    return HttpResponse.json(
+      {
+        error: {
+          code: "NOT_FOUND",
+          message: "Route not found",
+        },
+      },
+      { status: 404 },
+    );
   });
 }
 

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
@@ -118,15 +118,7 @@ export function stubRunMcpConnectorsUnavailable(
   origin = "http://localhost:3000",
 ) {
   return http.get(`${origin}/api/zero/mcp-connectors`, () => {
-    return HttpResponse.json(
-      {
-        error: {
-          code: "NOT_FOUND",
-          message: "Route not found",
-        },
-      },
-      { status: 404 },
-    );
+    return HttpResponse.json({ error: "Not found" }, { status: 404 });
   });
 }
 

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -24,9 +24,11 @@ import {
 
 import { server } from "../../../../mocks/server";
 import {
-  customConnector,
   mcpCustomConnector,
+  runMcpConnector,
   stubCustomConnectors,
+  stubRunMcpConnectors,
+  stubRunMcpConnectorsUnavailable,
 } from "../../__tests__/helpers/custom-connectors";
 import { zeroMcpCommand } from "../index";
 
@@ -200,9 +202,9 @@ function stubMcpServer(options: McpServerOptions): SeenMcpRequest[] {
 }
 
 function stubConnectorList(
-  overrides: Parameters<typeof mcpCustomConnector>[0] = {},
+  overrides: Parameters<typeof runMcpConnector>[0] = {},
 ): void {
-  server.use(stubCustomConnectors([mcpCustomConnector(overrides)]));
+  server.use(stubRunMcpConnectors([runMcpConnector(overrides)]));
 }
 
 function outputText(spy: ReturnType<typeof vi.spyOn>): string {
@@ -237,28 +239,19 @@ describe("zero mcp command", () => {
     await rm(inputDirectory, { recursive: true, force: true });
   });
 
-  it("lists only admitted MCP definitions in slug order with safe JSON fields", async () => {
+  it("lists server-authorized MCP definitions with safe JSON fields", async () => {
     const secondId = "55555555-5555-4555-8555-555555555555";
-    const httpId = "33333333-3333-4333-8333-333333333333";
-    vi.stubEnv(
-      "ZERO_CUSTOM_CONNECTOR_IDS",
-      JSON.stringify([secondId, CONNECTOR_ID, httpId]),
-    );
+    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "malformed legacy metadata");
     server.use(
-      stubCustomConnectors([
-        mcpCustomConnector({ slug: "_zulu" }),
-        customConnector(),
-        mcpCustomConnector({
+      stubRunMcpConnectors([
+        runMcpConnector({
           id: secondId,
           slug: "_alpha",
           displayName: "Alpha MCP",
           endpoint: "https://alpha-mcp.example.test/server",
           connected: false,
         }),
-        mcpCustomConnector({
-          id: "66666666-6666-4666-8666-666666666666",
-          slug: "_not-admitted",
-        }),
+        runMcpConnector({ slug: "_zulu" }),
       ]),
     );
 
@@ -287,13 +280,24 @@ describe("zero mcp command", () => {
     const output = outputText(consoleLog);
     expect(output).not.toContain("Authorization");
     expect(output).not.toContain("secrets.secret");
-    expect(output).not.toContain(httpId);
   });
 
-  it("rejects malformed run metadata before requesting connector definitions", async () => {
+  it("uses legacy metadata only when the discovery route is unavailable", async () => {
+    server.use(
+      stubRunMcpConnectorsUnavailable(),
+      stubCustomConnectors([mcpCustomConnector()]),
+    );
+
+    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
+
+    expect(outputText(consoleLog)).toContain("_acme-mcp");
+  });
+
+  it("rejects malformed legacy metadata before requesting connector definitions", async () => {
     let apiCalls = 0;
     vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "x".repeat(128 * 1024 + 1));
     server.use(
+      stubRunMcpConnectorsUnavailable(),
       http.get("http://localhost:3000/api/zero/custom-connectors", () => {
         apiCalls++;
         return HttpResponse.json({ connectors: [] });
@@ -314,7 +318,10 @@ describe("zero mcp command", () => {
       "ZERO_CUSTOM_CONNECTOR_IDS",
       JSON.stringify([CONNECTOR_ID, CONNECTOR_ID.toUpperCase()]),
     );
-    server.use(stubCustomConnectors([mcpCustomConnector()]));
+    server.use(
+      stubRunMcpConnectorsUnavailable(),
+      stubCustomConnectors([mcpCustomConnector()]),
+    );
 
     await expect(
       zeroMcpCommand.parseAsync(["node", "zero", "list"]),
@@ -330,6 +337,7 @@ describe("zero mcp command", () => {
     });
     vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", JSON.stringify(ids));
     server.use(
+      stubRunMcpConnectorsUnavailable(),
       stubCustomConnectors([
         mcpCustomConnector({ id: ids[256], slug: "_after-batch" }),
       ]),
@@ -693,13 +701,63 @@ describe("zero mcp command", () => {
     expect(outputText(consoleError)).toContain("MCP server request failed");
   });
 
-  it("treats an empty fixed run set as an ordinary empty result", async () => {
+  it("treats an empty legacy run set as an ordinary empty result", async () => {
     vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "[]");
-    server.use(stubCustomConnectors([mcpCustomConnector()]));
+    server.use(
+      stubRunMcpConnectorsUnavailable(),
+      stubCustomConnectors([mcpCustomConnector()]),
+    );
 
     await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
 
     expect(consoleLog).toHaveBeenCalledWith('{"connectors":[]}');
+  });
+
+  it("does not fall back after a discovery server error", async () => {
+    let legacyCalls = 0;
+    server.use(
+      http.get("http://localhost:3000/api/zero/mcp-connectors", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Discovery failed",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
+        legacyCalls++;
+        return HttpResponse.json({ connectors: [mcpCustomConnector()] });
+      }),
+    );
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(legacyCalls).toBe(0);
+    expect(outputText(consoleError)).toContain("Discovery failed");
+  });
+
+  it("rejects malformed discovery responses without falling back", async () => {
+    let legacyCalls = 0;
+    server.use(
+      http.get("http://localhost:3000/api/zero/mcp-connectors", () => {
+        return HttpResponse.json({ connectors: [{ id: CONNECTOR_ID }] });
+      }),
+      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
+        legacyCalls++;
+        return HttpResponse.json({ connectors: [mcpCustomConnector()] });
+      }),
+    );
+
+    await expect(
+      zeroMcpCommand.parseAsync(["node", "zero", "list"]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(legacyCalls).toBe(0);
   });
 
   it("rejects an unknown slug before opening an MCP connection", async () => {

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -713,6 +713,23 @@ describe("zero mcp command", () => {
     expect(consoleLog).toHaveBeenCalledWith('{"connectors":[]}');
   });
 
+  it("treats an empty discovery response as authoritative", async () => {
+    let legacyCalls = 0;
+    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "malformed legacy metadata");
+    server.use(
+      stubRunMcpConnectors([]),
+      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
+        legacyCalls++;
+        return HttpResponse.json({ connectors: [mcpCustomConnector()] });
+      }),
+    );
+
+    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
+
+    expect(consoleLog).toHaveBeenCalledWith('{"connectors":[]}');
+    expect(legacyCalls).toBe(0);
+  });
+
   it("does not fall back after a discovery server error", async () => {
     let legacyCalls = 0;
     server.use(
@@ -775,7 +792,7 @@ describe("zero mcp command", () => {
 
     expect(seen).toHaveLength(0);
     expect(outputText(consoleError)).toContain(
-      'MCP connector "_not-admitted" is not available in this run',
+      'MCP connector "_not-admitted" is not authorized for this Agent',
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/mcp/client.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/client.ts
@@ -6,7 +6,7 @@ import {
   type JSONObject,
   type Tool,
 } from "@modelcontextprotocol/client";
-import type { CustomConnectorMcpClientResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { ZeroMcpConnector } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
 
 declare const __CLI_VERSION__: string;
 
@@ -179,7 +179,7 @@ function safeMcpError(
 }
 
 async function runMcpOperation<T>(
-  connector: CustomConnectorMcpClientResponse,
+  connector: ZeroMcpConnector,
   timeoutSeconds: number,
   operation: (
     client: Client,
@@ -317,7 +317,7 @@ async function discoverMcpTools(
 }
 
 export async function listMcpTools(
-  connector: CustomConnectorMcpClientResponse,
+  connector: ZeroMcpConnector,
   timeoutSeconds: number,
 ): Promise<McpOperationResult<Tool[]>> {
   return runMcpOperation(
@@ -330,7 +330,7 @@ export async function listMcpTools(
 }
 
 export async function callMcpTool(
-  connector: CustomConnectorMcpClientResponse,
+  connector: ZeroMcpConnector,
   toolName: string,
   input: JSONObject,
   timeoutSeconds: number,

--- a/turbo/apps/cli/src/commands/zero/mcp/index.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/index.ts
@@ -30,7 +30,7 @@ function printCleanupWarning(cleanupWarning: boolean): void {
 
 const listCommand = new Command()
   .name("list")
-  .description("List MCP Custom Connectors admitted to this run")
+  .description("List MCP Custom Connectors authorized for this Agent")
   .option("--json", "Print compact JSON")
   .action(
     withErrorHandler(async (options: JsonOptions) => {
@@ -49,7 +49,9 @@ const listCommand = new Command()
         return;
       }
       if (connectors.length === 0) {
-        console.log(chalk.dim("No MCP connectors are available in this run"));
+        console.log(
+          chalk.dim("No MCP connectors are authorized for this Agent"),
+        );
         return;
       }
 
@@ -86,7 +88,7 @@ const listCommand = new Command()
 
 const listToolsCommand = new Command()
   .name("list-tools")
-  .description("List tools exposed by an admitted MCP connector")
+  .description("List tools exposed by an authorized MCP connector")
   .argument("<connector-slug>", "MCP Custom Connector slug")
   .option("--json", "Print compact JSON")
   .action(
@@ -139,7 +141,7 @@ const inputFileOption = new Option(
 
 const callCommand = new Command()
   .name("call")
-  .description("Call one tool on an admitted MCP connector")
+  .description("Call one tool on an authorized MCP connector")
   .argument("<connector-slug>", "MCP Custom Connector slug")
   .argument("<tool-name>", "Exact MCP tool name")
   .addOption(inputOption)
@@ -172,7 +174,7 @@ const callCommand = new Command()
 
 export const zeroMcpCommand = new Command()
   .name("mcp")
-  .description("Use MCP Custom Connectors admitted to this Agent Run")
+  .description("Use MCP Custom Connectors authorized for this Agent")
   .addCommand(listCommand)
   .addCommand(listToolsCommand)
   .addCommand(callCommand)
@@ -180,13 +182,14 @@ export const zeroMcpCommand = new Command()
     "after",
     `
 Examples:
-  List admitted MCP connectors:  zero mcp list
+  List authorized MCP connectors: zero mcp list
   List connector tools:          zero mcp list-tools _acme-mcp --json
   Call a tool:                   zero mcp call _acme-mcp search --input '{"query":"vm0"}' --json
   Pipe tool input:               printf '{"query":"vm0"}' | zero mcp call _acme-mcp search
 
 Notes:
-  - Available only inside an Agent Run that admitted the connector
+  - Available only inside an Agent Run and scoped to its Agent's current authorization
+  - Runner remains execution authority; authorization changes may require a new Run
   - Runner applies endpoint policy and injects connector credentials
   - Tool calls are never automatically retried`,
   );

--- a/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
@@ -79,7 +79,7 @@ export async function resolveRunMcpConnector(
   });
   if (!connector) {
     throw new Error(
-      `MCP connector "${connectorSlug}" is not available in this run`,
+      `MCP connector "${connectorSlug}" is not authorized for this Agent`,
     );
   }
   return connector;

--- a/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
@@ -2,9 +2,13 @@ import {
   ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY,
   type CustomConnectorMcpClientResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { ZeroMcpConnector } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
 import { z } from "zod";
 
-import { listZeroCustomConnectors } from "../../../lib/api/domains/zero-connectors";
+import {
+  listZeroCustomConnectors,
+  listZeroRunMcpConnectors,
+} from "../../../lib/api/domains/zero-connectors";
 
 const MAX_RUN_CONNECTOR_IDS_BYTES = 128 * 1024;
 const RUN_METADATA_ERROR =
@@ -43,9 +47,14 @@ function readRunConnectorIds(): Set<string> {
   return uniqueIds;
 }
 
-export async function listRunMcpConnectors(): Promise<
-  CustomConnectorMcpClientResponse[]
-> {
+export async function listRunMcpConnectors(): Promise<ZeroMcpConnector[]> {
+  const discoveredConnectors = await listZeroRunMcpConnectors();
+  if (discoveredConnectors !== null) {
+    return discoveredConnectors;
+  }
+
+  // Compatibility fallback for old API deployments. Remove in #26389 after
+  // all supported CLIs observe the server-authored discovery endpoint.
   const admittedIds = readRunConnectorIds();
   const connectors = await listZeroCustomConnectors();
 
@@ -62,7 +71,7 @@ export async function listRunMcpConnectors(): Promise<
 
 export async function resolveRunMcpConnector(
   connectorSlug: string,
-): Promise<CustomConnectorMcpClientResponse> {
+): Promise<ZeroMcpConnector> {
   const connectors = await listRunMcpConnectors();
   const connector = connectors.find((candidate) => {
     return candidate.slug === connectorSlug;

--- a/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
@@ -53,8 +53,9 @@ export async function listRunMcpConnectors(): Promise<ZeroMcpConnector[]> {
     return discoveredConnectors;
   }
 
-  // Compatibility fallback for old API deployments. Remove in #26389 after
-  // all supported CLIs observe the server-authored discovery endpoint.
+  // Commit-addressed CLI ↔ backend rollout fallback: a newly selected CLI can
+  // reach an API deployment that predates this additive route. Remove with
+  // #26389 after its >4-hour queue/run drain and production evidence gate.
   const admittedIds = readRunConnectorIds();
   const connectors = await listZeroCustomConnectors();
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -29,6 +29,11 @@ import {
   type CustomConnectorClientResponse,
   type UpdateCustomConnectorBody,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import {
+  zeroMcpConnectorListResponseSchema,
+  zeroMcpConnectorsContract,
+  type ZeroMcpConnector,
+} from "@vm0/api-contracts/contracts/zero-mcp-connectors";
 import type {
   ConnectorListResponse,
   ConnectorResponse,
@@ -194,6 +199,25 @@ export async function listZeroCustomConnectors(): Promise<
   }
 
   handleError(result, "Failed to list custom connectors");
+}
+
+export async function listZeroRunMcpConnectors(): Promise<
+  ZeroMcpConnector[] | null
+> {
+  const config = await getClientConfig();
+  const client = initClient(zeroMcpConnectorsContract, config);
+
+  const result = await client.list({ headers: {} });
+  if (result.status === 200) {
+    return zeroMcpConnectorListResponseSchema.parse(result.body).connectors;
+  }
+  // This collection has no resource-level 404. A 404 means the API
+  // deployment predates this route and activates the temporary CLI fallback.
+  if (result.status === 404) {
+    return null;
+  }
+
+  handleError(result, "Failed to list MCP connectors for this run");
 }
 
 export async function createZeroCustomConnector(

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -116,7 +116,7 @@ const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
   },
   {
     name: "mcp",
-    description: "Use MCP Custom Connectors admitted to this Agent Run",
+    description: "Use MCP Custom Connectors authorized for this Agent",
     load: async () => {
       return (await import("./commands/zero/mcp")).zeroMcpCommand;
     },

--- a/turbo/packages/api-contracts/src/contracts/zero-mcp-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-mcp-connectors.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { customConnectorMcpClientResponseSchema } from "./zero-custom-connectors";
+
+const c = initContract();
+
+export const zeroMcpConnectorSchema =
+  customConnectorMcpClientResponseSchema.pick({
+    id: true,
+    slug: true,
+    displayName: true,
+    transport: true,
+    endpoint: true,
+    connected: true,
+  });
+export type ZeroMcpConnector = z.infer<typeof zeroMcpConnectorSchema>;
+
+export const zeroMcpConnectorListResponseSchema = z.object({
+  connectors: z.array(zeroMcpConnectorSchema),
+});
+
+export const zeroMcpConnectorsContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/mcp-connectors",
+    headers: authHeadersSchema,
+    responses: {
+      200: zeroMcpConnectorListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List MCP connectors authorized for the current Agent Run",
+  },
+});
+
+export type ZeroMcpConnectorsContract = typeof zeroMcpConnectorsContract;


### PR DESCRIPTION
## Summary

- add a Zero-token-only `GET /api/zero/mcp-connectors` endpoint that derives the current Agent from the authenticated Run and returns only that user's enabled MCP grants
- make `zero mcp` consume the narrow server-authored response directly, including current connector definitions and connection readiness
- preserve mixed-version deployment compatibility by falling back to `ZERO_CUSTOM_CONNECTOR_IDS` plus the legacy org connector list only when the new route returns 404

## Compatibility and scope

- old CLI + new API remains supported because existing run metadata injection and the legacy list route are unchanged
- new CLI + old API remains supported through the exact-404 fallback
- 200 responses, including an empty list, are authoritative; server errors and malformed responses never broaden access through fallback
- CLI copy now describes current Agent authorization accurately; Runner targets, firewall policy, runtime sync, and connector intent remain execution authority
- no schema, migration, or persisted-data changes
- removal of the legacy environment metadata is intentionally deferred to #26389 after deployment drain

## Fallbacks

- `run-connectors.ts:listRunMcpConnectors` — accepts 404 from an API deployment that predates the additive server-authored discovery route, then uses the legacy Run ID metadata and org connector list. Surface: commit-addressed CLI ↔ backend rollout; current source bounds exceed four hours for queue, claimed execution, and finalization drain. Remove after production evidence satisfies the drain gates in #26389.

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/zero-cli lint`
- `pnpm -F @vm0/zero-cli check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F @vm0/zero-cli exec vitest run --maxWorkers=4 --silent=passed-only` (978 passed, 1 skipped)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-mcp-connectors.test.ts --silent=passed-only` (3 passed)

The full local API suite was also attempted. The changed MCP suite passed, while unrelated shared-state chat snapshot tests encountered a persisted sequence mismatch; the independent chat race failure passed when rerun alone. CI will run against its clean test database.

Closes #26387

Parent delivery issue: #26383

Follow-up cleanup: #26389
