### PR TITLE
fix(runner): exclude codex websocket prewarm usage

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1576,8 +1576,9 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     if getattr(message, "from_client", False):
         if uses_openai_responses:
             body = message.content.encode() if isinstance(message.content, str) else message.content
-            event_type = usage.inspect_openai_responses_event_type_json(body)
-            codex_output_timing.observe_client_event(flow, event_type, message.timestamp)
+            event = usage.inspect_openai_responses_client_event_json(body)
+            codex_output_timing.observe_client_event(flow, event.event_type, message.timestamp)
+            response_streaming.observe_model_websocket_client_event(flow, event)
         return
     body = message.content.encode() if isinstance(message.content, str) else message.content
     event = usage.inspect_openai_responses_event_json(body)

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -649,18 +649,21 @@ def feed_model_websocket_usage(
             isinstance(prewarm_state, _OpenAIResponsesPrewarmState)
             and prewarm_state.response_id == message_id
         ):
-            if not prewarm_state.diagnostic_emitted and usage.has_positive_model_provider_usage(
-                usage_result
-            ):
-                usage.log_ignored_model_provider_usage_source(
-                    flow,
-                    flow_metadata.run_id(flow.metadata),
-                    message_id,
-                    usage_result,
-                    reason="responses_generate_false",
-                )
-                prewarm_state.diagnostic_emitted = True
-            return
+            lifecycle = usage.inspect_openai_responses_server_lifecycle(event)
+            if lifecycle.is_terminal and lifecycle.response_id == message_id:
+                if not prewarm_state.diagnostic_emitted and usage.has_positive_model_provider_usage(
+                    usage_result
+                ):
+                    usage.log_ignored_model_provider_usage_source(
+                        flow,
+                        flow_metadata.run_id(flow.metadata),
+                        message_id,
+                        usage_result,
+                        reason="responses_generate_false",
+                    )
+                    prewarm_state.diagnostic_emitted = True
+                return
+            prewarm_state.response_id = None
         usage_sources = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_SOURCES)
         if not isinstance(usage_sources, dict):
             usage_sources = {}

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -4,8 +4,9 @@ Lifecycle:
 - ``mitm_addon.responseheaders()`` calls ``configure_response_stream()`` to
   install the streaming callback, exact byte accounting, optional capped body
   buffer, and incremental usage parsers.
-- ``mitm_addon.websocket_message()`` calls ``feed_model_websocket_usage()`` for
-  terminal server-side usage frames on model-provider WebSocket upgrades.
+- ``mitm_addon.websocket_message()`` calls ``observe_model_websocket_client_event()``
+  for client request intent and ``feed_model_websocket_usage()`` for server-side
+  usage frames on model-provider WebSocket upgrades.
 - ``mitm_addon.response()`` finalizes HTTP model and connector usage before
   reporting it.
 - ``mitm_addon.error()`` may finalize partial SSE or opted-in connector usage
@@ -18,6 +19,7 @@ Lifecycle:
 """
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Literal, NamedTuple
 
 from mitmproxy import http
@@ -44,6 +46,7 @@ _HTTP_STATUS_NOT_MODIFIED = 304
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
+_MODEL_WEBSOCKET_PREWARM_STATE = "_model_websocket_prewarm_state"
 _CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
 _CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION = "connector_response_report_on_interruption"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
@@ -88,6 +91,13 @@ class CapturedResponseStreamBody(NamedTuple):
 class _ResponseUsageStreamSetup(NamedTuple):
     parser: _ResponseChunkParser | None
     needs_buffered_fallback: bool
+
+
+@dataclass(slots=True)
+class _OpenAIResponsesPrewarmState:
+    pending_response_created: bool = False
+    response_id: str | None = None
+    diagnostic_emitted: bool = False
 
 
 def model_usage_protocol(flow: http.HTTPFlow) -> ModelUsageProtocol:
@@ -135,6 +145,22 @@ def is_model_websocket_usage_enabled(flow: http.HTTPFlow) -> bool:
 def release_model_websocket_usage_state(flow: http.HTTPFlow) -> None:
     """Disable WebSocket usage extraction after a terminal websocket/error hook."""
     flow.metadata.pop(_MODEL_WEBSOCKET_USAGE_ENABLED, None)
+    flow.metadata.pop(_MODEL_WEBSOCKET_PREWARM_STATE, None)
+
+
+def observe_model_websocket_client_event(
+    flow: http.HTTPFlow,
+    event: usage.OpenAIResponsesClientEvent,
+) -> None:
+    """Track exact non-generating request intent on one WebSocket flow."""
+    state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
+    if not isinstance(state, _OpenAIResponsesPrewarmState):
+        return
+
+    state.pending_response_created = event.is_prewarm
+    if event.is_prewarm:
+        state.response_id = None
+        state.diagnostic_emitted = False
 
 
 def _make_response_decode_session(
@@ -244,6 +270,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
     ):
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {}
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
+        flow.metadata[_MODEL_WEBSOCKET_PREWARM_STATE] = _OpenAIResponsesPrewarmState()
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return _ResponseUsageStreamSetup(None, False)
     if not _response_can_have_body(flow, response):
@@ -592,6 +619,17 @@ def feed_model_websocket_usage(
     """
     if not is_model_websocket_usage_enabled(flow):
         return
+    prewarm_state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
+    if isinstance(prewarm_state, _OpenAIResponsesPrewarmState) and (
+        prewarm_state.pending_response_created
+    ):
+        lifecycle = usage.inspect_openai_responses_server_lifecycle(event)
+        if lifecycle.event_type == "response.created":
+            prewarm_state.pending_response_created = False
+            prewarm_state.response_id = lifecycle.response_id
+        elif lifecycle.is_terminal:
+            prewarm_state.pending_response_created = False
+
     usage_result, inspection_error = usage.extract_openai_responses_usage_from_event(event)
     if inspection_error is not None:
         log_proxy_entry(
@@ -607,6 +645,22 @@ def feed_model_websocket_usage(
         return
     message_id = usage_result.get("message_id")
     if isinstance(message_id, str) and message_id:
+        if (
+            isinstance(prewarm_state, _OpenAIResponsesPrewarmState)
+            and prewarm_state.response_id == message_id
+        ):
+            if not prewarm_state.diagnostic_emitted and usage.has_positive_model_provider_usage(
+                usage_result
+            ):
+                usage.log_ignored_model_provider_usage_source(
+                    flow,
+                    flow_metadata.run_id(flow.metadata),
+                    message_id,
+                    usage_result,
+                    reason="responses_generate_false",
+                )
+                prewarm_state.diagnostic_emitted = True
+            return
         usage_sources = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_SOURCES)
         if not isinstance(usage_sources, dict):
             usage_sources = {}

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -60,13 +60,17 @@ from .openai_chat_completions import (
     extract_openai_chat_completions_usage_with_error_from_json,
 )
 from .openai_responses import (
+    OpenAIResponsesClientEvent,
     OpenAIResponsesEvent,
+    OpenAIResponsesServerLifecycle,
     create_openai_responses_json_usage_extractor,
     create_openai_responses_sse_usage_extractor,
     extract_openai_responses_usage_from_event,
     extract_openai_responses_usage_with_error_from_json,
+    inspect_openai_responses_client_event_json,
     inspect_openai_responses_event_json,
     inspect_openai_responses_event_type_json,
+    inspect_openai_responses_server_lifecycle,
     merge_openai_responses_usage_result,
 )
 from .providers.connectors import (
@@ -78,6 +82,7 @@ from .providers.connectors import (
 from .providers.model_provider import (
     has_positive_model_provider_usage,
     is_model_provider_usage_observable,
+    log_ignored_model_provider_usage_source,
     log_terminal_model_provider_usage_sources,
     release_model_provider_usage_tiers,
     report_model_provider_usage,
@@ -88,7 +93,9 @@ from .providers.model_provider import (
 __all__ = [
     "DEFAULT_FLUSH_INTERVAL_SECONDS",
     "BufferedReportLease",
+    "OpenAIResponsesClientEvent",
     "OpenAIResponsesEvent",
+    "OpenAIResponsesServerLifecycle",
     "admit_buffered_report",
     "buffer_model_usage_observations",
     "buffer_source_model_usage_observations",
@@ -113,9 +120,12 @@ __all__ = [
     "has_connector_response_parser",
     "has_positive_model_provider_usage",
     "increment_in_flight_flows",
+    "inspect_openai_responses_client_event_json",
     "inspect_openai_responses_event_json",
     "inspect_openai_responses_event_type_json",
+    "inspect_openai_responses_server_lifecycle",
     "is_model_provider_usage_observable",
+    "log_ignored_model_provider_usage_source",
     "log_terminal_model_provider_usage_sources",
     "merge_openai_responses_usage_result",
     "needs_connector_response_buffer_fallback",

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -62,7 +62,6 @@ from .openai_chat_completions import (
 from .openai_responses import (
     OpenAIResponsesClientEvent,
     OpenAIResponsesEvent,
-    OpenAIResponsesServerLifecycle,
     create_openai_responses_json_usage_extractor,
     create_openai_responses_sse_usage_extractor,
     extract_openai_responses_usage_from_event,
@@ -94,7 +93,6 @@ __all__ = [
     "BufferedReportLease",
     "OpenAIResponsesClientEvent",
     "OpenAIResponsesEvent",
-    "OpenAIResponsesServerLifecycle",
     "admit_buffered_report",
     "buffer_model_usage_observations",
     "buffer_source_model_usage_observations",

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -69,7 +69,6 @@ from .openai_responses import (
     extract_openai_responses_usage_with_error_from_json,
     inspect_openai_responses_client_event_json,
     inspect_openai_responses_event_json,
-    inspect_openai_responses_event_type_json,
     inspect_openai_responses_server_lifecycle,
     merge_openai_responses_usage_result,
 )
@@ -122,7 +121,6 @@ __all__ = [
     "increment_in_flight_flows",
     "inspect_openai_responses_client_event_json",
     "inspect_openai_responses_event_json",
-    "inspect_openai_responses_event_type_json",
     "inspect_openai_responses_server_lifecycle",
     "is_model_provider_usage_observable",
     "log_ignored_model_provider_usage_source",

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -34,7 +34,7 @@ PathSegment = str | _PathMarker
 Path = tuple[PathSegment, ...]
 WildcardPath = tuple[str, ...]
 _ScalarPath = TypeVar("_ScalarPath", bound=Path)
-ScalarKind = Literal["string", "int"]
+ScalarKind = Literal["string", "int", "bool"]
 ScalarOverflowPolicy = Literal["error", "discard"]
 _JsonStringScanner = Callable[[str, int, bool], tuple[str, int]]
 # `scanstring` is the stdlib JSON string scanner, but typeshed does not expose it.
@@ -113,8 +113,8 @@ def json_nesting_within_limit(body: bytes, *, max_depth: int = _DEFAULT_MAX_DEPT
 class ScalarField:
     """Selected scalar field configuration.
 
-    ``kind`` must be ``"string"`` or ``"int"``. ``max_bytes`` is the capture
-    limit for the selected scalar token. ``overflow_policy`` defaults to
+    ``kind`` must be ``"string"``, ``"int"``, or ``"bool"``. ``max_bytes`` is
+    the capture limit for selected string and integer tokens. ``overflow_policy`` defaults to
     ``"error"``, which fails extraction with ``"string limit exceeded"`` or
     ``"number limit exceeded"``. Selected strings may use ``"discard"`` to
     stop retaining an oversized optional observation while continuing to
@@ -126,8 +126,8 @@ class ScalarField:
     overflow_policy: ScalarOverflowPolicy = "error"
 
     def __post_init__(self) -> None:
-        if self.kind not in ("string", "int"):
-            raise ValueError("scalar field kind must be 'string' or 'int'")
+        if self.kind not in ("string", "int", "bool"):
+            raise ValueError("scalar field kind must be 'string', 'int', or 'bool'")
         _validate_positive_int("scalar field max_bytes", self.max_bytes)
         if self.overflow_policy not in ("error", "discard"):
             raise ValueError("scalar field overflow_policy must be 'error' or 'discard'")
@@ -198,6 +198,8 @@ class _NumberState:
 @dataclass
 class _LiteralState:
     literal: bytes
+    path: Path
+    selected_value: bool | None = None
     offset: int = 0
 
 
@@ -578,13 +580,23 @@ class JsonSelectiveExtractor:
             )
             return self._consume_number(chunk, i)
         if b == ord("t"):
-            self._literal = _LiteralState(b"true")
+            field = self.scalar_fields.get(path)
+            self._literal = _LiteralState(
+                b"true",
+                path,
+                selected_value=True if field and field.kind == "bool" else None,
+            )
             return self._consume_literal(chunk, i)
         if b == ord("f"):
-            self._literal = _LiteralState(b"false")
+            field = self.scalar_fields.get(path)
+            self._literal = _LiteralState(
+                b"false",
+                path,
+                selected_value=False if field and field.kind == "bool" else None,
+            )
             return self._consume_literal(chunk, i)
         if b == ord("n"):
-            self._literal = _LiteralState(b"null")
+            self._literal = _LiteralState(b"null", path)
             return self._consume_literal(chunk, i)
         self._error = "expected json value"
         return i + 1
@@ -1028,6 +1040,9 @@ class JsonSelectiveExtractor:
             self._slow_work_bytes_remaining -= i - start
         if not self._error and state.offset == len(state.literal):
             self._literal = None
+            if state.selected_value is not None:
+                self._record_scalar_consistency(state.path, state.selected_value)
+                self.values[state.path] = state.selected_value
             self._value_complete()
         return i
 

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -113,12 +113,12 @@ def json_nesting_within_limit(body: bytes, *, max_depth: int = _DEFAULT_MAX_DEPT
 class ScalarField:
     """Selected scalar field configuration.
 
-    ``kind`` must be ``"string"``, ``"int"``, or ``"bool"``. ``max_bytes`` is
-    the capture limit for selected string and integer tokens. ``overflow_policy`` defaults to
-    ``"error"``, which fails extraction with ``"string limit exceeded"`` or
-    ``"number limit exceeded"``. Selected strings may use ``"discard"`` to
-    stop retaining an oversized optional observation while continuing to
-    validate the document.
+    ``kind`` must be ``"string"``, ``"int"``, or ``"bool"``. ``max_bytes``
+    limits selected string and integer tokens; booleans use fixed JSON literals.
+    ``overflow_policy`` defaults to ``"error"``, which fails extraction with
+    ``"string limit exceeded"`` or ``"number limit exceeded"``. Selected
+    strings may use ``"discard"`` to stop retaining an oversized optional
+    observation while continuing to validate the document.
     """
 
     kind: ScalarKind
@@ -216,7 +216,7 @@ class JsonSelectiveExtractor:
 
     The extractor observes five kinds of data while parsing:
 
-    - ``scalar_fields`` captures selected string or integer values.
+    - ``scalar_fields`` captures selected string, integer, or boolean values.
     - ``array_count_paths`` counts arrays at exact paths.
     - ``wildcard_array_count_paths`` counts arrays at wildcard paths with one
       ``"*"`` segment, recording counts by the concrete wildcard key.

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -206,7 +206,7 @@ _RESPONSES_CREATED_SCALAR_FIELDS = {
 
 def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesClientEvent:
     """Inspect client event timing and exact non-generating request intent."""
-    observed_event_type = inspect_openai_responses_event_type_json(body)
+    observed_event_type = _inspect_openai_responses_event_type_json(body)
     extractor = JsonSelectiveExtractor(
         scalar_fields=_RESPONSES_CLIENT_SCALAR_FIELDS,
         max_work_units=_RESPONSES_MAX_WORK_UNITS,
@@ -239,7 +239,7 @@ def inspect_openai_responses_event_json(body: bytes) -> OpenAIResponsesEvent:
     )
 
 
-def inspect_openai_responses_event_type_json(body: bytes) -> str | None:
+def _inspect_openai_responses_event_type_json(body: bytes) -> str | None:
     """Probe one Responses frame for its top-level ``type`` without retaining it."""
     return _observed_responses_event_type(_probe_responses_event_type(body))
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -198,7 +198,7 @@ _RESPONSES_CLIENT_SCALAR_FIELDS = {
     ("type",): ScalarField("string", max_bytes=1024, overflow_policy="discard"),
     ("generate",): ScalarField("bool"),
 }
-_RESPONSES_CREATED_SCALAR_FIELDS = {
+_RESPONSES_LIFECYCLE_SCALAR_FIELDS = {
     ("type",): ScalarField("string", max_bytes=1024, overflow_policy="discard"),
     ("response", "id"): ScalarField("string", max_bytes=1024),
 }
@@ -250,13 +250,13 @@ def _inspect_openai_responses_event_type_json(body: bytes) -> str | None:
 def inspect_openai_responses_server_lifecycle(
     event: OpenAIResponsesEvent,
 ) -> OpenAIResponsesServerLifecycle:
-    """Inspect an exact created or terminal event while correlation is pending."""
+    """Inspect an exact created or terminal event for WebSocket correlation."""
     relevant_event_types = _RESPONSES_TERMINAL_USAGE_EVENTS | {_RESPONSES_CREATED_EVENT}
     if event.event_type is not None and event.event_type not in relevant_event_types:
         return OpenAIResponsesServerLifecycle(event.event_type, None)
 
     extractor = JsonSelectiveExtractor(
-        scalar_fields=_RESPONSES_CREATED_SCALAR_FIELDS,
+        scalar_fields=_RESPONSES_LIFECYCLE_SCALAR_FIELDS,
         scalar_consistency_paths={("type",), ("response", "id")},
         max_work_units=_RESPONSES_MAX_WORK_UNITS,
     )

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -11,11 +11,11 @@ model-provider usage billing:
   ``mitm_addon.py`` fallback used by legacy/test flows without
   response-streaming parser state.
 - Single-frame WebSocket event JSON via
-  ``inspect_openai_responses_event_type_json``,
+  ``inspect_openai_responses_client_event_json``,
   ``inspect_openai_responses_event_json``, and
   ``extract_openai_responses_usage_from_event``, consumed by
-  ``mitm_addon.py`` and ``response_streaming.py`` for client event-type timing
-  and server usage events received over upgrades.
+  ``mitm_addon.py`` and ``response_streaming.py`` for client request intent,
+  event-type timing, and server usage events received over upgrades.
 - Per-event usage aggregation via ``merge_openai_responses_usage_result``,
   used by ``response_streaming.py`` to fold terminal SSE and WebSocket event
   usage into a per-flow accumulator.
@@ -136,6 +136,28 @@ _RESPONSES_EVENT_PREFILTER_MAX_BYTES = 4096
 # parser's bulk-scan path for ordinary large content strings.
 _RESPONSES_MAX_WORK_UNITS = 65_536
 _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
+_RESPONSES_CREATE_EVENT = "response.create"
+_RESPONSES_CREATED_EVENT = "response.created"
+
+
+@dataclass(frozen=True)
+class OpenAIResponsesClientEvent:
+    """Bounded observations from one client-originated Responses frame."""
+
+    event_type: str | None
+    is_prewarm: bool
+
+
+@dataclass(frozen=True)
+class OpenAIResponsesServerLifecycle:
+    """Bounded lifecycle observations needed before WebSocket settlement."""
+
+    event_type: str | None
+    response_id: str | None
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.event_type in _RESPONSES_TERMINAL_USAGE_EVENTS
 
 
 @dataclass(frozen=True)
@@ -172,6 +194,33 @@ _RESPONSES_SSE_SCALAR_FIELDS = {
     ("type",): ScalarField("string", max_bytes=1024, overflow_policy="discard"),
     **_RESPONSES_SSE_RESPONSE_SCALAR_FIELDS,
 }
+_RESPONSES_CLIENT_SCALAR_FIELDS = {
+    ("type",): ScalarField("string", max_bytes=1024, overflow_policy="discard"),
+    ("generate",): ScalarField("bool"),
+}
+_RESPONSES_CREATED_SCALAR_FIELDS = {
+    ("type",): ScalarField("string", max_bytes=1024, overflow_policy="discard"),
+    ("response", "id"): ScalarField("string", max_bytes=1024),
+}
+
+
+def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesClientEvent:
+    """Inspect client event timing and exact non-generating request intent."""
+    observed_event_type = inspect_openai_responses_event_type_json(body)
+    extractor = JsonSelectiveExtractor(
+        scalar_fields=_RESPONSES_CLIENT_SCALAR_FIELDS,
+        max_work_units=_RESPONSES_MAX_WORK_UNITS,
+    )
+    extractor.feed(body)
+    result = extractor.finish()
+    if not result.complete:
+        return OpenAIResponsesClientEvent(observed_event_type, False)
+
+    return OpenAIResponsesClientEvent(
+        observed_event_type,
+        result.values.get(("type",)) == _RESPONSES_CREATE_EVENT
+        and result.values.get(("generate",)) is False,
+    )
 
 
 def inspect_openai_responses_event_json(body: bytes) -> OpenAIResponsesEvent:
@@ -193,6 +242,35 @@ def inspect_openai_responses_event_json(body: bytes) -> OpenAIResponsesEvent:
 def inspect_openai_responses_event_type_json(body: bytes) -> str | None:
     """Probe one Responses frame for its top-level ``type`` without retaining it."""
     return _observed_responses_event_type(_probe_responses_event_type(body))
+
+
+def inspect_openai_responses_server_lifecycle(
+    event: OpenAIResponsesEvent,
+) -> OpenAIResponsesServerLifecycle:
+    """Inspect an exact created or terminal event while correlation is pending."""
+    relevant_event_types = _RESPONSES_TERMINAL_USAGE_EVENTS | {_RESPONSES_CREATED_EVENT}
+    if event.event_type is not None and event.event_type not in relevant_event_types:
+        return OpenAIResponsesServerLifecycle(event.event_type, None)
+
+    extractor = JsonSelectiveExtractor(
+        scalar_fields=_RESPONSES_CREATED_SCALAR_FIELDS,
+        max_work_units=_RESPONSES_MAX_WORK_UNITS,
+    )
+    extractor.feed(event._body)
+    result = extractor.finish()
+    if not result.complete:
+        return OpenAIResponsesServerLifecycle(event.event_type, None)
+    event_type = result.values.get(("type",))
+    if not isinstance(event_type, str):
+        return OpenAIResponsesServerLifecycle(event.event_type, None)
+    response_id = result.values.get(("response", "id"))
+    if (
+        event_type != _RESPONSES_CREATED_EVENT
+        or not isinstance(response_id, str)
+        or not response_id
+    ):
+        response_id = None
+    return OpenAIResponsesServerLifecycle(event_type, response_id)
 
 
 def _probe_responses_event_type(body: bytes) -> TopLevelStringFieldProbeResult:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -271,7 +271,7 @@ def inspect_openai_responses_server_lifecycle(
         return OpenAIResponsesServerLifecycle(event.event_type, None)
     response_id = result.values.get(("response", "id"))
     if (
-        event_type != _RESPONSES_CREATED_EVENT
+        event_type not in relevant_event_types
         or not extractor.selected_scalar_values_are_consistent(("response", "id"))
         or not isinstance(response_id, str)
         or not response_id

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -209,6 +209,7 @@ def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesCl
     observed_event_type = _inspect_openai_responses_event_type_json(body)
     extractor = JsonSelectiveExtractor(
         scalar_fields=_RESPONSES_CLIENT_SCALAR_FIELDS,
+        scalar_consistency_paths={("type",), ("generate",)},
         max_work_units=_RESPONSES_MAX_WORK_UNITS,
     )
     extractor.feed(body)
@@ -218,7 +219,9 @@ def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesCl
 
     return OpenAIResponsesClientEvent(
         observed_event_type,
-        result.values.get(("type",)) == _RESPONSES_CREATE_EVENT
+        extractor.selected_scalar_values_are_consistent(("type",))
+        and extractor.selected_scalar_values_are_consistent(("generate",))
+        and result.values.get(("type",)) == _RESPONSES_CREATE_EVENT
         and result.values.get(("generate",)) is False,
     )
 
@@ -254,11 +257,14 @@ def inspect_openai_responses_server_lifecycle(
 
     extractor = JsonSelectiveExtractor(
         scalar_fields=_RESPONSES_CREATED_SCALAR_FIELDS,
+        scalar_consistency_paths={("type",), ("response", "id")},
         max_work_units=_RESPONSES_MAX_WORK_UNITS,
     )
     extractor.feed(event._body)
     result = extractor.finish()
     if not result.complete:
+        return OpenAIResponsesServerLifecycle(event.event_type, None)
+    if not extractor.selected_scalar_values_are_consistent(("type",)):
         return OpenAIResponsesServerLifecycle(event.event_type, None)
     event_type = result.values.get(("type",))
     if not isinstance(event_type, str):
@@ -266,6 +272,7 @@ def inspect_openai_responses_server_lifecycle(
     response_id = result.values.get(("response", "id"))
     if (
         event_type != _RESPONSES_CREATED_EVENT
+        or not extractor.selected_scalar_values_are_consistent(("response", "id"))
         or not isinstance(response_id, str)
         or not response_id
     ):

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -316,6 +316,47 @@ def report_model_provider_usage_source(
     )
 
 
+def log_ignored_model_provider_usage_source(
+    flow: http.HTTPFlow,
+    run_id: str,
+    message_id: str,
+    source_usage: dict,
+    *,
+    reason: str,
+) -> None:
+    """Log one intentionally ignored WebSocket response usage source."""
+    if not has_positive_model_provider_usage(source_usage):
+        return
+
+    url_projection = project_url_for_proxy_log(flow_metadata.original_url(flow.metadata))
+    log_proxy_entry(
+        flow_metadata.proxy_log_path(flow.metadata),
+        "info",
+        "Model provider usage source ignored",
+        type="model_usage_source",
+        disposition="ignored",
+        reason=reason,
+        run_id=run_id,
+        flow_id=flow.id,
+        source_id=f"{flow.id}:{message_id}",
+        method=flow.request.method,
+        url=url_projection,
+        transport="websocket",
+        buffer_mode="source",
+        firewall_name=flow_metadata.firewall_name(flow.metadata),
+        reported_model=_reported_model(flow, source_usage),
+        provider_response_id=message_id,
+        usage={
+            category: quantity
+            for category in MODEL_USAGE_CATEGORIES
+            if _is_positive_int(quantity := source_usage.get(category))
+        },
+        usage_events=[],
+        model_usage_observations=[],
+        **url_projection.truncation_fields(),
+    )
+
+
 def log_terminal_model_provider_usage_sources(
     flow: http.HTTPFlow,
     run_id: str,

--- a/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
@@ -100,6 +100,12 @@ def feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
     mitm_addon.websocket_message(flow)
 
 
+def feed_websocket_client_message(flow: http.HTTPFlow, content: bytes) -> None:
+    _assert_model_websocket_usage_started(flow)
+    set_websocket_message(flow, from_client=True, content=content)
+    mitm_addon.websocket_message(flow)
+
+
 def feed_websocket_server_text_message(flow: http.HTTPFlow, content: str) -> None:
     _assert_model_websocket_usage_started(flow)
     set_websocket_message(flow, from_client=False, content=content.encode())

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -311,6 +311,38 @@ class TestModelProviderWebSocketPrewarmUsage:
             expected_rows,
         )
 
+    def test_model_websocket_conflicting_terminal_ids_fail_open(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                _openai_websocket_created_frame("warm-ambiguous"),
+            )
+            feed_websocket_server_message(
+                flow,
+                b'{"type":"response.completed","response":'
+                b'{"id":"other","id":"warm-ambiguous","model":"gpt-5.5",'
+                b'"usage":{"input_tokens":13,"output_tokens":0}}}',
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 13)]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+
     def test_model_websocket_malformed_client_frame_retires_unbound_prewarm(
         self,
         tmp_path,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -246,6 +246,8 @@ class TestModelProviderWebSocketPrewarmUsage:
             b'{"type":"response.create"}',
             b'{"type":"response.create","generate":true}',
             b'{"type":"response.create","generate":"false"}',
+            b'{"type":"response.create","generate":true,"generate":false}',
+            b'{"type":"other","type":"response.create","generate":false}',
         ],
     )
     def test_model_websocket_non_prewarm_requests_retain_input_only_usage(
@@ -271,6 +273,37 @@ class TestModelProviderWebSocketPrewarmUsage:
             usage.flush_usage_events(trigger="test")
 
         expected_rows = [("gpt-5.5", "tokens.input", 9)]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+
+    def test_model_websocket_conflicting_created_ids_fail_open(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                b'{"type":"response.created","response":{"id":"first","id":"second"}}',
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "second",
+                    input_tokens=11,
+                    output_tokens=0,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 11)]
         _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
         _assert_usage_event_rows(
             webhook.model_usage_observation_events(),

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -326,6 +326,14 @@ class TestModelProviderWebSocketPrewarmUsage:
                 prewarm_flow,
                 _openai_websocket_created_frame("shared-response-id"),
             )
+            feed_websocket_server_message(
+                prewarm_flow,
+                openai_websocket_usage_frame(
+                    "shared-response-id",
+                    input_tokens=5,
+                    output_tokens=0,
+                ),
+            )
 
             feed_websocket_client_message(
                 normal_flow,
@@ -343,6 +351,22 @@ class TestModelProviderWebSocketPrewarmUsage:
                     output_tokens=0,
                 ),
             )
+            feed_websocket_client_message(
+                normal_flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                normal_flow,
+                _openai_websocket_created_frame("second-prewarm"),
+            )
+            feed_websocket_server_message(
+                normal_flow,
+                openai_websocket_usage_frame(
+                    "second-prewarm",
+                    input_tokens=6,
+                    output_tokens=0,
+                ),
+            )
             usage.flush_usage_events(trigger="test")
 
         expected_rows = [("gpt-5.5", "tokens.input", 7)]
@@ -352,6 +376,18 @@ class TestModelProviderWebSocketPrewarmUsage:
             "model",
             expected_rows,
         )
+        ignored_entries = [
+            entry
+            for entry in model_usage_source_entries(prewarm_flow)
+            if entry.get("disposition") == "ignored"
+        ]
+        assert {
+            (entry["flow_id"], entry["provider_response_id"], entry["usage"]["tokens.input"])
+            for entry in ignored_entries
+        } == {
+            (prewarm_flow.id, "shared-response-id", 5),
+            (normal_flow.id, "second-prewarm", 6),
+        }
 
 
 class TestModelProviderWebSocketUsageSourceRelease:

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -116,7 +116,6 @@ class TestModelProviderWebSocketPrewarmUsage:
                 output_tokens=0,
             )
             feed_websocket_server_message(flow, prewarm_usage)
-            feed_websocket_server_message(flow, prewarm_usage)
 
             feed_websocket_client_message(
                 flow,
@@ -131,6 +130,7 @@ class TestModelProviderWebSocketPrewarmUsage:
                     output_tokens=0,
                 ),
             )
+            feed_websocket_server_message(flow, prewarm_usage)
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -10,6 +10,7 @@ from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import response_streaming
 import usage
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import (
@@ -20,6 +21,7 @@ from tests.model_provider_flow_helpers import (
 from tests.model_provider_websocket_helpers import (
     ScheduledWebSocketTrim,
     capture_deferred_websocket_trims,
+    feed_websocket_client_message,
     feed_websocket_server_message,
     feed_websocket_server_text_message,
     openai_websocket_usage_frame,
@@ -70,6 +72,286 @@ def _openai_websocket_zero_usage_frame(response_id: str, *, model: str | None = 
             "response": response,
         }
     ).encode()
+
+
+def _openai_websocket_created_frame(response_id: str) -> bytes:
+    return json.dumps(
+        {
+            "type": "response.created",
+            "response": {"id": response_id},
+        }
+    ).encode()
+
+
+class TestModelProviderWebSocketPrewarmUsage:
+    """Tests for exact non-generating response source exclusion."""
+
+    @pytest.fixture(autouse=True)
+    def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
+        self._usage_webhook_api = usage_webhook_api
+
+    def test_model_websocket_ignores_bound_prewarm_and_reports_normal_input_only_turn(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        sensitive_marker = "prewarm-sensitive-marker"
+        prewarm_request = json.dumps(
+            {
+                "type": "response.create",
+                "input": [{"role": "user", "content": sensitive_marker * 300}],
+                "tools": [{"name": "test-tool", "description": "x" * 5000}],
+                "generate": False,
+            }
+        ).encode()
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(flow, prewarm_request)
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-1"))
+            prewarm_usage = openai_websocket_usage_frame(
+                "warm-1",
+                input_tokens=6050,
+                output_tokens=0,
+            )
+            feed_websocket_server_message(flow, prewarm_usage)
+            feed_websocket_server_message(flow, prewarm_usage)
+
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "input": []}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("resp-1"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "resp-1",
+                    input_tokens=10,
+                    output_tokens=0,
+                ),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 10)]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        ignored_entries = [
+            entry
+            for entry in model_usage_source_entries(flow)
+            if entry.get("disposition") == "ignored"
+        ]
+        [ignored_entry] = ignored_entries
+        assert ignored_entry["reason"] == "responses_generate_false"
+        assert ignored_entry["provider_response_id"] == "warm-1"
+        assert ignored_entry["source_id"] == f"{flow.id}:warm-1"
+        assert ignored_entry["usage"] == {"tokens.input": 6050}
+        assert ignored_entry["usage_events"] == []
+        assert ignored_entry["model_usage_observations"] == []
+        assert ignored_entry["url"] == "https://api.openai.com/v1/responses"
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        assert sensitive_marker not in proxy_log.read_text()
+        assert model_provider_usage_sources(flow) == {}
+        assert response_streaming.is_model_websocket_usage_enabled(flow) is False
+        assert "_model_websocket_prewarm_state" not in flow.metadata
+
+    def test_model_websocket_unbound_prewarm_usage_fails_open(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "warm-without-created",
+                    input_tokens=12,
+                    output_tokens=0,
+                ),
+            )
+            feed_websocket_server_message(
+                flow,
+                _openai_websocket_created_frame("response-after-unbound-terminal"),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "response-after-unbound-terminal",
+                    input_tokens=4,
+                    output_tokens=0,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [
+            ("gpt-5.5", "tokens.input", 12),
+            ("gpt-5.5", "tokens.input", 4),
+        ]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+
+    def test_model_websocket_prewarm_with_missing_created_id_fails_open(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                json.dumps({"type": "response.created", "response": {}}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "unbound-response",
+                    input_tokens=6,
+                    output_tokens=0,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 6)]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+
+    @pytest.mark.parametrize(
+        "client_request",
+        [
+            b'{"type":"response.create"}',
+            b'{"type":"response.create","generate":true}',
+            b'{"type":"response.create","generate":"false"}',
+        ],
+    )
+    def test_model_websocket_non_prewarm_requests_retain_input_only_usage(
+        self,
+        tmp_path,
+        real_flow,
+        client_request: bytes,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(flow, client_request)
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("resp-input-only"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "resp-input-only",
+                    input_tokens=9,
+                    output_tokens=0,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 9)]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+
+    def test_model_websocket_malformed_client_frame_retires_unbound_prewarm(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_client_message(flow, b'{"type":"response.create"')
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("resp-after-bad"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "resp-after-bad",
+                    input_tokens=8,
+                    output_tokens=0,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 8)]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+
+    def test_model_websocket_prewarm_state_isolated_by_flow(self, tmp_path, real_flow):
+        prewarm_flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        normal_flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(prewarm_flow)
+        mitm_addon.responseheaders(normal_flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                prewarm_flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                prewarm_flow,
+                _openai_websocket_created_frame("shared-response-id"),
+            )
+
+            feed_websocket_client_message(
+                normal_flow,
+                json.dumps({"type": "response.create"}).encode(),
+            )
+            feed_websocket_server_message(
+                normal_flow,
+                _openai_websocket_created_frame("shared-response-id"),
+            )
+            feed_websocket_server_message(
+                normal_flow,
+                openai_websocket_usage_frame(
+                    "shared-response-id",
+                    input_tokens=7,
+                    output_tokens=0,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 7)]
+        _assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        _assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
 
 
 class TestModelProviderWebSocketUsageSourceRelease:


### PR DESCRIPTION
## Summary

- inspect Codex Responses WebSocket client frames for the exact `response.create` / `generate=false` operation without materializing prompt or tool content
- bind that operation to its provider response ID at `response.created` and exclude only matching terminal usage from billable events and model usage observations
- retain flow-scoped, bounded correlation state and emit one content-free ignored-source diagnostic for rollout reconciliation
- preserve current reporting for normal input-only inference and for malformed, unsupported, or unbound lifecycles

## Implementation

- extend the bounded selective JSON parser with boolean scalar selection
- keep prewarm correlation private to the observable OpenAI Responses WebSocket flow lifecycle
- retain the ignored response ID through flow cleanup so duplicate terminal delivery stays unbilled while the diagnostic is emitted once
- require a complete, unambiguous terminal response identity before excluding its usage
- cover the public mitmproxy hook path, including large client frames, normal input-only usage, fail-open behavior, duplicates, flow isolation, and terminal cleanup

## Scope

- no database schema or persisted-data migration
- no historical usage correction
- no change to OpenAI Responses HTTP/SSE, Chat Completions, Anthropic Messages, or connector accounting
- production reconciliation should be evaluated after old runners drain and provider reporting latency elapses

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,294 passed)
- `lefthook run pre-commit`

Closes #26475

Parent context: #26303
