### PR TITLE
fix(chat): cold-start background snapshot sync

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
@@ -22,6 +22,7 @@ import { setupRealtime$ } from "../../realtime.ts";
 import { resetSignal } from "../../utils.ts";
 import { setupChatEventBackgroundSync$ } from "../chat-event-background-sync.ts";
 import { writeIndexedDbChatEventRows$ } from "../chat-event-row-indexed-db.ts";
+import { createChatEventSignals } from "../chat-event-signals.ts";
 import { createChatEventStorageSignals } from "../chat-event-storage-signals.ts";
 import {
   listEventsAfter$,
@@ -452,6 +453,205 @@ describe("chat event snapshot read", () => {
           appDb.get(CHAT_EVENT_ROWS_STORE, tailEventRow.id),
         ).resolves.toStrictEqual(tailEventRow);
       });
+    } finally {
+      context.store.set(resetSubscriberSignal$, context.signal);
+      await expect(subscription).rejects.toMatchObject({ name: "AbortError" });
+      appDb.close();
+    }
+  });
+
+  it("background-cold-starts raw rows and forwards them to an active thread", async () => {
+    mockSignedInUser();
+    enableSnapshotRead();
+    rejectProjectedEventsEndpoint();
+    const { threadId, promptEventRow, assistantEventRow, tailEventRow } =
+      threadFixture();
+    const appDb = await context.store.get(chatIdb$);
+
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(200, {
+        url: SNAPSHOT_URL,
+        expiresInSeconds: 900,
+        lastSeqId: assistantEventRow.seqId,
+      });
+    });
+    context.mocks.http.get(SNAPSHOT_URL, () => {
+      return new Response(snapshotNdjson([promptEventRow, assistantEventRow]));
+    });
+    const rowRequests: number[] = [];
+    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+      rowRequests.push(query.sinceSeqId);
+      if (query.sinceSeqId === assistantEventRow.seqId) {
+        return respond(200, { rows: [tailEventRow] });
+      }
+      return respond(200, { rows: [] });
+    });
+
+    const signals = createChatEventSignals(threadId);
+    await context.store.set(signals.setup$, context.signal);
+    await context.store.set(setupRealtime$, context.signal);
+    const subscriberSignal = context.store.set(
+      resetSubscriberSignal$,
+      context.signal,
+    );
+    const subscription = context.store.set(
+      setupChatEventBackgroundSync$,
+      subscriberSignal,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+      });
+
+      context.mocks.ably.trigger(`chatThreadMessageCreated:${threadId}`);
+
+      await waitFor(() => {
+        expect(
+          context.store.get(signals.chatEvents$).map((event) => {
+            return event.id;
+          }),
+        ).toStrictEqual([
+          promptEventRow.id,
+          assistantEventRow.id,
+          tailEventRow.id,
+        ]);
+      });
+      expect(rowRequests).toStrictEqual([assistantEventRow.seqId]);
+      await expect(
+        appDb.get(CHAT_EVENT_ROWS_STORE, tailEventRow.id),
+      ).resolves.toStrictEqual(tailEventRow);
+    } finally {
+      context.store.set(resetSubscriberSignal$, context.signal);
+      await expect(subscription).rejects.toMatchObject({ name: "AbortError" });
+      appDb.close();
+    }
+  });
+
+  it("background-cold-starts from row zero when no snapshot exists", async () => {
+    mockSignedInUser();
+    enableSnapshotRead();
+    rejectProjectedEventsEndpoint();
+    const { threadId, promptEventRow, assistantEventRow } = threadFixture();
+    const appDb = await context.store.get(chatIdb$);
+
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(404, {
+        error: {
+          code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+          message: "Chat event snapshot not found",
+        },
+      });
+    });
+    const rowRequests: number[] = [];
+    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+      rowRequests.push(query.sinceSeqId);
+      if (query.sinceSeqId === 0) {
+        return respond(200, { rows: [promptEventRow, assistantEventRow] });
+      }
+      return respond(200, { rows: [] });
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    const subscriberSignal = context.store.set(
+      resetSubscriberSignal$,
+      context.signal,
+    );
+    const subscription = context.store.set(
+      setupChatEventBackgroundSync$,
+      subscriberSignal,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+      });
+
+      context.mocks.ably.trigger(`chatThreadMessageCreated:${threadId}`);
+
+      await waitFor(async () => {
+        await expect(
+          appDb.get(CHAT_EVENT_ROWS_STORE, assistantEventRow.id),
+        ).resolves.toStrictEqual(assistantEventRow);
+      });
+      expect(rowRequests).toStrictEqual([0]);
+    } finally {
+      context.store.set(resetSubscriberSignal$, context.signal);
+      await expect(subscription).rejects.toMatchObject({ name: "AbortError" });
+      appDb.close();
+    }
+  });
+
+  it("background-rebuilds raw rows when the cached cursor expires", async () => {
+    mockSignedInUser();
+    enableSnapshotRead();
+    rejectProjectedEventsEndpoint();
+    const { threadId, promptEventRow, assistantEventRow, tailEventRow } =
+      threadFixture();
+    const staleRow = baseRow(threadId, 5);
+    const appDb = await context.store.get(chatIdb$);
+    await context.store.set(
+      writeIndexedDbChatEventRows$,
+      [staleRow],
+      context.signal,
+    );
+
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(200, {
+        url: SNAPSHOT_URL,
+        expiresInSeconds: 900,
+        lastSeqId: assistantEventRow.seqId,
+      });
+    });
+    context.mocks.http.get(SNAPSHOT_URL, () => {
+      return new Response(snapshotNdjson([promptEventRow, assistantEventRow]));
+    });
+    const rowRequests: number[] = [];
+    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+      rowRequests.push(query.sinceSeqId);
+      if (query.sinceSeqId === staleRow.seqId) {
+        return respond(410, {
+          error: {
+            code: "CHAT_EVENTS_EXPIRED",
+            message: "Chat events cursor has expired",
+          },
+        });
+      }
+      return respond(200, { rows: [tailEventRow] });
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    const subscriberSignal = context.store.set(
+      resetSubscriberSignal$,
+      context.signal,
+    );
+    const subscription = context.store.set(
+      setupChatEventBackgroundSync$,
+      subscriberSignal,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
+      });
+
+      context.mocks.ably.trigger(`chatThreadMessageCreated:${threadId}`);
+
+      await waitFor(async () => {
+        await expect(
+          appDb.get(CHAT_EVENT_ROWS_STORE, tailEventRow.id),
+        ).resolves.toStrictEqual(tailEventRow);
+      });
+      expect(rowRequests).toStrictEqual([
+        staleRow.seqId,
+        assistantEventRow.seqId,
+      ]);
+      await expect(
+        appDb.get(CHAT_EVENT_ROWS_STORE, staleRow.id),
+      ).resolves.toBeUndefined();
+      await expect(
+        appDb.get(CHAT_EVENT_ROWS_STORE, promptEventRow.id),
+      ).resolves.toStrictEqual(promptEventRow);
     } finally {
       context.store.set(resetSubscriberSignal$, context.signal);
       await expect(subscription).rejects.toMatchObject({ name: "AbortError" });

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
@@ -20,6 +20,7 @@ import {
 } from "./remote-chat-event-data-source.ts";
 import {
   CHAT_EVENT_ROWS_PAGE_LIMIT,
+  fetchChatEventSnapshotRows$,
   listRowsAfter$,
 } from "./remote-chat-event-row-data-source.ts";
 import { receiveActiveChatEvents$ } from "./chat-event-signal-registry.ts";
@@ -32,6 +33,7 @@ import {
 
 const L = logger("ChatEventBackgroundSync");
 const CHAT_THREAD_MESSAGE_CREATED_PREFIX = "chatThreadMessageCreated:";
+const THREAD_START_SEQ_ID = 0;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -68,10 +70,33 @@ function createdMessageSyncThroughSeqId(message: unknown): number | null {
   return message.data.syncThroughSeqId;
 }
 
+const coldStartChatThreadRows$ = command(
+  async (
+    { set },
+    threadId: string,
+    signal: AbortSignal,
+  ): Promise<{
+    readonly events: readonly ChatEvent[];
+    readonly lastSeqId: number;
+  }> => {
+    const snapshot = await set(fetchChatEventSnapshotRows$, threadId, signal);
+    if (snapshot === null) {
+      return { events: [], lastSeqId: THREAD_START_SEQ_ID };
+    }
+    await set(writeIndexedDbChatEventRows$, snapshot.rows, signal);
+    return {
+      events: snapshot.rows.map((row) => {
+        return chatEventFromRow(row);
+      }),
+      lastSeqId: snapshot.lastSeqId,
+    };
+  },
+);
+
 /**
- * Snapshot-read variant: tails the raw-row cache. A thread without cached
- * rows is left to its foreground pane, which owns the snapshot cold start; a
- * 410 clears the cache so the next foreground sync rebuilds it.
+ * Snapshot-read variant: cold-starts an empty raw-row cache from the archive,
+ * then tails it through the raw-row endpoint. An expired cursor rebuilds the
+ * cache in the same pass.
  */
 const syncChatThreadRowsToIndexedDb$ = command(
   async (
@@ -91,11 +116,11 @@ const syncChatThreadRowsToIndexedDb$ = command(
       signal,
     );
     signal.throwIfAborted();
-    if (lastSeqId === null) {
-      L.debug("skipped background row sync: no cached rows", { threadId });
-      return [];
-    }
-    if (syncThroughSeqId !== null && lastSeqId >= syncThroughSeqId) {
+    if (
+      lastSeqId !== null &&
+      syncThroughSeqId !== null &&
+      lastSeqId >= syncThroughSeqId
+    ) {
       L.debug("skipped background row sync: seq watermark already cached", {
         threadId,
         syncThroughSeqId,
@@ -104,18 +129,33 @@ const syncChatThreadRowsToIndexedDb$ = command(
     }
 
     const syncedEvents: ChatEvent[] = [];
-    let sinceSeqId = lastSeqId;
+    let cursorFromServer = false;
+    let sinceSeqId: number;
+    if (lastSeqId === null) {
+      const coldStart = await set(coldStartChatThreadRows$, threadId, signal);
+      syncedEvents.push(...coldStart.events);
+      sinceSeqId = coldStart.lastSeqId;
+      cursorFromServer = true;
+    } else {
+      sinceSeqId = lastSeqId;
+    }
+
     let shouldLoadNextPage = true;
     while (shouldLoadNextPage) {
       const page = await set(listRowsAfter$, { threadId, sinceSeqId }, signal);
       signal.throwIfAborted();
       if (page.kind === "expired") {
+        if (cursorFromServer) {
+          throw new Error(
+            "chat event rows cursor expired right after a background cold start",
+          );
+        }
         await set(clearIndexedDbChatEventRows$, threadId, signal);
-        signal.throwIfAborted();
-        L.debug("background row sync cursor expired; cache cleared", {
-          threadId,
-        });
-        return syncedEvents;
+        const coldStart = await set(coldStartChatThreadRows$, threadId, signal);
+        syncedEvents.push(...coldStart.events);
+        sinceSeqId = coldStart.lastSeqId;
+        cursorFromServer = true;
+        continue;
       }
       if (page.rows.length === 0) {
         return syncedEvents;


### PR DESCRIPTION
## Summary

- cold-start an empty raw chat-event cache from the snapshot before tailing `/event-rows`
- rebuild an expired background cursor from a fresh snapshot in the same sync pass
- forward every recovered event through the existing active-thread receiver independently of cache state
- fall back to reading `/event-rows` from sequence zero when no snapshot exists

## Verification

- `pnpm exec prettier --write apps/platform/src/signals/chat-page/chat-event-background-sync.ts apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts`
- `pnpm exec oxlint src/signals/chat-page/chat-event-background-sync.ts src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/signals/chat-page/chat-event-background-sync.ts src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts`
- `pnpm exec eslint src/signals/chat-page/chat-event-background-sync.ts src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts --max-warnings 0`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts` (9 tests)
