### PR TITLE
feat(desktop): add zero migration bridge

### DIFF
--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -179,7 +179,7 @@ under independent release tags and update manifests.
 
 ### Final Zero bridge release
 
-Production Zero builds at version `0.33.4` or newer show a soft migration
+Production Zero builds at version `0.34.0` or newer show a soft migration
 reminder for Okou. `Remind Me Later` keeps Zero running and defers the reminder
 for seven days. `Download Okou` records the migration handoff before waiting for
 the active Computer Use command, stops the Zero host after that command finishes,

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -177,6 +177,23 @@ associates those permissions with the application identity. The current
 release promotion signs and notarizes both product lines while publishing them
 under independent release tags and update manifests.
 
+### Final Zero bridge release
+
+Production Zero builds at version `0.33.4` or newer show a soft migration
+reminder for Okou. `Remind Me Later` keeps Zero running and defers the reminder
+for seven days. `Download Okou` records the migration handoff before waiting for
+the active Computer Use command, stops the Zero host after that command finishes,
+and then opens the stable signed Okou DMG route:
+
+`https://api.vm0.ai/api/okou/desktop/updates/stable/darwin/arm64/dmg`
+
+Once the handoff starts, Zero does not automatically register or relaunch its
+host on restart. The migration notice remains available so the user can retry
+the Okou download or explicitly resume Zero if installation or setup fails.
+This bridge is limited to packaged production Zero builds and does not change
+either product's updater feed. The later remote hard-stop, cohort rollout,
+telemetry thresholds, and Zero retirement remain separate rollout work.
+
 This does not submit or publish the app to the Mac App Store. The App Store
 Connect API key is only used as notarytool authentication for Apple's
 notarization service.

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -711,6 +711,66 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
+  it("drains an active command before stopping without claiming more work", async () => {
+    vi.useFakeTimers();
+    const command: ComputerUseCommand = {
+      id: "cmd-1",
+      kind: "keyboard.type_text",
+      payload: { app: "Chrome", text: "okou" },
+    };
+    const execution = deferred<ComputerUseCommandExecutionResult>();
+    const events: string[] = [];
+    let nextCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls += 1;
+        events.push("claim");
+        return jsonResponse({ status: "command", command });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        events.push("complete");
+        return jsonResponse({ ok: true });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/stop")) {
+        events.push("stop");
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const executeCommand = vi.fn(async () => {
+      events.push("execute");
+      const result = await execution.promise;
+      events.push("executed");
+      return result;
+    });
+    const { runtime } = createRuntime({ hostFetch, executeCommand });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(executeCommand).toHaveBeenCalledOnce();
+
+    const drain = runtime.drainAndStop();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(events).not.toContain("stop");
+
+    execution.resolve({ status: "succeeded", result: {} });
+    await vi.advanceTimersByTimeAsync(100);
+    await drain;
+
+    expect(nextCalls).toBe(1);
+    expect(events).toEqual([
+      "claim",
+      "execute",
+      "executed",
+      "complete",
+      "stop",
+    ]);
+    expect(runtime.getState().status).toBe("offline");
+  });
+
   it("retries transient command completion failures", async () => {
     vi.useFakeTimers();
     let nextCalls = 0;

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -249,6 +249,7 @@ export class ComputerUseHostRuntime {
   private commandTimer: NodeJS.Timeout | null = null;
   private recoveryTimer: NodeJS.Timeout | null = null;
   private commandExecutionRunning = false;
+  private draining = false;
   private lastCommandActivityAtMs: number | null = null;
   private lastCommandCompletionAtMs: number | null = null;
   private hostToken: string | null = null;
@@ -290,6 +291,7 @@ export class ComputerUseHostRuntime {
       return;
     }
     this.running = true;
+    this.draining = false;
     try {
       const nextDelay = await this.startHost();
       if (nextDelay === null) {
@@ -305,6 +307,7 @@ export class ComputerUseHostRuntime {
 
   async stop(): Promise<void> {
     this.running = false;
+    this.draining = false;
     this.clearHeartbeatTimer();
     this.clearCommandTimer();
     this.clearRecoveryTimer();
@@ -326,6 +329,17 @@ export class ComputerUseHostRuntime {
     } catch (error) {
       this.setRuntimeErrorState("stop", error);
     }
+  }
+
+  async drainAndStop(): Promise<void> {
+    this.draining = true;
+    this.clearCommandTimer();
+    while (this.commandExecutionRunning) {
+      await new Promise<void>((resolve) => {
+        this.scheduleTimeout(resolve, 50);
+      });
+    }
+    await this.stop();
   }
 
   getState(): ComputerUseHostRuntimeState {
@@ -619,7 +633,7 @@ export class ComputerUseHostRuntime {
   }
 
   private scheduleCommandPoll(delayMs: number): void {
-    if (!this.running || this.commandTimer) {
+    if (!this.running || this.draining || this.commandTimer) {
       return;
     }
     this.commandTimer = this.scheduleTimeout(() => {
@@ -659,6 +673,7 @@ export class ComputerUseHostRuntime {
       if (
         scheduleNextPoll &&
         this.running &&
+        !this.draining &&
         this.hostToken &&
         this.state.recovery?.phase !== "command_poll"
       ) {

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.test.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.test.ts
@@ -36,6 +36,12 @@ function createFakeRuntime(options: { readonly hangOnStop?: boolean } = {}) {
       }
       state = hostState("offline");
     }),
+    drainAndStop: vi.fn(async () => {
+      if (options.hangOnStop) {
+        await new Promise<void>(() => {});
+      }
+      state = hostState("offline");
+    }),
     getState: () => state,
   };
 }
@@ -141,6 +147,18 @@ describe("ComputerUseRuntimeController", () => {
     await controller.start({ userInitiated: true });
     expect(runtime.start).toHaveBeenCalledTimes(2);
     expect(createRuntime).toHaveBeenCalledOnce();
+  });
+
+  it("drains active work before marking the host offline", async () => {
+    const { controller, runtime, setHostRuntimeOnline } = createController();
+    await controller.start();
+
+    await controller.drainAndStop();
+
+    expect(runtime.drainAndStop).toHaveBeenCalledOnce();
+    expect(setHostRuntimeOnline).toHaveBeenLastCalledWith(false);
+    await controller.start();
+    expect(runtime.start).toHaveBeenCalledOnce();
   });
 
   it("detaches on auth change so the next start builds a fresh runtime", async () => {

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -13,6 +13,7 @@ const DEFAULT_QUIT_STOP_TIMEOUT_MS = 1_000;
 interface ComputerUseRuntimeLike {
   start(): Promise<void>;
   stop(): Promise<void>;
+  drainAndStop(): Promise<void>;
   getState(): ComputerUseHostRuntimeState;
 }
 
@@ -117,6 +118,14 @@ export class ComputerUseRuntimeController {
     this.manualStopRequested = true;
     this.setHostRuntimeOnline(false);
     await this.runtime?.stop();
+    this.onChange();
+  }
+
+  /** Stops admitting work, lets the active command finish, then stops. */
+  async drainAndStop(): Promise<void> {
+    this.manualStopRequested = true;
+    await this.runtime?.drainAndStop();
+    this.setHostRuntimeOnline(false);
     this.onChange();
   }
 

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -3,6 +3,7 @@ import type {
   DesktopComputerUseState,
 } from "./computer-use-types";
 import type { DesktopIdentity } from "./config";
+import type { DesktopZeroMigrationState } from "./desktop-zero-migration-types";
 
 export interface DesktopAuthUser {
   readonly userId: string;
@@ -93,6 +94,14 @@ export interface DesktopDeveloperToolsApi {
   readonly subscribe: (callback: () => void) => () => void;
 }
 
+export interface DesktopZeroMigrationApi {
+  readonly getState: () => Promise<DesktopZeroMigrationState>;
+  readonly remindLater: () => Promise<DesktopZeroMigrationState>;
+  readonly beginMigration: () => Promise<DesktopZeroMigrationState>;
+  readonly resumeZero: () => Promise<DesktopZeroMigrationState>;
+  readonly subscribe: (callback: () => void) => () => void;
+}
+
 export type DesktopIdentityInfo = Pick<
   DesktopIdentity,
   "brandName" | "displayName" | "product"
@@ -103,6 +112,7 @@ declare global {
     vm0DesktopAuth?: DesktopAuthApi;
     vm0DesktopComputerUse?: DesktopComputerUseApi;
     vm0DesktopDeveloperTools?: DesktopDeveloperToolsApi;
+    vm0DesktopZeroMigration?: DesktopZeroMigrationApi;
     vm0DesktopIdentity?: DesktopIdentityInfo;
   }
 }

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -7,6 +7,8 @@ import type {
 import type { DesktopAuthState } from "./desktop-bridge";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
+import { DESKTOP_ZERO_MIGRATION_CHANNELS } from "./desktop-zero-migration-ipc-channels";
+import type { DesktopZeroMigrationState } from "./desktop-zero-migration-types";
 
 type IpcEvent = {
   readonly senderFrame?: {
@@ -278,6 +280,30 @@ describe("Desktop IPC boundary", () => {
     expect(api.setEnabled).toHaveBeenCalledWith(true);
   });
 
+  it("rejects every Zero migration handler from untrusted sender frames", async () => {
+    const { installDesktopZeroMigrationIpc } =
+      await import("./desktop-zero-migration-electron");
+    const api = createDesktopZeroMigrationApi();
+
+    installDesktopZeroMigrationIpc(api, { rendererUrl });
+
+    for (const channel of [
+      DESKTOP_ZERO_MIGRATION_CHANNELS.getState,
+      DESKTOP_ZERO_MIGRATION_CHANNELS.remindLater,
+      DESKTOP_ZERO_MIGRATION_CHANNELS.beginMigration,
+      DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero,
+    ]) {
+      await expect(invokeIpc(channel, blockedAppUrl)).rejects.toThrow(
+        "Zero migration is unavailable on this page",
+      );
+    }
+
+    expect(api.getState).not.toHaveBeenCalled();
+    expect(api.remindLater).not.toHaveBeenCalled();
+    expect(api.beginMigration).not.toHaveBeenCalled();
+    expect(api.resumeZero).not.toHaveBeenCalled();
+  });
+
   it("notifies only live windows when computer use state changes", async () => {
     const { notifyDesktopComputerUseChanged } =
       await import("./computer-use-electron");
@@ -319,6 +345,21 @@ describe("Desktop IPC boundary", () => {
 
     expect(liveWindow.webContents.send).toHaveBeenCalledWith(
       DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed,
+    );
+    expect(destroyedWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it("notifies only live windows when Zero migration state changes", async () => {
+    const { notifyDesktopZeroMigrationChanged } =
+      await import("./desktop-zero-migration-electron");
+    const liveWindow = createMockWindow({ destroyed: false });
+    const destroyedWindow = createMockWindow({ destroyed: true });
+    electronMock.windows.push(liveWindow, destroyedWindow);
+
+    notifyDesktopZeroMigrationChanged();
+
+    expect(liveWindow.webContents.send).toHaveBeenCalledWith(
+      DESKTOP_ZERO_MIGRATION_CHANNELS.changed,
     );
     expect(destroyedWindow.webContents.send).not.toHaveBeenCalled();
   });
@@ -436,6 +477,31 @@ function createDesktopDeveloperToolsApi(): {
     setEnabled: vi.fn((enabled) => {
       return { available: true, enabled };
     }),
+  };
+}
+
+function createDesktopZeroMigrationApi(): {
+  readonly getState: ReturnType<typeof vi.fn<() => DesktopZeroMigrationState>>;
+  readonly remindLater: ReturnType<
+    typeof vi.fn<() => DesktopZeroMigrationState>
+  >;
+  readonly beginMigration: ReturnType<
+    typeof vi.fn<() => Promise<DesktopZeroMigrationState>>
+  >;
+  readonly resumeZero: ReturnType<
+    typeof vi.fn<() => Promise<DesktopZeroMigrationState>>
+  >;
+} {
+  const state: DesktopZeroMigrationState = {
+    mode: "soft_reminder",
+    nextReminderAt: null,
+    errorMessage: null,
+  };
+  return {
+    getState: vi.fn(() => state),
+    remindLater: vi.fn(() => state),
+    beginMigration: vi.fn(async () => state),
+    resumeZero: vi.fn(async () => state),
   };
 }
 

--- a/turbo/apps/desktop/src/desktop-zero-migration-config.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-config.ts
@@ -1,5 +1,5 @@
 export const ZERO_MIGRATION_BRIDGE_CONFIG = {
-  minimumVersion: "0.33.4",
+  minimumVersion: "0.34.0",
   downloadUrl:
     "https://api.vm0.ai/api/okou/desktop/updates/stable/darwin/arm64/dmg",
   reminderDelayMs: 7 * 24 * 60 * 60 * 1_000,

--- a/turbo/apps/desktop/src/desktop-zero-migration-config.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-config.ts
@@ -1,0 +1,54 @@
+export const ZERO_MIGRATION_BRIDGE_CONFIG = {
+  minimumVersion: "0.33.4",
+  downloadUrl:
+    "https://api.vm0.ai/api/okou/desktop/updates/stable/darwin/arm64/dmg",
+  reminderDelayMs: 7 * 24 * 60 * 60 * 1_000,
+  copy: {
+    title: "Zero Computer Use is moving to Okou",
+    detail:
+      "Okou is a separate app. Download it, sign in again, and grant Accessibility, Screen Recording, and browser Automation permissions again. Zero will keep working until you choose to migrate.",
+    pausedTitle: "Zero is paused while you set up Okou",
+    pausedDetail:
+      "Finish installing and setting up Okou. If that does not work, you can resume Zero and try again later.",
+  },
+} as const;
+
+function releaseVersionParts(value: string): readonly number[] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value);
+  if (!match) {
+    return null;
+  }
+  return match.slice(1).map(Number);
+}
+
+export function isVersionAtLeast(
+  currentVersion: string,
+  minimumVersion: string,
+): boolean {
+  const current = releaseVersionParts(currentVersion);
+  const minimum = releaseVersionParts(minimumVersion);
+  if (!current || !minimum) {
+    return false;
+  }
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (current[index] !== minimum[index]) {
+      return (current[index] ?? 0) > (minimum[index] ?? 0);
+    }
+  }
+  return true;
+}
+
+export function isTrustedZeroMigrationDownloadUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return (
+      url.protocol === "https:" &&
+      url.origin === "https://api.vm0.ai" &&
+      url.pathname === "/api/okou/desktop/updates/stable/darwin/arm64/dmg" &&
+      url.search === "" &&
+      url.hash === ""
+    );
+  } catch {
+    return false;
+  }
+}

--- a/turbo/apps/desktop/src/desktop-zero-migration-electron.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-electron.ts
@@ -1,0 +1,53 @@
+import type { IpcMainInvokeEvent } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
+import { isDesktopComputerUsePageUrl } from "./computer-use-page-url";
+import { DESKTOP_ZERO_MIGRATION_CHANNELS } from "./desktop-zero-migration-ipc-channels";
+import type { DesktopZeroMigrationState } from "./desktop-zero-migration-types";
+
+interface DesktopZeroMigrationNativeApi {
+  readonly getState: () => DesktopZeroMigrationState;
+  readonly remindLater: () => DesktopZeroMigrationState;
+  readonly beginMigration: () => Promise<DesktopZeroMigrationState>;
+  readonly resumeZero: () => Promise<DesktopZeroMigrationState>;
+}
+
+export function notifyDesktopZeroMigrationChanged(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(DESKTOP_ZERO_MIGRATION_CHANNELS.changed);
+    }
+  }
+}
+
+export function installDesktopZeroMigrationIpc(
+  api: DesktopZeroMigrationNativeApi,
+  options: { readonly rendererUrl: string },
+): void {
+  const assertComputerUsePage = (event: IpcMainInvokeEvent): void => {
+    if (
+      !isDesktopComputerUsePageUrl(
+        event.senderFrame?.url ?? "",
+        options.rendererUrl,
+      )
+    ) {
+      throw new Error("Zero migration is unavailable on this page");
+    }
+  };
+
+  ipcMain.handle(DESKTOP_ZERO_MIGRATION_CHANNELS.getState, (event) => {
+    assertComputerUsePage(event);
+    return api.getState();
+  });
+  ipcMain.handle(DESKTOP_ZERO_MIGRATION_CHANNELS.remindLater, (event) => {
+    assertComputerUsePage(event);
+    return api.remindLater();
+  });
+  ipcMain.handle(DESKTOP_ZERO_MIGRATION_CHANNELS.beginMigration, (event) => {
+    assertComputerUsePage(event);
+    return api.beginMigration();
+  });
+  ipcMain.handle(DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero, (event) => {
+    assertComputerUsePage(event);
+    return api.resumeZero();
+  });
+}

--- a/turbo/apps/desktop/src/desktop-zero-migration-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-ipc-channels.ts
@@ -1,0 +1,7 @@
+export const DESKTOP_ZERO_MIGRATION_CHANNELS = {
+  getState: "desktop-zero-migration:get-state",
+  remindLater: "desktop-zero-migration:remind-later",
+  beginMigration: "desktop-zero-migration:begin-migration",
+  resumeZero: "desktop-zero-migration:resume-zero",
+  changed: "desktop-zero-migration:changed",
+} as const;

--- a/turbo/apps/desktop/src/desktop-zero-migration-types.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-types.ts
@@ -1,0 +1,12 @@
+export type DesktopZeroMigrationMode =
+  | "hidden"
+  | "soft_reminder"
+  | "waiting_for_command"
+  | "paused"
+  | "download_failed";
+
+export interface DesktopZeroMigrationState {
+  readonly mode: DesktopZeroMigrationMode;
+  readonly nextReminderAt: string | null;
+  readonly errorMessage: string | null;
+}

--- a/turbo/apps/desktop/src/desktop-zero-migration.test.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration.test.ts
@@ -1,0 +1,165 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ZERO_MIGRATION_BRIDGE_CONFIG } from "./desktop-zero-migration-config";
+import { DesktopZeroMigrationController } from "./desktop-zero-migration";
+
+const directories: string[] = [];
+
+async function preferencesPath(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zero-migration-"));
+  directories.push(directory);
+  return path.join(directory, "desktop-preferences.json");
+}
+
+function createController(options: {
+  readonly filePath: string;
+  readonly enabled?: boolean;
+  readonly product?: "zero" | "okou";
+  readonly appVersion?: string;
+  readonly now?: () => number;
+  readonly drainAndStopZero?: () => Promise<void>;
+  readonly startZero?: () => Promise<void>;
+  readonly openDownload?: (url: string) => Promise<void>;
+  readonly onChange?: () => void;
+}) {
+  return new DesktopZeroMigrationController({
+    enabled: options.enabled ?? true,
+    product: options.product ?? "zero",
+    appVersion: options.appVersion ?? "0.33.4",
+    preferencesPath: options.filePath,
+    drainAndStopZero: options.drainAndStopZero ?? vi.fn(async () => {}),
+    startZero: options.startZero ?? vi.fn(async () => {}),
+    openDownload: options.openDownload ?? vi.fn(async () => {}),
+    onChange: options.onChange,
+    now: options.now,
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map(async (directory) => {
+      await rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("DesktopZeroMigrationController", () => {
+  it("offers the bridge only to eligible Zero production versions", async () => {
+    const filePath = await preferencesPath();
+
+    expect(createController({ filePath }).getState().mode).toBe(
+      "soft_reminder",
+    );
+    expect(
+      createController({ filePath, product: "okou" }).getState().mode,
+    ).toBe("hidden");
+    expect(
+      createController({ filePath, appVersion: "0.33.3" }).getState().mode,
+    ).toBe("hidden");
+    expect(createController({ filePath, enabled: false }).getState().mode).toBe(
+      "hidden",
+    );
+  });
+
+  it("persists a seven-day reminder deferral without stopping Zero", async () => {
+    const filePath = await preferencesPath();
+    const now = Date.parse("2026-08-12T00:00:00.000Z");
+    const drainAndStopZero = vi.fn(async () => {});
+    const controller = createController({
+      filePath,
+      now: () => now,
+      drainAndStopZero,
+    });
+
+    const state = controller.remindLater();
+
+    expect(state).toEqual({
+      mode: "hidden",
+      nextReminderAt: new Date(
+        now + ZERO_MIGRATION_BRIDGE_CONFIG.reminderDelayMs,
+      ).toISOString(),
+      errorMessage: null,
+    });
+    expect(drainAndStopZero).not.toHaveBeenCalled();
+  });
+
+  it("persists suppression, drains Zero, then opens the stable Okou route", async () => {
+    const filePath = await preferencesPath();
+    const events: string[] = [];
+    const drain = vi.fn(async () => {
+      events.push("drain");
+    });
+    const openDownload = vi.fn(async () => {
+      events.push("download");
+    });
+    const controller = createController({
+      filePath,
+      drainAndStopZero: drain,
+      openDownload,
+    });
+
+    const state = await controller.beginMigration();
+
+    expect(drain).toHaveBeenCalledOnce();
+    expect(openDownload).toHaveBeenCalledWith(
+      ZERO_MIGRATION_BRIDGE_CONFIG.downloadUrl,
+    );
+    expect(events).toStrictEqual(["drain", "download"]);
+    expect(state.mode).toBe("paused");
+    expect(controller.shouldSuppressAutoStart()).toBe(true);
+    expect(createController({ filePath }).shouldSuppressAutoStart()).toBe(true);
+  });
+
+  it("waits for the drain before opening the download", async () => {
+    const filePath = await preferencesPath();
+    let finishDrain!: () => void;
+    const drainAndStopZero = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        finishDrain = resolve;
+      });
+    });
+    const openDownload = vi.fn(async () => {});
+    const controller = createController({
+      filePath,
+      drainAndStopZero,
+      openDownload,
+    });
+
+    const migration = controller.beginMigration();
+    await Promise.resolve();
+    expect(controller.getState().mode).toBe("waiting_for_command");
+    expect(createController({ filePath }).shouldSuppressAutoStart()).toBe(true);
+    expect(openDownload).not.toHaveBeenCalled();
+
+    finishDrain();
+    await migration;
+    expect(openDownload).toHaveBeenCalledOnce();
+  });
+
+  it("keeps Zero paused on download failure and can resume it", async () => {
+    const filePath = await preferencesPath();
+    const startZero = vi.fn(async () => {});
+    const controller = createController({
+      filePath,
+      startZero,
+      openDownload: vi.fn(async () => {
+        throw new Error("Download could not be opened");
+      }),
+    });
+
+    expect((await controller.beginMigration()).mode).toBe("download_failed");
+    expect(controller.shouldSuppressAutoStart()).toBe(true);
+
+    const resumed = await controller.resumeZero();
+    expect(startZero).toHaveBeenCalledOnce();
+    expect(resumed.mode).toBe("soft_reminder");
+    expect(controller.shouldSuppressAutoStart()).toBe(false);
+    const persisted = JSON.parse(await readFile(filePath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.zeroMigration).toBeUndefined();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-zero-migration.test.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration.test.ts
@@ -27,7 +27,7 @@ function createController(options: {
   return new DesktopZeroMigrationController({
     enabled: options.enabled ?? true,
     product: options.product ?? "zero",
-    appVersion: options.appVersion ?? "0.33.4",
+    appVersion: options.appVersion ?? "0.34.0",
     preferencesPath: options.filePath,
     drainAndStopZero: options.drainAndStopZero ?? vi.fn(async () => {}),
     startZero: options.startZero ?? vi.fn(async () => {}),
@@ -56,7 +56,7 @@ describe("DesktopZeroMigrationController", () => {
       createController({ filePath, product: "okou" }).getState().mode,
     ).toBe("hidden");
     expect(
-      createController({ filePath, appVersion: "0.33.3" }).getState().mode,
+      createController({ filePath, appVersion: "0.33.4" }).getState().mode,
     ).toBe("hidden");
     expect(createController({ filePath, enabled: false }).getState().mode).toBe(
       "hidden",

--- a/turbo/apps/desktop/src/desktop-zero-migration.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration.ts
@@ -1,0 +1,218 @@
+import {
+  readDesktopPreferenceRecord,
+  writeDesktopPreferenceRecord,
+} from "./desktop-preferences";
+import {
+  ZERO_MIGRATION_BRIDGE_CONFIG,
+  isTrustedZeroMigrationDownloadUrl,
+  isVersionAtLeast,
+} from "./desktop-zero-migration-config";
+import type { DesktopZeroMigrationState } from "./desktop-zero-migration-types";
+
+interface ZeroMigrationPreferences {
+  readonly deferredUntil: string | null;
+  readonly startedAt: string | null;
+  readonly lastError: string | null;
+}
+
+interface DesktopZeroMigrationControllerOptions {
+  readonly enabled: boolean;
+  readonly product: "zero" | "okou";
+  readonly appVersion: string;
+  readonly preferencesPath: string;
+  readonly drainAndStopZero: () => Promise<void>;
+  readonly startZero: () => Promise<void>;
+  readonly openDownload: (url: string) => Promise<void>;
+  readonly onChange?: () => void;
+  readonly now?: () => number;
+}
+
+const PREFERENCE_KEY = "zeroMigration";
+
+function optionalIsoDate(value: unknown): string | null {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    return null;
+  }
+  return value;
+}
+
+function readZeroMigrationPreferences(
+  preferencesPath: string,
+): ZeroMigrationPreferences {
+  const value = readDesktopPreferenceRecord(preferencesPath)[PREFERENCE_KEY];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { deferredUntil: null, startedAt: null, lastError: null };
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    deferredUntil: optionalIsoDate(record.deferredUntil),
+    startedAt: optionalIsoDate(record.startedAt),
+    lastError: typeof record.lastError === "string" ? record.lastError : null,
+  };
+}
+
+function migrationErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : "Unable to open the Okou download.";
+}
+
+export class DesktopZeroMigrationController {
+  private readonly enabled: boolean;
+  private readonly product: "zero" | "okou";
+  private readonly appVersion: string;
+  private readonly preferencesPath: string;
+  private readonly drainAndStopZero: () => Promise<void>;
+  private readonly startZero: () => Promise<void>;
+  private readonly openDownload: (url: string) => Promise<void>;
+  private readonly onChange: () => void;
+  private readonly now: () => number;
+  private waitingForCommand = false;
+
+  constructor(options: DesktopZeroMigrationControllerOptions) {
+    this.enabled = options.enabled;
+    this.product = options.product;
+    this.appVersion = options.appVersion;
+    this.preferencesPath = options.preferencesPath;
+    this.drainAndStopZero = options.drainAndStopZero;
+    this.startZero = options.startZero;
+    this.openDownload = options.openDownload;
+    this.onChange = options.onChange ?? (() => {});
+    this.now = options.now ?? Date.now;
+  }
+
+  getState(): DesktopZeroMigrationState {
+    if (!this.isEligible()) {
+      return { mode: "hidden", nextReminderAt: null, errorMessage: null };
+    }
+    const preferences = readZeroMigrationPreferences(this.preferencesPath);
+    if (this.waitingForCommand) {
+      return {
+        mode: "waiting_for_command",
+        nextReminderAt: null,
+        errorMessage: null,
+      };
+    }
+    if (preferences.startedAt) {
+      return {
+        mode: preferences.lastError ? "download_failed" : "paused",
+        nextReminderAt: null,
+        errorMessage: preferences.lastError,
+      };
+    }
+    if (
+      preferences.deferredUntil &&
+      Date.parse(preferences.deferredUntil) > this.now()
+    ) {
+      return {
+        mode: "hidden",
+        nextReminderAt: preferences.deferredUntil,
+        errorMessage: null,
+      };
+    }
+    return {
+      mode: "soft_reminder",
+      nextReminderAt: null,
+      errorMessage: null,
+    };
+  }
+
+  shouldSuppressAutoStart(): boolean {
+    return (
+      this.product === "zero" &&
+      readZeroMigrationPreferences(this.preferencesPath).startedAt !== null
+    );
+  }
+
+  shouldOpenWindowOnLaunch(): boolean {
+    return this.getState().mode !== "hidden";
+  }
+
+  remindLater(): DesktopZeroMigrationState {
+    if (!this.isEligible()) {
+      return this.getState();
+    }
+    this.writePreferences({
+      deferredUntil: new Date(
+        this.now() + ZERO_MIGRATION_BRIDGE_CONFIG.reminderDelayMs,
+      ).toISOString(),
+      startedAt: null,
+      lastError: null,
+    });
+    this.onChange();
+    return this.getState();
+  }
+
+  async beginMigration(): Promise<DesktopZeroMigrationState> {
+    if (!this.isEligible() || this.waitingForCommand) {
+      return this.getState();
+    }
+    const existing = readZeroMigrationPreferences(this.preferencesPath);
+    this.writePreferences({
+      deferredUntil: null,
+      startedAt: existing.startedAt ?? new Date(this.now()).toISOString(),
+      lastError: null,
+    });
+    this.waitingForCommand = true;
+    this.onChange();
+    try {
+      await this.drainAndStopZero();
+      await this.openDownload(ZERO_MIGRATION_BRIDGE_CONFIG.downloadUrl);
+    } catch (error) {
+      this.writePreferences({
+        deferredUntil: null,
+        startedAt:
+          readZeroMigrationPreferences(this.preferencesPath).startedAt ??
+          new Date(this.now()).toISOString(),
+        lastError: migrationErrorMessage(error),
+      });
+    } finally {
+      this.waitingForCommand = false;
+      this.onChange();
+    }
+    return this.getState();
+  }
+
+  async resumeZero(): Promise<DesktopZeroMigrationState> {
+    this.clearPreferences();
+    this.onChange();
+    await this.startZero();
+    return this.getState();
+  }
+
+  clearForUserInitiatedStart(): void {
+    if (!this.shouldSuppressAutoStart()) {
+      return;
+    }
+    this.clearPreferences();
+    this.onChange();
+  }
+
+  private isEligible(): boolean {
+    return (
+      this.enabled &&
+      this.product === "zero" &&
+      isVersionAtLeast(
+        this.appVersion,
+        ZERO_MIGRATION_BRIDGE_CONFIG.minimumVersion,
+      ) &&
+      isTrustedZeroMigrationDownloadUrl(
+        ZERO_MIGRATION_BRIDGE_CONFIG.downloadUrl,
+      )
+    );
+  }
+
+  private writePreferences(value: ZeroMigrationPreferences): void {
+    const preferences = readDesktopPreferenceRecord(this.preferencesPath);
+    writeDesktopPreferenceRecord(this.preferencesPath, {
+      ...preferences,
+      [PREFERENCE_KEY]: value,
+    });
+  }
+
+  private clearPreferences(): void {
+    const preferences = readDesktopPreferenceRecord(this.preferencesPath);
+    delete preferences[PREFERENCE_KEY];
+    writeDesktopPreferenceRecord(this.preferencesPath, preferences);
+  }
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -115,6 +115,11 @@ import {
   isDesktopRendererUrl,
 } from "./desktop-renderer-url";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
+import { DesktopZeroMigrationController } from "./desktop-zero-migration";
+import {
+  installDesktopZeroMigrationIpc,
+  notifyDesktopZeroMigrationChanged,
+} from "./desktop-zero-migration-electron";
 
 const config = resolveDesktopConfig();
 const desktopApiBaseUrl = resolveComputerUseApiBaseUrl(config.platformUrl);
@@ -151,6 +156,7 @@ let appIsQuitting = false;
 let computerUseNativeBackendDisposed = false;
 let desktopTray: DesktopTrayController | null = null;
 let keepAwakeController: DesktopKeepAwakeController | null = null;
+let zeroMigrationController: DesktopZeroMigrationController | null = null;
 
 const desktopIdentity: DesktopIdentityInfo = {
   product: config.identity.product,
@@ -245,7 +251,9 @@ function notifyComputerUseChanged(): void {
   );
   notifyDesktopComputerUseChanged();
   refreshDesktopTray();
-  computerUseAutoStart.restartRecoverableRuntimeState();
+  if (!zeroMigrationController?.shouldSuppressAutoStart()) {
+    computerUseAutoStart.restartRecoverableRuntimeState();
+  }
 }
 
 function notifyAuthChanged(): void {
@@ -525,6 +533,12 @@ function createComputerUseHostRuntime(): ComputerUseHostRuntime {
 async function startComputerUseRuntime(
   options: { readonly userInitiated?: boolean } = {},
 ): Promise<DesktopComputerUseState> {
+  if (zeroMigrationController?.shouldSuppressAutoStart()) {
+    if (options.userInitiated !== true) {
+      return getComputerUseBridgeState();
+    }
+    zeroMigrationController.clearForUserInitiatedStart();
+  }
   await computerUseController.start(options);
   return getComputerUseBridgeState();
 }
@@ -639,6 +653,38 @@ function installDesktopDeveloperTools(): void {
     {
       getState: () => developerTools.getState(),
       setEnabled: (enabled) => developerTools.setEnabled(enabled),
+    },
+    { rendererUrl: localRendererUrl },
+  );
+}
+
+function installZeroMigration(): void {
+  zeroMigrationController = new DesktopZeroMigrationController({
+    enabled:
+      config.environment === "production" &&
+      app.isPackaged &&
+      !isDesktopSmokeTestEnabled(process.env),
+    product: config.identity.product,
+    appVersion: app.getVersion(),
+    preferencesPath: desktopPreferencesPath(),
+    drainAndStopZero: async () => {
+      await computerUseController.drainAndStop();
+    },
+    startZero: async () => {
+      await computerUseController.start({ userInitiated: true });
+    },
+    openDownload: async (url) => {
+      await shell.openExternal(url);
+    },
+    onChange: notifyDesktopZeroMigrationChanged,
+  });
+  const controller = zeroMigrationController;
+  installDesktopZeroMigrationIpc(
+    {
+      getState: () => controller.getState(),
+      remindLater: () => controller.remindLater(),
+      beginMigration: () => controller.beginMigration(),
+      resumeZero: () => controller.resumeZero(),
     },
     { rendererUrl: localRendererUrl },
   );
@@ -1025,6 +1071,7 @@ interface DesktopSmokeBridgeState {
   readonly auth: boolean;
   readonly computerUse: boolean;
   readonly developerTools: boolean;
+  readonly zeroMigration: boolean;
   readonly identity: DesktopIdentityInfo | null;
 }
 
@@ -1053,6 +1100,8 @@ function isDesktopSmokeBridgeState(
     typeof value.computerUse === "boolean" &&
     "developerTools" in value &&
     typeof value.developerTools === "boolean" &&
+    "zeroMigration" in value &&
+    typeof value.zeroMigration === "boolean" &&
     "identity" in value &&
     (value.identity === null || isDesktopIdentityInfo(value.identity))
   );
@@ -1065,6 +1114,7 @@ async function verifyDesktopSmokeBridge(): Promise<void> {
       auth: typeof window.vm0DesktopAuth === "object",
       computerUse: typeof window.vm0DesktopComputerUse === "object",
       developerTools: typeof window.vm0DesktopDeveloperTools === "object",
+      zeroMigration: typeof window.vm0DesktopZeroMigration === "object",
       identity: window.vm0DesktopIdentity ?? null,
     })`,
     true,
@@ -1081,6 +1131,7 @@ async function verifyDesktopSmokeBridge(): Promise<void> {
     !state.auth ||
     !state.computerUse ||
     !state.developerTools ||
+    !state.zeroMigration ||
     !state.identity ||
     state.identity.product !== desktopIdentity.product ||
     state.identity.brandName !== desktopIdentity.brandName ||
@@ -1213,7 +1264,10 @@ async function maybeStartComputerUseAfterAuth(): Promise<void> {
   notifyAuthChanged();
   const permissions = await refreshComputerUsePermissionState();
   notifyComputerUseChanged();
-  if (hasRequiredComputerUsePermissions(permissions)) {
+  if (
+    hasRequiredComputerUsePermissions(permissions) &&
+    !zeroMigrationController?.shouldSuppressAutoStart()
+  ) {
     await computerUseController.start({ userInitiated: true });
   }
 }
@@ -1334,6 +1388,7 @@ if (!hasSingleInstanceLock) {
     installKeepAwake();
     installComputerUse();
     installDesktopDeveloperTools();
+    installZeroMigration();
     refreshComputerUsePermissionsForState();
     const desktopAuthSession = getAuthSession();
     installDesktopAuth();
@@ -1355,6 +1410,10 @@ if (!hasSingleInstanceLock) {
       logAuthError: logDesktopAuthError,
       logLaunchError: logComputerUseLaunchError,
     });
+
+    if (zeroMigrationController?.shouldOpenWindowOnLaunch()) {
+      await createMainWindow();
+    }
 
     app.on("activate", () => {
       void createMainWindow();

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -3,10 +3,12 @@ import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
 import { DESKTOP_IDENTITY_CHANNEL } from "./desktop-identity-ipc-channels";
+import { DESKTOP_ZERO_MIGRATION_CHANNELS } from "./desktop-zero-migration-ipc-channels";
 import type {
   DesktopAuthApi,
   DesktopComputerUseApi,
   DesktopDeveloperToolsApi,
+  DesktopZeroMigrationApi,
 } from "./desktop-bridge";
 
 type ExposeInMainWorld = (key: string, api: unknown) => void;
@@ -89,6 +91,7 @@ describe("Desktop preload bridge", () => {
       "vm0DesktopAuth",
       "vm0DesktopComputerUse",
       "vm0DesktopDeveloperTools",
+      "vm0DesktopZeroMigration",
       "vm0DesktopIdentity",
     ]);
     expect(exposedApi<DesktopAuthApi>("vm0DesktopAuth")).toBeTruthy();
@@ -97,6 +100,9 @@ describe("Desktop preload bridge", () => {
     ).toBeTruthy();
     expect(
       exposedApi<DesktopDeveloperToolsApi>("vm0DesktopDeveloperTools"),
+    ).toBeTruthy();
+    expect(
+      exposedApi<DesktopZeroMigrationApi>("vm0DesktopZeroMigration"),
     ).toBeTruthy();
     expect(exposedApi("vm0DesktopIdentity")).toStrictEqual({
       product: "zero",
@@ -190,7 +196,26 @@ describe("Desktop preload bridge", () => {
     ]);
   });
 
-  it("cleans up auth, computer use, and developer tools IPC subscriptions", async () => {
+  it("routes Zero migration API calls through IPC channels", async () => {
+    await loadPreload();
+    const zeroMigration = exposedApi<DesktopZeroMigrationApi>(
+      "vm0DesktopZeroMigration",
+    );
+
+    await zeroMigration.getState();
+    await zeroMigration.remindLater();
+    await zeroMigration.beginMigration();
+    await zeroMigration.resumeZero();
+
+    expect(electronMock.ipcRenderer.invoke.mock.calls).toStrictEqual([
+      [DESKTOP_ZERO_MIGRATION_CHANNELS.getState],
+      [DESKTOP_ZERO_MIGRATION_CHANNELS.remindLater],
+      [DESKTOP_ZERO_MIGRATION_CHANNELS.beginMigration],
+      [DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero],
+    ]);
+  });
+
+  it("cleans up desktop IPC subscriptions", async () => {
     await loadPreload();
     const auth = exposedApi<DesktopAuthApi>("vm0DesktopAuth");
     const computerUse = exposedApi<DesktopComputerUseApi>(
@@ -199,41 +224,57 @@ describe("Desktop preload bridge", () => {
     const developerTools = exposedApi<DesktopDeveloperToolsApi>(
       "vm0DesktopDeveloperTools",
     );
+    const zeroMigration = exposedApi<DesktopZeroMigrationApi>(
+      "vm0DesktopZeroMigration",
+    );
     const authChanged = vi.fn<() => void>();
     const computerUseChanged = vi.fn<() => void>();
     const developerToolsChanged = vi.fn<() => void>();
+    const zeroMigrationChanged = vi.fn<() => void>();
 
     const unsubscribeAuth = auth.subscribe(authChanged);
     const unsubscribeComputerUse = computerUse.subscribe(computerUseChanged);
     const unsubscribeDeveloperTools = developerTools.subscribe(
       developerToolsChanged,
     );
+    const unsubscribeZeroMigration =
+      zeroMigration.subscribe(zeroMigrationChanged);
 
     electronMock.emit(DESKTOP_AUTH_CHANNELS.changed, { ignored: true });
     electronMock.emit(COMPUTER_USE_CHANNELS.changed, { ignored: true });
     electronMock.emit(DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed, {
       ignored: true,
     });
+    electronMock.emit(DESKTOP_ZERO_MIGRATION_CHANNELS.changed, {
+      ignored: true,
+    });
 
     expect(authChanged).toHaveBeenCalledOnce();
     expect(computerUseChanged).toHaveBeenCalledOnce();
     expect(developerToolsChanged).toHaveBeenCalledOnce();
+    expect(zeroMigrationChanged).toHaveBeenCalledOnce();
 
     const authListener = listenerFor(DESKTOP_AUTH_CHANNELS.changed);
     const computerUseListener = listenerFor(COMPUTER_USE_CHANNELS.changed);
     const developerToolsListener = listenerFor(
       DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed,
     );
+    const zeroMigrationListener = listenerFor(
+      DESKTOP_ZERO_MIGRATION_CHANNELS.changed,
+    );
     unsubscribeAuth();
     unsubscribeComputerUse();
     unsubscribeDeveloperTools();
+    unsubscribeZeroMigration();
     electronMock.emit(DESKTOP_AUTH_CHANNELS.changed);
     electronMock.emit(COMPUTER_USE_CHANNELS.changed);
     electronMock.emit(DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed);
+    electronMock.emit(DESKTOP_ZERO_MIGRATION_CHANNELS.changed);
 
     expect(authChanged).toHaveBeenCalledOnce();
     expect(computerUseChanged).toHaveBeenCalledOnce();
     expect(developerToolsChanged).toHaveBeenCalledOnce();
+    expect(zeroMigrationChanged).toHaveBeenCalledOnce();
     expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
       DESKTOP_AUTH_CHANNELS.changed,
       authListener,
@@ -245,6 +286,10 @@ describe("Desktop preload bridge", () => {
     expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
       DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed,
       developerToolsListener,
+    );
+    expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
+      DESKTOP_ZERO_MIGRATION_CHANNELS.changed,
+      zeroMigrationListener,
     );
   });
 });

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -4,11 +4,13 @@ import type {
   DesktopComputerUseApi,
   DesktopDeveloperToolsApi,
   DesktopIdentityInfo,
+  DesktopZeroMigrationApi,
 } from "./desktop-bridge";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
 import { DESKTOP_IDENTITY_CHANNEL } from "./desktop-identity-ipc-channels";
+import { DESKTOP_ZERO_MIGRATION_CHANNELS } from "./desktop-zero-migration-ipc-channels";
 import type { DesktopComputerUseState } from "./computer-use-types";
 
 const desktopAuthApi: DesktopAuthApi = {
@@ -159,6 +161,30 @@ const desktopDeveloperToolsApi: DesktopDeveloperToolsApi = {
   },
 };
 
+const desktopZeroMigrationApi: DesktopZeroMigrationApi = {
+  getState() {
+    return ipcRenderer.invoke(DESKTOP_ZERO_MIGRATION_CHANNELS.getState);
+  },
+  remindLater() {
+    return ipcRenderer.invoke(DESKTOP_ZERO_MIGRATION_CHANNELS.remindLater);
+  },
+  beginMigration() {
+    return ipcRenderer.invoke(DESKTOP_ZERO_MIGRATION_CHANNELS.beginMigration);
+  },
+  resumeZero() {
+    return ipcRenderer.invoke(DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero);
+  },
+  subscribe(callback: () => void): () => void {
+    const listener = (): void => {
+      callback();
+    };
+    ipcRenderer.on(DESKTOP_ZERO_MIGRATION_CHANNELS.changed, listener);
+    return () => {
+      ipcRenderer.off(DESKTOP_ZERO_MIGRATION_CHANNELS.changed, listener);
+    };
+  },
+};
+
 const desktopIdentity = ipcRenderer.sendSync(
   DESKTOP_IDENTITY_CHANNEL,
 ) as DesktopIdentityInfo;
@@ -168,5 +194,9 @@ contextBridge.exposeInMainWorld("vm0DesktopComputerUse", desktopComputerUseApi);
 contextBridge.exposeInMainWorld(
   "vm0DesktopDeveloperTools",
   desktopDeveloperToolsApi,
+);
+contextBridge.exposeInMainWorld(
+  "vm0DesktopZeroMigration",
+  desktopZeroMigrationApi,
 );
 contextBridge.exposeInMainWorld("vm0DesktopIdentity", desktopIdentity);

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -23,7 +23,9 @@ import type {
   DesktopComputerUseApi,
   DesktopDeveloperToolsApi,
   DesktopDeveloperToolsState,
+  DesktopZeroMigrationApi,
 } from "../desktop-bridge";
+import type { DesktopZeroMigrationState } from "../desktop-zero-migration-types";
 import { App } from "./App";
 
 const signedInAuthState: DesktopAuthState = {
@@ -47,6 +49,12 @@ const signedOutAuthState: DesktopAuthState = {
 const defaultDeveloperToolsState: DesktopDeveloperToolsState = {
   available: false,
   enabled: false,
+};
+
+const hiddenZeroMigrationState: DesktopZeroMigrationState = {
+  mode: "hidden",
+  nextReminderAt: null,
+  errorMessage: null,
 };
 
 function createComputerUsePluginsState(): DesktopComputerUsePluginsState {
@@ -373,29 +381,97 @@ function createDeveloperToolsBridge(initialState: DesktopDeveloperToolsState): {
   };
 }
 
+function createZeroMigrationBridge(initialState: DesktopZeroMigrationState): {
+  readonly api: DesktopZeroMigrationApi;
+  readonly beginMigration: ReturnType<
+    typeof vi.fn<DesktopZeroMigrationApi["beginMigration"]>
+  >;
+  readonly remindLater: ReturnType<
+    typeof vi.fn<DesktopZeroMigrationApi["remindLater"]>
+  >;
+  readonly resumeZero: ReturnType<
+    typeof vi.fn<DesktopZeroMigrationApi["resumeZero"]>
+  >;
+} {
+  let currentState = initialState;
+  const subscribers = new Set<() => void>();
+  const getState = vi.fn<DesktopZeroMigrationApi["getState"]>(async () => {
+    return currentState;
+  });
+  const remindLater = vi.fn<DesktopZeroMigrationApi["remindLater"]>(
+    async () => {
+      currentState = hiddenZeroMigrationState;
+      return currentState;
+    },
+  );
+  const beginMigration = vi.fn<DesktopZeroMigrationApi["beginMigration"]>(
+    async () => {
+      currentState = {
+        mode: "paused",
+        nextReminderAt: null,
+        errorMessage: null,
+      };
+      return currentState;
+    },
+  );
+  const resumeZero = vi.fn<DesktopZeroMigrationApi["resumeZero"]>(async () => {
+    currentState = {
+      mode: "soft_reminder",
+      nextReminderAt: null,
+      errorMessage: null,
+    };
+    return currentState;
+  });
+  const subscribe = vi.fn<DesktopZeroMigrationApi["subscribe"]>((callback) => {
+    subscribers.add(callback);
+    return () => {
+      subscribers.delete(callback);
+    };
+  });
+
+  return {
+    api: {
+      getState,
+      remindLater,
+      beginMigration,
+      resumeZero,
+      subscribe,
+    },
+    beginMigration,
+    remindLater,
+    resumeZero,
+  };
+}
+
 function installDesktopBridges({
   authState = signedInAuthState,
   computerUseState = createComputerUseState(),
   developerToolsState = defaultDeveloperToolsState,
+  zeroMigrationState = hiddenZeroMigrationState,
 }: {
   readonly authState?: DesktopAuthState;
   readonly computerUseState?: DesktopComputerUseState;
   readonly developerToolsState?: DesktopDeveloperToolsState;
+  readonly zeroMigrationState?: DesktopZeroMigrationState;
 } = {}): {
   readonly auth: ReturnType<typeof createAuthBridge>;
   readonly computerUse: ReturnType<typeof createComputerUseBridge>;
   readonly developerTools: ReturnType<typeof createDeveloperToolsBridge>;
+  readonly zeroMigration: ReturnType<typeof createZeroMigrationBridge>;
 } {
   const auth = createAuthBridge(authState);
   const computerUse = createComputerUseBridge(computerUseState);
   const developerTools = createDeveloperToolsBridge(developerToolsState);
+  const zeroMigration = createZeroMigrationBridge(zeroMigrationState);
   window.vm0DesktopAuth = auth.api;
   window.vm0DesktopComputerUse = computerUse.api;
   window.vm0DesktopDeveloperTools = developerTools.api;
+  window.vm0DesktopZeroMigration = zeroMigration.api;
   return {
     auth,
     computerUse,
     developerTools,
+    zeroMigration,
   };
 }
 
@@ -420,11 +496,66 @@ afterEach(() => {
   delete window.vm0DesktopAuth;
   delete window.vm0DesktopComputerUse;
   delete window.vm0DesktopDeveloperTools;
+  delete window.vm0DesktopZeroMigration;
   delete window.vm0DesktopIdentity;
   vi.clearAllMocks();
 });
 
 describe("Desktop renderer bridge integration", () => {
+  it("offers the soft Okou migration reminder and supports deferral", async () => {
+    const { zeroMigration } = installDesktopBridges({
+      zeroMigrationState: {
+        mode: "soft_reminder",
+        nextReminderAt: null,
+        errorMessage: null,
+      },
+    });
+
+    renderDesktopApp();
+
+    expect(
+      await screen.findByText("Zero Computer Use is moving to Okou"),
+    ).toBeTruthy();
+    expect(await screen.findByText("Download Okou")).toBeTruthy();
+    fireEvent.click(buttonForText("Remind Me Later"));
+
+    await waitFor(() => {
+      expect(zeroMigration.remindLater).toHaveBeenCalledOnce();
+      expect(
+        screen.queryByText("Zero Computer Use is moving to Okou"),
+      ).toBeNull();
+    });
+  });
+
+  it("supports download retry and explicit Zero recovery", async () => {
+    const { zeroMigration } = installDesktopBridges({
+      zeroMigrationState: {
+        mode: "download_failed",
+        nextReminderAt: null,
+        errorMessage: "Unable to open the Okou download.",
+      },
+    });
+
+    renderDesktopApp();
+
+    expect(
+      await screen.findByText("Zero is paused while you set up Okou"),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText("Unable to open the Okou download."),
+    ).toBeTruthy();
+    fireEvent.click(buttonForText("Try Download Again"));
+
+    await waitFor(() => {
+      expect(zeroMigration.beginMigration).toHaveBeenCalledOnce();
+    });
+    fireEvent.click(buttonForText("Resume Zero"));
+
+    await waitFor(() => {
+      expect(zeroMigration.resumeZero).toHaveBeenCalledOnce();
+    });
+  });
+
   it("shows Okou identity and fresh permission guidance", async () => {
     window.vm0DesktopIdentity = {
       product: "okou",

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import {
 import { Panel, ZeroFace } from "./components";
 import { ReadyExperience } from "./hero";
 import { currentDesktopIdentity } from "./desktop-identity";
+import { ZeroMigrationNotice } from "./zero-migration-notice";
 import {
   AuthStepCard,
   PermissionAutoRefresh,
@@ -175,6 +176,7 @@ export function App() {
       <BridgeSubscription />
       <Header />
       <main className="content">
+        <ZeroMigrationNotice />
         <ComputerUsePage />
       </main>
     </div>

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -122,6 +122,70 @@ button {
   width: min(1120px, 100%);
 }
 
+.zero-migration-notice {
+  border: 1px solid rgba(237, 78, 1, 0.24);
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  background: linear-gradient(135deg, #fff8f3, #ffffff);
+  box-shadow: 0 12px 34px rgba(17, 24, 39, 0.07);
+}
+
+.zero-migration-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.zero-migration-copy strong {
+  color: #202631;
+  font-size: 15px;
+  line-height: 1.3;
+}
+
+.zero-migration-copy > span {
+  color: #5d6675;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.zero-migration-copy .zero-migration-error {
+  color: #b42318;
+}
+
+.zero-migration-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.zero-migration-spinner {
+  animation: zero-migration-spin 900ms linear infinite;
+}
+
+@keyframes zero-migration-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 760px) {
+  .zero-migration-notice {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .zero-migration-actions {
+    justify-content: flex-start;
+  }
+}
+
 .panel {
   border: 1px solid rgba(30, 38, 52, 0.1);
   background: rgba(255, 255, 255, 0.86);

--- a/turbo/apps/desktop/src/renderer/zero-migration-notice.tsx
+++ b/turbo/apps/desktop/src/renderer/zero-migration-notice.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { Clock3, Download, LoaderCircle, RotateCcw } from "lucide-react";
+import type { DesktopZeroMigrationState } from "../desktop-zero-migration-types";
+import { ZERO_MIGRATION_BRIDGE_CONFIG } from "../desktop-zero-migration-config";
+import { IconButton } from "./components";
+
+export function ZeroMigrationNotice() {
+  const [state, setState] = useState<DesktopZeroMigrationState | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const api = window.vm0DesktopZeroMigration;
+
+  useEffect(() => {
+    if (!api) {
+      return undefined;
+    }
+    let active = true;
+    const refresh = (): void => {
+      void api
+        .getState()
+        .then((nextState) => {
+          if (active) {
+            setState(nextState);
+          }
+        })
+        .catch((error: unknown) => {
+          if (active) {
+            setActionError(
+              error instanceof Error
+                ? error.message
+                : "Unable to load the Zero migration notice.",
+            );
+          }
+        });
+    };
+    refresh();
+    const unsubscribe = api.subscribe(refresh);
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [api]);
+
+  if (!api || !state || state.mode === "hidden") {
+    return null;
+  }
+
+  const waiting = state.mode === "waiting_for_command";
+  const paused = state.mode === "paused" || state.mode === "download_failed";
+  const runAction = (
+    action: () => Promise<DesktopZeroMigrationState>,
+  ): void => {
+    setActionError(null);
+    void action()
+      .then(setState)
+      .catch((error: unknown) => {
+        setActionError(
+          error instanceof Error ? error.message : "Migration action failed.",
+        );
+      });
+  };
+
+  return (
+    <section className="zero-migration-notice" aria-live="polite">
+      <div className="zero-migration-copy">
+        <strong>
+          {paused
+            ? ZERO_MIGRATION_BRIDGE_CONFIG.copy.pausedTitle
+            : ZERO_MIGRATION_BRIDGE_CONFIG.copy.title}
+        </strong>
+        <span>
+          {paused
+            ? ZERO_MIGRATION_BRIDGE_CONFIG.copy.pausedDetail
+            : waiting
+              ? "Waiting for the current Computer Use command to finish. Zero will stop before the Okou download opens."
+              : ZERO_MIGRATION_BRIDGE_CONFIG.copy.detail}
+        </span>
+        {(state.errorMessage || actionError) && (
+          <span className="zero-migration-error">
+            {state.errorMessage ?? actionError}
+          </span>
+        )}
+      </div>
+      <div className="zero-migration-actions">
+        <IconButton
+          tone="primary"
+          icon={
+            waiting ? (
+              <LoaderCircle className="zero-migration-spinner" size={15} />
+            ) : (
+              <Download size={15} />
+            )
+          }
+          disabled={waiting}
+          onClick={() => {
+            runAction(() => api.beginMigration());
+          }}
+        >
+          {waiting
+            ? "Finishing current work..."
+            : paused
+              ? "Try Download Again"
+              : "Download Okou"}
+        </IconButton>
+        {paused ? (
+          <IconButton
+            icon={<RotateCcw size={15} />}
+            disabled={waiting}
+            onClick={() => {
+              runAction(() => api.resumeZero());
+            }}
+          >
+            Resume Zero
+          </IconButton>
+        ) : (
+          <IconButton
+            icon={<Clock3 size={15} />}
+            disabled={waiting}
+            onClick={() => {
+              runAction(() => api.remindLater());
+            }}
+          >
+            Remind Me Later
+          </IconButton>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- add the final Zero-to-Okou soft migration reminder for packaged production Zero builds
- persist seven-day deferrals and migration handoff state across restarts
- drain the active Computer Use command, stop the Zero host, then open the stable signed Okou DMG route
- suppress automatic Zero host registration after handoff while keeping retry and explicit Resume Zero recovery
- keep Zero and Okou updater feeds unchanged and isolated

Part of #26369 and #26364. This PR intentionally does not enable the remote hard stop or close the rollout issue; the signed Zero bridge release and production acceptance remain required after merge.

## User impact

Eligible Zero users see **Download Okou** and **Remind Me Later**. The notice explains that Okou is a separate app requiring sign-in and fresh macOS permissions. Choosing migration waits for current work to finish before stopping Zero. If download or setup fails, the user can retry or resume Zero.

## Validation

- `pnpm -F @vm0/desktop test -- --maxWorkers=4 --silent=passed-only` (37 files, 333 tests)
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop build`
- Developer ID packaged development identity launched and reported the renderer bridge ready
- stable Okou DMG route followed redirects to `Okou-darwin-arm64-0.33.4.dmg` and returned HTTP 200
- `pnpm knip --workspace @vm0/desktop` reports the existing `@sentry/cli` false positive; the dependency is consumed by `apps/desktop/scripts/upload-sentry-artifacts.js` and is unchanged by this PR
