### PR TITLE
perf(python): bound sigv4 query-pair cardinality

### DIFF
--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -60,6 +60,12 @@ _RAW_WHITESPACE_CHARS = frozenset(" \t\n\r\f\v")
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
 _DEFAULT_PORTS = {"http": 80, "https": 443}
+# ALB caps the complete request line at 16 KiB; CloudFront and API Gateway
+# impose smaller URL limits. Even one-byte non-empty query pairs require
+# 2 * count - 1 bytes with separators, so this admits every request within
+# those documented front-door limits while bounding synchronous signing work.
+MAX_AWS_SIGV4_QUERY_PAIRS = 8 * 1024
+_RAW_QUERY_PAIR_RE = re.compile(r"[^&]+")
 
 AwsSigV4BodyHash = NewType("AwsSigV4BodyHash", str)
 
@@ -744,6 +750,7 @@ def _parse_query_pairs(query: str) -> list[tuple[str, str]]:
     if not query:
         return []
 
+    _validate_query_pair_count(query)
     pairs: list[tuple[str, str]] = []
     for raw_pair in query.split("&"):
         if not raw_pair:
@@ -751,6 +758,12 @@ def _parse_query_pairs(query: str) -> list[tuple[str, str]]:
         raw_key, _separator, raw_value = raw_pair.partition("=")
         pairs.append((_unquote_query_component(raw_key), _unquote_query_component(raw_value)))
     return pairs
+
+
+def _validate_query_pair_count(query: str) -> None:
+    for pair_count, _match in enumerate(_RAW_QUERY_PAIR_RE.finditer(query), start=1):
+        if pair_count > MAX_AWS_SIGV4_QUERY_PAIRS:
+            raise AwsSigV4SigningError("AWS request has too many query parameters")
 
 
 def _unquote_query_component(value: str) -> str:

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -7,6 +7,7 @@ import pytest
 
 import runtime_url_parsing
 from aws_sigv4 import (
+    MAX_AWS_SIGV4_QUERY_PAIRS,
     AwsSigV4Credentials,
     AwsSigV4SigningError,
     hash_request_body,
@@ -134,6 +135,15 @@ def _presigned_url(
     timestamp: str = DEFAULT_SIGV4_TIMESTAMP,
 ) -> str:
     return aws_sigv4_presigned_url(host, date=timestamp[:8], timestamp=timestamp)
+
+
+def _presigned_url_with_query_pair_count(pair_count: int) -> str:
+    base_url = aws_sigv4_presigned_url(STS_HOST, leading_query="")
+    base_query = urllib.parse.urlsplit(base_url).query
+    base_pair_count = len(base_query.split("&"))
+    assert pair_count >= base_pair_count
+    leading_query = "&".join(("a=",) * (pair_count - base_pair_count))
+    return aws_sigv4_presigned_url(STS_HOST, leading_query=leading_query)
 
 
 _REJECTED_SIGNING_CONTEXTS = (
@@ -414,6 +424,67 @@ def test_presigned_query_preserves_ordinary_pairs() -> None:
         "&X-Amz-SignedHeaders=host"
         "&X-Amz-Signature=9245f52c735ed2e7286981a0013837d6c69b227b74cee0a9611b3f0257fc1c68"
     )
+
+
+@pytest.mark.parametrize(
+    ("pair_count", "accepted"),
+    [
+        (MAX_AWS_SIGV4_QUERY_PAIRS, True),
+        (MAX_AWS_SIGV4_QUERY_PAIRS + 1, False),
+    ],
+    ids=["exact-limit", "over-limit"],
+)
+def test_query_pair_count_boundary(pair_count: int, accepted: bool) -> None:
+    url = _presigned_url_with_query_pair_count(pair_count)
+    parts = urllib.parse.urlsplit(url)
+    assert len(f"{parts.path}?{parts.query}".encode()) < 64 * 1024
+    headers = [("Host", STS_HOST)]
+
+    if accepted:
+        inspection = inspect_request(url=url, headers=headers)
+        signed_url, _signed_headers = sign_request(
+            method="GET",
+            url=url,
+            headers=headers,
+            body=None,
+            credentials=_credentials(),
+            inspection=inspection,
+        )
+        signed_query = urllib.parse.urlsplit(signed_url).query
+        assert len(signed_query.split("&")) == MAX_AWS_SIGV4_QUERY_PAIRS
+        return
+
+    with patch("aws_sigv4._unquote_query_component") as unquote_query_component:
+        with pytest.raises(
+            AwsSigV4SigningError,
+            match=r"^AWS request has too many query parameters$",
+        ):
+            inspect_request(url=url, headers=headers)
+        with pytest.raises(
+            AwsSigV4SigningError,
+            match=r"^AWS request has too many query parameters$",
+        ):
+            sign_request(
+                method="GET",
+                url=url,
+                headers=headers,
+                body=None,
+                credentials=_credentials(),
+            )
+
+    unquote_query_component.assert_not_called()
+
+
+def test_query_pair_count_ignores_empty_segments() -> None:
+    url = aws_sigv4_presigned_url(
+        STS_HOST,
+        leading_query="&" * (MAX_AWS_SIGV4_QUERY_PAIRS + 1),
+    )
+    raw_query = urllib.parse.urlsplit(url).query
+    assert raw_query.count("&") > MAX_AWS_SIGV4_QUERY_PAIRS
+
+    inspection = inspect_request(url=url, headers=[("Host", STS_HOST)])
+    assert inspection.requires_body is True
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -436,6 +436,11 @@ def test_presigned_query_preserves_ordinary_pairs() -> None:
 )
 def test_query_pair_count_boundary(pair_count: int, accepted: bool) -> None:
     url = _presigned_url_with_query_pair_count(pair_count)
+    if not accepted:
+        assert "?a=" in url
+        # %FF has valid percent syntax but invalid UTF-8, so this also proves
+        # the pair-count preflight runs before query-component decoding.
+        url = url.replace("?a=", "?invalid=%FF", 1)
     parts = urllib.parse.urlsplit(url)
     assert len(f"{parts.path}?{parts.query}".encode()) < 64 * 1024
     headers = [("Host", STS_HOST)]
@@ -454,25 +459,22 @@ def test_query_pair_count_boundary(pair_count: int, accepted: bool) -> None:
         assert len(signed_query.split("&")) == MAX_AWS_SIGV4_QUERY_PAIRS
         return
 
-    with patch("aws_sigv4._unquote_query_component") as unquote_query_component:
-        with pytest.raises(
-            AwsSigV4SigningError,
-            match=r"^AWS request has too many query parameters$",
-        ):
-            inspect_request(url=url, headers=headers)
-        with pytest.raises(
-            AwsSigV4SigningError,
-            match=r"^AWS request has too many query parameters$",
-        ):
-            sign_request(
-                method="GET",
-                url=url,
-                headers=headers,
-                body=None,
-                credentials=_credentials(),
-            )
-
-    unquote_query_component.assert_not_called()
+    with pytest.raises(
+        AwsSigV4SigningError,
+        match=r"^AWS request has too many query parameters$",
+    ):
+        inspect_request(url=url, headers=headers)
+    with pytest.raises(
+        AwsSigV4SigningError,
+        match=r"^AWS request has too many query parameters$",
+    ):
+        sign_request(
+            method="GET",
+            url=url,
+            headers=headers,
+            body=None,
+            credentials=_credentials(),
+        )
 
 
 def test_query_pair_count_ignores_empty_segments() -> None:

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 import threading
+import urllib.parse
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -18,7 +19,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
 import request_streaming
-from aws_sigv4 import AwsSigV4BodyHash, hash_request_body
+from aws_sigv4 import MAX_AWS_SIGV4_QUERY_PAIRS, AwsSigV4BodyHash, hash_request_body
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.aws_sigv4_helpers import (
     RESOLVED_AWS_ACCESS_KEY_ID,
@@ -157,6 +158,15 @@ def _header_auth_flow(
             )
         ),
     )
+
+
+def _s3_presigned_query_path_with_pair_count(pair_count: int) -> str:
+    base_path = aws_sigv4_presigned_query_path(service="s3", leading_query="")
+    base_query = urllib.parse.urlsplit(base_path).query
+    base_pair_count = len(base_query.split("&"))
+    assert pair_count >= base_pair_count
+    leading_query = "&".join(("a=",) * (pair_count - base_pair_count))
+    return aws_sigv4_presigned_query_path(service="s3", leading_query=leading_query)
 
 
 def _raw_header_list_size(request_headers: http.Headers) -> int:
@@ -327,6 +337,73 @@ async def test_sigv4_request_target_inspection_boundary(
 
         assert metadata_keys.AWS_SIGV4_REQUEST_INSPECTION not in flow.metadata
         mitm_addon.response(flow)
+
+    get_headers.assert_awaited_once()
+    assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
+
+
+@pytest.mark.parametrize(
+    ("pair_count", "accepted"),
+    [
+        (MAX_AWS_SIGV4_QUERY_PAIRS, True),
+        (MAX_AWS_SIGV4_QUERY_PAIRS + 1, False),
+    ],
+    ids=["exact-limit", "over-limit"],
+)
+async def test_presigned_s3_query_pair_count_inspection_boundary(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    pair_count: int,
+    accepted: bool,
+) -> None:
+    host = "bucket.s3.amazonaws.com"
+    registry_path = _write_aws_registry(tmp_path, base=f"https://{host}")
+    path = _s3_presigned_query_path_with_pair_count(pair_count)
+    assert len(path.encode()) < auth.MAX_AWS_SIGV4_REQUEST_TARGET_BYTES
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host=host,
+        method="GET",
+        path=path,
+        request_headers=headers(
+            ("Host", host),
+            ("Content-Length", "0"),
+        ),
+    )
+    original_url = flow.request.url
+    get_headers = AsyncMock(return_value=_resolved_token_meta())
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        if accepted:
+            await await_requestheaders_result(requestheaders_result)
+            assert flow.response is None
+            assert callable(flow.request.stream)
+            assert f"X-Amz-Credential={RESOLVED_AWS_ACCESS_KEY_ID}%2F" in flow.request.url
+            signed_query = urllib.parse.urlsplit(flow.request.url).query
+            assert len(signed_query.split("&")) == MAX_AWS_SIGV4_QUERY_PAIRS + 1
+            flow.response = http.Response.make(200, b"ok")
+        else:
+            assert requestheaders_result is None
+            assert metadata_keys.AWS_SIGV4_REQUEST_INSPECTION in flow.metadata
+            await mitm_addon.request(flow)
+
+            assert flow.response is not None
+            assert flow.response.status_code == 502
+            assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+            assert flow.response.json()["message"] == ("AWS request has too many query parameters")
+            assert flow.request.url == original_url
+            assert RESOLVED_AWS_ACCESS_KEY_ID not in flow.request.url
+
+        assert metadata_keys.AWS_SIGV4_REQUEST_INSPECTION not in flow.metadata
+        mitm_addon.response(flow)
+        assert metadata_keys.AWS_SIGV4_BODY_ADMISSION not in flow.metadata
 
     get_headers.assert_awaited_once()
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)


### PR DESCRIPTION
## Summary

- cap managed SigV4 input at 8,192 non-empty query pairs, covering the documented ALB 16 KiB request-line ceiling and smaller CloudFront/API Gateway URL ceilings
- reject pair 8,193 before raw query splitting, percent decoding, or decoded pair materialization
- preserve accepted duplicate, blank, bare, empty-segment, ordering, and canonical signature behavior
- cover the public signer boundary and the real S3 request hook's accepted and fail-closed paths

## Behavior and compatibility

The limit counts every non-empty input pair, including `X-Amz-*` fields. Empty `&&` segments remain ignored. Resolved session credentials may add one signer-owned `X-Amz-Security-Token`, so an accepted 8,192-pair input can deterministically produce 8,193 output pairs.

Over-bound managed requests continue through the existing conservative inspection path and finish as local HTTP 502 `aws_sigv4_auth_failed` responses without placing resolved credentials into the request or continuing upstream.

## Exclusions

- no changes to non-SigV4 proxy traffic
- no changes to the existing 64 KiB request-target/header limits or auth hook ownership
- no API, schema, dependency, protocol, migration, environment, feature-switch, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_aws_sigv4.py tests/test_request_handler_aws_sigv4_body.py -q` — 128 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 5,305 passed

Closes #26514
