### PR TITLE
refactor(python): centralize billable model category derivation

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -88,22 +88,34 @@ _MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE = {
     MODEL_USAGE_CATEGORY_CACHE_READ: _MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
     MODEL_USAGE_CATEGORY_CACHE_CREATION: _MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
 }
+_MODEL_INPUT_PARTITION_BASE_CATEGORIES = (
+    MODEL_USAGE_CATEGORY_INPUT,
+    MODEL_USAGE_CATEGORY_CACHE_READ,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION,
+)
+
+
+def _billable_model_usage_category(
+    category: str,
+    billing_tier: _ModelUsageTier,
+    fast: bool,
+) -> str:
+    billable_category = (
+        _MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE[category]
+        if billing_tier == _MODEL_USAGE_TIER_LONG_CONTEXT
+        else category
+    )
+    if fast:
+        return f"{billable_category}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}"
+    return billable_category
+
+
 _MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT = 100
 _MODEL_INPUT_PARTITION_CATEGORIES = frozenset(
-    (
-        MODEL_USAGE_CATEGORY_INPUT,
-        MODEL_USAGE_CATEGORY_CACHE_READ,
-        MODEL_USAGE_CATEGORY_CACHE_CREATION,
-        _MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT,
-        _MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT,
-        _MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT,
-        f"{MODEL_USAGE_CATEGORY_INPUT}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}",
-        f"{MODEL_USAGE_CATEGORY_CACHE_READ}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}",
-        f"{MODEL_USAGE_CATEGORY_CACHE_CREATION}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}",
-        f"{_MODEL_USAGE_CATEGORY_INPUT_LONG_CONTEXT}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}",
-        f"{_MODEL_USAGE_CATEGORY_CACHE_READ_LONG_CONTEXT}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}",
-        f"{_MODEL_USAGE_CATEGORY_CACHE_CREATION_LONG_CONTEXT}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}",
-    )
+    _billable_model_usage_category(category, billing_tier, fast)
+    for category in _MODEL_INPUT_PARTITION_BASE_CATEGORIES
+    for billing_tier in (_MODEL_USAGE_TIER_BASE, _MODEL_USAGE_TIER_LONG_CONTEXT)
+    for fast in (False, True)
 )
 
 
@@ -705,13 +717,11 @@ def _build_usage_events(
         quantity = usage.get(category)
         if not _is_positive_int(quantity):
             continue
-        billable_category = (
-            _MODEL_USAGE_LONG_CONTEXT_CATEGORY_BY_BASE[category]
-            if billing_tier == _MODEL_USAGE_TIER_LONG_CONTEXT
-            else category
+        billable_category = _billable_model_usage_category(
+            category,
+            billing_tier,
+            fast,
         )
-        if fast:
-            billable_category = f"{billable_category}{_MODEL_USAGE_FAST_CATEGORY_SUFFIX}"
         event: UsageEvent = {
             "idempotencyKey": derive_usage_idempotency_key(
                 namespace,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -623,28 +623,66 @@ class TestModelProviderWebSocketUsage:
 
         assert metadata_keys.MODEL_PROVIDER_USAGE_TIERS not in flow.metadata
 
+    @pytest.mark.parametrize(
+        (
+            "input_tokens",
+            "cached_tokens",
+            "cache_write_tokens",
+            "service_tier",
+            "category_suffix",
+        ),
+        [
+            pytest.param(100, 20, 30, None, "", id="base"),
+            pytest.param(
+                300_000,
+                20_000,
+                30_000,
+                None,
+                ".long_context",
+                id="long-context",
+            ),
+            pytest.param(100, 20, 30, "priority", ".fast", id="fast"),
+            pytest.param(
+                300_000,
+                20_000,
+                30_000,
+                "priority",
+                ".long_context.fast",
+                id="long-context-fast",
+            ),
+        ],
+    )
     def test_model_websocket_late_same_id_snapshot_does_not_mix_input_partition(
-        self, tmp_path, real_flow
+        self,
+        tmp_path,
+        real_flow,
+        input_tokens,
+        cached_tokens,
+        cache_write_tokens,
+        service_tier,
+        category_suffix,
     ):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.6-sol"
         mitm_addon.responseheaders(flow)
+        first_response = {
+            "id": "resp_ws_partition",
+            "model": "gpt-5.6-sol",
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": 0,
+                "input_tokens_details": {"cached_tokens": cached_tokens},
+            },
+        }
+        if service_tier is not None:
+            first_response["service_tier"] = service_tier
 
         webhook = self._run_websocket_messages_and_end(
             flow,
             json.dumps(
                 {
                     "type": "response.completed",
-                    "response": {
-                        "id": "resp_ws_partition",
-                        "model": "gpt-5.6-sol",
-                        "service_tier": "priority",
-                        "usage": {
-                            "input_tokens": 300_000,
-                            "output_tokens": 0,
-                            "input_tokens_details": {"cached_tokens": 20_000},
-                        },
-                    },
+                    "response": first_response,
                 }
             ).encode(),
             json.dumps(
@@ -654,11 +692,11 @@ class TestModelProviderWebSocketUsage:
                         "id": "resp_ws_partition",
                         "model": "gpt-5.6-sol",
                         "usage": {
-                            "input_tokens": 300_000,
+                            "input_tokens": input_tokens,
                             "output_tokens": 40,
                             "input_tokens_details": {
-                                "cached_tokens": 20_000,
-                                "cache_write_tokens": 30_000,
+                                "cached_tokens": cached_tokens,
+                                "cache_write_tokens": cache_write_tokens,
                             },
                         },
                     },
@@ -671,19 +709,23 @@ class TestModelProviderWebSocketUsage:
         assert len(events) == len(by_category) == 3
         assert len({event["idempotencyKey"] for event in events}) == 3
         assert by_category == {
-            "tokens.input.long_context.fast": 280_000,
-            "tokens.output.long_context.fast": 40,
-            "tokens.cache_read.long_context.fast": 20_000,
+            f"tokens.input{category_suffix}": input_tokens - cached_tokens,
+            f"tokens.output{category_suffix}": 40,
+            f"tokens.cache_read{category_suffix}": cached_tokens,
         }
+        for event in events:
+            uuid.UUID(event["idempotencyKey"])
         observation_events = webhook.model_usage_observation_events()
         observations_by_category = compact_observation_quantities(observation_events)
         assert len(observation_events) == 2
         assert len({event["idempotencyKey"] for event in observation_events}) == 2
         assert observations_by_category == {
-            "tokens.input": 280_000,
+            "tokens.input": input_tokens - cached_tokens,
             "tokens.output": 40,
-            "tokens.cache_read": 20_000,
+            "tokens.cache_read": cached_tokens,
         }
+        for event in observation_events:
+            uuid.UUID(event["idempotencyKey"])
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert model_provider_usage_sources(flow) == {}
 


### PR DESCRIPTION
## Summary

- centralize normalized-to-billable model category transformation in one Python helper
- derive every atomic input-partition variant from that helper instead of maintaining 12 wire strings by hand
- parameterize source-preserving WebSocket coverage across base, long-context, fast, and long-context-fast billing

## Scope

This is an internal mitm-addon refactor. It does not change wire category strings, usage or observation idempotency inputs, webhook payloads, buffer APIs, normalized model observations, generated contracts, database state, or deployment protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_websocket_usage.py` (31 passed)
- `uv run --no-sync python -m pytest tests/` (5291 passed)

Closes #26517
