### PR TITLE
perf(python): bound auth.base trusted query rewrites

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -58,7 +58,11 @@ from firewall_auth_config import auth_config_injects_credentials
 from logging_utils import log_proxy_entry
 from runtime_url_parsing import split_runtime_url
 from url_syntax import has_unsafe_runtime_url_syntax
-from url_utils import build_rewrite_url
+from url_utils import (
+    MAX_AUTH_BASE_QUERY_PAIRS,
+    AuthBaseQueryTooManyPairsError,
+    build_rewrite_url,
+)
 
 
 class FirewallAuthHandlingResult(Enum):
@@ -99,6 +103,10 @@ FIREWALL_AUTH_FETCH_SATURATED_ERROR = "firewall_auth_fetch_saturated"
 AWS_SIGV4_REQUEST_BODY_ADMISSION_SATURATED_ERROR = "aws_sigv4_request_body_admission_saturated"
 AWS_SIGV4_REQUEST_BODY_LENGTH_REQUIRED_ERROR = "aws_sigv4_request_body_length_required"
 AWS_SIGV4_REQUEST_BODY_TOO_LARGE_ERROR = "aws_sigv4_request_body_too_large"
+# Auth-base uses a separately named request-target policy because its forwarding
+# behavior can evolve independently, while the shared 64 KiB scale remains well
+# above ordinary connector request targets.
+MAX_AUTH_BASE_REQUEST_TARGET_BYTES = 64 * 1024
 # Managed SigV4 request inspection uses the pinned HTTP/2 stack's 64 KiB
 # decompressed header-list policy. HPACK accounts for 32 bytes of overhead per
 # field; using the same formula also bounds HTTP/1 header count before decoding.
@@ -844,6 +852,58 @@ def _request_body_exceeds_auth_base_limit(flow: http.HTTPFlow) -> bool:
     return body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES
 
 
+def _set_auth_base_request_target_too_large(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    request_target_size = len(flow.request.data.path)
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "auth.base request target too large",
+        type="firewall",
+        firewall_base=firewall_base,
+        request_target_size_bytes=request_target_size,
+        request_target_limit_bytes=MAX_AUTH_BASE_REQUEST_TARGET_BYTES,
+    )
+    _set_matched_firewall_failure_response(
+        flow,
+        status=414,
+        action="ALLOW",
+        error_code="auth_base_request_target_too_large",
+        message="auth.base request target is too large",
+        permission=allow.name,
+    )
+
+
+def _set_auth_base_query_too_many_pairs(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "auth.base rewritten query has too many pairs",
+        type="firewall",
+        firewall_base=firewall_base,
+        query_pair_limit=MAX_AUTH_BASE_QUERY_PAIRS,
+    )
+    _set_matched_firewall_failure_response(
+        flow,
+        status=414,
+        action="ALLOW",
+        error_code="auth_base_query_too_many_pairs",
+        message="auth.base rewritten query has too many parameters",
+        permission=allow.name,
+    )
+
+
 def _log_auth_base_request_too_large(
     flow: http.HTTPFlow,
     *,
@@ -1054,6 +1114,15 @@ def _preflight_firewall_auth(
     plan: _FirewallAuthPlan,
 ) -> FirewallAuthHandlingResult | None:
     """Handle local firewall auth failures that must happen before auth resolution."""
+    if plan.uses_auth_base and len(flow.request.data.path) > MAX_AUTH_BASE_REQUEST_TARGET_BYTES:
+        _set_auth_base_request_target_too_large(
+            flow,
+            allow=context.allow,
+            proxy_log_path=context.proxy_log_path,
+            firewall_base=context.firewall_base,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
+
     if plan.uses_auth_base and _request_body_exceeds_auth_base_limit(flow):
         _set_auth_base_request_too_large(
             flow,
@@ -1309,6 +1378,14 @@ async def _apply_url_rewrite(
     try:
         orig_query = _request_path_query(flow)
         new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
+    except AuthBaseQueryTooManyPairsError:
+        _set_auth_base_query_too_many_pairs(
+            flow,
+            allow=allow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
     except ValueError as e:
         _set_url_rewrite_forward_failed(
             flow,

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -41,6 +41,14 @@ _URL_PATH_SAFE_CHARS = "/%:@!$&'()*+,;="
 _URL_QUERY_SAFE_CHARS = "/?%:@!$&'()*+,;="
 _VALID_AUTH_BASE_SCHEME = "https"
 _DEFAULT_HTTPS_PORT = 443
+# This matches the runner's existing managed-query work scale while retaining
+# ample room for ordinary connector URLs. Count every segment that auth.base
+# materializes, including empty segments separated by either ``&`` or ``;``.
+MAX_AUTH_BASE_QUERY_PAIRS = 8 * 1024
+
+
+class AuthBaseQueryTooManyPairsError(ValueError):
+    """The aggregate auth.base rewrite query exceeds its pair work budget."""
 
 
 @dataclass(frozen=True)
@@ -380,6 +388,34 @@ def _encode_query_pairs(query: dict[str, str] | None) -> list[_QueryPair]:
     return _split_query_pairs(urllib.parse.urlencode(query))
 
 
+def _consume_query_pair_budget(query: str, remaining_pairs: int) -> int:
+    if not query:
+        return remaining_pairs
+
+    remaining_pairs -= 1
+    if remaining_pairs < 0:
+        raise AuthBaseQueryTooManyPairsError("auth.base rewritten query has too many pairs")
+    for char in query:
+        if char in ("&", ";"):
+            remaining_pairs -= 1
+            if remaining_pairs < 0:
+                raise AuthBaseQueryTooManyPairsError("auth.base rewritten query has too many pairs")
+    return remaining_pairs
+
+
+def _validate_rewrite_query_pair_count(
+    base_query: str,
+    orig_query: str,
+    resolved_query: dict[str, str] | None,
+) -> None:
+    remaining_pairs = MAX_AUTH_BASE_QUERY_PAIRS - len(resolved_query or {})
+    if remaining_pairs < 0:
+        raise AuthBaseQueryTooManyPairsError("auth.base rewritten query has too many pairs")
+
+    remaining_pairs = _consume_query_pair_budget(orig_query, remaining_pairs)
+    _consume_query_pair_budget(base_query, remaining_pairs)
+
+
 def _merge_rewrite_query(
     base_query: str,
     orig_query: str,
@@ -388,6 +424,7 @@ def _merge_rewrite_query(
     if not base_query and not resolved_query:
         return orig_query
 
+    _validate_rewrite_query_pair_count(base_query, orig_query, resolved_query)
     base_pairs = _split_query_pairs(base_query)
     orig_pairs = _split_query_pairs(orig_query)
     auth_keys = set(resolved_query or {})
@@ -491,7 +528,14 @@ def build_rewrite_url(
     Unsafe path syntax in ``rel_path`` is rejected as an invariant; firewall
     matching should already have blocked it before auth is applied.
 
+    Trusted-query rewrites accept at most ``MAX_AUTH_BASE_QUERY_PAIRS``
+    aggregate query segments across the resolved base, original request, and
+    resolved auth data. Query-free trusted sources retain the original query
+    without segment inspection.
+
     Raises:
+        AuthBaseQueryTooManyPairsError: If a trusted-query rewrite exceeds the
+            aggregate query pair work budget.
         ValueError: If ``resolved_base`` is not a safe absolute HTTPS URL,
             ``rel_path`` has unsafe path syntax, or a URL component contains
             Unicode that cannot be safely encoded.

--- a/crates/runner/mitm-addon/src/url_utils.py
+++ b/crates/runner/mitm-addon/src/url_utils.py
@@ -41,6 +41,7 @@ _URL_PATH_SAFE_CHARS = "/%:@!$&'()*+,;="
 _URL_QUERY_SAFE_CHARS = "/?%:@!$&'()*+,;="
 _VALID_AUTH_BASE_SCHEME = "https"
 _DEFAULT_HTTPS_PORT = 443
+
 # This matches the runner's existing managed-query work scale while retaining
 # ample room for ordinary connector URLs. Count every segment that auth.base
 # materializes, including empty segments separated by either ``&`` or ``;``.

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -18,16 +18,6 @@ from tests.firewall_rewrite_helpers import make_safety_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
 
-def _query_with_segment_count(
-    segment_count: int,
-    *,
-    separator: str,
-    raw_pair: str,
-) -> str:
-    assert segment_count > 0
-    return separator.join([raw_pair] * segment_count)
-
-
 class TestAuthBaseUrlRewriteSafety:
     """auth.base rewrite safety and fail-closed handler tests."""
 
@@ -184,7 +174,7 @@ class TestAuthBaseUrlRewriteSafety:
             pytest.param(1, False, id="over-limit"),
         ],
     )
-    async def test_request_target_size_boundary_fails_before_auth_resolution(
+    async def test_request_target_size_boundary(
         self,
         real_flow,
         mitm_ctx,
@@ -270,7 +260,7 @@ class TestAuthBaseUrlRewriteSafety:
             ),
         ],
     )
-    async def test_trusted_query_pair_boundary_fails_before_forwarding(
+    async def test_trusted_query_pair_boundary(
         self,
         real_flow,
         mitm_ctx,
@@ -280,11 +270,7 @@ class TestAuthBaseUrlRewriteSafety:
         raw_pair: str,
         accepted: bool,
     ):
-        client_query = _query_with_segment_count(
-            client_segments,
-            separator=separator,
-            raw_pair=raw_pair,
-        )
+        client_query = separator.join([raw_pair] * client_segments)
         request_path = f"/hook?{client_query}"
         flow, allow, vm_info, token_meta = make_safety_rewrite_inputs(
             real_flow,

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -6,14 +6,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
 
 import pytest
+from mitmproxy import http
 
 import auth
 import auth_base_forwarder as forwarder
 import flow_metadata_keys as metadata_keys
+import url_utils
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
 from tests.firewall_rewrite_helpers import make_safety_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
+
+
+def _query_with_segment_count(
+    segment_count: int,
+    *,
+    separator: str,
+    raw_pair: str,
+) -> str:
+    assert segment_count > 0
+    return separator.join([raw_pair] * segment_count)
 
 
 class TestAuthBaseUrlRewriteSafety:
@@ -164,6 +176,174 @@ class TestAuthBaseUrlRewriteSafety:
         assert "Firewall URL rewrite:" not in log_text
         assert "super-secret-token" not in log_text
         assert "real-token" not in log_text
+
+    @pytest.mark.parametrize(
+        ("extra_bytes", "accepted"),
+        [
+            pytest.param(0, True, id="exact-limit"),
+            pytest.param(1, False, id="over-limit"),
+        ],
+    )
+    async def test_request_target_size_boundary_fails_before_auth_resolution(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        extra_bytes: int,
+        accepted: bool,
+    ):
+        path_prefix = "/hook?"
+        request_path = path_prefix + "x" * (
+            auth.MAX_AUTH_BASE_REQUEST_TARGET_BYTES - len(path_prefix) + extra_bytes
+        )
+        flow, allow, vm_info, token_meta = make_safety_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path=request_path,
+            resolved_base="https://real.example.com/webhook/super-secret-token?base=trusted",
+        )
+        assert len(flow.request.data.path) == (
+            auth.MAX_AUTH_BASE_REQUEST_TARGET_BYTES + extra_bytes
+        )
+        get_headers = AsyncMock(return_value=token_meta)
+        mock_forward = AsyncMock(return_value=(200, b"", http.Headers()))
+        mock_log = MagicMock()
+
+        with (
+            patch.object(auth, "get_firewall_headers", get_headers),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        assert flow.request.path == request_path
+        if accepted:
+            assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+            get_headers.assert_awaited_once()
+            mock_forward.assert_awaited_once()
+            assert flow.response is not None
+            assert flow.response.status_code == 200
+            assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
+            assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+            return
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        get_headers.assert_not_awaited()
+        mock_forward.assert_not_awaited()
+        assert flow.response is not None
+        assert flow.response.status_code == 414
+        assert json.loads(flow.response.content)["error"] == "auth_base_request_target_too_large"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_target_too_large"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata
+        [limit_log] = [
+            call
+            for call in mock_log.call_args_list
+            if call.args[2] == "auth.base request target too large"
+        ]
+        assert limit_log.kwargs["request_target_size_bytes"] == (
+            auth.MAX_AUTH_BASE_REQUEST_TARGET_BYTES + 1
+        )
+        assert limit_log.kwargs["request_target_limit_bytes"] == (
+            auth.MAX_AUTH_BASE_REQUEST_TARGET_BYTES
+        )
+        assert "super-secret-token" not in flow.response.text
+        assert "super-secret-token" not in json.dumps(mock_log.call_args_list)
+
+    @pytest.mark.parametrize(
+        ("client_segments", "separator", "raw_pair", "accepted"),
+        [
+            pytest.param(
+                url_utils.MAX_AUTH_BASE_QUERY_PAIRS - 2,
+                "&",
+                "x",
+                True,
+                id="exact-aggregate-limit",
+            ),
+            pytest.param(
+                url_utils.MAX_AUTH_BASE_QUERY_PAIRS - 1,
+                ";",
+                "",
+                False,
+                id="over-limit-empty-semicolon-segments",
+            ),
+        ],
+    )
+    async def test_trusted_query_pair_boundary_fails_before_forwarding(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+        client_segments: int,
+        separator: str,
+        raw_pair: str,
+        accepted: bool,
+    ):
+        client_query = _query_with_segment_count(
+            client_segments,
+            separator=separator,
+            raw_pair=raw_pair,
+        )
+        request_path = f"/hook?{client_query}"
+        flow, allow, vm_info, token_meta = make_safety_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path=request_path,
+            resolved_base="https://real.example.com/webhook/super-secret-token?base=trusted",
+            auth_overrides={
+                "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+                "query": {"api_key": "${{ secrets.API_KEY }}"},
+            },
+            token_overrides={
+                "headers": {"Authorization": "Bearer real-token"},
+                "query": {"api_key": "resolved-secret"},
+                "resolved_secrets": ["TOKEN", "API_KEY"],
+            },
+        )
+        get_headers = AsyncMock(return_value=token_meta)
+        mock_forward = AsyncMock(return_value=(200, b"", http.Headers()))
+        mock_log = MagicMock()
+
+        with (
+            patch.object(auth, "get_firewall_headers", get_headers),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(flow, allow, vm_info)
+
+        get_headers.assert_awaited_once()
+        assert flow.request.path == request_path
+        assert "Authorization" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        if accepted:
+            assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
+            mock_forward.assert_awaited_once()
+            assert flow.response is not None
+            assert flow.response.status_code == 200
+            assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
+            assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+            return
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        mock_forward.assert_not_awaited()
+        assert flow.response is not None
+        assert flow.response.status_code == 414
+        assert json.loads(flow.response.content)["error"] == "auth_base_query_too_many_pairs"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_query_too_many_pairs"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata
+        [limit_log] = [
+            call
+            for call in mock_log.call_args_list
+            if call.args[2] == "auth.base rewritten query has too many pairs"
+        ]
+        assert limit_log.kwargs["query_pair_limit"] == url_utils.MAX_AUTH_BASE_QUERY_PAIRS
+        assert "super-secret-token" not in flow.response.text
+        assert "resolved-secret" not in flow.response.text
+        assert "super-secret-token" not in json.dumps(mock_log.call_args_list)
+        assert "resolved-secret" not in json.dumps(mock_log.call_args_list)
 
     async def test_truncated_upstream_response_returns_502_without_partial_body(
         self, headers, real_flow, mitm_ctx, tmp_path


### PR DESCRIPTION
## Summary

- reject auth.base request targets above 64 KiB before firewall-auth resolution
- cap trusted-query rewrites at 8,192 aggregate `&`/`;` segments before pair allocation or key decoding
- return secret-safe local 414 responses for both limits while preserving accepted precedence behavior and the no-trusted-query fast path
- cover exact and over-limit behavior through the public auth handler with real mitmproxy flows

## Compatibility

This intentionally changes only extreme auth.base requests: request targets above 64 KiB or trusted-query rewrites above 8,192 aggregate segments now fail locally instead of reaching the provider. There are no API, schema, persistence, runner protocol, dependency, configuration, feature-switch, migration, or deployment-order changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_url_utils.py tests/test_auth_query_injection.py tests/test_firewall_rewrite_success.py tests/test_firewall_rewrite_forwarding.py tests/test_firewall_rewrite_safety.py` (200 passed)
- `uv run --no-sync python -m pytest tests/` (5,331 passed)

Closes #26553
