### PR TITLE
refactor(platform): join mail part previews onto draft lists

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
+++ b/turbo/apps/platform/src/signals/chat-page/mail-draft.ts
@@ -8,7 +8,9 @@ import {
 } from "ccstate";
 import {
   zeroMailContract,
+  type ZeroMailAttachment,
   type ZeroMailDraft,
+  type ZeroMailInlineImage,
 } from "@vm0/api-contracts/contracts/zero-mail";
 
 import { accept } from "../../lib/accept.ts";
@@ -34,9 +36,27 @@ export interface MailDraftDescriptor {
   readonly href: string;
 }
 
+interface MailAttachmentPartPreview {
+  readonly attachment: ZeroMailAttachment;
+  /** Object URL of the fetched part; null when the part no longer exists. */
+  readonly url: string | null;
+  readonly text$: TextPreviewComputed | undefined;
+}
+
+export interface MailInlineImagePreview {
+  readonly image: ZeroMailInlineImage;
+  /** Object URL of the fetched part; null when the part no longer exists. */
+  readonly url: string | null;
+}
+
+/**
+ * Fetched part previews joined onto the draft's own attachment and inline
+ * image lists. The part lookup happens here, so the sidebar walks these lists
+ * directly instead of resolving parts by id while rendering.
+ */
 export interface MailAttachmentPreviews {
-  readonly text: ReadonlyMap<string, TextPreviewComputed>;
-  readonly urls: ReadonlyMap<string, string | null>;
+  readonly attachments: readonly MailAttachmentPartPreview[];
+  readonly inlineImages: readonly MailInlineImagePreview[];
 }
 
 export interface MailDraftSignals extends MailDraftDescriptor {
@@ -155,7 +175,7 @@ function createAttachmentPreviews(
   const attachmentPreviews$ = computed(
     async (get): Promise<MailAttachmentPreviews> => {
       if (!get(attachmentScopeActive$)) {
-        return { text: new Map(), urls: new Map() };
+        return { attachments: [], inlineImages: [] };
       }
       const currentLoadVersion = ++loadVersion;
       const draftPromise = get(sidebarDraft$);
@@ -175,7 +195,7 @@ function createAttachmentPreviews(
       const draft = await draftPromise;
       signal.throwIfAborted();
       if (currentLoadVersion !== loadVersion) {
-        return { text: new Map(), urls: new Map() };
+        return { attachments: [], inlineImages: [] };
       }
       const attachments = draft?.version === 3 ? draft.attachments : [];
       const attachmentPartIds = new Set(
@@ -208,27 +228,39 @@ function createAttachmentPreviews(
       );
       signal.throwIfAborted();
       if (currentLoadVersion !== loadVersion) {
-        return { text: new Map(), urls: new Map() };
+        return { attachments: [], inlineImages: [] };
       }
       revokeAttachmentObjectUrls();
-      const textPreviews = new Map<string, TextPreviewComputed>();
-      const urls = new Map<string, string | null>();
+      const urlByPartId = new Map<string, string | null>();
+      const textByPartId = new Map<string, TextPreviewComputed>();
       for (const { partId, response } of responses) {
         if (response.status === 404) {
-          urls.set(partId, null);
+          urlByPartId.set(partId, null);
           continue;
         }
         const url = URL.createObjectURL(response.body);
         attachmentObjectUrls.set(partId, url);
-        urls.set(partId, url);
+        urlByPartId.set(partId, url);
         if (attachmentPartIds.has(partId)) {
-          textPreviews.set(
+          textByPartId.set(
             partId,
             createTextPreviewComputedFromBlob(response.body),
           );
         }
       }
-      return { text: textPreviews, urls };
+      return {
+        attachments: attachments.map((attachment) => {
+          const partId = attachment.partId;
+          return {
+            attachment,
+            url: partId ? (urlByPartId.get(partId) ?? null) : null,
+            text$: partId ? textByPartId.get(partId) : undefined,
+          };
+        }),
+        inlineImages: (draft?.inlineImages ?? []).map((image) => {
+          return { image, url: urlByPartId.get(image.partId) ?? null };
+        }),
+      };
     },
   );
   const setAttachmentScopeRef$ = onRef(

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-sidebar.tsx
@@ -21,7 +21,10 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import type { CSSProperties, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { MailDraftSignals } from "../../signals/chat-page/mail-draft.ts";
+import type {
+  MailDraftSignals,
+  MailInlineImagePreview,
+} from "../../signals/chat-page/mail-draft.ts";
 import { classifyChatAttachment } from "../../signals/chat-page/parse-body-blocks.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
@@ -732,20 +735,21 @@ function isElementNode(node: ChildNode): node is Element {
 function renderMailImage(args: {
   readonly element: Element;
   readonly key: string;
-  readonly inlineImages: ReadonlyMap<string, ZeroMailInlineImage>;
-  readonly inlineImageUrls: ReadonlyMap<string, string | null> | null;
-  readonly inlineImageUrlsLoading: boolean;
+  readonly inlineImages: ReadonlyMap<string, MailInlineImagePreview>;
+  readonly inlineImagesLoading: boolean;
 }): ReactNode {
   const source = args.element.getAttribute("src");
-  const image = source?.toLowerCase().startsWith("cid:")
+  const preview = source?.toLowerCase().startsWith("cid:")
     ? args.inlineImages.get(normalizedContentId(source))
     : undefined;
-  if (image) {
-    const imageUrl = args.inlineImageUrlsLoading
-      ? undefined
-      : (args.inlineImageUrls?.get(image.partId) ?? null);
+  if (preview) {
+    const imageUrl = args.inlineImagesLoading ? undefined : preview.url;
     return (
-      <MailDraftInlineImage key={args.key} image={image} imageUrl={imageUrl} />
+      <MailDraftInlineImage
+        key={args.key}
+        image={preview.image}
+        imageUrl={imageUrl}
+      />
     );
   }
   const remoteSource = safeMailImageSrc(source);
@@ -837,9 +841,8 @@ function renderAllowedMailElement(args: {
 function renderMailHtmlNode(args: {
   readonly node: ChildNode;
   readonly key: string;
-  readonly inlineImages: ReadonlyMap<string, ZeroMailInlineImage>;
-  readonly inlineImageUrls: ReadonlyMap<string, string | null> | null;
-  readonly inlineImageUrlsLoading: boolean;
+  readonly inlineImages: ReadonlyMap<string, MailInlineImagePreview>;
+  readonly inlineImagesLoading: boolean;
 }): ReactNode {
   if (args.node.nodeType === 3) {
     return args.node.textContent;
@@ -857,8 +860,7 @@ function renderMailHtmlNode(args: {
       element,
       key: args.key,
       inlineImages: args.inlineImages,
-      inlineImageUrls: args.inlineImageUrls,
-      inlineImageUrlsLoading: args.inlineImageUrlsLoading,
+      inlineImagesLoading: args.inlineImagesLoading,
     });
   }
   const children = Array.from(element.childNodes).map((child, index) => {
@@ -866,8 +868,7 @@ function renderMailHtmlNode(args: {
       node: child,
       key: `${args.key}-${index}`,
       inlineImages: args.inlineImages,
-      inlineImageUrls: args.inlineImageUrls,
-      inlineImageUrlsLoading: args.inlineImageUrlsLoading,
+      inlineImagesLoading: args.inlineImagesLoading,
     });
   });
   const allowedTag = allowedMailHtmlElement(tag);
@@ -891,13 +892,13 @@ function renderMailHtmlNode(args: {
 }
 
 function MailDraftRichMessage({
-  attachmentUrls,
-  attachmentUrlsLoading,
+  inlineImages,
+  inlineImagesLoading,
   draft,
   signals,
 }: {
-  readonly attachmentUrls: ReadonlyMap<string, string | null> | null;
-  readonly attachmentUrlsLoading: boolean;
+  readonly inlineImages: readonly MailInlineImagePreview[] | null;
+  readonly inlineImagesLoading: boolean;
   readonly draft: ZeroMailDraft;
   readonly signals: MailDraftSignals;
 }) {
@@ -905,9 +906,16 @@ function MailDraftRichMessage({
     return null;
   }
   const document = new DOMParser().parseFromString(draft.bodyHtml, "text/html");
-  const inlineImages = new Map(
-    (draft.inlineImages ?? []).map((image) => {
-      return [normalizedContentId(image.contentId), image] as const;
+  // While previews load, the draft's own list stands in so cid: images render
+  // their placeholders; the walk keys its own input by content id.
+  const inlineImagePreviews =
+    inlineImages ??
+    (draft.inlineImages ?? []).map((image): MailInlineImagePreview => {
+      return { image, url: null };
+    });
+  const inlineImagesByContentId = new Map(
+    inlineImagePreviews.map((preview) => {
+      return [normalizedContentId(preview.image.contentId), preview] as const;
     }),
   );
   return (
@@ -923,9 +931,8 @@ function MailDraftRichMessage({
         return renderMailHtmlNode({
           node,
           key: `mail-html-${index}`,
-          inlineImages,
-          inlineImageUrls: attachmentUrls,
-          inlineImageUrlsLoading: attachmentUrlsLoading,
+          inlineImages: inlineImagesByContentId,
+          inlineImagesLoading,
         });
       })}
     </div>
@@ -933,13 +940,13 @@ function MailDraftRichMessage({
 }
 
 function MailDraftMessage({
-  attachmentUrls,
-  attachmentUrlsLoading,
+  inlineImages,
+  inlineImagesLoading,
   draft,
   signals,
 }: {
-  readonly attachmentUrls: ReadonlyMap<string, string | null> | null;
-  readonly attachmentUrlsLoading: boolean;
+  readonly inlineImages: readonly MailInlineImagePreview[] | null;
+  readonly inlineImagesLoading: boolean;
   readonly draft: ZeroMailDraft;
   readonly signals: MailDraftSignals;
 }) {
@@ -947,8 +954,8 @@ function MailDraftMessage({
   if (draft.bodyHtml && typeof DOMParser !== "undefined") {
     return (
       <MailDraftRichMessage
-        attachmentUrls={attachmentUrls}
-        attachmentUrlsLoading={attachmentUrlsLoading}
+        inlineImages={inlineImages}
+        inlineImagesLoading={inlineImagesLoading}
         draft={draft}
         signals={signals}
       />
@@ -987,9 +994,15 @@ function MailDraftDetails({
     attachmentPreviewsLoadable.state === "hasData"
       ? attachmentPreviewsLoadable.data
       : null;
-  const attachmentUrls = attachmentPreviews?.urls ?? null;
-  const attachmentUrlsLoading = attachmentPreviewsLoadable.state === "loading";
+  const attachmentPreviewsLoading =
+    attachmentPreviewsLoadable.state === "loading";
   const attachments = draft.version === 3 ? draft.attachments : [];
+  // While previews load, the draft's own list stands in with loading tiles.
+  const previewedAttachments =
+    attachmentPreviews?.attachments ??
+    attachments.map((attachment) => {
+      return { attachment, url: undefined, text$: undefined };
+    });
   return (
     <div ref={setAttachmentScopeRef} className="flex min-h-0 flex-1 flex-col">
       <div className="shrink-0 px-5 pt-5">
@@ -998,8 +1011,8 @@ function MailDraftDetails({
       <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
         <div className="py-5">
           <MailDraftMessage
-            attachmentUrls={attachmentUrls}
-            attachmentUrlsLoading={attachmentUrlsLoading}
+            inlineImages={attachmentPreviews?.inlineImages ?? null}
+            inlineImagesLoading={attachmentPreviewsLoading}
             draft={draft}
             signals={signals}
           />
@@ -1012,18 +1025,14 @@ function MailDraftDetails({
               })}
             </div>
             <div className="flex flex-wrap gap-3">
-              {attachments.map((attachment) => {
+              {previewedAttachments.map(({ attachment, text$, url }) => {
                 const key = `${attachment.filename}-${attachment.contentType}-${attachment.size}`;
                 return attachment.partId ? (
                   <MailAttachmentPreview
                     key={key}
                     attachment={attachment}
-                    text$={attachmentPreviews?.text.get(attachment.partId)}
-                    url={
-                      attachmentUrlsLoading
-                        ? undefined
-                        : (attachmentUrls?.get(attachment.partId) ?? null)
-                    }
+                    text$={text$}
+                    url={url}
                   />
                 ) : (
                   <AttachmentSummary key={key} attachment={attachment} />


### PR DESCRIPTION
## Summary

Registry audit follow-up for the chat event pipeline: the mail draft sidebar was the last surface resolving per-part resources through exposed maps at render time.

`attachmentPreviews$` used to resolve `{ text: Map<partId, TextPreviewComputed>, urls: Map<partId, string | null> }`, and the sidebar looked parts up by id in three places while rendering (attachment tile `text$`, attachment tile `url`, and inline `cid:` images inside the HTML walk).

The computed now performs that join itself and resolves draft-shaped lists:

- `attachments: readonly { attachment, url, text$ }[]` — the tiles walk this directly; while previews load, the draft's own attachment list stands in with loading tiles.
- `inlineImages: readonly { image, url }[]` — the HTML walker keys its own input by normalized content id (a walk-local join of forward-flowing data, same shape as the transcript projection joins), replacing the two store maps it used to receive.

No behavior change intended: loading (`undefined`) vs missing (`null`) url semantics and the object-URL revocation lifecycle are preserved.
