### PR TITLE
docs(guest-agent): clarify secret length byte threshold

### DIFF
--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -11,7 +11,7 @@ use base64::Engine;
 use serde_json::{Map, Value};
 use std::{collections::HashSet, ops::Range};
 
-/// Minimum secret length to avoid false-positive masking.
+/// Minimum secret length in UTF-8 bytes to avoid false-positive masking.
 const MIN_SECRET_LEN: usize = 5;
 
 /// Holds compiled secret matchers for efficient masking.
@@ -35,9 +35,10 @@ impl SecretMasker {
 
     /// Build a masker from a raw comma-separated base64-encoded secret string.
     ///
-    /// For each secret ≥ 5 chars, the normal matcher stores plain,
-    /// base64-encoded, and percent-encoded variants. The diagnostic matcher
-    /// also stores multiline-only variants for bounded stderr masking.
+    /// For each secret of at least five UTF-8 bytes, the normal matcher stores
+    /// plain, base64-encoded, and percent-encoded variants. Diagnostic-only
+    /// multiline variants, including individual lines, use the same byte
+    /// threshold for bounded stderr masking.
     pub fn from_raw(raw: &str) -> Self {
         if raw.is_empty() {
             return Self::empty();
@@ -844,7 +845,7 @@ mod tests {
         // "hello-world-secret" is masked (all three variants)
         assert_eq!(masker.mask_string("hello-world-secret"), "***");
         assert_eq!(masker.mask_string(&s1), "***");
-        // "tiny" is < 5 chars, not masked
+        // "tiny" is < 5 UTF-8 bytes, not masked
         assert_eq!(masker.mask_string("tiny"), "tiny");
     }
 
@@ -869,7 +870,7 @@ mod tests {
     #[test]
     fn from_raw_skips_short_secrets() {
         let engine = base64::engine::general_purpose::STANDARD;
-        let short = engine.encode("abcd"); // 4 chars < MIN_SECRET_LEN
+        let short = engine.encode("abcd"); // 4 UTF-8 bytes < MIN_SECRET_LEN
         let masker = SecretMasker::from_raw(&short);
         assert_eq!(masker.mask_string("abcd"), "abcd");
     }

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -20,6 +20,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "beta-multiline-secret-fragment\n",
         "-----END VM0 TEST KEY-----\n",
     );
+    let short_unicode_multiline_secret = "密钥\n令牌\n";
     let tail_only_secret = [
         "tail-boundary-start",
         "dropped-tail-fragment-zero",
@@ -72,6 +73,11 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     stderr_payload.push_str("\nbeta-multiline-secret-fragment\r");
     stderr_payload.push_str("\n-----END VM0 TEST KEY-----");
     stderr_payload.push_str("\nafter-multiline-secret");
+    stderr_payload.push_str("\nshort unicode multiline fragments begin");
+    stderr_payload.push_str("\n密钥");
+    stderr_payload.push_str("\nnon-secret separator");
+    stderr_payload.push_str("\n令牌");
+    stderr_payload.push_str("\nshort unicode multiline fragments end");
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &format!("@fail:{stderr_payload}"), 3, 1)?;
@@ -82,9 +88,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     let engine = base64::engine::general_purpose::STANDARD;
     let encoded_secret = engine.encode(secret);
     let encoded_multiline_secret = engine.encode(multiline_secret);
+    let encoded_short_unicode_multiline_secret = engine.encode(short_unicode_multiline_secret);
     let encoded_tail_only_secret = engine.encode(&tail_only_secret);
     let masker = SecretMasker::from_raw(&format!(
-        "{encoded_secret},{encoded_multiline_secret},{encoded_tail_only_secret}"
+        "{encoded_secret},{encoded_multiline_secret},{encoded_short_unicode_multiline_secret},{encoded_tail_only_secret}"
     ));
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
@@ -158,6 +165,8 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "retained-tail-fragment-one",
         "retained-tail-fragment-two",
         "retained-tail-fragment-three",
+        "密钥",
+        "令牌",
     ] {
         assert!(
             !stderr.contains(leaked_fragment),

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -20,7 +20,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "beta-multiline-secret-fragment\n",
         "-----END VM0 TEST KEY-----\n",
     );
-    let short_unicode_multiline_secret = "密钥\n令牌\n";
+    let short_unicode_multiline_secret = "密ab\n钥cd\n";
     let tail_only_secret = [
         "tail-boundary-start",
         "dropped-tail-fragment-zero",
@@ -74,9 +74,9 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     stderr_payload.push_str("\n-----END VM0 TEST KEY-----");
     stderr_payload.push_str("\nafter-multiline-secret");
     stderr_payload.push_str("\nshort unicode multiline fragments begin");
-    stderr_payload.push_str("\n密钥");
+    stderr_payload.push_str("\n密ab");
     stderr_payload.push_str("\nnon-secret separator");
-    stderr_payload.push_str("\n令牌");
+    stderr_payload.push_str("\n钥cd");
     stderr_payload.push_str("\nshort unicode multiline fragments end");
 
     unsafe {
@@ -165,8 +165,8 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         "retained-tail-fragment-one",
         "retained-tail-fragment-two",
         "retained-tail-fragment-three",
-        "密钥",
-        "令牌",
+        "密ab",
+        "钥cd",
     ] {
         assert!(
             !stderr.contains(leaked_fragment),

--- a/crates/guest-agent/tests/secret_masker_minimum_length.rs
+++ b/crates/guest-agent/tests/secret_masker_minimum_length.rs
@@ -3,9 +3,9 @@ use guest_agent::masker::SecretMasker;
 
 #[test]
 fn from_raw_uses_utf8_byte_length_for_minimum_secret_length() {
-    let secret = "密钥";
+    let secret = "密ab";
     assert!(secret.chars().count() < 5);
-    assert!(secret.len() >= 5);
+    assert_eq!(secret.len(), 5);
 
     let encoded = base64::engine::general_purpose::STANDARD.encode(secret);
     let masker = SecretMasker::from_raw(&encoded);

--- a/crates/guest-agent/tests/secret_masker_minimum_length.rs
+++ b/crates/guest-agent/tests/secret_masker_minimum_length.rs
@@ -1,0 +1,14 @@
+use base64::Engine;
+use guest_agent::masker::SecretMasker;
+
+#[test]
+fn from_raw_uses_utf8_byte_length_for_minimum_secret_length() {
+    let secret = "密钥";
+    assert!(secret.chars().count() < 5);
+    assert!(secret.len() >= 5);
+
+    let encoded = base64::engine::general_purpose::STANDARD.encode(secret);
+    let masker = SecretMasker::from_raw(&encoded);
+
+    assert_eq!(masker.mask_string(secret), "***");
+}


### PR DESCRIPTION
## Summary

- document the guest-agent secret masking threshold as five UTF-8 bytes
- clarify that diagnostic multiline variants and individual lines use the same byte threshold
- cover the non-ASCII boundary through the public masker and CLI stderr integration paths

This preserves the existing Rust behavior; it does not change the masking threshold or runtime logic.

Closes #26438

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --test secret_masker_minimum_length`
- `cargo test -p guest-agent --test cli_stderr_logging`
- `cargo test -p guest-agent`
