### PR TITLE
test(api): isolate desktop manifest cache state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -1,13 +1,15 @@
 import { desktopUpdatesContract } from "@vm0/api-contracts/contracts/desktop-updates";
+import { testDesktopUpdateManifestStateContract } from "@vm0/api-contracts/contracts/test-desktop-update-manifest-state";
 import { HttpResponse, http } from "msw";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { clearMockNow, mockNow } from "../../../lib/time";
+import { mockNow, withMockNowForTest } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { desktopUpdateRoutes } from "../desktop-updates";
+import { testDesktopUpdateManifestStateRoutes } from "../test-desktop-update-manifest-state";
 
 const TEST_APP_ROUTES = Object.freeze([...desktopUpdateRoutes]);
 
@@ -38,6 +40,12 @@ interface DesktopUpdateManifest {
 function client() {
   return setupApp({ context, routes: desktopUpdateRoutes })(
     desktopUpdatesContract,
+  );
+}
+
+function manifestStateClient() {
+  return setupApp({ context, routes: testDesktopUpdateManifestStateRoutes })(
+    testDesktopUpdateManifestStateContract,
   );
 }
 
@@ -108,15 +116,8 @@ function legacyDarwinX64Release(version: string, url: string) {
 }
 
 describe("desktop update routes", () => {
-  let testIndex = 0;
-
-  beforeEach(() => {
-    mockNow(Date.parse("2026-06-08T00:00:00.000Z") + testIndex * 120_000);
-    testIndex += 1;
-  });
-
-  afterEach(() => {
-    clearMockNow();
+  beforeEach(async () => {
+    await accept(manifestStateClient().reset({ body: {} }), [200]);
   });
 
   it("redirects the release page route to the current stable desktop release", async () => {
@@ -191,6 +192,55 @@ describe("desktop update routes", () => {
           },
         },
       ],
+    });
+  });
+
+  it("caches the desktop manifest until the 60-second ttl expires", async () => {
+    const initialNow = Date.parse("2026-06-08T00:00:00.000Z");
+    const firstZipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip";
+    const refreshedZipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.2/Zero-darwin-arm64-0.2.2.zip";
+
+    await withMockNowForTest(initialNow, async () => {
+      mockDesktopUpdateManifest(
+        stableManifest("0.2.1", {
+          "0.2.1": darwinArm64Release("0.2.1", firstZipUrl),
+        }),
+      );
+
+      const firstResponse = await accept(
+        client().feed({
+          params: { channel: "stable", platform: "darwin", arch: "arm64" },
+        }),
+        [200],
+      );
+      expect(firstResponse.body.currentRelease).toBe("0.2.1");
+
+      mockDesktopUpdateManifest(
+        stableManifest("0.2.2", {
+          "0.2.2": darwinArm64Release("0.2.2", refreshedZipUrl),
+        }),
+      );
+      mockNow(initialNow + 59_999);
+
+      const cachedResponse = await accept(
+        client().feed({
+          params: { channel: "stable", platform: "darwin", arch: "arm64" },
+        }),
+        [200],
+      );
+      expect(cachedResponse.body.currentRelease).toBe("0.2.1");
+
+      mockNow(initialNow + 60_000);
+
+      const refreshedResponse = await accept(
+        client().feed({
+          params: { channel: "stable", platform: "darwin", arch: "arm64" },
+        }),
+        [200],
+      );
+      expect(refreshedResponse.body.currentRelease).toBe("0.2.2");
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/test-desktop-update-manifest-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-desktop-update-manifest-state.ts
@@ -1,0 +1,26 @@
+import { testDesktopUpdateManifestStateContract } from "@vm0/api-contracts/contracts/test-desktop-update-manifest-state";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import type { RouteEntry } from "../route-entry";
+import { clearDesktopUpdateManifestCacheForTest } from "../services/desktop-updates.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const resetDesktopUpdateManifestState$ = command(({ get }) => {
+  if (!isTestEndpointAllowed(get(request$))) {
+    return testEndpointNotFoundResponse();
+  }
+
+  clearDesktopUpdateManifestCacheForTest();
+  return { status: 200 as const, body: { ok: true as const } };
+});
+
+export const testDesktopUpdateManifestStateRoutes: readonly RouteEntry[] = [
+  {
+    route: testDesktopUpdateManifestStateContract.reset,
+    handler: resetDesktopUpdateManifestState$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -90,6 +90,11 @@ const desktopUpdateManifestOverride = testOverride<
   return {};
 });
 
+export function clearDesktopUpdateManifestCacheForTest(): void {
+  desktopUpdateManifestCache.clear();
+  desktopUpdateManifestOverride.clear();
+}
+
 function compareDesktopVersions(left: string, right: string): number {
   const leftParts = left.split(/[+-]/, 1)[0]?.split(".").map(Number) ?? [];
   const rightParts = right.split(/[+-]/, 1)[0]?.split(".").map(Number) ?? [];

--- a/turbo/packages/api-contracts/src/contracts/test-desktop-update-manifest-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-desktop-update-manifest-state.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testDesktopUpdateManifestStateContract = c.router({
+  reset: {
+    method: "POST",
+    path: "/api/test/desktop-update-manifest-state/reset",
+    body: z.object({}),
+    responses: {
+      200: z.object({ ok: z.literal(true) }),
+      404: z.string(),
+    },
+    summary: "Reset desktop update manifest test state",
+  },
+});


### PR DESCRIPTION
## Summary

- add a guarded test-only reset boundary for the process-wide desktop manifest cache and override
- reset that state explicitly before every desktop update route test and remove `testIndex` time staggering plus teardown clock cleanup
- cover cache reuse before the existing 60-second TTL and refresh exactly at expiration through the public feed route

## Isolation boundaries

- integration coverage remains at the route boundary; the reset endpoint is only mounted by the focused test and is guarded by the existing test-endpoint policy
- production route registration, cache selection, and TTL behavior are unchanged
- no test serialization, advisory lock, broad mocked-time partition, residue-tolerant assertion, or unrelated cleanup was added

## Validation

- `pnpm format` — passed
- `pnpm turbo run lint --concurrency=1 --log-order grouped` — passed; existing non-failing warnings remain confined to untouched files
- `pnpm knip` — passed with existing configuration hints only
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'` — 12/12 tasks passed
- `pnpm --filter @vm0/app run check-types` — passed
- `pnpm --filter api run check-types` — passed, including API boundary checks
- focused desktop update route test — 13/13 passed in normal registration order
- focused TTL test — 1/1 passed independently
- focused desktop update route test with shuffled registration order, seeds `26601` and `26569` — 13/13 passed for each seed
- post-rebase focused shuffled run on current `main`, seed `26601` — 13/13 passed
- `git diff --check` — passed

The full local Vitest suite and local development server were intentionally not run; repository-wide coverage is delegated to the PR pipeline.

Closes #26601

Part of #26569
