### PR TITLE
fix(pi): align event sequences with output projection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-edge-loop.test.ts
@@ -1009,13 +1009,13 @@ describe("PiLoop edge turn", () => {
         return (
           event?.runId === edge.runId &&
           event?.eventType === "pi.message.completed" &&
-          eventData?.messageId === `${edge.runId}/2`
+          eventData?.messageId === `${edge.runId}/1`
         );
       });
     const handoffEventData = recordOf(handoffTelemetry?.eventData);
     expect(handoffEventData).toMatchObject({
       source: "api",
-      messageId: `${edge.runId}/2`,
+      messageId: `${edge.runId}/1`,
       role: "assistant",
       handoff: { from: "api", to: "sandbox" },
     });
@@ -1034,8 +1034,8 @@ describe("PiLoop edge turn", () => {
       events: [
         {
           type: "pi.message.completed",
-          sequenceNumber: 3,
-          messageId: `${edge.runId}/3`,
+          sequenceNumber: 2,
+          messageId: `${edge.runId}/2`,
           message: {
             role: "toolResult",
             toolCallId: deepseekToolCallId("read_skill_1"),
@@ -1053,8 +1053,8 @@ describe("PiLoop edge turn", () => {
         },
         {
           type: "pi.message.completed",
-          sequenceNumber: 4,
-          messageId: `${edge.runId}/4`,
+          sequenceNumber: 3,
+          messageId: `${edge.runId}/3`,
           message: {
             role: "assistant",
             content: [
@@ -1085,8 +1085,9 @@ describe("PiLoop edge turn", () => {
       ],
     };
     await webhooks.requestAgentEvents(resumeEvents, sandboxHeaders, [200]);
+    context.mocks.axiomLogging.warn.mockClear();
     await webhooks.requestAgentComplete(
-      { runId: edge.runId, exitCode: 0, lastEventSequence: 4 },
+      { runId: edge.runId, exitCode: 0, lastEventSequence: 3 },
       { authorization: `Bearer ${standbyContext.sandboxToken}` },
       [200],
     );
@@ -1099,9 +1100,9 @@ describe("PiLoop edge turn", () => {
       messages: [
         {
           ordinal: 1,
-          messageId: `${edge.runId}/1`,
+          messageId: `${edge.runId}/0`,
           runId: edge.runId,
-          runEventSequenceNumber: 1,
+          runEventSequenceNumber: 0,
           role: "user",
           payload: {
             role: "user",
@@ -1110,9 +1111,9 @@ describe("PiLoop edge turn", () => {
         },
         {
           ordinal: 2,
-          messageId: `${edge.runId}/2`,
+          messageId: `${edge.runId}/1`,
           runId: edge.runId,
-          runEventSequenceNumber: 2,
+          runEventSequenceNumber: 1,
           role: "assistant",
           payload: {
             role: "assistant",
@@ -1135,9 +1136,9 @@ describe("PiLoop edge turn", () => {
         },
         {
           ordinal: 3,
-          messageId: `${edge.runId}/3`,
+          messageId: `${edge.runId}/2`,
           runId: edge.runId,
-          runEventSequenceNumber: 3,
+          runEventSequenceNumber: 2,
           role: "toolResult",
           payload: {
             role: "toolResult",
@@ -1156,9 +1157,9 @@ describe("PiLoop edge turn", () => {
         },
         {
           ordinal: 4,
-          messageId: `${edge.runId}/4`,
+          messageId: `${edge.runId}/3`,
           runId: edge.runId,
-          runEventSequenceNumber: 4,
+          runEventSequenceNumber: 3,
           role: "assistant",
           payload: {
             role: "assistant",
@@ -1172,6 +1173,15 @@ describe("PiLoop edge turn", () => {
       ],
     });
     expect(JSON.stringify(transcript)).not.toContain(legacyPrompt);
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.some(([message, fields]) => {
+        return (
+          message ===
+            "Run output projection is incomplete at terminal callback" &&
+          recordOf(fields)?.runId === edge.runId
+        );
+      }),
+    ).toBeFalsy();
 
     const projected = await outputMessages(fixture.actor, edge.threadId);
     expect(projected).toHaveLength(1);
@@ -1250,13 +1260,13 @@ describe("PiLoop edge turn", () => {
         expect.objectContaining({
           ordinal: 5,
           runId: followUp.runId,
-          messageId: `${followUp.runId}/1`,
+          messageId: `${followUp.runId}/0`,
           role: "user",
         }),
         expect.objectContaining({
           ordinal: 6,
           runId: followUp.runId,
-          messageId: `${followUp.runId}/2`,
+          messageId: `${followUp.runId}/1`,
           role: "assistant",
           payload: expect.objectContaining({
             content: [
@@ -1364,8 +1374,8 @@ describe("PiLoop edge turn", () => {
       events: [
         {
           type: "pi.message.completed",
-          sequenceNumber: 3,
-          messageId: `${run.runId}/3`,
+          sequenceNumber: 2,
+          messageId: `${run.runId}/2`,
           message: {
             role: "toolResult",
             toolCallId: deepseekToolCallId("read_memory_1"),
@@ -1377,8 +1387,8 @@ describe("PiLoop edge turn", () => {
         },
         {
           type: "pi.message.completed",
-          sequenceNumber: 4,
-          messageId: `${run.runId}/4`,
+          sequenceNumber: 3,
+          messageId: `${run.runId}/3`,
           message: {
             role: "assistant",
             content: [
@@ -1393,7 +1403,7 @@ describe("PiLoop edge turn", () => {
     };
     await webhooks.requestAgentEvents(resumeEvents, sandboxHeaders, [200]);
     await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0, lastEventSequence: 4 },
+      { runId: run.runId, exitCode: 0, lastEventSequence: 3 },
       { authorization: `Bearer ${standbyContext.sandboxToken}` },
       [200],
     );
@@ -1463,8 +1473,8 @@ describe("PiLoop edge turn", () => {
       events: [
         {
           type: "pi.message.completed",
-          sequenceNumber: 3,
-          messageId: `${run.runId}/3`,
+          sequenceNumber: 2,
+          messageId: `${run.runId}/2`,
           message: {
             role: "toolResult",
             toolCallId: deepseekToolCallId("read_billing_1"),
@@ -1476,8 +1486,8 @@ describe("PiLoop edge turn", () => {
         },
         {
           type: "pi.message.completed",
-          sequenceNumber: 4,
-          messageId: `${run.runId}/4`,
+          sequenceNumber: 3,
+          messageId: `${run.runId}/3`,
           message: {
             role: "assistant",
             content: [
@@ -1492,7 +1502,7 @@ describe("PiLoop edge turn", () => {
     };
     await webhooks.requestAgentEvents(resumeEvents, sandboxHeaders, [200]);
     await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0, lastEventSequence: 4 },
+      { runId: run.runId, exitCode: 0, lastEventSequence: 3 },
       { authorization: `Bearer ${standbyContext.sandboxToken}` },
       [200],
     );
@@ -1511,7 +1521,7 @@ describe("PiLoop edge turn", () => {
     expect((await billing.readBillingStatus(fixture.actor)).credits).toBe(
       creditsBefore - 111,
     );
-    const observationKeys = [piEdgeUsageObservationKey(run.runId, 2)];
+    const observationKeys = [piEdgeUsageObservationKey(run.runId, 1)];
     const observations = await readModelStatsObservations(
       context,
       observationKeys,
@@ -1553,6 +1563,7 @@ describe("PiLoop edge turn", () => {
       }),
     );
 
+    context.mocks.axiomLogging.warn.mockClear();
     const run = await sendChatRun(fixture, "do not charge vm0 for BYOK");
     await flushWaitUntilForTest();
 
@@ -1565,7 +1576,31 @@ describe("PiLoop edge turn", () => {
     expect((await billing.readBillingStatus(fixture.actor)).credits).toBe(
       creditsBefore,
     );
-    const idempotencyKey = piEdgeUsageObservationKey(run.runId, 2);
+    await expect(readTranscript(run.runId)).resolves.toMatchObject({
+      lastOrdinal: 2,
+      messages: [
+        {
+          messageId: `${run.runId}/0`,
+          runEventSequenceNumber: 0,
+          role: "user",
+        },
+        {
+          messageId: `${run.runId}/1`,
+          runEventSequenceNumber: 1,
+          role: "assistant",
+        },
+      ],
+    });
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.some(([message, fields]) => {
+        return (
+          message ===
+            "Run output projection is incomplete at terminal callback" &&
+          recordOf(fields)?.runId === run.runId
+        );
+      }),
+    ).toBeFalsy();
+    const idempotencyKey = piEdgeUsageObservationKey(run.runId, 1);
     await expect(
       readModelStatsObservations(context, [idempotencyKey]),
     ).resolves.toStrictEqual([{ idempotencyKey, aggregatedAt: null }]);
@@ -1616,7 +1651,7 @@ describe("PiLoop edge turn", () => {
         runId: run.runId,
         exitCode: 1,
         error: "the Sandbox failed after the handoff",
-        lastEventSequence: 2,
+        lastEventSequence: 1,
       },
       { authorization: `Bearer ${standbyContext.sandboxToken}` },
       [200],
@@ -1662,7 +1697,7 @@ describe("PiLoop edge turn", () => {
         runId: run.runId,
         exitCode: 1,
         error: "Pi standby timed out waiting for a persisted tool call",
-        lastEventSequence: 1,
+        lastEventSequence: 0,
       },
       { authorization: `Bearer ${standbyContext.sandboxToken}` },
       [200],
@@ -1807,7 +1842,7 @@ describe("PiLoop edge turn", () => {
         runId: run.runId,
         exitCode: 1,
         error: "Pi standby timed out waiting for a persisted tool call",
-        lastEventSequence: 2,
+        lastEventSequence: 1,
       },
       { authorization: `Bearer ${standbyContext.sandboxToken}` },
       [200],
@@ -1822,7 +1857,7 @@ describe("PiLoop edge turn", () => {
       messages: [
         {
           ordinal: 1,
-          messageId: `${run.runId}/1`,
+          messageId: `${run.runId}/0`,
           role: "user",
           payload: {
             role: "user",
@@ -1831,7 +1866,7 @@ describe("PiLoop edge turn", () => {
         },
         {
           ordinal: 2,
-          messageId: `${run.runId}/2`,
+          messageId: `${run.runId}/1`,
           role: "assistant",
           payload: {
             role: "assistant",
@@ -1887,12 +1922,12 @@ describe("PiLoop edge turn", () => {
       messages: [
         {
           ordinal: 1,
-          messageId: `${run.runId}/1`,
+          messageId: `${run.runId}/0`,
           role: "user",
         },
         {
           ordinal: 2,
-          messageId: `${run.runId}/2`,
+          messageId: `${run.runId}/1`,
           role: "assistant",
           payload: {
             role: "assistant",
@@ -1951,8 +1986,8 @@ describe("PiLoop edge turn", () => {
       events: [
         {
           type: "pi.message.completed",
-          sequenceNumber: 3,
-          messageId: `${run.runId}/3`,
+          sequenceNumber: 2,
+          messageId: `${run.runId}/2`,
           message: {
             role: "toolResult",
             toolCallId: deepseekToolCallId("bash_handoff_1"),
@@ -1965,8 +2000,8 @@ describe("PiLoop edge turn", () => {
         },
         {
           type: "pi.message.completed",
-          sequenceNumber: 4,
-          messageId: `${run.runId}/4`,
+          sequenceNumber: 3,
+          messageId: `${run.runId}/3`,
           message: {
             role: "assistant",
             content: [
@@ -2015,7 +2050,7 @@ describe("PiLoop edge turn", () => {
     await webhooks.requestAgentUsageEvent(runnerUsage, usageHeaders, [200]);
     await webhooks.requestAgentUsageEvent(runnerUsage, usageHeaders, [200]);
     await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0, lastEventSequence: 4 },
+      { runId: run.runId, exitCode: 0, lastEventSequence: 3 },
       { authorization: `Bearer ${standbyContext.sandboxToken}` },
       [200],
     );
@@ -2029,14 +2064,14 @@ describe("PiLoop edge turn", () => {
       lastOrdinal: 4,
       hasMore: false,
       messages: [
+        expect.objectContaining({ messageId: `${run.runId}/0` }),
         expect.objectContaining({ messageId: `${run.runId}/1` }),
-        expect.objectContaining({ messageId: `${run.runId}/2` }),
         expect.objectContaining({
-          messageId: `${run.runId}/3`,
+          messageId: `${run.runId}/2`,
           role: "toolResult",
         }),
         expect.objectContaining({
-          messageId: `${run.runId}/4`,
+          messageId: `${run.runId}/3`,
           role: "assistant",
           payload: expect.objectContaining({
             stopReason: "stop",

--- a/turbo/apps/api/src/signals/services/pi-edge-loop.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-edge-loop.service.ts
@@ -218,7 +218,7 @@ export const runPiEdgeTurn$ = command(
     const priorMessages = parsePiAgentMessages(
       transcript.messages.map(transcriptMessagePayload),
     );
-    let sequenceNumber = 1;
+    let sequenceNumber = 0;
 
     await runPiAgentPrompt(
       {

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -348,39 +348,6 @@ describe("internal Pi standby agent loop", () => {
     });
   });
 
-  it("reports sequence zero when resume emits no additional messages", async () => {
-    const io = new FakeIo([
-      {
-        type: "pi-transcript",
-        requestId: "transcript-1",
-        transcript: transcriptPage([persistedMessage(1, 0, HANDOFF_ASSISTANT)]),
-      },
-    ]);
-    const executionEnv = createPiNodeExecutionEnv({ cwd: tmpdir() });
-
-    try {
-      await runPiStandbyAgentLoop(
-        {
-          io,
-          config: CONFIG,
-          executionEnv,
-          standbyTtlSeconds: 1,
-          resume: async () => {},
-        },
-        new AbortController().signal,
-      );
-    } finally {
-      await executionEnv.cleanup();
-    }
-
-    expect(io.outputs.at(-1)).toMatchObject({
-      type: "pi-complete",
-      exitCode: 0,
-      lastEventSequence: 0,
-      skillSnapshotDigest: SNAPSHOT_DIGEST,
-    });
-  });
-
   it("drains transcript pages before taking over", async () => {
     const io = new FakeIo([
       {

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -288,18 +288,18 @@ describe("internal Pi standby agent loop", () => {
       {
         type: "pi-transcript",
         requestId: "transcript-1",
-        transcript: transcriptPage([persistedMessage(3, 7, HANDOFF_ASSISTANT)]),
+        transcript: transcriptPage([persistedMessage(1, 0, HANDOFF_ASSISTANT)]),
       },
       { type: "pi-handoff" },
       {
         type: "pi-message-ack",
-        messageId: `${CONFIG.runId}/8`,
+        messageId: `${CONFIG.runId}/1`,
         status: 200,
       },
       { type: "pi-standby-release", reason: "api-complete" },
       {
         type: "pi-message-ack",
-        messageId: `${CONFIG.runId}/9`,
+        messageId: `${CONFIG.runId}/2`,
         status: 200,
       },
     ]);
@@ -331,19 +331,52 @@ describe("internal Pi standby agent loop", () => {
     expect(messageFrames).toHaveLength(2);
     expect(messageFrames[0]?.event).toMatchObject({
       type: "pi.message.completed",
-      sequenceNumber: 8,
-      messageId: `${CONFIG.runId}/8`,
+      sequenceNumber: 1,
+      messageId: `${CONFIG.runId}/1`,
     });
     expect(eventMessage(messageFrames[0]!)).toEqual(TOOL_RESULT);
     expect(messageFrames[1]?.event).toMatchObject({
-      sequenceNumber: 9,
-      messageId: `${CONFIG.runId}/9`,
+      sequenceNumber: 2,
+      messageId: `${CONFIG.runId}/2`,
     });
     expect(eventMessage(messageFrames[1]!)).toEqual(FINAL_ASSISTANT);
     expect(io.outputs.at(-1)).toMatchObject({
       type: "pi-complete",
       exitCode: 0,
-      lastEventSequence: 9,
+      lastEventSequence: 2,
+      skillSnapshotDigest: SNAPSHOT_DIGEST,
+    });
+  });
+
+  it("reports sequence zero when resume emits no additional messages", async () => {
+    const io = new FakeIo([
+      {
+        type: "pi-transcript",
+        requestId: "transcript-1",
+        transcript: transcriptPage([persistedMessage(1, 0, HANDOFF_ASSISTANT)]),
+      },
+    ]);
+    const executionEnv = createPiNodeExecutionEnv({ cwd: tmpdir() });
+
+    try {
+      await runPiStandbyAgentLoop(
+        {
+          io,
+          config: CONFIG,
+          executionEnv,
+          standbyTtlSeconds: 1,
+          resume: async () => {},
+        },
+        new AbortController().signal,
+      );
+    } finally {
+      await executionEnv.cleanup();
+    }
+
+    expect(io.outputs.at(-1)).toMatchObject({
+      type: "pi-complete",
+      exitCode: 0,
+      lastEventSequence: 0,
       skillSnapshotDigest: SNAPSHOT_DIGEST,
     });
   });

--- a/turbo/apps/cli/src/lib/pi-agent-loop.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.ts
@@ -132,19 +132,18 @@ function transcriptTail(
   transcript: FollowedTranscript,
   runId: string,
 ): TranscriptTail {
-  let lastRunSequence = 0;
+  let lastRunSequence: number | undefined;
   for (const message of transcript.messages) {
     if (message.runId === runId) {
       lastRunSequence = Math.max(
-        lastRunSequence,
+        lastRunSequence ?? -1,
         message.runEventSequenceNumber,
       );
     }
   }
   return {
-    nextSequence: lastRunSequence + 1,
-    lastAcknowledgedSequence:
-      lastRunSequence === 0 ? undefined : lastRunSequence,
+    nextSequence: (lastRunSequence ?? -1) + 1,
+    lastAcknowledgedSequence: lastRunSequence,
   };
 }
 

--- a/turbo/apps/cli/src/lib/pi-agent-loop.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.ts
@@ -143,7 +143,7 @@ function transcriptTail(
   }
   return {
     nextSequence: (lastRunSequence ?? -1) + 1,
-    lastAcknowledgedSequence: lastRunSequence,
+    lastAcknowledgedSequence: undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- start Pi API event sequences at zero so they match the output projection watermark
- continue standby sequencing from the persisted current-run maximum while reporting only messages acknowledged by that standby process
- update Pi API/standby integration coverage, including terminal projection-warning regressions

## Scope

- no API, schema, or persisted-format migration
- no historical event backfill
- no changes to generic output projection semantics

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/pi-edge-loop.test.ts`
- `pnpm -F @vm0/okou-cli exec vitest run src/lib/pi-agent-loop.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/okou-cli lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/okou-cli check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/okou-cli`
- repository pre-commit hooks (Prettier, full Knip, full Turbo type checking, file-size validation)

Closes #26476
