### PR TITLE
test(e2e): restore mock claude runtime regressions

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -10,6 +10,7 @@ RUNNER_HELPERS=(
   "${REPO_ROOT}/e2e/helpers/runner-chat.bash"
 )
 RUNNER_TOKEN="${REPO_ROOT}/e2e/playwright/runner-token.ts"
+RUNNER_MOCK_CLAUDE_BOOTSTRAP="${REPO_ROOT}/e2e/playwright/runner-mock-claude-bootstrap.bash"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -39,14 +40,14 @@ grep -Fq 'startVideoOnboardingCheckout' "$RUNNER_TOKEN" ||
   fail "real runner accounts must upgrade through public paid onboarding"
 grep -Fq 'fillStripeCheckout' "$RUNNER_TOKEN" ||
   fail "real runner accounts must complete the public Stripe checkout"
-if [[ "$(grep -Fc 'upgradeToPro: true' "$RUNNER_TOKEN")" -ne 2 ]]; then
-  fail "real Codex and Claude runner accounts must both upgrade to Pro"
+if [[ "$(grep -Fc 'upgradeToPro: true' "$RUNNER_TOKEN")" -ne 3 ]]; then
+  fail "real Codex, real Claude, and mock Claude runner accounts must upgrade to Pro"
 fi
 if [[ "$(grep -Fc 'upgradeToPro: false' "$RUNNER_TOKEN")" -ne 1 ]]; then
-  fail "the mock runner account must remain on limited-free"
+  fail "the default mock runner account must remain on limited-free"
 fi
 
-ruby -ryaml - "$WORKFLOW" <<'RUBY'
+ruby -ryaml - "$WORKFLOW" "$RUNNER_MOCK_CLAUDE_BOOTSTRAP" <<'RUBY'
 workflow = YAML.load_file(ARGV.fetch(0))
 jobs = workflow.fetch("jobs")
 prepare = jobs.fetch("prepare")
@@ -140,6 +141,7 @@ expected_organization_outputs = {
   "runner-organization-id" => "runner-organization-id",
   "codex-organization-id" => "codex-organization-id",
   "claude-organization-id" => "claude-organization-id",
+  "mock-claude-organization-id" => "mock-claude-organization-id",
 }
 expected_organization_outputs.each do |job_output, step_output|
   expected = "${{ steps.account.outputs.#{step_output} }}"
@@ -174,6 +176,10 @@ end
 unless token_step.dig("env", "ZERO_APP_URL") == "${{ needs.deploy-app.outputs.preview-url }}"
   raise "runner E2E token generation must use the app preview URL"
 end
+unless token_step.dig("env", "E2E_RUNNER_MOCK_CLAUDE_ORGANIZATION_ID") ==
+    "${{ steps.account.outputs.mock-claude-organization-id }}"
+  raise "runner E2E token generation must receive the mock Claude organization"
+end
 
 upload_step = account_prepare.fetch("steps").find do |step|
   step["name"] == "Upload runner E2E API tokens"
@@ -187,6 +193,7 @@ end
   e2e-api-credentials-runner.json
   e2e-api-credentials-runner-real-codex.json
   e2e-api-credentials-runner-real-claude.json
+  e2e-api-credentials-runner-mock-claude.json
 ].each do |file_name|
   unless upload_step.dig("with", "path").include?(file_name)
     raise "runner E2E token artifact must include #{file_name}"
@@ -197,6 +204,11 @@ unless Array(bootstrap["needs"]).include?("cli-e2e-03-runner-prepare")
   raise "runner bootstrap must wait for the token artifact"
 end
 bootstrap_steps = bootstrap.fetch("steps")
+unless bootstrap_steps.any? do |step|
+    step["uses"]&.start_with?("actions/checkout@")
+  end
+  raise "runner bootstrap must checkout the focused helper scripts"
+end
 unless bootstrap_steps.any? do |step|
     step["name"] == "Download runner E2E API tokens" &&
       step.dig("with", "name") == "e2e-tokens"
@@ -228,6 +240,37 @@ unless provider_step.fetch("run").include?(
     '{"type":"claude-code-oauth-token","secret":"mock-oauth-token-for-e2e"}',
   )
   raise "runner bootstrap must restore the historical mock provider"
+end
+mock_claude_step = bootstrap_steps.find do |step|
+  step["name"] == "Bootstrap mock Claude account"
+end
+raise "missing mock Claude account bootstrap" unless mock_claude_step
+unless mock_claude_step.fetch("run").end_with?(
+    "runner-mock-claude-bootstrap.bash /tmp/e2e-api-credentials-runner-mock-claude.json",
+  )
+  raise "mock Claude account bootstrap must use the focused executable"
+end
+unless mock_claude_step.dig("env", "VERCEL_AUTOMATION_BYPASS_SECRET") ==
+    "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}"
+  raise "mock Claude bootstrap must receive the preview bypass secret"
+end
+mock_claude_script = File.read(ARGV.fetch(1))
+%w[
+  /api/zero/model-providers
+  /api/zero/model-policies
+  /api/zero/feature-switches
+  claude-code-oauth-token
+  claude-sonnet-4-6
+  realAgentInPreview
+].each do |required_fragment|
+  unless mock_claude_script.include?(required_fragment)
+    raise "mock Claude bootstrap must include #{required_fragment}"
+  end
+end
+unless mock_claude_script.include?(
+    '.effectiveSwitches.realAgentInPreview == false',
+  )
+  raise "mock Claude bootstrap must keep the real runtime disabled"
 end
 codex_step = bootstrap_steps.find do |step|
   step["name"] == "Bootstrap real Codex account"
@@ -277,6 +320,12 @@ raise "missing runner E2E shard scaffold" unless shard_step
 unless runner.dig("env", "E2E_RUNNER_TEST_FILES_JSON") == "${{ toJSON(matrix.files) }}" &&
     runner.dig("env", "E2E_RUNNER_SHARD_TOTAL") == "${{ strategy.job-total }}"
   raise "runner E2E shards must receive their exact file list and dynamic total"
+end
+unless runner.dig("env", "E2E_RUNNER_MOCK_CLAUDE_ORG_ID") ==
+    "${{ needs.cli-e2e-03-runner-prepare.outputs.mock-claude-organization-id }}" &&
+    runner.dig("env", "E2E_RUNNER_MOCK_CLAUDE_EMAIL") ==
+      "${{ needs.cli-e2e-03-runner-prepare.outputs.mock-claude-email }}"
+  raise "runner E2E shards must receive the mock Claude identity"
 end
 
 run_step = runner.fetch("steps").find do |step|
@@ -328,6 +377,7 @@ end
   E2E_RUNNER_ORGANIZATION_ID
   E2E_RUNNER_CODEX_ORGANIZATION_ID
   E2E_RUNNER_CLAUDE_ORGANIZATION_ID
+  E2E_RUNNER_MOCK_CLAUDE_ORGANIZATION_ID
 ].each do |environment_name|
   if cleanup_step.fetch("env", {}).key?(environment_name)
     raise "runner E2E cleanup must not depend on #{environment_name}"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -256,7 +256,7 @@ unless mock_claude_step.dig("env", "VERCEL_AUTOMATION_BYPASS_SECRET") ==
 end
 mock_claude_script = File.read(ARGV.fetch(1))
 %w[
-  /api/zero/model-providers
+  /api/zero/me/model-providers
   /api/zero/model-policies
   /api/zero/feature-switches
   claude-code-oauth-token

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -272,6 +272,10 @@ unless mock_claude_script.include?(
   )
   raise "mock Claude bootstrap must keep the real runtime disabled"
 end
+unless mock_claude_script.include?('credentialScope: "member"') &&
+    mock_claude_script.include?("modelProviderId: null")
+  raise "mock Claude OAuth policy must use member credentials"
+end
 codex_step = bootstrap_steps.find do |step|
   step["name"] == "Bootstrap real Codex account"
 end

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2584,9 +2584,11 @@ jobs:
       runner-organization-id: ${{ steps.account.outputs.runner-organization-id }}
       codex-organization-id: ${{ steps.account.outputs.codex-organization-id }}
       claude-organization-id: ${{ steps.account.outputs.claude-organization-id }}
+      mock-claude-organization-id: ${{ steps.account.outputs.mock-claude-organization-id }}
       runner-email: ${{ steps.account.outputs.runner-email }}
       codex-email: ${{ steps.account.outputs.codex-email }}
       claude-email: ${{ steps.account.outputs.claude-email }}
+      mock-claude-email: ${{ steps.account.outputs.mock-claude-email }}
       runner-shard-matrix: ${{ steps.shards.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2628,6 +2630,7 @@ jobs:
           E2E_RUNNER_ORGANIZATION_ID: ${{ steps.account.outputs.runner-organization-id }}
           E2E_RUNNER_CODEX_ORGANIZATION_ID: ${{ steps.account.outputs.codex-organization-id }}
           E2E_RUNNER_CLAUDE_ORGANIZATION_ID: ${{ steps.account.outputs.claude-organization-id }}
+          E2E_RUNNER_MOCK_CLAUDE_ORGANIZATION_ID: ${{ steps.account.outputs.mock-claude-organization-id }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Upload runner E2E API tokens
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -2637,6 +2640,7 @@ jobs:
             /tmp/e2e-api-credentials-runner.json
             /tmp/e2e-api-credentials-runner-real-codex.json
             /tmp/e2e-api-credentials-runner-real-claude.json
+            /tmp/e2e-api-credentials-runner-mock-claude.json
           retention-days: 1
 
   cli-e2e-03-runner-bootstrap:
@@ -2656,6 +2660,7 @@ jobs:
       needs.deploy-api.result == 'success' &&
       needs.cli-e2e-03-runner-prepare.result == 'success'
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download runner E2E API tokens
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -2704,6 +2709,11 @@ jobs:
             -X POST \
             -d '{"type":"claude-code-oauth-token","secret":"mock-oauth-token-for-e2e"}' \
             "${E2E_API_URL}/api/zero/model-providers" >/dev/null
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Bootstrap mock Claude account
+        shell: bash
+        run: cd e2e && bash playwright/runner-mock-claude-bootstrap.bash /tmp/e2e-api-credentials-runner-mock-claude.json
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Bootstrap real Codex account
@@ -2862,9 +2872,11 @@ jobs:
       E2E_CLERK_ORG_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.runner-organization-id }}
       E2E_RUNNER_CODEX_ORG_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.codex-organization-id }}
       E2E_RUNNER_CLAUDE_ORG_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.claude-organization-id }}
+      E2E_RUNNER_MOCK_CLAUDE_ORG_ID: ${{ needs.cli-e2e-03-runner-prepare.outputs.mock-claude-organization-id }}
       E2E_RUNNER_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.runner-email }}
       E2E_RUNNER_CODEX_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.codex-email }}
       E2E_RUNNER_CLAUDE_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.claude-email }}
+      E2E_RUNNER_MOCK_CLAUDE_EMAIL: ${{ needs.cli-e2e-03-runner-prepare.outputs.mock-claude-email }}
       E2E_RUNNER_SHARD_INDEX: ${{ matrix.index }}
       E2E_RUNNER_SHARD_TOTAL: ${{ strategy.job-total }}
       E2E_RUNNER_TEST_FILES_JSON: ${{ toJSON(matrix.files) }}
@@ -2891,7 +2903,8 @@ jobs:
           for credential_file in \
             /tmp/e2e-api-credentials-runner.json \
             /tmp/e2e-api-credentials-runner-real-codex.json \
-            /tmp/e2e-api-credentials-runner-real-claude.json; do
+            /tmp/e2e-api-credentials-runner-real-claude.json \
+            /tmp/e2e-api-credentials-runner-mock-claude.json; do
             jq -er '.token | select(type == "string" and length > 0)' "$credential_file" >/dev/null
             jq -er '.apiUrl | select(type == "string" and length > 0)' "$credential_file" >/dev/null
           done
@@ -2907,9 +2920,11 @@ jobs:
           : "${E2E_CLERK_ORG_ID:?runner E2E organization is required}"
           : "${E2E_RUNNER_CODEX_ORG_ID:?runner Codex E2E organization is required}"
           : "${E2E_RUNNER_CLAUDE_ORG_ID:?runner Claude E2E organization is required}"
+          : "${E2E_RUNNER_MOCK_CLAUDE_ORG_ID:?runner mock Claude E2E organization is required}"
           : "${E2E_RUNNER_EMAIL:?runner E2E account is required}"
           : "${E2E_RUNNER_CODEX_EMAIL:?runner Codex E2E account is required}"
           : "${E2E_RUNNER_CLAUDE_EMAIL:?runner Claude E2E account is required}"
+          : "${E2E_RUNNER_MOCK_CLAUDE_EMAIL:?runner mock Claude E2E account is required}"
           : "${E2E_API_TOKEN:?runner E2E API token is required}"
           : "${E2E_API_URL:?runner E2E API URL is required}"
           jq -e '

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -55,6 +55,8 @@ test("creates and parses generation-scoped test identities", () => {
         runner: "pr-123+clerk_test+31500000000-2+runner@vm0-e2e.ai",
         codex: "pr-123+clerk_test+31500000000-2+runner-real-codex@vm0-e2e.ai",
         claude: "pr-123+clerk_test+31500000000-2+runner-real-claude@vm0-e2e.ai",
+        mockClaude:
+          "pr-123+clerk_test+31500000000-2+runner-mock-claude@vm0-e2e.ai",
       });
     },
   );

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -17,6 +17,7 @@ export const CLERK_TEST_ROLES = [
   "runner",
   "runner-real-codex",
   "runner-real-claude",
+  "runner-mock-claude",
 ] as const;
 
 export type ClerkTestRole = (typeof CLERK_TEST_ROLES)[number];
@@ -31,6 +32,7 @@ export interface RunnerTestAccounts {
   readonly runner: string;
   readonly codex: string;
   readonly claude: string;
+  readonly mockClaude: string;
 }
 
 export interface ClerkCleanupOptions {
@@ -156,6 +158,7 @@ export function runnerTestAccounts(): RunnerTestAccounts {
     runner: generateTestEmail("runner"),
     codex: generateTestEmail("runner-real-codex"),
     claude: generateTestEmail("runner-real-claude"),
+    mockClaude: generateTestEmail("runner-mock-claude"),
   };
 }
 

--- a/e2e/playwright/lib/runner-account.test.ts
+++ b/e2e/playwright/lib/runner-account.test.ts
@@ -75,6 +75,11 @@ test("prepares and cleans one generation of runner accounts", async () => {
         "e2e-runner-real-claude-pr-123",
         "runner-real-claude",
       ),
+      organizationRequest(
+        "user_4",
+        "e2e-runner-mock-claude-pr-123",
+        "runner-mock-claude",
+      ),
     ]);
     assert.equal(
       await readFile(githubOutput, "utf8"),
@@ -82,9 +87,11 @@ test("prepares and cleans one generation of runner accounts", async () => {
         "runner-organization-id=org_1",
         "codex-organization-id=org_2",
         "claude-organization-id=org_3",
+        "mock-claude-organization-id=org_4",
         "runner-email=pr-123+clerk_test+9001-3+runner@vm0-e2e.ai",
         "codex-email=pr-123+clerk_test+9001-3+runner-real-codex@vm0-e2e.ai",
         "claude-email=pr-123+clerk_test+9001-3+runner-real-claude@vm0-e2e.ai",
+        "mock-claude-email=pr-123+clerk_test+9001-3+runner-mock-claude@vm0-e2e.ai",
         "",
       ].join("\n"),
     );
@@ -114,9 +121,11 @@ test("prepares and cleans one generation of runner accounts", async () => {
       "organization:org_1",
       "organization:org_2",
       "organization:org_3",
+      "organization:org_4",
       "user:user_1",
       "user:user_2",
       "user:user_3",
+      "user:user_4",
     ]);
     assert.deepEqual(fixture.state.users, [
       {

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -13,6 +13,7 @@ const RUNNER_TEST_ROLES = [
   "runner",
   "runner-real-codex",
   "runner-real-claude",
+  "runner-mock-claude",
 ] as const satisfies readonly ClerkTestRole[];
 
 async function main(): Promise<void> {
@@ -54,6 +55,12 @@ async function prepareRunnerAccounts(
       claudeUserId,
       "runner-real-claude",
     );
+    const mockClaudeUserId = await createUser(runnerAccounts.mockClaude);
+    const mockClaudeOrganizationId = await createOrganization(
+      `e2e-runner-mock-claude-${jobRef}`,
+      mockClaudeUserId,
+      "runner-mock-claude",
+    );
 
     await appendFile(
       requiredEnvironmentVariable("GITHUB_OUTPUT"),
@@ -61,9 +68,11 @@ async function prepareRunnerAccounts(
         `runner-organization-id=${runnerOrganizationId}`,
         `codex-organization-id=${codexOrganizationId}`,
         `claude-organization-id=${claudeOrganizationId}`,
+        `mock-claude-organization-id=${mockClaudeOrganizationId}`,
         `runner-email=${runnerAccounts.runner}`,
         `codex-email=${runnerAccounts.codex}`,
         `claude-email=${runnerAccounts.claude}`,
+        `mock-claude-email=${runnerAccounts.mockClaude}`,
         "",
       ].join("\n"),
       "utf8",
@@ -73,6 +82,7 @@ async function prepareRunnerAccounts(
       runnerOrganizationId,
       codexOrganizationId,
       claudeOrganizationId,
+      mockClaudeOrganizationId,
       ...runnerAccounts,
     });
   } catch (cause) {

--- a/e2e/playwright/runner-mock-claude-bootstrap.bash
+++ b/e2e/playwright/runner-mock-claude-bootstrap.bash
@@ -14,7 +14,7 @@ fi
 provider_response=$(curl -fsS "${headers[@]}" \
     -X POST \
     -d '{"type":"claude-code-oauth-token","secret":"mock-oauth-token-for-e2e"}' \
-    "${api_url}/api/zero/model-providers")
+    "${api_url}/api/zero/me/model-providers")
 jq -e '.provider.type == "claude-code-oauth-token"' \
     <<<"$provider_response" \
     >/dev/null

--- a/e2e/playwright/runner-mock-claude-bootstrap.bash
+++ b/e2e/playwright/runner-mock-claude-bootstrap.bash
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+credentials="${1:?Usage: runner-mock-claude-bootstrap.bash <credentials-file>}"
+token=$(jq -er '.token | select(type == "string" and length > 0)' "$credentials")
+api_url=$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$credentials")
+echo "::add-mask::$token"
+
+headers=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")
+if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+    headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+fi
+
+provider_response=$(curl -fsS "${headers[@]}" \
+    -X POST \
+    -d '{"type":"claude-code-oauth-token","secret":"mock-oauth-token-for-e2e"}' \
+    "${api_url}/api/zero/model-providers")
+provider_id=$(jq -er '.provider.id | select(type == "string" and length > 0)' \
+    <<<"$provider_response")
+
+policies=$(curl -fsS "${headers[@]}" "${api_url}/api/zero/model-policies")
+policy_payload=$(jq -c --arg providerId "$provider_id" '
+    {
+      policies: (
+        [.policies[] |
+          select(.model != "claude-sonnet-4-6") |
+          {
+            model,
+            isDefault,
+            defaultProviderType,
+            credentialScope,
+            modelProviderId
+          }
+        ] + [
+          {
+            model: "claude-sonnet-4-6",
+            isDefault: false,
+            defaultProviderType: "claude-code-oauth-token",
+            credentialScope: "org",
+            modelProviderId: $providerId
+          }
+        ]
+      )
+    }
+' <<<"$policies")
+curl -fsS "${headers[@]}" \
+    -X PUT \
+    -d "$policy_payload" \
+    "${api_url}/api/zero/model-policies" \
+    >/dev/null
+
+curl -fsS "${headers[@]}" \
+    -X POST \
+    -d '{"switches":{"realAgentInPreview":false}}' \
+    "${api_url}/api/zero/feature-switches" \
+    | jq -e '.effectiveSwitches.realAgentInPreview == false' \
+    >/dev/null

--- a/e2e/playwright/runner-mock-claude-bootstrap.bash
+++ b/e2e/playwright/runner-mock-claude-bootstrap.bash
@@ -15,11 +15,12 @@ provider_response=$(curl -fsS "${headers[@]}" \
     -X POST \
     -d '{"type":"claude-code-oauth-token","secret":"mock-oauth-token-for-e2e"}' \
     "${api_url}/api/zero/model-providers")
-provider_id=$(jq -er '.provider.id | select(type == "string" and length > 0)' \
-    <<<"$provider_response")
+jq -e '.provider.type == "claude-code-oauth-token"' \
+    <<<"$provider_response" \
+    >/dev/null
 
 policies=$(curl -fsS "${headers[@]}" "${api_url}/api/zero/model-policies")
-policy_payload=$(jq -c --arg providerId "$provider_id" '
+policy_payload=$(jq -c '
     {
       policies: (
         [.policies[] |
@@ -36,8 +37,8 @@ policy_payload=$(jq -c --arg providerId "$provider_id" '
             model: "claude-sonnet-4-6",
             isDefault: false,
             defaultProviderType: "claude-code-oauth-token",
-            credentialScope: "org",
-            modelProviderId: $providerId
+            credentialScope: "member",
+            modelProviderId: null
           }
         ]
       )

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -57,6 +57,14 @@ async function main(): Promise<void> {
       ),
       upgradeToPro: true,
     },
+    {
+      email: accounts.mockClaude,
+      fileName: "e2e-api-credentials-runner-mock-claude.json",
+      organizationId: requiredEnvironmentVariable(
+        "E2E_RUNNER_MOCK_CLAUDE_ORGANIZATION_ID",
+      ),
+      upgradeToPro: true,
+    },
   ];
   const vercelAutomationBypassSecret =
     process.env.VERCEL_AUTOMATION_BYPASS_SECRET;

--- a/e2e/tests/03-runner/run-t21-claude-runtime-regressions.bats
+++ b/e2e/tests/03-runner/run-t21-claude-runtime-regressions.bats
@@ -1,0 +1,253 @@
+#!/usr/bin/env bats
+
+# Mock Claude runtime regressions through the deployed public chat flow.
+
+load '../../helpers/setup'
+load '../../helpers/runner-chat'
+load '../../helpers/runner-api'
+
+setup() {
+    local credentials="/tmp/e2e-api-credentials-runner-mock-claude.json"
+    export E2E_API_TOKEN E2E_API_URL
+    E2E_API_TOKEN="$(jq -er '.token | select(type == "string" and length > 0)' "$credentials")"
+    E2E_API_URL="$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$credentials")"
+    runner_e2e_require_environment
+    runner_e2e_setup_test
+}
+
+teardown() {
+    runner_e2e_teardown_test
+}
+
+wait_for_mock_claude_events() {
+    local run_id="$1"
+    local timeout="${2:-45}"
+    local interval="${RUNNER_EVENT_POLL_INTERVAL_SECONDS:-2}"
+    local start=$SECONDS
+    local response=""
+
+    while ((SECONDS - start < timeout)); do
+        if response="$(runner_api_curl \
+            "/api/zero/runs/$run_id/telemetry/agent?limit=100&order=asc" \
+            2>&1)" &&
+            jq -e '
+                .framework == "claude-code" and
+                any(.events[]?.eventData |
+                    . as $eventData |
+                    if type == "string" then
+                        try fromjson catch $eventData
+                    else
+                        .
+                    end;
+                    type == "object" and
+                    .type == "result" and
+                    .subtype == "success"
+                )
+            ' <<<"$response" >/dev/null; then
+            printf '%s\n' "$response"
+            return 0
+        fi
+        sleep "$interval"
+    done
+
+    echo "# Timed out (${timeout}s) waiting for mock Claude events for run $run_id" >&2
+    echo "# Last event response: $response" >&2
+    return 1
+}
+
+wait_for_system_log_text() {
+    local run_id="$1"
+    local expected="$2"
+    local timeout="${3:-45}"
+    local start=$SECONDS
+    local response=""
+
+    while ((SECONDS - start < timeout)); do
+        if response="$(runner_api_curl \
+            "/api/zero/runs/$run_id/telemetry/system-log?limit=100&order=desc" \
+            2>&1)" &&
+            jq -e --arg expected "$expected" \
+                '.systemLog | contains($expected)' \
+                <<<"$response" >/dev/null; then
+            printf '%s\n' "$response"
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "# Timed out (${timeout}s) waiting for system log text for run $run_id" >&2
+    echo "# Last system log response: $response" >&2
+    return 1
+}
+
+@test "public chat filters mock Claude JSONL stream noise" {
+    run create_runner_agent "e2e-mock-claude-echo-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    local session_id assistant_text protocol_noise prompt
+    session_id="$(_runner_uuid)"
+    assistant_text="echo-jsonl fixture response"
+    protocol_noise="partial echo that should stay out of chat"
+    prompt=$(cat <<EOF
+@ECHO@
+{"type":"system","subtype":"init","cwd":"/home/user/workspace","session_id":"$session_id","tools":["Bash"],"model":"mock-claude"}
+{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_echo_01"}}}
+{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"$protocol_noise"}}}
+{"type":"stream_event","event":{"type":"content_block_stop"}}
+{"type":"stream_event","event":{"type":"message_stop"}}
+{"type":"assistant","session_id":"$session_id","message":{"role":"assistant","content":[{"type":"text","text":"$assistant_text"}]}}
+{"type":"result","subtype":"success","session_id":"$session_id","is_error":false,"duration_ms":100,"num_turns":1,"result":"Done.","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}
+EOF
+)
+
+    run runner_chat_send "$AGENT_ID" "$prompt" "" "claude-sonnet-4-6"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
+
+    run runner_wait_for_run "$RUN_ID" 120
+    echo "$output"
+    assert_success
+    run jq -e --arg sessionId "$session_id" '
+        .status == "completed" and
+        .result.agentSessionId == $sessionId
+    ' <<<"$output"
+    echo "$output"
+    assert_success
+
+    run _wait_for_runner_chat_completion "$THREAD_ID" "$RUN_ID" 45
+    echo "$output"
+    assert_success
+    assert_output "$assistant_text"
+
+    run runner_api_curl "/api/zero/chat-threads/${THREAD_ID}/events?limit=50"
+    echo "$output"
+    assert_success
+    local chat_events="$output"
+    run jq -e \
+        --arg runId "$RUN_ID" \
+        --arg assistantText "$assistant_text" \
+        --arg protocolNoise "$protocol_noise" '
+        [.events[]? |
+            select(.eventType == "output.message" and .runId == $runId) |
+            .content
+        ] as $outputs |
+        ($outputs == [$assistantText]) and
+        all($outputs[]; contains($protocolNoise) | not) and
+        any(.events[]?;
+            .eventType == "run.completed" and .runId == $runId
+        )
+    ' <<<"$chat_events"
+    echo "$output"
+    assert_success
+
+    run wait_for_mock_claude_events "$RUN_ID"
+    echo "$output"
+    assert_success
+    local agent_events="$output"
+    run jq -e \
+        --arg sessionId "$session_id" \
+        --arg assistantText "$assistant_text" \
+        --arg protocolNoise "$protocol_noise" '
+        [.events[]?.eventData |
+            . as $eventData |
+            if type == "string" then
+                try fromjson catch $eventData
+            else
+                .
+            end
+        ] as $payloads |
+        .framework == "claude-code" and
+        ($payloads | map(.type)) == ["system", "assistant", "result"] and
+        ($payloads[0].subtype == "init") and
+        ($payloads[0].session_id == $sessionId) and
+        ($payloads[1].session_id == $sessionId) and
+        ($payloads[1].message.content == [{type: "text", text: $assistantText}]) and
+        ($payloads[2].session_id == $sessionId) and
+        ($payloads[2].subtype == "success") and
+        ($payloads[2].is_error == false) and
+        ($payloads[2].result == "Done.") and
+        ($payloads | tostring | contains($protocolNoise) | not)
+    ' <<<"$agent_events"
+    echo "$output"
+    assert_success
+}
+
+@test "public chat completes after draining an orphaned Claude stdout pipe" {
+    run create_runner_agent "e2e-mock-claude-orphan-pipe-${TEST_ID}"
+    echo "$output"
+    assert_success
+    AGENT_ID="$output"
+
+    run runner_chat_send "$AGENT_ID" "@orphan-pipe" "" "claude-sonnet-4-6"
+    echo "$output"
+    assert_success
+    RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
+    THREAD_ID=$(jq -er '.threadId | select(type == "string" and length > 0)' <<<"$output")
+
+    local started_at=$SECONDS
+    run runner_wait_for_run "$RUN_ID" 90
+    local elapsed=$((SECONDS - started_at))
+    echo "$output"
+    assert_success
+    ((elapsed < 90))
+    run jq -e '
+        .status == "completed" and
+        (.result.agentSessionId | type == "string" and length > 0)
+    ' <<<"$output"
+    echo "$output"
+    assert_success
+
+    run _wait_for_runner_chat_completion "$THREAD_ID" "$RUN_ID" 45
+    echo "$output"
+    assert_success
+    assert_output "Done."
+
+    run runner_api_curl "/api/zero/chat-threads/${THREAD_ID}/events?limit=50"
+    echo "$output"
+    assert_success
+    local chat_events="$output"
+    run jq -e --arg runId "$RUN_ID" '
+        ([.events[]? |
+            select(.eventType == "output.message" and .runId == $runId) |
+            .content
+        ] == ["Done."]) and
+        any(.events[]?;
+            .eventType == "run.completed" and .runId == $runId
+        )
+    ' <<<"$chat_events"
+    echo "$output"
+    assert_success
+
+    run wait_for_mock_claude_events "$RUN_ID"
+    echo "$output"
+    assert_success
+    local agent_events="$output"
+    run jq -e '
+        [.events[]?.eventData |
+            . as $eventData |
+            if type == "string" then
+                try fromjson catch $eventData
+            else
+                .
+            end
+        ] as $payloads |
+        .framework == "claude-code" and
+        ($payloads | map(.type)) == ["system", "result"] and
+        ($payloads[0].subtype == "init") and
+        ($payloads[1].subtype == "success") and
+        ($payloads[1].is_error == false) and
+        ($payloads[1].result == "Done.")
+    ' <<<"$agent_events"
+    echo "$output"
+    assert_success
+
+    run wait_for_system_log_text \
+        "$RUN_ID" \
+        "Stdout drain deadline reached after 5s, possible orphaned child process"
+    echo "$output"
+    assert_success
+}

--- a/e2e/tests/03-runner/run-t21-claude-runtime-regressions.bats
+++ b/e2e/tests/03-runner/run-t21-claude-runtime-regressions.bats
@@ -111,9 +111,9 @@ EOF
     run runner_wait_for_run "$RUN_ID" 120
     echo "$output"
     assert_success
-    run jq -e --arg sessionId "$session_id" '
+    run jq -e '
         .status == "completed" and
-        .result.agentSessionId == $sessionId
+        (.result.agentSessionId | type == "string" and length > 0)
     ' <<<"$output"
     echo "$output"
     assert_success


### PR DESCRIPTION
## Summary

- add a fourth isolated runner E2E identity configured for the mock Claude runtime
- drive the existing `@ECHO@` marker through the public chat API and verify JSONL filtering plus the final assistant output
- drive the existing `@orphan-pipe` marker through the same public flow and verify bounded completion after stdout drain
- extend runner account and workflow contract coverage for token generation, bootstrap, sharding, and cleanup

## Regression assertions

- JSONL echo completes with the supplied Claude session, exposes only `system`, `assistant`, and `result` telemetry, returns `echo-jsonl fixture response`, and excludes stream-event noise from assistant output
- orphan-pipe completes within 90 seconds, returns `Done.`, exposes only `system` and `result` telemetry, and records the stdout drain-deadline log

## Verification

- `npx --yes prettier@3.8.1 --check <touched YAML and TypeScript files>`
- `cd e2e && corepack pnpm check-types`
- targeted Node tests for Clerk accounts, runner account lifecycle, and runner shard planning (11 passed)
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `actionlint -oneline .github/workflows/turbo.yml`
- Bats parse/count check (2 cases)
- runner shard planner includes the new file as an independent weight-2 shard

The deployed runner cases are CI-only and rely on the pull request pipeline for execution against the preview API, queue, and runner fleet.
