### PR TITLE
test(e2e): restore runner network telemetry

### DIFF
--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -17,6 +17,8 @@ entry points. The current suite covers:
   workflow files and agent instructions;
 - connector firewall placeholder and authentication behavior through the
   deployed preview API, runner, sandbox, and proxy.
+- raw network protocol, DNS, connector diagnostic, browser classification, and
+  opt-in body-capture telemetry through the deployed runner and public run API.
 
 An E2E test must not call `/api/test/*`, mint a test-only API token, write the
 database directly, or use an internal fixture endpoint to construct or inspect
@@ -94,6 +96,10 @@ For active-run connector refresh cases, coordinate through a run-scoped output
 message in the public chat-events API. Network telemetry is uploaded after the
 run completes, so use it only as the final ordered policy assertion, not as a
 live synchronization point.
+
+Body capture must be enabled on the individual chat run. Do not mutate the
+shared runner account's next-run capture preference: runner files execute in
+parallel, so user-scoped mutable preferences are not isolated between shards.
 
 The workflow discovers the checked-in BATS files, weighs each file by its test
 count, and assigns whole files to at most twelve non-empty shards. New files are

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -144,9 +144,16 @@ runner_e2e_wait_for_run_status() {
 runner_e2e_start_chat_run() {
     local agent_id="$1"
     local prompt="$2"
+    local capture_network_bodies="${3:-false}"
     local shell_prompt
     shell_prompt=$(printf '@shell@\n%s' "$prompt")
-    runner_chat_send "$agent_id" "$shell_prompt" "" "deepseek-v4-flash"
+    runner_chat_send \
+        "$agent_id" \
+        "$shell_prompt" \
+        "" \
+        "deepseek-v4-flash" \
+        "" \
+        "$capture_network_bodies"
 }
 
 runner_e2e_continue_chat_run() {

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -84,6 +84,7 @@ runner_chat_send() {
     local thread_id="$3"
     local selected_model="$4"
     local client_event_id="${5:-}"
+    local capture_network_bodies="${6:-false}"
     local parts
 
     parts="$(jq -nc --arg prompt "$prompt" '[{type: "text", text: $prompt}]')"
@@ -93,7 +94,8 @@ runner_chat_send() {
         "$parts" \
         "$thread_id" \
         "$selected_model" \
-        "$client_event_id"
+        "$client_event_id" \
+        "$capture_network_bodies"
 }
 
 runner_chat_send_parts() {
@@ -102,7 +104,9 @@ runner_chat_send_parts() {
     local parts="$3"
     local thread_id="$4"
     local selected_model="$5"
-    local client_event_id="${6:-}" payload
+    local client_event_id="${6:-}"
+    local capture_network_bodies="${7:-false}"
+    local payload
 
     if [[ -z "$client_event_id" ]]; then
         client_event_id="$(_runner_uuid)"
@@ -114,6 +118,7 @@ runner_chat_send_parts() {
             --arg threadId "$thread_id" \
             --arg clientEventId "$client_event_id" \
             --argjson parts "$parts" \
+            --argjson captureNetworkBodies "$capture_network_bodies" \
             '{
                 agentId: $agentId,
                 prompt: $prompt,
@@ -121,7 +126,7 @@ runner_chat_send_parts() {
                 clientEventId: $clientEventId,
                 userMessage: {version: 1, parts: $parts},
                 hasTextContent: true
-            }')"
+            } + if $captureNetworkBodies then {captureNetworkBodies: true} else {} end')"
     else
         payload="$(jq -nc \
             --arg agentId "$agent_id" \
@@ -129,6 +134,7 @@ runner_chat_send_parts() {
             --arg model "$selected_model" \
             --arg clientEventId "$client_event_id" \
             --argjson parts "$parts" \
+            --argjson captureNetworkBodies "$capture_network_bodies" \
             '{
                 agentId: $agentId,
                 prompt: $prompt,
@@ -136,7 +142,7 @@ runner_chat_send_parts() {
                 clientEventId: $clientEventId,
                 userMessage: {version: 1, parts: $parts},
                 hasTextContent: true
-            }')"
+            } + if $captureNetworkBodies then {captureNetworkBodies: true} else {} end')"
     fi
 
     runner_api_curl "/api/zero/chat/events" -X POST -d "$payload"

--- a/e2e/tests/03-runner/run-t06-network-telemetry.bats
+++ b/e2e/tests/03-runner/run-t06-network-telemetry.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test
+}
+
+@test "runner publishes protocol, diagnostic, browser, and captured-body network telemetry" {
+    run create_runner_agent "runner-network-telemetry-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    local prompt
+    prompt=$(cat <<'EOF'
+python3 - <<'PY'
+import socket
+import struct
+
+
+def dns_query(transaction_id, name):
+    labels = b"".join(bytes([len(label)]) + label.encode() for label in name.split("."))
+    return struct.pack("!HHHHHH", transaction_id, 0x0100, 1, 0, 0, 0) + labels + b"\x00\x00\x01\x00\x01"
+
+
+def read_exact(connection, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = connection.recv(size - len(data))
+        if not chunk:
+            raise RuntimeError("DNS connection closed before the response completed")
+        data.extend(chunk)
+    return bytes(data)
+
+
+try:
+    with socket.create_connection(("192.0.2.1", 4444), timeout=3) as connection:
+        connection.sendall(b"vm0-raw-tcp-probe")
+except OSError:
+    pass
+print("RAW_TCP_PROBE_DONE")
+
+with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as connection:
+    connection.sendto(b"vm0-udp-probe", ("192.0.2.1", 9999))
+print("UDP_PROBE_DONE")
+
+udp_query = dns_query(0x4501, "udp-dns.invalid")
+with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as connection:
+    connection.settimeout(5)
+    connection.sendto(udp_query, ("192.0.2.1", 53))
+    udp_response, _ = connection.recvfrom(4096)
+assert udp_response[:2] == udp_query[:2] and udp_response[2] & 0x80
+print("UDP_DNS_PROBE_DONE")
+
+tcp_query = dns_query(0x4502, "tcp-dns.invalid")
+with socket.create_connection(("192.0.2.1", 53), timeout=5) as connection:
+    connection.sendall(struct.pack("!H", len(tcp_query)) + tcp_query)
+    response_size = struct.unpack("!H", read_exact(connection, 2))[0]
+    tcp_response = read_exact(connection, response_size)
+assert tcp_response[:2] == tcp_query[:2] and tcp_response[2] & 0x80
+print("TCP_DNS_PROBE_DONE")
+PY
+
+replicate_status=$(curl --silent --show-error --max-time 10 \
+    --output /tmp/replicate-diagnostic.json \
+    --write-out '%{http_code}' \
+    https://api.replicate.com/v1/models || true)
+cat /tmp/replicate-diagnostic.json 2>/dev/null || true
+printf '\nREPLICATE_STATUS=%s\n' "$replicate_status"
+
+curl --silent --show-error --max-time 10 \
+    --request GET \
+    --user-agent 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' \
+    --header 'Content-Type: text/plain' \
+    --data 'vm0-captured-request-body' \
+    --output /tmp/browser-response.txt \
+    https://www.google.com/ || true
+printf 'BROWSER_REQUEST_DONE\n'
+printf 'NETWORK_PROBES_DONE\n'
+EOF
+)
+    run runner_e2e_start_chat_run "$AGENT_ID" "$prompt" true
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId' <<<"$output")
+
+    run runner_wait_for_run "$RUN_ID" 150
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_agent_text "$RUN_ID" NETWORK_PROBES_DONE 30
+    echo "$output"
+    assert_success
+    assert_output --partial "RAW_TCP_PROBE_DONE"
+    assert_output --partial "UDP_PROBE_DONE"
+    assert_output --partial "UDP_DNS_PROBE_DONE"
+    assert_output --partial "TCP_DNS_PROBE_DONE"
+    assert_output --partial "REPLICATE_STATUS=424"
+    assert_output --partial "BROWSER_REQUEST_DONE"
+
+    local network_logs='[]'
+    local telemetry_found=false
+    local started_at=$SECONDS
+    while ((SECONDS - started_at < 60)); do
+        if network_logs=$(runner_e2e_network_logs "$RUN_ID" 2>&1) &&
+            jq -e '
+                any(.[];
+                    .type == "tcp" and
+                    .host == "192.0.2.1" and
+                    .port == 4444) and
+                any(.[];
+                    .type == "udp" and
+                    .host == "192.0.2.1" and
+                    .port == 9999) and
+                any(.[];
+                    .type == "dns" and
+                    .host == "udp-dns.invalid" and
+                    .port == 53 and
+                    .dns_event == "query") and
+                any(.[];
+                    .type == "dns" and
+                    .host == "tcp-dns.invalid" and
+                    .port == 53 and
+                    .dns_event == "query") and
+                any(.[];
+                    .type == "http" and
+                    .host == "api.replicate.com" and
+                    .status == 424 and
+                    .connector_diagnostic_slug == "replicate" and
+                    .connector_diagnostic_reason == "not_configured_for_run" and
+                    .connector_diagnostic_env_names == ["REPLICATE_TOKEN"] and
+                    .connector_diagnostic_base == "https://api.replicate.com") and
+                any(.[];
+                    .type == "http" and
+                    .host == "www.google.com" and
+                    .browser_user_agent == true and
+                    .request_body == "vm0-captured-request-body" and
+                    (.response_body | type) == "string" and
+                    (.response_body | length) > 0)
+            ' <<<"$network_logs" >/dev/null; then
+            telemetry_found=true
+            break
+        fi
+        sleep 2
+    done
+
+    if [[ "$telemetry_found" != "true" ]]; then
+        echo "Missing required network telemetry for run ${RUN_ID}" >&2
+        echo "Last network telemetry: ${network_logs}" >&2
+        return 1
+    fi
+}

--- a/e2e/tests/03-runner/run-t06-network-telemetry.bats
+++ b/e2e/tests/03-runner/run-t06-network-telemetry.bats
@@ -41,11 +41,21 @@ def read_exact(connection, size):
     return bytes(data)
 
 
-try:
-    with socket.create_connection(("192.0.2.1", 4444), timeout=3) as connection:
-        connection.sendall(b"vm0-raw-tcp-probe")
-except OSError:
-    pass
+with socket.create_connection(("ssh.github.com", 443), timeout=5) as connection:
+    connection.settimeout(5)
+    banner = bytearray()
+    while b"\n" not in banner:
+        chunk = connection.recv(4096)
+        if not chunk:
+            raise RuntimeError("ssh.github.com:443 closed before the SSH banner")
+        banner.extend(chunk)
+    assert bytes(banner).startswith(b"SSH-2.0-")
+    connection.shutdown(socket.SHUT_WR)
+    try:
+        while connection.recv(4096):
+            pass
+    except ConnectionResetError:
+        pass
 print("RAW_TCP_PROBE_DONE")
 
 with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as connection:
@@ -87,12 +97,12 @@ print("REPLICATE_DIAGNOSTIC_DONE")
 PY
 
 curl --silent --show-error --max-time 10 \
-    --request GET \
+    --http1.1 \
     --user-agent 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' \
     --header 'Content-Type: text/plain' \
     --data 'vm0-captured-request-body' \
     --output /tmp/browser-response.txt \
-    https://www.google.com/ || true
+    https://www.google.com/
 printf 'BROWSER_REQUEST_DONE\n'
 printf 'NETWORK_PROBES_DONE\n'
 EOF
@@ -125,8 +135,8 @@ EOF
             jq -e '
                 any(.[];
                     .type == "tcp" and
-                    .host == "192.0.2.1" and
-                    .port == 4444) and
+                    .port == 443 and
+                    .response_size > 0) and
                 any(.[];
                     .type == "udp" and
                     .host == "192.0.2.1" and

--- a/e2e/tests/03-runner/run-t06-network-telemetry.bats
+++ b/e2e/tests/03-runner/run-t06-network-telemetry.bats
@@ -174,7 +174,46 @@ EOF
 
     if [[ "$telemetry_found" != "true" ]]; then
         echo "Missing required network telemetry for run ${RUN_ID}" >&2
-        echo "Last network telemetry: ${network_logs}" >&2
+        local telemetry_summary
+        if telemetry_summary=$(jq -c '
+            {
+                tcp: [.[] |
+                    select(.type == "tcp" and .port == 443) |
+                    {host, port, request_size, response_size, error}],
+                udp: [.[] |
+                    select(.type == "udp" and .port == 9999) |
+                    {host, port, size}],
+                dns: [.[] |
+                    select(
+                        .type == "dns" and
+                        (.host == "udp-dns.invalid" or .host == "tcp-dns.invalid")) |
+                    {host, port, dns_event}],
+                replicate: [.[] |
+                    select(.type == "http" and .host == "api.replicate.com") |
+                    {
+                        status,
+                        error,
+                        connector_diagnostic_slug,
+                        connector_diagnostic_reason,
+                        connector_diagnostic_env_names,
+                        connector_diagnostic_base
+                    }],
+                google: [.[] |
+                    select(.type == "http" and .host == "www.google.com") |
+                    {
+                        method,
+                        status,
+                        error,
+                        browser_user_agent,
+                        request_body_matches: (.request_body == "vm0-captured-request-body"),
+                        response_body_length: ((.response_body // "") | length)
+                    }]
+            }
+        ' <<<"$network_logs" 2>/dev/null); then
+            echo "Relevant network telemetry: ${telemetry_summary}" >&2
+        else
+            echo "Network telemetry response could not be decoded" >&2
+        fi
         return 1
     fi
 }

--- a/e2e/tests/03-runner/run-t06-network-telemetry.bats
+++ b/e2e/tests/03-runner/run-t06-network-telemetry.bats
@@ -69,12 +69,22 @@ assert tcp_response[:2] == tcp_query[:2] and tcp_response[2] & 0x80
 print("TCP_DNS_PROBE_DONE")
 PY
 
-replicate_status=$(curl --silent --show-error --max-time 10 \
+curl --silent --show-error --max-time 10 \
     --output /tmp/replicate-diagnostic.json \
-    --write-out '%{http_code}' \
-    https://api.replicate.com/v1/models || true)
-cat /tmp/replicate-diagnostic.json 2>/dev/null || true
-printf '\nREPLICATE_STATUS=%s\n' "$replicate_status"
+    https://api.replicate.com/v1/models || true
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+
+diagnostic = json.loads(Path("/tmp/replicate-diagnostic.json").read_text())
+assert diagnostic["error"] == "connector_not_configured_for_run"
+assert diagnostic["connector"] == "replicate"
+assert diagnostic["reason"] == "not_configured_for_run"
+assert diagnostic["envNames"] == ["REPLICATE_TOKEN"]
+assert diagnostic["base"] == "https://api.replicate.com"
+print("REPLICATE_DIAGNOSTIC_DONE")
+PY
 
 curl --silent --show-error --max-time 10 \
     --request GET \
@@ -104,7 +114,7 @@ EOF
     assert_output --partial "UDP_PROBE_DONE"
     assert_output --partial "UDP_DNS_PROBE_DONE"
     assert_output --partial "TCP_DNS_PROBE_DONE"
-    assert_output --partial "REPLICATE_STATUS=424"
+    assert_output --partial "REPLICATE_DIAGNOSTIC_DONE"
     assert_output --partial "BROWSER_REQUEST_DONE"
 
     local network_logs='[]'
@@ -134,7 +144,6 @@ EOF
                 any(.[];
                     .type == "http" and
                     .host == "api.replicate.com" and
-                    .status == 424 and
                     .connector_diagnostic_slug == "replicate" and
                     .connector_diagnostic_reason == "not_configured_for_run" and
                     .connector_diagnostic_env_names == ["REPLICATE_TOKEN"] and

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -328,6 +328,7 @@ interface ChatRunSendBody {
   readonly template?: GenerationTemplateRequest;
   readonly computerUseHostId?: string | null;
   readonly revokesEventId?: string;
+  readonly captureNetworkBodies?: boolean;
 }
 
 /**
@@ -3805,6 +3806,28 @@ describe("CHAT-02: model-first provider policies", () => {
       }
     }
   }, 90_000);
+
+  it("passes request-scoped network body capture into the runner claim", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const captured = await sendChatRun(actor, {
+      agentId,
+      prompt: "capture this run's network bodies",
+      captureNetworkBodies: true,
+    });
+    const capturedClaim = await claimChatRun(runnerGroup, captured.runId);
+    expect(capturedClaim.claim.captureNetworkBodies).toBeTruthy();
+    await cancelChatRun(actor, captured.runId);
+
+    const ordinary = await sendChatRun(actor, {
+      agentId,
+      prompt: "keep ordinary network logging metadata-only",
+    });
+    const ordinaryClaim = await claimChatRun(runnerGroup, ordinary.runId);
+    expect(ordinaryClaim.claim.captureNetworkBodies).toBeUndefined();
+    await cancelChatRun(actor, ordinary.runId);
+  });
 
   it("routes DeepSeek V4 Flash through the native Responses adapter", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1346,6 +1346,28 @@ describe("CHAT-02: web chat send and client ids", () => {
       "Only the private agent owner can run this agent",
     );
   }, 30_000);
+
+  it("passes request-scoped network body capture into the runner claim", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const captured = await sendChatRun(actor, {
+      agentId,
+      prompt: "capture this run's network bodies",
+      captureNetworkBodies: true,
+    });
+    const capturedClaim = await claimChatRun(runnerGroup, captured.runId);
+    expect(capturedClaim.claim.captureNetworkBodies).toBeTruthy();
+    await cancelChatRun(actor, captured.runId);
+
+    const ordinary = await sendChatRun(actor, {
+      agentId,
+      prompt: "keep ordinary network logging metadata-only",
+    });
+    const ordinaryClaim = await claimChatRun(runnerGroup, ordinary.runId);
+    expect(ordinaryClaim.claim.captureNetworkBodies).toBeUndefined();
+    await cancelChatRun(actor, ordinary.runId);
+  });
 });
 
 describe("CHAT-02: interrupting active chat runs", () => {
@@ -3806,28 +3828,6 @@ describe("CHAT-02: model-first provider policies", () => {
       }
     }
   }, 90_000);
-
-  it("passes request-scoped network body capture into the runner claim", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-
-    const captured = await sendChatRun(actor, {
-      agentId,
-      prompt: "capture this run's network bodies",
-      captureNetworkBodies: true,
-    });
-    const capturedClaim = await claimChatRun(runnerGroup, captured.runId);
-    expect(capturedClaim.claim.captureNetworkBodies).toBeTruthy();
-    await cancelChatRun(actor, captured.runId);
-
-    const ordinary = await sendChatRun(actor, {
-      agentId,
-      prompt: "keep ordinary network logging metadata-only",
-    });
-    const ordinaryClaim = await claimChatRun(runnerGroup, ordinary.runId);
-    expect(ordinaryClaim.claim.captureNetworkBodies).toBeUndefined();
-    await cancelChatRun(actor, ordinary.runId);
-  });
 
   it("routes DeepSeek V4 Flash through the native Responses adapter", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -105,6 +105,7 @@ type BddSendEventBody =
       readonly clientEventId?: string;
       readonly chatThreadSortEventId?: string;
       readonly realAgentInPreview?: boolean;
+      readonly captureNetworkBodies?: boolean;
       readonly revokesEventId?: string;
     }
   | {
@@ -1220,6 +1221,9 @@ export function createChatFilesBddApi(context: TestContext) {
                 ...(body.realAgentInPreview === undefined
                   ? {}
                   : { realAgentInPreview: body.realAgentInPreview }),
+                ...(body.captureNetworkBodies === undefined
+                  ? {}
+                  : { captureNetworkBodies: body.captureNetworkBodies }),
                 ...(body.revokesEventId === undefined
                   ? {}
                   : { revokesEventId: body.revokesEventId }),

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -150,6 +150,7 @@ interface NormalSendBody {
   readonly cloudBrowserEnabled?: boolean;
   readonly clientEventId?: string;
   readonly realAgentInPreview?: boolean;
+  readonly captureNetworkBodies?: boolean;
   readonly revokesEventId?: string;
 }
 
@@ -2859,6 +2860,7 @@ function buildCreateZeroRunArgs(params: {
         ? { modelProvider: providerAdmission.effectiveModelProvider }
         : {}),
       ...(params.realAgentInPreviewEnabled ? { realAgentInPreview: true } : {}),
+      ...(args.body.captureNetworkBodies ? { captureNetworkBodies: true } : {}),
     },
     triggerSource: prepared.triggerSource,
     dispatchFailedCallbacks: dispatchFailedRunCallbacks,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -869,6 +869,9 @@ const chatNormalSendBodyShape = {
   // Preview evaluation escape hatch: when enabled, the request asks the
   // runner to bypass preview mock CLIs and use the real agent runtime.
   realAgentInPreview: z.boolean().optional(),
+  // Internal diagnostic option: capture bounded request/response data in this
+  // run's network logs. Production authorization is enforced at run creation.
+  captureNetworkBodies: z.boolean().optional(),
 } as const;
 
 const chatEventNormalSendBodySchema = z
@@ -1340,6 +1343,7 @@ export const chatEventsContract = c.router({
           computerUseHostId: z.undefined().optional(),
           hasTextContent: z.undefined().optional(),
           realAgentInPreview: z.undefined().optional(),
+          captureNetworkBodies: z.undefined().optional(),
           interruptsRunId: z.undefined().optional(),
         })
         .strict(),
@@ -1359,6 +1363,7 @@ export const chatEventsContract = c.router({
           computerUseHostId: z.undefined().optional(),
           hasTextContent: z.undefined().optional(),
           realAgentInPreview: z.undefined().optional(),
+          captureNetworkBodies: z.undefined().optional(),
           revokesEventId: z.undefined().optional(),
         })
         .strict(),


### PR DESCRIPTION
## Summary

- add request-scoped network body capture to normal chat sends and preserve the existing production internal-account gate
- restore deployed runner E2E coverage for raw TCP, non-DNS UDP, UDP/TCP DNS, connector diagnostics, Google browser classification, and captured request/response bodies
- document the public telemetry assertion boundary and complete the 42-file #25550 audit

## Behavior

The new BATS file creates one private mock-agent run through supported public APIs, performs bounded sandbox probes, waits for terminal upload, and reads structured telemetry from `GET /api/zero/runs/:runId/network`. Body capture is optional per send; omission remains unchanged and no preference, database row, queue payload, or runner protocol is added.

The full historical audit is recorded in [#26321](https://github.com/vm0-ai/vm0/issues/26321#issuecomment-5256643327).

## Exclusions

- no `/api/test/*` route, direct database mutation, synthetic provider, or skipped test
- no local execution of the deployed runner BATS; the live preview runner matrix is the authoritative gate
- no restoration of retired compose/storage CLI fixtures or external Slack, Telegram, and Teams mocks

## Validation

- `cd turbo && pnpm exec prettier --write ...`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F @vm0/api-contracts test -- --silent=passed-only`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --silent=passed-only`
- `cd turbo && pnpm knip --workspace api --workspace @vm0/api-contracts`
- `cd turbo && pnpm check-types`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test`
- helper `bash -n`, BATS discovery/count, non-empty shard generation, and `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`

Closes #26321

Parent: #26285
