### PR TITLE
test(api): introduce non-destructive pricing fixtures

### DIFF
--- a/turbo/apps/api/src/__tests__/test-app.ts
+++ b/turbo/apps/api/src/__tests__/test-app.ts
@@ -8,6 +8,7 @@ import {
 } from "@vm0/api-contracts/contracts/trpc-contract";
 
 import { createAppWithRoutes } from "../app-factory-core";
+import type { UsagePricingResolution } from "../signals/context/usage-pricing-resolution";
 import type { RouteEntry } from "../signals/route-entry";
 import type { TestContext } from "./test-context";
 
@@ -15,6 +16,7 @@ interface SetupAppWithRoutesOptions {
   readonly context: TestContext;
   readonly routes: readonly RouteEntry[];
   readonly signal?: AbortSignal;
+  readonly usagePricingResolution?: UsagePricingResolution;
 }
 
 function parseResponseBody(response: Response): Promise<unknown> | undefined {
@@ -56,10 +58,12 @@ function createAppFetcher(
   context: TestContext,
   routes: readonly RouteEntry[],
   signal?: AbortSignal,
+  usagePricingResolution?: UsagePricingResolution,
 ): ApiFetcher {
   const app = createAppWithRoutes({
     signal: signal ?? context.signal,
     routes,
+    usagePricingResolution,
   });
 
   return (args) => {
@@ -71,8 +75,9 @@ export function setupAppWithRoutes({
   context,
   routes,
   signal,
+  usagePricingResolution,
 }: SetupAppWithRoutesOptions) {
-  const app = createAppFetcher(context, routes, signal);
+  const app = createAppFetcher(context, routes, signal, usagePricingResolution);
 
   return <TContract extends AppRouter>(
     contract: TContract,

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -1,3 +1,4 @@
+import type { UsagePricingResolution } from "../signals/context/usage-pricing-resolution";
 import type { RouteEntry } from "../signals/route-entry";
 import { setupAppWithRoutes } from "./test-app";
 import type { TestContext } from "./test-context";
@@ -6,8 +7,19 @@ interface SetupAppOptions {
   readonly context: TestContext;
   readonly routes: readonly RouteEntry[];
   readonly signal?: AbortSignal;
+  readonly usagePricingResolution?: UsagePricingResolution;
 }
 
-export function setupApp({ context, routes, signal }: SetupAppOptions) {
-  return setupAppWithRoutes({ context, routes, signal });
+export function setupApp({
+  context,
+  routes,
+  signal,
+  usagePricingResolution,
+}: SetupAppOptions) {
+  return setupAppWithRoutes({
+    context,
+    routes,
+    signal,
+    usagePricingResolution,
+  });
 }

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -43,6 +43,7 @@ import {
 } from "./signals/route-entry";
 import { configureChatRunFinishedEventDispatcher } from "./signals/services/chat-run-finished-event-registration.service";
 import { configurePiEdgeTurnDispatcher } from "./signals/services/pi-edge-turn-registration.service";
+import type { UsagePricingResolution } from "./signals/context/usage-pricing-resolution";
 import {
   isAbortError,
   normalizeThrown,
@@ -549,11 +550,13 @@ function handleError(error: unknown, context: Context): Response {
 interface CreateAppWithRoutesOptions {
   readonly signal: AbortSignal;
   readonly routes: readonly RouteEntry[];
+  readonly usagePricingResolution?: UsagePricingResolution;
 }
 
 export function createAppWithRoutes({
   routes,
   signal,
+  usagePricingResolution,
 }: CreateAppWithRoutesOptions): Hono {
   configureChatRunFinishedEventDispatcher();
   configurePiEdgeTurnDispatcher();
@@ -600,7 +603,11 @@ export function createAppWithRoutes({
   }
 
   for (const { route, handler } of withApiNamespaceAliases(routes)) {
-    app.on(route.method, route.path, honoSignalHandler(handler, route, signal));
+    app.on(
+      route.method,
+      route.path,
+      honoSignalHandler(handler, route, signal, usagePricingResolution),
+    );
   }
 
   app.notFound((context) => {

--- a/turbo/apps/api/src/signals/context/route.ts
+++ b/turbo/apps/api/src/signals/context/route.ts
@@ -7,6 +7,10 @@ import type { Handler } from "hono";
 import type { ContentfulStatusCode, StatusCode } from "hono/utils/http-status";
 
 import { now } from "../../lib/time";
+import {
+  setUsagePricingResolution$,
+  type UsagePricingResolution,
+} from "./usage-pricing-resolution";
 import { initHono$ } from "./hono";
 import { requestValidation$ } from "./request";
 import { setRootSignal$ } from "./root";
@@ -96,12 +100,16 @@ export function honoSignalHandler(
   handler$: SignalRouteHandler<unknown>,
   contract: AppRoute,
   signal: AbortSignal,
+  usagePricingResolution?: UsagePricingResolution,
 ): Handler {
   return async (context) => {
     const apiStartTime = now();
     const store = createStore();
     store.set(setRootSignal$, signal);
     store.set(initHono$, context, contract, apiStartTime);
+    if (usagePricingResolution) {
+      store.set(setUsagePricingResolution$, usagePricingResolution);
+    }
 
     // Mirror the contract client order: path/query validation
     // precedes auth and downstream services, so a malformed request returns

--- a/turbo/apps/api/src/signals/context/usage-pricing-resolution.ts
+++ b/turbo/apps/api/src/signals/context/usage-pricing-resolution.ts
@@ -1,0 +1,46 @@
+import { command, computed, state, type Computed } from "ccstate";
+
+export interface UsagePricingProviderResolution {
+  readonly kind: string;
+  readonly provider: string;
+  readonly lookupProvider: string;
+}
+
+export type UsagePricingResolution = readonly UsagePricingProviderResolution[];
+
+const innerUsagePricingResolution$ = state<UsagePricingResolution>([]);
+
+export const usagePricingResolution$: Computed<UsagePricingResolution> =
+  computed((get) => {
+    return get(innerUsagePricingResolution$);
+  });
+
+export const setUsagePricingResolution$ = command(
+  ({ set }, resolution: UsagePricingResolution): void => {
+    set(innerUsagePricingResolution$, resolution);
+  },
+);
+
+export function resolveUsagePricingProvider(
+  resolution: UsagePricingResolution,
+  kind: string,
+  provider: string,
+): string {
+  return (
+    resolution.find((entry) => {
+      return entry.kind === kind && entry.provider === provider;
+    })?.lookupProvider ?? provider
+  );
+}
+
+export function canonicalUsagePricingProvider(
+  resolution: UsagePricingResolution,
+  kind: string,
+  lookupProvider: string,
+): string {
+  return (
+    resolution.find((entry) => {
+      return entry.kind === kind && entry.lookupProvider === lookupProvider;
+    })?.provider ?? lookupProvider
+  );
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-usage-settlement.test.ts
@@ -8,8 +8,11 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import {
+  createUsagePricingFixture,
   deleteUsagePricingRows,
   seedUsagePricingRows,
+  type UsagePricingFixture,
+  type UsagePricingKey,
 } from "../../../test-fixtures/system-config-seeds";
 import { testUsageSettlementRoutes } from "../test-usage-settlement";
 import {
@@ -25,10 +28,12 @@ import {
 const context = testContext();
 const store = createStore();
 
-function client() {
-  return setupApp({ context, routes: testUsageSettlementRoutes })(
-    testUsageSettlementContract,
-  );
+function client(usagePricingResolution?: UsagePricingFixture["resolution"]) {
+  return setupApp({
+    context,
+    routes: testUsageSettlementRoutes,
+    usagePricingResolution,
+  })(testUsageSettlementContract);
 }
 
 async function setupSettlementFixture(
@@ -126,8 +131,14 @@ async function insertCharge(args: {
   return idempotencyKey;
 }
 
-async function processSettlement(orgId: string): Promise<void> {
-  await accept(client().process({ body: { org_id: orgId } }), [200]);
+async function processSettlement(
+  orgId: string,
+  usagePricingResolution?: UsagePricingFixture["resolution"],
+): Promise<void> {
+  await accept(
+    client(usagePricingResolution).process({ body: { org_id: orgId } }),
+    [200],
+  );
 }
 
 async function readSettlementState(orgId: string) {
@@ -246,6 +257,82 @@ describe("POST /api/test/usage-settlement/process", () => {
       status: "processed",
       creditsCharged: 10,
       billingError: null,
+    });
+  });
+
+  it("isolates configured, custom, and missing pricing by fixture scope", async () => {
+    const pricingKey: UsagePricingKey = {
+      kind: "model",
+      provider: "deepseek-v4-flash",
+      category: "tokens.input",
+    };
+    const [configuredPricing, customPricing, missingPricing] =
+      await Promise.all([
+        createUsagePricingFixture({
+          configured: [{ ...pricingKey, unitPrice: 19, unitSize: 100 }],
+        }),
+        createUsagePricingFixture({
+          configured: [{ ...pricingKey, unitPrice: 7, unitSize: 1 }],
+        }),
+        createUsagePricingFixture({ missing: [pricingKey] }),
+      ]);
+    onTestFinished(async () => {
+      await Promise.all([
+        configuredPricing.cleanup(),
+        customPricing.cleanup(),
+        missingPricing.cleanup(),
+      ]);
+    });
+
+    const [configuredState, customState, missingState] = await Promise.all([
+      setupSettlementFixture(10_000),
+      setupSettlementFixture(10_000),
+      setupSettlementFixture(10_000),
+    ]);
+    const [configuredEvent, customEvent, missingEvent] = await Promise.all([
+      insertCharge({
+        fixture: configuredState,
+        provider: pricingKey.provider,
+        amount: 100,
+      }),
+      insertCharge({
+        fixture: customState,
+        provider: pricingKey.provider,
+        amount: 100,
+      }),
+      insertCharge({
+        fixture: missingState,
+        provider: pricingKey.provider,
+        amount: 100,
+      }),
+    ]);
+
+    await Promise.all([
+      processSettlement(configuredState.orgId, configuredPricing.resolution),
+      processSettlement(customState.orgId, customPricing.resolution),
+      processSettlement(missingState.orgId, missingPricing.resolution),
+    ]);
+
+    await expect(
+      store.set(readUsageEventState$, configuredEvent, context.signal),
+    ).resolves.toMatchObject({
+      status: "processed",
+      creditsCharged: 19,
+      billingError: null,
+    });
+    await expect(
+      store.set(readUsageEventState$, customEvent, context.signal),
+    ).resolves.toMatchObject({
+      status: "processed",
+      creditsCharged: 700,
+      billingError: null,
+    });
+    await expect(
+      store.set(readUsageEventState$, missingEvent, context.signal),
+    ).resolves.toMatchObject({
+      status: "processed",
+      creditsCharged: 0,
+      billingError: "missing_pricing",
     });
   });
 

--- a/turbo/apps/api/src/signals/services/openrouter-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/openrouter-usage.service.ts
@@ -6,6 +6,10 @@ import { v5 as uuidv5 } from "uuid";
 
 import type { OpenRouterUsage } from "../external/openrouter";
 import { writeDb$ } from "../external/db";
+import {
+  resolveUsagePricingProvider,
+  usagePricingResolution$,
+} from "../context/usage-pricing-resolution";
 import { processOrgUsageEvents$ } from "./zero-credit-usage.service";
 
 const OPENROUTER_USAGE_IDEMPOTENCY_NAMESPACE =
@@ -90,18 +94,23 @@ function usageIdempotencyKey(args: {
 
 export const checkOpenRouterUsagePricing$ = command(
   async (
-    { set },
+    { get, set },
     args: { readonly provider: string; readonly operation: string },
     signal: AbortSignal,
   ): Promise<readonly string[]> => {
     const writeDb = set(writeDb$);
+    const provider = resolveUsagePricingProvider(
+      get(usagePricingResolution$),
+      args.operation,
+      args.provider,
+    );
     const rows = await writeDb
       .select({ category: usagePricing.category })
       .from(usagePricing)
       .where(
         and(
           eq(usagePricing.kind, args.operation),
-          eq(usagePricing.provider, args.provider),
+          eq(usagePricing.provider, provider),
           inArray(usagePricing.category, [...OPENROUTER_USAGE_CATEGORIES]),
         ),
       );

--- a/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-avatar-video.service.ts
@@ -11,6 +11,10 @@ import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { and, eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
+import {
+  resolveUsagePricingProvider,
+  usagePricingResolution$,
+} from "../context/usage-pricing-resolution";
 import { db$, writeDb$ } from "../external/db";
 import { safeJsonParse } from "../utils";
 import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
@@ -251,6 +255,11 @@ export const avatarVideoPricing$: Computed<
   Promise<AvatarVideoPricingRow | null>
 > = computed(async (get): Promise<AvatarVideoPricingRow | null> => {
   const db = get(db$);
+  const provider = resolveUsagePricingProvider(
+    get(usagePricingResolution$),
+    "video",
+    JOGGAI_AVATAR_VIDEO_MODEL,
+  );
   const [row] = await db
     .select({
       provider: usagePricing.provider,
@@ -262,7 +271,7 @@ export const avatarVideoPricing$: Computed<
     .where(
       and(
         eq(usagePricing.kind, "video"),
-        eq(usagePricing.provider, JOGGAI_AVATAR_VIDEO_MODEL),
+        eq(usagePricing.provider, provider),
         eq(usagePricing.category, JOGGAI_AVATAR_VIDEO_PRICING_CATEGORY),
       ),
     )

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -11,6 +11,11 @@ import { nowDate } from "../../lib/time";
 import { logger } from "../../lib/log";
 import { usageUnderbillingFields } from "../usage-underbilling";
 import { tapError } from "../utils";
+import {
+  resolveUsagePricingProvider,
+  usagePricingResolution$,
+  type UsagePricingResolution,
+} from "../context/usage-pricing-resolution";
 import { maybeEmitRunUsageEvent$ } from "./zero-chat-usage-event.service";
 import {
   enqueueCreditLowBalanceAlert$,
@@ -223,6 +228,7 @@ function priceUsageEvents(
   records: readonly UsageEventRecord[],
   pricingRecords: readonly UsagePricingRecord[],
   orgId: string,
+  pricingResolution: UsagePricingResolution,
 ): PricedUsageEvent[] {
   const pricingByKey = new Map(
     pricingRecords.map((pricing) => {
@@ -234,12 +240,17 @@ function priceUsageEvents(
   );
   const pricedEvents: PricedUsageEvent[] = [];
   for (const record of records) {
+    const lookupProvider = resolveUsagePricingProvider(
+      pricingResolution,
+      record.kind,
+      record.provider,
+    );
     const exactPricing = pricingByKey.get(
-      `${record.kind}|${record.provider}|${record.category}`,
+      `${record.kind}|${lookupProvider}|${record.category}`,
     );
     const pricing =
       exactPricing ??
-      pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
+      pricingByKey.get(`${record.kind}|${lookupProvider}|__fallback__`);
 
     if (!pricing) {
       L.error("Missing usage_pricing — charged zero", {
@@ -332,6 +343,7 @@ async function markUsageEventsProcessed(
 async function processOrgUsageEventsInTransaction(
   tx: WriteTx,
   orgId: string,
+  pricingResolution: UsagePricingResolution,
   signal: AbortSignal,
 ): Promise<ProcessOrgUsageEventsResult> {
   // Same advisory key as web: 'credit_' prefix + orgId.
@@ -370,7 +382,12 @@ async function processOrgUsageEventsInTransaction(
   ];
 
   const pricingRecords = await tx.select().from(usagePricing);
-  const pricedEvents = priceUsageEvents(pendingRecords, pricingRecords, orgId);
+  const pricedEvents = priceUsageEvents(
+    pendingRecords,
+    pricingRecords,
+    orgId,
+    pricingResolution,
+  );
 
   const allowanceByUsageEvent =
     await applyUsageAllowanceToUsageEventsInLockedTransaction(tx, {
@@ -470,12 +487,18 @@ async function processOrgUsageEventsInTransaction(
  * envelope. Low-balance alert failures are logged without affecting billing.
  */
 export const processOrgUsageEvents$ = command(
-  async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
+  async ({ get, set }, orgId: string, signal: AbortSignal): Promise<void> => {
     const writeDb = set(writeDb$);
+    const pricingResolution = get(usagePricingResolution$);
 
     const { sharedCreditsCharged, runIds, lowBalanceAlert } =
       await writeDb.transaction((tx) => {
-        return processOrgUsageEventsInTransaction(tx, orgId, signal);
+        return processOrgUsageEventsInTransaction(
+          tx,
+          orgId,
+          pricingResolution,
+          signal,
+        );
       });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -7,6 +7,12 @@ import { and, eq, inArray } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
+import {
+  canonicalUsagePricingProvider,
+  resolveUsagePricingProvider,
+  usagePricingResolution$,
+  type UsagePricingResolution,
+} from "../context/usage-pricing-resolution";
 import { db$, writeDb$ } from "../external/db";
 import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
 import { storeGeneratedArtifactObject$ } from "./artifact-storage.service";
@@ -1162,10 +1168,13 @@ function mapPricingRows(
     readonly unitPrice: number;
     readonly unitSize: number;
   }[],
+  resolution: UsagePricingResolution,
 ): ImagePricing {
   const pricing = new Map<string, ImagePricingRow>();
   for (const row of rows) {
-    const model = normalizeImageModel(row.provider);
+    const model = normalizeImageModel(
+      canonicalUsagePricingProvider(resolution, USAGE_KIND, row.provider),
+    );
     if (model && includesString(IMAGE_PRICING_CATEGORIES, row.category)) {
       pricing.set(imagePricingKey(model, row.category), {
         provider: model,
@@ -1181,6 +1190,10 @@ function mapPricingRows(
 export const imagePricing$: Computed<Promise<ImagePricing>> = computed(
   async (get): Promise<ImagePricing> => {
     const db = get(db$);
+    const resolution = get(usagePricingResolution$);
+    const lookupProviders = IMAGE_MODELS.map((provider) => {
+      return resolveUsagePricingProvider(resolution, USAGE_KIND, provider);
+    });
     const rows = await db
       .select({
         provider: usagePricing.provider,
@@ -1192,12 +1205,12 @@ export const imagePricing$: Computed<Promise<ImagePricing>> = computed(
       .where(
         and(
           eq(usagePricing.kind, USAGE_KIND),
-          inArray(usagePricing.provider, [...IMAGE_MODELS]),
+          inArray(usagePricing.provider, lookupProviders),
           inArray(usagePricing.category, [...IMAGE_PRICING_CATEGORIES]),
         ),
       );
 
-    return mapPricingRows(rows);
+    return mapPricingRows(rows, resolution);
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-managed-usage.service.ts
@@ -12,6 +12,10 @@ import {
   nullableDriverValueDecoder,
   pgInt8ToBigIntDecoder,
 } from "../../lib/db-structured-result";
+import {
+  resolveUsagePricingProvider,
+  usagePricingResolution$,
+} from "../context/usage-pricing-resolution";
 import { writeDb$ } from "../external/db";
 import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 import { getSpendableUsagePackCredits } from "./usage-pack-credit.service";
@@ -83,7 +87,7 @@ function estimatedCredits(
 
 export const checkManagedCredits$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly orgId: string;
       readonly userId: string;
@@ -93,6 +97,11 @@ export const checkManagedCredits$ = command(
     signal: AbortSignal,
   ): Promise<ManagedUsageErrorResponse | null> => {
     const writeDb = set(writeDb$);
+    const pricingProvider = resolveUsagePricingProvider(
+      get(usagePricingResolution$),
+      args.resource.kind,
+      args.resource.provider,
+    );
     const expired = writeDb.$with("expired").as(
       writeDb
         .select({
@@ -129,7 +138,7 @@ export const checkManagedCredits$ = command(
         usagePricing,
         and(
           eq(usagePricing.kind, args.resource.kind),
-          eq(usagePricing.provider, args.resource.provider),
+          eq(usagePricing.provider, pricingProvider),
           eq(usagePricing.category, args.resource.category),
         ),
       );

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -25,6 +25,12 @@ import {
 import { and, eq, inArray } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
+import {
+  canonicalUsagePricingProvider,
+  resolveUsagePricingProvider,
+  usagePricingResolution$,
+  type UsagePricingResolution,
+} from "../context/usage-pricing-resolution";
 import { db$, writeDb$ } from "../external/db";
 import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
 import { storeGeneratedArtifactObject$ } from "./artifact-storage.service";
@@ -1008,10 +1014,13 @@ function mapPricingRows(
     readonly unitPrice: number;
     readonly unitSize: number;
   }[],
+  resolution: UsagePricingResolution,
 ): VideoPricing {
   const pricing = new Map<string, VideoPricingRow>();
   for (const row of rows) {
-    const model = normalizeVideoModel(row.provider);
+    const model = normalizeVideoModel(
+      canonicalUsagePricingProvider(resolution, USAGE_KIND, row.provider),
+    );
     if (model && includesString(VIDEO_PRICING_CATEGORIES, row.category)) {
       pricing.set(videoPricingKey(model, row.category), {
         provider: model,
@@ -1097,6 +1106,10 @@ export function getMissingVideoPricing(
 export const videoPricing$: Computed<Promise<VideoPricing>> = computed(
   async (get): Promise<VideoPricing> => {
     const db = get(db$);
+    const resolution = get(usagePricingResolution$);
+    const lookupProviders = VIDEO_MODELS.map((provider) => {
+      return resolveUsagePricingProvider(resolution, USAGE_KIND, provider);
+    });
     const rows = await db
       .select({
         provider: usagePricing.provider,
@@ -1108,12 +1121,12 @@ export const videoPricing$: Computed<Promise<VideoPricing>> = computed(
       .where(
         and(
           eq(usagePricing.kind, USAGE_KIND),
-          inArray(usagePricing.provider, [...VIDEO_MODELS]),
+          inArray(usagePricing.provider, lookupProviders),
           inArray(usagePricing.category, [...VIDEO_PRICING_CATEGORIES]),
         ),
       );
 
-    return mapPricingRows(rows);
+    return mapPricingRows(rows, resolution);
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -9,6 +9,10 @@ import { parseBuffer } from "music-metadata";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
+import {
+  resolveUsagePricingProvider,
+  usagePricingResolution$,
+} from "../context/usage-pricing-resolution";
 import { db$, writeDb$ } from "../external/db";
 import { checkBillableOperationCredits$ } from "./billable-operation-admission.service";
 import { nowDate } from "../../lib/time";
@@ -875,6 +879,11 @@ export async function getAudioDuration(file: File): Promise<number | null> {
 export const speechPricing$: Computed<Promise<SpeechPricing | null>> = computed(
   async (get): Promise<SpeechPricing | null> => {
     const db = get(db$);
+    const provider = resolveUsagePricingProvider(
+      get(usagePricingResolution$),
+      USAGE_KIND,
+      USAGE_PROVIDER,
+    );
     const [pricing] = await db
       .select({
         unitPrice: usagePricing.unitPrice,
@@ -884,7 +893,7 @@ export const speechPricing$: Computed<Promise<SpeechPricing | null>> = computed(
       .where(
         and(
           eq(usagePricing.kind, USAGE_KIND),
-          eq(usagePricing.provider, USAGE_PROVIDER),
+          eq(usagePricing.provider, provider),
           eq(usagePricing.category, USAGE_CATEGORY),
         ),
       )

--- a/turbo/apps/api/src/test-fixtures/system-config-seeds.ts
+++ b/turbo/apps/api/src/test-fixtures/system-config-seeds.ts
@@ -6,19 +6,13 @@ import {
   createUsagePricingFixture,
   deleteUsagePricingRows,
   ensureUsagePricingRow,
-  type CreateUsagePricingFixtureOptions,
   type UsagePricingFixture,
   type UsagePricingKey,
   type UsagePricingRow,
   upsertUsagePricingRows,
 } from "./usage-pricing";
 
-export type {
-  CreateUsagePricingFixtureOptions,
-  UsagePricingFixture,
-  UsagePricingKey,
-  UsagePricingRow,
-};
+export type { UsagePricingFixture, UsagePricingKey, UsagePricingRow };
 
 export const seedOrgMetadata = upsertOrgMetadataFixture;
 export { setOnboardingPaymentPendingFixture };

--- a/turbo/apps/api/src/test-fixtures/system-config-seeds.ts
+++ b/turbo/apps/api/src/test-fixtures/system-config-seeds.ts
@@ -3,15 +3,28 @@ import {
   upsertOrgMetadataFixture,
 } from "./org-metadata";
 import {
+  createUsagePricingFixture,
   deleteUsagePricingRows,
   ensureUsagePricingRow,
+  type CreateUsagePricingFixtureOptions,
+  type UsagePricingFixture,
+  type UsagePricingKey,
   type UsagePricingRow,
   upsertUsagePricingRows,
 } from "./usage-pricing";
 
-export type { UsagePricingRow };
+export type {
+  CreateUsagePricingFixtureOptions,
+  UsagePricingFixture,
+  UsagePricingKey,
+  UsagePricingRow,
+};
 
 export const seedOrgMetadata = upsertOrgMetadataFixture;
 export { setOnboardingPaymentPendingFixture };
 export const seedUsagePricingRows = upsertUsagePricingRows;
-export { deleteUsagePricingRows, ensureUsagePricingRow };
+export {
+  createUsagePricingFixture,
+  deleteUsagePricingRows,
+  ensureUsagePricingRow,
+};

--- a/turbo/apps/api/src/test-fixtures/usage-pricing.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-pricing.ts
@@ -3,26 +3,105 @@
  *
  * Usage pricing is operator-managed global configuration with no product API
  * (rows are written by ops tooling/migrations in production), so tests cannot
- * construct or clear pricing state through any product endpoint. This module
- * is the narrow test-boundary exception for that state: it only upserts,
- * ensures, and deletes pricing rows keyed by (kind, provider, category).
+ * construct pricing state through any product endpoint. New route tests use
+ * `createUsagePricingFixture` to own unique lookup providers. The raw helpers
+ * remain while their existing callers migrate to the scoped model.
  */
+import { randomUUID } from "node:crypto";
+
 import { createStore } from "ccstate";
 import { usagePricing } from "@vm0/db/schema/usage-pricing";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../signals/external/db";
+import {
+  resolveUsagePricingProvider,
+  type UsagePricingProviderResolution,
+  type UsagePricingResolution,
+} from "../signals/context/usage-pricing-resolution";
 
-export interface UsagePricingRow {
+export interface UsagePricingKey {
   readonly kind: string;
   readonly provider: string;
   readonly category: string;
+}
+
+export interface UsagePricingRow extends UsagePricingKey {
   readonly unitPrice: number;
   readonly unitSize: number;
 }
 
+export interface UsagePricingFixture {
+  readonly resolution: UsagePricingResolution;
+  readonly cleanup: () => Promise<void>;
+}
+
+export interface CreateUsagePricingFixtureOptions {
+  readonly configured?: readonly UsagePricingRow[];
+  readonly missing?: readonly UsagePricingKey[];
+}
+
 function fixtureDb(): Db {
   return createStore().set(writeDb$);
+}
+
+function usagePricingResolution(
+  keys: readonly UsagePricingKey[],
+): UsagePricingProviderResolution[] {
+  const resolution: UsagePricingProviderResolution[] = [];
+  for (const key of keys) {
+    if (
+      resolution.some((entry) => {
+        return entry.kind === key.kind && entry.provider === key.provider;
+      })
+    ) {
+      continue;
+    }
+    resolution.push({
+      kind: key.kind,
+      provider: key.provider,
+      lookupProvider: `pricing-fixture-${randomUUID()}`,
+    });
+  }
+  return resolution;
+}
+
+export async function createUsagePricingFixture({
+  configured = [],
+  missing = [],
+}: CreateUsagePricingFixtureOptions): Promise<UsagePricingFixture> {
+  const db = fixtureDb();
+  const resolution = usagePricingResolution([...configured, ...missing]);
+  if (configured.length > 0) {
+    await db.insert(usagePricing).values(
+      configured.map((row) => {
+        return {
+          ...row,
+          provider: resolveUsagePricingProvider(
+            resolution,
+            row.kind,
+            row.provider,
+          ),
+        };
+      }),
+    );
+  }
+
+  return {
+    resolution,
+    cleanup: async () => {
+      for (const entry of resolution) {
+        await db
+          .delete(usagePricing)
+          .where(
+            and(
+              eq(usagePricing.kind, entry.kind),
+              eq(usagePricing.provider, entry.lookupProvider),
+            ),
+          );
+      }
+    },
+  };
 }
 
 export async function upsertUsagePricingRows(

--- a/turbo/apps/api/src/test-fixtures/usage-pricing.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-pricing.ts
@@ -36,7 +36,7 @@ export interface UsagePricingFixture {
   readonly cleanup: () => Promise<void>;
 }
 
-export interface CreateUsagePricingFixtureOptions {
+interface CreateUsagePricingFixtureOptions {
   readonly configured?: readonly UsagePricingRow[];
   readonly missing?: readonly UsagePricingKey[];
 }


### PR DESCRIPTION
## Summary

- Add `createUsagePricingFixture` with UUID-owned lookup providers for configured, custom-price, and missing-pricing scenarios.
- Carry fixture resolution through the test app into each request Store and every production pricing reader; an empty resolution preserves canonical production lookups.
- Prove three concurrent scopes using the same canonical pricing key receive independent configured, custom, and missing outcomes.

## Isolation invariants

- The scoped fixture never updates or deletes fixed shared pricing keys.
- Missing-pricing resolution targets an owned provider identity with no row.
- Assertions complete before cleanup; cleanup deletes only UUID-owned providers and only bounds residue.
- The operator-managed schema and production lookup behavior remain unchanged.
- No test serialization, advisory lock, mocked-time partition, or residue-tolerant assertion is introduced.

## Validation

- `pnpm exec prettier --write` on all changed API files — unchanged after formatting.
- `pnpm -F api lint` — passed with exit 0; emitted only repository-existing Oxlint warnings.
- `pnpm -F api check-types` — passed all dependency, boundary, gateway, core, bootstrap, test, and bootstrap-wiring partitions.
- `pnpm knip` — passed on revised HEAD `1a80df19ae3c23e8d2a223f69b9f7ec0cd01c456`; emitted only existing configuration hints.
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/test-usage-settlement.test.ts` — 1 file passed, 10 tests passed.
- `git diff --check` — passed.

## Remote checks

- Rebased onto `main` at `d22e940ccfa5d74a5df5ea086c4df93e68276b05`.
- Scanned all 31 open PRs and fully paginated large diffs. PRs #25722, #26549, and #26555 overlap only in request bootstrap/context files; none changes pricing resolution.
- GitHub `lint-knip` passed on revised HEAD `1a80df19ae3c23e8d2a223f69b9f7ec0cd01c456`.

Closes #26587
Epic: #26569