### PR TITLE
refactor(api): reclaim unsupported chat event snapshots

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -404,7 +404,7 @@ describe("cron snapshot chat events", () => {
     expect(rebuiltHead.object_key).not.toBe(headPut.key);
   }, 60_000);
 
-  it("resumes a bounded non-v4 rebuild until every head converges", async () => {
+  it("reclaims retired heads while a bounded rebuild resumes", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {
       displayName: "Resumable snapshot agent",
@@ -420,6 +420,7 @@ describe("cron snapshot chat events", () => {
     await projectChatEventSearch();
     await runSnapshotCron();
 
+    const retiredObjectKeys: string[] = [];
     for (const threadId of threadIds) {
       const head = await readChatEventSnapshotHead(context, threadId);
       const priorObjectKey = `chat-events/${threadId}/non-v4-${randomUUID()}.ndjson.gz`;
@@ -428,6 +429,7 @@ describe("cron snapshot chat events", () => {
         throw new Error("Expected the v4 fixture object");
       }
       writeFakeChatEventObject(priorObjectKey, body);
+      retiredObjectKeys.push(priorObjectKey);
       await setChatEventSnapshotHeadVersion(
         context,
         threadId,
@@ -438,12 +440,22 @@ describe("cron snapshot chat events", () => {
 
     mockOptionalEnv("CHAT_EVENT_SNAPSHOT_BATCH_SIZE", "1");
     const firstPass = await runSnapshotCron();
-    expect(firstPass.nonV4SnapshotHeads).toBe(1);
-    const incomplete = await verifySnapshotConvergence();
-    expect(incomplete.status).toBe(409);
+    expect(firstPass).toMatchObject({
+      snapshots: 1,
+      nonV4SnapshotHeads: 0,
+    });
+    expect(firstPass.retiredSnapshotReferencesDeleted).toBeGreaterThanOrEqual(
+      2,
+    );
+    for (const objectKey of retiredObjectKeys) {
+      expect(readFakeChatEventObject(objectKey)).toBeUndefined();
+    }
 
     const secondPass = await runSnapshotCron();
-    expect(secondPass.nonV4SnapshotHeads).toBe(0);
+    expect(secondPass).toMatchObject({
+      snapshots: 1,
+      nonV4SnapshotHeads: 0,
+    });
     const converged = await verifySnapshotConvergence();
     expect(converged.status).toBe(200);
     for (const threadId of threadIds) {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-chat-event-r2.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-chat-event-r2.ts
@@ -142,7 +142,11 @@ function fakeListObjects(record: FakeS3CommandRecord) {
   });
 }
 
-function fakeDeleteObjects(record: FakeS3CommandRecord) {
+async function fakeDeleteObjects(
+  record: FakeS3CommandRecord,
+  beforeDelete?: () => Promise<void>,
+) {
+  await beforeDelete?.();
   for (const object of record.input?.Delete?.Objects ?? []) {
     if (!object.Key) {
       continue;
@@ -152,13 +156,14 @@ function fakeDeleteObjects(record: FakeS3CommandRecord) {
       unlinkSync(path);
     }
   }
-  return Promise.resolve({ Errors: [] });
+  return { Errors: [] };
 }
 
 function handleFakeS3Command(
   command: unknown,
   recordedPuts?: RecordedChatEventPut[],
   beforePut?: (put: RecordedChatEventPut) => Promise<void>,
+  beforeDelete?: () => Promise<void>,
 ) {
   const record = command as FakeS3CommandRecord;
   const commandName = record.constructor.name;
@@ -175,7 +180,7 @@ function handleFakeS3Command(
     return fakeListObjects(record);
   }
   if (commandName === "DeleteObjectsCommand") {
-    return fakeDeleteObjects(record);
+    return fakeDeleteObjects(record, beforeDelete);
   }
   return Promise.resolve({ ContentLength: 1024 });
 }
@@ -184,11 +189,12 @@ export function installFakeChatEventR2(
   context: TestContext,
   recordedPuts?: RecordedChatEventPut[],
   beforePut?: (put: RecordedChatEventPut) => Promise<void>,
+  beforeDelete?: () => Promise<void>,
 ): void {
   // The suite-wide mock reset primes getSignedUrl in afterEach, so the first
   // test of a file starts unprimed; presigned downloads are part of this fake.
   context.mocks.s3.getSignedUrl.mockResolvedValue(FAKE_CHAT_EVENT_SNAPSHOT_URL);
   context.mocks.s3.send.mockImplementation((command: unknown) => {
-    return handleFakeS3Command(command, recordedPuts, beforePut);
+    return handleFakeS3Command(command, recordedPuts, beforePut, beforeDelete);
   });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
@@ -92,6 +92,20 @@ async function sendNoCreditMessage(
   return sent.body.threadId;
 }
 
+async function replaceHeadWithRetiredVersion(
+  threadId: string,
+): Promise<string> {
+  const head = await readChatEventSnapshotHead(context, threadId);
+  const body = readFakeChatEventObject(head.object_key);
+  if (body === undefined) {
+    throw new Error("Expected a current snapshot object");
+  }
+  const retiredKey = `chat-events/${threadId}/retired-v3-${randomUUID()}.ndjson.gz`;
+  writeFakeChatEventObject(retiredKey, body);
+  await setChatEventSnapshotHeadVersion(context, threadId, 3, retiredKey);
+  return retiredKey;
+}
+
 describe("chat event snapshot read endpoints", () => {
   beforeEach(() => {
     installFakeChatEventR2(context);
@@ -262,6 +276,57 @@ describe("chat event snapshot read endpoints", () => {
     });
   }, 60_000);
 
+  it("immediately retires snapshot versions below the supported minimum", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Snapshot version retirement agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `snapshot-version-retirement-${randomUUID()}`,
+    });
+
+    await projectChatEventSearch();
+    await runSnapshotCron();
+    const retiredKey = await replaceHeadWithRetiredVersion(threadId);
+
+    const retired = await runSnapshotCron();
+    expect(retired.retiredSnapshotReferencesDeleted).toBeGreaterThanOrEqual(1);
+    expect(readFakeChatEventObject(retiredKey)).toBeUndefined();
+    const current = await readChatEventSnapshotHead(context, threadId);
+    expect(current).toMatchObject({
+      archive_schema_version: 4,
+      snapshot_count: 1,
+    });
+  }, 60_000);
+
+  it("keeps database retirement successful when R2 deletion fails", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Snapshot best-effort cleanup agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `snapshot-best-effort-${randomUUID()}`,
+    });
+
+    await projectChatEventSearch();
+    await runSnapshotCron();
+    const retiredKey = await replaceHeadWithRetiredVersion(threadId);
+    installFakeChatEventR2(context, undefined, undefined, () => {
+      return Promise.reject(new Error("R2 delete unavailable"));
+    });
+
+    const retired = await runSnapshotCron();
+    expect(retired.retiredSnapshotReferencesDeleted).toBeGreaterThanOrEqual(1);
+    expect(readFakeChatEventObject(retiredKey)).toBeDefined();
+    const current = await readChatEventSnapshotHead(context, threadId);
+    expect(current).toMatchObject({
+      archive_schema_version: 4,
+      snapshot_count: 1,
+    });
+  }, 60_000);
+
   it("garbage-collects unreferenced snapshot objects", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {
@@ -323,5 +388,30 @@ describe("chat event snapshot read endpoints", () => {
     const newHead = await readChatEventSnapshotHead(context, threadId);
     expect(newHead.object_key).not.toBe(head.object_key);
     expect(readFakeChatEventObject(newHead.object_key)).toBeDefined();
+  }, 120_000);
+
+  it("limits object cleanup to the fixed per-pass quota", async () => {
+    const shard = "ffe";
+    const marker = randomUUID();
+    const keys = Array.from({ length: 1001 }, (_, index) => {
+      const subpartition = (index % 16).toString(16);
+      return `chat-events/${shard}${subpartition}-quota-${marker}-${index.toString().padStart(4, "0")}.ndjson.gz`;
+    });
+    for (const key of keys) {
+      writeFakeChatEventObject(key, Buffer.from("orphan"));
+    }
+    mockNow(new Date(now() + 8 * 24 * 60 * 60 * 1000));
+    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD", shard);
+    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_DRY_RUN", "false");
+
+    const result = await runSnapshotCron();
+
+    expect(
+      result.retiredSnapshotReferencesDeleted + result.r2ObjectsDeleted,
+    ).toBe(1000);
+    const remaining = keys.filter((key) => {
+      return readFakeChatEventObject(key) !== undefined;
+    });
+    expect(remaining.length).toBeGreaterThanOrEqual(1);
   }, 120_000);
 });

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -41,6 +41,7 @@ type ComputedGetter = <T>(computedValue: Computed<T>) => T;
 interface ChatEventSnapshotStats {
   readonly snapshots: number;
   readonly archivedEvents: number;
+  readonly retiredSnapshotReferencesDeleted: number;
   readonly r2ObjectsScanned: number;
   readonly r2ObjectsMeasured: number;
   readonly r2ObjectsDeleted: number;
@@ -80,6 +81,12 @@ interface SnapshotCandidate {
  * so browser downloads are transparently decompressed.
  */
 export const ARCHIVE_SCHEMA_VERSION = 4;
+/**
+ * Old archive contracts below this version are no longer supported. Raise
+ * this only after the App force-upgrade floor requires a reader that supports
+ * the new minimum; changing the constant intentionally starts reclamation.
+ */
+const MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION = 4;
 const ARCHIVE_CONTENT_TYPE = "application/x-ndjson";
 const ARCHIVE_CONTENT_ENCODING = "gzip";
 /**
@@ -93,6 +100,7 @@ const DEFAULT_R2_GC_GRACE_HOURS = 24 * 7;
 const R2_GC_SHARDS_PER_RUN = 16;
 const R2_GC_SHARD_COUNT = 16 ** 3;
 const R2_GC_PAGE_SIZE = 1000;
+const SNAPSHOT_GC_DELETE_QUOTA = 1000;
 /**
  * Matches the cron cadence so every invocation advances to the next shard
  * window; the 4096 shards are swept in about 1.8 days.
@@ -392,6 +400,69 @@ interface R2GcStats {
   readonly subpartitionedShards: number;
 }
 
+interface RetiredSnapshotVersionGcStats {
+  readonly selected: number;
+  readonly referencesDeleted: number;
+}
+
+async function deleteRetiredSnapshotVersions(
+  get: ComputedGetter,
+  db: Db,
+  bucket: string,
+  deleteQuota: number,
+  signal: AbortSignal,
+): Promise<RetiredSnapshotVersionGcStats> {
+  const candidates = await db
+    .select({
+      id: chatEventSnapshots.id,
+      objectKey: chatEventSnapshots.objectKey,
+    })
+    .from(chatEventSnapshots)
+    .where(
+      lt(
+        chatEventSnapshots.archiveSchemaVersion,
+        MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION,
+      ),
+    )
+    .limit(deleteQuota);
+  signal.throwIfAborted();
+  if (candidates.length === 0) {
+    return { selected: 0, referencesDeleted: 0 };
+  }
+
+  const candidateIds = candidates.map((candidate) => {
+    return candidate.id;
+  });
+  const objectKeys = candidates.map((candidate) => {
+    return candidate.objectKey;
+  });
+  const referenceDeletion = db
+    .delete(chatEventSnapshots)
+    .where(
+      and(
+        inArray(chatEventSnapshots.id, candidateIds),
+        lt(
+          chatEventSnapshots.archiveSchemaVersion,
+          MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION,
+        ),
+      ),
+    )
+    .returning({ id: chatEventSnapshots.id });
+  // R2 cleanup is deliberately best-effort. Running it beside the database
+  // delete keeps either system's failure from preventing the other attempt;
+  // failed object deletes become ordinary unreferenced-object GC candidates.
+  const objectDeletion = settle(get(deleteS3Objects(bucket, objectKeys)));
+  const [deletedReferences] = await Promise.all([
+    referenceDeletion,
+    objectDeletion,
+  ]);
+  signal.throwIfAborted();
+  return {
+    selected: candidates.length,
+    referencesDeleted: deletedReferences.length,
+  };
+}
+
 function chatEventSnapshotGcPrefixes(now: Date): readonly string[] {
   const override = optionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD");
   if (override !== undefined) {
@@ -438,6 +509,7 @@ async function collectR2SnapshotGarbage(
   get: ComputedGetter,
   db: Db,
   bucket: string,
+  deleteQuota: number,
   signal: AbortSignal,
 ): Promise<R2GcStats> {
   const now = nowDate();
@@ -456,8 +528,21 @@ async function collectR2SnapshotGarbage(
   let bytesDeleted = 0;
   let shardsScanned = 0;
   let subpartitionedShards = 0;
+  let remainingDeleteQuota = deleteQuota;
 
-  for (const prefix of chatEventSnapshotGcPrefixes(now)) {
+  if (remainingDeleteQuota === 0) {
+    return {
+      scanned,
+      measured,
+      deleted,
+      bytesMeasured,
+      bytesDeleted,
+      shardsScanned,
+      subpartitionedShards,
+    };
+  }
+
+  gcPrefixes: for (const prefix of chatEventSnapshotGcPrefixes(now)) {
     const pages = await boundedGcObjectPages(get, bucket, prefix);
     signal.throwIfAborted();
     shardsScanned += 1;
@@ -504,10 +589,11 @@ async function collectR2SnapshotGarbage(
         continue;
       }
 
-      const garbageKeys = garbage.map((object) => {
+      const deletionBatch = garbage.slice(0, remainingDeleteQuota);
+      const garbageKeys = deletionBatch.map((object) => {
         return object.key;
       });
-      await db
+      const referenceDeletion = db
         .delete(chatEventSnapshots)
         .where(
           and(
@@ -516,32 +602,22 @@ async function collectR2SnapshotGarbage(
             lt(chatEventSnapshots.createdAt, olderThan),
           ),
         );
-      const stillReferenced = await db
-        .select({ objectKey: chatEventSnapshots.objectKey })
-        .from(chatEventSnapshots)
-        .where(inArray(chatEventSnapshots.objectKey, garbageKeys));
+      const objectDeletion = settle(get(deleteS3Objects(bucket, garbageKeys)));
+      const [, objectDeletionResult] = await Promise.all([
+        referenceDeletion,
+        objectDeletion,
+      ]);
       signal.throwIfAborted();
-      const protectedKeys = new Set(
-        stillReferenced.map((reference) => {
-          return reference.objectKey;
-        }),
-      );
-      const deletable = garbage.filter((object) => {
-        return !protectedKeys.has(object.key);
-      });
-      await get(
-        deleteS3Objects(
-          bucket,
-          deletable.map((object) => {
-            return object.key;
-          }),
-        ),
-      );
-      signal.throwIfAborted();
-      deleted += deletable.length;
-      bytesDeleted += deletable.reduce((total, object) => {
-        return total + object.size;
-      }, 0);
+      remainingDeleteQuota -= deletionBatch.length;
+      if (objectDeletionResult.ok) {
+        deleted += deletionBatch.length;
+        bytesDeleted += deletionBatch.reduce((total, object) => {
+          return total + object.size;
+        }, 0);
+      }
+      if (remainingDeleteQuota === 0) {
+        break gcPrefixes;
+      }
     }
   }
   return {
@@ -630,13 +706,28 @@ export const snapshotChatEvents$ = command(
         archivedEvents += archived;
       }
     }
+    const retiredSnapshots = await deleteRetiredSnapshotVersions(
+      get,
+      db,
+      bucket,
+      SNAPSHOT_GC_DELETE_QUOTA,
+      signal,
+    );
+    signal.throwIfAborted();
     const convergence = await chatEventSnapshotConvergence(db);
     signal.throwIfAborted();
-    const r2Gc = await collectR2SnapshotGarbage(get, db, bucket, signal);
+    const r2Gc = await collectR2SnapshotGarbage(
+      get,
+      db,
+      bucket,
+      SNAPSHOT_GC_DELETE_QUOTA - retiredSnapshots.selected,
+      signal,
+    );
     signal.throwIfAborted();
     return {
       snapshots,
       archivedEvents,
+      retiredSnapshotReferencesDeleted: retiredSnapshots.referencesDeleted,
       r2ObjectsScanned: r2Gc.scanned,
       r2ObjectsMeasured: r2Gc.measured,
       r2ObjectsDeleted: r2Gc.deleted,

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -405,63 +405,65 @@ interface RetiredSnapshotVersionGcStats {
   readonly referencesDeleted: number;
 }
 
-async function deleteRetiredSnapshotVersions(
-  get: ComputedGetter,
-  db: Db,
-  bucket: string,
-  deleteQuota: number,
-  signal: AbortSignal,
-): Promise<RetiredSnapshotVersionGcStats> {
-  const candidates = await db
-    .select({
-      id: chatEventSnapshots.id,
-      objectKey: chatEventSnapshots.objectKey,
-    })
-    .from(chatEventSnapshots)
-    .where(
-      lt(
-        chatEventSnapshots.archiveSchemaVersion,
-        MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION,
-      ),
-    )
-    .limit(deleteQuota);
-  signal.throwIfAborted();
-  if (candidates.length === 0) {
-    return { selected: 0, referencesDeleted: 0 };
-  }
-
-  const candidateIds = candidates.map((candidate) => {
-    return candidate.id;
-  });
-  const objectKeys = candidates.map((candidate) => {
-    return candidate.objectKey;
-  });
-  const referenceDeletion = db
-    .delete(chatEventSnapshots)
-    .where(
-      and(
-        inArray(chatEventSnapshots.id, candidateIds),
+const deleteRetiredSnapshotVersions$ = command(
+  async (
+    { get },
+    db: Db,
+    bucket: string,
+    deleteQuota: number,
+    signal: AbortSignal,
+  ): Promise<RetiredSnapshotVersionGcStats> => {
+    const candidates = await db
+      .select({
+        id: chatEventSnapshots.id,
+        objectKey: chatEventSnapshots.objectKey,
+      })
+      .from(chatEventSnapshots)
+      .where(
         lt(
           chatEventSnapshots.archiveSchemaVersion,
           MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION,
         ),
-      ),
-    )
-    .returning({ id: chatEventSnapshots.id });
-  // R2 cleanup is deliberately best-effort. Running it beside the database
-  // delete keeps either system's failure from preventing the other attempt;
-  // failed object deletes become ordinary unreferenced-object GC candidates.
-  const objectDeletion = settle(get(deleteS3Objects(bucket, objectKeys)));
-  const [deletedReferences] = await Promise.all([
-    referenceDeletion,
-    objectDeletion,
-  ]);
-  signal.throwIfAborted();
-  return {
-    selected: candidates.length,
-    referencesDeleted: deletedReferences.length,
-  };
-}
+      )
+      .limit(deleteQuota);
+    signal.throwIfAborted();
+    if (candidates.length === 0) {
+      return { selected: 0, referencesDeleted: 0 };
+    }
+
+    const candidateIds = candidates.map((candidate) => {
+      return candidate.id;
+    });
+    const objectKeys = candidates.map((candidate) => {
+      return candidate.objectKey;
+    });
+    const referenceDeletion = db
+      .delete(chatEventSnapshots)
+      .where(
+        and(
+          inArray(chatEventSnapshots.id, candidateIds),
+          lt(
+            chatEventSnapshots.archiveSchemaVersion,
+            MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION,
+          ),
+        ),
+      )
+      .returning({ id: chatEventSnapshots.id });
+    // R2 cleanup is deliberately best-effort. Running it beside the database
+    // delete keeps either system's failure from preventing the other attempt;
+    // failed object deletes become ordinary unreferenced-object GC candidates.
+    const objectDeletion = settle(get(deleteS3Objects(bucket, objectKeys)));
+    const [deletedReferences] = await Promise.all([
+      referenceDeletion,
+      objectDeletion,
+    ]);
+    signal.throwIfAborted();
+    return {
+      selected: candidates.length,
+      referencesDeleted: deletedReferences.length,
+    };
+  },
+);
 
 function chatEventSnapshotGcPrefixes(now: Date): readonly string[] {
   const override = optionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD");
@@ -706,8 +708,8 @@ export const snapshotChatEvents$ = command(
         archivedEvents += archived;
       }
     }
-    const retiredSnapshots = await deleteRetiredSnapshotVersions(
-      get,
+    const retiredSnapshots = await set(
+      deleteRetiredSnapshotVersions$,
       db,
       bucket,
       SNAPSHOT_GC_DELETE_QUOTA,

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -99,6 +99,7 @@ const cronSnapshotChatEventsResponseSchema =
     success: z.literal(true),
     snapshots: z.number(),
     archivedEvents: z.number(),
+    retiredSnapshotReferencesDeleted: z.number().int().nonnegative(),
     r2ObjectsScanned: z.number().int().nonnegative(),
     r2ObjectsMeasured: z.number().int().nonnegative(),
     r2ObjectsDeleted: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary

- define snapshot schema version 4 as the code-owned minimum supported version
- reclaim every database snapshot reference below the minimum from the existing 10-minute cron
- run R2 deletion beside database deletion as best-effort cleanup, so R2 failures do not block reference deletion
- share a fixed 1,000-item deletion quota with the existing age-based orphan/non-head GC
- report retired reference deletions in the cron response

## Concurrency and failure behavior

- version retirement rechecks `archive_schema_version < 4` in the delete statement
- current v4 heads are outside the retirement predicate
- stale heads below v4 may be removed; the existing archiver recreates a missing current head from Postgres on a later pass
- failed R2 deletes leave unreferenced objects for the existing age-based GC
- database failures still fail the cron

## Verification

- Prettier 3.8.1 check on all changed TypeScript files
- Oxlint 1.75.0 on changed API and contract files (one pre-existing conditional-expect warning remains)
- `git diff --check`
- added route-level integration coverage for immediate `<4` retirement, best-effort R2 failure, old-head recovery, and the shared per-pass quota

Local type checking and Vitest were not run because the workspace dependency install exhausted the 7.8 GB sandbox filesystem (`ENOSPC`); the PR pipeline will run the full required checks.