### PR TITLE
test(api): synchronize clerk deletion cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -5570,6 +5570,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     const response = await api.requestClerkWebhook("{}", {}, [200]);
     expect(response.body).toBe("OK");
 
+    await flushWaitUntilForTest();
     await waitForExpectation(() => {
       expect(context.mocks.stripe.subscriptions.list).toHaveBeenNthCalledWith(
         1,


### PR DESCRIPTION
## Summary

- wait for the tracked Clerk `user.deleted` cleanup before asserting its Stripe and billing outcomes
- preserve the webhook's immediate production acknowledgement and all existing behavioral assertions
- avoid timeout inflation by synchronizing on the owned `waitUntil` task

## Scope

This is a test-only change. It does not modify production webhook handling, Stripe behavior, APIs, database state, or timeout values.

## Validation

- focused failing scenario: 5 consecutive passes
- complete `webhooks-callbacks.bdd.test.ts`: 46 passed
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit: Prettier, full Knip, full Turbo type checking, file-size check
- commitlint

Closes #26453
