### PR TITLE
fix(api): delete connector owners before organization storage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -5184,10 +5184,10 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       displayName: "BDD Org Teardown Agent",
       visibility: "public",
     });
-    const customManual = await connectors.createCustomConnector(
-      actor,
-      customManualConnectorBodyForTeardown("org"),
-    );
+    const customManual = await connectors.createCustomConnector(actor, {
+      ...customManualConnectorBodyForTeardown("org"),
+      skillMarkdown: "Keep this registered teardown skill active.",
+    });
     await connectors.setCustomConnectorSecret(
       actor,
       customManual.id,

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -788,12 +788,12 @@ async function deleteOrgData(
   await db.delete(artifacts).where(eq(artifacts.orgId, orgId));
   await db.delete(agentRuns).where(eq(agentRuns.orgId, orgId));
   await db.delete(agentComposes).where(eq(agentComposes.orgId, orgId));
+  await deleteConnectorOwnerState(db, { kind: "organization", orgId }, signal);
   await db.delete(storages).where(eq(storages.orgId, orgId));
   await db.delete(modelProviders).where(eq(modelProviders.orgId, orgId));
   await db
     .delete(modelProviderAuthSessions)
     .where(eq(modelProviderAuthSessions.orgId, orgId));
-  await deleteConnectorOwnerState(db, { kind: "organization", orgId }, signal);
   await db.delete(secrets).where(eq(secrets.orgId, orgId));
   await db.delete(variables).where(eq(variables.orgId, orgId));
   await db


### PR DESCRIPTION
## Summary

- delete organization connector owner state before deleting its storage rows
- cover Clerk organization teardown with an exact-version Custom connector skill

## Scope

- no schema, migration, API contract, or R2 cleanup changes

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts -t "cleans up organization state after a verified organization.deleted event"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm format`
- full pre-commit checks

Closes #26414
