### PR TITLE
feat(api): add okou namespace compatibility

### DIFF
--- a/turbo/apps/api/scripts/check-typecheck-boundaries.mjs
+++ b/turbo/apps/api/scripts/check-typecheck-boundaries.mjs
@@ -294,6 +294,7 @@ function checkImporters(target, expectedNames) {
 
 checkImporters(resolve(sourceRoot, "signals/route.ts"), [
   "src/production-bootstrap.ts",
+  "src/__tests__/api-namespace-compatibility.test.ts",
   "src/__tests__/vercel-crons.test.ts",
 ]);
 checkImporters(resolve(sourceRoot, "production-bootstrap.ts"), [

--- a/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
@@ -2,6 +2,7 @@ import { apiNamespaceAliasPaths } from "@vm0/api-contracts/contracts/api-namespa
 
 import { ROUTES } from "../signals/route";
 import {
+  assertUniqueRouteRegistrations,
   type RouteEntry,
   withApiNamespaceAliases,
 } from "../signals/route-entry";
@@ -53,6 +54,9 @@ describe("API namespace compatibility", () => {
         return count !== 1;
       }),
     ).toStrictEqual([]);
+    expect(() => {
+      assertUniqueRouteRegistrations(registeredRoutes);
+    }).not.toThrow();
   });
 
   it("keeps neutral health, webhook, and product-scoped Desktop routes single", () => {
@@ -90,8 +94,11 @@ describe("API namespace compatibility", () => {
 
   it("rejects duplicate method and path registrations", () => {
     const source = requireBrandedRoute();
+    const composedRouteSlice = withApiNamespaceAliases([source, source]);
+
+    expect(composedRouteSlice).toHaveLength(4);
     expect(() => {
-      withApiNamespaceAliases([source, source]);
+      assertUniqueRouteRegistrations(composedRouteSlice);
     }).toThrow(`Duplicate API route registration: ${routeKey(source)}`);
   });
 });

--- a/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
@@ -1,0 +1,97 @@
+import { apiNamespaceAliasPaths } from "@vm0/api-contracts/contracts/api-namespaces";
+
+import { ROUTES } from "../signals/route";
+import {
+  type RouteEntry,
+  withApiNamespaceAliases,
+} from "../signals/route-entry";
+
+function routeKey(entry: RouteEntry): string {
+  return `${entry.route.method} ${entry.route.path}`;
+}
+
+function requireBrandedRoute(): RouteEntry {
+  const entry = ROUTES.find(({ route }) => {
+    return route.path.startsWith("/api/zero/");
+  });
+  if (!entry) {
+    throw new Error("Expected at least one branded API route");
+  }
+  return entry;
+}
+
+describe("API namespace compatibility", () => {
+  const registeredRoutes = withApiNamespaceAliases(ROUTES);
+
+  it("registers symmetric Zero and Okou paths with the same handler and schema", () => {
+    const registrationCounts = new Map<string, number>();
+    for (const entry of registeredRoutes) {
+      const key = routeKey(entry);
+      registrationCounts.set(key, (registrationCounts.get(key) ?? 0) + 1);
+    }
+
+    for (const source of ROUTES) {
+      const paths = apiNamespaceAliasPaths(source.route.path);
+      for (const path of paths) {
+        const matches = registeredRoutes.filter(({ route }) => {
+          return route.method === source.route.method && route.path === path;
+        });
+        expect(matches).toHaveLength(1);
+        const match = matches[0];
+        if (!match) {
+          throw new Error(
+            `Missing API namespace alias for ${routeKey(source)}`,
+          );
+        }
+        expect(match.handler).toBe(source.handler);
+        expect(match.route).toStrictEqual({ ...source.route, path });
+      }
+    }
+
+    expect(
+      [...registrationCounts.values()].filter((count) => {
+        return count !== 1;
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps neutral health, webhook, and product-scoped Desktop routes single", () => {
+    const neutralPaths = [
+      "/health",
+      "/api/webhooks/clerk",
+      "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+    ] as const;
+
+    for (const path of neutralPaths) {
+      const matches = registeredRoutes.filter((entry) => {
+        return entry.route.path === path;
+      });
+      expect(matches).toHaveLength(1);
+      expect(apiNamespaceAliasPaths(path)).toStrictEqual([path]);
+    }
+  });
+
+  it("remains symmetric when the source contract is canonical Okou", () => {
+    const source = requireBrandedRoute();
+    const okouSource: RouteEntry = {
+      route: {
+        ...source.route,
+        path: source.route.path.replace("/api/zero/", "/api/okou/"),
+      },
+      handler: source.handler,
+    };
+
+    expect(
+      withApiNamespaceAliases([okouSource]).map(({ route }) => {
+        return route.path;
+      }),
+    ).toStrictEqual([source.route.path, okouSource.route.path]);
+  });
+
+  it("rejects duplicate method and path registrations", () => {
+    const source = requireBrandedRoute();
+    expect(() => {
+      withApiNamespaceAliases([source, source]);
+    }).toThrow(`Duplicate API route registration: ${routeKey(source)}`);
+  });
+});

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -37,7 +37,10 @@ import {
   getDatasetName,
   ingestToAxiom,
 } from "./signals/external/axiom";
-import type { RouteEntry } from "./signals/route-entry";
+import {
+  type RouteEntry,
+  withApiNamespaceAliases,
+} from "./signals/route-entry";
 import { configureChatRunFinishedEventDispatcher } from "./signals/services/chat-run-finished-event-registration.service";
 import { configurePiEdgeTurnDispatcher } from "./signals/services/pi-edge-turn-registration.service";
 import {
@@ -596,7 +599,7 @@ export function createAppWithRoutes({
     app.get(`${path}/*`, redirectToWeb);
   }
 
-  for (const { route, handler } of routes) {
+  for (const { route, handler } of withApiNamespaceAliases(routes)) {
     app.on(route.method, route.path, honoSignalHandler(handler, route, signal));
   }
 

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -13,7 +13,9 @@ function routeRegistrationKey(entry: RouteEntry): string {
   return `${entry.route.method} ${entry.route.path}`;
 }
 
-function assertUniqueRouteRegistrations(routes: readonly RouteEntry[]): void {
+export function assertUniqueRouteRegistrations(
+  routes: readonly RouteEntry[],
+): void {
   const keys = new Set<string>();
   for (const entry of routes) {
     const key = routeRegistrationKey(entry);
@@ -43,11 +45,9 @@ function routeEntryWithPath(entry: RouteEntry, path: string): RouteEntry {
 export function withApiNamespaceAliases(
   routes: readonly RouteEntry[],
 ): readonly RouteEntry[] {
-  const aliasedRoutes = routes.flatMap((entry) => {
+  return routes.flatMap((entry) => {
     return apiNamespaceAliasPaths(entry.route.path).map((path) => {
       return routeEntryWithPath(entry, path);
     });
   });
-  assertUniqueRouteRegistrations(aliasedRoutes);
-  return aliasedRoutes;
 }

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -1,4 +1,5 @@
 import type { AppRoute } from "@vm0/api-contracts/contracts/trpc-contract";
+import { apiNamespaceAliasPaths } from "@vm0/api-contracts/contracts/api-namespaces";
 import type { SignalRouteHandler } from "./context/route";
 
 export type { SignalRouteHandler };
@@ -6,4 +7,47 @@ export type { SignalRouteHandler };
 export interface RouteEntry {
   readonly route: AppRoute;
   readonly handler: SignalRouteHandler<unknown>;
+}
+
+function routeRegistrationKey(entry: RouteEntry): string {
+  return `${entry.route.method} ${entry.route.path}`;
+}
+
+function assertUniqueRouteRegistrations(routes: readonly RouteEntry[]): void {
+  const keys = new Set<string>();
+  for (const entry of routes) {
+    const key = routeRegistrationKey(entry);
+    if (keys.has(key)) {
+      throw new Error(`Duplicate API route registration: ${key}`);
+    }
+    keys.add(key);
+  }
+}
+
+function routeEntryWithPath(entry: RouteEntry, path: string): RouteEntry {
+  if (path === entry.route.path) {
+    return entry;
+  }
+  return {
+    route: { ...entry.route, path },
+    handler: entry.handler,
+  };
+}
+
+/**
+ * Phase A compatibility for #26487. Remove only in a separately authorized
+ * cleanup after legacy Platform, CLI, runner, Desktop, and stored callback
+ * callers have drained, production telemetry confirms no Zero dependency,
+ * and rollback no longer targets a release that requires /api/zero/**.
+ */
+export function withApiNamespaceAliases(
+  routes: readonly RouteEntry[],
+): readonly RouteEntry[] {
+  const aliasedRoutes = routes.flatMap((entry) => {
+    return apiNamespaceAliasPaths(entry.route.path).map((path) => {
+      return routeEntryWithPath(entry, path);
+    });
+  });
+  assertUniqueRouteRegistrations(aliasedRoutes);
+  return aliasedRoutes;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-by-id.test.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import type { BrandedApiNamespace } from "@vm0/api-contracts/contracts/api-namespaces";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 
+import { createApp } from "../../../app-factory";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
@@ -34,6 +36,40 @@ function agentsClient() {
 
 function bearerHeaders(token: string): { readonly authorization: string } {
   return { authorization: `Bearer ${token}` };
+}
+
+async function requestAgentThroughNamespace(
+  namespace: BrandedApiNamespace,
+  agentId: string,
+  headers: { readonly authorization?: string },
+): Promise<{
+  readonly status: number;
+  readonly body: unknown;
+  readonly contentType: string | null;
+}> {
+  const app = createApp({
+    signal: context.signal,
+    routes: zeroAgentsRoutes,
+  });
+  const response = await app.request(`/api/${namespace}/agents/${agentId}`, {
+    headers,
+  });
+  return {
+    status: response.status,
+    body: await response.json(),
+    contentType: response.headers.get("content-type"),
+  };
+}
+
+async function expectNamespaceParity(
+  agentId: string,
+  headers: { readonly authorization?: string },
+): Promise<unknown> {
+  const zero = await requestAgentThroughNamespace("zero", agentId, headers);
+  const okou = await requestAgentThroughNamespace("okou", agentId, headers);
+  expect(okou).toStrictEqual(zero);
+  expect(zero.status).toBe(200);
+  return zero.body;
 }
 
 function commandInput(command: unknown): Record<string, unknown> {
@@ -112,6 +148,39 @@ function zeroTokenFor(
 }
 
 describe("GET /api/zero/agents/:id", () => {
+  it("keeps session, PAT, and run-capability auth in parity across namespaces", async () => {
+    const actor = bdd.user({ orgRole: "org:member" });
+    const agent = await createAgent(actor, {
+      displayName: "Namespace Parity Agent",
+      visibility: "private",
+    });
+
+    const sessionBody = await expectNamespaceParity(agent.agentId, {
+      authorization: "Bearer clerk-session",
+    });
+
+    const patBody = await expectNamespaceParity(
+      agent.agentId,
+      await apiKeyHeaders(actor, "org:member"),
+    );
+
+    const capabilityBody = await expectNamespaceParity(
+      agent.agentId,
+      bearerHeaders(zeroTokenFor(actor, ["agent:read"])),
+    );
+
+    expect(patBody).toStrictEqual(sessionBody);
+    expect(capabilityBody).toStrictEqual(sessionBody);
+  });
+
+  it("keeps path validation responses in parity across namespaces", async () => {
+    const zero = await requestAgentThroughNamespace("zero", "not-a-uuid", {});
+    const okou = await requestAgentThroughNamespace("okou", "not-a-uuid", {});
+
+    expect(okou).toStrictEqual(zero);
+    expect(zero.status).toBe(400);
+  });
+
   it("returns 401 when the request is unauthenticated", async () => {
     const response = await bdd.requestReadAgent(null, randomUUID(), [401]);
     expect(response.body).toStrictEqual({

--- a/turbo/packages/api-contracts/src/contracts/api-namespaces.ts
+++ b/turbo/packages/api-contracts/src/contracts/api-namespaces.ts
@@ -1,0 +1,46 @@
+export const BRANDED_API_NAMESPACE_PATHS = ["/api/zero", "/api/okou"] as const;
+
+export type BrandedApiNamespacePath =
+  (typeof BRANDED_API_NAMESPACE_PATHS)[number];
+
+export type BrandedApiNamespace =
+  BrandedApiNamespacePath extends `/api/${infer Namespace}` ? Namespace : never;
+
+function brandedPathSuffix(path: string): string | undefined {
+  for (const namespacePath of BRANDED_API_NAMESPACE_PATHS) {
+    if (path === namespacePath) {
+      return "";
+    }
+    if (path.startsWith(`${namespacePath}/`)) {
+      return path.slice(namespacePath.length);
+    }
+  }
+  return undefined;
+}
+
+export function brandedApiNamespace(
+  path: string,
+): BrandedApiNamespace | undefined {
+  if (path === "/api/zero" || path.startsWith("/api/zero/")) {
+    return "zero";
+  }
+  if (path === "/api/okou" || path.startsWith("/api/okou/")) {
+    return "okou";
+  }
+  return undefined;
+}
+
+/**
+ * Returns both supported paths for a branded API route and the original path
+ * for a neutral route. The result is independent of which branded namespace
+ * the source contract currently uses.
+ */
+export function apiNamespaceAliasPaths(path: string): readonly string[] {
+  const suffix = brandedPathSuffix(path);
+  if (suffix === undefined) {
+    return [path];
+  }
+  return BRANDED_API_NAMESPACE_PATHS.map((namespacePath) => {
+    return `${namespacePath}${suffix}`;
+  });
+}

--- a/turbo/packages/api-contracts/src/runtime-api-schema/__tests__/schema.test.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/__tests__/schema.test.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+import { initContract } from "../../contracts/base";
+import { buildRuntimeApiSchemaDocument } from "../schema";
+import type { RuntimeApiRouteBinding } from "../routes";
+
+const c = initContract();
+
+function binding(id: string, path: string): RuntimeApiRouteBinding {
+  const contract = c.router({
+    get: {
+      method: "GET",
+      path,
+      query: z.object({ cursor: z.string().optional() }),
+      responses: {
+        200: z.object({ ok: z.boolean() }),
+      },
+    },
+  });
+  return { id, owner: "guest-agent", route: contract.get };
+}
+
+describe("runtime API schema namespaces", () => {
+  it.each(["/api/zero/example", "/api/okou/example"] as const)(
+    "publishes both branded namespaces from $sourcePath with schema parity",
+    (sourcePath) => {
+      const document = buildRuntimeApiSchemaDocument(
+        "2026-08-12T00:00:00.000Z",
+        [binding("guest.example", sourcePath)],
+      );
+
+      expect(document.supportedBrandedApiNamespacePaths).toStrictEqual([
+        "/api/zero",
+        "/api/okou",
+      ]);
+      expect(
+        document.routes.map(({ id, path }) => {
+          return { id, path };
+        }),
+      ).toStrictEqual([
+        { id: "guest.example.okou", path: "/api/okou/example" },
+        { id: "guest.example.zero", path: "/api/zero/example" },
+      ]);
+
+      const [okou, zero] = document.routes;
+      if (!okou || !zero) {
+        throw new Error("Expected both runtime API namespace routes");
+      }
+      expect({ ...okou, id: zero.id, path: zero.path }).toStrictEqual(zero);
+    },
+  );
+
+  it("keeps neutral runtime routes single", () => {
+    const document = buildRuntimeApiSchemaDocument("2026-08-12T00:00:00.000Z", [
+      binding("guest.example", "/api/webhooks/agent/example"),
+    ]);
+
+    expect(document.routes).toHaveLength(1);
+    expect(document.routes[0]).toMatchObject({
+      id: "guest.example",
+      path: "/api/webhooks/agent/example",
+    });
+  });
+
+  it("rejects duplicate ids and duplicate method/path registrations", () => {
+    expect(() => {
+      buildRuntimeApiSchemaDocument("2026-08-12T00:00:00.000Z", [
+        binding("guest.example", "/api/webhooks/agent/one"),
+        binding("guest.example", "/api/webhooks/agent/two"),
+      ]);
+    }).toThrow("Duplicate runtime API route id: guest.example");
+
+    expect(() => {
+      buildRuntimeApiSchemaDocument("2026-08-12T00:00:00.000Z", [
+        binding("guest.one", "/api/webhooks/agent/example"),
+        binding("guest.two", "/api/webhooks/agent/example"),
+      ]);
+    }).toThrow(
+      "Duplicate runtime API route registration: GET /api/webhooks/agent/example",
+    );
+  });
+});

--- a/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
@@ -40,11 +40,6 @@ export interface RuntimeApiRouteBinding {
 
 export const runtimeApiRouteBindings = [
   {
-    id: "webhooks.agent.modelUsageObservation",
-    owner: "mitm-addon",
-    route: webhookModelUsageObservationContract.send,
-  },
-  {
     id: "runners.poll",
     owner: "runner",
     route: runnersPollContract.poll,

--- a/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
@@ -1,6 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { z } from "zod";
 import packageJson from "../../package.json" with { type: "json" };
+import {
+  apiNamespaceAliasPaths,
+  brandedApiNamespace,
+  BRANDED_API_NAMESPACE_PATHS,
+  type BrandedApiNamespacePath,
+} from "../contracts/api-namespaces";
 import { type RuntimeApiRouteBinding, runtimeApiRouteBindings } from "./routes";
 
 export const runtimeApiSchemaFormatVersion = 1;
@@ -16,6 +22,7 @@ export interface RuntimeApiSchemaDocument {
   readonly packageName: string;
   readonly packageVersion: string;
   readonly generatedAt: string;
+  readonly supportedBrandedApiNamespacePaths?: readonly BrandedApiNamespacePath[];
   readonly routes: readonly RuntimeApiRouteSnapshot[];
 }
 
@@ -47,18 +54,21 @@ export type RuntimeSchemaSnapshot =
 
 export function buildRuntimeApiSchemaDocument(
   generatedAt = new Date().toISOString(),
+  bindings: readonly RuntimeApiRouteBinding[] = runtimeApiRouteBindings,
 ): RuntimeApiSchemaDocument {
-  const routes = runtimeApiRouteBindings
-    .map(normalizeRuntimeApiRoute)
+  const routes = bindings
+    .flatMap(normalizeRuntimeApiRouteAliases)
     .sort((left, right) => {
       return left.id.localeCompare(right.id);
     });
+  assertUniqueRuntimeApiRoutes(routes);
 
   return {
     schemaFormatVersion: runtimeApiSchemaFormatVersion,
     packageName: packageJson.name,
     packageVersion: packageJson.version,
     generatedAt,
+    supportedBrandedApiNamespacePaths: BRANDED_API_NAMESPACE_PATHS,
     routes,
   };
 }
@@ -125,6 +135,41 @@ function normalizeRuntimeApiRoute(
     },
     responses: normalizeResponses(route.responses, binding.id),
   };
+}
+
+function normalizeRuntimeApiRouteAliases(
+  binding: RuntimeApiRouteBinding,
+): readonly RuntimeApiRouteSnapshot[] {
+  const sourcePath = validateString(binding.route.path, `${binding.id}.path`);
+  return apiNamespaceAliasPaths(sourcePath).map((path) => {
+    const namespace = brandedApiNamespace(path);
+    return normalizeRuntimeApiRoute({
+      ...binding,
+      id: namespace ? `${binding.id}.${namespace}` : binding.id,
+      route: { ...binding.route, path },
+    });
+  });
+}
+
+function assertUniqueRuntimeApiRoutes(
+  routes: readonly RuntimeApiRouteSnapshot[],
+): void {
+  const ids = new Set<string>();
+  const registrations = new Set<string>();
+  for (const route of routes) {
+    if (ids.has(route.id)) {
+      throw new Error(`Duplicate runtime API route id: ${route.id}`);
+    }
+    ids.add(route.id);
+
+    const registration = `${route.method} ${route.path}`;
+    if (registrations.has(registration)) {
+      throw new Error(
+        `Duplicate runtime API route registration: ${registration}`,
+      );
+    }
+    registrations.add(registration);
+  }
 }
 
 function normalizeResponses(
@@ -278,5 +323,8 @@ const runtimeApiSchemaDocumentSchema: z.ZodType<RuntimeApiSchemaDocument> =
     packageName: z.string(),
     packageVersion: z.string(),
     generatedAt: z.string(),
+    supportedBrandedApiNamespacePaths: z
+      .array(z.enum(BRANDED_API_NAMESPACE_PATHS))
+      .optional(),
     routes: z.array(runtimeApiRouteSnapshotSchema),
   });

--- a/turbo/packages/eslint-rules/src/ccstate/__tests__/no-non-zero-api.test.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/__tests__/no-non-zero-api.test.ts
@@ -17,6 +17,13 @@ ruleTester.run("no-non-zero-api", rule, {
     {
       code: 'fetchFn("/api/zero/agents")',
     },
+    // Okou API paths are also allowed without allowing arbitrary /api/ paths
+    {
+      code: 'const url = "/api/okou/billing/status"',
+    },
+    {
+      code: "fetchFn(`/api/okou/agents/${agentId}`)",
+    },
     // Non-API strings are fine
     {
       code: 'const msg = "hello world"',
@@ -51,6 +58,10 @@ ruleTester.run("no-non-zero-api", rule, {
     },
     {
       code: 'const path = "/api/agent/composes/123/instructions"',
+      errors: [{ messageId: "nonZeroApi" }],
+    },
+    {
+      code: 'const path = "/api/okou-internal/agents"',
       errors: [{ messageId: "nonZeroApi" }],
     },
   ],

--- a/turbo/packages/eslint-rules/src/ccstate/index.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/index.ts
@@ -14,7 +14,7 @@
  * - computed-const-args-package-scope: Enforce package scope for constant functions
  * - no-store-in-params: Prevent Store type in function params
  * - no-side-effect-in-render: Prevent side-effect calls (set, detach) directly in render
- * - no-non-zero-api: Enforce that platform app only calls /api/zero/ endpoints
+ * - no-non-zero-api: Enforce that platform app only calls branded API endpoints
  * - command-async-signal: Async commands must accept AbortSignal as last param
  * - no-getter-setter-params: Functions must not accept ccstate Getter/Setter — use command()
  * - no-accessor-escape: ccstate get/set accessors must only be called directly

--- a/turbo/packages/eslint-rules/src/ccstate/rules/no-non-zero-api.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/rules/no-non-zero-api.ts
@@ -1,11 +1,12 @@
 /**
  * ESLint rule: no-non-zero-api
  *
- * Enforces that the platform app only calls /api/zero/ endpoints.
+ * Enforces that the platform app only calls branded API endpoints.
  * Catches string literals and template literals containing /api/ paths
- * that do not start with /api/zero/.
+ * that do not start with /api/zero/ or /api/okou/.
  *
  * Good: "/api/zero/billing/status"
+ * Good: "/api/okou/billing/status"
  * Bad: "/api/billing/status"
  */
 
@@ -19,8 +20,8 @@ const createRule = ESLintUtils.RuleCreator(
 type MessageIds = "nonZeroApi";
 
 /**
- * Check if a string contains a non-zero API path.
- * Matches /api/ followed by anything that is NOT zero/.
+ * Check if a string contains a non-branded API path.
+ * Matches /api/ followed by anything that is not zero/ or okou/.
  * Ignores external URLs (e.g. https://slack.com/api/...).
  */
 function containsNonZeroApiPath(value: string): boolean {
@@ -29,8 +30,8 @@ function containsNonZeroApiPath(value: string): boolean {
   if (/https?:\/\/[^/]+\/api\//.test(value)) {
     return false;
   }
-  // Match /api/ that is NOT followed by zero/
-  return /\/api\/(?!zero\/)/.test(value);
+  // Match /api/ that is not followed by an approved branded namespace.
+  return /\/api\/(?!(?:zero|okou)\/)/.test(value);
 }
 
 export default createRule<[], MessageIds>({
@@ -38,12 +39,13 @@ export default createRule<[], MessageIds>({
   meta: {
     type: "problem",
     docs: {
-      description: "Enforce that platform app only calls /api/zero/ endpoints",
+      description:
+        "Enforce that platform app only calls /api/zero/ or /api/okou/ endpoints",
     },
     schema: [],
     messages: {
       nonZeroApi:
-        "Platform app must only call /api/zero/ endpoints. Found non-zero API path: '{{path}}'. Use a zero contract + route instead.",
+        "Platform app must only call /api/zero/ or /api/okou/ endpoints. Found unapproved API path: '{{path}}'. Use a branded contract + route instead.",
     },
   },
   defaultOptions: [],


### PR DESCRIPTION
## Summary

- add one typed API registration-boundary alias mechanism that exposes every branded route through both `/api/zero/**` and `/api/okou/**`, regardless of which namespace is canonical in the source contract
- publish both supported branded namespace paths in the runtime API schema and preserve old published-schema parsing compatibility
- allow both approved branded paths in the Platform lint rule while continuing to reject arbitrary `/api/**` paths
- cover route/schema symmetry, duplicate detection, neutral-route isolation, validation parity, and session, PAT, and run-capability authentication parity

## Deployment compatibility

- this is additive Phase A behavior: all first-party callers remain on `/api/zero/**`, and no Zero route is removed, redirected, or changed
- both namespace registrations reuse the same handler and contract object, preserving validation, authentication, responses, headers, and route-template observability
- alias generation is symmetric, so changing a contract's canonical path to Okou in Phase B cannot remove its Zero compatibility path
- previous runtime schema artifacts remain readable because the new namespace metadata is optional when parsing, while newly built artifacts always publish both paths
- rollback requires only the previous API release and no client or state change

## Validation

- `pnpm exec prettier --check --ignore-unknown <changed files>`
- `pnpm turbo run lint --filter=api --filter=@vm0/api-contracts --filter=@vm0/eslint-rules --concurrency=1 --output-logs=errors-only`
- `pnpm turbo run check-types --filter=api --filter=@vm0/api-contracts --filter=@vm0/eslint-rules --concurrency=1 --output-logs=errors-only`
- `pnpm -F @vm0/api-contracts test -- --maxWorkers=4 --silent=passed-only` (28 files, 534 tests)
- `pnpm -F @vm0/eslint-rules test -- --maxWorkers=4 --silent=passed-only` (49 files, 643 tests)
- `pnpm -F api exec vitest run src/__tests__/api-namespace-compatibility.test.ts src/signals/routes/__tests__/zero-agents-by-id.test.ts --maxWorkers=1 --silent=passed-only` (2 files, 27 tests)
- production `runtime-api-schema-prod` download + `build:runtime-api-schema` + `lint-runtime-api-compat` (passed; both branded paths published)
- `pnpm -F @vm0/api-contracts run generate:python` and `generate:rust`, followed by a binding diff check (no diff)

Local `pnpm knip` reports the repository-wide workspace baseline (4 unused files, 1 unused dev dependency, and 1549 unused exports), with no finding in the changed files. The latest `main` `lint-knip` check is green.

## Related

Closes #26488

[EPIC #26487](https://github.com/vm0-ai/vm0/issues/26487)
