### PR TITLE
refactor: remove legacy mcp discovery handoff

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -13,10 +13,7 @@ import {
   type ConnectorRuntimeSyncResult,
   type Job as RunnerJob,
 } from "@vm0/api-contracts/contracts/runners";
-import {
-  type CreateCustomConnectorBody,
-  ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY,
-} from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import type { CreateCustomConnectorBody } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { testCustomConnectorSkillVersionAssociationContract } from "@vm0/api-contracts/contracts/test-custom-connector-skill-version-association";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
@@ -8808,9 +8805,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.heartbeatRunner(runnerGroup);
     const disabledClaim = await api.claimRunnerJob(disabledRun.runId);
     const mcpInternalName = `custom_connector_${mcp.id.replaceAll("-", "")}`;
-    expect(disabledClaim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
-      JSON.stringify([http.id]),
-    );
     expect(disabledClaim.connectorRuntimeTargets).not.toContainEqual(
       expect.objectContaining({
         kind: "custom",
@@ -8841,7 +8835,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
           framework: "claude-code",
           environment: {
             ANTHROPIC_API_KEY: "bdd-inline-key",
-            [ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]: JSON.stringify([randomUUID()]),
           },
         },
       },
@@ -8856,9 +8849,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     const claim = await api.claimRunnerJob(run.runId);
     const admittedIds = [http.id, mcp.id].sort();
-    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
-      JSON.stringify(admittedIds),
-    );
     expect(
       claim.connectorRuntimeTargets
         .flatMap((target) => {
@@ -9018,9 +9008,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(
       availableCustomConnectorRuntime(removedGrantResult).baseUrlVars,
     ).toStrictEqual({});
-    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
-      JSON.stringify(admittedIds),
-    );
 
     await connectors.deleteCustomConnector(actor, mcp.id);
     const [deletedResult] = await api.syncConnectorRuntime(run.runId, {
@@ -9105,9 +9092,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
     const expectedIds = [...createdIds].sort();
-    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
-      JSON.stringify(expectedIds),
-    );
     expect(
       claim.connectorRuntimeTargets
         .flatMap((target) => {
@@ -9922,9 +9906,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
-    expect(claim.environment?.[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]).toBe(
-      JSON.stringify([mcp.id]),
-    );
     const internalName = `custom_connector_${mcp.id.replaceAll("-", "")}`;
     expect(inlineFirewallApis(claim.firewalls, internalName)[0]).toMatchObject({
       base: "https://mcp-oauth.example.test/oauth/mcp",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -18,7 +18,6 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { CodexServiceTier } from "@vm0/api-contracts/contracts/chat-threads";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
-import { ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   connectorSlugSchema,
   type ConnectorAuthMethodId,
@@ -5859,13 +5858,6 @@ async function buildStoredExecutionContextDraft(args: {
     permissionManifest: permissions,
     customTargets: args.customConnectorContext.targets,
   });
-  const customConnectorIds = [
-    ...new Set(
-      connectorRuntimeTargets.flatMap((target) => {
-        return target.kind === "custom" ? [target.customConnectorId] : [];
-      }),
-    ),
-  ].sort();
   const environment = {
     ...expandEnvironment({
       content: args.resolved.content,
@@ -5878,7 +5870,6 @@ async function buildStoredExecutionContextDraft(args: {
     }),
     ...args.extraEnvironment,
     CLI_PKG_URL: env("CLI_PKG_URL"),
-    [ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY]: JSON.stringify(customConnectorIds),
   };
   const environmentKeyByValue = new Map<string, string>();
   for (const [key, value] of Object.entries(environment)) {

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/custom-connectors.ts
@@ -1,7 +1,6 @@
 import { http, HttpResponse } from "msw";
 import type {
   CustomConnectorHttpResponse,
-  CustomConnectorMcpResponse,
   CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type { ZeroMcpConnector } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
@@ -43,45 +42,6 @@ export function customConnector(
   };
 }
 
-export function mcpCustomConnector(
-  overrides: Partial<CustomConnectorMcpResponse> = {},
-): CustomConnectorMcpResponse {
-  return {
-    kind: "mcp",
-    id: "44444444-4444-4444-8444-444444444444",
-    slug: "_acme-mcp",
-    displayName: "Acme MCP",
-    endpoint: "https://mcp.example.test/server",
-    transport: "streamable-http",
-    prefixTemplates: [],
-    permissionBundleRef: null,
-    fields: [
-      {
-        key: "secret",
-        label: "Secret",
-        kind: "secret",
-        required: true,
-      },
-    ],
-    headerInjections: [
-      {
-        name: "Authorization",
-        valueTemplate: "Bearer {{secrets.secret}}",
-      },
-    ],
-    queryInjections: [],
-    authMode: "manual",
-    storageVersion: 1,
-    connected: true,
-    missingRequiredFields: [],
-    configuredFieldKeys: ["secret"],
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    hasSecret: true,
-    ...overrides,
-  };
-}
-
 export function stubCustomConnectors(
   connectors: readonly CustomConnectorResponse[],
   origin = "http://localhost:3000",
@@ -111,14 +71,6 @@ export function stubRunMcpConnectors(
 ) {
   return http.get(`${origin}/api/zero/mcp-connectors`, () => {
     return HttpResponse.json({ connectors });
-  });
-}
-
-export function stubRunMcpConnectorsUnavailable(
-  origin = "http://localhost:3000",
-) {
-  return http.get(`${origin}/api/zero/mcp-connectors`, () => {
-    return HttpResponse.json({ error: "Not found" }, { status: 404 });
   });
 }
 

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -24,11 +24,8 @@ import {
 
 import { server } from "../../../../mocks/server";
 import {
-  mcpCustomConnector,
   runMcpConnector,
-  stubCustomConnectors,
   stubRunMcpConnectors,
-  stubRunMcpConnectorsUnavailable,
 } from "../../__tests__/helpers/custom-connectors";
 import { zeroMcpCommand } from "../index";
 
@@ -225,7 +222,6 @@ describe("zero mcp command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", JSON.stringify([CONNECTOR_ID]));
   });
 
   afterEach(() => {
@@ -241,7 +237,6 @@ describe("zero mcp command", () => {
 
   it("lists server-authorized MCP definitions with safe JSON fields", async () => {
     const secondId = "55555555-5555-4555-8555-555555555555";
-    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "malformed legacy metadata");
     server.use(
       stubRunMcpConnectors([
         runMcpConnector({
@@ -280,72 +275,6 @@ describe("zero mcp command", () => {
     const output = outputText(consoleLog);
     expect(output).not.toContain("Authorization");
     expect(output).not.toContain("secrets.secret");
-  });
-
-  it("uses legacy metadata only when the discovery route is unavailable", async () => {
-    server.use(
-      stubRunMcpConnectorsUnavailable(),
-      stubCustomConnectors([mcpCustomConnector()]),
-    );
-
-    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
-
-    expect(outputText(consoleLog)).toContain("_acme-mcp");
-  });
-
-  it("rejects malformed legacy metadata before requesting connector definitions", async () => {
-    let apiCalls = 0;
-    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "x".repeat(128 * 1024 + 1));
-    server.use(
-      stubRunMcpConnectorsUnavailable(),
-      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
-        apiCalls++;
-        return HttpResponse.json({ connectors: [] });
-      }),
-    );
-
-    await expect(
-      zeroMcpCommand.parseAsync(["node", "zero", "list"]),
-    ).rejects.toThrow("process.exit called");
-
-    expect(apiCalls).toBe(0);
-    expect(outputText(consoleError)).toContain("Start a new Agent Run");
-    expect(outputText(consoleError)).not.toContain("xxxx");
-  });
-
-  it("rejects duplicate run IDs without a broad fallback", async () => {
-    vi.stubEnv(
-      "ZERO_CUSTOM_CONNECTOR_IDS",
-      JSON.stringify([CONNECTOR_ID, CONNECTOR_ID.toUpperCase()]),
-    );
-    server.use(
-      stubRunMcpConnectorsUnavailable(),
-      stubCustomConnectors([mcpCustomConnector()]),
-    );
-
-    await expect(
-      zeroMcpCommand.parseAsync(["node", "zero", "list"]),
-    ).rejects.toThrow("process.exit called");
-
-    expect(outputText(consoleError)).toContain("Start a new Agent Run");
-    expect(outputText(consoleLog)).not.toContain("Acme MCP");
-  });
-
-  it("does not apply the 256-item runtime-sync batch as a membership limit", async () => {
-    const ids = Array.from({ length: 257 }, (_, index) => {
-      return `00000000-0000-4000-8000-${index.toString(16).padStart(12, "0")}`;
-    });
-    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", JSON.stringify(ids));
-    server.use(
-      stubRunMcpConnectorsUnavailable(),
-      stubCustomConnectors([
-        mcpCustomConnector({ id: ids[256], slug: "_after-batch" }),
-      ]),
-    );
-
-    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
-
-    expect(outputText(consoleLog)).toContain("_after-batch");
   });
 
   it("discovers modern tools page by page with exact intent and cleanup", async () => {
@@ -701,37 +630,15 @@ describe("zero mcp command", () => {
     expect(outputText(consoleError)).toContain("MCP server request failed");
   });
 
-  it("treats an empty legacy run set as an ordinary empty result", async () => {
-    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "[]");
-    server.use(
-      stubRunMcpConnectorsUnavailable(),
-      stubCustomConnectors([mcpCustomConnector()]),
-    );
+  it("treats an empty discovery response as an ordinary empty result", async () => {
+    server.use(stubRunMcpConnectors([]));
 
     await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
 
     expect(consoleLog).toHaveBeenCalledWith('{"connectors":[]}');
   });
 
-  it("treats an empty discovery response as authoritative", async () => {
-    let legacyCalls = 0;
-    vi.stubEnv("ZERO_CUSTOM_CONNECTOR_IDS", "malformed legacy metadata");
-    server.use(
-      stubRunMcpConnectors([]),
-      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
-        legacyCalls++;
-        return HttpResponse.json({ connectors: [mcpCustomConnector()] });
-      }),
-    );
-
-    await zeroMcpCommand.parseAsync(["node", "zero", "list", "--json"]);
-
-    expect(consoleLog).toHaveBeenCalledWith('{"connectors":[]}');
-    expect(legacyCalls).toBe(0);
-  });
-
-  it("does not fall back after a discovery server error", async () => {
-    let legacyCalls = 0;
+  it("reports a discovery server error", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/mcp-connectors", () => {
         return HttpResponse.json(
@@ -744,37 +651,25 @@ describe("zero mcp command", () => {
           { status: 500 },
         );
       }),
-      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
-        legacyCalls++;
-        return HttpResponse.json({ connectors: [mcpCustomConnector()] });
-      }),
     );
 
     await expect(
       zeroMcpCommand.parseAsync(["node", "zero", "list"]),
     ).rejects.toThrow("process.exit called");
 
-    expect(legacyCalls).toBe(0);
     expect(outputText(consoleError)).toContain("Discovery failed");
   });
 
-  it("rejects malformed discovery responses without falling back", async () => {
-    let legacyCalls = 0;
+  it("rejects malformed discovery responses", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/mcp-connectors", () => {
         return HttpResponse.json({ connectors: [{ id: CONNECTOR_ID }] });
       }),
-      http.get("http://localhost:3000/api/zero/custom-connectors", () => {
-        legacyCalls++;
-        return HttpResponse.json({ connectors: [mcpCustomConnector()] });
-      }),
     );
 
     await expect(
       zeroMcpCommand.parseAsync(["node", "zero", "list"]),
     ).rejects.toThrow("process.exit called");
-
-    expect(legacyCalls).toBe(0);
   });
 
   it("rejects an unknown slug before opening an MCP connection", async () => {

--- a/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/run-connectors.ts
@@ -1,73 +1,9 @@
-import {
-  ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY,
-  type CustomConnectorMcpClientResponse,
-} from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type { ZeroMcpConnector } from "@vm0/api-contracts/contracts/zero-mcp-connectors";
-import { z } from "zod";
 
-import {
-  listZeroCustomConnectors,
-  listZeroRunMcpConnectors,
-} from "../../../lib/api/domains/zero-connectors";
+import { listZeroRunMcpConnectors } from "../../../lib/api/domains/zero-connectors";
 
-const MAX_RUN_CONNECTOR_IDS_BYTES = 128 * 1024;
-const RUN_METADATA_ERROR =
-  "MCP connector metadata is unavailable for this run. Start a new Agent Run and try again.";
-
-const runConnectorIdsSchema = z.array(z.uuid());
-
-function readRunConnectorIds(): Set<string> {
-  const raw = process.env[ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY];
-  if (
-    raw === undefined ||
-    Buffer.byteLength(raw, "utf8") > MAX_RUN_CONNECTOR_IDS_BYTES
-  ) {
-    throw new Error(RUN_METADATA_ERROR);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(RUN_METADATA_ERROR);
-  }
-
-  const result = runConnectorIdsSchema.safeParse(parsed);
-  if (!result.success) {
-    throw new Error(RUN_METADATA_ERROR);
-  }
-
-  const normalizedIds = result.data.map((id) => {
-    return id.toLowerCase();
-  });
-  const uniqueIds = new Set(normalizedIds);
-  if (uniqueIds.size !== normalizedIds.length) {
-    throw new Error(RUN_METADATA_ERROR);
-  }
-  return uniqueIds;
-}
-
-export async function listRunMcpConnectors(): Promise<ZeroMcpConnector[]> {
-  const discoveredConnectors = await listZeroRunMcpConnectors();
-  if (discoveredConnectors !== null) {
-    return discoveredConnectors;
-  }
-
-  // Commit-addressed CLI ↔ backend rollout fallback: a newly selected CLI can
-  // reach an API deployment that predates this additive route. Remove with
-  // #26389 after its >4-hour queue/run drain and production evidence gate.
-  const admittedIds = readRunConnectorIds();
-  const connectors = await listZeroCustomConnectors();
-
-  return connectors
-    .filter((connector): connector is CustomConnectorMcpClientResponse => {
-      return (
-        connector.kind === "mcp" && admittedIds.has(connector.id.toLowerCase())
-      );
-    })
-    .sort((left, right) => {
-      return left.slug.localeCompare(right.slug);
-    });
+export function listRunMcpConnectors(): Promise<ZeroMcpConnector[]> {
+  return listZeroRunMcpConnectors();
 }
 
 export async function resolveRunMcpConnector(

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -201,20 +201,13 @@ export async function listZeroCustomConnectors(): Promise<
   handleError(result, "Failed to list custom connectors");
 }
 
-export async function listZeroRunMcpConnectors(): Promise<
-  ZeroMcpConnector[] | null
-> {
+export async function listZeroRunMcpConnectors(): Promise<ZeroMcpConnector[]> {
   const config = await getClientConfig();
   const client = initClient(zeroMcpConnectorsContract, config);
 
   const result = await client.list({ headers: {} });
   if (result.status === 200) {
     return zeroMcpConnectorListResponseSchema.parse(result.body).connectors;
-  }
-  // This collection has no resource-level 404. A 404 means the API
-  // deployment predates this route and activates the temporary CLI fallback.
-  if (result.status === 404) {
-    return null;
   }
 
   handleError(result, "Failed to list MCP connectors for this run");

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -5,8 +5,6 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-export const ZERO_CUSTOM_CONNECTOR_IDS_ENV_KEY = "ZERO_CUSTOM_CONNECTOR_IDS";
-
 export const customConnectorSlugSchema = z
   .string()
   .regex(/^_[a-z0-9][a-z0-9-]{0,60}[a-z0-9]$/u);

--- a/turbo/packages/api-contracts/src/contracts/zero-mcp-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-mcp-connectors.ts
@@ -29,7 +29,6 @@ export const zeroMcpConnectorsContract = c.router({
       200: zeroMcpConnectorListResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
-      404: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "List MCP connectors authorized for the current Agent Run",


### PR DESCRIPTION
## Summary

- stop serializing custom connector IDs into `ZERO_CUSTOM_CONNECTOR_IDS` when an Agent Run is created
- make `zero mcp` discovery use only the server-authored `/api/zero/mcp-connectors` response
- remove the rollout-only 404 contract, legacy CLI fallback, and compatibility-specific tests and helpers

## Preserved behavior

- custom connector management APIs remain unchanged
- Runner connector runtime targets, firewall policy, runtime sync, and intent remain unchanged
- no database schema, migration, or persisted data changes are included

## Merge gate

**Do not merge this PR yet.** The canonical discovery route from #26399 is deployed, but the compatibility handoff must remain available until production evidence confirms that no queued, pending, running, or finalizing execution context can still select the pre-route CLI or depend on `ZERO_CUSTOM_CONNECTOR_IDS`.

The conservative time-only drain checkpoint is 2026-08-11 21:24:45 UTC (2026-08-12 05:24:45 Asia/Shanghai), based on the two-hour Agent Run queue context TTL, a fresh two-hour Runner job TTL after promotion, the two-hour Runner timeout, and finalization margins. Before merge, also verify that no external caller depends on the removed environment variable and that rollback no longer requires the fallback.

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm exec prettier --check <changed files>`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/zero-cli lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/zero-cli check-types`
- `pnpm -F api check-types`
- `pnpm check-types` (14/14 workspaces, via pre-commit hook)
- `pnpm knip`
- `pnpm -F @vm0/zero-cli exec vitest run src/commands/zero/mcp/__tests__/index.test.ts` (25 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-mcp-connectors.test.ts` (3 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (158 tests)
- `pnpm -F @vm0/api-contracts exec vitest run` (567 tests)

Closes #26389

Parent context: #26383
