### PR TITLE
fix(platform): restore artifact share and download actions

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,5 +1,5 @@
 import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from "react";
-import { Download, Loader2, Share } from "lucide-react";
+import { Download, Loader2, Share2 } from "lucide-react";
 import {
   cn,
   Popover,
@@ -328,7 +328,7 @@ export function ArtifactShareButton({
         title={publicAttachmentUrl(url)}
         className={iconButtonClassName(className)}
       >
-        <Share size={iconSize} />
+        <Share2 size={iconSize} />
       </a>
     </ArtifactActionTooltip>
   );
@@ -713,6 +713,7 @@ export function ArtifactDownloadMenu({
       <PopoverContent
         role="menu"
         align={align}
+        positionerClassName="!z-[10000]"
         sideOffset={6}
         style={{ pointerEvents: "auto" }}
         onOpenAutoFocus={(event) => {

--- a/turbo/packages/ui/src/components/ui/__tests__/popover.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/popover.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+
+describe("Popover", () => {
+  it("applies a caller-provided positioner layer", () => {
+    render(
+      <Popover open>
+        <PopoverTrigger>Open menu</PopoverTrigger>
+        <PopoverContent positionerClassName="!z-[10000]">
+          Menu content
+        </PopoverContent>
+      </Popover>,
+    );
+
+    expect(screen.getByText("Menu content").parentElement).toHaveClass(
+      "!z-[10000]",
+    );
+  });
+});

--- a/turbo/packages/ui/src/components/ui/popover.tsx
+++ b/turbo/packages/ui/src/components/ui/popover.tsx
@@ -200,6 +200,7 @@ type PopoverContentProps = PopoverPrimitive.Popup.Props &
     onCloseAutoFocus?: LegacyAutoFocusHandler;
     onOpenAutoFocus?: LegacyAutoFocusHandler;
     portalContainer?: HTMLElement | null;
+    positionerClassName?: string;
     updatePositionStrategy?: "always" | "optimized";
   };
 
@@ -223,6 +224,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
       onOpenAutoFocus,
       portalContainer,
       positionMethod = "fixed",
+      positionerClassName,
       side = "bottom",
       sideOffset = 4,
       sticky,
@@ -258,6 +260,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
           anchor={resolvedAnchor}
           className={cn(
             "isolate z-50",
+            positionerClassName,
             hideWhenDetached && "data-anchor-hidden:invisible",
           )}
           collisionAvoidance={resolvedCollisionAvoidance}


### PR DESCRIPTION
## Summary

- replace the artifact copy-link glyph with Lucide's connected-node share icon
- raise the artifact download popover positioner above its iframe dismiss overlay
- cover custom popover positioner layering in the shared UI package

## Root cause

The Base UI migration introduced a `z-50` stacking context on the popover positioner. The artifact menu's `z-[10000]` popup was trapped inside that context, below the `z-[9999]` full-screen dismiss overlay, so browser clicks hit the transparent overlay instead of the download menu.

## Verification

- `pnpm -F @vm0/ui exec vitest run src/components/ui/__tests__/popover.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/thread-sidebar.test.tsx`
- `pnpm -F @vm0/ui lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/ui check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm knip --workspace @vm0/ui --workspace @vm0/app`
