### PR TITLE
feat: move fast selection into model picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -674,6 +674,25 @@ describe("chat composer models", () => {
     expect(standardOption.querySelector("svg.lucide-check")).not.toBeNull();
     expect(fastModeOption.querySelector("svg.lucide-check")).toBeNull();
 
+    await user.hover(fastModeOption);
+    fireEvent.mouseMove(fastModeOption);
+    expect(
+      screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
+    ).not.toBeInTheDocument();
+    const activeFastModeTooltip = await screen.findByText(
+      "Fast · 1.5× model speed · 2.5× credit usage",
+      {},
+      { timeout: 2000 },
+    );
+    expect(activeFastModeTooltip).toBeInTheDocument();
+
+    await user.unhover(fastModeOption);
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
+      ).not.toBeInTheDocument();
+    });
+
     await user.click(standardOption);
     await expectComposerModel("GPT 5.6 Sol");
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -108,20 +108,36 @@ async function navigateToChatThread(threadId: string): Promise<void> {
   click(link);
 }
 
-function queryFastModeButton(name = "Fast"): HTMLElement | undefined {
-  return queryAllByRoleFast("button").find((button) => {
-    return button.getAttribute("aria-label") === name;
+function queryFastModeOption(
+  modelLabel: string,
+  fastLabel = "Fast",
+): HTMLElement | undefined {
+  return (
+    screen.queryByRole("option", {
+      name: `${modelLabel} ${fastLabel}`,
+    }) ?? undefined
+  );
+}
+
+function findFastModeOption(
+  modelLabel: string,
+  fastLabel = "Fast",
+): Promise<HTMLElement> {
+  return waitFor(() => {
+    const option = queryFastModeOption(modelLabel, fastLabel);
+    if (!option) {
+      throw new Error(`Fast mode option not found: ${modelLabel} ${fastLabel}`);
+    }
+    return option;
   });
 }
 
-function findFastModeButton(name = "Fast"): Promise<HTMLElement> {
-  return waitFor(() => {
-    const button = queryFastModeButton(name);
-    if (!button) {
-      throw new Error(`Fast mode button not found: ${name}`);
-    }
-    return button;
-  });
+function fastModeIcon(option: HTMLElement): SVGElement {
+  const icon = option.querySelector<SVGElement>("svg.lucide-zap");
+  if (!icon) {
+    throw new Error("Fast mode icon not found");
+  }
+  return icon;
 }
 
 describe("chat composer models", () => {
@@ -436,29 +452,21 @@ describe("chat composer models", () => {
         path: `/agents/${AGENT_ID}/chat`,
       });
 
-      await expectComposerModel("GPT 5.6 Sol");
-      const modelTrigger = await findComposerModel("GPT 5.6 Sol");
-
-      const fastModeButton = await findFastModeButton();
-      expect(fastModeButton).toHaveAttribute(
-        "aria-pressed",
-        String(!expectedZapIcon),
+      const initialLabel =
+        defaultServiceTier === "priority" ? "GPT 5.6 Sol Fast" : "GPT 5.6 Sol";
+      const targetLabel = expectedZapIcon ? "GPT 5.6 Sol Fast" : "GPT 5.6 Sol";
+      await user.click(await findComposerModel(initialLabel));
+      const fastModeOption = await findFastModeOption("GPT 5.6 Sol");
+      expect(fastModeIcon(fastModeOption)).toHaveAttribute(
+        "fill",
+        expectedZapIcon ? "none" : "currentColor",
       );
-      expect(
-        fastModeButton.compareDocumentPosition(modelTrigger) &
-          Node.DOCUMENT_POSITION_FOLLOWING,
-      ).toBeTruthy();
-      click(fastModeButton);
-      await waitFor(() => {
-        expect(fastModeButton).toHaveAttribute(
-          "aria-pressed",
-          String(expectedZapIcon),
-        );
-        expect(fastModeButton.querySelector("svg.lucide-zap")).toHaveAttribute(
-          "fill",
-          expectedZapIcon ? "currentColor" : "none",
-        );
-      });
+      await user.click(
+        expectedZapIcon
+          ? fastModeOption
+          : screen.getByRole("option", { name: "GPT 5.6 Sol" }),
+      );
+      await expectComposerModel(targetLabel);
       await expect(screen.findByText(notice)).resolves.toBeInTheDocument();
       await user.click(buttonContainingText("Set as default", document.body));
 
@@ -530,10 +538,7 @@ describe("chat composer models", () => {
     });
 
     await user.click(await findComposerModel("Claude Fable 5"));
-    await user.click(
-      await screen.findByRole("option", { name: /GPT 5\.6 Sol/ }),
-    );
-    click(await findFastModeButton());
+    await user.click(await findFastModeOption("GPT 5.6 Sol"));
 
     await expect(
       screen.findByText("Temporarily switched to GPT 5.6 Sol Fast"),
@@ -589,7 +594,7 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows Fast impact on hover without opening it on toggle clicks", async () => {
+  it("selects Standard or Fast from one model row and shows the Fast impact", async () => {
     const user = userEvent.setup({ delay: null });
     let sentBody:
       | {
@@ -629,71 +634,54 @@ describe("chat composer models", () => {
       path: `/agents/${AGENT_ID}/chat`,
     });
 
-    const fastModeButton = await findFastModeButton();
-    await user.hover(fastModeButton);
-    fireEvent.mouseMove(fastModeButton);
+    await user.click(await findComposerModel("GPT 5.6 Sol"));
+    let fastModeOption = await findFastModeOption("GPT 5.6 Sol");
+    expect(fastModeIcon(fastModeOption)).toHaveAttribute("fill", "none");
+    await user.hover(fastModeOption);
+    fireEvent.mouseMove(fastModeOption);
     expect(
       screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
     ).not.toBeInTheDocument();
-    let fastModeTooltip = await screen.findByText(
+    const fastModeTooltip = await screen.findByText(
       "Fast · 1.5× model speed · 2.5× credit usage",
       {},
       { timeout: 2000 },
     );
     expect(fastModeTooltip).toBeInTheDocument();
 
-    await user.unhover(fastModeButton);
+    await user.unhover(fastModeOption);
     await waitFor(() => {
       expect(
         screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
       ).not.toBeInTheDocument();
     });
 
-    await user.click(fastModeButton);
-    await waitFor(() => {
-      expect(fastModeButton).toHaveAttribute("aria-pressed", "true");
-    });
+    await user.click(fastModeOption);
+    await expectComposerModel("GPT 5.6 Sol Fast");
     expect(
       screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
     ).not.toBeInTheDocument();
 
-    await user.unhover(fastModeButton);
-    await user.hover(fastModeButton);
-    fireEvent.mouseMove(fastModeButton);
-    expect(
-      screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
-    ).not.toBeInTheDocument();
-    fastModeTooltip = await screen.findByText(
-      "Fast · 1.5× model speed · 2.5× credit usage",
-      {},
-      { timeout: 2000 },
+    await user.click(await findComposerModel("GPT 5.6 Sol Fast"));
+    fastModeOption = await findFastModeOption("GPT 5.6 Sol");
+    const standardOption = screen.getByRole("option", {
+      name: "GPT 5.6 Sol",
+    });
+    expect(fastModeIcon(fastModeOption)).toHaveAttribute(
+      "fill",
+      "currentColor",
     );
-    expect(fastModeTooltip).toBeInTheDocument();
+    expect(standardOption.querySelector("svg.lucide-check")).not.toBeNull();
+    expect(fastModeOption.querySelector("svg.lucide-check")).toBeNull();
 
-    await user.unhover(fastModeButton);
-    await waitFor(() => {
-      expect(
-        screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
-      ).not.toBeInTheDocument();
-    });
+    await user.click(standardOption);
+    await expectComposerModel("GPT 5.6 Sol");
 
-    await user.click(fastModeButton);
-    await waitFor(() => {
-      expect(fastModeButton).toHaveAttribute("aria-pressed", "false");
-    });
-    expect(
-      screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
-    ).not.toBeInTheDocument();
-    await user.unhover(fastModeButton);
-
-    await user.click(fastModeButton);
-    await waitFor(() => {
-      expect(fastModeButton).toHaveAttribute("aria-pressed", "true");
-    });
-    expect(
-      screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
-    ).not.toBeInTheDocument();
-    await user.unhover(fastModeButton);
+    await user.click(await findComposerModel("GPT 5.6 Sol"));
+    fastModeOption = await findFastModeOption("GPT 5.6 Sol");
+    expect(fastModeIcon(fastModeOption)).toHaveAttribute("fill", "none");
+    await user.click(fastModeOption);
+    await expectComposerModel("GPT 5.6 Sol Fast");
 
     await sendMessageInUI(
       user,
@@ -749,10 +737,11 @@ describe("chat composer models", () => {
       path: `/agents/${AGENT_ID}/chat`,
     });
 
-    const fastModeButton = await findFastModeButton("Rápido");
-    expect(fastModeButton).toHaveAttribute("aria-pressed", "false");
-    await user.hover(fastModeButton);
-    fireEvent.mouseMove(fastModeButton);
+    await user.click(await findComposerModel("GPT 5.6 Sol"));
+    const fastModeOption = await findFastModeOption("GPT 5.6 Sol", "Rápido");
+    expect(fastModeIcon(fastModeOption)).toHaveAttribute("fill", "none");
+    await user.hover(fastModeOption);
+    fireEvent.mouseMove(fastModeOption);
     expect(
       screen.queryByText(
         "Rápido · Velocidade do modelo 1,5× · uso de créditos 2,5×",
@@ -765,7 +754,7 @@ describe("chat composer models", () => {
     );
     expect(fastModeTooltip).toBeInTheDocument();
 
-    await user.unhover(fastModeButton);
+    await user.unhover(fastModeOption);
     await waitFor(() => {
       expect(
         screen.queryByText(
@@ -774,18 +763,15 @@ describe("chat composer models", () => {
       ).not.toBeInTheDocument();
     });
 
-    await user.click(fastModeButton);
-    await waitFor(() => {
-      expect(fastModeButton).toHaveAttribute("aria-pressed", "true");
-    });
+    await user.click(fastModeOption);
+    await expectComposerModel("GPT 5.6 Sol Rápido");
     expect(
       screen.queryByText(
         "Rápido · Velocidade do modelo 1,5× · uso de créditos 2,5×",
       ),
     ).not.toBeInTheDocument();
 
-    await user.unhover(fastModeButton);
-    await user.click(await findComposerModel("GPT 5.6 Sol"));
+    await user.click(await findComposerModel("GPT 5.6 Sol Rápido"));
     const modelPicker = await screen.findByRole("listbox");
 
     await user.hover(within(modelPicker).getByText("$"));
@@ -855,11 +841,9 @@ describe("chat composer models", () => {
       path: `/agents/${AGENT_ID}/chat`,
     });
 
-    const fastModeButton = await findFastModeButton();
-    click(fastModeButton);
-    await waitFor(() => {
-      expect(fastModeButton).toHaveAttribute("aria-pressed", "true");
-    });
+    await user.click(await findComposerModel("GPT 5.6 Luna"));
+    await user.click(await findFastModeOption("GPT 5.6 Luna"));
+    await expectComposerModel("GPT 5.6 Luna Fast");
     act(() => {
       triggerAblyEvent("userPreferenceChanged", {
         kinds: ["defaultModel"],
@@ -869,7 +853,7 @@ describe("chat composer models", () => {
       context.store.set(resetChatPageModelSelection$);
     });
 
-    await expectComposerModel("GPT 5.6 Luna");
+    await expectComposerModel("GPT 5.6 Luna Fast");
 
     await sendMessageInUI(
       user,
@@ -938,8 +922,10 @@ describe("chat composer models", () => {
       expect(
         screen.getByRole("combobox", { name: /^GPT 5\.6 Terra$/ }),
       ).toBeInTheDocument();
-      expect(queryFastModeButton()).toBeUndefined();
     });
+    await user.click(await findComposerModel("GPT 5.6 Terra"));
+    expect(queryFastModeOption("GPT 5.6 Terra")).toBeUndefined();
+    await user.keyboard("{Escape}");
 
     await sendMessageInUI(
       user,
@@ -1034,8 +1020,9 @@ describe("chat composer models", () => {
         path: `/agents/${AGENT_ID}/chat`,
       });
 
-      await findComposerModel(modelLabel);
-      expect(queryFastModeButton()).toBeUndefined();
+      await user.click(await findComposerModel(modelLabel));
+      expect(queryFastModeOption(modelLabel)).toBeUndefined();
+      await user.keyboard("{Escape}");
       await sendMessageInUI(
         user,
         screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
@@ -1150,15 +1137,11 @@ describe("chat composer models", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("combobox", { name: /GPT 5\.6 Sol/ }),
-      ).toBeInTheDocument();
-    });
-    await expect(findFastModeButton()).resolves.toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    await user.click(await findComposerModel("GPT 5.6 Sol Fast"));
+    expect(
+      fastModeIcon(await findFastModeOption("GPT 5.6 Sol")),
+    ).toHaveAttribute("fill", "currentColor");
+    await user.keyboard("{Escape}");
 
     await sendMessageInUI(
       user,
@@ -1216,10 +1199,9 @@ describe("chat composer models", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    await screen.findByRole("combobox", {
-      name: "GPT 5.6 Terra",
-    });
-    const showedFast = queryFastModeButton() !== undefined;
+    await user.click(await findComposerModel("GPT 5.6 Terra"));
+    const showedFast = queryFastModeOption("GPT 5.6 Terra") !== undefined;
+    await user.keyboard("{Escape}");
 
     await sendMessageInUI(
       user,
@@ -1266,13 +1248,11 @@ describe("chat composer models", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    await screen.findByRole("combobox", {
-      name: "GPT 5.6 Luna",
-    });
-    await expect(findFastModeButton()).resolves.toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    await user.click(await findComposerModel("GPT 5.6 Luna Fast"));
+    expect(
+      fastModeIcon(await findFastModeOption("GPT 5.6 Luna")),
+    ).toHaveAttribute("fill", "currentColor");
+    await user.keyboard("{Escape}");
 
     await sendMessageInUI(
       user,
@@ -1328,21 +1308,13 @@ describe("chat composer models", () => {
       featureSwitches: { [FeatureSwitchKey.CodexFastMode]: true },
       path: `/chats/${THREAD_ID}`,
     });
-    await waitFor(() => {
-      expect(
-        screen.getByRole("combobox", { name: /GPT 5\.6 Sol/ }),
-      ).toBeInTheDocument();
-    });
-    const fastModeButton = await findFastModeButton();
-    expect(fastModeButton).toHaveAttribute("aria-pressed", "true");
+    await expectComposerModel("GPT 5.6 Sol Fast");
 
     lifecycle.setCodexServiceTier(null);
     act(() => {
       triggerAblyEvent("threadListChanged");
     });
-    await waitFor(() => {
-      expect(fastModeButton).toHaveAttribute("aria-pressed", "false");
-    });
+    await expectComposerModel("GPT 5.6 Sol");
     await sendMessageInUI(
       user,
       screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
@@ -1354,7 +1326,7 @@ describe("chat composer models", () => {
     });
   });
 
-  it("preserves Fast across supported models and clears it for unsupported models", async () => {
+  it("uses each model row click as an exact Standard or Fast selection", async () => {
     const user = userEvent.setup({ delay: null });
     const codexProvider = buildProvider({
       id: "00000000-0000-4000-a000-000000000915",
@@ -1426,31 +1398,27 @@ describe("chat composer models", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
+    await user.click(await findComposerModel("GPT 5.6 Sol Fast"));
     await user.click(
-      await screen.findByRole("combobox", { name: /GPT 5\.6 Sol/ }),
+      await screen.findByRole("option", { name: "GPT 5.6 Luna" }),
     );
-    await user.click(
-      await screen.findByRole("option", { name: /GPT 5\.6 Luna/ }),
-    );
-    await waitFor(() => {
-      expect(
-        screen.getByRole("combobox", { name: /GPT 5\.6 Luna/ }),
-      ).toBeInTheDocument();
-    });
-    await expect(findFastModeButton()).resolves.toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    await expectComposerModel("GPT 5.6 Luna");
 
-    await user.click(screen.getByRole("combobox", { name: /GPT 5\.6 Luna/ }));
+    await user.click(await findComposerModel("GPT 5.6 Luna"));
+    await user.click(await findFastModeOption("GPT 5.6 Luna"));
+    await expectComposerModel("GPT 5.6 Luna Fast");
+    await waitFor(() => {
+      expect(updatedModelSelection?.modelSelection?.selectedModel).toBe(
+        "gpt-5.6-luna",
+      );
+      expect(updatedModelSelection?.codexServiceTier).toBe("fast");
+    });
+
+    await user.click(await findComposerModel("GPT 5.6 Luna Fast"));
     await user.click(
       await screen.findByRole("option", { name: /Claude Sonnet 5/ }),
     );
-    await waitFor(() => {
-      expect(
-        screen.getByRole("combobox", { name: /Claude Sonnet 5/ }),
-      ).toBeInTheDocument();
-    });
+    await expectComposerModel("Claude Sonnet 5");
 
     await sendMessageInUI(
       user,
@@ -1502,7 +1470,7 @@ describe("chat composer models", () => {
     click(await findComposerModel("GPT 5.6 Luna"));
     await waitFor(() => {
       expect(screen.getByRole("listbox")).toBeInTheDocument();
-      expect(queryFastModeButton()).toBeUndefined();
+      expect(queryFastModeOption("GPT 5.6 Luna")).toBeUndefined();
     });
   });
 
@@ -1538,7 +1506,7 @@ describe("chat composer models", () => {
     click(await findComposerModel("Claude Sonnet 5"));
     await waitFor(() => {
       expect(screen.getByRole("listbox")).toBeInTheDocument();
-      expect(queryFastModeButton()).toBeUndefined();
+      expect(queryFastModeOption("Claude Sonnet 5")).toBeUndefined();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -6,7 +6,7 @@ import {
   useLoadable,
   useSet,
 } from "ccstate-react";
-import { Check, Cpu } from "lucide-react";
+import { Check, Cpu, Zap } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -25,6 +25,7 @@ import {
 import {
   getCanonicalModelDisplayName,
   getProvidersForModel,
+  isCodexFastModeModel,
   isSupportedRunModel,
   VM0_MODEL_TO_PROVIDER,
   type ModelProviderType,
@@ -94,11 +95,15 @@ interface ModelProviderPickerProps {
    * not user/workspace defaults.
    */
   resolveDefaultSelection?: boolean;
+  /** Enables the inline Codex Fast choices in the model list. */
+  codexFastModeEnabled?: boolean;
 }
 
 // Keep the inherit option distinct from an empty model identifier at the UI
 // boundary so its value remains stable across controlled Select updates.
 const INHERIT_SENTINEL = "__inherit_default__";
+const CODEX_FAST_OPTION_PREFIX = "__codex_fast_option__:";
+const CODEX_FAST_SELECTED_PREFIX = "__codex_fast_selected__:";
 
 // Select uses the selected item's offsetHeight as the scroll-button
 // step. Keep hidden selected items measurable so native hover scrolling works.
@@ -284,16 +289,40 @@ function selectionAllowedValue(
   return allowed ? value : null;
 }
 
+function selectionLabel({
+  selection,
+  placeholder,
+  codexFastModeEnabled,
+  fastLabel,
+}: {
+  selection: ModelProviderSelection | null;
+  placeholder: string;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
+}): string {
+  if (!selection) {
+    return placeholder;
+  }
+  const modelLabel = getCanonicalModelDisplayName(selection.selectedModel);
+  return codexFastModeEnabled && selection.codexServiceTier === "fast"
+    ? `${modelLabel} ${fastLabel}`
+    : modelLabel;
+}
+
 function ModelFirstTriggerLabel({
-  selectedModel,
+  selection,
   placeholder,
   mobileIcon,
+  codexFastModeEnabled,
+  fastLabel,
 }: {
-  selectedModel: string | null;
+  selection: ModelProviderSelection | null;
   placeholder: string;
   mobileIcon: boolean;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }) {
-  if (!selectedModel) {
+  if (!selection) {
     return (
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
@@ -302,14 +331,19 @@ function ModelFirstTriggerLabel({
       />
     );
   }
-  const iconType = getModelFirstIconType(selectedModel);
+  const iconType = getModelFirstIconType(selection.selectedModel);
   return (
     <ResponsiveTriggerContent
       mobileIcon={mobileIcon}
       iconType={iconType}
       label={
         <span className="min-w-0 truncate">
-          {getCanonicalModelDisplayName(selectedModel)}
+          {selectionLabel({
+            selection,
+            placeholder,
+            codexFastModeEnabled,
+            fastLabel,
+          })}
         </span>
       }
     />
@@ -323,6 +357,8 @@ function ModelFirstDisabledPickerLabel({
   triggerClassName,
   userPreference,
   policies,
+  codexFastModeEnabled,
+  fastLabel,
 }: Pick<
   ModelProviderPickerProps,
   | "value"
@@ -336,25 +372,30 @@ function ModelFirstDisabledPickerLabel({
   mobileIconTrigger: boolean;
   policies: OrgModelPolicy[];
   userPreference: { selectedModel: string | null } | null | undefined;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }) {
   const resolved = resolveModelFirstDefault(value, userPreference, policies);
-  const selectedModel = resolved?.selectedModel ?? null;
+  const label = selectionLabel({
+    selection: resolved,
+    placeholder,
+    codexFastModeEnabled,
+    fastLabel,
+  });
   return (
     <span
-      aria-label={
-        selectedModel
-          ? getCanonicalModelDisplayName(selectedModel)
-          : placeholder
-      }
+      aria-label={label}
       className={cn(
         "inline-flex items-center px-2 text-sm text-muted-foreground cursor-default",
         stripInteractiveClasses(triggerClassName),
       )}
     >
       <ModelFirstTriggerLabel
-        selectedModel={selectedModel}
+        selection={resolved}
         placeholder={placeholder}
         mobileIcon={mobileIconTrigger}
+        codexFastModeEnabled={codexFastModeEnabled}
+        fastLabel={fastLabel}
       />
     </span>
   );
@@ -362,8 +403,20 @@ function ModelFirstDisabledPickerLabel({
 
 function modelFirstSelectionFromRaw(
   raw: string,
+  codexFastModeEnabled: boolean,
 ): ModelProviderSelection | null {
   if (raw === INHERIT_SENTINEL) {
+    return null;
+  }
+  if (raw.startsWith(CODEX_FAST_OPTION_PREFIX)) {
+    const selectedModel = raw.slice(CODEX_FAST_OPTION_PREFIX.length);
+    if (
+      codexFastModeEnabled &&
+      isSupportedRunModel(selectedModel) &&
+      isCodexFastModeModel(selectedModel)
+    ) {
+      return { selectedModel, codexServiceTier: "fast" };
+    }
     return null;
   }
   if (!isSupportedRunModel(raw)) {
@@ -372,6 +425,27 @@ function modelFirstSelectionFromRaw(
   return {
     selectedModel: raw,
   };
+}
+
+function modelFirstSelectValue(
+  selection: ModelProviderSelection | null,
+): string {
+  if (!selection) {
+    return INHERIT_SENTINEL;
+  }
+  return selection.codexServiceTier === "fast"
+    ? `${CODEX_FAST_SELECTED_PREFIX}${selection.selectedModel}`
+    : selection.selectedModel;
+}
+
+function codexFastOptionValue(model: string): string {
+  return `${CODEX_FAST_OPTION_PREFIX}${model}`;
+}
+
+function isHiddenModelFirstSelectValue(value: string): boolean {
+  return (
+    value === INHERIT_SENTINEL || value.startsWith(CODEX_FAST_SELECTED_PREFIX)
+  );
 }
 
 function ModelFirstPolicyRowContent({
@@ -415,10 +489,80 @@ function ModelFirstPolicyRowContent({
 function ModelFirstPolicyRow({
   policy,
   modelCapabilities,
+  selection,
+  codexFastModeEnabled,
 }: {
   policy: OrgModelPolicy;
   modelCapabilities: ModelPlanCapabilities;
+  selection: ModelProviderSelection | null;
+  codexFastModeEnabled: boolean;
 }) {
+  const { t } = useTranslation();
+  const fastAvailable =
+    codexFastModeEnabled &&
+    policy.routeStatus === "valid" &&
+    isCodexFastModeModel(policy.model);
+  if (fastAvailable) {
+    const modelLabel =
+      policy.modelLabel || getCanonicalModelDisplayName(policy.model);
+    const selected = selection?.selectedModel === policy.model;
+    const fastSelected = selected && selection.codexServiceTier === "fast";
+    const fastLabel = t(($) => {
+      return $.settings.models.picker.fast;
+    });
+    const fastImpact = t(($) => {
+      return $.settings.models.picker.fastImpact;
+    });
+    return (
+      <div
+        className={cn(
+          "flex overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))]",
+          selected && "bg-state-selected",
+        )}
+      >
+        <SelectItem
+          value={policy.model}
+          aria-label={modelLabel}
+          className={cn(
+            "min-w-0 flex-1 rounded-r-none",
+            fastSelected && "pr-2",
+            selected && !fastSelected && "bg-state-selected-hover",
+          )}
+        >
+          <ModelFirstPolicyRowContent
+            policy={policy}
+            modelCapabilities={modelCapabilities}
+            selected={selected}
+            showSelectedIndicator={fastSelected}
+          />
+        </SelectItem>
+        <TooltipProvider delayDuration={800} skipDelayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <SelectItem
+                value={codexFastOptionValue(policy.model)}
+                aria-label={`${modelLabel} ${fastLabel}`}
+                className={cn(
+                  "w-10 shrink-0 justify-center rounded-l-none border-l-[0.7px] border-[hsl(var(--gray-400))] px-0 text-muted-foreground",
+                  fastSelected &&
+                    "bg-state-selected-hover text-amber-600 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200",
+                )}
+              >
+                <Zap
+                  size={18}
+                  fill={fastSelected ? "currentColor" : "none"}
+                  aria-hidden="true"
+                />
+              </SelectItem>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="text-xs">
+              {fastLabel} · {fastImpact}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    );
+  }
   return (
     <SelectItem
       key={policy.id}
@@ -435,16 +579,19 @@ function ModelFirstPolicyRow({
 
 function ModelFirstPolicyItems({
   policies,
-  explicitSelectedModel,
+  selection,
   modelCapabilities,
+  codexFastModeEnabled,
   showSeparator = true,
 }: {
   policies: OrgModelPolicy[];
-  explicitSelectedModel: string | null;
+  selection: ModelProviderSelection | null;
   modelCapabilities: ModelPlanCapabilities;
+  codexFastModeEnabled: boolean;
   showSeparator?: boolean;
 }) {
   const { t } = useTranslation();
+  const explicitSelectedModel = selection?.selectedModel ?? null;
   const hasExplicitSelectedPolicy =
     explicitSelectedModel === null ||
     policies.some((policy) => {
@@ -484,6 +631,8 @@ function ModelFirstPolicyItems({
                 key={policy.id}
                 policy={policy}
                 modelCapabilities={modelCapabilities}
+                selection={selection}
+                codexFastModeEnabled={codexFastModeEnabled}
               />
             );
           })}
@@ -497,33 +646,43 @@ interface ModelFirstModelPickerContentBaseProps {
   selectValue: string;
   placeholder: string;
   policies: OrgModelPolicy[];
-  selectableValue: ModelProviderSelection | null;
+  selection: ModelProviderSelection | null;
   modelCapabilities: ModelPlanCapabilities;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }
 
 function ModelFirstModelPickerContentLayout({
   selectValue,
   placeholder,
   policies,
-  selectableValue,
+  selection,
   modelCapabilities,
+  codexFastModeEnabled,
+  fastLabel,
 }: ModelFirstModelPickerContentBaseProps) {
   return (
     <SelectContent className="max-h-[280px] min-w-[260px]">
-      {selectValue === INHERIT_SENTINEL && (
+      {isHiddenModelFirstSelectValue(selectValue) && (
         <SelectItem
-          value={INHERIT_SENTINEL}
+          value={selectValue}
           className={MEASURABLE_HIDDEN_SELECT_ITEM_CLASS}
           disabled
           aria-hidden="true"
         >
-          {placeholder}
+          {selectionLabel({
+            selection,
+            placeholder,
+            codexFastModeEnabled,
+            fastLabel,
+          })}
         </SelectItem>
       )}
       <ModelFirstPolicyItems
         policies={policies}
-        explicitSelectedModel={selectableValue?.selectedModel ?? null}
+        selection={selection}
         modelCapabilities={modelCapabilities}
+        codexFastModeEnabled={codexFastModeEnabled}
         showSeparator={false}
       />
     </SelectContent>
@@ -534,7 +693,7 @@ interface ModelFirstModelPickerState {
   policies: OrgModelPolicy[];
   selectablePolicies: OrgModelPolicy[];
   selectableValue: ModelProviderSelection | null;
-  selectedModel: string | null;
+  selection: ModelProviderSelection | null;
   selectValue: string;
   triggerAriaLabel: string;
 }
@@ -546,6 +705,8 @@ function resolveModelFirstModelPickerState({
   modelCapabilities,
   resolveDefaultSelection,
   placeholder,
+  codexFastModeEnabled,
+  fastLabel,
 }: {
   value: ModelProviderSelection | null;
   userPreference: { selectedModel: string | null } | null | undefined;
@@ -553,6 +714,8 @@ function resolveModelFirstModelPickerState({
   modelCapabilities: ModelPlanCapabilities;
   resolveDefaultSelection: boolean;
   placeholder: string;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }): ModelFirstModelPickerState {
   const policies = policyResponse?.policies ?? [];
   const selectablePolicies = selectablePoliciesForPlan(
@@ -571,17 +734,18 @@ function resolveModelFirstModelPickerState({
         selectablePolicies,
       )
     : selectableValue;
-  const selectedModel = resolved?.selectedModel ?? null;
   return {
     policies,
     selectablePolicies,
     selectableValue,
-    selectedModel,
-    selectValue:
-      selectableValue?.selectedModel ?? selectedModel ?? INHERIT_SENTINEL,
-    triggerAriaLabel: selectedModel
-      ? getCanonicalModelDisplayName(selectedModel)
-      : placeholder,
+    selection: resolved,
+    selectValue: modelFirstSelectValue(resolved),
+    triggerAriaLabel: selectionLabel({
+      selection: resolved,
+      placeholder,
+      codexFastModeEnabled,
+      fastLabel,
+    }),
   };
 }
 
@@ -592,6 +756,8 @@ function ModelFirstSelectPicker({
   triggerClassName,
   mobileIconTrigger,
   modelCapabilities,
+  codexFastModeEnabled,
+  fastLabel,
   open,
   onOpenChange,
   onValueChange,
@@ -602,6 +768,8 @@ function ModelFirstSelectPicker({
   triggerClassName: string | undefined;
   mobileIconTrigger: boolean;
   modelCapabilities: ModelPlanCapabilities;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
   open: boolean | undefined;
   onOpenChange: ((open: boolean) => void) | undefined;
   onValueChange: (raw: string) => void;
@@ -619,9 +787,11 @@ function ModelFirstSelectPicker({
       >
         <SelectValue placeholder={placeholder}>
           <ModelFirstTriggerLabel
-            selectedModel={state.selectedModel}
+            selection={state.selection}
             placeholder={placeholder}
             mobileIcon={mobileIconTrigger}
+            codexFastModeEnabled={codexFastModeEnabled}
+            fastLabel={fastLabel}
           />
         </SelectValue>
       </SelectTrigger>
@@ -631,8 +801,10 @@ function ModelFirstSelectPicker({
             selectValue={state.selectValue}
             placeholder={placeholder}
             policies={state.policies}
-            selectableValue={state.selectableValue}
+            selection={state.selection}
             modelCapabilities={modelCapabilities}
+            codexFastModeEnabled={codexFastModeEnabled}
+            fastLabel={fastLabel}
           />
         ))}
     </Select>
@@ -651,12 +823,15 @@ function SubscribedModelFirstModelPicker({
   disabled,
   userPreference,
   resolveDefaultSelection,
+  codexFastModeEnabled = false,
+  fastLabel,
 }: ModelProviderPickerProps & {
   placeholder: string;
   compactTrigger: boolean;
   mobileIconTrigger: boolean;
   userPreference: { selectedModel: string | null } | null | undefined;
   resolveDefaultSelection: boolean;
+  fastLabel: string;
 }) {
   const policiesLoadable = useLastLoadable(orgModelPolicies$);
   const modelCapabilitiesLoadable = useLoadable(modelPlanCapabilities$);
@@ -677,6 +852,8 @@ function SubscribedModelFirstModelPicker({
     modelCapabilities,
     resolveDefaultSelection,
     placeholder,
+    codexFastModeEnabled,
+    fastLabel,
   });
 
   if (disabled) {
@@ -689,6 +866,8 @@ function SubscribedModelFirstModelPicker({
         triggerClassName={triggerClassName}
         userPreference={resolveDefaultSelection ? userPreference : null}
         policies={resolveDefaultSelection ? state.selectablePolicies : []}
+        codexFastModeEnabled={codexFastModeEnabled}
+        fastLabel={fastLabel}
       />
     );
   }
@@ -699,12 +878,13 @@ function SubscribedModelFirstModelPicker({
   };
 
   const handleRawValueChange = (raw: string) => {
-    if (raw !== INHERIT_SENTINEL) {
+    const selection = modelFirstSelectionFromRaw(raw, codexFastModeEnabled);
+    if (selection) {
       const policy = state.policies.find((candidate) => {
-        return candidate.model === raw;
+        return candidate.model === selection.selectedModel;
       });
       if (
-        !modelAllowedForPlan(raw, modelCapabilities) ||
+        !modelAllowedForPlan(selection.selectedModel, modelCapabilities) ||
         (policy !== undefined &&
           !modelPolicyAllowedForPlan(policy, modelCapabilities))
       ) {
@@ -712,7 +892,7 @@ function SubscribedModelFirstModelPicker({
         return;
       }
     }
-    onChange(modelFirstSelectionFromRaw(raw));
+    onChange(selection);
   };
 
   return (
@@ -722,6 +902,8 @@ function SubscribedModelFirstModelPicker({
       triggerClassName={triggerClassName}
       mobileIconTrigger={mobileIconTrigger}
       modelCapabilities={modelCapabilities}
+      codexFastModeEnabled={codexFastModeEnabled}
+      fastLabel={fastLabel}
       open={open}
       onOpenChange={onOpenChange}
       onValueChange={handleRawValueChange}
@@ -732,32 +914,42 @@ function SubscribedModelFirstModelPicker({
 function resolveExplicitModelFirstModelPickerState({
   value,
   placeholder,
+  codexFastModeEnabled,
+  fastLabel,
 }: {
   value: ModelProviderSelection | null;
   placeholder: string;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }): ModelFirstModelPickerState {
-  const selectedModel = value?.selectedModel ?? null;
   return {
     policies: [],
     selectablePolicies: [],
     selectableValue: value,
-    selectedModel,
-    selectValue: selectedModel ?? INHERIT_SENTINEL,
-    triggerAriaLabel: selectedModel
-      ? getCanonicalModelDisplayName(selectedModel)
-      : placeholder,
+    selection: value,
+    selectValue: modelFirstSelectValue(value),
+    triggerAriaLabel: selectionLabel({
+      selection: value,
+      placeholder,
+      codexFastModeEnabled,
+      fastLabel,
+    }),
   };
 }
 
 function LoadingModelFirstModelPickerContent({
   value,
   placeholder,
+  codexFastModeEnabled,
+  fastLabel,
 }: {
   value: ModelProviderSelection | null;
   placeholder: string;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }) {
   const { t } = useTranslation();
-  const selectValue = value?.selectedModel ?? INHERIT_SENTINEL;
+  const selectValue = modelFirstSelectValue(value);
   return (
     <SelectContent className="min-w-[260px]">
       <SelectItem
@@ -766,9 +958,12 @@ function LoadingModelFirstModelPickerContent({
         disabled
         aria-hidden="true"
       >
-        {value?.selectedModel
-          ? getCanonicalModelDisplayName(value.selectedModel)
-          : placeholder}
+        {selectionLabel({
+          selection: value,
+          placeholder,
+          codexFastModeEnabled,
+          fastLabel,
+        })}
       </SelectItem>
       <div className="px-2 py-2 text-sm text-muted-foreground">
         {t(($) => {
@@ -782,12 +977,16 @@ function LoadingModelFirstModelPickerContent({
 function ErrorModelFirstModelPickerContent({
   value,
   placeholder,
+  codexFastModeEnabled,
+  fastLabel,
 }: {
   value: ModelProviderSelection | null;
   placeholder: string;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }) {
   const { t } = useTranslation();
-  const selectValue = value?.selectedModel ?? INHERIT_SENTINEL;
+  const selectValue = modelFirstSelectValue(value);
   return (
     <SelectContent className="min-w-[260px]">
       <SelectItem
@@ -796,9 +995,12 @@ function ErrorModelFirstModelPickerContent({
         disabled
         aria-hidden="true"
       >
-        {value?.selectedModel
-          ? getCanonicalModelDisplayName(value.selectedModel)
-          : placeholder}
+        {selectionLabel({
+          selection: value,
+          placeholder,
+          codexFastModeEnabled,
+          fastLabel,
+        })}
       </SelectItem>
       <div className="px-2 py-2 text-sm text-muted-foreground">
         {t(($) => {
@@ -812,9 +1014,13 @@ function ErrorModelFirstModelPickerContent({
 function SubscribedExplicitModelFirstModelPickerContent({
   value,
   placeholder,
+  codexFastModeEnabled,
+  fastLabel,
 }: {
   value: ModelProviderSelection | null;
   placeholder: string;
+  codexFastModeEnabled: boolean;
+  fastLabel: string;
 }) {
   const policiesLoadable = useLastLoadable(orgModelPolicies$);
   const modelCapabilities =
@@ -824,6 +1030,8 @@ function SubscribedExplicitModelFirstModelPickerContent({
       <LoadingModelFirstModelPickerContent
         value={value}
         placeholder={placeholder}
+        codexFastModeEnabled={codexFastModeEnabled}
+        fastLabel={fastLabel}
       />
     );
   }
@@ -832,6 +1040,8 @@ function SubscribedExplicitModelFirstModelPickerContent({
       <ErrorModelFirstModelPickerContent
         value={value}
         placeholder={placeholder}
+        codexFastModeEnabled={codexFastModeEnabled}
+        fastLabel={fastLabel}
       />
     );
   }
@@ -842,14 +1052,18 @@ function SubscribedExplicitModelFirstModelPickerContent({
     modelCapabilities: DEFAULT_MODEL_PLAN_CAPABILITIES,
     resolveDefaultSelection: false,
     placeholder,
+    codexFastModeEnabled,
+    fastLabel,
   });
   return (
     <ModelFirstModelPickerContentLayout
       selectValue={state.selectValue}
       placeholder={placeholder}
       policies={state.policies}
-      selectableValue={state.selectableValue}
+      selection={state.selection}
       modelCapabilities={modelCapabilities}
+      codexFastModeEnabled={codexFastModeEnabled}
+      fastLabel={fastLabel}
     />
   );
 }
@@ -859,6 +1073,7 @@ function EnabledExplicitModelFirstModelPicker(
     placeholder: string;
     compactTrigger: boolean;
     mobileIconTrigger: boolean;
+    fastLabel: string;
   },
 ) {
   const resolveSelection = useSet(resolveExplicitModelSelection$);
@@ -868,13 +1083,18 @@ function EnabledExplicitModelFirstModelPicker(
   const state = resolveExplicitModelFirstModelPickerState({
     value: props.value,
     placeholder: props.placeholder,
+    codexFastModeEnabled: props.codexFastModeEnabled ?? false,
+    fastLabel: props.fastLabel,
   });
   const handleRawValueChange = (raw: string) => {
     detach(
       (async () => {
         const result = await resolveSelection(
           {
-            selection: modelFirstSelectionFromRaw(raw),
+            selection: modelFirstSelectionFromRaw(
+              raw,
+              props.codexFastModeEnabled ?? false,
+            ),
           },
           pageSignal,
         );
@@ -896,6 +1116,8 @@ function EnabledExplicitModelFirstModelPicker(
           <SubscribedExplicitModelFirstModelPickerContent
             value={props.value}
             placeholder={props.placeholder}
+            codexFastModeEnabled={props.codexFastModeEnabled ?? false}
+            fastLabel={props.fastLabel}
           />
         ) : undefined
       }
@@ -903,6 +1125,8 @@ function EnabledExplicitModelFirstModelPicker(
       triggerClassName={props.triggerClassName}
       mobileIconTrigger={props.mobileIconTrigger}
       modelCapabilities={DEFAULT_MODEL_PLAN_CAPABILITIES}
+      codexFastModeEnabled={props.codexFastModeEnabled ?? false}
+      fastLabel={props.fastLabel}
       open={props.open}
       onOpenChange={props.onOpenChange}
       onValueChange={handleRawValueChange}
@@ -915,6 +1139,7 @@ function ModelFirstModelPicker(
     placeholder: string;
     compactTrigger: boolean;
     mobileIconTrigger: boolean;
+    fastLabel: string;
   },
 ) {
   if (props.disabled) {
@@ -927,6 +1152,8 @@ function ModelFirstModelPicker(
         triggerClassName={props.triggerClassName}
         userPreference={null}
         policies={[]}
+        codexFastModeEnabled={props.codexFastModeEnabled ?? false}
+        fastLabel={props.fastLabel}
       />
     );
   }
@@ -938,6 +1165,7 @@ function ModelFirstModelPickerWithDefaultSelection(
     placeholder: string;
     compactTrigger: boolean;
     mobileIconTrigger: boolean;
+    fastLabel: string;
   },
 ) {
   const userPreference = useLastResolved(userModelPreference$);
@@ -961,6 +1189,7 @@ export function ModelProviderPicker({
   onOpenChange,
   disabled = false,
   resolveDefaultSelection = true,
+  codexFastModeEnabled = false,
 }: ModelProviderPickerProps) {
   const { t } = useTranslation();
   const resolvedPlaceholder =
@@ -968,6 +1197,9 @@ export function ModelProviderPicker({
     t(($) => {
       return $.settings.models.picker.inheritDefault;
     });
+  const fastLabel = t(($) => {
+    return $.settings.models.picker.fast;
+  });
   const props = {
     value,
     onChange,
@@ -978,6 +1210,8 @@ export function ModelProviderPicker({
     open,
     onOpenChange,
     disabled,
+    codexFastModeEnabled,
+    fastLabel,
   };
   if (resolveDefaultSelection) {
     return <ModelFirstModelPickerWithDefaultSelection {...props} />;

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -559,7 +559,7 @@ function ModelFirstPolicyRow({
                 />
               </SelectItem>
             </TooltipTrigger>
-            <TooltipContent side="right" className="text-xs">
+            <TooltipContent side="top" className="text-xs">
               {fastLabel} · {fastImpact}
             </TooltipContent>
           </Tooltip>

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -516,17 +516,17 @@ function ModelFirstPolicyRow({
     return (
       <div
         className={cn(
-          "flex overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))]",
-          selected && "bg-state-selected",
+          "flex overflow-hidden rounded-lg transition-colors hover:bg-state-hover has-[[data-highlighted]]:bg-state-hover",
+          selected &&
+            "bg-state-selected hover:bg-state-selected-hover has-[[data-highlighted]]:bg-state-selected-hover",
         )}
       >
         <SelectItem
           value={policy.model}
           aria-label={modelLabel}
           className={cn(
-            "min-w-0 flex-1 rounded-r-none",
+            "min-w-0 flex-1 rounded-r-none hover:bg-transparent data-highlighted:bg-transparent",
             fastSelected && "pr-2",
-            selected && !fastSelected && "bg-state-selected-hover",
           )}
         >
           <ModelFirstPolicyRowContent
@@ -543,14 +543,18 @@ function ModelFirstPolicyRow({
                 value={codexFastOptionValue(policy.model)}
                 aria-label={`${modelLabel} ${fastLabel}`}
                 className={cn(
-                  "w-10 shrink-0 justify-center rounded-l-none border-l-[0.7px] border-[hsl(var(--gray-400))] px-0 text-muted-foreground",
+                  "group/fast-option w-10 shrink-0 justify-center rounded-l-none px-0 text-muted-foreground hover:bg-transparent data-highlighted:bg-transparent",
                   fastSelected &&
-                    "bg-state-selected-hover text-amber-600 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200",
+                    "text-amber-600 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200",
                 )}
               >
                 <Zap
                   size={18}
                   fill={fastSelected ? "currentColor" : "none"}
+                  className={cn(
+                    !fastSelected &&
+                      "group-hover/fast-option:fill-current group-data-[highlighted]/fast-option:fill-current",
+                  )}
                   aria-hidden="true"
                 />
               </SelectItem>

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -478,7 +478,7 @@ function ModelFirstPolicyRowContent({
       )}
       {restricted && <ProBadge />}
       {showSelectedIndicator && (
-        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-foreground">
+        <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center text-foreground">
           {selected && <Check size={15} />}
         </span>
       )}
@@ -516,7 +516,7 @@ function ModelFirstPolicyRow({
     return (
       <div
         className={cn(
-          "flex overflow-hidden rounded-lg transition-colors hover:bg-state-hover has-[[data-highlighted]]:bg-state-hover",
+          "relative flex overflow-hidden rounded-lg transition-colors hover:bg-state-hover has-[[data-highlighted]]:bg-state-hover",
           selected &&
             "bg-state-selected hover:bg-state-selected-hover has-[[data-highlighted]]:bg-state-selected-hover",
         )}
@@ -525,8 +525,8 @@ function ModelFirstPolicyRow({
           value={policy.model}
           aria-label={modelLabel}
           className={cn(
-            "min-w-0 flex-1 rounded-r-none hover:bg-transparent data-highlighted:bg-transparent",
-            fastSelected && "pr-2",
+            "min-w-0 flex-1 rounded-lg hover:bg-transparent data-highlighted:bg-transparent",
+            selected ? "pr-16" : "pr-8",
           )}
         >
           <ModelFirstPolicyRowContent
@@ -543,7 +543,8 @@ function ModelFirstPolicyRow({
                 value={codexFastOptionValue(policy.model)}
                 aria-label={`${modelLabel} ${fastLabel}`}
                 className={cn(
-                  "group/fast-option w-10 shrink-0 justify-center rounded-l-none px-0 text-muted-foreground hover:bg-transparent data-highlighted:bg-transparent",
+                  "group/fast-option absolute inset-y-0 right-0 w-8 justify-center rounded-lg px-0 text-muted-foreground hover:bg-transparent data-highlighted:bg-transparent",
+                  selected && "right-8",
                   fastSelected &&
                     "text-amber-600 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200",
                 )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -49,7 +49,6 @@ import {
   User,
   Video,
   X,
-  Zap,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -231,10 +230,7 @@ import {
   avatarTemplateSelection,
   toAvatarGenerationTemplate,
 } from "../../signals/zero-page/avatar-template-selection.ts";
-import {
-  isCodexFastModeAvailableForSelection,
-  resolveModelFirstUserDefaultSelection,
-} from "../../signals/zero-page/model-default-selection.ts";
+import { resolveModelFirstUserDefaultSelection } from "../../signals/zero-page/model-default-selection.ts";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 const COMPOSER_CONTROL_FOCUS_CLASS =
@@ -7386,68 +7382,9 @@ function ModelConfigurationWarning({
   );
 }
 
-function ComposerFastModeButton({
-  value,
-  onChange,
-  disabled,
-  codexFastModeEnabled,
-}: ComposerModelPicker & { codexFastModeEnabled: boolean }) {
-  const { t } = useTranslation();
-  const policies = useLastResolved(orgModelPolicies$);
-  const available = isCodexFastModeAvailableForSelection({
-    policies,
-    selectedModel: value?.selectedModel,
-    codexFastModeEnabled,
-  });
-  if (!value || !available) {
-    return null;
-  }
-  const active = value.codexServiceTier === "fast";
-  const label = t(($) => {
-    return $.settings.models.picker.fast;
-  });
-  const impact = t(($) => {
-    return $.settings.models.picker.fastImpact;
-  });
-  return (
-    <TooltipProvider delayDuration={800} skipDelayDuration={0}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="quiet"
-            size="icon-sm"
-            className={cn(
-              "shrink-0",
-              COMPOSER_CONTROL_ICON_CLASS,
-              active &&
-                "text-amber-600 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200",
-            )}
-            aria-label={label}
-            aria-pressed={active}
-            disabled={disabled}
-            onClick={() => {
-              onChange({
-                selectedModel: value.selectedModel,
-                ...(active ? {} : { codexServiceTier: "fast" }),
-              });
-            }}
-          >
-            <Zap fill={active ? "currentColor" : "none"} aria-hidden="true" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          {label} · {impact}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
 function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const { t } = useTranslation();
   const codexFastModeEnabled = useGet(codexFastModeEnabled$);
-  const policies = useLastResolved(orgModelPolicies$);
   const modelPickerOpen = useGet(signals.model.modelPickerOpen$);
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
   const modelSelection = useLastLoadable(signals.model.modelSelection$);
@@ -7460,27 +7397,14 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const pageSignal = useGet(pageSignal$);
   const value = modelSelection.state === "hasData" ? modelSelection.data : null;
   const modelPickerLoading = modelSelection.state === "loading";
-  const onFastModeButtonChange = (selection: ModelProviderSelection | null) => {
-    detach(setModelSelection(selection, pageSignal), Reason.DomCallback);
-  };
   const onModelPickerChange = (selection: ModelProviderSelection | null) => {
-    const nextSelection =
-      selection &&
-      value?.codexServiceTier === "fast" &&
-      isCodexFastModeAvailableForSelection({
-        policies,
-        selectedModel: selection.selectedModel,
-        codexFastModeEnabled,
-      })
-        ? { ...selection, codexServiceTier: "fast" as const }
-        : selection;
     const nextUnsupported = getVisualAttachmentUnsupportedState(
       {
         value,
         onChange: onModelPickerChange,
       },
       imageRecognitionEnabled,
-      nextSelection,
+      selection,
     );
     if (
       nextUnsupported &&
@@ -7490,7 +7414,7 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
     ) {
       showVisualAttachmentUnsupportedToast(nextUnsupported);
     }
-    detach(setModelSelection(nextSelection, pageSignal), Reason.DomCallback);
+    detach(setModelSelection(selection, pageSignal), Reason.DomCallback);
   };
   const modelPicker: ComposerModelPicker = {
     value,
@@ -7517,12 +7441,6 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   return (
     <>
       {submitBlocker && <ModelConfigurationWarning blocker={submitBlocker} />}
-      <ComposerFastModeButton
-        value={modelPicker.value}
-        onChange={onFastModeButtonChange}
-        disabled={modelPicker.disabled}
-        codexFastModeEnabled={codexFastModeEnabled}
-      />
       <ModelProviderPicker
         value={modelPicker.value}
         onChange={onModelPickerChange}
@@ -7541,6 +7459,7 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
         onOpenChange={setModelPickerOpen}
         disabled={modelPicker.disabled}
         resolveDefaultSelection={false}
+        codexFastModeEnabled={codexFastModeEnabled}
       />
       <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
     </>


### PR DESCRIPTION
## Summary

- move Codex Fast into a trailing hot zone on each supported model row
- make the main model region select Standard and show Fast in the composer trigger label
- keep the interaction behind the existing Codex Fast feature switch, with a solid bolt and the model check when Fast is selected

## Test plan

- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app check-types
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx --maxWorkers=1