### PR TITLE
test(api): isolate computer-use screenshot cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -39,9 +39,8 @@ import { createFixtureTracker } from "./helpers/zero-route-test";
  *   calls refreshing lastSeenAt (#15750) to bring a stale host back online.
  * - The screenshot retention chain builds >30-day-old rows by running the
  *   full command flow under mockNow(now - 40d), then clears the mock before
- *   invoking the cleanup cron so the retention cutoff is computed at real
- *   time. The cleanup cron is a global sweep; see the single-file-ownership
- *   comment on runComputerUseScreenshotCleanupCron.
+ *   invoking fixture-scoped cleanup so the retention cutoff is computed at
+ *   real time.
  */
 
 const context = testContext();
@@ -1365,7 +1364,9 @@ describe("FILE-03 desktop computer-use runtime", () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     const actor = bdd.user({ orgId, userId });
-    const peer = bdd.user();
+    const peerOrgId = `org_${randomUUID()}`;
+    const peerUserId = `user_${randomUUID()}`;
+    const peer = bdd.user({ orgId: peerOrgId, userId: peerUserId });
 
     mockNow(now() - 40 * 24 * 60 * 60 * 1000);
     const host = await api.startComputerUseHost(actor);
@@ -1454,6 +1455,31 @@ describe("FILE-03 desktop computer-use runtime", () => {
     expectApiError(legacyScreenshot.body);
     expect(legacyScreenshot.body.error.code).toBe("NOT_FOUND");
 
+    const sentinelHost = await api.startComputerUseHost(peer);
+    const sentinel = await api.createComputerUseReadCommand(peer, {
+      kind: "app.state",
+      app: "Safari",
+    });
+    const claimedSentinel = await api.claimNextComputerUseCommand(
+      sentinelHost.hostToken,
+    );
+    expect(claimedSentinel.status).toBe("command");
+    const sentinelBytes = Buffer.from("bdd-expired-sentinel-png-bytes");
+    await api.completeComputerUseCommandWith(
+      sentinelHost.hostToken,
+      sentinel.commandId,
+      {
+        status: "succeeded",
+        result: {
+          snapshotId: "snap_bdd_expired_sentinel",
+          screenshot: `data:image/png;base64,${sentinelBytes.toString("base64")}`,
+          screenshotWidth: 1024,
+          screenshotHeight: 768,
+        },
+      },
+    );
+    const sentinelKey = `computer-use/${peerOrgId}/${peerUserId}/${sentinel.commandId}/screenshot.png`;
+
     // Back to real time: the retention cutoff must be computed against the
     // wall clock so only the 40-day-old rows above fall outside the window.
     clearMockNow();
@@ -1476,24 +1502,33 @@ describe("FILE-03 desktop computer-use runtime", () => {
       },
     });
     const thirdKey = `computer-use/${orgId}/${userId}/${third.commandId}/screenshot.png`;
+    const ownedCommandIds = [first.commandId, second.commandId];
 
-    const invalidCron =
-      await api.runComputerUseScreenshotCleanupCron("invalid");
+    const invalidCron = await api.runComputerUseScreenshotCleanupCron(
+      "invalid",
+      ownedCommandIds,
+    );
     expect(invalidCron.status).toBe(401);
     expectApiError(invalidCron.body);
     expect(invalidCron.body.error.message).toBe("Invalid cron secret");
 
-    const missingCron =
-      await api.runComputerUseScreenshotCleanupCron("missing");
+    const missingCron = await api.runComputerUseScreenshotCleanupCron(
+      "missing",
+      ownedCommandIds,
+    );
     expect(missingCron.status).toBe(401);
 
-    const swept = await api.runComputerUseScreenshotCleanupCron("valid");
+    const swept = await api.runComputerUseScreenshotCleanupCron(
+      "valid",
+      ownedCommandIds,
+    );
     if (swept.status !== 200) {
       throw new Error("Expected the screenshot cleanup cron to run");
     }
-    expect(swept.body.cleaned).toBeGreaterThanOrEqual(2);
+    expect(swept.body.cleaned).toBe(2);
     expect(fake.deletedKeys).toContain(firstKey);
     expect(fake.deletedKeys).not.toContain(thirdKey);
+    expect(fake.deletedKeys).not.toContain(sentinelKey);
 
     const expiredPointer = await api.readComputerUseCommand(
       actor,
@@ -1511,8 +1546,16 @@ describe("FILE-03 desktop computer-use runtime", () => {
     });
     const keptRecent = await api.readComputerUseCommand(actor, third.commandId);
     expect(keptRecent.result?.screenshot).toMatchObject({ type: "s3" });
+    const keptSentinel = await api.readComputerUseCommand(
+      peer,
+      sentinel.commandId,
+    );
+    expect(keptSentinel.result?.screenshot).toMatchObject({ type: "s3" });
 
-    const resweep = await api.runComputerUseScreenshotCleanupCron("valid");
+    const resweep = await api.runComputerUseScreenshotCleanupCron(
+      "valid",
+      ownedCommandIds,
+    );
     if (resweep.status !== 200) {
       throw new Error("Expected the second cleanup sweep to run");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -35,7 +35,7 @@ import { setupApp } from "../../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../../auth/tokens";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
-import { cronComputerUseScreenshotCleanupRoutes } from "../../cron-computer-use-screenshot-cleanup";
+import { cronComputerUseScreenshotCleanupRoutesForTest } from "../../cron-computer-use-screenshot-cleanup";
 import { zeroComputerUseRoutes } from "../../zero-computer-use";
 import { zeroComputerUseAuthorizationRoutes } from "../../zero-computer-use-authorization";
 
@@ -405,10 +405,10 @@ export function createComputerUseBddApi(context: TestContext) {
     );
   }
 
-  function cleanupCronClient() {
+  function cleanupCronClient(commandIds: readonly string[]) {
     return setupApp({
       context,
-      routes: cronComputerUseScreenshotCleanupRoutes,
+      routes: cronComputerUseScreenshotCleanupRoutesForTest(commandIds),
     })(cronComputerUseScreenshotCleanupContract);
   }
 
@@ -974,16 +974,9 @@ export function createComputerUseBddApi(context: TestContext) {
       );
     },
 
-    // Kept out of any shared safe-cron helper for the same shared-database
-    // reason as reconcileBillingCron in api-bdd-runs.ts: the
-    // screenshot-cleanup sweep is global (no org filter) and tombstones every
-    // screenshot row older than the 30-day retention window. Only
-    // computer-use.bdd.test.ts may invoke this cron, and only that file may
-    // create screenshot rows older than the retention window; sweep counts
-    // are asserted as `>=` on the first run because earlier aborted local
-    // runs can leave old rows behind.
     async runComputerUseScreenshotCleanupCron(
       auth: "valid" | "invalid" | "missing",
+      commandIds: readonly string[],
     ) {
       const headers =
         auth === "missing"
@@ -994,7 +987,10 @@ export function createComputerUseBddApi(context: TestContext) {
                   ? "Bearer test-cron-secret"
                   : "Bearer wrong-secret",
             };
-      return await accept(cleanupCronClient().cleanup({ headers }), [200, 401]);
+      return await accept(
+        cleanupCronClient(commandIds).cleanup({ headers }),
+        [200, 401],
+      );
     },
   };
 }

--- a/turbo/apps/api/src/signals/routes/cron-computer-use-screenshot-cleanup.ts
+++ b/turbo/apps/api/src/signals/routes/cron-computer-use-screenshot-cleanup.ts
@@ -2,27 +2,45 @@ import { cronComputerUseScreenshotCleanupContract } from "@vm0/api-contracts/con
 import { command } from "ccstate";
 
 import type { RouteEntry } from "../route-entry";
-import { cleanupComputerUseScreenshots$ } from "../services/cron-computer-use-screenshot-cleanup.service";
+import {
+  cleanupComputerUseScreenshots$,
+  type ComputerUseScreenshotCleanupOptions,
+} from "../services/cron-computer-use-screenshot-cleanup.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
-const computerUseScreenshotCleanupRoute$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+function computerUseScreenshotCleanupRoute(
+  options: ComputerUseScreenshotCleanupOptions,
+) {
+  return command(async ({ get, set }, signal: AbortSignal) => {
     if (!get(hasValidCronSecret$)) {
       return cronUnauthorized();
     }
 
-    const cleaned = await set(cleanupComputerUseScreenshots$, signal);
+    const cleaned = await set(cleanupComputerUseScreenshots$, options, signal);
     signal.throwIfAborted();
     return {
       status: 200 as const,
       body: { cleaned },
     };
-  },
-);
+  });
+}
 
-export const cronComputerUseScreenshotCleanupRoutes: readonly RouteEntry[] = [
-  {
-    route: cronComputerUseScreenshotCleanupContract.cleanup,
-    handler: computerUseScreenshotCleanupRoute$,
-  },
-];
+function computerUseScreenshotCleanupRoutes(
+  options: ComputerUseScreenshotCleanupOptions,
+): readonly RouteEntry[] {
+  return [
+    {
+      route: cronComputerUseScreenshotCleanupContract.cleanup,
+      handler: computerUseScreenshotCleanupRoute(options),
+    },
+  ];
+}
+
+export function cronComputerUseScreenshotCleanupRoutesForTest(
+  commandIds: readonly string[],
+): readonly RouteEntry[] {
+  return computerUseScreenshotCleanupRoutes({ commandIds });
+}
+
+export const cronComputerUseScreenshotCleanupRoutes =
+  computerUseScreenshotCleanupRoutes({});

--- a/turbo/apps/api/src/signals/services/cron-computer-use-screenshot-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-computer-use-screenshot-cleanup.service.ts
@@ -11,6 +11,10 @@ import { deleteS3Objects } from "../external/s3";
 const SCREENSHOT_RETENTION_DAYS = 30;
 const SCREENSHOT_CLEANUP_BATCH_SIZE = 500;
 
+export interface ComputerUseScreenshotCleanupOptions {
+  readonly commandIds?: readonly string[];
+}
+
 /**
  * Delete computer-use screenshots older than the retention window from object
  * storage and rewrite the result pointer to `{ type: "expired" }`. Also sheds
@@ -18,7 +22,11 @@ const SCREENSHOT_CLEANUP_BATCH_SIZE = 500;
  * tombstoning them, removing existing JSONB bloat. Batched to avoid long locks.
  */
 export const cleanupComputerUseScreenshots$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<number> => {
+  async (
+    { get, set },
+    options: ComputerUseScreenshotCleanupOptions,
+    signal: AbortSignal,
+  ): Promise<number> => {
     const db = set(writeDb$);
     const cutoff = nowDate();
     cutoff.setDate(cutoff.getDate() - SCREENSHOT_RETENTION_DAYS);
@@ -46,6 +54,9 @@ export const cleanupComputerUseScreenshots$ = command(
                 sql`'string'`,
               ),
             ),
+            options.commandIds
+              ? inArray(computerUseCommands.id, options.commandIds)
+              : undefined,
           ),
         )
         .limit(SCREENSHOT_CLEANUP_BATCH_SIZE);


### PR DESCRIPTION
## Summary

- keep the production computer-use screenshot cleanup cron global while adding an explicit command-ID boundary for its focused integration test route
- scope the retention scenario to uniquely owned command fixtures and assert the exact first-sweep count
- prove that an unrelated expired S3 screenshot sentinel remains untouched, while retaining the existing recent-screenshot and zero-resweep checks

## Isolation invariants

- no test serialization, advisory locks, broad mocked-time partitions, or residue-tolerant assertions
- no production filtering change: the registered production route still invokes the global cleanup query
- no unrelated cleanup or changes outside the screenshot cleanup route, service, helper, and focused BDD scenario

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (passed; existing repository warnings only)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts apps/api/src/signals/routes/cron-computer-use-screenshot-cleanup.ts apps/api/src/signals/services/cron-computer-use-screenshot-cleanup.service.ts`
- `pnpm --filter api run lint` (passed; existing repository warnings only)
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/computer-use.bdd.test.ts` (17 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/__tests__/vercel-crons.test.ts` (3 passed)

Closes #26586

Parent epic: #26569
