### PR TITLE
feat(runner): log model usage source admission

### DIFF
--- a/crates/runner/mitm-addon/src/terminal_usage.py
+++ b/crates/runner/mitm-addon/src/terminal_usage.py
@@ -37,9 +37,30 @@ def report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
     """Avoid duplicate usage webhook enqueue if response/error both fire."""
     if flow.metadata.get(_MODEL_PROVIDER_USAGE_REPORTED, False):
         return
-    reported_usage = usage.report_model_provider_usage(flow, run_id)
-    reported_observation = usage.report_model_provider_usage_observation(flow, run_id)
+    accepted_usage_keys: set[str] = set()
+    accepted_observation_keys: set[str] = set()
+    reported_usage = usage.report_model_provider_usage(
+        flow,
+        run_id,
+        accepted_source_keys=accepted_usage_keys,
+    )
+    reported_observation = usage.report_model_provider_usage_observation(
+        flow,
+        run_id,
+        accepted_source_keys=accepted_observation_keys,
+    )
     if reported_usage or reported_observation:
+        usage.log_terminal_model_provider_usage_sources(
+            flow,
+            run_id,
+            include_usage_events=reported_usage,
+            include_observations=reported_observation,
+            accepted_usage_keys=accepted_usage_keys,
+            accepted_observation_keys=accepted_observation_keys,
+            transport=(
+                "websocket" if response_streaming.is_model_websocket_usage_enabled(flow) else "http"
+            ),
+        )
         flow.metadata[_MODEL_PROVIDER_USAGE_REPORTED] = True
 
 

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -78,6 +78,7 @@ from .providers.connectors import (
 from .providers.model_provider import (
     has_positive_model_provider_usage,
     is_model_provider_usage_observable,
+    log_terminal_model_provider_usage_sources,
     release_model_provider_usage_tiers,
     report_model_provider_usage,
     report_model_provider_usage_observation,
@@ -115,6 +116,7 @@ __all__ = [
     "inspect_openai_responses_event_json",
     "inspect_openai_responses_event_type_json",
     "is_model_provider_usage_observable",
+    "log_terminal_model_provider_usage_sources",
     "merge_openai_responses_usage_result",
     "needs_connector_response_buffer_fallback",
     "read_usage_flush_request_id",

--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -83,12 +83,15 @@ def buffer_usage_events(
     run_id: str,
     events: Iterable[UsageEvent],
     proxy_log_path: str,
+    *,
+    accepted_source_keys: set[str] | None = None,
 ) -> int:
     """Buffer source events on the singleton and return the accepted count.
 
     Source idempotency-key duplicates are dropped before aggregation, so the
     accepted count can be smaller than the number of input events. A threshold
-    flush may be enqueued before this returns.
+    flush may be enqueued before this returns. When provided, the caller-owned
+    set accumulates the source payload keys accepted by this call.
     """
     return _usage_event_buffer.buffer_usage_events(
         url,
@@ -96,6 +99,7 @@ def buffer_usage_events(
         run_id,
         events,
         proxy_log_path,
+        accepted_source_keys=accepted_source_keys,
     )
 
 
@@ -105,14 +109,17 @@ def buffer_model_usage_observations(
     run_id: str,
     observations: Iterable[ModelUsageObservation],
     proxy_log_path: str,
+    *,
+    accepted_source_keys: set[str] | None = None,
 ) -> int:
-    """Buffer model usage observations with the observation webhook shape."""
+    """Buffer observations and optionally collect accepted source payload keys."""
     return _usage_event_buffer.buffer_model_usage_observations(
         url,
         sandbox_token,
         run_id,
         observations,
         proxy_log_path,
+        accepted_source_keys=accepted_source_keys,
     )
 
 
@@ -124,12 +131,14 @@ def buffer_source_usage_events(
     proxy_log_path: str,
     *,
     atomic_source_key: str | None = None,
+    accepted_source_keys: set[str] | None = None,
 ) -> int:
     """Buffer source events without replacing their idempotency keys.
 
     When ``atomic_source_key`` is provided, the batch is admitted only when the
     group key and every member event key are new to the bounded source-key set.
-    The internal group key is not included in the webhook payload.
+    The internal group key is not included in the webhook payload or accepted
+    source-key collector.
     """
     return _usage_event_buffer.buffer_usage_events(
         url,
@@ -139,6 +148,7 @@ def buffer_source_usage_events(
         proxy_log_path,
         preserve_source_idempotency=True,
         atomic_source_key=atomic_source_key,
+        accepted_source_keys=accepted_source_keys,
     )
 
 
@@ -148,8 +158,10 @@ def buffer_source_model_usage_observations(
     run_id: str,
     observations: Iterable[ModelUsageObservation],
     proxy_log_path: str,
+    *,
+    accepted_source_keys: set[str] | None = None,
 ) -> int:
-    """Buffer compact source observations without replacing their identities."""
+    """Buffer source observations and optionally collect accepted payload keys."""
     return _usage_event_buffer.buffer_model_usage_observations(
         url,
         sandbox_token,
@@ -157,6 +169,7 @@ def buffer_source_model_usage_observations(
         observations,
         proxy_log_path,
         preserve_source_idempotency=True,
+        accepted_source_keys=accepted_source_keys,
     )
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -118,8 +118,9 @@ class UsageEventBuffer:
         log_type: str = "usage_event",
         preserve_source_idempotency: bool = False,
         atomic_source_key: str | None = None,
+        accepted_source_keys: set[str] | None = None,
     ) -> int:
-        """Add source usage events and flush if the buffer exceeds a bound."""
+        """Add source events, collect accepted keys when requested, and maybe flush."""
         flush_now = False
         timer_to_start: _TimerHandle | None = None
         with self._lock:
@@ -134,6 +135,7 @@ class UsageEventBuffer:
                 log_type=log_type,
                 preserve_source_idempotency=preserve_source_idempotency,
                 atomic_source_key=atomic_source_key,
+                accepted_source_keys=accepted_source_keys,
             )
             if accepted_count == 0:
                 timer_to_start = self._schedule_timer_if_buffered_locked()
@@ -158,8 +160,9 @@ class UsageEventBuffer:
         proxy_log_path: str,
         *,
         preserve_source_idempotency: bool = False,
+        accepted_source_keys: set[str] | None = None,
     ) -> int:
-        """Add compact model observations and flush if a bound is exceeded."""
+        """Add observations, collect accepted keys when requested, and maybe flush."""
         flush_now = False
         timer_to_start: _TimerHandle | None = None
         with self._lock:
@@ -170,6 +173,7 @@ class UsageEventBuffer:
                 observations,
                 proxy_log_path,
                 preserve_source_idempotency=preserve_source_idempotency,
+                accepted_source_keys=accepted_source_keys,
             )
             if accepted_count == 0:
                 timer_to_start = self._schedule_timer_if_buffered_locked()

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -163,6 +163,7 @@ class _UsageBufferState:
         log_type: str,
         preserve_source_idempotency: bool,
         atomic_source_key: str | None,
+        accepted_source_keys: set[str] | None,
     ) -> int:
         if atomic_source_key is not None:
             events = tuple(events)
@@ -208,6 +209,8 @@ class _UsageBufferState:
                 bucket.source_event_count += 1
             self._source_event_count += 1
             accepted_count += 1
+            if accepted_source_keys is not None:
+                accepted_source_keys.add(source_key)
         # Insert the admission key after its member keys so its bounded
         # insertion-order lifetime covers the entire group.
         if atomic_source_key is not None and accepted_count > 0:
@@ -224,6 +227,7 @@ class _UsageBufferState:
         proxy_log_path: str,
         *,
         preserve_source_idempotency: bool,
+        accepted_source_keys: set[str] | None,
     ) -> int:
         destination = _DestinationKey(
             url,
@@ -265,6 +269,8 @@ class _UsageBufferState:
                 bucket.source_event_count += 1
             self._source_event_count += 1
             accepted_count += 1
+            if accepted_source_keys is not None:
+                accepted_source_keys.add(source_key)
         self._evict_source_keys()
         return accepted_count
 

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -30,7 +30,7 @@ from mitmproxy import http
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 from generated.model_usage import MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS
-from logging_utils import log_proxy_entry
+from logging_utils import log_proxy_entry, project_url_for_proxy_log
 
 from ..buffer import (
     ModelUsageObservation,
@@ -57,6 +57,8 @@ from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
 type _ModelUsageTier = Literal["base", "long_context"]
+type _ModelUsageTransport = Literal["http", "websocket"]
+type _ModelUsageBufferMode = Literal["aggregate", "source"]
 _MODEL_USAGE_TIER_BASE: _ModelUsageTier = "base"
 _MODEL_USAGE_TIER_LONG_CONTEXT: _ModelUsageTier = "long_context"
 _MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT = "tokens.input.long_context"
@@ -71,6 +73,13 @@ class _ModelUsageTierDecision:
     tier: _ModelUsageTier
     fast: bool
     committed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _ModelProviderUsageSource:
+    source_id: str
+    provider_response_id: str | None
+    usage: dict
 
 
 _MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE = {
@@ -117,7 +126,12 @@ def has_positive_model_provider_usage(source_usage: dict) -> bool:
     return any(_is_positive_int(source_usage.get(category)) for category in MODEL_USAGE_CATEGORIES)
 
 
-def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
+def report_model_provider_usage(
+    flow: http.HTTPFlow,
+    run_id: str,
+    *,
+    accepted_source_keys: set[str] | None = None,
+) -> bool:
     """Buffer billable token usage for model-provider responses if available.
 
     Accepted reporting requires all universal gates to pass:
@@ -130,9 +144,11 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
       quantity.
     - ``vm_sandbox_token`` and ``get_api_url()`` are both non-empty.
 
-    Returns whether usage was accepted into the reporting path. All failed
-    gates are silent by design except missing sandbox token or API URL, which
-    writes an underbilling signal because billable usage cannot be reported.
+    Returns whether usage was accepted into the reporting path. When provided,
+    the caller-owned set accumulates source payload keys accepted by the
+    process-local buffer. All failed gates are silent by design except missing
+    sandbox token or API URL, which writes an underbilling signal because
+    billable usage cannot be reported.
     """
     if not run_id:
         return False
@@ -148,10 +164,21 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     )
     if not events:
         return False
-    return _buffer_model_provider_usage_events(flow, run_id, firewall_name, events)
+    return _buffer_model_provider_usage_events(
+        flow,
+        run_id,
+        firewall_name,
+        events,
+        accepted_source_keys=accepted_source_keys,
+    )
 
 
-def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) -> bool:
+def report_model_provider_usage_observation(
+    flow: http.HTTPFlow,
+    run_id: str,
+    *,
+    accepted_source_keys: set[str] | None = None,
+) -> bool:
     """Buffer model usage statistics for observable model-provider responses.
 
     Observations are sent to
@@ -170,9 +197,10 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
 
     Non-billable BYOK model-provider flows with ``MODEL_USAGE_PROVIDER`` are
     expected to report observations without reporting billable usage events.
-    All failed gates are silent by design except missing sandbox token or API
-    URL, which writes a proxy warning because that indicates an
-    environment/reporting setup problem.
+    When provided, the caller-owned set accumulates source payload keys
+    accepted by the process-local buffer. All failed gates are silent by design
+    except missing sandbox token or API URL, which writes a proxy warning
+    because that indicates an environment/reporting setup problem.
     """
     if not run_id:
         return False
@@ -181,7 +209,12 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
     observations = _build_model_provider_usage_observations(flow, run_id)
     if not observations:
         return False
-    return _buffer_model_provider_usage_observations(flow, run_id, observations)
+    return _buffer_model_provider_usage_observations(
+        flow,
+        run_id,
+        observations,
+        accepted_source_keys=accepted_source_keys,
+    )
 
 
 def report_model_provider_usage_source(
@@ -252,18 +285,84 @@ def report_model_provider_usage_source(
             _log_model_usage_observation_context_missing(context)
         return
 
+    accepted_usage_keys: set[str] = set()
+    accepted_observation_keys: set[str] = set()
     if usage_events:
         _buffer_source_model_provider_usage_events(
             context,
             run_id,
             source_id,
             usage_events,
+            accepted_source_keys=accepted_usage_keys,
         )
     if observations:
         _buffer_source_model_provider_usage_observations(
             context,
             run_id,
             observations,
+            accepted_source_keys=accepted_observation_keys,
+        )
+    _log_model_provider_usage_source(
+        flow,
+        run_id,
+        _ModelProviderUsageSource(source_id, message_id, source_usage),
+        provider,
+        usage_events,
+        observations,
+        accepted_usage_keys=accepted_usage_keys,
+        accepted_observation_keys=accepted_observation_keys,
+        transport="websocket",
+        buffer_mode="source",
+    )
+
+
+def log_terminal_model_provider_usage_sources(
+    flow: http.HTTPFlow,
+    run_id: str,
+    *,
+    include_usage_events: bool,
+    include_observations: bool,
+    accepted_usage_keys: set[str],
+    accepted_observation_keys: set[str],
+    transport: _ModelUsageTransport,
+) -> None:
+    """Log aggregate-buffer admission for terminal model usage sources."""
+    for source in _iter_model_provider_usage_sources(flow):
+        provider = _reported_model(flow, source.usage)
+        usage_events: list[UsageEvent] = []
+        if include_usage_events:
+            billing_tier = _model_usage_tier(provider, source.usage)
+            if billing_tier is not None:
+                usage_events = _build_usage_events(
+                    run_id,
+                    source.source_id,
+                    provider,
+                    source.usage,
+                    USAGE_EVENT_NAMESPACE_MODEL,
+                    billing_tier,
+                    _is_fast_service_tier(source.usage),
+                )
+        observations = (
+            _build_model_usage_observations(
+                run_id,
+                source.source_id,
+                provider,
+                source.usage,
+            )
+            if include_observations
+            else []
+        )
+        _log_model_provider_usage_source(
+            flow,
+            run_id,
+            source,
+            provider,
+            usage_events,
+            observations,
+            accepted_usage_keys=accepted_usage_keys,
+            accepted_observation_keys=accepted_observation_keys,
+            transport=transport,
+            buffer_mode="aggregate",
         )
 
 
@@ -277,6 +376,8 @@ def _buffer_model_provider_usage_events(
     run_id: str,
     firewall_name: str,
     events: list[UsageEvent],
+    *,
+    accepted_source_keys: set[str] | None,
 ) -> bool:
     context = usage_reporting_context(flow)
     if not context.is_complete:
@@ -288,6 +389,7 @@ def _buffer_model_provider_usage_events(
         run_id,
         events,
         context.proxy_log_path,
+        accepted_source_keys=accepted_source_keys,
     )
     return True
 
@@ -296,6 +398,8 @@ def _buffer_model_provider_usage_observations(
     flow: http.HTTPFlow,
     run_id: str,
     observations: list[ModelUsageObservation],
+    *,
+    accepted_source_keys: set[str] | None,
 ) -> bool:
     context = usage_reporting_context(flow)
     if not context.is_complete:
@@ -307,6 +411,7 @@ def _buffer_model_provider_usage_observations(
         run_id,
         observations,
         context.proxy_log_path,
+        accepted_source_keys=accepted_source_keys,
     )
     return True
 
@@ -316,6 +421,8 @@ def _buffer_source_model_provider_usage_events(
     run_id: str,
     source_id: str,
     events: list[UsageEvent],
+    *,
+    accepted_source_keys: set[str],
 ) -> None:
     input_partition_events, independent_events = _split_model_input_partition_events(events)
     if input_partition_events:
@@ -330,6 +437,7 @@ def _buffer_source_model_provider_usage_events(
                 run_id,
                 source_id,
             ),
+            accepted_source_keys=accepted_source_keys,
         )
     if independent_events:
         buffer_source_usage_events(
@@ -338,6 +446,7 @@ def _buffer_source_model_provider_usage_events(
             run_id,
             independent_events,
             context.proxy_log_path,
+            accepted_source_keys=accepted_source_keys,
         )
 
 
@@ -345,6 +454,8 @@ def _buffer_source_model_provider_usage_observations(
     context: UsageReportingContext,
     run_id: str,
     observations: list[ModelUsageObservation],
+    *,
+    accepted_source_keys: set[str],
 ) -> None:
     buffer_source_model_usage_observations(
         context.model_usage_observation_url(),
@@ -352,6 +463,7 @@ def _buffer_source_model_provider_usage_observations(
         run_id,
         observations,
         context.proxy_log_path,
+        accepted_source_keys=accepted_source_keys,
     )
 
 
@@ -411,22 +523,22 @@ def _build_model_provider_usage_events(
     namespace: uuid.UUID,
 ) -> list[UsageEvent]:
     events: list[UsageEvent] = []
-    for source_id, usage in _iter_model_provider_usage_sources(flow):
-        provider = _reported_model(flow, usage)
-        billing_tier = _model_usage_tier(provider, usage)
+    for source in _iter_model_provider_usage_sources(flow):
+        provider = _reported_model(flow, source.usage)
+        billing_tier = _model_usage_tier(provider, source.usage)
         if billing_tier is None:
-            if has_positive_model_provider_usage(usage):
+            if has_positive_model_provider_usage(source.usage):
                 _log_model_usage_tier_unresolved(flow, run_id, provider)
             continue
         events.extend(
             _build_usage_events(
                 run_id,
-                source_id,
+                source.source_id,
                 provider,
-                usage,
+                source.usage,
                 namespace,
                 billing_tier,
-                _is_fast_service_tier(usage),
+                _is_fast_service_tier(source.usage),
             )
         )
     return events
@@ -437,13 +549,13 @@ def _build_model_provider_usage_observations(
     run_id: str,
 ) -> list[ModelUsageObservation]:
     observations: list[ModelUsageObservation] = []
-    for source_id, usage in _iter_model_provider_usage_sources(flow):
+    for source in _iter_model_provider_usage_sources(flow):
         observations.extend(
             _build_model_usage_observations(
                 run_id,
-                source_id,
-                _reported_model(flow, usage),
-                usage,
+                source.source_id,
+                _reported_model(flow, source.usage),
+                source.usage,
             )
         )
     return observations
@@ -494,7 +606,7 @@ def _build_model_usage_observations(
     return observations
 
 
-def _iter_model_provider_usage_sources(flow: http.HTTPFlow) -> Iterator[tuple[str, dict]]:
+def _iter_model_provider_usage_sources(flow: http.HTTPFlow) -> Iterator[_ModelProviderUsageSource]:
     usage_sources = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_SOURCES)
     if isinstance(usage_sources, dict):
         valid_sources = (
@@ -503,11 +615,80 @@ def _iter_model_provider_usage_sources(flow: http.HTTPFlow) -> Iterator[tuple[st
             if isinstance(message_id, str) and message_id and isinstance(source_usage, dict)
         )
         for message_id, source_usage in valid_sources:
-            yield f"{flow.id}:{message_id}", source_usage
+            yield _ModelProviderUsageSource(
+                f"{flow.id}:{message_id}",
+                message_id,
+                source_usage,
+            )
 
     usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
     if usage and isinstance(usage, dict):
-        yield flow.id, usage
+        yield _ModelProviderUsageSource(
+            flow.id,
+            _string_or_none(usage.get("message_id")),
+            usage,
+        )
+
+
+def _log_model_provider_usage_source(
+    flow: http.HTTPFlow,
+    run_id: str,
+    source: _ModelProviderUsageSource,
+    provider: str,
+    usage_events: list[UsageEvent],
+    observations: list[ModelUsageObservation],
+    *,
+    accepted_usage_keys: set[str],
+    accepted_observation_keys: set[str],
+    transport: _ModelUsageTransport,
+    buffer_mode: _ModelUsageBufferMode,
+) -> None:
+    if not usage_events and not observations:
+        return
+
+    url_projection = project_url_for_proxy_log(flow_metadata.original_url(flow.metadata))
+    log_proxy_entry(
+        flow_metadata.proxy_log_path(flow.metadata),
+        "info",
+        "Model provider usage source reported",
+        type="model_usage_source",
+        run_id=run_id,
+        flow_id=flow.id,
+        source_id=source.source_id,
+        method=flow.request.method,
+        url=url_projection,
+        transport=transport,
+        buffer_mode=buffer_mode,
+        firewall_name=flow_metadata.firewall_name(flow.metadata),
+        reported_model=provider,
+        provider_response_id=source.provider_response_id,
+        usage={
+            category: quantity
+            for category in MODEL_USAGE_CATEGORIES
+            if _is_positive_int(quantity := source.usage.get(category))
+        },
+        usage_events=[
+            {
+                "source_idempotency_key": event["idempotencyKey"],
+                "category": event["category"],
+                "quantity": event["quantity"],
+                "buffer_accepted": event["idempotencyKey"] in accepted_usage_keys,
+            }
+            for event in usage_events
+        ],
+        model_usage_observations=[
+            {
+                "source_idempotency_key": observation["idempotencyKey"],
+                "input_tokens": observation["inputTokens"],
+                "output_tokens": observation["outputTokens"],
+                "cache_read_input_tokens": observation["cacheReadInputTokens"],
+                "cache_creation_input_tokens": observation["cacheCreationInputTokens"],
+                "buffer_accepted": observation["idempotencyKey"] in accepted_observation_keys,
+            }
+            for observation in observations
+        ],
+        **url_projection.truncation_fields(),
+    )
 
 
 def _build_usage_events(

--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -9,6 +9,7 @@ from mitmproxy.test import tutils
 import flow_metadata_keys as metadata_keys
 import http_network_log
 from tests.flow_helpers import header_map
+from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 
 RealFlowFactory = Callable[..., http.HTTPFlow]
 _WEBSOCKET_KEY = "dGhlIHNhbXBsZSBub25jZQ=="
@@ -153,3 +154,14 @@ def model_provider_usage_sources(flow: http.HTTPFlow) -> dict:
     sources = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES]
     assert isinstance(sources, dict)
     return sources
+
+
+def model_usage_source_entries(flow: http.HTTPFlow) -> list[dict]:
+    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+    if not jsonl_exists_after_flush(proxy_log):
+        return []
+    return [
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log)
+        if entry.get("type") == "model_usage_source"
+    ]

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
@@ -117,6 +117,88 @@ class TestModelProviderJsonFallback:
             "tokens.cache_creation.long_context": cache_write_tokens,
         }
 
+    def test_json_source_diagnostic_records_aggregate_admission_without_secrets(
+        self, tmp_path, real_flow
+    ):
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = model_provider_flow(
+            real_flow,
+            tmp_path,
+            OPENAI_RESPONSES_CASE,
+            proxy_log_path=proxy_log_path,
+        )
+        secret_userinfo = "diagnostic-user:diagnostic-password"
+        secret_query = "diagnostic-query-secret"
+        secret_fragment = "diagnostic-fragment-secret"
+        secret_authorization = "Bearer diagnostic-authorization-secret"
+        secret_prompt = b"diagnostic-prompt-secret"
+        raw_url = (
+            f"https://{secret_userinfo}@api.openai.com/"
+            + "p" * (logging_utils.URL_LOG_MAX_CHARACTERS + 1)
+            + f"?token={secret_query}#{secret_fragment}"
+        )
+        flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+        flow.request.headers["authorization"] = secret_authorization
+        flow.request.content = secret_prompt
+        body = standard_success_payload(OPENAI_RESPONSES_CASE)
+        set_response_stream_buffer(flow, body)
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+
+        webhook = run_response(flow, self._usage_webhook_api)
+
+        [source_entry] = [
+            entry
+            for entry in read_jsonl_entries_after_flush(proxy_log_path)
+            if entry.get("type") == "model_usage_source"
+        ]
+        assert source_entry["level"] == "info"
+        assert source_entry["message"] == "Model provider usage source reported"
+        assert source_entry["run_id"] == "run-abc-123"
+        assert source_entry["flow_id"] == flow.id
+        assert source_entry["source_id"] == flow.id
+        assert source_entry["method"] == flow.request.method
+        assert source_entry["url"] == "[truncated]"
+        assert source_entry["url_truncated"] is True
+        assert source_entry["url_original_char_count"] == len(raw_url)
+        assert source_entry["transport"] == "http"
+        assert source_entry["buffer_mode"] == "aggregate"
+        assert source_entry["firewall_name"] == "model-provider:openai-api-key"
+        assert source_entry["reported_model"] == OPENAI_RESPONSES_CASE.model
+        assert source_entry["provider_response_id"] == OPENAI_RESPONSES_CASE.message_id
+        assert source_entry["usage"] == expected_event_quantities(OPENAI_RESPONSES_CASE)
+
+        source_events = source_entry["usage_events"]
+        assert {
+            event["category"]: event["quantity"] for event in source_events
+        } == expected_event_quantities(OPENAI_RESPONSES_CASE)
+        assert all(event["buffer_accepted"] is True for event in source_events)
+        source_event_keys = {event["source_idempotency_key"] for event in source_events}
+        aggregate_event_keys = {event["idempotencyKey"] for event in webhook.usage_events()}
+        assert source_event_keys.isdisjoint(aggregate_event_keys)
+
+        source_observations = source_entry["model_usage_observations"]
+        assert all(observation["buffer_accepted"] is True for observation in source_observations)
+        aggregate_observation_keys = {
+            event["idempotencyKey"] for event in webhook.model_usage_observation_events()
+        }
+        assert {
+            observation["source_idempotency_key"] for observation in source_observations
+        }.isdisjoint(aggregate_observation_keys)
+
+        serialized = read_jsonl_text_after_flush(proxy_log_path)
+        for secret in (
+            secret_userinfo,
+            secret_query,
+            secret_fragment,
+            secret_authorization,
+            secret_prompt.decode(),
+        ):
+            assert secret not in serialized
+        assert len(serialized.encode()) < 5_000
+
     def test_anthropic_json_fallback_parse_error_logs_proxy_warning(self, tmp_path, real_flow):
         """Legacy JSON fallback parse failures should be observable."""
         proxy_log_path = tmp_path / "proxy.jsonl"
@@ -561,11 +643,13 @@ class TestModelProviderJsonFallback:
     def test_non_billable_openai_json_reports_observation_without_billing(
         self, tmp_path, real_flow
     ):
+        proxy_log_path = tmp_path / "proxy.jsonl"
         flow = model_provider_flow(
             real_flow,
             tmp_path,
             OPENAI_RESPONSES_CASE,
             billable=False,
+            proxy_log_path=proxy_log_path,
         )
         body = standard_success_payload(OPENAI_RESPONSES_CASE)
         set_response_stream_buffer(flow, body)
@@ -581,6 +665,16 @@ class TestModelProviderJsonFallback:
         by_category = compact_observation_quantities(observations)
         assert by_category == expected_event_quantities(OPENAI_RESPONSES_CASE)
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "gpt-5.5"
+        [source_entry] = [
+            entry
+            for entry in read_jsonl_entries_after_flush(proxy_log_path)
+            if entry.get("type") == "model_usage_source"
+        ]
+        assert source_entry["usage_events"] == []
+        assert all(
+            observation["buffer_accepted"] is True
+            for observation in source_entry["model_usage_observations"]
+        )
 
     def test_non_observable_json_fallback_parse_error_stays_quiet(self, tmp_path, real_flow):
         """Model-provider fallback without MODEL_USAGE_PROVIDER must not emit warnings."""

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
@@ -19,6 +19,7 @@ from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
 )
+from tests.model_provider_flow_helpers import model_usage_source_entries
 from tests.model_provider_response_helpers import (
     ANTHROPIC_JSON_CASE,
     CODEX_OAUTH_RESPONSES_CASE,
@@ -149,11 +150,7 @@ class TestModelProviderJsonFallback:
 
         webhook = run_response(flow, self._usage_webhook_api)
 
-        [source_entry] = [
-            entry
-            for entry in read_jsonl_entries_after_flush(proxy_log_path)
-            if entry.get("type") == "model_usage_source"
-        ]
+        [source_entry] = model_usage_source_entries(flow)
         assert source_entry["level"] == "info"
         assert source_entry["message"] == "Model provider usage source reported"
         assert source_entry["run_id"] == "run-abc-123"
@@ -665,11 +662,7 @@ class TestModelProviderJsonFallback:
         by_category = compact_observation_quantities(observations)
         assert by_category == expected_event_quantities(OPENAI_RESPONSES_CASE)
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "gpt-5.5"
-        [source_entry] = [
-            entry
-            for entry in read_jsonl_entries_after_flush(proxy_log_path)
-            if entry.get("type") == "model_usage_source"
-        ]
+        [source_entry] = model_usage_source_entries(flow)
         assert source_entry["usage_events"] == []
         assert all(
             observation["buffer_accepted"] is True

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -24,7 +24,10 @@ from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
-from tests.model_provider_flow_helpers import make_model_provider_sse_flow
+from tests.model_provider_flow_helpers import (
+    make_model_provider_sse_flow,
+    model_usage_source_entries,
+)
 from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import event as usage_event
 from tests.usage_helpers import (
@@ -147,17 +150,6 @@ def _model_sse_parse_warnings(flow: http.HTTPFlow) -> list[dict]:
         entry
         for entry in read_jsonl_entries_after_flush(proxy_log)
         if entry.get("message") == "Model provider SSE usage extraction failed"
-    ]
-
-
-def _model_usage_source_entries(flow: http.HTTPFlow) -> list[dict]:
-    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
-    if not jsonl_exists_after_flush(proxy_log):
-        return []
-    return [
-        entry
-        for entry in read_jsonl_entries_after_flush(proxy_log)
-        if entry.get("type") == "model_usage_source"
     ]
 
 
@@ -398,7 +390,7 @@ class TestModelProviderSseUsage:
             event["category"]: event["quantity"] for event in webhook.usage_events()
         } == expected
         assert compact_observation_quantities(webhook.model_usage_observation_events()) == expected
-        [source_entry] = _model_usage_source_entries(flow)
+        [source_entry] = model_usage_source_entries(flow)
         assert source_entry["source_id"] == flow.id
         assert source_entry["provider_response_id"] == "resp_sse_1"
         assert source_entry["transport"] == "http"

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -150,6 +150,17 @@ def _model_sse_parse_warnings(flow: http.HTTPFlow) -> list[dict]:
     ]
 
 
+def _model_usage_source_entries(flow: http.HTTPFlow) -> list[dict]:
+    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+    if not jsonl_exists_after_flush(proxy_log):
+        return []
+    return [
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log)
+        if entry.get("type") == "model_usage_source"
+    ]
+
+
 def _assert_single_model_sse_parse_warning(
     flow: http.HTTPFlow,
     *,
@@ -387,6 +398,29 @@ class TestModelProviderSseUsage:
             event["category"]: event["quantity"] for event in webhook.usage_events()
         } == expected
         assert compact_observation_quantities(webhook.model_usage_observation_events()) == expected
+        [source_entry] = _model_usage_source_entries(flow)
+        assert source_entry["source_id"] == flow.id
+        assert source_entry["provider_response_id"] == "resp_sse_1"
+        assert source_entry["transport"] == "http"
+        assert source_entry["buffer_mode"] == "aggregate"
+        assert source_entry["usage"] == expected
+        assert all(event["buffer_accepted"] is True for event in source_entry["usage_events"])
+        assert all(
+            observation["buffer_accepted"] is True
+            for observation in source_entry["model_usage_observations"]
+        )
+        assert {
+            event["source_idempotency_key"] for event in source_entry["usage_events"]
+        }.isdisjoint({event["idempotencyKey"] for event in webhook.usage_events()})
+        assert {
+            observation["source_idempotency_key"]
+            for observation in source_entry["model_usage_observations"]
+        }.isdisjoint(
+            {
+                observation["idempotencyKey"]
+                for observation in webhook.model_usage_observation_events()
+            }
+        )
         _assert_single_model_sse_parse_warning(
             flow,
             usage_protocol="openai_responses_sse",

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -15,6 +15,7 @@ from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries
 from tests.model_provider_flow_helpers import (
     make_openai_responses_websocket_flow,
     model_provider_usage_sources,
+    model_usage_source_entries,
 )
 from tests.model_provider_websocket_helpers import (
     ScheduledWebSocketTrim,
@@ -69,17 +70,6 @@ def _openai_websocket_zero_usage_frame(response_id: str, *, model: str | None = 
             "response": response,
         }
     ).encode()
-
-
-def _model_usage_source_entries(flow: http.HTTPFlow) -> list[dict]:
-    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
-    if not jsonl_exists_after_flush(proxy_log):
-        return []
-    return [
-        entry
-        for entry in read_jsonl_entries_after_flush(proxy_log)
-        if entry.get("type") == "model_usage_source"
-    ]
 
 
 class TestModelProviderWebSocketUsageSourceRelease:
@@ -257,7 +247,7 @@ class TestModelProviderWebSocketUsage:
                 ("gpt-5.5", "tokens.cache_creation", 15),
             ],
         )
-        [source_entry] = _model_usage_source_entries(flow)
+        [source_entry] = model_usage_source_entries(flow)
         assert source_entry["flow_id"] == flow.id
         assert source_entry["source_id"] == f"{flow.id}:resp_ws_1"
         assert source_entry["provider_response_id"] == "resp_ws_1"
@@ -386,7 +376,7 @@ class TestModelProviderWebSocketUsage:
         ]
         _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
         _assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
-        source_entries = _model_usage_source_entries(flow)
+        source_entries = model_usage_source_entries(flow)
         assert len(source_entries) == 2
         first_entry = next(
             entry for entry in source_entries if entry["usage"]["tokens.input"] == 20
@@ -983,7 +973,7 @@ class TestModelProviderWebSocketUsage:
         ]
         _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
         _assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
-        source_entries = _model_usage_source_entries(flow)
+        source_entries = model_usage_source_entries(flow)
         assert len(source_entries) == 2
         [source_preserving_entry] = [
             entry for entry in source_entries if entry["buffer_mode"] == "source"

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -71,6 +71,17 @@ def _openai_websocket_zero_usage_frame(response_id: str, *, model: str | None = 
     ).encode()
 
 
+def _model_usage_source_entries(flow: http.HTTPFlow) -> list[dict]:
+    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+    if not jsonl_exists_after_flush(proxy_log):
+        return []
+    return [
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log)
+        if entry.get("type") == "model_usage_source"
+    ]
+
+
 class TestModelProviderWebSocketUsageSourceRelease:
     """Tests for sources that cannot be delivered to the usage webhook."""
 
@@ -98,6 +109,7 @@ class TestModelProviderWebSocketUsageSourceRelease:
         [observation_entry] = [
             entry for entry in entries if entry.get("type") == "model_usage_observation"
         ]
+        assert not any(entry.get("type") == "model_usage_source" for entry in entries)
         assert entry["type"] == "usage_underbilling"
         assert entry["reason"] == "missing_reporting_context"
         assert entry["underbilling_class"] == "confirmed"
@@ -245,6 +257,29 @@ class TestModelProviderWebSocketUsage:
                 ("gpt-5.5", "tokens.cache_creation", 15),
             ],
         )
+        [source_entry] = _model_usage_source_entries(flow)
+        assert source_entry["flow_id"] == flow.id
+        assert source_entry["source_id"] == f"{flow.id}:resp_ws_1"
+        assert source_entry["provider_response_id"] == "resp_ws_1"
+        assert source_entry["transport"] == "websocket"
+        assert source_entry["buffer_mode"] == "source"
+        assert source_entry["method"] == "GET"
+        assert source_entry["url"] == "https://api.openai.com/v1/responses"
+        assert all(event["buffer_accepted"] is True for event in source_entry["usage_events"])
+        assert {event["source_idempotency_key"] for event in source_entry["usage_events"]} == {
+            event["idempotencyKey"] for event in webhook.usage_events()
+        }
+        assert all(
+            observation["buffer_accepted"] is True
+            for observation in source_entry["model_usage_observations"]
+        )
+        assert {
+            observation["source_idempotency_key"]
+            for observation in source_entry["model_usage_observations"]
+        } == {
+            observation["idempotencyKey"]
+            for observation in webhook.model_usage_observation_events()
+        }
 
     def test_model_websocket_work_limit_warns_and_later_frame_reports(
         self,
@@ -351,6 +386,28 @@ class TestModelProviderWebSocketUsage:
         ]
         _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
         _assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
+        source_entries = _model_usage_source_entries(flow)
+        assert len(source_entries) == 2
+        first_entry = next(
+            entry for entry in source_entries if entry["usage"]["tokens.input"] == 20
+        )
+        repeated_entry = next(
+            entry for entry in source_entries if entry["usage"]["tokens.input"] == 10
+        )
+        assert first_entry["source_id"] == repeated_entry["source_id"]
+        assert first_entry["provider_response_id"] == "resp_ws_1"
+        assert {event["source_idempotency_key"] for event in first_entry["usage_events"]} == {
+            event["source_idempotency_key"] for event in repeated_entry["usage_events"]
+        }
+        assert all(event["buffer_accepted"] is True for event in first_entry["usage_events"])
+        assert all(event["buffer_accepted"] is False for event in repeated_entry["usage_events"])
+        first_observations = first_entry["model_usage_observations"]
+        repeated_observations = repeated_entry["model_usage_observations"]
+        assert {observation["source_idempotency_key"] for observation in first_observations} == {
+            observation["source_idempotency_key"] for observation in repeated_observations
+        }
+        assert all(observation["buffer_accepted"] is True for observation in first_observations)
+        assert all(observation["buffer_accepted"] is False for observation in repeated_observations)
 
     def test_model_websocket_late_same_id_frame_can_add_new_category_after_release(
         self, tmp_path, real_flow
@@ -926,6 +983,30 @@ class TestModelProviderWebSocketUsage:
         ]
         _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
         _assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
+        source_entries = _model_usage_source_entries(flow)
+        assert len(source_entries) == 2
+        [source_preserving_entry] = [
+            entry for entry in source_entries if entry["buffer_mode"] == "source"
+        ]
+        [aggregate_entry] = [
+            entry for entry in source_entries if entry["buffer_mode"] == "aggregate"
+        ]
+        assert source_preserving_entry["provider_response_id"] == "resp_ws_1"
+        assert aggregate_entry["provider_response_id"] is None
+        assert aggregate_entry["source_id"] == flow.id
+        assert aggregate_entry["transport"] == "websocket"
+        webhook_usage_keys = {event["idempotencyKey"] for event in webhook.usage_events()}
+        assert {
+            event["source_idempotency_key"] for event in source_preserving_entry["usage_events"]
+        }.issubset(webhook_usage_keys)
+        assert {
+            event["source_idempotency_key"] for event in aggregate_entry["usage_events"]
+        }.isdisjoint(webhook_usage_keys)
+        assert all(
+            event["buffer_accepted"] is True
+            for entry in source_entries
+            for event in entry["usage_events"]
+        )
 
     @pytest.mark.parametrize(
         "later_cache_write_tokens",

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -82,6 +82,7 @@ def test_model_usage_observation_buffer_uses_model_event_shape(tmp_path):
 def test_source_preserving_usage_buffer_keeps_source_idempotency_keys(tmp_path):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    accepted_source_keys: set[str] = set()
 
     usage.buffer_source_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -93,7 +94,9 @@ def test_source_preserving_usage_buffer_keeps_source_idempotency_keys(tmp_path):
             event(source_key="source-1", quantity=100),
         ],
         str(tmp_path / "proxy.jsonl"),
+        accepted_source_keys=accepted_source_keys,
     )
+    assert accepted_source_keys == {"source-1", "source-2"}
     assert usage.flush_usage_events(trigger="test") == 1
 
     enqueue.assert_called_once()
@@ -122,6 +125,7 @@ def test_source_preserving_atomic_group_rejects_repeated_group_key(tmp_path):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
     proxy_log_path = str(tmp_path / "proxy.jsonl")
+    accepted_source_keys: set[str] = set()
 
     assert (
         usage.buffer_source_usage_events(
@@ -149,9 +153,12 @@ def test_source_preserving_atomic_group_rejects_repeated_group_key(tmp_path):
             ],
             proxy_log_path,
             atomic_source_key="input-partition-1",
+            accepted_source_keys=accepted_source_keys,
         )
         == 2
     )
+    assert accepted_source_keys == {"source-input", "source-cache-read"}
+    rejected_source_keys: set[str] = set()
     assert (
         usage.buffer_source_usage_events(
             "https://api.test/api/webhooks/agent/usage-event",
@@ -166,9 +173,11 @@ def test_source_preserving_atomic_group_rejects_repeated_group_key(tmp_path):
             ],
             proxy_log_path,
             atomic_source_key="input-partition-1",
+            accepted_source_keys=rejected_source_keys,
         )
         == 0
     )
+    assert rejected_source_keys == set()
 
     assert usage.flush_usage_events(trigger="test") == 1
     enqueue.assert_called_once()
@@ -298,6 +307,7 @@ def test_source_preserving_atomic_group_rejects_duplicate_member_keys(tmp_path):
 def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    accepted_source_keys: set[str] = set()
 
     usage.buffer_source_model_usage_observations(
         "https://api.test/api/webhooks/agent/model-usage-observation",
@@ -311,7 +321,9 @@ def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):
             )
         ],
         str(tmp_path / "proxy.jsonl"),
+        accepted_source_keys=accepted_source_keys,
     )
+    assert accepted_source_keys == {"source-1"}
     assert usage.flush_usage_events(trigger="test") == 1
 
     enqueue.assert_called_once()

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_idempotency.py
@@ -54,6 +54,46 @@ def test_rejected_events_do_not_leave_empty_destination_buckets(tmp_path):
     assert enqueue.last_call.payload["runId"] == "run-1"
 
 
+def test_aggregate_buffer_collects_only_accepted_source_keys(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    accepted_source_keys: set[str] = set()
+
+    accepted_count = usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [
+            event(source_key="source-1", quantity=10),
+            event(source_key="source-1", quantity=100),
+            event(source_key="source-2", quantity=5),
+        ],
+        proxy_log_path,
+        accepted_source_keys=accepted_source_keys,
+    )
+
+    assert accepted_count == 2
+    assert accepted_source_keys == {"source-1", "source-2"}
+
+    duplicate_keys: set[str] = set()
+    assert (
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1", quantity=200)],
+            proxy_log_path,
+            accepted_source_keys=duplicate_keys,
+        )
+        == 0
+    )
+    assert duplicate_keys == set()
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    assert enqueue.last_call.payload["events"][0]["quantity"] == 15
+
+
 def test_aggregate_idempotency_key_changes_between_flush_batches(tmp_path):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)


### PR DESCRIPTION
## Summary

- expose the exact source idempotency keys accepted by existing usage-buffer calls through an optional collector
- emit one bounded `model_usage_source` proxy diagnostic for terminal HTTP/SSE and incremental Responses WebSocket reporting
- distinguish aggregate and source-preserving identity semantics, including per-key `buffer_accepted` decisions
- cover JSON, SSE interruption, WebSocket repeats/missing IDs, observation-only reporting, atomic admission, and secret-safe URL projection

## Why

The production reconciliation in #26303 cannot currently attribute model usage contributions to provider requests. Source idempotency keys alone are insufficient: terminal HTTP/SSE usage is deduplicated by source key, then flushed with newly derived aggregate webhook/database keys. Incremental WebSocket usage preserves source keys.

This change records the authoritative process-local source-buffer decision and explicitly names the buffer mode. It does not claim that buffer acceptance proves webhook delivery, database insertion, or credit settlement.

## Behavior and exclusions

- existing accepted-count returns, dedupe rules, atomic groups, aggregation, timers, thresholds, flushes, and webhook payloads are unchanged
- source-preserving WebSocket keys remain directly joinable to webhook/database rows
- aggregate HTTP/SSE source keys are diagnostic contribution identities, not persisted aggregate identities
- no parser eligibility, pricing, billing, API, database, migration, or uploaded network-log contract changes
- proxy JSONL remains runner-local and best effort

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 5285 passed

Closes #26386

Parent context: #26303
