### PR TITLE
fix(chat): align initial thinking generation and animation

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -56,6 +56,7 @@ interface OpenRouterResponse {
 }
 
 interface OpenRouterGenerateTextOptions {
+  readonly reasoning?: { readonly effort: "none" };
   readonly responseFormat?: { readonly type: "json_object" };
   readonly temperature?: number;
 }
@@ -228,6 +229,9 @@ export async function generateTextWithUsage(
       ...(options?.responseFormat === undefined
         ? {}
         : { response_format: options.responseFormat }),
+      ...(options?.reasoning === undefined
+        ? {}
+        : { reasoning: options.reasoning }),
       temperature: options?.temperature ?? 0.3,
     }),
     signal,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -351,7 +351,10 @@ function userMessageWithTemplate(
 }
 
 const openRouterBodySchema = z.object({
+  model: z.string(),
   messages: z.array(z.object({ role: z.string(), content: z.string() })),
+  max_tokens: z.number().optional(),
+  reasoning: z.object({ effort: z.literal("none") }).optional(),
 });
 
 async function entitledChatActor(
@@ -6460,9 +6463,10 @@ describe("CHAT-02: initial thinking indicator", () => {
 
     let thinkingAuthorization: string | null = null;
     let thinkingPromptPayload = "";
+    let thinkingRequestBody: z.infer<typeof openRouterBodySchema> | undefined;
     const titleResponse = "Launch Checklist";
     const thinkingResponse =
-      "Reviewing the launch request and recent context.\n\nOrganizing the checklist into practical sections before the main response starts.";
+      "Reviewing the launch request and recent context.\nIdentifying the checklist's major sections.\nChecking where owners and timing matter.\nPreparing a clear order for the response.";
     server.use(
       http.post(
         "https://openrouter.ai/api/v1/chat/completions",
@@ -6475,6 +6479,7 @@ describe("CHAT-02: initial thinking indicator", () => {
           }
           if (systemContent.includes("Write user-visible progress copy")) {
             thinkingAuthorization = request.headers.get("authorization");
+            thinkingRequestBody = payload;
             thinkingPromptPayload = payload.messages
               .map((message) => {
                 return message.content;
@@ -6525,13 +6530,82 @@ describe("CHAT-02: initial thinking indicator", () => {
       thinking: thinkingResponse,
     });
     expect(thinkingAuthorization).toBe("Bearer thinking-key");
-    expect(thinkingPromptPayload).toContain("few short paragraphs");
+    expect(thinkingRequestBody).toMatchObject({
+      model: "google/gemini-3.1-flash-lite-preview",
+      max_tokens: 160,
+      reasoning: { effort: "none" },
+    });
+    expect(thinkingPromptPayload).toContain("one paragraph at a time");
+    expect(thinkingPromptPayload).toContain(
+      "about 20 Chinese characters or 7 English words",
+    );
+    expect(thinkingPromptPayload).toContain("around four short paragraphs");
+    expect(thinkingPromptPayload).toContain("Do not answer the user");
+    expect(thinkingPromptPayload).toContain("Do not reveal hidden reasoning");
     expect(thinkingPromptPayload).toContain(
       "Match the current user's language",
     );
     expect(thinkingPromptPayload).toContain("Draft a launch checklist");
     await flushWaitUntilForTest();
     expect(firstAssistantEventsForRun(run.runId)).toStrictEqual([]);
+
+    await cancelChatRun(actor, run.runId);
+  });
+
+  it("discards token-limited progress copy instead of persisting a truncated marker", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+
+    let thinkingRequests = 0;
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          const payload = openRouterBodySchema.parse(await request.json());
+          const systemContent = payload.messages[0]?.content ?? "";
+          if (systemContent.includes("Write user-visible progress copy")) {
+            thinkingRequests += 1;
+            return HttpResponse.json({
+              choices: [
+                {
+                  finish_reason: "length",
+                  native_finish_reason: "MAX_TOKENS",
+                  message: {
+                    content: "Incomplete progress copy that must not persist",
+                  },
+                },
+              ],
+            });
+          }
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: { content: "Token Limit Title" },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "Draft a concise migration update",
+    });
+    await flushWaitUntilForTest();
+
+    const page = await chat.listThreadEvents(actor, run.threadId);
+    expect(thinkingRequests).toBe(1);
+    expect(
+      assistantMessages(page.events).some((message) => {
+        return (
+          message.runId === run.runId &&
+          message.runEventId === "thinking:initial"
+        );
+      }),
+    ).toBeFalsy();
 
     await cancelChatRun(actor, run.runId);
   });

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -206,11 +206,12 @@ async function generateInitialThinkingText(args: {
       {
         role: "system",
         content: [
-          "Write user-visible progress copy for a chat UI while the assistant is preparing its response.",
-          "Use the current user message and recent thread history to describe what is being prepared. It can be a few short paragraphs when useful, and should feel concrete, relevant, and specific rather than generic.",
+          "Write user-visible progress copy for a chat UI while the assistant is preparing its separate response.",
+          "The UI shows one paragraph at a time, then replaces it with the next. On a typical mobile screen, a paragraph visibly holds about 20 Chinese characters or 7 English words, excluding punctuation; overflow is ellipsized and never shown later. A few distinct paragraphs give the animation enough material to rotate.",
+          "Use the current user message and recent thread history as context for around four short paragraphs about what is being prepared. Keep each paragraph close to the visible mobile width, concrete, relevant, and specific rather than generic or repetitive.",
           "Do not answer the user. Do not reveal hidden reasoning, chain-of-thought, private analysis, or internal steps. Do not mention tools unless the user explicitly asked for a tool-like task.",
           "Match the current user's language.",
-          "Return plain text only, with no markdown, headings, bullets, or quotes.",
+          "Return plain text only. Separate paragraphs with a single newline. Do not use markdown, headings, bullets, or quotes.",
         ].join("\n"),
       },
       {
@@ -226,6 +227,7 @@ async function generateInitialThinkingText(args: {
       },
     ],
     THINKING_MAX_TOKENS,
+    { reasoning: { effort: "none" } },
   );
 
   return sanitizeThinkingText(text);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3046,11 +3046,11 @@ function createCancelRunWithQueuedRecall({
 // ---------------------------------------------------------------------------
 
 const THINKING_TYPEWRITER_INTERVAL_MS = IN_VITEST ? 10 : 100;
-const THINKING_TYPEWRITER_CHUNK_HOLD_MS = 700;
-const THINKING_TYPEWRITER_CHUNK_HOLD_TICKS = IN_VITEST
+const THINKING_TYPEWRITER_LINE_HOLD_MS = 700;
+const THINKING_TYPEWRITER_LINE_HOLD_TICKS = IN_VITEST
   ? 1
   : Math.ceil(
-      THINKING_TYPEWRITER_CHUNK_HOLD_MS / THINKING_TYPEWRITER_INTERVAL_MS,
+      THINKING_TYPEWRITER_LINE_HOLD_MS / THINKING_TYPEWRITER_INTERVAL_MS,
     );
 /** Keep in sync with the opacity transition on the thinking label. */
 const THINKING_TYPEWRITER_FADE_MS = 200;
@@ -3060,15 +3060,11 @@ const THINKING_TYPEWRITER_FADE_TICKS = IN_VITEST
 const THINKING_TYPEWRITER_WIDTH_GUARD_PX = 8;
 /** Fallback glyph advance used only when text measurement is unavailable. */
 const THINKING_TYPEWRITER_FALLBACK_GLYPH_PX = 14;
-/** Clause terminators that always end a chunk. */
-const THINKING_TYPEWRITER_BREAKS = "，、；：。！？…";
-/** Clause terminators that only end a chunk when followed by a space. */
-const THINKING_TYPEWRITER_SPACED_BREAKS = ",;:.!?";
+const THINKING_TYPEWRITER_ELLIPSIS = "…";
 
 interface ThinkingTypewriterLine {
   readonly startIndex: number;
   readonly endIndex: number;
-  readonly text: string;
 }
 
 interface ThinkingTypewriterFrame {
@@ -3080,6 +3076,7 @@ interface ThinkingTypewriterFrame {
   readonly pauseTicksRemaining: number;
   readonly fadeTicksRemaining: number;
   readonly fadingOut: boolean;
+  readonly lineOverflowed: boolean;
   readonly displayedText: string;
   readonly complete: boolean;
 }
@@ -3094,6 +3091,7 @@ function emptyThinkingTypewriterFrame(): ThinkingTypewriterFrame {
     pauseTicksRemaining: 0,
     fadeTicksRemaining: 0,
     fadingOut: false,
+    lineOverflowed: false,
     displayedText: "",
     complete: false,
   };
@@ -3171,243 +3169,104 @@ function thinkingLabelWidth(el: HTMLElement): number {
   );
 }
 
-function wrapThinkingTextForWidth(args: {
-  readonly graphemes: readonly string[];
-  readonly width: number;
-  readonly measureText: (value: string) => number | undefined;
-}): ThinkingTypewriterLine[] {
-  if (args.graphemes.length === 0) {
+function thinkingTypewriterLines(
+  graphemes: readonly string[],
+): ThinkingTypewriterLine[] {
+  if (graphemes.length === 0) {
     return [];
   }
 
-  const hardLines: ThinkingTypewriterLine[] = [];
+  const lines: ThinkingTypewriterLine[] = [];
   let startIndex = 0;
 
-  for (let index = 0; index <= args.graphemes.length; index++) {
-    const grapheme = args.graphemes[index]!;
+  for (let index = 0; index <= graphemes.length; index++) {
+    const grapheme = graphemes[index]!;
     const isHardBreak =
-      index === args.graphemes.length || grapheme === "\n" || grapheme === "\r";
+      index === graphemes.length || grapheme === "\n" || grapheme === "\r";
     if (!isHardBreak) {
       continue;
     }
 
-    const text = args.graphemes.slice(startIndex, index).join("");
+    const text = graphemes.slice(startIndex, index).join("");
     if (text.trim().length > 0) {
-      hardLines.push({
+      lines.push({
         startIndex,
         endIndex: index,
-        text,
       });
     }
     startIndex = index + 1;
   }
 
-  if (!Number.isFinite(args.width) || args.width <= 0) {
-    return hardLines;
-  }
-
-  const maxWidth = Math.max(1, args.width - THINKING_TYPEWRITER_WIDTH_GUARD_PX);
-  const lines: ThinkingTypewriterLine[] = [];
-
-  for (const hardLine of hardLines) {
-    lines.push(
-      ...packThinkingClauses({
-        graphemes: args.graphemes,
-        line: hardLine,
-        maxWidth,
-        measureText: args.measureText,
-      }),
-    );
-  }
-
-  return lines.length > 0 ? lines : hardLines;
+  return lines;
 }
 
-/**
- * Split a line at clause terminators. The terminator and any whitespace that
- * follows it stay with the clause they close, so the next clause never starts
- * with a stray space.
- */
-function thinkingClauseSegments(
-  graphemes: readonly string[],
-  line: ThinkingTypewriterLine,
-): ThinkingTypewriterLine[] {
-  const segments: ThinkingTypewriterLine[] = [];
-  let startIndex = line.startIndex;
-
-  for (let index = line.startIndex; index < line.endIndex; index++) {
-    const grapheme = graphemes[index]!;
-    const next = index + 1 < line.endIndex ? graphemes[index + 1] : undefined;
-    const breaksHere =
-      THINKING_TYPEWRITER_BREAKS.includes(grapheme) ||
-      (THINKING_TYPEWRITER_SPACED_BREAKS.includes(grapheme) &&
-        (next === undefined || next.trim().length === 0));
-    if (!breaksHere) {
-      continue;
-    }
-
-    let endIndex = index + 1;
-    while (
-      endIndex < line.endIndex &&
-      graphemes[endIndex]!.trim().length === 0
-    ) {
-      endIndex++;
-    }
-    segments.push({
-      startIndex,
-      endIndex,
-      text: graphemes.slice(startIndex, endIndex).join(""),
-    });
-    startIndex = endIndex;
-    index = endIndex - 1;
-  }
-
-  if (startIndex < line.endIndex) {
-    segments.push({
-      startIndex,
-      endIndex: line.endIndex,
-      text: graphemes.slice(startIndex, line.endIndex).join(""),
-    });
-  }
-
-  return segments.length > 0 ? segments : [line];
-}
-
-/** Split a segment that is too wide to show at once, one grapheme at a time. */
-function splitThinkingSegmentByWidth(args: {
-  readonly graphemes: readonly string[];
-  readonly segment: ThinkingTypewriterLine;
+function fitThinkingTypewriterLine(args: {
+  readonly text: string;
   readonly maxWidth: number;
   readonly measureText: (value: string) => number | undefined;
-}): ThinkingTypewriterLine[] {
-  const parts: ThinkingTypewriterLine[] = [];
-  let startIndex = args.segment.startIndex;
-  let current: string[] = [];
-
-  for (
-    let index = args.segment.startIndex;
-    index < args.segment.endIndex;
-    index++
-  ) {
-    const grapheme = args.graphemes[index]!;
-    const candidate = [...current, grapheme];
-    const measured = args.measureText(candidate.join(""));
-    if (measured === undefined) {
-      return [];
-    }
-    if (measured <= args.maxWidth || current.length === 0) {
-      current = candidate;
-      continue;
-    }
-    parts.push({
-      startIndex,
-      endIndex: index,
-      text: current.join(""),
-    });
-    startIndex = index;
-    current = [grapheme];
+}): { readonly displayedText: string; readonly lineOverflowed: boolean } {
+  const textWidth = (value: string): number => {
+    return (
+      args.measureText(value) ??
+      thinkingTextGraphemes(value).length *
+        THINKING_TYPEWRITER_FALLBACK_GLYPH_PX
+    );
+  };
+  if (textWidth(args.text) <= args.maxWidth) {
+    return { displayedText: args.text, lineOverflowed: false };
   }
 
-  if (current.length > 0) {
-    parts.push({
-      startIndex,
-      endIndex: args.segment.endIndex,
-      text: current.join(""),
-    });
+  const graphemes = thinkingTextGraphemes(args.text);
+  for (let endIndex = graphemes.length - 1; endIndex >= 0; endIndex--) {
+    const displayedText = `${graphemes.slice(0, endIndex).join("")}${THINKING_TYPEWRITER_ELLIPSIS}`;
+    if (textWidth(displayedText) <= args.maxWidth) {
+      return { displayedText, lineOverflowed: true };
+    }
   }
-  return parts;
+  return {
+    displayedText: THINKING_TYPEWRITER_ELLIPSIS,
+    lineOverflowed: true,
+  };
 }
 
-/** Last resort when the canvas measurer is unavailable: split by glyph count. */
-function splitThinkingSegmentByCount(
-  graphemes: readonly string[],
-  segment: ThinkingTypewriterLine,
-  maxGraphemes: number,
-): ThinkingTypewriterLine[] {
-  const parts: ThinkingTypewriterLine[] = [];
-  for (
-    let startIndex = segment.startIndex;
-    startIndex < segment.endIndex;
-    startIndex += maxGraphemes
-  ) {
-    const endIndex = Math.min(startIndex + maxGraphemes, segment.endIndex);
-    parts.push({
-      startIndex,
-      endIndex,
-      text: graphemes.slice(startIndex, endIndex).join(""),
-    });
-  }
-  return parts;
-}
-
-/**
- * Greedily merge neighbouring clauses while they still fit the label, so every
- * emitted line is short enough to display whole and never has to scroll.
- */
-function packThinkingClauses(args: {
+function revealThinkingTypewriterLine(args: {
+  readonly currentFrame: ThinkingTypewriterFrame;
   readonly graphemes: readonly string[];
   readonly line: ThinkingTypewriterLine;
+  readonly lineIndex: number;
   readonly maxWidth: number;
   readonly measureText: (value: string) => number | undefined;
-}): ThinkingTypewriterLine[] {
-  const segments = thinkingClauseSegments(args.graphemes, args.line);
-  const lines: ThinkingTypewriterLine[] = [];
-  let pending: ThinkingTypewriterLine | undefined;
+  readonly nextLineExists: boolean;
+  readonly step: number;
+}): ThinkingTypewriterFrame {
+  const charIndex = Math.min(
+    args.line.endIndex,
+    args.currentFrame.charIndex + args.step,
+  );
+  const revealedText = args.graphemes
+    .slice(args.line.startIndex, charIndex)
+    .join("");
+  const { displayedText, lineOverflowed } = fitThinkingTypewriterLine({
+    text: revealedText,
+    maxWidth: args.maxWidth,
+    measureText: args.measureText,
+  });
+  const lineFinished = charIndex >= args.line.endIndex || lineOverflowed;
 
-  for (const segment of segments) {
-    const merged: ThinkingTypewriterLine = pending
-      ? {
-          startIndex: pending.startIndex,
-          endIndex: segment.endIndex,
-          text: args.graphemes
-            .slice(pending.startIndex, segment.endIndex)
-            .join(""),
-        }
-      : segment;
-    const mergedWidth = args.measureText(merged.text);
-    if (mergedWidth !== undefined && mergedWidth <= args.maxWidth) {
-      pending = merged;
-      continue;
-    }
-
-    if (pending) {
-      lines.push(pending);
-      pending = undefined;
-    }
-
-    const segmentWidth = args.measureText(segment.text);
-    if (segmentWidth !== undefined && segmentWidth <= args.maxWidth) {
-      pending = segment;
-      continue;
-    }
-
-    const byWidth =
-      segmentWidth === undefined
-        ? []
-        : splitThinkingSegmentByWidth({
-            graphemes: args.graphemes,
-            segment,
-            maxWidth: args.maxWidth,
-            measureText: args.measureText,
-          });
-    lines.push(
-      ...(byWidth.length > 0
-        ? byWidth
-        : splitThinkingSegmentByCount(
-            args.graphemes,
-            segment,
-            Math.max(
-              1,
-              Math.floor(args.maxWidth / THINKING_TYPEWRITER_FALLBACK_GLYPH_PX),
-            ),
-          )),
-    );
-  }
-
-  if (pending) {
-    lines.push(pending);
-  }
-  return lines;
+  return {
+    ...args.currentFrame,
+    lineIndex: args.lineIndex,
+    charIndex,
+    pauseTicksRemaining:
+      lineFinished && args.nextLineExists
+        ? THINKING_TYPEWRITER_LINE_HOLD_TICKS
+        : 0,
+    fadeTicksRemaining: 0,
+    fadingOut: false,
+    lineOverflowed,
+    displayedText,
+    complete: lineFinished && !args.nextLineExists,
+  };
 }
 
 function nextThinkingTypewriterFrame(args: {
@@ -3422,14 +3281,14 @@ function nextThinkingTypewriterFrame(args: {
   if (graphemes.length === 0) {
     return emptyThinkingTypewriterFrame();
   }
-  const lines = wrapThinkingTextForWidth({
-    graphemes,
-    width,
-    measureText: args.measureText,
-  });
+  const lines = thinkingTypewriterLines(graphemes);
   if (lines.length === 0) {
     return emptyThinkingTypewriterFrame();
   }
+  const maxWidth =
+    width > 0
+      ? Math.max(1, width - THINKING_TYPEWRITER_WIDTH_GUARD_PX)
+      : Number.POSITIVE_INFINITY;
 
   const currentFrame =
     args.currentFrame.eventId === args.eventId &&
@@ -3446,7 +3305,7 @@ function nextThinkingTypewriterFrame(args: {
   const currentLine = lines[lineIndex]!;
   const nextLine = lines[lineIndex + 1];
 
-  // Fading out the finished chunk before the next one types in.
+  // Fading out the finished line before the next one types in.
   if (currentFrame.fadeTicksRemaining > 0) {
     const fadeTicksRemaining = currentFrame.fadeTicksRemaining - 1;
     if (fadeTicksRemaining > 0 || !nextLine) {
@@ -3455,30 +3314,27 @@ function nextThinkingTypewriterFrame(args: {
         lineIndex,
         fadeTicksRemaining,
         fadingOut: fadeTicksRemaining > 0,
-        displayedText: currentLine.text,
+        displayedText: currentFrame.displayedText,
         complete: false,
       };
     }
 
-    const nextCharIndex = Math.min(
-      nextLine.endIndex,
-      nextLine.startIndex + thinkingTypewriterStep(width),
-    );
-    return {
-      ...currentFrame,
+    return revealThinkingTypewriterLine({
+      currentFrame: {
+        ...currentFrame,
+        charIndex: nextLine.startIndex,
+      },
+      graphemes,
+      line: nextLine,
       lineIndex: lineIndex + 1,
-      charIndex: nextCharIndex,
-      pauseTicksRemaining: 0,
-      fadeTicksRemaining: 0,
-      fadingOut: false,
-      displayedText: graphemes
-        .slice(nextLine.startIndex, nextCharIndex)
-        .join(""),
-      complete: false,
-    };
+      maxWidth,
+      measureText: args.measureText,
+      nextLineExists: lines[lineIndex + 2] !== undefined,
+      step: thinkingTypewriterStep(width),
+    });
   }
 
-  // Holding on a fully typed chunk so it can be read before it is replaced.
+  // Holding on a finished line so it can be read before it is replaced.
   if (currentFrame.pauseTicksRemaining > 0) {
     const pauseTicksRemaining = currentFrame.pauseTicksRemaining - 1;
     const startFade = pauseTicksRemaining === 0 && nextLine !== undefined;
@@ -3488,39 +3344,34 @@ function nextThinkingTypewriterFrame(args: {
       pauseTicksRemaining,
       fadeTicksRemaining: startFade ? THINKING_TYPEWRITER_FADE_TICKS : 0,
       fadingOut: startFade,
-      displayedText: currentLine.text,
+      displayedText: currentFrame.displayedText,
       complete: false,
     };
   }
 
-  if (currentFrame.charIndex >= currentLine.endIndex) {
+  if (
+    currentFrame.charIndex >= currentLine.endIndex ||
+    currentFrame.lineOverflowed
+  ) {
     return {
       ...currentFrame,
       lineIndex,
-      pauseTicksRemaining: nextLine ? THINKING_TYPEWRITER_CHUNK_HOLD_TICKS : 0,
-      displayedText: currentLine.text,
+      pauseTicksRemaining: nextLine ? THINKING_TYPEWRITER_LINE_HOLD_TICKS : 0,
+      displayedText: currentFrame.displayedText,
       complete: !nextLine,
     };
   }
 
-  const nextCharIndex = Math.min(
-    currentLine.endIndex,
-    currentFrame.charIndex + thinkingTypewriterStep(width),
-  );
-
-  return {
-    ...currentFrame,
+  return revealThinkingTypewriterLine({
+    currentFrame,
+    graphemes,
+    line: currentLine,
     lineIndex,
-    charIndex: nextCharIndex,
-    pauseTicksRemaining:
-      nextCharIndex >= currentLine.endIndex && nextLine !== undefined
-        ? THINKING_TYPEWRITER_CHUNK_HOLD_TICKS
-        : 0,
-    displayedText: graphemes
-      .slice(currentLine.startIndex, nextCharIndex)
-      .join(""),
-    complete: nextCharIndex >= graphemes.length,
-  };
+    maxWidth,
+    measureText: args.measureText,
+    nextLineExists: nextLine !== undefined,
+    step: thinkingTypewriterStep(width),
+  });
 }
 
 function thinkingTypewriterFrameComplete(

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -352,6 +352,7 @@ body {
   display: block;
   width: 166.666667%;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
   background-color: hsl(var(--foreground));
   -webkit-background-clip: text;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
@@ -692,7 +692,7 @@ describe("initial thinking indicator", () => {
     threadGate.resolve();
   });
 
-  it("restarts on every follow-up line instead of sliding a short tail", async () => {
+  it("ellipsizes an overflowing thinking line without animating its remainder", async () => {
     const threadId = "e1000000-0000-4000-a000-000000000015";
     const thinking = "ABCDEFG";
     mockThinkingTypewriterLayout({
@@ -755,21 +755,21 @@ describe("initial thinking indicator", () => {
     });
 
     const label = await screen.findByLabelText(thinking);
-    const sawFollowUpLine = () => {
+    const sawEllipsis = () => {
       if (label.textContent) {
         displayedLabels.add(label.textContent);
       }
-      return Array.from(displayedLabels).some((value) => {
-        return value === "D" || value === "DE" || value === "DEF";
-      });
+      return displayedLabels.has("AB…");
     };
     await waitFor(() => {
-      expect(sawFollowUpLine()).toBeTruthy();
+      expect(sawEllipsis()).toBeTruthy();
     });
-    await waitFor(() => {
-      expect(label).toHaveTextContent(/^G$/);
-    });
-    expect(displayedLabels.has("...EFG")).toBeFalsy();
+    expect(label).toHaveTextContent(/^AB…$/);
+    expect(
+      Array.from(displayedLabels).some((value) => {
+        return /[D-G]/.test(value);
+      }),
+    ).toBeFalsy();
     expect(label).not.toHaveTextContent(thinking);
     expect(label.closest("[data-thinking-indicator]")).not.toBeNull();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-indicator.test.tsx
@@ -4,37 +4,24 @@ import { context, detachedSetupPage } from "./chat-lifecycle-test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const THREAD_ID = "b0000000-0000-4000-a000-000000000210";
-const RUN_ID = "run-thinking-indicator-chunks";
+const RUN_ID = "run-thinking-indicator-lines";
 
-/**
- * Two clauses that cannot share a line under the stubbed metrics below: 3 and
- * 4 glyphs fit on their own (390px and 520px) but merging them would need
- * 910px against a 552px budget, so the label must show exactly two chunks.
- *
- * The clause boundary deliberately disagrees with a pure width break: 4 glyphs
- * fit per line, so splitting on width alone would put "建好，在" on the first
- * line and leave "统计。" starting mid-phrase on the second. Only clause-aware
- * chunking produces the two chunks asserted below.
- */
-const CLAUSE_1 = "建好，";
-const CLAUSE_2 = "在统计。";
-const THINKING_TEXT = `${CLAUSE_1}${CLAUSE_2}`;
-const FIRST_CHUNK = CLAUSE_1;
-const LAST_CHUNK = CLAUSE_2;
+const FIRST_LINE = "整理这些文件，隐藏后缀不会出现。";
+const SECOND_LINE = "生成结果。";
+const THINKING_TEXT = `${FIRST_LINE}\n${SECOND_LINE}`;
 
 const LABEL_WIDTH_PX = 560;
-const CJK_GLYPH_PX = 130;
-const LATIN_GLYPH_PX = 65;
+const CJK_GLYPH_PX = 100;
+const LATIN_GLYPH_PX = 50;
 /** First code point of the CJK radical/ideograph range (U+2E80). */
 const CJK_RANGE_START = 11_904;
+const FIRST_OVERFLOW_FRAME = "整理这些文…";
 const NBSP = "\u00a0";
 
 /**
- * happy-dom reports `clientWidth === 0` and returns `null` from
- * `getContext("2d")`, so the label would fall back to glyph-count splitting and
- * never exercise clause packing. Stub both DOM capabilities — canvas text
- * metrics and the label's measured width — so the real production code path
- * runs against deterministic metrics.
+ * happy-dom does not provide canvas text metrics or useful layout widths.
+ * Stub those browser boundaries so the first line overflows after its sixth
+ * glyph while the explicit second line still fits in full.
  */
 function stubLabelTextMeasurement(): void {
   const originalGetContext = HTMLCanvasElement.prototype.getContext;
@@ -89,14 +76,10 @@ function serverThinkingLabelText(): string {
   const label = document.querySelector<HTMLElement>(
     "[data-thinking-indicator] p.zero-shimmer-text",
   );
-  // Only the server-driven label carries the full text as its accessible name;
-  // the rotating placeholder phrase does not.
   if (label?.getAttribute("aria-label") !== THINKING_TEXT) {
     return "";
   }
   const text = label.textContent ?? "";
-  // The label renders a non-breaking space to hold its height before the first
-  // chunk has any characters; that is an empty line, not rendered status text.
   return text === NBSP ? "" : text;
 }
 
@@ -127,21 +110,21 @@ function setupThinkingRun(): string[] {
     activeRunIds: [RUN_ID],
     chatEvents: [
       {
-        id: "msg-thinking-chunks-user",
+        id: "msg-thinking-lines-user",
         role: "user",
         content: "统计一下这些文件",
         runId: RUN_ID,
         createdAt: "2026-08-05T10:00:00Z",
       },
       {
-        id: "msg-thinking-chunks-start",
+        id: "msg-thinking-lines-start",
         role: "assistant",
         content: null,
         runId: RUN_ID,
         createdAt: "2026-08-05T10:00:01Z",
       },
       {
-        id: "msg-thinking-chunks-thinking",
+        id: "msg-thinking-lines-thinking",
         role: "assistant",
         content: null,
         thinking: THINKING_TEXT,
@@ -152,82 +135,52 @@ function setupThinkingRun(): string[] {
   });
 
   const rendered = recordRenderedLabelText();
-
   detachedSetupPage({
     context,
     path: `/chats/${THREAD_ID}`,
   });
-
   return rendered;
 }
 
-function expectedChunks(): readonly string[] {
-  return [FIRST_CHUNK, LAST_CHUNK];
-}
-
-/**
- * Walk the run one chunk at a time. Each wait covers at most a couple of
- * typewriter ticks, so no single step depends on the whole animation fitting
- * inside one timeout. The waits assert against the recorded frames rather than
- * a live DOM read, because a completed chunk only stays on screen for one tick
- * before it fades out.
- */
-async function waitForBothChunks(rendered: readonly string[]): Promise<void> {
+async function waitForBothLines(rendered: readonly string[]): Promise<void> {
   await waitFor(() => {
-    expect(rendered.length).toBeGreaterThan(0);
+    expect(rendered).toContain(FIRST_OVERFLOW_FRAME);
   });
   await waitFor(() => {
-    expect(rendered).toContain(FIRST_CHUNK);
-  });
-  await waitFor(() => {
-    expect(rendered).toContain(LAST_CHUNK);
+    expect(rendered).toContain(SECOND_LINE);
   });
 }
 
 describe("chat thinking indicator", () => {
-  it("advances the live status text one clause-bounded chunk at a time", async () => {
+  it("discards an overflowing line remainder before showing the next explicit line", async () => {
     const rendered = setupThinkingRun();
-    await waitForBothChunks(rendered);
+    await waitForBothLines(rendered);
 
-    const chunkOfFrame = rendered.map((frame) => {
-      return expectedChunks().findIndex((chunk) => {
-        return chunk.startsWith(frame);
-      });
+    expect(rendered).toContain(FIRST_OVERFLOW_FRAME);
+    expect(rendered).toContain(SECOND_LINE);
+    expect(
+      rendered.some((frame) => {
+        return frame.includes("隐藏后缀");
+      }),
+    ).toBeFalsy();
+
+    const secondLineStart = rendered.findIndex((frame) => {
+      return SECOND_LINE.startsWith(frame);
     });
-
-    // Both chunks were displayed, so the line really did advance rather than
-    // stopping on the first one.
-    expect(chunkOfFrame).toContain(0);
-    expect(chunkOfFrame).toContain(1);
-
-    // The second chunk replaces the first outright: the first frame of chunk
-    // two does not continue the text that was on screen just before it.
-    const swapAt = chunkOfFrame.indexOf(1);
-    const beforeSwap = rendered[swapAt - 1]!;
-    const afterSwap = rendered[swapAt]!;
-    expect(afterSwap.startsWith(beforeSwap)).toBeFalsy();
-
-    // The settled line is a whole clause, not a phrase cut in half.
-    expect(serverThinkingLabelText().endsWith("。")).toBeTruthy();
+    expect(secondLineStart).toBeGreaterThan(0);
+    expect(rendered[secondLineStart - 1]).toBe(FIRST_OVERFLOW_FRAME);
   });
 
-  it("never renders a horizontally scrolled window of the status text", async () => {
+  it("never turns an overflowing remainder into another displayed line", async () => {
     const rendered = setupThinkingRun();
-    await waitForBothChunks(rendered);
+    await waitForBothLines(rendered);
 
-    expect(rendered.length).toBeGreaterThan(0);
-
-    // A sliding window renders a tail of the text behind an ellipsis prefix
-    // and starts mid-phrase. Every frame must instead be a growing prefix of
-    // one of the two chunks, which is what proves the line never scrolls
-    // sideways and never starts mid-clause.
     for (const frame of rendered) {
-      expect(frame.startsWith("...")).toBeFalsy();
       expect(
-        expectedChunks().some((chunk) => {
-          return chunk.startsWith(frame);
-        }),
+        FIRST_LINE.startsWith(frame.replace(/…$/, "")) ||
+          SECOND_LINE.startsWith(frame),
       ).toBeTruthy();
     }
+    expect(serverThinkingLabelText()).toBe(SECOND_LINE);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4952,7 +4952,7 @@ function ShimmerText({
     >
       <p
         ref={setRef}
-        className="zero-shimmer-text h-5 w-full overflow-hidden whitespace-nowrap"
+        className="zero-shimmer-text h-5 w-full truncate"
         aria-label={ariaLabel}
       >
         {children}


### PR DESCRIPTION
## Summary

- opt initial-thinking progress generation out of OpenRouter reasoning while keeping the existing 160-token output budget
- rewrite the prompt around stable UI context: the actual response is separate, one paragraph is shown at a time, a mobile line holds about 20 Chinese characters or 7 English words, and around four short paragraphs give the animation material to rotate
- preserve the safety contract that progress copy must not answer the user or expose hidden reasoning
- treat only explicit paragraph breaks as rotation boundaries; when one line exceeds the measured width, end it with `…`, discard the unseen remainder, and advance to the next paragraph after the existing hold/fade interval
- preserve strict completion semantics: `length` / `MAX_TOKENS` provider output remains rejected even when partial content is present

## Production evidence

For `vm0-web-logs-prod` in the exact window `2026-08-11T03:16:38Z` through `2026-08-12T03:16:38Z`:

- 104 `Initial thinking generation failed` warnings
- 103 were `OpenRouter completion finished with length (native: MAX_TOKENS)` across 103 runs and 51 threads
- 1 was an unrelated OpenRouter 503
- 2,369 `thinking:initial` events were persisted in the same window; `103 / (2,369 + 103) = 4.17%` is the observable capped-output ratio and an upper bound on the true attempt failure rate because a successful generation can still be discarded when the run advances before persistence

The service sent `max_tokens: 160` while allowing a few short paragraphs and applying the 600-character cap only after completion. OpenRouter counts reasoning in the output budget, and the selected Gemini model advertises reasoning enabled by default. OpenRouter normalizes the native `MAX_TOKENS` outcome to `finish_reason: length`; the shared wrapper intentionally throws on every non-`stop` finish before reading `message.content`, so partial progress copy was correctly discarded but logged.

## Design

The generation prompt now supplies presentation facts instead of encoding the frontend's wrapping algorithm as model instructions. Its target is around four mobile-width paragraphs: roughly 80 Chinese characters or 28 English words in total when the model follows the stated width. That fits the existing budget after reasoning is disabled, so this PR does not rely on a token-budget increase.

The frontend no longer manufactures additional lines from an overlong paragraph. It types only the visible prefix, replaces the tail with an ellipsis when the measured width is exceeded, keeps the existing 700 ms hold and 200 ms fade, then starts the next explicit paragraph. The skipped suffix is never animated later.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-thinking-indicator.test.tsx` (2 passed)
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx -t 'initial thinking indicator'` (6 passed, 13 skipped)
- `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'initial thinking indicator'` (2 passed, 85 skipped)

Per repository instructions, no full Vitest suite or local dev server was run. The page-level tests exercise deterministic mobile-width overflow and paragraph rotation; broad and preview checks are left to the PR pipeline.

## Remaining uncertainty

OpenRouter currently reports reasoning as non-mandatory for `google/gemini-3.1-flash-lite-preview`, so `effort: none` is the gateway-supported opt-out. Gemini 3 providers may internally map that opt-out to their minimum thinking level rather than literal zero reasoning. Model adherence to the approximate paragraph width also cannot be guaranteed; the frontend now handles violations deterministically, and the production warning rate should still be checked after deployment.
