### PR TITLE
test(e2e): cover deployed runner toolchain browser smoke

### DIFF
--- a/e2e/tests/03-runner/run-t20-runner-toolchain-browser.bats
+++ b/e2e/tests/03-runner/run-t20-runner-toolchain-browser.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+# Default deployed runner profile toolchain smoke through the public chat API.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test
+}
+
+@test "deployed runner executes gh and reads a local page with Chromium" {
+    run create_runner_agent "e2e-runner-toolchain-browser-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    local browser_marker="RUNNER_BROWSER_DOM_${TEST_ID}"
+    local output_marker="RUNNER_TOOLCHAIN_OK_${TEST_ID}"
+    local prompt
+    prompt=$(cat <<'EOF'
+set -euo pipefail
+
+gh_version="$(gh --version | sed -n '1p')"
+grep -Eq '^gh version [0-9]+\.[0-9]+\.[0-9]+([.-][[:alnum:].-]+)?([[:space:]]|$)' <<<"$gh_version"
+
+browser_session="runner-toolchain-__TEST_ID__"
+browser_marker="__BROWSER_MARKER__"
+browser_url="data:text/html,%3Cmain%20id%3D%22runner-toolchain-marker%22%3E${browser_marker}%3C%2Fmain%3E"
+trap 'agent-browser --session "$browser_session" close >/dev/null 2>&1 || true' EXIT
+agent-browser --session "$browser_session" open "$browser_url"
+dom_marker="$(agent-browser --session "$browser_session" get text '#runner-toolchain-marker')"
+test "$dom_marker" = "$browser_marker"
+agent-browser --session "$browser_session" close >/dev/null
+trap - EXIT
+
+printf 'GH_VERSION_OK=%s\n' "$gh_version"
+printf 'BROWSER_DOM_OK=%s\n' "$dom_marker"
+printf '__OUTPUT_MARKER__\n'
+EOF
+)
+    prompt=${prompt//__TEST_ID__/$TEST_ID}
+    prompt=${prompt//__BROWSER_MARKER__/$browser_marker}
+    prompt=${prompt//__OUTPUT_MARKER__/$output_marker}
+
+    run runner_e2e_start_chat_run "$AGENT_ID" "$prompt"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
+
+    run runner_wait_for_run "$RUN_ID" 180
+    echo "$output"
+    assert_success
+
+    run runner_e2e_wait_for_agent_text "$RUN_ID" "$output_marker"
+    echo "$output"
+    assert_success
+    assert_output --regexp 'GH_VERSION_OK=gh version [0-9]+\.[0-9]+\.[0-9]+'
+    assert_output --partial "BROWSER_DOM_OK=${browser_marker}"
+}


### PR DESCRIPTION
## Summary

- Add one public `/api/zero/*` chat-flow E2E for the deployed default runner profile.
- Execute `gh --version` inside the runner and require semver-shaped GitHub CLI output.
- Launch an isolated `agent-browser` Chromium session on a local `data:` page, read a unique DOM marker, and close the session.
- Clean up the test-specific run, thread, agent, and browser session.

## Verification

- `./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t20-runner-toolchain-browser.bats` (1 test)
- `./scripts/check-file-size.sh e2e/tests/03-runner/run-t20-runner-toolchain-browser.bats`
- `git diff --check`
- Same shell payload command-checked locally with `gh 2.97.0` and `agent-browser 0.33.0-vm0.1`; deployed runner execution is CI-only and will run in the PR pipeline.

## Scope

- Adds only `e2e/tests/03-runner/run-t20-runner-toolchain-browser.bats`.
- Does not change helpers, fixtures, workflows, or production code.
