### PR TITLE
test(api): await queued attachment auto-send drain

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7792,6 +7792,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
     const messages = await waitForThreadMessages(
       actor,
       anchor.threadId,
@@ -7886,6 +7887,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
     // run whose prompt carries the resolved attachment references.
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
     const messages = await waitForThreadMessages(
       actor,
       anchor.threadId,


### PR DESCRIPTION
## Summary

- wait for terminal `waitUntil` work before observing queued attachment promotion
- cover both queued structured-part and attachment-preservation scenarios at the same completion boundary
- keep the canonical thread and attachment assertions unchanged

## Root cause

The complete webhook returns `200` after committing the terminal run state, while `dispatchCompleteSideEffects$` is registered through `waitUntil(...)`. That deferred work owns the chat callback, per-thread queue drain, auto-sent follow-up creation, and canonical event publication.

These tests started `waitForThreadMessages` immediately after the webhook response. Under CI scheduling pressure, its predicate window could expire before the registered queue drain published the promoted message. The failure was therefore missing test synchronization, not a product data-loss path.

The triggering connector commit does not touch this test or the chat queue/event path. The same test passed on the parent-main run in 569 ms, on the source PR head in 506 ms, and on the next merge-group run in 477 ms.

## Evidence

- Triggering run: https://github.com/vm0-ai/vm0/actions/runs/31564011205
- Substantive failing job: https://github.com/vm0-ai/vm0/actions/runs/31564011205/job/94012069428
- Parent-main comparison: https://github.com/vm0-ai/vm0/actions/runs/31563495753/job/94010543589
- Source PR head comparison: https://github.com/vm0-ai/vm0/actions/runs/31563122735/job/94009459727
- Next merge-group comparison: https://github.com/vm0-ai/vm0/actions/runs/31564113142/job/94012370594

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

The targeted BDD test was not run locally because it requires PostgreSQL and the repair contract prohibits starting a local service. The PR pipeline will run the affected `test-api (6)` shard in its managed database environment.

Preview validation is not applicable because this PR changes test synchronization only.