### PR TITLE
fix(pi): bound tool execution deadlines

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__agent-loop.ts
+++ b/turbo/apps/cli/src/commands/zero/__agent-loop.ts
@@ -29,6 +29,13 @@ export const zeroAgentLoopCommand = new Command()
   .action(async (options: { standby: true; standbyTtlSeconds: number }) => {
     const io = new StdioPiAgentLoopIo(process.stdin, process.stdout);
     const executionEnv = createPiNodeExecutionEnv();
+    const abortController = new AbortController();
+    const abortOnSigterm = () => {
+      const error = new Error("Pi agent loop received SIGTERM");
+      error.name = "AbortError";
+      abortController.abort(error);
+    };
+    process.once("SIGTERM", abortOnSigterm);
     try {
       await runPiStandbyAgentLoop(
         {
@@ -37,7 +44,7 @@ export const zeroAgentLoopCommand = new Command()
           executionEnv,
           standbyTtlSeconds: options.standbyTtlSeconds,
         },
-        new AbortController().signal,
+        abortController.signal,
       );
     } catch (error) {
       await io.write({
@@ -46,6 +53,7 @@ export const zeroAgentLoopCommand = new Command()
       });
       process.exitCode = 1;
     } finally {
+      process.removeListener("SIGTERM", abortOnSigterm);
       io.close();
       await executionEnv.cleanup();
     }

--- a/turbo/apps/cli/src/commands/zero/__agent-loop.ts
+++ b/turbo/apps/cli/src/commands/zero/__agent-loop.ts
@@ -34,6 +34,7 @@ export const zeroAgentLoopCommand = new Command()
       const error = new Error("Pi agent loop received SIGTERM");
       error.name = "AbortError";
       abortController.abort(error);
+      io.close();
     };
     process.once("SIGTERM", abortOnSigterm);
     try {

--- a/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { getEventListeners } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -495,8 +496,10 @@ describe("Pi DeepSeek provider", () => {
     await writeFile(initialPath, "initial tool result\n");
     const env = new LaterBashExecutionEnv({ cwd: root });
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const controller = new AbortController();
     const requestBodies: unknown[] = [];
     const events: AgentEvent[] = [];
+    let firstEventAbortListener: unknown = null;
     server.use(
       http.post(DEEPSEEK_RESPONSES_URL, async ({ request }) => {
         const body: unknown = await request.json();
@@ -532,10 +535,15 @@ describe("Pi DeepSeek provider", () => {
           ],
           executionEnv: env,
           onEvent(event) {
+            if (events.length === 0) {
+              const listeners = getEventListeners(controller.signal, "abort");
+              expect(listeners).toHaveLength(1);
+              firstEventAbortListener = listeners[0];
+            }
             events.push(event);
           },
         },
-        new AbortController().signal,
+        controller.signal,
       );
 
       await waitForAbort(env.started);
@@ -576,6 +584,10 @@ describe("Pi DeepSeek provider", () => {
         content: [{ type: "text", text: "recovered after timeout" }],
       });
       expect(env.abortedCommands).toEqual(["never-finish"]);
+      expect(firstEventAbortListener).not.toBeNull();
+      expect(getEventListeners(controller.signal, "abort")).not.toContain(
+        firstEventAbortListener,
+      );
     } finally {
       timeoutSpy.mockRestore();
       await env.cleanup();

--- a/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
@@ -1,10 +1,28 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { http } from "msw";
 import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 
-import { resolvePiAgentModel, runPiAgentPrompt } from "./agent-loop";
+import {
+  resolvePiAgentModel,
+  runPiAgentPrompt,
+  runPiAgentResume,
+} from "./agent-loop";
 
 const CODEX_ACCOUNT_ID_CLAIM_PATH = "https://api.openai.com/auth";
 const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
@@ -12,6 +30,15 @@ const CODEX_PLACEHOLDER_ACCOUNT_ID = "ws_VM0_PLACEHOLDER_DO_NOT_TRUST";
 const DEEPSEEK_BASE_URL = "https://api.deepseek.com/";
 const DEEPSEEK_RESPONSES_URL = "https://api.deepseek.com/responses";
 const server = setupServer();
+
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
@@ -107,6 +134,148 @@ function responsesTextSse(text: string): string {
       return `data: ${JSON.stringify(event)}\n\n`;
     })
     .join("");
+}
+
+function responsesToolSse(args: {
+  readonly id: string;
+  readonly name: string;
+  readonly arguments: Readonly<Record<string, unknown>>;
+}): string {
+  const serializedArguments = JSON.stringify(args.arguments);
+  const functionItem = {
+    type: "function_call",
+    id: `fc_${args.id}`,
+    call_id: args.id,
+    name: args.name,
+    arguments: serializedArguments,
+    status: "completed",
+  };
+  const events = [
+    {
+      type: "response.created",
+      response: {
+        id: "resp_pi_tool_test",
+        object: "response",
+        status: "in_progress",
+        output: [],
+        usage: null,
+      },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...functionItem, arguments: "", status: "in_progress" },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      output_index: 0,
+      delta: serializedArguments,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      output_index: 0,
+      arguments: serializedArguments,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: functionItem,
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_pi_tool_test",
+        object: "response",
+        status: "completed",
+        output: [functionItem],
+        usage: {
+          input_tokens: 5,
+          output_tokens: 3,
+          total_tokens: 8,
+        },
+      },
+    },
+  ];
+  return events
+    .map((event) => {
+      return `data: ${JSON.stringify(event)}\n\n`;
+    })
+    .join("");
+}
+
+function assistantToolMessage(args: {
+  readonly id: string;
+  readonly name: string;
+  readonly arguments: Readonly<Record<string, unknown>>;
+}): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", ...args }],
+    api: "openai-responses",
+    provider: "deepseek",
+    model: "deepseek-v4-flash",
+    usage: ZERO_USAGE,
+    stopReason: "toolUse",
+    timestamp: 1,
+  };
+}
+
+function isDeadlineCallback(value: unknown): value is () => void {
+  return typeof value === "function";
+}
+
+function fireScheduledDeadline(
+  call: readonly unknown[] | undefined,
+  expectedTimeoutMs: number,
+): void {
+  if (!call) {
+    throw new Error("Expected a scheduled Pi tool deadline");
+  }
+  const [callback, timeoutMs] = call;
+  if (!isDeadlineCallback(callback)) {
+    throw new Error("Expected the Pi tool deadline callback");
+  }
+  callback();
+  expect(timeoutMs).toBe(expectedTimeoutMs);
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) {
+    throw new Error("Deferred promise was not initialized");
+  }
+  return { promise, resolve: resolvePromise };
+}
+
+class LaterBashExecutionEnv extends NodeExecutionEnv {
+  readonly started = createDeferred<void>();
+  readonly abortedCommands: string[] = [];
+
+  override exec(
+    command: string,
+    options?: Parameters<NodeExecutionEnv["exec"]>[1],
+  ): ReturnType<NodeExecutionEnv["exec"]> {
+    if (command !== "never-finish") {
+      return super.exec(command, options);
+    }
+    options?.abortSignal?.addEventListener(
+      "abort",
+      () => {
+        this.abortedCommands.push(command);
+      },
+      { once: true },
+    );
+    this.started.resolve();
+    return new Promise<never>(() => {});
+  }
 }
 
 function sseResponse(body: string): Response {
@@ -318,6 +487,154 @@ describe("Pi DeepSeek provider", () => {
       expect(text).toContain("deepseek answer");
     } finally {
       await env.cleanup();
+    }
+  });
+
+  it("returns a structured timeout from a later Pi tool batch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-later-timeout-"));
+    const initialPath = join(root, "initial.txt");
+    await writeFile(initialPath, "initial tool result\n");
+    const env = new LaterBashExecutionEnv({ cwd: root });
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const requestBodies: unknown[] = [];
+    const events: AgentEvent[] = [];
+    server.use(
+      http.post(DEEPSEEK_RESPONSES_URL, async ({ request }) => {
+        const body: unknown = await request.json();
+        requestBodies.push(body);
+        return sseResponse(
+          requestBodies.length === 1
+            ? responsesToolSse({
+                id: "later-bash",
+                name: "bash",
+                arguments: { command: "never-finish", timeout: 60 },
+              })
+            : responsesTextSse("recovered after timeout"),
+        );
+      }),
+    );
+
+    try {
+      const messagesPromise = runPiAgentResume(
+        {
+          model: {
+            provider: "deepseek",
+            baseUrl: DEEPSEEK_BASE_URL,
+            apiKey: "sk-deepseek-pi-responses",
+            model: "deepseek-v4-flash",
+          },
+          systemPrompt: "You are a test Pi agent.",
+          messages: [
+            assistantToolMessage({
+              id: "initial-read|fc_initial-read",
+              name: "read",
+              arguments: { path: initialPath },
+            }),
+          ],
+          executionEnv: env,
+          onEvent(event) {
+            events.push(event);
+          },
+        },
+        new AbortController().signal,
+      );
+
+      await env.started.promise;
+      const laterDeadline = timeoutSpy.mock.calls.find((call) => {
+        return call[1] === 60_000;
+      });
+      fireScheduledDeadline(laterDeadline, 60_000);
+      const messages = await messagesPromise;
+
+      expect(requestBodies).toHaveLength(2);
+      expect(JSON.stringify(requestBodies[0])).toContain(
+        "Timeout in seconds (optional; default 600, maximum 1800)",
+      );
+      expect(JSON.stringify(requestBodies[1])).toContain(
+        "Tool execution timed out after 60 seconds",
+      );
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          role: "toolResult",
+          toolName: "bash",
+          isError: true,
+          details: { code: "tool_timeout", timeoutMs: 60_000 },
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "message_end",
+          message: expect.objectContaining({
+            role: "toolResult",
+            toolName: "bash",
+            isError: true,
+            details: { code: "tool_timeout", timeoutMs: 60_000 },
+          }),
+        }),
+      );
+      expect(messages.at(-1)).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "recovered after timeout" }],
+      });
+      expect(env.abortedCommands).toEqual(["never-finish"]);
+    } finally {
+      timeoutSpy.mockRestore();
+      await env.cleanup();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates parent cancellation from a later Pi tool batch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-later-cancel-"));
+    const initialPath = join(root, "initial.txt");
+    await writeFile(initialPath, "initial tool result\n");
+    const env = new LaterBashExecutionEnv({ cwd: root });
+    const controller = new AbortController();
+    server.use(
+      http.post(DEEPSEEK_RESPONSES_URL, () => {
+        return sseResponse(
+          responsesToolSse({
+            id: "later-bash-cancel",
+            name: "bash",
+            arguments: { command: "never-finish", timeout: 60 },
+          }),
+        );
+      }),
+    );
+
+    try {
+      const messagesPromise = runPiAgentResume(
+        {
+          model: {
+            provider: "deepseek",
+            baseUrl: DEEPSEEK_BASE_URL,
+            apiKey: "sk-deepseek-pi-responses",
+            model: "deepseek-v4-flash",
+          },
+          systemPrompt: "You are a test Pi agent.",
+          messages: [
+            assistantToolMessage({
+              id: "initial-read|fc_initial-read",
+              name: "read",
+              arguments: { path: initialPath },
+            }),
+          ],
+          executionEnv: env,
+          onEvent() {},
+        },
+        controller.signal,
+      );
+
+      await env.started.promise;
+      const reason = new Error("parent cancelled later Pi tool");
+      reason.name = "AbortError";
+      controller.abort(reason);
+
+      await expect(messagesPromise).rejects.toBe(reason);
+      expect(env.abortedCommands).toEqual(["never-finish"]);
+    } finally {
+      await env.cleanup();
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
@@ -636,4 +636,55 @@ describe("Pi DeepSeek provider", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("propagates parent cancellation while result persistence is pending", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-persistence-cancel-"));
+    const initialPath = join(root, "initial.txt");
+    await writeFile(initialPath, "initial tool result\n");
+    const env = new NodeExecutionEnv({ cwd: root });
+    const controller = new AbortController();
+    const persistenceStarted = new AbortController();
+
+    try {
+      const messagesPromise = runPiAgentResume(
+        {
+          model: {
+            provider: "deepseek",
+            baseUrl: DEEPSEEK_BASE_URL,
+            apiKey: "sk-deepseek-pi-responses",
+            model: "deepseek-v4-flash",
+          },
+          systemPrompt: "You are a test Pi agent.",
+          messages: [
+            assistantToolMessage({
+              id: "initial-read|fc_initial-read",
+              name: "read",
+              arguments: { path: initialPath },
+            }),
+          ],
+          executionEnv: env,
+          onEvent(event) {
+            if (
+              event.type === "message_end" &&
+              event.message.role === "toolResult"
+            ) {
+              persistenceStarted.abort();
+              return new Promise<never>(() => {});
+            }
+          },
+        },
+        controller.signal,
+      );
+
+      await waitForAbort(persistenceStarted);
+      const reason = new Error("parent cancelled pending persistence");
+      reason.name = "AbortError";
+      controller.abort(reason);
+
+      await expect(messagesPromise).rejects.toBe(reason);
+    } finally {
+      await env.cleanup();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.test.ts
@@ -239,24 +239,23 @@ function fireScheduledDeadline(
   expect(timeoutMs).toBe(expectedTimeoutMs);
 }
 
-interface Deferred<T> {
-  readonly promise: Promise<T>;
-  readonly resolve: (value: T) => void;
-}
-
-function createDeferred<T>(): Deferred<T> {
-  let resolvePromise: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((resolve) => {
-    resolvePromise = resolve;
-  });
-  if (!resolvePromise) {
-    throw new Error("Deferred promise was not initialized");
+function waitForAbort(controller: AbortController): Promise<void> {
+  if (controller.signal.aborted) {
+    return Promise.resolve();
   }
-  return { promise, resolve: resolvePromise };
+  return new Promise((resolve) => {
+    controller.signal.addEventListener(
+      "abort",
+      () => {
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }
 
 class LaterBashExecutionEnv extends NodeExecutionEnv {
-  readonly started = createDeferred<void>();
+  readonly started = new AbortController();
   readonly abortedCommands: string[] = [];
 
   override exec(
@@ -273,7 +272,7 @@ class LaterBashExecutionEnv extends NodeExecutionEnv {
       },
       { once: true },
     );
-    this.started.resolve();
+    this.started.abort();
     return new Promise<never>(() => {});
   }
 }
@@ -539,7 +538,7 @@ describe("Pi DeepSeek provider", () => {
         new AbortController().signal,
       );
 
-      await env.started.promise;
+      await waitForAbort(env.started);
       const laterDeadline = timeoutSpy.mock.calls.find((call) => {
         return call[1] === 60_000;
       });
@@ -625,7 +624,7 @@ describe("Pi DeepSeek provider", () => {
         controller.signal,
       );
 
-      await env.started.promise;
+      await waitForAbort(env.started);
       const reason = new Error("parent cancelled later Pi tool");
       reason.name = "AbortError";
       controller.abort(reason);

--- a/turbo/packages/pi-agent-runtime/src/agent-loop.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.ts
@@ -17,11 +17,45 @@ import { openrouterProvider } from "@earendil-works/pi-ai/providers/openrouter";
 import { vercelAIGatewayProvider } from "@earendil-works/pi-ai/providers/vercel-ai-gateway";
 import type { Api, Message, Model } from "@earendil-works/pi-ai";
 
-import { createPiExecutionTools, type PiAgentTool } from "./tools";
+import {
+  createPiExecutionTools,
+  isPiToolTimeoutResult,
+  type PiAgentTool,
+} from "./tools";
 import { executePiToolBatch } from "./tool-batch";
 import type { PiAgentModelConfig, PiOpenAICompatibleProvider } from "./types";
 
 type PiCatalogProvider = Exclude<PiOpenAICompatibleProvider, "codex">;
+type PiAgentEventSink = (event: AgentEvent) => Promise<void> | void;
+
+function abortAwareEventSink(
+  onEvent: PiAgentEventSink,
+  signal: AbortSignal,
+): PiAgentEventSink {
+  return async (event: AgentEvent): Promise<void> => {
+    signal.throwIfAborted();
+    let abortListener: (() => void) | undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      const rejectWithReason = () => {
+        reject(signal.reason);
+      };
+      if (signal.aborted) {
+        rejectWithReason();
+      } else {
+        abortListener = rejectWithReason;
+        signal.addEventListener("abort", rejectWithReason, { once: true });
+      }
+    });
+    try {
+      await Promise.race([Promise.resolve(onEvent(event)), aborted]);
+      signal.throwIfAborted();
+    } finally {
+      if (abortListener) {
+        signal.removeEventListener("abort", abortListener);
+      }
+    }
+  };
+}
 
 function providerModels(provider: PiCatalogProvider) {
   switch (provider) {
@@ -268,12 +302,13 @@ export async function runPiAgentResume(
       `Pi provider ${args.model.provider} does not catalog model ${args.model.model}`,
     );
   }
+  const onEvent = abortAwareEventSink(args.onEvent, signal);
   const messages = [...args.messages];
   const toolResults = await executePiToolBatch(
     {
       messages,
       executionEnv: args.executionEnv,
-      onEvent: args.onEvent,
+      onEvent,
     },
     signal,
   );
@@ -291,11 +326,17 @@ export async function runPiAgentResume(
       model,
       apiKey: args.model.apiKey,
       timeoutMs: 120_000,
+      afterToolCall(context) {
+        const result: unknown = context.result;
+        return Promise.resolve(
+          isPiToolTimeoutResult(result) ? { isError: true } : undefined,
+        );
+      },
       convertToLlm(currentMessages) {
         return currentMessages.filter(isPiLlmMessage);
       },
     },
-    args.onEvent,
+    onEvent,
     signal,
     piAgentStream,
   );

--- a/turbo/packages/pi-agent-runtime/src/agent-loop.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.ts
@@ -32,23 +32,26 @@ function abortAwareEventSink(
   onEvent: PiAgentEventSink,
   signal: AbortSignal,
 ): PiAgentEventSink {
-  const aborted = new Promise<void>((resolve) => {
-    if (signal.aborted) {
-      resolve();
-    } else {
-      signal.addEventListener(
-        "abort",
-        () => {
-          resolve();
-        },
-        { once: true },
-      );
-    }
-  });
   return async (event: AgentEvent): Promise<void> => {
     signal.throwIfAborted();
-    await Promise.race([Promise.resolve(onEvent(event)), aborted]);
-    signal.throwIfAborted();
+    let abortListener: (() => void) | undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      abortListener = () => {
+        reject(signal.reason);
+      };
+      signal.addEventListener("abort", abortListener, { once: true });
+    });
+    try {
+      await Promise.race([Promise.resolve(onEvent(event)), aborted]);
+      signal.throwIfAborted();
+    } catch (error) {
+      signal.throwIfAborted();
+      throw error;
+    } finally {
+      if (abortListener) {
+        signal.removeEventListener("abort", abortListener);
+      }
+    }
   };
 }
 

--- a/turbo/packages/pi-agent-runtime/src/agent-loop.ts
+++ b/turbo/packages/pi-agent-runtime/src/agent-loop.ts
@@ -32,28 +32,23 @@ function abortAwareEventSink(
   onEvent: PiAgentEventSink,
   signal: AbortSignal,
 ): PiAgentEventSink {
+  const aborted = new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+    } else {
+      signal.addEventListener(
+        "abort",
+        () => {
+          resolve();
+        },
+        { once: true },
+      );
+    }
+  });
   return async (event: AgentEvent): Promise<void> => {
     signal.throwIfAborted();
-    let abortListener: (() => void) | undefined;
-    const aborted = new Promise<never>((_resolve, reject) => {
-      const rejectWithReason = () => {
-        reject(signal.reason);
-      };
-      if (signal.aborted) {
-        rejectWithReason();
-      } else {
-        abortListener = rejectWithReason;
-        signal.addEventListener("abort", rejectWithReason, { once: true });
-      }
-    });
-    try {
-      await Promise.race([Promise.resolve(onEvent(event)), aborted]);
-      signal.throwIfAborted();
-    } finally {
-      if (abortListener) {
-        signal.removeEventListener("abort", abortListener);
-      }
-    }
+    await Promise.race([Promise.resolve(onEvent(event)), aborted]);
+    signal.throwIfAborted();
   };
 }
 

--- a/turbo/packages/pi-agent-runtime/src/tool-batch.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/tool-batch.test.ts
@@ -1,12 +1,14 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { AgentEvent } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
+import { vi } from "vitest";
 
 import { executePiToolBatch } from "./tool-batch";
+import { PI_TOOL_DEFAULT_TIMEOUT_MS, PI_TOOL_MAX_TIMEOUT_MS } from "./tools";
 
 const ZERO_USAGE = {
   input: 0,
@@ -16,6 +18,117 @@ const ZERO_USAGE = {
   totalTokens: 0,
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  if (!resolvePromise) {
+    throw new Error("Deferred promise was not initialized");
+  }
+  return { promise, resolve: resolvePromise };
+}
+
+function hasNonEmptyTextContent(value: unknown): boolean {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("content" in value) ||
+    !Array.isArray(value.content)
+  ) {
+    return false;
+  }
+  return value.content.some((content: unknown) => {
+    return (
+      typeof content === "object" &&
+      content !== null &&
+      "type" in content &&
+      content.type === "text" &&
+      "text" in content &&
+      typeof content.text === "string" &&
+      content.text.trim() !== ""
+    );
+  });
+}
+
+function isDeadlineCallback(value: unknown): value is () => void {
+  return typeof value === "function";
+}
+
+function fireScheduledDeadline(
+  call: readonly unknown[] | undefined,
+  expectedTimeoutMs: number,
+): void {
+  if (!call) {
+    throw new Error("Expected a scheduled Pi tool deadline");
+  }
+  const [callback, timeoutMs] = call;
+  if (!isDeadlineCallback(callback)) {
+    throw new Error("Expected the Pi tool deadline callback");
+  }
+  callback();
+  expect(timeoutMs).toBe(expectedTimeoutMs);
+}
+
+class HangingReadExecutionEnv extends NodeExecutionEnv {
+  readonly started = createDeferred<void>();
+  readonly abortedPaths: string[] = [];
+  readonly #hangingPathSuffix: string;
+
+  constructor(
+    options: ConstructorParameters<typeof NodeExecutionEnv>[0],
+    hangingPathSuffix = "never-settles.txt",
+  ) {
+    super(options);
+    this.#hangingPathSuffix = hangingPathSuffix;
+  }
+
+  override readBinaryFile(
+    path: string,
+    abortSignal?: AbortSignal,
+  ): ReturnType<NodeExecutionEnv["readBinaryFile"]> {
+    if (!path.endsWith(this.#hangingPathSuffix)) {
+      return super.readBinaryFile(path, abortSignal);
+    }
+    abortSignal?.addEventListener(
+      "abort",
+      () => {
+        this.abortedPaths.push(path);
+      },
+      { once: true },
+    );
+    this.started.resolve();
+    return new Promise<never>(() => {});
+  }
+}
+
+class HangingBashExecutionEnv extends NodeExecutionEnv {
+  readonly started = createDeferred<void>();
+  readonly abortedCommands: string[] = [];
+  readonly nativeTimeouts: Array<number | undefined> = [];
+
+  override exec(
+    command: string,
+    options?: Parameters<NodeExecutionEnv["exec"]>[1],
+  ): ReturnType<NodeExecutionEnv["exec"]> {
+    this.nativeTimeouts.push(options?.timeout);
+    options?.abortSignal?.addEventListener(
+      "abort",
+      () => {
+        this.abortedCommands.push(command);
+      },
+      { once: true },
+    );
+    this.started.resolve();
+    return new Promise<never>(() => {});
+  }
+}
 
 function assistant(
   id: string,
@@ -111,6 +224,272 @@ describe("Pi handoff tool batch", () => {
       });
     } finally {
       await env.cleanup();
+    }
+  });
+
+  it("applies the runtime default to a tool without a timeout", async () => {
+    const env = new HangingReadExecutionEnv({ cwd: tmpdir() });
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const resultsPromise = executePiToolBatch(
+        {
+          messages: [
+            assistant("handoff", [
+              {
+                id: "read-default-timeout",
+                name: "read",
+                arguments: { path: "never-settles.txt" },
+              },
+            ]),
+          ],
+          executionEnv: env,
+          onEvent() {},
+        },
+        new AbortController().signal,
+      );
+
+      await env.started.promise;
+      fireScheduledDeadline(
+        timeoutSpy.mock.calls[0],
+        PI_TOOL_DEFAULT_TIMEOUT_MS,
+      );
+
+      await expect(resultsPromise).resolves.toMatchObject([
+        {
+          toolCallId: "read-default-timeout",
+          isError: true,
+          details: {
+            code: "tool_timeout",
+            timeoutMs: PI_TOOL_DEFAULT_TIMEOUT_MS,
+          },
+        },
+      ]);
+      expect(env.abortedPaths).toHaveLength(1);
+    } finally {
+      timeoutSpy.mockRestore();
+      await env.cleanup();
+    }
+  });
+
+  it.each([
+    {
+      name: "shorter than the default",
+      requestedSeconds: 60,
+      expectedTimeoutMs: 60_000,
+    },
+    {
+      name: "longer than the default",
+      requestedSeconds: 20 * 60,
+      expectedTimeoutMs: 20 * 60 * 1_000,
+    },
+    {
+      name: "above the runtime maximum",
+      requestedSeconds: 60 * 60,
+      expectedTimeoutMs: PI_TOOL_MAX_TIMEOUT_MS,
+    },
+  ])(
+    "applies an explicit Bash timeout $name",
+    async ({ requestedSeconds, expectedTimeoutMs }) => {
+      const env = new HangingBashExecutionEnv({ cwd: tmpdir() });
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      try {
+        const resultsPromise = executePiToolBatch(
+          {
+            messages: [
+              assistant("handoff", [
+                {
+                  id: "bash-explicit-timeout",
+                  name: "bash",
+                  arguments: {
+                    command: "never-finish",
+                    timeout: requestedSeconds,
+                  },
+                },
+              ]),
+            ],
+            executionEnv: env,
+            onEvent() {},
+          },
+          new AbortController().signal,
+        );
+
+        await env.started.promise;
+        fireScheduledDeadline(timeoutSpy.mock.calls[0], expectedTimeoutMs);
+
+        await expect(resultsPromise).resolves.toMatchObject([
+          {
+            toolCallId: "bash-explicit-timeout",
+            isError: true,
+            details: {
+              code: "tool_timeout",
+              timeoutMs: expectedTimeoutMs,
+            },
+          },
+        ]);
+        expect(env.nativeTimeouts).toEqual([undefined]);
+        expect(env.abortedCommands).toEqual(["never-finish"]);
+      } finally {
+        timeoutSpy.mockRestore();
+        await env.cleanup();
+      }
+    },
+  );
+
+  it("propagates parent cancellation instead of returning a tool result", async () => {
+    const env = new HangingReadExecutionEnv({ cwd: tmpdir() });
+    const controller = new AbortController();
+    try {
+      const resultsPromise = executePiToolBatch(
+        {
+          messages: [
+            assistant("handoff", [
+              {
+                id: "read-parent-cancel",
+                name: "read",
+                arguments: { path: "never-settles.txt" },
+              },
+            ]),
+          ],
+          executionEnv: env,
+          onEvent() {},
+        },
+        controller.signal,
+      );
+
+      await env.started.promise;
+      const reason = new Error("parent cancelled");
+      reason.name = "AbortError";
+      controller.abort(reason);
+
+      await expect(resultsPromise).rejects.toBe(reason);
+      expect(env.abortedPaths).toHaveLength(1);
+    } finally {
+      await env.cleanup();
+    }
+  });
+
+  it("preserves parallel result order without cancelling a successful sibling", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-parallel-timeout-"));
+    const fastPath = join(root, "fast.txt");
+    await writeFile(fastPath, "fast result\n");
+    const env = new HangingReadExecutionEnv({ cwd: root }, "slow.txt");
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const resultsPromise = executePiToolBatch(
+        {
+          messages: [
+            assistant("handoff", [
+              {
+                id: "slow-first",
+                name: "read",
+                arguments: { path: "slow.txt" },
+              },
+              {
+                id: "fast-second",
+                name: "read",
+                arguments: { path: fastPath },
+              },
+            ]),
+          ],
+          executionEnv: env,
+          onEvent() {},
+        },
+        new AbortController().signal,
+      );
+
+      await env.started.promise;
+      fireScheduledDeadline(
+        timeoutSpy.mock.calls[0],
+        PI_TOOL_DEFAULT_TIMEOUT_MS,
+      );
+      const results = await resultsPromise;
+
+      expect(results).toMatchObject([
+        {
+          toolCallId: "slow-first",
+          isError: true,
+          details: {
+            code: "tool_timeout",
+            timeoutMs: PI_TOOL_DEFAULT_TIMEOUT_MS,
+          },
+        },
+        {
+          toolCallId: "fast-second",
+          isError: false,
+          content: [{ type: "text", text: "fast result\n" }],
+        },
+      ]);
+      expect(env.abortedPaths).toHaveLength(1);
+    } finally {
+      timeoutSpy.mockRestore();
+      await env.cleanup();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("terminates a Bash subprocess tree when its deadline expires", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-bash-timeout-"));
+    const pidFile = join(root, "pids.txt");
+    const env = new NodeExecutionEnv({ cwd: root });
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const ready = createDeferred<void>();
+    try {
+      const resultsPromise = executePiToolBatch(
+        {
+          messages: [
+            assistant("handoff", [
+              {
+                id: "bash-process-tree",
+                name: "bash",
+                arguments: {
+                  command: `sleep 30 & child=$!; echo "$$ $child" | tee ${JSON.stringify(pidFile)}; wait`,
+                  timeout: 60,
+                },
+              },
+            ]),
+          ],
+          executionEnv: env,
+          onEvent(event) {
+            if (
+              event.type === "tool_execution_update" &&
+              hasNonEmptyTextContent(event.partialResult)
+            ) {
+              ready.resolve();
+            }
+          },
+        },
+        new AbortController().signal,
+      );
+
+      await ready.promise;
+      const pids = (await readFile(pidFile, "utf8"))
+        .trim()
+        .split(" ")
+        .map(Number);
+      expect(pids).toHaveLength(2);
+      fireScheduledDeadline(timeoutSpy.mock.calls[0], 60_000);
+
+      await expect(resultsPromise).resolves.toMatchObject([
+        {
+          toolCallId: "bash-process-tree",
+          isError: true,
+          details: { code: "tool_timeout", timeoutMs: 60_000 },
+        },
+      ]);
+      await vi.waitFor(
+        () => {
+          for (const pid of pids) {
+            expect(() => {
+              process.kill(pid, 0);
+            }).toThrow();
+          }
+        },
+        { timeout: 2_000, interval: 10 },
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      await env.cleanup();
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/turbo/packages/pi-agent-runtime/src/tool-batch.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/tool-batch.test.ts
@@ -19,20 +19,19 @@ const ZERO_USAGE = {
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
-interface Deferred<T> {
-  readonly promise: Promise<T>;
-  readonly resolve: (value: T) => void;
-}
-
-function createDeferred<T>(): Deferred<T> {
-  let resolvePromise: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((resolve) => {
-    resolvePromise = resolve;
-  });
-  if (!resolvePromise) {
-    throw new Error("Deferred promise was not initialized");
+function waitForAbort(controller: AbortController): Promise<void> {
+  if (controller.signal.aborted) {
+    return Promise.resolve();
   }
-  return { promise, resolve: resolvePromise };
+  return new Promise((resolve) => {
+    controller.signal.addEventListener(
+      "abort",
+      () => {
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }
 
 function hasNonEmptyTextContent(value: unknown): boolean {
@@ -77,7 +76,7 @@ function fireScheduledDeadline(
 }
 
 class HangingReadExecutionEnv extends NodeExecutionEnv {
-  readonly started = createDeferred<void>();
+  readonly started = new AbortController();
   readonly abortedPaths: string[] = [];
   readonly #hangingPathSuffix: string;
 
@@ -103,13 +102,13 @@ class HangingReadExecutionEnv extends NodeExecutionEnv {
       },
       { once: true },
     );
-    this.started.resolve();
+    this.started.abort();
     return new Promise<never>(() => {});
   }
 }
 
 class HangingBashExecutionEnv extends NodeExecutionEnv {
-  readonly started = createDeferred<void>();
+  readonly started = new AbortController();
   readonly abortedCommands: string[] = [];
   readonly nativeTimeouts: Array<number | undefined> = [];
 
@@ -125,7 +124,7 @@ class HangingBashExecutionEnv extends NodeExecutionEnv {
       },
       { once: true },
     );
-    this.started.resolve();
+    this.started.abort();
     return new Promise<never>(() => {});
   }
 }
@@ -248,7 +247,7 @@ describe("Pi handoff tool batch", () => {
         new AbortController().signal,
       );
 
-      await env.started.promise;
+      await waitForAbort(env.started);
       fireScheduledDeadline(
         timeoutSpy.mock.calls[0],
         PI_TOOL_DEFAULT_TIMEOUT_MS,
@@ -313,7 +312,7 @@ describe("Pi handoff tool batch", () => {
           new AbortController().signal,
         );
 
-        await env.started.promise;
+        await waitForAbort(env.started);
         fireScheduledDeadline(timeoutSpy.mock.calls[0], expectedTimeoutMs);
 
         await expect(resultsPromise).resolves.toMatchObject([
@@ -356,13 +355,42 @@ describe("Pi handoff tool batch", () => {
         controller.signal,
       );
 
-      await env.started.promise;
+      await waitForAbort(env.started);
       const reason = new Error("parent cancelled");
       reason.name = "AbortError";
       controller.abort(reason);
 
       await expect(resultsPromise).rejects.toBe(reason);
       expect(env.abortedPaths).toHaveLength(1);
+    } finally {
+      await env.cleanup();
+    }
+  });
+
+  it("propagates parent cancellation while emitting an immediate result", async () => {
+    const env = new NodeExecutionEnv({ cwd: tmpdir() });
+    const controller = new AbortController();
+    const reason = new Error("parent cancelled during result emission");
+    reason.name = "AbortError";
+    try {
+      const resultsPromise = executePiToolBatch(
+        {
+          messages: [
+            assistant("handoff", [
+              { id: "unknown-cancel", name: "unknown", arguments: {} },
+            ]),
+          ],
+          executionEnv: env,
+          onEvent(event) {
+            if (event.type === "tool_execution_end") {
+              controller.abort(reason);
+            }
+          },
+        },
+        controller.signal,
+      );
+
+      await expect(resultsPromise).rejects.toBe(reason);
     } finally {
       await env.cleanup();
     }
@@ -397,7 +425,7 @@ describe("Pi handoff tool batch", () => {
         new AbortController().signal,
       );
 
-      await env.started.promise;
+      await waitForAbort(env.started);
       fireScheduledDeadline(
         timeoutSpy.mock.calls[0],
         PI_TOOL_DEFAULT_TIMEOUT_MS,
@@ -432,7 +460,7 @@ describe("Pi handoff tool batch", () => {
     const pidFile = join(root, "pids.txt");
     const env = new NodeExecutionEnv({ cwd: root });
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    const ready = createDeferred<void>();
+    const ready = new AbortController();
     try {
       const resultsPromise = executePiToolBatch(
         {
@@ -443,7 +471,7 @@ describe("Pi handoff tool batch", () => {
                 name: "bash",
                 arguments: {
                   command: `sleep 30 & child=$!; echo "$$ $child" | tee ${JSON.stringify(pidFile)}; wait`,
-                  timeout: 60,
+                  timeout: 1,
                 },
               },
             ]),
@@ -454,26 +482,26 @@ describe("Pi handoff tool batch", () => {
               event.type === "tool_execution_update" &&
               hasNonEmptyTextContent(event.partialResult)
             ) {
-              ready.resolve();
+              ready.abort();
             }
           },
         },
         new AbortController().signal,
       );
 
-      await ready.promise;
+      await waitForAbort(ready);
       const pids = (await readFile(pidFile, "utf8"))
         .trim()
         .split(" ")
         .map(Number);
       expect(pids).toHaveLength(2);
-      fireScheduledDeadline(timeoutSpy.mock.calls[0], 60_000);
+      fireScheduledDeadline(timeoutSpy.mock.calls[0], 1_000);
 
       await expect(resultsPromise).resolves.toMatchObject([
         {
           toolCallId: "bash-process-tree",
           isError: true,
-          details: { code: "tool_timeout", timeoutMs: 60_000 },
+          details: { code: "tool_timeout", timeoutMs: 1_000 },
         },
       ]);
       await vi.waitFor(

--- a/turbo/packages/pi-agent-runtime/src/tool-batch.ts
+++ b/turbo/packages/pi-agent-runtime/src/tool-batch.ts
@@ -11,7 +11,11 @@ import type {
   ExecutionEnv,
 } from "@earendil-works/pi-agent-core";
 
-import { createPiExecutionTools, type PiAgentTool } from "./tools";
+import {
+  createPiExecutionTools,
+  isPiToolTimeoutResult,
+  type PiAgentTool,
+} from "./tools";
 
 type PiAgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
@@ -73,6 +77,7 @@ function prepareToolCall(
   toolCall: AgentToolCall,
   signal: AbortSignal,
 ): ToolCallPreparation {
+  signal.throwIfAborted();
   const tool = tools.find((candidate) => {
     return candidate.name === toolCall.name;
   });
@@ -95,16 +100,10 @@ function prepareToolCall(
             arguments: preparedArguments as AgentToolCall["arguments"],
           };
     const args = validateToolArguments(tool, preparedToolCall);
-    if (signal.aborted) {
-      return {
-        kind: "immediate",
-        toolCall,
-        result: errorToolResult("Operation aborted"),
-        isError: true,
-      };
-    }
+    signal.throwIfAborted();
     return { kind: "prepared", toolCall, tool, args };
   } catch (error) {
+    signal.throwIfAborted();
     return {
       kind: "immediate",
       toolCall,
@@ -147,10 +146,16 @@ async function executePreparedToolCall(
     );
     acceptingUpdates = false;
     await Promise.all(updateEvents);
-    return { toolCall: prepared.toolCall, result, isError: false };
+    signal.throwIfAborted();
+    return {
+      toolCall: prepared.toolCall,
+      result,
+      isError: isPiToolTimeoutResult(result),
+    };
   } catch (error) {
     acceptingUpdates = false;
     await Promise.all(updateEvents);
+    signal.throwIfAborted();
     return {
       toolCall: prepared.toolCall,
       result: errorToolResult(

--- a/turbo/packages/pi-agent-runtime/src/tool-batch.ts
+++ b/turbo/packages/pi-agent-runtime/src/tool-batch.ts
@@ -213,10 +213,12 @@ async function executeToolCalls(
       toolName: toolCall.name,
       args: toolCall.arguments,
     });
+    signal.throwIfAborted();
     const preparation = prepareToolCall(tools, toolCall, signal);
     if (preparation.kind === "immediate") {
       const finalized: FinalizedToolCall = preparation;
       await emitToolExecutionEnd(finalized, onEvent);
+      signal.throwIfAborted();
       finalizedCalls.push(finalized);
     } else {
       finalizedCalls.push(async () => {
@@ -226,12 +228,11 @@ async function executeToolCalls(
           onEvent,
         );
         await emitToolExecutionEnd(finalized, onEvent);
+        signal.throwIfAborted();
         return finalized;
       });
     }
-    if (signal.aborted) {
-      break;
-    }
+    signal.throwIfAborted();
   }
 
   const ordered = await Promise.all(
@@ -239,11 +240,14 @@ async function executeToolCalls(
       return typeof entry === "function" ? entry() : Promise.resolve(entry);
     }),
   );
+  signal.throwIfAborted();
   const messages: ToolResultMessage[] = [];
   for (const finalized of ordered) {
     const message = toolResultMessage(finalized);
     await onEvent({ type: "message_start", message });
+    signal.throwIfAborted();
     await onEvent({ type: "message_end", message });
+    signal.throwIfAborted();
     messages.push(message);
   }
   return messages;

--- a/turbo/packages/pi-agent-runtime/src/tools.ts
+++ b/turbo/packages/pi-agent-runtime/src/tools.ts
@@ -161,17 +161,18 @@ export function createPiReadTool(env: ExecutionEnv): PiAgentTool {
 
 function createPiBashTool(env: ExecutionEnv): PiAgentTool {
   const tool = createBashTool();
+  const defaultTimeoutSeconds = PI_TOOL_DEFAULT_TIMEOUT_MS / 1_000;
+  const maxTimeoutSeconds = PI_TOOL_MAX_TIMEOUT_MS / 1_000;
   return {
     ...tool,
-    description: `${tool.description} Commands time out after 600 seconds by default; timeout may be set up to 1800 seconds.`,
+    description: `${tool.description} Commands time out after ${defaultTimeoutSeconds} seconds by default; timeout may be set up to ${maxTimeoutSeconds} seconds.`,
     parameters: {
       ...tool.parameters,
       properties: {
         ...tool.parameters.properties,
         timeout: {
           ...tool.parameters.properties.timeout,
-          description:
-            "Timeout in seconds (optional; default 600, maximum 1800)",
+          description: `Timeout in seconds (optional; default ${defaultTimeoutSeconds}, maximum ${maxTimeoutSeconds})`,
         },
       },
     },

--- a/turbo/packages/pi-agent-runtime/src/tools.ts
+++ b/turbo/packages/pi-agent-runtime/src/tools.ts
@@ -5,6 +5,7 @@ import {
   createWriteTool,
   type AgentContext,
   type AgentMessage,
+  type AgentToolResult,
   type BashToolInput,
   type EditToolInput,
   type ExecutionEnv,
@@ -15,12 +16,109 @@ import { validateToolArguments } from "@earendil-works/pi-ai";
 
 export type PiAgentTool = NonNullable<AgentContext["tools"]>[number];
 
+export const PI_TOOL_DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
+export const PI_TOOL_MAX_TIMEOUT_MS = 30 * 60 * 1_000;
+
+interface PiToolTimeoutDetails {
+  readonly code: "tool_timeout";
+  readonly timeoutMs: number;
+}
+
 type PiExecutionTools = readonly [
   PiAgentTool,
   PiAgentTool,
   PiAgentTool,
   PiAgentTool,
 ];
+
+function piToolTimeoutResult(
+  timeoutMs: number,
+): AgentToolResult<PiToolTimeoutDetails> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Tool execution timed out after ${timeoutMs / 1_000} seconds`,
+      },
+    ],
+    details: { code: "tool_timeout", timeoutMs },
+  };
+}
+
+export function isPiToolTimeoutResult(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || !("details" in value)) {
+    return false;
+  }
+  const details: unknown = value.details;
+  return (
+    typeof details === "object" &&
+    details !== null &&
+    "code" in details &&
+    details.code === "tool_timeout" &&
+    "timeoutMs" in details &&
+    typeof details.timeoutMs === "number"
+  );
+}
+
+async function executeWithPiToolTimeout<TDetails>(
+  timeoutMs: number,
+  parentSignal: AbortSignal | undefined,
+  execute: (signal: AbortSignal) => Promise<AgentToolResult<TDetails>>,
+): Promise<AgentToolResult<TDetails | PiToolTimeoutDetails>> {
+  parentSignal?.throwIfAborted();
+  const timeoutController = new AbortController();
+  const signal = parentSignal
+    ? AbortSignal.any([parentSignal, timeoutController.signal])
+    : timeoutController.signal;
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    const rejectWithReason = () => {
+      reject(signal.reason);
+    };
+    if (signal.aborted) {
+      rejectWithReason();
+    } else {
+      abortListener = rejectWithReason;
+      signal.addEventListener("abort", rejectWithReason, { once: true });
+    }
+  });
+  const timeout = setTimeout(() => {
+    const error = new Error(
+      `Pi tool execution timed out after ${timeoutMs} ms`,
+    );
+    error.name = "TimeoutError";
+    timeoutController.abort(error);
+  }, timeoutMs);
+
+  try {
+    const result = await Promise.race([execute(signal), aborted]);
+    parentSignal?.throwIfAborted();
+    return timeoutController.signal.aborted
+      ? piToolTimeoutResult(timeoutMs)
+      : result;
+  } catch (error) {
+    parentSignal?.throwIfAborted();
+    if (timeoutController.signal.aborted) {
+      return piToolTimeoutResult(timeoutMs);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
+function effectiveBashTimeoutMs(timeoutSeconds: number | undefined): number {
+  if (timeoutSeconds === undefined) {
+    return PI_TOOL_DEFAULT_TIMEOUT_MS;
+  }
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+    throw new Error("Invalid timeout: must be a finite number of seconds");
+  }
+  return Math.min(timeoutSeconds, PI_TOOL_MAX_TIMEOUT_MS / 1_000) * 1_000;
+}
 
 function validatedToolArguments(
   tool: Parameters<typeof validateToolArguments>[0],
@@ -48,7 +146,15 @@ export function createPiReadTool(env: ExecutionEnv): PiAgentTool {
         toolCallId,
         params,
       ) as ReadToolInput;
-      return tool.execute(toolCallId, input, signal, onUpdate, { env });
+      return executeWithPiToolTimeout(
+        PI_TOOL_DEFAULT_TIMEOUT_MS,
+        signal,
+        (executionSignal) => {
+          return tool.execute(toolCallId, input, executionSignal, onUpdate, {
+            env,
+          });
+        },
+      );
     },
   };
 }
@@ -57,13 +163,34 @@ function createPiBashTool(env: ExecutionEnv): PiAgentTool {
   const tool = createBashTool();
   return {
     ...tool,
+    description: `${tool.description} Commands time out after 600 seconds by default; timeout may be set up to 1800 seconds.`,
+    parameters: {
+      ...tool.parameters,
+      properties: {
+        ...tool.parameters.properties,
+        timeout: {
+          ...tool.parameters.properties.timeout,
+          description:
+            "Timeout in seconds (optional; default 600, maximum 1800)",
+        },
+      },
+    },
     execute(toolCallId, params, signal, onUpdate) {
       const input = validatedToolArguments(
         tool,
         toolCallId,
         params,
       ) as BashToolInput;
-      return tool.execute(toolCallId, input, signal, onUpdate, { env });
+      const timeoutMs = effectiveBashTimeoutMs(input.timeout);
+      return executeWithPiToolTimeout(timeoutMs, signal, (executionSignal) => {
+        return tool.execute(
+          toolCallId,
+          { command: input.command },
+          executionSignal,
+          onUpdate,
+          { env },
+        );
+      });
     },
   };
 }
@@ -78,7 +205,15 @@ function createPiWriteTool(env: ExecutionEnv): PiAgentTool {
         toolCallId,
         params,
       ) as WriteToolInput;
-      return tool.execute(toolCallId, input, signal, onUpdate, { env });
+      return executeWithPiToolTimeout(
+        PI_TOOL_DEFAULT_TIMEOUT_MS,
+        signal,
+        (executionSignal) => {
+          return tool.execute(toolCallId, input, executionSignal, onUpdate, {
+            env,
+          });
+        },
+      );
     },
   };
 }
@@ -93,7 +228,15 @@ function createPiEditTool(env: ExecutionEnv): PiAgentTool {
         toolCallId,
         params,
       ) as EditToolInput;
-      return tool.execute(toolCallId, input, signal, onUpdate, { env });
+      return executeWithPiToolTimeout(
+        PI_TOOL_DEFAULT_TIMEOUT_MS,
+        signal,
+        (executionSignal) => {
+          return tool.execute(toolCallId, input, executionSignal, onUpdate, {
+            env,
+          });
+        },
+      );
     },
   };
 }


### PR DESCRIPTION
## Summary

- bound every Pi read, Bash, write, and edit invocation with a 10-minute runtime default and a 30-minute maximum
- preserve Bash's optional model-selected timeout while returning stable, recoverable `tool_timeout` details from both recovered and later Pi batches
- propagate parent cancellation through the Pi runtime and bridge guest-agent SIGTERM into the CLI loop's abort signal
- verify timeout capping, parallel isolation and ordering, parent cancellation, later-batch recovery, and real Bash subprocess-tree cleanup

## Exclusions

- no API, database, queue, runner protocol, or persisted message-envelope changes
- no timeout parameters for read, write, or edit
- no environment-variable override or separate telemetry pipeline

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F @vm0/pi-agent-runtime lint`
- `cd turbo && pnpm -F @vm0/pi-agent-runtime check-types`
- `cd turbo && pnpm -F @vm0/pi-agent-runtime test`
- `cd turbo && pnpm -F @vm0/okou-cli lint`
- `cd turbo && pnpm -F @vm0/okou-cli check-types`
- `cd turbo && pnpm -F @vm0/okou-cli test`
- `cd turbo && pnpm knip --workspace @vm0/pi-agent-runtime`
- `cd turbo && pnpm knip --workspace @vm0/okou-cli`
- pre-commit hook: repository-wide Knip and TypeScript checks

Closes #26464
