### PR TITLE
fix(ci): make clerk test cleanup generation-safe

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -16,6 +16,11 @@ if [[ "$generated_email" != "pr-123+clerk_test+8000-2+browser@vm0-e2e.ai" ]]; th
   echo "browser helper did not generate the canonical account" >&2
   exit 1
 fi
+if JOB_REF="invalid_ref" bash -c \
+  'source "$1"; generate_test_email' _ "$browser_helper" >/dev/null 2>&1; then
+  echo "browser helper accepted a JOB_REF that its cleanup rejects" >&2
+  exit 1
+fi
 if [[ "$(grep -c '^[[:space:]]*delete_e2e_account_if_exists' "$browser_test")" -ne 2 ]]; then
   echo "browser E2E must clean its exact account before and after the test" >&2
   exit 1

--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+browser_helper="${repo_root}/e2e/helpers/browser.bash"
+browser_test="${repo_root}/e2e/tests/02-browser/brw-t01-platform-e2e.bats"
+
+generated_email="$(
+  JOB_REF="pr-123" \
+    GITHUB_RUN_ID="8000" \
+    GITHUB_RUN_ATTEMPT="2" \
+    bash -c 'source "$1"; generate_test_email' _ "$browser_helper"
+)"
+if [[ "$generated_email" != "pr-123+clerk_test+8000-2+browser@vm0-e2e.ai" ]]; then
+  echo "browser helper did not generate the canonical account" >&2
+  exit 1
+fi
+if [[ "$(grep -c '^[[:space:]]*delete_e2e_account_if_exists' "$browser_test")" -ne 2 ]]; then
+  echo "browser E2E must clean its exact account before and after the test" >&2
+  exit 1
+fi
+
+ruby -ryaml - \
+  "${repo_root}/.github/workflows/turbo.yml" \
+  "${repo_root}/.github/workflows/cleanup.yml" \
+  "${repo_root}/.github/workflows/cleanup-stale.yml" <<'RUBY'
+turbo = YAML.load_file(ARGV.fetch(0))
+cleanup = YAML.load_file(ARGV.fetch(1))
+stale = YAML.load_file(ARGV.fetch(2))
+
+turbo_jobs = turbo.fetch("jobs")
+browser = turbo_jobs.fetch("cli-e2e-02-browser")
+browser_steps = browser.fetch("steps")
+browser_run = browser_steps.find { |step| step["name"] == "Run browser E2E tests" }
+browser_cleanup = browser_steps.find { |step| step["name"] == "Cleanup browser E2E account" }
+raise "missing browser E2E execution" unless browser_run
+raise "missing browser E2E account finalizer" unless browser_cleanup
+
+expected_browser_email = "${{ needs.prepare.outputs.job-ref }}+clerk_test+${{ github.run_id }}-${{ github.run_attempt }}+browser@vm0-e2e.ai"
+unless browser_run.dig("env", "E2E_ACCOUNT") == expected_browser_email &&
+    browser_cleanup.dig("env", "E2E_ACCOUNT") == expected_browser_email
+  raise "browser account must be scoped to the current run and attempt"
+end
+unless browser_cleanup.fetch("if") == "always()" &&
+    browser_cleanup.fetch("run").include?("delete_e2e_account_if_exists")
+  raise "browser account cleanup must always use the exact shared helper"
+end
+
+playwright = turbo_jobs.fetch("cli-e2e-02-playwright")
+playwright_cleanup = playwright.fetch("steps").find do |step|
+  step["name"] == "Cleanup Playwright E2E accounts"
+end
+raise "missing Playwright E2E account finalizer" unless playwright_cleanup
+unless playwright_cleanup.fetch("if") == "always()" &&
+    playwright_cleanup.fetch("run").include?("cleanup-generation playwright,paid-onboarding")
+  raise "Playwright cleanup must always target only its current-generation roles"
+end
+
+runner_cleanup = turbo_jobs.fetch("cli-e2e-03-runner-cleanup")
+runner_condition = runner_cleanup.fetch("if")
+unless runner_condition.include?("always()") &&
+    !runner_condition.include?("!= 'cancelled'")
+  raise "runner cleanup must remain eligible after cancelled preparation"
+end
+runner_cleanup_step = runner_cleanup.fetch("steps").find do |step|
+  step["name"] == "Cleanup runner E2E accounts"
+end
+raise "missing runner E2E account finalizer" unless runner_cleanup_step
+unless runner_cleanup_step.fetch("run").end_with?("runner-account.ts cleanup")
+  raise "runner cleanup must use generation reconciliation"
+end
+legacy_output_environment = %w[
+  E2E_RUNNER_ORGANIZATION_ID
+  E2E_RUNNER_CODEX_ORGANIZATION_ID
+  E2E_RUNNER_CLAUDE_ORGANIZATION_ID
+]
+if legacy_output_environment.any? { |name| runner_cleanup_step.fetch("env", {}).key?(name) }
+  raise "runner cleanup must not depend on complete preparation outputs"
+end
+
+closed_pr_cleanup = cleanup.fetch("jobs").fetch("cleanup-clerk-test-resources")
+unless closed_pr_cleanup.dig("permissions", "contents") == "read"
+  raise "closed-PR Clerk cleanup must use read-only repository permissions"
+end
+closed_pr_checkout = closed_pr_cleanup.fetch("steps").find do |step|
+  step.fetch("uses", "").start_with?("actions/checkout@")
+end
+raise "missing trusted checkout for closed-PR Clerk cleanup" unless closed_pr_checkout
+unless closed_pr_checkout.dig("with", "ref") == "${{ github.event.repository.default_branch }}" &&
+    closed_pr_checkout.dig("with", "persist-credentials") == false
+  raise "closed-PR Clerk cleanup must execute credential-free default-branch code"
+end
+closed_pr_step = closed_pr_cleanup.fetch("steps").find do |step|
+  step["name"] == "Delete Clerk test resources for closed PR"
+end
+raise "missing closed-PR Clerk cleanup command" unless closed_pr_step
+unless closed_pr_step.fetch("run").end_with?("clerk-test-resources.ts cleanup-job-ref") &&
+    closed_pr_step.dig("env", "JOB_REF") == "pr-${{ github.event.pull_request.number }}"
+  raise "closed-PR cleanup must use the tested strict JOB_REF selector"
+end
+
+stale_jobs = stale.fetch("jobs")
+stale_cleanup = stale_jobs.fetch("cleanup-clerk-test-resources")
+unless stale_cleanup.dig("permissions", "contents") == "read"
+  raise "stale Clerk cleanup must use read-only repository permissions"
+end
+if stale_jobs.key?("cleanup-clerk-test-users") || stale_jobs.key?("cleanup-clerk-empty-orgs")
+  raise "legacy Clerk cleanup jobs must be removed"
+end
+stale_checkout = stale_cleanup.fetch("steps").find do |step|
+  step.fetch("uses", "").start_with?("actions/checkout@")
+end
+raise "missing trusted checkout for stale Clerk cleanup" unless stale_checkout
+unless stale_checkout.dig("with", "ref") == "${{ github.event.repository.default_branch }}" &&
+    stale_checkout.dig("with", "persist-credentials") == false
+  raise "stale Clerk cleanup must execute credential-free default-branch code"
+end
+stale_step = stale_cleanup.fetch("steps").find do |step|
+  step["name"] == "Delete stale marked Clerk test resources"
+end
+raise "missing stale Clerk cleanup command" unless stale_step
+unless stale_step.fetch("run").include?("cleanup-stale --older-than-hours 6") &&
+    stale_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
+  raise "stale Clerk cleanup must retain the six-hour marker gate and dry-run"
+end
+
+cleanup_sources = [File.read(ARGV.fetch(1)), File.read(ARGV.fetch(2))].join("\n")
+if cleanup_sources.include?("api.clerk.com") ||
+    cleanup_sources.include?("memberships?limit=1")
+  raise "untested legacy Clerk deletion logic remains in maintenance workflows"
+end
+RUBY
+
+echo "clerk-test-resource-workflow-test: ok"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -321,13 +321,16 @@ end
 unless cleanup_step.fetch("run").end_with?("runner-account.ts cleanup")
   raise "runner E2E account cleanup must use the shared lifecycle entry point"
 end
+if account_cleanup.fetch("if").include?("!= 'cancelled'")
+  raise "runner E2E cleanup must run after cancelled account preparation"
+end
 %w[
   E2E_RUNNER_ORGANIZATION_ID
   E2E_RUNNER_CODEX_ORGANIZATION_ID
   E2E_RUNNER_CLAUDE_ORGANIZATION_ID
 ].each do |environment_name|
-  unless cleanup_step.fetch("env").key?(environment_name)
-    raise "runner E2E cleanup must receive #{environment_name}"
+  if cleanup_step.fetch("env", {}).key?(environment_name)
+    raise "runner E2E cleanup must not depend on #{environment_name}"
   end
 end
 

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -338,147 +338,29 @@ jobs:
           echo "Cleaned: $CLEANED"
           echo "Failures: $FAILED"
 
-  cleanup-clerk-test-users:
+  cleanup-clerk-test-resources:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      contents: read
     steps:
-      - name: Find recently closed PRs
-        id: prs
-        uses: actions/github-script@v9
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          script: |
-            const since = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
-            const { data: pulls } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed',
-              sort: 'updated',
-              direction: 'desc',
-              per_page: 100
-            });
-            const recent = pulls
-              .filter(pr => pr.closed_at && pr.closed_at >= since)
-              .map(pr => pr.number);
-            console.log(`Found ${recent.length} PRs closed since ${since}: ${recent.join(', ')}`);
-            core.setOutput('numbers', JSON.stringify(recent));
-            core.setOutput('has-prs', recent.length > 0 ? 'true' : 'false');
-
-      - name: Delete stale Clerk test users for closed PRs
-        if: steps.prs.outputs.has-prs == 'true'
-        env:
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          PR_NUMBERS: ${{ steps.prs.outputs.numbers }}
-          DRY_RUN: ${{ env.DRY_RUN }}
-        run: |
-          set -eu
-
-          DELETED=0
-          SKIPPED=0
-
-          for PR_NUMBER in $(echo "$PR_NUMBERS" | jq -r '.[]'); do
-            JOB_REF="pr-${PR_NUMBER}"
-            echo "--- Searching for test users matching ${JOB_REF}+clerk_test ---"
-
-            USERS=$(curl -sS -X GET "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
-              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-              -H "Content-Type: application/json")
-
-            while read -r user; do
-              USER_ID=$(echo "$user" | jq -r '.id')
-              EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
-
-              # Verify email actually matches this PR (Clerk query is fuzzy)
-              if [[ "$EMAIL" != "${JOB_REF}+clerk_test"* ]]; then
-                echo "Skipping $USER_ID ($EMAIL) — does not match ${JOB_REF}"
-                SKIPPED=$((SKIPPED + 1))
-                continue
-              fi
-
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "[DRY-RUN] Would delete $USER_ID ($EMAIL)"
-              else
-                echo "Deleting $USER_ID ($EMAIL)"
-                if ! curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
-                  -H "Authorization: Bearer ${CLERK_SECRET_KEY}"; then
-                  echo "::warning::Failed to delete user $USER_ID ($EMAIL)"
-                fi
-              fi
-              DELETED=$((DELETED + 1))
-            done < <(echo "$USERS" | jq -c '.[]' 2>/dev/null)
-          done
-
-          echo ""
-          echo "=== Clerk Test User Cleanup Summary ==="
-          echo "Deleted: $DELETED"
-          echo "Skipped: $SKIPPED"
-
-  cleanup-clerk-empty-orgs:
-    runs-on: ubuntu-latest
-    needs: cleanup-clerk-test-users
-    steps:
-      - name: Delete Clerk organizations with no members
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install pnpm
+        run: corepack enable pnpm
+      - name: Install E2E dependencies
+        run: cd e2e && pnpm install --frozen-lockfile
+      - name: Delete stale marked Clerk test resources
+        run: >-
+          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
+          cleanup-stale --older-than-hours 6
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           DRY_RUN: ${{ env.DRY_RUN }}
-        run: |
-          set -eu
-
-          DELETED=0
-          SKIPPED=0
-          OFFSET=0
-          LIMIT=100
-
-          # Collect all org IDs first
-          ORG_IDS=()
-          ORG_NAMES=()
-          TOTAL=$(curl -sS -X GET "https://api.clerk.com/v1/organizations?limit=1" \
-            -H "Authorization: Bearer ${CLERK_SECRET_KEY}" | jq '.total_count')
-
-          echo "Total organizations: $TOTAL"
-
-          while [ "$OFFSET" -lt "$TOTAL" ]; do
-            ORGS=$(curl -sS -X GET "https://api.clerk.com/v1/organizations?limit=${LIMIT}&offset=${OFFSET}" \
-              -H "Authorization: Bearer ${CLERK_SECRET_KEY}")
-
-            while read -r org; do
-              ORG_IDS+=("$(echo "$org" | jq -r '.id')")
-              ORG_NAMES+=("$(echo "$org" | jq -r '.name')")
-            done < <(echo "$ORGS" | jq -c '.data[]')
-
-            OFFSET=$((OFFSET + LIMIT))
-          done
-
-          echo "Fetched ${#ORG_IDS[@]} organizations, checking memberships..."
-
-          for i in "${!ORG_IDS[@]}"; do
-            ORG_ID="${ORG_IDS[$i]}"
-            ORG_NAME="${ORG_NAMES[$i]}"
-
-            MEMBER_COUNT=$(curl -sS -X GET "https://api.clerk.com/v1/organizations/${ORG_ID}/memberships?limit=1" \
-              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" | jq '.total_count')
-
-            if [ "$MEMBER_COUNT" -gt 0 ]; then
-              SKIPPED=$((SKIPPED + 1))
-              continue
-            fi
-
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "[DRY-RUN] Would delete org ${ORG_ID} (${ORG_NAME})"
-            else
-              echo "Deleting org ${ORG_ID} (${ORG_NAME})"
-              if ! curl -sS -X DELETE "https://api.clerk.com/v1/organizations/${ORG_ID}" \
-                -H "Authorization: Bearer ${CLERK_SECRET_KEY}" > /dev/null; then
-                echo "::warning::Failed to delete org ${ORG_ID} (${ORG_NAME})"
-              fi
-            fi
-            DELETED=$((DELETED + 1))
-          done
-
-          echo ""
-          echo "=== Clerk Empty Org Cleanup Summary ==="
-          echo "Deleted: $DELETED"
-          echo "Skipped (has members): $SKIPPED"
 
   cleanup-git-branches:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -138,38 +138,29 @@ jobs:
           branch-name: "pr-${{ github.event.pull_request.number }}"
           action: "cleanup"
 
-  cleanup-test-users:
-    # Delete Clerk test users created by e2e browser tests for this PR
+  cleanup-clerk-test-resources:
+    # Delete generation-scoped Clerk test users and organizations for this PR.
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Delete test users from Clerk
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install pnpm
+        run: corepack enable pnpm
+      - name: Install E2E dependencies
+        run: cd e2e && pnpm install --frozen-lockfile
+      - name: Delete Clerk test resources for closed PR
+        run: cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts cleanup-job-ref
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          JOB_REF="pr-${PR_NUMBER}"
-          echo "Searching for test users with email matching ${JOB_REF}+clerk_test"
-          USERS=$(curl -sS -X GET "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
-            -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-            -H "Content-Type: application/json")
-
-          while read -r user; do
-            USER_ID=$(echo "$user" | jq -r '.id')
-            EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
-
-            # Verify email actually matches this PR (Clerk query is fuzzy)
-            if [[ "$EMAIL" != "${JOB_REF}+clerk_test"* ]]; then
-              echo "Skipping $USER_ID ($EMAIL) — does not match ${JOB_REF}"
-              continue
-            fi
-
-            echo "Deleting $USER_ID ($EMAIL)"
-            if ! curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
-              -H "Authorization: Bearer ${CLERK_SECRET_KEY}"; then
-              echo "::warning::Failed to delete user $USER_ID ($EMAIL)"
-            fi
-          done < <(echo "$USERS" | jq -c '.[]' 2>/dev/null)
+          JOB_REF: pr-${{ github.event.pull_request.number }}
 
   cleanup-deployments:
     # Skip for release-please PRs (only version bumps and changelogs)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -255,7 +255,9 @@ jobs:
             .github/scripts/tests/runner-promotion-ansible-test.sh \
             .github/scripts/tests/run-semgrep-test.sh \
             .github/scripts/tests/semgrep-results-test.sh \
-            .github/scripts/tests/runner-behavior-balloon-test.sh
+            .github/scripts/tests/runner-behavior-balloon-test.sh \
+            e2e/helpers/browser.bash \
+            e2e/tests/02-browser/brw-t01-platform-e2e.bats
           # actionlint assumes Bash when shell is omitted and does not model the
           # sh default used by container jobs.
           .github/scripts/check-workflow-shell-compatibility.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -242,6 +242,7 @@ jobs:
             .github/scripts/tests/check-release-please-component-releases-test.sh \
             .github/scripts/tests/check-workflow-shell-compatibility-test.sh \
             .github/scripts/tests/checkout-depth-test.sh \
+            .github/scripts/tests/clerk-test-resource-workflow-test.sh \
             .github/scripts/tests/cloudflare-ssh-command-test.sh \
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
             .github/scripts/tests/cloudflare-ssh-proxy-test.sh \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1798,7 +1798,16 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test+browser@vm0-e2e.ai
+          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test+${{ github.run_id }}-${{ github.run_attempt }}+browser@vm0-e2e.ai
+      - name: Cleanup browser E2E account
+        if: always()
+        shell: bash
+        run: |
+          source e2e/helpers/browser.bash
+          delete_e2e_account_if_exists
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test+${{ github.run_id }}-${{ github.run_attempt }}+browser@vm0-e2e.ai
   cli-e2e-02-playwright:
     runs-on: ubuntu-latest
     timeout-minutes: 8
@@ -1903,6 +1912,14 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Cleanup Playwright E2E accounts
+        if: always()
+        run: >-
+          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
+          cleanup-generation playwright,paid-onboarding
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
       - name: Print Stripe webhook forwarding log
         if: always() && github.event_name == 'push' && needs.prepare.outputs.job-ref != 'staging'
         run: |
@@ -2962,8 +2979,7 @@ jobs:
       always() &&
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      needs.cli-e2e-03-runner-prepare.result != 'skipped' &&
-      needs.cli-e2e-03-runner-prepare.result != 'cancelled'
+      needs.cli-e2e-03-runner-prepare.result != 'skipped'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -2977,9 +2993,6 @@ jobs:
         run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          E2E_RUNNER_ORGANIZATION_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.runner-organization-id }}
-          E2E_RUNNER_CODEX_ORGANIZATION_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.codex-organization-id }}
-          E2E_RUNNER_CLAUDE_ORGANIZATION_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.claude-organization-id }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
 
   lint-runtime-api-compat:

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -159,14 +159,21 @@ report_auth_page_failure() {
 }
 
 # ---------------------------------------------------------------------------
-# generate_test_email — Generate a random test email with +clerk_test suffix
-# Format: ${JOB_REF}+clerk_test@${8_RANDOM_HEX}.ai
+# generate_test_email — Generate the generation-scoped browser test email
+# Format: ${JOB_REF}+clerk_test+${RUN_ID}-${ATTEMPT}+browser@vm0-e2e.ai
 # ---------------------------------------------------------------------------
 generate_test_email() {
   local job_ref="${JOB_REF:-local}"
-  local rand_hex
-  rand_hex=$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 8)
-  echo "${job_ref}+clerk_test@${rand_hex}.ai"
+  local generation="local-1"
+  if [[ -n "${GITHUB_RUN_ID:-}" || -n "${GITHUB_RUN_ATTEMPT:-}" ]]; then
+    if [[ ! "${GITHUB_RUN_ID:-}" =~ ^[1-9][0-9]*$ ]] ||
+      [[ ! "${GITHUB_RUN_ATTEMPT:-}" =~ ^[1-9][0-9]*$ ]]; then
+      echo "GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT must both be positive integers" >&2
+      return 1
+    fi
+    generation="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+  fi
+  echo "${job_ref}+clerk_test+${generation}+browser@vm0-e2e.ai"
 }
 
 # ---------------------------------------------------------------------------
@@ -424,27 +431,66 @@ delete_e2e_account_if_exists() {
     echo "CLERK_SECRET_KEY is required but not set" >&2
     return 1
   fi
+  if [[ ! "${E2E_ACCOUNT:-}" =~ ^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?\+clerk_test\+([1-9][0-9]*-[1-9][0-9]*|local-1)\+browser@vm0-e2e\.ai$ ]]; then
+    echo "E2E_ACCOUNT is not a canonical browser test email" >&2
+    return 1
+  fi
 
   local clerk_api_url="https://api.clerk.com"
 
-  local users_response
-  users_response=$(curl -sS -X GET \
-    "${clerk_api_url}/v1/users?email_address[]=${E2E_ACCOUNT}" \
+  local users_payload
+  users_payload=$(curl -sS \
+    --retry 3 \
+    --retry-max-time 30 \
+    --retry-all-errors \
+    -w '\n%{http_code}' \
+    --get "${clerk_api_url}/v1/users" \
+    --data-urlencode "email_address[]=${E2E_ACCOUNT}" \
     -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-    -H "Content-Type: application/json")
+    -H "Content-Type: application/json") || return
 
-  local user_id
-  user_id=$(echo "$users_response" | jq -r '.[0].id // empty' 2>/dev/null)
-  if [[ -z "$user_id" ]]; then
-    echo "# E2E account does not exist, nothing to delete" >&3
+  local lookup_status="${users_payload##*$'\n'}"
+  local users_response="${users_payload%$'\n'*}"
+  if [[ ! "$lookup_status" =~ ^2[0-9][0-9]$ ]]; then
+    echo "Clerk user lookup failed with HTTP ${lookup_status}" >&2
+    return 1
+  fi
+
+  if ! jq -e 'type == "array"' <<<"$users_response" >/dev/null; then
+    echo "Clerk returned an unexpected user lookup response" >&2
+    return 1
+  fi
+
+  local user_ids
+  user_ids=$(jq -r --arg email "$E2E_ACCOUNT" \
+    '.[] | select(any(.email_addresses[]?; .email_address == $email)) | .id' \
+    <<<"$users_response")
+  if [[ -z "$user_ids" ]]; then
+    echo "E2E account does not exist, nothing to delete" >&2
     return 0
   fi
 
-  echo "# Deleting existing E2E account: ${E2E_ACCOUNT} (${user_id})" >&3
-  curl -sS -X DELETE \
-    "${clerk_api_url}/v1/users/${user_id}" \
-    -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-    -H "Content-Type: application/json" > /dev/null
+  local user_id
+  while read -r user_id; do
+    echo "Deleting E2E account: ${E2E_ACCOUNT} (${user_id})" >&2
+    local delete_status
+    if ! delete_status=$(curl -sS \
+      --retry 3 \
+      --retry-max-time 30 \
+      --retry-all-errors \
+      -o /dev/null \
+      -w '%{http_code}' \
+      -X DELETE \
+      "${clerk_api_url}/v1/users/${user_id}" \
+      -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+      -H "Content-Type: application/json"); then
+      return 1
+    fi
+    if [[ ! "$delete_status" =~ ^2[0-9][0-9]$ && "$delete_status" != "404" ]]; then
+      echo "Clerk user deletion failed with HTTP ${delete_status}" >&2
+      return 1
+    fi
+  done <<<"$user_ids"
 }
 
 # ---------------------------------------------------------------------------

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -164,6 +164,10 @@ report_auth_page_failure() {
 # ---------------------------------------------------------------------------
 generate_test_email() {
   local job_ref="${JOB_REF:-local}"
+  if [[ ! "$job_ref" =~ ^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$ ]]; then
+    echo "JOB_REF must use lowercase letters, numbers, and hyphens" >&2
+    return 1
+  fi
   local generation="local-1"
   if [[ -n "${GITHUB_RUN_ID:-}" || -n "${GITHUB_RUN_ATTEMPT:-}" ]]; then
     if [[ ! "${GITHUB_RUN_ID:-}" =~ ^[1-9][0-9]*$ ]] ||

--- a/e2e/playwright/clerk-test-resources.ts
+++ b/e2e/playwright/clerk-test-resources.ts
@@ -1,0 +1,109 @@
+import {
+  cleanupClerkTestJobRef,
+  cleanupCurrentClerkTestGeneration,
+  cleanupStaleClerkTestResources,
+  currentClerkTestJobRef,
+  parseClerkTestRole,
+  type ClerkCleanupResult,
+  type ClerkTestRole,
+} from "./lib/clerk-api";
+
+const STALE_CLEANUP_ARGUMENT = "--older-than-hours";
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+  const dryRun = parseDryRun();
+  let result: ClerkCleanupResult;
+
+  switch (command) {
+    case "cleanup-generation":
+      result = await cleanupCurrentClerkTestGeneration(
+        parseRoles(requiredArgument(3, "role list")),
+        { dryRun },
+      );
+      break;
+    case "cleanup-job-ref":
+      assertNoExtraArguments(3);
+      result = await cleanupClerkTestJobRef(currentClerkTestJobRef(), {
+        dryRun,
+      });
+      break;
+    case "cleanup-stale":
+      if (process.argv[3] !== STALE_CLEANUP_ARGUMENT) {
+        throw new Error(
+          `cleanup-stale requires ${STALE_CLEANUP_ARGUMENT} <hours>`,
+        );
+      }
+      result = await cleanupStaleClerkTestResources(
+        staleCutoff(requiredArgument(4, "stale age")),
+        { dryRun },
+      );
+      assertNoExtraArguments(5);
+      break;
+    default:
+      throw new Error(
+        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale --older-than-hours <hours>",
+      );
+  }
+
+  console.log("Clerk test resource cleanup", {
+    dryRun,
+    ...result,
+  });
+}
+
+function parseRoles(value: string): readonly ClerkTestRole[] {
+  const roles: ClerkTestRole[] = [];
+  for (const roleValue of value.split(",")) {
+    const role = parseClerkTestRole(roleValue);
+    if (!role) {
+      throw new Error(`Unknown Clerk test role: ${roleValue}`);
+    }
+    if (!roles.includes(role)) {
+      roles.push(role);
+    }
+  }
+  if (roles.length === 0) {
+    throw new Error("At least one Clerk test role is required");
+  }
+  assertNoExtraArguments(4);
+  return roles;
+}
+
+function staleCutoff(value: string): Date {
+  const hours = Number(value);
+  if (!Number.isFinite(hours) || hours <= 0) {
+    throw new Error("Stale cleanup age must be a positive number of hours");
+  }
+  return new Date(Date.now() - hours * 60 * 60 * 1_000);
+}
+
+function parseDryRun(): boolean {
+  const value = process.env.DRY_RUN;
+  if (value === undefined || value === "false") {
+    return false;
+  }
+  if (value === "true") {
+    return true;
+  }
+  throw new Error("DRY_RUN must be true or false");
+}
+
+function requiredArgument(index: number, name: string): string {
+  const value = process.argv[index];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function assertNoExtraArguments(firstExtraArgument: number): void {
+  if (process.argv[firstExtraArgument] !== undefined) {
+    throw new Error(`Unexpected argument: ${process.argv[firstExtraArgument]}`);
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -2,7 +2,7 @@ import { clerkSetup } from "@clerk/testing/playwright";
 import {
   createOrganization,
   createUser,
-  deleteStaleTestUsers,
+  deleteClerkTestOwnerResources,
   generateTestEmail,
 } from "./lib/clerk-api";
 
@@ -13,14 +13,22 @@ export default async function globalSetup(): Promise<void> {
   // fetched inside one test body never reaches the other workers.
   await clerkSetup();
 
-  const email = generateTestEmail();
+  const email = generateTestEmail("playwright");
   console.log("[globalSetup] email:", email);
-
-  await deleteStaleTestUsers();
-  const userId = await createUser(email);
-  const orgId = await createOrganization("E2E Test Org", userId);
-  console.log("[globalSetup] userId:", userId, "orgId:", orgId);
-
   process.env.E2E_CLERK_USER_EMAIL = email;
-  process.env.E2E_CLERK_ORG_ID = orgId;
+
+  let organizationId: string | undefined;
+  try {
+    const userId = await createUser(email);
+    organizationId = await createOrganization(
+      "E2E Test Org",
+      userId,
+      "playwright",
+    );
+    process.env.E2E_CLERK_ORG_ID = organizationId;
+    console.log("[globalSetup] userId:", userId, "orgId:", organizationId);
+  } catch (cause) {
+    await deleteClerkTestOwnerResources(email, organizationId);
+    throw cause;
+  }
 }

--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -28,7 +28,7 @@ export default async function globalSetup(): Promise<void> {
     process.env.E2E_CLERK_ORG_ID = organizationId;
     console.log("[globalSetup] userId:", userId, "orgId:", organizationId);
   } catch (cause) {
-    await deleteClerkTestOwnerResources(email, organizationId);
+    await deleteClerkTestOwnerResources(email, organizationId, "playwright");
     throw cause;
   }
 }

--- a/e2e/playwright/global-teardown.ts
+++ b/e2e/playwright/global-teardown.ts
@@ -4,6 +4,10 @@ export default async function globalTeardown(): Promise<void> {
   const email = process.env.E2E_CLERK_USER_EMAIL;
   if (email) {
     console.log("Cleaning up test user:", email);
-    await deleteClerkTestOwnerResources(email, process.env.E2E_CLERK_ORG_ID);
+    await deleteClerkTestOwnerResources(
+      email,
+      process.env.E2E_CLERK_ORG_ID,
+      "playwright",
+    );
   }
 }

--- a/e2e/playwright/global-teardown.ts
+++ b/e2e/playwright/global-teardown.ts
@@ -1,9 +1,9 @@
-import { deleteUserByEmail } from "./lib/clerk-api";
+import { deleteClerkTestOwnerResources } from "./lib/clerk-api";
 
 export default async function globalTeardown(): Promise<void> {
   const email = process.env.E2E_CLERK_USER_EMAIL;
   if (email) {
     console.log("Cleaning up test user:", email);
-    await deleteUserByEmail(email);
+    await deleteClerkTestOwnerResources(email, process.env.E2E_CLERK_ORG_ID);
   }
 }

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -588,7 +588,7 @@ test("retries exact deletion and surfaces permanent HTTP failures", async () => 
       }
       sendJson(response, 404, { errors: [] });
     },
-    async () => {
+    async (requests) => {
       const error = await captureError(async () => {
         await deleteUserByEmail(email);
       });
@@ -597,6 +597,16 @@ test("retries exact deletion and surfaces permanent HTTP failures", async () => 
         /delete Clerk test user failed with HTTP 400 \(json\)/,
       );
       assert.doesNotMatch(error.message, /must-not-be-logged/);
+      const lookup = requests.find(
+        (request) =>
+          request.method === "GET" && request.url.startsWith("/v1/users?"),
+      );
+      assert.ok(lookup);
+      const lookupUrl = new URL(lookup.url, "http://clerk.test");
+      assert.deepEqual(lookupUrl.searchParams.getAll("email_address[]"), [
+        email,
+      ]);
+      assert.equal(lookupUrl.searchParams.has("query"), false);
     },
   );
 

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -387,6 +387,17 @@ test("collects all pages before generation cleanup and isolates roles", async ()
         alreadyAbsentUsers: 0,
         skippedUsers: 500,
       });
+      const listRequests = requests.filter(
+        (request) =>
+          request.method === "GET" &&
+          (request.url.startsWith("/v1/users?") ||
+            request.url.startsWith("/v1/organizations?")),
+      );
+      assert.ok(listRequests.length >= 4);
+      for (const request of listRequests) {
+        const listUrl = new URL(request.url, "http://clerk.test");
+        assert.equal(listUrl.searchParams.get("order_by"), "+created_at");
+      }
       assert.equal(
         countRequests(requests, "DELETE", "/v1/organizations/org_playwright"),
         2,
@@ -461,6 +472,14 @@ test("job-ref cleanup rejects fuzzy lookalikes and deletes organizations first",
       const result = await cleanupClerkTestJobRef("pr-123");
       assert.equal(result.selectedOrganizations, 1);
       assert.equal(result.selectedUsers, 1);
+      const userListRequest = requests.find(
+        (request) =>
+          request.method === "GET" && request.url.startsWith("/v1/users?"),
+      );
+      assert.ok(userListRequest);
+      const userListUrl = new URL(userListRequest.url, "http://clerk.test");
+      assert.equal(userListUrl.searchParams.has("query"), false);
+      assert.deepEqual(userListUrl.searchParams.getAll("email_address[]"), []);
       assert.deepEqual(
         requests
           .filter((request) => request.method === "DELETE")

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -7,35 +7,235 @@ import {
 import { test } from "node:test";
 
 import {
+  cleanupClerkTestJobRef,
+  cleanupCurrentClerkTestGeneration,
+  cleanupStaleClerkTestResources,
   createOrganization,
   createUser,
+  currentClerkTestGeneration,
   deleteOrganizationById,
-  deleteStaleTestUsers,
   deleteUserByEmail,
+  generateTestEmail,
+  parseClerkTestEmail,
+  parseClerkTestOrganizationMetadata,
   runnerTestAccounts,
 } from "./clerk-api";
 
 interface ObservedRequest {
   readonly method: string;
   readonly url: string;
+  readonly body: unknown;
 }
 
 type ClerkServerHandler = (
-  request: IncomingMessage,
+  request: ObservedRequest,
   response: ServerResponse,
   requests: readonly ObservedRequest[],
 ) => void;
 
-test("does not replay user creation after a transient response", async () => {
+test("creates and parses generation-scoped test identities", () => {
+  withEnvironment(
+    {
+      JOB_REF: "pr-123",
+      GITHUB_RUN_ID: "31500000000",
+      GITHUB_RUN_ATTEMPT: "2",
+    },
+    () => {
+      assert.equal(currentClerkTestGeneration(), "31500000000-2");
+      assert.equal(
+        generateTestEmail("browser"),
+        "pr-123+clerk_test+31500000000-2+browser@vm0-e2e.ai",
+      );
+      assert.match(
+        generateTestEmail("playwright"),
+        /^pr-123\+clerk_test\+31500000000-2\+playwright-[0-9a-f]{8}@vm0-e2e\.ai$/,
+      );
+      assert.deepEqual(runnerTestAccounts(), {
+        runner: "pr-123+clerk_test+31500000000-2+runner@vm0-e2e.ai",
+        codex: "pr-123+clerk_test+31500000000-2+runner-real-codex@vm0-e2e.ai",
+        claude: "pr-123+clerk_test+31500000000-2+runner-real-claude@vm0-e2e.ai",
+      });
+    },
+  );
+
+  assert.deepEqual(
+    parseClerkTestEmail(
+      "staging+clerk_test+31500000000-1+paid-onboarding-0123abcd@vm0-e2e.ai",
+    ),
+    {
+      jobRef: "staging",
+      generation: "31500000000-1",
+      role: "paid-onboarding",
+    },
+  );
+  assert.equal(
+    parseClerkTestEmail("pr-123+clerk_test+31500000000-1+browser@example.com"),
+    null,
+  );
+  assert.equal(
+    parseClerkTestEmail("pr-123+clerk_test+browser@vm0-e2e.ai"),
+    null,
+  );
+  assert.equal(
+    parseClerkTestEmail(
+      "pr-123+clerk_test+31500000000-1+browser-deadbeef@vm0-e2e.ai",
+    ),
+    null,
+  );
+  assert.equal(
+    parseClerkTestOrganizationMetadata({
+      vm0CiTest: {
+        jobRef: "pr-123",
+        generation: "31500000000-1",
+        role: "playwright",
+        extra: true,
+      },
+    }),
+    null,
+  );
+  assert.equal(
+    parseClerkTestOrganizationMetadata({
+      vm0CiTest: {
+        jobRef: "pr-123",
+        generation: "31500000000-1",
+        role: "admin",
+      },
+    }),
+    null,
+  );
+
+  withEnvironment(
+    {
+      JOB_REF: undefined,
+      GITHUB_RUN_ID: undefined,
+      GITHUB_RUN_ATTEMPT: undefined,
+    },
+    () => {
+      assert.equal(
+        generateTestEmail("browser"),
+        "local+clerk_test+local-1+browser@vm0-e2e.ai",
+      );
+    },
+  );
+});
+
+test("creates organizations with exact ownership metadata and retries membership update", async () => {
   await withClerkServer(
     (request, response, requests) => {
-      const postCount = countRequests(requests, "POST", "/v1/users");
-      if (request.method === "POST" && request.url === "/v1/users") {
-        if (postCount === 1) {
-          sendJson(response, 503, { errors: [] });
+      if (request.method === "POST" && request.url === "/v1/organizations") {
+        sendJson(response, 200, { id: "org_test" });
+        return;
+      }
+      if (
+        request.method === "PATCH" &&
+        request.url === "/v1/organizations/org_test/memberships/user_test"
+      ) {
+        const patchCount = countRequests(
+          requests,
+          "PATCH",
+          "/v1/organizations/org_test/memberships/user_test",
+        );
+        if (patchCount === 1) {
+          sendJson(response, 429, { errors: [] }, { "retry-after": "0" });
         } else {
-          sendJson(response, 200, { id: "user_replayed" });
+          sendJson(response, 200, { role: "org:admin" });
         }
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      const organizationId = await createOrganization(
+        "E2E Test Org",
+        "user_test",
+        "playwright",
+      );
+
+      assert.equal(organizationId, "org_test");
+      const createRequest = requests.find(
+        (request) =>
+          request.method === "POST" && request.url === "/v1/organizations",
+      );
+      assert.deepEqual(createRequest?.body, {
+        name: "E2E Test Org",
+        created_by: "user_test",
+        private_metadata: {
+          vm0CiTest: {
+            jobRef: "test-job",
+            generation: "4000-2",
+            role: "playwright",
+          },
+        },
+      });
+      assert.deepEqual(
+        parseClerkTestOrganizationMetadata(
+          isRecord(createRequest?.body)
+            ? createRequest.body.private_metadata
+            : undefined,
+        ),
+        {
+          jobRef: "test-job",
+          generation: "4000-2",
+          role: "playwright",
+        },
+      );
+      assert.equal(
+        countRequests(
+          requests,
+          "PATCH",
+          "/v1/organizations/org_test/memberships/user_test",
+        ),
+        2,
+      );
+    },
+  );
+});
+
+test("removes a newly created organization when membership setup fails", async () => {
+  await withClerkServer(
+    (request, response) => {
+      if (request.method === "POST" && request.url === "/v1/organizations") {
+        sendJson(response, 200, { id: "org_partial" });
+        return;
+      }
+      if (
+        request.method === "PATCH" &&
+        request.url === "/v1/organizations/org_partial/memberships/user_test"
+      ) {
+        sendJson(response, 400, { errors: [] });
+        return;
+      }
+      if (
+        request.method === "DELETE" &&
+        request.url === "/v1/organizations/org_partial"
+      ) {
+        response.writeHead(204);
+        response.end();
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      const error = await captureError(async () => {
+        await createOrganization("E2E Test Org", "user_test", "playwright");
+      });
+      assert.match(
+        error.message,
+        /update Clerk organization membership failed with HTTP 400 \(json\)/,
+      );
+      assert.equal(
+        countRequests(requests, "DELETE", "/v1/organizations/org_partial"),
+        1,
+      );
+    },
+  );
+});
+
+test("does not replay non-idempotent user creation", async () => {
+  await withClerkServer(
+    (request, response) => {
+      if (request.method === "POST" && request.url === "/v1/users") {
+        sendJson(response, 503, { errors: [] });
         return;
       }
       sendJson(response, 404, { errors: [] });
@@ -54,116 +254,266 @@ test("does not replay user creation after a transient response", async () => {
   );
 });
 
-test("retries an idempotent membership role update", async () => {
-  await withClerkServer(
-    (request, response, requests) => {
-      if (request.method === "POST" && request.url === "/v1/organizations") {
-        sendJson(response, 200, { id: "org_test" });
-        return;
-      }
-      if (
-        request.method === "PATCH" &&
-        request.url === "/v1/organizations/org_test/memberships/user_test"
-      ) {
-        const patchCount = countRequests(
-          requests,
-          "PATCH",
-          "/v1/organizations/org_test/memberships/user_test",
-        );
-        if (patchCount === 1) {
-          sendJson(response, 503, { errors: [] }, { "retry-after": "0" });
-        } else {
-          sendJson(response, 200, { role: "org:admin" });
-        }
-        return;
-      }
-      sendJson(response, 404, { errors: [] });
-    },
-    async (requests) => {
-      const organizationId = await createOrganization(
-        "E2E Test Org",
-        "user_test",
-      );
-
-      assert.equal(organizationId, "org_test");
-      assert.equal(
-        countRequests(
-          requests,
-          "PATCH",
-          "/v1/organizations/org_test/memberships/user_test",
-        ),
-        2,
-      );
-    },
+test("collects all pages before generation cleanup and isolates roles", async () => {
+  const currentPlaywrightEmail =
+    "test-job+clerk_test+4000-2+playwright-deadbeef@vm0-e2e.ai";
+  const currentPaidEmail =
+    "test-job+clerk_test+4000-2+paid-onboarding-0123abcd@vm0-e2e.ai";
+  const firstUserPage = Array.from({ length: 500 }, (_, index) =>
+    clerkUser(
+      index === 499 ? "user_playwright" : `foreign_user_${index}`,
+      index === 499 ? currentPlaywrightEmail : `person-${index}@example.com`,
+    ),
   );
-});
+  const firstOrganizationPage = Array.from({ length: 500 }, (_, index) =>
+    clerkOrganization(
+      index === 499 ? "org_playwright" : `foreign_org_${index}`,
+      index === 499
+        ? clerkOwner("test-job", "4000-2", "playwright")
+        : undefined,
+    ),
+  );
 
-test("creates runner accounts with the historical three email names", () => {
-  const previousJobRef = process.env.JOB_REF;
-  process.env.JOB_REF = "pr-123";
-  try {
-    assert.deepEqual(runnerTestAccounts(), {
-      runner: "pr-123+clerk_test+runner@vm0-e2e.ai",
-      codex: "pr-123+clerk_test+runner-real-codex@vm0-e2e.ai",
-      claude: "pr-123+clerk_test+runner-real-claude@vm0-e2e.ai",
-    });
-  } finally {
-    restoreEnvironmentVariable("JOB_REF", previousJobRef);
-  }
-});
-
-test("retries organization cleanup and accepts not found", async () => {
   await withClerkServer(
     (request, response, requests) => {
+      const url = new URL(request.url, "http://clerk.test");
+      if (request.method === "GET" && url.pathname === "/v1/users") {
+        const offset = url.searchParams.get("offset");
+        sendJson(
+          response,
+          200,
+          offset === "0"
+            ? firstUserPage
+            : [clerkUser("user_paid", currentPaidEmail)],
+        );
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/v1/organizations") {
+        const offset = url.searchParams.get("offset");
+        sendJson(response, 200, {
+          data:
+            offset === "0"
+              ? firstOrganizationPage
+              : [
+                  clerkOrganization(
+                    "org_paid",
+                    clerkOwner("test-job", "4000-2", "paid-onboarding"),
+                  ),
+                ],
+          total_count: 501,
+        });
+        return;
+      }
       if (
         request.method === "DELETE" &&
-        request.url === "/v1/organizations/org_cleanup"
+        request.url === "/v1/organizations/org_playwright"
       ) {
-        const deleteCount = countRequests(
+        const attempt = countRequests(
           requests,
           "DELETE",
-          "/v1/organizations/org_cleanup",
+          "/v1/organizations/org_playwright",
         );
-        if (deleteCount === 1) {
+        if (attempt === 1) {
           sendJson(response, 503, { errors: [] }, { "retry-after": "0" });
         } else {
           sendJson(response, 404, { errors: [] });
         }
         return;
       }
+      if (
+        request.method === "DELETE" &&
+        request.url === "/v1/users/user_playwright"
+      ) {
+        response.writeHead(204);
+        response.end();
+        return;
+      }
+      sendJson(response, 500, { unexpected: request.url });
+    },
+    async (requests) => {
+      const result = await cleanupCurrentClerkTestGeneration(["playwright"]);
+
+      assert.deepEqual(result, {
+        scannedOrganizations: 501,
+        selectedOrganizations: 1,
+        deletedOrganizations: 0,
+        alreadyAbsentOrganizations: 1,
+        skippedOrganizations: 500,
+        scannedUsers: 501,
+        selectedUsers: 1,
+        deletedUsers: 1,
+        alreadyAbsentUsers: 0,
+        skippedUsers: 500,
+      });
+      assert.equal(
+        countRequests(requests, "DELETE", "/v1/organizations/org_playwright"),
+        2,
+      );
+      assert.equal(
+        countRequests(requests, "DELETE", "/v1/organizations/org_paid"),
+        0,
+      );
+      assert.equal(countRequests(requests, "DELETE", "/v1/users/user_paid"), 0);
+      const firstDeleteIndex = requests.findIndex(
+        (request) => request.method === "DELETE",
+      );
+      const lastCollectionIndex = requests
+        .map((request) => request.method)
+        .lastIndexOf("GET");
+      assert.ok(firstDeleteIndex > lastCollectionIndex);
+      const deletePaths = requests
+        .filter((request) => request.method === "DELETE")
+        .map((request) => request.url);
+      assert.deepEqual(deletePaths.slice(-2), [
+        "/v1/organizations/org_playwright",
+        "/v1/users/user_playwright",
+      ]);
+    },
+  );
+});
+
+test("job-ref cleanup rejects fuzzy lookalikes and deletes organizations first", async () => {
+  const targetEmail = "pr-123+clerk_test+4000-2+runner@vm0-e2e.ai";
+  await withClerkServer(
+    (request, response) => {
+      const url = new URL(request.url, "http://clerk.test");
+      if (request.method === "GET" && url.pathname === "/v1/users") {
+        sendJson(response, 200, [
+          clerkUser("user_target", targetEmail),
+          clerkUser(
+            "user_other_pr",
+            "pr-1234+clerk_test+4000-2+runner@vm0-e2e.ai",
+          ),
+          clerkUser(
+            "user_lookalike",
+            "pr-123+clerk_test+4000-2+runner@vm0-e2e.ai.example",
+          ),
+        ]);
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/v1/organizations") {
+        sendJson(response, 200, {
+          data: [
+            clerkOrganization(
+              "org_target",
+              clerkOwner("pr-123", "4000-2", "runner"),
+            ),
+            clerkOrganization(
+              "org_other_pr",
+              clerkOwner("pr-1234", "4000-2", "runner"),
+            ),
+            clerkOrganization("org_unmarked"),
+          ],
+          total_count: 3,
+        });
+        return;
+      }
+      if (request.method === "DELETE") {
+        response.writeHead(204);
+        response.end();
+        return;
+      }
       sendJson(response, 404, { errors: [] });
     },
     async (requests) => {
-      await deleteOrganizationById("org_cleanup");
-      assert.equal(
-        countRequests(requests, "DELETE", "/v1/organizations/org_cleanup"),
-        2,
+      const result = await cleanupClerkTestJobRef("pr-123");
+      assert.equal(result.selectedOrganizations, 1);
+      assert.equal(result.selectedUsers, 1);
+      assert.deepEqual(
+        requests
+          .filter((request) => request.method === "DELETE")
+          .map((request) => request.url),
+        ["/v1/organizations/org_target", "/v1/users/user_target"],
       );
     },
   );
 });
 
-test("retries exact lookup failures and accepts delete not found", async () => {
+test("stale cleanup requires strict markers and supports dry-run", async () => {
+  const cutoff = new Date(10_000);
+  await withClerkServer(
+    (request, response) => {
+      const url = new URL(request.url, "http://clerk.test");
+      if (request.method === "GET" && url.pathname === "/v1/users") {
+        sendJson(response, 200, [
+          clerkUser(
+            "user_old",
+            "staging+clerk_test+3000-1+browser@vm0-e2e.ai",
+            1_000,
+          ),
+          clerkUser(
+            "user_new",
+            "staging+clerk_test+3000-1+playwright-deadbeef@vm0-e2e.ai",
+            20_000,
+          ),
+          clerkUser(
+            "user_legacy",
+            "staging+clerk_test+browser@vm0-e2e.ai",
+            1_000,
+          ),
+          clerkUser(
+            "user_at_cutoff",
+            "staging+clerk_test+3000-1+runner@vm0-e2e.ai",
+            10_000,
+          ),
+        ]);
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/v1/organizations") {
+        sendJson(response, 200, {
+          data: [
+            clerkOrganization(
+              "org_old",
+              clerkOwner("staging", "3000-1", "browser"),
+              1_000,
+            ),
+            clerkOrganization(
+              "org_new",
+              clerkOwner("staging", "3000-1", "playwright"),
+              20_000,
+            ),
+            clerkOrganization("org_unmarked", undefined, 1_000),
+            clerkOrganization(
+              "org_at_cutoff",
+              clerkOwner("staging", "3000-1", "runner"),
+              10_000,
+            ),
+          ],
+          total_count: 4,
+        });
+        return;
+      }
+      sendJson(response, 500, { unexpected: request.url });
+    },
+    async (requests) => {
+      const result = await cleanupStaleClerkTestResources(cutoff, {
+        dryRun: true,
+      });
+      assert.equal(result.selectedOrganizations, 1);
+      assert.equal(result.selectedUsers, 1);
+      assert.equal(result.deletedOrganizations, 0);
+      assert.equal(result.deletedUsers, 0);
+      assert.equal(
+        requests.filter((request) => request.method === "DELETE").length,
+        0,
+      );
+    },
+  );
+});
+
+test("retries exact deletion and surfaces permanent HTTP failures", async () => {
   const email = "cleanup@example.com";
   await withClerkServer(
     (request, response, requests) => {
-      if (request.method === "GET" && request.url?.startsWith("/v1/users?")) {
-        const getCount = countRequestsStartingWith(
-          requests,
-          "GET",
-          "/v1/users?",
-        );
-        if (getCount === 1) {
-          request.socket.destroy();
-        } else if (getCount === 2) {
-          sendJson(response, 429, { errors: [] }, { "retry-after": "0" });
+      if (request.method === "GET" && request.url.startsWith("/v1/users?")) {
+        const attempt = requests.filter(
+          (observed) =>
+            observed.method === "GET" && observed.url.startsWith("/v1/users?"),
+        ).length;
+        if (attempt === 1) {
+          requestSocketFailure(response);
         } else {
-          sendJson(response, 200, [
-            {
-              id: "user_cleanup",
-              email_addresses: [{ email_address: email }],
-            },
-          ]);
+          sendJson(response, 200, [clerkUser("user_cleanup", email)]);
         }
         return;
       }
@@ -171,24 +521,41 @@ test("retries exact lookup failures and accepts delete not found", async () => {
         request.method === "DELETE" &&
         request.url === "/v1/users/user_cleanup"
       ) {
-        sendJson(response, 404, { errors: [] });
+        sendJson(response, 400, { sensitive: "must-not-be-logged" });
         return;
       }
       sendJson(response, 404, { errors: [] });
     },
-    async (requests) => {
-      await deleteUserByEmail(email);
-
-      assert.equal(countRequestsStartingWith(requests, "GET", "/v1/users?"), 3);
-      assert.equal(
-        countRequests(requests, "DELETE", "/v1/users/user_cleanup"),
-        1,
+    async () => {
+      const error = await captureError(async () => {
+        await deleteUserByEmail(email);
+      });
+      assert.match(
+        error.message,
+        /delete Clerk test user failed with HTTP 400 \(json\)/,
       );
+      assert.doesNotMatch(error.message, /must-not-be-logged/);
+    },
+  );
+
+  await withClerkServer(
+    (request, response) => {
+      if (
+        request.method === "DELETE" &&
+        request.url === "/v1/organizations/org_missing"
+      ) {
+        sendJson(response, 404, { errors: [] });
+        return;
+      }
+      sendJson(response, 500, { unexpected: request.url });
+    },
+    async () => {
+      assert.equal(await deleteOrganizationById("org_missing"), false);
     },
   );
 });
 
-test("rejects non-JSON success without exposing its body", async () => {
+test("rejects non-JSON success and non-loopback test endpoints", async () => {
   const responseMarker = "sensitive-external-response-marker";
   await withClerkServer(
     (request, response) => {
@@ -202,97 +569,71 @@ test("rejects non-JSON success without exposing its body", async () => {
       const error = await captureError(async () => {
         await createUser("invalid-response@example.com");
       });
-
       assert.match(
         error.message,
         /create Clerk user returned invalid JSON: HTTP 200 \(html\)/,
       );
       assert.doesNotMatch(error.message, new RegExp(responseMarker));
-      assert.equal(error.cause, undefined);
     },
   );
-});
 
-test("keeps bulk stale-user deletion single-attempt and best-effort", async () => {
-  const responseMarker = "bulk-delete-response-marker";
-  await withClerkServer(
-    (request, response) => {
-      if (request.method === "GET" && request.url?.startsWith("/v1/users?")) {
-        sendJson(response, 200, [
-          {
-            id: "user_stale",
-            email_addresses: [
-              {
-                email_address: "test-job+clerk_test@e2e-browser-stale.example",
-              },
-            ],
-          },
-        ]);
-        return;
-      }
-      if (
-        request.method === "DELETE" &&
-        request.url === "/v1/users/user_stale"
-      ) {
-        sendText(response, 503, responseMarker, "text/html");
-        return;
-      }
-      sendJson(response, 404, { errors: [] });
+  await withEnvironmentAsync(
+    {
+      CLERK_API_TEST_BASE_URL: "https://example.com/v1",
+      CLERK_SECRET_KEY: "sk_test_fixture",
     },
-    async (requests) => {
-      const originalWarn = console.warn;
-      const warnings: string[] = [];
-      console.warn = (...values: unknown[]): void => {
-        warnings.push(values.map(String).join(" "));
-      };
-      try {
-        await deleteStaleTestUsers();
-      } finally {
-        console.warn = originalWarn;
-      }
-
+    async () => {
+      const error = await captureError(async () => {
+        await createUser("invalid-endpoint@example.com");
+      });
       assert.equal(
-        countRequests(requests, "DELETE", "/v1/users/user_stale"),
-        1,
+        error.message,
+        "CLERK_API_TEST_BASE_URL must use an HTTP 127.0.0.1 URL",
       );
-      assert.equal(warnings.length, 1);
-      assert.match(warnings[0] ?? "", /HTTP 503 \(html\)/);
-      assert.doesNotMatch(warnings[0] ?? "", new RegExp(responseMarker));
     },
   );
 });
 
-test("rejects a non-loopback Clerk test endpoint", async () => {
-  const previousBaseUrl = process.env.CLERK_API_TEST_BASE_URL;
-  const previousSecretKey = process.env.CLERK_SECRET_KEY;
-  process.env.CLERK_API_TEST_BASE_URL = "https://example.com/v1";
-  process.env.CLERK_SECRET_KEY = "sk_test_fixture";
-  try {
-    const error = await captureError(async () => {
-      await createUser("invalid-endpoint@example.com");
-    });
-    assert.equal(
-      error.message,
-      "CLERK_API_TEST_BASE_URL must use an HTTP 127.0.0.1 URL",
-    );
-  } finally {
-    restoreEnvironmentVariable("CLERK_API_TEST_BASE_URL", previousBaseUrl);
-    restoreEnvironmentVariable("CLERK_SECRET_KEY", previousSecretKey);
-  }
-});
+function clerkUser(id: string, email: string, createdAt?: number): object {
+  return {
+    id,
+    ...(createdAt === undefined ? {} : { created_at: createdAt }),
+    email_addresses: [{ email_address: email }],
+  };
+}
+
+function clerkOwner(jobRef: string, generation: string, role: string): object {
+  return { vm0CiTest: { jobRef, generation, role } };
+}
+
+function clerkOrganization(
+  id: string,
+  privateMetadata?: object,
+  createdAt?: number,
+): object {
+  return {
+    id,
+    ...(createdAt === undefined ? {} : { created_at: createdAt }),
+    ...(privateMetadata === undefined
+      ? {}
+      : { private_metadata: privateMetadata }),
+  };
+}
 
 async function withClerkServer(
   handler: ClerkServerHandler,
   run: (requests: readonly ObservedRequest[]) => Promise<void>,
 ): Promise<void> {
   const requests: ObservedRequest[] = [];
-  const server = createServer((request, response) => {
-    requests.push({
-      method: request.method ?? "",
-      url: request.url ?? "",
-    });
-    request.resume();
-    handler(request, response, requests);
+  const server = createServer((incomingRequest, response) => {
+    observeRequest(incomingRequest)
+      .then((request) => {
+        requests.push(request);
+        handler(request, response, requests);
+      })
+      .catch((error: unknown) => {
+        response.destroy(error instanceof Error ? error : undefined);
+      });
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -309,21 +650,40 @@ async function withClerkServer(
     throw new Error("Expected Clerk test server to listen on a TCP port");
   }
 
-  const previousBaseUrl = process.env.CLERK_API_TEST_BASE_URL;
-  const previousSecretKey = process.env.CLERK_SECRET_KEY;
-  const previousJobRef = process.env.JOB_REF;
-  process.env.CLERK_API_TEST_BASE_URL = `http://127.0.0.1:${address.port}/v1`;
-  process.env.CLERK_SECRET_KEY = "sk_test_fixture";
-  process.env.JOB_REF = "test-job";
+  await withEnvironmentAsync(
+    {
+      CLERK_API_TEST_BASE_URL: `http://127.0.0.1:${address.port}/v1`,
+      CLERK_SECRET_KEY: "sk_test_fixture",
+      JOB_REF: "test-job",
+      GITHUB_RUN_ID: "4000",
+      GITHUB_RUN_ATTEMPT: "2",
+    },
+    async () => {
+      try {
+        await run(requests);
+      } finally {
+        await closeServer(server);
+      }
+    },
+  );
+}
 
-  try {
-    await run(requests);
-  } finally {
-    restoreEnvironmentVariable("CLERK_API_TEST_BASE_URL", previousBaseUrl);
-    restoreEnvironmentVariable("CLERK_SECRET_KEY", previousSecretKey);
-    restoreEnvironmentVariable("JOB_REF", previousJobRef);
-    await closeServer(server);
-  }
+async function observeRequest(
+  request: IncomingMessage,
+): Promise<ObservedRequest> {
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve, reject) => {
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", resolve);
+    request.on("error", reject);
+  });
+  const bodyText = Buffer.concat(chunks).toString("utf8");
+  const body: unknown = bodyText ? JSON.parse(bodyText) : undefined;
+  return {
+    method: request.method ?? "",
+    url: request.url ?? "",
+    body,
+  };
 }
 
 async function closeServer(
@@ -340,14 +700,54 @@ async function closeServer(
   });
 }
 
-function restoreEnvironmentVariable(
-  name: string,
-  previousValue: string | undefined,
+function withEnvironment(
+  values: Readonly<Record<string, string | undefined>>,
+  action: () => void,
 ): void {
-  if (previousValue === undefined) {
-    delete process.env[name];
-  } else {
-    process.env[name] = previousValue;
+  const previousValues = applyEnvironment(values);
+  try {
+    action();
+  } finally {
+    restoreEnvironment(previousValues);
+  }
+}
+
+async function withEnvironmentAsync(
+  values: Readonly<Record<string, string | undefined>>,
+  action: () => Promise<void>,
+): Promise<void> {
+  const previousValues = applyEnvironment(values);
+  try {
+    await action();
+  } finally {
+    restoreEnvironment(previousValues);
+  }
+}
+
+function applyEnvironment(
+  values: Readonly<Record<string, string | undefined>>,
+): Readonly<Record<string, string | undefined>> {
+  const previousValues: Record<string, string | undefined> = {};
+  for (const [name, value] of Object.entries(values)) {
+    previousValues[name] = process.env[name];
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+  return previousValues;
+}
+
+function restoreEnvironment(
+  previousValues: Readonly<Record<string, string | undefined>>,
+): void {
+  for (const [name, value] of Object.entries(previousValues)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
   }
 }
 
@@ -361,16 +761,6 @@ function countRequests(
   ).length;
 }
 
-function countRequestsStartingWith(
-  requests: readonly ObservedRequest[],
-  method: string,
-  urlPrefix: string,
-): number {
-  return requests.filter(
-    (request) => request.method === method && request.url.startsWith(urlPrefix),
-  ).length;
-}
-
 async function captureError(action: () => Promise<void>): Promise<Error> {
   let caught: unknown;
   try {
@@ -380,6 +770,10 @@ async function captureError(action: () => Promise<void>): Promise<Error> {
   }
   assert.ok(caught instanceof Error);
   return caught;
+}
+
+function requestSocketFailure(response: ServerResponse): void {
+  response.destroy();
 }
 
 function sendJson(
@@ -403,4 +797,8 @@ function sendText(
 ): void {
   response.writeHead(status, { "content-type": contentType });
   response.end(body);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -13,6 +13,7 @@ import {
   createOrganization,
   createUser,
   currentClerkTestGeneration,
+  deleteClerkTestOwnerResources,
   deleteOrganizationById,
   deleteUserByEmail,
   generateTestEmail,
@@ -226,6 +227,47 @@ test("removes a newly created organization when membership setup fails", async (
       assert.equal(
         countRequests(requests, "DELETE", "/v1/organizations/org_partial"),
         1,
+      );
+    },
+  );
+});
+
+test("reconciles owner resources when setup loses the organization ID", async () => {
+  const email = "test-job+clerk_test+4000-2+playwright-deadbeef@vm0-e2e.ai";
+  await withClerkServer(
+    (request, response) => {
+      const url = new URL(request.url, "http://clerk.test");
+      if (request.method === "GET" && url.pathname === "/v1/users") {
+        sendJson(response, 200, [clerkUser("user_partial", email)]);
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/v1/organizations") {
+        sendJson(response, 200, {
+          data: [
+            clerkOrganization(
+              "org_partial",
+              clerkOwner("test-job", "4000-2", "playwright"),
+            ),
+          ],
+          total_count: 1,
+        });
+        return;
+      }
+      if (request.method === "DELETE") {
+        response.writeHead(204);
+        response.end();
+        return;
+      }
+      sendJson(response, 404, { errors: [] });
+    },
+    async (requests) => {
+      await deleteClerkTestOwnerResources(email, undefined, "playwright");
+
+      assert.deepEqual(
+        requests
+          .filter((request) => request.method === "DELETE")
+          .map((request) => request.url),
+        ["/v1/organizations/org_partial", "/v1/users/user_partial"],
       );
     },
   );
@@ -456,6 +498,21 @@ test("stale cleanup requires strict markers and supports dry-run", async () => {
             "staging+clerk_test+3000-1+runner@vm0-e2e.ai",
             10_000,
           ),
+          clerkUser(
+            "user_before_owned_org_cutoff",
+            "staging+clerk_test+3000-1+paid-onboarding-deadbeef@vm0-e2e.ai",
+            9_000,
+          ),
+          {
+            id: "user_with_unowned_email",
+            created_at: 1_000,
+            email_addresses: [
+              {
+                email_address: "staging+clerk_test+3000-1+browser@vm0-e2e.ai",
+              },
+              { email_address: "owner@example.com" },
+            ],
+          },
         ]);
         return;
       }
@@ -478,8 +535,13 @@ test("stale cleanup requires strict markers and supports dry-run", async () => {
               clerkOwner("staging", "3000-1", "runner"),
               10_000,
             ),
+            clerkOrganization(
+              "org_after_user_cutoff",
+              clerkOwner("staging", "3000-1", "paid-onboarding"),
+              11_000,
+            ),
           ],
-          total_count: 4,
+          total_count: 5,
         });
         return;
       }

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -349,24 +349,43 @@ async function cleanupClerkTestResources(
   const users = await listClerkUsers(userQuery);
   const organizations = await listClerkOrganizations();
 
-  const selectedOrganizations = organizations.filter((organization) => {
-    const owner = parseClerkTestOrganizationMetadata(
-      organization.private_metadata,
-    );
-    return (
-      owner !== null &&
-      cleanupSelectionMatches(selection, owner, organization.created_at)
-    );
-  });
-  const selectedUsers = users.filter((user) =>
-    user.email_addresses.some((emailAddress) => {
-      const owner = parseClerkTestEmail(emailAddress.email_address);
+  const organizationsWithOwners = organizations.map((organization) => ({
+    organization,
+    owner: parseClerkTestOrganizationMetadata(organization.private_metadata),
+  }));
+  const selectedOrganizations = organizationsWithOwners
+    .filter(({ organization, owner }) => {
       return (
         owner !== null &&
-        cleanupSelectionMatches(selection, owner, user.created_at)
+        cleanupSelectionMatches(selection, owner, organization.created_at)
       );
-    }),
-  );
+    })
+    .map(({ organization }) => organization);
+  const retainedOrganizationOwners = new Set<string>();
+  if (selection.kind === "stale") {
+    // Keep an owner user until every marked organization in its scope is old
+    // enough to delete, including resources that straddle the age cutoff.
+    for (const { organization, owner } of organizationsWithOwners) {
+      if (
+        owner !== null &&
+        !cleanupSelectionMatches(selection, owner, organization.created_at)
+      ) {
+        retainedOrganizationOwners.add(clerkTestOwnerKey(owner));
+      }
+    }
+  }
+  const selectedUsers = users.filter((user) => {
+    const emailAddress = user.email_addresses[0];
+    if (user.email_addresses.length !== 1 || !emailAddress) {
+      return false;
+    }
+    const owner = parseClerkTestEmail(emailAddress.email_address);
+    return (
+      owner !== null &&
+      cleanupSelectionMatches(selection, owner, user.created_at) &&
+      !retainedOrganizationOwners.has(clerkTestOwnerKey(owner))
+    );
+  });
 
   let deletedOrganizations = 0;
   let alreadyAbsentOrganizations = 0;
@@ -426,6 +445,10 @@ function cleanupSelectionMatches(
     case "stale":
       return createdAt !== undefined && createdAt < selection.createdBeforeMs;
   }
+}
+
+function clerkTestOwnerKey(owner: ClerkTestOwner): string {
+  return `${owner.jobRef}\0${owner.generation}\0${owner.role}`;
 }
 
 async function listClerkUsers(
@@ -501,11 +524,16 @@ export async function deleteOrganizationById(
 
 export async function deleteClerkTestOwnerResources(
   email: string,
-  organizationId?: string,
+  organizationId: string | undefined,
+  role: ClerkTestRole,
 ): Promise<void> {
-  if (organizationId) {
-    await deleteOrganizationById(organizationId);
+  if (!organizationId) {
+    // Organization creation may have committed even when its response was lost.
+    // Reconcile the owner scope so the user is never deleted ahead of that org.
+    await cleanupCurrentClerkTestGeneration([role]);
+    return;
   }
+  await deleteOrganizationById(organizationId);
   await deleteUserByEmail(email);
 }
 

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -342,11 +342,7 @@ async function cleanupClerkTestResources(
   selection: ClerkCleanupSelection,
   options: ClerkCleanupOptions,
 ): Promise<ClerkCleanupResult> {
-  const userQuery =
-    selection.kind === "stale"
-      ? undefined
-      : `${selection.jobRef}+${CLERK_TEST_MARKER}+`;
-  const users = await listClerkUsers(userQuery);
+  const users = await listClerkUsers();
   const organizations = await listClerkOrganizations();
 
   const organizationsWithOwners = organizations.map((organization) => ({
@@ -452,7 +448,7 @@ function clerkTestOwnerKey(owner: ClerkTestOwner): string {
 }
 
 async function listClerkUsers(
-  query?: string,
+  emailAddress?: string,
 ): Promise<readonly ClerkUserSummary[]> {
   const users: ClerkUserSummary[] = [];
   let offset = 0;
@@ -460,9 +456,10 @@ async function listClerkUsers(
     const parameters = new URLSearchParams({
       limit: String(CLERK_PAGE_LIMIT),
       offset: String(offset),
+      order_by: "+created_at",
     });
-    if (query) {
-      parameters.set("query", query);
+    if (emailAddress) {
+      parameters.append("email_address[]", emailAddress);
     }
     const response = await requestClerkWithRetry(
       "list Clerk test users",
@@ -487,6 +484,7 @@ async function listClerkOrganizations(): Promise<
     const parameters = new URLSearchParams({
       limit: String(CLERK_PAGE_LIMIT),
       offset: String(offset),
+      order_by: "+created_at",
     });
     const response = await requestClerkWithRetry(
       "list Clerk test organizations",

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -1,20 +1,30 @@
 import { randomBytes } from "node:crypto";
 
 const DEFAULT_CLERK_API_BASE = "https://api.clerk.com/v1";
-const CLERK_RETRY_DELAYS_MS = [500, 1_500] as const;
-const CLERK_MAX_RETRY_AFTER_MS = 2_000;
+const CLERK_PAGE_LIMIT = 500;
+const CLERK_RETRY_DELAYS_MS = [500, 1_500, 3_500] as const;
+const CLERK_MAX_RETRY_AFTER_MS = 30_000;
+const CLERK_DELETE_PACE_MS = 110;
+const CLERK_TEST_DOMAIN = "vm0-e2e.ai";
+const CLERK_TEST_MARKER = "clerk_test";
+const LOCAL_JOB_REF = "local";
+const LOCAL_GENERATION = "local-1";
 
-interface ClerkEmailAddress {
-  readonly email_address: string;
-}
+export const CLERK_TEST_ROLES = [
+  "browser",
+  "playwright",
+  "paid-onboarding",
+  "runner",
+  "runner-real-codex",
+  "runner-real-claude",
+] as const;
 
-interface ClerkUserSummary {
-  readonly id: string;
-  readonly email_addresses: readonly ClerkEmailAddress[];
-}
+export type ClerkTestRole = (typeof CLERK_TEST_ROLES)[number];
 
-interface RetryableClerkRequestInit extends RequestInit {
-  readonly method: "GET" | "DELETE" | "PATCH";
+export interface ClerkTestOwner {
+  readonly jobRef: string;
+  readonly generation: string;
+  readonly role: ClerkTestRole;
 }
 
 export interface RunnerTestAccounts {
@@ -22,6 +32,58 @@ export interface RunnerTestAccounts {
   readonly codex: string;
   readonly claude: string;
 }
+
+export interface ClerkCleanupOptions {
+  readonly dryRun?: boolean;
+}
+
+export interface ClerkCleanupResult {
+  readonly scannedOrganizations: number;
+  readonly selectedOrganizations: number;
+  readonly deletedOrganizations: number;
+  readonly alreadyAbsentOrganizations: number;
+  readonly skippedOrganizations: number;
+  readonly scannedUsers: number;
+  readonly selectedUsers: number;
+  readonly deletedUsers: number;
+  readonly alreadyAbsentUsers: number;
+  readonly skippedUsers: number;
+}
+
+interface ClerkEmailAddress {
+  readonly email_address: string;
+}
+
+interface ClerkUserSummary {
+  readonly id: string;
+  readonly created_at?: number;
+  readonly email_addresses: readonly ClerkEmailAddress[];
+}
+
+interface ClerkOrganizationSummary {
+  readonly id: string;
+  readonly created_at?: number;
+  readonly private_metadata?: unknown;
+}
+
+interface ClerkOrganizationList {
+  readonly data: readonly ClerkOrganizationSummary[];
+  readonly total_count: number;
+}
+
+interface RetryableClerkRequestInit extends RequestInit {
+  readonly method: "GET" | "DELETE" | "PATCH";
+}
+
+type ClerkCleanupSelection =
+  | {
+      readonly kind: "generation";
+      readonly jobRef: string;
+      readonly generation: string;
+      readonly roles: readonly ClerkTestRole[];
+    }
+  | { readonly kind: "job-ref"; readonly jobRef: string }
+  | { readonly kind: "stale"; readonly createdBeforeMs: number };
 
 function getClerkApiBase(): string {
   const testApiBase = process.env.CLERK_API_TEST_BASE_URL;
@@ -47,19 +109,108 @@ function getClerkHeaders(): Record<string, string> {
   };
 }
 
-export function generateTestEmail(): string {
-  const jobRef = process.env.JOB_REF ?? "local";
-  const randHex = randomBytes(4).toString("hex");
-  return `${jobRef}+clerk_test@e2e-browser-${randHex}.ai`;
+export function currentClerkTestJobRef(): string {
+  const jobRef = process.env.JOB_REF ?? LOCAL_JOB_REF;
+  if (!isClerkTestJobRef(jobRef)) {
+    throw new Error(`Invalid Clerk test JOB_REF: ${jobRef}`);
+  }
+  return jobRef;
+}
+
+export function currentClerkTestGeneration(): string {
+  const runId = process.env.GITHUB_RUN_ID;
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT;
+  if (!runId && !runAttempt) {
+    return LOCAL_GENERATION;
+  }
+  if (
+    !runId ||
+    !runAttempt ||
+    !isPositiveIntegerString(runId) ||
+    !isPositiveIntegerString(runAttempt)
+  ) {
+    throw new Error(
+      "GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT must both be positive integers",
+    );
+  }
+  return `${runId}-${runAttempt}`;
+}
+
+export function currentClerkTestOwner(role: ClerkTestRole): ClerkTestOwner {
+  return {
+    jobRef: currentClerkTestJobRef(),
+    generation: currentClerkTestGeneration(),
+    role,
+  };
+}
+
+export function generateTestEmail(role: ClerkTestRole): string {
+  const nonce = roleSupportsNonce(role)
+    ? randomBytes(4).toString("hex")
+    : undefined;
+  return formatClerkTestEmail(currentClerkTestOwner(role), nonce);
 }
 
 export function runnerTestAccounts(): RunnerTestAccounts {
-  const jobRef = process.env.JOB_REF ?? "local";
   return {
-    runner: `${jobRef}+clerk_test+runner@vm0-e2e.ai`,
-    codex: `${jobRef}+clerk_test+runner-real-codex@vm0-e2e.ai`,
-    claude: `${jobRef}+clerk_test+runner-real-claude@vm0-e2e.ai`,
+    runner: generateTestEmail("runner"),
+    codex: generateTestEmail("runner-real-codex"),
+    claude: generateTestEmail("runner-real-claude"),
   };
+}
+
+export function parseClerkTestRole(value: string): ClerkTestRole | null {
+  return CLERK_TEST_ROLES.find((role) => role === value) ?? null;
+}
+
+export function parseClerkTestEmail(email: string): ClerkTestOwner | null {
+  const addressParts = email.split("@");
+  if (addressParts.length !== 2 || addressParts[1] !== CLERK_TEST_DOMAIN) {
+    return null;
+  }
+
+  const localParts = addressParts[0]?.split("+");
+  if (!localParts || localParts.length !== 4) {
+    return null;
+  }
+  const [jobRef, marker, generation, rolePart] = localParts;
+  if (
+    !jobRef ||
+    !generation ||
+    !rolePart ||
+    marker !== CLERK_TEST_MARKER ||
+    !isClerkTestJobRef(jobRef) ||
+    !isClerkTestGeneration(generation)
+  ) {
+    return null;
+  }
+
+  const role = parseRolePart(rolePart);
+  return role ? { jobRef, generation, role } : null;
+}
+
+export function parseClerkTestOrganizationMetadata(
+  privateMetadata: unknown,
+): ClerkTestOwner | null {
+  if (!isRecord(privateMetadata)) {
+    return null;
+  }
+  const marker = privateMetadata.vm0CiTest;
+  if (!isRecord(marker) || Object.keys(marker).length !== 3) {
+    return null;
+  }
+  const { jobRef, generation, role } = marker;
+  if (
+    typeof jobRef !== "string" ||
+    typeof generation !== "string" ||
+    typeof role !== "string" ||
+    !isClerkTestJobRef(jobRef) ||
+    !isClerkTestGeneration(generation)
+  ) {
+    return null;
+  }
+  const parsedRole = parseClerkTestRole(role);
+  return parsedRole ? { jobRef, generation, role: parsedRole } : null;
 }
 
 export async function createUser(email: string): Promise<string> {
@@ -84,14 +235,20 @@ export async function createUser(email: string): Promise<string> {
 export async function createOrganization(
   name: string,
   createdByUserId: string,
+  role: ClerkTestRole,
 ): Promise<string> {
+  const owner = currentClerkTestOwner(role);
   const response = await requestClerk(
     "create Clerk organization",
     "/organizations",
     {
       method: "POST",
       headers: getClerkHeaders(),
-      body: JSON.stringify({ name, created_by: createdByUserId }),
+      body: JSON.stringify({
+        name,
+        created_by: createdByUserId,
+        private_metadata: { vm0CiTest: owner },
+      }),
     },
   );
   const data = await readClerkJson(response, "create Clerk organization");
@@ -100,7 +257,17 @@ export async function createOrganization(
       `create Clerk organization returned an unexpected response: ${formatClerkResponseSummary(response)}`,
     );
   }
-  await updateOrganizationMembershipRole(data.id, createdByUserId, "org:admin");
+
+  try {
+    await updateOrganizationMembershipRole(
+      data.id,
+      createdByUserId,
+      "org:admin",
+    );
+  } catch (cause) {
+    await deleteOrganizationById(data.id);
+    throw cause;
+  }
   return data.id;
 }
 
@@ -129,53 +296,195 @@ async function updateOrganizationMembershipRole(
   }
 }
 
-export async function deleteStaleTestUsers(): Promise<void> {
-  const jobRef = process.env.JOB_REF ?? "local";
-  const prefix = `${jobRef}+clerk_test@e2e-browser-`;
-  let users: readonly ClerkUserSummary[];
-  try {
-    const searchResponse = await requestClerkWithRetry(
-      "list stale Clerk test users",
-      `/users?query=${encodeURIComponent(`${jobRef}+clerk_test`)}&limit=100`,
-      { method: "GET", headers: getClerkHeaders() },
+export async function cleanupCurrentClerkTestGeneration(
+  roles: readonly ClerkTestRole[],
+  options: ClerkCleanupOptions = {},
+): Promise<ClerkCleanupResult> {
+  if (roles.length === 0) {
+    throw new Error("At least one Clerk test role is required for cleanup");
+  }
+  return await cleanupClerkTestResources(
+    {
+      kind: "generation",
+      jobRef: currentClerkTestJobRef(),
+      generation: currentClerkTestGeneration(),
+      roles,
+    },
+    options,
+  );
+}
+
+export async function cleanupClerkTestJobRef(
+  jobRef: string,
+  options: ClerkCleanupOptions = {},
+): Promise<ClerkCleanupResult> {
+  if (!isClerkTestJobRef(jobRef)) {
+    throw new Error(`Invalid Clerk test JOB_REF: ${jobRef}`);
+  }
+  return await cleanupClerkTestResources({ kind: "job-ref", jobRef }, options);
+}
+
+export async function cleanupStaleClerkTestResources(
+  createdBefore: Date,
+  options: ClerkCleanupOptions = {},
+): Promise<ClerkCleanupResult> {
+  const createdBeforeMs = createdBefore.getTime();
+  if (!Number.isFinite(createdBeforeMs)) {
+    throw new Error("Stale Clerk cleanup cutoff must be a valid date");
+  }
+  return await cleanupClerkTestResources(
+    { kind: "stale", createdBeforeMs },
+    options,
+  );
+}
+
+async function cleanupClerkTestResources(
+  selection: ClerkCleanupSelection,
+  options: ClerkCleanupOptions,
+): Promise<ClerkCleanupResult> {
+  const userQuery =
+    selection.kind === "stale"
+      ? undefined
+      : `${selection.jobRef}+${CLERK_TEST_MARKER}+`;
+  const users = await listClerkUsers(userQuery);
+  const organizations = await listClerkOrganizations();
+
+  const selectedOrganizations = organizations.filter((organization) => {
+    const owner = parseClerkTestOrganizationMetadata(
+      organization.private_metadata,
     );
-    users = await readClerkUsers(searchResponse, "list stale Clerk test users");
-  } catch {
-    console.warn(
-      "Failed to list stale Clerk test users; continuing without stale cleanup",
+    return (
+      owner !== null &&
+      cleanupSelectionMatches(selection, owner, organization.created_at)
     );
-    return;
+  });
+  const selectedUsers = users.filter((user) =>
+    user.email_addresses.some((emailAddress) => {
+      const owner = parseClerkTestEmail(emailAddress.email_address);
+      return (
+        owner !== null &&
+        cleanupSelectionMatches(selection, owner, user.created_at)
+      );
+    }),
+  );
+
+  let deletedOrganizations = 0;
+  let alreadyAbsentOrganizations = 0;
+  let deletedUsers = 0;
+  let alreadyAbsentUsers = 0;
+  if (!options.dryRun) {
+    const deletionCount = selectedOrganizations.length + selectedUsers.length;
+    let deletionIndex = 0;
+    for (const organization of selectedOrganizations) {
+      if (await deleteOrganizationById(organization.id)) {
+        deletedOrganizations += 1;
+      } else {
+        alreadyAbsentOrganizations += 1;
+      }
+      deletionIndex += 1;
+      await paceClerkDeletion(deletionIndex, deletionCount);
+    }
+    for (const user of selectedUsers) {
+      if (await deleteUserById(user.id)) {
+        deletedUsers += 1;
+      } else {
+        alreadyAbsentUsers += 1;
+      }
+      deletionIndex += 1;
+      await paceClerkDeletion(deletionIndex, deletionCount);
+    }
   }
 
-  for (const user of users) {
-    const userEmail = user.email_addresses[0]?.email_address;
-    if (!userEmail?.startsWith(prefix)) {
-      continue;
-    }
+  return {
+    scannedOrganizations: organizations.length,
+    selectedOrganizations: selectedOrganizations.length,
+    deletedOrganizations,
+    alreadyAbsentOrganizations,
+    skippedOrganizations: organizations.length - selectedOrganizations.length,
+    scannedUsers: users.length,
+    selectedUsers: selectedUsers.length,
+    deletedUsers,
+    alreadyAbsentUsers,
+    skippedUsers: users.length - selectedUsers.length,
+  };
+}
 
-    try {
-      const deleteResponse = await requestClerk(
-        "delete stale Clerk test user",
-        `/users/${user.id}`,
-        { method: "DELETE", headers: getClerkHeaders() },
+function cleanupSelectionMatches(
+  selection: ClerkCleanupSelection,
+  owner: ClerkTestOwner,
+  createdAt: number | undefined,
+): boolean {
+  switch (selection.kind) {
+    case "generation":
+      return (
+        owner.jobRef === selection.jobRef &&
+        owner.generation === selection.generation &&
+        selection.roles.includes(owner.role)
       );
-      await deleteResponse.body?.cancel();
-      if (!deleteResponse.ok && deleteResponse.status !== 404) {
-        console.warn(
-          `Failed to delete a stale Clerk test user with ${formatClerkResponseSummary(deleteResponse)}`,
-        );
-      }
-    } catch {
-      console.warn(
-        "Failed to delete a stale Clerk test user; continuing stale cleanup",
-      );
+    case "job-ref":
+      return owner.jobRef === selection.jobRef;
+    case "stale":
+      return createdAt !== undefined && createdAt < selection.createdBeforeMs;
+  }
+}
+
+async function listClerkUsers(
+  query?: string,
+): Promise<readonly ClerkUserSummary[]> {
+  const users: ClerkUserSummary[] = [];
+  let offset = 0;
+  while (true) {
+    const parameters = new URLSearchParams({
+      limit: String(CLERK_PAGE_LIMIT),
+      offset: String(offset),
+    });
+    if (query) {
+      parameters.set("query", query);
     }
+    const response = await requestClerkWithRetry(
+      "list Clerk test users",
+      `/users?${parameters.toString()}`,
+      { method: "GET", headers: getClerkHeaders() },
+    );
+    const page = await readClerkUsers(response, "list Clerk test users");
+    users.push(...page);
+    if (page.length < CLERK_PAGE_LIMIT) {
+      return users;
+    }
+    offset += page.length;
+  }
+}
+
+async function listClerkOrganizations(): Promise<
+  readonly ClerkOrganizationSummary[]
+> {
+  const organizations: ClerkOrganizationSummary[] = [];
+  let offset = 0;
+  while (true) {
+    const parameters = new URLSearchParams({
+      limit: String(CLERK_PAGE_LIMIT),
+      offset: String(offset),
+    });
+    const response = await requestClerkWithRetry(
+      "list Clerk test organizations",
+      `/organizations?${parameters.toString()}`,
+      { method: "GET", headers: getClerkHeaders() },
+    );
+    const page = await readClerkOrganizations(
+      response,
+      "list Clerk test organizations",
+    );
+    organizations.push(...page.data);
+    if (page.data.length === 0 || organizations.length >= page.total_count) {
+      return organizations;
+    }
+    offset += page.data.length;
   }
 }
 
 export async function deleteOrganizationById(
   organizationId: string,
-): Promise<void> {
+): Promise<boolean> {
   const response = await requestClerkWithRetry(
     "delete Clerk test organization",
     `/organizations/${organizationId}`,
@@ -187,35 +496,54 @@ export async function deleteOrganizationById(
       `delete Clerk test organization failed with ${formatClerkResponseSummary(response)}`,
     );
   }
+  return response.status !== 404;
+}
+
+export async function deleteClerkTestOwnerResources(
+  email: string,
+  organizationId?: string,
+): Promise<void> {
+  if (organizationId) {
+    await deleteOrganizationById(organizationId);
+  }
+  await deleteUserByEmail(email);
 }
 
 export async function deleteUserByEmail(email: string): Promise<void> {
-  const searchResponse = await requestClerkWithRetry(
-    "find Clerk test user",
-    `/users?query=${encodeURIComponent(email)}&limit=10`,
-    { method: "GET", headers: getClerkHeaders() },
+  const users = await listClerkUsers(email);
+  const user = users.find((candidate) =>
+    candidate.email_addresses.some(
+      (emailAddress) => emailAddress.email_address === email,
+    ),
   );
-  const users = await readClerkUsers(searchResponse, "find Clerk test user");
+  if (user) {
+    await deleteUserById(user.id);
+  }
+}
 
-  for (const user of users) {
-    const userEmail = user.email_addresses[0]?.email_address;
-    if (userEmail !== email) {
-      continue;
-    }
-
-    const deleteResponse = await requestClerkWithRetry(
-      "delete Clerk test user",
-      `/users/${user.id}`,
-      { method: "DELETE", headers: getClerkHeaders() },
+async function deleteUserById(userId: string): Promise<boolean> {
+  const response = await requestClerkWithRetry(
+    "delete Clerk test user",
+    `/users/${userId}`,
+    { method: "DELETE", headers: getClerkHeaders() },
+  );
+  await response.body?.cancel();
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      `delete Clerk test user failed with ${formatClerkResponseSummary(response)}`,
     );
-    await deleteResponse.body?.cancel();
-    if (!deleteResponse.ok && deleteResponse.status !== 404) {
-      throw new Error(
-        `delete Clerk test user failed with ${formatClerkResponseSummary(deleteResponse)}`,
-      );
-    }
+  }
+  return response.status !== 404;
+}
+
+async function paceClerkDeletion(
+  deletionIndex: number,
+  deletionCount: number,
+): Promise<void> {
+  if (deletionIndex >= deletionCount || process.env.CLERK_API_TEST_BASE_URL) {
     return;
   }
+  await wait(CLERK_DELETE_PACE_MS);
 }
 
 async function requestClerk(
@@ -237,16 +565,24 @@ async function requestClerkWithRetry(
   init: RetryableClerkRequestInit,
 ): Promise<Response> {
   const url = `${getClerkApiBase()}${path}`;
-  for (const fallbackDelayMs of CLERK_RETRY_DELAYS_MS) {
+  for (let attempt = 0; attempt <= CLERK_RETRY_DELAYS_MS.length; attempt += 1) {
     let response: Response;
     try {
       response = await fetch(url, init);
-    } catch {
+    } catch (cause) {
+      const fallbackDelayMs = CLERK_RETRY_DELAYS_MS[attempt];
+      if (fallbackDelayMs === undefined) {
+        throw new Error(`${operation} request failed`, { cause });
+      }
       await wait(fallbackDelayMs);
       continue;
     }
 
-    if (!isTransientClerkStatus(response.status)) {
+    const fallbackDelayMs = CLERK_RETRY_DELAYS_MS[attempt];
+    if (
+      !isTransientClerkStatus(response.status) ||
+      fallbackDelayMs === undefined
+    ) {
       return response;
     }
 
@@ -257,8 +593,7 @@ async function requestClerkWithRetry(
     await response.body?.cancel();
     await wait(delayMs);
   }
-
-  return await requestClerk(operation, path, init);
+  throw new Error(`${operation} exhausted its retry budget`);
 }
 
 function isTransientClerkStatus(status: number): boolean {
@@ -328,22 +663,102 @@ async function readClerkUsers(
   return data;
 }
 
+async function readClerkOrganizations(
+  response: Response,
+  operation: string,
+): Promise<ClerkOrganizationList> {
+  const data = await readClerkJson(response, operation);
+  if (!isClerkOrganizationList(data)) {
+    throw new Error(
+      `${operation} returned an unexpected response: ${formatClerkResponseSummary(response)}`,
+    );
+  }
+  return data;
+}
+
 function isClerkUserList(value: unknown): value is readonly ClerkUserSummary[] {
+  return Array.isArray(value) && value.every(isClerkUserSummary);
+}
+
+function isClerkUserSummary(value: unknown): value is ClerkUserSummary {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    return false;
+  }
+  if ("created_at" in value && typeof value.created_at !== "number") {
+    return false;
+  }
+  const emailAddresses = value.email_addresses;
   return (
-    Array.isArray(value) &&
-    value.every((user: unknown) => {
-      if (!isRecord(user) || typeof user.id !== "string") {
-        return false;
-      }
-      const emailAddresses = user.email_addresses;
-      return (
-        Array.isArray(emailAddresses) &&
-        emailAddresses.every((emailAddress: unknown) =>
-          hasStringProperty(emailAddress, "email_address"),
-        )
-      );
-    })
+    Array.isArray(emailAddresses) &&
+    emailAddresses.every((emailAddress: unknown) =>
+      hasStringProperty(emailAddress, "email_address"),
+    )
   );
+}
+
+function isClerkOrganizationList(
+  value: unknown,
+): value is ClerkOrganizationList {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.data) &&
+    value.data.every(isClerkOrganizationSummary) &&
+    typeof value.total_count === "number" &&
+    Number.isInteger(value.total_count) &&
+    value.total_count >= 0
+  );
+}
+
+function isClerkOrganizationSummary(
+  value: unknown,
+): value is ClerkOrganizationSummary {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (!("created_at" in value) || typeof value.created_at === "number")
+  );
+}
+
+function formatClerkTestEmail(owner: ClerkTestOwner, nonce?: string): string {
+  const role = nonce ? `${owner.role}-${nonce}` : owner.role;
+  return `${owner.jobRef}+${CLERK_TEST_MARKER}+${owner.generation}+${role}@${CLERK_TEST_DOMAIN}`;
+}
+
+function parseRolePart(rolePart: string): ClerkTestRole | null {
+  const exactRole = parseClerkTestRole(rolePart);
+  if (exactRole) {
+    return exactRole;
+  }
+  for (const role of CLERK_TEST_ROLES) {
+    if (!roleSupportsNonce(role)) {
+      continue;
+    }
+    const prefix = `${role}-`;
+    if (rolePart.startsWith(prefix) && isNonce(rolePart.slice(prefix.length))) {
+      return role;
+    }
+  }
+  return null;
+}
+
+function roleSupportsNonce(role: ClerkTestRole): boolean {
+  return role === "playwright" || role === "paid-onboarding";
+}
+
+function isNonce(value: string): boolean {
+  return /^[0-9a-f]{8}$/.test(value);
+}
+
+function isClerkTestJobRef(value: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(value);
+}
+
+function isClerkTestGeneration(value: string): boolean {
+  return value === LOCAL_GENERATION || /^[1-9][0-9]*-[1-9][0-9]*$/.test(value);
+}
+
+function isPositiveIntegerString(value: string): boolean {
+  return /^[1-9][0-9]*$/.test(value);
 }
 
 function hasStringProperty<K extends string>(

--- a/e2e/playwright/lib/clerk-test-resources.test.ts
+++ b/e2e/playwright/lib/clerk-test-resources.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { promisify } from "node:util";
+import { test } from "node:test";
+
+const execFileAsync = promisify(execFile);
+
+test("runs generation and stale cleanup through the command entry point", async () => {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "", "http://clerk.test");
+    if (request.method === "GET" && url.pathname === "/v1/users") {
+      sendJson(response, []);
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/v1/organizations") {
+      sendJson(response, { data: [], total_count: 0 });
+      return;
+    }
+    sendJson(response, { error: "not found" }, 404);
+  });
+  await listen(server);
+  try {
+    const environment = clerkCommandEnvironment(server);
+    const generation = await runClerkCommand(
+      ["cleanup-generation", "playwright,paid-onboarding"],
+      environment,
+    );
+    assert.match(generation.stdout, /Clerk test resource cleanup/);
+    assert.match(generation.stdout, /selectedOrganizations: 0/);
+
+    const jobRef = await runClerkCommand(["cleanup-job-ref"], environment);
+    assert.match(jobRef.stdout, /selectedUsers: 0/);
+
+    const stale = await runClerkCommand(
+      ["cleanup-stale", "--older-than-hours", "6"],
+      { ...environment, DRY_RUN: "true" },
+    );
+    assert.match(stale.stdout, /dryRun: true/);
+
+    await assert.rejects(
+      runClerkCommand(
+        ["cleanup-generation", "playwright,unknown"],
+        environment,
+      ),
+      /Unknown Clerk test role: unknown/,
+    );
+  } finally {
+    await closeServer(server);
+  }
+});
+
+function clerkCommandEnvironment(
+  server: Server,
+): Readonly<Record<string, string>> {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected Clerk fixture to listen on a TCP port");
+  }
+  return {
+    CLERK_API_TEST_BASE_URL: `http://127.0.0.1:${address.port}/v1`,
+    CLERK_SECRET_KEY: "clerk-test-secret",
+    GITHUB_RUN_ATTEMPT: "1",
+    GITHUB_RUN_ID: "7000",
+    JOB_REF: "pr-321",
+  };
+}
+
+async function runClerkCommand(
+  arguments_: readonly string[],
+  environment: Readonly<Record<string, string>>,
+): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  return await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", "playwright/clerk-test-resources.ts", ...arguments_],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, ...environment },
+    },
+  );
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function sendJson(response: ServerResponse, body: unknown, status = 200): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}

--- a/e2e/playwright/lib/runner-account.test.ts
+++ b/e2e/playwright/lib/runner-account.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import {
   createServer,
   type IncomingMessage,
+  type Server,
   type ServerResponse,
 } from "node:http";
 import { tmpdir } from "node:os";
@@ -13,64 +14,67 @@ import { test } from "node:test";
 
 const execFileAsync = promisify(execFile);
 
+interface TestOwner {
+  readonly jobRef: string;
+  readonly generation: string;
+  readonly role: string;
+}
+
 interface OrganizationRequest {
   readonly created_by: string;
   readonly name: string;
+  readonly private_metadata: {
+    readonly vm0CiTest: TestOwner;
+  };
 }
 
-test("prepares and cleans up three independent runner organizations", async () => {
-  const organizationRequests: OrganizationRequest[] = [];
-  const deletedOrganizationPaths: string[] = [];
-  let userSequence = 0;
-  let organizationSequence = 0;
-  const server = createServer((request, response) => {
-    handleClerkRequest(request, response, {
-      createOrganization: (body) => {
-        organizationRequests.push(body);
-        organizationSequence += 1;
-        return `org_${organizationSequence}`;
-      },
-      createUser: () => {
-        userSequence += 1;
-        return `user_${userSequence}`;
-      },
-      deleteOrganization: (path) => {
-        deletedOrganizationPaths.push(path);
-      },
-    }).catch((error: unknown) => {
-      response.writeHead(500, { "Content-Type": "application/json" });
-      response.end(JSON.stringify({ error: String(error) }));
-    });
-  });
+interface StoredUser {
+  readonly id: string;
+  readonly email: string;
+}
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
+interface StoredOrganization {
+  readonly id: string;
+  readonly request: OrganizationRequest;
+}
+
+interface ClerkFixtureState {
+  readonly users: StoredUser[];
+  readonly organizations: StoredOrganization[];
+  readonly organizationRequests: OrganizationRequest[];
+  readonly deletionEvents: string[];
+  userCreateCount: number;
+}
+
+interface ClerkFixture {
+  readonly apiUrl: string;
+  readonly server: Server;
+  readonly state: ClerkFixtureState;
+}
+
+test("prepares and cleans one generation of runner accounts", async () => {
+  const fixture = await startClerkFixture();
   const tempDirectory = await mkdtemp(join(tmpdir(), "runner-account-test-"));
   try {
-    const address = server.address();
-    assert(address && typeof address === "object");
-    const clerkApiUrl = `http://127.0.0.1:${address.port}/v1`;
     const githubOutput = join(tempDirectory, "github-output");
-
-    await runRunnerAccount("prepare", {
-      CLERK_API_TEST_BASE_URL: clerkApiUrl,
-      CLERK_SECRET_KEY: "clerk-test-secret",
+    const environment = runnerEnvironment(fixture.apiUrl, {
       GITHUB_OUTPUT: githubOutput,
-      JOB_REF: "pr-123",
     });
 
-    assert.deepEqual(organizationRequests, [
-      { created_by: "user_1", name: "e2e-runner-pr-123" },
-      {
-        created_by: "user_2",
-        name: "e2e-runner-real-codex-pr-123",
-      },
-      {
-        created_by: "user_3",
-        name: "e2e-runner-real-claude-pr-123",
-      },
+    await runRunnerAccount("prepare", environment);
+
+    assert.deepEqual(fixture.state.organizationRequests, [
+      organizationRequest("user_1", "e2e-runner-pr-123", "runner"),
+      organizationRequest(
+        "user_2",
+        "e2e-runner-real-codex-pr-123",
+        "runner-real-codex",
+      ),
+      organizationRequest(
+        "user_3",
+        "e2e-runner-real-claude-pr-123",
+        "runner-real-claude",
+      ),
     ]);
     assert.equal(
       await readFile(githubOutput, "utf8"),
@@ -78,106 +82,302 @@ test("prepares and cleans up three independent runner organizations", async () =
         "runner-organization-id=org_1",
         "codex-organization-id=org_2",
         "claude-organization-id=org_3",
-        "runner-email=pr-123+clerk_test+runner@vm0-e2e.ai",
-        "codex-email=pr-123+clerk_test+runner-real-codex@vm0-e2e.ai",
-        "claude-email=pr-123+clerk_test+runner-real-claude@vm0-e2e.ai",
+        "runner-email=pr-123+clerk_test+9001-3+runner@vm0-e2e.ai",
+        "codex-email=pr-123+clerk_test+9001-3+runner-real-codex@vm0-e2e.ai",
+        "claude-email=pr-123+clerk_test+9001-3+runner-real-claude@vm0-e2e.ai",
         "",
       ].join("\n"),
     );
 
-    await runRunnerAccount("cleanup", {
-      CLERK_API_TEST_BASE_URL: clerkApiUrl,
-      CLERK_SECRET_KEY: "clerk-test-secret",
-      E2E_RUNNER_ORGANIZATION_ID: "org_1",
-      E2E_RUNNER_CODEX_ORGANIZATION_ID: "org_2",
-      E2E_RUNNER_CLAUDE_ORGANIZATION_ID: "org_3",
-      JOB_REF: "pr-123",
+    fixture.state.users.push({
+      id: "user_foreign",
+      email: "pr-123+clerk_test+9001-2+runner@vm0-e2e.ai",
     });
-    assert.deepEqual(deletedOrganizationPaths, [
-      "/v1/organizations/org_1",
-      "/v1/organizations/org_2",
-      "/v1/organizations/org_3",
+    fixture.state.organizations.push({
+      id: "org_foreign",
+      request: {
+        created_by: "user_foreign",
+        name: "foreign generation",
+        private_metadata: {
+          vm0CiTest: {
+            jobRef: "pr-123",
+            generation: "9001-2",
+            role: "runner",
+          },
+        },
+      },
+    });
+
+    await runRunnerAccount("cleanup", runnerEnvironment(fixture.apiUrl));
+
+    assert.deepEqual(fixture.state.deletionEvents, [
+      "organization:org_1",
+      "organization:org_2",
+      "organization:org_3",
+      "user:user_1",
+      "user:user_2",
+      "user:user_3",
     ]);
+    assert.deepEqual(fixture.state.users, [
+      {
+        id: "user_foreign",
+        email: "pr-123+clerk_test+9001-2+runner@vm0-e2e.ai",
+      },
+    ]);
+    assert.deepEqual(
+      fixture.state.organizations.map((organization) => organization.id),
+      ["org_foreign"],
+    );
   } finally {
     await rm(tempDirectory, { recursive: true, force: true });
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
-    });
+    await closeServer(fixture.server);
   }
 });
 
-interface ClerkRequestHandlers {
-  readonly createOrganization: (body: OrganizationRequest) => string;
-  readonly createUser: () => string;
-  readonly deleteOrganization: (path: string) => void;
+test("partial runner preparation cleans resources without outputs", async () => {
+  const fixture = await startClerkFixture({ failUserCreateAt: 2 });
+  const tempDirectory = await mkdtemp(
+    join(tmpdir(), "runner-account-partial-test-"),
+  );
+  try {
+    await assert.rejects(
+      runRunnerAccount(
+        "prepare",
+        runnerEnvironment(fixture.apiUrl, {
+          GITHUB_OUTPUT: join(tempDirectory, "github-output"),
+        }),
+      ),
+      /create Clerk user failed with HTTP 400 \(json\)/,
+    );
+
+    assert.deepEqual(fixture.state.users, []);
+    assert.deepEqual(fixture.state.organizations, []);
+    assert.deepEqual(fixture.state.deletionEvents, [
+      "organization:org_1",
+      "user:user_1",
+    ]);
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+    await closeServer(fixture.server);
+  }
+});
+
+async function startClerkFixture(
+  options: { readonly failUserCreateAt?: number } = {},
+): Promise<ClerkFixture> {
+  const state: ClerkFixtureState = {
+    users: [],
+    organizations: [],
+    organizationRequests: [],
+    deletionEvents: [],
+    userCreateCount: 0,
+  };
+  const server = createServer((request, response) => {
+    handleClerkRequest(request, response, state, options).catch(
+      (error: unknown) => {
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: String(error) }));
+      },
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("Expected Clerk fixture to listen on a TCP port");
+  }
+  return {
+    apiUrl: `http://127.0.0.1:${address.port}/v1`,
+    server,
+    state,
+  };
 }
 
 async function handleClerkRequest(
   request: IncomingMessage,
   response: ServerResponse,
-  handlers: ClerkRequestHandlers,
+  state: ClerkFixtureState,
+  options: { readonly failUserCreateAt?: number },
 ): Promise<void> {
   const path = request.url ?? "";
-  if (request.method === "GET" && path.startsWith("/v1/users?")) {
-    sendJson(response, []);
+  const url = new URL(path, "http://clerk.test");
+  if (request.method === "GET" && url.pathname === "/v1/users") {
+    sendJson(
+      response,
+      state.users.map((user) => ({
+        id: user.id,
+        email_addresses: [{ email_address: user.email }],
+      })),
+    );
     return;
   }
-  if (request.method === "POST" && path === "/v1/users") {
-    sendJson(response, { id: handlers.createUser() });
+  if (request.method === "GET" && url.pathname === "/v1/organizations") {
+    sendJson(response, {
+      data: state.organizations.map((organization) => ({
+        id: organization.id,
+        private_metadata: organization.request.private_metadata,
+      })),
+      total_count: state.organizations.length,
+    });
     return;
   }
-  if (request.method === "POST" && path === "/v1/organizations") {
+  if (request.method === "POST" && url.pathname === "/v1/users") {
+    state.userCreateCount += 1;
+    if (state.userCreateCount === options.failUserCreateAt) {
+      sendJson(response, { errors: [] }, 400);
+      return;
+    }
+    const email = await readUserEmail(request);
+    const id = `user_${state.userCreateCount}`;
+    state.users.push({ id, email });
+    sendJson(response, { id });
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/v1/organizations") {
     const body = await readOrganizationRequest(request);
-    sendJson(response, { id: handlers.createOrganization(body) });
+    const id = `org_${state.organizations.length + 1}`;
+    state.organizationRequests.push(body);
+    state.organizations.push({ id, request: body });
+    sendJson(response, { id });
     return;
   }
   if (
     request.method === "PATCH" &&
-    /^\/v1\/organizations\/org_\d+\/memberships\/user_\d+$/.test(path)
+    /^\/v1\/organizations\/org_\d+\/memberships\/user_\d+$/.test(url.pathname)
   ) {
     sendJson(response, { role: "org:admin" });
     return;
   }
   if (
     request.method === "DELETE" &&
-    /^\/v1\/organizations\/org_\d+$/.test(path)
+    url.pathname.startsWith("/v1/organizations/")
   ) {
-    handlers.deleteOrganization(path);
+    const id = url.pathname.slice("/v1/organizations/".length);
+    deleteStoredResource(
+      state.organizations,
+      id,
+      state.deletionEvents,
+      "organization",
+    );
+    sendJson(response, {});
+    return;
+  }
+  if (request.method === "DELETE" && url.pathname.startsWith("/v1/users/")) {
+    const id = url.pathname.slice("/v1/users/".length);
+    deleteStoredResource(state.users, id, state.deletionEvents, "user");
     sendJson(response, {});
     return;
   }
   sendJson(response, { error: "not found" }, 404);
 }
 
+function deleteStoredResource<T extends { readonly id: string }>(
+  resources: T[],
+  id: string,
+  events: string[],
+  type: "organization" | "user",
+): void {
+  const index = resources.findIndex((resource) => resource.id === id);
+  if (index === -1) {
+    return;
+  }
+  resources.splice(index, 1);
+  events.push(`${type}:${id}`);
+}
+
+async function readUserEmail(request: IncomingMessage): Promise<string> {
+  const parsed = await readJsonBody(request);
+  if (!isRecord(parsed) || !Array.isArray(parsed.email_address)) {
+    throw new Error("Invalid user request");
+  }
+  const email = parsed.email_address[0];
+  if (typeof email !== "string") {
+    throw new Error("Invalid user request email");
+  }
+  return email;
+}
+
 async function readOrganizationRequest(
   request: IncomingMessage,
 ): Promise<OrganizationRequest> {
+  const parsed = await readJsonBody(request);
+  if (
+    !isRecord(parsed) ||
+    typeof parsed.name !== "string" ||
+    typeof parsed.created_by !== "string" ||
+    !isRecord(parsed.private_metadata) ||
+    !isRecord(parsed.private_metadata.vm0CiTest)
+  ) {
+    throw new Error("Invalid organization request");
+  }
+  const owner = parsed.private_metadata.vm0CiTest;
+  if (
+    typeof owner.jobRef !== "string" ||
+    typeof owner.generation !== "string" ||
+    typeof owner.role !== "string"
+  ) {
+    throw new Error("Invalid organization owner metadata");
+  }
+  return {
+    name: parsed.name,
+    created_by: parsed.created_by,
+    private_metadata: {
+      vm0CiTest: {
+        jobRef: owner.jobRef,
+        generation: owner.generation,
+        role: owner.role,
+      },
+    },
+  };
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
   await new Promise<void>((resolve, reject) => {
-    request.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", resolve);
     request.on("error", reject);
   });
   const parsed: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
-  if (
-    typeof parsed !== "object" ||
-    parsed === null ||
-    !("name" in parsed) ||
-    typeof parsed.name !== "string" ||
-    !("created_by" in parsed) ||
-    typeof parsed.created_by !== "string"
-  ) {
-    throw new Error("Invalid organization request");
-  }
-  return { name: parsed.name, created_by: parsed.created_by };
+  return parsed;
+}
+
+function organizationRequest(
+  createdBy: string,
+  name: string,
+  role: string,
+): OrganizationRequest {
+  return {
+    created_by: createdBy,
+    name,
+    private_metadata: {
+      vm0CiTest: {
+        jobRef: "pr-123",
+        generation: "9001-3",
+        role,
+      },
+    },
+  };
+}
+
+function runnerEnvironment(
+  clerkApiUrl: string,
+  extra: Readonly<Record<string, string>> = {},
+): Readonly<Record<string, string>> {
+  return {
+    CLERK_API_TEST_BASE_URL: clerkApiUrl,
+    CLERK_SECRET_KEY: "clerk-test-secret",
+    GITHUB_RUN_ATTEMPT: "3",
+    GITHUB_RUN_ID: "9001",
+    JOB_REF: "pr-123",
+    ...extra,
+  };
 }
 
 async function runRunnerAccount(
@@ -194,7 +394,23 @@ async function runRunnerAccount(
   );
 }
 
-function sendJson(response: ServerResponse, body: object, status = 200): void {
-  response.writeHead(status, { "Content-Type": "application/json" });
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function sendJson(response: ServerResponse, body: unknown, status = 200): void {
+  response.writeHead(status, { "content-type": "application/json" });
   response.end(JSON.stringify(body));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -1,13 +1,19 @@
 import { appendFile } from "node:fs/promises";
 
 import {
+  cleanupCurrentClerkTestGeneration,
   createOrganization,
   createUser,
-  deleteOrganizationById,
-  deleteUserByEmail,
   runnerTestAccounts,
+  type ClerkTestRole,
   type RunnerTestAccounts,
 } from "./lib/clerk-api";
+
+const RUNNER_TEST_ROLES = [
+  "runner",
+  "runner-real-codex",
+  "runner-real-claude",
+] as const satisfies readonly ClerkTestRole[];
 
 async function main(): Promise<void> {
   const command = process.argv[2];
@@ -21,7 +27,7 @@ async function main(): Promise<void> {
   if (command === "prepare") {
     await prepareRunnerAccounts(accounts, jobRef);
   } else {
-    await cleanupRunnerAccounts(accounts);
+    await cleanupRunnerAccounts();
   }
 }
 
@@ -29,70 +35,55 @@ async function prepareRunnerAccounts(
   runnerAccounts: RunnerTestAccounts,
   jobRef: string,
 ): Promise<void> {
-  await deleteRunnerUsers(runnerAccounts);
+  try {
+    const runnerUserId = await createUser(runnerAccounts.runner);
+    const runnerOrganizationId = await createOrganization(
+      `e2e-runner-${jobRef}`,
+      runnerUserId,
+      "runner",
+    );
+    const codexUserId = await createUser(runnerAccounts.codex);
+    const codexOrganizationId = await createOrganization(
+      `e2e-runner-real-codex-${jobRef}`,
+      codexUserId,
+      "runner-real-codex",
+    );
+    const claudeUserId = await createUser(runnerAccounts.claude);
+    const claudeOrganizationId = await createOrganization(
+      `e2e-runner-real-claude-${jobRef}`,
+      claudeUserId,
+      "runner-real-claude",
+    );
 
-  const runnerUserId = await createUser(runnerAccounts.runner);
-  const runnerOrganizationId = await createOrganization(
-    `e2e-runner-${jobRef}`,
-    runnerUserId,
-  );
-  const codexUserId = await createUser(runnerAccounts.codex);
-  const codexOrganizationId = await createOrganization(
-    `e2e-runner-real-codex-${jobRef}`,
-    codexUserId,
-  );
-  const claudeUserId = await createUser(runnerAccounts.claude);
-  const claudeOrganizationId = await createOrganization(
-    `e2e-runner-real-claude-${jobRef}`,
-    claudeUserId,
-  );
+    await appendFile(
+      requiredEnvironmentVariable("GITHUB_OUTPUT"),
+      [
+        `runner-organization-id=${runnerOrganizationId}`,
+        `codex-organization-id=${codexOrganizationId}`,
+        `claude-organization-id=${claudeOrganizationId}`,
+        `runner-email=${runnerAccounts.runner}`,
+        `codex-email=${runnerAccounts.codex}`,
+        `claude-email=${runnerAccounts.claude}`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
 
-  await appendFile(
-    requiredEnvironmentVariable("GITHUB_OUTPUT"),
-    [
-      `runner-organization-id=${runnerOrganizationId}`,
-      `codex-organization-id=${codexOrganizationId}`,
-      `claude-organization-id=${claudeOrganizationId}`,
-      `runner-email=${runnerAccounts.runner}`,
-      `codex-email=${runnerAccounts.codex}`,
-      `claude-email=${runnerAccounts.claude}`,
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-
-  console.log("Prepared runner E2E accounts", {
-    runnerOrganizationId,
-    codexOrganizationId,
-    claudeOrganizationId,
-    ...runnerAccounts,
-  });
+    console.log("Prepared runner E2E accounts", {
+      runnerOrganizationId,
+      codexOrganizationId,
+      claudeOrganizationId,
+      ...runnerAccounts,
+    });
+  } catch (cause) {
+    await cleanupRunnerAccounts();
+    throw cause;
+  }
 }
 
-async function cleanupRunnerAccounts(
-  runnerAccounts: RunnerTestAccounts,
-): Promise<void> {
-  const organizationIds = [
-    process.env.E2E_RUNNER_ORGANIZATION_ID,
-    process.env.E2E_RUNNER_CODEX_ORGANIZATION_ID,
-    process.env.E2E_RUNNER_CLAUDE_ORGANIZATION_ID,
-  ];
-  for (const organizationId of organizationIds) {
-    if (organizationId) {
-      await deleteOrganizationById(organizationId);
-    }
-  }
-
-  await deleteRunnerUsers(runnerAccounts);
-  console.log("Cleaned up runner E2E accounts");
-}
-
-async function deleteRunnerUsers(
-  runnerAccounts: RunnerTestAccounts,
-): Promise<void> {
-  for (const email of Object.values(runnerAccounts)) {
-    await deleteUserByEmail(email);
-  }
+async function cleanupRunnerAccounts(): Promise<void> {
+  const result = await cleanupCurrentClerkTestGeneration(RUNNER_TEST_ROLES);
+  console.log("Cleaned up runner E2E accounts", result);
 }
 
 function requiredEnvironmentVariable(name: string): string {

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -3,7 +3,7 @@ import { signInWithClerkTestingHelper } from "../lib/auth";
 import {
   createOrganization,
   createUser,
-  deleteUserByEmail,
+  deleteClerkTestOwnerResources,
   generateTestEmail,
 } from "../lib/clerk-api";
 import {
@@ -20,14 +20,19 @@ test("paid onboarding completes through the video workflow", async ({
 
   const apiUrl = process.env.VM0_API_BACKEND_URL!;
   const appUrl = deriveAppUrl(apiUrl);
-  const email = generateTestEmail();
+  const email = generateTestEmail("paid-onboarding");
+  let organizationId: string | undefined;
 
   try {
     const userId = await createUser(email);
-    const orgId = await createOrganization("E2E Paid Onboarding Org", userId);
+    organizationId = await createOrganization(
+      "E2E Paid Onboarding Org",
+      userId,
+      "paid-onboarding",
+    );
 
     await signInWithClerkTestingHelper(page, email, appUrl, {
-      activeOrganizationId: orgId,
+      activeOrganizationId: organizationId,
     });
 
     await startVideoOnboardingCheckout(page, { appUrl });
@@ -40,6 +45,6 @@ test("paid onboarding completes through the video workflow", async ({
       /^\/(?:prompt|agents\/[^/]+\/chat|chats\/[^/]+)$/,
     );
   } finally {
-    await deleteUserByEmail(email);
+    await deleteClerkTestOwnerResources(email, organizationId);
   }
 });

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -45,6 +45,10 @@ test("paid onboarding completes through the video workflow", async ({
       /^\/(?:prompt|agents\/[^/]+\/chat|chats\/[^/]+)$/,
     );
   } finally {
-    await deleteClerkTestOwnerResources(email, organizationId);
+    await deleteClerkTestOwnerResources(
+      email,
+      organizationId,
+      "paid-onboarding",
+    );
   }
 });

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -10,10 +10,11 @@
 # by the Playwright suite and have been removed from this file.
 #
 # Required env vars:
-#   VM0_AUTH_URL   - Target auth URL (e.g., https://pr-123-app.omby.ai)
+#   VM0_API_BACKEND_URL - API URL and local fallback for the auth URL
+#   CLERK_SECRET_KEY    - Backend key used to clean the exact test account
 #
 # Optional env vars:
-#   VM0_API_BACKEND_URL            - API URL, used as a local fallback for auth URL
+#   VM0_AUTH_URL           - Target auth URL (e.g., https://pr-123-app.omby.ai)
 #   VM0_AUTH_DOMAIN        - API domain override for auth callbacks
 #   VM0_AUTH_REDIRECT_URL  - Post-auth app URL to verify Clerk completion
 #   E2E_ACCOUNT            - Test email (auto-generated if empty)

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -26,6 +26,7 @@ setup_file() {
   export BROWSER_SESSION_PREFIX
   export AGENT_BROWSER_SESSION="${BROWSER_SESSION_PREFIX}-sign-up"
   browser_setup
+  delete_e2e_account_if_exists
 
   # Generate a password for sign-up
   SIGNUP_PASSWORD="$(generate_password)"
@@ -41,7 +42,10 @@ setup_file() {
 }
 
 teardown_file() {
-  browser_teardown
+  local status=0
+  browser_teardown || status=$?
+  delete_e2e_account_if_exists || status=$?
+  return "$status"
 }
 
 auth_url() {


### PR DESCRIPTION
## Summary

- scope every CI Clerk test identity to its workflow run, attempt, and bounded role, and mark test organizations atomically with the same ownership metadata
- clean organizations before users from Browser, Playwright, paid-onboarding, and runner paths, including partial runner preparation and cancelled preparation cleanup
- replace fuzzy, unpaginated PR-close cleanup and unrestricted empty-organization cleanup with a typed, paginated lifecycle command
- add role-scoped workflow finalizers plus a six-hour strict-marker safety sweep with dry-run, pacing, retry, and accurate deletion accounting

## Safety

- finalizers select only their own roles, so parallel Playwright and runner jobs in one workflow cannot delete each other's resources
- recurring organization deletion requires exact private metadata and never relies on an organization merely being empty
- `pull_request_target` cleanup executes credential-free default-branch code with read-only repository permissions
- non-idempotent create requests remain single-attempt; only GET, PATCH, and DELETE operations retry bounded transient failures

No production API, database schema, product behavior, or E2E test purpose is changed. Legacy unmarked resources require the separately documented one-time cleanup after rollout; permanent legacy-name matching is intentionally excluded.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test`
- Prettier check for all changed TypeScript and workflow files
- Bash syntax and ShellCheck for changed helpers and workflow tests
- Clerk lifecycle, runner workflow, app preview ingress, checkout depth, and workflow shell compatibility tests
- `actionlint`
- `git diff --check`

Closes #26526
