### PR TITLE
feat: add independent website registry generation

### DIFF
--- a/turbo/docs/website-template-registry.md
+++ b/turbo/docs/website-template-registry.md
@@ -1,0 +1,47 @@
+# Independent Website template registry
+
+The built-in Website template registry can be generated and published without
+republishing the report, poster, dashboard, mobile-app, and docs registries.
+
+## Generate only the Website registry
+
+From `turbo/`:
+
+```bash
+pnpm html-resource-index:build \
+  --output-dir /tmp/website-resource-index \
+  --target website
+```
+
+The command writes `website.json` and a `manifest.json` containing only the
+Website entry. Publish both files under a new content-addressed directory whose
+name is the `website.json` SHA-256 recorded by the manifest.
+
+Omitting `--target` preserves the existing behavior and generates all six HTML
+resource registries plus their shared manifest. This is the compatibility path
+for existing publication jobs.
+
+## Migration compatibility
+
+- Existing registry URLs are immutable and remain available to released
+  clients.
+- A new Website registry must be added at a new versioned, content-addressed
+  path; never overwrite or remove an existing path.
+- Non-Website consumers continue using the shared registry directory.
+- Switch the Website consumer only after every resource referenced by the new
+  registry is available and its server-side pins have deployed.
+- Keep the previous Website registry and template resource versions available
+  for the full client migration window.
+
+## Verification
+
+Verify both generator modes before publishing:
+
+1. Run the command above and confirm the output directory contains only
+   `website.json` and `manifest.json`.
+2. Confirm the manifest has exactly one file entry with `target: "website"`,
+   and that its byte size and SHA-256 match `website.json`.
+3. Run the command without `--target` into a separate directory and confirm it
+   still contains all six target registries plus `manifest.json`.
+4. Confirm no existing static-file path is modified or removed by the
+   publication PR.

--- a/turbo/scripts/build-html-resource-index.ts
+++ b/turbo/scripts/build-html-resource-index.ts
@@ -17,6 +17,12 @@ const HTML_RESOURCE_TARGETS = [
 
 type HtmlResourceTarget = (typeof HTML_RESOURCE_TARGETS)[number];
 
+function isHtmlResourceTarget(value: string): value is HtmlResourceTarget {
+  return HTML_RESOURCE_TARGETS.some((target) => {
+    return target === value;
+  });
+}
+
 interface HtmlResourceIndexEntry {
   readonly id: string;
   readonly name: string;
@@ -210,12 +216,20 @@ async function main(): Promise<void> {
     throw new Error("--output-dir is required");
   }
 
+  const targetOption = readOption("--target");
+  if (targetOption && !isHtmlResourceTarget(targetOption)) {
+    throw new Error(
+      `--target must be one of: ${HTML_RESOURCE_TARGETS.join(", ")}`,
+    );
+  }
+
   const outputDir = path.resolve(outputDirOption);
   await mkdir(outputDir, { recursive: true });
 
   const files: HtmlResourceIndexManifest["files"][number][] = [];
+  const targets = targetOption ? [targetOption] : HTML_RESOURCE_TARGETS;
 
-  for (const target of HTML_RESOURCE_TARGETS) {
+  for (const target of targets) {
     const index = buildTargetIndex(target);
 
     const fileName = `${target}.json`;


### PR DESCRIPTION
## Summary

- add an optional `--target` selector to the existing HTML resource-index generator
- allow `--target website` to emit only `website.json` and its one-entry `manifest.json`
- preserve the existing no-argument behavior that emits all six HTML resource indexes
- document the independent, append-only Website registry publication and migration contract

## Responsibility boundary

This PR contains only the mechanism for generating the Website registry independently.

- No Website template SHA or R2 version pin changes.
- No Presentation resource or mapping changes.
- No generation prompt changes.
- No client URL cutover.
- No static resource publication.

The latest Website archives and R2 compatibility pins are isolated in #26434. The client URL switch remains isolated in #26409. The append-only static files are in `vm0-ai/static-files#122`.

## Compatibility

- Omitting `--target` preserves the current publication command and output shape.
- Existing immutable registry URLs remain available to released clients.
- Non-Website consumers remain on the shared registry directory.
- The Website client is switched only after the referenced template resources and server-side pins are available.

## Verification

- Website-only mode emitted exactly `website.json` and `manifest.json`.
- The Website-only manifest contained one `website` entry and its byte size and SHA-256 matched the generated file.
- Legacy mode emitted all six target registries and `manifest.json`.
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- all staged workspace type checks from `commit-check`

## Review gate

This PR remains Draft. Nothing will be merged before explicit review approval.
