### PR TITLE
fix(platform): show invitation redirect feedback

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2524,6 +2524,18 @@
       "degraded": "Bei Live-Updates ist ein Problem aufgetreten. Bitte aktualisieren Sie die Seite."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "Einladung für ein anderes Konto angenommen"
+    },
+    "actions": {
+      "switchAccount": "Konto wechseln",
+      "switchWorkspace": "Arbeitsbereich wechseln"
+    },
+    "success": {
+      "title": "Einladung für {{workspace}} angenommen"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "Abbestellen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2524,6 +2524,18 @@
       "degraded": "Live updates ran into a problem. Please refresh the page."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "Invitation accepted for another account"
+    },
+    "actions": {
+      "switchAccount": "Switch account",
+      "switchWorkspace": "Switch workspace"
+    },
+    "success": {
+      "title": "Invitation accepted for {{workspace}}"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "Unsubscribe",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2567,6 +2567,18 @@
       "degraded": "Se produjo un problema con las actualizaciones en directo. Actualiza la página."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "Invitación aceptada para otra cuenta"
+    },
+    "actions": {
+      "switchAccount": "Cambiar de cuenta",
+      "switchWorkspace": "Cambiar de espacio de trabajo"
+    },
+    "success": {
+      "title": "Invitación a {{workspace}} aceptada"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "Cancelar suscripción",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2567,6 +2567,18 @@
       "degraded": "Les mises à jour en direct ont rencontré un problème. Veuillez actualiser la page."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "Invitation acceptée pour un autre compte"
+    },
+    "actions": {
+      "switchAccount": "Changer de compte",
+      "switchWorkspace": "Changer d'espace de travail"
+    },
+    "success": {
+      "title": "Invitation à {{workspace}} acceptée"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "Se désabonner",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2524,6 +2524,18 @@
       "degraded": "लाइव अपडेट में समस्या आई। कृपया पृष्ठ को ताज़ा करें."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "किसी अन्य खाते के लिए आमंत्रण स्वीकार किया गया"
+    },
+    "actions": {
+      "switchAccount": "खाता बदलें",
+      "switchWorkspace": "वर्कस्पेस बदलें"
+    },
+    "success": {
+      "title": "{{workspace}} का आमंत्रण स्वीकार किया गया"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "सदस्यता रद्द",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2523,6 +2523,18 @@
       "degraded": "Pembaruan langsung mengalami masalah. Segarkan halaman."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "Undangan diterima untuk akun lain"
+    },
+    "actions": {
+      "switchAccount": "Ganti akun",
+      "switchWorkspace": "Ganti ruang kerja"
+    },
+    "success": {
+      "title": "Undangan untuk {{workspace}} diterima"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "Berhenti berlangganan",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2567,6 +2567,18 @@
       "degraded": "Gli aggiornamenti in tempo reale hanno riscontrato un problema. Aggiorna la pagina."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "Invito accettato per un altro account"
+    },
+    "actions": {
+      "switchAccount": "Cambia account",
+      "switchWorkspace": "Cambia area di lavoro"
+    },
+    "success": {
+      "title": "Invito per {{workspace}} accettato"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "Annulla l'iscrizione",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2523,6 +2523,18 @@
       "degraded": "ライブアップデートで問題が発生しました。ページを更新してください。"
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "別のアカウントで招待を承諾しました"
+    },
+    "actions": {
+      "switchAccount": "アカウントを切り替える",
+      "switchWorkspace": "ワークスペースを切り替える"
+    },
+    "success": {
+      "title": "{{workspace}} への招待を承諾しました"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "購読を解除する",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2523,6 +2523,18 @@
       "degraded": "실시간 업데이트에 문제가 발생했습니다. 페이지를 새로고침하세요."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "다른 계정으로 초대를 수락했습니다"
+    },
+    "actions": {
+      "switchAccount": "계정 전환",
+      "switchWorkspace": "워크스페이스 전환"
+    },
+    "success": {
+      "title": "{{workspace}} 초대를 수락했습니다"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "구독 취소",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2567,6 +2567,18 @@
       "degraded": "As atualizações em tempo real encontraram um problema. Atualize a página."
     }
   },
+  "invitationRedirect": {
+    "accountMismatch": {
+      "title": "Convite aceito para outra conta"
+    },
+    "actions": {
+      "switchAccount": "Trocar de conta",
+      "switchWorkspace": "Trocar de espaço de trabalho"
+    },
+    "success": {
+      "title": "Convite para {{workspace}} aceito"
+    }
+  },
   "lifecycle": {
     "emailUnsubscribe": {
       "action": "Cancelar inscrição",

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -84,6 +84,7 @@ import { setupSharedThreadPage$ } from "./shared-thread-page/shared-thread-page-
 import { setupGlobalKeyboardShortcuts$ } from "./zero-page/zero-nav.ts";
 import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
 import { checkUnifiedSettingsParam$ } from "./zero-page/settings/settings-dialog.ts";
+import { captureInvitationRedirect$ } from "./invitation-redirect.ts";
 
 const setupNotFoundPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(NotFoundPage));
@@ -443,6 +444,7 @@ const setupNotificationListener$ = command(({ set }, signal: AbortSignal) => {
 
 export const bootstrap$ = command(
   async ({ set }, render: () => void, signal: AbortSignal) => {
+    set(captureInvitationRedirect$);
     await set(initLocale$, signal);
     signal.throwIfAborted();
     set(initTheme$);

--- a/turbo/apps/platform/src/signals/invitation-redirect.ts
+++ b/turbo/apps/platform/src/signals/invitation-redirect.ts
@@ -1,0 +1,153 @@
+import { command, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { clerk$ } from "./auth.ts";
+import { replaceSearchParams$, searchParams$ } from "./route.ts";
+import { jsonParseOr, onDomEventFn } from "./utils.ts";
+import { i18n } from "../i18n/index.ts";
+
+const CLERK_STATUS_PARAM = "__clerk_status";
+const CLERK_TICKET_PARAM = "__clerk_ticket";
+const INVITATION_ACTION_CLASS_NAMES = {
+  actionButton: "underline-offset-4 hover:underline active:opacity-80",
+} as const;
+const INVITATION_ACTION_STYLE = {
+  background: "transparent",
+  color: "hsl(var(--primary))",
+  fontSize: "inherit",
+  height: "auto",
+  lineHeight: "1.5",
+  padding: 0,
+} as const;
+
+interface InvitationRedirect {
+  readonly organizationId: string;
+}
+
+const internalInvitationRedirect$ = state<InvitationRedirect | null>(null);
+
+function organizationIdFromTicket(ticket: string): string | null {
+  const parts = ticket.split(".");
+  const encodedPayload = parts.length === 3 ? parts[1] : undefined;
+  if (!encodedPayload) {
+    return null;
+  }
+  if (
+    !/^[A-Za-z0-9_-]+$/u.test(encodedPayload) ||
+    encodedPayload.length % 4 === 1
+  ) {
+    return null;
+  }
+
+  const base64Payload = encodedPayload
+    .replaceAll("-", "+")
+    .replaceAll("_", "/")
+    .padEnd(Math.ceil(encodedPayload.length / 4) * 4, "=");
+
+  const payload = jsonParseOr<unknown>(atob(base64Payload), null);
+  if (
+    payload !== null &&
+    typeof payload === "object" &&
+    "st" in payload &&
+    payload.st === "organization_invitation" &&
+    "oid" in payload &&
+    typeof payload.oid === "string" &&
+    payload.oid.length > 0
+  ) {
+    return payload.oid;
+  }
+
+  return null;
+}
+
+/**
+ * Capture a completed Clerk organization-invitation redirect before route
+ * analytics run, retaining only the target organization ID needed for UI.
+ */
+export const captureInvitationRedirect$ = command(({ get, set }) => {
+  const searchParams = new URLSearchParams(get(searchParams$));
+  if (searchParams.get(CLERK_STATUS_PARAM) !== "complete") {
+    return;
+  }
+
+  const ticket = searchParams.get(CLERK_TICKET_PARAM);
+  searchParams.delete(CLERK_STATUS_PARAM);
+  searchParams.delete(CLERK_TICKET_PARAM);
+  set(replaceSearchParams$, searchParams);
+
+  if (!ticket) {
+    return;
+  }
+
+  const organizationId = organizationIdFromTicket(ticket);
+  if (organizationId) {
+    set(internalInvitationRedirect$, { organizationId });
+  }
+});
+
+export const handleInvitationRedirect$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const redirect = get(internalInvitationRedirect$);
+    set(internalInvitationRedirect$, null);
+    if (!redirect) {
+      return;
+    }
+
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+
+    // The ticket payload only identifies the target. Current Clerk membership
+    // is the authoritative signal that the active account accepted the invite.
+    const membership = clerk.user?.organizationMemberships.find((item) => {
+      return item.organization.id === redirect.organizationId;
+    });
+
+    if (membership) {
+      const title = i18n.t(
+        ($) => {
+          return $.invitationRedirect.success.title;
+        },
+        { workspace: membership.organization.name },
+      );
+
+      if (clerk.organization?.id === redirect.organizationId) {
+        toast.success(title);
+        return;
+      }
+
+      toast.success(title, {
+        actionButtonStyle: INVITATION_ACTION_STYLE,
+        classNames: INVITATION_ACTION_CLASS_NAMES,
+        action: {
+          label: i18n.t(($) => {
+            return $.invitationRedirect.actions.switchWorkspace;
+          }),
+          onClick: onDomEventFn(async () => {
+            await clerk.setActive({ organization: redirect.organizationId });
+          }),
+        },
+      });
+      return;
+    }
+
+    toast.success(
+      i18n.t(($) => {
+        return $.invitationRedirect.accountMismatch.title;
+      }),
+      {
+        actionButtonStyle: INVITATION_ACTION_STYLE,
+        classNames: INVITATION_ACTION_CLASS_NAMES,
+        action: {
+          label: i18n.t(($) => {
+            return $.invitationRedirect.actions.switchAccount;
+          }),
+          onClick: onDomEventFn(async () => {
+            await clerk.openSignIn({
+              fallbackRedirectUrl: "/",
+              forceRedirectUrl: "/",
+            });
+          }),
+        },
+      },
+    );
+  },
+);

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import type { Store } from "ccstate";
-import { StoreProvider, useSet } from "ccstate-react";
+import { StoreProvider, useGet, useSet } from "ccstate-react";
 import { Toaster } from "@vm0/ui/components/ui/sonner";
 import { ErrorBoundary } from "./error-boundary.tsx";
 import { AppSkeletonOverlay, Router } from "./router.tsx";
@@ -10,6 +10,7 @@ import { InspectLogFileInput } from "./inspect-log-file-input.tsx";
 import { listenForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
 import { setupAuthenticatedDaemons$ } from "../signals/authenticated-daemons.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
+import { handleInvitationRedirect$ } from "../signals/invitation-redirect.ts";
 import { handleBillingRedirect$ } from "../signals/zero-page/billing.ts";
 import { detach, Reason } from "../signals/utils.ts";
 import {
@@ -19,15 +20,26 @@ import {
 import { IN_VITEST } from "../env.ts";
 import "./css/index.css";
 
-function BillingToaster() {
+function AppToaster() {
+  const signal = useGet(rootSignal$);
   const handleBillingRedirect = useSet(handleBillingRedirect$);
+  const handleInvitationRedirect = useSet(handleInvitationRedirect$);
+
+  const handleReady = () => {
+    handleBillingRedirect();
+    detach(
+      handleInvitationRedirect(signal),
+      Reason.DomCallback,
+      "invitation-redirect",
+    );
+  };
 
   return (
     <Toaster
       position="top-center"
       visibleToasts={1}
       duration={IN_VITEST ? Infinity : undefined}
-      onReady={handleBillingRedirect}
+      onReady={handleReady}
     />
   );
 }
@@ -60,7 +72,7 @@ export const setupRouter = (
           <InspectLogFileInput />
           <ForceUpgradeDialog />
         </ErrorBoundary>
-        <BillingToaster />
+        <AppToaster />
       </StoreProvider>
     </StrictMode>,
   );

--- a/turbo/apps/platform/src/views/router/__tests__/invitation-redirect-toast.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/invitation-redirect-toast.test.tsx
@@ -1,0 +1,128 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { search } from "../../../signals/location.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function base64Url(value: object): string {
+  return btoa(JSON.stringify(value))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+function invitationPath(organizationId: string): string {
+  const ticket = `${base64Url({ alg: "RS256", typ: "JWT" })}.${base64Url({
+    oid: organizationId,
+    st: "organization_invitation",
+  })}.test-signature`;
+  const searchParams = new URLSearchParams({
+    __clerk_status: "complete",
+    __clerk_ticket: ticket,
+    source: "invitation-test",
+  });
+  return `/?${searchParams.toString()}`;
+}
+
+describe("organization invitation redirect toast", () => {
+  it("offers to switch workspaces when the current account accepted the invitation", async () => {
+    detachedSetupPage({
+      context,
+      path: invitationPath("org_invited"),
+      user: {
+        id: "user_invited",
+        fullName: "Invited User",
+        email: "invited@example.test",
+      },
+      org: {
+        activeOrg: { id: "org_current", name: "Current Workspace" },
+        memberships: [
+          {
+            id: "orgmem_current",
+            organization: { id: "org_current", name: "Current Workspace" },
+          },
+          {
+            id: "orgmem_invited",
+            organization: {
+              id: "org_invited",
+              name: "Invited Workspace",
+            },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      const searchParams = new URLSearchParams(search());
+      expect(searchParams.has("__clerk_status")).toBeFalsy();
+      expect(searchParams.has("__clerk_ticket")).toBeFalsy();
+      expect(searchParams.get("source")).toBe("invitation-test");
+    });
+    const successTitle = await screen.findByText(
+      "Invitation accepted for Invited Workspace",
+    );
+    expect(successTitle).toBeInTheDocument();
+    expect(
+      screen.getByText("Switch workspace", {
+        selector: "button[data-action]",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers to switch accounts when the active account is not the invitee", async () => {
+    detachedSetupPage({
+      context,
+      path: invitationPath("org_invited"),
+      user: {
+        id: "user_current",
+        fullName: "Current User",
+        email: "current@example.test",
+      },
+      org: {
+        activeOrg: { id: "org_current", name: "Current Workspace" },
+        memberships: [
+          {
+            id: "orgmem_current",
+            organization: { id: "org_current", name: "Current Workspace" },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      const searchParams = new URLSearchParams(search());
+      expect(searchParams.has("__clerk_status")).toBeFalsy();
+      expect(searchParams.has("__clerk_ticket")).toBeFalsy();
+    });
+    const mismatchTitle = await screen.findByText(
+      "Invitation accepted for another account",
+    );
+    expect(mismatchTitle).toBeInTheDocument();
+    expect(
+      screen.getByText("Switch account", { selector: "button[data-action]" }),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves unfinished Clerk invitation redirects untouched", async () => {
+    detachedSetupPage({
+      context,
+      path: invitationPath("org_invited").replace(
+        "__clerk_status=complete",
+        "__clerk_status=sign_in",
+      ),
+    });
+
+    await waitFor(() => {
+      const searchParams = new URLSearchParams(search());
+      expect(searchParams.get("__clerk_status")).toBe("sign_in");
+      expect(searchParams.has("__clerk_ticket")).toBeTruthy();
+    });
+    expect(screen.queryByText("Invitation accepted")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Invitation accepted for another account"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Toaster, toast } from "../sonner";
 
 describe("Toaster", () => {
@@ -40,5 +40,20 @@ describe("Toaster", () => {
     expect(
       (toaster as HTMLElement).style.getPropertyValue("--mobile-offset-bottom"),
     ).toBe("calc(var(--sab, 0px) + 16px)");
+  });
+
+  it("calls onReady only once when its callback identity changes", async () => {
+    const firstOnReady = vi.fn<() => void>();
+    const secondOnReady = vi.fn<() => void>();
+    const { rerender } = render(<Toaster onReady={firstOnReady} />);
+
+    await waitFor(() => {
+      expect(firstOnReady).toHaveBeenCalledOnce();
+    });
+    rerender(<Toaster onReady={secondOnReady} />);
+
+    await waitFor(() => {
+      expect(secondOnReady).not.toHaveBeenCalled();
+    });
   });
 });

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Toaster as Sonner, toast } from "sonner";
 
@@ -19,9 +19,11 @@ const DEFAULT_TOASTER_MOBILE_OFFSET = {
 } satisfies ToasterProps["mobileOffset"];
 
 function ToasterReady({ onReady }: { readonly onReady: () => void }) {
+  const initialOnReadyRef = useRef(onReady);
+
   useEffect(() => {
-    onReady();
-  }, [onReady]);
+    initialOnReadyRef.current();
+  }, []);
 
   return null;
 }


### PR DESCRIPTION
## Summary

- show a single-line success toast after a completed Clerk organization invitation redirect
- use lightweight primary-color link actions to switch to the invited workspace or another account
- show a single-line account-mismatch toast when the active account does not belong to the invited workspace
- remove completed Clerk invitation parameters before route analytics while leaving unfinished sign-in/sign-up redirects untouched
- make the shared Toaster `onReady` callback mount-only so redirect feedback is not replaced during app re-renders
- localize the new feedback across all supported platform locales

## Testing

- `pnpm --filter @vm0/app exec vitest run src/views/router/__tests__/invitation-redirect-toast.test.tsx`
- `pnpm --filter @vm0/ui exec vitest run src/components/ui/__tests__/sonner.test.tsx`
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/ui check-types`
- `pnpm --filter @vm0/app i18n:check`
- `pnpm --filter @vm0/app lint:static-assets`
- `pnpm --filter @vm0/app lint:localized-ui`
- `pnpm --filter @vm0/ui lint`
- platform `oxlint`, type-aware `oxlint`, and `eslint`