### PR TITLE
fix(python): centralize firewall permission name validation

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -20,7 +20,6 @@ from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 MAX_BUILTIN_FIREWALL_CATALOG_BYTES = 16 * 1024 * 1024
 _CACHE_SCHEMA_VERSION = 1
 _SHA256_HEX_LENGTH = 64
-_RESERVED_PERMISSION_NAMES = frozenset(("all", "__unknown__"))
 _UNTRUSTED_WRITE_BITS = stat.S_IWGRP | stat.S_IWOTH
 # Use the shortest valid witness for each URL component so materialization does
 # not push an otherwise satisfiable DNS label past its 63-byte limit.
@@ -412,11 +411,16 @@ def _validate_api_entry(firewall_name: str, api: dict) -> None:
                 f'catalog cache firewall "{firewall_name}" permissions must be objects'
             )
         raw_name = permission.get("name")
-        if not isinstance(raw_name, str) or raw_name == "":
+        if not isinstance(raw_name, str):
             raise BuiltinFirewallCatalogCacheError(
                 f'catalog cache firewall "{firewall_name}" permission names must be non-empty'
             )
-        if raw_name in _RESERVED_PERMISSION_NAMES:
+        invalid_reason = matching.declared_firewall_permission_name_invalid_reason(raw_name)
+        if invalid_reason == "empty":
+            raise BuiltinFirewallCatalogCacheError(
+                f'catalog cache firewall "{firewall_name}" permission names must be non-empty'
+            )
+        if invalid_reason == "reserved":
             raise BuiltinFirewallCatalogCacheError(
                 f'catalog cache firewall "{firewall_name}" permission name is reserved'
             )

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -73,6 +73,7 @@ _VALID_RULE_METHODS = frozenset(
         "ANY",
     )
 )
+_RESERVED_DECLARED_FIREWALL_PERMISSION_NAMES = frozenset(("all", "__unknown__"))
 _VALID_AUTH_BASE_SCHEME = "https"
 _AUTH_TEMPLATE_START = "${{"
 _AUTH_TEMPLATE_URL_PLACEHOLDER = "placeholder"
@@ -777,6 +778,24 @@ def firewall_rule_is_valid(rule_str: str) -> bool:
     return _compile_rule(rule_str) is not None
 
 
+DeclaredFirewallPermissionNameInvalidReason = Literal["empty", "reserved"]
+
+
+def declared_firewall_permission_name_invalid_reason(
+    name: str,
+) -> DeclaredFirewallPermissionNameInvalidReason | None:
+    """Return why a declared permission name is invalid, or ``None`` when valid.
+
+    This validates permission definitions only. Network-policy grant storage may
+    use ``__unknown__`` as the unknown-endpoint sentinel.
+    """
+    if name == "":
+        return "empty"
+    if name in _RESERVED_DECLARED_FIREWALL_PERMISSION_NAMES:
+        return "reserved"
+    return None
+
+
 # Compiled matcher contract
 #
 # Registry loading stores these compiled objects and request handling later
@@ -881,7 +900,7 @@ def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
                 if not isinstance(raw_name, str):
                     has_malformed_rules = True
                     continue
-                if raw_name in ("", "all"):
+                if declared_firewall_permission_name_invalid_reason(raw_name) is not None:
                     has_malformed_rules = True
                     continue
                 if raw_name in seen_permission_names:

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_permissions.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_permissions.py
@@ -65,6 +65,7 @@ def test_duplicate_permission_name_does_not_expand_allowed_scope():
         [None],
         [{"name": "", "rules": [REPO_RULE]}],
         [{"name": "all", "rules": [REPO_RULE]}],
+        [{"name": "__unknown__", "rules": [REPO_RULE]}],
         [{"rules": [REPO_RULE]}],
         [{"name": 123, "rules": [REPO_RULE]}],
         [{"name": "repo-read", "rules": []}],

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
@@ -388,8 +388,8 @@ class TestRegistryBuiltinCatalogValidation:
 
         _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-    @pytest.mark.parametrize("permission_name", ["all", "__unknown__"])
-    def test_reserved_permission_runner_catalog_cache_fails_closed(
+    @pytest.mark.parametrize("permission_name", ["", "all", "__unknown__"])
+    def test_invalid_permission_name_runner_catalog_cache_fails_closed(
         self, tmp_path, mitm_ctx, permission_name
     ):
         firewall = cache_firewall("fallback", "https://cache.example.com")


### PR DESCRIPTION
## Summary

- centralize declared firewall permission-name validation in the Python matcher facade
- make matcher compilation fail closed for the reserved `__unknown__` permission name
- reuse the canonical validation from builtin catalog-cache validation while preserving its diagnostics
- align compiled-matcher and registry/cache integration coverage for empty and reserved names

## Scope

This change applies only to permission names declared in firewall definitions. It does not change the `__unknown__` grant-storage sentinel, `unknownPolicy`, APIs, runner protocols, or persisted data.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_compiled_firewall_malformed_permissions.py tests/test_registry_builtin_catalog_validation.py` (42 passed)
- `uv run --no-sync python -m pytest tests/` (5,284 passed)

Closes #26443
