### PR TITLE
ci: run bench jobs on every pr commit

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -531,11 +531,11 @@ jobs:
     needs: [detect-turbo-ts-checks, prepare]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Run on perf branches, on PRs labeled `bench`, or on pushes to main (baseline).
+    # Run on every PR commit and on pushes to main (baseline). Skipped in the
+    # merge queue: benches only report numbers, they must not delay merges.
     if: |
       needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true' && (
-        startsWith(github.head_ref, 'perf/') ||
-        contains(github.event.pull_request.labels.*.name, 'bench') ||
+        github.event_name == 'pull_request' ||
         (github.event_name == 'push' && github.ref == 'refs/heads/main')
       )
     container:
@@ -582,11 +582,11 @@ jobs:
     needs: [detect-turbo-ts-checks, prepare]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Run on perf branches, on PRs labeled `bench`, or on pushes to main (baseline).
+    # Run on every PR commit and on pushes to main (baseline). Skipped in the
+    # merge queue: benches only report numbers, they must not delay merges.
     if: |
       needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true' && (
-        startsWith(github.head_ref, 'perf/') ||
-        contains(github.event.pull_request.labels.*.name, 'bench') ||
+        github.event_name == 'pull_request' ||
         (github.event_name == 'push' && github.ref == 'refs/heads/main')
       )
     container:

--- a/turbo/apps/platform/src/views/components/__tests__/__benches__/markdown.bench.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/__benches__/markdown.bench.tsx
@@ -5,6 +5,11 @@ import { bench, describe } from "vitest";
 
 import { parseMarkdownTree } from "../../../../lib/markdown/pipeline.ts";
 import {
+  chatEventTreeContent,
+  chatEventTreePlan,
+} from "../../../../signals/chat-page/chat-event-body-blocks.ts";
+import type { ChatEvent } from "../../../../signals/chat-page/chat-event-types.ts";
+import {
   createImageLoadSignals,
   embedImageLoadSignals,
 } from "../../../../signals/image-load.ts";
@@ -13,7 +18,7 @@ import {
   embedMermaidSignals,
 } from "../../../../signals/mermaid-diagram.ts";
 import { testContext } from "../../../../signals/__tests__/test-helpers.ts";
-import { MarkdownEventBody } from "../../markdown.tsx";
+import { Markdown, MarkdownEventBody } from "../../markdown.tsx";
 
 // ---------------------------------------------------------------------------
 // Chat markdown pipeline benchmarks.
@@ -158,4 +163,96 @@ describe("thread switch parse volume", () => {
       prepareTree(source);
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// Tree cache behavior. `ensureEventTrees$` runs after every write that can
+// change the visible window — including scroll captures — so its unchanged
+// path must cost a content lookup per event. These benches mirror that loop
+// (minus card registries; this thread has no cards) over real ChatEvents.
+// ---------------------------------------------------------------------------
+
+const THREAD_ID = "bench-thread";
+
+function assistantEvent(index: number, content: string): ChatEvent {
+  return {
+    id: `event-${String(index)}`,
+    threadId: THREAD_ID,
+    eventType: "output.message",
+    content,
+    seqId: index + 1,
+    createdAt: "2026-08-12T00:00:00.000Z",
+  };
+}
+
+const THREAD_EVENTS: readonly ChatEvent[] = THREAD.map((content, index) => {
+  return assistantEvent(index, content);
+});
+
+interface CachedEventTree {
+  readonly content: string;
+  readonly tree: Root;
+}
+
+function ensurePass(
+  events: readonly ChatEvent[],
+  cache: ReadonlyMap<string, CachedEventTree>,
+): ReadonlyMap<string, CachedEventTree> {
+  let next: Map<string, CachedEventTree> | undefined;
+  for (const event of events) {
+    const content = chatEventTreeContent(event);
+    if (content === null || cache.get(event.id)?.content === content) {
+      continue;
+    }
+    const plan = chatEventTreePlan(event, THREAD_ID);
+    if (plan === null) {
+      continue;
+    }
+    const tree = parseMarkdownTree(plan.treeSource, {
+      mathEnabled: true,
+      mermaid: true,
+    });
+    embedMermaidSignals(tree, createMermaidDiagramSignals);
+    embedImageLoadSignals(tree, createImageLoadSignals);
+    next ??= new Map(cache);
+    next.set(event.id, { content: plan.content, tree });
+  }
+  return next ?? cache;
+}
+
+describe("ensure pass over the event tree cache", () => {
+  const warmCache = ensurePass(THREAD_EVENTS, new Map());
+  const streamingEvents: readonly ChatEvent[] = [
+    ...THREAD_EVENTS.slice(0, -1),
+    assistantEvent(
+      THREAD_EVENTS.length - 1,
+      `${REPORT_MESSAGE}\n\nOne more streamed paragraph.`,
+    ),
+  ];
+  bench(
+    `unchanged thread (${String(THREAD_EVENTS.length)} events, scroll capture path)`,
+    () => {
+      ensurePass(THREAD_EVENTS, warmCache);
+    },
+  );
+  bench("streaming delta (re-parses only the growing report message)", () => {
+    ensurePass(streamingEvents, warmCache);
+  });
+});
+
+// The 8 surfaces still on `Markdown({source})` parse inside render. Contrast
+// with "render from prepared tree" on the same report message to price the
+// pending migration.
+describe("standalone Markdown (parse-in-render surfaces)", () => {
+  bench(
+    `report message (${String(REPORT_MESSAGE.length)} chars, parses per render)`,
+    () => {
+      render(
+        <StoreProvider value={context.store}>
+          <Markdown source={REPORT_MESSAGE} mediaPreview />
+        </StoreProvider>,
+      );
+      cleanup();
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- `bench-api` and `bench-app` now run on **every PR commit** (any PR with Turbo TS changes), plus pushes to `main` for the baseline. Previously they only ran on `perf/*` branches or PRs labeled `bench`. They stay out of the merge queue: benches report numbers and must not delay merges.
- Extends the platform markdown bench with the cache-layer behaviors of the tree pipeline:
  - **`ensure pass over the event tree cache`** — mirrors `ensureEventTrees$` over 98 real `ChatEvent`s: the unchanged path (what every scroll capture pays) vs a streaming delta that re-parses only the growing report message.
  - **`standalone Markdown (parse-in-render surfaces)`** — prices parse-inside-render against `render from prepared tree` on the same report message, quantifying the pending migration of the 8 remaining `Markdown({source})` surfaces.

## Local numbers (jsdom, relative comparisons are the signal)

| bench | mean |
| --- | --- |
| unchanged thread, 98 events (cheap-skip / scroll capture path) | **0.019 ms** |
| streaming delta (1 of 98 re-parsed, ~5.8 KB report) | 40.1 ms |
| standalone `Markdown` report message (parses per render) | 100.0 ms |
| render from prepared tree, report message | 46.0 ms |

The cheap-skip pass is ~2080× cheaper than a single streaming re-parse, confirming the unchanged path costs a content lookup per event. Parse-in-render is ~2.2× a tree render for the same content.

## Not benchable here

Real mermaid render cost is not measurable under vitest: jsdom lacks the SVG measurement APIs, so `mermaid` is aliased to a mock (`vitest.config.ts`). Registry/memoization hits are O(1) map reads and not worth CI time.
