### PR TITLE
refactor(runner): centralize setup directory trust walking

### DIFF
--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -6,16 +6,14 @@
 
 mod artifacts;
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
-use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::OpenOptionsExt;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 
-use nix::fcntl::{OFlag, open, openat};
-use nix::sys::stat::{Mode, SFlag, fstat, mkdirat};
 use sha2::{Digest, Sha256};
 use tempfile::TempPath;
 use tokio::io::AsyncWriteExt;
@@ -24,7 +22,6 @@ use crate::deps::{FIRECRACKER_VERSION, MITMPROXY_VERSION, SYSTEM_CA_BUNDLE};
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
-const SETUP_SHARED_DIR_MODE: u32 = 0o755;
 const SETUP_TEMP_ARTIFACT_MODE: u32 = 0o600;
 const SETUP_EXECUTABLE_ARTIFACT_MODE: u32 = 0o755;
 const SETUP_KERNEL_ARTIFACT_MODE: u32 = 0o644;
@@ -34,7 +31,6 @@ const SETUP_READ_TIMEOUT: Duration = Duration::from_secs(60);
 const SETUP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
-const STICKY_BIT: u32 = 0o1000;
 const START_SYSTEM_DEPENDENCIES: [&str; 11] = [
     "ip",
     "iptables",
@@ -157,228 +153,12 @@ async fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
 }
 
 fn ensure_setup_shared_dir(path: &Path) -> RunnerResult<()> {
-    if path.as_os_str().is_empty() {
-        return Err(RunnerError::Internal(
-            "empty setup directory path is not supported".into(),
-        ));
-    }
-
-    let expected_uid = nix::unistd::geteuid().as_raw();
-    let start = if path.is_absolute() {
-        Path::new("/")
-    } else {
-        Path::new(".")
-    };
-    let mut current = open(start, setup_dir_open_flags(), Mode::empty()).map_err(|e| {
-        RunnerError::Internal(format!(
-            "open setup directory root for {}: {e}",
-            path.display()
-        ))
-    })?;
-    let mut current_path = start.to_path_buf();
-    let mut components = path.components().peekable();
-    let mut saw_normal_component = false;
-
-    while let Some(component) = components.next() {
-        match component {
-            Component::RootDir | Component::CurDir => {}
-            Component::ParentDir => {
-                return Err(RunnerError::Internal(format!(
-                    "{} contains a parent directory segment",
-                    path.display()
-                )));
-            }
-            Component::Normal(name) => {
-                saw_normal_component = true;
-                let is_final = components.peek().is_none();
-                current = open_or_create_setup_dir_component(
-                    &current,
-                    name,
-                    &current_path,
-                    path,
-                    expected_uid,
-                    is_final,
-                )?;
-                current_path = path_component(&current_path, name);
-            }
-            Component::Prefix(prefix) => {
-                return Err(RunnerError::Internal(format!(
-                    "{} contains unsupported path prefix {}",
-                    path.display(),
-                    prefix.as_os_str().to_string_lossy()
-                )));
-            }
-        }
-    }
-
-    if !saw_normal_component {
-        secure_setup_dir_component(&current, &current_path, path, expected_uid, true, false)?;
-    }
-
-    Ok(())
-}
-
-fn open_or_create_setup_dir_component(
-    parent: &(impl AsFd + AsRawFd),
-    name: &OsStr,
-    parent_path: &Path,
-    full_path: &Path,
-    expected_uid: u32,
-    is_final: bool,
-) -> RunnerResult<OwnedFd> {
-    ensure_setup_parent_not_replaceable(parent, parent_path, full_path, expected_uid)?;
-    let component_path = path_component(parent_path, name);
-
-    match openat(parent, name, setup_dir_open_flags(), Mode::empty()) {
-        Ok(fd) => {
-            secure_setup_dir_component(
-                &fd,
-                &component_path,
-                full_path,
-                expected_uid,
-                is_final,
-                false,
-            )?;
-            Ok(fd)
-        }
-        Err(nix::errno::Errno::ENOENT) => {
-            match mkdirat(
-                parent,
-                name,
-                Mode::from_bits_truncate(SETUP_SHARED_DIR_MODE),
-            ) {
-                Ok(()) | Err(nix::errno::Errno::EEXIST) => {}
-                Err(e) => {
-                    return Err(RunnerError::Internal(format!(
-                        "create setup directory component {} for {}: {e}",
-                        name.to_string_lossy(),
-                        full_path.display()
-                    )));
-                }
-            }
-
-            let fd = openat(parent, name, setup_dir_open_flags(), Mode::empty())
-                .map_err(|e| setup_dir_component_error("open", name, full_path, e))?;
-            secure_setup_dir_component(
-                &fd,
-                &component_path,
-                full_path,
-                expected_uid,
-                is_final,
-                true,
-            )?;
-            Ok(fd)
-        }
-        Err(e) => Err(setup_dir_component_error("open", name, full_path, e)),
-    }
-}
-
-fn ensure_setup_parent_not_replaceable(
-    parent: &(impl AsFd + AsRawFd),
-    parent_path: &Path,
-    full_path: &Path,
-    expected_uid: u32,
-) -> RunnerResult<()> {
-    let stat = fstat(parent).map_err(|e| {
-        RunnerError::Internal(format!(
-            "stat setup directory parent {} for {}: {e}",
-            parent_path.display(),
-            full_path.display()
-        ))
-    })?;
-    let mode = (stat.st_mode as u32) & 0o7777;
-    if stat.st_uid != ROOT_UID && stat.st_uid != expected_uid {
-        return Err(RunnerError::Internal(format!(
-            "setup directory parent {} is owned by untrusted uid {}",
-            parent_path.display(),
-            stat.st_uid
-        )));
-    }
-    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && mode & STICKY_BIT == 0 {
-        return Err(RunnerError::Internal(format!(
-            "setup directory parent {} is group/other writable without the sticky bit",
-            parent_path.display()
-        )));
-    }
-    Ok(())
-}
-
-fn secure_setup_dir_component(
-    fd: &(impl AsFd + AsRawFd),
-    component_path: &Path,
-    full_path: &Path,
-    expected_uid: u32,
-    is_final: bool,
-    created: bool,
-) -> RunnerResult<()> {
-    let stat = fstat(fd).map_err(|e| {
-        RunnerError::Internal(format!(
-            "stat setup directory component {} for {}: {e}",
-            component_path.display(),
-            full_path.display()
-        ))
-    })?;
-    let file_type = SFlag::from_bits_truncate(stat.st_mode & SFlag::S_IFMT.bits());
-    if file_type != SFlag::S_IFDIR {
-        return Err(RunnerError::Internal(format!(
-            "{} is not a directory",
-            component_path.display()
-        )));
-    }
-    if stat.st_uid != ROOT_UID && stat.st_uid != expected_uid {
-        return Err(RunnerError::Internal(format!(
-            "setup directory component {} is owned by untrusted uid {}",
-            component_path.display(),
-            stat.st_uid
-        )));
-    }
-
-    let mode = (stat.st_mode as u32) & 0o7777;
-    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 && (is_final || mode & STICKY_BIT == 0) {
-        return Err(RunnerError::Internal(format!(
-            "setup directory component {} is group/other writable",
-            component_path.display()
-        )));
-    }
-
-    if (created || is_final) && stat.st_uid == expected_uid && mode != SETUP_SHARED_DIR_MODE {
-        chmod_fd(fd, component_path, SETUP_SHARED_DIR_MODE, "setup directory")?;
-    }
-
-    Ok(())
-}
-
-fn setup_dir_component_error(
-    operation: &str,
-    name: &OsStr,
-    full_path: &Path,
-    error: nix::errno::Errno,
-) -> RunnerError {
-    match error {
-        nix::errno::Errno::ELOOP => RunnerError::Internal(format!(
-            "{} contains symlink component {}",
-            full_path.display(),
-            name.to_string_lossy()
-        )),
-        nix::errno::Errno::ENOTDIR => {
-            RunnerError::Internal(format!("{} is not a directory", full_path.display()))
-        }
-        _ => RunnerError::Internal(format!(
-            "{operation} setup directory component {} for {}: {error}",
-            name.to_string_lossy(),
-            full_path.display()
-        )),
-    }
-}
-
-fn path_component(parent_path: &Path, name: &OsStr) -> PathBuf {
-    let mut path = parent_path.to_path_buf();
-    path.push(Path::new(name));
-    path
-}
-
-fn setup_dir_open_flags() -> OFlag {
-    OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC
+    crate::host_file::ensure_dir(
+        path,
+        crate::host_file::DirMode::SharedTrusted,
+        "setup directory",
+    )
+    .map_err(|e| RunnerError::Internal(format!("ensure setup directory {}: {e}", path.display())))
 }
 
 fn create_setup_temp_file(target: &Path, kind: &str) -> RunnerResult<(TempPath, File)> {
@@ -1143,6 +923,7 @@ mod tests {
 
     use flate2::Compression;
     use flate2::write::GzEncoder;
+    use nix::sys::stat::Mode;
     use tokio::sync::oneshot;
 
     fn mode(path: &Path) -> u32 {
@@ -1264,8 +1045,41 @@ mod tests {
 
         ensure_setup_shared_dir(&path).unwrap();
 
-        assert_eq!(mode(&path), SETUP_SHARED_DIR_MODE);
+        assert_eq!(mode(&path), crate::host_file::SHARED_TRUSTED_DIR_MODE);
         assert!(path.is_dir());
+    }
+
+    #[test]
+    fn ensure_setup_shared_dir_normalizes_existing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("setup");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        ensure_setup_shared_dir(&path).unwrap();
+
+        assert_eq!(mode(&path), crate::host_file::SHARED_TRUSTED_DIR_MODE);
+    }
+
+    #[test]
+    fn ensure_setup_shared_dir_rejects_parent_segment_before_creating_missing_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("base");
+        std::fs::create_dir(&base).unwrap();
+
+        let error =
+            ensure_setup_shared_dir(&base.join("missing").join("..").join("leaf")).unwrap_err();
+
+        assert!(
+            matches!(error, RunnerError::Internal(_)),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.to_string().contains("parent directory segment"),
+            "unexpected error: {error}"
+        );
+        assert!(!base.join("missing").exists());
+        assert!(!base.join("leaf").exists());
     }
 
     #[test]

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -26,6 +26,8 @@ pub(crate) enum DirMode {
     TrustedParent,
     /// Create missing directories as shared/trusted, but only validate existing ones.
     SharedTrustedParent,
+    /// Create missing directories as shared/trusted and normalize the owned final directory.
+    SharedTrusted,
 }
 
 struct DirWalk<'a> {
@@ -379,7 +381,7 @@ fn create_and_open_dir_component(
 fn create_dir_mode(mode: DirMode) -> u32 {
     match mode {
         DirMode::Private | DirMode::TrustedParent => PRIVATE_DIR_MODE,
-        DirMode::SharedTrustedParent => SHARED_TRUSTED_DIR_MODE,
+        DirMode::SharedTrustedParent | DirMode::SharedTrusted => SHARED_TRUSTED_DIR_MODE,
     }
 }
 
@@ -508,16 +510,13 @@ fn secure_dir_component(
                 )));
             }
         }
-        DirMode::SharedTrustedParent => {
+        DirMode::SharedTrustedParent | DirMode::SharedTrusted => {
             validate_trusted_component_owner(
                 stat.st_uid,
                 walk.expected_uid,
                 walk.context,
                 component_path,
             )?;
-            if created && stat.st_uid == walk.expected_uid {
-                chmod_dir_fd(fd, component_path, SHARED_TRUSTED_DIR_MODE, walk.context)?;
-            }
             let component_mode = (stat.st_mode as u32) & 0o7777;
             if is_final {
                 if component_mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
@@ -535,6 +534,13 @@ fn secure_dir_component(
                     walk.context,
                     component_path.display()
                 )));
+            }
+            let normalize_final = matches!(walk.mode, DirMode::SharedTrusted) && is_final;
+            if (created || normalize_final)
+                && stat.st_uid == walk.expected_uid
+                && component_mode != SHARED_TRUSTED_DIR_MODE
+            {
+                chmod_dir_fd(fd, component_path, SHARED_TRUSTED_DIR_MODE, walk.context)?;
             }
         }
         _ => {
@@ -759,13 +765,19 @@ mod tests {
         }
 
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("base").join("child");
         let _umask = UmaskGuard::set(Mode::from_bits_truncate(0o777));
-        let result = ensure_dir(&path, DirMode::SharedTrustedParent, "test directory");
+        for (name, dir_mode) in [
+            ("shared-parent", DirMode::SharedTrustedParent),
+            ("shared", DirMode::SharedTrusted),
+        ] {
+            let base = dir.path().join(name);
+            let path = base.join("child");
 
-        result.unwrap();
-        assert_eq!(mode(&dir.path().join("base")), SHARED_TRUSTED_DIR_MODE);
-        assert_eq!(mode(&path), SHARED_TRUSTED_DIR_MODE);
+            ensure_dir(&path, dir_mode, "test directory").unwrap();
+
+            assert_eq!(mode(&base), SHARED_TRUSTED_DIR_MODE);
+            assert_eq!(mode(&path), SHARED_TRUSTED_DIR_MODE);
+        }
     }
 
     struct UmaskGuard {
@@ -878,6 +890,64 @@ mod tests {
         ensure_dir(&path, DirMode::SharedTrustedParent, "test directory").unwrap();
 
         assert_eq!(mode(&path), PRIVATE_DIR_MODE);
+    }
+
+    #[test]
+    fn ensure_dir_normalizes_existing_shared_trusted_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE)).unwrap();
+
+        ensure_dir(&path, DirMode::SharedTrusted, "test directory").unwrap();
+
+        assert_eq!(mode(&path), SHARED_TRUSTED_DIR_MODE);
+    }
+
+    #[test]
+    fn ensure_dir_rejects_writable_shared_trusted_final_before_normalizing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let error = ensure_dir(&path, DirMode::SharedTrusted, "test directory").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(mode(&path), 0o777);
+    }
+
+    #[test]
+    fn create_dir_component_keeps_eexist_intermediate_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let component = dir.path().join("existing");
+        std::fs::create_dir(&component).unwrap();
+        std::fs::set_permissions(
+            &component,
+            std::fs::Permissions::from_mode(PRIVATE_DIR_MODE),
+        )
+        .unwrap();
+        let parent = open(dir.path(), dir_open_flags(), Mode::empty()).unwrap();
+        let full_path = component.join("child");
+        let walk = DirWalk {
+            full_path: &full_path,
+            mode: DirMode::SharedTrusted,
+            context: "test directory",
+            expected_uid: nix::unistd::geteuid().as_raw(),
+            create_missing: true,
+        };
+
+        let component_fd = create_and_open_dir_component(
+            &parent,
+            Path::new("existing").as_os_str(),
+            dir.path(),
+            &walk,
+            false,
+        )
+        .unwrap();
+
+        drop(component_fd);
+        assert_eq!(mode(&component), PRIVATE_DIR_MODE);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit canonical host-file directory policy for setup's shared `0755` directories
- delegate setup directory traversal and trust enforcement to the fd-relative `host_file` walker
- cover lexical preflight, final normalization, restrictive umask, and `mkdirat`/`EEXIST` bookkeeping on real filesystems

## Behavior preserved

- setup still rejects symlink components, untrusted owners, unsafe writable parents, and writable final directories
- setup still normalizes safe current-user-owned final directories to `0755`
- local queue `SharedTrustedParent` semantics remain unchanged and continue preserving existing final modes
- setup artifact download, hashing, temporary files, identity validation, and atomic publication are unchanged

## Validation

- `cargo test -p runner host_file::tests`
- `cargo test -p runner cmd::setup::tests::ensure_setup_shared_dir`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (`3120 passed`, `20 ignored`)

Closes #26441
