### PR TITLE
fix: flatten artifact cards and pin the artifacts kind filter

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifact-catalog-page.test.tsx
@@ -119,6 +119,36 @@ describe("artifact catalog page", () => {
     );
   });
 
+  it("keeps the kind filter outside the scrolling catalog region", async () => {
+    context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
+      return respond(200, {
+        artifacts: [artifact({ kind: "presentation", title: "launch-deck" })],
+        nextCursor: null,
+      });
+    });
+
+    setupArtifactCatalogPage();
+
+    const card = await findCard("launch-deck");
+    const filter = buttonByLabel(
+      i18n.t(($) => {
+        return $.artifacts.catalog.filters.presentationAria;
+      }),
+    );
+    if (!filter) {
+      throw new Error("Expected the presentation kind filter to render");
+    }
+    const viewport = document.querySelector("main");
+    if (!viewport) {
+      throw new Error("Expected the artifacts page to render a scroll region");
+    }
+
+    // The filter stays pinned only while it lives outside the scroll
+    // container; moving it back inside would silently scroll it away.
+    expect(viewport.contains(filter)).toBeFalsy();
+    expect(viewport.contains(card)).toBeTruthy();
+  });
+
   it("defaults to presentations and uses the requested filter order", async () => {
     const requestedKinds: (string | undefined)[] = [];
     context.mocks.api(artifactCatalogContract.list, ({ query, respond }) => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx
@@ -171,7 +171,7 @@ function ArtifactCatalogCard({
         event.preventDefault();
         onOpen(artifact.id);
       }}
-      className="group flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card shadow-sm outline-none transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className="group flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card outline-none transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
       <div
         data-testid="artifact-catalog-card-preview"
@@ -195,7 +195,7 @@ function ArtifactCatalogCard({
         )}
         <ArtifactKindIcon kind={artifact.kind} />
       </div>
-      <div className="flex h-16 min-w-0 shrink-0 items-center border-t border-border p-3">
+      <div className="flex min-w-0 shrink-0 items-center border-t border-border p-3">
         <h2
           title={artifact.title}
           className="min-w-0 truncate text-sm font-semibold leading-5 text-foreground"
@@ -324,8 +324,8 @@ export function ArtifactCatalogSkeleton({
             className="flex flex-col overflow-hidden rounded-lg border border-border bg-card"
           >
             <div className="aspect-[16/10] w-full shrink-0 bg-muted/30" />
-            <div className="flex h-16 shrink-0 items-center p-3">
-              <div className="h-4 w-3/4 rounded bg-muted/60" />
+            <div className="flex shrink-0 items-center border-t border-border p-3">
+              <div className="h-5 w-3/4 rounded bg-muted/60" />
             </div>
           </div>
         );
@@ -514,8 +514,10 @@ export function ArtifactCatalogPage() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {lightboxUrl && <AttachmentLightbox />}
-      <header className="shrink-0 bg-transparent px-4 pb-0 pt-3 sm:px-6 md:pb-3 md:pt-10">
-        <div className="mx-auto w-full max-w-[900px]">
+      {/* The header sits outside the scroll container so the kind filter stays
+          pinned to the top while the catalog scrolls under it. */}
+      <header className="shrink-0 bg-transparent px-4 pb-3 pt-3 sm:px-6 md:pt-10">
+        <div className="mx-auto flex w-full max-w-[900px] flex-col gap-3">
           <div className="hidden min-w-0 md:block">
             <h1 className="text-lg font-semibold tracking-tight text-foreground">
               {t(($) => {
@@ -528,14 +530,6 @@ export function ArtifactCatalogPage() {
               })}
             </p>
           </div>
-        </div>
-      </header>
-
-      <main
-        onScroll={handleScroll}
-        className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6 [scrollbar-gutter:stable]"
-      >
-        <div className="mx-auto flex w-full max-w-[900px] flex-col gap-4">
           <ArtifactCatalogKindFilter
             selectedKind={selectedKind}
             avatarEnabled={
@@ -546,6 +540,14 @@ export function ArtifactCatalogPage() {
             }
             onKindChange={setKind}
           />
+        </div>
+      </header>
+
+      <main
+        onScroll={handleScroll}
+        className="flex-1 overflow-auto px-4 pb-8 pt-1 sm:px-6 [scrollbar-gutter:stable]"
+      >
+        <div className="mx-auto flex w-full max-w-[900px] flex-col gap-4">
           {catalog.state === "loading" ? (
             <ArtifactCatalogSkeleton
               layout={sharedConversationLayout ? "list" : "grid"}

--- a/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
@@ -18,9 +18,9 @@ interface BrowserSessionCardProps {
 }
 
 const BROWSER_SESSION_CARD_CLASS =
-  "inline-flex w-[min(100%,400px)] flex-col overflow-hidden rounded-lg border border-foreground/10 bg-background text-left align-top text-foreground shadow-sm transition-all duration-200";
+  "inline-flex w-[min(100%,400px)] flex-col overflow-hidden rounded-lg border border-foreground/10 bg-background text-left align-top text-foreground transition-all duration-200";
 const BROWSER_SESSION_CARD_HOVER_CLASS =
-  "hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
+  "hover:scale-[1.015] hover:border-foreground/20";
 
 function BrowserSessionStatus({ live }: { readonly live: boolean }) {
   const { t } = useTranslation();

--- a/turbo/apps/platform/src/views/zero-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-body-cards.tsx
@@ -82,8 +82,8 @@ type ChatImagePreviewLinkProps = {
 };
 
 const CHAT_INLINE_MEDIA_PREVIEW_CHROME_CLASS = cn(
-  "border border-foreground/10 shadow-sm transition-all duration-200",
-  "hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30",
+  "border border-foreground/10 transition-all duration-200",
+  "hover:scale-[1.015] hover:border-foreground/20",
 );
 
 const CHAT_INLINE_MEDIA_THUMBNAIL_PREVIEW_CLASS = cn(

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -81,9 +81,9 @@ type TextPreviewProps = {
 };
 
 const MEDIA_PREVIEW_CARD_CLASS =
-  "inline-flex w-[min(100%,400px)] overflow-hidden rounded-lg border border-foreground/10 bg-background text-left align-top text-foreground no-underline shadow-sm transition-all duration-200";
+  "inline-flex w-[min(100%,400px)] overflow-hidden rounded-lg border border-foreground/10 bg-background text-left align-top text-foreground no-underline transition-all duration-200";
 const MEDIA_PREVIEW_CARD_HOVER_CLASS =
-  "hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
+  "hover:scale-[1.015] hover:border-foreground/20";
 
 function TextPreview({ filename, kind, text$, url }: TextPreviewProps) {
   return (


### PR DESCRIPTION
Three artifact-card fixes reported from the Artifacts page.

## 1. Shadows removed from artifact cards

Artifact cards used Tailwind's `shadow-sm`. Under Tailwind v4 that resolves to the old `shadow` (`0 1px 3px rgb(0 0 0 / .1)`), which is much heavier than the app-wide `--zero-card-shadow` (`0 2px 12px hsl(220 12% 50% / .04)`) — hence the "too heavy" report.

Swept the product for surfaces that render an artifact as a card and removed both the resting shadow and the `hover:shadow-lg hover:shadow-black/10` lift. The border-color shift and `hover:scale-[1.015]` remain, so every card keeps a visible hover state.

| Surface | File |
| --- | --- |
| Artifacts page grid + thread artifacts sidebar (shared component) | `artifacts-page/artifact-catalog-page.tsx` |
| In-chat artifact preview cards (image / video / site / document) | `zero-page/zero-attachment-preview.tsx` |
| Inline chat media previews | `zero-page/chat-body-cards.tsx` |
| Browser session card | `zero-page/browser-session-card.tsx` |

The browser session card is not an artifact, but it is built from the identical card recipe and sits inline next to artifact cards in the chat stream — leaving it elevated would have been the only raised card left in the thread.

**Left alone (raise if wanted):** the shared-conversations list on the Artifacts page uses the `zero-card` class, which carries the app-wide `--zero-card-shadow`. That token is used by every list card in the product, so removing it here would make the page inconsistent with the rest of the app.

## 2. Even padding under the card title

The title row paired a fixed `h-16` with `p-3`: horizontal padding was 12px while vertical worked out to ~22px on a 20px line box. Removed the fixed height so `p-3` applies evenly on all four sides (44px row). The loading skeleton now matches the same box — same `border-t` and a 20px bar — so nothing shifts when data lands.

## 3. Kind filter pinned to the top

The tab row lived inside the scrolling `<main>` and scrolled away. Moved it into the `<header>`, which is already `shrink-0` and outside the scroll container, so it stays pinned with no sticky background seam over the `zero-workspace-bg` gradient. Header/main padding was rebalanced to preserve the existing 16px gap to the first card row.

## Verification

`pnpm format`, `tsc --noEmit`, and `eslint` clean on `@vm0/app`. Tests: `artifacts-page` (all), `zero-attachment-chips`, `chat-event-action-cards`, `thread-sidebar` — 122 passed. Not browser-verified locally; please check the preview deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)