### PR TITLE
test(e2e): cover completed run checkpoint

### DIFF
--- a/e2e/tests/03-runner/run-t16-checkpoint.bats
+++ b/e2e/tests/03-runner/run-t16-checkpoint.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Completed-run checkpoint coverage through the supported agent, chat, and run APIs.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test
+}
+
+@test "completed chat run exposes a checkpoint id" {
+    run create_runner_agent "e2e-run-checkpoint-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    local marker="CHECKPOINT_COMPLETED_${TEST_ID}"
+    run runner_e2e_start_chat_run \
+        "$AGENT_ID" \
+        "printf '${marker}\\n'"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
+
+    run runner_e2e_wait_for_run_status "$RUN_ID" completed 180
+    echo "$output"
+    assert_success
+
+    run runner_api_curl "/api/zero/runs/${RUN_ID}"
+    echo "$output"
+    assert_success
+    run jq -e '
+        .status == "completed" and
+        (.result.checkpointId | type == "string" and length > 0)
+    ' <<<"$output"
+    echo "$output"
+    assert_success
+}


### PR DESCRIPTION
## Summary

- add isolated runner E2E coverage for completed-run checkpoint IDs
- start a minimal deterministic run through the supported agent and chat APIs
- read GET /api/zero/runs/:id after completion and require result.checkpointId to be a non-empty string
- clean up the unique run, thread, and agent through existing public-API helpers

## Verification

- `./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t16-checkpoint.bats` (1 test parsed)
- `corepack pnpm exec tsx playwright/runner-shards.ts tests/03-runner` (new file discovered)
- `node --import tsx --test playwright/lib/runner-shards.test.ts` (2 passed)
- `git diff --check origin/main...HEAD`

The runner E2E itself is CI-only and is left to the PR pipeline as documented.
