### PR TITLE
fix(ui): restore the chat list header tone and unstack the sidebar footer gap

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1286,6 +1286,52 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("recedes both sidebar section headers at rest and lifts them on hover", async () => {
+    prepareDefaultAgent();
+    mockChatThreadSnapshot(() => {
+      return [createThread(EXISTING_THREAD_ID, "Release plan")];
+    });
+
+    setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const chatTitle = await waitFor(() => {
+      return within(sidebar()).getByText("Chats with Zero");
+    });
+    const pinnedTitle = within(
+      screen.getByTestId("pinned-section-header"),
+    ).getByText("Pinned");
+
+    // The chat list and pinned headers are the same control, so they must
+    // carry the same resting tone. A full-strength resting tone also makes
+    // the header's own group-hover class a no-op and drops the hover lift.
+    const restingTone = "text-sidebar-foreground/50";
+    expect(pinnedTitle).toHaveClass(restingTone);
+    expect(chatTitle).toHaveClass(
+      restingTone,
+      "group-hover:text-sidebar-foreground",
+    );
+  });
+
+  it("leaves the footer as the only owner of the gap below the thread list", async () => {
+    prepareDefaultAgent();
+    mockChatThreadSnapshot(() => {
+      return [createThread(EXISTING_THREAD_ID, "Release plan")];
+    });
+
+    setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      return within(sidebar()).getByText("Chats with Zero");
+    });
+
+    // The footer below supplies the 8px boundary out of its own padding.
+    // A bottom padding here stacks a second one on top of it, which reads as
+    // a void under the last thread row.
+    expect(sidebar()).toHaveClass("px-2", "pt-1");
+    expect(sidebar()).not.toHaveClass("p-2");
+    expect(sidebar()).not.toHaveClass("pb-2");
+  });
+
   it("scrolls the current chat into the virtualized sidebar on page setup", async () => {
     prepareDefaultAgent();
     const leadingThreads = Array.from({ length: 24 }, (_, index) => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -708,7 +708,7 @@ function ChatThreadsTitle() {
         return setCollapsed(!collapsed);
       }}
     >
-      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground group-hover:text-sidebar-foreground transition-colors">
+      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
         {titleLabel}
         <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
           <ChevronRight

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -406,7 +406,7 @@ function ExpandedMainNav() {
       aria-label={t(($) => {
         return $.appShell.sidebar.ariaLabel;
       })}
-      className="flex-1 flex flex-col min-h-0 overflow-hidden p-2 pt-1"
+      className="flex-1 flex flex-col min-h-0 overflow-hidden px-2 pt-1"
     >
       <ExpandedManageSection />
       <ExpandedSidebarSections />
@@ -488,8 +488,10 @@ function ExpandedSidebarSections() {
 }
 
 function ExpandedUpgradeSection() {
+  // The nav above has no bottom padding, so the card carries its own top gap.
+  // Collapses to nothing when SidebarUpgradeCard renders null.
   return (
-    <div className="px-2">
+    <div className="px-2 pt-2 empty:hidden">
       <SidebarUpgradeCard />
     </div>
   );


### PR DESCRIPTION
Two sidebar regressions Tong caught in the expanded sidebar.

## Header tone

`#25995` set out to make an icon match the label beside it, but applied that to a section header, lifting the "Chats with &lt;agent&gt;" label from `text-sidebar-foreground/50` to full strength.

The header is not an icon-then-text row: its chevron sits *after* the label and already picked up its own `opacity-35` in that same PR, so the label never had to move. Three things went wrong as a result:

- the peer **Pinned** header kept `/50`, so two headers with identical structure now render at different weights
- the label's own `group-hover:text-sidebar-foreground` became a no-op, dropping the header's hover lift
- the rule only ever applied to left-icon / right-text nav rows (Agents, Workflows, Connectors, Artifacts), which this is not

Restoring `/50` is the whole fix. I re-scanned every alpha change in `#25995`: this was the only *text* label affected — all the rest were icon-only elements, which stay as they are.

## Footer gap

`ExpandedMainNav`'s `p-2` bottom and `ExpandedFooter`'s `p-2` top stacked into a 16px void between the last thread row and the first footer link — four times the 4px row rhythm, with no divider to carry it.

Measured off the reported screenshot: scroll viewport ends at 538px, the "Where Okou works" row starts at 554px.

Drop the nav's bottom padding so the footer alone owns the boundary at 8px. This matches the three-column chat column, which already runs `px-2 pt-1`. The upgrade card lived inside that padding, so it now carries its own `pt-2` and `empty:hidden`s when `SidebarUpgradeCard` renders null — no 8px stub in the common case.

## Testing

Both defects were class-string regressions with nothing asserting them, which is how a PR about icon stroke width silently changed the header tone. Two regression tests in `zero-sidebar.test.tsx`, both through `setupSidebarPage`:

- the chat list header carries the same resting tone as its peer `pinned-section-header` label and keeps its `group-hover` lift
- the sidebar `nav` has no bottom padding, so the footer stays the single owner of that boundary

Verified both fail against the pre-fix classes and pass against the fix. Layout in px is not observable under jsdom, so these pin the class contract rather than the computed gap.

Local: `pnpm format`, `pnpm turbo run lint` (0 errors), `pnpm check-types` (14/14), full `zero-sidebar.test.tsx` (53 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
