### PR TITLE
refactor(ui): rely on portal ownership for floating layers

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -468,7 +468,6 @@
       "backToArtifacts": "Zurück zu den Artefakten",
       "close": "Schließen",
       "closeArtifact": "Artefakt schließen",
-      "closeDownloadMenu": "Download-Menü schließen",
       "closeNamed": "Schließen {{title}}",
       "closePreviewMenu": "Vorschaumenü schließen",
       "download": "Herunterladen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -468,7 +468,6 @@
       "backToArtifacts": "Back to artifacts",
       "close": "Close",
       "closeArtifact": "Close artifact",
-      "closeDownloadMenu": "Close download menu",
       "closeNamed": "Close {{title}}",
       "closePreviewMenu": "Close preview menu",
       "download": "Download",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -482,7 +482,6 @@
       "backToArtifacts": "Volver a los artefactos",
       "close": "Cerrar",
       "closeArtifact": "Cerrar artefacto",
-      "closeDownloadMenu": "Cerrar menú de descarga",
       "closeNamed": "Cerrar {{title}}",
       "closePreviewMenu": "Cerrar menú de vista previa",
       "download": "Descargar",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -482,7 +482,6 @@
       "backToArtifacts": "Retour aux artéfacts",
       "close": "Fermer",
       "closeArtifact": "Fermer l'artéfact",
-      "closeDownloadMenu": "Fermer le menu de téléchargement",
       "closeNamed": "Fermer {{title}}",
       "closePreviewMenu": "Fermer le menu d'aperçu",
       "download": "Télécharger",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -468,7 +468,6 @@
       "backToArtifacts": "आर्टिफ़ैक्ट्स पर वापस जाएँ",
       "close": "बंद करना",
       "closeArtifact": "आर्टिफ़ैक्ट बंद करें",
-      "closeDownloadMenu": "डाउनलोड मेनू बंद करें",
       "closeNamed": "{{title}} बंद करें",
       "closePreviewMenu": "पूर्वावलोकन मेनू बंद करें",
       "download": "डाउनलोड करना",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -468,7 +468,6 @@
       "backToArtifacts": "Kembali ke artefak",
       "close": "Tutup",
       "closeArtifact": "Tutup artefak",
-      "closeDownloadMenu": "Tutup menu unduhan",
       "closeNamed": "Tutup {{title}}",
       "closePreviewMenu": "Tutup menu pratinjau",
       "download": "Unduh",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -482,7 +482,6 @@
       "backToArtifacts": "Torna agli artefatti",
       "close": "Chiudi",
       "closeArtifact": "Chiudi artefatto",
-      "closeDownloadMenu": "Chiudi il menu di download",
       "closeNamed": "Chiudi {{title}}",
       "closePreviewMenu": "Chiudi il menu di anteprima",
       "download": "Scarica",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -468,7 +468,6 @@
       "backToArtifacts": "アーティファクトに戻る",
       "close": "閉じる",
       "closeArtifact": "アーティファクトを閉じる",
-      "closeDownloadMenu": "ダウンロードメニューを閉じる",
       "closeNamed": "{{title}} を閉じる",
       "closePreviewMenu": "プレビューメニューを閉じる",
       "download": "ダウンロード",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -468,7 +468,6 @@
       "backToArtifacts": "아티팩트로 돌아가기",
       "close": "닫기",
       "closeArtifact": "아티팩트 닫기",
-      "closeDownloadMenu": "다운로드 메뉴 닫기",
       "closeNamed": "{{title}} 닫기",
       "closePreviewMenu": "미리보기 메뉴 닫기",
       "download": "다운로드",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -482,7 +482,6 @@
       "backToArtifacts": "Voltar aos artefatos",
       "close": "Fechar",
       "closeArtifact": "Fechar artefato",
-      "closeDownloadMenu": "Fechar menu de download",
       "closeNamed": "Fechar {{title}}",
       "closePreviewMenu": "Fechar menu de visualização",
       "download": "Baixar",

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -389,11 +389,11 @@ export const openAudioLightbox$ = command(
 );
 
 // ---------------------------------------------------------------------------
-// Escape-key handler for global attachment preview — closes on Escape
+// Global attachment preview mount owner — releases resources on route unmount
 // ---------------------------------------------------------------------------
 
-const closeLightboxOnEscape$ = command(
-  ({ get, set }, el: HTMLDivElement, signal: AbortSignal) => {
+const ownLightboxDialogMount$ = command(
+  ({ get, set }, _element: HTMLDivElement, signal: AbortSignal) => {
     const mountToken = get(internalLightboxDialogMountToken$) + 1;
     set(internalLightboxDialogMountToken$, mountToken);
     signal.addEventListener(
@@ -408,20 +408,7 @@ const closeLightboxOnEscape$ = command(
       },
       { once: true },
     );
-    document.addEventListener(
-      "keydown",
-      (e: KeyboardEvent) => {
-        if (e.key === "Escape") {
-          e.preventDefault();
-          e.stopPropagation();
-          e.stopImmediatePropagation();
-          set(closeLightboxWithDialogExit$, signal);
-        }
-      },
-      { capture: true, signal },
-    );
-    el.focus({ preventScroll: true });
   },
 );
 
-export const lightboxDialogRef$ = onRef(closeLightboxOnEscape$);
+export const lightboxDialogMountRef$ = onRef(ownLightboxDialogMount$);

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -68,7 +68,7 @@ describe("platform entrypoint safe area behavior", () => {
       /html,\s*body,\s*#root\s*{[\s\S]*overflow:\s*hidden;[\s\S]*overscroll-behavior:\s*none;/,
     );
     expect(globalCss).toMatch(
-      /#root\s*{[\s\S]*position:\s*fixed;[\s\S]*top:\s*0;[\s\S]*right:\s*0;[\s\S]*left:\s*0;/,
+      /#root\s*{[\s\S]*isolation:\s*isolate;[\s\S]*position:\s*fixed;[\s\S]*top:\s*0;[\s\S]*right:\s*0;[\s\S]*left:\s*0;/,
     );
     expect(globalCss).toMatch(
       /#root\s*{[\s\S]*box-sizing:\s*border-box;[\s\S]*background-color:\s*hsl\(var\(--background\)\);[\s\S]*padding:\s*var\(--sat\)\s+var\(--sar\)\s+var\(--sab-raw\)\s+var\(--sal\);/,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -88,6 +88,10 @@ body {
 
 #root {
   box-sizing: border-box;
+  /* Base UI appends top-level portals after #root and nests descendant portals
+     under their owning portal. Isolating the app lets that DOM order define
+     floating-layer priority without global z-index values on every primitive. */
+  isolation: isolate;
   position: fixed;
   top: 0;
   right: 0;

--- a/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/thread-sidebar.tsx
@@ -218,9 +218,12 @@ function ThreadArtifactsPanel({ thread }: { thread: ChatPanelSignals }) {
       </div>
     </aside>
   );
-  return fullscreen && typeof document !== "undefined"
-    ? createPortal(panel, document.body)
-    : panel;
+  // This is an app-local fullscreen surface, not a modal. Keep it inside the
+  // isolated app stack so body-level Base UI portals remain above it by
+  // structure rather than by competing z-index values.
+  const appRoot =
+    typeof document === "undefined" ? null : document.getElementById("root");
+  return fullscreen && appRoot ? createPortal(panel, appRoot) : panel;
 }
 
 function ThreadArtifactUnavailable({

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,8 +1,7 @@
-import {
-  forwardRef,
-  type ComponentPropsWithoutRef,
-  type MouseEvent,
-  type ReactElement,
+import type {
+  ComponentPropsWithRef,
+  MouseEvent,
+  ReactElement,
 } from "react";
 import { Download, Loader2, Share2 } from "lucide-react";
 import {
@@ -554,18 +553,20 @@ type ArtifactDownloadMenuProps = {
   url: string;
 };
 
-const ArtifactDownloadTrigger = forwardRef<
-  HTMLButtonElement,
-  ComponentPropsWithoutRef<"button"> & {
-    ariaLabel: string;
-    downloadPending: boolean;
-    iconSize: number;
-    open: boolean;
-  }
->(function ArtifactDownloadTrigger(
-  { ariaLabel, className, downloadPending, iconSize, open, ...props },
+function ArtifactDownloadTrigger({
+  ariaLabel,
+  className,
+  downloadPending,
+  iconSize,
+  open,
   ref,
-) {
+  ...props
+}: ComponentPropsWithRef<"button"> & {
+  ariaLabel: string;
+  downloadPending: boolean;
+  iconSize: number;
+  open: boolean;
+}) {
   return (
     <button
       {...props}
@@ -590,7 +591,7 @@ const ArtifactDownloadTrigger = forwardRef<
       )}
     </button>
   );
-});
+}
 
 function setArtifactDownloadMenuOpen(params: {
   readonly closeMenu: () => void;

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,8 +1,4 @@
-import type {
-  ComponentPropsWithRef,
-  MouseEvent,
-  ReactElement,
-} from "react";
+import type { ComponentPropsWithRef, MouseEvent, ReactElement } from "react";
 import { Download, Loader2, Share2 } from "lucide-react";
 import {
   cn,

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -2,10 +2,10 @@ import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from "react";
 import { Download, Loader2, Share2 } from "lucide-react";
 import {
   cn,
-  Popover,
-  PopoverContent,
-  PopoverOverlay,
-  PopoverTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -58,8 +58,8 @@ import {
 } from "./zero-attachment-url.ts";
 
 const GOOGLE_DRIVE_CONNECTOR_SLUG = "google-drive";
-const ARTIFACT_FLOATING_LAYER_CLASS =
-  "!z-[10000] transition-[opacity,transform] duration-[180ms] ease data-open:!animate-none data-closed:!animate-none data-open:translate-y-0 data-open:opacity-100 data-closed:translate-y-2 data-closed:opacity-0";
+const ARTIFACT_FLOATING_TRANSITION_CLASS =
+  "transition-[opacity,transform] duration-[180ms] ease data-open:!animate-none data-closed:!animate-none data-open:translate-y-0 data-open:opacity-100 data-closed:translate-y-2 data-closed:opacity-0";
 
 function siteSlugFromUrl(value: string): string | null {
   if (!URL.canParse(value)) {
@@ -288,7 +288,10 @@ export function ArtifactActionTooltip({
     <TooltipProvider delayDuration={200}>
       <Tooltip>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent side={side} className={ARTIFACT_FLOATING_LAYER_CLASS}>
+        <TooltipContent
+          side={side}
+          className={ARTIFACT_FLOATING_TRANSITION_CLASS}
+        >
           <p className="text-xs">{label}</p>
         </TooltipContent>
       </Tooltip>
@@ -331,37 +334,6 @@ export function ArtifactShareButton({
         <Share2 size={iconSize} />
       </a>
     </ArtifactActionTooltip>
-  );
-}
-
-type ArtifactDownloadMenuItemProps = Omit<
-  ComponentPropsWithoutRef<"button">,
-  "type"
-> & {
-  children: ReactNode;
-};
-
-function ArtifactDownloadMenuItem({
-  children,
-  className,
-  disabled = false,
-  ...props
-}: ArtifactDownloadMenuItemProps) {
-  return (
-    <button
-      {...props}
-      type="button"
-      role="menuitem"
-      aria-disabled={disabled ? "true" : undefined}
-      disabled={disabled}
-      className={cn(
-        "relative flex w-full select-none items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm outline-none transition-colors hover:bg-state-hover focus:bg-state-hover disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-        disabled ? "cursor-default" : "cursor-pointer",
-        className,
-      )}
-    >
-      {children}
-    </button>
   );
 }
 
@@ -430,21 +402,16 @@ function GoogleDriveDisabledMenuItem({
             return $.artifacts.googleDrive.upload;
           });
   return (
-    <ArtifactDownloadMenuItem
-      className={muted ? "text-muted-foreground" : ""}
-      disabled
-    >
+    <DropdownMenuItem className={muted ? "text-muted-foreground" : ""} disabled>
       <BrandGoogleDrive size={14} />
       {text}
-    </ArtifactDownloadMenuItem>
+    </DropdownMenuItem>
   );
 }
 
 function GoogleDriveMenuItem({
-  closeMenu,
   syncTarget,
 }: {
-  closeMenu: () => void;
   syncTarget?: ArtifactDownloadSyncTarget;
 }) {
   const { t } = useTranslation();
@@ -479,7 +446,6 @@ function GoogleDriveMenuItem({
   }
 
   const syncOrConnect = () => {
-    closeMenu();
     const run = async () => {
       const success = await syncArtifactFileToGoogleDrive(
         {
@@ -530,12 +496,12 @@ function GoogleDriveMenuItem({
 
   if (googleDriveReady) {
     return (
-      <ArtifactDownloadMenuItem onClick={syncOrConnect}>
+      <DropdownMenuItem onClick={syncOrConnect}>
         <BrandGoogleDrive size={14} />
         {t(($) => {
           return $.artifacts.googleDrive.upload;
         })}
-      </ArtifactDownloadMenuItem>
+      </DropdownMenuItem>
     );
   }
 
@@ -543,7 +509,7 @@ function GoogleDriveMenuItem({
     <TooltipProvider delayDuration={200}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <ArtifactDownloadMenuItem
+          <DropdownMenuItem
             disabled={
               !googleDriveConnected &&
               (!googleDriveConnector || !googleDriveAuthMethod)
@@ -554,9 +520,12 @@ function GoogleDriveMenuItem({
             {t(($) => {
               return $.artifacts.googleDrive.connect;
             })}
-          </ArtifactDownloadMenuItem>
+          </DropdownMenuItem>
         </TooltipTrigger>
-        <TooltipContent side="left" className={ARTIFACT_FLOATING_LAYER_CLASS}>
+        <TooltipContent
+          side="left"
+          className={ARTIFACT_FLOATING_TRANSITION_CLASS}
+        >
           {t(($) => {
             return $.artifacts.googleDrive.connectTooltip;
           })}
@@ -630,14 +599,12 @@ function setArtifactDownloadMenuOpen(params: {
 }
 
 function startArtifactDownloadWithCleanup(params: {
-  readonly closeMenu: () => void;
   readonly operation: string;
   readonly download: Promise<void>;
   readonly downloadKey: string;
   readonly finish: (key: string) => void;
   readonly start: (key: string) => void;
 }): void {
-  params.closeMenu();
   params.start(params.downloadKey);
   detach(
     withCleanup(params.download, () => {
@@ -678,8 +645,7 @@ export function ArtifactDownloadMenu({
   const downloadPending = pendingKey === artifactDownloadKey;
   const downloadName = artifactDownloadFilename(artifactKind, filename, url);
   return (
-    <Popover
-      modal={false}
+    <DropdownMenu
       open={open}
       onOpenChange={(nextOpen) => {
         setArtifactDownloadMenuOpen({
@@ -691,7 +657,7 @@ export function ArtifactDownloadMenu({
       }}
     >
       <ArtifactActionTooltip label={label}>
-        <PopoverTrigger asChild>
+        <DropdownMenuTrigger asChild>
           <ArtifactDownloadTrigger
             ariaLabel={label}
             className={className}
@@ -699,38 +665,19 @@ export function ArtifactDownloadMenu({
             iconSize={iconSize}
             open={open}
           />
-        </PopoverTrigger>
+        </DropdownMenuTrigger>
       </ArtifactActionTooltip>
-      {open && (
-        <PopoverOverlay
-          data-testid="artifact-download-menu-dismiss-layer"
-          aria-label={t(($) => {
-            return $.artifacts.actions.closeDownloadMenu;
-          })}
-          className="z-[9999]"
-        />
-      )}
-      <PopoverContent
-        role="menu"
+      <DropdownMenuContent
         align={align}
-        positionerClassName="!z-[10000]"
         sideOffset={6}
-        style={{ pointerEvents: "auto" }}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-        }}
         onCloseAutoFocus={(event) => {
           event.preventDefault();
         }}
-        className={cn(
-          "pointer-events-auto w-56 p-1",
-          ARTIFACT_FLOATING_LAYER_CLASS,
-        )}
+        className={cn("w-56", ARTIFACT_FLOATING_TRANSITION_CLASS)}
       >
-        <ArtifactDownloadMenuItem
+        <DropdownMenuItem
           onClick={() => {
             startArtifactDownloadWithCleanup({
-              closeMenu,
               operation: "artifact download",
               download: downloadAttachment(
                 { filename: downloadName, url },
@@ -746,9 +693,9 @@ export function ArtifactDownloadMenu({
           {t(($) => {
             return $.artifacts.actions.download;
           })}
-        </ArtifactDownloadMenuItem>
-        <GoogleDriveMenuItem closeMenu={closeMenu} syncTarget={syncTarget} />
-      </PopoverContent>
-    </Popover>
+        </DropdownMenuItem>
+        <GoogleDriveMenuItem syncTarget={syncTarget} />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,4 +1,9 @@
-import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from "react";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type MouseEvent,
+  type ReactElement,
+} from "react";
 import { Download, Loader2, Share2 } from "lucide-react";
 import {
   cn,
@@ -280,14 +285,14 @@ export function ArtifactActionTooltip({
   label,
   side = "bottom",
 }: {
-  children: ReactNode;
+  children: ReactElement;
   label: string;
   side?: "top" | "right" | "bottom" | "left";
 }) {
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
-        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipTrigger render={children} />
         <TooltipContent
           side={side}
           className={ARTIFACT_FLOATING_TRANSITION_CLASS}
@@ -508,20 +513,22 @@ function GoogleDriveMenuItem({
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuItem
-            disabled={
-              !googleDriveConnected &&
-              (!googleDriveConnector || !googleDriveAuthMethod)
-            }
-            onClick={syncOrConnect}
-          >
-            <BrandGoogleDrive size={14} />
-            {t(($) => {
-              return $.artifacts.googleDrive.connect;
-            })}
-          </DropdownMenuItem>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <DropdownMenuItem
+              disabled={
+                !googleDriveConnected &&
+                (!googleDriveConnector || !googleDriveAuthMethod)
+              }
+              onClick={syncOrConnect}
+            >
+              <BrandGoogleDrive size={14} />
+              {t(($) => {
+                return $.artifacts.googleDrive.connect;
+              })}
+            </DropdownMenuItem>
+          }
+        />
         <TooltipContent
           side="left"
           className={ARTIFACT_FLOATING_TRANSITION_CLASS}
@@ -547,22 +554,22 @@ type ArtifactDownloadMenuProps = {
   url: string;
 };
 
-function ArtifactDownloadTrigger({
-  ariaLabel,
-  className,
-  downloadPending,
-  iconSize,
-  open,
-  ...props
-}: ComponentPropsWithoutRef<"button"> & {
-  ariaLabel: string;
-  downloadPending: boolean;
-  iconSize: number;
-  open: boolean;
-}) {
+const ArtifactDownloadTrigger = forwardRef<
+  HTMLButtonElement,
+  ComponentPropsWithoutRef<"button"> & {
+    ariaLabel: string;
+    downloadPending: boolean;
+    iconSize: number;
+    open: boolean;
+  }
+>(function ArtifactDownloadTrigger(
+  { ariaLabel, className, downloadPending, iconSize, open, ...props },
+  ref,
+) {
   return (
     <button
       {...props}
+      ref={ref}
       type="button"
       aria-label={ariaLabel}
       aria-busy={downloadPending ? "true" : undefined}
@@ -583,7 +590,7 @@ function ArtifactDownloadTrigger({
       )}
     </button>
   );
-}
+});
 
 function setArtifactDownloadMenuOpen(params: {
   readonly closeMenu: () => void;
@@ -657,15 +664,17 @@ export function ArtifactDownloadMenu({
       }}
     >
       <ArtifactActionTooltip label={label}>
-        <DropdownMenuTrigger asChild>
-          <ArtifactDownloadTrigger
-            ariaLabel={label}
-            className={className}
-            downloadPending={downloadPending}
-            iconSize={iconSize}
-            open={open}
-          />
-        </DropdownMenuTrigger>
+        <DropdownMenuTrigger
+          render={
+            <ArtifactDownloadTrigger
+              ariaLabel={label}
+              className={className}
+              downloadPending={downloadPending}
+              iconSize={iconSize}
+              open={open}
+            />
+          }
+        />
       </ArtifactActionTooltip>
       <DropdownMenuContent
         align={align}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent, ReactNode } from "react";
-import { Button } from "@vm0/ui";
+import { Button, Dialog, DialogContent, cn } from "@vm0/ui";
 import {
   useGet,
   useLastLoadable,
@@ -7,7 +7,6 @@ import {
   useLoadable,
   useSet,
 } from "ccstate-react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
   ChevronLeft,
@@ -46,7 +45,7 @@ import {
   closeLightboxWithDialogExit$,
   lightboxDialogFullscreen$,
   lightboxDialogVisible$,
-  lightboxDialogRef$,
+  lightboxDialogMountRef$,
   navigateImageLightbox$,
   openAudioLightbox$,
   openDocumentLightbox$,
@@ -209,42 +208,6 @@ export function CsvPreviewTable({ rows }: { rows: string[][] }) {
         </tbody>
       </table>
     </div>
-  );
-}
-
-function LightboxBodyScrollLock() {
-  let restore: (() => void) | null = null;
-
-  return (
-    <span
-      ref={(node) => {
-        if (node === null) {
-          restore?.();
-          restore = null;
-          return;
-        }
-
-        const bodyOverflow = document.body.style.overflow;
-        const bodyOverscrollBehavior = document.body.style.overscrollBehavior;
-        const rootOverflow = document.documentElement.style.overflow;
-        const rootOverscrollBehavior =
-          document.documentElement.style.overscrollBehavior;
-
-        document.body.style.overflow = "hidden";
-        document.body.style.overscrollBehavior = "contain";
-        document.documentElement.style.overflow = "hidden";
-        document.documentElement.style.overscrollBehavior = "contain";
-
-        restore = () => {
-          document.body.style.overflow = bodyOverflow;
-          document.body.style.overscrollBehavior = bodyOverscrollBehavior;
-          document.documentElement.style.overflow = rootOverflow;
-          document.documentElement.style.overscrollBehavior =
-            rootOverscrollBehavior;
-        };
-      }}
-      hidden
-    />
   );
 }
 
@@ -626,9 +589,9 @@ function ArtifactDialogImageNavigationKeydown({
           }
         };
 
-        document.addEventListener("keydown", onKeyDown);
+        document.addEventListener("keydown", onKeyDown, true);
         cleanup = () => {
-          document.removeEventListener("keydown", onKeyDown);
+          document.removeEventListener("keydown", onKeyDown, true);
         };
       }}
       hidden
@@ -1332,7 +1295,7 @@ function ArtifactPreviewDialogContent({
 }) {
   const { t } = useTranslation();
   const rootSignal = useGet(rootSignal$);
-  const dialogRef = useSet(lightboxDialogRef$);
+  const dialogMountRef = useSet(lightboxDialogMountRef$);
   const closeLightboxWithDialogExit = useSet(closeLightboxWithDialogExit$);
   const filename = artifact?.filename ?? artifactDialogFilename(preview);
   const subtitle = artifactDialogKindLabel(preview, artifact);
@@ -1349,62 +1312,66 @@ function ArtifactPreviewDialogContent({
     }
   };
 
-  return createPortal(
-    <div
-      ref={dialogRef}
-      tabIndex={-1}
-      className={`zero-dialog-enter-overlay zero-pwa-fixed-cover fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease ${
-        visible
-          ? "pointer-events-auto opacity-100"
-          : "pointer-events-none opacity-0"
-      } ${fullscreen ? "p-0" : "p-6"}`}
-      onClick={handleBackdropClick}
-      role="dialog"
-      aria-modal="true"
-      aria-label={t(
-        ($) => {
-          return $.artifacts.preview.dialogLabel;
-        },
-        { filename },
-      )}
-      data-testid="attachment-lightbox"
+  return (
+    <Dialog
+      open={visible}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && visible) {
+          closeWithAnimation();
+        }
+      }}
     >
-      <LightboxBodyScrollLock />
-      <ArtifactDialogImageNavigationKeydown
-        navigation={preview.kind === "image" ? imageNavigation : undefined}
-      />
-      <div
-        className={`zero-dialog-enter-content flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)] transition-transform duration-[180ms] ease ${
-          visible ? "translate-y-0" : "translate-y-2"
-        } ${
-          fullscreen
-            ? "zero-fixed-viewport-shell w-dvw rounded-none"
-            : "h-[min(700px,86vh)] w-[min(980px,92vw)] rounded-2xl"
-        }`}
-        data-testid="attachment-lightbox-panel"
+      <DialogContent
+        ref={dialogMountRef}
+        showCloseButton={false}
+        overlayClassName="zero-pwa-fixed-cover bg-gray-900/45 dark:bg-gray-900/45"
+        className={cn(
+          "zero-pwa-fixed-cover fixed inset-0 left-0 top-0 flex max-h-none w-auto max-w-none translate-x-0 translate-y-0 items-center justify-center gap-0 overflow-hidden rounded-none border-0 bg-transparent shadow-none",
+          fullscreen ? "p-0" : "p-6",
+        )}
+        onClick={handleBackdropClick}
+        aria-label={t(
+          ($) => {
+            return $.artifacts.preview.dialogLabel;
+          },
+          { filename },
+        )}
+        data-testid="attachment-lightbox"
       >
-        <div className="flex h-14 shrink-0 items-center gap-2 border-b border-border/70 pl-4 pr-3">
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-medium">{filename}</div>
-            <div className="truncate text-xs text-muted-foreground">
-              {subtitle}
+        <ArtifactDialogImageNavigationKeydown
+          navigation={preview.kind === "image" ? imageNavigation : undefined}
+        />
+        <div
+          className={cn(
+            "flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)]",
+            fullscreen
+              ? "zero-fixed-viewport-shell w-dvw rounded-none"
+              : "h-[min(700px,86vh)] w-[min(980px,92vw)] rounded-2xl",
+          )}
+          data-testid="attachment-lightbox-panel"
+        >
+          <div className="flex h-14 shrink-0 items-center gap-2 border-b border-border/70 pl-4 pr-3">
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-medium">{filename}</div>
+              <div className="truncate text-xs text-muted-foreground">
+                {subtitle}
+              </div>
             </div>
+            <ArtifactPreviewDialogActions
+              artifact={artifact}
+              fullscreen={fullscreen}
+              preview={preview}
+            />
           </div>
-          <ArtifactPreviewDialogActions
-            artifact={artifact}
-            fullscreen={fullscreen}
-            preview={preview}
-          />
+          <div className="min-h-0 flex-1 bg-background">
+            <ArtifactDialogBody
+              imageNavigation={imageNavigation}
+              preview={preview}
+            />
+          </div>
         </div>
-        <div className="min-h-0 flex-1 bg-background">
-          <ArtifactDialogBody
-            imageNavigation={imageNavigation}
-            preview={preview}
-          />
-        </div>
-      </div>
-    </div>,
-    document.body,
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -19,7 +19,7 @@ export function ZeroUnsavedBar({
   discardLabel = "Discard",
   saveLabel = "Save",
 }: ZeroUnsavedBarProps) {
-  return createPortal(
+  const bar = (
     <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4">
       <div
         data-testid="unsaved-bar"
@@ -58,7 +58,12 @@ export function ZeroUnsavedBar({
           </Button>
         </div>
       </div>
-    </div>,
-    document.body,
+    </div>
   );
+  // Keep this app-local notice inside the isolated app stack. Modal and
+  // floating Base UI portals live outside it and therefore stay above it
+  // without coordinating z-index values with this component.
+  const appRoot =
+    typeof document === "undefined" ? null : document.getElementById("root");
+  return appRoot ? createPortal(bar, appRoot) : bar;
 }

--- a/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
@@ -36,4 +36,16 @@ describe("Dialog", () => {
 
     expect(document.querySelectorAll(".zero-dialog-overlay")).toHaveLength(2);
   });
+
+  it("can leave close controls to a custom dialog header", () => {
+    render(
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogTitle>Custom header dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
 });

--- a/turbo/packages/ui/src/components/ui/__tests__/dropdown-menu.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/dropdown-menu.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { Dialog, DialogContent, DialogTitle } from "../dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,6 +11,12 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "../dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../tooltip";
 
 function TestMenu({ keepOpen = false }: { keepOpen?: boolean }) {
   return (
@@ -102,5 +109,41 @@ describe("DropdownMenu", () => {
     expect(
       await screen.findByRole("menuitem", { name: "Archive" }),
     ).toBeVisible();
+  });
+
+  it("nests menu and tooltip portals in their owning dialog", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Artifact preview</DialogTitle>
+          <DropdownMenu open>
+            <DropdownMenuTrigger>Download options</DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <TooltipProvider>
+                <Tooltip open>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuItem>Download</DropdownMenuItem>
+                  </TooltipTrigger>
+                  <TooltipContent>Download artifact</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialogPortal = screen
+      .getByRole("dialog", { name: "Artifact preview" })
+      .closest<HTMLElement>("[data-base-ui-portal]");
+    const menuPortal = screen
+      .getByRole("menu")
+      .closest<HTMLElement>("[data-base-ui-portal]");
+    const tooltipPortal = screen
+      .getByText("Download artifact")
+      .closest<HTMLElement>("[data-base-ui-portal]");
+
+    expect(dialogPortal).toContainElement(menuPortal);
+    expect(menuPortal).toContainElement(tooltipPortal);
   });
 });

--- a/turbo/packages/ui/src/components/ui/__tests__/dropdown-menu.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/dropdown-menu.test.tsx
@@ -84,6 +84,34 @@ describe("DropdownMenu", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("opens when its trigger is composed with a tooltip", async () => {
+    render(
+      <DropdownMenu>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  render={<button type="button">Download options</button>}
+                />
+              }
+            />
+            <TooltipContent>Download artifact</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Download</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download options" }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Download" }),
+    ).toBeVisible();
+  });
+
   it("opens a submenu when its trigger is clicked", async () => {
     render(
       <DropdownMenu>

--- a/turbo/packages/ui/src/components/ui/__tests__/popover.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/popover.test.tsx
@@ -1,21 +1,33 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { Dialog, DialogContent, DialogTitle } from "../dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover";
 
 describe("Popover", () => {
-  it("applies a caller-provided positioner layer", () => {
+  it("nests its portal under the owning dialog portal", () => {
     render(
-      <Popover open>
-        <PopoverTrigger>Open menu</PopoverTrigger>
-        <PopoverContent positionerClassName="!z-[10000]">
-          Menu content
-        </PopoverContent>
-      </Popover>,
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Artifact preview</DialogTitle>
+          <Popover open>
+            <PopoverTrigger>Open menu</PopoverTrigger>
+            <PopoverContent>Menu content</PopoverContent>
+          </Popover>
+        </DialogContent>
+      </Dialog>,
     );
 
-    expect(screen.getByText("Menu content").parentElement).toHaveClass(
-      "!z-[10000]",
-    );
+    const dialogPortal = screen
+      .getByRole("dialog", { name: "Artifact preview" })
+      .closest<HTMLElement>("[data-base-ui-portal]");
+    const popoverPortal = screen
+      .getByText("Menu content")
+      .closest<HTMLElement>("[data-base-ui-portal]");
+
+    expect(dialogPortal).toBeInTheDocument();
+    expect(popoverPortal).toBeInTheDocument();
+    expect(dialogPortal).not.toBe(popoverPortal);
+    expect(dialogPortal).toContainElement(popoverPortal);
   });
 });

--- a/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/select.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { Dialog, DialogContent, DialogTrigger } from "../dialog";
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "../dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover";
 import {
   Select,
@@ -83,6 +83,7 @@ describe("SelectItem", () => {
       <Dialog>
         <DialogTrigger>Open dialog</DialogTrigger>
         <DialogContent>
+          <DialogTitle>Filters dialog</DialogTitle>
           <Popover>
             <PopoverTrigger>Filters</PopoverTrigger>
             <PopoverContent>
@@ -97,9 +98,23 @@ describe("SelectItem", () => {
     await user.click(screen.getByRole("button", { name: "Filters" }));
     await user.click(screen.getByLabelText("Style: All"));
 
-    await user.click(
-      await screen.findByRole("option", { name: "Professional" }),
+    const professionalOption = await screen.findByRole("option", {
+      name: "Professional",
+    });
+    const dialogPortal = screen
+      .getByRole("dialog", { name: "Filters dialog" })
+      .closest<HTMLElement>("[data-base-ui-portal]");
+    const popoverPortal = screen
+      .getByLabelText("Style: All")
+      .closest<HTMLElement>("[data-base-ui-portal]");
+    const selectPortal = professionalOption.closest<HTMLElement>(
+      "[data-base-ui-portal]",
     );
+
+    expect(dialogPortal).toContainElement(popoverPortal);
+    expect(popoverPortal).toContainElement(selectPortal);
+
+    await user.click(professionalOption);
     expect(screen.getByLabelText("Style: All")).toHaveTextContent(
       "Professional",
     );

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -75,7 +75,7 @@ const DialogOverlay = React.forwardRef<
       ref={ref}
       data-slot="dialog-overlay"
       className={cn(
-        "zero-dialog-overlay fixed inset-0 z-50 bg-overlay/45 dark:bg-overlay/55",
+        "zero-dialog-overlay fixed inset-0 bg-overlay/45 dark:bg-overlay/55",
         className,
       )}
       {...props}
@@ -89,6 +89,7 @@ interface DialogContentProps extends DialogPrimitive.Popup.Props {
   readonly onCloseAutoFocus?: LegacyAutoFocusHandler;
   readonly onOpenAutoFocus?: LegacyAutoFocusHandler;
   readonly overlayClassName?: string;
+  readonly showCloseButton?: boolean;
 }
 
 const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
@@ -102,6 +103,7 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
       onCloseAutoFocus,
       onOpenAutoFocus,
       overlayClassName,
+      showCloseButton = true,
       ...props
     },
     ref,
@@ -113,7 +115,7 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
           ref={ref}
           data-slot="dialog-content"
           className={cn(
-            "zero-dialog-content fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg outline-none dialog-scrollable",
+            "zero-dialog-content fixed left-[50%] top-[50%] grid max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg outline-none dialog-scrollable",
             className,
           )}
           finalFocus={withLegacyAutoFocus(
@@ -129,18 +131,20 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
           {...props}
         >
           {children}
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            render={
-              <button
-                type="button"
-                className="icon-button absolute right-4 top-4 opacity-70 hover:opacity-100"
-                aria-label={closeLabel}
-              />
-            }
-          >
-            <X size={20} className="text-foreground" />
-          </DialogPrimitive.Close>
+          {showCloseButton ? (
+            <DialogPrimitive.Close
+              data-slot="dialog-close"
+              render={
+                <button
+                  type="button"
+                  className="icon-button absolute right-4 top-4 opacity-70 hover:opacity-100"
+                  aria-label={closeLabel}
+                />
+              }
+            >
+              <X size={20} className="text-foreground" />
+            </DialogPrimitive.Close>
+          ) : null}
         </DialogPrimitive.Popup>
       </DialogPortal>
     );

--- a/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -172,7 +172,7 @@ const DropdownMenuContent = React.forwardRef<
           align={align}
           alignOffset={alignOffset}
           className={cn(
-            "isolate z-50 outline-none",
+            "outline-none",
             hideWhenDetached && "data-anchor-hidden:invisible",
           )}
           collisionAvoidance={resolvedCollisionAvoidance}
@@ -190,7 +190,7 @@ const DropdownMenuContent = React.forwardRef<
             ref={ref}
             data-slot="dropdown-menu-content"
             className={cn(
-              "z-50 max-h-[var(--available-height)] min-w-[8rem] origin-[var(--transform-origin)] overflow-x-hidden overflow-y-auto rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:shadow-[0_8px_40px_-8px_rgba(0,0,0,0.6)]",
+              "max-h-[var(--available-height)] min-w-[8rem] origin-[var(--transform-origin)] overflow-x-hidden overflow-y-auto rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:shadow-[0_8px_40px_-8px_rgba(0,0,0,0.6)]",
               className,
             )}
             finalFocus={withLegacyAutoFocus(

--- a/turbo/packages/ui/src/components/ui/popover.tsx
+++ b/turbo/packages/ui/src/components/ui/popover.tsx
@@ -141,43 +141,6 @@ const PopoverClose = React.forwardRef<HTMLButtonElement, PopoverCloseProps>(
 );
 PopoverClose.displayName = "PopoverClose";
 
-const PopoverOverlay = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentPropsWithoutRef<"button">
->(
-  (
-    {
-      "aria-label": ariaLabel = "Close popover",
-      className,
-      tabIndex = -1,
-      type = "button",
-      ...props
-    },
-    ref,
-  ) => {
-    return (
-      <PopoverPrimitive.Portal>
-        <PopoverPrimitive.Close
-          render={
-            <button
-              ref={ref}
-              type={type}
-              tabIndex={tabIndex}
-              aria-label={ariaLabel}
-              className={cn(
-                "fixed inset-0 z-40 cursor-default appearance-none border-0 bg-transparent p-0 outline-none",
-                className,
-              )}
-              {...props}
-            />
-          }
-        />
-      </PopoverPrimitive.Portal>
-    );
-  },
-);
-PopoverOverlay.displayName = "PopoverOverlay";
-
 type PopoverPositionerProps = Pick<
   PopoverPrimitive.Positioner.Props,
   | "align"
@@ -200,7 +163,6 @@ type PopoverContentProps = PopoverPrimitive.Popup.Props &
     onCloseAutoFocus?: LegacyAutoFocusHandler;
     onOpenAutoFocus?: LegacyAutoFocusHandler;
     portalContainer?: HTMLElement | null;
-    positionerClassName?: string;
     updatePositionStrategy?: "always" | "optimized";
   };
 
@@ -224,7 +186,6 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
       onOpenAutoFocus,
       portalContainer,
       positionMethod = "fixed",
-      positionerClassName,
       side = "bottom",
       sideOffset = 4,
       sticky,
@@ -258,11 +219,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
           align={align}
           alignOffset={alignOffset}
           anchor={resolvedAnchor}
-          className={cn(
-            "isolate z-50",
-            positionerClassName,
-            hideWhenDetached && "data-anchor-hidden:invisible",
-          )}
+          className={cn(hideWhenDetached && "data-anchor-hidden:invisible")}
           collisionAvoidance={resolvedCollisionAvoidance}
           collisionBoundary={collisionBoundary}
           collisionPadding={collisionPadding}
@@ -278,7 +235,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
             ref={ref}
             data-slot="popover-content"
             className={cn(
-              "z-50 w-72 origin-[var(--transform-origin)] rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-4 text-foreground outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+              "w-72 origin-[var(--transform-origin)] rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-4 text-foreground outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
               className,
             )}
             finalFocus={withLegacyAutoFocus(
@@ -317,11 +274,4 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
 );
 PopoverContent.displayName = "PopoverContent";
 
-export {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-  PopoverAnchor,
-  PopoverClose,
-  PopoverOverlay,
-};
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, PopoverClose };

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -259,7 +259,6 @@ const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
           align={align}
           alignItemWithTrigger={resolvedAlignItemWithTrigger}
           alignOffset={alignOffset}
-          className="isolate z-50"
           collisionAvoidance={collisionAvoidance}
           collisionBoundary={collisionBoundary}
           collisionPadding={collisionPadding}
@@ -272,7 +271,7 @@ const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
             ref={ref}
             data-slot="select-content"
             className={cn(
-              "relative z-50 max-h-[min(24rem,var(--available-height))] min-w-[max(8rem,var(--anchor-width))] origin-[var(--transform-origin)] overflow-x-hidden overflow-y-auto rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card text-foreground outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+              "relative max-h-[min(24rem,var(--available-height))] min-w-[max(8rem,var(--anchor-width))] origin-[var(--transform-origin)] overflow-x-hidden overflow-y-auto rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card text-foreground outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
               className,
             )}
             style={

--- a/turbo/packages/ui/src/components/ui/sheet.tsx
+++ b/turbo/packages/ui/src/components/ui/sheet.tsx
@@ -74,7 +74,7 @@ const SheetOverlay = React.forwardRef<
     <SheetPrimitive.Backdrop
       ref={ref}
       data-slot="sheet-overlay"
-      className={cn("fixed inset-0 z-50", className)}
+      className={cn("fixed inset-0", className)}
       {...props}
     />
   );
@@ -111,7 +111,7 @@ const SheetContent = React.forwardRef<HTMLDivElement, SheetContentProps>(
           data-slot="sheet-content"
           data-side={side}
           className={cn(
-            "sheet-content fixed z-50 flex flex-col gap-4 overflow-x-hidden bg-card p-6 outline-none",
+            "sheet-content fixed flex flex-col gap-4 overflow-x-hidden bg-card p-6 outline-none",
             side === "right" &&
               "inset-y-0 right-0 h-full w-3/4 shadow-[-8px_0_24px_-12px_rgba(0,0,0,0.1)] sm:max-w-lg dark:shadow-[-16px_0_48px_-8px_rgba(0,0,0,0.5)]",
             side === "left" &&

--- a/turbo/packages/ui/src/components/ui/tooltip.tsx
+++ b/turbo/packages/ui/src/components/ui/tooltip.tsx
@@ -103,7 +103,6 @@ const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentProps>(
         <TooltipPrimitive.Positioner
           align={align}
           alignOffset={alignOffset}
-          className="isolate z-50"
           collisionAvoidance={collisionAvoidance}
           collisionBoundary={collisionBoundary}
           collisionPadding={collisionPadding}
@@ -115,7 +114,7 @@ const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentProps>(
             ref={ref}
             data-slot="tooltip-content"
             className={cn(
-              "z-50 max-w-xs origin-[var(--transform-origin)] overflow-hidden rounded-md px-2 py-1 text-xs data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+              "max-w-xs origin-[var(--transform-origin)] overflow-hidden rounded-md px-2 py-1 text-xs data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
               className,
             )}
             style={

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -60,7 +60,6 @@ export {
   PopoverContent,
   PopoverAnchor,
   PopoverClose,
-  PopoverOverlay,
 } from "./components/ui/popover";
 export {
   Select,

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -557,21 +557,11 @@
     animation: zero-dialog-content-out 180ms ease;
   }
 
-  .zero-dialog-enter-overlay {
-    animation: zero-dialog-overlay-in 180ms ease;
-  }
-
-  .zero-dialog-enter-content {
-    animation: zero-dialog-content-in 180ms ease;
-  }
-
   @media (prefers-reduced-motion: reduce) {
     .zero-dialog-overlay[data-open],
     .zero-dialog-overlay[data-ending-style],
     .zero-dialog-content[data-open],
-    .zero-dialog-content[data-ending-style],
-    .zero-dialog-enter-overlay,
-    .zero-dialog-enter-content {
+    .zero-dialog-content[data-ending-style] {
       animation: none;
     }
 


### PR DESCRIPTION
## Summary

- isolate the app root and remove shared z-index values from Base UI dialog, sheet, popover, menu, select, and tooltip wrappers so nested portal order owns floating-layer priority
- replace the attachment lightbox and artifact download pseudo-menu with Base UI Dialog and DropdownMenu behavior, removing the manual overlay, Escape listener, and scroll lock
- compose the shared download button through nested Base UI render props so tooltip and menu trigger behavior reach the same ref-forwarding DOM button
- keep non-modal fullscreen and unsaved surfaces inside the app stacking context and add nested portal regression coverage

## Testing

- pnpm --filter @vm0/ui lint
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/ui check-types
- pnpm --filter @vm0/app check-types
- pnpm --filter @vm0/ui exec vitest run src/components/ui/__tests__/dialog.test.tsx src/components/ui/__tests__/dropdown-menu.test.tsx src/components/ui/__tests__/popover.test.tsx src/components/ui/__tests__/select.test.tsx
- pnpm --filter @vm0/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/thread-sidebar.test.tsx