### PR TITLE
perf(python): bound connector diagnostic query inspection

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -56,6 +56,9 @@ _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_FORBIDDEN = 403
 _HTTP_STATUS_FAILED_DEPENDENCY = 424
 
+MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS = 64 * 1024
+MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS = 8 * 1024
+
 _CONNECTOR_DIAGNOSTIC_ELIGIBLE = "_connector_diagnostic_eligible"
 _CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES = "_connector_diagnostic_active_firewall_names"
 _CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT = "_connector_diagnostic_catalog_snapshot"
@@ -166,7 +169,7 @@ def maybe_make_local_response(
     candidate = _resolve_candidate(flow, original_url=original_url)
     if candidate is None:
         return False
-    if _request_has_auth_material(flow, candidate, original_url):
+    if _request_may_have_auth_material(flow, candidate, original_url):
         return False
 
     flow_metadata.start_request_timing(flow.metadata)
@@ -237,7 +240,7 @@ def maybe_make_firewall_allow_local_response(
         return False
 
     candidate = resolution.candidate
-    if _request_has_auth_material(flow, candidate, original_url):
+    if _request_may_have_auth_material(flow, candidate, original_url):
         return False
 
     flow.metadata[_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT] = diagnostic_snapshot
@@ -290,7 +293,7 @@ def install_response_stream_if_needed(flow: http.HTTPFlow) -> bool:
     candidate = _resolve_candidate(flow, original_url=original_url)
     if candidate is None:
         return False
-    if _request_has_auth_material(flow, candidate, original_url):
+    if _request_may_have_auth_material(flow, candidate, original_url):
         return False
 
     upstream_status = flow.response.status_code
@@ -367,7 +370,7 @@ def maybe_replace_response(
     if candidate is None:
         return
     upstream_status = flow.response.status_code
-    if _request_has_auth_material(flow, candidate, original_url):
+    if _request_may_have_auth_material(flow, candidate, original_url):
         return
 
     _set_failure_metadata(flow, candidate)
@@ -406,7 +409,7 @@ def maybe_make_error_response(
     candidate = _resolve_candidate(flow, original_url=original_url)
     if candidate is None:
         return
-    if _request_has_auth_material(flow, candidate, original_url):
+    if _request_may_have_auth_material(flow, candidate, original_url):
         return
     _set_failure_metadata(flow, candidate)
     flow.response = _make_local_response(
@@ -679,11 +682,12 @@ def _message(
     )
 
 
-def _request_has_auth_material(
+def _request_may_have_auth_material(
     flow: http.HTTPFlow,
     candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
     original_url: str,
 ) -> bool:
+    """Return whether auth is present or bounded query inspection is inconclusive."""
     configured_headers = {name.lower() for name in candidate.auth_header_names}
     auth_headers = configured_headers | _GENERIC_AUTH_HEADER_NAMES
     for name in auth_headers:
@@ -696,15 +700,41 @@ def _request_has_auth_material(
         parsed = runtime_url_parsing.split_runtime_url(original_url)
     except ValueError:
         return False
-    for name, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True):
-        normalized_name = name.lower()
-        is_auth_param = (
-            name in configured_query_params
-            or normalized_name in normalized_configured_query_params
-            or normalized_name in _GENERIC_AUTH_QUERY_PARAM_NAMES
-        )
-        if is_auth_param and _query_param_has_auth_material(value):
-            return True
+
+    query = parsed.query
+    if len(query) > MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS:
+        return True
+
+    field_count = 0
+    field_start = 0
+    query_end = len(query)
+    while field_start < query_end:
+        field_end = query.find("&", field_start)
+        if field_end == -1:
+            field_end = query_end
+
+        if field_start < field_end:
+            field_count += 1
+            if field_count > MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS:
+                return True
+
+            separator_index = query.find("=", field_start, field_end)
+            name_end = field_end if separator_index == -1 else separator_index
+            name = urllib.parse.unquote_plus(query[field_start:name_end])
+            normalized_name = name.lower()
+            is_auth_param = (
+                name in configured_query_params
+                or normalized_name in normalized_configured_query_params
+                or normalized_name in _GENERIC_AUTH_QUERY_PARAM_NAMES
+            )
+            if is_auth_param:
+                value_start = field_end if separator_index == -1 else separator_index + 1
+                value = urllib.parse.unquote_plus(query[value_start:field_end])
+                if _query_param_has_auth_material(value):
+                    return True
+
+        field_start = field_end + 1
+
     return False
 
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import connector_diagnostics
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
@@ -477,6 +478,7 @@ async def test_inactive_builtin_connector_head_diagnostic_is_bodyless(
         ("/fal-ai/nano-banana-pro", [("Authorization", "Key ")]),
         ("/fal-ai/nano-banana-pro", [("Proxy-Authorization", "Basic proxy-secret")]),
         ("/fal-ai/nano-banana-pro?api_key=", []),
+        ("/fal-ai/nano-banana-pro?&&api_key&api_key=+&&", []),
     ],
 )
 async def test_inactive_builtin_connector_url_with_empty_auth_gets_local_diagnostic(
@@ -500,6 +502,120 @@ async def test_inactive_builtin_connector_url_with_empty_auth_gets_local_diagnos
         await mitm_addon.request(flow)
 
     _assert_fal_local_connector_diagnostic(flow)
+
+
+@pytest.mark.parametrize(
+    ("query", "expect_diagnostic"),
+    [
+        (
+            "&".join(["x"] * connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS),
+            True,
+        ),
+        (
+            "&".join(["x"] * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS + 1)),
+            False,
+        ),
+        (
+            "noise="
+            + "x"
+            * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS - len("noise=")),
+            True,
+        ),
+        (
+            "noise="
+            + "x"
+            * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS - len("noise=") + 1),
+            False,
+        ),
+    ],
+    ids=["field-limit", "over-field-limit", "character-limit", "over-character-limit"],
+)
+async def test_inactive_builtin_connector_query_inspection_boundaries(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    query,
+    expect_diagnostic,
+):
+    write_connector_diagnostic_catalog_cache(tmp_path)
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=f"/fal-ai/nano-banana-pro?{query}",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    if expect_diagnostic:
+        _assert_fal_local_connector_diagnostic(flow)
+    else:
+        assert flow.response is None
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
+
+
+async def test_inactive_builtin_connector_stops_at_auth_before_field_limit(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    write_connector_diagnostic_catalog_cache(tmp_path)
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    trailing_query = "&".join(
+        ["x"] * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS + 1)
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=f"/fal-ai/nano-banana-pro?api_key=user-token&{trailing_query}",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "API%5fKEY=user+token",
+        "api_key=&noise=x&api_key=user-token",
+        "api_key=user=token",
+        "api_key=%ZZ",
+    ],
+    ids=["percent-plus", "duplicate", "first-equals", "invalid-percent"],
+)
+async def test_inactive_builtin_connector_encoded_query_auth_allows_upstream(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    query,
+):
+    write_connector_diagnostic_catalog_cache(tmp_path)
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=f"/fal-ai/nano-banana-pro?{query}",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
@@ -533,8 +649,9 @@ async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
     [
         ("/items", [("X-Workspace-Session", "user-provided")]),
         ("/items?workspace_session=user-provided", []),
+        ("/items?WORKSPACE%5FSESSION=user+provided", []),
     ],
-    ids=["configured-header", "configured-query"],
+    ids=["configured-header", "configured-query", "encoded-configured-query"],
 )
 async def test_inactive_connector_url_with_configured_auth_allows_upstream(
     tmp_path,

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -2,10 +2,10 @@
 
 import json
 import urllib.parse
-from unittest.mock import patch
 
 from mitmproxy.test import tutils
 
+import connector_diagnostics
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.connector_diagnostic_helpers import (
@@ -315,9 +315,15 @@ async def test_streams_unauthenticated_connector_401_diagnostic_without_upstream
     assert sum(entry["type"] == "connector_diagnostic" for entry in proxy_entries) == 1
 
 
-def test_responseheaders_parses_large_connector_auth_query_once(tmp_path, real_flow, mitm_ctx):
+def test_responseheaders_preserves_upstream_for_query_over_inspection_limit(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
     reg_path = write_connector_diagnostic_capture_registry(tmp_path)
-    query = "&".join(["noise=x"] * 25_000)
+    query = "noise=" + "x" * (
+        connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS - len("noise=") + 1
+    )
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
@@ -338,23 +344,20 @@ def test_responseheaders_parses_large_connector_auth_query_once(tmp_path, real_f
         try:
             urllib.parse.urlsplit("https://stable-config.example.com")
             stable_cache = urllib.parse.urlsplit.cache_info()
-            real_parse_qsl = urllib.parse.parse_qsl
-            with patch.object(
-                urllib.parse,
-                "parse_qsl",
-                wraps=real_parse_qsl,
-            ) as parse_qsl:
-                mitm_addon.responseheaders(flow)
-
-            assert parse_qsl.call_count == 1
+            mitm_addon.responseheaders(flow)
             assert urllib.parse.urlsplit.cache_info() == stable_cache
         finally:
             urllib.parse.urlsplit.cache_clear()
 
-        diagnostic_body = _drain_connector_diagnostic_response_stream(flow)
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_REASON not in flow.metadata
+        assert response_stream(flow)(b"upstream") == b"upstream"
         mitm_addon.response(flow)
 
-    assert flow.response.content == diagnostic_body
+    assert flow.response.status_code == 401
+    assert flow.response.content == b"upstream"
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert "firewall_error" not in entry
 
 
 async def test_restores_connector_diagnostic_body_when_headers_end_stream(


### PR DESCRIPTION
## Summary

- replace eager connector diagnostic `parse_qsl` materialization with an indexed scanner bounded to 64 KiB query characters and 8,192 nonempty fields
- decode inspected names and only credential-relevant values, stopping as soon as nonblank auth material is found
- treat exhausted inspection budgets as possible auth so request, response, and error hooks preserve ordinary upstream handling
- cover exact and over-limit boundaries, early credentials, encoded names and values, duplicate and blank fields, and response-header behavior through real hook integration tests

## Exclusions

- no global request-target rejection policy
- no cross-hook cache or new flow metadata
- no API, schema, persisted-state, protocol, dependency, feature-switch, or deployment-order changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_request_handler_connector_diagnostics.py tests/test_response_handler_connector_diagnostics.py tests/test_error_handler.py` (84 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` (0 errors)
- `uv run --no-sync python -m pytest tests/` (5,338 passed)

Closes #26551
