### PR TITLE
fix(db): fail fast on blocking database migrations

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -222,11 +222,11 @@ jobs:
             fi
           done
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -qE "^turbo/packages/db/src/(migrations|schema|jsonb-contracts)/"; then
-            echo "Migration, schema, or JSONB contract changes detected"
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^turbo/packages/db/(src/(migrations|schema|jsonb-contracts)/|scripts/(migration-runner|test-migration-runner-timeouts)\.ts$)'; then
+            echo "Migration, schema, JSONB contract, or migration runner changes detected"
             echo "migration-changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No migration, schema, or JSONB contract changes"
+            echo "No migration, schema, JSONB contract, or migration runner changes"
             echo "migration-changed=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -4,6 +4,12 @@ Generate migrations with `pnpm -F @vm0/db db:generate` and verify them with
 `pnpm -F @vm0/db test:migration-consistency`. Do not edit an existing migration
 or snapshot after it has shipped.
 
+Transactional migrations start with a `1s` `lock_timeout` and a `10s`
+`statement_timeout`. A migration that needs more time may override either
+default with a later `SET LOCAL` statement in that migration. Non-transactional
+migrations do not receive these defaults and must manage their own timeout
+requirements.
+
 ## Transition validators
 
 A transition validator protects an expand → contract rollout while old and new

--- a/turbo/packages/db/package.json
+++ b/turbo/packages/db/package.json
@@ -30,7 +30,8 @@
     "db:migrate": "tsx scripts/migrate.ts",
     "db:studio": "drizzle-kit studio",
     "db:reset": "tsx scripts/reset-db.ts",
-    "test:migration-consistency": "tsx scripts/test-migration-consistency-schema.ts",
+    "test:migration-consistency": "pnpm test:migration-runner && tsx scripts/test-migration-consistency-schema.ts",
+    "test:migration-runner": "tsx scripts/test-migration-runner-timeouts.ts",
     "lint:jsonb-contracts": "tsx scripts/check-jsonb-contracts.ts"
   },
   "dependencies": {

--- a/turbo/packages/db/scripts/migration-runner.ts
+++ b/turbo/packages/db/scripts/migration-runner.ts
@@ -60,6 +60,9 @@ export async function applyPendingMigrations(sql: postgres.Sql): Promise<void> {
     }
 
     await sql.begin(async (transaction) => {
+      await transaction`SET LOCAL lock_timeout = '1s'`;
+      await transaction`SET LOCAL statement_timeout = '10s'`;
+
       for (const statement of migration.sql) {
         if (statement.trim().length === 0) {
           continue;

--- a/turbo/packages/db/scripts/test-migration-runner-timeouts.ts
+++ b/turbo/packages/db/scripts/test-migration-runner-timeouts.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env tsx
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import postgres from "postgres";
+import { Client } from "pg";
+import {
+  applyPendingMigrations,
+  NON_TRANSACTIONAL_MIGRATION_MARKER,
+} from "./migration-runner";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable is required");
+}
+const DATABASE_URL = process.env.DATABASE_URL;
+
+const testDatabase = `migration_runner_timeouts_${process.pid}_${Date.now()}`;
+const fixtureDirectory = await fs.mkdtemp(
+  path.join(tmpdir(), "vm0-migration-runner-"),
+);
+
+async function createTestDatabase(): Promise<void> {
+  const client = new Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(`CREATE DATABASE "${testDatabase}"`);
+  } finally {
+    await client.end();
+  }
+}
+
+async function dropTestDatabase(): Promise<void> {
+  const client = new Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(`DROP DATABASE IF EXISTS "${testDatabase}"`);
+  } finally {
+    await client.end();
+  }
+}
+
+async function writeMigrationFixture(): Promise<void> {
+  const migrationsDirectory = path.join(fixtureDirectory, "src", "migrations");
+  await fs.mkdir(path.join(migrationsDirectory, "meta"), { recursive: true });
+  await fs.writeFile(
+    path.join(migrationsDirectory, "meta", "_journal.json"),
+    JSON.stringify({
+      version: "7",
+      dialect: "postgresql",
+      entries: [
+        {
+          idx: 0,
+          version: "7",
+          when: 1,
+          tag: "0000_transactional_timeouts",
+          breakpoints: true,
+        },
+        {
+          idx: 1,
+          version: "7",
+          when: 2,
+          tag: "0001_non_transactional_timeouts",
+          breakpoints: true,
+        },
+      ],
+    }),
+  );
+  await fs.writeFile(
+    path.join(migrationsDirectory, "0000_transactional_timeouts.sql"),
+    `DO $$
+BEGIN
+  IF current_setting('lock_timeout')::interval <> interval '1 second' THEN
+    RAISE EXCEPTION 'expected lock_timeout 1s, got %', current_setting('lock_timeout');
+  END IF;
+  IF current_setting('statement_timeout')::interval <> interval '10 seconds' THEN
+    RAISE EXCEPTION 'expected statement_timeout 10s, got %', current_setting('statement_timeout');
+  END IF;
+END
+$$;
+--> statement-breakpoint
+SET LOCAL lock_timeout = '3s';
+--> statement-breakpoint
+SET LOCAL statement_timeout = '30s';
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF current_setting('lock_timeout')::interval <> interval '3 seconds' THEN
+    RAISE EXCEPTION 'expected overridden lock_timeout 3s, got %', current_setting('lock_timeout');
+  END IF;
+  IF current_setting('statement_timeout')::interval <> interval '30 seconds' THEN
+    RAISE EXCEPTION 'expected overridden statement_timeout 30s, got %', current_setting('statement_timeout');
+  END IF;
+END
+$$;
+`,
+  );
+  await fs.writeFile(
+    path.join(migrationsDirectory, "0001_non_transactional_timeouts.sql"),
+    `${NON_TRANSACTIONAL_MIGRATION_MARKER}
+DO $$
+BEGIN
+  IF current_setting('lock_timeout')::interval <> interval '7 seconds' THEN
+    RAISE EXCEPTION 'expected session lock_timeout 7s, got %', current_setting('lock_timeout');
+  END IF;
+  IF current_setting('statement_timeout')::interval <> interval '70 seconds' THEN
+    RAISE EXCEPTION 'expected session statement_timeout 70s, got %', current_setting('statement_timeout');
+  END IF;
+END
+$$;
+`,
+  );
+}
+
+async function validateMigrationRunnerTimeouts(): Promise<void> {
+  const testDatabaseUrl = new URL(DATABASE_URL);
+  testDatabaseUrl.pathname = `/${testDatabase}`;
+  testDatabaseUrl.searchParams.set(
+    "options",
+    "-c lock_timeout=7s -c statement_timeout=70s",
+  );
+
+  const originalDirectory = process.cwd();
+  const sql = postgres(testDatabaseUrl.toString(), { max: 1 });
+  process.chdir(fixtureDirectory);
+  try {
+    await applyPendingMigrations(sql);
+    const ledger = await sql<{ count: number }[]>`
+      SELECT count(*)::integer AS count
+      FROM "drizzle"."__drizzle_migrations"
+    `;
+    assert.equal(ledger.length, 1);
+    assert.equal(ledger[0]?.count, 2);
+  } finally {
+    process.chdir(originalDirectory);
+    await sql.end();
+  }
+}
+
+try {
+  await writeMigrationFixture();
+  await createTestDatabase();
+  try {
+    await validateMigrationRunnerTimeouts();
+  } finally {
+    await dropTestDatabase();
+  }
+} finally {
+  await fs.rm(fixtureDirectory, { recursive: true, force: true });
+}
+
+console.log("Migration runner timeout defaults validated");


### PR DESCRIPTION
## Summary

- apply `lock_timeout = '1s'` and `statement_timeout = '10s'` at the start of every transactional migration
- preserve migration-local overrides and leave non-transactional migrations unchanged
- document the defaults and add a real PostgreSQL integration fixture for the runner boundary

Closes #26442

## Verification

- `pnpm exec prettier --check packages/db/scripts/migration-runner.ts packages/db/scripts/test-migration-runner-timeouts.ts packages/db/MIGRATIONS.md packages/db/package.json`
- `pnpm -F @vm0/db lint`
- `pnpm -F @vm0/db check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:55432/postgres pnpm -F @vm0/db test:migration-runner` against a temporary PostgreSQL 18 instance

Full local Vitest was not run, following the repository PR verification policy.
