### PR TITLE
fix(pi): accept connector skill names independent of slugs

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/runtime.test.ts
@@ -247,4 +247,82 @@ describe("Pi run Skill runtime", () => {
       await rm(hostSkillsRoot, { recursive: true, force: true });
     }
   });
+
+  it("accepts connector slug and Skill name separation without hiding other diagnostics", async () => {
+    const hostSkillsRoot = await mkdtemp(join(tmpdir(), "vm0-runtime-test-"));
+    const githubDirectory = join(PI_SKILLS_ROOT, "github");
+    const invalidDirectory = join(PI_SKILLS_ROOT, "data247");
+    const env = new GuestSkillsExecutionEnv(hostSkillsRoot);
+
+    try {
+      await writeSkill(
+        join(hostSkillsRoot, "github"),
+        "github-automation",
+        "Use for GitHub operations.",
+        "GitHub instructions.",
+      );
+      await writeSkill(
+        join(hostSkillsRoot, "data247"),
+        "Data247",
+        "Use for Data247 operations.",
+        "Data247 instructions.",
+      );
+
+      const snapshot: RunSkillSnapshot = {
+        schemaVersion: 1,
+        policyVersion: 1,
+        root: PI_SKILLS_ROOT,
+        digest: SHA256_ZERO,
+        entries: [
+          {
+            logicalDir: githubDirectory,
+            skillFile: join(githubDirectory, "SKILL.md"),
+            orgId: "__system__",
+            userId: "__org__",
+            storageName: "connector-skill@github",
+            storageId: "storage_github",
+            versionId: "version_github",
+          },
+          {
+            logicalDir: invalidDirectory,
+            skillFile: join(invalidDirectory, "SKILL.md"),
+            orgId: "__system__",
+            userId: "__org__",
+            storageName: "connector-skill@data247",
+            storageId: "storage_data247",
+            versionId: "version_data247",
+          },
+        ],
+      };
+      const resources = await loadPiRunSkills(env, snapshot);
+
+      expect(
+        resources.skills.map(({ name }) => {
+          return name;
+        }),
+      ).toEqual(["github-automation", "Data247"]);
+      expect(resources.diagnostics).toEqual([
+        expect.objectContaining({
+          code: "invalid_metadata",
+          message:
+            "name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)",
+          path: join(invalidDirectory, "SKILL.md"),
+          source: expect.objectContaining({
+            storageName: "connector-skill@data247",
+          }),
+        }),
+      ]);
+      expect(
+        formatPiUserPrompt(
+          "/skill:github-automation inspect the repository",
+          resources.skills,
+        ),
+      ).toContain(
+        `<skill name="github-automation" location="${githubDirectory}/SKILL.md">`,
+      );
+    } finally {
+      await env.cleanup();
+      await rm(hostSkillsRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/turbo/packages/pi-agent-runtime/src/runtime.ts
+++ b/turbo/packages/pi-agent-runtime/src/runtime.ts
@@ -4,12 +4,17 @@ import {
   loadSourcedSkills,
   type ExecutionEnv,
   type Skill,
+  type SkillDiagnostic,
 } from "@earendil-works/pi-agent-core";
-import type { RunSkillSnapshot } from "@vm0/api-contracts/contracts/runners";
+import type {
+  RunSkillSnapshot,
+  RunSkillSnapshotEntry,
+} from "@vm0/api-contracts/contracts/runners";
 
 import type { PiRunSkills } from "./types";
 
 const PI_AGENT_NAME_PLACEHOLDER = "{{agent_name}}";
+const CONNECTOR_SKILL_STORAGE_PREFIX = "connector-skill@";
 
 const PI_BASE_SYSTEM_PROMPT_TEMPLATE = `You are ${PI_AGENT_NAME_PLACEHOLDER}, an AI agent. You and the user share one workspace, and your job is to collaborate with them until their goal is genuinely handled.
 
@@ -65,6 +70,40 @@ function renderPiBaseSystemPrompt(agentName: string): string {
 /** Default base prompt used when no user-facing agent identity is available. */
 export const PI_BASE_SYSTEM_PROMPT = renderPiBaseSystemPrompt("Okou");
 
+function finalPathSegment(path: string): string {
+  const normalized = path.replace(/\/+$/u, "");
+  return normalized.slice(normalized.lastIndexOf("/") + 1);
+}
+
+function isConnectorSkillNameDiagnostic(
+  diagnostic: SkillDiagnostic & { readonly source: RunSkillSnapshotEntry },
+  sourcedSkills: ReadonlyArray<{
+    readonly skill: Skill;
+    readonly source: RunSkillSnapshotEntry;
+  }>,
+): boolean {
+  const directoryName = finalPathSegment(diagnostic.source.logicalDir);
+  if (
+    diagnostic.code !== "invalid_metadata" ||
+    diagnostic.source.storageName !==
+      `${CONNECTOR_SKILL_STORAGE_PREFIX}${directoryName}` ||
+    diagnostic.path !== diagnostic.source.skillFile
+  ) {
+    return false;
+  }
+  const sourcedSkill = sourcedSkills.find(({ skill, source }) => {
+    return source === diagnostic.source && skill.filePath === diagnostic.path;
+  });
+  if (!sourcedSkill) {
+    return false;
+  }
+  return (
+    sourcedSkill.skill.name !== directoryName &&
+    diagnostic.message ===
+      `name "${sourcedSkill.skill.name}" does not match parent directory "${directoryName}"`
+  );
+}
+
 /** Load only the exact Skill directories pinned in this run's snapshot. */
 export async function loadPiRunSkills(
   env: ExecutionEnv,
@@ -81,7 +120,12 @@ export async function loadPiRunSkills(
       return skill;
     }),
     sourcedSkills: loaded.skills,
-    diagnostics: loaded.diagnostics,
+    // Connector storage is mounted at its stable catalog slug, while the
+    // framework-facing frontmatter name is intentionally independent. Pi's
+    // generic filesystem convention reports that valid split as a warning.
+    diagnostics: loaded.diagnostics.filter((diagnostic) => {
+      return !isConnectorSkillNameDiagnostic(diagnostic, loaded.skills);
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary

- adapt Pi's Skill catalog boundary to the connector catalog contract, where a connector's stable slug and its framework-facing Skill name are independent
- remove only the generic parent-directory mismatch diagnostic for exact `connector-skill@<slug>` snapshot entries while preserving the loaded Skill name and every other diagnostic
- cover the production GitHub shape, explicit `/skill:github-automation` invocation, and retention of an unrelated invalid-name diagnostic

## Root cause

In Axiom dataset `vm0-web-logs-prod`, the exact window from `2026-08-11T03:16:38Z` through `2026-08-12T03:16:38Z` contains 621 warnings across 621 distinct runs. All 621 contain the same diagnostic:

```text
invalid_metadata: name "github-automation" does not match parent directory "github"
```

The production Skill version `5ef2531486484881e930ada2aa5de7ee2e8afcf9746ca83e004f984d917728fb` reproduces exactly from [`vm0-ai/vm0-connectors@cc08ceb/connectors/github/skill/SKILL.md`](https://github.com/vm0-ai/vm0-connectors/blob/cc08ceb1a18e2ee767fde2af803b873d2f5e8a5f/connectors/github/skill/SKILL.md), confirming that repository as the durable source of `connector-skill@github`.

The connector catalog deliberately treats the connector slug as runtime/storage identity and permits the framework-facing frontmatter name to differ. The current catalog has 138 such names among 726 bundled Skills. vm0 correctly mounts each connector Skill at `<skills root>/<connector slug>`, but Pi's generic filesystem loader reports the valid name/slug split as an advisory metadata warning.

Changing `github-automation` to `github` would change the Skill name exposed in prompts and explicit invocations. Changing the logical directory would require a new catalog/runtime mapping and cross-version deployment compatibility. The focused fix therefore belongs at vm0's Pi connector-catalog adapter boundary.

## Compatibility

- no connector source, archive, version, storage, mount path, snapshot, or wire format changes
- existing framework-facing Skill names and explicit invocations remain unchanged
- non-connector diagnostics and all connector diagnostics other than the exact expected name/slug split remain visible
- no deployment fallback or compatibility branch is introduced

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/pi-agent-runtime exec vitest run src/runtime.test.ts` (4 tests passed)
