### PR TITLE
feat(desktop): publish signed okou releases

### DIFF
--- a/.github/scripts/build-okou-desktop-artifact.sh
+++ b/.github/scripts/build-okou-desktop-artifact.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$#" -ne 4 ]]; then
-  echo "Usage: $0 <commit-sha> <desktop-version> <app-directory> <output-directory>" >&2
+if [[ "$#" -lt 4 || "$#" -gt 5 ]]; then
+  echo "Usage: $0 <commit-sha> <desktop-version> <zero-app-directory> <output-directory> [okou-app-directory]" >&2
   exit 1
 fi
 
@@ -10,6 +10,8 @@ commit_sha="$1"
 desktop_version="$2"
 app_dir="${3%/}"
 output_dir="$4"
+okou_app_dir="${5:-}"
+okou_app_dir="${okou_app_dir%/}"
 
 if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
   echo "Desktop artifact commit must be a full lowercase SHA-1: $commit_sha" >&2
@@ -23,11 +25,16 @@ if [[ ! -d "$app_dir" || "$(basename "$app_dir")" != "Zero Computer Use.app" ]];
   echo "Desktop artifact requires a Zero Computer Use.app directory: $app_dir" >&2
   exit 1
 fi
+if [[ -n "$okou_app_dir" && (! -d "$okou_app_dir" || "$(basename "$okou_app_dir")" != "Okou Computer Use.app") ]]; then
+  echo "Desktop artifact requires an Okou Computer Use.app directory: $okou_app_dir" >&2
+  exit 1
+fi
 
 mkdir -p "$output_dir"
 output_dir="$(cd "$output_dir" && pwd -P)"
 rm -f \
   "$output_dir/app.tar.gz" \
+  "$output_dir/okou-app.tar.gz" \
   "$output_dir/manifest.json" \
   "$output_dir/ready.json"
 
@@ -37,11 +44,23 @@ COPYFILE_DISABLE=1 tar -czf "$output_dir/app.tar.gz" \
 
 archive_sha256="$(shasum -a 256 "$output_dir/app.tar.gz" | cut -d ' ' -f 1)"
 archive_size="$(wc -c < "$output_dir/app.tar.gz" | tr -d '[:space:]')"
+okou_archive_sha256=""
+okou_archive_size=0
+if [[ -n "$okou_app_dir" ]]; then
+  COPYFILE_DISABLE=1 tar -czf "$output_dir/okou-app.tar.gz" \
+    -C "$(dirname "$okou_app_dir")" \
+    "$(basename "$okou_app_dir")"
+  okou_archive_sha256="$(shasum -a 256 "$output_dir/okou-app.tar.gz" | cut -d ' ' -f 1)"
+  okou_archive_size="$(wc -c < "$output_dir/okou-app.tar.gz" | tr -d '[:space:]')"
+fi
+
 jq -n \
   --arg commit_sha "$commit_sha" \
   --arg desktop_version "$desktop_version" \
   --arg archive_sha256 "$archive_sha256" \
   --argjson archive_size "$archive_size" \
+  --arg okou_archive_sha256 "$okou_archive_sha256" \
+  --argjson okou_archive_size "$okou_archive_size" \
   '{
     version: 1,
     commitSha: $commit_sha,
@@ -54,7 +73,15 @@ jq -n \
       sha256: $archive_sha256,
       size: $archive_size
     }
-  }' > "$output_dir/manifest.json"
+  }
+  | if $okou_archive_sha256 == "" then . else . + {
+      okouAppName: "Okou Computer Use.app",
+      okouArchive: {
+        path: "okou-app.tar.gz",
+        sha256: $okou_archive_sha256,
+        size: $okou_archive_size
+      }
+    } end' > "$output_dir/manifest.json"
 
 manifest_sha256="$(shasum -a 256 "$output_dir/manifest.json" | cut -d ' ' -f 1)"
 jq -n \
@@ -64,7 +91,8 @@ jq -n \
   > "$output_dir/ready.json"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-bash "$script_dir/verify-okou-desktop-artifact.sh" \
-  "$output_dir" \
-  "$commit_sha" \
-  "$desktop_version"
+verify_args=("$output_dir" "$commit_sha" "$desktop_version")
+if [[ -n "$okou_app_dir" ]]; then
+  verify_args+=(--require-okou)
+fi
+bash "$script_dir/verify-okou-desktop-artifact.sh" "${verify_args[@]}"

--- a/.github/scripts/fetch-okou-desktop-artifact.sh
+++ b/.github/scripts/fetch-okou-desktop-artifact.sh
@@ -56,3 +56,17 @@ for filename in app.tar.gz manifest.json ready.json; do
     exit 1
   fi
 done
+
+okou_archive_path="$(jq -r '.okouArchive.path // ""' "$destination/manifest.json")"
+if [[ -n "$okou_archive_path" ]]; then
+  if [[ "$okou_archive_path" != "okou-app.tar.gz" ]]; then
+    echo "Desktop artifact manifest contains an unexpected Okou archive path: $okou_archive_path" >&2
+    exit 1
+  fi
+  if ! copy_with_retry \
+    "$artifact_uri/$okou_archive_path" \
+    "$destination/$okou_archive_path"; then
+    echo "Desktop artifact download failed: $artifact_uri/$okou_archive_path" >&2
+    exit 1
+  fi
+fi

--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -44,6 +44,14 @@ ruby -e '
 
   build_step = deploy.fetch("steps").find { |step| step["name"] == "Build canonical unsigned Desktop app" }
   raise "canonical Desktop build must skip signing" unless build_step.fetch("env").fetch("VM0_DESKTOP_SKIP_SIGNING") == "true"
+  raise "canonical Desktop build must package Okou" unless build_step.fetch("run").include?("Okou Computer Use.app")
+  raise "canonical Okou build must target app.okou.ai" unless build_step.fetch("run").include?("VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai")
+
+  artifact_build = deploy.fetch("steps").find { |step| step["name"] == "Create canonical Desktop artifact" }.fetch("run")
+  raise "canonical artifact must contain the Okou app" unless artifact_build.include?("Okou Computer Use-darwin-arm64/Okou Computer Use.app")
+
+  artifact_upload = deploy.fetch("steps").find { |step| step["name"] == "Upload canonical Desktop artifact" }.fetch("run")
+  raise "canonical artifact must upload the Okou archive" unless artifact_upload.include?("okou-app.tar.gz")
 
   promote = release.fetch("promote-desktop-release")
   raise "Desktop promotion must use production environment" unless promote.fetch("environment") == "production"
@@ -54,13 +62,23 @@ ruby -e '
   raise "Desktop promotion must fetch the canonical R2 artifact" unless download.include?("fetch-okou-desktop-artifact.sh")
   raise "Desktop promotion must verify the canonical R2 artifact" unless download.include?("verify-okou-desktop-artifact.sh")
   raise "Desktop promotion must address artifacts by release_target" unless download.include?(ARGV[5])
+  raise "Desktop promotion must require the Okou app archive" unless download.include?("--require-okou")
 
   promote_text = File.read(ARGV[1]).split("  promote-desktop-release:\n", 2).fetch(1).split(/\n  [a-zA-Z0-9_-]+:\n/, 2).first
   raise "Desktop promotion must not rebuild the app" if promote_text.include?("pnpm -F @vm0/desktop build")
   raise "Desktop promotion must sign the downloaded app" unless promote_text.include?("sign-and-notarize-packaged-app.mjs")
+  raise "Desktop promotion must select a product signing identity" unless promote_text.include?("--product")
+  raise "Desktop promotion must publish an independent Okou release" unless promote_text.include?("OKOU_RELEASE_TAG: okou-desktop-v")
+  raise "Desktop promotion must publish Okou artifacts" unless promote_text.include?("Okou-darwin-arm64-$DESKTOP_VERSION")
+  raise "Desktop promotion must smoke-test Okou installation" unless promote_text.include?("okou-install-smoke")
+  raise "Desktop promotion must smoke-test Okou updates" unless promote_text.include?("okou-update-smoke")
 
   publish = release.fetch("publish-desktop-update-manifest")
   raise "Desktop manifest must wait for promotion" unless Array(publish.fetch("needs")).include?("promote-desktop-release")
+  publish_text = publish.fetch("steps").find { |step| step["name"] == "Publish Desktop update manifest" }.fetch("run")
+  raise "Desktop manifests must preserve the Zero feed" unless publish_text.include?("desktop-update-manifest.json")
+  raise "Desktop manifests must publish the Okou feed" unless publish_text.include?("okou-desktop-update-manifest.json")
+  raise "Desktop manifests must publish under the Okou mutable tag" unless publish_text.include?("okou-desktop-updates")
 ' \
   "$desktop_workflow" \
   "$release_workflow" \

--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -69,7 +69,7 @@ ruby -e '
   raise "Desktop promotion must sign the downloaded app" unless promote_text.include?("sign-and-notarize-packaged-app.mjs")
   raise "Desktop promotion must select a product signing identity" unless promote_text.include?("--product")
   raise "Desktop promotion must publish an independent Okou release" unless promote_text.include?("OKOU_RELEASE_TAG: okou-desktop-v")
-  raise "Desktop promotion must publish Okou artifacts" unless promote_text.include?("Okou-darwin-arm64-$DESKTOP_VERSION")
+  raise "Desktop promotion must publish Okou artifacts" unless promote_text.include?("Okou-darwin-arm64-")
   raise "Desktop promotion must smoke-test Okou installation" unless promote_text.include?("okou-install-smoke")
   raise "Desktop promotion must smoke-test Okou updates" unless promote_text.include?("okou-update-smoke")
 

--- a/.github/scripts/tests/fetch-okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/fetch-okou-desktop-artifact-test.sh
@@ -9,7 +9,8 @@ trap 'rm -rf "$tmp_dir"' EXIT
 source_dir="${tmp_dir}/source"
 mkdir -p "$source_dir" "${tmp_dir}/bin"
 printf 'archive\n' > "$source_dir/app.tar.gz"
-printf '{"version":1}\n' > "$source_dir/manifest.json"
+printf 'okou archive\n' > "$source_dir/okou-app.tar.gz"
+printf '{"version":1,"okouArchive":{"path":"okou-app.tar.gz"}}\n' > "$source_dir/manifest.json"
 printf '{"version":1}\n' > "$source_dir/ready.json"
 
 cat > "${tmp_dir}/bin/aws" <<'EOF'
@@ -52,10 +53,11 @@ mkdir -p "$destination"
 MOCK_AWS_LOG="${tmp_dir}/fetch.log" \
   bash "$script" "$r2_endpoint" "$artifact_uri" "$destination"
 cmp "$source_dir/app.tar.gz" "$destination/app.tar.gz"
+cmp "$source_dir/okou-app.tar.gz" "$destination/okou-app.tar.gz"
 cmp "$source_dir/manifest.json" "$destination/manifest.json"
 cmp "$source_dir/ready.json" "$destination/ready.json"
-if (( "$(grep -c 's3 cp' "${tmp_dir}/fetch.log")" != 3 )); then
-  echo "Expected exactly three Desktop artifact object copies" >&2
+if (( "$(grep -c 's3 cp' "${tmp_dir}/fetch.log")" != 4 )); then
+  echo "Expected exactly four Desktop artifact object copies" >&2
   exit 1
 fi
 if grep -q -- '--recursive' "${tmp_dir}/fetch.log"; then
@@ -86,10 +88,24 @@ MOCK_AWS_TRANSIENT_FAILURES=2 \
   bash "$script" "$r2_endpoint" "$artifact_uri" "$retry_destination" \
     >/dev/null 2>&1
 test -f "$retry_destination/app.tar.gz"
-if (( "$(grep -c 's3 cp' "${tmp_dir}/retry.log")" != 5 )); then
-  echo "Expected two retries followed by all three object copies" >&2
+if (( "$(grep -c 's3 cp' "${tmp_dir}/retry.log")" != 6 )); then
+  echo "Expected two retries followed by all four object copies" >&2
   exit 1
 fi
+
+legacy_source_dir="${tmp_dir}/legacy-source"
+legacy_destination="${tmp_dir}/legacy-destination"
+mkdir -p "$legacy_source_dir" "$legacy_destination"
+cp "$source_dir/app.tar.gz" "$source_dir/ready.json" "$legacy_source_dir/"
+printf '{"version":1}\n' > "$legacy_source_dir/manifest.json"
+MOCK_SOURCE_DIR="$legacy_source_dir" \
+  MOCK_AWS_LOG="${tmp_dir}/legacy.log" \
+  bash "$script" "$r2_endpoint" "$artifact_uri" "$legacy_destination"
+if (( "$(grep -c 's3 cp' "${tmp_dir}/legacy.log")" != 3 )); then
+  echo "Expected a legacy Zero-only artifact to use three object copies" >&2
+  exit 1
+fi
+test ! -e "$legacy_destination/okou-app.tar.gz"
 
 if MOCK_AWS_LOG="${tmp_dir}/absent.log" \
   bash "$script" "$r2_endpoint" "$artifact_uri" "${tmp_dir}/absent" \

--- a/.github/scripts/tests/okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/okou-desktop-artifact-test.sh
@@ -10,33 +10,71 @@ trap 'rm -rf "$tmp_dir"' EXIT
 commit_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 desktop_version="1.2.3"
 app_dir="${tmp_dir}/package/Zero Computer Use.app"
+okou_app_dir="${tmp_dir}/package/Okou Computer Use.app"
 artifact_dir="${tmp_dir}/artifact"
 mkdir -p \
   "$app_dir/Contents/MacOS" \
-  "$app_dir/Contents/Frameworks/Example.framework/Versions/A"
+  "$app_dir/Contents/Frameworks/Example.framework/Versions/A" \
+  "$okou_app_dir/Contents/MacOS"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$app_dir/Contents/MacOS/Zero Computer Use"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$okou_app_dir/Contents/MacOS/Okou Computer Use"
 chmod +x "$app_dir/Contents/MacOS/Zero Computer Use"
+chmod +x "$okou_app_dir/Contents/MacOS/Okou Computer Use"
 ln -s A "$app_dir/Contents/Frameworks/Example.framework/Versions/Current"
 
-bash "$build_script" "$commit_sha" "$desktop_version" "$app_dir" "$artifact_dir"
-bash "$verify_script" "$artifact_dir" "$commit_sha" "$desktop_version"
+bash "$build_script" \
+  "$commit_sha" \
+  "$desktop_version" \
+  "$app_dir" \
+  "$artifact_dir" \
+  "$okou_app_dir"
+bash "$verify_script" "$artifact_dir" "$commit_sha" "$desktop_version" --require-okou
 jq -e \
   --arg commit_sha "$commit_sha" \
   --arg desktop_version "$desktop_version" \
-  '.commitSha == $commit_sha and .desktopVersion == $desktop_version' \
+  '.commitSha == $commit_sha
+    and .desktopVersion == $desktop_version
+    and .okouAppName == "Okou Computer Use.app"
+    and .okouArchive.path == "okou-app.tar.gz"' \
   "$artifact_dir/manifest.json" >/dev/null
 
 extracted_dir="${tmp_dir}/extracted"
 mkdir -p "$extracted_dir"
 tar -xzf "$artifact_dir/app.tar.gz" -C "$extracted_dir"
+tar -xzf "$artifact_dir/okou-app.tar.gz" -C "$extracted_dir"
 test -x "$extracted_dir/Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
+test -x "$extracted_dir/Okou Computer Use.app/Contents/MacOS/Okou Computer Use"
 test -L "$extracted_dir/Zero Computer Use.app/Contents/Frameworks/Example.framework/Versions/Current"
+
+legacy_artifact_dir="${tmp_dir}/legacy-artifact"
+bash "$build_script" \
+  "$commit_sha" \
+  "$desktop_version" \
+  "$app_dir" \
+  "$legacy_artifact_dir"
+bash "$verify_script" "$legacy_artifact_dir" "$commit_sha" "$desktop_version"
+if bash "$verify_script" \
+  "$legacy_artifact_dir" \
+  "$commit_sha" \
+  "$desktop_version" \
+  --require-okou >/dev/null 2>&1; then
+  echo "Expected a legacy Zero-only artifact to fail the Okou requirement" >&2
+  exit 1
+fi
 
 tampered_dir="${tmp_dir}/tampered"
 cp -a "$artifact_dir" "$tampered_dir"
 printf 'tampered\n' >> "$tampered_dir/app.tar.gz"
-if bash "$verify_script" "$tampered_dir" "$commit_sha" "$desktop_version" >/dev/null 2>&1; then
+if bash "$verify_script" "$tampered_dir" "$commit_sha" "$desktop_version" --require-okou >/dev/null 2>&1; then
   echo "Expected a tampered Desktop archive to fail" >&2
+  exit 1
+fi
+
+tampered_okou_dir="${tmp_dir}/tampered-okou"
+cp -a "$artifact_dir" "$tampered_okou_dir"
+printf 'tampered\n' >> "$tampered_okou_dir/okou-app.tar.gz"
+if bash "$verify_script" "$tampered_okou_dir" "$commit_sha" "$desktop_version" --require-okou >/dev/null 2>&1; then
+  echo "Expected a tampered Okou Desktop archive to fail" >&2
   exit 1
 fi
 
@@ -61,12 +99,12 @@ jq \
   --arg archive_sha "$unsafe_archive_sha" \
   --argjson archive_size "$unsafe_archive_size" \
   '.archive.sha256 = $archive_sha | .archive.size = $archive_size' \
-  "$artifact_dir/manifest.json" > "$unsafe_dir/manifest.json"
+  "$legacy_artifact_dir/manifest.json" > "$unsafe_dir/manifest.json"
 unsafe_manifest_sha="$(shasum -a 256 "$unsafe_dir/manifest.json" | cut -d ' ' -f 1)"
 jq \
   --arg manifest_sha "$unsafe_manifest_sha" \
   '.manifestSha256 = $manifest_sha' \
-  "$artifact_dir/ready.json" > "$unsafe_dir/ready.json"
+  "$legacy_artifact_dir/ready.json" > "$unsafe_dir/ready.json"
 if bash "$verify_script" "$unsafe_dir" "$commit_sha" "$desktop_version" >/dev/null 2>&1; then
   echo "Expected an archive with another top-level path to fail" >&2
   exit 1
@@ -130,6 +168,12 @@ if (
   )
 ) {
   throw new Error("Okou packaged app path must be product scoped");
+}
+if (
+  packagedAppPaths({ appBundlePath: "/tmp/Okou Computer Use.app" })
+    .appBundlePath !== "/tmp/Okou Computer Use.app"
+) {
+  throw new Error("Desktop smoke tests must support an installed app path");
 }
 NODE
 

--- a/.github/scripts/verify-okou-desktop-artifact.sh
+++ b/.github/scripts/verify-okou-desktop-artifact.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$#" -ne 3 ]]; then
-  echo "Usage: $0 <artifact-directory> <expected-commit-sha> <expected-desktop-version>" >&2
+if [[ "$#" -lt 3 || "$#" -gt 4 || ("$#" -eq 4 && "$4" != "--require-okou") ]]; then
+  echo "Usage: $0 <artifact-directory> <expected-commit-sha> <expected-desktop-version> [--require-okou]" >&2
   exit 1
 fi
 
 artifact_dir="$1"
 expected_commit_sha="$2"
 expected_desktop_version="$3"
-archive_path="$artifact_dir/app.tar.gz"
+require_okou="${4:-}"
 manifest_path="$artifact_dir/manifest.json"
 ready_path="$artifact_dir/ready.json"
 
@@ -22,7 +22,7 @@ if [[ ! "$expected_desktop_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.
   exit 1
 fi
 
-for artifact_path in "$archive_path" "$manifest_path" "$ready_path"; do
+for artifact_path in "$artifact_dir/app.tar.gz" "$manifest_path" "$ready_path"; do
   if [[ ! -f "$artifact_path" ]]; then
     echo "Desktop artifact is missing $(basename "$artifact_path")" >&2
     exit 1
@@ -43,17 +43,74 @@ jq -e \
     and (.archive.size | type == "number" and . > 0)' \
   "$manifest_path" >/dev/null
 
-archive_sha256="$(shasum -a 256 "$archive_path" | cut -d ' ' -f 1)"
-manifest_archive_sha256="$(jq -er '.archive.sha256' "$manifest_path")"
-if [[ "$archive_sha256" != "$manifest_archive_sha256" ]]; then
-  echo "Desktop app archive digest does not match manifest" >&2
-  exit 1
-fi
+verify_archive() {
+  local archive_path="$1"
+  local expected_app_name="$2"
+  local archive_manifest_path="$3"
+  local archive_sha256
+  local manifest_archive_sha256
+  local archive_size
+  local manifest_archive_size
+  local archive_entries
 
-archive_size="$(wc -c < "$archive_path" | tr -d '[:space:]')"
-manifest_archive_size="$(jq -er '.archive.size' "$manifest_path")"
-if [[ "$archive_size" != "$manifest_archive_size" ]]; then
-  echo "Desktop app archive size does not match manifest" >&2
+  if [[ ! -f "$archive_path" ]]; then
+    echo "Desktop artifact is missing $(basename "$archive_path")" >&2
+    exit 1
+  fi
+
+  archive_sha256="$(shasum -a 256 "$archive_path" | cut -d ' ' -f 1)"
+  manifest_archive_sha256="$(jq -er "$archive_manifest_path.sha256" "$manifest_path")"
+  if [[ "$archive_sha256" != "$manifest_archive_sha256" ]]; then
+    echo "Desktop app archive digest does not match manifest: $(basename "$archive_path")" >&2
+    exit 1
+  fi
+
+  archive_size="$(wc -c < "$archive_path" | tr -d '[:space:]')"
+  manifest_archive_size="$(jq -er "$archive_manifest_path.size" "$manifest_path")"
+  if [[ "$archive_size" != "$manifest_archive_size" ]]; then
+    echo "Desktop app archive size does not match manifest: $(basename "$archive_path")" >&2
+    exit 1
+  fi
+
+  archive_entries="$(tar -tzf "$archive_path")"
+  if [[ -z "$archive_entries" ]]; then
+    echo "Desktop app archive is empty: $(basename "$archive_path")" >&2
+    exit 1
+  fi
+  while IFS= read -r entry; do
+    case "$entry" in
+      "$expected_app_name" | "$expected_app_name/" | "$expected_app_name/"*) ;;
+      *)
+        echo "Desktop app archive contains an unexpected path: $entry" >&2
+        exit 1
+        ;;
+    esac
+    if [[ "$entry" == /* || "/$entry/" == *"/../"* ]]; then
+      echo "Desktop app archive contains an unsafe path: $entry" >&2
+      exit 1
+    fi
+  done <<< "$archive_entries"
+}
+
+verify_archive \
+  "$artifact_dir/app.tar.gz" \
+  "Zero Computer Use.app" \
+  '.archive'
+
+has_okou_archive="$(jq -r 'has("okouAppName") or has("okouArchive")' "$manifest_path")"
+if [[ "$has_okou_archive" == "true" ]]; then
+  jq -e \
+    '.okouAppName == "Okou Computer Use.app"
+      and .okouArchive.path == "okou-app.tar.gz"
+      and (.okouArchive.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+      and (.okouArchive.size | type == "number" and . > 0)' \
+    "$manifest_path" >/dev/null
+  verify_archive \
+    "$artifact_dir/okou-app.tar.gz" \
+    "Okou Computer Use.app" \
+    '.okouArchive'
+elif [[ "$require_okou" == "--require-okou" ]]; then
+  echo "Desktop artifact does not contain the required Okou app archive" >&2
   exit 1
 fi
 
@@ -65,24 +122,5 @@ jq -e \
     and .commitSha == $commit_sha
     and .manifestSha256 == $manifest_sha256' \
   "$ready_path" >/dev/null
-
-archive_entries="$(tar -tzf "$archive_path")"
-if [[ -z "$archive_entries" ]]; then
-  echo "Desktop app archive is empty" >&2
-  exit 1
-fi
-while IFS= read -r entry; do
-  case "$entry" in
-    "Zero Computer Use.app" | "Zero Computer Use.app/" | "Zero Computer Use.app/"*) ;;
-    *)
-      echo "Desktop app archive contains an unexpected path: $entry" >&2
-      exit 1
-      ;;
-  esac
-  if [[ "$entry" == /* || "/$entry/" == *"/../"* ]]; then
-    echo "Desktop app archive contains an unsafe path: $entry" >&2
-    exit 1
-  fi
-done <<< "$archive_entries"
 
 echo "Verified Desktop artifact for $expected_commit_sha"

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -593,26 +593,35 @@ jobs:
           : "${R2_BUCKET_NAME:?R2_STATIC_BUCKET_NAME variable is required}"
 
           r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          ready_key="${ARTIFACT_PREFIX}/ready.json"
           error_log="$(mktemp)"
+          artifact_ready=true
 
-          set +e
-          aws s3api head-object \
-            --endpoint-url "$r2_endpoint" \
-            --bucket "$R2_BUCKET_NAME" \
-            --key "$ready_key" \
-            >/dev/null 2>"$error_log"
-          status=$?
-          set -e
+          for filename in ready.json okou-app.tar.gz; do
+            set +e
+            aws s3api head-object \
+              --endpoint-url "$r2_endpoint" \
+              --bucket "$R2_BUCKET_NAME" \
+              --key "${ARTIFACT_PREFIX}/${filename}" \
+              >/dev/null 2>"$error_log"
+            status=$?
+            set -e
 
-          if (( status == 0 )); then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Artifact already ready: s3://${R2_BUCKET_NAME}/${ARTIFACT_PREFIX}/"
-          elif grep -Eq '404|NotFound|Not Found|NoSuchKey' "$error_log"; then
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          else
+            if (( status == 0 )); then
+              continue
+            fi
+            if grep -Eq '404|NotFound|Not Found|NoSuchKey' "$error_log"; then
+              artifact_ready=false
+              break
+            fi
             cat "$error_log" >&2
             exit "$status"
+          done
+
+          if [[ "$artifact_ready" == "true" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Artifact already ready: s3://${R2_BUCKET_NAME}/${ARTIFACT_PREFIX}/"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -643,7 +652,12 @@ jobs:
           VM0_DESKTOP_SKIP_SIGNING: "true"
         working-directory: turbo
         run: |
-          rm -f apps/desktop/desktop-runtime-config.json
+          cleanup_runtime_config() {
+            rm -f apps/desktop/desktop-runtime-config.json
+          }
+          trap cleanup_runtime_config EXIT
+
+          cleanup_runtime_config
           rm -rf apps/desktop/out
 
           pnpm -F @vm0/desktop build
@@ -665,6 +679,49 @@ jobs:
 
           node apps/desktop/scripts/smoke-test-packaged-app.js
 
+          VM0_DESKTOP_PRODUCT=okou \
+          VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          fs.writeFileSync(
+            "apps/desktop/desktop-runtime-config.json",
+            `${JSON.stringify(
+              {
+                platformUrl: process.env.VM0_DESKTOP_PLATFORM_URL,
+                product: process.env.VM0_DESKTOP_PRODUCT,
+              },
+              null,
+              2,
+            )}\n`,
+          );
+          NODE
+
+          VM0_DESKTOP_PRODUCT=okou \
+          VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+          pnpm -F @vm0/desktop build
+          VM0_DESKTOP_PRODUCT=okou \
+          VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+          pnpm --dir apps/desktop exec electron-forge package \
+            --platform darwin \
+            --arch arm64
+
+          okou_app_dir="$PWD/apps/desktop/out/Okou Computer Use-darwin-arm64/Okou Computer Use.app"
+          if [ ! -d "$okou_app_dir" ]; then
+            echo "No packaged Okou app found: $okou_app_dir"
+            find apps/desktop/out -maxdepth 4 -type d -print || true
+            exit 1
+          fi
+          okou_runtime_config="$okou_app_dir/Contents/Resources/app/desktop-runtime-config.json"
+          if [ ! -f "$okou_runtime_config" ]; then
+            echo "Canonical Okou artifact must contain Desktop runtime config"
+            exit 1
+          fi
+
+          VM0_DESKTOP_PRODUCT=okou \
+          VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+          node apps/desktop/scripts/smoke-test-packaged-app.js
+
       - name: Create canonical Desktop artifact
         if: steps.existing.outputs.exists != 'true'
         env:
@@ -676,7 +733,8 @@ jobs:
             "$ARTIFACT_SHA" \
             "$DESKTOP_VERSION" \
             "turbo/apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app" \
-            /tmp/okou-desktop-artifact
+            /tmp/okou-desktop-artifact \
+            "turbo/apps/desktop/out/Okou Computer Use-darwin-arm64/Okou Computer Use.app"
 
       - name: Upload canonical Desktop artifact
         if: steps.existing.outputs.exists != 'true'
@@ -698,6 +756,14 @@ jobs:
             --bucket "$R2_BUCKET_NAME" \
             --key "${ARTIFACT_PREFIX}/app.tar.gz" \
             --body /tmp/okou-desktop-artifact/app.tar.gz \
+            --content-type application/gzip \
+            --cache-control "$cache_control"
+
+          aws s3api put-object \
+            --endpoint-url "$r2_endpoint" \
+            --bucket "$R2_BUCKET_NAME" \
+            --key "${ARTIFACT_PREFIX}/okou-app.tar.gz" \
+            --body /tmp/okou-desktop-artifact/okou-app.tar.gz \
             --content-type application/gzip \
             --cache-control "$cache_control"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -193,6 +193,8 @@ jobs:
     env:
       DESKTOP_VERSION: ${{ needs.release-please.outputs.desktop_version }}
       RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
+      OKOU_RELEASE_TAG: okou-desktop-v${{ needs.release-please.outputs.desktop_version }}
+      RELEASE_TARGET: ${{ needs.release-please.outputs.release_target }}
       VM0_DESKTOP_SIGNING_IDENTITY: "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)"
       MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
       MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -287,7 +289,8 @@ jobs:
           artifact_uri="s3://${R2_BUCKET_NAME}/okou-desktop/${ARTIFACT_SHA}"
           ready_key="okou-desktop/${ARTIFACT_SHA}/ready.json"
           artifact_dir="$(mktemp -d)"
-          package_dir="$PWD/apps/desktop/out/Zero Computer Use-darwin-arm64"
+          zero_package_dir="$PWD/apps/desktop/out/Zero Computer Use-darwin-arm64"
+          okou_package_dir="$PWD/apps/desktop/out/Okou Computer Use-darwin-arm64"
           error_log="$(mktemp)"
 
           for attempt in $(seq 1 60); do
@@ -322,17 +325,27 @@ jobs:
           bash ../.github/scripts/verify-okou-desktop-artifact.sh \
             "$artifact_dir" \
             "$ARTIFACT_SHA" \
-            "$DESKTOP_VERSION"
+            "$DESKTOP_VERSION" \
+            --require-okou
 
-          rm -rf "$package_dir"
-          mkdir -p "$package_dir"
-          tar -xzf "$artifact_dir/app.tar.gz" -C "$package_dir"
-          app_dir="$package_dir/Zero Computer Use.app"
-          if [ ! -d "$app_dir" ]; then
+          rm -rf "$zero_package_dir" "$okou_package_dir"
+          mkdir -p "$zero_package_dir" "$okou_package_dir"
+          tar -xzf "$artifact_dir/app.tar.gz" -C "$zero_package_dir"
+          tar -xzf "$artifact_dir/okou-app.tar.gz" -C "$okou_package_dir"
+          zero_app_dir="$zero_package_dir/Zero Computer Use.app"
+          okou_app_dir="$okou_package_dir/Okou Computer Use.app"
+          if [ ! -d "$zero_app_dir" ]; then
             echo "Canonical Desktop artifact did not contain Zero Computer Use.app" >&2
             exit 1
           fi
-          echo "app_dir=$app_dir" >> "$GITHUB_OUTPUT"
+          if [ ! -d "$okou_app_dir" ]; then
+            echo "Canonical Desktop artifact did not contain Okou Computer Use.app" >&2
+            exit 1
+          fi
+          {
+            echo "zero_app_dir=$zero_app_dir"
+            echo "okou_app_dir=$okou_app_dir"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Validate macOS release secrets
         run: |
@@ -399,128 +412,239 @@ jobs:
           VM0_DESKTOP_NOTARIZE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           VM0_DESKTOP_NOTARIZE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
-          app_dir="${{ steps.desktop-app.outputs.app_dir }}"
-          zip_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-          dmg_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
+          create_product_artifacts() {
+            local product="$1"
+            local app_dir="$2"
+            local artifact_name="$3"
+            local volume_name="$4"
+            local background_svg="${5:-}"
+            local zip_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.zip"
+            local dmg_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.dmg"
+            local background_args=()
 
-          node apps/desktop/scripts/sign-and-notarize-packaged-app.mjs \
-            --app "$app_dir"
-          ditto -c -k --sequesterRsrc --keepParent \
-            "$app_dir" \
-            "$zip_artifact_path"
-          node apps/desktop/scripts/create-styled-dmg.mjs \
-            --app "$app_dir" \
-            --out "$dmg_artifact_path" \
-            --volume-name "Zero Computer Use"
-          codesign --force --sign "$VM0_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
-          xcrun notarytool submit "$dmg_artifact_path" \
-            --key "$VM0_DESKTOP_NOTARIZE_API_KEY_PATH" \
-            --key-id "$VM0_DESKTOP_NOTARIZE_API_KEY_ID" \
-            --issuer "$VM0_DESKTOP_NOTARIZE_API_ISSUER" \
-            --wait
-          xcrun stapler staple "$dmg_artifact_path"
+            if [ -n "$background_svg" ]; then
+              background_args=(--background-svg "$background_svg")
+            fi
 
-          echo "zip_path=$zip_artifact_path" >> "$GITHUB_OUTPUT"
-          echo "dmg_path=$dmg_artifact_path" >> "$GITHUB_OUTPUT"
+            node apps/desktop/scripts/sign-and-notarize-packaged-app.mjs \
+              --app "$app_dir" \
+              --product "$product"
+            ditto -c -k --sequesterRsrc --keepParent \
+              "$app_dir" \
+              "$zip_artifact_path"
+            node apps/desktop/scripts/create-styled-dmg.mjs \
+              --app "$app_dir" \
+              --out "$dmg_artifact_path" \
+              --volume-name "$volume_name" \
+              "${background_args[@]}"
+            codesign --force --sign "$VM0_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
+            xcrun notarytool submit "$dmg_artifact_path" \
+              --key "$VM0_DESKTOP_NOTARIZE_API_KEY_PATH" \
+              --key-id "$VM0_DESKTOP_NOTARIZE_API_KEY_ID" \
+              --issuer "$VM0_DESKTOP_NOTARIZE_API_ISSUER" \
+              --wait
+            xcrun stapler staple "$dmg_artifact_path"
+          }
+
+          create_product_artifacts \
+            zero \
+            "${{ steps.desktop-app.outputs.zero_app_dir }}" \
+            Zero \
+            "Zero Computer Use"
+          create_product_artifacts \
+            okou \
+            "${{ steps.desktop-app.outputs.okou_app_dir }}" \
+            Okou \
+            "Okou Computer Use" \
+            apps/desktop/assets/dmg-background-okou.svg
+
+          {
+            echo "zero_zip_path=apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
+            echo "zero_dmg_path=apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
+            echo "okou_zip_path=apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.zip"
+            echo "okou_dmg_path=apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.dmg"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify signed and notarized macOS artifacts
         run: |
-          zip_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-          dmg_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
-          app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
-          plist="$app_dir/Contents/Info.plist"
-          dmg_mount="$RUNNER_TEMP/zero-desktop-dmg"
+          verify_product_artifacts() {
+            local product="$1"
+            local app_name="$2"
+            local artifact_name="$3"
+            local bundle_id="$4"
+            local auth_scheme="$5"
+            local app_dir="apps/desktop/out/${app_name}-darwin-arm64/${app_name}.app"
+            local plist="$app_dir/Contents/Info.plist"
+            local runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
+            local zip_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.zip"
+            local dmg_artifact_path="apps/desktop/out/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.dmg"
+            local dmg_mount="$RUNNER_TEMP/${product}-desktop-dmg"
 
-          if [ ! -f "$zip_artifact_path" ]; then
-            echo "No desktop zip artifact found"
-            find apps/desktop/out -maxdepth 5 -type f -print || true
-            exit 1
-          fi
-          if [ ! -f "$dmg_artifact_path" ]; then
-            echo "No desktop dmg artifact found"
-            find apps/desktop/out -maxdepth 5 -type f -print || true
-            exit 1
-          fi
-          if [ ! -d "$app_dir" ]; then
-            echo "No packaged app found: $app_dir"
-            find apps/desktop/out -maxdepth 4 -type d -print || true
-            exit 1
-          fi
-          if [ -e "$app_dir/Contents/Resources/app/desktop-runtime-config.json" ]; then
-            echo "Production artifact should not contain desktop runtime config"
-            exit 1
-          fi
+            if [ ! -f "$zip_artifact_path" ] || [ ! -f "$dmg_artifact_path" ]; then
+              echo "Missing $app_name release artifacts"
+              find apps/desktop/out -maxdepth 5 -type f -print || true
+              exit 1
+            fi
+            if [ ! -d "$app_dir" ]; then
+              echo "No packaged app found: $app_dir"
+              find apps/desktop/out -maxdepth 4 -type d -print || true
+              exit 1
+            fi
+            if [ "$product" = "zero" ] && [ -e "$runtime_config" ]; then
+              echo "Zero production artifact should not contain Desktop runtime config"
+              exit 1
+            fi
+            if [ "$product" = "okou" ]; then
+              if [ ! -f "$runtime_config" ]; then
+                echo "Okou production artifact should contain Desktop runtime config"
+                exit 1
+              fi
+              RUNTIME_CONFIG="$runtime_config" node <<'NODE'
+          const fs = require("node:fs");
 
-          minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$plist" 2>/dev/null || true)
-          if [ "$minimum_system_version" != "14.0" ]; then
-            echo "::error::Expected LSMinimumSystemVersion 14.0, found ${minimum_system_version:-missing}"
-            exit 1
-          fi
-          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop"
-          file "$app_dir/Contents/MacOS/Zero Computer Use" | grep -q "arm64"
-          file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
-          codesign --verify --deep --strict --verbose=2 "$app_dir"
-          codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
-          xcrun stapler validate "$app_dir"
-          unzip -l "$zip_artifact_path" | grep -q "Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
-          codesign --verify --verbose=2 "$dmg_artifact_path"
-          codesign --display --verbose=4 "$dmg_artifact_path" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
-          xcrun stapler validate "$dmg_artifact_path"
-          hdiutil verify "$dmg_artifact_path"
-
-          rm -rf "$dmg_mount"
-          mkdir -p "$dmg_mount"
-          hdiutil attach "$dmg_artifact_path" -nobrowse -readonly -mountpoint "$dmg_mount"
-          cleanup_dmg_mount() {
-            hdiutil detach "$dmg_mount"
+          const config = JSON.parse(
+            fs.readFileSync(process.env.RUNTIME_CONFIG, "utf8"),
+          );
+          if (
+            config.product !== "okou" ||
+            config.platformUrl !== "https://app.okou.ai"
+          ) {
+            throw new Error(`Unexpected Okou runtime config: ${JSON.stringify(config)}`);
           }
-          trap cleanup_dmg_mount EXIT
+          NODE
+            fi
 
-          if [ ! -d "$dmg_mount/Zero Computer Use.app" ]; then
-            echo "DMG should contain Zero Computer Use.app"
-            find "$dmg_mount" -maxdepth 2 -print || true
-            exit 1
-          fi
-          mounted_plist="$dmg_mount/Zero Computer Use.app/Contents/Info.plist"
-          mounted_minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$mounted_plist" 2>/dev/null || true)
-          if [ "$mounted_minimum_system_version" != "14.0" ]; then
-            echo "::error::Expected mounted app LSMinimumSystemVersion 14.0, found ${mounted_minimum_system_version:-missing}"
-            exit 1
-          fi
-          if [ ! -L "$dmg_mount/Applications" ]; then
-            echo "DMG should contain an Applications symlink"
-            find "$dmg_mount" -maxdepth 2 -print || true
-            exit 1
-          fi
-          if [ "$(readlink "$dmg_mount/Applications")" != "/Applications" ]; then
-            echo "DMG Applications symlink should point to /Applications"
-            readlink "$dmg_mount/Applications" || true
-            exit 1
-          fi
-          if [ ! -f "$dmg_mount/.background/background.png" ]; then
-            echo "DMG should contain the Finder background image"
-            find "$dmg_mount" -maxdepth 3 -print || true
-            exit 1
-          fi
-          background_info="$(sips -g pixelWidth -g pixelHeight -g dpiWidth -g dpiHeight "$dmg_mount/.background/background.png")"
-          echo "$background_info"
-          echo "$background_info" | grep -q "pixelWidth: 1320"
-          echo "$background_info" | grep -q "pixelHeight: 800"
-          echo "$background_info" | grep -q "dpiWidth: 144.000"
-          echo "$background_info" | grep -q "dpiHeight: 144.000"
-          codesign --verify --deep --strict --verbose=2 "$dmg_mount/Zero Computer Use.app"
-          xcrun stapler validate "$dmg_mount/Zero Computer Use.app"
+            minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$plist" 2>/dev/null || true)
+            if [ "$minimum_system_version" != "14.0" ]; then
+              echo "::error::Expected LSMinimumSystemVersion 14.0, found ${minimum_system_version:-missing}"
+              exit 1
+            fi
+            /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "$app_name"
+            /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "$app_name"
+            /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "$app_name"
+            /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "$bundle_id"
+            /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "$auth_scheme"
+            file "$app_dir/Contents/MacOS/$app_name" | grep -q "arm64"
+            file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
+            codesign --verify --deep --strict --verbose=2 "$app_dir"
+            codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
+            xcrun stapler validate "$app_dir"
+            unzip -l "$zip_artifact_path" | grep -q "$app_name.app/Contents/MacOS/$app_name"
+            codesign --verify --verbose=2 "$dmg_artifact_path"
+            codesign --display --verbose=4 "$dmg_artifact_path" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
+            xcrun stapler validate "$dmg_artifact_path"
+            hdiutil verify "$dmg_artifact_path"
 
-      - name: Upload Desktop artifacts to GitHub Release
+            (
+              rm -rf "$dmg_mount"
+              mkdir -p "$dmg_mount"
+              hdiutil attach "$dmg_artifact_path" -nobrowse -readonly -mountpoint "$dmg_mount"
+              trap 'hdiutil detach "$dmg_mount"' EXIT
+
+              mounted_app="$dmg_mount/$app_name.app"
+              if [ ! -d "$mounted_app" ]; then
+                echo "DMG should contain $app_name.app"
+                find "$dmg_mount" -maxdepth 2 -print || true
+                exit 1
+              fi
+              mounted_plist="$mounted_app/Contents/Info.plist"
+              mounted_minimum_system_version=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$mounted_plist" 2>/dev/null || true)
+              if [ "$mounted_minimum_system_version" != "14.0" ]; then
+                echo "::error::Expected mounted app LSMinimumSystemVersion 14.0, found ${mounted_minimum_system_version:-missing}"
+                exit 1
+              fi
+              if [ ! -L "$dmg_mount/Applications" ] || [ "$(readlink "$dmg_mount/Applications")" != "/Applications" ]; then
+                echo "DMG Applications symlink should point to /Applications"
+                exit 1
+              fi
+              if [ ! -f "$dmg_mount/.background/background.png" ]; then
+                echo "DMG should contain the Finder background image"
+                find "$dmg_mount" -maxdepth 3 -print || true
+                exit 1
+              fi
+              background_info="$(sips -g pixelWidth -g pixelHeight -g dpiWidth -g dpiHeight "$dmg_mount/.background/background.png")"
+              echo "$background_info"
+              echo "$background_info" | grep -q "pixelWidth: 1320"
+              echo "$background_info" | grep -q "pixelHeight: 800"
+              echo "$background_info" | grep -q "dpiWidth: 144.000"
+              echo "$background_info" | grep -q "dpiHeight: 144.000"
+              codesign --verify --deep --strict --verbose=2 "$mounted_app"
+              xcrun stapler validate "$mounted_app"
+
+              if [ "$product" = "okou" ]; then
+                install_dir="$RUNNER_TEMP/okou-install-smoke/Applications"
+                installed_app="$install_dir/Okou Computer Use.app"
+                update_dir="$RUNNER_TEMP/okou-update-smoke"
+                rm -rf "$install_dir" "$update_dir"
+                mkdir -p "$install_dir" "$update_dir"
+
+                ditto "$mounted_app" "$installed_app"
+                VM0_DESKTOP_PRODUCT=okou \
+                VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+                VM0_DESKTOP_SMOKE_APP_PATH="$installed_app" \
+                node apps/desktop/scripts/smoke-test-packaged-app.js
+
+                unzip -q "$zip_artifact_path" -d "$update_dir"
+                rm -rf "$installed_app"
+                ditto "$update_dir/Okou Computer Use.app" "$installed_app"
+                VM0_DESKTOP_PRODUCT=okou \
+                VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+                VM0_DESKTOP_SMOKE_APP_PATH="$installed_app" \
+                node apps/desktop/scripts/smoke-test-packaged-app.js
+              fi
+            )
+          }
+
+          verify_product_artifacts \
+            zero \
+            "Zero Computer Use" \
+            Zero \
+            ai.vm0.zero.desktop \
+            ai.vm0.zero.desktop
+          verify_product_artifacts \
+            okou \
+            "Okou Computer Use" \
+            Okou \
+            ai.okou.computer-use \
+            ai.okou.computer-use
+
+          zero_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${{ steps.desktop-app.outputs.zero_app_dir }}/Contents/Info.plist")
+          okou_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${{ steps.desktop-app.outputs.okou_app_dir }}/Contents/Info.plist")
+          if [ "$zero_bundle_id" = "$okou_bundle_id" ]; then
+            echo "Zero and Okou release artifacts must keep independent identities"
+            exit 1
+          fi
+
+      - name: Upload Desktop artifacts to GitHub Releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if gh release view "$OKOU_RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            okou_release_target=$(gh release view "$OKOU_RELEASE_TAG" \
+              --repo "${{ github.repository }}" \
+              --json targetCommitish \
+              --jq .targetCommitish)
+            if [ "$okou_release_target" != "$RELEASE_TARGET" ]; then
+              echo "::error::Okou Desktop release $OKOU_RELEASE_TAG targets $okou_release_target instead of $RELEASE_TARGET"
+              exit 1
+            fi
+          else
+            gh release create "$OKOU_RELEASE_TAG" \
+              --repo "${{ github.repository }}" \
+              --target "$RELEASE_TARGET" \
+              --title "Okou Computer Use $DESKTOP_VERSION" \
+              --notes "Signed and notarized Okou Computer Use release for Apple silicon Macs." \
+              --latest=false
+          fi
+
           gh release upload "$RELEASE_TAG" \
-            "${{ steps.desktop-artifacts.outputs.zip_path }}" \
-            "${{ steps.desktop-artifacts.outputs.dmg_path }}" \
+            "${{ steps.desktop-artifacts.outputs.zero_zip_path }}" \
+            "${{ steps.desktop-artifacts.outputs.zero_dmg_path }}" \
+            --repo "${{ github.repository }}" \
+            --clobber
+          gh release upload "$OKOU_RELEASE_TAG" \
+            "${{ steps.desktop-artifacts.outputs.okou_zip_path }}" \
+            "${{ steps.desktop-artifacts.outputs.okou_dmg_path }}" \
             --repo "${{ github.repository }}" \
             --clobber
 
@@ -549,7 +673,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Desktop App* ✅ Published signed macOS Apple silicon artifacts\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.dmg|Download macOS DMG>\n🔄 <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.zip|Auto-update ZIP>"
+                  text: "*Desktop App* ✅ Published signed macOS Apple silicon artifacts\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n0️⃣ <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|Zero Release>\n🟠 <${{ github.server_url }}/${{ github.repository }}/releases/tag/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}|Okou Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}/Okou-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.dmg|Download Okou macOS DMG>\n🔄 <${{ github.server_url }}/${{ github.repository }}/releases/download/okou-desktop-v${{ needs.release-please.outputs.desktop_version }}/Okou-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.zip|Okou auto-update ZIP>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}
@@ -584,8 +708,8 @@ jobs:
       contents: write
     env:
       DESKTOP_VERSION: ${{ needs.release-please.outputs.desktop_version }}
-      RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
-      MANIFEST_TAG: desktop-updates
+      ZERO_RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
+      OKOU_RELEASE_TAG: okou-desktop-v${{ needs.release-please.outputs.desktop_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -595,60 +719,94 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          release_assets="$(gh release view "$RELEASE_TAG" \
-            --repo "${{ github.repository }}" \
-            --json assets \
-            --jq '.assets[].name')"
+          verify_release_assets() {
+            local release_tag="$1"
+            local artifact_name="$2"
+            local release_assets
+            local asset_name
 
-          for extension in zip dmg; do
-            asset_name="Zero-darwin-arm64-$DESKTOP_VERSION.$extension"
-            if ! printf '%s\n' "$release_assets" | grep -qx "$asset_name"; then
-              echo "::error::Missing Desktop release asset: $asset_name"
-              printf '%s\n' "$release_assets"
-              exit 1
-            fi
-          done
+            release_assets="$(gh release view "$release_tag" \
+              --repo "${{ github.repository }}" \
+              --json assets \
+              --jq '.assets[].name')"
+
+            for extension in zip dmg; do
+              asset_name="$artifact_name-darwin-arm64-$DESKTOP_VERSION.$extension"
+              if ! printf '%s\n' "$release_assets" | grep -qx "$asset_name"; then
+                echo "::error::Missing Desktop release asset: $asset_name"
+                printf '%s\n' "$release_assets"
+                exit 1
+              fi
+            done
+          }
+
+          verify_release_assets "$ZERO_RELEASE_TAG" Zero
+          verify_release_assets "$OKOU_RELEASE_TAG" Okou
 
       - name: Publish Desktop update manifest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          manifest_dir="apps/desktop/out/update-manifest"
-          manifest_path="$manifest_dir/desktop-update-manifest.json"
+          publish_manifest() {
+            local product="$1"
+            local artifact_name="$2"
+            local release_tag="$3"
+            local manifest_tag="$4"
+            local manifest_filename="$5"
+            local manifest_title="$6"
+            local manifest_dir="apps/desktop/out/update-manifest/$product"
+            local manifest_path="$manifest_dir/$manifest_filename"
+            local zip_url
 
-          mkdir -p "$manifest_dir"
-          if gh release view "$MANIFEST_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            if gh release view "$MANIFEST_TAG" \
-              --repo "${{ github.repository }}" \
-              --json assets \
-              --jq '.assets[].name' | grep -qx desktop-update-manifest.json; then
-              gh release download "$MANIFEST_TAG" \
+            mkdir -p "$manifest_dir"
+            if gh release view "$manifest_tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              if gh release view "$manifest_tag" \
                 --repo "${{ github.repository }}" \
-                --pattern desktop-update-manifest.json \
-                --dir "$manifest_dir" \
-                --clobber
+                --json assets \
+                --jq '.assets[].name' | grep -qx "$manifest_filename"; then
+                gh release download "$manifest_tag" \
+                  --repo "${{ github.repository }}" \
+                  --pattern "$manifest_filename" \
+                  --dir "$manifest_dir" \
+                  --clobber
+              fi
+            else
+              gh release create "$manifest_tag" \
+                --repo "${{ github.repository }}" \
+                --title "$manifest_title" \
+                --notes "Mutable manifest used by the $artifact_name Computer Use auto-update feed." \
+                --latest=false
             fi
-          else
-            gh release create "$MANIFEST_TAG" \
+
+            zip_url="https://github.com/${{ github.repository }}/releases/download/$release_tag/${artifact_name}-darwin-arm64-$DESKTOP_VERSION.zip"
+            node apps/desktop/scripts/update-desktop-release-manifest.mjs \
+              --manifest "$manifest_path" \
+              --product "$product" \
+              --version "$DESKTOP_VERSION" \
+              --zip-url "$zip_url" \
+              --channel stable \
+              --platform darwin \
+              --arch arm64
+
+            gh release upload "$manifest_tag" "$manifest_path" \
               --repo "${{ github.repository }}" \
-              --title "Desktop Updates" \
-              --notes "Mutable manifest used by the Desktop auto-update feed." \
-              --latest=false
-          fi
+              --clobber
+          }
 
-          zip_url="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-          node apps/desktop/scripts/update-desktop-release-manifest.mjs \
-            --manifest "$manifest_path" \
-            --product zero \
-            --version "$DESKTOP_VERSION" \
-            --zip-url "$zip_url" \
-            --channel stable \
-            --platform darwin \
-            --arch arm64
-
-          gh release upload "$MANIFEST_TAG" "$manifest_path" \
-            --repo "${{ github.repository }}" \
-            --clobber
+          publish_manifest \
+            zero \
+            Zero \
+            "$ZERO_RELEASE_TAG" \
+            desktop-updates \
+            desktop-update-manifest.json \
+            "Desktop Updates"
+          publish_manifest \
+            okou \
+            Okou \
+            "$OKOU_RELEASE_TAG" \
+            okou-desktop-updates \
+            okou-desktop-update-manifest.json \
+            "Okou Desktop Updates"
 
   detect-host-worker-deploy-inputs:
     needs: release-please

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -126,19 +126,24 @@ Desktop releases are versioned by release-please. Changes under
 `desktop-vX.Y.Z` GitHub Release.
 
 When a release-please merge group changes the Desktop package version, the
-`deploy-desktop` job builds the unsigned production `Zero Computer Use.app` for
-Apple silicon Macs and publishes it to R2 under
+`deploy-desktop` job builds the unsigned production `Zero Computer Use.app` and
+`Okou Computer Use.app` for Apple silicon Macs and publishes both to R2 under
 `okou-desktop/<commit-sha>/`. The matching release run resolves the same commit
-as `release_target`, downloads and verifies that immutable app artifact, signs
-it with the Developer ID Application certificate, notarizes it for direct
-distribution outside the Mac App Store, and uploads
-`Zero-darwin-arm64-X.Y.Z.zip` and `Zero-darwin-arm64-X.Y.Z.dmg` to the matching
-GitHub Release. The release workflow then updates the Desktop update manifest.
+as `release_target`, downloads and verifies those immutable app artifacts,
+signs them with the Developer ID Application certificate, notarizes them for
+direct distribution outside the Mac App Store, and publishes separate releases:
 
-Use the DMG for manual installation. It opens with a styled Finder background,
-`Zero Computer Use.app` on the left, and an `/Applications` symlink on the right
-for drag-to-install. The update manifest continues to point at the ZIP artifact
-because the auto-update feed consumes ZIP releases.
+- `desktop-vX.Y.Z` contains `Zero-darwin-arm64-X.Y.Z.zip` and `.dmg`.
+- `okou-desktop-vX.Y.Z` contains `Okou-darwin-arm64-X.Y.Z.zip` and `.dmg`.
+
+The release workflow then updates the independent Zero and Okou manifests.
+
+Use the product's DMG for manual installation. It opens with a product-specific
+Finder background, the app on the left, and an `/Applications` symlink on the
+right for drag-to-install. Update manifests continue to point at the ZIP
+artifacts because the auto-update feeds consume ZIP releases. Release smoke
+tests copy Okou from the DMG into an isolated Applications directory, launch it,
+replace it from the Okou update ZIP, and launch it again.
 
 ### Zero and Okou update compatibility
 
@@ -169,8 +174,8 @@ Zero, gets its own Electron `userData` root and installation ID, and does not
 copy Zero's Chromium profile. Users sign in again and grant Accessibility,
 Screen Recording, and browser Automation permissions again because macOS TCC
 associates those permissions with the application identity. The current
-release promotion remains on the Zero line until the signed Okou promotion
-workflow is enabled.
+release promotion signs and notarizes both product lines while publishing them
+under independent release tags and update manifests.
 
 This does not submit or publish the app to the Mac App Store. The App Store
 Connect API key is only used as notarytool authentication for Apple's

--- a/turbo/apps/desktop/assets/dmg-background-okou.svg
+++ b/turbo/apps/desktop/assets/dmg-background-okou.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="660" height="400" viewBox="0 0 660 400">
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#f3f6fa"/>
+    </linearGradient>
+    <linearGradient id="arrow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#f28a2f"/>
+      <stop offset="1" stop-color="#2f8fe8"/>
+    </linearGradient>
+    <radialGradient id="blueGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(95 88) rotate(45) scale(210)">
+      <stop offset="0" stop-color="#2f8fe8" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#2f8fe8" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="orangeGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(574 318) rotate(45) scale(220)">
+      <stop offset="0" stop-color="#f28a2f" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#f28a2f" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softShadow" x="-30%" y="-50%" width="160%" height="200%">
+      <feDropShadow dx="0" dy="8" stdDeviation="9" flood-color="#2f8fe8" flood-opacity="0.2"/>
+    </filter>
+  </defs>
+
+  <rect width="660" height="400" fill="url(#panel)"/>
+  <rect width="660" height="400" fill="url(#blueGlow)"/>
+  <rect width="660" height="400" fill="url(#orangeGlow)"/>
+
+  <g opacity="0.32">
+    <path d="M0 84H660M0 112H660M0 140H660M0 168H660M0 196H660M0 224H660M0 252H660M0 280H660M0 308H660M0 336H660" stroke="#d7dde6" stroke-width="1"/>
+    <path d="M72 0V400M100 0V400M128 0V400M156 0V400M184 0V400M212 0V400M240 0V400M268 0V400M296 0V400M324 0V400M352 0V400M380 0V400M408 0V400M436 0V400M464 0V400M492 0V400M520 0V400M548 0V400M576 0V400" stroke="#d7dde6" stroke-width="1"/>
+  </g>
+
+  <text x="330" y="52" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="25" font-weight="700" fill="#22252a">Okou Computer Use</text>
+  <text x="330" y="78" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="13" font-weight="500" fill="#6f737a">Drag the app into Applications to install</text>
+
+  <g filter="url(#softShadow)">
+    <line x1="248" y1="214" x2="401" y2="214" stroke="url(#arrow)" stroke-width="5" stroke-linecap="round"/>
+    <path d="M389 196L407 214L389 232" fill="none" stroke="#2f8fe8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <text x="330" y="252" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="13" font-weight="700" fill="#4f555d">Drag to install</text>
+  <text x="330" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="12" fill="#7d828a">Open Okou Computer Use from Applications after copying.</text>
+</svg>

--- a/turbo/apps/desktop/scripts/packaged-app-paths.js
+++ b/turbo/apps/desktop/scripts/packaged-app-paths.js
@@ -5,12 +5,14 @@ const { resolveDesktopBuildConfig } = require("./desktop-build-config");
 function packagedAppPaths(options = {}) {
   const appRoot = path.resolve(__dirname, "..");
   const appName = resolveDesktopBuildConfig(options).identity.displayName;
-  const appBundlePath = path.join(
-    appRoot,
-    "out",
-    `${appName}-${process.platform}-${process.arch}`,
-    `${appName}.app`,
-  );
+  const appBundlePath = options.appBundlePath
+    ? path.resolve(options.appBundlePath)
+    : path.join(
+        appRoot,
+        "out",
+        `${appName}-${process.platform}-${process.arch}`,
+        `${appName}.app`,
+      );
 
   return {
     appBundlePath,

--- a/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
+++ b/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
@@ -11,6 +11,7 @@ if (process.platform !== "darwin") {
 }
 
 const { executablePath, mainBundlePath, mcpBundlePath } = packagedAppPaths({
+  appBundlePath: process.env.VM0_DESKTOP_SMOKE_APP_PATH,
   platformUrl: process.env.VM0_DESKTOP_PLATFORM_URL,
   product: process.env.VM0_DESKTOP_PRODUCT,
 });


### PR DESCRIPTION
## Summary

- stage both Zero and Okou immutable macOS app bundles while preserving the legacy Zero artifact contract
- sign and notarize both products, publish Okou under an independent `okou-desktop-v*` release, and keep Zero assets unchanged
- publish isolated Zero and Okou update manifests and add Okou clean-install/ZIP-upgrade release smoke coverage
- add an Okou-specific DMG presentation and document the dual release lifecycle

Part of #26373.

## Validation

- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test` (36 files, 321 tests)
- `bash .github/scripts/tests/okou-desktop-artifact-test.sh`
- `bash .github/scripts/tests/fetch-okou-desktop-artifact-test.sh`
- `bash .github/scripts/tests/deploy-desktop-workflow-test.sh`
- ShellCheck for all changed shell scripts
- Actionlint for `desktop.yml` and `release-please.yml`
- real dual-product archive build and verification from packaged Zero/Okou apps
- real Okou DMG creation plus `hdiutil verify`
- Okou launch smoke from an isolated Applications path

## Known baseline

- `pnpm knip` continues to report the repository's existing unused-file/export findings, including the script-invoked Desktop `@sentry/cli` dependency; this PR adds no dependency or export findings.
