### PR TITLE
test(api): own fake snapshot object cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-chat-event-r2.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-chat-event-r2.ts
@@ -49,6 +49,14 @@ export function readFakeChatEventObject(key: string): Buffer | undefined {
   return readFileSync(path);
 }
 
+export function deleteFakeChatEventObject(key: string): Promise<void> {
+  const path = objectPath(key);
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+  return Promise.resolve();
+}
+
 export function ageFakeChatEventObject(key: string, modifiedAt: Date): void {
   const path = objectPath(key);
   if (!existsSync(path)) {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
@@ -21,6 +21,7 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
   ageFakeChatEventObject,
+  deleteFakeChatEventObject,
   FAKE_CHAT_EVENT_SNAPSHOT_URL,
   installFakeChatEventR2,
   readFakeChatEventObject,
@@ -30,12 +31,19 @@ import {
   readChatEventSnapshotHead,
   setChatEventSnapshotHeadVersion,
 } from "./helpers/runtime-state";
-import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
 
 const context = testContext();
 const bdd = createBddApi(context);
 const api = createRunsApi(context);
 const chat = createChatFilesBddApi(context);
+// Manual objects share the fake R2 directory, so each test owns its teardown.
+const trackFakeChatEventObject = createFixtureTracker(
+  deleteFakeChatEventObject,
+);
 
 const CRON_SECRET = "test-cron-secret";
 
@@ -102,6 +110,7 @@ async function replaceHeadWithRetiredVersion(
   }
   const retiredKey = `chat-events/${threadId}/retired-v3-${randomUUID()}.ndjson.gz`;
   writeFakeChatEventObject(retiredKey, body);
+  await trackFakeChatEventObject(Promise.resolve(retiredKey));
   await setChatEventSnapshotHeadVersion(context, threadId, 3, retiredKey);
   return retiredKey;
 }
@@ -357,6 +366,7 @@ describe("chat event snapshot read endpoints", () => {
 
     const orphanKey = `chat-events/${threadId.slice(0, 3)}-orphan.ndjson.gz`;
     writeFakeChatEventObject(orphanKey, Buffer.from("orphan"));
+    await trackFakeChatEventObject(Promise.resolve(orphanKey));
     ageFakeChatEventObject(
       orphanKey,
       new Date(future.getTime() - 8 * 24 * 60 * 60 * 1000),
@@ -399,6 +409,7 @@ describe("chat event snapshot read endpoints", () => {
     });
     for (const key of keys) {
       writeFakeChatEventObject(key, Buffer.from("orphan"));
+      await trackFakeChatEventObject(Promise.resolve(key));
     }
     mockNow(new Date(now() + 8 * 24 * 60 * 60 * 1000));
     mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD", shard);


### PR DESCRIPTION
## Summary

- register every manually written chat-event fake-R2 object with the existing awaited fixture tracker
- remove those owned objects after each test so a deliberate delete failure cannot pollute the next GC shard assertion
- preserve the production snapshot GC behavior and every existing assertion

## Failure evidence

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/31569117148
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/31569117148/job/94027177817
- Failing SHA: `ca531ec0043d3e618285e929d8be78721455ddd2`
- Failure: `garbage-collects unreferenced snapshot objects` expected `r2ObjectsMeasured: 1` and received `2`, while `r2ObjectsDeleted` remained `0`
- The same SHA passed the preceding merge-group job: https://github.com/vm0-ai/vm0/actions/runs/31568653077/job/94025782101
- Attempt 2 did not rerun `test-api (5)`; GitHub copied the attempt-1 job record, so it is not counted as another reproduction or a pass

<!-- turbo-flaky-repair -->
TURBO_FLAKY_KEY: test-api-5:zero-chat-event-snapshot:garbage-collects-unreferenced-snapshot-objects:unexpected-extra-r2-object

## Root cause

The fake R2 store uses one temp directory across tests. The immediately preceding best-effort deletion test intentionally leaves an unreferenced retired object when its mocked R2 delete fails. The GC test then advances time by eight days and scans the first three hex characters of a new random thread ID. When those three characters collide with the prior test's thread ID (1 in 4096), both the owned orphan and the leaked retired object are eligible, producing the observed metric-only `+1`.

This is test fixture ownership pollution, not a product race. The fix keeps manually created objects in the shared fake while the test is running, then deletes them through the fixture tracker's awaited `afterEach` cleanup. Product-created content-addressed snapshot objects retain the existing shared-store behavior.

## Validation

- service-free focused Vitest for fake-R2 write/read/awaited delete: 5 consecutive passes
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/helpers/fake-chat-event-r2.ts apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts`
- `pnpm exec oxlint` on both changed files
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json` on both changed files
- `pnpm exec eslint ... --max-warnings 0` on both changed files
- `pnpm run check-types:tests` in `turbo/apps/api`
- PR Turbo `test-api (5)`: 24 files / 336 tests passed, including all 6 tests in `zero-chat-event-snapshot.test.ts`: https://github.com/vm0-ai/vm0/actions/runs/31571182118/job/94033377965
- All PR checks completed successfully with no failed checks
- The route integration file was not run locally because API Vitest global setup requires PostgreSQL; no local database or service was started. The PR pipeline provided that coverage.

## Preview

- App preview: https://pr-26522-app.omby.ai
- `deploy-app` build, readiness, and gateway smoke test passed: https://github.com/vm0-ai/vm0/actions/runs/31571182118/job/94033332668
- Browser check passed: the preview loaded, redirected to its development Clerk sign-in page, rendered the complete sign-in form, and reported no page errors
- Screenshot: https://cdn.vm0.io/artifacts/oucqyg06ht.png
- No product source changed, so authenticated product-flow testing is not applicable to this test-only repair
