### PR TITLE
refactor(connectors): read custom credentials from shared storage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -52,6 +52,7 @@ import { readUserSecrets } from "./helpers/user-config-state";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import {
+  deleteCustomConnectorCredentialValues,
   readConnectorCredentialStorageState,
   readCustomConnectorCredentialStorageParent,
   readCustomConnectorOAuthStorageState,
@@ -3149,6 +3150,101 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connected: true,
       configuredFieldKeys: ["api_key", "subdomain"],
       missingRequiredFields: [],
+    });
+
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("reads custom connector configured markers only from shared storage", async () => {
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    const orgId = requiredOrgId(admin);
+    const created = await connectorsApi.createCustomConnector(admin, {
+      displayName: "BDD Shared Credential Markers",
+      prefixTemplates: [
+        "https://{{variables.subdomain}}.shared-markers.example.test/v1/",
+      ],
+      fields: [
+        {
+          key: "api_key",
+          label: "API key",
+          kind: "secret",
+          required: true,
+        },
+        {
+          key: "subdomain",
+          label: "Subdomain",
+          kind: "variable",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.api_key}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+    });
+    const values = [
+      { key: "api_key", kind: "secret" as const, value: "shared-secret" },
+      { key: "subdomain", kind: "variable" as const, value: "shared" },
+    ];
+    await connectorsApi.setCustomConnectorValues(admin, created.id, values);
+
+    await deleteCustomConnectorCredentialValues(context, {
+      orgId,
+      userId: admin.userId,
+      customConnectorId: created.id,
+      storage: "legacy",
+    });
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject({
+      connected: true,
+      configuredFieldKeys: ["api_key", "subdomain"],
+      missingRequiredFields: [],
+    });
+    await expect(
+      readCustomConnectorCredentialStorageParent(context, {
+        orgId,
+        userId: admin.userId,
+        customConnectorId: created.id,
+      }),
+    ).resolves.toMatchObject({
+      secrets: [{ name: "api_key" }],
+      variables: [{ name: "subdomain", value: "shared" }],
+      legacy_custom_values: [],
+      legacy_custom_secret_encrypted_value: null,
+    });
+
+    await connectorsApi.setCustomConnectorValues(admin, created.id, values);
+    await deleteCustomConnectorCredentialValues(context, {
+      orgId,
+      userId: admin.userId,
+      customConnectorId: created.id,
+      storage: "shared",
+    });
+    await expect(
+      readCustomConnectorCredentialStorageParent(context, {
+        orgId,
+        userId: admin.userId,
+        customConnectorId: created.id,
+      }),
+    ).resolves.toMatchObject({
+      secrets: [],
+      variables: [],
+      legacy_custom_values: [
+        { kind: "secret", key: "api_key" },
+        { kind: "variable", key: "subdomain" },
+      ],
+    });
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject({
+      connected: false,
+      configuredFieldKeys: [],
+      missingRequiredFields: ["api_key", "subdomain"],
     });
 
     await connectorsApi.deleteCustomConnector(admin, created.id);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -85,6 +85,24 @@ export async function readCustomConnectorOAuthStorageState(
   });
 }
 
+export async function deleteCustomConnectorCredentialValues(
+  context: TestContext,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly customConnectorId: string;
+    readonly storage: "legacy" | "shared";
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "delete-custom-credential-values",
+    org_id: args.orgId,
+    user_id: args.userId,
+    custom_connector_id: args.customConnectorId,
+    storage: args.storage,
+  });
+}
+
 export async function seedOwnedConnectorSecret(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -93,6 +93,7 @@ import {
   seedSlackOrgInstallation$,
 } from "./helpers/zero-integrations-slack";
 import {
+  deleteCustomConnectorCredentialValues,
   seedCustomConnectorRuntimeConnectors,
   setConnectorCredentialStorageState,
   setCustomConnectorCredentialStorageState,
@@ -395,7 +396,6 @@ const API_DISPATCH_CUSTOM_CONNECTOR_SUBSTEP_ACTION_TYPES = [
   "api_dispatch_prepare_context_build_custom_connector_firewalls",
 ] as const;
 const API_DISPATCH_CUSTOM_CONNECTOR_BUILD_PHASE_ACTION_TYPES = [
-  "api_dispatch_prepare_context_decrypt_custom_connector_values",
   "api_dispatch_prepare_context_render_custom_connector_auth_templates",
   "api_dispatch_prepare_context_render_custom_connector_prefixes",
   "api_dispatch_prepare_context_assemble_custom_connector_firewalls",
@@ -407,7 +407,6 @@ const API_DISPATCH_CUSTOM_CONNECTOR_TIMING_ACTION_TYPES = [
 const CUSTOM_CONNECTOR_RUNTIME_BUCKET_DIMENSION_KEYS = [
   "custom_connector_runtime_connector_count_bucket",
   "custom_connector_runtime_configured_value_count_bucket",
-  "custom_connector_runtime_decrypted_value_count_bucket",
   "custom_connector_runtime_prefix_template_count_bucket",
   "custom_connector_runtime_rendered_api_count_bucket",
   "custom_connector_runtime_missing_required_count_bucket",
@@ -9713,6 +9712,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped run actor");
+    }
     const rand = randomUUID().replace(/-/g, "").slice(0, 8);
 
     const saved = await connectors.saveCustomConnectorProposal(actor, {
@@ -9764,6 +9766,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       ],
       agentId,
     });
+    await deleteCustomConnectorCredentialValues(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: saved.connector.id,
+      storage: "legacy",
+    });
 
     await enableFakeKms(context);
     onTestFinished(async () => {
@@ -9775,7 +9783,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       prompt: "use the proposed custom connector",
       modelProvider: "anthropic-api-key",
     });
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(1);
+    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(0);
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
       timingEvents,
@@ -9850,6 +9858,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       tenant: "münich",
       scope: "initial-scope",
     });
+    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(1);
 
     context.mocks.ably.publish.mockClear();
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
@@ -9900,6 +9909,55 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("does not admit legacy-only custom connector credentials", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped run actor");
+    }
+    const slug = `_bdd-shared-only-${randomUUID().slice(0, 8)}`;
+    const connector = await connectors.createCustomConnector(
+      actor,
+      manualHttpCustomConnectorCreateBody({
+        slug,
+        displayName: "BDD Shared-only Runtime",
+        prefixTemplates: ["https://shared-only-runtime.example.test/v1/"],
+      }),
+    );
+    await connectors.setCustomConnectorSecret(
+      actor,
+      connector.id,
+      "legacy-only-secret",
+    );
+    await connectors.updateAgentCustomConnectors(actor, agentId, [
+      connector.id,
+    ]);
+    await deleteCustomConnectorCredentialValues(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: connector.id,
+      storage: "shared",
+    });
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "do not use legacy-only custom credentials",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const internalName = `custom_connector_${connector.id.replaceAll("-", "")}`;
+    expect(findFirewallEntry(claim.firewalls, internalName)).toBeUndefined();
+    expect(claim.connectorRuntimeTargets).not.toContainEqual({
+      kind: "custom",
+      customConnectorId: connector.id,
+      baseUrlVars: {},
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("fails closed when a custom auth header references an optional missing value", async () => {

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -269,6 +269,80 @@ async function readCustomOAuthState(
   });
 }
 
+async function deleteCustomCredentialValues(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"delete-custom-credential-values">,
+  signal: AbortSignal,
+) {
+  if (body.storage === "legacy") {
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(orgCustomConnectorValues)
+        .where(
+          and(
+            eq(orgCustomConnectorValues.orgId, body.org_id),
+            eq(orgCustomConnectorValues.userId, body.user_id),
+            eq(orgCustomConnectorValues.connectorId, body.custom_connector_id),
+          ),
+        );
+      await tx
+        .delete(orgCustomConnectorSecrets)
+        .where(
+          and(
+            eq(orgCustomConnectorSecrets.orgId, body.org_id),
+            eq(orgCustomConnectorSecrets.userId, body.user_id),
+            eq(orgCustomConnectorSecrets.connectorId, body.custom_connector_id),
+          ),
+        );
+    });
+    signal.throwIfAborted();
+    return actionOk();
+  }
+
+  const [connector] = await db
+    .select({ id: connectors.id })
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, body.org_id),
+        eq(connectors.userId, body.user_id),
+        eq(connectors.customConnectorId, body.custom_connector_id),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  if (!connector) {
+    return {
+      status: 400 as const,
+      body: { error: "Custom connector storage test fixture was not found" },
+    };
+  }
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(secrets)
+      .where(
+        and(
+          eq(secrets.connectorId, connector.id),
+          eq(secrets.orgId, body.org_id),
+          eq(secrets.userId, body.user_id),
+          eq(secrets.type, "connector"),
+        ),
+      );
+    await tx
+      .delete(variables)
+      .where(
+        and(
+          eq(variables.connectorId, connector.id),
+          eq(variables.orgId, body.org_id),
+          eq(variables.userId, body.user_id),
+          eq(variables.type, "connector"),
+        ),
+      );
+  });
+  signal.throwIfAborted();
+  return actionOk();
+}
+
 async function seedOwnedSecret(
   db: Db,
   body: ConnectorCredentialStorageAction<"seed-owned-secret">,
@@ -517,6 +591,9 @@ const mutateConnectorCredentialStorageState$ = command(
       }
       case "read-custom-oauth-state": {
         return await readCustomOAuthState(db, body, signal);
+      }
+      case "delete-custom-credential-values": {
+        return await deleteCustomCredentialValues(db, body, signal);
       }
       case "seed-owned-secret": {
         return await seedOwnedSecret(db, body, signal);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -193,10 +193,10 @@ import {
   customConnectorMissingRequiredFieldKeys,
   customConnectorPrefixTemplateVariableKeys,
   customConnectorValueMarkerKey,
-  decryptCustomConnectorValues,
   loadCustomConnectorRuntimeData,
   renderCustomConnectorRuntimePrefix,
   renderTemplateForRuntime,
+  type StoredValueRow,
 } from "./zero-custom-connector.service";
 import { refreshCustomConnectorOAuth2ValuesIfNeeded } from "./custom-connector-oauth2.service";
 import {
@@ -3821,16 +3821,11 @@ export type CustomConnectorRuntimeDataRows = Awaited<
 >;
 
 type CustomConnectorRuntimeBuildPhase =
-  | "decryptValues"
   | "renderAuthTemplates"
   | "renderPrefixes"
   | "assembleFirewalls";
 
 const CUSTOM_CONNECTOR_RUNTIME_BUILD_PHASE_TIMINGS = [
-  {
-    phase: "decryptValues",
-    actionType: "api_dispatch_prepare_context_decrypt_custom_connector_values",
-  },
   {
     phase: "renderAuthTemplates",
     actionType:
@@ -3855,7 +3850,6 @@ class CustomConnectorRuntimeBuildStats {
     CustomConnectorRuntimeBuildPhase,
     number
   > = {
-    decryptValues: 0,
     renderAuthTemplates: 0,
     renderPrefixes: 0,
     assembleFirewalls: 0,
@@ -3864,7 +3858,6 @@ class CustomConnectorRuntimeBuildStats {
   private readonly connectorCount: number;
   private readonly configuredValueCount: number;
   private readonly prefixTemplateCount: number;
-  private decryptedValueCount = 0;
   private renderedApiCount = 0;
   private missingRequiredCount = 0;
   private noAuthInjectionCount = 0;
@@ -3893,10 +3886,6 @@ class CustomConnectorRuntimeBuildStats {
     finishedAt: number = now(),
   ): void {
     this.phaseDurationsMs[phase] += Math.max(0, finishedAt - startedAt);
-  }
-
-  recordDecryptedValues(count: number): void {
-    this.decryptedValueCount += count;
   }
 
   recordRenderedApi(): void {
@@ -3956,9 +3945,6 @@ class CustomConnectorRuntimeBuildStats {
       ),
       custom_connector_runtime_configured_value_count_bucket: countBucket(
         this.configuredValueCount,
-      ),
-      custom_connector_runtime_decrypted_value_count_bucket: countBucket(
-        this.decryptedValueCount,
       ),
       custom_connector_runtime_prefix_template_count_bucket: countBucket(
         this.prefixTemplateCount,
@@ -4091,13 +4077,11 @@ function buildCustomConnectorRuntimeApis(args: {
   return apis;
 }
 
-async function resolveCustomConnectorBaseUrlVars(args: {
+function resolveCustomConnectorBaseUrlVars(args: {
   readonly row: CustomConnectorRuntimeDataRows[number];
-  readonly featureSwitchContext: FeatureSwitchContext;
   readonly provided: Readonly<Record<string, string>> | undefined;
   readonly hasProvided: boolean;
-  readonly stats: CustomConnectorRuntimeBuildStats;
-}): Promise<Readonly<Record<string, string>> | undefined> {
+}): Readonly<Record<string, string>> | undefined {
   if (args.row.connector.kind === "mcp") {
     if (!args.hasProvided) {
       return {};
@@ -4119,23 +4103,24 @@ async function resolveCustomConnectorBaseUrlVars(args: {
   if (variableKeys.length === 0) {
     return {};
   }
-  const prefixValues = args.row.values.filter((value) => {
-    return value.kind === "variable" && variableKeys.includes(value.key);
-  });
+  const prefixValues = args.row.values.filter(
+    (
+      value,
+    ): value is Extract<StoredValueRow, { readonly kind: "variable" }> => {
+      return value.kind === "variable" && variableKeys.includes(value.key);
+    },
+  );
   if (prefixValues.length !== variableKeys.length) {
     return undefined;
   }
-  const decryptStartedAt = now();
-  const decryptedValues = await decryptCustomConnectorValues({
-    values: prefixValues,
-    featureSwitchContext: args.featureSwitchContext,
-  });
-  args.stats.recordPhaseDuration("decryptValues", decryptStartedAt);
-  args.stats.recordDecryptedValues(prefixValues.length);
+  const valuesByKey = new Map(
+    prefixValues.map((value) => {
+      return [value.key, value.value] as const;
+    }),
+  );
   const baseUrlVars: Record<string, string> = {};
   for (const key of variableKeys) {
-    const value =
-      decryptedValues[customConnectorValueMarkerKey({ kind: "variable", key })];
+    const value = valuesByKey.get(key);
     if (value === undefined) {
       return undefined;
     }
@@ -4278,12 +4263,10 @@ async function buildCustomConnectorRuntimeRow(args: {
 }): Promise<BuiltCustomConnectorRuntimeRow> {
   const hasProvidedBaseUrlVars =
     args.context.baseUrlVarsByConnectorId?.has(args.row.connector.id) ?? false;
-  const baseUrlVars = await resolveCustomConnectorBaseUrlVars({
+  const baseUrlVars = resolveCustomConnectorBaseUrlVars({
     row: args.row,
-    featureSwitchContext: args.context.featureSwitchContext,
     provided: args.context.baseUrlVarsByConnectorId?.get(args.row.connector.id),
     hasProvided: hasProvidedBaseUrlVars,
-    stats: args.stats,
   });
   const targetIdentity = {
     kind: "custom" as const,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -4480,13 +4480,21 @@ function hasEmptyAwsSigv4Credential(
   );
 }
 
-interface CurrentCustomConnectorAuthRef {
-  readonly secretName: string;
-  readonly connectorId: string;
-  readonly kind: "secret" | "variable";
-  readonly key: string;
-  readonly encryptedValue: string | null;
-}
+type CurrentCustomConnectorAuthRef =
+  | {
+      readonly secretName: string;
+      readonly connectorId: string;
+      readonly kind: "secret";
+      readonly key: string;
+      readonly encryptedValue: string | null;
+    }
+  | {
+      readonly secretName: string;
+      readonly connectorId: string;
+      readonly kind: "variable";
+      readonly key: string;
+      readonly value: string | null;
+    };
 
 async function loadCurrentCustomConnectorAuthRefs(args: {
   readonly db: Db;
@@ -4529,25 +4537,47 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
       // longer part of the executable credential contract.
       continue;
     }
-    refs.set(secretName, {
+    refs.set(
       secretName,
-      connectorId: runtime.connector.id,
-      kind: value.kind,
-      key: value.key,
-      encryptedValue: value.encryptedValue,
-    });
+      value.kind === "secret"
+        ? {
+            secretName,
+            connectorId: runtime.connector.id,
+            kind: "secret",
+            key: value.key,
+            encryptedValue: value.encryptedValue,
+          }
+        : {
+            secretName,
+            connectorId: runtime.connector.id,
+            kind: "variable",
+            key: value.key,
+            value: value.value,
+          },
+    );
   }
   for (const [secretName, field] of declaredFields) {
     if (refs.has(secretName)) {
       continue;
     }
-    refs.set(secretName, {
+    refs.set(
       secretName,
-      connectorId: runtime.connector.id,
-      kind: field.kind,
-      key: field.key,
-      encryptedValue: null,
-    });
+      field.kind === "secret"
+        ? {
+            secretName,
+            connectorId: runtime.connector.id,
+            kind: "secret",
+            key: field.key,
+            encryptedValue: null,
+          }
+        : {
+            secretName,
+            connectorId: runtime.connector.id,
+            kind: "variable",
+            key: field.key,
+            value: null,
+          },
+    );
   }
   if (runtime.connector.authMode === "oauth") {
     const secretName = customConnectorSecretKey({
@@ -4611,6 +4641,12 @@ async function resolveCurrentCustomConnectorSecrets(args: {
     const ref = refsByAlias.get(alias);
     if (!ref) {
       return { kind: "unavailable" };
+    }
+    if (ref.kind === "variable") {
+      if (ref.value !== null) {
+        currentSecrets[alias] = ref.value;
+      }
+      continue;
     }
     let encryptedValue = ref.encryptedValue;
     if (

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -115,7 +115,6 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_prepare_context_load_custom_connector_rows"
   | "api_dispatch_prepare_context_load_custom_connector_value_rows"
   | "api_dispatch_prepare_context_build_custom_connector_firewalls"
-  | "api_dispatch_prepare_context_decrypt_custom_connector_values"
   | "api_dispatch_prepare_context_render_custom_connector_auth_templates"
   | "api_dispatch_prepare_context_render_custom_connector_prefixes"
   | "api_dispatch_prepare_context_assemble_custom_connector_firewalls"

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -1,19 +1,18 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   orgCustomConnectors,
   type OrgCustomConnectorAuthMode,
 } from "@vm0/db/schema/org-custom-connector";
-import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
-import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { connectors } from "@vm0/db/schema/connector";
 import { secrets } from "@vm0/db/schema/secret";
+import { variables } from "@vm0/db/schema/variable";
 import { alias } from "drizzle-orm/pg-core";
 
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import type { ReadonlyDb } from "../external/db";
 import { connectorCredentialStatusForAccess } from "./connector-credential-status.service";
 
-const LEGACY_SECRET_KEY = "secret";
 const OAUTH_ACCESS_TOKEN_SECRET_NAME = "access_token";
 const OAUTH_REFRESH_TOKEN_SECRET_NAME = "refresh_token";
 
@@ -33,6 +32,20 @@ export interface CustomConnectorCredentialValueMarker {
   readonly kind: "secret" | "variable";
   readonly key: string;
 }
+
+export type CustomConnectorStoredValue =
+  | {
+      readonly connectorId: string;
+      readonly kind: "secret";
+      readonly key: string;
+      readonly encryptedValue: string;
+    }
+  | {
+      readonly connectorId: string;
+      readonly kind: "variable";
+      readonly key: string;
+      readonly value: string;
+    };
 
 interface CustomConnectorCredentialDefinition {
   readonly id: string;
@@ -241,83 +254,81 @@ export async function loadCurrentCustomConnectorValueMarkers(
   if (args.connectorIds?.length === 0) {
     return [];
   }
-  const [valueRows, legacyRows] = await Promise.all([
-    db
-      .select({
-        connectorId: orgCustomConnectorValues.connectorId,
-        authMode: orgCustomConnectors.authMode,
-        storageVersion: orgCustomConnectors.storageVersion,
-        kind: orgCustomConnectorValues.kind,
-        key: orgCustomConnectorValues.key,
-      })
-      .from(orgCustomConnectorValues)
-      .innerJoin(
-        orgCustomConnectors,
-        and(
-          eq(orgCustomConnectors.id, orgCustomConnectorValues.connectorId),
-          eq(orgCustomConnectors.orgId, orgCustomConnectorValues.orgId),
-        ),
-      )
-      .innerJoin(
-        connectors,
-        and(
-          eq(connectors.customConnectorId, orgCustomConnectors.id),
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          eq(connectors.authMethod, orgCustomConnectors.authMode),
-          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
-        ),
-      )
-      .where(
-        and(
-          eq(orgCustomConnectorValues.orgId, args.orgId),
-          eq(orgCustomConnectorValues.userId, args.userId),
-          args.connectorIds
-            ? inArray(orgCustomConnectorValues.connectorId, [
-                ...args.connectorIds,
-              ])
-            : undefined,
-        ),
+  const secretQuery = db
+    .select({
+      connectorId: orgCustomConnectors.id,
+      authMode: orgCustomConnectors.authMode,
+      storageVersion: orgCustomConnectors.storageVersion,
+      kind: sql`'secret'`.mapWith(pgTextDecoder).as("kind"),
+      key: secrets.name,
+    })
+    .from(secrets)
+    .innerJoin(
+      connectors,
+      and(
+        eq(connectors.id, secrets.connectorId),
+        eq(connectors.orgId, secrets.orgId),
+        eq(connectors.userId, secrets.userId),
       ),
-    db
-      .select({
-        connectorId: orgCustomConnectorSecrets.connectorId,
-        authMode: orgCustomConnectors.authMode,
-        storageVersion: orgCustomConnectors.storageVersion,
-      })
-      .from(orgCustomConnectorSecrets)
-      .innerJoin(
-        orgCustomConnectors,
-        and(
-          eq(orgCustomConnectors.id, orgCustomConnectorSecrets.connectorId),
-          eq(orgCustomConnectors.orgId, orgCustomConnectorSecrets.orgId),
-          eq(orgCustomConnectors.authMode, "manual"),
-        ),
-      )
-      .innerJoin(
-        connectors,
-        and(
-          eq(connectors.customConnectorId, orgCustomConnectors.id),
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          eq(connectors.authMethod, orgCustomConnectors.authMode),
-          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
-        ),
-      )
-      .where(
-        and(
-          eq(orgCustomConnectorSecrets.orgId, args.orgId),
-          eq(orgCustomConnectorSecrets.userId, args.userId),
-          args.connectorIds
-            ? inArray(orgCustomConnectorSecrets.connectorId, [
-                ...args.connectorIds,
-              ])
-            : undefined,
-        ),
+    )
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, connectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, connectors.orgId),
+        eq(orgCustomConnectors.authMode, connectors.authMethod),
+        eq(orgCustomConnectors.storageVersion, connectors.storageVersion),
       ),
-  ]);
-  const markers: CustomConnectorCredentialValueMarker[] = valueRows.flatMap(
-    (row) => {
+    )
+    .where(
+      and(
+        eq(secrets.type, "connector"),
+        eq(secrets.orgId, args.orgId),
+        eq(secrets.userId, args.userId),
+        args.connectorIds
+          ? inArray(orgCustomConnectors.id, [...args.connectorIds])
+          : undefined,
+      ),
+    );
+  const variableQuery = db
+    .select({
+      connectorId: orgCustomConnectors.id,
+      authMode: orgCustomConnectors.authMode,
+      storageVersion: orgCustomConnectors.storageVersion,
+      kind: sql`'variable'`.mapWith(pgTextDecoder).as("kind"),
+      key: variables.name,
+    })
+    .from(variables)
+    .innerJoin(
+      connectors,
+      and(
+        eq(connectors.id, variables.connectorId),
+        eq(connectors.orgId, variables.orgId),
+        eq(connectors.userId, variables.userId),
+      ),
+    )
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, connectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, connectors.orgId),
+        eq(orgCustomConnectors.authMode, connectors.authMethod),
+        eq(orgCustomConnectors.storageVersion, connectors.storageVersion),
+      ),
+    )
+    .where(
+      and(
+        eq(variables.type, "connector"),
+        eq(variables.orgId, args.orgId),
+        eq(variables.userId, args.userId),
+        args.connectorIds
+          ? inArray(orgCustomConnectors.id, [...args.connectorIds])
+          : undefined,
+      ),
+    );
+  const rows = await secretQuery.unionAll(variableQuery);
+  return rows.flatMap(
+    (row): readonly CustomConnectorCredentialValueMarker[] => {
       return row.kind === "secret" || row.kind === "variable"
         ? [
             {
@@ -331,25 +342,135 @@ export async function loadCurrentCustomConnectorValueMarkers(
         : [];
     },
   );
-  const markerKeys = new Set(
-    markers.map((marker) => {
-      return `${marker.connectorId}:${marker.authMode}:${marker.storageVersion}:${marker.kind}:${marker.key}`;
-    }),
-  );
-  for (const row of legacyRows) {
-    const markerKey = `${row.connectorId}:${row.authMode}:${row.storageVersion}:secret:${LEGACY_SECRET_KEY}`;
-    if (!markerKeys.has(markerKey)) {
-      markers.push({
-        connectorId: row.connectorId,
-        authMode: row.authMode,
-        storageVersion: row.storageVersion,
-        kind: "secret",
-        key: LEGACY_SECRET_KEY,
-      });
-      markerKeys.add(markerKey);
+}
+
+export async function loadCurrentCustomConnectorStoredValues(
+  db: Pick<ReadonlyDb, "select">,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly definitions: readonly CustomConnectorCredentialDefinition[];
+    readonly accesses: ReadonlyMap<string, CustomConnectorCredentialAccess>;
+  },
+): Promise<readonly CustomConnectorStoredValue[]> {
+  const expectedByMemberConnectorId = new Map<
+    string,
+    CustomConnectorCredentialDefinition
+  >();
+  for (const definition of args.definitions) {
+    const access = args.accesses.get(definition.id);
+    if (access?.kind === "current") {
+      expectedByMemberConnectorId.set(access.memberConnectorId, definition);
     }
   }
-  return markers;
+  const memberConnectorIds = [...expectedByMemberConnectorId.keys()];
+  if (memberConnectorIds.length === 0) {
+    return [];
+  }
+
+  const secretQuery = db
+    .select({
+      memberConnectorId: connectors.id,
+      connectorId: orgCustomConnectors.id,
+      authMode: orgCustomConnectors.authMode,
+      storageVersion: orgCustomConnectors.storageVersion,
+      kind: sql`'secret'`.mapWith(pgTextDecoder).as("kind"),
+      key: secrets.name,
+      storedValue: secrets.encryptedValue,
+    })
+    .from(secrets)
+    .innerJoin(
+      connectors,
+      and(
+        eq(connectors.id, secrets.connectorId),
+        eq(connectors.orgId, secrets.orgId),
+        eq(connectors.userId, secrets.userId),
+      ),
+    )
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, connectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, connectors.orgId),
+        eq(orgCustomConnectors.authMode, connectors.authMethod),
+        eq(orgCustomConnectors.storageVersion, connectors.storageVersion),
+      ),
+    )
+    .where(
+      and(
+        eq(secrets.type, "connector"),
+        eq(secrets.orgId, args.orgId),
+        eq(secrets.userId, args.userId),
+        inArray(connectors.id, memberConnectorIds),
+      ),
+    );
+  const variableQuery = db
+    .select({
+      memberConnectorId: connectors.id,
+      connectorId: orgCustomConnectors.id,
+      authMode: orgCustomConnectors.authMode,
+      storageVersion: orgCustomConnectors.storageVersion,
+      kind: sql`'variable'`.mapWith(pgTextDecoder).as("kind"),
+      key: variables.name,
+      storedValue: variables.value,
+    })
+    .from(variables)
+    .innerJoin(
+      connectors,
+      and(
+        eq(connectors.id, variables.connectorId),
+        eq(connectors.orgId, variables.orgId),
+        eq(connectors.userId, variables.userId),
+      ),
+    )
+    .innerJoin(
+      orgCustomConnectors,
+      and(
+        eq(orgCustomConnectors.id, connectors.customConnectorId),
+        eq(orgCustomConnectors.orgId, connectors.orgId),
+        eq(orgCustomConnectors.authMode, connectors.authMethod),
+        eq(orgCustomConnectors.storageVersion, connectors.storageVersion),
+      ),
+    )
+    .where(
+      and(
+        eq(variables.type, "connector"),
+        eq(variables.orgId, args.orgId),
+        eq(variables.userId, args.userId),
+        inArray(connectors.id, memberConnectorIds),
+      ),
+    );
+  const rows = await secretQuery.unionAll(variableQuery);
+  const values: CustomConnectorStoredValue[] = [];
+  for (const row of rows) {
+    const expected = expectedByMemberConnectorId.get(row.memberConnectorId);
+    if (
+      !expected ||
+      row.connectorId !== expected.id ||
+      row.authMode !== expected.authMode ||
+      row.storageVersion !== expected.storageVersion
+    ) {
+      continue;
+    }
+    if (row.kind === "secret") {
+      values.push({
+        connectorId: row.connectorId,
+        kind: "secret",
+        key: row.key,
+        encryptedValue: row.storedValue,
+      });
+    } else if (row.kind === "variable") {
+      values.push({
+        connectorId: row.connectorId,
+        kind: "variable",
+        key: row.key,
+        value: row.storedValue,
+      });
+    } else {
+      throw new Error("Invalid custom connector stored value kind");
+    }
+  }
+  return values;
 }
 
 export async function loadUsableCustomConnectorConnections(

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -45,10 +45,7 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { safeSync } from "../utils";
-import {
-  encryptStoredSecretValue,
-  decryptStoredSecretValue,
-} from "./crypto.utils";
+import { encryptStoredSecretValue } from "./crypto.utils";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 import { addUserCustomConnector } from "./user-connectors.service";
 import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
@@ -66,10 +63,12 @@ import { loadCustomConnectorPermissionBundle } from "./custom-connector-permissi
 import {
   customConnectorDefinitionHasUsableConnection,
   loadCustomConnectorCredentialAccesses,
+  loadCurrentCustomConnectorStoredValues,
   loadCurrentCustomConnectorValueMarkers,
   loadUsableCustomConnectorConnections,
   type CustomConnectorCredentialAccess,
   type CustomConnectorCredentialValueMarker,
+  type CustomConnectorStoredValue,
 } from "./custom-connector-credential-access.service";
 import { effectiveCustomConnectorPermissionBundleRef } from "./feishu-custom-connector-permissions";
 import {
@@ -294,11 +293,9 @@ export class CustomConnectorRuntimePrefixError extends Error {
   }
 }
 
-export interface StoredValueRow extends ValueMarker {
-  readonly encryptedValue: string;
-}
+export type StoredValueRow = CustomConnectorStoredValue;
 
-type FeatureSwitchContextArg = Parameters<typeof decryptStoredSecretValue>[1];
+type FeatureSwitchContextArg = Parameters<typeof encryptStoredSecretValue>[1];
 
 function isBadRequest(value: unknown): value is BadRequestResponse {
   return (
@@ -3048,126 +3045,6 @@ export const disconnectCustomConnector$ = command(
   },
 );
 
-async function loadStoredValuesForConnector(args: {
-  readonly db: ReadonlyDb;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly connectorId: string;
-  readonly authMode: CustomConnectorAuthMode;
-  readonly storageVersion: number;
-}): Promise<readonly StoredValueRow[]> {
-  const [valueRows, legacyRows] = await Promise.all([
-    args.db
-      .select({
-        connectorId: orgCustomConnectorValues.connectorId,
-        kind: orgCustomConnectorValues.kind,
-        key: orgCustomConnectorValues.key,
-        encryptedValue: orgCustomConnectorValues.encryptedValue,
-      })
-      .from(orgCustomConnectorValues)
-      .innerJoin(
-        orgCustomConnectors,
-        and(
-          eq(orgCustomConnectors.id, orgCustomConnectorValues.connectorId),
-          eq(orgCustomConnectors.orgId, orgCustomConnectorValues.orgId),
-          eq(orgCustomConnectors.authMode, args.authMode),
-          eq(orgCustomConnectors.storageVersion, args.storageVersion),
-        ),
-      )
-      .innerJoin(
-        connectors,
-        and(
-          eq(connectors.customConnectorId, orgCustomConnectors.id),
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          eq(connectors.authMethod, orgCustomConnectors.authMode),
-          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
-        ),
-      )
-      .where(
-        and(
-          eq(orgCustomConnectorValues.orgId, args.orgId),
-          eq(orgCustomConnectorValues.userId, args.userId),
-          eq(orgCustomConnectorValues.connectorId, args.connectorId),
-        ),
-      ),
-    args.db
-      .select({
-        connectorId: orgCustomConnectorSecrets.connectorId,
-        encryptedValue: orgCustomConnectorSecrets.encryptedValue,
-      })
-      .from(orgCustomConnectorSecrets)
-      .innerJoin(
-        orgCustomConnectors,
-        and(
-          eq(orgCustomConnectors.id, orgCustomConnectorSecrets.connectorId),
-          eq(orgCustomConnectors.orgId, orgCustomConnectorSecrets.orgId),
-          eq(orgCustomConnectors.authMode, "manual"),
-          eq(orgCustomConnectors.authMode, args.authMode),
-          eq(orgCustomConnectors.storageVersion, args.storageVersion),
-        ),
-      )
-      .innerJoin(
-        connectors,
-        and(
-          eq(connectors.customConnectorId, orgCustomConnectors.id),
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          eq(connectors.authMethod, orgCustomConnectors.authMode),
-          eq(connectors.storageVersion, orgCustomConnectors.storageVersion),
-        ),
-      )
-      .where(
-        and(
-          eq(orgCustomConnectorSecrets.orgId, args.orgId),
-          eq(orgCustomConnectorSecrets.userId, args.userId),
-          eq(orgCustomConnectorSecrets.connectorId, args.connectorId),
-        ),
-      ),
-  ]);
-  const rows: StoredValueRow[] = valueRows
-    .filter((row): row is StoredValueRow => {
-      return row.kind === "secret" || row.kind === "variable";
-    })
-    .map((row) => {
-      return {
-        connectorId: row.connectorId,
-        kind: row.kind,
-        key: row.key,
-        encryptedValue: row.encryptedValue,
-      };
-    });
-  const hasLegacySecret = rows.some((row) => {
-    return row.kind === "secret" && row.key === LEGACY_SECRET_KEY;
-  });
-  for (const row of legacyRows) {
-    if (!hasLegacySecret) {
-      rows.push({
-        connectorId: row.connectorId,
-        kind: "secret",
-        key: LEGACY_SECRET_KEY,
-        encryptedValue: row.encryptedValue,
-      });
-    }
-  }
-  return rows;
-}
-
-export async function decryptCustomConnectorValues(args: {
-  readonly values: readonly StoredValueRow[];
-  readonly featureSwitchContext: FeatureSwitchContextArg;
-}): Promise<Record<string, string>> {
-  const result: Record<string, string> = {};
-  for (const value of args.values) {
-    result[customConnectorValueMarkerKey(value)] =
-      await decryptStoredSecretValue(
-        value.encryptedValue,
-        args.featureSwitchContext,
-      );
-  }
-  return result;
-}
-
 export function customConnectorInternalName(connectorId: string): string {
   return `custom_connector_${connectorId.replaceAll("-", "")}`;
 }
@@ -3398,41 +3275,51 @@ export async function loadCustomConnectorRuntimeData(
   }
 
   return await measure("connectorValueRows", async () => {
+    const definitions = connectorRows.map((row) => {
+      return {
+        id: row.connector.id,
+        authMode: row.connector.authMode,
+        storageVersion: row.connector.storageVersion,
+      };
+    });
     const credentialAccesses = await loadCustomConnectorCredentialAccesses(db, {
       orgId: args.orgId,
       userId: args.userId,
-      definitions: connectorRows.map((row) => {
-        return {
-          id: row.connector.id,
-          authMode: row.connector.authMode,
-          storageVersion: row.connector.storageVersion,
-        };
-      }),
+      definitions,
     });
-    return await Promise.all(
-      connectorRows.map(async (row) => {
-        const connector = normaliseCustomConnectorRow(
-          row.connector,
-          row.oauthConfig,
-        );
-        const credentialAccess = credentialAccesses.get(connector.id);
-        if (!credentialAccess) {
-          throw new Error("Expected custom connector credential access");
-        }
-        const values =
-          credentialAccess.kind === "current"
-            ? await loadStoredValuesForConnector({
-                db,
-                orgId: args.orgId,
-                userId: args.userId,
-                connectorId: connector.id,
-                authMode: connector.authMode,
-                storageVersion: connector.storageVersion,
-              })
-            : [];
-        return { connector, values, credentialAccess };
-      }),
-    );
+    const storedValues = await loadCurrentCustomConnectorStoredValues(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      definitions,
+      accesses: credentialAccesses,
+    });
+    const valuesByConnectorId = new Map<string, StoredValueRow[]>();
+    for (const value of storedValues) {
+      const values = valuesByConnectorId.get(value.connectorId) ?? [];
+      values.push(value);
+      valuesByConnectorId.set(value.connectorId, values);
+    }
+    return connectorRows.map((row) => {
+      const connector = normaliseCustomConnectorRow(
+        row.connector,
+        row.oauthConfig,
+      );
+      const credentialAccess = credentialAccesses.get(connector.id);
+      if (!credentialAccess) {
+        throw new Error("Expected custom connector credential access");
+      }
+      const declaredFields = new Set(
+        connector.fields.map((field) => {
+          return customConnectorValueMarkerKey(field);
+        }),
+      );
+      const values = (valuesByConnectorId.get(connector.id) ?? []).filter(
+        (value) => {
+          return declaredFields.has(customConnectorValueMarkerKey(value));
+        },
+      );
+      return { connector, values, credentialAccess };
+    });
   });
 }
 

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -54,6 +54,13 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       state: z.string(),
     }),
     z.object({
+      action: z.literal("delete-custom-credential-values"),
+      org_id: z.string(),
+      user_id: z.string(),
+      custom_connector_id: z.uuid(),
+      storage: z.enum(["legacy", "shared"]),
+    }),
+    z.object({
       action: z.literal("seed-owned-secret"),
       org_id: z.string(),
       user_id: z.string(),


### PR DESCRIPTION
## Summary

- make shared connector-owned secrets and variables authoritative for Custom connector configured markers and runtime values
- batch current Custom credential reads into one shared-storage statement and decrypt only secret rows
- preserve active-run routing-variable pinning while resolving current non-routing values from shared storage
- remove obsolete variable-decryption timing fields and add integration coverage for shared/legacy divergence

## Compatibility

- keeps all legacy writes, deletes, compatibility checks, migration artifacts, and tables for rollback
- adds no database schema, public API, runner protocol, persisted runtime payload, feature switch, or legacy read fallback
- remains safe while old API instances read dual-written legacy rows and new API instances read shared rows

## Validation

- `pnpm format`
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test -- --maxWorkers=4 --silent=passed-only` (27 files, 534 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/zero-mcp-connectors.test.ts --maxWorkers=4 --silent=passed-only` (4 files, 271 tests)
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- pre-commit full Turbo type checks and Knip

Closes #26242

Parent context: #26080
