### PR TITLE
fix(chat): keep skeleton through snapshot hydration

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
@@ -206,9 +206,7 @@ describe("chat event snapshot read", () => {
         parts: [{ type: "text", text: "snapshot prompt" }],
       });
       expect(prompt).not.toHaveProperty("contextType");
-      expect(
-        context.store.get(signals.initialRemoteEventsResolved$),
-      ).toBeTruthy();
+      expect(context.store.get(signals.initialEventsReady$)).toBeTruthy();
       expect(rowRequests).toStrictEqual([3]);
 
       await expect(
@@ -265,9 +263,7 @@ describe("chat event snapshot read", () => {
         { id: assistantEventRow.id, seqId: 2 },
       ]);
       expect(rowRequests).toStrictEqual([0]);
-      expect(
-        context.store.get(signals.initialRemoteEventsResolved$),
-      ).toBeTruthy();
+      expect(context.store.get(signals.initialEventsReady$)).toBeTruthy();
       await expect(
         appDb.get(CHAT_EVENT_ROWS_STORE, assistantEventRow.id),
       ).resolves.toStrictEqual(assistantEventRow);

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
@@ -1,10 +1,4 @@
-import {
-  command,
-  computed,
-  type Command,
-  type Computed,
-  type State,
-} from "ccstate";
+import { command, computed, type Command, type Computed } from "ccstate";
 import type {
   ChatRunOptionsRequest,
   UserMessageInputDocument,
@@ -341,13 +335,11 @@ function createSendChatEvent(
 
 function createChatEventSetup({
   threadId,
-  initialRemoteEventsResolved$,
   initializeIndexedDbEvents$,
   mergePersistentEvents$,
   syncRemoteEvents$,
 }: {
   readonly threadId: string;
-  readonly initialRemoteEventsResolved$: State<boolean>;
   readonly initializeIndexedDbEvents$: Command<Promise<void>, [AbortSignal]>;
   readonly mergePersistentEvents$: Command<
     Promise<void>,
@@ -388,7 +380,6 @@ function createChatEventSetup({
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       signal.throwIfAborted();
       if (get(optimisticCreateUnsettled$)) {
-        set(initialRemoteEventsResolved$, true);
         return;
       }
       await set(syncRemoteEvents$, signal);
@@ -402,7 +393,7 @@ export interface ChatEventSignals {
   readonly threadId: string;
   readonly chatEvents$: Computed<ChatEvent[]>;
   readonly hasOptimisticUserMessage$: Computed<boolean>;
-  readonly initialRemoteEventsResolved$: Computed<boolean>;
+  readonly initialEventsReady$: Computed<boolean>;
   readonly setup$: Command<Promise<void>, [AbortSignal]>;
   readonly catchUp$: Command<Promise<void>, [AbortSignal]>;
   readonly sendEvent$: Command<
@@ -427,19 +418,18 @@ export function createChatEventSignals(threadId: string): ChatEventSignals {
   });
   const setup = createChatEventSetup({
     threadId,
-    initialRemoteEventsResolved$: events.initialRemoteEventsResolved$,
     initializeIndexedDbEvents$: events.initializeIndexedDbEvents$,
     mergePersistentEvents$: events.mergePersistentEvents$,
     syncRemoteEvents$: events.syncRemoteEvents$,
   });
-  const initialRemoteEventsResolved$ = computed((get): boolean => {
-    return get(events.initialRemoteEventsResolved$);
+  const initialEventsReady$ = computed((get): boolean => {
+    return get(events.initialEventsReady$);
   });
   return {
     threadId,
     chatEvents$: events.chatEvents$,
     hasOptimisticUserMessage$: events.hasOptimisticUserMessage$,
-    initialRemoteEventsResolved$,
+    initialEventsReady$,
     ...setup,
     sendEvent$,
   };

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
@@ -168,7 +168,7 @@ interface RemoteSyncDependencies {
   readonly threadId: string;
   readonly persistentEvents$: PersistentChatEvents$;
   readonly hasReachedOldestEvent$: Computed<boolean>;
-  readonly initialRemoteEventsResolved$: State<boolean>;
+  readonly initialEventsReady$: State<boolean>;
   readonly mergePersistentEvents$: Command<
     Promise<void>,
     [PersistedChatEvent[], AbortSignal]
@@ -180,7 +180,7 @@ function createSyncRemoteEventsCommand({
   threadId,
   persistentEvents$,
   hasReachedOldestEvent$,
-  initialRemoteEventsResolved$,
+  initialEventsReady$,
   mergePersistentEvents$,
   dataSource,
 }: RemoteSyncDependencies): Command<Promise<void>, [AbortSignal]> {
@@ -198,22 +198,22 @@ function createSyncRemoteEventsCommand({
     async function syncEventsAfter(): Promise<void> {
       const requestedSinceSeqId = sinceSeqId;
       const isInitialPage = requestedSinceSeqId === undefined;
-      const resolvesInitialRemoteEvents = !get(initialRemoteEventsResolved$);
+      const resolvesInitialEvents = !get(initialEventsReady$);
       const events = await set(
         dataSource.listEventsAfter$,
         { threadId, sinceSeqId: requestedSinceSeqId },
         signal,
       );
       signal.throwIfAborted();
-      if (resolvesInitialRemoteEvents) {
-        set(initialRemoteEventsResolved$, true);
-      }
       L.debug("sync remote events after", {
         threadId,
         sinceSeqId: requestedSinceSeqId ?? null,
         count: events.length,
       });
       if (events.length === 0) {
+        if (resolvesInitialEvents) {
+          set(initialEventsReady$, true);
+        }
         return;
       }
       await set(writeIndexedDbChatEvents$, threadId, events, signal);
@@ -221,6 +221,10 @@ function createSyncRemoteEventsCommand({
       if (isInitialPage) {
         initialPageOldestEvent = events[0]!;
         await mergeEvents(events);
+        signal.throwIfAborted();
+        if (resolvesInitialEvents) {
+          set(initialEventsReady$, true);
+        }
       } else {
         accumulatedEvents.push(...events);
       }
@@ -291,7 +295,7 @@ function createSyncRemoteEventsCommand({
 interface RowSyncDependencies {
   readonly threadId: string;
   readonly persistentEvents$: PersistentChatEvents$;
-  readonly initialRemoteEventsResolved$: State<boolean>;
+  readonly initialEventsReady$: State<boolean>;
   readonly mergePersistentEvents$: Command<
     Promise<void>,
     [PersistedChatEvent[], AbortSignal]
@@ -307,7 +311,7 @@ interface RowSyncDependencies {
 function createSyncRemoteRowsCommand({
   threadId,
   persistentEvents$,
-  initialRemoteEventsResolved$,
+  initialEventsReady$,
   mergePersistentEvents$,
 }: RowSyncDependencies): Command<Promise<void>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
@@ -337,10 +341,10 @@ function createSyncRemoteRowsCommand({
         set(fetchChatEventSnapshotRows$, threadId, signal),
         signal,
       );
-      // The skeleton must resolve even when the snapshot request fails; the
-      // error surfaces through the normal toast path.
-      set(initialRemoteEventsResolved$, true);
       if (!snapshot.ok) {
+        // The skeleton must resolve even when the snapshot request fails; the
+        // error surfaces through the normal toast path.
+        set(initialEventsReady$, true);
         throw snapshot.error;
       }
       if (snapshot.value === null) {
@@ -349,6 +353,7 @@ function createSyncRemoteRowsCommand({
       await set(writeIndexedDbChatEventRows$, snapshot.value.rows, signal);
       signal.throwIfAborted();
       await mergeRows(snapshot.value.rows);
+      set(initialEventsReady$, true);
       return snapshot.value.lastSeqId;
     };
 
@@ -370,9 +375,9 @@ function createSyncRemoteRowsCommand({
     while (shouldLoadNextPage) {
       const page = await set(listRowsAfter$, { threadId, sinceSeqId }, signal);
       signal.throwIfAborted();
-      set(initialRemoteEventsResolved$, true);
       if (page.kind === "expired") {
         if (cursorFromServer) {
+          set(initialEventsReady$, true);
           throw new Error(
             "chat event rows cursor expired right after a cold start",
           );
@@ -388,6 +393,7 @@ function createSyncRemoteRowsCommand({
       signal.throwIfAborted();
       await mergeRows(page.rows);
       signal.throwIfAborted();
+      set(initialEventsReady$, true);
       const lastRow = page.rows.at(-1);
       if (lastRow !== undefined) {
         sinceSeqId = lastRow.seqId;
@@ -445,6 +451,9 @@ export function createChatEventStorageSignals({
     persistentEvents$: persistentChatEvents$,
     optimisticEvents$,
   });
+  // This is presentation readiness, not network readiness. Event-backed
+  // paths set it only after the durable cache and event projections finish.
+  const initialEventsReady$ = state(false);
   const appendOptimisticEvent$: AppendOptimisticEventCommand = command(
     async (
       { set },
@@ -453,6 +462,8 @@ export function createChatEventStorageSignals({
     ): Promise<void> => {
       set(appendOptimisticChatEvent$, createOptimisticChatEventEntry(input));
       await set(notifyChatEventsChanged$, chatEvents$, signal);
+      signal.throwIfAborted();
+      set(initialEventsReady$, true);
     },
   );
   const indexedDbEventCache = createIndexedDbEventCacheSignals(
@@ -483,19 +494,18 @@ export function createChatEventStorageSignals({
   const hasReachedOldestEvent$ = computed((get): boolean => {
     return get(persistentChatEvents$)[0]?.seqId === FIRST_CHAT_EVENT_SEQ_ID;
   });
-  const initialRemoteEventsResolved$ = state(false);
   const syncLegacyRemoteEvents$ = createSyncRemoteEventsCommand({
     threadId,
     persistentEvents$: persistentChatEvents$,
     hasReachedOldestEvent$,
-    initialRemoteEventsResolved$,
+    initialEventsReady$,
     mergePersistentEvents$,
     dataSource,
   });
   const syncRemoteRows$ = createSyncRemoteRowsCommand({
     threadId,
     persistentEvents$: persistentChatEvents$,
-    initialRemoteEventsResolved$,
+    initialEventsReady$,
     mergePersistentEvents$,
   });
   const syncRemoteEvents$ = command(
@@ -522,7 +532,11 @@ export function createChatEventStorageSignals({
       await set(notifyChatEventsChanged$, chatEvents$, signal);
       signal.throwIfAborted();
       if (!result.ok) {
+        set(initialEventsReady$, true);
         throw result.error;
+      }
+      if (get(chatEvents$).length > 0) {
+        set(initialEventsReady$, true);
       }
     },
   );
@@ -530,7 +544,7 @@ export function createChatEventStorageSignals({
   return {
     chatEvents$,
     hasOptimisticUserMessage$,
-    initialRemoteEventsResolved$,
+    initialEventsReady$,
     initializeIndexedDbEvents$,
     mergePersistentEvents$,
     appendOptimisticEvent$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2151,10 +2151,7 @@ function createChatThreadMessagePipeline({
     syncVisibleEventTrees$,
   );
   const chatSkeletonVisible$ = computed((get): boolean => {
-    return (
-      !get(chatEvents.initialRemoteEventsResolved$) &&
-      get(projections.rawEvents$).length === 0
-    );
+    return !get(chatEvents.initialEventsReady$);
   });
   const setup$ = command(
     async ({ set }, signal: AbortSignal): Promise<void> => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatEventRowV4 } from "@vm0/api-contracts/contracts/chat-event-rows";
 import {
   chatThreadArtifactsContract,
   chatThreadByIdContract,
@@ -8,11 +9,13 @@ import {
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroBrowserContract } from "@vm0/api-contracts/contracts/zero-browser";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockOrganization, mockUser } from "../../../__tests__/mock-auth.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
+  CHAT_EVENT_ROWS_STORE,
   CHAT_MESSAGES_STORE,
   CHAT_THREAD_EVENTS_STORE,
   CHAT_THREAD_EVENT_SYNC_STORE,
@@ -112,7 +115,9 @@ async function primeRuntimeChatDb(): Promise<
   return await context.store.get(chatIdb$);
 }
 
-function setupChatPage(): void {
+function setupChatPage(
+  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>,
+): void {
   detachedSetupPage({
     context,
     path: `/chats/${THREAD_ID}`,
@@ -121,6 +126,7 @@ function setupChatPage(): void {
       activeOrg: { id: IDB_ORG_ID, name: "Default Org" },
       memberships: [{ id: IDB_ORG_ID }],
     },
+    featureSwitches,
   });
 }
 
@@ -129,6 +135,7 @@ async function clearCachedChatData(): Promise<void> {
   try {
     const tx = db.transaction(
       [
+        CHAT_EVENT_ROWS_STORE,
         CHAT_MESSAGES_STORE,
         CHAT_THREAD_SNAPSHOT_STORE,
         CHAT_THREAD_EVENTS_STORE,
@@ -136,10 +143,12 @@ async function clearCachedChatData(): Promise<void> {
       ],
       "readwrite",
     );
+    const eventRowsStore = tx.objectStore(CHAT_EVENT_ROWS_STORE);
     const messagesStore = tx.objectStore(CHAT_MESSAGES_STORE);
     const threadSnapshotStore = tx.objectStore(CHAT_THREAD_SNAPSHOT_STORE);
     const threadEventsStore = tx.objectStore(CHAT_THREAD_EVENTS_STORE);
     const threadEventSyncStore = tx.objectStore(CHAT_THREAD_EVENT_SYNC_STORE);
+    const clearEventRows = eventRowsStore.clear.bind(eventRowsStore);
     const clearMessages = messagesStore.clear.bind(messagesStore);
     const clearThreadSnapshot =
       threadSnapshotStore.clear.bind(threadSnapshotStore);
@@ -147,6 +156,7 @@ async function clearCachedChatData(): Promise<void> {
     const clearThreadEventSync =
       threadEventSyncStore.clear.bind(threadEventSyncStore);
     await Promise.all([
+      clearEventRows(),
       clearMessages(),
       clearThreadSnapshot(),
       clearThreadEvents(),
@@ -978,6 +988,112 @@ describe("okou chat thread IndexedDB fallback", () => {
     } finally {
       if (!initialMessageList.settled()) {
         initialMessageList.resolve();
+      }
+      runtimeDb.close();
+    }
+  });
+
+  it("keeps the skeleton visible through the snapshot render handoff", async () => {
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    mockSidebarThread();
+    const runtimeDb = await primeRuntimeChatDb();
+    const snapshotUrl =
+      "https://r2.example.com/chat-events/loading-handoff.ndjson.gz";
+    const snapshotBodyRequested = context.mocks.deferred<void>();
+    const releaseSnapshotBody = context.mocks.deferred<void>();
+    const snapshotRows = [
+      {
+        id: "00000000-0000-4000-8000-000000000201",
+        chatThreadId: THREAD_ID,
+        runId: null,
+        revokesEventId: null,
+        eventType: "input.prompt",
+        payload: {
+          userMessage: {
+            version: 1,
+            parts: [{ type: "text", text: USER_MESSAGE }],
+          },
+        },
+        contextType: "web",
+        contextId: null,
+        runEventSequenceNumber: null,
+        runEventId: null,
+        seqId: 1,
+        createdAt: "2026-08-12T06:22:00.000Z",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000202",
+        chatThreadId: THREAD_ID,
+        runId: null,
+        revokesEventId: null,
+        eventType: "output.message",
+        payload: { content: ASSISTANT_MESSAGE },
+        contextType: null,
+        contextId: null,
+        runEventSequenceNumber: null,
+        runEventId: null,
+        seqId: 2,
+        createdAt: "2026-08-12T06:22:01.000Z",
+      },
+    ] satisfies ChatEventRowV4[];
+
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(200, {
+        url: snapshotUrl,
+        expiresInSeconds: 900,
+        lastSeqId: 2,
+      });
+    });
+    context.mocks.http.get(snapshotUrl, async () => {
+      snapshotBodyRequested.resolve();
+      await releaseSnapshotBody.promise;
+      return new Response(
+        `${snapshotRows
+          .map((row) => {
+            return JSON.stringify(row);
+          })
+          .join("\n")}\n`,
+      );
+    });
+    context.mocks.api(chatThreadEventsContract.rows, ({ respond }) => {
+      return respond(200, { rows: [] });
+    });
+    context.mocks.api(chatThreadEventsContract.list, () => {
+      throw new Error("projected events endpoint must not be called");
+    });
+
+    let uncoveredLoadingGap = false;
+    const observer = new MutationObserver(() => {
+      if (
+        document.querySelector("[data-chat-skeleton]") === null &&
+        screen.queryByText(USER_MESSAGE) === null
+      ) {
+        uncoveredLoadingGap = true;
+      }
+    });
+    try {
+      setupChatPage({ [FeatureSwitchKey.ChatEventSnapshotRead]: true });
+      await snapshotBodyRequested.promise;
+
+      await waitFor(() => {
+        expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      releaseSnapshotBody.resolve();
+
+      await expect(
+        screen.findByText(USER_MESSAGE),
+      ).resolves.toBeInTheDocument();
+      await expect(
+        screen.findByText(ASSISTANT_MESSAGE),
+      ).resolves.toBeInTheDocument();
+      expect(uncoveredLoadingGap).toBeFalsy();
+    } finally {
+      observer.disconnect();
+      if (!releaseSnapshotBody.settled()) {
+        releaseSnapshotBody.resolve();
       }
       runtimeDb.close();
     }


### PR DESCRIPTION
## Summary

- replace remote-request completion with a presentation-readiness signal for the initial chat handoff
- keep the skeleton mounted until snapshot or row events are persisted to IndexedDB and the visible event projection has finished
- preserve the fast path for cached and optimistic events, and add a page-level regression test for the transient empty state

## Root cause

With ChatEventSnapshotRead enabled, the reader resolved initial loading as soon as the remote response arrived. The skeleton also had a raw-events shortcut, while visible rendered groups were still being prepared asynchronously. That allowed the empty-chat state to commit between the skeleton and the message list.

The new integration test fails on main by observing a DOM mutation where neither the skeleton nor the first message is present. It passes after the readiness handoff moves behind IndexedDB persistence and event projection.

## Verification

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged workspace, Platform, and API type checks
- Platform Vitest: chat-event-snapshot-read.test.ts (9 passed)
- Platform Vitest: zero-chat-thread-idb.test.tsx targeted skeleton cases (3 passed)
- Platform Vitest: chat-lifecycle.test.tsx optimistic message case (1 passed)