### PR TITLE
fix(connectors): snapshot custom credential reads

### DIFF
--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -89,29 +89,57 @@ export type CustomConnectorCredentialAccess =
       readonly definitionStorageVersion: number;
     };
 
-async function loadCustomConnectorStoredConnections(
+interface CustomConnectorRuntimeStorageSnapshot {
+  readonly accesses: ReadonlyMap<string, CustomConnectorCredentialAccess>;
+  readonly values: readonly CustomConnectorStoredValue[];
+}
+
+interface CustomConnectorRuntimeStorageRow extends CustomConnectorStoredConnection {
+  readonly kind: string;
+  readonly key: string;
+  readonly storedValue: string;
+}
+
+function customConnectorStoredConnectionsQuery(
   db: Pick<ReadonlyDb, "select">,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly connectorIds?: readonly string[];
   },
-): Promise<readonly CustomConnectorStoredConnection[]> {
-  if (args.connectorIds?.length === 0) {
-    return [];
-  }
-  return await db
+) {
+  return db
     .select({
-      id: connectors.id,
-      customConnectorId: orgCustomConnectors.id,
-      storedAuthMethod: connectors.authMethod,
-      storedStorageVersion: connectors.storageVersion,
-      storedNeedsReconnect: connectors.needsReconnect,
-      tokenExpiresAt: connectors.tokenExpiresAt,
-      definitionAuthMethod: orgCustomConnectors.authMode,
-      definitionStorageVersion: orgCustomConnectors.storageVersion,
-      oauthAccessTokenId: customConnectorAccessTokenSecret.id,
-      oauthRefreshTokenId: customConnectorRefreshTokenSecret.id,
+      id: sql`${connectors.id}`
+        .mapWith(connectors.id)
+        .as("member_connector_id"),
+      customConnectorId: sql`${orgCustomConnectors.id}`
+        .mapWith(orgCustomConnectors.id)
+        .as("custom_connector_id"),
+      storedAuthMethod: sql`${connectors.authMethod}`
+        .mapWith(connectors.authMethod)
+        .as("stored_auth_method"),
+      storedStorageVersion: sql`${connectors.storageVersion}`
+        .mapWith(connectors.storageVersion)
+        .as("stored_storage_version"),
+      storedNeedsReconnect: sql`${connectors.needsReconnect}`
+        .mapWith(connectors.needsReconnect)
+        .as("stored_needs_reconnect"),
+      tokenExpiresAt: sql`${connectors.tokenExpiresAt}`
+        .mapWith(connectors.tokenExpiresAt)
+        .as("token_expires_at"),
+      definitionAuthMethod: sql`${orgCustomConnectors.authMode}`
+        .mapWith(orgCustomConnectors.authMode)
+        .as("definition_auth_method"),
+      definitionStorageVersion: sql`${orgCustomConnectors.storageVersion}`
+        .mapWith(orgCustomConnectors.storageVersion)
+        .as("definition_storage_version"),
+      oauthAccessTokenId: sql`${customConnectorAccessTokenSecret.id}`
+        .mapWith(customConnectorAccessTokenSecret.id)
+        .as("oauth_access_token_id"),
+      oauthRefreshTokenId: sql`${customConnectorRefreshTokenSecret.id}`
+        .mapWith(customConnectorRefreshTokenSecret.id)
+        .as("oauth_refresh_token_id"),
     })
     .from(connectors)
     .innerJoin(
@@ -152,6 +180,20 @@ async function loadCustomConnectorStoredConnections(
     );
 }
 
+async function loadCustomConnectorStoredConnections(
+  db: Pick<ReadonlyDb, "select">,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorIds?: readonly string[];
+  },
+): Promise<readonly CustomConnectorStoredConnection[]> {
+  if (args.connectorIds?.length === 0) {
+    return [];
+  }
+  return await customConnectorStoredConnectionsQuery(db, args);
+}
+
 function customConnectorStoredConnectionIsCurrent(
   connection: CustomConnectorStoredConnection,
 ): boolean {
@@ -184,25 +226,10 @@ function customConnectorStoredConnectionIsUsable(
   );
 }
 
-export async function loadCustomConnectorCredentialAccesses(
-  db: Pick<ReadonlyDb, "select">,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly definitions: readonly CustomConnectorCredentialDefinition[];
-  },
-): Promise<ReadonlyMap<string, CustomConnectorCredentialAccess>> {
-  if (args.definitions.length === 0) {
-    return new Map();
-  }
-
-  const rows = await loadCustomConnectorStoredConnections(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    connectorIds: args.definitions.map((definition) => {
-      return definition.id;
-    }),
-  });
+function customConnectorCredentialAccesses(
+  definitions: readonly CustomConnectorCredentialDefinition[],
+  rows: readonly CustomConnectorStoredConnection[],
+): ReadonlyMap<string, CustomConnectorCredentialAccess> {
   const memberByConnectorId = new Map<
     string,
     CustomConnectorStoredConnection
@@ -213,7 +240,7 @@ export async function loadCustomConnectorCredentialAccesses(
 
   const accesses = new Map<string, CustomConnectorCredentialAccess>();
   const now = nowDate();
-  for (const definition of args.definitions) {
+  for (const definition of definitions) {
     const member = memberByConnectorId.get(definition.id);
     if (!member) {
       accesses.set(definition.id, { kind: "absent" });
@@ -241,6 +268,58 @@ export async function loadCustomConnectorCredentialAccesses(
     }
   }
   return accesses;
+}
+
+function customConnectorRuntimeStorageSnapshot(
+  definitions: readonly CustomConnectorCredentialDefinition[],
+  rows: readonly CustomConnectorRuntimeStorageRow[],
+): CustomConnectorRuntimeStorageSnapshot {
+  const connectionsById = new Map<string, CustomConnectorStoredConnection>();
+  for (const row of rows) {
+    connectionsById.set(row.id, row);
+  }
+  const accesses = customConnectorCredentialAccesses(definitions, [
+    ...connectionsById.values(),
+  ]);
+  const expectedByMemberConnectorId = new Map(
+    definitions.flatMap((definition) => {
+      const access = accesses.get(definition.id);
+      return access?.kind === "current"
+        ? ([[access.memberConnectorId, definition]] as const)
+        : [];
+    }),
+  );
+  const values: CustomConnectorStoredValue[] = [];
+  for (const row of rows) {
+    const expected = expectedByMemberConnectorId.get(row.id);
+    if (
+      !expected ||
+      row.kind === "connection" ||
+      row.customConnectorId !== expected.id ||
+      row.definitionAuthMethod !== expected.authMode ||
+      row.definitionStorageVersion !== expected.storageVersion
+    ) {
+      continue;
+    }
+    if (row.kind === "secret") {
+      values.push({
+        connectorId: row.customConnectorId,
+        kind: "secret",
+        key: row.key,
+        encryptedValue: row.storedValue,
+      });
+    } else if (row.kind === "variable") {
+      values.push({
+        connectorId: row.customConnectorId,
+        kind: "variable",
+        key: row.key,
+        value: row.storedValue,
+      });
+    } else {
+      throw new Error("Invalid custom connector stored value kind");
+    }
+  }
+  return { accesses, values };
 }
 
 export async function loadCurrentCustomConnectorValueMarkers(
@@ -345,132 +424,96 @@ export async function loadCurrentCustomConnectorValueMarkers(
 }
 
 export async function loadCurrentCustomConnectorStoredValues(
-  db: Pick<ReadonlyDb, "select">,
+  db: ReadonlyDb,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly definitions: readonly CustomConnectorCredentialDefinition[];
-    readonly accesses: ReadonlyMap<string, CustomConnectorCredentialAccess>;
   },
-): Promise<readonly CustomConnectorStoredValue[]> {
-  const expectedByMemberConnectorId = new Map<
-    string,
-    CustomConnectorCredentialDefinition
-  >();
-  for (const definition of args.definitions) {
-    const access = args.accesses.get(definition.id);
-    if (access?.kind === "current") {
-      expectedByMemberConnectorId.set(access.memberConnectorId, definition);
-    }
-  }
-  const memberConnectorIds = [...expectedByMemberConnectorId.keys()];
-  if (memberConnectorIds.length === 0) {
-    return [];
+): Promise<CustomConnectorRuntimeStorageSnapshot> {
+  if (args.definitions.length === 0) {
+    return { accesses: new Map(), values: [] };
   }
 
+  const connectorIds = args.definitions.map((definition) => {
+    return definition.id;
+  });
+  const storedConnections = customConnectorStoredConnectionsQuery(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorIds,
+  }).as("custom_connector_runtime_connections");
   const secretQuery = db
     .select({
-      memberConnectorId: connectors.id,
-      connectorId: orgCustomConnectors.id,
-      authMode: orgCustomConnectors.authMode,
-      storageVersion: orgCustomConnectors.storageVersion,
+      id: storedConnections.id,
+      customConnectorId: storedConnections.customConnectorId,
+      storedAuthMethod: storedConnections.storedAuthMethod,
+      storedStorageVersion: storedConnections.storedStorageVersion,
+      storedNeedsReconnect: storedConnections.storedNeedsReconnect,
+      tokenExpiresAt: storedConnections.tokenExpiresAt,
+      definitionAuthMethod: storedConnections.definitionAuthMethod,
+      definitionStorageVersion: storedConnections.definitionStorageVersion,
+      oauthAccessTokenId: storedConnections.oauthAccessTokenId,
+      oauthRefreshTokenId: storedConnections.oauthRefreshTokenId,
       kind: sql`'secret'`.mapWith(pgTextDecoder).as("kind"),
       key: secrets.name,
       storedValue: secrets.encryptedValue,
     })
-    .from(secrets)
-    .innerJoin(
-      connectors,
-      and(
-        eq(connectors.id, secrets.connectorId),
-        eq(connectors.orgId, secrets.orgId),
-        eq(connectors.userId, secrets.userId),
-      ),
-    )
-    .innerJoin(
-      orgCustomConnectors,
-      and(
-        eq(orgCustomConnectors.id, connectors.customConnectorId),
-        eq(orgCustomConnectors.orgId, connectors.orgId),
-        eq(orgCustomConnectors.authMode, connectors.authMethod),
-        eq(orgCustomConnectors.storageVersion, connectors.storageVersion),
-      ),
-    )
+    .from(storedConnections)
+    .innerJoin(secrets, eq(secrets.connectorId, storedConnections.id))
     .where(
       and(
         eq(secrets.type, "connector"),
         eq(secrets.orgId, args.orgId),
         eq(secrets.userId, args.userId),
-        inArray(connectors.id, memberConnectorIds),
       ),
     );
   const variableQuery = db
     .select({
-      memberConnectorId: connectors.id,
-      connectorId: orgCustomConnectors.id,
-      authMode: orgCustomConnectors.authMode,
-      storageVersion: orgCustomConnectors.storageVersion,
+      id: storedConnections.id,
+      customConnectorId: storedConnections.customConnectorId,
+      storedAuthMethod: storedConnections.storedAuthMethod,
+      storedStorageVersion: storedConnections.storedStorageVersion,
+      storedNeedsReconnect: storedConnections.storedNeedsReconnect,
+      tokenExpiresAt: storedConnections.tokenExpiresAt,
+      definitionAuthMethod: storedConnections.definitionAuthMethod,
+      definitionStorageVersion: storedConnections.definitionStorageVersion,
+      oauthAccessTokenId: storedConnections.oauthAccessTokenId,
+      oauthRefreshTokenId: storedConnections.oauthRefreshTokenId,
       kind: sql`'variable'`.mapWith(pgTextDecoder).as("kind"),
       key: variables.name,
       storedValue: variables.value,
     })
-    .from(variables)
-    .innerJoin(
-      connectors,
-      and(
-        eq(connectors.id, variables.connectorId),
-        eq(connectors.orgId, variables.orgId),
-        eq(connectors.userId, variables.userId),
-      ),
-    )
-    .innerJoin(
-      orgCustomConnectors,
-      and(
-        eq(orgCustomConnectors.id, connectors.customConnectorId),
-        eq(orgCustomConnectors.orgId, connectors.orgId),
-        eq(orgCustomConnectors.authMode, connectors.authMethod),
-        eq(orgCustomConnectors.storageVersion, connectors.storageVersion),
-      ),
-    )
+    .from(storedConnections)
+    .innerJoin(variables, eq(variables.connectorId, storedConnections.id))
     .where(
       and(
         eq(variables.type, "connector"),
         eq(variables.orgId, args.orgId),
         eq(variables.userId, args.userId),
-        inArray(connectors.id, memberConnectorIds),
       ),
     );
-  const rows = await secretQuery.unionAll(variableQuery);
-  const values: CustomConnectorStoredValue[] = [];
-  for (const row of rows) {
-    const expected = expectedByMemberConnectorId.get(row.memberConnectorId);
-    if (
-      !expected ||
-      row.connectorId !== expected.id ||
-      row.authMode !== expected.authMode ||
-      row.storageVersion !== expected.storageVersion
-    ) {
-      continue;
-    }
-    if (row.kind === "secret") {
-      values.push({
-        connectorId: row.connectorId,
-        kind: "secret",
-        key: row.key,
-        encryptedValue: row.storedValue,
-      });
-    } else if (row.kind === "variable") {
-      values.push({
-        connectorId: row.connectorId,
-        kind: "variable",
-        key: row.key,
-        value: row.storedValue,
-      });
-    } else {
-      throw new Error("Invalid custom connector stored value kind");
-    }
-  }
-  return values;
+  const connectionQuery = db
+    .select({
+      id: storedConnections.id,
+      customConnectorId: storedConnections.customConnectorId,
+      storedAuthMethod: storedConnections.storedAuthMethod,
+      storedStorageVersion: storedConnections.storedStorageVersion,
+      storedNeedsReconnect: storedConnections.storedNeedsReconnect,
+      tokenExpiresAt: storedConnections.tokenExpiresAt,
+      definitionAuthMethod: storedConnections.definitionAuthMethod,
+      definitionStorageVersion: storedConnections.definitionStorageVersion,
+      oauthAccessTokenId: storedConnections.oauthAccessTokenId,
+      oauthRefreshTokenId: storedConnections.oauthRefreshTokenId,
+      kind: sql`'connection'`.mapWith(pgTextDecoder).as("kind"),
+      key: sql`''`.mapWith(pgTextDecoder).as("key"),
+      storedValue: sql`''`.mapWith(pgTextDecoder).as("stored_value"),
+    })
+    .from(storedConnections);
+  const rows = await connectionQuery
+    .unionAll(secretQuery)
+    .unionAll(variableQuery);
+  return customConnectorRuntimeStorageSnapshot(args.definitions, rows);
 }
 
 export async function loadUsableCustomConnectorConnections(

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -62,7 +62,6 @@ import {
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 import {
   customConnectorDefinitionHasUsableConnection,
-  loadCustomConnectorCredentialAccesses,
   loadCurrentCustomConnectorStoredValues,
   loadCurrentCustomConnectorValueMarkers,
   loadUsableCustomConnectorConnections,
@@ -3282,19 +3281,13 @@ export async function loadCustomConnectorRuntimeData(
         storageVersion: row.connector.storageVersion,
       };
     });
-    const credentialAccesses = await loadCustomConnectorCredentialAccesses(db, {
+    const runtimeStorage = await loadCurrentCustomConnectorStoredValues(db, {
       orgId: args.orgId,
       userId: args.userId,
       definitions,
-    });
-    const storedValues = await loadCurrentCustomConnectorStoredValues(db, {
-      orgId: args.orgId,
-      userId: args.userId,
-      definitions,
-      accesses: credentialAccesses,
     });
     const valuesByConnectorId = new Map<string, StoredValueRow[]>();
-    for (const value of storedValues) {
+    for (const value of runtimeStorage.values) {
       const values = valuesByConnectorId.get(value.connectorId) ?? [];
       values.push(value);
       valuesByConnectorId.set(value.connectorId, values);
@@ -3304,7 +3297,7 @@ export async function loadCustomConnectorRuntimeData(
         row.connector,
         row.oauthConfig,
       );
-      const credentialAccess = credentialAccesses.get(connector.id);
+      const credentialAccess = runtimeStorage.accesses.get(connector.id);
       if (!credentialAccess) {
         throw new Error("Expected custom connector credential access");
       }


### PR DESCRIPTION
## Summary

- read Custom connector connection state and shared secret/variable values from one PostgreSQL statement snapshot
- derive credential access and runtime values from the same result set so concurrent connection metadata changes cannot combine stale access state with newer values
- keep a metadata row for current connections that have no stored value rows

## Compatibility

- adds no Custom connector revision, schema migration, public API, runner protocol, or persisted payload change
- preserves existing ownership, auth method, storage version, reconnect, OAuth token, and required-field behavior

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/zero-mcp-connectors.test.ts --maxWorkers=4 --silent=passed-only` (4 files, 271 tests)
- pre-commit full Turbo Knip and TypeScript checks (14 workspaces)

Follow-up fix for #26423.
