### PR TITLE
feat(desktop): isolate okou updater and auth

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -639,6 +639,7 @@ jobs:
           zip_url="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
           node apps/desktop/scripts/update-desktop-release-manifest.mjs \
             --manifest "$manifest_path" \
+            --product zero \
             --version "$DESKTOP_VERSION" \
             --zip-url "$zip_url" \
             --channel stable \

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
@@ -131,7 +131,7 @@ describe("AUTH-02: CLI device authorization", () => {
 });
 
 describe("AUTH-02: desktop auth handoff", () => {
-  it("requires a session, returns a safe callback URL, and consumes the handoff once", async () => {
+  it("requires a session, returns a safe legacy Zero callback URL, and consumes the handoff once", async () => {
     authDevice.mockDesktopSignInToken("ticket_desktop_bdd");
 
     const unauthenticated = await authDevice.requestDesktopHandoff(
@@ -188,6 +188,30 @@ describe("AUTH-02: desktop auth handoff", () => {
     const missingCode = await authDevice.requestDesktopConsume("", [400]);
     expectApiError(missingCode.body);
     expect(missingCode.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("creates and consumes an Okou desktop auth callback", async () => {
+    authDevice.mockDesktopSignInToken("ticket_okou_desktop_bdd");
+
+    const handoff = await authDevice.requestDesktopHandoff(
+      bdd.user(),
+      { callbackScheme: "ai.okou.computer-use" },
+      [200],
+    );
+    if (handoff.status !== 200) {
+      throw new Error(
+        `Expected Okou desktop handoff to succeed, got ${handoff.status}`,
+      );
+    }
+
+    const callbackUrl = new URL(handoff.body.callbackUrl);
+    expect(callbackUrl.protocol).toBe("ai.okou.computer-use:");
+    expect(callbackUrl.hostname).toBe("auth");
+    expect(callbackUrl.pathname).toBe("/callback");
+
+    const code = authDevice.callbackCode(handoff.body.callbackUrl);
+    const consumed = await authDevice.requestDesktopConsume(code, [200]);
+    expect(consumed.body).toStrictEqual({ token: "ticket_okou_desktop_bdd" });
   });
 
   it("tracks handoff status through consume and complete for the creating user only", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -14,6 +14,8 @@ const TEST_APP_ROUTES = Object.freeze([...desktopUpdateRoutes]);
 const context = testContext();
 const DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
+const OKOU_DESKTOP_UPDATE_MANIFEST_URL =
+  "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json";
 
 interface DesktopUpdateRelease {
   readonly version: string;
@@ -25,6 +27,7 @@ interface DesktopUpdateRelease {
 
 interface DesktopUpdateManifest {
   readonly schemaVersion: 1;
+  readonly product?: "zero" | "okou";
   readonly channels: Record<
     string,
     { readonly latest: string; readonly blocked?: readonly string[] }
@@ -47,9 +50,12 @@ function appRequest(path: string): Promise<Response> {
   );
 }
 
-function mockDesktopUpdateManifest(manifest: DesktopUpdateManifest): void {
+function mockDesktopUpdateManifest(
+  manifest: DesktopUpdateManifest,
+  manifestUrl = DESKTOP_UPDATE_MANIFEST_URL,
+): void {
   server.use(
-    http.get(DESKTOP_UPDATE_MANIFEST_URL, () => {
+    http.get(manifestUrl, () => {
       return HttpResponse.json(manifest);
     }),
   );
@@ -69,10 +75,14 @@ function stableManifest(
   };
 }
 
-function darwinArm64Release(version: string, url: string) {
+function darwinArm64Release(
+  version: string,
+  url: string,
+  productName = "Zero",
+) {
   return {
     version,
-    name: `Zero Computer Use ${version}`,
+    name: `${productName} Computer Use ${version}`,
     notes: `Release ${version}`,
     pubDate: "2026-06-08T00:00:00.000Z",
     platforms: {
@@ -182,6 +192,128 @@ describe("desktop update routes", () => {
         },
       ],
     });
+  });
+
+  it("serves an Okou release only from the isolated Okou manifest", async () => {
+    const zipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
+    mockDesktopUpdateManifest(
+      {
+        ...stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", zipUrl, "Okou"),
+        }),
+        product: "okou",
+      },
+      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+    );
+
+    const response = await accept(
+      client().productFeed({
+        params: {
+          product: "okou",
+          channel: "stable",
+          platform: "darwin",
+          arch: "arm64",
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      currentRelease: "1.2.3",
+      releases: [
+        {
+          version: "1.2.3",
+          updateTo: {
+            name: "Okou Computer Use 1.2.3",
+            version: "1.2.3",
+            pub_date: "2026-06-08T00:00:00.000Z",
+            url: zipUrl,
+            notes: "Release 1.2.3",
+          },
+        },
+      ],
+    });
+  });
+
+  it("redirects Okou product routes to Okou release assets", async () => {
+    const zipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
+    mockDesktopUpdateManifest(
+      {
+        ...stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", zipUrl, "Okou"),
+        }),
+        product: "okou",
+      },
+      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+    );
+
+    const releaseResponse = await appRequest(
+      "http://api.test/api/desktop/updates/okou/stable/darwin/arm64/release",
+    );
+    expect(releaseResponse.status).toBe(302);
+    expect(releaseResponse.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
+    );
+
+    const dmgResponse = await appRequest(
+      "http://api.test/api/desktop/updates/okou/stable/darwin/arm64/dmg",
+    );
+    expect(dmgResponse.status).toBe(302);
+    expect(dmgResponse.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
+    );
+  });
+
+  it("does not serve a Zero artifact from the Okou feed", async () => {
+    mockDesktopUpdateManifest(
+      {
+        ...stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release(
+            "1.2.3",
+            "https://github.com/vm0-ai/vm0/releases/download/desktop-v1.2.3/Zero-darwin-arm64-1.2.3.zip",
+          ),
+        }),
+        product: "okou",
+      },
+      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+    );
+
+    const response = await accept(
+      client().productFeed({
+        params: {
+          product: "okou",
+          channel: "stable",
+          platform: "darwin",
+          arch: "arm64",
+        },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("does not serve an Okou artifact from the legacy Zero feed", async () => {
+    mockDesktopUpdateManifest(
+      stableManifest("1.2.3", {
+        "1.2.3": darwinArm64Release(
+          "1.2.3",
+          "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip",
+          "Okou",
+        ),
+      }),
+    );
+
+    const response = await accept(
+      client().feed({
+        params: { channel: "stable", platform: "darwin", arch: "arm64" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
   it("rejects the retired macOS x64 update feed", async () => {

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -1,4 +1,5 @@
 import { desktopUpdatesContract } from "@vm0/api-contracts/contracts/desktop-updates";
+import { DESKTOP_PRODUCT_ZERO } from "@vm0/api-contracts/contracts/client-headers";
 import { command } from "ccstate";
 
 import { notFound } from "../../lib/error";
@@ -13,9 +14,19 @@ import {
 const feedParams$ = pathParamsOf(desktopUpdatesContract.feed);
 const releasePageParams$ = pathParamsOf(desktopUpdatesContract.releasePage);
 const dmgDownloadParams$ = pathParamsOf(desktopUpdatesContract.dmgDownload);
+const productFeedParams$ = pathParamsOf(desktopUpdatesContract.productFeed);
+const productReleasePageParams$ = pathParamsOf(
+  desktopUpdatesContract.productReleasePage,
+);
+const productDmgDownloadParams$ = pathParamsOf(
+  desktopUpdatesContract.productDmgDownload,
+);
 
 const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
-  const url = await loadDesktopReleasePageUrl(get(releasePageParams$), signal);
+  const url = await loadDesktopReleasePageUrl(
+    { product: DESKTOP_PRODUCT_ZERO, ...get(releasePageParams$) },
+    signal,
+  );
   signal.throwIfAborted();
 
   if (!url) {
@@ -32,7 +43,10 @@ const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
 });
 
 const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
-  const feed = await loadDesktopUpdateFeed(get(feedParams$), signal);
+  const feed = await loadDesktopUpdateFeed(
+    { product: DESKTOP_PRODUCT_ZERO, ...get(feedParams$) },
+    signal,
+  );
   signal.throwIfAborted();
 
   if (!feed) {
@@ -46,7 +60,10 @@ const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
 });
 
 const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
-  const url = await loadDesktopDmgDownloadUrl(get(dmgDownloadParams$), signal);
+  const url = await loadDesktopDmgDownloadUrl(
+    { product: DESKTOP_PRODUCT_ZERO, ...get(dmgDownloadParams$) },
+    signal,
+  );
   signal.throwIfAborted();
 
   if (!url) {
@@ -62,6 +79,66 @@ const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
   });
 });
 
+const getProductDesktopReleasePage$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    const url = await loadDesktopReleasePageUrl(
+      get(productReleasePageParams$),
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!url) {
+      return notFound("No desktop release is available for this feed.");
+    }
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: url,
+        "Cache-Control": "no-store",
+      },
+    });
+  },
+);
+
+const getProductDesktopUpdateFeed$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    const feed = await loadDesktopUpdateFeed(get(productFeedParams$), signal);
+    signal.throwIfAborted();
+
+    if (!feed) {
+      return notFound("No desktop update is available for this feed.");
+    }
+
+    return {
+      status: 200 as const,
+      body: feed,
+    };
+  },
+);
+
+const getProductDesktopDmgDownload$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    const url = await loadDesktopDmgDownloadUrl(
+      get(productDmgDownloadParams$),
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!url) {
+      return notFound("No desktop DMG is available for this feed.");
+    }
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: url,
+        "Cache-Control": "no-store",
+      },
+    });
+  },
+);
+
 export const desktopUpdateRoutes: readonly RouteEntry[] = [
   {
     route: desktopUpdatesContract.releasePage,
@@ -74,5 +151,17 @@ export const desktopUpdateRoutes: readonly RouteEntry[] = [
   {
     route: desktopUpdatesContract.feed,
     handler: getDesktopUpdateFeed$,
+  },
+  {
+    route: desktopUpdatesContract.productReleasePage,
+    handler: getProductDesktopReleasePage$,
+  },
+  {
+    route: desktopUpdatesContract.productDmgDownload,
+    handler: getProductDesktopDmgDownload$,
+  },
+  {
+    route: desktopUpdatesContract.productFeed,
+    handler: getProductDesktopUpdateFeed$,
   },
 ];

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -4,20 +4,38 @@ import type {
   DesktopUpdatePlatform,
   SquirrelMacReleases,
 } from "@vm0/api-contracts/contracts/desktop-updates";
+import {
+  DESKTOP_PRODUCTS,
+  DESKTOP_PRODUCT_OKOU,
+  DESKTOP_PRODUCT_ZERO,
+  type DesktopProduct,
+} from "@vm0/api-contracts/contracts/client-headers";
 import { z } from "zod";
 
 import { testOverride } from "../../lib/singleton";
 import { now } from "../../lib/time";
 
-const DESKTOP_UPDATE_MANIFEST_URL =
-  "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
-const DESKTOP_RELEASE_PAGE_URL_PREFIX =
-  "https://github.com/vm0-ai/vm0/releases/tag/desktop-v";
 const DESKTOP_RELEASE_DOWNLOAD_URL_PREFIX =
   "https://github.com/vm0-ai/vm0/releases/download";
+const DESKTOP_RELEASE_PAGE_URL_PREFIX =
+  "https://github.com/vm0-ai/vm0/releases/tag";
 const MIN_DESKTOP_DMG_VERSION = "0.12.0";
 
 const DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS = 60_000;
+
+function desktopUpdateManifestUrl(product: DesktopProduct): string {
+  return product === DESKTOP_PRODUCT_OKOU
+    ? "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json"
+    : "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
+}
+
+function desktopProductArtifactName(product: DesktopProduct): string {
+  return product === DESKTOP_PRODUCT_OKOU ? "Okou" : "Zero";
+}
+
+function desktopProductReleaseTagPrefix(product: DesktopProduct): string {
+  return product === DESKTOP_PRODUCT_OKOU ? "okou-desktop-v" : "desktop-v";
+}
 
 const desktopUpdateAssetSchema = z.object({
   url: z.string().url(),
@@ -41,6 +59,7 @@ const desktopUpdateChannelSchema = z.object({
 
 const desktopUpdateManifestSchema = z.object({
   schemaVersion: z.literal(1),
+  product: z.enum(DESKTOP_PRODUCTS).optional(),
   channels: z.record(z.string(), desktopUpdateChannelSchema),
   releases: z.record(z.string(), desktopUpdateReleaseSchema),
 });
@@ -48,6 +67,7 @@ const desktopUpdateManifestSchema = z.object({
 type DesktopUpdateManifest = z.infer<typeof desktopUpdateManifestSchema>;
 
 interface DesktopUpdateFeedRequest {
+  readonly product: DesktopProduct;
   readonly channel: DesktopUpdateChannel;
   readonly platform: DesktopUpdatePlatform;
   readonly arch: DesktopUpdateArchitecture;
@@ -58,15 +78,16 @@ interface DesktopUpdateManifestCacheEntry {
   readonly manifest: DesktopUpdateManifest;
 }
 
-const desktopUpdateManifestCache =
-  testOverride<DesktopUpdateManifestCacheEntry | null>(() => {
-    return null;
-  });
+const desktopUpdateManifestCache = testOverride<
+  Partial<Record<DesktopProduct, DesktopUpdateManifestCacheEntry>>
+>(() => {
+  return {};
+});
 
 const desktopUpdateManifestOverride = testOverride<
-  DesktopUpdateManifest | undefined
+  Partial<Record<DesktopProduct, DesktopUpdateManifest>>
 >(() => {
-  return undefined;
+  return {};
 });
 
 function compareDesktopVersions(left: string, right: string): number {
@@ -91,17 +112,29 @@ function assetForRelease(
   release: DesktopUpdateManifest["releases"][string],
   request: DesktopUpdateFeedRequest,
 ): { readonly url: string } | null {
-  return release.platforms[request.platform]?.[request.arch] ?? null;
+  const asset = release.platforms[request.platform]?.[request.arch];
+  if (!asset) {
+    return null;
+  }
+
+  const expectedAssetName = `${desktopProductArtifactName(request.product)}-${request.platform}-${request.arch}-${release.version}.zip`;
+  const actualAssetName = decodeURIComponent(
+    new URL(asset.url).pathname.split("/").at(-1) ?? "",
+  );
+  return actualAssetName === expectedAssetName ? asset : null;
 }
 
 function squirrelRelease(
   release: DesktopUpdateManifest["releases"][string],
   asset: { readonly url: string },
+  product: DesktopProduct,
 ) {
   return {
     version: release.version,
     updateTo: {
-      name: release.name ?? `Zero ${release.version}`,
+      name:
+        release.name ??
+        `${desktopProductArtifactName(product)} ${release.version}`,
       version: release.version,
       pub_date: release.pubDate,
       url: asset.url,
@@ -112,18 +145,18 @@ function squirrelRelease(
 
 function desktopReleasePageUrl(
   release: DesktopUpdateManifest["releases"][string],
+  product: DesktopProduct,
 ): string {
-  return `${DESKTOP_RELEASE_PAGE_URL_PREFIX}${encodeURIComponent(
-    release.version,
-  )}`;
+  const tagName = `${desktopProductReleaseTagPrefix(product)}${release.version}`;
+  return `${DESKTOP_RELEASE_PAGE_URL_PREFIX}/${encodeURIComponent(tagName)}`;
 }
 
 function desktopDmgDownloadUrl(
   release: DesktopUpdateManifest["releases"][string],
   request: DesktopUpdateFeedRequest,
 ): string {
-  const tagName = `desktop-v${release.version}`;
-  const assetName = `Zero-${request.platform}-${request.arch}-${release.version}.dmg`;
+  const tagName = `${desktopProductReleaseTagPrefix(request.product)}${release.version}`;
+  const assetName = `${desktopProductArtifactName(request.product)}-${request.platform}-${request.arch}-${release.version}.dmg`;
   return `${DESKTOP_RELEASE_DOWNLOAD_URL_PREFIX}/${encodeURIComponent(
     tagName,
   )}/${encodeURIComponent(assetName)}`;
@@ -181,19 +214,22 @@ function buildDesktopUpdateFeed(
 
   return {
     currentRelease: selected.release.version,
-    releases: [squirrelRelease(selected.release, selected.asset)],
+    releases: [
+      squirrelRelease(selected.release, selected.asset, request.product),
+    ],
   };
 }
 
 async function fetchDesktopUpdateManifest(
+  product: DesktopProduct,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
-  const override = desktopUpdateManifestOverride.get();
+  const override = desktopUpdateManifestOverride.get()[product];
   if (override) {
     return override;
   }
 
-  const response = await fetch(DESKTOP_UPDATE_MANIFEST_URL, {
+  const response = await fetch(desktopUpdateManifestUrl(product), {
     headers: { accept: "application/json" },
     signal,
   });
@@ -203,22 +239,34 @@ async function fetchDesktopUpdateManifest(
     );
   }
 
-  return desktopUpdateManifestSchema.parse(await response.json());
+  const manifest = desktopUpdateManifestSchema.parse(await response.json());
+  const manifestProduct = manifest.product ?? DESKTOP_PRODUCT_ZERO;
+  if (manifestProduct !== product) {
+    throw new Error(
+      `Desktop update manifest product mismatch: expected ${product}, received ${manifestProduct}`,
+    );
+  }
+  return manifest;
 }
 
 async function loadDesktopUpdateManifest(
+  product: DesktopProduct,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
-  const cacheEntry = desktopUpdateManifestCache.get();
+  const cache = desktopUpdateManifestCache.get();
+  const cacheEntry = cache[product];
   const nowMs = now();
   if (cacheEntry && cacheEntry.expiresAt > nowMs) {
     return cacheEntry.manifest;
   }
 
-  const manifest = await fetchDesktopUpdateManifest(signal);
+  const manifest = await fetchDesktopUpdateManifest(product, signal);
   desktopUpdateManifestCache.set({
-    expiresAt: nowMs + DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS,
-    manifest,
+    ...cache,
+    [product]: {
+      expiresAt: nowMs + DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS,
+      manifest,
+    },
   });
   return manifest;
 }
@@ -227,7 +275,7 @@ export async function loadDesktopUpdateFeed(
   request: DesktopUpdateFeedRequest,
   signal: AbortSignal,
 ): Promise<SquirrelMacReleases | null> {
-  const manifest = await loadDesktopUpdateManifest(signal);
+  const manifest = await loadDesktopUpdateManifest(request.product, signal);
   return buildDesktopUpdateFeed(manifest, request);
 }
 
@@ -235,16 +283,18 @@ export async function loadDesktopReleasePageUrl(
   request: DesktopUpdateFeedRequest,
   signal: AbortSignal,
 ): Promise<string | null> {
-  const manifest = await loadDesktopUpdateManifest(signal);
+  const manifest = await loadDesktopUpdateManifest(request.product, signal);
   const selected = selectDesktopRelease(manifest, request);
-  return selected ? desktopReleasePageUrl(selected.release) : null;
+  return selected
+    ? desktopReleasePageUrl(selected.release, request.product)
+    : null;
 }
 
 export async function loadDesktopDmgDownloadUrl(
   request: DesktopUpdateFeedRequest,
   signal: AbortSignal,
 ): Promise<string | null> {
-  const manifest = await loadDesktopUpdateManifest(signal);
+  const manifest = await loadDesktopUpdateManifest(request.product, signal);
   const selected = selectDesktopRelease(manifest, request);
   if (
     !selected ||

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -124,6 +124,24 @@ Use the DMG for manual installation. It opens with a styled Finder background,
 for drag-to-install. The update manifest continues to point at the ZIP artifact
 because the auto-update feed consumes ZIP releases.
 
+### Zero and Okou update compatibility
+
+Zero and Okou desktop releases are independent products during the rename
+rollout. Existing Zero installations keep using
+`/api/desktop/updates/stable/darwin/arm64` and the `desktop-updates` manifest.
+Okou installations use
+`/api/desktop/updates/okou/stable/darwin/arm64` and the separate
+`okou-desktop-updates` manifest. Each manifest identifies its product, and the
+API rejects ZIP assets whose product filename does not match the requested
+feed. A Zero feed must never publish an Okou artifact, or vice versa.
+
+The release systems may deploy independently. The API therefore preserves the
+legacy Zero routes and accepts both Zero callback schemes
+(`ai.vm0.zero.desktop` and `ai.vm0.zero.desktop.dev`) while also accepting the
+Okou schemes (`ai.okou.computer-use` and `ai.okou.computer-use.dev`). Desktop
+builds select exactly one product feed and one callback scheme from their
+packaged identity; they do not discover or switch products at runtime.
+
 This does not submit or publish the app to the Mac App Store. The App Store
 Connect API key is only used as notarytool authentication for Apple's
 notarization service.

--- a/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
+++ b/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
@@ -1,6 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
+const DESKTOP_PRODUCTS = ["zero", "okou"];
+const DESKTOP_PRODUCT_ARTIFACT_NAMES = {
+  zero: "Zero",
+  okou: "Okou",
+};
+
 function parseArgs(argv) {
   const args = new Map();
   for (let index = 0; index < argv.length; index += 2) {
@@ -45,13 +51,36 @@ const args = parseArgs(process.argv.slice(2));
 const manifestPath = requiredArg(args, "manifest");
 const version = requiredArg(args, "version");
 const zipUrl = requiredArg(args, "zip-url");
+const product = args.get("product") ?? "zero";
 const channel = args.get("channel") ?? "stable";
 const platform = args.get("platform") ?? "darwin";
 const arch = args.get("arch") ?? "arm64";
 const pubDate = args.get("pub-date") ?? new Date().toISOString();
 
+if (!DESKTOP_PRODUCTS.includes(product)) {
+  throw new Error(`Unsupported desktop product: ${product}`);
+}
+
+const expectedZipAssetName = `${DESKTOP_PRODUCT_ARTIFACT_NAMES[product]}-${platform}-${arch}-${version}.zip`;
+const actualZipAssetName = decodeURIComponent(
+  new URL(zipUrl).pathname.split("/").at(-1) ?? "",
+);
+if (actualZipAssetName !== expectedZipAssetName) {
+  throw new Error(
+    `Desktop update asset must be ${expectedZipAssetName}, received ${actualZipAssetName}`,
+  );
+}
+
 const manifest = ensureRecord(readManifest(manifestPath));
+const existingProduct =
+  manifest.product ?? (existsSync(manifestPath) ? "zero" : product);
+if (existingProduct !== product) {
+  throw new Error(
+    `Desktop update manifest product mismatch: expected ${product}, received ${existingProduct}`,
+  );
+}
 manifest.schemaVersion = 1;
+manifest.product = product;
 manifest.channels = ensureRecord(manifest.channels);
 manifest.releases = ensureRecord(manifest.releases);
 
@@ -76,7 +105,9 @@ platforms[platform] = platformAssets;
 manifest.releases[version] = {
   ...currentRelease,
   version,
-  name: currentRelease.name ?? `Zero Computer Use ${version}`,
+  name:
+    currentRelease.name ??
+    `${DESKTOP_PRODUCT_ARTIFACT_NAMES[product]} Computer Use ${version}`,
   notes: currentRelease.notes ?? "",
   pubDate,
   platforms,

--- a/turbo/apps/desktop/src/bootstrap-degraded.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.test.ts
@@ -67,6 +67,7 @@ function productionConfig(): DesktopConfig {
     webUrl: new URL("https://app.vm0.ai"),
     environment: "production",
     identity: {
+      product: "zero",
       displayName: "Zero Computer Use",
       bundleId: "ai.vm0.desktop",
       authProtocolName: "Zero Desktop",

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { DesktopProduct } from "@vm0/api-contracts/contracts/client-headers";
 import desktopIdentities from "./desktop-identities.json";
 import { rewriteDesktopServiceHostname } from "./desktop-api-base-url";
 
@@ -10,14 +11,30 @@ export type DesktopEnvironment = "production" | "staging" | "development";
 type DesktopIdentityKind = "production" | "development";
 
 interface DesktopIdentity {
+  readonly product: DesktopProduct;
   readonly displayName: string;
   readonly bundleId: string;
   readonly authProtocolName: string;
   readonly authScheme: string;
 }
 
-const DESKTOP_IDENTITIES: Record<DesktopIdentityKind, DesktopIdentity> =
-  desktopIdentities;
+function desktopProduct(value: string): DesktopProduct {
+  if (value === "zero" || value === "okou") {
+    return value;
+  }
+  throw new Error(`Unsupported desktop product: ${value}`);
+}
+
+const DESKTOP_IDENTITIES = {
+  production: {
+    ...desktopIdentities.production,
+    product: desktopProduct(desktopIdentities.production.product),
+  },
+  development: {
+    ...desktopIdentities.development,
+    product: desktopProduct(desktopIdentities.development.product),
+  },
+} satisfies Record<DesktopIdentityKind, DesktopIdentity>;
 
 export interface DesktopConfig {
   readonly platformUrl: URL;

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -78,6 +78,7 @@ const productionConfig: DesktopConfig = {
   webUrl: new URL("https://www.vm0.ai"),
   environment: "production",
   identity: {
+    product: "zero",
     displayName: "Zero Computer Use",
     bundleId: "ai.vm0.desktop",
     authProtocolName: "Zero Computer Use",
@@ -206,14 +207,44 @@ describe("desktop auto-updates", () => {
     expect(mocks.updateElectronApp).not.toHaveBeenCalled();
   });
 
+  it("selects the isolated Okou update feed for an Okou identity", () => {
+    const okouConfig: DesktopConfig = {
+      ...productionConfig,
+      identity: {
+        product: "okou",
+        displayName: "Okou Computer Use",
+        bundleId: "ai.okou.computer-use",
+        authProtocolName: "Okou Desktop Auth",
+        authScheme: "ai.okou.computer-use",
+      },
+    };
+
+    expect(
+      installDesktopAutoUpdates({
+        config: okouConfig,
+        apiBaseUrl: "https://api.okou.ai",
+        getComputerUseHostState: () => OFFLINE_COMPUTER_USE_HOST_STATE,
+        prepareForQuitAndInstall: vi.fn(async () => {}),
+      }),
+    ).toBe(true);
+    expect(mocks.updateElectronApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updateSource: expect.objectContaining({
+          baseUrl:
+            "https://api.okou.ai/api/desktop/updates/okou/stable/darwin/arm64",
+        }),
+      }),
+    );
+  });
+
   it("checks for updates on request", () => {
-    expect(checkForDesktopUpdates()).toBe(true);
+    expect(checkForDesktopUpdates("Zero Computer Use")).toBe(true);
 
     expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
   });
 
   it("shows when requested update checks find no update", async () => {
-    expect(checkForDesktopUpdates()).toBe(true);
+    expect(checkForDesktopUpdates("Zero Computer Use")).toBe(true);
 
     emitAutoUpdaterEvent("update-not-available");
     await flushDownloadedUpdateCallback();
@@ -235,7 +266,7 @@ describe("desktop auto-updates", () => {
       throw error;
     });
 
-    expect(checkForDesktopUpdates()).toBe(false);
+    expect(checkForDesktopUpdates("Zero Computer Use")).toBe(false);
     await flushDownloadedUpdateCallback();
 
     expect(consoleError).toHaveBeenCalledWith(

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -23,24 +23,27 @@ async function restartForUpdate(
   autoUpdater.quitAndInstall();
 }
 
-async function notifyNoDesktopUpdatesFound(): Promise<void> {
+async function notifyNoDesktopUpdatesFound(displayName: string): Promise<void> {
   await dialog.showMessageBox({
     type: "info",
     buttons: ["OK"],
     defaultId: 0,
     title: "No Updates Available",
-    message: "Zero Computer Use is up to date.",
+    message: `${displayName} is up to date.`,
   });
 }
 
-async function notifyDesktopUpdateCheckFailed(error: unknown): Promise<void> {
+async function notifyDesktopUpdateCheckFailed(
+  displayName: string,
+  error: unknown,
+): Promise<void> {
   console.error("Desktop update check failed", error);
   await dialog.showMessageBox({
     type: "error",
     buttons: ["OK"],
     defaultId: 0,
     title: "Unable to Check for Updates",
-    message: "Zero Computer Use could not check for updates.",
+    message: `${displayName} could not check for updates.`,
     detail: error instanceof Error ? error.message : undefined,
   });
 }
@@ -70,7 +73,10 @@ export function installDesktopAutoUpdates(
     return false;
   }
 
-  const baseUrl = desktopUpdateFeedBaseUrl(options.apiBaseUrl);
+  const baseUrl = desktopUpdateFeedBaseUrl(
+    options.apiBaseUrl,
+    options.config.identity.product,
+  );
   if (new URL(baseUrl).protocol !== "https:") {
     console.warn("Desktop auto-updates require an HTTPS feed URL");
     return false;
@@ -120,10 +126,10 @@ export function installDesktopAutoUpdates(
   return true;
 }
 
-export function checkForDesktopUpdates(): boolean {
+export function checkForDesktopUpdates(displayName: string): boolean {
   const handleNoUpdate = (): void => {
     cleanup();
-    void notifyNoDesktopUpdatesFound().catch((error) => {
+    void notifyNoDesktopUpdatesFound(displayName).catch((error) => {
       console.error("Desktop update status dialog failed", error);
     });
   };
@@ -132,9 +138,11 @@ export function checkForDesktopUpdates(): boolean {
   };
   const handleError = (error: Error): void => {
     cleanup();
-    void notifyDesktopUpdateCheckFailed(error).catch((dialogError) => {
-      console.error("Desktop update failure dialog failed", dialogError);
-    });
+    void notifyDesktopUpdateCheckFailed(displayName, error).catch(
+      (dialogError) => {
+        console.error("Desktop update failure dialog failed", dialogError);
+      },
+    );
   };
 
   function cleanup(): void {
@@ -152,9 +160,11 @@ export function checkForDesktopUpdates(): boolean {
     return true;
   } catch (error) {
     cleanup();
-    void notifyDesktopUpdateCheckFailed(error).catch((dialogError) => {
-      console.error("Desktop update failure dialog failed", dialogError);
-    });
+    void notifyDesktopUpdateCheckFailed(displayName, error).catch(
+      (dialogError) => {
+        console.error("Desktop update failure dialog failed", dialogError);
+      },
+    );
     return false;
   }
 }

--- a/turbo/apps/desktop/src/desktop-identities.json
+++ b/turbo/apps/desktop/src/desktop-identities.json
@@ -1,11 +1,13 @@
 {
   "production": {
+    "product": "zero",
     "displayName": "Zero Computer Use",
     "bundleId": "ai.vm0.zero.desktop",
     "authProtocolName": "Zero Desktop Auth",
     "authScheme": "ai.vm0.zero.desktop"
   },
   "development": {
+    "product": "zero",
     "displayName": "Zero CU Dev",
     "bundleId": "ai.vm0.zero.desktop.dev",
     "authProtocolName": "Zero CU Dev Desktop Auth",

--- a/turbo/apps/desktop/src/desktop-update-feed.test.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.test.ts
@@ -59,8 +59,11 @@ describe("desktop update feed", () => {
   });
 
   it("builds the static feed base URL used by update-electron-app", () => {
-    expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai")).toBe(
+    expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai", "zero")).toBe(
       "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
+    );
+    expect(desktopUpdateFeedBaseUrl("https://api.okou.ai", "okou")).toBe(
+      "https://api.okou.ai/api/desktop/updates/okou/stable/darwin/arm64",
     );
   });
 });

--- a/turbo/apps/desktop/src/desktop-update-feed.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.ts
@@ -1,8 +1,4 @@
 import type { DesktopConfig } from "./config";
-import {
-  DESKTOP_PRODUCT_ZERO,
-  type DesktopProduct,
-} from "@vm0/api-contracts/contracts/client-headers";
 
 const DESKTOP_UPDATE_CHANNEL = "stable";
 const DESKTOP_UPDATE_PLATFORM = "darwin";
@@ -28,11 +24,11 @@ export function shouldInstallDesktopAutoUpdates(
 
 export function desktopUpdateFeedBaseUrl(
   apiBaseUrl: string,
-  product: DesktopProduct,
+  product: DesktopConfig["identity"]["product"],
 ): string {
   const url = new URL(apiBaseUrl);
   const productPath =
-    product === DESKTOP_PRODUCT_ZERO ? "" : `/${encodeURIComponent(product)}`;
+    product === "zero" ? "" : `/${encodeURIComponent(product)}`;
   url.pathname = `/api/desktop/updates${productPath}/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
   url.search = "";
   url.hash = "";

--- a/turbo/apps/desktop/src/desktop-update-feed.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.ts
@@ -1,4 +1,8 @@
 import type { DesktopConfig } from "./config";
+import {
+  DESKTOP_PRODUCT_ZERO,
+  type DesktopProduct,
+} from "@vm0/api-contracts/contracts/client-headers";
 
 const DESKTOP_UPDATE_CHANNEL = "stable";
 const DESKTOP_UPDATE_PLATFORM = "darwin";
@@ -22,9 +26,14 @@ export function shouldInstallDesktopAutoUpdates(
   );
 }
 
-export function desktopUpdateFeedBaseUrl(apiBaseUrl: string): string {
+export function desktopUpdateFeedBaseUrl(
+  apiBaseUrl: string,
+  product: DesktopProduct,
+): string {
   const url = new URL(apiBaseUrl);
-  url.pathname = `/api/desktop/updates/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
+  const productPath =
+    product === DESKTOP_PRODUCT_ZERO ? "" : `/${encodeURIComponent(product)}`;
+  url.pathname = `/api/desktop/updates${productPath}/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
   url.search = "";
   url.hash = "";
   return url.toString().replace(/\/$/, "");

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -117,6 +117,7 @@ const config = resolveDesktopConfig();
 const desktopApiBaseUrl = resolveComputerUseApiBaseUrl(config.platformUrl);
 const addDesktopClientHeaders = createDesktopClientHeaderInjector({
   clientVersion: app.getVersion(),
+  product: config.identity.product,
 });
 const desktopAuthStartUrl = buildDesktopAuthStartUrl(
   config.webUrl,
@@ -758,7 +759,7 @@ function requestDesktopUpdateCheck(): void {
     return;
   }
 
-  checkForDesktopUpdates();
+  checkForDesktopUpdates(config.identity.displayName);
 }
 
 function applyApplicationMenu(): void {

--- a/turbo/apps/desktop/src/update-desktop-release-manifest.test.ts
+++ b/turbo/apps/desktop/src/update-desktop-release-manifest.test.ts
@@ -1,0 +1,105 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+const scriptPath = join(
+  __dirname,
+  "..",
+  "scripts",
+  "update-desktop-release-manifest.mjs",
+);
+
+function temporaryManifestPath(): string {
+  const directory = mkdtempSync(join(tmpdir(), "desktop-manifest-"));
+  temporaryDirectories.push(directory);
+  return join(directory, "manifest.json");
+}
+
+function runManifestUpdate(
+  manifestPath: string,
+  product: "zero" | "okou",
+  zipAssetName: string,
+): SpawnSyncReturns<string> {
+  return spawnSync(
+    process.execPath,
+    [
+      scriptPath,
+      "--manifest",
+      manifestPath,
+      "--product",
+      product,
+      "--version",
+      "1.2.3",
+      "--zip-url",
+      `https://github.com/vm0-ai/vm0/releases/download/test/${zipAssetName}`,
+      "--pub-date",
+      "2026-08-11T00:00:00.000Z",
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("update desktop release manifest", () => {
+  it.each([
+    {
+      product: "zero" as const,
+      artifactName: "Zero-darwin-arm64-1.2.3.zip",
+      releaseName: "Zero Computer Use 1.2.3",
+    },
+    {
+      product: "okou" as const,
+      artifactName: "Okou-darwin-arm64-1.2.3.zip",
+      releaseName: "Okou Computer Use 1.2.3",
+    },
+  ])("publishes an isolated $product manifest", (testCase) => {
+    const manifestPath = temporaryManifestPath();
+    const result = runManifestUpdate(
+      manifestPath,
+      testCase.product,
+      testCase.artifactName,
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const manifest: unknown = JSON.parse(readFileSync(manifestPath, "utf8"));
+    expect(manifest).toMatchObject({
+      schemaVersion: 1,
+      product: testCase.product,
+      channels: { stable: { latest: "1.2.3", blocked: [] } },
+      releases: {
+        "1.2.3": {
+          version: "1.2.3",
+          name: testCase.releaseName,
+          platforms: {
+            darwin: {
+              arm64: {
+                url: `https://github.com/vm0-ai/vm0/releases/download/test/${testCase.artifactName}`,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects a Zero artifact when publishing an Okou manifest", () => {
+    const result = runManifestUpdate(
+      temporaryManifestPath(),
+      "okou",
+      "Zero-darwin-arm64-1.2.3.zip",
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Desktop update asset must be Okou-darwin-arm64-1.2.3.zip",
+    );
+  });
+});

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -191,6 +191,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.webUrl.toString()).toBe("https://www.vm0.ai/");
     expect(config.environment).toBe("production");
     expect(config.identity).toMatchObject({
+      product: "zero",
       displayName: "Zero Computer Use",
       bundleId: "ai.vm0.zero.desktop",
       authScheme: "ai.vm0.zero.desktop",
@@ -209,6 +210,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("staging");
     expect(config.webUrl.toString()).toBe("https://staging-www.omby.ai/");
     expect(config.identity).toMatchObject({
+      product: "zero",
       displayName: "Zero CU Dev",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
@@ -231,6 +233,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("development");
     expect(config.webUrl.toString()).toBe("https://www.vm7.ai:8443/");
     expect(config.identity).toMatchObject({
+      product: "zero",
       displayName: "Zero CU Dev",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
@@ -247,6 +250,7 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("development");
     expect(config.webUrl.toString()).toBe("https://pr-123-www.omby.ai/");
     expect(config.identity).toMatchObject({
+      product: "zero",
       displayName: "Zero CU Dev",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
@@ -390,6 +394,17 @@ describe("desktop auth", () => {
     );
   });
 
+  it("builds the Okou system-browser desktop auth start URL", () => {
+    expect(
+      buildDesktopAuthStartUrl(
+        new URL("https://www.okou.ai"),
+        "ai.okou.computer-use",
+      ),
+    ).toBe(
+      "https://www.okou.ai/desktop-auth/start?callbackScheme=ai.okou.computer-use",
+    );
+  });
+
   it("deduplicates repeated desktop auth start attempts", () => {
     let now = 1_000;
     const gate = createDesktopAuthStartGate(() => now);
@@ -447,6 +462,18 @@ describe("desktop auth", () => {
       parseDesktopAuthCallback(
         `ai.vm0.zero.desktop.dev://auth/callback?code=${code}`,
         "ai.vm0.zero.desktop.dev",
+      ),
+    ).toStrictEqual({ code, handoffId: null });
+    expect(
+      parseDesktopAuthCallback(
+        `ai.okou.computer-use://auth/callback?code=${code}`,
+        "ai.okou.computer-use",
+      ),
+    ).toStrictEqual({ code, handoffId: null });
+    expect(
+      parseDesktopAuthCallback(
+        `ai.okou.computer-use.dev://auth/callback?code=${code}`,
+        "ai.okou.computer-use.dev",
       ),
     ).toStrictEqual({ code, handoffId: null });
     expect(

--- a/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
@@ -7,6 +7,8 @@ const c = initContract();
 export const desktopAuthCallbackSchemes = [
   "ai.vm0.zero.desktop",
   "ai.vm0.zero.desktop.dev",
+  "ai.okou.computer-use",
+  "ai.okou.computer-use.dev",
 ] as const;
 export const defaultDesktopAuthCallbackScheme = desktopAuthCallbackSchemes[0];
 export const desktopAuthCallbackSchemeSchema = z.enum(

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { initContract } from "./base";
+import { DESKTOP_PRODUCTS } from "./client-headers";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -7,6 +8,7 @@ const c = initContract();
 const desktopUpdateChannelSchema = z.enum(["stable"]);
 const desktopUpdatePlatformSchema = z.enum(["darwin"]);
 const desktopUpdateArchitectureSchema = z.enum(["arm64"]);
+const desktopUpdateProductSchema = z.enum(DESKTOP_PRODUCTS);
 
 export type DesktopUpdateChannel = z.infer<typeof desktopUpdateChannelSchema>;
 export type DesktopUpdatePlatform = z.infer<typeof desktopUpdatePlatformSchema>;
@@ -75,5 +77,51 @@ export const desktopUpdatesContract = c.router({
       404: apiErrorSchema,
     },
     summary: "Get the desktop auto-update feed",
+  },
+  productReleasePage: {
+    method: "GET",
+    path: "/api/desktop/updates/:product/:channel/:platform/:arch/release",
+    pathParams: z.object({
+      product: desktopUpdateProductSchema,
+      channel: desktopUpdateChannelSchema,
+      platform: desktopUpdatePlatformSchema,
+      arch: desktopUpdateArchitectureSchema,
+    }),
+    responses: {
+      302: c.noBody(),
+      404: apiErrorSchema,
+    },
+    summary: "Redirect to a product-specific desktop release page",
+  },
+  productDmgDownload: {
+    method: "GET",
+    path: "/api/desktop/updates/:product/:channel/:platform/:arch/dmg",
+    pathParams: z.object({
+      product: desktopUpdateProductSchema,
+      channel: desktopUpdateChannelSchema,
+      platform: desktopUpdatePlatformSchema,
+      arch: desktopUpdateArchitectureSchema,
+    }),
+    responses: {
+      302: c.noBody(),
+      404: apiErrorSchema,
+    },
+    summary: "Redirect to a product-specific desktop DMG download",
+  },
+  productFeed: {
+    method: "GET",
+    path: "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+    pathParams: z.object({
+      product: desktopUpdateProductSchema,
+      channel: desktopUpdateChannelSchema,
+      platform: desktopUpdatePlatformSchema,
+      arch: desktopUpdateArchitectureSchema,
+    }),
+    responses: {
+      200: squirrelMacReleasesSchema,
+      400: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get a product-specific desktop auto-update feed",
   },
 });


### PR DESCRIPTION
## Summary

- preserve the legacy Zero updater routes and manifest while adding product-scoped Okou feeds
- isolate Zero and Okou manifests, release tags, ZIP/DMG names, and cache entries with fail-closed artifact checks
- add Okou production/development auth callback schemes without removing either Zero scheme
- make Desktop product identity drive updater selection, client headers, and update-dialog branding
- document the independent deployment compatibility contract

## Compatibility

- Zero continues to use `/api/desktop/updates/stable/darwin/arm64` and `desktop-updates/desktop-update-manifest.json`
- Okou uses `/api/desktop/updates/okou/stable/darwin/arm64` and `okou-desktop-updates/okou-desktop-update-manifest.json`
- this PR does not change bundle IDs or ship an Okou artifact; the packaging cutover remains a later EPIC slice
- #26349 is not a dependency

## Validation

- `pnpm format`
- affected API contracts, Desktop, and API type checks
- affected API contracts, Desktop, and API lint
- 119 focused API/Desktop/workflow tests
- `pnpm -F @vm0/desktop build:electron`
- repository-wide `pnpm knip` was also run; it still reports the existing baseline of unused files/exports and did not identify a new item from this change

Closes #26371