### PR TITLE
fix(guest-agent): bound oversized codex event delivery

### DIFF
--- a/crates/guest-agent/src/cli/codex_event_delivery.rs
+++ b/crates/guest-agent/src/cli/codex_event_delivery.rs
@@ -3,7 +3,7 @@
 //! The app-server backend writes the complete normalized event to the local
 //! agent log before this module sees the webhook copy. Normal events retain
 //! their existing serialization. Only events that cannot fit in one delivery
-//! request receive visible, metadata-backed content reduction.
+//! request receive visibly marked content reduction.
 
 use std::collections::BTreeSet;
 
@@ -11,11 +11,9 @@ use serde_json::{Map, Value, json};
 
 use crate::error::AgentError;
 
-const DELIVERY_METADATA_KEY: &str = "vm0_delivery";
-const DELIVERY_NOTICE: &str = "[vm0: event content truncated for delivery]";
+const DELIVERY_NOTICE: &str = "[event content truncated for delivery]";
 const MAX_REDUCTION_CANDIDATES: usize = 256;
 const MAX_REDUCED_FIELDS: usize = 16;
-const METADATA_SIZE_STABILIZATION_ATTEMPTS: usize = 8;
 const RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS: usize = 4;
 
 pub(super) struct PreparedCodexEvent {
@@ -89,21 +87,13 @@ pub(super) fn prepare_for_delivery(
             original,
         });
 
-        let minimum_bytes = original_bytes
-            .saturating_sub(reducible_bytes)
-            .saturating_add(delivery_metadata_added_bytes(
-                original_bytes,
-                max_serialized_event_bytes,
-                &reduced_categories,
-                false,
-            )?);
+        let minimum_bytes = original_bytes.saturating_sub(reducible_bytes);
         if minimum_bytes > max_serialized_event_bytes {
             continue;
         }
 
         apply_retained_budget(&mut event, &selected, 0, 1)?;
-        let minimum =
-            serialize_with_metadata(&mut event, original_bytes, &reduced_categories, false)?;
+        let minimum = serde_json::to_vec(&event)?;
         if minimum.len() > max_serialized_event_bytes {
             continue;
         }
@@ -116,8 +106,7 @@ pub(super) fn prepare_for_delivery(
 
         for _ in 0..RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS {
             apply_retained_budget(&mut event, &selected, retained_bytes, total_original_bytes)?;
-            let serialized =
-                serialize_with_metadata(&mut event, original_bytes, &reduced_categories, false)?;
+            let serialized = serde_json::to_vec(&event)?;
             if serialized.len() <= max_serialized_event_bytes {
                 return Ok(reduced_event(
                     serialized,
@@ -148,9 +137,8 @@ pub(super) fn prepare_for_delivery(
         .map(|candidate| candidate.category)
         .collect::<BTreeSet<_>>();
     fallback_categories.insert("event_structure");
-    let mut fallback = fallback_event(&event)?;
-    let serialized =
-        serialize_with_metadata(&mut fallback, original_bytes, &fallback_categories, true)?;
+    let fallback = fallback_event(&event)?;
+    let serialized = serde_json::to_vec(&fallback)?;
     if serialized.len() > max_serialized_event_bytes {
         return Err(AgentError::Execution(format!(
             "Codex event delivery fallback is {} bytes, exceeding the {max_serialized_event_bytes}-byte serialized event budget",
@@ -229,9 +217,6 @@ fn collect_value(
         }
         Value::Object(fields) => {
             for (key, value) in fields {
-                if key == DELIVERY_METADATA_KEY {
-                    continue;
-                }
                 path.push(PathSegment::Key(key.clone()));
                 collect_value(value, item_type, path, candidates);
                 path.pop();
@@ -389,7 +374,7 @@ fn truncated_text(original: &str, retained_bytes: usize) -> String {
     let preserved = head_end + original.len().saturating_sub(tail_start);
     let omitted = original.len().saturating_sub(preserved);
     format!(
-        "{}\n[vm0: {omitted} bytes truncated for delivery]\n{}",
+        "{}\n[{omitted} bytes truncated for delivery]\n{}",
         &original[..head_end],
         &original[tail_start..]
     )
@@ -409,87 +394,6 @@ fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
         index += 1;
     }
     index
-}
-
-fn serialize_with_metadata(
-    event: &mut Value,
-    original_bytes: usize,
-    fields: &BTreeSet<&'static str>,
-    fallback: bool,
-) -> Result<Vec<u8>, AgentError> {
-    let event = event.as_object_mut().ok_or_else(|| {
-        AgentError::Execution("normalized Codex event is not an object".to_string())
-    })?;
-    event.insert(
-        DELIVERY_METADATA_KEY.to_string(),
-        delivery_metadata(original_bytes, 0, fields, fallback),
-    );
-
-    let mut expected_bytes = 0usize;
-    for _ in 0..METADATA_SIZE_STABILIZATION_ATTEMPTS {
-        let metadata = event
-            .get_mut(DELIVERY_METADATA_KEY)
-            .and_then(Value::as_object_mut)
-            .ok_or_else(|| {
-                AgentError::Execution("Codex event delivery metadata disappeared".to_string())
-            })?;
-        metadata.insert("delivered_event_bytes".to_string(), json!(expected_bytes));
-        let serialized = serde_json::to_vec(&*event)?;
-        if serialized.len() == expected_bytes {
-            return Ok(serialized);
-        }
-        expected_bytes = serialized.len();
-    }
-
-    Err(AgentError::Execution(
-        "Codex event delivery metadata size did not stabilize".to_string(),
-    ))
-}
-
-fn delivery_metadata(
-    original_bytes: usize,
-    delivered_bytes: usize,
-    fields: &BTreeSet<&'static str>,
-    fallback: bool,
-) -> Value {
-    let mut metadata = Map::new();
-    metadata.insert("content_truncated".to_string(), Value::Bool(true));
-    metadata.insert(
-        "notice".to_string(),
-        Value::String(DELIVERY_NOTICE.to_string()),
-    );
-    metadata.insert("original_event_bytes".to_string(), json!(original_bytes));
-    metadata.insert("delivered_event_bytes".to_string(), json!(delivered_bytes));
-    metadata.insert(
-        "fields".to_string(),
-        Value::Array(
-            fields
-                .iter()
-                .map(|field| Value::String((*field).to_string()))
-                .collect(),
-        ),
-    );
-    if fallback {
-        metadata.insert("fallback".to_string(), Value::Bool(true));
-    }
-    Value::Object(metadata)
-}
-
-fn delivery_metadata_added_bytes(
-    original_bytes: usize,
-    delivered_bytes: usize,
-    fields: &BTreeSet<&'static str>,
-    fallback: bool,
-) -> Result<usize, AgentError> {
-    let singleton = json!({
-        DELIVERY_METADATA_KEY: delivery_metadata(
-            original_bytes,
-            delivered_bytes,
-            fields,
-            fallback,
-        )
-    });
-    Ok(serde_json::to_vec(&singleton)?.len().saturating_sub(1))
 }
 
 fn fallback_event(source: &Value) -> Result<Value, AgentError> {

--- a/crates/guest-agent/src/cli/codex_event_delivery.rs
+++ b/crates/guest-agent/src/cli/codex_event_delivery.rs
@@ -501,12 +501,7 @@ fn fallback_item(item: &Map<String, Value>) -> Value {
                 }]),
             );
         }
-        _ => {
-            output.insert(
-                "delivery_notice".to_string(),
-                Value::String(DELIVERY_NOTICE.to_string()),
-            );
-        }
+        _ => {}
     }
     Value::Object(output)
 }

--- a/crates/guest-agent/src/cli/codex_event_delivery.rs
+++ b/crates/guest-agent/src/cli/codex_event_delivery.rs
@@ -1,0 +1,646 @@
+//! Bounded webhook representation for normalized Codex events.
+//!
+//! The app-server backend writes the complete normalized event to the local
+//! agent log before this module sees the webhook copy. Normal events retain
+//! their existing serialization. Only events that cannot fit in one delivery
+//! request receive visible, metadata-backed content reduction.
+
+use std::collections::BTreeSet;
+
+use serde_json::{Map, Value, json};
+
+use crate::error::AgentError;
+
+const DELIVERY_METADATA_KEY: &str = "vm0_delivery";
+const DELIVERY_NOTICE: &str = "[vm0: event content truncated for delivery]";
+const MAX_REDUCTION_CANDIDATES: usize = 256;
+const MAX_REDUCED_FIELDS: usize = 16;
+const METADATA_SIZE_STABILIZATION_ATTEMPTS: usize = 8;
+const RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS: usize = 4;
+
+pub(super) struct PreparedCodexEvent {
+    pub(super) serialized: Vec<u8>,
+    pub(super) reduction: Option<CodexEventReduction>,
+}
+
+pub(super) struct CodexEventReduction {
+    pub(super) event_type: &'static str,
+    pub(super) item_type: &'static str,
+    pub(super) original_bytes: usize,
+    pub(super) delivered_bytes: usize,
+    pub(super) fields: Vec<&'static str>,
+    pub(super) fallback: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PathSegment {
+    Key(String),
+    Index(usize),
+}
+
+#[derive(Clone, Debug)]
+struct ContentCandidate {
+    path: Vec<PathSegment>,
+    path_key: String,
+    category: &'static str,
+    reducible_bytes: usize,
+}
+
+struct SelectedContent {
+    path: Vec<PathSegment>,
+    original: String,
+}
+
+pub(super) fn prepare_for_delivery(
+    mut event: Value,
+    max_serialized_event_bytes: usize,
+) -> Result<PreparedCodexEvent, AgentError> {
+    let serialized = serde_json::to_vec(&event)?;
+    if serialized.len() <= max_serialized_event_bytes {
+        return Ok(PreparedCodexEvent {
+            serialized,
+            reduction: None,
+        });
+    }
+
+    let original_bytes = serialized.len();
+    drop(serialized);
+    let event_type = event_type_label(&event);
+    let item_type = item_type_label(&event);
+    let mut candidates = collect_content_candidates(&event);
+    candidates.sort_by(|left, right| {
+        right
+            .reducible_bytes
+            .cmp(&left.reducible_bytes)
+            .then_with(|| left.path_key.cmp(&right.path_key))
+    });
+
+    let mut reduced_categories = BTreeSet::new();
+    let mut selected = Vec::new();
+    let mut reducible_bytes = 0usize;
+    for candidate in candidates.iter().take(MAX_REDUCED_FIELDS) {
+        let Some(original) = string_at_path(&event, &candidate.path).map(str::to_owned) else {
+            continue;
+        };
+        reduced_categories.insert(candidate.category);
+        reducible_bytes = reducible_bytes.saturating_add(candidate.reducible_bytes);
+        selected.push(SelectedContent {
+            path: candidate.path.clone(),
+            original,
+        });
+
+        let minimum_bytes = original_bytes
+            .saturating_sub(reducible_bytes)
+            .saturating_add(delivery_metadata_added_bytes(
+                original_bytes,
+                max_serialized_event_bytes,
+                &reduced_categories,
+                false,
+            )?);
+        if minimum_bytes > max_serialized_event_bytes {
+            continue;
+        }
+
+        apply_retained_budget(&mut event, &selected, 0, 1)?;
+        let minimum =
+            serialize_with_metadata(&mut event, original_bytes, &reduced_categories, false)?;
+        if minimum.len() > max_serialized_event_bytes {
+            continue;
+        }
+        let total_original_bytes = selected
+            .iter()
+            .map(|content| content.original.len())
+            .sum::<usize>();
+        let available_bytes = max_serialized_event_bytes - minimum.len();
+        let mut retained_bytes = available_bytes.min(total_original_bytes);
+
+        for _ in 0..RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS {
+            apply_retained_budget(&mut event, &selected, retained_bytes, total_original_bytes)?;
+            let serialized =
+                serialize_with_metadata(&mut event, original_bytes, &reduced_categories, false)?;
+            if serialized.len() <= max_serialized_event_bytes {
+                return Ok(reduced_event(
+                    serialized,
+                    event_type,
+                    item_type,
+                    original_bytes,
+                    reduced_categories,
+                    false,
+                ));
+            }
+
+            let added_bytes = serialized.len().saturating_sub(minimum.len()).max(1);
+            retained_bytes = retained_bytes.saturating_mul(available_bytes) / added_bytes;
+        }
+
+        return Ok(reduced_event(
+            minimum,
+            event_type,
+            item_type,
+            original_bytes,
+            reduced_categories,
+            false,
+        ));
+    }
+
+    let mut fallback_categories = candidates
+        .iter()
+        .map(|candidate| candidate.category)
+        .collect::<BTreeSet<_>>();
+    fallback_categories.insert("event_structure");
+    let mut fallback = fallback_event(&event)?;
+    let serialized =
+        serialize_with_metadata(&mut fallback, original_bytes, &fallback_categories, true)?;
+    if serialized.len() > max_serialized_event_bytes {
+        return Err(AgentError::Execution(format!(
+            "Codex event delivery fallback is {} bytes, exceeding the {max_serialized_event_bytes}-byte serialized event budget",
+            serialized.len()
+        )));
+    }
+
+    Ok(reduced_event(
+        serialized,
+        event_type,
+        item_type,
+        original_bytes,
+        fallback_categories,
+        true,
+    ))
+}
+
+fn reduced_event(
+    serialized: Vec<u8>,
+    event_type: &'static str,
+    item_type: &'static str,
+    original_bytes: usize,
+    fields: BTreeSet<&'static str>,
+    fallback: bool,
+) -> PreparedCodexEvent {
+    let delivered_bytes = serialized.len();
+    PreparedCodexEvent {
+        serialized,
+        reduction: Some(CodexEventReduction {
+            event_type,
+            item_type,
+            original_bytes,
+            delivered_bytes,
+            fields: fields.into_iter().collect(),
+            fallback,
+        }),
+    }
+}
+
+fn collect_content_candidates(event: &Value) -> Vec<ContentCandidate> {
+    let item_type = event.pointer("/item/type").and_then(Value::as_str);
+    let mut candidates = Vec::new();
+    collect_value(event, item_type, &mut Vec::new(), &mut candidates);
+    candidates
+}
+
+fn collect_value(
+    value: &Value,
+    item_type: Option<&str>,
+    path: &mut Vec<PathSegment>,
+    candidates: &mut Vec<ContentCandidate>,
+) {
+    if candidates.len() >= MAX_REDUCTION_CANDIDATES {
+        return;
+    }
+
+    match value {
+        Value::String(text) if !protected_string(path) => {
+            candidates.push(ContentCandidate {
+                path: path.clone(),
+                path_key: path_key(path),
+                category: field_category(path, item_type),
+                reducible_bytes: json_string_bytes(text)
+                    .saturating_sub(json_string_bytes(&truncated_text(text, 0))),
+            });
+        }
+        Value::Array(values) => {
+            for (index, value) in values.iter().enumerate() {
+                path.push(PathSegment::Index(index));
+                collect_value(value, item_type, path, candidates);
+                path.pop();
+                if candidates.len() >= MAX_REDUCTION_CANDIDATES {
+                    break;
+                }
+            }
+        }
+        Value::Object(fields) => {
+            for (key, value) in fields {
+                if key == DELIVERY_METADATA_KEY {
+                    continue;
+                }
+                path.push(PathSegment::Key(key.clone()));
+                collect_value(value, item_type, path, candidates);
+                path.pop();
+                if candidates.len() >= MAX_REDUCTION_CANDIDATES {
+                    break;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn json_string_bytes(value: &str) -> usize {
+    value.chars().fold(2usize, |bytes, character| {
+        bytes
+            + match character {
+                '"' | '\\' | '\u{0008}' | '\t' | '\n' | '\u{000c}' | '\r' => 2,
+                '\u{0000}'..='\u{001f}' => 6,
+                _ => character.len_utf8(),
+            }
+    })
+}
+
+fn apply_retained_budget(
+    event: &mut Value,
+    selected: &[SelectedContent],
+    retained_bytes: usize,
+    total_original_bytes: usize,
+) -> Result<(), AgentError> {
+    let retained_bytes = retained_bytes.min(total_original_bytes);
+    let mut allocations = selected
+        .iter()
+        .map(|content| {
+            ((retained_bytes as u128 * content.original.len() as u128)
+                / total_original_bytes as u128) as usize
+        })
+        .collect::<Vec<_>>();
+    let allocated = allocations.iter().sum::<usize>();
+    let mut remainder = retained_bytes.saturating_sub(allocated);
+    while remainder > 0 {
+        for (allocation, content) in allocations.iter_mut().zip(selected) {
+            if *allocation < content.original.len() {
+                *allocation += 1;
+                remainder -= 1;
+                if remainder == 0 {
+                    break;
+                }
+            }
+        }
+    }
+
+    for (content, allocation) in selected.iter().zip(allocations) {
+        set_string_at_path(
+            event,
+            &content.path,
+            truncated_text(&content.original, allocation),
+        )?;
+    }
+    Ok(())
+}
+
+fn protected_string(path: &[PathSegment]) -> bool {
+    let Some(PathSegment::Key(key)) = path.last() else {
+        return false;
+    };
+    matches!(
+        key.as_str(),
+        "id" | "type" | "status" | "kind" | "thread_id" | "turn_id"
+    )
+}
+
+fn field_category(path: &[PathSegment], item_type: Option<&str>) -> &'static str {
+    let keys = path
+        .iter()
+        .filter_map(|segment| match segment {
+            PathSegment::Key(key) => Some(key.as_str()),
+            PathSegment::Index(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    match keys.as_slice() {
+        ["item", "text"] => match item_type {
+            Some("agent_message") => "agent_message_text",
+            Some("reasoning") => "reasoning_text",
+            Some("plan") => "plan_text",
+            _ => "item_text",
+        },
+        ["item", "aggregated_output"] | ["item", "output"] => "command_output",
+        ["item", "command"] => "command",
+        ["item", "changes", "diff"] => "file_diff",
+        ["item", "changes", "path"] => "file_path",
+        ["plan", "step"] => "plan_step",
+        ["explanation"] => "plan_explanation",
+        ["message"] | ["error", "message"] | ["turn", "error", "message"] => "message",
+        _ => "other_content",
+    }
+}
+
+fn path_key(path: &[PathSegment]) -> String {
+    let mut output = String::new();
+    for segment in path {
+        match segment {
+            PathSegment::Key(key) => {
+                output.push('/');
+                output.push_str(key);
+            }
+            PathSegment::Index(index) => {
+                output.push('/');
+                output.push_str(&index.to_string());
+            }
+        }
+    }
+    output
+}
+
+fn string_at_path<'a>(value: &'a Value, path: &[PathSegment]) -> Option<&'a str> {
+    let mut current = value;
+    for segment in path {
+        current = match segment {
+            PathSegment::Key(key) => current.get(key)?,
+            PathSegment::Index(index) => current.get(*index)?,
+        };
+    }
+    current.as_str()
+}
+
+fn set_string_at_path(
+    value: &mut Value,
+    path: &[PathSegment],
+    replacement: String,
+) -> Result<(), AgentError> {
+    let mut current = value;
+    for segment in path {
+        current = match segment {
+            PathSegment::Key(key) => current.get_mut(key),
+            PathSegment::Index(index) => current.get_mut(*index),
+        }
+        .ok_or_else(|| {
+            AgentError::Execution("Codex event reduction path disappeared".to_string())
+        })?;
+    }
+    *current = Value::String(replacement);
+    Ok(())
+}
+
+fn truncated_text(original: &str, retained_bytes: usize) -> String {
+    if retained_bytes >= original.len() {
+        return original.to_string();
+    }
+
+    let head_target = retained_bytes.div_ceil(2);
+    let tail_target = retained_bytes / 2;
+    let head_end = floor_char_boundary(original, head_target);
+    let tail_start = ceil_char_boundary(original, original.len().saturating_sub(tail_target));
+    let preserved = head_end + original.len().saturating_sub(tail_start);
+    let omitted = original.len().saturating_sub(preserved);
+    format!(
+        "{}\n[vm0: {omitted} bytes truncated for delivery]\n{}",
+        &original[..head_end],
+        &original[tail_start..]
+    )
+}
+
+fn floor_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while !value.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}
+
+fn serialize_with_metadata(
+    event: &mut Value,
+    original_bytes: usize,
+    fields: &BTreeSet<&'static str>,
+    fallback: bool,
+) -> Result<Vec<u8>, AgentError> {
+    let event = event.as_object_mut().ok_or_else(|| {
+        AgentError::Execution("normalized Codex event is not an object".to_string())
+    })?;
+    event.insert(
+        DELIVERY_METADATA_KEY.to_string(),
+        delivery_metadata(original_bytes, 0, fields, fallback),
+    );
+
+    let mut expected_bytes = 0usize;
+    for _ in 0..METADATA_SIZE_STABILIZATION_ATTEMPTS {
+        let metadata = event
+            .get_mut(DELIVERY_METADATA_KEY)
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| {
+                AgentError::Execution("Codex event delivery metadata disappeared".to_string())
+            })?;
+        metadata.insert("delivered_event_bytes".to_string(), json!(expected_bytes));
+        let serialized = serde_json::to_vec(&*event)?;
+        if serialized.len() == expected_bytes {
+            return Ok(serialized);
+        }
+        expected_bytes = serialized.len();
+    }
+
+    Err(AgentError::Execution(
+        "Codex event delivery metadata size did not stabilize".to_string(),
+    ))
+}
+
+fn delivery_metadata(
+    original_bytes: usize,
+    delivered_bytes: usize,
+    fields: &BTreeSet<&'static str>,
+    fallback: bool,
+) -> Value {
+    let mut metadata = Map::new();
+    metadata.insert("content_truncated".to_string(), Value::Bool(true));
+    metadata.insert(
+        "notice".to_string(),
+        Value::String(DELIVERY_NOTICE.to_string()),
+    );
+    metadata.insert("original_event_bytes".to_string(), json!(original_bytes));
+    metadata.insert("delivered_event_bytes".to_string(), json!(delivered_bytes));
+    metadata.insert(
+        "fields".to_string(),
+        Value::Array(
+            fields
+                .iter()
+                .map(|field| Value::String((*field).to_string()))
+                .collect(),
+        ),
+    );
+    if fallback {
+        metadata.insert("fallback".to_string(), Value::Bool(true));
+    }
+    Value::Object(metadata)
+}
+
+fn delivery_metadata_added_bytes(
+    original_bytes: usize,
+    delivered_bytes: usize,
+    fields: &BTreeSet<&'static str>,
+    fallback: bool,
+) -> Result<usize, AgentError> {
+    let singleton = json!({
+        DELIVERY_METADATA_KEY: delivery_metadata(
+            original_bytes,
+            delivered_bytes,
+            fields,
+            fallback,
+        )
+    });
+    Ok(serde_json::to_vec(&singleton)?.len().saturating_sub(1))
+}
+
+fn fallback_event(source: &Value) -> Result<Value, AgentError> {
+    let source = source.as_object().ok_or_else(|| {
+        AgentError::Execution("normalized Codex event is not an object".to_string())
+    })?;
+    let mut output = Map::new();
+    copy_fields(
+        source,
+        &mut output,
+        &[
+            "type",
+            "thread_id",
+            "turn_id",
+            "sequenceNumber",
+            "started_at_ms",
+            "completed_at_ms",
+            "will_retry",
+        ],
+    );
+
+    if let Some(turn) = source.get("turn").and_then(Value::as_object) {
+        let mut retained_turn = Map::new();
+        copy_fields(
+            turn,
+            &mut retained_turn,
+            &[
+                "id",
+                "type",
+                "status",
+                "started_at",
+                "completed_at",
+                "duration_ms",
+            ],
+        );
+        if turn.get("error").is_some_and(|error| !error.is_null()) {
+            retained_turn.insert("error".to_string(), fallback_error());
+        }
+        output.insert("turn".to_string(), Value::Object(retained_turn));
+    }
+
+    if let Some(item) = source.get("item").and_then(Value::as_object) {
+        output.insert("item".to_string(), fallback_item(item));
+    }
+
+    match source.get("type").and_then(Value::as_str) {
+        Some("turn.plan.updated") => {
+            output.insert(
+                "plan".to_string(),
+                json!([{ "step": DELIVERY_NOTICE, "status": "pending" }]),
+            );
+            output.insert(
+                "explanation".to_string(),
+                Value::String(DELIVERY_NOTICE.to_string()),
+            );
+        }
+        Some("warning" | "error") => {
+            output.insert(
+                "message".to_string(),
+                Value::String(DELIVERY_NOTICE.to_string()),
+            );
+            if source.contains_key("error") {
+                output.insert("error".to_string(), fallback_error());
+            }
+        }
+        _ => {}
+    }
+
+    Ok(Value::Object(output))
+}
+
+fn fallback_item(item: &Map<String, Value>) -> Value {
+    let mut output = Map::new();
+    copy_fields(
+        item,
+        &mut output,
+        &["id", "type", "status", "exit_code", "duration_ms"],
+    );
+    if item.get("error").is_some_and(|error| !error.is_null()) {
+        output.insert("error".to_string(), fallback_error());
+    }
+    match item.get("type").and_then(Value::as_str) {
+        Some("agent_message" | "reasoning" | "plan") => {
+            output.insert(
+                "text".to_string(),
+                Value::String(DELIVERY_NOTICE.to_string()),
+            );
+        }
+        Some("command_execution") => {
+            output.insert(
+                "command".to_string(),
+                Value::String(DELIVERY_NOTICE.to_string()),
+            );
+            output.insert(
+                "aggregated_output".to_string(),
+                Value::String(DELIVERY_NOTICE.to_string()),
+            );
+        }
+        Some("file_change") => {
+            output.insert(
+                "changes".to_string(),
+                json!([{
+                    "path": DELIVERY_NOTICE,
+                    "diff": DELIVERY_NOTICE,
+                }]),
+            );
+        }
+        _ => {
+            output.insert(
+                "delivery_notice".to_string(),
+                Value::String(DELIVERY_NOTICE.to_string()),
+            );
+        }
+    }
+    Value::Object(output)
+}
+
+fn fallback_error() -> Value {
+    json!({ "message": DELIVERY_NOTICE })
+}
+
+fn copy_fields(source: &Map<String, Value>, output: &mut Map<String, Value>, fields: &[&str]) {
+    for field in fields {
+        if let Some(value) = source.get(*field) {
+            output.insert((*field).to_string(), value.clone());
+        }
+    }
+}
+
+fn event_type_label(event: &Value) -> &'static str {
+    match event.get("type").and_then(Value::as_str) {
+        Some("thread.started") => "thread.started",
+        Some("turn.started") => "turn.started",
+        Some("turn.completed") => "turn.completed",
+        Some("turn.plan.updated") => "turn.plan.updated",
+        Some("item.started") => "item.started",
+        Some("item.completed") => "item.completed",
+        Some("warning") => "warning",
+        Some("error") => "error",
+        _ => "other",
+    }
+}
+
+fn item_type_label(event: &Value) -> &'static str {
+    match event.pointer("/item/type").and_then(Value::as_str) {
+        Some("agent_message") => "agent_message",
+        Some("plan") => "plan",
+        Some("reasoning") => "reasoning",
+        Some("command_execution") => "command_execution",
+        Some("file_change") => "file_change",
+        Some(_) => "other",
+        None => "none",
+    }
+}

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -56,6 +56,18 @@ impl EventDeliverySender {
     ) -> Result<(), AgentError> {
         let serialized_event = serde_json::to_vec(&event)?;
         drop(event);
+        self.try_send_serialized(sequence, serialized_event)
+    }
+
+    pub(super) fn max_serialized_event_bytes(&self) -> usize {
+        EVENT_DELIVERY_MAX_REQUEST_BYTES.saturating_sub(self.payload_envelope.singleton_bytes(0))
+    }
+
+    pub(super) fn try_send_serialized(
+        &self,
+        sequence: u32,
+        serialized_event: Vec<u8>,
+    ) -> Result<(), AgentError> {
         let event = Bytes::from(serialized_event.into_boxed_slice());
         let conservative_bytes = self.payload_envelope.singleton_bytes(event.len());
         if conservative_bytes > EVENT_DELIVERY_MAX_REQUEST_BYTES {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -26,6 +26,7 @@ mod claude;
 pub mod codex_app_server;
 mod codex_app_server_backend;
 mod codex_app_server_events;
+mod codex_event_delivery;
 mod codex_runtime_config;
 mod codex_setup;
 mod codex_startup;
@@ -522,6 +523,7 @@ enum ParsedEventAction {
 }
 
 struct CliEventIngestor<'a> {
+    framework: env::Framework,
     seq: u32,
     api_start_time: String,
     last_read_event_at: Option<Instant>,
@@ -533,6 +535,7 @@ struct CliEventIngestor<'a> {
 impl<'a> CliEventIngestor<'a> {
     fn new(runtime: &CliRuntimeConfig<'_>, codex_startup: Option<&'a CodexStartupTiming>) -> Self {
         Self {
+            framework: runtime.framework,
             seq: 0,
             api_start_time: runtime.api_start_time.to_string(),
             last_read_event_at: None,
@@ -628,7 +631,28 @@ impl<'a> CliEventIngestor<'a> {
         self.seq += 1;
         if should_send_events {
             let event = events::prepare_event_for_delivery(event, sequence, masker);
-            event_tx.try_send(sequence, event)?;
+            if self.framework == env::Framework::Codex {
+                let prepared = codex_event_delivery::prepare_for_delivery(
+                    event,
+                    event_tx.max_serialized_event_bytes(),
+                )?;
+                if let Some(reduction) = prepared.reduction {
+                    log_warn!(
+                        LOG_TAG,
+                        "Codex event reduced for delivery: seq={} event_type={} item_type={} original_bytes={} delivered_bytes={} fields={} fallback={}",
+                        sequence,
+                        reduction.event_type,
+                        reduction.item_type,
+                        reduction.original_bytes,
+                        reduction.delivered_bytes,
+                        reduction.fields.join(","),
+                        reduction.fallback
+                    );
+                }
+                event_tx.try_send_serialized(sequence, prepared.serialized)?;
+            } else {
+                event_tx.try_send(sequence, event)?;
+            }
         }
         Ok(())
     }

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -96,7 +96,8 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
     assert!(
         requests
             .iter()
-            .all(|request| !request.body.contains("[vm0:"))
+            .all(|request| !request.body.contains("[vm0:")
+                && !request.body.contains("\"delivery_notice\""))
     );
     assert_eq!(
         delivered

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -1,0 +1,256 @@
+//! Oversized Codex app-server events must retain a bounded webhook
+//! representation without changing the complete local normalized event.
+
+mod common;
+
+use base64::Engine as _;
+use guest_agent::masker::SecretMasker;
+use serde_json::Value;
+use std::time::Duration;
+
+const RUN_ID: &str = "codex-app-server-oversized-event-delivery-test";
+const MAX_REQUEST_BYTES: usize = 4 * 1024 * 1024;
+const SECRET: &str = "delivery-secret-value";
+const DELIVERY_MARKER: &str = "bytes truncated for delivery";
+
+#[tokio::test]
+async fn codex_app_server_reduces_oversized_events_before_delivery()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let server = common::RecordingServer::start(200, Duration::ZERO).await?;
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: RUN_ID,
+                prompt: "drive oversized app-server event delivery",
+                scenario: Some("runtime-oversized-delivery"),
+                resume_session_id: None,
+            },
+        )?;
+        std::env::set_var("VM0_API_BACKEND_URL", &server.base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &server.base_url,
+        "test-token",
+        "",
+        RUN_ID,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let _system_log = common::SystemLogOverrideGuard::set(runtime.paths.system_log_file());
+    let encoded_secret = base64::engine::general_purpose::STANDARD.encode(SECRET);
+    let masker = SecretMasker::from_raw(&encoded_secret);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+    )
+    .await
+    .expect("oversized Codex delivery should finish promptly")?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert!(result.control_error.is_none());
+    assert_eq!(result.last_event_sequence, Some(9));
+
+    server
+        .wait_for_quiet(Duration::from_millis(50), Duration::from_secs(5))
+        .await?;
+    let requests = server
+        .requests()?
+        .into_iter()
+        .filter(|request| request.path == "/api/webhooks/agent/events")
+        .collect::<Vec<_>>();
+    assert!(!requests.is_empty());
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.body.len() <= MAX_REQUEST_BYTES)
+    );
+
+    let delivered = requests
+        .iter()
+        .map(|request| serde_json::from_str::<Value>(&request.body))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flat_map(|payload| {
+            payload
+                .get("events")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(delivered.len(), 10);
+    assert_eq!(
+        delivered
+            .iter()
+            .map(|event| event["sequenceNumber"].as_u64())
+            .collect::<Vec<_>>(),
+        (0..10).map(Some).collect::<Vec<_>>()
+    );
+
+    for item_id in [
+        "oversized-agent-message",
+        "oversized-reasoning",
+        "oversized-plan",
+        "oversized-command",
+        "oversized-file-change",
+        "oversized-structure",
+    ] {
+        let event = delivered_item(&delivered, item_id)?;
+        assert_reduction_metadata(event)?;
+        assert_eq!(event["item"]["id"], item_id);
+        assert_eq!(event["type"], "item.completed");
+    }
+
+    let agent_message = delivered_item(&delivered, "oversized-agent-message")?;
+    let agent_text = agent_message["item"]["text"]
+        .as_str()
+        .ok_or("reduced agent message omitted text")?;
+    assert!(agent_text.starts_with("agent-head-***-"));
+    assert!(agent_text.ends_with("-agent-tail"));
+    assert!(agent_text.contains(DELIVERY_MARKER));
+    assert!(!agent_text.contains(SECRET));
+    assert_eq!(agent_message["item"]["type"], "agent_message");
+
+    let reasoning = delivered_item(&delivered, "oversized-reasoning")?;
+    assert_eq!(reasoning["item"]["type"], "reasoning");
+    assert!(reasoning["item"]["text"].as_str().is_some_and(|text| {
+        text.starts_with("reasoning-head-")
+            && text.ends_with("-reasoning-tail")
+            && text.contains(DELIVERY_MARKER)
+    }));
+
+    let plan = delivered_item(&delivered, "oversized-plan")?;
+    assert_eq!(plan["item"]["type"], "plan");
+    assert!(
+        plan["item"]["text"]
+            .as_str()
+            .is_some_and(|text| text.starts_with("plan-head-")
+                && text.ends_with("-plan-tail")
+                && text.contains(DELIVERY_MARKER))
+    );
+
+    let command = delivered_item(&delivered, "oversized-command")?;
+    assert_eq!(command["item"]["type"], "command_execution");
+    assert_eq!(command["item"]["status"], "completed");
+    assert_eq!(command["item"]["exit_code"], 0);
+    assert!(command["item"]["command"].as_str().is_some_and(
+        |text| text.starts_with("command-head-")
+            && text.ends_with("-command-tail")
+            && text.contains(DELIVERY_MARKER)
+    ));
+    assert!(
+        command["item"]["aggregated_output"]
+            .as_str()
+            .is_some_and(|text| text.starts_with("output-head-***-")
+                && text.ends_with("-output-tail")
+                && text.contains(DELIVERY_MARKER))
+    );
+    assert_eq!(
+        command["vm0_delivery"]["fields"],
+        serde_json::json!(["command", "command_output"])
+    );
+
+    let file_change = delivered_item(&delivered, "oversized-file-change")?;
+    assert_eq!(file_change["item"]["type"], "file_change");
+    assert_eq!(file_change["item"]["status"], "completed");
+    assert_eq!(file_change["item"]["changes"][0]["path"], "large.txt");
+    assert!(
+        file_change["item"]["changes"][0]["diff"]
+            .as_str()
+            .is_some_and(|text| text.starts_with("diff-head-***-")
+                && text.ends_with("-diff-tail")
+                && text.contains(DELIVERY_MARKER))
+    );
+
+    let structure = delivered_item(&delivered, "oversized-structure")?;
+    assert_eq!(structure["item"]["type"], "file_change");
+    assert_eq!(structure["item"]["status"], "completed");
+    assert_eq!(structure["vm0_delivery"]["fallback"], true);
+    assert_eq!(
+        structure["item"]["changes"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        structure["item"]["changes"][0]["diff"],
+        "[vm0: event content truncated for delivery]"
+    );
+    assert!(structure["item"]["changes"][0].get("kind").is_none());
+
+    let warning = delivered
+        .iter()
+        .find(|event| event["type"] == "warning")
+        .ok_or("normal warning was not delivered")?;
+    assert_eq!(warning["message"], "guest-mock-codex warning 999");
+    assert!(warning.get("vm0_delivery").is_none());
+
+    let local_events = read_jsonl(runtime.paths.agent_log_file())?;
+    let local_agent = delivered_item(&local_events, "oversized-agent-message")?;
+    let local_text = local_agent["item"]["text"]
+        .as_str()
+        .ok_or("local agent message omitted text")?;
+    assert!(local_text.len() > MAX_REQUEST_BYTES);
+    assert!(local_text.contains(SECRET));
+    assert!(!local_text.contains(DELIVERY_MARKER));
+    assert!(local_agent.get("vm0_delivery").is_none());
+
+    let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
+    assert_eq!(
+        system_log
+            .matches("Codex event reduced for delivery")
+            .count(),
+        6
+    );
+    assert!(system_log.contains("fallback=true"));
+    assert!(!system_log.contains(SECRET));
+    assert!(!system_log.contains("agent-head"));
+    assert!(!system_log.contains("large.txt"));
+
+    Ok(())
+}
+
+fn delivered_item<'a>(events: &'a [Value], item_id: &str) -> Result<&'a Value, String> {
+    events
+        .iter()
+        .find(|event| event.pointer("/item/id").and_then(Value::as_str) == Some(item_id))
+        .ok_or_else(|| format!("missing item {item_id}"))
+}
+
+fn assert_reduction_metadata(event: &Value) -> Result<(), Box<dyn std::error::Error>> {
+    let metadata = event
+        .get("vm0_delivery")
+        .ok_or("reduced event omitted vm0_delivery")?;
+    assert_eq!(metadata["content_truncated"], true);
+    assert_eq!(
+        metadata["notice"],
+        "[vm0: event content truncated for delivery]"
+    );
+    let original = metadata["original_event_bytes"]
+        .as_u64()
+        .ok_or("missing original_event_bytes")?;
+    let delivered = metadata["delivered_event_bytes"]
+        .as_u64()
+        .ok_or("missing delivered_event_bytes")?;
+    assert!(original > delivered);
+    assert_eq!(delivered as usize, serde_json::to_vec(event)?.len());
+    assert!(
+        metadata["fields"]
+            .as_array()
+            .is_some_and(|fields| !fields.is_empty() && fields.len() <= 16)
+    );
+    Ok(())
+}
+
+fn read_jsonl(path: &str) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    std::fs::read_to_string(path)?
+        .lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -12,6 +12,7 @@ const RUN_ID: &str = "codex-app-server-oversized-event-delivery-test";
 const MAX_REQUEST_BYTES: usize = 4 * 1024 * 1024;
 const SECRET: &str = "delivery-secret-value";
 const DELIVERY_MARKER: &str = "bytes truncated for delivery";
+const FALLBACK_MARKER: &str = "[event content truncated for delivery]";
 
 #[tokio::test]
 async fn codex_app_server_reduces_oversized_events_before_delivery()
@@ -87,6 +88,16 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
         })
         .collect::<Vec<_>>();
     assert_eq!(delivered.len(), 10);
+    assert!(
+        delivered
+            .iter()
+            .all(|event| event.get("vm0_delivery").is_none())
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| !request.body.contains("[vm0:"))
+    );
     assert_eq!(
         delivered
             .iter()
@@ -104,7 +115,6 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
         "oversized-structure",
     ] {
         let event = delivered_item(&delivered, item_id)?;
-        assert_reduction_metadata(event)?;
         assert_eq!(event["item"]["id"], item_id);
         assert_eq!(event["type"], "item.completed");
     }
@@ -153,11 +163,6 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
                 && text.ends_with("-output-tail")
                 && text.contains(DELIVERY_MARKER))
     );
-    assert_eq!(
-        command["vm0_delivery"]["fields"],
-        serde_json::json!(["command", "command_output"])
-    );
-
     let file_change = delivered_item(&delivered, "oversized-file-change")?;
     assert_eq!(file_change["item"]["type"], "file_change");
     assert_eq!(file_change["item"]["status"], "completed");
@@ -173,15 +178,11 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
     let structure = delivered_item(&delivered, "oversized-structure")?;
     assert_eq!(structure["item"]["type"], "file_change");
     assert_eq!(structure["item"]["status"], "completed");
-    assert_eq!(structure["vm0_delivery"]["fallback"], true);
     assert_eq!(
         structure["item"]["changes"].as_array().map(Vec::len),
         Some(1)
     );
-    assert_eq!(
-        structure["item"]["changes"][0]["diff"],
-        "[vm0: event content truncated for delivery]"
-    );
+    assert_eq!(structure["item"]["changes"][0]["diff"], FALLBACK_MARKER);
     assert!(structure["item"]["changes"][0].get("kind").is_none());
 
     let warning = delivered
@@ -221,31 +222,6 @@ fn delivered_item<'a>(events: &'a [Value], item_id: &str) -> Result<&'a Value, S
         .iter()
         .find(|event| event.pointer("/item/id").and_then(Value::as_str) == Some(item_id))
         .ok_or_else(|| format!("missing item {item_id}"))
-}
-
-fn assert_reduction_metadata(event: &Value) -> Result<(), Box<dyn std::error::Error>> {
-    let metadata = event
-        .get("vm0_delivery")
-        .ok_or("reduced event omitted vm0_delivery")?;
-    assert_eq!(metadata["content_truncated"], true);
-    assert_eq!(
-        metadata["notice"],
-        "[vm0: event content truncated for delivery]"
-    );
-    let original = metadata["original_event_bytes"]
-        .as_u64()
-        .ok_or("missing original_event_bytes")?;
-    let delivered = metadata["delivered_event_bytes"]
-        .as_u64()
-        .ok_or("missing delivered_event_bytes")?;
-    assert!(original > delivered);
-    assert_eq!(delivered as usize, serde_json::to_vec(event)?.len());
-    assert!(
-        metadata["fields"]
-            .as_array()
-            .is_some_and(|fields| !fields.is_empty() && fields.len() <= 16)
-    );
-    Ok(())
 }
 
 fn read_jsonl(path: &str) -> Result<Vec<Value>, Box<dyn std::error::Error>> {

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -4,9 +4,9 @@ use super::messages::{
     reasoning_item_started_notification, server_notification, server_notification_with_index,
     server_request, thread_response, thread_started_notification, turn,
     turn_completed_notification, turn_failed_notification, turn_started_notification,
-    warning_notification, write_error, write_json_line, write_split_json_line_prefix,
-    write_success, write_turn_completion_notifications, write_turn_notifications,
-    write_turn_start_notifications,
+    warning_notification, write_error, write_json_line, write_oversized_delivery_notifications,
+    write_split_json_line_prefix, write_success, write_turn_completion_notifications,
+    write_turn_notifications, write_turn_start_notifications,
 };
 use super::persistence::{InputEventContext, persist_input_events};
 use super::scenario::Scenario;
@@ -422,6 +422,11 @@ impl AppServerState {
                 )?;
                 thread::sleep(std::time::Duration::from_millis(50));
             }
+            write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;
+        }
+        if self.scenario == Scenario::RuntimeOversizedDelivery {
+            write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
+            write_oversized_delivery_notifications(output, &thread_id, &turn_id)?;
             write_json_line(output, &turn_completed_notification(&thread_id, &turn_id))?;
         }
         Ok(ServerAction::Continue)

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -144,6 +144,128 @@ pub(super) fn assistant_item_completed_notification(
     })
 }
 
+pub(super) fn write_oversized_delivery_notifications<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+) -> io::Result<()> {
+    let large = "α".repeat(2_150_000);
+    let secret = "delivery-secret-value";
+    let completed_at_ms = 2;
+    write_json_line(
+        output,
+        &json!({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "completedAtMs": completed_at_ms,
+                "item": {
+                    "id": "oversized-agent-message",
+                    "type": "agentMessage",
+                    "text": format!("agent-head-{secret}-{large}-agent-tail"),
+                }
+            }
+        }),
+    )?;
+    write_json_line(
+        output,
+        &json!({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "completedAtMs": completed_at_ms + 1,
+                "item": {
+                    "id": "oversized-reasoning",
+                    "type": "reasoning",
+                    "summary": [format!("reasoning-head-{large}")],
+                    "content": [format!("{secret}-{large}-reasoning-tail")],
+                }
+            }
+        }),
+    )?;
+    write_json_line(
+        output,
+        &json!({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "completedAtMs": completed_at_ms + 2,
+                "item": {
+                    "id": "oversized-plan",
+                    "type": "plan",
+                    "text": format!("plan-head-{large}-{secret}-plan-tail"),
+                }
+            }
+        }),
+    )?;
+    write_json_line(
+        output,
+        &json!({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "completedAtMs": completed_at_ms + 3,
+                "item": {
+                    "id": "oversized-command",
+                    "type": "commandExecution",
+                    "command": format!("command-head-{large}-command-tail"),
+                    "cwd": "/workspace",
+                    "status": "completed",
+                    "aggregatedOutput": format!("output-head-{secret}-{large}-output-tail"),
+                    "exitCode": 0,
+                    "durationMs": 123,
+                }
+            }
+        }),
+    )?;
+    write_json_line(
+        output,
+        &json!({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "completedAtMs": completed_at_ms + 4,
+                "item": {
+                    "id": "oversized-file-change",
+                    "type": "fileChange",
+                    "status": "completed",
+                    "changes": [{
+                        "path": "large.txt",
+                        "kind": "modify",
+                        "diff": format!("diff-head-{secret}-{large}-diff-tail"),
+                    }],
+                }
+            }
+        }),
+    )?;
+    write_json_line(
+        output,
+        &json!({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "completedAtMs": completed_at_ms + 5,
+                "item": {
+                    "id": "oversized-structure",
+                    "type": "fileChange",
+                    "status": "completed",
+                    "changes": (0..75_000).map(|index| json!({
+                        "path": format!("path-{index:06}-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz"),
+                        "kind": "modify",
+                    })).collect::<Vec<_>>(),
+                }
+            }
+        }),
+    )?;
+    write_json_line(output, &warning_notification(thread_id, 999))
+}
+
 pub(super) fn turn_completed_notification(thread_id: &str, turn_id: &str) -> Value {
     json!({
         "method": "turn/completed",

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -36,6 +36,7 @@ pub(super) enum Scenario {
     RuntimeTurnCompleteWithoutThreadStarted,
     RuntimeEventFlood,
     RuntimeLargeEventFlood,
+    RuntimeOversizedDelivery,
     ResumeDifferentThreadId,
     ResumeRpcErrorWithThreadId,
     ThreadStartInvalidThreadId,
@@ -93,6 +94,7 @@ impl Scenario {
                 }
                 "runtime-event-flood" => Ok(Self::RuntimeEventFlood),
                 "runtime-large-event-flood" => Ok(Self::RuntimeLargeEventFlood),
+                "runtime-oversized-delivery" => Ok(Self::RuntimeOversizedDelivery),
                 "resume-different-thread-id" => Ok(Self::ResumeDifferentThreadId),
                 "resume-rpc-error-with-thread-id" => Ok(Self::ResumeRpcErrorWithThreadId),
                 "thread-start-invalid-thread-id" => Ok(Self::ThreadStartInvalidThreadId),


### PR DESCRIPTION
## Summary

- reduce only oversized Codex webhook copies against the sender's exact singleton-event budget
- preserve event identity, status, sequence, and UTF-8 head/tail context with a neutral inline truncation marker
- add no event-level delivery metadata and no `vm0:`-prefixed content marker
- keep complete normalized Codex events in the local agent log and retain the shared 4 MiB sender invariant
- add boundary integration coverage for large messages, reasoning, plans, commands, file changes, masking, fallback, and unchanged normal events

## Exclusions

- no new webhook payload fields
- no API, UI, database, storage, configuration, or feature-switch changes
- no change to non-Codex oversized-event behavior
- no change to the 4 MiB webhook request limit

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent -p guest-mock-codex --all-features --no-deps`
- `cargo test -p guest-agent -p guest-mock-codex --all-targets --all-features`
- `cargo test -p guest-agent --test codex_app_server_oversized_event_delivery`

Closes #26466
