### PR TITLE
fix(api): preserve thread context for queued web runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -9286,6 +9286,10 @@ describe("CHAT-02: shared user message queue", () => {
       "You are communicating with the user through the web chat UI.",
     ].join("\n\n");
     expect(run.appendSystemPrompt).toContain(webPrompt);
+    expect(run.appendSystemPrompt).toContain("# This Chat Thread");
+    expect(run.appendSystemPrompt).toContain(
+      `- CHAT_THREAD_ID: ${anchor.threadId}`,
+    );
     expect(run.appendSystemPrompt).toContain("# Inline Templates");
     expect(run.appendSystemPrompt).toContain(style.illustrationStyleId);
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -138,7 +138,7 @@ import {
   projectUserMessage,
   requiredUserMessageForEvent,
 } from "./zero-chat-user-message.service";
-import { buildAgentRunSourceContext } from "./zero-web-chat-session-prompt.service";
+import { buildWebChatAppendSystemPrompt } from "./zero-web-chat-session-prompt.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import {
   integrationCompletionFallbackEventIdForRun,
@@ -2227,13 +2227,6 @@ async function runTerminalChatCallbackSideEffects(args: {
   });
 }
 
-function buildWebChatPrompt(): string {
-  return [
-    "# Current Integration\nYou are currently running inside: Web",
-    "You are communicating with the user through the web chat UI.",
-  ].join("\n\n");
-}
-
 function buildAppendSystemPrompt(
   integrationPrompt: string,
   incompleteContext: string,
@@ -2759,12 +2752,16 @@ type LaunchLoader = (
 const loadWebQueuedLaunchMaterial: LaunchLoader = (_db, args) => {
   return Promise.resolve({
     prompt: args.userMessageProjection.agentPrompt,
-    appendSystemPrompt: [
-      buildWebChatPrompt(),
-      ...(args.agentRunSource
-        ? [buildAgentRunSourceContext(args.agentRunSource)]
-        : []),
-    ].join("\n\n"),
+    appendSystemPrompt: buildWebChatAppendSystemPrompt({
+      threadId: args.chatThreadId,
+      incompleteContext: "",
+      priorContext: "",
+      context: {
+        generationTemplatePrompt: "",
+        computerUseHostDisplayName: null,
+        agentRunSource: args.agentRunSource,
+      },
+    }),
     delivery: {},
   });
 };

--- a/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts
@@ -97,7 +97,7 @@ function buildCurrentThreadContext(threadId: string): string {
  * to do with them. What the run needs from the source thread depends on the
  * message, so the commands are listed and the choice is left to the run.
  */
-export function buildAgentRunSourceContext(
+function buildAgentRunSourceContext(
   source: ChatAgentRunSourceAnnotation,
 ): string {
   return [


### PR DESCRIPTION
## Summary

- build callback auto-sent Web prompts through the canonical Web chat prompt builder
- preserve `# This Chat Thread` and the exact thread ID for queued follow-ups without leaking one-shot generation templates
- strengthen the forced queued auto-send API integration test at the public route boundary

## Root cause

[Turbo run 31576337172](https://github.com/vm0-ai/vm0/actions/runs/31576337172) failed at [`test-api (6)`](https://github.com/vm0-ai/vm0/actions/runs/31576337172/job/94049991816) on `1db44b9d4a41427fc2c635b75ed2e01bb9aab9e8` because the second prompt did not contain `# This Chat Thread`.

Normal direct follow-ups use `buildWebChatAppendSystemPrompt`, while callback-owned queue promotion assembled only the Web integration and source context. Whether the follow-up used the direct path or the queued callback path depended on its interleaving with terminal callback completion, so queued follow-ups lost their thread coordinates. The one-shot generation-template behavior itself remained correct.

The `ci-gate-turbo` failure was an aggregate result, and the other cancelled or skipped jobs were downstream fail-fast/dependency noise. No teardown rejection was causal.

## Verification

- `pnpm prettier --check turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts turbo/apps/api/src/signals/services/zero-web-chat-session-prompt.service.ts turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm --filter api run lint`
- API TypeScript project checks: `boundaries`, `gateways`, `core`, `bootstrap`, `tests`, and `bootstrap-wiring`
- `pnpm knip --workspace api`
- `git diff --check`

The focused Vitest case was not run locally because PostgreSQL was unavailable and no local database or service was started. The PR's `test-api` job runs the integration test with its required PostgreSQL service.

## Preview

Not applicable. The invariant is backend `appendSystemPrompt` materialization during callback-owned queue promotion, not a stable browser-visible surface. The forced API integration test exercises the production boundary deterministically.
