### PR TITLE
fix(platform): keep invalid mermaid diagrams in fixed cards

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4545,6 +4545,7 @@
     "mermaid": {
       "diagramLabel": "Diagramm",
       "expand": "Diagramm vergrößern",
+      "invalidDiagram": "Ungültiges Diagramm",
       "viewSource": "Diagrammquelle"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4545,6 +4545,7 @@
     "mermaid": {
       "diagramLabel": "Diagram",
       "expand": "Expand diagram",
+      "invalidDiagram": "Invalid diagram",
       "viewSource": "Diagram source"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4596,6 +4596,7 @@
     "mermaid": {
       "diagramLabel": "Diagrama",
       "expand": "Ampliar diagrama",
+      "invalidDiagram": "Diagrama no válido",
       "viewSource": "Código del diagrama"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4596,6 +4596,7 @@
     "mermaid": {
       "diagramLabel": "Diagramme",
       "expand": "Agrandir le diagramme",
+      "invalidDiagram": "Diagramme non valide",
       "viewSource": "Source du diagramme"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4545,6 +4545,7 @@
     "mermaid": {
       "diagramLabel": "आरेख",
       "expand": "आरेख बड़ा करें",
+      "invalidDiagram": "अमान्य आरेख",
       "viewSource": "आरेख स्रोत"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4544,6 +4544,7 @@
     "mermaid": {
       "diagramLabel": "Diagram",
       "expand": "Perbesar diagram",
+      "invalidDiagram": "Diagram tidak valid",
       "viewSource": "Sumber diagram"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4596,6 +4596,7 @@
     "mermaid": {
       "diagramLabel": "Diagramma",
       "expand": "Ingrandisci diagramma",
+      "invalidDiagram": "Diagramma non valido",
       "viewSource": "Codice del diagramma"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4544,6 +4544,7 @@
     "mermaid": {
       "diagramLabel": "図",
       "expand": "図を拡大",
+      "invalidDiagram": "無効な図",
       "viewSource": "図のソース"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4544,6 +4544,7 @@
     "mermaid": {
       "diagramLabel": "다이어그램",
       "expand": "다이어그램 확대",
+      "invalidDiagram": "유효하지 않은 다이어그램",
       "viewSource": "다이어그램 소스"
     },
     "notFound": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4596,6 +4596,7 @@
     "mermaid": {
       "diagramLabel": "Diagrama",
       "expand": "Ampliar diagrama",
+      "invalidDiagram": "Diagrama inválido",
       "viewSource": "Código do diagrama"
     },
     "notFound": {

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -548,7 +548,7 @@ describe("assistant markdown", () => {
     );
   });
 
-  it("keeps the source visible when a mermaid diagram cannot be parsed", async () => {
+  it("keeps the diagram card and source when mermaid cannot parse it", async () => {
     mockThread("```mermaid\nthis is not a diagram\n```");
 
     detachedSetupPage({
@@ -556,15 +556,28 @@ describe("assistant markdown", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("mermaid-diagram-fallback"),
-      ).toBeInTheDocument();
+    const diagram = await waitFor(() => {
+      const found = queryAllByRoleFast("button").find((element) => {
+        return element.getAttribute("aria-label") === "Invalid diagram";
+      });
+      if (!found) {
+        throw new Error("Expected invalid diagram card");
+      }
+      return found;
     });
-    expect(screen.getByTestId("mermaid-diagram-fallback").textContent).toBe(
-      "this is not a diagram",
-    );
+    expect(diagram).toBeDisabled();
+    expect(diagram).toHaveClass("mermaid-diagram-expand");
+    expect(within(diagram).getByText("Invalid diagram")).toBeVisible();
     expect(screen.queryByAltText("Diagram")).toBeNull();
+
+    const sourceSummary = screen.getByText("Diagram source");
+    const source = sourceSummary.closest("details");
+    if (!(source instanceof HTMLDetailsElement)) {
+      throw new Error("Expected diagram source disclosure");
+    }
+    click(sourceSummary);
+    expect(source.open).toBeTruthy();
+    expect(within(source).getByText("this is not a diagram")).toBeVisible();
   });
 
   it("keeps external links safe", async () => {

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -566,7 +566,6 @@ describe("assistant markdown", () => {
       return found;
     });
     expect(diagram).toBeDisabled();
-    expect(diagram).toHaveClass("mermaid-diagram-expand");
     expect(within(diagram).getByText("Invalid diagram")).toBeVisible();
     expect(screen.queryByAltText("Diagram")).toBeNull();
 

--- a/turbo/apps/platform/src/views/components/mermaid-diagram.tsx
+++ b/turbo/apps/platform/src/views/components/mermaid-diagram.tsx
@@ -8,11 +8,10 @@ import { openImageLightbox$ } from "../../signals/zero-page/zero-attachment-chip
 /**
  * Renders a ```mermaid fenced block as a diagram from its signals.
  *
- * The diagram is shown by an <img> inside a box whose size is reserved before
- * the render starts, so a message keeps the same height whatever the diagram's
- * own aspect ratio turns out to be, and the render cannot move the thread under
- * a reader. The SVG is letterboxed inside that box and opens at full size in
- * the lightbox.
+ * A rendered diagram or its invalid state is shown inside a box whose size is
+ * reserved before the render starts, so a message keeps the same height across
+ * every render outcome and the thread cannot move under a reader. A valid SVG
+ * is letterboxed inside that box and opens at full size in the lightbox.
  */
 export function MermaidDiagramView({
   signals,
@@ -22,6 +21,12 @@ export function MermaidDiagramView({
   const { t } = useTranslation();
   const openImageLightbox = useSet(openImageLightbox$);
   const loadable = useLoadable(signals.diagram$);
+  const expandDiagram = t(($) => {
+    return $.shared.mermaid.expand;
+  });
+  const invalidDiagram = t(($) => {
+    return $.shared.mermaid.invalidDiagram;
+  });
   const status =
     loadable.state === "hasData"
       ? "rendered"
@@ -31,58 +36,50 @@ export function MermaidDiagramView({
 
   return (
     <div className="mermaid-block" data-mermaid-status={status}>
-      {status === "error" ? (
-        <pre data-testid="mermaid-diagram-fallback">
+      <button
+        type="button"
+        className="mermaid-diagram-expand"
+        disabled={loadable.state !== "hasData"}
+        aria-label={status === "error" ? invalidDiagram : expandDiagram}
+        onClick={() => {
+          if (loadable.state !== "hasData") {
+            return;
+          }
+          // File metadata lets each preview surface present the diagram as
+          // diagram.svg with download support.
+          openImageLightbox({
+            url: loadable.data.url,
+            file: loadable.data.file,
+            shareAvailable: false,
+          });
+        }}
+      >
+        {loadable.state === "hasData" ? (
+          <img
+            src={loadable.data.url}
+            alt={t(($) => {
+              return $.shared.mermaid.diagramLabel;
+            })}
+            className="mermaid-diagram-image"
+          />
+        ) : loadable.state === "hasError" ? (
+          <span className="mermaid-diagram-invalid">{invalidDiagram}</span>
+        ) : (
+          <span className="mermaid-diagram-pending" aria-hidden="true">
+            <Loader2 size={18} className="animate-spin" />
+          </span>
+        )}
+      </button>
+      <details className="mermaid-diagram-source">
+        <summary>
+          {t(($) => {
+            return $.shared.mermaid.viewSource;
+          })}
+        </summary>
+        <pre>
           <code>{signals.code}</code>
         </pre>
-      ) : (
-        <>
-          <button
-            type="button"
-            className="mermaid-diagram-expand"
-            disabled={loadable.state !== "hasData"}
-            aria-label={t(($) => {
-              return $.shared.mermaid.expand;
-            })}
-            onClick={() => {
-              if (loadable.state !== "hasData") {
-                return;
-              }
-              // File metadata lets each preview surface present the diagram as
-              // diagram.svg with download support.
-              openImageLightbox({
-                url: loadable.data.url,
-                file: loadable.data.file,
-                shareAvailable: false,
-              });
-            }}
-          >
-            {loadable.state === "hasData" ? (
-              <img
-                src={loadable.data.url}
-                alt={t(($) => {
-                  return $.shared.mermaid.diagramLabel;
-                })}
-                className="mermaid-diagram-image"
-              />
-            ) : (
-              <span className="mermaid-diagram-pending" aria-hidden="true">
-                <Loader2 size={18} className="animate-spin" />
-              </span>
-            )}
-          </button>
-          <details className="mermaid-diagram-source">
-            <summary>
-              {t(($) => {
-                return $.shared.mermaid.viewSource;
-              })}
-            </summary>
-            <pre>
-              <code>{signals.code}</code>
-            </pre>
-          </details>
-        </>
-      )}
+      </details>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/css/__tests__/mermaid-diagram-fit.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/mermaid-diagram-fit.test.ts
@@ -4,7 +4,7 @@ import { readCssRule, readGlobalCss } from "./global-css.ts";
 
 const BOX_SELECTOR = ".wmde-markdown .mermaid-diagram-expand";
 const IMAGE_SELECTOR = ".wmde-markdown .mermaid-diagram-image";
-const INSET_CHILDREN_SELECTOR = `${IMAGE_SELECTOR},\n.wmde-markdown .mermaid-diagram-pending`;
+const INSET_CHILDREN_SELECTOR = `${IMAGE_SELECTOR},\n.wmde-markdown .mermaid-diagram-pending,\n.wmde-markdown .mermaid-diagram-invalid`;
 
 function readPixels(rule: string, pattern: RegExp): number {
   const match = pattern.exec(rule);

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1190,20 +1190,14 @@ body {
   cursor: default;
 }
 
-/* A source that mermaid cannot render shows as source instead of an empty box. */
-.wmde-markdown
-  .mermaid-block[data-mermaid-status="error"]
-  .mermaid-diagram-expand {
-  display: none;
-}
-
-/* Both children are taken out of flow so neither can size the box: the diagram
-   is serialized at lightbox scale, and an in-flow image that wide would win
-   over `aspect-ratio` through its content-based minimum size. Letterboxed
-   rather than stretched, since a single box can only hold diagrams of
-   different aspect ratios undistorted by leaving margins. */
+/* The image and state indicators are taken out of flow so none can size the
+   box: the diagram is serialized at lightbox scale, and an in-flow image that
+   wide would win over `aspect-ratio` through its content-based minimum size.
+   Letterboxed rather than stretched, since a single box can only hold diagrams
+   of different aspect ratios undistorted by leaving margins. */
 .wmde-markdown .mermaid-diagram-image,
-.wmde-markdown .mermaid-diagram-pending {
+.wmde-markdown .mermaid-diagram-pending,
+.wmde-markdown .mermaid-diagram-invalid {
   /* Inset by the box's own padding: an absolutely positioned child is placed
      against the padding box, which the padding would otherwise not clear. */
   position: absolute;
@@ -1224,11 +1218,16 @@ body {
   background: none;
 }
 
-.wmde-markdown .mermaid-diagram-pending {
+.wmde-markdown .mermaid-diagram-pending,
+.wmde-markdown .mermaid-diagram-invalid {
   display: flex;
   align-items: center;
   justify-content: center;
   color: hsl(var(--muted-foreground));
+}
+
+.wmde-markdown .mermaid-diagram-invalid {
+  font-size: 0.875rem;
 }
 
 .wmde-markdown .mermaid-diagram-source > summary {


### PR DESCRIPTION
## Summary

- keep the fixed-size Mermaid card mounted when diagram parsing fails
- show a localized `Invalid diagram` state while preserving the collapsible diagram source
- cover invalid-state card geometry and source disclosure behavior

## Verification

- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/components/__tests__/markdown.test.tsx src/views/css/__tests__/mermaid-diagram-fit.test.ts` (22 tests)
- `pnpm exec knip --workspace @vm0/app`
- browser verification deferred to the PR preview because no local dev server was requested
