### PR TITLE
feat(api): expose admitted mcp connectors to agents

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -150,6 +150,7 @@ function manualMcpRuntimeConnectorBody(args: {
   readonly displayName: string;
   readonly endpoint: string;
   readonly skillMarkdown?: string;
+  readonly slug?: string;
 }): McpCustomConnectorCreateBody {
   return {
     kind: "mcp",
@@ -175,6 +176,7 @@ function manualMcpRuntimeConnectorBody(args: {
     ...(args.skillMarkdown === undefined
       ? {}
       : { skillMarkdown: args.skillMarkdown }),
+    ...(args.slug === undefined ? {} : { slug: args.slug }),
   };
 }
 
@@ -183,9 +185,26 @@ function runnerPreference(job: RunnerJob | null | undefined) {
 }
 
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "okou web upload-file -f <path>";
+const MCP_CONNECTOR_PROMPT_HEADING = "# MCP Custom Connectors";
+const MCP_CONNECTOR_PROMPT_INVENTORY_LIMIT = 20;
 const API_DISPATCH_ATOMIC_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_atomic_launch",
 ] as const;
+
+function mcpConnectorPromptSection(prompt: string): string | undefined {
+  const sectionStart = prompt.indexOf(MCP_CONNECTOR_PROMPT_HEADING);
+  if (sectionStart === -1) {
+    return undefined;
+  }
+  const nextSectionStart = prompt.indexOf(
+    "\n\n# ",
+    sectionStart + MCP_CONNECTOR_PROMPT_HEADING.length,
+  );
+  return prompt.slice(
+    sectionStart,
+    nextSectionStart === -1 ? undefined : nextSectionStart,
+  );
+}
 const EXPECTED_ZERO_RUN_DISALLOWED_TOOLS = [
   "CronCreate",
   "CronList",
@@ -8559,31 +8578,19 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         name: getCustomConnectorSkillStorageName(mcp.id),
       }),
     );
+    expect(
+      mcpConnectorPromptSection(disabledClaim.appendSystemPrompt ?? ""),
+    ).toBeUndefined();
     await api.requestCancelRun(actor, disabledRun.runId, [200]);
 
     await connectors.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
     });
-    const composeName = `bdd-mcp-runtime-${randomUUID().slice(0, 8)}`;
-    const compose = await api.createCompose(actor, {
-      version: "1",
-      agents: {
-        [composeName]: {
-          framework: "claude-code",
-          environment: {
-            ANTHROPIC_API_KEY: "bdd-inline-key",
-          },
-        },
-      },
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use the admitted MCP connector",
+      modelProvider: "anthropic-api-key",
     });
-    const run = await api.createDirectRun(
-      actor,
-      zeroBackedDirectRunBody({
-        agentId,
-        agentComposeVersionId: compose.versionId,
-        prompt: "use the admitted MCP connector",
-      }),
-    );
     const claim = await api.claimRunnerJob(run.runId);
     const admittedIds = [http.id, mcp.id].sort();
     expect(
@@ -8598,6 +8605,16 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       customConnectorId: mcp.id,
       baseUrlVars: {},
     });
+    const mcpPrompt = mcpConnectorPromptSection(claim.appendSystemPrompt ?? "");
+    expect(mcpPrompt).toContain(`- \`${mcp.slug}\``);
+    expect(mcpPrompt).toContain("okou mcp list --json");
+    expect(mcpPrompt).toContain("okou mcp list-tools <connector-slug> --json");
+    expect(mcpPrompt).toContain("okou mcp call <connector-slug> <tool-name>");
+    expect(mcpPrompt).not.toContain(http.slug);
+    expect(mcpPrompt).not.toContain(mcpDefinition.displayName);
+    expect(mcpPrompt).not.toContain(mcpDefinition.endpoint);
+    expect(mcpPrompt).not.toContain("Use the admitted MCP server.");
+    expect(mcpPrompt).not.toContain("mcp-runtime-token");
 
     const [mcpApi] = inlineFirewallApis(claim.firewalls, mcpInternalName);
     expect(mcpApi).toMatchObject({
@@ -8712,6 +8729,17 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       code: "CONNECTOR_NOT_CONFIGURED",
     });
 
+    const disconnectedRun = await api.createRun(actor, {
+      agentId,
+      prompt: "do not advertise a disconnected MCP connector",
+      modelProvider: "anthropic-api-key",
+    });
+    const disconnectedClaim = await api.claimRunnerJob(disconnectedRun.runId);
+    expect(
+      mcpConnectorPromptSection(disconnectedClaim.appendSystemPrompt ?? ""),
+    ).toBeUndefined();
+    await api.requestCancelRun(actor, disconnectedRun.runId, [200]);
+
     const [mismatchedRoutingResult] = await api.syncConnectorRuntime(
       run.runId,
       {
@@ -8757,6 +8785,168 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
 
     await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("bounds admitted MCP awareness across frameworks and continuation", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const admittedSlugs = Array.from(
+      { length: MCP_CONNECTOR_PROMPT_INVENTORY_LIMIT + 1 },
+      (_, index) => {
+        return `_mcp-awareness-${String(index).padStart(2, "0")}`;
+      },
+    );
+    const admittedConnectorIds: string[] = [];
+    for (const slug of [...admittedSlugs].reverse()) {
+      const connector = await connectors.createCustomConnector(
+        actor,
+        manualMcpRuntimeConnectorBody({
+          displayName: `Remote display ${slug}`,
+          endpoint: `https://${slug.slice(1)}.example.test/mcp`,
+          slug,
+        }),
+      );
+      await connectors.setCustomConnectorValues(actor, connector.id, [
+        { key: "secret", kind: "secret", value: `credential-${slug}` },
+      ]);
+      admittedConnectorIds.push(connector.id);
+    }
+
+    const incompleteSlug = "_mcp-awareness-incomplete";
+    const incomplete = await connectors.createCustomConnector(
+      actor,
+      manualMcpRuntimeConnectorBody({
+        displayName: "Incomplete MCP connector",
+        endpoint: "https://incomplete-mcp.example.test/mcp",
+        slug: incompleteSlug,
+      }),
+    );
+    const ungrantedSlug = "_mcp-awareness-ungranted";
+    const ungranted = await connectors.createCustomConnector(
+      actor,
+      manualMcpRuntimeConnectorBody({
+        displayName: "Ungranted MCP connector",
+        endpoint: "https://ungranted-mcp.example.test/mcp",
+        slug: ungrantedSlug,
+      }),
+    );
+    await connectors.setCustomConnectorValues(actor, ungranted.id, [
+      { key: "secret", kind: "secret", value: "ungranted-credential" },
+    ]);
+    await connectors.updateAgentCustomConnectors(actor, agentId, [
+      ...admittedConnectorIds,
+      incomplete.id,
+    ]);
+
+    const claudeRun = await api.createRun(actor, {
+      agentId,
+      prompt: "inspect bounded MCP awareness",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claudeClaim = await api.claimRunnerJob(claudeRun.runId);
+    expect(claudeClaim.cliAgentType).toBe("claude-code");
+    expect(claudeClaim.appendSystemPrompt).toContain("# Agent Tools");
+    const claudeMcpPrompt = mcpConnectorPromptSection(
+      claudeClaim.appendSystemPrompt ?? "",
+    );
+    if (!claudeMcpPrompt) {
+      throw new Error("Expected Claude Code to receive MCP awareness");
+    }
+    const expectedListedSlugs = [...admittedSlugs]
+      .sort()
+      .slice(0, MCP_CONNECTOR_PROMPT_INVENTORY_LIMIT);
+    expect(
+      claudeMcpPrompt.split("\n").filter((line) => {
+        return line.startsWith("- `");
+      }),
+    ).toStrictEqual(
+      expectedListedSlugs.map((slug) => {
+        return `- \`${slug}\``;
+      }),
+    );
+    expect(claudeMcpPrompt).not.toContain(
+      admittedSlugs[MCP_CONNECTOR_PROMPT_INVENTORY_LIMIT],
+    );
+    expect(claudeMcpPrompt).toContain(
+      "1 additional admitted MCP connector was omitted from this prompt",
+    );
+    expect(claudeMcpPrompt).not.toContain(incompleteSlug);
+    expect(claudeMcpPrompt).not.toContain(ungrantedSlug);
+    expect(claudeMcpPrompt).not.toContain("Remote display");
+    expect(claudeMcpPrompt).not.toContain("example.test");
+    expect(claudeMcpPrompt).not.toContain("credential-");
+
+    const history = `bounded MCP awareness history ${claudeRun.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    mockSessionHistoryBlob(historyHash, history);
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: claudeRun.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-mcp-awareness-${claudeRun.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      { authorization: `Bearer ${claudeClaim.sandboxToken}` },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: claudeRun.runId, exitCode: 0, lastEventSequence: 0 },
+      { authorization: `Bearer ${claudeClaim.sandboxToken}` },
+      [200],
+    );
+
+    const resumedRun = await api.createRun(actor, {
+      agentId,
+      sessionId: claudeRun.sessionId,
+      prompt: "continue with bounded MCP awareness",
+      modelProvider: "anthropic-api-key",
+    });
+    const resumedClaim = await api.claimRunnerJob(resumedRun.runId);
+    expect(resumedClaim.appendSystemPrompt).toContain("# Agent Tools");
+    expect(
+      mcpConnectorPromptSection(resumedClaim.appendSystemPrompt ?? ""),
+    ).toBe(claudeMcpPrompt);
+    await api.requestCancelRun(actor, resumedRun.runId, [200]);
+
+    await fw.seedOrgCodexProvider(actor, {
+      accessToken: "mcp-awareness-codex-access",
+      refreshToken: "mcp-awareness-codex-refresh",
+      accountId: "mcp-awareness-codex-account",
+      idToken: "mcp-awareness-codex-id",
+      expiresIn: 3600,
+    });
+    const codexRun = await api.createRun(actor, {
+      agentId,
+      prompt: "inspect MCP awareness with Codex",
+      modelProvider: "codex-oauth-token",
+    });
+    const codexClaim = await api.claimRunnerJob(codexRun.runId);
+    expect(codexClaim.cliAgentType).toBe("codex");
+    expect(mcpConnectorPromptSection(codexClaim.appendSystemPrompt ?? "")).toBe(
+      claudeMcpPrompt,
+    );
+    await api.requestCancelRun(actor, codexRun.runId, [200]);
+
+    const genericDirectRun = await api.createDirectRun(
+      actor,
+      zeroBackedDirectRunBody({
+        agentId,
+        prompt: "do not advertise Zero MCP without a server-issued token",
+      }),
+    );
+    const genericDirectClaim = await api.claimRunnerJob(genericDirectRun.runId);
+    expect(
+      mcpConnectorPromptSection(genericDirectClaim.appendSystemPrompt ?? ""),
+    ).toBeUndefined();
+    await api.requestCancelRun(actor, genericDirectRun.runId, [200]);
   });
 
   it("hands off more than one runtime-sync batch without truncation", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -18,6 +18,7 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import type { CodexServiceTier } from "@vm0/api-contracts/contracts/chat-threads";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
+import { customConnectorSlugSchema } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   connectorSlugSchema,
   type ConnectorAuthMethodId,
@@ -357,6 +358,43 @@ const CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT =
   "If you use the built-in image generation tool and it saves generated output image file(s) to local paths, upload each output file you intend to show with `okou web upload-file -f <path>` before telling the web chat user the image is available. Quote the path when needed. Do not provide only sandbox-local paths, because users cannot open local files.";
 const ZERO_IMAGE_RECOGNITION_PROMPT =
   '# Image Recognition Fallback\n\nThis run\'s selected model cannot inspect images directly. To inspect one local PNG, JPEG, or WebP image up to 20 MB, run `okou recognize --file <image-path> --prompt "<instruction>"`.';
+const MCP_CONNECTOR_PROMPT_INVENTORY_LIMIT = 20;
+
+function buildMcpConnectorPrompt(
+  connectorSlugs: readonly string[],
+): string | undefined {
+  if (connectorSlugs.length === 0) {
+    return undefined;
+  }
+  const sortedSlugs = [...connectorSlugs].sort();
+  const listedSlugs = sortedSlugs.slice(
+    0,
+    MCP_CONNECTOR_PROMPT_INVENTORY_LIMIT,
+  );
+  const omittedCount = sortedSlugs.length - listedSlugs.length;
+  const inventory = listedSlugs.map((slug) => {
+    return `- \`${slug}\``;
+  });
+  if (omittedCount > 0) {
+    inventory.push(
+      `- ${omittedCount} additional admitted MCP connector${omittedCount === 1 ? " was" : "s were"} omitted from this prompt`,
+    );
+  }
+
+  return [
+    "# MCP Custom Connectors",
+    "",
+    "The following MCP Custom Connectors were admitted when this Run started:",
+    ...inventory,
+    "",
+    "Use the Okou CLI to discover and invoke their tools:",
+    "1. Run `okou mcp list --json` to check current connector metadata and availability.",
+    "2. Before choosing a tool, run `okou mcp list-tools <connector-slug> --json`.",
+    "3. Invoke the exact returned tool name with `okou mcp call <connector-slug> <tool-name> --input '<json>' --json`, providing JSON that matches its input schema.",
+    "",
+    "Current connector authorization or configuration may differ from this Run-start snapshot. Runner enforcement is authoritative; if discovery or invocation reports that a connector is unavailable, do not bypass it and start a new Run after authorization is updated.",
+  ].join("\n");
+}
 
 function withZeroTokenSecret(
   body: CreateRunBody,
@@ -375,30 +413,38 @@ function withPendingZeroTokenSecret(body: CreateRunBody): CreateRunBody {
   return withZeroTokenSecret(body, "__pending_zero_token__");
 }
 
-function withFinalRunAppendSystemPrompt(
-  body: CreateRunBody,
-  framework: SupportedFramework,
-  chatThreadId: string | undefined,
-  imageRecognitionAvailable: boolean,
-): CreateRunBody {
+function withFinalRunAppendSystemPrompt(args: {
+  readonly body: CreateRunBody;
+  readonly framework: SupportedFramework;
+  readonly chatThreadId: string | undefined;
+  readonly imageRecognitionAvailable: boolean;
+  readonly mcpConnectorSlugs: readonly string[];
+  readonly zeroCliAvailable: boolean;
+}): CreateRunBody {
   const appendedParts: string[] = [];
-  if (imageRecognitionAvailable) {
+  if (args.zeroCliAvailable) {
+    const mcpConnectorPrompt = buildMcpConnectorPrompt(args.mcpConnectorSlugs);
+    if (mcpConnectorPrompt) {
+      appendedParts.push(mcpConnectorPrompt);
+    }
+  }
+  if (args.imageRecognitionAvailable) {
     appendedParts.push(ZERO_IMAGE_RECOGNITION_PROMPT);
   }
   if (
-    framework === "codex" &&
-    isWebChatTriggerSource(body.triggerSource) &&
-    chatThreadId
+    args.framework === "codex" &&
+    isWebChatTriggerSource(args.body.triggerSource) &&
+    args.chatThreadId
   ) {
     appendedParts.push(CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT);
   }
   if (appendedParts.length === 0) {
-    return body;
+    return args.body;
   }
 
   return {
-    ...body,
-    appendSystemPrompt: [body.appendSystemPrompt, ...appendedParts]
+    ...args.body,
+    appendSystemPrompt: [args.body.appendSystemPrompt, ...appendedParts]
       .filter((part): part is string => {
         return Boolean(part);
       })
@@ -893,6 +939,7 @@ interface CustomConnectorRuntimeContext {
   readonly permissionPolicies: FirewallPolicies | undefined;
   readonly targets: readonly ConnectorRuntimeTargetRegistration[];
   readonly customConnectorIdByFirewallName: Readonly<Record<string, string>>;
+  readonly mcpConnectorSlugs: readonly string[];
   readonly skills: readonly {
     readonly connectorId: string;
     readonly connectorSlug: string;
@@ -4349,6 +4396,7 @@ export async function buildCustomConnectorRuntimeContext(
   const permissionPolicies: FirewallPolicies = {};
   const targets: ConnectorRuntimeTargetRegistration[] = [];
   const customConnectorIdByFirewallName: Record<string, string> = {};
+  const mcpConnectorSlugs: string[] = [];
   const skills: {
     connectorId: string;
     connectorSlug: string;
@@ -4379,6 +4427,12 @@ export async function buildCustomConnectorRuntimeContext(
     }
     firewalls.push(built.firewall);
     customConnectorIdByFirewallName[built.firewall.name] = row.connector.id;
+    if (row.connector.kind === "mcp") {
+      const slug = customConnectorSlugSchema.safeParse(row.connector.slug);
+      if (slug.success) {
+        mcpConnectorSlugs.push(slug.data);
+      }
+    }
     if (built.permissionPolicy) {
       permissionPolicies[built.firewall.name] = built.permissionPolicy;
     }
@@ -4395,6 +4449,7 @@ export async function buildCustomConnectorRuntimeContext(
     permissionPolicies: compactRecord(permissionPolicies),
     targets,
     customConnectorIdByFirewallName,
+    mcpConnectorSlugs,
     skills,
   };
   stats.recordPhaseDuration("assembleFirewalls", finalAssemblyStartedAt);
@@ -4516,6 +4571,7 @@ async function loadCustomConnectorContext(
       permissionPolicies: undefined,
       targets: [],
       customConnectorIdByFirewallName: {},
+      mcpConnectorSlugs: [],
       skills: [],
     };
   }
@@ -4544,6 +4600,7 @@ async function loadCustomConnectorContext(
       permissionPolicies: undefined,
       targets: [],
       customConnectorIdByFirewallName: {},
+      mcpConnectorSlugs: [],
       skills: [],
     };
   }
@@ -8980,15 +9037,18 @@ function finalizePreparedRunContext(
 ): PreparedRunContext {
   return {
     ...prepared.context,
-    body: withFinalRunAppendSystemPrompt(
-      {
+    body: withFinalRunAppendSystemPrompt({
+      body: {
         ...prepared.context.body,
         appendSystemPrompt: finalAppendSystemPrompt,
       },
-      prepared.context.framework,
-      prepared.args.chatThreadId,
-      prepared.context.imageRecognitionAvailable,
-    ),
+      framework: prepared.context.framework,
+      chatThreadId: prepared.args.chatThreadId,
+      imageRecognitionAvailable: prepared.context.imageRecognitionAvailable,
+      mcpConnectorSlugs:
+        prepared.context.customConnectorContext.mcpConnectorSlugs,
+      zeroCliAvailable: prepared.args.includeZeroTokenSecret === true,
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary

- project successfully admitted MCP Custom Connector slugs into a bounded, deterministic Run-start prompt
- teach sandbox Agents to discover tools with `zero mcp list` / `list-tools` and invoke them with `zero mcp call`
- keep the guidance framework-independent so Codex and Claude Code receive the same capability through the existing append-system-prompt path
- cover feature-gated, disconnected, incomplete, ungranted, ordinary HTTP, continuation, framework, and inventory-bound behavior at the Run lifecycle entry point

## Scope and behavior

Only MCP connectors that pass the existing new-Run admission path are advertised. The prompt contains validated connector slugs and vm0-authored CLI guidance; it never includes remote MCP instructions, endpoints, credentials, tool schemas, or results. Invalid persisted slugs are omitted from awareness without changing the existing runtime authority.

The inventory is sorted and capped at 20 entries. When more connectors are admitted, the prompt reports the omitted count and directs the Agent to `zero mcp list --json` for current discovery. The prompt is emitted only for Runs where the API issues the Zero CLI token.

This PR does not add database schema or persisted Run state, change Runner/API protocols, alter firewall or authorization semantics, configure framework-native MCP servers, or modify `zero mcp` transport.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (153 passed)
- pre-commit Prettier, Knip, repository type checks, file-size check, and commitlint

Closes #26445

Parent: #25031
