### PR TITLE
test(e2e): serialize clerk activation navigation

### DIFF
--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -1,5 +1,5 @@
 import { clerk } from "@clerk/testing/playwright";
-import { errors, type Page } from "@playwright/test";
+import { errors, type Page, type Route } from "@playwright/test";
 
 const CLERK_BOOTSTRAP_TIMEOUTS_MS = [15_000, 30_000] as const;
 
@@ -57,22 +57,11 @@ export async function signInWithClerkTestingHelper(
     timeout: 30_000,
   });
   if (options.activeOrganizationId) {
-    // Activating the organization lets the skeleton route redirect to the app.
-    // Observe that redirect before setActive so it cannot race the token read.
-    await Promise.all([
-      page.waitForURL(
-        (url) =>
-          url.origin === helperUrl.origin &&
-          url.pathname !== helperUrl.pathname,
-        {
-          timeout: 30_000,
-          waitUntil: "domcontentloaded",
-        },
-      ),
-      page.evaluate(async (organizationId) => {
-        await window.Clerk?.setActive({ organization: organizationId });
-      }, options.activeOrganizationId),
-    ]);
+    await activateClerkOrganization(
+      page,
+      helperUrl,
+      options.activeOrganizationId,
+    );
     await page.waitForFunction(
       () => Boolean(window.Clerk?.loaded && window.Clerk?.session),
       undefined,
@@ -104,6 +93,62 @@ export async function signInWithClerkTestingHelper(
 
   await gotoAboutBlankAfterClerkNavigation(page);
   return token;
+}
+
+async function activateClerkOrganization(
+  page: Page,
+  helperUrl: URL,
+  organizationId: string,
+): Promise<void> {
+  let resolveActivationFinished!: () => void;
+  const activationFinished = new Promise<void>((resolve) => {
+    resolveActivationFinished = resolve;
+  });
+  const routePattern = `${helperUrl.origin}/**`;
+  const holdPostActivationNavigation = async (route: Route): Promise<void> => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (
+      request.isNavigationRequest() &&
+      request.frame() === page.mainFrame() &&
+      url.origin === helperUrl.origin &&
+      url.pathname !== helperUrl.pathname
+    ) {
+      // The app reloads after the Clerk organization event. Keep the old
+      // document alive until Playwright receives the setActive result.
+      await activationFinished;
+    }
+    await route.continue();
+  };
+
+  await page.route(routePattern, holdPostActivationNavigation);
+  try {
+    await Promise.all([
+      page.waitForURL(
+        (url) =>
+          url.origin === helperUrl.origin &&
+          url.pathname !== helperUrl.pathname,
+        {
+          timeout: 30_000,
+          waitUntil: "domcontentloaded",
+        },
+      ),
+      (async () => {
+        try {
+          await page.evaluate(async (targetOrganizationId) => {
+            await window.Clerk?.setActive({
+              organization: targetOrganizationId,
+            });
+          }, organizationId);
+        } finally {
+          resolveActivationFinished();
+        }
+      })(),
+    ]);
+  } finally {
+    resolveActivationFinished();
+    await page.unroute(routePattern, holdPostActivationNavigation);
+  }
 }
 
 async function navigateToLoadedClerk(


### PR DESCRIPTION
## Summary

- hold only the same-origin main-frame reload triggered by Clerk organization activation until the originating browser evaluation has settled
- then allow the real app navigation and retain the existing loaded-Clerk, session, active-organization, and token assertions
- preserve the runner credential-generation contract without retries, sleeps, timeout increases, skipped checks, or swallowed rejections

## Root cause

[Turbo run 31581814872](https://github.com/vm0-ai/vm0/actions/runs/31581814872) failed in [cli-e2e-03-runner-prepare](https://github.com/vm0-ai/vm0/actions/runs/31581814872/job/94066928599) at exact merge-group SHA `c92893f1b84798a7ad10dd1a2d271e55913a3d83`.

After `window.Clerk.setActive()` emits the organization change, `watchOrgSwitch$` refreshes the session token and assigns `location.href = "/"`. The shared Playwright helper awaited that activation inside `page.evaluate()` while concurrently waiting for the reload. On the second runner identity, the new document committed before Playwright received the evaluation result, destroying the old execution context at `e2e/playwright/lib/auth.ts:72`.

PR #26608 does not modify the authentication helper or app auth lifecycle. Its PR-head runner preparation passed, and its later merge-group attempt [31582626838](https://github.com/vm0-ai/vm0/actions/runs/31582626838) also passed the same three-account credential preparation unchanged. That comparison establishes the scheduling-dependent window without attributing it to the represented PR.

The repair adds an explicit lifecycle boundary: only a matching main-frame document request is held until the activation evaluation settles. The request is then continued normally, and the helper still verifies the real destination document, Clerk session, requested organization, and refreshed token.

## Validation

- `cd e2e && corepack pnpm check-types`
- `cd e2e && corepack pnpm test` repeated 5 times: 16/16 passed each run
- `npx --yes prettier@3.8.1 --check e2e/playwright/lib/auth.ts`
- `git diff --check`

Live Clerk and deployed-preview validation is pending this draft PR pipeline because the runner preparation path depends on temporary Clerk organizations and the provisioned app/API previews.