### PR TITLE
fix(api): keep chat event cursors consistent on conflicts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3544,7 +3544,7 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     ).toBeFalsy();
   }, 30_000);
 
-  it("keeps repeated at-least-once event batches idempotent", async () => {
+  it("reclaims only unused suffixes from repeated event batches", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const run = await startChatRun(actor, {
       agentId,
@@ -3552,41 +3552,106 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
     });
     const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
 
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      await webhooks.requestAgentEvents(
-        {
-          runId: run.runId,
-          events: [
-            {
-              type: "assistant",
-              sequenceNumber: 0,
-              message: {
-                id: "msg_repeated_event_batch",
-                content: [{ type: "text", text: "Store this output once." }],
-              },
+    const sequenceOne = {
+      type: "assistant" as const,
+      sequenceNumber: 1,
+      message: {
+        id: "msg_repeated_event_batch_1",
+        content: [{ type: "text" as const, text: "Stored sequence one." }],
+      },
+    };
+    const sequenceZero = {
+      type: "assistant" as const,
+      sequenceNumber: 0,
+      message: {
+        id: "msg_repeated_event_batch_0",
+        content: [{ type: "text" as const, text: "Stored sequence zero." }],
+      },
+    };
+    await webhooks.requestAgentEvents(
+      { runId: run.runId, events: [sequenceOne] },
+      sandboxHeaders,
+      [200],
+    );
+    // The existing sequence-one row is the rejected suffix of this batch.
+    await webhooks.requestAgentEvents(
+      { runId: run.runId, events: [sequenceZero, sequenceOne] },
+      sandboxHeaders,
+      [200],
+    );
+    // A fully repeated batch releases its entire reservation.
+    await webhooks.requestAgentEvents(
+      { runId: run.runId, events: [sequenceZero] },
+      sandboxHeaders,
+      [200],
+    );
+    // This time the rejected sequence-one row is an interior gap before a
+    // newly accepted row and must not cause the accepted row to be renumbered.
+    await webhooks.requestAgentEvents(
+      {
+        runId: run.runId,
+        events: [
+          sequenceOne,
+          {
+            type: "assistant",
+            sequenceNumber: 2,
+            message: {
+              id: "msg_repeated_event_batch_2",
+              content: [
+                { type: "text", text: "Stored sequence two after a gap." },
+              ],
             },
-          ],
-        },
-        sandboxHeaders,
-        [200],
-      );
-    }
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
+    await webhooks.requestAgentEvents(
+      {
+        runId: run.runId,
+        events: [
+          {
+            type: "assistant",
+            sequenceNumber: 3,
+            message: {
+              id: "msg_repeated_event_batch_3",
+              content: [{ type: "text", text: "Stored sequence three." }],
+            },
+          },
+        ],
+      },
+      sandboxHeaders,
+      [200],
+    );
     await flushWaitUntilForTest();
 
     const messages = await chat.listThreadEvents(actor, run.threadId);
-    expect(
+    const outputByRunSequence = new Map(
       eventBackedContents(messages.events, run.runId).map((message) => {
-        return {
-          content: message.content,
-          sequenceNumber: message.sequenceNumber,
-        };
+        return [message.sequenceNumber, message] as const;
       }),
-    ).toStrictEqual([
-      {
-        content: "Store this output once.",
-        sequenceNumber: 0,
-      },
-    ]);
+    );
+    expect(
+      [...outputByRunSequence.keys()].sort((left, right) => {
+        return (left ?? 0) - (right ?? 0);
+      }),
+    ).toStrictEqual([0, 1, 2, 3]);
+    const sequenceZeroRow = outputByRunSequence.get(0);
+    const sequenceOneRow = outputByRunSequence.get(1);
+    const sequenceTwoRow = outputByRunSequence.get(2);
+    const sequenceThreeRow = outputByRunSequence.get(3);
+    if (
+      sequenceZeroRow === undefined ||
+      sequenceOneRow === undefined ||
+      sequenceTwoRow === undefined ||
+      sequenceThreeRow === undefined
+    ) {
+      throw new Error("Expected every canonical repeated-batch output");
+    }
+    expect(sequenceZeroRow.seqId).toBe(sequenceOneRow.seqId + 1);
+    expect(sequenceTwoRow.seqId).toBe(sequenceZeroRow.seqId + 2);
+    expect(sequenceThreeRow.seqId).toBe(sequenceTwoRow.seqId + 1);
     expect(firstAssistantEventsForRun(run.runId)).toHaveLength(1);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -9914,6 +9914,38 @@ describe("CHAT-02: shared user message queue", () => {
         return run.prompt === prompt;
       }),
     ).toHaveLength(0);
+
+    const recalledEvent = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === messageId && !message.runId;
+    });
+    if (recalledEvent === undefined) {
+      throw new Error("Expected the winning recall event");
+    }
+    const probeEventId = randomUUID();
+    const probe = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: "append after the lost queue claim",
+        clientEventId: probeEventId,
+      },
+      [201],
+    );
+    if (probe.status !== 201) {
+      throw new Error("Expected the post-race probe event to be accepted");
+    }
+    const afterProbe = await chat.listThreadEvents(actor, anchor.threadId);
+    const probeEvent = userMessages(afterProbe.events).find((message) => {
+      return message.id === probeEventId;
+    });
+    if (probeEvent === undefined) {
+      throw new Error("Expected the post-race probe event");
+    }
+    expect(probeEvent.seqId).toBe(recalledEvent.seqId + 1);
+    if (probe.body.runId !== null) {
+      await cancelChatRun(actor, probe.body.runId);
+    }
   }, 90_000);
 
   it("does not publish a queued auto-send after thread deletion wins", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -23,6 +23,7 @@ import {
   type RecordedChatEventPut,
 } from "./helpers/fake-chat-event-r2";
 import {
+  advanceChatEventSequenceAsPreviousApi,
   readChatEventSnapshotHead,
   setChatEventSnapshotHeadVersion,
 } from "./helpers/runtime-state";
@@ -128,6 +129,7 @@ function archivedLines(body: Buffer): readonly ArchivedLine[] {
 function expectArchiveInvariants(
   put: RecordedPut,
   threadId: string,
+  lastPhysicalSeqId?: number,
 ): readonly ArchivedLine[] {
   const match = OBJECT_KEY_PATTERN.exec(put.key);
   expect(match?.[1]).toBe(threadId);
@@ -139,7 +141,7 @@ function expectArchiveInvariants(
   const lines = archivedLines(put.body);
   expect(lines.length).toBeGreaterThan(0);
   const lastLine = lines[lines.length - 1];
-  expect(String(lastLine?.seqId)).toBe(match?.[2]);
+  expect(lastLine?.seqId).toBe(lastPhysicalSeqId ?? Number(match?.[2]));
   for (const [index, line] of lines.entries()) {
     expect(Object.keys(line).sort()).toStrictEqual(ARCHIVE_V4_KEYS);
     expect(line.chatThreadId).toBe(threadId);
@@ -251,6 +253,54 @@ describe("cron snapshot chat events", () => {
 
     await runSnapshotCron();
     expect(putsForThread(threadId)).toHaveLength(2);
+  }, 60_000);
+
+  it("publishes sparse indexed coverage and tails later rows", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Sparse snapshot agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `sparse-snapshot-${randomUUID()}`,
+    });
+    const initialRows = await chat.listThreadEventRows(owner, threadId);
+    const lastPhysicalRow = initialRows.at(-1);
+    if (lastPhysicalRow === undefined) {
+      throw new Error("Expected a physical chat event before the sparse tail");
+    }
+    const coveredSeqId = lastPhysicalRow.seqId + 1;
+
+    await advanceChatEventSequenceAsPreviousApi(context, threadId, 1);
+    await projectChatEventSearch();
+    const result = await runSnapshotCron();
+    expect(result.success).toBeTruthy();
+
+    const put = putsForThread(threadId)[0];
+    if (put === undefined) {
+      throw new Error("Expected a sparse-coverage snapshot object");
+    }
+    expectArchiveInvariants(put, threadId, lastPhysicalRow.seqId);
+    expect(OBJECT_KEY_PATTERN.exec(put.key)?.[2]).toBe(coveredSeqId.toString());
+    const head = await readChatEventSnapshotHead(context, threadId);
+    expect(head.last_seq_id).toBe(coveredSeqId);
+
+    await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      threadId,
+      prompt: `sparse-snapshot-tail-${randomUUID()}`,
+    });
+    const tail = await chat.listThreadEventRows(owner, threadId, coveredSeqId);
+    expect(tail.length).toBeGreaterThan(0);
+    expect(
+      tail.map((row) => {
+        return row.seqId;
+      }),
+    ).toStrictEqual(
+      tail.map((_, index) => {
+        return coveredSeqId + index + 1;
+      }),
+    );
   }, 60_000);
 
   it("rebuilds an idle retained v3 head and reports convergence", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -435,6 +435,18 @@ export async function setChatEventSnapshotHeadVersion(
   });
 }
 
+export async function advanceChatEventSequenceAsPreviousApi(
+  context: TestContext,
+  threadId: string,
+  count: number,
+): Promise<void> {
+  await postAction(context, {
+    action: "advance-chat-event-sequence-as-previous-api",
+    thread_id: threadId,
+    count,
+  });
+}
+
 export async function readChatEventSnapshotHead(
   context: TestContext,
   threadId: string,

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -1330,29 +1330,47 @@ async function customConnectorAuthTemplateFixtureActionResponse(
   return { status: 200 as const, body: { ok: true as const } };
 }
 
-type ChatEventSnapshotFixtureAction = Extract<
+type ChatEventFixtureAction = Extract<
   TestRuntimeStateActionBody,
   {
     action:
+      | "advance-chat-event-sequence-as-previous-api"
       | "read-chat-event-snapshot-head"
       | "set-chat-event-snapshot-head-version";
   }
 >;
 
-function isChatEventSnapshotFixtureAction(
+function isChatEventFixtureAction(
   body: TestRuntimeStateActionBody,
-): body is ChatEventSnapshotFixtureAction {
+): body is ChatEventFixtureAction {
   return (
+    body.action === "advance-chat-event-sequence-as-previous-api" ||
     body.action === "read-chat-event-snapshot-head" ||
     body.action === "set-chat-event-snapshot-head-version"
   );
 }
 
-async function chatEventSnapshotFixtureActionResponse(
+async function chatEventFixtureActionResponse(
   db: Db,
-  body: ChatEventSnapshotFixtureAction,
+  body: ChatEventFixtureAction,
   signal: AbortSignal,
 ) {
+  if (body.action === "advance-chat-event-sequence-as-previous-api") {
+    const [updated] = await db
+      .update(chatThreads)
+      .set({
+        lastChatEventSeqId: sql`${chatThreads.lastChatEventSeqId} + ${body.count}`,
+      })
+      .where(eq(chatThreads.id, body.thread_id))
+      .returning({ id: chatThreads.id });
+    signal.throwIfAborted();
+    if (!updated) {
+      throw new Error(
+        "advance-chat-event-sequence-as-previous-api missing thread",
+      );
+    }
+    return { status: 200 as const, body: { ok: true as const } };
+  }
   if (body.action === "set-chat-event-snapshot-head-version") {
     const updated = await db
       .update(chatEventSnapshots)
@@ -1504,8 +1522,8 @@ const postRuntimeStateAction$ = command(
     if (isThreadSessionStateAction(body)) {
       return await threadSessionStateActionResponse(db, body, signal);
     }
-    if (isChatEventSnapshotFixtureAction(body)) {
-      return await chatEventSnapshotFixtureActionResponse(db, body, signal);
+    if (isChatEventFixtureAction(body)) {
+      return await chatEventFixtureActionResponse(db, body, signal);
     }
     if (isCompatibilityFixtureAction(body)) {
       return await compatibilityFixtureActionResponse(db, body, signal);

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -249,12 +249,12 @@ async function readCanonicalEvents(
       cursor = lastRow.seqId;
     }
     if (rows.length < EVENT_PAGE_SIZE) {
-      if (count === 0 || cursor !== candidate.indexedSeqId) {
+      if (count === 0) {
         throw new Error(
-          `chat event snapshot rebuild for ${candidate.chatThreadId} ended at ${cursor.toString()} instead of indexed seq ${candidate.indexedSeqId.toString()}`,
+          `chat event snapshot rebuild for ${candidate.chatThreadId} contained no events through indexed seq ${candidate.indexedSeqId.toString()}`,
         );
       }
-      return { lines, count, lastSeqId: cursor };
+      return { lines, count, lastSeqId: candidate.indexedSeqId };
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -1129,14 +1129,19 @@ async function reserveChatEventSeqIds(
   return thread.lastSeqId - count + 1;
 }
 
-async function releaseChatEventSeqId(
+async function releaseChatEventSeqIds(
   tx: ChatEventWriteTransaction,
   chatThreadId: string,
+  count: number,
 ): Promise<void> {
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error("chat event seq_id release count must be positive");
+  }
+
   const [thread] = await tx
     .update(chatThreads)
     .set({
-      lastChatEventSeqId: sql`${chatThreads.lastChatEventSeqId} - 1`,
+      lastChatEventSeqId: sql`${chatThreads.lastChatEventSeqId} - ${count}`,
     })
     .where(eq(chatThreads.id, chatThreadId))
     .returning({ id: chatThreads.id });
@@ -1232,7 +1237,7 @@ export async function insertChatEvent(
   if (rows.length === 0) {
     // A rejected idempotent write is not part of the canonical stream, so it
     // must not consume the thread's next cursor.
-    await releaseChatEventSeqId(tx, values.chatThreadId);
+    await releaseChatEventSeqIds(tx, values.chatThreadId, 1);
   } else {
     const inserted = rows[0];
     if (!inserted) {
@@ -1268,16 +1273,63 @@ export async function insertChatEvents(
   const insertTable = payloadSchemaAvailable
     ? chatEvents
     : chatEventsBeforePayload;
-  return await tx
+  const rows = await tx
     .insert(insertTable)
     .values([...valuesWithSeqIds])
     .onConflictDoNothing()
     .returning({
       id: insertTable.id,
+      chatThreadId: insertTable.chatThreadId,
       createdAt: insertTable.createdAt,
       seqId: insertTable.seqId,
       sequenceNumber: insertTable.runEventSequenceNumber,
     });
+
+  const reservedRangeByThread = new Map<
+    string,
+    { readonly firstSeqId: number; lastSeqId: number }
+  >();
+  for (const value of valuesWithSeqIds) {
+    const range = reservedRangeByThread.get(value.chatThreadId);
+    if (range === undefined) {
+      reservedRangeByThread.set(value.chatThreadId, {
+        firstSeqId: value.seqId,
+        lastSeqId: value.seqId,
+      });
+    } else {
+      range.lastSeqId = value.seqId;
+    }
+  }
+
+  const acceptedLastSeqIdByThread = new Map<string, number>();
+  for (const row of rows) {
+    const acceptedLastSeqId = acceptedLastSeqIdByThread.get(row.chatThreadId);
+    if (acceptedLastSeqId === undefined || row.seqId > acceptedLastSeqId) {
+      acceptedLastSeqIdByThread.set(row.chatThreadId, row.seqId);
+    }
+  }
+
+  for (const [chatThreadId, range] of [...reservedRangeByThread].sort(
+    ([left], [right]) => {
+      return left.localeCompare(right);
+    },
+  )) {
+    const acceptedLastSeqId =
+      acceptedLastSeqIdByThread.get(chatThreadId) ?? range.firstSeqId - 1;
+    const unusedSuffixCount = range.lastSeqId - acceptedLastSeqId;
+    if (unusedSuffixCount > 0) {
+      await releaseChatEventSeqIds(tx, chatThreadId, unusedSuffixCount);
+    }
+  }
+
+  return rows.map((row) => {
+    return {
+      id: row.id,
+      createdAt: row.createdAt,
+      seqId: row.seqId,
+      sequenceNumber: row.sequenceNumber,
+    };
+  });
 }
 
 /** Append a replacement event after validating its immutable revoke edge. */
@@ -1361,6 +1413,7 @@ export async function replaceLoadedChatEvent(
     });
   const inserted = rows[0];
   if (!inserted) {
+    await releaseChatEventSeqIds(tx, replacement.chatThreadId, 1);
     return null;
   }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event.service.ts
@@ -1285,40 +1285,42 @@ export async function insertChatEvents(
       sequenceNumber: insertTable.runEventSequenceNumber,
     });
 
-  const reservedRangeByThread = new Map<
-    string,
-    { readonly firstSeqId: number; lastSeqId: number }
-  >();
-  for (const value of valuesWithSeqIds) {
-    const range = reservedRangeByThread.get(value.chatThreadId);
-    if (range === undefined) {
-      reservedRangeByThread.set(value.chatThreadId, {
-        firstSeqId: value.seqId,
-        lastSeqId: value.seqId,
-      });
-    } else {
-      range.lastSeqId = value.seqId;
+  if (rows.length < valuesWithSeqIds.length) {
+    const reservedRangeByThread = new Map<
+      string,
+      { readonly firstSeqId: number; lastSeqId: number }
+    >();
+    for (const value of valuesWithSeqIds) {
+      const range = reservedRangeByThread.get(value.chatThreadId);
+      if (range === undefined) {
+        reservedRangeByThread.set(value.chatThreadId, {
+          firstSeqId: value.seqId,
+          lastSeqId: value.seqId,
+        });
+      } else {
+        range.lastSeqId = value.seqId;
+      }
     }
-  }
 
-  const acceptedLastSeqIdByThread = new Map<string, number>();
-  for (const row of rows) {
-    const acceptedLastSeqId = acceptedLastSeqIdByThread.get(row.chatThreadId);
-    if (acceptedLastSeqId === undefined || row.seqId > acceptedLastSeqId) {
-      acceptedLastSeqIdByThread.set(row.chatThreadId, row.seqId);
+    const acceptedLastSeqIdByThread = new Map<string, number>();
+    for (const row of rows) {
+      const acceptedLastSeqId = acceptedLastSeqIdByThread.get(row.chatThreadId);
+      if (acceptedLastSeqId === undefined || row.seqId > acceptedLastSeqId) {
+        acceptedLastSeqIdByThread.set(row.chatThreadId, row.seqId);
+      }
     }
-  }
 
-  for (const [chatThreadId, range] of [...reservedRangeByThread].sort(
-    ([left], [right]) => {
-      return left.localeCompare(right);
-    },
-  )) {
-    const acceptedLastSeqId =
-      acceptedLastSeqIdByThread.get(chatThreadId) ?? range.firstSeqId - 1;
-    const unusedSuffixCount = range.lastSeqId - acceptedLastSeqId;
-    if (unusedSuffixCount > 0) {
-      await releaseChatEventSeqIds(tx, chatThreadId, unusedSuffixCount);
+    for (const [chatThreadId, range] of [...reservedRangeByThread].sort(
+      ([left], [right]) => {
+        return left.localeCompare(right);
+      },
+    )) {
+      const acceptedLastSeqId =
+        acceptedLastSeqIdByThread.get(chatThreadId) ?? range.firstSeqId - 1;
+      const unusedSuffixCount = range.lastSeqId - acceptedLastSeqId;
+      if (unusedSuffixCount > 0) {
+        await releaseChatEventSeqIds(tx, chatThreadId, unusedSuffixCount);
+      }
     }
   }
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
@@ -154,19 +154,19 @@ describe("chat event snapshot read", () => {
     clearMockedAuth();
   });
 
-  it("cold-starts from the snapshot object and tails the rows endpoint", async () => {
+  it("tails from snapshot coverage beyond the final archive row", async () => {
     mockSignedInUser();
     enableSnapshotRead();
     rejectLegacyEventsEndpoint();
-    const { threadId, promptEventRow, assistantEventRow, tailEventRow } =
-      threadFixture();
+    const { threadId, promptEventRow, assistantEventRow } = threadFixture();
+    const tailEventRow = canonicalChatEventRow(baseRow(threadId, 4));
     const appDb = await context.store.get(chatIdb$);
 
     context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
       return respond(200, {
         url: SNAPSHOT_URL,
         expiresInSeconds: 900,
-        lastSeqId: 2,
+        lastSeqId: 3,
       });
     });
     context.mocks.http.get(SNAPSHOT_URL, () => {
@@ -175,7 +175,7 @@ describe("chat event snapshot read", () => {
     const rowRequests: number[] = [];
     context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
       rowRequests.push(query.sinceSeqId);
-      if (query.sinceSeqId === 2) {
+      if (query.sinceSeqId === 3) {
         return respond(200, { rows: [tailEventRow] });
       }
       return respond(200, { rows: [] });
@@ -203,7 +203,7 @@ describe("chat event snapshot read", () => {
       ).toStrictEqual([
         { id: promptEventRow.id, seqId: 1, eventType: "input.prompt" },
         { id: assistantEventRow.id, seqId: 2, eventType: "output.message" },
-        { id: tailEventRow.id, seqId: 3, eventType: "output.message" },
+        { id: tailEventRow.id, seqId: 4, eventType: "output.message" },
       ]);
       const prompt = events[0];
       if (prompt?.eventType !== "input.prompt") {
@@ -217,7 +217,7 @@ describe("chat event snapshot read", () => {
       expect(
         context.store.get(signals.initialRemoteEventsResolved$),
       ).toBeTruthy();
-      expect(rowRequests).toStrictEqual([2]);
+      expect(rowRequests).toStrictEqual([3]);
 
       await expect(
         appDb.get(CHAT_EVENT_ROWS_STORE, tailEventRow.id),

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -121,6 +121,11 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     thread_id: z.uuid(),
   }),
   z.object({
+    action: z.literal("advance-chat-event-sequence-as-previous-api"),
+    thread_id: z.uuid(),
+    count: z.int().positive(),
+  }),
+  z.object({
     action: z.literal("set-chat-event-snapshot-head-version"),
     thread_id: z.uuid(),
     archive_schema_version: z.int().positive(),


### PR DESCRIPTION
## Summary

- reclaim only the unused suffix of reserved chat event sequence IDs after idempotent batch conflicts
- release a losing replacement claim without renumbering already accepted events
- publish snapshots at their indexed coverage cursor when historical or valid interior sequence gaps leave the final archive row behind that cursor
- cover repeated batches, replacement races, sparse snapshot coverage, and client tailing through integration tests

## Scope

- preserves the existing bulk insert path and adds no database round trip for conflict-free batches
- skips suffix analysis entirely when every submitted row is accepted
- preserves interior sequence gaps because accepted rows are immutable
- does not change the database schema, migrate persisted data, or change a public API

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm knip --workspace api --workspace @vm0/app --workspace @vm0/api-contracts`
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (187 files, 2,898 tests)
- `pnpm -F @vm0/api-contracts test` (27 files, 567 tests)
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts` (7 tests)
- post-rebase focused API regressions (3 tests across the repeated-batch, replacement-race, and sparse-snapshot suites)
- post-self-review API lint, API type checks, Knip, and the repeated-batch regression

Closes #26358
