### PR TITLE
fix(core): correct presentation templates switch maintainer

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -316,7 +316,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PresentationTemplates]: {
-    maintainer: "bingjie@vm0.ai",
+    maintainer: "okou@vm0.ai",
     description:
       "Enable owner-scoped presentation template imports and catalog APIs.",
     enabled: false,


### PR DESCRIPTION
## Summary

- attribute the `presentationTemplates` feature switch to `okou@vm0.ai`
- remove `bingjie@vm0.ai` from the switch metadata without changing rollout behavior

## Attribution

The switch was introduced by Okou while addressing the missing-gate review finding on #26301. Okou also independently authored the same switch on #26361 before that stacked PR was rebased. The GitHub author identity on #26301 reflected the invoking account rather than the implementation agent.

## Validation

- `pnpm exec prettier --check packages/core/src/feature-switch.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm knip --workspace @vm0/core`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 tests)