### PR TITLE
test(e2e): cover independent thread session isolation

### DIFF
--- a/e2e/tests/03-runner/run-t18-independent-thread-sessions.bats
+++ b/e2e/tests/03-runner/run-t18-independent-thread-sessions.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+# Independent chat threads on one agent must not share an agent session.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+load '../../helpers/runner-api'
+
+setup() {
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+    FIRST_RUN_ID=""
+    FIRST_THREAD_ID=""
+    SECOND_RUN_ID=""
+    SECOND_THREAD_ID=""
+}
+
+teardown() {
+    if [[ -n "${FIRST_RUN_ID:-}" ]]; then
+        runner_e2e_cancel_run "$FIRST_RUN_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${SECOND_RUN_ID:-}" ]]; then
+        runner_e2e_cancel_run "$SECOND_RUN_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${FIRST_THREAD_ID:-}" ]]; then
+        runner_e2e_delete_chat_thread "$FIRST_THREAD_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${SECOND_THREAD_ID:-}" ]]; then
+        runner_e2e_delete_chat_thread "$SECOND_THREAD_ID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${AGENT_ID:-}" ]]; then
+        delete_runner_agent "$AGENT_ID" >/dev/null 2>&1 || true
+    fi
+}
+
+@test "independent chat threads use separate agent sessions" {
+    run create_runner_agent "e2e-independent-thread-sessions-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    run set_runner_agent_instructions \
+        "$AGENT_ID" \
+        "Independent thread session isolation test instructions."
+    echo "$output"
+    assert_success
+
+    run runner_e2e_start_chat_run \
+        "$AGENT_ID" \
+        "printf 'FIRST_INDEPENDENT_THREAD_${TEST_ID}\\n'"
+    echo "$output"
+    assert_success
+    FIRST_RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    FIRST_THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
+
+    run runner_wait_for_run "$FIRST_RUN_ID" 180
+    echo "$output"
+    assert_success
+    local first_run_response="$output"
+    run jq -e '
+        .status == "completed" and
+        (.result.agentSessionId | type == "string" and length > 0)
+    ' <<<"$first_run_response"
+    echo "$output"
+    assert_success
+    local first_session_id
+    first_session_id=$(jq -er \
+        '.result.agentSessionId | select(type == "string" and length > 0)' \
+        <<<"$first_run_response")
+
+    run runner_e2e_start_chat_run \
+        "$AGENT_ID" \
+        "printf 'SECOND_INDEPENDENT_THREAD_${TEST_ID}\\n'"
+    echo "$output"
+    assert_success
+    SECOND_RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    SECOND_THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
+
+    run runner_wait_for_run "$SECOND_RUN_ID" 180
+    echo "$output"
+    assert_success
+    local second_run_response="$output"
+    run jq -e '
+        .status == "completed" and
+        (.result.agentSessionId | type == "string" and length > 0)
+    ' <<<"$second_run_response"
+    echo "$output"
+    assert_success
+    local second_session_id
+    second_session_id=$(jq -er \
+        '.result.agentSessionId | select(type == "string" and length > 0)' \
+        <<<"$second_run_response")
+
+    [[ "$SECOND_THREAD_ID" != "$FIRST_THREAD_ID" ]]
+    [[ "$second_session_id" != "$first_session_id" ]]
+}


### PR DESCRIPTION
## Summary

- add a self-contained runner E2E case for two independent chat threads on one unique agent
- assert both runs complete with non-empty, distinct `agentSessionId` values
- clean up both unique threads and the agent through public `/api/zero/*` APIs

## Verification

- `./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t18-independent-thread-sessions.bats` (1 test parsed)
- `git diff --check`
- deployed runner execution is CI-only and will run in the PR pipeline
