### PR TITLE
fix(desktop): restore packaged preload bridge

### DIFF
--- a/turbo/apps/desktop/src/desktop-identity-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-identity-ipc-channels.ts
@@ -1,0 +1,1 @@
+export const DESKTOP_IDENTITY_CHANNEL = "desktop-identity:get";

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -6,6 +6,7 @@ import {
   app,
   BrowserWindow,
   dialog,
+  ipcMain,
   Menu,
   net,
   powerSaveBlocker,
@@ -64,6 +65,8 @@ import { readOrCreateComputerUseInstallationId } from "./desktop-computer-use-in
 import { DesktopFilesystemPluginManager } from "./desktop-filesystem-plugin";
 import { DesktopMcpPluginManager } from "./desktop-mcp-plugin";
 import { DesktopKeepAwakeController } from "./desktop-keep-awake";
+import type { DesktopIdentityInfo } from "./desktop-bridge";
+import { DESKTOP_IDENTITY_CHANNEL } from "./desktop-identity-ipc-channels";
 import { startDesktopLaunchComputerUse } from "./desktop-launch-computer-use";
 import {
   DesktopQuitConfirmationController,
@@ -148,6 +151,16 @@ let appIsQuitting = false;
 let computerUseNativeBackendDisposed = false;
 let desktopTray: DesktopTrayController | null = null;
 let keepAwakeController: DesktopKeepAwakeController | null = null;
+
+const desktopIdentity: DesktopIdentityInfo = {
+  product: config.identity.product,
+  brandName: config.identity.brandName,
+  displayName: config.identity.displayName,
+};
+
+ipcMain.on(DESKTOP_IDENTITY_CHANNEL, (event) => {
+  event.returnValue = desktopIdentity;
+});
 let filesystemPluginManager: DesktopFilesystemPluginManager | null = null;
 let mcpPluginManager: DesktopMcpPluginManager | null = null;
 let desktopAutoUpdatesInstalled = false;
@@ -1008,6 +1021,77 @@ async function createMainWindow(): Promise<BrowserWindow> {
   return window;
 }
 
+interface DesktopSmokeBridgeState {
+  readonly auth: boolean;
+  readonly computerUse: boolean;
+  readonly developerTools: boolean;
+  readonly identity: DesktopIdentityInfo | null;
+}
+
+function isDesktopIdentityInfo(value: unknown): value is DesktopIdentityInfo {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "product" in value &&
+    (value.product === "zero" || value.product === "okou") &&
+    "brandName" in value &&
+    (value.brandName === "Zero" || value.brandName === "Okou") &&
+    "displayName" in value &&
+    typeof value.displayName === "string"
+  );
+}
+
+function isDesktopSmokeBridgeState(
+  value: unknown,
+): value is DesktopSmokeBridgeState {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "auth" in value &&
+    typeof value.auth === "boolean" &&
+    "computerUse" in value &&
+    typeof value.computerUse === "boolean" &&
+    "developerTools" in value &&
+    typeof value.developerTools === "boolean" &&
+    "identity" in value &&
+    (value.identity === null || isDesktopIdentityInfo(value.identity))
+  );
+}
+
+async function verifyDesktopSmokeBridge(): Promise<void> {
+  const window = await createMainWindow();
+  const rawState: unknown = await window.webContents.executeJavaScript(
+    `({
+      auth: typeof window.vm0DesktopAuth === "object",
+      computerUse: typeof window.vm0DesktopComputerUse === "object",
+      developerTools: typeof window.vm0DesktopDeveloperTools === "object",
+      identity: window.vm0DesktopIdentity ?? null,
+    })`,
+    true,
+  );
+
+  if (!isDesktopSmokeBridgeState(rawState)) {
+    throw new Error(
+      `Desktop renderer bridge returned an invalid result: ${JSON.stringify(rawState)}`,
+    );
+  }
+
+  const state = rawState;
+  if (
+    !state.auth ||
+    !state.computerUse ||
+    !state.developerTools ||
+    !state.identity ||
+    state.identity.product !== desktopIdentity.product ||
+    state.identity.brandName !== desktopIdentity.brandName ||
+    state.identity.displayName !== desktopIdentity.displayName
+  ) {
+    throw new Error(
+      `Desktop renderer bridge failed acceptance: ${JSON.stringify(state)}`,
+    );
+  }
+}
+
 function installAuthConsumeWindowPolicy(window: BrowserWindow): void {
   window.webContents.on("will-navigate", (event, url) => {
     if (isAllowedAppNavigation(url, config.allowedAppOrigins)) {
@@ -1277,6 +1361,13 @@ if (!hasSingleInstanceLock) {
     });
 
     if (isDesktopSmokeTestEnabled(process.env)) {
+      try {
+        await verifyDesktopSmokeBridge();
+      } catch (error) {
+        console.error("[smoke-test] desktop renderer bridge failed", error);
+        app.exit(1);
+        return;
+      }
       console.log(DESKTOP_SMOKE_TEST_READY_MARKER);
       quitConfirmation.allowQuitWithoutConfirmation();
       app.quit();

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
+import { DESKTOP_IDENTITY_CHANNEL } from "./desktop-identity-ipc-channels";
 import type {
   DesktopAuthApi,
   DesktopComputerUseApi,
@@ -13,6 +14,7 @@ type IpcInvoke = (channel: string, ...args: unknown[]) => Promise<unknown>;
 type IpcListener = (...args: unknown[]) => void;
 type IpcOn = (channel: string, listener: IpcListener) => void;
 type IpcOff = (channel: string, listener: IpcListener) => void;
+type IpcSendSync = (channel: string) => unknown;
 
 const electronMock = vi.hoisted(() => {
   const exposed = new Map<string, unknown>();
@@ -31,6 +33,11 @@ const electronMock = vi.hoisted(() => {
   const off = vi.fn<IpcOff>((channel, listener) => {
     listeners.get(channel)?.delete(listener);
   });
+  const sendSync = vi.fn<IpcSendSync>(() => ({
+    product: "zero",
+    brandName: "Zero",
+    displayName: "Zero Computer Use",
+  }));
 
   return {
     contextBridge: {
@@ -46,6 +53,7 @@ const electronMock = vi.hoisted(() => {
       invoke,
       off,
       on,
+      sendSync,
     },
     listeners,
   };
@@ -66,6 +74,7 @@ beforeEach(() => {
   electronMock.ipcRenderer.invoke.mockClear();
   electronMock.ipcRenderer.off.mockClear();
   electronMock.ipcRenderer.on.mockClear();
+  electronMock.ipcRenderer.sendSync.mockClear();
 });
 
 describe("Desktop preload bridge", () => {
@@ -94,6 +103,9 @@ describe("Desktop preload bridge", () => {
       brandName: "Zero",
       displayName: "Zero Computer Use",
     });
+    expect(electronMock.ipcRenderer.sendSync).toHaveBeenCalledExactlyOnceWith(
+      DESKTOP_IDENTITY_CHANNEL,
+    );
   });
 
   it("routes desktop auth API calls through IPC channels", async () => {

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -5,10 +5,10 @@ import type {
   DesktopDeveloperToolsApi,
   DesktopIdentityInfo,
 } from "./desktop-bridge";
-import { resolveDesktopConfig } from "./config";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
+import { DESKTOP_IDENTITY_CHANNEL } from "./desktop-identity-ipc-channels";
 import type { DesktopComputerUseState } from "./computer-use-types";
 
 const desktopAuthApi: DesktopAuthApi = {
@@ -159,12 +159,9 @@ const desktopDeveloperToolsApi: DesktopDeveloperToolsApi = {
   },
 };
 
-const identity = resolveDesktopConfig().identity;
-const desktopIdentity: DesktopIdentityInfo = {
-  product: identity.product,
-  brandName: identity.brandName,
-  displayName: identity.displayName,
-};
+const desktopIdentity = ipcRenderer.sendSync(
+  DESKTOP_IDENTITY_CHANNEL,
+) as DesktopIdentityInfo;
 
 contextBridge.exposeInMainWorld("vm0DesktopAuth", desktopAuthApi);
 contextBridge.exposeInMainWorld("vm0DesktopComputerUse", desktopComputerUseApi);


### PR DESCRIPTION
## Summary

- keep the sandboxed preload bundle free of filesystem-backed runtime config imports
- pass desktop product identity from the main process over a synchronous IPC channel
- strengthen packaged smoke acceptance to load the renderer and verify all exposed bridges and identity

## Context

The signed Okou 0.33.0 app could not load its preload script because the preload imported the desktop runtime config and transitively required `node:fs`. The renderer therefore showed `Desktop bridge unavailable` even though the app launched.

This PR deliberately keeps the existing VM0 web auth origin for compatibility. The real Okou Clerk satellite path remains tracked separately and must pass deployed start/callback acceptance before the desktop auth origin changes.

## Validation

- `pnpm format`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test` (36 files, 321 tests)
- `pnpm -F @vm0/desktop build:electron`
- packaged Okou smoke test, including renderer bridge and identity acceptance
- manual packaged UI check: `Okou Computer Use` renders without the bridge-unavailable fallback

Closes #26470