### PR TITLE
chore(api): refresh preview qa marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-31)
+// (no-op API release marker refreshed again on 2026-08-12)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- refresh the no-op API marker to create a preview environment
- use the preview to reproduce chat background sync behavior with snapshot reads enabled

## Verification

- `git diff --check`
- runtime behavior unchanged; rely on the PR pipeline for repository checks
