### PR TITLE
fix(api): avoid thread-list invalidation for assistant output

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -14,10 +14,7 @@ import type {
 import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
-import {
-  publishChatThreadMessageCreatedSafely,
-  publishThreadListChangedSafely,
-} from "../external/realtime";
+import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
 import type { ModelTokenCategory } from "./model-token-categories";
 import { projectPiEventsInTransaction } from "./pi-transcript.service";
 import {
@@ -514,7 +511,5 @@ export async function publishMaterializedChatProjection(
       projection.thread.chatThreadId,
     );
   }
-  signal.throwIfAborted();
-  await publishThreadListChangedSafely(projection.thread.userId);
   signal.throwIfAborted();
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
@@ -15,10 +15,7 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { writeDb$, type Db } from "../external/db";
-import {
-  publishChatThreadMessageCreatedSafely,
-  publishThreadListChangedSafely,
-} from "../external/realtime";
+import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
 import { nowDate } from "../../lib/time";
 import { assistantEventIdForRunEvent } from "./assistant-event-id";
 import { insertChatEvents } from "./zero-chat-event.service";
@@ -251,9 +248,6 @@ export async function insertAssistantEvents(
     } else {
       await publishChatThreadMessageCreatedSafely(args.userId, args.threadId);
     }
-    signal.throwIfAborted();
-
-    await publishThreadListChangedSafely(args.userId);
     signal.throwIfAborted();
   }
 


### PR DESCRIPTION
## Summary

- stop ordinary assistant event materialization from publishing the user-scoped `threadListChanged` event
- keep thread-scoped `chatThreadMessageCreated` delivery and existing thread/run lifecycle invalidations
- avoid sidebar and unread-list refetch fan-out while assistant output is being persisted

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`

No Vitest suite was run and no negative publication test was added. Existing tests that cover legitimate send and lifecycle publications remain unchanged.
