### PR TITLE
refactor(platform): scope markdown signal registries to their surfaces

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -121,10 +121,15 @@ import {
   type CardDescriptorBlock,
 } from "./parse-body-blocks.ts";
 import {
+  createMermaidDiagramRegistry,
   embedMermaidSignals,
-  registerMermaidDiagram$,
+  type MermaidDiagramRegistry,
 } from "../mermaid-diagram.ts";
-import { embedImageLoadSignals, registerImageLoad$ } from "../image-load.ts";
+import {
+  createImageLoadRegistry,
+  embedImageLoadSignals,
+  type ImageLoadRegistry,
+} from "../image-load.ts";
 import {
   chatEventTreeContent,
   chatEventTreePlan,
@@ -1683,6 +1688,8 @@ interface EventTreeRegistries {
   readonly browserSessionSignals: ReturnType<
     typeof createBrowserSessionSignals
   >;
+  readonly mermaidDiagrams: MermaidDiagramRegistry;
+  readonly imageLoads: ImageLoadRegistry;
 }
 
 function createEventTreeSignals({
@@ -1694,6 +1701,8 @@ function createEventTreeSignals({
   planUpgradeCardSignals,
   mailDraftCardSignals,
   browserSessionSignals,
+  mermaidDiagrams,
+  imageLoads,
 }: EventTreeRegistries) {
   interface EventTree {
     readonly content: string;
@@ -1800,10 +1809,10 @@ function createEventTreeSignals({
           cards,
         });
         embedMermaidSignals(tree, (code) => {
-          return set(registerMermaidDiagram$, code);
+          return set(mermaidDiagrams.register$, code);
         });
         embedImageLoadSignals(tree, (url) => {
-          return set(registerImageLoad$, url);
+          return set(imageLoads.register$, url);
         });
         next ??= new Map(current);
         next.set(event.id, { content: plan.content, tree });
@@ -1822,6 +1831,7 @@ function createPagedEventResources(
   chatEvents$: Computed<ChatEvent[]>,
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
   browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents,
+  ownerSignal: AbortSignal,
 ) {
   const mailDraftCardSignals = createMailDraftCardSignalsRegistry(threadId);
   const browserSessionSignals = createBrowserSessionSignals(
@@ -1837,6 +1847,8 @@ function createPagedEventResources(
   const computerUseAuthorizationCardSignals =
     createComputerUseAuthorizationCardSignalsRegistry();
   const planUpgradeCardSignals = createPlanUpgradeCardSignalsRegistry();
+  const mermaidDiagrams = createMermaidDiagramRegistry(ownerSignal);
+  const imageLoads = createImageLoadRegistry();
 
   const registerChatEvent$ = command(
     ({ set }, event: ChatEvent): RegisteredChatEvent => {
@@ -1863,6 +1875,8 @@ function createPagedEventResources(
     planUpgradeCardSignals,
     mailDraftCardSignals,
     browserSessionSignals,
+    mermaidDiagrams,
+    imageLoads,
   });
 
   const registeredEvents$ = state<RegisteredChatEvent[]>([]);
@@ -2131,6 +2145,7 @@ function createChatThreadMessagePipeline(
     chatEvents.chatEvents$,
     previewImageUrlsByUrl$,
     browserLifecycleOptimisticEvents,
+    ownerSignal,
   );
   const projections = createPagedEventProjections({
     chatEvents$: chatEvents.chatEvents$,

--- a/turbo/apps/platform/src/signals/image-load.ts
+++ b/turbo/apps/platform/src/signals/image-load.ts
@@ -33,19 +33,25 @@ export function createImageLoadSignals(): ImageLoadSignals {
   };
 }
 
-const internalImageLoadByUrl$ = state<ReadonlyMap<string, ImageLoadSignals>>(
-  new Map(),
-);
+export interface ImageLoadRegistry {
+  /** Get-or-create by source URL; idempotent per URL. */
+  readonly register$: Command<ImageLoadSignals, [string]>;
+}
 
 /**
- * Get-or-create by source URL. Copies of the same image share one entry, and
- * an entry survives the re-parses of a streaming message — the reused `<img>`
- * element never refires its load event, so fresh signals would strand a loaded
- * image behind its placeholder.
+ * A per-surface registry of load signals keyed by source URL. Copies of the
+ * same image share one entry, and an entry survives the re-parses of a
+ * streaming message — the reused `<img>` element never refires its load event,
+ * so fresh signals would strand a loaded image behind its placeholder. The map
+ * is a `state` written only by `register$` and never leaves the registry: the
+ * command that parses a tree embeds each entry on its node.
  */
-export const registerImageLoad$ = command(
-  ({ get, set }, url: string): ImageLoadSignals => {
-    const current = get(internalImageLoadByUrl$);
+export function createImageLoadRegistry(): ImageLoadRegistry {
+  const internalByUrl$ = state<ReadonlyMap<string, ImageLoadSignals>>(
+    new Map(),
+  );
+  const register$ = command(({ get, set }, url: string): ImageLoadSignals => {
+    const current = get(internalByUrl$);
     const existing = current.get(url);
     if (existing !== undefined) {
       return existing;
@@ -53,10 +59,11 @@ export const registerImageLoad$ = command(
     const signals = createImageLoadSignals();
     const next = new Map(current);
     next.set(url, signals);
-    set(internalImageLoadByUrl$, next);
+    set(internalByUrl$, next);
     return signals;
-  },
-);
+  });
+  return { register$ };
+}
 
 // Written by the tree-preparing command alongside `mermaidSignals`; the parse
 // pipeline itself never produces it.

--- a/turbo/apps/platform/src/signals/mermaid-diagram.ts
+++ b/turbo/apps/platform/src/signals/mermaid-diagram.ts
@@ -1,31 +1,27 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { Element, Root } from "hast";
 
 import { createObjectUrlResource } from "./object-url-resource.ts";
-import { rootSignal$ } from "./root-signal.ts";
 import { theme$ } from "./theme.ts";
 import { settle } from "./utils.ts";
 
 /**
- * Mermaid diagrams render through a pull model. Each unique diagram source
- * owns one `MermaidDiagramSignals` in a module-scope registry; its `diagram$`
- * computed loads mermaid, lays the diagram out and resolves to an image the
- * view shows in an `<img>` — or to `null` when the parser rejects the source,
- * in which case the fence simply stays a code block. Reading the theme inside
- * the computed makes a theme switch re-render every diagram without any
- * remounting.
+ * Mermaid diagrams render through a pull model. Each diagram source owns one
+ * `MermaidDiagramSignals` in the registry of the surface showing it; its
+ * `diagram$` computed loads mermaid, lays the diagram out and resolves to an
+ * image the view shows in an `<img>` — or to `null` when the parser rejects
+ * the source, in which case the fence simply stays a code block. Reading the
+ * theme inside the computed makes a theme switch re-render every diagram
+ * without any remounting.
  *
  * The command that parses a tree registers each diagram and embeds the
  * returned signals on the marker node, so rendering receives the signals
- * object directly. The registry is content-addressed: the rendered image
- * depends only on the source and the theme, so the same fence in two threads
- * shares one entry.
+ * object directly and never resolves diagrams by key.
  *
- * Each resolved theme has one blob URL owned by the lifetime supplied to its
- * signal factory. The chat registry supplies the application root; disposable
- * preview trees supply their own surface lifetime. The light/dark cache is a
- * hard two-entry bound, so switching themes reuses the prior rendering instead
- * of stranding another blob.
+ * Each resolved theme has one blob URL owned by the surface lifetime the
+ * registry (or a preview tree) supplies. The light/dark cache is a hard
+ * two-entry bound, so switching themes reuses the prior rendering instead of
+ * stranding another blob.
  */
 export interface MermaidDiagramImage {
   readonly url: string;
@@ -71,10 +67,6 @@ export function embedMermaidSignals(
   };
   visitNode(tree);
 }
-
-const internalMermaidDiagramsByCode$ = state<
-  ReadonlyMap<string, MermaidDiagramSignals>
->(new Map());
 
 // mermaid costs ~170 KB gzipped for the first diagram, so it is only fetched
 // once a diagram actually needs rendering; the computed memoizes the promise.
@@ -174,9 +166,10 @@ function svgFile(markup: string): File {
 
 /**
  * Pure factory for a diagram's signals. `ownerSignal` must match the consumer
- * surface: preview trees create signals per disposable tree, while the chat
- * pipeline goes through `registerMermaidDiagram$` so a streaming message keeps
- * stable signal identities for fences its growing body re-parses.
+ * surface: preview trees create signals per disposable tree, while surfaces
+ * that re-parse — the chat transcript, the shared thread page — go through a
+ * `MermaidDiagramRegistry` so a streaming message keeps stable signal
+ * identities for fences its growing body re-parses.
  */
 export function createMermaidDiagramSignals(
   code: string,
@@ -261,17 +254,36 @@ export function createMermaidDiagramSignals(
   return { code, diagram$ };
 }
 
-export const registerMermaidDiagram$ = command(
-  ({ get, set }, code: string): MermaidDiagramSignals => {
-    const current = get(internalMermaidDiagramsByCode$);
-    const existing = current.get(code);
-    if (existing !== undefined) {
-      return existing;
-    }
-    const signals = createMermaidDiagramSignals(code, get(rootSignal$));
-    const next = new Map(current);
-    next.set(code, signals);
-    set(internalMermaidDiagramsByCode$, next);
-    return signals;
-  },
-);
+export interface MermaidDiagramRegistry {
+  /** Get-or-create by diagram source; idempotent per source. */
+  readonly register$: Command<MermaidDiagramSignals, [string]>;
+}
+
+/**
+ * A per-surface registry keyed by diagram source. The map is a `state` written
+ * only by `register$` and never leaves the registry: the command that parses a
+ * tree embeds each entry on its marker node. `ownerSignal` owns every entry's
+ * blob URLs, so tearing the surface down releases its diagrams.
+ */
+export function createMermaidDiagramRegistry(
+  ownerSignal: AbortSignal,
+): MermaidDiagramRegistry {
+  const internalByCode$ = state<ReadonlyMap<string, MermaidDiagramSignals>>(
+    new Map(),
+  );
+  const register$ = command(
+    ({ get, set }, code: string): MermaidDiagramSignals => {
+      const current = get(internalByCode$);
+      const existing = current.get(code);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const signals = createMermaidDiagramSignals(code, ownerSignal);
+      const next = new Map(current);
+      next.set(code, signals);
+      set(internalByCode$, next);
+      return signals;
+    },
+  );
+  return { register$ };
+}

--- a/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
+++ b/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
@@ -13,10 +13,13 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import {
+  createMermaidDiagramRegistry,
   embedMermaidSignals,
-  registerMermaidDiagram$,
 } from "../mermaid-diagram.ts";
-import { embedImageLoadSignals, registerImageLoad$ } from "../image-load.ts";
+import {
+  createImageLoadRegistry,
+  embedImageLoadSignals,
+} from "../image-load.ts";
 import { pathParams$ } from "../route.ts";
 import { updatePage$ } from "../react-router.ts";
 import { setPageSignal$ } from "../page-signal.ts";
@@ -32,6 +35,10 @@ export const setupSharedThreadPage$ = command(
       [200, 404],
       signal,
     );
+    // Page-scoped registries: repeated fences share one entry, and leaving
+    // the page releases the diagrams it rendered.
+    const mermaidDiagrams = createMermaidDiagramRegistry(signal);
+    const imageLoads = createImageLoadRegistry();
     const sharedThread: SharedDisplayThread | null =
       result.status === 200
         ? {
@@ -48,10 +55,10 @@ export const setupSharedThreadPage$ = command(
                 mermaid: true,
               });
               embedMermaidSignals(tree, (code) => {
-                return set(registerMermaidDiagram$, code);
+                return set(mermaidDiagrams.register$, code);
               });
               embedImageLoadSignals(tree, (url) => {
-                return set(registerImageLoad$, url);
+                return set(imageLoads.register$, url);
               });
               return { ...message, tree };
             }),

--- a/turbo/apps/platform/src/views/components/__tests__/markdown-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown-behavior.test.tsx
@@ -2,8 +2,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { StoreProvider } from "ccstate-react";
 import { describe, expect, it, vi } from "vitest";
 
-import { registerMermaidDiagram$ } from "../../../signals/mermaid-diagram.ts";
-import { setRootSignal$ } from "../../../signals/root-signal.ts";
+import { createMermaidDiagramRegistry } from "../../../signals/mermaid-diagram.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { Markdown } from "../markdown.tsx";
 
@@ -77,25 +76,14 @@ describe("parse-in-render markdown", () => {
     expect(rendered).not.toContain("mermaid-block");
   });
 
-  // The diagram registry is content-addressed: the rendered image depends only
-  // on the source and the theme, so the same fence shares one entry wherever
-  // it appears and different sources never collide.
+  // A surface's registry is keyed by source, so the same fence shares one
+  // entry wherever it appears in that surface and different sources never
+  // collide.
   it("keys diagram registration by source", () => {
-    // The registry hands each new entry the application root as its blob-URL
-    // owner, so registration requires the root signal a page always sets up.
-    context.store.set(setRootSignal$, context.signal);
-    const first = context.store.set(
-      registerMermaidDiagram$,
-      "graph TD; A-->B;",
-    );
-    const again = context.store.set(
-      registerMermaidDiagram$,
-      "graph TD; A-->B;",
-    );
-    const other = context.store.set(
-      registerMermaidDiagram$,
-      "graph TD; B-->C;",
-    );
+    const registry = createMermaidDiagramRegistry(context.signal);
+    const first = context.store.set(registry.register$, "graph TD; A-->B;");
+    const again = context.store.set(registry.register$, "graph TD; A-->B;");
+    const other = context.store.set(registry.register$, "graph TD; B-->C;");
 
     expect(again).toBe(first);
     expect(other).not.toBe(first);


### PR DESCRIPTION
## Summary

Follow-up to the registry audit: the last two module-scope signal registries move into the surfaces that own them, as immutable map `state`s behind register-only commands. No keyed store is reachable from anywhere: registries never expose their maps, and every entry is embedded at parse time into the tree the consumer renders from.

- `registerMermaidDiagram$` (module command over a module map, blob URLs owned by the application root) → `createMermaidDiagramRegistry(ownerSignal)`. The chat thread creates one per `createPagedEventResources` alongside the card registries, owned by the thread lifetime; the shared thread page creates one per page setup. Tearing the surface down now releases exactly the diagrams it rendered — this also removes the previously unbounded session-lifetime growth (review finding RC-3 on #26360) and drops the `rootSignal$` dependency from the mermaid path entirely.
- `registerImageLoad$` (module command over a module URL-keyed map) → `createImageLoadRegistry()`, instantiated per thread and per shared page the same way. Within a surface, streaming re-parses still reuse entries so a reused `<img>` never strands behind its placeholder.

Trade-off: the same fence in two different threads now renders once per thread instead of sharing one session-global entry. That sharing only ever helped cross-thread revisits, which already re-parse their trees; boundedness wins.

Stacked on #26419 (base `perf/mermaid-blob-url`); retarget/rebase onto `main` after that merges.
