### PR TITLE
fix(platform): restore auth title logo visibility

### DIFF
--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -480,7 +480,10 @@ describe("app auth pages", () => {
     expect(layout.className).not.toContain("var(--sat)");
     expect(layout.className).not.toContain("var(--sab)");
 
-    const logo = screen.getByAltText("VM0").closest("a");
+    const logoImage = screen.getByAltText("VM0");
+    expect(logoImage).toHaveAttribute("crossorigin", "anonymous");
+
+    const logo = logoImage.closest("a");
     expect(logo).toHaveClass("left-6");
     expect(logo).toHaveClass("top-6");
     expect(logo?.className).not.toContain("var(--sat)");

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -398,6 +398,7 @@ export function AuthLayout({ children }: AuthLayoutProps) {
             alt={t(($) => {
               return $.appShell.logoAlt;
             })}
+            crossOrigin="anonymous"
             width={82}
             height={20}
           />


### PR DESCRIPTION
## Summary

- align the auth shell logo with Clerk anonymous CORS loading
- prevent the shared SVG cache entry from hiding the logo above the sign-in title
- add a regression assertion for the shell image CORS mode

## Root cause

The auth shell requested the shared SVG without CORS before Clerk requested the same URL with anonymous CORS. The browser reused the non-CORS cache entry, the Clerk image completed with zero natural dimensions, and Clerk hid the failed logo.

## Verification

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged Turbo type checks for non-app packages, app, and API
- pnpm --filter @vm0/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx