### PR TITLE
fix: allow arbitrary file uploads in the composer

### DIFF
--- a/turbo/apps/api/src/lib/mimetype.ts
+++ b/turbo/apps/api/src/lib/mimetype.ts
@@ -36,6 +36,7 @@ const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
   md: "text/markdown",
   html: "text/html",
   htm: "text/html",
+  har: "application/json",
   json: "application/json",
   xml: "application/xml",
   yaml: "application/yaml",

--- a/turbo/apps/api/src/lib/uploads-constants.ts
+++ b/turbo/apps/api/src/lib/uploads-constants.ts
@@ -8,6 +8,7 @@
 
 export const MAX_UPLOAD_SIZE_BYTES = 1024 * 1024 * 1024;
 export const MAX_UPLOAD_SIZE_LABEL = "1 GB";
+const GENERIC_UPLOAD_CONTENT_TYPE = "application/octet-stream";
 
 const ALLOWED_UPLOAD_TYPES: Readonly<Set<string>> = new Set([
   "image/png",
@@ -104,4 +105,15 @@ const ALLOWED_UPLOAD_TYPES: Readonly<Set<string>> = new Set([
 
 export function isAllowedUploadType(contentType: string): boolean {
   return ALLOWED_UPLOAD_TYPES.has(contentType);
+}
+
+/**
+ * Keep recognized metadata and represent every other web upload as opaque
+ * bytes. Slack canonical assets use isAllowedUploadType as a separate gate.
+ */
+export function normalizeWebUploadContentType(contentType: string): string {
+  const normalized = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  return isAllowedUploadType(normalized)
+    ? normalized
+    : GENERIC_UPLOAD_CONTENT_TYPE;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -776,17 +776,16 @@ describe("FILE-01 uploads, storage, and host APIs", () => {
     expectApiError(crossUserComplete.body);
     expect(crossUserComplete.body.error.code).toBe("NOT_FOUND");
 
-    const unsupported = await api.requestPrepareUpload(
-      actor,
-      {
-        filename: "malware.exe",
-        contentType: "application/x-msdownload",
-        size: 10,
-      },
-      [400],
-    );
-    expectApiError(unsupported.body);
-    expect(unsupported.body.error.message).toContain("Unsupported file type");
+    const generic = await api.prepareUpload(actor, {
+      filename: "capture.custom",
+      contentType: "application/x-custom",
+      size: 10,
+    });
+    expect(generic).toMatchObject({
+      filename: "capture.custom",
+      contentType: "application/octet-stream",
+      size: 10,
+    });
   });
 
   it("prepares and completes a hosted-site deployment through host APIs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
@@ -200,7 +200,7 @@ describe("POST /api/zero/uploads/complete", () => {
     });
   });
 
-  it("uses the validated complete content type when provided", async () => {
+  it("uses a recognized complete content type when provided", async () => {
     const fixture = await createRunUploadFixture();
     const fileId = randomUUID();
     addUploadObject(fixture, fileId, "data.bin", 9);
@@ -346,21 +346,27 @@ describe("POST /api/zero/uploads/complete", () => {
     });
   });
 
-  it("returns 400 for unsupported content types", async () => {
-    const response = await chat.completeUploadWithBearer(
-      zeroBearer(),
-      {
-        id: randomUUID(),
-        contentType: "application/x-msdownload",
-      },
-      [400],
+  it("falls back to a generic complete content type for unrecognized MIME values", async () => {
+    const actor = bdd.user();
+    const objectStore = chatCallbacks.acceptChatObjectStorage();
+    const fileId = randomUUID();
+    addUploadObject(
+      { actor: { ...actor, orgId: requireOrgId(actor) }, objectStore },
+      fileId,
+      "capture.custom",
+      10,
     );
 
-    expect(response.body).toStrictEqual({
-      error: {
-        message: "Unsupported file type: application/x-msdownload",
-        code: "BAD_REQUEST",
-      },
+    const response = await chat.completeUpload(actor, {
+      id: fileId,
+      contentType: "application/x-custom",
+    });
+
+    expect(response).toMatchObject({
+      id: fileId,
+      filename: "capture.custom",
+      contentType: "application/octet-stream",
+      size: 10,
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
@@ -131,7 +131,7 @@ describe("POST /api/zero/uploads/prepare", () => {
     expect(response.body.error.message).toContain("File too large");
   });
 
-  it("rejects unsupported content types with 400", async () => {
+  it("falls back to a generic content type for unrecognized MIME values", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
@@ -139,18 +139,24 @@ describe("POST /api/zero/uploads/prepare", () => {
     const client = setupApp({ context, routes: zeroUploadsTestRoutes })(
       zeroUploadsContract,
     );
-    const response = await accept(
-      client.prepare({
-        body: {
-          filename: "bad.exe",
-          contentType: "application/x-msdownload",
-          size: 10,
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [400],
-    );
-    expect(response.body.error.message).toContain("Unsupported file type");
+    const response = await client.prepare({
+      body: {
+        filename: "capture.custom",
+        contentType: "Application/X-Custom; Version=1",
+        size: 10,
+      },
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    expect(response.status).toBe(200);
+    if (response.status !== 200) {
+      return;
+    }
+    expect(response.body).toMatchObject({
+      filename: "capture.custom",
+      contentType: "application/octet-stream",
+      size: 10,
+    });
   });
 
   it("returns presigned upload URL and final CDN URL with full body shape", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-uploads-complete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-complete.ts
@@ -4,7 +4,7 @@ import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { isAllowedUploadType } from "../../lib/uploads-constants";
+import { normalizeWebUploadContentType } from "../../lib/uploads-constants";
 import { resolveArtifactObject$ } from "../services/artifact-storage.service";
 import { recordWebUploadedFile$ } from "../services/run-uploaded-files.service";
 import { rejectSuspendedOrg$ } from "../services/zero-org-suspension.service";
@@ -26,18 +26,6 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const { id, contentType: requestedContentType } = body.data;
-
-  if (requestedContentType && !isAllowedUploadType(requestedContentType)) {
-    return {
-      status: 400 as const,
-      body: {
-        error: {
-          message: `Unsupported file type: ${requestedContentType}`,
-          code: "BAD_REQUEST",
-        },
-      },
-    };
-  }
 
   if (auth.orgId) {
     const suspended = await set(rejectSuspendedOrg$, auth.orgId, signal);
@@ -61,7 +49,9 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const filename = s3Object.filename;
-  const contentType = requestedContentType ?? s3Object.contentType;
+  const contentType = requestedContentType
+    ? normalizeWebUploadContentType(requestedContentType)
+    : s3Object.contentType;
   const size = s3Object.size;
   const url = s3Object.url;
   const lastModified = s3Object.lastModified?.toISOString();

--- a/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/zero-uploads-prepare.ts
@@ -4,9 +4,9 @@ import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { env } from "../../lib/env";
 import { badRequestMessage } from "../../lib/error";
 import {
-  isAllowedUploadType,
   MAX_UPLOAD_SIZE_BYTES,
   MAX_UPLOAD_SIZE_LABEL,
+  normalizeWebUploadContentType,
 } from "../../lib/uploads-constants";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -37,16 +37,13 @@ const prepareUploadInner$ = command(
     }
 
     const { filename, size } = bodyResult.data;
-    const contentType =
-      bodyResult.data.contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+    const contentType = normalizeWebUploadContentType(
+      bodyResult.data.contentType,
+    );
 
     if (size > MAX_UPLOAD_SIZE_BYTES) {
       return badRequestMessage(`File too large (max ${MAX_UPLOAD_SIZE_LABEL})`);
     }
-    if (!isAllowedUploadType(contentType)) {
-      return badRequestMessage(`Unsupported file type: ${contentType}`);
-    }
-
     if (auth.orgId) {
       const suspended = await set(rejectSuspendedOrg$, auth.orgId, signal);
       if (suspended) {

--- a/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-event-shared.service.ts
@@ -56,6 +56,7 @@ const EXT_MIMETYPE_MAP: Readonly<Record<string, string>> = {
   md: "text/markdown",
   html: "text/html",
   htm: "text/html",
+  har: "application/json",
   json: "application/json",
 };
 const revoker = alias(chatEvents, "revoker");

--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -276,6 +276,8 @@ describe("okou web upload-file command", () => {
       ["image.avif", "image/avif"],
       ["clip.mp3", "audio/mpeg"],
       ["voice.wav", "audio/wav"],
+      ["network.har", "application/json"],
+      ["payload.vm0unknown", "application/octet-stream"],
     ])("should infer %s as %s", async (filename, expectedContentType) => {
       const filePath = join(tmpDir, basename(filename));
       writeFileSync(filePath, Buffer.from("fake bytes"));

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -37,9 +37,8 @@ const BUILT_IN_GENERATION_WAIT_TIMEOUT_MS_BY_TYPE = {
 const ABLY_CONNECT_TIMEOUT_MS = 10_000;
 
 /**
- * Minimal extension → MIME map covering the server allowlist for
- * `/api/zero/uploads/prepare`. Kept in this file rather than a shared module
- * to match the YAGNI pattern used elsewhere in the CLI.
+ * Known extension → MIME map for accurate upload metadata. Unknown extensions
+ * remain opaque as `application/octet-stream`.
  */
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",
@@ -74,6 +73,7 @@ const MIME_BY_EXTENSION: Record<string, string> = {
   ".md": "text/markdown",
   ".html": "text/html",
   ".htm": "text/html",
+  ".har": "application/json",
   ".json": "application/json",
   ".xml": "application/xml",
   ".yaml": "application/yaml",

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -791,7 +791,7 @@ function createDraftSync(threadId: string, draft: DraftSignals) {
           id: r.info.id,
           url: r.info.url,
           filename: r.attachment.filename,
-          contentType: r.attachment.contentType,
+          contentType: r.info.contentType,
           size: r.attachment.size,
         };
       });

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -32,6 +32,7 @@ interface PreparedUserMessage {
 interface AttachmentFileInfo {
   id: string;
   url: string;
+  contentType: string;
 }
 
 interface ResolvedDraftAttachment {
@@ -182,7 +183,7 @@ export const prepareUserMessageFromDraft$ = command(
             return {
               id: r.info.id,
               filename: r.attachment.filename,
-              contentType: r.attachment.contentType,
+              contentType: r.info.contentType,
               size: r.attachment.size,
               url: r.info.url,
             };

--- a/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
@@ -127,7 +127,7 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
           id: result.info.id,
           url: result.info.url,
           filename: result.attachment.filename,
-          contentType: result.attachment.contentType,
+          contentType: result.info.contentType,
           size: result.attachment.size,
         };
       });

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -32,6 +32,14 @@ import { i18n } from "../../i18n/index.ts";
 interface FileInfo {
   id: string;
   url: string;
+  contentType: string;
+}
+
+function uploadFileInfo(
+  file: Pick<FileInfo, "id" | "url">,
+  contentType: string,
+): FileInfo {
+  return { id: file.id, url: file.url, contentType };
 }
 
 type AttachmentUploadState =
@@ -101,6 +109,7 @@ function uploadContentTypeByExtension(ext: string): string | undefined {
     flac: "audio/flac",
     gif: "image/gif",
     gz: "application/gzip",
+    har: "application/json",
     heic: "image/heic",
     heif: "image/heif",
     htm: "text/html",
@@ -249,7 +258,6 @@ function createChatAttachment(file: File): ZeroChatAttachment {
   const uploadPending$ = computed((get): boolean => {
     return get(internalUpload$).status === "pending";
   });
-
   const cancel$ = command(({ set }) => {
     set(resetSignal$);
   });
@@ -306,7 +314,7 @@ function createChatAttachment(file: File): ZeroChatAttachment {
               [200],
             );
             signal.throwIfAborted();
-            return completed.body;
+            return uploadFileInfo(completed.body, prepared.body.contentType);
           })(),
           async () => {
             const cleanupSignal = AbortSignal.timeout(
@@ -343,7 +351,7 @@ function createChatAttachment(file: File): ZeroChatAttachment {
         );
       }
 
-      return { id: prepared.body.id, url: prepared.body.url };
+      return uploadFileInfo(prepared.body, prepared.body.contentType);
     })();
 
     set(internalUpload$, { status: "pending", promise });
@@ -415,11 +423,13 @@ export interface DraftInputSyncTarget {
 export function createRestoredAttachment(
   persisted: PersistedAttachment,
 ): ZeroChatAttachment {
-  const fileInfo$ = computed(
-    (): Promise<{ id: string; url: string } | null> => {
-      return Promise.resolve({ id: persisted.id, url: persisted.url });
-    },
-  );
+  const fileInfo$ = computed((): Promise<FileInfo | null> => {
+    return Promise.resolve({
+      id: persisted.id,
+      url: persisted.url,
+      contentType: persisted.contentType,
+    });
+  });
 
   const cancel$ = command(() => {
     // no-op: already uploaded, nothing to cancel

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -1435,63 +1435,73 @@ describe("chat drafts", () => {
     });
   });
 
-  it("infers attachment content type when the browser reports a generic file type", async () => {
-    const user = userEvent.setup({ delay: null });
-    let capturedPrepareBody: unknown = null;
+  it.each([
+    {
+      filename: "network.har",
+      expectedContentType: "application/json",
+      contents: '{"log":{"entries":[]}}',
+    },
+    {
+      filename: "payload.vm0unknown",
+      expectedContentType: "application/octet-stream",
+      contents: "opaque bytes",
+    },
+  ])(
+    "allows picker uploads and infers $expectedContentType for $filename",
+    async ({ filename, expectedContentType, contents }) => {
+      const user = userEvent.setup({ delay: null });
+      let capturedPrepareBody: unknown = null;
+      const uploadUrl = `https://mock-upload.example.com/${filename}`;
 
-    context.mocks.data.userModelPreference({
-      selectedModel: "claude-sonnet-4-6",
-      serviceTier: null,
-      updatedAt: "2026-03-10T00:00:00Z",
-    });
-    mockThreadDetails();
-    context.mocks.http.post(
-      "*/api/zero/uploads/prepare",
-      async ({ request }) => {
-        capturedPrepareBody = await request.json();
-        return HttpResponse.json({
-          id: "upload-launch-plan",
-          filename: "launch-plan.pdf",
-          contentType: "application/pdf",
-          size: 11,
-          uploadUrl: "https://mock-upload.example.com/launch-plan.pdf",
-          uploadHeaders: {},
-          url: "https://example.com/launch-plan.pdf",
-        });
-      },
-    );
-    context.mocks.http.put(
-      "https://mock-upload.example.com/launch-plan.pdf",
-      () => {
-        return new HttpResponse(null, { status: 200 });
-      },
-    );
-
-    detachedSetupPage({ context, path: `/chats/${THREAD_UPLOADS_ID}` });
-
-    await waitFor(() => {
-      expect(textarea()).toBeInTheDocument();
-    });
-
-    const fileInput =
-      document.querySelector<HTMLInputElement>('input[type="file"]')!;
-    await user.upload(
-      fileInput,
-      new File(["release pdf"], "launch-plan.pdf", {
-        type: "application/octet-stream",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByLabelText("Remove launch-plan.pdf"),
-      ).toBeInTheDocument();
-      expect(capturedPrepareBody).toMatchObject({
-        filename: "launch-plan.pdf",
-        contentType: "application/pdf",
+      context.mocks.data.userModelPreference({
+        selectedModel: "claude-sonnet-4-6",
+        serviceTier: null,
+        updatedAt: "2026-03-10T00:00:00Z",
       });
-    });
-  });
+      mockThreadDetails();
+      context.mocks.http.post(
+        "*/api/zero/uploads/prepare",
+        async ({ request }) => {
+          capturedPrepareBody = await request.json();
+          return HttpResponse.json({
+            id: `upload-${filename}`,
+            filename,
+            contentType: expectedContentType,
+            size: contents.length,
+            uploadUrl,
+            uploadHeaders: {},
+            url: `https://example.com/${filename}`,
+          });
+        },
+      );
+      context.mocks.http.put(uploadUrl, () => {
+        return new HttpResponse(null, { status: 200 });
+      });
+
+      detachedSetupPage({ context, path: `/chats/${THREAD_UPLOADS_ID}` });
+
+      await waitFor(() => {
+        expect(textarea()).toBeInTheDocument();
+      });
+
+      const fileInput =
+        document.querySelector<HTMLInputElement>('input[type="file"]')!;
+      await user.upload(
+        fileInput,
+        new File([contents], filename, {
+          type: "application/octet-stream",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(`Remove ${filename}`)).toBeInTheDocument();
+        expect(capturedPrepareBody).toMatchObject({
+          filename,
+          contentType: expectedContentType,
+        });
+      });
+    },
+  );
 
   it("uploads dropped files and reports oversized drops", async () => {
     const threadId = THREAD_UPLOADS_ID;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7847,7 +7847,6 @@ function ComposerFileInput({ signals }: { signals: ComposerSignals }) {
       ref={setFileInput}
       type="file"
       className="hidden"
-      accept="image/*,audio/*,video/mp4,video/webm,video/quicktime,.pdf,.txt,.csv,.tsv,.md,.json,.xml,.yaml,.yml,.html,.htm,.doc,.docx,.docm,.dotx,.dotm,.odt,.rtf,.xls,.xlsx,.xlsm,.xlsb,.xltx,.xltm,.ods,.ppt,.pptx,.pptm,.potx,.potm,.ppsx,.ppsm,.odp,.zip,.rar,.7z,.tar,.tar.gz,.tgz,.gz,.bz2,.xz,.pages,.numbers,.key,.heic,.heif,.tif,.tiff,.bmp,.parquet,.sqlite,.sqlite3,.db,.epub,.psd,.ai"
       multiple
       onChange={(event) => {
         const files = event.target.files;


### PR DESCRIPTION
## Summary

- remove the composer file-picker allowlist so HAR and other file extensions reach the upload flow
- identify HAR files as application/json and normalize unrecognized web-upload MIME values to application/octet-stream
- propagate server-normalized MIME metadata into chat and agent drafts while retaining the Slack canonical-asset allowlist
- add browser, CLI, and API regression coverage

## Verification

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- 5 targeted Vitest files, 77 tests passed

Closes #26415