### PR TITLE
fix(python): preserve malformed base literal scope

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -323,7 +323,14 @@ def _compile_base_segments_for_match(
         parsed_segment = _parse_segment(segment)
         if isinstance(parsed_segment, SegmentError):
             has_malformed_segment = True
-            parsed.append(SegmentParam("", f"__malformed_base_segment_{index}", "", ""))
+            parsed.append(
+                SegmentParam(
+                    parsed_segment.prefix,
+                    f"__malformed_base_segment_{index}",
+                    parsed_segment.suffix,
+                    "",
+                )
+            )
         elif (
             isinstance(parsed_segment, SegmentParam)
             and parsed_segment.greedy

--- a/crates/runner/mitm-addon/src/firewall_matching/patterns.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/patterns.py
@@ -23,6 +23,8 @@ class SegmentParam(NamedTuple):
 
 class SegmentError(NamedTuple):
     reason: str
+    prefix: str = ""
+    suffix: str = ""
 
 
 ParsedSegment = SegmentLiteral | SegmentParam | SegmentError
@@ -57,15 +59,23 @@ def _parse_segment(seg: str) -> ParsedSegment:
         return SegmentError(f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}')
 
     if open_count >= _MULTI_PARAM_BRACE_COUNT:
+        prefix = seg[:open1]
+        suffix = seg[seg.rfind("}") + 1 :]
+        if "{" in suffix:
+            suffix = ""
         open2 = seg.find("{", close1 + 1)
         if close1 + 1 == open2:
             return SegmentError(
                 f'adjacent parameters in segment "{seg}" — only one parameter '
-                f"per segment is allowed; {_SEGMENT_ERROR_HINT}"
+                f"per segment is allowed; {_SEGMENT_ERROR_HINT}",
+                prefix,
+                suffix,
             )
         return SegmentError(
             f'literal-separated parameters in segment "{seg}" — only one parameter '
-            f"per segment is allowed; {_SEGMENT_ERROR_HINT}"
+            f"per segment is allowed; {_SEGMENT_ERROR_HINT}",
+            prefix,
+            suffix,
         )
 
     prefix = seg[:open1]

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_base.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_base.py
@@ -176,6 +176,62 @@ def test_malformed_base_params_fail_closed_after_base_match(base, url):
     assert matched.reason == "malformed_firewall_config"
 
 
+@pytest.mark.parametrize(
+    ("base", "matched_url", "unrelated_url"),
+    [
+        pytest.param(
+            "https://api-{region}-{env}.example.com",
+            "https://api-us-prod.example.com/items",
+            "https://evil.example.com/items",
+            id="host-prefix",
+        ),
+        pytest.param(
+            "https://{region}-{env}-api.example.com",
+            "https://us-prod-api.example.com/items",
+            "https://us-prod-evil.example.com/items",
+            id="host-suffix",
+        ),
+        pytest.param(
+            "https://api.example.com/admin-{region}-{env}",
+            "https://api.example.com/admin-us-prod/items",
+            "https://api.example.com/public/items",
+            id="path-prefix",
+        ),
+        pytest.param(
+            "https://api.example.com/{region}-{env}-admin",
+            "https://api.example.com/us-prod-admin/items",
+            "https://api.example.com/us-prod-public/items",
+            id="path-suffix",
+        ),
+    ],
+)
+def test_malformed_multi_param_base_respects_outer_literal_scope(
+    base,
+    matched_url,
+    unrelated_url,
+):
+    compiled_firewalls = compile_firewalls_or_fail(_github_firewalls(base))
+    policies = _github_policies()
+
+    unrelated = matching.match_compiled_firewall_request(
+        unrelated_url,
+        "GET",
+        compiled_firewalls,
+        policies,
+    )
+    matched = matching.match_compiled_firewall_request(
+        matched_url,
+        "GET",
+        compiled_firewalls,
+        policies,
+    )
+
+    assert unrelated is None
+    assert isinstance(matched, matching.FirewallBlock)
+    assert matched.permissions == ()
+    assert matched.reason == "malformed_firewall_config"
+
+
 def test_malformed_base_path_plus_requires_segment_scope():
     compiled_firewalls = compile_firewalls_or_fail(
         _github_firewalls("https://api.example.com/{path+}")


### PR DESCRIPTION
## Summary

- preserve the outer literal prefix and suffix when compiling malformed multi-parameter firewall base segments
- keep in-scope malformed bases fail-closed while excluding unrelated host labels and path segments
- add compiled matcher regressions for host/path prefix and suffix scope

## Scope

- leaves the accepted connector grammar and public segment parser output unchanged
- leaves other malformed segment categories on their existing fallback behavior
- introduces no API, persisted-state, migration, or rollout contract changes

## Verification

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,286 passed)

Closes #26444
