### PR TITLE
test(runner): assert remote exec error output

### DIFF
--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -76,6 +76,17 @@ pub struct ExecArgs {
 /// as [`ExitCode::FAILURE`]. Other sandbox-control errors are propagated as
 /// [`RunnerError::Config`].
 pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerResult<ExitCode> {
+    let mut stdout = std::io::stdout();
+    let mut stderr = std::io::stderr();
+    run_exec_with_writers(args, control, &mut stdout, &mut stderr).await
+}
+
+async fn run_exec_with_writers(
+    args: ExecArgs,
+    control: &dyn SandboxControl,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> RunnerResult<ExitCode> {
     let target = if let Some(ref sid) = args.sandbox {
         SandboxControlTarget::sandbox(sid)
     } else if let Some(ref rid) = args.run {
@@ -103,16 +114,13 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
         .await
     {
         Ok(result) => {
-            let _ = std::io::stdout().lock().write_all(&result.stdout);
-
-            let err = std::io::stderr();
-            let mut err = err.lock();
-            write_remote_exec_stderr(&mut err, &result);
+            let _ = stdout.write_all(&result.stdout);
+            write_remote_exec_stderr(stderr, &result);
 
             Ok(remote_exec_exit_code(result.termination))
         }
         Err(SandboxControlError::Remote(msg)) => {
-            eprintln!("error: {msg}");
+            let _ = writeln!(stderr, "error: {msg}");
             Ok(ExitCode::FAILURE)
         }
         Err(e) => Err(RunnerError::Config(e.to_string())),
@@ -272,11 +280,21 @@ mod tests {
     async fn remote_error_prints_message_and_returns_failure() {
         let control = MockSandboxControl::new("/tmp");
         control.push_exec_remote_result(Err(SandboxControlError::Remote("command failed".into())));
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
 
-        let result = run_exec(make_args("test-id", "fail"), &control)
-            .await
-            .unwrap();
+        let result = run_exec_with_writers(
+            make_args("test-id", "fail"),
+            &control,
+            &mut stdout,
+            &mut stderr,
+        )
+        .await
+        .unwrap();
+
         assert_eq!(result, ExitCode::FAILURE);
+        assert!(stdout.is_empty());
+        assert_eq!(stderr, b"error: command failed\n");
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -225,21 +225,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn success_propagates_exit_code() {
+    async fn success_forwards_output_and_propagates_exit_code() {
         let control = MockSandboxControl::new("/tmp");
         control.push_exec_remote_result(Ok(RemoteExecResult {
             termination: ExecTermination::Exited { exit_code: 42 },
-            stdout: Vec::new(),
-            stderr: Vec::new(),
+            stdout: b"command output\n".to_vec(),
+            stderr: b"command warning\n".to_vec(),
             diagnostic: String::new(),
             stdout_truncated: false,
             stderr_truncated: false,
         }));
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
 
-        let result = run_exec(make_args("test-id", "echo hello"), &control)
-            .await
-            .unwrap();
+        let result = run_exec_with_writers(
+            make_args("test-id", "echo hello"),
+            &control,
+            &mut stdout,
+            &mut stderr,
+        )
+        .await
+        .unwrap();
+
         assert_eq!(result, ExitCode::from(42));
+        assert_eq!(stdout, b"command output\n");
+        assert_eq!(stderr, b"command warning\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- route `runner exec` output through a private injected-writer command boundary
- assert handled remote errors return failure, write the exact diagnostic to stderr, and leave stdout empty
- preserve the existing success output order and non-remote error propagation

## Scope

- no CLI protocol, sandbox-control protocol, dependency, persisted-state, or deployment change
- no generic command-output abstraction beyond `runner exec`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner cmd::exec::tests` (25 passed)
- pre-commit workspace Rust documentation and Clippy checks

Closes #26548
