### PR TITLE
test(e2e): cover steer and successor run boundary

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -36,9 +36,15 @@ if grep -R -Fq '/api/test/' "$RUNNER_TESTS" "${RUNNER_HELPERS[@]}"; then
   fail "runner E2E coverage must use supported public APIs"
 fi
 grep -Fq 'startVideoOnboardingCheckout' "$RUNNER_TOKEN" ||
-  fail "runner Claude account must upgrade through public paid onboarding"
+  fail "real runner accounts must upgrade through public paid onboarding"
 grep -Fq 'fillStripeCheckout' "$RUNNER_TOKEN" ||
-  fail "runner Claude account must complete the public Stripe checkout"
+  fail "real runner accounts must complete the public Stripe checkout"
+if [[ "$(grep -Fc 'upgradeToPro: true' "$RUNNER_TOKEN")" -ne 2 ]]; then
+  fail "real Codex and Claude runner accounts must both upgrade to Pro"
+fi
+if [[ "$(grep -Fc 'upgradeToPro: false' "$RUNNER_TOKEN")" -ne 1 ]]; then
+  fail "the mock runner account must remain on limited-free"
+fi
 
 ruby -ryaml - "$WORKFLOW" <<'RUBY'
 workflow = YAML.load_file(ARGV.fetch(0))

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -223,6 +223,26 @@ unless provider_step.fetch("run").include?(
   )
   raise "runner bootstrap must restore the historical mock provider"
 end
+codex_step = bootstrap_steps.find do |step|
+  step["name"] == "Bootstrap real Codex account"
+end
+raise "missing real Codex account bootstrap" unless codex_step
+codex_script = codex_step.fetch("run")
+%w[
+  /api/zero/model-providers
+  /api/zero/model-policies
+  /api/zero/feature-switches
+  gpt-5.6-luna
+  realAgentInPreview
+].each do |required_fragment|
+  unless codex_script.include?(required_fragment)
+    raise "real Codex bootstrap must include #{required_fragment}"
+  end
+end
+unless codex_step.dig("env", "OPENAI_API_KEY") ==
+    "${{ secrets.OPENAI_API_KEY }}"
+  raise "real Codex bootstrap must receive the OpenAI credential"
+end
 claude_step = bootstrap_steps.find do |step|
   step["name"] == "Bootstrap real Claude account"
 end
@@ -232,7 +252,7 @@ claude_script = claude_step.fetch("run")
   /api/zero/model-providers
   /api/zero/model-policies
   /api/zero/feature-switches
-  claude-sonnet-5
+  claude-sonnet-4-6
   realAgentInPreview
 ].each do |required_fragment|
   unless claude_script.include?(required_fragment)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2685,6 +2685,69 @@ jobs:
             "${E2E_API_URL}/api/zero/model-providers" >/dev/null
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Bootstrap real Codex account
+        shell: bash
+        run: |
+          set -euo pipefail
+          token=$(jq -er '.token | select(type == "string" and length > 0)' /tmp/e2e-api-credentials-runner-real-codex.json)
+          api_url=$(jq -er '.apiUrl | select(type == "string" and length > 0)' /tmp/e2e-api-credentials-runner-real-codex.json)
+          echo "::add-mask::$token"
+
+          headers=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")
+          if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+            headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+          fi
+
+          provider_payload=$(jq -nc \
+            --arg secret "$OPENAI_API_KEY" \
+            '{type: "openai-api-key", secret: $secret}')
+          provider_response=$(curl -fsS "${headers[@]}" \
+            -X POST \
+            -d "$provider_payload" \
+            "${api_url}/api/zero/model-providers")
+          provider_id=$(jq -er '.provider.id | select(type == "string" and length > 0)' \
+            <<< "$provider_response")
+
+          policies=$(curl -fsS "${headers[@]}" "${api_url}/api/zero/model-policies")
+          policy_payload=$(jq -c --arg providerId "$provider_id" '
+            {
+              policies: (
+                [.policies[] |
+                  select(.model != "gpt-5.6-luna") |
+                  {
+                    model,
+                    isDefault,
+                    defaultProviderType,
+                    credentialScope,
+                    modelProviderId
+                  }
+                ] + [
+                  {
+                    model: "gpt-5.6-luna",
+                    isDefault: false,
+                    defaultProviderType: "openai-api-key",
+                    credentialScope: "org",
+                    modelProviderId: $providerId
+                  }
+                ]
+              )
+            }
+          ' <<< "$policies")
+          curl -fsS "${headers[@]}" \
+            -X PUT \
+            -d "$policy_payload" \
+            "${api_url}/api/zero/model-policies" \
+            >/dev/null
+
+          curl -fsS "${headers[@]}" \
+            -X POST \
+            -d '{"switches":{"realAgentInPreview":true}}' \
+            "${api_url}/api/zero/feature-switches" \
+            | jq -e '.effectiveSwitches.realAgentInPreview == true' \
+            >/dev/null
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Bootstrap real Claude account
         shell: bash
         run: |
@@ -2713,7 +2776,7 @@ jobs:
             {
               policies: (
                 [.policies[] |
-                  select(.model != "claude-sonnet-5") |
+                  select(.model != "claude-sonnet-4-6") |
                   {
                     model,
                     isDefault,
@@ -2723,7 +2786,7 @@ jobs:
                   }
                 ] + [
                   {
-                    model: "claude-sonnet-5",
+                    model: "claude-sonnet-4-6",
                     isDefault: false,
                     defaultProviderType: "anthropic-api-key",
                     credentialScope: "org",

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -83,9 +83,11 @@ runner_chat_send() {
     local prompt="$2"
     local thread_id="$3"
     local selected_model="$4"
-    local client_event_id payload
+    local client_event_id="${5:-}" payload
 
-    client_event_id="$(_runner_uuid)"
+    if [[ -z "$client_event_id" ]]; then
+        client_event_id="$(_runner_uuid)"
+    fi
     if [[ -n "$thread_id" ]]; then
         payload="$(jq -nc \
             --arg agentId "$agent_id" \
@@ -149,6 +151,36 @@ runner_wait_for_run() {
     return 1
 }
 
+runner_wait_for_run_running() {
+    local run_id="$1"
+    local timeout="${2:-60}"
+    local interval="${RUNNER_RUN_POLL_INTERVAL_SECONDS:-2}"
+    local start=$SECONDS
+    local response="" run_status=""
+
+    while (( SECONDS - start < timeout )); do
+        if response="$(runner_api_curl "/api/zero/runs/$run_id" 2>&1)"; then
+            run_status="$(jq -r '.status // empty' <<< "$response")"
+            case "$run_status" in
+                running)
+                    printf '%s\n' "$response"
+                    return 0
+                    ;;
+                completed|failed|timeout|cancelled)
+                    echo "# Run $run_id reached terminal status before steer: $run_status" >&2
+                    echo "# Run response: $response" >&2
+                    return 1
+                    ;;
+            esac
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for run $run_id to start" >&2
+    echo "# Last run response: $response" >&2
+    return 1
+}
+
 _wait_for_runner_chat_output() {
     local thread_id="$1"
     local run_id="$2"
@@ -177,6 +209,55 @@ _wait_for_runner_chat_output() {
     done
 
     echo "# Timed out (${timeout}s) waiting for chat output for run $run_id" >&2
+    echo "# Last chat event response: $response" >&2
+    return 1
+}
+
+_wait_for_runner_chat_steer_consumed() {
+    local thread_id="$1"
+    local run_id="$2"
+    local steer_event_id="$3"
+    local steer_prompt="$4"
+    local expected_output="$5"
+    local timeout="${6:-45}"
+    local interval="${RUNNER_CHAT_EVENT_POLL_INTERVAL_SECONDS:-2}"
+    local start=$SECONDS
+    local response=""
+
+    while (( SECONDS - start < timeout )); do
+        if response="$(runner_api_curl "/api/zero/chat-threads/$thread_id/events?limit=200" 2>&1)"; then
+            if jq -e \
+                --arg runId "$run_id" \
+                --arg steerEventId "$steer_event_id" \
+                --arg steerPrompt "$steer_prompt" \
+                --arg expectedOutput "$expected_output" '
+                any(.events[]?;
+                    .eventType == "input.prompt" and
+                    .runId == $runId and
+                    .revokesEventId == $steerEventId and
+                    any(.userMessage.parts[]?;
+                        .type == "text" and .text == $steerPrompt
+                    )
+                ) and
+                any(.events[]?;
+                    .eventType == "output.message" and
+                    .runId == $runId and
+                    (.content | contains($expectedOutput))
+                ) and
+                any(.events[]?;
+                    .eventType == "run.completed" and .runId == $runId
+                ) and
+                all(.events[]?;
+                    (.runId == null or .runId == $runId)
+                )
+            ' <<< "$response" >/dev/null; then
+                return 0
+            fi
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for steer $steer_event_id to be consumed by run $run_id" >&2
     echo "# Last chat event response: $response" >&2
     return 1
 }
@@ -210,6 +291,125 @@ _wait_for_runner_codex_events() {
     echo "# Timed out (${timeout}s) waiting for Codex events for run $run_id" >&2
     echo "# Last event response: $response" >&2
     return 1
+}
+
+runner_chat_steer() {
+    local agent_id="$1"
+    local initial_prompt="$2"
+    local steer_prompt="$3"
+    local selected_model="$4"
+    local expected_output="$5"
+    local run_timeout="${6:-180}"
+    local send_response run_id thread_id steer_event_id steer_response run_response
+
+    send_response="$(runner_chat_send \
+        "$agent_id" \
+        "$initial_prompt" \
+        "" \
+        "$selected_model")" || return 1
+    run_id="$(jq -er '.runId | select(type == "string" and length > 0)' \
+        <<< "$send_response")" || return 1
+    thread_id="$(jq -er '.threadId | select(type == "string" and length > 0)' \
+        <<< "$send_response")" || return 1
+
+    runner_wait_for_run_running "$run_id" 60 >/dev/null || return 1
+
+    steer_event_id="$(_runner_uuid)"
+    steer_response="$(runner_chat_send \
+        "$agent_id" \
+        "$steer_prompt" \
+        "$thread_id" \
+        "" \
+        "$steer_event_id")" || return 1
+    if ! jq -e --arg threadId "$thread_id" '
+        has("runId") and .runId == null and .threadId == $threadId
+    ' <<< "$steer_response" >/dev/null; then
+        echo "# Steer created a separate run or thread: $steer_response" >&2
+        return 1
+    fi
+
+    run_response="$(runner_wait_for_run "$run_id" "$run_timeout")" || return 1
+    if ! jq -e '
+        .status == "completed" and
+        (.result.agentSessionId | type == "string" and length > 0)
+    ' <<< "$run_response" >/dev/null; then
+        echo "# Completed steered run did not contain a session id: $run_response" >&2
+        return 1
+    fi
+
+    _wait_for_runner_chat_steer_consumed \
+        "$thread_id" \
+        "$run_id" \
+        "$steer_event_id" \
+        "$steer_prompt" \
+        "$expected_output" \
+        45 || return 1
+
+    jq -cn \
+        --arg runId "$run_id" \
+        --arg threadId "$thread_id" \
+        --arg steerEventId "$steer_event_id" \
+        --arg sessionId "$(jq -er '.result.agentSessionId' <<< "$run_response")" \
+        '{
+            runId: $runId,
+            threadId: $threadId,
+            steerEventId: $steerEventId,
+            sessionId: $sessionId,
+            status: "completed"
+        }'
+}
+
+runner_chat_send_after_completion() {
+    local agent_id="$1"
+    local thread_id="$2"
+    local completed_run_id="$3"
+    local prompt="$4"
+    local expected_output="$5"
+    local run_timeout="${6:-180}"
+    local send_response run_id run_response
+
+    send_response="$(runner_chat_send \
+        "$agent_id" \
+        "$prompt" \
+        "$thread_id" \
+        "")" || return 1
+    if ! jq -e \
+        --arg threadId "$thread_id" \
+        --arg completedRunId "$completed_run_id" '
+        .threadId == $threadId and
+        (.runId | type == "string" and length > 0) and
+        .runId != $completedRunId
+    ' <<< "$send_response" >/dev/null; then
+        echo "# Post-completion message did not create a successor run: $send_response" >&2
+        return 1
+    fi
+    run_id="$(jq -er '.runId' <<< "$send_response")" || return 1
+
+    run_response="$(runner_wait_for_run "$run_id" "$run_timeout")" || return 1
+    if ! jq -e '
+        .status == "completed" and
+        (.result.agentSessionId | type == "string" and length > 0)
+    ' <<< "$run_response" >/dev/null; then
+        echo "# Completed successor run did not contain a session id: $run_response" >&2
+        return 1
+    fi
+
+    _wait_for_runner_chat_output \
+        "$thread_id" \
+        "$run_id" \
+        "$expected_output" \
+        45 || return 1
+
+    jq -cn \
+        --arg runId "$run_id" \
+        --arg threadId "$thread_id" \
+        --arg sessionId "$(jq -er '.result.agentSessionId' <<< "$run_response")" \
+        '{
+            runId: $runId,
+            threadId: $threadId,
+            sessionId: $sessionId,
+            status: "completed"
+        }'
 }
 
 _runner_chat_execute() {

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -225,7 +225,7 @@ _wait_for_runner_chat_steer_consumed() {
     local response=""
 
     while (( SECONDS - start < timeout )); do
-        if response="$(runner_api_curl "/api/zero/chat-threads/$thread_id/events?limit=200" 2>&1)"; then
+        if response="$(runner_api_curl "/api/zero/chat-threads/$thread_id/events?limit=50" 2>&1)"; then
             if jq -e \
                 --arg runId "$run_id" \
                 --arg steerEventId "$steer_event_id" \

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
       organizationId: requiredEnvironmentVariable(
         "E2E_RUNNER_CODEX_ORGANIZATION_ID",
       ),
-      upgradeToPro: false,
+      upgradeToPro: true,
     },
     {
       email: accounts.claude,

--- a/e2e/tests/03-runner/t-real-codex-steer.bats
+++ b/e2e/tests/03-runner/t-real-codex-steer.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+# Real Codex steer test through the supported agent and chat APIs.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+
+setup_file() {
+    local credentials="/tmp/e2e-api-credentials-runner-real-codex.json"
+    export E2E_API_TOKEN E2E_API_URL
+    E2E_API_TOKEN="$(jq -er '.token | select(type == "string" and length > 0)' "$credentials")"
+    E2E_API_URL="$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$credentials")"
+    require_runner_api_credentials
+
+    export RUNNER_AGENT_ID
+    RUNNER_AGENT_ID="$(create_runner_agent \
+        "e2e-real-codex-steer-$(date +%s%3N)-$RANDOM")"
+    set_runner_agent_instructions \
+        "$RUNNER_AGENT_ID" \
+        "Real Codex steer test instructions."
+}
+
+teardown_file() {
+    if [[ -n "${RUNNER_AGENT_ID:-}" ]]; then
+        delete_runner_agent "$RUNNER_AGENT_ID"
+    fi
+}
+
+run_real_codex_steer() {
+    local steer_prompt="$1"
+    local after_complete_prompt="$2"
+    local initial_prompt='Run `sleep 10` with Bash, then read the follow-up message received during this run. Reply only RESULT=codex-initial-8m6+FOLLOWUP, replacing FOLLOWUP with its exact text. If no follow-up is received, reply only RESULT=missing.'
+    local expected_output="RESULT=codex-initial-8m6+$steer_prompt"
+    local after_complete_output="RESULT=codex-after-complete+$after_complete_prompt"
+    local steer_result run_id events_response successor_result successor_run_id successor_events_response
+
+    steer_result="$(runner_chat_steer \
+        "$RUNNER_AGENT_ID" \
+        "$initial_prompt" \
+        "$steer_prompt" \
+        "gpt-5.6-luna" \
+        "$expected_output" \
+        180)" || return 1
+    run_id="$(jq -er '.runId' <<< "$steer_result")" || return 1
+    events_response="$(_wait_for_runner_codex_events \
+        "$run_id" \
+        "$expected_output" \
+        45)" || return 1
+    successor_result="$(runner_chat_send_after_completion \
+        "$RUNNER_AGENT_ID" \
+        "$(jq -er '.threadId' <<< "$steer_result")" \
+        "$run_id" \
+        "Reply only $after_complete_output" \
+        "$after_complete_output" \
+        180)" || return 1
+    successor_run_id="$(jq -er '.runId' <<< "$successor_result")" || return 1
+    successor_events_response="$(_wait_for_runner_codex_events \
+        "$successor_run_id" \
+        "$after_complete_output" \
+        45)" || return 1
+
+    jq -c \
+        --arg framework "$(jq -er '.framework' <<< "$events_response")" \
+        --arg successorRunId "$successor_run_id" \
+        --arg successorThreadId "$(jq -er '.threadId' <<< "$successor_result")" \
+        --arg successorSessionId "$(jq -er '.sessionId' <<< "$successor_result")" \
+        '. + {
+            framework: $framework,
+            successorRunId: $successorRunId,
+            successorThreadId: $successorThreadId,
+            successorSessionId: $successorSessionId
+        }' \
+        <<< "$steer_result"
+    jq -r '.events[].eventData |
+        if type == "string" then . else tojson end
+    ' <<< "$events_response"
+    jq -r '.events[].eventData |
+        if type == "string" then . else tojson end
+    ' <<< "$successor_events_response"
+}
+
+@test "real codex steers an active run then starts a successor" {
+    local steer_nonce steer_prompt after_complete_nonce after_complete_prompt
+    steer_nonce="$(_runner_uuid)"
+    steer_prompt="codex-steer-${steer_nonce%%-*}"
+    after_complete_nonce="$(_runner_uuid)"
+    after_complete_prompt="codex-new-run-${after_complete_nonce%%-*}"
+
+    run run_real_codex_steer "$steer_prompt" "$after_complete_prompt"
+
+    assert_success
+    assert_output --partial '"framework":"codex"'
+    assert_output --partial "RESULT=codex-initial-8m6+$steer_prompt"
+    assert_output --partial "RESULT=codex-after-complete+$after_complete_prompt"
+    assert_output --partial '"type":"thread.started"'
+    assert_output --partial '"type":"turn.completed"'
+    [[ -n "$(runner_chat_field "$output" '.runId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.steerEventId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.sessionId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.successorRunId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.successorSessionId')" ]]
+    [[ "$(runner_chat_field "$output" '.successorRunId')" != \
+        "$(runner_chat_field "$output" '.runId')" ]]
+    [[ "$(runner_chat_field "$output" '.successorThreadId')" == \
+        "$(runner_chat_field "$output" '.threadId')" ]]
+}

--- a/e2e/tests/03-runner/t-real-codex-steer.bats
+++ b/e2e/tests/03-runner/t-real-codex-steer.bats
@@ -5,7 +5,7 @@
 load '../../helpers/setup'
 load '../../helpers/runner-chat'
 
-BATS_TEST_TIMEOUT=450
+BATS_TEST_TIMEOUT=600
 
 setup_file() {
     local credentials="/tmp/e2e-api-credentials-runner-real-codex.json"
@@ -42,7 +42,7 @@ run_real_codex_steer() {
         "$steer_prompt" \
         "gpt-5.6-luna" \
         "$expected_output" \
-        90)" || return 1
+        150)" || return 1
     run_id="$(jq -er '.runId' <<< "$steer_result")" || return 1
     events_response="$(_wait_for_runner_codex_events \
         "$run_id" \
@@ -54,7 +54,7 @@ run_real_codex_steer() {
         "$run_id" \
         "Reply only $after_complete_output" \
         "$after_complete_output" \
-        90)" || return 1
+        150)" || return 1
     successor_run_id="$(jq -er '.runId' <<< "$successor_result")" || return 1
     successor_events_response="$(_wait_for_runner_codex_events \
         "$successor_run_id" \

--- a/e2e/tests/03-runner/t-real-codex-steer.bats
+++ b/e2e/tests/03-runner/t-real-codex-steer.bats
@@ -5,6 +5,8 @@
 load '../../helpers/setup'
 load '../../helpers/runner-chat'
 
+BATS_TEST_TIMEOUT=450
+
 setup_file() {
     local credentials="/tmp/e2e-api-credentials-runner-real-codex.json"
     export E2E_API_TOKEN E2E_API_URL
@@ -40,7 +42,7 @@ run_real_codex_steer() {
         "$steer_prompt" \
         "gpt-5.6-luna" \
         "$expected_output" \
-        180)" || return 1
+        90)" || return 1
     run_id="$(jq -er '.runId' <<< "$steer_result")" || return 1
     events_response="$(_wait_for_runner_codex_events \
         "$run_id" \
@@ -52,7 +54,7 @@ run_real_codex_steer() {
         "$run_id" \
         "Reply only $after_complete_output" \
         "$after_complete_output" \
-        180)" || return 1
+        90)" || return 1
     successor_run_id="$(jq -er '.runId' <<< "$successor_result")" || return 1
     successor_events_response="$(_wait_for_runner_codex_events \
         "$successor_run_id" \

--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -5,6 +5,8 @@
 load '../../helpers/setup'
 load '../../helpers/runner-chat'
 
+BATS_TEST_TIMEOUT=450
+
 setup_file() {
     local credentials="/tmp/e2e-api-credentials-runner-real-claude.json"
     export E2E_API_TOKEN E2E_API_URL
@@ -119,7 +121,7 @@ run_real_claude_steer() {
         "$steer_prompt" \
         "claude-sonnet-4-6" \
         "$expected_output" \
-        180)" || return 1
+        90)" || return 1
     run_id="$(jq -er '.runId' <<< "$steer_result")" || return 1
     events_response="$(wait_for_real_claude_events "$run_id" 45)" || return 1
     successor_result="$(runner_chat_send_after_completion \
@@ -128,7 +130,7 @@ run_real_claude_steer() {
         "$run_id" \
         "Reply only $after_complete_output" \
         "$after_complete_output" \
-        180)" || return 1
+        90)" || return 1
     successor_run_id="$(jq -er '.runId' <<< "$successor_result")" || return 1
     successor_events_response="$(wait_for_real_claude_events \
         "$successor_run_id" \

--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -5,7 +5,7 @@
 load '../../helpers/setup'
 load '../../helpers/runner-chat'
 
-BATS_TEST_TIMEOUT=450
+BATS_TEST_TIMEOUT=600
 
 setup_file() {
     local credentials="/tmp/e2e-api-credentials-runner-real-claude.json"
@@ -121,7 +121,7 @@ run_real_claude_steer() {
         "$steer_prompt" \
         "claude-sonnet-4-6" \
         "$expected_output" \
-        90)" || return 1
+        150)" || return 1
     run_id="$(jq -er '.runId' <<< "$steer_result")" || return 1
     events_response="$(wait_for_real_claude_events "$run_id" 45)" || return 1
     successor_result="$(runner_chat_send_after_completion \
@@ -130,7 +130,7 @@ run_real_claude_steer() {
         "$run_id" \
         "Reply only $after_complete_output" \
         "$after_complete_output" \
-        90)" || return 1
+        150)" || return 1
     successor_run_id="$(jq -er '.runId' <<< "$successor_result")" || return 1
     successor_events_response="$(wait_for_real_claude_events \
         "$successor_run_id" \

--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -74,7 +74,7 @@ run_real_claude_chat() {
         "$RUNNER_AGENT_ID" \
         "$prompt" \
         "" \
-        "claude-sonnet-5")" || return 1
+        "claude-sonnet-4-6")" || return 1
     run_id="$(jq -er '.runId | select(type == "string" and length > 0)' \
         <<< "$send_response")" || return 1
     thread_id="$(jq -er '.threadId | select(type == "string" and length > 0)' \
@@ -105,6 +105,55 @@ run_real_claude_chat() {
     ' <<< "$events_response"
 }
 
+run_real_claude_steer() {
+    local steer_prompt="$1"
+    local after_complete_prompt="$2"
+    local initial_prompt='Run `sleep 10` with Bash, then read the follow-up message received during this run. Reply only RESULT=claude-initial-5k2+FOLLOWUP, replacing FOLLOWUP with its exact text. If no follow-up is received, reply only RESULT=missing.'
+    local expected_output="RESULT=claude-initial-5k2+$steer_prompt"
+    local after_complete_output="RESULT=claude-after-complete+$after_complete_prompt"
+    local steer_result run_id events_response successor_result successor_run_id successor_events_response
+
+    steer_result="$(runner_chat_steer \
+        "$RUNNER_AGENT_ID" \
+        "$initial_prompt" \
+        "$steer_prompt" \
+        "claude-sonnet-4-6" \
+        "$expected_output" \
+        180)" || return 1
+    run_id="$(jq -er '.runId' <<< "$steer_result")" || return 1
+    events_response="$(wait_for_real_claude_events "$run_id" 45)" || return 1
+    successor_result="$(runner_chat_send_after_completion \
+        "$RUNNER_AGENT_ID" \
+        "$(jq -er '.threadId' <<< "$steer_result")" \
+        "$run_id" \
+        "Reply only $after_complete_output" \
+        "$after_complete_output" \
+        180)" || return 1
+    successor_run_id="$(jq -er '.runId' <<< "$successor_result")" || return 1
+    successor_events_response="$(wait_for_real_claude_events \
+        "$successor_run_id" \
+        45)" || return 1
+
+    jq -c \
+        --arg framework "$(jq -er '.framework' <<< "$events_response")" \
+        --arg successorRunId "$successor_run_id" \
+        --arg successorThreadId "$(jq -er '.threadId' <<< "$successor_result")" \
+        --arg successorSessionId "$(jq -er '.sessionId' <<< "$successor_result")" \
+        '. + {
+            framework: $framework,
+            successorRunId: $successorRunId,
+            successorThreadId: $successorThreadId,
+            successorSessionId: $successorSessionId
+        }' \
+        <<< "$steer_result"
+    jq -r '.events[].eventData |
+        if type == "string" then . else tojson end
+    ' <<< "$events_response"
+    jq -r '.events[].eventData |
+        if type == "string" then . else tojson end
+    ' <<< "$successor_events_response"
+}
+
 @test "t27-1: real claude returns a successful answer" {
     run run_real_claude_chat \
         "123+456. Reply only RESULT=<answer>." \
@@ -117,4 +166,30 @@ run_real_claude_chat() {
     assert_output --partial '"subtype":"success"'
     [[ -n "$(runner_chat_field "$output" '.runId')" ]]
     [[ -n "$(runner_chat_field "$output" '.sessionId')" ]]
+}
+
+@test "t27-2: real claude steers an active run then starts a successor" {
+    local steer_nonce steer_prompt after_complete_nonce after_complete_prompt
+    steer_nonce="$(_runner_uuid)"
+    steer_prompt="claude-steer-${steer_nonce%%-*}"
+    after_complete_nonce="$(_runner_uuid)"
+    after_complete_prompt="claude-new-run-${after_complete_nonce%%-*}"
+
+    run run_real_claude_steer "$steer_prompt" "$after_complete_prompt"
+
+    assert_success
+    assert_output --partial '"framework":"claude-code"'
+    assert_output --partial "RESULT=claude-initial-5k2+$steer_prompt"
+    assert_output --partial "RESULT=claude-after-complete+$after_complete_prompt"
+    assert_output --partial '"type":"result"'
+    assert_output --partial '"subtype":"success"'
+    [[ -n "$(runner_chat_field "$output" '.runId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.steerEventId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.sessionId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.successorRunId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.successorSessionId')" ]]
+    [[ "$(runner_chat_field "$output" '.successorRunId')" != \
+        "$(runner_chat_field "$output" '.runId')" ]]
+    [[ "$(runner_chat_field "$output" '.successorThreadId')" == \
+        "$(runner_chat_field "$output" '.threadId')" ]]
 }


### PR DESCRIPTION
## Summary

- add real Claude Code and Codex runner E2E coverage for active-run steer through public APIs
- prove canonical steer consumption by the original run and reject any premature successor run
- prove a message sent after completion creates a distinct run on the same thread and is consumed there
- upgrade both real-provider test accounts through public paid onboarding before configuring BYOK, use supported lower-cost models, and protect the workflow configuration with structure tests
- bound each real-provider run to 150 seconds while giving only the two real-agent BATS files enough end-to-end diagnostic time

## Compatibility and exclusions

- test and CI changes only; no production API, schema, queue, runner protocol, or persisted-state change
- real provider and preview runner execution remains CI-only
- Claude Haiku is intentionally not used because it is rejected by the current public run-model schema

## Validation

- `cd e2e && pnpm test`
- `cd e2e && pnpm check-types`
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash -n e2e/helpers/runner-chat.bash`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t27-real-claude-smoke.bats e2e/tests/03-runner/t-real-codex-steer.bats`
- generated and validated the non-empty `03-runner` shard matrix with `e2e/playwright/runner-shards.ts`
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `cd turbo && pnpm exec prettier --check ../.github/workflows/turbo.yml ../.github/scripts/tests/turbo-playwright-runner-workflow-test.sh ../e2e/helpers/runner-chat.bash ../e2e/tests/03-runner/t27-real-claude-smoke.bats ../e2e/tests/03-runner/t-real-codex-steer.bats --ignore-unknown`
- `git diff --check`

Closes #26408

Parent context: #26285
