### PR TITLE
fix(ci): force-cancel superseded merge-group runs

### DIFF
--- a/.github/scripts/cancel-superseded-merge-group-runs.sh
+++ b/.github/scripts/cancel-superseded-merge-group-runs.sh
@@ -133,9 +133,13 @@ printf '%s\n' "$superseded_runs"
 run_ids=()
 while IFS= read -r run_record; do
   run_id=${run_record%%$'\t'*}
+  # These workflows contain always()-guarded jobs and steps that GitHub may
+  # continue after a regular cancellation is accepted. Force cancellation is
+  # required for this shared-resource handoff; the completion barrier below
+  # still fails closed until GitHub reports the old run as terminal.
   if ! cancel_error=$(
     gh api --method POST \
-      "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" 2>&1
+      "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel" 2>&1
   ); then
     current_status=$(
       gh api --method GET \
@@ -144,7 +148,7 @@ while IFS= read -r run_record; do
     )
     if [ "$current_status" != "completed" ]; then
       # GitHub can wedge a run so that it keeps reporting an active status
-      # while refusing every cancel request with HTTP 409. A run only claims
+      # while refusing force cancellation with HTTP 409. A run only claims
       # the shared pr-N runner once it starts a job, so a wedged run whose
       # latest attempt started no job cannot be the writer this barrier
       # protects against, and it would never reach "completed" for the

--- a/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
+++ b/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
@@ -77,9 +77,9 @@ JSON
 ]}]
 JSON
     ;;
-  repos/vm0-ai/vm0/actions/runs/*/cancel)
+  repos/vm0-ai/vm0/actions/runs/*/force-cancel)
     [ "$method" = "POST" ] || exit 1
-    run_id=${endpoint%/cancel}
+    run_id=${endpoint%/force-cancel}
     run_id=${run_id##*/}
     printf '%s\n' "$run_id" >>"$MOCK_CANCEL_LOG"
     case " ${MOCK_WEDGED_RUN_IDS:-} " in
@@ -88,6 +88,9 @@ JSON
         exit 1
         ;;
     esac
+    if [ "${MOCK_FORCE_CANCEL_COMPLETION:-0}" = "1" ]; then
+      touch "$MOCK_RUNS_RELEASED"
+    fi
     ;;
   repos/vm0-ai/vm0/actions/runs/*/jobs)
     run_id=${endpoint%/jobs}
@@ -177,6 +180,20 @@ grep -q "Waiting for superseded CI runs" <<<"$output" ||
   fail "expected an explicit completion barrier"
 [ "$(wc -l <"${tmp_dir}/sleep.log")" -eq 1 ] ||
   fail "expected one poll before superseded runs completed"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+: >"${tmp_dir}/sleep.log"
+rm -f "${tmp_dir}/runs-released"
+output=$(
+  run_cancel \
+    MOCK_DELAY_COMPLETION=1 \
+    MOCK_FORCE_CANCEL_COMPLETION=1
+)
+grep -q "All superseded CI runs completed" <<<"$output" ||
+  fail "expected force cancellation to terminate otherwise-active runs"
+[ ! -s "${tmp_dir}/sleep.log" ] ||
+  fail "force-cancelled runs must not need a completion poll"
 
 : >"${tmp_dir}/gh.log"
 : >"${tmp_dir}/cancel.log"


### PR DESCRIPTION
## Summary

- force-cancel strictly selected older Turbo, Crates, and Runner Image runs before rebuilding shared `pr-N` runner resources
- retain the existing fail-closed barrier that requires every cancellable old run to report `completed`
- cover force cancellation terminating an otherwise-active run without adding retries, sleeps, or a larger timeout

## Root cause

GitHub's regular workflow cancellation returns `202 Accepted`, but it does not guarantee that the old workflow has stopped. These workflows contain `always()`-guarded jobs and steps, and three independent merge-group recurrences showed old shared-runner consumers continuing long after the regular cancellation request:

1. [Turbo 31569118184](https://github.com/vm0-ai/vm0/actions/runs/31569118184) cascaded from [Runner Image 31569118124](https://github.com/vm0-ai/vm0/actions/runs/31569118124). Old Turbo run 31568935988 started runner shards after cancellation and kept Playwright active until 06:15:29Z, beyond the three-minute barrier.
2. [Turbo 31569386204](https://github.com/vm0-ai/vm0/actions/runs/31569386204) cascaded from [Runner Image 31569386266](https://github.com/vm0-ai/vm0/actions/runs/31569386266). Old Turbo run 31569119172 kept Playwright active until 06:24:36Z, more than eight minutes after cancellation was requested.
3. [Turbo 31569644303](https://github.com/vm0-ai/vm0/actions/runs/31569644303) cascaded from [Runner Image 31569644342](https://github.com/vm0-ai/vm0/actions/runs/31569644342). Old Crates run 31569420451 kept `runner-behavior-lane-d` active until 06:25:55Z.

The Turbo manifest waits, skipped runner jobs, and aggregate gates were downstream fallout. The represented PRs did not change this cancellation coordinator.

GitHub documents the force-cancel endpoint as the path that bypasses conditions such as `always()` when a normal cancellation does not stop a run. The coordinator now uses that endpoint for the same narrowly selected old runs. An accepted request is still not treated as sufficient: Runner Image `prepare` remains blocked until each run is terminal, so the no-concurrent-consumer invariant is preserved.

## Validation

- `cancel-superseded-merge-group-runs-test.sh`: 5/5 passes
- `runner-image-workflow-test.sh`: pass
- `runner-image-context-test.sh`: pass
- `turbo-playwright-runner-workflow-test.sh`: pass
- ShellCheck on both changed scripts: pass
- `bash -n`: pass
- `git diff --check`: pass

`prepare-runner-image-test.sh` is unchanged and cannot reach its assertions in this agent runtime because process substitution fails with `/dev/fd/63: No such file or directory`; the production preparation script is not changed.

Preview/browser validation is not applicable: this PR changes only a GitHub Actions Bash coordinator and its process-boundary test, with no deployed app, API, or browser surface.
