### PR TITLE
refactor: read website registry from its independent static path

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -51,7 +51,7 @@ describe("okou generate website command", () => {
     expect(stdout).not.toContain("federated");
     expect(stdout).toContain("## Stage 1: Resource Selection");
     expect(stdout).toContain(
-      "https://static.vm0.io/html-resources/9e005c4ace807d67338dfa701877df10175a4d2a1c677dea1414aba76867493d/website.json",
+      "https://static.vm0.io/html-resources/website/v1/f0ad1af26306b7cbd9e4e1505a9991e8e9330ca507d5890245553c760878be04/website.json",
     );
     expect(stdout).not.toContain("Sources:");
     expect(stdout).not.toContain("vm0-ai/vm0-skills");

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -16,9 +16,11 @@ export type HtmlArtifactKind = Extract<
 
 const HTML_RESOURCE_INDEX_BASE_URL =
   "https://static.vm0.io/html-resources/9e005c4ace807d67338dfa701877df10175a4d2a1c677dea1414aba76867493d";
+const WEBSITE_RESOURCE_INDEX_URL =
+  "https://static.vm0.io/html-resources/website/v1/f0ad1af26306b7cbd9e4e1505a9991e8e9330ca507d5890245553c760878be04/website.json";
 
 const HTML_RESOURCE_INDEX_URLS: Record<HtmlArtifactKind, string> = {
-  website: `${HTML_RESOURCE_INDEX_BASE_URL}/website.json`,
+  website: WEBSITE_RESOURCE_INDEX_URL,
   report: `${HTML_RESOURCE_INDEX_BASE_URL}/report.json`,
   poster: `${HTML_RESOURCE_INDEX_BASE_URL}/poster.json`,
   "dashboard-design": `${HTML_RESOURCE_INDEX_BASE_URL}/dashboard-design.json`,


### PR DESCRIPTION
## Summary

- read only the Website template registry from its new Website-specific Static File path
- keep Report, Poster, Dashboard, Mobile App, and Docs on the existing shared HTML resource directory
- verify the Website cutover at the CLI command boundary while retaining the existing neighboring-HTML coverage

## Why

Today all HTML registries share one directory:

`https://static.vm0.io/html-resources/9e005c4ace807d67338dfa701877df10175a4d2a1c677dea1414aba76867493d/<type>.json`

That couples Website registry publication to unrelated HTML types. Static Files PR vm0-ai/static-files#122 adds one independently versioned Website file:

`https://static.vm0.io/html-resources/website/v1/f0ad1af26306b7cbd9e4e1505a9991e8e9330ca507d5890245553c760878be04/website.json`

After this cutover, a built-in Website template refresh only needs a new Website registry file and this Website URL pin. It does not republish or move any other HTML registry.

## Scope

This PR changes exactly two files:

- the Website URL selection in `html-artifact-authoring.ts`
- its CLI test

It contains no generator changes, R2 mappings, template archive builds, prompt changes, Presentation changes, or Static File payloads.

## Compatibility and rollout

- The old shared Website URL remains published, so released clients keep working.
- Non-Website consumers remain on their existing shared URLs.
- vm0-ai/static-files#122 is merged and the independent registry is live.
- vm0 #26434 is merged and the new Website archive hashes plus dual-version server pins are live on `main`.
- Both old and new registry URLs return HTTP 200.

## Verification

- `pnpm format` — passed
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` — passed
- `pnpm knip` — passed
- non-API/non-App, App, and API type checks — passed
- Website CLI test — 8/8 passed
- other HTML artifact CLI test — 15/15 passed
- current-head PR CI — running; required to be fully green before merge

## Review gate

The dependency gates are complete and the exact current head has an `LGTM` pr-auto review. Merge only after current-head CI is fully green.
