### PR TITLE
test(api): split agentphone media session timeout

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -734,9 +734,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(sends.messages).toHaveLength(sendsAfterCompletion);
   });
 
-  it("renders media prompts, provider recent history, and restarts sessions when the model route changes", async () => {
+  it("renders media prompts", async () => {
     const ap = createAgentPhoneBddApi(context);
-    const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
+    const { phone, runnerGroup } = await entitledLinkedActor();
 
     // A media DM walks both percent-decode branches of the filename.
     const mediaMessageId = await ap.postAgentPhoneInboundMessage({
@@ -752,10 +752,23 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
         `[AgentPhone file] photo one+final%2zraw.png (image/png)\n   [ID] ${mediaMessageId}`,
       ].join("\n\n"),
     );
+    await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
+  });
+
+  it("renders provider recent history and reuses the linked session", async () => {
+    const ap = createAgentPhoneBddApi(context);
+    const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
+
+    await ap.postAgentPhoneInboundMessage({
+      channel: "sms",
+      from: phone,
+      body: "establish history session",
+    });
+    const run1 = await claimDispatchedRun(runnerGroup);
     const beforeRun1Completion = sends.messages.length;
     await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
     await waitForSendCount(sends, beforeRun1Completion + 1);
-    const mediaSession = await waitForRunSessionIdPresent(actor, run1.runId);
+    const historySession = await waitForRunSessionIdPresent(actor, run1.runId);
 
     // Provider-sent recent history wins over stored context: full entries
     // keep channel and timestamp lines, media-only entries become file
@@ -795,7 +808,21 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     const beforeRun2Completion = sends.messages.length;
     await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
     await waitForSendCount(sends, beforeRun2Completion + 1);
-    await waitForRunSessionId(actor, run2.runId, mediaSession);
+    await waitForRunSessionId(actor, run2.runId, historySession);
+  });
+
+  it("restarts linked sessions when the model route changes", async () => {
+    const ap = createAgentPhoneBddApi(context);
+    const { actor, phone, runnerGroup } = await entitledLinkedActor();
+
+    await ap.postAgentPhoneInboundMessage({
+      channel: "sms",
+      from: phone,
+      body: "establish model session",
+    });
+    const run1 = await claimDispatchedRun(runnerGroup);
+    await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
+    const originalSession = await waitForRunSessionIdPresent(actor, run1.runId);
 
     // Re-pointing the default model policy at an incompatible provider
     // forces the next DM onto a fresh session.
@@ -805,10 +832,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       from: phone,
       body: "after provider switch",
     });
-    const run3 = await claimDispatchedRun(runnerGroup);
-    await completeSandboxRun(run3.sandboxToken, run3.runId, 0);
-    await expect(ap.readRunSessionId(actor, run3.runId)).resolves.not.toBe(
-      mediaSession,
+    const run2 = await claimDispatchedRun(runnerGroup);
+    await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
+    await expect(ap.readRunSessionId(actor, run2.runId)).resolves.not.toBe(
+      originalSession,
     );
   });
 


### PR DESCRIPTION
## Summary

- split the compound AgentPhone media/history/model-route scenario into three independently seeded integration tests
- preserve the media prompt, provider recent-history, linked-session reuse, and model-route restart assertions
- keep the production contract unchanged without retries, sleeps, timeout increases, or weakened assertions

## Root cause

The first causal failure in [Turbo run 31572040519](https://github.com/vm0-ai/vm0/actions/runs/31572040519), [test-api (4)](https://github.com/vm0-ai/vm0/actions/runs/31572040519/job/94035972681), was the compound `INT-03` test timing out at 5,006 ms.

This is a test-isolation/time-budget flake:

- the exact test passed in 843 ms, 750 ms, and 949 ms in three nearby runs, including two earlier merge-group runs for PR #26477
- the failing log shows all three dispatched runs continuing to complete in order, with the final completion landing at the five-second boundary; there is no stalled async gate or teardown error before the timeout
- the whole test file slowed to 17.6 seconds in the failing shard versus 6.8-7.6 seconds in the passing shards
- the test and shared run helper have identical Git blobs across the failing SHA and the passing merge-group SHAs; PR #26477 does not modify either file

The later `Job not found in queue` failure occurred only after the timed-out async test continued into the next case, so it is downstream contamination rather than the first failure.

## Fix

Each logical scenario now owns a fresh linked actor, phone, runner group, and queue state:

1. media prompt rendering
2. provider recent-history rendering plus linked-session reuse
3. model-route changes forcing a fresh linked session

This gives each existing business invariant its own normal test budget and prevents a timeout in one compound scenario from leaking queue work into the next test.

## Validation

- full `agentphone.bdd.test.ts` file passed 5/5 times against five independently cloned migrated PostgreSQL databases (`15/15` tests each)
- `pnpm -F api run check-types`
- `pnpm -F api run lint`
- `pnpm knip --workspace api`
- Prettier check for the changed file
- targeted Oxlint, type-aware Oxlint, and ESLint for the changed file
- `git diff --check`

Preview validation is not applicable because this PR changes only test isolation and has no deployed runtime or UI surface.
