### PR TITLE
test(api): add item-scoped email outbox drain coverage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from "node:crypto";
+
+import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { mockOptionalEnv } from "../../../lib/env";
+import { nowDate } from "../../../lib/time";
+import { createDeferredPromise } from "../../utils";
+import { createEmailOutboxStateApi } from "./helpers/email-outbox-state";
+
+const context = testContext();
+const outbox = createEmailOutboxStateApi(context);
+
+function fixtureAddress(): string {
+  return `email-outbox-${randomUUID()}@example.test`;
+}
+
+function fixtureSubject(): string {
+  return `Email outbox fixture ${randomUUID()}`;
+}
+
+async function seedItem(options: {
+  readonly status: "pending" | "failed";
+  readonly createdAt: Date;
+}) {
+  const toAddress = fixtureAddress();
+  const subject = fixtureSubject();
+  const item = await outbox.seedItem({
+    toAddress,
+    subject,
+    ...options,
+  });
+  onTestFinished(async () => {
+    await outbox.deleteItems([item.id]);
+  });
+  return { ...item, toAddress, subject };
+}
+
+beforeEach(() => {
+  context.mocks.resend.send.mockReset();
+  context.mocks.resend.send.mockResolvedValue({
+    data: { id: `resend-${randomUUID()}` },
+    error: null,
+  });
+  mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
+});
+
+describe("scoped email outbox drain", () => {
+  it("drains and expires only explicitly selected items", async () => {
+    const createdAt = nowDate();
+    const expiredAt = new Date(0);
+    const [dueItem, unrelatedDueSentinel, expiredPending, expiredFailed] =
+      await Promise.all([
+        seedItem({ status: "pending", createdAt }),
+        seedItem({ status: "pending", createdAt }),
+        seedItem({ status: "pending", createdAt: expiredAt }),
+        seedItem({ status: "failed", createdAt: expiredAt }),
+      ]);
+    const unrelatedExpiredSentinel = await seedItem({
+      status: "failed",
+      createdAt: expiredAt,
+    });
+
+    const drained = await outbox.drainItems([dueItem.id]);
+
+    expect(drained).toBe(1);
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
+    expect(context.mocks.resend.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: dueItem.toAddress,
+        subject: dueItem.subject,
+      }),
+    );
+    expect((await outbox.readItem(dueItem.id))?.status).toBe("sent");
+    expect((await outbox.readItem(unrelatedDueSentinel.id))?.status).toBe(
+      "pending",
+    );
+    expect((await outbox.readItem(unrelatedExpiredSentinel.id))?.status).toBe(
+      "failed",
+    );
+
+    const cleaned = await outbox.cleanupExpiredItems([
+      expiredPending.id,
+      expiredFailed.id,
+    ]);
+
+    expect(cleaned).toBe(2);
+    await expect(outbox.readItem(expiredPending.id)).resolves.toBeNull();
+    await expect(outbox.readItem(expiredFailed.id)).resolves.toBeNull();
+    expect((await outbox.readItem(unrelatedDueSentinel.id))?.status).toBe(
+      "pending",
+    );
+    expect((await outbox.readItem(unrelatedExpiredSentinel.id))?.status).toBe(
+      "failed",
+    );
+  });
+
+  it("skips a selected item already locked by another drain", async () => {
+    const toAddress = fixtureAddress();
+    const subject = fixtureSubject();
+    const seeded = await outbox.seedItem({
+      toAddress,
+      subject,
+      status: "pending",
+      createdAt: nowDate(),
+    });
+    const item = await outbox.findItem({ toAddress, subject });
+    expect(item.id).toBe(seeded.id);
+
+    const sendStarted = createDeferredPromise<void>(context.signal);
+    const releaseSend = createDeferredPromise<void>(context.signal);
+    onTestFinished(async () => {
+      if (!releaseSend.settled()) {
+        releaseSend.resolve(undefined);
+      }
+      await outbox.deleteItems([item.id]);
+    });
+    context.mocks.resend.send.mockImplementation(async () => {
+      sendStarted.resolve(undefined);
+      await releaseSend.promise;
+      return { data: { id: "resend-scoped-lock" }, error: null };
+    });
+
+    const firstDrain = outbox.drainItems([item.id]);
+    await sendStarted.promise;
+
+    await expect(outbox.drainItems([item.id])).resolves.toBe(0);
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
+
+    releaseSend.resolve(undefined);
+    await expect(firstDrain).resolves.toBe(1);
+    expect((await outbox.readItem(item.id))?.status).toBe("sent");
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/email-outbox-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/email-outbox-state.ts
@@ -1,0 +1,113 @@
+import {
+  testEmailOutboxStateContract,
+  type TestEmailOutboxStateActionBody,
+  type TestEmailOutboxStateActionResponse,
+  type TestEmailOutboxStateItem,
+} from "@vm0/api-contracts/contracts/test-email-outbox-state";
+
+import { setupAppWithRoutes } from "../../../../__tests__/test-app";
+import { accept, type TestContext } from "../../../../__tests__/test-context";
+import { testEmailOutboxStateRoutes } from "../../test-email-outbox-state";
+
+interface SeedEmailOutboxItemOptions {
+  readonly toAddress: string;
+  readonly subject: string;
+  readonly status: "pending" | "failed";
+  readonly createdAt: Date;
+}
+
+function stateClient(context: TestContext) {
+  return setupAppWithRoutes({
+    context,
+    routes: testEmailOutboxStateRoutes,
+  })(testEmailOutboxStateContract);
+}
+
+async function postAction(
+  context: TestContext,
+  body: TestEmailOutboxStateActionBody,
+): Promise<TestEmailOutboxStateActionResponse> {
+  const response = await accept(stateClient(context).action({ body }), [200]);
+  return response.body;
+}
+
+export function createEmailOutboxStateApi(context: TestContext) {
+  return {
+    async seedItem(
+      options: SeedEmailOutboxItemOptions,
+    ): Promise<TestEmailOutboxStateItem> {
+      const response = await postAction(context, {
+        action: "seed-item",
+        to_address: options.toAddress,
+        subject: options.subject,
+        status: options.status,
+        created_at: options.createdAt.toISOString(),
+      });
+      if (response.action !== "seed-item") {
+        throw new Error("Expected the email outbox seed response");
+      }
+      return response.item;
+    },
+
+    async findItem(options: {
+      readonly toAddress: string;
+      readonly subject: string;
+    }): Promise<TestEmailOutboxStateItem> {
+      const response = await postAction(context, {
+        action: "find-item",
+        to_address: options.toAddress,
+        subject: options.subject,
+      });
+      if (response.action !== "find-item" || response.items.length !== 1) {
+        throw new Error(
+          `Expected one email outbox item, found ${
+            response.action === "find-item" ? response.items.length : 0
+          }`,
+        );
+      }
+      const item = response.items[0];
+      if (!item) {
+        throw new Error("Expected the uniquely matched email outbox item");
+      }
+      return item;
+    },
+
+    async readItem(itemId: string): Promise<TestEmailOutboxStateItem | null> {
+      const response = await postAction(context, {
+        action: "read-items",
+        item_ids: [itemId],
+      });
+      if (response.action !== "read-items") {
+        throw new Error("Expected the email outbox read response");
+      }
+      return response.items[0] ?? null;
+    },
+
+    async deleteItems(itemIds: readonly string[]): Promise<number> {
+      const response = await postAction(context, {
+        action: "delete-items",
+        item_ids: [...itemIds],
+      });
+      if (response.action !== "delete-items") {
+        throw new Error("Expected the email outbox delete response");
+      }
+      return response.deleted;
+    },
+
+    async drainItems(itemIds: readonly string[]): Promise<number> {
+      const response = await accept(
+        stateClient(context).drain({ body: { item_ids: [...itemIds] } }),
+        [200],
+      );
+      return response.body.drained;
+    },
+
+    async cleanupExpiredItems(itemIds: readonly string[]): Promise<number> {
+      const response = await accept(
+        stateClient(context).cleanup({ body: { item_ids: [...itemIds] } }),
+        [200],
+      );
+      return response.body.cleaned;
+    },
+  };
+}

--- a/turbo/apps/api/src/signals/routes/test-email-outbox-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-email-outbox-state.ts
@@ -1,0 +1,180 @@
+import {
+  testEmailOutboxStateContract,
+  type TestEmailOutboxStateActionBody,
+} from "@vm0/api-contracts/contracts/test-email-outbox-state";
+import { emailOutbox } from "@vm0/db/schema/email-outbox";
+import { command } from "ccstate";
+import { and, asc, eq, inArray } from "drizzle-orm";
+
+import { now } from "../../lib/time";
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import { writeDb$, type Db } from "../external/db";
+import type { RouteEntry } from "../route-entry";
+import {
+  cleanupExpiredEmailOutboxItems$,
+  drainEmailOutboxItems$,
+} from "../services/zero-email-common.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const actionBody$ = bodyResultOf(testEmailOutboxStateContract.action);
+const drainBody$ = bodyResultOf(testEmailOutboxStateContract.drain);
+const cleanupBody$ = bodyResultOf(testEmailOutboxStateContract.cleanup);
+
+function itemStateSelection() {
+  return {
+    id: emailOutbox.id,
+    status: emailOutbox.status,
+    attempts: emailOutbox.attempts,
+    resend_id: emailOutbox.resendId,
+  };
+}
+
+async function applyAction(
+  db: Db,
+  body: TestEmailOutboxStateActionBody,
+  signal: AbortSignal,
+) {
+  switch (body.action) {
+    case "seed-item": {
+      const [item] = await db
+        .insert(emailOutbox)
+        .values({
+          fromAddress: "Zero <outbox-fixture@mail.example.com>",
+          toAddresses: body.to_address,
+          subject: body.subject,
+          template: {
+            template: "data-export-ready",
+            props: {
+              downloadUrl: "https://storage.example/email-outbox-fixture.zip",
+              expiresAt: "January 1, 2030",
+              artifactCount: 1,
+            },
+          },
+          status: body.status,
+          attempts: 0,
+          createdAt: new Date(body.created_at),
+        })
+        .returning(itemStateSelection());
+      signal.throwIfAborted();
+      if (!item) {
+        throw new Error("Failed to seed email outbox item");
+      }
+      return {
+        status: 200 as const,
+        body: { action: "seed-item" as const, item },
+      };
+    }
+    case "find-item": {
+      const items = await db
+        .select(itemStateSelection())
+        .from(emailOutbox)
+        .where(
+          and(
+            eq(emailOutbox.toAddresses, body.to_address),
+            eq(emailOutbox.subject, body.subject),
+          ),
+        )
+        .orderBy(asc(emailOutbox.createdAt));
+      signal.throwIfAborted();
+      return {
+        status: 200 as const,
+        body: { action: "find-item" as const, items },
+      };
+    }
+    case "read-items": {
+      const items = await db
+        .select(itemStateSelection())
+        .from(emailOutbox)
+        .where(inArray(emailOutbox.id, body.item_ids));
+      signal.throwIfAborted();
+      return {
+        status: 200 as const,
+        body: { action: "read-items" as const, items },
+      };
+    }
+    case "delete-items": {
+      const deleted = await db
+        .delete(emailOutbox)
+        .where(inArray(emailOutbox.id, body.item_ids))
+        .returning({ id: emailOutbox.id });
+      signal.throwIfAborted();
+      return {
+        status: 200 as const,
+        body: { action: "delete-items" as const, deleted: deleted.length },
+      };
+    }
+  }
+}
+
+const mutateTestEmailOutboxState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(actionBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    return await applyAction(set(writeDb$), bodyResult.data, signal);
+  },
+);
+
+const drainTestEmailOutboxState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(drainBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const drained = await set(
+      drainEmailOutboxItems$,
+      { currentTimeMs: now(), itemIds: bodyResult.data.item_ids },
+      signal,
+    );
+    signal.throwIfAborted();
+    return { status: 200 as const, body: { drained } };
+  },
+);
+
+const cleanupTestEmailOutboxState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(cleanupBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const cleaned = await set(
+      cleanupExpiredEmailOutboxItems$,
+      { currentTimeMs: now(), itemIds: bodyResult.data.item_ids },
+      signal,
+    );
+    signal.throwIfAborted();
+    return { status: 200 as const, body: { cleaned } };
+  },
+);
+
+export const testEmailOutboxStateRoutes: readonly RouteEntry[] = [
+  {
+    route: testEmailOutboxStateContract.action,
+    handler: mutateTestEmailOutboxState$,
+  },
+  {
+    route: testEmailOutboxStateContract.drain,
+    handler: drainTestEmailOutboxState$,
+  },
+  {
+    route: testEmailOutboxStateContract.cleanup,
+    handler: cleanupTestEmailOutboxState$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -25,6 +25,10 @@ interface EmailOutboxDrainContext {
   readonly currentTimeMs: number;
 }
 
+interface EmailOutboxItemsContext extends EmailOutboxDrainContext {
+  readonly itemIds: readonly string[];
+}
+
 const log = logger("zero:email");
 const USER_CACHE_TTL_MS = 900_000;
 const MAX_ATTEMPTS = 3;
@@ -465,6 +469,7 @@ async function processOutboxItem(
 async function drainNextOutboxItem(
   db: Db,
   currentTimeMs: number,
+  itemIds?: readonly string[],
 ): Promise<boolean> {
   return await db.transaction(async (tx) => {
     const currentTime = new Date(currentTimeMs);
@@ -473,6 +478,9 @@ async function drainNextOutboxItem(
       .from(emailOutbox)
       .where(
         and(
+          itemIds === undefined
+            ? undefined
+            : inArray(emailOutbox.id, [...itemIds]),
           eq(emailOutbox.status, "pending"),
           or(
             isNull(emailOutbox.nextRetryAt),
@@ -490,38 +498,94 @@ async function drainNextOutboxItem(
   });
 }
 
+async function drainEmailOutboxBatch(
+  db: Db,
+  context: EmailOutboxDrainContext,
+  signal: AbortSignal,
+  itemIds?: readonly string[],
+): Promise<number> {
+  let processed = 0;
+
+  for (let index = 0; index < MAX_OUTBOX_BATCH_SIZE; index++) {
+    signal.throwIfAborted();
+    const hadItem = await drainNextOutboxItem(
+      db,
+      context.currentTimeMs,
+      itemIds,
+    );
+    signal.throwIfAborted();
+    if (!hadItem) {
+      break;
+    }
+
+    processed++;
+    if (index < MAX_OUTBOX_BATCH_SIZE - 1) {
+      const delayMs = outboxDrainDelayMs();
+      if (delayMs > 0) {
+        await delay(delayMs, { signal });
+      }
+    }
+  }
+
+  if (processed > 0) {
+    log.debug("Drained emails from outbox", { processed });
+  }
+  return processed;
+}
+
 export const drainEmailOutboxBatch$ = command(
   async (
     { set },
     context: EmailOutboxDrainContext,
     signal: AbortSignal,
   ): Promise<number> => {
-    const db = set(writeDb$);
-    let processed = 0;
-
-    for (let index = 0; index < MAX_OUTBOX_BATCH_SIZE; index++) {
-      signal.throwIfAborted();
-      const hadItem = await drainNextOutboxItem(db, context.currentTimeMs);
-      signal.throwIfAborted();
-      if (!hadItem) {
-        break;
-      }
-
-      processed++;
-      if (index < MAX_OUTBOX_BATCH_SIZE - 1) {
-        const delayMs = outboxDrainDelayMs();
-        if (delayMs > 0) {
-          await delay(delayMs, { signal });
-        }
-      }
-    }
-
-    if (processed > 0) {
-      log.debug("Drained emails from outbox", { processed });
-    }
-    return processed;
+    return await drainEmailOutboxBatch(set(writeDb$), context, signal);
   },
 );
+
+export const drainEmailOutboxItems$ = command(
+  async (
+    { set },
+    context: EmailOutboxItemsContext,
+    signal: AbortSignal,
+  ): Promise<number> => {
+    return await drainEmailOutboxBatch(
+      set(writeDb$),
+      context,
+      signal,
+      context.itemIds,
+    );
+  },
+);
+
+async function cleanupExpiredEmailOutbox(
+  db: Db,
+  context: EmailOutboxDrainContext,
+  signal: AbortSignal,
+  itemIds?: readonly string[],
+): Promise<number> {
+  const cutoff = new Date(context.currentTimeMs - OUTBOX_TTL_MS);
+  const deleted = await db
+    .delete(emailOutbox)
+    .where(
+      and(
+        itemIds === undefined
+          ? undefined
+          : inArray(emailOutbox.id, [...itemIds]),
+        lt(emailOutbox.createdAt, cutoff),
+        or(eq(emailOutbox.status, "pending"), eq(emailOutbox.status, "failed")),
+      ),
+    )
+    .returning({ id: emailOutbox.id });
+  signal.throwIfAborted();
+
+  if (deleted.length > 0) {
+    log.debug("Cleaned up expired email outbox items", {
+      cleaned: deleted.length,
+    });
+  }
+  return deleted.length;
+}
 
 export const cleanupExpiredEmailOutbox$ = command(
   async (
@@ -529,28 +593,22 @@ export const cleanupExpiredEmailOutbox$ = command(
     context: EmailOutboxDrainContext,
     signal: AbortSignal,
   ): Promise<number> => {
-    const db = set(writeDb$);
-    const cutoff = new Date(context.currentTimeMs - OUTBOX_TTL_MS);
-    const deleted = await db
-      .delete(emailOutbox)
-      .where(
-        and(
-          lt(emailOutbox.createdAt, cutoff),
-          or(
-            eq(emailOutbox.status, "pending"),
-            eq(emailOutbox.status, "failed"),
-          ),
-        ),
-      )
-      .returning({ id: emailOutbox.id });
-    signal.throwIfAborted();
+    return await cleanupExpiredEmailOutbox(set(writeDb$), context, signal);
+  },
+);
 
-    if (deleted.length > 0) {
-      log.debug("Cleaned up expired email outbox items", {
-        cleaned: deleted.length,
-      });
-    }
-    return deleted.length;
+export const cleanupExpiredEmailOutboxItems$ = command(
+  async (
+    { set },
+    context: EmailOutboxItemsContext,
+    signal: AbortSignal,
+  ): Promise<number> => {
+    return await cleanupExpiredEmailOutbox(
+      set(writeDb$),
+      context,
+      signal,
+      context.itemIds,
+    );
   },
 );
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -354,6 +354,20 @@ export {
   type TestMailDraftStateContract,
 } from "./test-mail-draft-state";
 export {
+  testEmailOutboxStateActionBodySchema,
+  testEmailOutboxStateActionResponseSchema,
+  testEmailOutboxStateCleanupBodySchema,
+  testEmailOutboxStateCleanupResponseSchema,
+  testEmailOutboxStateContract,
+  testEmailOutboxStateDrainBodySchema,
+  testEmailOutboxStateDrainResponseSchema,
+  testEmailOutboxStateItemSchema,
+  type TestEmailOutboxStateActionBody,
+  type TestEmailOutboxStateActionResponse,
+  type TestEmailOutboxStateContract,
+  type TestEmailOutboxStateItem,
+} from "./test-email-outbox-state";
+export {
   testUsageStateActionBodySchema,
   testUsageStateActionResponseSchema,
   testUsageStateContract,

--- a/turbo/packages/api-contracts/src/contracts/test-email-outbox-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-email-outbox-state.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+const emailOutboxItemIdListSchema = z.array(z.string().uuid()).min(1);
+const emailOutboxItemStatusSchema = z.enum([
+  "pending",
+  "sending",
+  "sent",
+  "failed",
+]);
+
+export const testEmailOutboxStateItemSchema = z.object({
+  id: z.string().uuid(),
+  status: emailOutboxItemStatusSchema,
+  attempts: z.number().int().nonnegative(),
+  resend_id: z.string().nullable(),
+});
+
+export const testEmailOutboxStateActionBodySchema = z.discriminatedUnion(
+  "action",
+  [
+    z.object({
+      action: z.literal("seed-item"),
+      to_address: z.string().min(1),
+      subject: z.string().min(1),
+      status: z.enum(["pending", "failed"]),
+      created_at: z.iso.datetime(),
+    }),
+    z.object({
+      action: z.literal("find-item"),
+      to_address: z.string().min(1),
+      subject: z.string().min(1),
+    }),
+    z.object({
+      action: z.literal("read-items"),
+      item_ids: emailOutboxItemIdListSchema,
+    }),
+    z.object({
+      action: z.literal("delete-items"),
+      item_ids: emailOutboxItemIdListSchema,
+    }),
+  ],
+);
+
+export const testEmailOutboxStateActionResponseSchema = z.discriminatedUnion(
+  "action",
+  [
+    z.object({
+      action: z.literal("seed-item"),
+      item: testEmailOutboxStateItemSchema,
+    }),
+    z.object({
+      action: z.literal("find-item"),
+      items: z.array(testEmailOutboxStateItemSchema),
+    }),
+    z.object({
+      action: z.literal("read-items"),
+      items: z.array(testEmailOutboxStateItemSchema),
+    }),
+    z.object({
+      action: z.literal("delete-items"),
+      deleted: z.number().int().nonnegative(),
+    }),
+  ],
+);
+
+export const testEmailOutboxStateDrainBodySchema = z.object({
+  item_ids: emailOutboxItemIdListSchema,
+});
+
+export const testEmailOutboxStateDrainResponseSchema = z.object({
+  drained: z.number().int().nonnegative(),
+});
+
+export const testEmailOutboxStateCleanupBodySchema = z.object({
+  item_ids: emailOutboxItemIdListSchema,
+});
+
+export const testEmailOutboxStateCleanupResponseSchema = z.object({
+  cleaned: z.number().int().nonnegative(),
+});
+
+export const testEmailOutboxStateContract = c.router({
+  action: {
+    method: "POST",
+    path: "/api/test/email-outbox-state/action",
+    body: testEmailOutboxStateActionBodySchema,
+    responses: {
+      200: testEmailOutboxStateActionResponseSchema,
+      404: z.string(),
+    },
+    summary: "Mutate and read email outbox API test support state",
+  },
+  drain: {
+    method: "POST",
+    path: "/api/test/email-outbox-state/drain",
+    body: testEmailOutboxStateDrainBodySchema,
+    responses: {
+      200: testEmailOutboxStateDrainResponseSchema,
+      404: z.string(),
+    },
+    summary: "Drain selected email outbox items in API tests",
+  },
+  cleanup: {
+    method: "POST",
+    path: "/api/test/email-outbox-state/cleanup",
+    body: testEmailOutboxStateCleanupBodySchema,
+    responses: {
+      200: testEmailOutboxStateCleanupResponseSchema,
+      404: z.string(),
+    },
+    summary: "Clean up selected expired email outbox items in API tests",
+  },
+});
+
+export type TestEmailOutboxStateItem = z.infer<
+  typeof testEmailOutboxStateItemSchema
+>;
+export type TestEmailOutboxStateActionBody = z.infer<
+  typeof testEmailOutboxStateActionBodySchema
+>;
+export type TestEmailOutboxStateActionResponse = z.infer<
+  typeof testEmailOutboxStateActionResponseSchema
+>;
+export type TestEmailOutboxStateContract = typeof testEmailOutboxStateContract;


### PR DESCRIPTION
## Summary

- add ID-scoped email outbox drain and TTL cleanup commands while preserving the global production cron path
- expose a guarded test-only contract, route, and helper for explicitly owned outbox fixtures
- cover strict unrelated-row sentinels and concurrent row locking with `SKIP LOCKED`

## Validation

- `pnpm format` — passed
- `pnpm turbo run lint --concurrency=1 --log-order grouped` — 13/13 tasks passed; API lint reported 0 errors
- `pnpm knip` — passed
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'` — 12/12 tasks passed
- `pnpm --filter @vm0/app run check-types` — passed
- `pnpm --filter api run check-types` — passed, including boundary checks
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts` — 1 file, 2 tests passed
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/run-cron.bdd.test.ts` — 1 file, 11 tests passed

The full local Vitest suite was intentionally not run; repository-wide coverage is delegated to the PR pipeline.

Closes #26581

Part of #26569
