### PR TITLE
test(api): isolate agentphone media run from cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -7,7 +7,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, test as vitestTest } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
@@ -15,6 +15,7 @@ import {
   findAgentphoneChatEventByPromptFixture,
   readChatEventContextFixture,
 } from "../../../test-fixtures/chat-events";
+import { withThreadlessRunCleanupTestLockFixture } from "../../../test-fixtures/run-deletion";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { settle } from "../../utils";
 import {
@@ -38,6 +39,23 @@ import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 const context = testContext();
+const PHONE_MEDIA_RUN_TOKEN_TEST =
+  "uploads and streams phone media with a real run-scoped zero token";
+
+function it(name: string, test: () => Promise<void>): void {
+  vitestTest(name, async () => {
+    if (name === PHONE_MEDIA_RUN_TOKEN_TEST) {
+      // This case intentionally creates a test-only direct run. Share the
+      // cleanup suite's lock so its global sweep cannot cancel that run.
+      await withThreadlessRunCleanupTestLockFixture({
+        signal: context.signal,
+        run: test,
+      });
+      return;
+    }
+    await test();
+  });
+}
 
 interface LinkedAgentPhoneActor {
   readonly actor: ApiTestUser;
@@ -1177,7 +1195,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(sends.messages).toHaveLength(sendsBeforeCompletion);
   });
 
-  it("uploads and streams phone media with a real run-scoped zero token", async () => {
+  it(PHONE_MEDIA_RUN_TOKEN_TEST, async () => {
     const bdd = createBddApi(context);
     const runs = createRunsApi(context);
     const integrations = createBddIntegrationApi(context);


### PR DESCRIPTION
## Summary

- serialize the AgentPhone real run-scoped media scenario with the existing threadless-run cleanup integration lock
- keep the direct-run setup and all media upload, streaming, authorization, and runner-claim assertions unchanged

## Root cause

The media scenario creates a test-only direct zero run through `/api/test/zero-run-fixture`. That run defaults to `trigger_source = web`, has no chat thread, and is initially `pending`, so it is eligible for the global threadless-run sweep exercised by `cron-cleanup-sandboxes.test.ts` in the same `test-api (4)` shard.

Two independent merge-group recurrences reached different branches of the same race:

- Run 31577138943 returned `Run not found`: `claimRunnerJob` found the queued job, then the atomic claim transition observed that the run had disappeared or stopped being `pending`.
- Run 31580349889 returned `Job not found in queue`: the sweep removed the queued job before the initial claim lookup.

The existing integration-test advisory lock is the shared boundary for this sweep, so the media scenario now participates in that boundary.

This is distinct from #26537: that incident had a preceding compound-scenario timeout and a subsequent `Job not found in queue`; both recurrences here had no preceding AgentPhone timeout and used the independently seeded media scenario.

## Evidence

- First triggering Turbo run: https://github.com/vm0-ai/vm0/actions/runs/31577138943
- First failing job: https://github.com/vm0-ai/vm0/actions/runs/31577138943/job/94051781630
- First recurrence: `agentphone.bdd.test.ts` media scenario, HTTP 404 `Run not found` at `claimRunnerJob`; the other 14 AgentPhone scenarios passed
- Represented PR #26508 changes only Platform model-picker/composer files and does not touch AgentPhone, run lifecycle, runner claims, or API fixtures
- The concurrent adjacent run on the exact first merge-group base passed `test-api (4)`: https://github.com/vm0-ai/vm0/actions/runs/31577134335/job/94051751607
- Additional triggering Turbo run: https://github.com/vm0-ai/vm0/actions/runs/31580349889
- Additional failing job: https://github.com/vm0-ai/vm0/actions/runs/31580349889/job/94061804326
- Additional recurrence: the same media scenario failed after 149 ms with HTTP 404 `Job not found in queue`; the other 14 AgentPhone scenarios passed, and the shard completed 23 files and 426 tests successfully
- `cron-cleanup-sandboxes.test.ts` ran in the same additional-recurrence shard and completed immediately after the AgentPhone file
- Represented PR #26565 only adds `e2e/tests/03-runner/run-t17-network-request-headers.bats` and does not touch AgentPhone, cleanup, run claims, or API fixtures
- Run 31580349889 began at 08:52:37Z, before this repair PR was created, so it does not exercise the advisory-lock fix
- This PR's own `test-api (4)` passed: https://github.com/vm0-ai/vm0/actions/runs/31580835232/job/94063348503
- Open-PR searches found no equivalent AgentPhone/threadless-cleanup repair

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- AgentPhone plus cron-cleanup paired regression: 5 consecutive runs, each 2 files and 59/59 tests passed on the final rebased commit
- `git diff --check`

## Preview validation

Not applicable. This is a test-only change with no deployed application, API, or browser behavior change.
