### PR TITLE
fix(platform): keep square thumbnail radius proportional across sizes

### DIFF
--- a/turbo/apps/platform/src/views/components/avatar.tsx
+++ b/turbo/apps/platform/src/views/components/avatar.tsx
@@ -13,6 +13,16 @@ const THUMBNAIL_SIZE = {
   xl: "h-12 w-12",
 } as const;
 
+// Square thumbnails keep their corner radius at a constant quarter of the box,
+// so a 24px logo and a 40px one read as the same shape at different scales.
+// Same ratio the file-preview icon already uses (20px/5px, 40px/10px).
+const THUMBNAIL_RADIUS = {
+  sm: "rounded-[6px]",
+  md: "rounded-[8px]",
+  lg: "rounded-[10px]",
+  xl: "rounded-[12px]",
+} as const;
+
 const THUMBNAIL_INITIAL_TEXT = {
   sm: "text-[11px]",
   md: "text-xs",
@@ -77,8 +87,7 @@ export function WorkspaceLogo({
   imageUrl?: string | null;
   size?: ThumbnailSize;
 }) {
-  const radius = size === "sm" || size === "md" ? "rounded-md" : "rounded-xl";
-  const base = cn(THUMBNAIL_BASE, THUMBNAIL_SIZE[size], radius);
+  const base = cn(THUMBNAIL_BASE, THUMBNAIL_SIZE[size], THUMBNAIL_RADIUS[size]);
 
   if (imageUrl) {
     return (

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -1601,7 +1601,7 @@ function FeishuBotRow({
   return (
     <div className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:px-5">
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[10px]">
           <img
             src={bot.botAvatarUrl ?? feishuIconImg}
             alt={t(
@@ -1611,7 +1611,9 @@ function FeishuBotRow({
               { bot: title },
             )}
             className={
-              bot.botAvatarUrl ? "h-10 w-10 rounded-xl object-cover" : "h-7 w-7"
+              bot.botAvatarUrl
+                ? "h-10 w-10 rounded-[10px] object-cover"
+                : "h-7 w-7"
             }
             onError={(event) => {
               event.currentTarget.src = feishuIconImg;
@@ -1844,7 +1846,7 @@ function FeishuSettingsSkeleton() {
           <div key={index}>
             <div className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:px-5">
               <div className="flex min-w-0 flex-1 items-center gap-3">
-                <Skeleton className="h-10 w-10 shrink-0 rounded-xl" />
+                <Skeleton className="h-10 w-10 shrink-0 rounded-[10px]" />
                 <div className="flex min-w-0 flex-1 items-center gap-2">
                   <Skeleton className="h-4 w-32" />
                   <Skeleton className="h-6 w-20 rounded-lg" />
@@ -2188,7 +2190,7 @@ export function ZeroFeishuSettingsPage() {
             </Button>
           </div>
           <div className="flex min-w-0 items-center gap-3">
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted/40">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[10px] bg-muted/40">
               <img src={feishuIconImg} alt="" className="h-7 w-7" />
             </span>
             <div className="min-w-0">


### PR DESCRIPTION
## Problem

`WorkspaceLogo` has four size steps but only two radius steps: `sm`/`md` get `rounded-md` (6px) and `lg`/`xl` get `rounded-xl` (12px). As a ratio of the box that is 25% / 18.75% / 30% / 25% — the corner doubles between 32px and 40px.

The visible symptom is the org switcher, where the 24px logo in the menu row (6px, 25%) sits right above the 40px logo in the current-org card (12px, 30%): the larger mark reads noticeably rounder rather than like the same shape at a bigger scale.

## Change

- Give each thumbnail size its own radius on a regular ladder — 6 / 8 / 10 / 12px, a constant quarter of the box — as a `THUMBNAIL_RADIUS` map alongside `THUMBNAIL_SIZE`, so adding a size can no longer skip its radius.
- Align the 40px Feishu bot thumbnails from `rounded-xl` (12px) to the same 10px corner.

25% is the ratio already used elsewhere for square thumbnails: `zero-file-preview-icon.tsx` (20px→5px, 40px→10px), `permission-allow-page.tsx`, `onboarding-workflow-picker-page.tsx`.

## Visual impact

Only the 40px marks change (12px → 10px). `sm`/`xl` are already at 25% and stay pixel-identical; `md` moves 6px → 8px but is currently unused by `WorkspaceLogo`. 48px containers already at `rounded-xl` are correct at 25% and are left alone.

## Test plan

- No test asserts these classes; covered by the existing platform suite in CI.
- Manual: org switcher trigger, dropdown rows, and current-org card; Feishu connector settings bot rows.