### PR TITLE
refactor(chat): remove active input rollout compatibility

### DIFF
--- a/crates/api-contracts/src/generated/routes.rs
+++ b/crates/api-contracts/src/generated/routes.rs
@@ -99,69 +99,6 @@ pub mod runners {
         pub mod by_run_id {
             /// Generated route bindings under `runners::runs::by_run_id::active_inputs`.
             pub mod active_inputs {
-                /// List pending input prompts for a running agent run.
-                /// Route contract: `GET /api/runners/runs/:runId/active-inputs`.
-                pub const LIST: crate::RouteTemplate = crate::RouteTemplate {
-                    method: crate::Method::Get,
-                    path: "/api/runners/runs/:runId/active-inputs",
-                };
-
-                /// Path parameters for `GET /api/runners/runs/:runId/active-inputs`.
-                #[derive(Debug, Clone, Copy)]
-                pub struct Params<'a> {
-                    /// Value for the `:runId` path parameter.
-                    pub run_id: &'a str,
-                }
-
-                /// Build the concrete path for `GET /api/runners/runs/:runId/active-inputs`.
-                /// Percent-encodes each path parameter as a URL path segment.
-                #[must_use]
-                pub fn path(params: Params<'_>) -> String {
-                    format!(
-                        "/api/runners/runs/{}/active-inputs",
-                        crate::route::encode_path_segment(params.run_id),
-                    )
-                }
-
-                /// Build a resolved route for `GET /api/runners/runs/:runId/active-inputs`.
-                #[must_use]
-                pub fn route(params: Params<'_>) -> crate::ResolvedRoute {
-                    crate::ResolvedRoute::new(LIST.method, path(params))
-                }
-
-                /// Generated route bindings under `runners::runs::by_run_id::active_inputs::claim`.
-                pub mod claim {
-                    /// Claim pending input prompts for a running agent run.
-                    /// Route contract: `POST /api/runners/runs/:runId/active-inputs/claim`.
-                    pub const CLAIM: crate::RouteTemplate = crate::RouteTemplate {
-                        method: crate::Method::Post,
-                        path: "/api/runners/runs/:runId/active-inputs/claim",
-                    };
-
-                    /// Path parameters for `POST /api/runners/runs/:runId/active-inputs/claim`.
-                    #[derive(Debug, Clone, Copy)]
-                    pub struct Params<'a> {
-                        /// Value for the `:runId` path parameter.
-                        pub run_id: &'a str,
-                    }
-
-                    /// Build the concrete path for `POST /api/runners/runs/:runId/active-inputs/claim`.
-                    /// Percent-encodes each path parameter as a URL path segment.
-                    #[must_use]
-                    pub fn path(params: Params<'_>) -> String {
-                        format!(
-                            "/api/runners/runs/{}/active-inputs/claim",
-                            crate::route::encode_path_segment(params.run_id),
-                        )
-                    }
-
-                    /// Build a resolved route for `POST /api/runners/runs/:runId/active-inputs/claim`.
-                    #[must_use]
-                    pub fn route(params: Params<'_>) -> crate::ResolvedRoute {
-                        crate::ResolvedRoute::new(CLAIM.method, path(params))
-                    }
-                }
-
                 /// Generated route bindings under `runners::runs::by_run_id::active_inputs::deliveries`.
                 pub mod deliveries {
                     /// Generated route bindings under `runners::runs::by_run_id::active_inputs::deliveries::by_delivery_id`.

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, watch};
@@ -23,17 +23,16 @@ const ACTIVE_INPUT_DELIVERY_ID_CAPACITY: usize =
 /// Accepted follow-up user input waiting for the CLI follow-up sink.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActiveInputFrame {
-    /// Deterministic vm0 frame UUID assigned to this active input.
+    /// Stable delivery ID used as the CLI frame UUID.
     pub uuid: String,
     /// Follow-up user text to deliver to the running CLI process.
     pub text: String,
-    delivery_id: Option<String>,
 }
 
 impl ActiveInputFrame {
-    /// Return the durable delivery identity when this is a new-protocol frame.
-    pub fn delivery_id(&self) -> Option<&str> {
-        self.delivery_id.as_deref()
+    /// Return the stable delivery identity.
+    pub fn delivery_id(&self) -> &str {
+        &self.uuid
     }
 }
 
@@ -79,7 +78,7 @@ enum PendingState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DurableDeliveryState {
+enum DeliveryState {
     Queued,
     Writing,
     Accepted,
@@ -107,9 +106,9 @@ struct PendingInput {
 }
 
 #[derive(Debug)]
-struct DurableDelivery {
+struct Delivery {
     text_digest: Option<[u8; 32]>,
-    state: DurableDeliveryState,
+    state: DeliveryState,
 }
 
 #[derive(Debug)]
@@ -117,10 +116,9 @@ struct ActiveInputState {
     lifecycle: Lifecycle,
     initial_prompt_replay_seen: bool,
     observed_result: bool,
-    next_input_sequence: u64,
     pending_uuid_order: VecDeque<String>,
     pending_by_uuid: HashMap<String, PendingInput>,
-    durable_by_id: HashMap<String, DurableDelivery>,
+    deliveries_by_id: HashMap<String, Delivery>,
     accepted_delivery_ids: Vec<String>,
 }
 
@@ -130,22 +128,15 @@ impl Default for ActiveInputState {
             lifecycle: Lifecycle::Open,
             initial_prompt_replay_seen: false,
             observed_result: false,
-            next_input_sequence: 0,
             pending_uuid_order: VecDeque::new(),
             pending_by_uuid: HashMap::new(),
-            durable_by_id: HashMap::new(),
+            deliveries_by_id: HashMap::new(),
             accepted_delivery_ids: Vec::new(),
         }
     }
 }
 
 impl ActiveInputState {
-    fn allocate_active_input_uuid(&mut self, run_id: &str) -> String {
-        let sequence = self.next_input_sequence;
-        self.next_input_sequence = self.next_input_sequence.saturating_add(1);
-        claude_active_input_uuid(run_id, sequence)
-    }
-
     fn insert_pending(&mut self, uuid: String, input: PendingInput) {
         self.pending_uuid_order.push_back(uuid.clone());
         self.pending_by_uuid.insert(uuid, input);
@@ -249,15 +240,19 @@ impl ActiveInputState {
 
 #[derive(Debug)]
 struct ActiveInputInner {
-    enabled: bool,
-    run_id: String,
+    mode: ActiveInputMode,
     initial_prompt_uuid: String,
     initial_prompt_text: String,
     tx: mpsc::Sender<ActiveInputFrame>,
     close_tx: watch::Sender<bool>,
-    durable_in_flight_tx: watch::Sender<bool>,
-    receipts: Option<ActiveInputReceiptRuntime>,
+    sink_in_flight_tx: watch::Sender<bool>,
     state: Mutex<ActiveInputState>,
+}
+
+#[derive(Debug)]
+enum ActiveInputMode {
+    Disabled,
+    Enabled(ActiveInputReceiptRuntime),
 }
 
 /// Cloneable control-plane side of active input for one guest-agent run.
@@ -298,21 +293,9 @@ pub struct ActiveInputRuntime {
 struct ActiveInputPayload {
     #[serde(rename = "type")]
     payload_type: String,
-    // Optional until #26060 switches every Runner sender to identified delivery.
-    #[serde(
-        default,
-        rename = "deliveryId",
-        deserialize_with = "deserialize_delivery_id"
-    )]
-    delivery_id: Option<String>,
+    #[serde(rename = "deliveryId")]
+    delivery_id: String,
     text: String,
-}
-
-fn deserialize_delivery_id<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    String::deserialize(deserializer).map(Some)
 }
 
 /// Derives the deterministic Claude user-frame UUID for the run's initial prompt.
@@ -326,14 +309,6 @@ pub fn claude_initial_prompt_uuid(run_id: &str) -> String {
     Uuid::new_v5(
         &Uuid::NAMESPACE_OID,
         format!("vm0:{run_id}:claude-initial-prompt").as_bytes(),
-    )
-    .to_string()
-}
-
-fn claude_active_input_uuid(run_id: &str, sequence: u64) -> String {
-    Uuid::new_v5(
-        &Uuid::NAMESPACE_OID,
-        format!("vm0:{run_id}:claude-active-input:{sequence}").as_bytes(),
     )
     .to_string()
 }
@@ -408,25 +383,18 @@ impl ActiveInputRuntime {
     /// The paired writer still exists so the CLI execution path can use the
     /// same ownership and shutdown flow as enabled runs, but no follow-up frames
     /// will be accepted from the process-control side.
-    pub fn new_disabled(run_id: &str) -> Self {
-        Self::new_with_initial_prompt(run_id, false, "")
+    pub fn new_disabled(run_id: &str, initial_prompt_text: &str) -> Self {
+        Self::new_internal(
+            run_id,
+            initial_prompt_text,
+            ActiveInputMode::Disabled,
+            Vec::new(),
+        )
     }
 
-    /// Creates the controller/writer pair for one guest-agent run.
-    ///
-    /// When `enabled` is `false`, control payloads are rejected while the writer
-    /// can still be closed through the normal CLI lifecycle. When `enabled` is
-    /// `true`, accepted active-input frames are queued for the single writer.
-    /// `initial_prompt_text` is retained for replay filtering when CLI stdout
-    /// emits a prompt-like user event without the expected initial-prompt UUID.
-    pub fn new_with_initial_prompt(run_id: &str, enabled: bool, initial_prompt_text: &str) -> Self {
-        Self::new_internal(run_id, enabled, initial_prompt_text, None, Vec::new())
-    }
-
-    /// Create an active-input runtime with durable acceptance receipts.
+    /// Create an active-input runtime with acceptance receipts.
     pub fn new_with_receipts(
         run_id: &str,
-        enabled: bool,
         initial_prompt_text: &str,
         receipt_journal_path: impl AsRef<Path>,
         http: HttpClient,
@@ -435,44 +403,52 @@ impl ActiveInputRuntime {
             ActiveInputReceiptRuntime::start(run_id, receipt_journal_path, http)?;
         Ok(Self::new_internal(
             run_id,
-            enabled,
             initial_prompt_text,
-            Some(receipts),
+            ActiveInputMode::Enabled(receipts),
             recovered_delivery_ids,
         ))
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_for_test(run_id: &str, initial_prompt_text: &str) -> Self {
+        let (receipts, recovered_delivery_ids) = ActiveInputReceiptRuntime::start_for_test(run_id)
+            .expect("test receipt runtime should start");
+        Self::new_internal(
+            run_id,
+            initial_prompt_text,
+            ActiveInputMode::Enabled(receipts),
+            recovered_delivery_ids,
+        )
+    }
+
     fn new_internal(
         run_id: &str,
-        enabled: bool,
         initial_prompt_text: &str,
-        receipts: Option<ActiveInputReceiptRuntime>,
+        mode: ActiveInputMode,
         recovered_delivery_ids: Vec<String>,
     ) -> Self {
         let (tx, rx) = mpsc::channel(ACTIVE_INPUT_QUEUE_CAPACITY);
         let (close_tx, close_rx) = watch::channel(false);
-        let (durable_in_flight_tx, _) = watch::channel(false);
+        let (sink_in_flight_tx, _) = watch::channel(false);
         let mut state = ActiveInputState::default();
         for delivery_id in recovered_delivery_ids {
-            state.durable_by_id.insert(
+            state.deliveries_by_id.insert(
                 delivery_id.clone(),
-                DurableDelivery {
+                Delivery {
                     text_digest: None,
-                    state: DurableDeliveryState::Accepted,
+                    state: DeliveryState::Accepted,
                 },
             );
             state.accepted_delivery_ids.push(delivery_id);
         }
         let controller = ActiveInputController {
             inner: Arc::new(ActiveInputInner {
-                enabled,
-                run_id: run_id.to_owned(),
+                mode,
                 initial_prompt_uuid: claude_initial_prompt_uuid(run_id),
                 initial_prompt_text: initial_prompt_text.to_owned(),
                 tx,
                 close_tx,
-                durable_in_flight_tx,
-                receipts,
+                sink_in_flight_tx,
                 state: Mutex::new(state),
             }),
         };
@@ -510,15 +486,15 @@ impl ActiveInputController {
     /// input instead of queueing frames. Enabled runs may still reject payloads
     /// later if active input has closed or the bounded backlog is full.
     pub fn is_enabled(&self) -> bool {
-        self.inner.enabled
+        matches!(self.inner.mode, ActiveInputMode::Enabled(_))
     }
 
     /// Validates and queues one process-control active-input payload.
     ///
-    /// `payload` must be a JSON object with the required string fields `type`
-    /// and `text`. `type` must equal `active-input`, and `text` must be non-empty.
-    /// A canonical UUID `deliveryId` opts into durable deduplication and
-    /// backend-acceptance receipts:
+    /// `payload` must be a JSON object with the required string fields `type`,
+    /// `deliveryId`, and `text`. `type` must equal `active-input`, `deliveryId`
+    /// must be a canonical UUID, and `text` must be non-empty. The delivery ID
+    /// provides durable deduplication and backend-acceptance receipts:
     ///
     /// ```json
     /// {"type":"active-input","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":"follow-up prompt"}
@@ -532,11 +508,11 @@ impl ActiveInputController {
     /// backpressure from validation rejection. Callers should branch on the
     /// outcome variant rather than treating diagnostic text as a stable protocol.
     pub fn handle_control_payload(&self, payload: &[u8]) -> ActiveInputControlOutcome {
-        if !self.inner.enabled {
+        let ActiveInputMode::Enabled(_) = &self.inner.mode else {
             return ActiveInputControlOutcome::Rejected {
                 diagnostic: "active input is not supported for this agent",
             };
-        }
+        };
         let payload = match serde_json::from_slice::<ActiveInputPayload>(payload) {
             Ok(payload) => payload,
             Err(_) => {
@@ -557,50 +533,39 @@ impl ActiveInputController {
         }
 
         let text = payload.text;
-        let delivery = match payload.delivery_id {
-            Some(delivery_id) => {
-                let Ok(parsed) = Uuid::parse_str(&delivery_id) else {
-                    return ActiveInputControlOutcome::Rejected {
-                        diagnostic: "active input delivery id is invalid",
-                    };
-                };
-                let canonical_delivery_id = parsed.hyphenated().to_string();
-                if canonical_delivery_id != delivery_id {
-                    return ActiveInputControlOutcome::Rejected {
-                        diagnostic: "active input delivery id is not canonical",
-                    };
-                }
-                if self.inner.receipts.is_none() {
-                    return ActiveInputControlOutcome::Rejected {
-                        diagnostic: "active input receipt persistence is unavailable",
-                    };
-                }
-                Some((canonical_delivery_id, active_input_text_digest(&text)))
-            }
-            None => None,
+        let delivery_id = payload.delivery_id;
+        let Ok(parsed) = Uuid::parse_str(&delivery_id) else {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input delivery id is invalid",
+            };
         };
+        let canonical_delivery_id = parsed.hyphenated().to_string();
+        if canonical_delivery_id != delivery_id {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input delivery id is not canonical",
+            };
+        }
+        let text_digest = active_input_text_digest(&text);
 
         let mut state = self
             .inner
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        if let Some((delivery_id, text_digest)) = &delivery
-            && let Some(existing) = state.durable_by_id.get(delivery_id)
-        {
+        if let Some(existing) = state.deliveries_by_id.get(&delivery_id) {
             if existing
                 .text_digest
-                .is_some_and(|existing_digest| existing_digest != *text_digest)
+                .is_some_and(|existing_digest| existing_digest != text_digest)
             {
                 return ActiveInputControlOutcome::Rejected {
                     diagnostic: "active input delivery id was reused with different text",
                 };
             }
             return match existing.state {
-                DurableDeliveryState::Queued
-                | DurableDeliveryState::Writing
-                | DurableDeliveryState::Accepted => ActiveInputControlOutcome::Accepted,
-                DurableDeliveryState::Failed => ActiveInputControlOutcome::Rejected {
+                DeliveryState::Queued | DeliveryState::Writing | DeliveryState::Accepted => {
+                    ActiveInputControlOutcome::Accepted
+                }
+                DeliveryState::Failed => ActiveInputControlOutcome::Rejected {
                     diagnostic: "active input delivery previously failed",
                 },
             };
@@ -610,7 +575,7 @@ impl ActiveInputController {
                 diagnostic: "active input is closed",
             };
         }
-        if delivery.is_some() && state.durable_by_id.len() >= ACTIVE_INPUT_DELIVERY_ID_CAPACITY {
+        if state.deliveries_by_id.len() >= ACTIVE_INPUT_DELIVERY_ID_CAPACITY {
             return ActiveInputControlOutcome::QueueFull {
                 diagnostic: "active input delivery backlog is full",
             };
@@ -621,14 +586,10 @@ impl ActiveInputController {
             };
         }
 
-        let uuid = delivery.as_ref().map_or_else(
-            || state.allocate_active_input_uuid(&self.inner.run_id),
-            |value| value.0.clone(),
-        );
+        let uuid = delivery_id.clone();
         let frame = ActiveInputFrame {
             uuid: uuid.clone(),
             text: text.clone(),
-            delivery_id: delivery.as_ref().map(|value| value.0.clone()),
         };
         state.insert_pending(
             uuid.clone(),
@@ -637,32 +598,26 @@ impl ActiveInputController {
                 text,
             },
         );
-        if let Some((delivery_id, text_digest)) = delivery {
-            state.durable_by_id.insert(
-                delivery_id,
-                DurableDelivery {
-                    text_digest: Some(text_digest),
-                    state: DurableDeliveryState::Queued,
-                },
-            );
-        }
+        state.deliveries_by_id.insert(
+            delivery_id,
+            Delivery {
+                text_digest: Some(text_digest),
+                state: DeliveryState::Queued,
+            },
+        );
 
         match self.inner.tx.try_send(frame) {
             Ok(()) => ActiveInputControlOutcome::Accepted,
             Err(mpsc::error::TrySendError::Full(frame)) => {
                 state.remove_pending_by_uuid(&frame.uuid);
-                if let Some(delivery_id) = frame.delivery_id() {
-                    state.durable_by_id.remove(delivery_id);
-                }
+                state.deliveries_by_id.remove(frame.delivery_id());
                 ActiveInputControlOutcome::QueueFull {
                     diagnostic: "active input queue is full",
                 }
             }
             Err(mpsc::error::TrySendError::Closed(frame)) => {
                 state.remove_pending_by_uuid(&frame.uuid);
-                if let Some(delivery_id) = frame.delivery_id() {
-                    state.durable_by_id.remove(delivery_id);
-                }
+                state.deliveries_by_id.remove(frame.delivery_id());
                 state.lifecycle = Lifecycle::Closed;
                 ActiveInputControlOutcome::Rejected {
                     diagnostic: "active input is closed",
@@ -671,47 +626,13 @@ impl ActiveInputController {
         }
     }
 
-    /// Marks a legacy writer-owned frame as delivered to its follow-up sink.
-    ///
-    /// Writers should call this only for frames without a durable delivery ID.
-    /// Delivery-identified frames must use the backend-acceptance methods so
-    /// their acceptance is persisted before replay cleanup. For legacy frames,
-    /// this mark lets replay filtering later match the CLI's echoed user event,
-    /// or finish cleanup if a uuidless replay was already observed. Unknown
-    /// UUIDs are ignored.
-    pub fn mark_written(&self, uuid: &str) {
-        self.inner
-            .state
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .mark_pending_written(uuid);
-    }
-
-    /// Mark a writer-owned frame delivered by a sink that will not emit a
-    /// replayed user event back through CLI stdout.
-    fn mark_written_without_replay(&self, uuid: &str) {
-        let mut state = self
-            .inner
-            .state
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        state.remove_pending_by_uuid(uuid);
-    }
-
     fn mark_backend_accepted(
         &self,
         frame: &ActiveInputFrame,
         expects_replay: bool,
     ) -> Result<(), AgentError> {
-        let Some(delivery_id) = frame.delivery_id() else {
-            if expects_replay {
-                self.mark_written(&frame.uuid);
-            } else {
-                self.mark_written_without_replay(&frame.uuid);
-            }
-            return Ok(());
-        };
-        let Some(receipts) = self.inner.receipts.as_ref() else {
+        let delivery_id = frame.delivery_id();
+        let ActiveInputMode::Enabled(receipts) = &self.inner.mode else {
             self.mark_backend_failed(frame);
             return Err(AgentError::Execution(
                 "active-input receipt persistence is unavailable".to_string(),
@@ -727,12 +648,12 @@ impl ActiveInputController {
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        let delivery = state.durable_by_id.get_mut(delivery_id).ok_or_else(|| {
+        let delivery = state.deliveries_by_id.get_mut(delivery_id).ok_or_else(|| {
             AgentError::Execution(
                 "accepted active-input delivery is missing from live state".to_string(),
             )
         })?;
-        delivery.state = DurableDeliveryState::Accepted;
+        delivery.state = DeliveryState::Accepted;
         if !state
             .accepted_delivery_ids
             .iter()
@@ -746,25 +667,23 @@ impl ActiveInputController {
             state.remove_pending_by_uuid(&frame.uuid);
         }
         drop(state);
-        self.inner.durable_in_flight_tx.send_replace(false);
+        self.inner.sink_in_flight_tx.send_replace(false);
         Ok(())
     }
 
     fn mark_backend_failed(&self, frame: &ActiveInputFrame) {
-        let Some(delivery_id) = frame.delivery_id() else {
-            return;
-        };
+        let delivery_id = frame.delivery_id();
         let mut state = self
             .inner
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        if let Some(delivery) = state.durable_by_id.get_mut(delivery_id) {
-            delivery.state = DurableDeliveryState::Failed;
+        if let Some(delivery) = state.deliveries_by_id.get_mut(delivery_id) {
+            delivery.state = DeliveryState::Failed;
         }
         state.remove_pending_by_uuid(&frame.uuid);
         drop(state);
-        self.inner.durable_in_flight_tx.send_replace(false);
+        self.inner.sink_in_flight_tx.send_replace(false);
     }
 
     /// Marks a writer-owned frame as actively being delivered.
@@ -785,37 +704,37 @@ impl ActiveInputController {
         {
             input.state = PendingState::Writing;
         }
-        let durable_writing = if let Some(delivery) = state.durable_by_id.get_mut(uuid) {
-            delivery.state = DurableDeliveryState::Writing;
+        let delivery_writing = if let Some(delivery) = state.deliveries_by_id.get_mut(uuid) {
+            delivery.state = DeliveryState::Writing;
             true
         } else {
             false
         };
         drop(state);
-        if durable_writing {
-            self.inner.durable_in_flight_tx.send_replace(true);
+        if delivery_writing {
+            self.inner.sink_in_flight_tx.send_replace(true);
         }
     }
 
-    /// Return whether any delivery-identified input participated in this run.
-    pub fn has_durable_activity(&self) -> bool {
+    /// Return whether any active input participated in this run.
+    pub fn has_activity(&self) -> bool {
         !self
             .inner
             .state
             .lock()
             .unwrap_or_else(|error| error.into_inner())
-            .durable_by_id
+            .deliveries_by_id
             .is_empty()
     }
 
-    /// Return whether a delivery-identified sink operation is in flight.
-    pub fn durable_sink_in_flight(&self) -> bool {
-        *self.inner.durable_in_flight_tx.borrow()
+    /// Return whether an active-input sink operation is in flight.
+    pub fn sink_in_flight(&self) -> bool {
+        *self.inner.sink_in_flight_tx.borrow()
     }
 
-    /// Wait until the current delivery-identified sink operation settles.
-    pub async fn wait_for_durable_sink_idle(&self) -> Result<(), AgentError> {
-        let mut receiver = self.inner.durable_in_flight_tx.subscribe();
+    /// Wait until the current active-input sink operation settles.
+    pub async fn wait_for_sink_idle(&self) -> Result<(), AgentError> {
+        let mut receiver = self.inner.sink_in_flight_tx.subscribe();
         while *receiver.borrow() {
             receiver.changed().await.map_err(|_| {
                 AgentError::Execution(
@@ -828,8 +747,8 @@ impl ActiveInputController {
 
     /// Stop direct receipt delivery and return every backend-accepted ID.
     pub async fn finalize_receipts(&self) -> Result<Vec<String>, AgentError> {
-        let sink_in_flight = self.durable_sink_in_flight();
-        if let Some(receipts) = self.inner.receipts.as_ref() {
+        let sink_in_flight = self.sink_in_flight();
+        if let ActiveInputMode::Enabled(receipts) = &self.inner.mode {
             receipts.finalize().await;
         }
         if sink_in_flight {
@@ -855,7 +774,7 @@ impl ActiveInputController {
     ///
     /// This is a result-time idle check, not an unconditional terminal close.
     pub fn close_for_result_if_idle(&self) -> bool {
-        if !self.inner.enabled {
+        if !self.is_enabled() {
             return true;
         }
 
@@ -994,16 +913,6 @@ impl ActiveInputWriter {
         self.controller.is_enabled()
     }
 
-    /// Marks a legacy writer-owned frame as delivered.
-    ///
-    /// This delegates to [`ActiveInputController::mark_written`].
-    /// Delivery-identified frames must instead use
-    /// [`Self::mark_backend_accepted_with_replay`] or
-    /// [`Self::mark_backend_accepted_without_replay`].
-    pub fn mark_written(&self, uuid: &str) {
-        self.controller.mark_written(uuid);
-    }
-
     /// Persist backend acceptance for a sink whose user frame is replayed.
     pub fn mark_backend_accepted_with_replay(
         &self,
@@ -1020,22 +929,16 @@ impl ActiveInputWriter {
         self.controller.mark_backend_accepted(frame, false)
     }
 
-    /// Mark a delivery-identified sink operation as failed.
+    /// Mark an active-input sink operation as failed.
     pub fn mark_backend_failed(&self, frame: &ActiveInputFrame) {
         self.controller.mark_backend_failed(frame);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn mark_written_without_replay(&self, uuid: &str) {
-        self.controller.mark_written_without_replay(uuid);
     }
 
     /// Marks a writer-owned frame as actively being delivered by this writer.
     ///
     /// This delegates to [`ActiveInputController::mark_writing`]. After the sink
     /// settles, pair it with the matching backend-acceptance method or
-    /// [`Self::mark_backend_failed`]. Legacy-only callers may use
-    /// [`Self::mark_written`] after successful delivery.
+    /// [`Self::mark_backend_failed`].
     pub fn mark_writing(&self, uuid: &str) {
         self.controller.mark_writing(uuid);
     }

--- a/crates/guest-agent/src/active_input/tests.rs
+++ b/crates/guest-agent/src/active_input/tests.rs
@@ -9,27 +9,44 @@ fn enabled_runtime() -> ActiveInputRuntime {
 }
 
 fn enabled_runtime_with_initial_prompt(initial_prompt: &str) -> ActiveInputRuntime {
-    ActiveInputRuntime::new_with_initial_prompt(TEST_RUN_ID, true, initial_prompt)
+    ActiveInputRuntime::new_for_test(TEST_RUN_ID, initial_prompt)
 }
 
-fn active_input_payload(text: &str) -> Vec<u8> {
+fn active_input_uuid(sequence: u64) -> String {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("vm0:{TEST_RUN_ID}:active-input-test:{sequence}").as_bytes(),
+    )
+    .to_string()
+}
+
+fn active_input_payload(sequence: u64, text: &str) -> Vec<u8> {
     serde_json::to_vec(&json!({
         "type": ACTIVE_INPUT_TYPE,
+        "deliveryId": active_input_uuid(sequence),
         "text": text,
     }))
     .expect("active input payload should serialize")
 }
 
-fn active_input_uuid(sequence: u64) -> String {
-    claude_active_input_uuid(TEST_RUN_ID, sequence)
-}
-
 fn accept_active_input(controller: &ActiveInputController, sequence: u64, text: &str) -> String {
     assert_eq!(
-        controller.handle_control_payload(&active_input_payload(text)),
+        controller.handle_control_payload(&active_input_payload(sequence, text)),
         ActiveInputControlOutcome::Accepted
     );
     active_input_uuid(sequence)
+}
+
+fn mark_accepted(controller: &ActiveInputController, uuid: &str, expects_replay: bool) {
+    controller
+        .mark_backend_accepted(
+            &ActiveInputFrame {
+                uuid: uuid.to_owned(),
+                text: String::new(),
+            },
+            expects_replay,
+        )
+        .expect("test receipt acceptance should persist");
 }
 
 fn user_event(uuid: &str, text: &str) -> Value {
@@ -81,11 +98,11 @@ fn active_input_accepts_each_valid_payload() {
     let controller = runtime.controller();
 
     assert_eq!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"hello"}"#),
+        controller.handle_control_payload(&active_input_payload(0, "hello")),
         ActiveInputControlOutcome::Accepted
     );
     assert_eq!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"hello again"}"#),
+        controller.handle_control_payload(&active_input_payload(1, "hello again")),
         ActiveInputControlOutcome::Accepted
     );
 }
@@ -99,6 +116,10 @@ fn active_input_rejects_invalid_payloads() {
         ("bad-json", br#"{"type":"active-input""#.as_slice()),
         ("bad-type", br#"{"type":"other","text":"hello"}"#.as_slice()),
         ("empty", br#"{"type":"active-input","text":""}"#.as_slice()),
+        ("missing-delivery-id", br#"{"type":"active-input","text":"hello"}"#.as_slice()),
+        ("null-delivery-id", br#"{"type":"active-input","deliveryId":null,"text":"hello"}"#.as_slice()),
+        ("malformed-delivery-id", br#"{"type":"active-input","deliveryId":"invalid","text":"hello"}"#.as_slice()),
+        ("noncanonical-delivery-id", br#"{"type":"active-input","deliveryId":"223F8797-A456-4EEA-98F7-F7AB88C43C00","text":"hello"}"#.as_slice()),
     ] {
         assert!(
             matches!(
@@ -112,7 +133,7 @@ fn active_input_rejects_invalid_payloads() {
 
 #[test]
 fn active_input_rejects_when_disabled_or_closed() {
-    let disabled = ActiveInputRuntime::new_disabled("run-1");
+    let disabled = ActiveInputRuntime::new_disabled("run-1", "initial");
     assert!(matches!(
         disabled
             .controller()
@@ -125,7 +146,7 @@ fn active_input_rejects_when_disabled_or_closed() {
     let controller = runtime.controller();
     assert!(controller.close_for_result_if_idle());
     assert!(matches!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"hello"}"#),
+        controller.handle_control_payload(&active_input_payload(0, "hello")),
         ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
     ));
 }
@@ -135,15 +156,15 @@ fn active_input_capacity_counts_pending_inputs() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
 
-    for _ in 0..ACTIVE_INPUT_QUEUE_CAPACITY {
+    for index in 0..ACTIVE_INPUT_QUEUE_CAPACITY {
         assert_eq!(
-            controller.handle_control_payload(br#"{"type":"active-input","text":"hello"}"#),
+            controller.handle_control_payload(&active_input_payload(index as u64, "hello")),
             ActiveInputControlOutcome::Accepted
         );
     }
 
     assert!(matches!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"hello"}"#),
+        controller.handle_control_payload(&active_input_payload(100, "hello")),
         ActiveInputControlOutcome::QueueFull { diagnostic } if diagnostic == "active input queue is full"
     ));
 }
@@ -154,9 +175,9 @@ async fn active_input_can_release_capacity_for_sink_without_replay() {
     let controller = runtime.controller();
     let mut writer = runtime.into_writer();
 
-    for _ in 0..ACTIVE_INPUT_QUEUE_CAPACITY {
+    for index in 0..ACTIVE_INPUT_QUEUE_CAPACITY {
         assert_eq!(
-            controller.handle_control_payload(br#"{"type":"active-input","text":"hello"}"#),
+            controller.handle_control_payload(&active_input_payload(index as u64, "hello")),
             ActiveInputControlOutcome::Accepted
         );
         let frame = writer
@@ -164,12 +185,14 @@ async fn active_input_can_release_capacity_for_sink_without_replay() {
             .await
             .expect("active input frame should be queued");
         writer.mark_writing(&frame.uuid);
-        writer.mark_written_without_replay(&frame.uuid);
+        writer
+            .mark_backend_accepted_without_replay(&frame)
+            .expect("test receipt acceptance should persist");
         assert_not_pending(&controller, &frame.uuid);
     }
 
     assert_eq!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"next"}"#),
+        controller.handle_control_payload(&active_input_payload(100, "next")),
         ActiveInputControlOutcome::Accepted
     );
     let _frame = writer
@@ -193,7 +216,7 @@ fn replay_filter_consumes_initial_and_active_input_user_events() {
         controller.replay_user_event_action(&initial),
         ReplayUserEventAction::InternalInitialPrompt
     );
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let active = user_event(&active_uuid, "follow-up");
     assert_eq!(
@@ -278,7 +301,7 @@ fn replay_filter_consumes_matching_uuid_even_with_non_string_content() {
         controller.replay_user_event_action(&initial),
         ReplayUserEventAction::InternalInitialPrompt
     );
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let active = json!({
         "type": "user",
@@ -333,7 +356,7 @@ fn replay_filter_consumes_uuidless_active_input_replay_by_text() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
     assert!(!controller.close_for_result_if_idle());
 
     let event = uuidless_user_event("follow-up");
@@ -349,16 +372,16 @@ fn replay_filter_consumes_oldest_uuidless_text_match() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
 
-    for _ in ["msg-1", "msg-2"] {
+    for sequence in 0..2 {
         assert_eq!(
-            controller.handle_control_payload(br#"{"type":"active-input","text":"same-text"}"#),
+            controller.handle_control_payload(&active_input_payload(sequence, "same-text")),
             ActiveInputControlOutcome::Accepted
         );
     }
     let first_uuid = active_input_uuid(0);
     let second_uuid = active_input_uuid(1);
-    controller.mark_written(&first_uuid);
-    controller.mark_written(&second_uuid);
+    mark_accepted(&controller, &first_uuid, true);
+    mark_accepted(&controller, &second_uuid, true);
     assert!(!controller.close_for_result_if_idle());
 
     let event = uuidless_user_event("same-text");
@@ -391,7 +414,7 @@ fn replay_filter_defers_uuidless_text_match_while_writing_until_written() {
     );
     assert_pending(&controller, &active_uuid);
 
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
     assert!(controller.close_for_result_if_idle());
 }
 
@@ -400,12 +423,8 @@ fn replay_filter_clears_multiple_uuidless_writing_replays_after_writes() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
 
-    for (_, text) in [("msg-1", "first"), ("msg-2", "second")] {
-        let payload = serde_json::to_vec(&json!({
-            "type": ACTIVE_INPUT_TYPE,
-            "text": text,
-        }))
-        .expect("active input payload should serialize");
+    for (sequence, text) in [(0, "first"), (1, "second")] {
+        let payload = active_input_payload(sequence, text);
         assert_eq!(
             controller.handle_control_payload(&payload),
             ActiveInputControlOutcome::Accepted
@@ -425,14 +444,14 @@ fn replay_filter_clears_multiple_uuidless_writing_replays_after_writes() {
             controller.replay_user_event_action(&event),
             ReplayUserEventAction::InternalActiveInput
         );
-        controller.mark_written(uuid);
+        mark_accepted(&controller, uuid, true);
     }
 
     assert!(controller.close_for_result_if_idle());
 }
 
 #[test]
-fn followup_result_can_close_after_uuidless_replay_before_mark_written() {
+fn followup_result_can_close_after_uuidless_replay_before_backend_acceptance() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
@@ -446,9 +465,9 @@ fn followup_result_can_close_after_uuidless_replay_before_mark_written() {
     );
 
     assert!(controller.close_for_result_if_idle());
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
     assert!(matches!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"late"}"#),
+        controller.handle_control_payload(&active_input_payload(1, "late")),
         ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
     ));
 }
@@ -476,7 +495,7 @@ fn replay_filter_does_not_consume_unwritten_uuidless_text_match() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     assert_eq!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"same-text"}"#),
+        controller.handle_control_payload(&active_input_payload(0, "same-text")),
         ActiveInputControlOutcome::Accepted
     );
 
@@ -493,7 +512,7 @@ fn replay_filter_does_not_consume_uuidless_text_match_before_first_result() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "same-text");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let event = uuidless_user_event("same-text");
     assert_eq!(
@@ -508,12 +527,12 @@ fn followup_result_closes_writer_owned_pending_input_without_replay() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     assert!(!controller.close_for_result_if_idle());
     assert!(controller.close_for_result_if_idle());
     assert!(matches!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"late"}"#),
+        controller.handle_control_payload(&active_input_payload(1, "late")),
         ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
     ));
 }
@@ -523,16 +542,16 @@ fn followup_result_without_replay_completes_one_written_pending_input_at_a_time(
     let runtime = enabled_runtime();
     let controller = runtime.controller();
 
-    for _ in ["msg-1", "msg-2"] {
+    for sequence in 0..2 {
         assert_eq!(
-            controller.handle_control_payload(br#"{"type":"active-input","text":"follow-up"}"#),
+            controller.handle_control_payload(&active_input_payload(sequence, "follow-up")),
             ActiveInputControlOutcome::Accepted
         );
     }
     let first_uuid = active_input_uuid(0);
     let second_uuid = active_input_uuid(1);
-    controller.mark_written(&first_uuid);
-    controller.mark_written(&second_uuid);
+    mark_accepted(&controller, &first_uuid, true);
+    mark_accepted(&controller, &second_uuid, true);
 
     assert!(!controller.close_for_result_if_idle());
     assert!(!controller.close_for_result_if_idle());
@@ -546,15 +565,15 @@ fn followup_result_without_replay_keeps_later_unwritten_pending_input_open() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
 
-    for _ in ["msg-1", "msg-2"] {
+    for sequence in 0..2 {
         assert_eq!(
-            controller.handle_control_payload(br#"{"type":"active-input","text":"follow-up"}"#),
+            controller.handle_control_payload(&active_input_payload(sequence, "follow-up")),
             ActiveInputControlOutcome::Accepted
         );
     }
     let first_uuid = active_input_uuid(0);
     let second_uuid = active_input_uuid(1);
-    controller.mark_written(&first_uuid);
+    mark_accepted(&controller, &first_uuid, true);
 
     assert!(!controller.close_for_result_if_idle());
     assert!(!controller.close_for_result_if_idle());
@@ -562,7 +581,7 @@ fn followup_result_without_replay_keeps_later_unwritten_pending_input_open() {
     assert_pending(&controller, &second_uuid);
     assert!(!controller.close_for_result_if_idle());
 
-    controller.mark_written(&second_uuid);
+    mark_accepted(&controller, &second_uuid, true);
     assert!(controller.close_for_result_if_idle());
 }
 
@@ -575,7 +594,7 @@ fn followup_result_keeps_writing_pending_input_open_without_replay() {
 
     assert!(!controller.close_for_result_if_idle());
     assert!(!controller.close_for_result_if_idle());
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
     assert!(controller.close_for_result_if_idle());
 }
 
@@ -584,14 +603,14 @@ fn followup_result_keeps_unwritten_pending_input_open_without_replay() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     assert_eq!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"follow-up"}"#),
+        controller.handle_control_payload(&active_input_payload(0, "follow-up")),
         ActiveInputControlOutcome::Accepted
     );
 
     assert!(!controller.close_for_result_if_idle());
     assert!(!controller.close_for_result_if_idle());
     assert_eq!(
-        controller.handle_control_payload(br#"{"type":"active-input","text":"still-open"}"#),
+        controller.handle_control_payload(&active_input_payload(1, "still-open")),
         ActiveInputControlOutcome::Accepted
     );
 }
@@ -601,7 +620,7 @@ fn replay_filter_consumes_uuidless_text_match_after_initial_replay_before_first_
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let initial = uuidless_user_event("initial");
     assert_eq!(
@@ -622,7 +641,7 @@ fn replay_filter_does_not_consume_text_match_with_unknown_uuid() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
     assert!(!controller.close_for_result_if_idle());
 
     let unknown_uuid = json!({
@@ -648,7 +667,7 @@ fn replay_filter_does_not_consume_text_match_with_non_string_uuid() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
     assert!(!controller.close_for_result_if_idle());
 
     for uuid in [json!(123), Value::Null] {
@@ -676,7 +695,7 @@ fn replay_filter_does_not_unlock_initial_prompt_from_unknown_uuid() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let unknown_uuid_initial_text = json!({
         "type": "user",
@@ -717,7 +736,7 @@ fn replay_filter_does_not_unlock_initial_prompt_from_non_string_uuid() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let malformed_initial = json!({
         "type": "user",
@@ -754,7 +773,7 @@ fn replay_filter_waits_for_second_uuidless_same_text_before_first_result() {
     let runtime = enabled_runtime_with_initial_prompt("same-text");
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "same-text");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let initial = uuidless_user_event("same-text");
     assert_eq!(
@@ -775,7 +794,7 @@ fn replay_filter_consumes_uuidless_text_block_active_input_replay() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
     assert!(!controller.close_for_result_if_idle());
 
     let event = uuidless_text_block_user_event("follow-up");
@@ -815,7 +834,7 @@ fn replay_filter_keeps_non_user_role_events_external_without_advancing_prompt_re
     let runtime = enabled_runtime_with_initial_prompt("follow-up");
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let malformed = json!({
         "type": "user",
@@ -845,7 +864,7 @@ fn replay_filter_keeps_non_user_role_uuid_matches_external() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let malformed = json!({
         "type": "user",
@@ -874,7 +893,7 @@ fn replay_filter_keeps_non_string_role_events_external() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let malformed = json!({
         "type": "user",
@@ -903,7 +922,7 @@ fn replay_filter_keeps_child_user_events_external() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let child = json!({
         "type": "user",
@@ -934,7 +953,7 @@ fn replay_filter_does_not_unlock_uuidless_match_from_non_initial_prompt_like_eve
     let runtime = enabled_runtime();
     let controller = runtime.controller();
     let active_uuid = accept_active_input(&controller, 0, "follow-up");
-    controller.mark_written(&active_uuid);
+    mark_accepted(&controller, &active_uuid, true);
 
     let historical = uuidless_user_event("historical");
     assert_eq!(

--- a/crates/guest-agent/src/active_input_receipts.rs
+++ b/crates/guest-agent/src/active_input_receipts.rs
@@ -1,4 +1,4 @@
-//! Durable active-input acceptance persistence and direct receipt delivery.
+//! Active-input acceptance persistence and direct receipt delivery.
 
 use std::collections::HashSet;
 use std::io;
@@ -92,6 +92,8 @@ pub(crate) struct ActiveInputReceiptRuntime {
     upload_tx: mpsc::UnboundedSender<String>,
     finalize_tx: watch::Sender<bool>,
     worker: Mutex<Option<JoinHandle<()>>>,
+    #[cfg(test)]
+    _test_directory: Option<tempfile::TempDir>,
 }
 
 impl std::fmt::Debug for ActiveInputReceiptRuntime {
@@ -132,6 +134,31 @@ impl ActiveInputReceiptRuntime {
                 upload_tx,
                 finalize_tx,
                 worker: Mutex::new(Some(worker)),
+                #[cfg(test)]
+                _test_directory: None,
+            },
+            recovered,
+        ))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn start_for_test(run_id: &str) -> io::Result<(Self, Vec<String>)> {
+        let directory = tempfile::tempdir()?;
+        let journal = Arc::new(ReceiptJournal::load(
+            run_id,
+            directory.path().join("active-input-receipts.json"),
+        )?);
+        let recovered = journal.outstanding();
+        let (upload_tx, upload_rx) = mpsc::unbounded_channel();
+        drop(upload_rx);
+        let (finalize_tx, _) = watch::channel(false);
+        Ok((
+            Self {
+                journal,
+                upload_tx,
+                finalize_tx,
+                worker: Mutex::new(None),
+                _test_directory: Some(directory),
             },
             recovered,
         ))

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -119,7 +119,7 @@ where
     Run: Future<Output = Result<CliExecutionResult, AgentError>>,
 {
     active_input.close_terminal();
-    if !active_input.durable_sink_in_flight() {
+    if !active_input.sink_in_flight() {
         return stopped;
     }
 
@@ -127,7 +127,7 @@ where
         tokio::select! {
             biased;
             result = run.as_mut() => Ok(Some(result)),
-            idle = active_input.wait_for_durable_sink_idle() => idle.map(|()| None),
+            idle = active_input.wait_for_sink_idle() => idle.map(|()| None),
         }
     };
     match tokio::time::timeout(

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1454,7 +1454,7 @@ async fn execute_cli_inner(
                         LOG_TAG,
                         "Claude stdin writer finished after CLI loop with error: {error}"
                     );
-                    if active_input_controller.has_durable_activity() {
+                    if active_input_controller.has_activity() {
                         active_input_error = Some(error);
                     }
                 }
@@ -1463,14 +1463,14 @@ async fn execute_cli_inner(
                         LOG_TAG,
                         "Claude stdin writer failed after CLI loop: {error}"
                     );
-                    if active_input_controller.has_durable_activity() {
+                    if active_input_controller.has_activity() {
                         active_input_error = Some(AgentError::Execution(format!(
                             "Claude stdin writer task failed during active-input quiescence: {error}"
                         )));
                     }
                 }
             }
-        } else if active_input_controller.has_durable_activity() {
+        } else if active_input_controller.has_activity() {
             let mut handle = handle;
             match tokio::time::timeout(
                 Duration::from_secs(constants::ACTIVE_INPUT_SINK_QUIESCENCE_TIMEOUT_SECS),
@@ -2032,7 +2032,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn cli_exit_observation_distinguishes_stdout_drain_from_loop_completion() {
-        let active_input = ActiveInputRuntime::new_disabled("run-exit-observation");
+        let active_input = ActiveInputRuntime::new_disabled("run-exit-observation", "");
         let controller = active_input.controller();
         let termination_deadline = tokio::time::sleep(Duration::MAX);
         tokio::pin!(termination_deadline);

--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -349,6 +349,19 @@ mod tests {
 
     const CONTROL_TEST_READ_TIMEOUT: Duration = Duration::from_secs(3);
 
+    fn active_input_payload(sequence: u64) -> Vec<u8> {
+        let delivery_id = uuid::Uuid::new_v5(
+            &uuid::Uuid::NAMESPACE_OID,
+            format!("vm0:control-test:active-input:{sequence}").as_bytes(),
+        );
+        serde_json::to_vec(&serde_json::json!({
+            "type": "active-input",
+            "deliveryId": delivery_id.to_string(),
+            "text": "hello",
+        }))
+        .expect("active-input control payload should serialize")
+    }
+
     fn accept_control_stream_and_read_hello(
         listener: &std::os::unix::net::UnixListener,
     ) -> UnixStream {
@@ -369,11 +382,8 @@ mod tests {
         let shutdown = CancellationToken::new();
         let worker_shutdown = shutdown.clone();
         let stream_slot = Arc::new(Mutex::new(None));
-        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
-            "control-test",
-            true,
-            "initial",
-        );
+        let active_runtime =
+            crate::active_input::ActiveInputRuntime::new_for_test("control-test", "initial");
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
@@ -393,7 +403,7 @@ mod tests {
             &mut stream,
             &process_control_ipc::ControlRequest {
                 message_id: "msg-1".to_owned(),
-                payload: br#"{"type":"active-input","text":"hello"}"#.to_vec(),
+                payload: active_input_payload(0),
             },
         )
         .unwrap();
@@ -418,11 +428,8 @@ mod tests {
         let shutdown = CancellationToken::new();
         let worker_shutdown = shutdown.clone();
         let stream_slot = Arc::new(Mutex::new(None));
-        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
-            "control-test",
-            true,
-            "initial",
-        );
+        let active_runtime =
+            crate::active_input::ActiveInputRuntime::new_for_test("control-test", "initial");
         let active_input = active_runtime.controller();
         let cli_cancellation = CancellationToken::new();
         let worker_cli_cancellation = cli_cancellation.clone();
@@ -493,11 +500,8 @@ mod tests {
         let shutdown = CancellationToken::new();
         let worker_shutdown = shutdown.clone();
         let stream_slot = Arc::new(Mutex::new(None));
-        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
-            "control-test",
-            true,
-            "initial",
-        );
+        let active_runtime =
+            crate::active_input::ActiveInputRuntime::new_for_test("control-test", "initial");
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
@@ -517,7 +521,7 @@ mod tests {
             &mut stream,
             &process_control_ipc::ControlRequest {
                 message_id: "bad-1".to_owned(),
-                payload: br#"{"type":"other","text":"hello"}"#.to_vec(),
+                payload: br#"{"type":"other","deliveryId":"00000000-0000-4000-8000-000000000001","text":"hello"}"#.to_vec(),
             },
         )
         .unwrap();
@@ -546,11 +550,8 @@ mod tests {
         let shutdown = CancellationToken::new();
         let worker_shutdown = shutdown.clone();
         let stream_slot = Arc::new(Mutex::new(None));
-        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
-            "control-test",
-            true,
-            "initial",
-        );
+        let active_runtime =
+            crate::active_input::ActiveInputRuntime::new_for_test("control-test", "initial");
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
@@ -576,7 +577,7 @@ mod tests {
                 &mut stream,
                 &process_control_ipc::ControlRequest {
                     message_id: message_id.clone(),
-                    payload: br#"{"type":"active-input","text":"hello"}"#.to_vec(),
+                    payload: active_input_payload(index),
                 },
             )
             .unwrap();
@@ -617,11 +618,8 @@ mod tests {
         let endpoint = process_control_ipc::endpoint_name(43, &nonce);
         let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
         let shutdown = CancellationToken::new();
-        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
-            "control-test",
-            true,
-            "initial",
-        );
+        let active_runtime =
+            crate::active_input::ActiveInputRuntime::new_for_test("control-test", "initial");
         let active_input = active_runtime.controller();
         let handle = ControlHandle::spawn_endpoint(
             endpoint,
@@ -653,11 +651,8 @@ mod tests {
         let endpoint = process_control_ipc::endpoint_name(45, &nonce);
         let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
         let shutdown = CancellationToken::new();
-        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
-            "control-test",
-            true,
-            "initial",
-        );
+        let active_runtime =
+            crate::active_input::ActiveInputRuntime::new_for_test("control-test", "initial");
         let active_input = active_runtime.controller();
         let handle = ControlHandle::spawn_endpoint(
             endpoint,
@@ -691,11 +686,8 @@ mod tests {
         let shutdown = CancellationToken::new();
         let stream_slot = Arc::new(Mutex::new(None));
         let worker_slot = Arc::clone(&stream_slot);
-        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
-            "control-test",
-            true,
-            "initial",
-        );
+        let active_runtime =
+            crate::active_input::ActiveInputRuntime::new_for_test("control-test", "initial");
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -267,7 +267,6 @@ async fn run(runtime: GuestRuntime) -> i32 {
             );
         match guest_agent::active_input::ActiveInputRuntime::new_with_receipts(
             &runtime.config.run_id,
-            true,
             &runtime.config.prompt,
             receipt_journal_path,
             http.clone(),
@@ -284,9 +283,8 @@ async fn run(runtime: GuestRuntime) -> i32 {
             }
         }
     } else {
-        guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+        guest_agent::active_input::ActiveInputRuntime::new_disabled(
             &runtime.config.run_id,
-            false,
             &runtime.config.prompt,
         )
     };

--- a/crates/guest-agent/tests/active_input_receipts.rs
+++ b/crates/guest-agent/tests/active_input_receipts.rs
@@ -24,13 +24,11 @@ fn payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
 }
 
 #[tokio::test]
-async fn explicit_null_delivery_id_is_rejected_instead_of_using_legacy_delivery()
--> Result<(), Box<dyn std::error::Error>> {
+async fn explicit_null_delivery_id_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
     let tmp = tempfile::tempdir()?;
     let runtime = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         tmp.path().join("active-input-receipts.json"),
         receipt_http(&server.base_url())?,
@@ -71,7 +69,6 @@ async fn accepted_input_is_deduplicated_reported_and_compacted()
     let journal_path = tmp.path().join("active-input-receipts.json");
     let runtime = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         &journal_path,
         receipt_http(&server.base_url())?,
@@ -100,7 +97,7 @@ async fn accepted_input_is_deduplicated_reported_and_compacted()
         .await
         .expect("accepted input should reach the sink");
     assert_eq!(frame.uuid, DELIVERY_ID);
-    assert_eq!(frame.delivery_id(), Some(DELIVERY_ID));
+    assert_eq!(frame.delivery_id(), DELIVERY_ID);
     assert_eq!(frame.text, PROMPT);
     writer.mark_writing(&frame.uuid);
     writer.mark_backend_accepted_without_replay(&frame)?;
@@ -155,7 +152,6 @@ async fn failed_input_creates_no_receipt_or_completion_evidence()
     let journal_path = tmp.path().join("active-input-receipts.json");
     let runtime = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         &journal_path,
         receipt_http(&server.base_url())?,
@@ -210,7 +206,6 @@ async fn rejected_receipt_is_retained_without_a_finalization_retry()
     let journal_path = tmp.path().join("active-input-receipts.json");
     let runtime = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         &journal_path,
         receipt_http(&server.base_url())?,
@@ -263,7 +258,6 @@ async fn transport_failure_gets_only_one_finalization_retry()
     let journal_path = tmp.path().join("active-input-receipts.json");
     let runtime = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         &journal_path,
         receipt_http(&server.base_url())?,
@@ -325,7 +319,6 @@ async fn journal_publication_failure_is_terminal_after_backend_acceptance()
     let journal_path = tmp.path().join("run/active-input-receipts.json");
     let runtime = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         &journal_path,
         receipt_http(&server.base_url())?,
@@ -372,7 +365,6 @@ async fn unacknowledged_journal_recovers_without_requeueing_the_backend()
     });
     let runtime = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         &journal_path,
         receipt_http(&failed_server.base_url())?,
@@ -417,7 +409,6 @@ async fn unacknowledged_journal_recovers_without_requeueing_the_backend()
     });
     let recovered = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         "initial",
         &journal_path,
         receipt_http(&server.base_url())?,

--- a/crates/guest-agent/tests/claude_active_input_receipt.rs
+++ b/crates/guest-agent/tests/claude_active_input_receipt.rs
@@ -46,7 +46,6 @@ async fn claude_receipts_delivery_only_after_follow_up_reaches_stdin()
     );
     let active_input = ActiveInputRuntime::new_with_receipts(
         run_id,
-        true,
         &runtime.config.prompt,
         &journal_path,
         receipt_http,

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -70,9 +70,8 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         std::env::set_var("HOME", tmp.path().join("stale-home"));
     }
 
-    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_disabled(
         &runtime.config.run_id,
-        false,
         &runtime.config.prompt,
     );
     let result = cli::execute_cli_with_active_input_for_config(

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -53,7 +53,6 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
     );
     let active_input = ActiveInputRuntime::new_with_receipts(
         &runtime.config.run_id,
-        true,
         &runtime.config.prompt,
         &journal_path,
         HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -30,11 +30,7 @@ async fn codex_app_server_backend_rejects_active_input_after_turn_completion()
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        true,
-        &runtime.config.prompt,
-    );
+    let active_input = common::active_input_runtime(&runtime)?;
     let controller = active_input.controller();
 
     let masker = SecretMasker::from_raw("");

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -32,11 +32,7 @@ async fn codex_app_server_backend_steers_accepted_input_before_buffered_completi
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        true,
-        &runtime.config.prompt,
-    );
+    let active_input = common::active_input_runtime(&runtime)?;
     let payload = common::active_input_payload("follow-up before buffered completion")?;
     assert_eq!(
         active_input.controller().handle_control_payload(&payload),

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
@@ -58,7 +58,6 @@ async fn cancellation_preserves_a_steer_response_already_in_flight()
     );
     let active_input = ActiveInputRuntime::new_with_receipts(
         RUN_ID,
-        true,
         &runtime.config.prompt,
         &journal_path,
         HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -30,11 +30,7 @@ async fn codex_app_server_backend_fails_visible_when_child_exits_during_steer()
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        true,
-        &runtime.config.prompt,
-    );
+    let active_input = common::active_input_runtime(&runtime)?;
     let payload = common::active_input_payload("child-exit follow-up prompt")?;
     assert_eq!(
         active_input.controller().handle_control_payload(&payload),

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -50,7 +50,6 @@ async fn codex_app_server_backend_fails_visible_when_no_active_turn()
     );
     let active_input = ActiveInputRuntime::new_with_receipts(
         &runtime.config.run_id,
-        true,
         &runtime.config.prompt,
         &journal_path,
         HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -32,11 +32,7 @@ async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal(
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        true,
-        &runtime.config.prompt,
-    );
+    let active_input = common::active_input_runtime(&runtime)?;
     let payload = common::active_input_payload("follow-up before queued terminal")?;
     assert_eq!(
         active_input.controller().handle_control_payload(&payload),

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -31,11 +31,7 @@ async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        true,
-        &runtime.config.prompt,
-    );
+    let active_input = common::active_input_runtime(&runtime)?;
     let payload = common::active_input_payload("stale follow-up prompt")?;
     assert_eq!(
         active_input.controller().handle_control_payload(&payload),

--- a/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
@@ -68,9 +68,8 @@ async fn codex_app_server_backend_uses_runtime_snapshot_and_preserves_large_prom
         std::env::set_var("CUSTOM_USER_ENV", "stale-process-user-env");
     }
 
-    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_disabled(
         &runtime.config.run_id,
-        false,
         &runtime.config.prompt,
     );
     let cli_result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
@@ -5,7 +5,7 @@
 
 mod common;
 
-use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -36,11 +36,7 @@ async fn codex_app_server_backend_ignores_secondary_thread_notifications()
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        true,
-        &runtime.config.prompt,
-    );
+    let active_input = common::active_input_runtime(&runtime)?;
     let payload = common::active_input_payload("must wait for the top-level turn")?;
     assert_eq!(
         active_input.controller().handle_control_payload(&payload),

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -981,8 +981,24 @@ pub unsafe fn setup_codex_app_server_env(
 pub fn active_input_payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
     serde_json::to_vec(&json!({
         "type": "active-input",
+        "deliveryId": "223f8797-a456-4eea-98f7-f7ab88c43c00",
         "text": text,
     }))
+}
+
+pub fn active_input_runtime(
+    runtime: &guest_agent::run_context::GuestRuntime,
+) -> Result<guest_agent::active_input::ActiveInputRuntime, guest_agent::error::AgentError> {
+    let journal_path = guest_contracts::runtime_paths::active_input_receipt_journal_file(
+        runtime.paths.runtime_dir(),
+    );
+    guest_agent::active_input::ActiveInputRuntime::new_with_receipts(
+        &runtime.config.run_id,
+        &runtime.config.prompt,
+        journal_path,
+        guest_agent::http::HttpClient::new()?,
+    )
+    .map_err(guest_agent::error::AgentError::Io)
 }
 
 pub fn read_codex_session_history_events_for_paths(
@@ -1121,9 +1137,8 @@ pub async fn execute_cli_for_runtime(
     masker: &guest_agent::masker::SecretMasker,
     heartbeat: guest_agent::cli::HeartbeatMonitor,
 ) -> Result<guest_agent::cli::CliExecutionResult, guest_agent::error::AgentError> {
-    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_disabled(
         &runtime.config.run_id,
-        false,
         &runtime.config.prompt,
     );
     execute_cli_with_active_input_for_runtime(
@@ -1158,9 +1173,8 @@ pub async fn execute_cli_with_cancellation_for_runtime(
     heartbeat: guest_agent::cli::HeartbeatMonitor,
     cancellation: tokio_util::sync::CancellationToken,
 ) -> Result<guest_agent::cli::CliExecutionResult, guest_agent::error::AgentError> {
-    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_disabled(
         &runtime.config.run_id,
-        false,
         &runtime.config.prompt,
     );
     guest_agent::cli::execute_cli_with_controls_for_config_started_at(

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -80,11 +80,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     }
 
     let masker = SecretMasker::from_raw("");
-    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        true,
-        &runtime.config.prompt,
-    );
+    let active_input = common::active_input_runtime(&runtime)?;
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
         guest_agent::cli::execute_cli_with_active_input_for_config(

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -111,7 +111,6 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     let receipt_log_guard = SystemLogOverrideGuard::set(&receipt_log_path);
     let active_input = ActiveInputRuntime::new_with_receipts(
         &runtime.config.run_id,
-        true,
         &runtime.config.prompt,
         tmp.path().join("active-input-receipts.json"),
         http.clone(),
@@ -144,11 +143,8 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         "local active input must not attempt an API receipt: {receipt_log}",
     );
 
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        false,
-        &runtime.config.prompt,
-    );
+    let active_input =
+        ActiveInputRuntime::new_disabled(&runtime.config.run_id, &runtime.config.prompt);
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
         guest_agent::cli::execute_cli_with_active_input_for_config(

--- a/crates/guest-agent/tests/pi_standby_okou_command.rs
+++ b/crates/guest-agent/tests/pi_standby_okou_command.rs
@@ -88,9 +88,8 @@ printf '{"type":"pi-complete","exitCode":0,"error":null,"lastEventSequence":null
 
     let runtime = GuestRuntime::from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
-    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_disabled(
         &runtime.config.run_id,
-        false,
         &runtime.config.prompt,
     );
     let result = guest_agent::cli::execute_cli_with_active_input_for_config(

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -137,7 +137,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let pre_ready_ack = handle
         .control(
             PRE_READY_CONTROL_MESSAGE_ID,
-            br#"{"type":"active-input","text":"before-ready"}"#,
+            br#"{"type":"active-input","deliveryId":"1e208848-53bc-440a-85d8-adcd048e167c","text":"before-ready"}"#,
             Duration::from_secs(10),
         )
         .await?;
@@ -152,7 +152,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let ack = handle
         .control(
             READY_CONTROL_MESSAGE_ID,
-            br#"{"type":"active-input","text":"after-ready"}"#,
+            br#"{"type":"active-input","deliveryId":"e6c121e3-9a6f-4835-87c0-a31b042f3008","text":"after-ready"}"#,
             Duration::from_secs(10),
         )
         .await?;

--- a/crates/guest-agent/tests/zero_web_search_policy.rs
+++ b/crates/guest-agent/tests/zero_web_search_policy.rs
@@ -142,11 +142,8 @@ fn read_args(path: &Path) -> TestResult<Vec<String>> {
 }
 
 async fn execute(runtime: &GuestRuntime) -> TestResult<guest_agent::cli::CliExecutionResult> {
-    let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        &runtime.config.run_id,
-        false,
-        &runtime.config.prompt,
-    );
+    let active_input =
+        ActiveInputRuntime::new_disabled(&runtime.config.run_id, &runtime.config.prompt);
     Ok(guest_agent::cli::execute_cli_with_active_input_for_config(
         &SecretMasker::from_raw(""),
         common::spawn_dummy_heartbeat(),

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -12,10 +12,10 @@ use api_contracts::generated::{
     },
 };
 
-use crate::error::{RunnerError, RunnerResult};
+use crate::error::RunnerResult;
 use crate::ids::RunId;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
-use crate::provider::{ApiClient, ReserveActiveInputResult};
+use crate::provider::ApiClient;
 
 /// Exec-control payloads are bounded by the guest-side process-control IPC frame limit.
 pub(crate) const ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES: usize =
@@ -28,13 +28,13 @@ const _: () = assert!(
 pub(crate) struct ActiveInputPayload<'a> {
     #[serde(rename = "type")]
     payload_type: &'static str,
-    #[serde(rename = "deliveryId", skip_serializing_if = "Option::is_none")]
-    delivery_id: Option<&'a str>,
+    #[serde(rename = "deliveryId")]
+    delivery_id: &'a str,
     text: &'a str,
 }
 
 impl<'a> ActiveInputPayload<'a> {
-    pub(crate) fn new(delivery_id: Option<&'a str>, text: &'a str) -> Self {
+    pub(crate) fn new(delivery_id: &'a str, text: &'a str) -> Self {
         Self {
             payload_type: "active-input",
             delivery_id,
@@ -73,7 +73,7 @@ impl Write for CountingWriter {
 }
 
 pub(crate) fn active_input_payload_len(
-    delivery_id: Option<&str>,
+    delivery_id: &str,
     text: &str,
 ) -> Result<usize, serde_json::Error> {
     let mut counter = CountingWriter::default();
@@ -83,7 +83,7 @@ pub(crate) fn active_input_payload_len(
 
 pub(crate) fn identified_active_input_payload_len(text: &str) -> Result<usize, serde_json::Error> {
     let delivery_id = Uuid::nil().hyphenated().to_string();
-    active_input_payload_len(Some(&delivery_id), text)
+    active_input_payload_len(&delivery_id, text)
 }
 
 pub(crate) fn local_active_input_delivery_id(run_id: RunId, sequence: u64) -> String {
@@ -111,7 +111,6 @@ pub(crate) struct ApiActiveInputSource {
     run_id: RunId,
     sandbox_token: String,
     notifications: ActiveInputSubscription,
-    mode: ApiActiveInputMode,
 }
 
 #[derive(Clone)]
@@ -121,20 +120,9 @@ pub(crate) struct ApiActiveInputRecovery {
     sandbox_token: String,
 }
 
-#[derive(Clone, Copy)]
-enum ApiActiveInputMode {
-    Probe,
-    Reserve,
-    Legacy,
-}
-
 pub(crate) enum ActiveInputBatch {
     Local(Vec<ActiveInputEntry>),
-    ApiReserve(ActiveInputReserveResponse),
-    ApiLegacy {
-        prompt: Option<String>,
-        has_more: bool,
-    },
+    Api(ActiveInputReserveResponse),
 }
 
 const LOCAL_ACTIVE_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(250);
@@ -199,7 +187,6 @@ impl ActiveInputSource {
             run_id,
             sandbox_token,
             notifications,
-            mode: ApiActiveInputMode::Probe,
         })
     }
 
@@ -259,75 +246,12 @@ impl ApiActiveInputRecovery {
     }
 }
 
-async fn read_api_active_input(
-    source: &mut ApiActiveInputSource,
-) -> RunnerResult<ActiveInputBatch> {
-    match source.mode {
-        ApiActiveInputMode::Legacy => read_legacy_api_active_input(source).await,
-        ApiActiveInputMode::Probe => {
-            let result = source
-                .api
-                .reserve_active_inputs(source.run_id, &source.sandbox_token)
-                .await;
-            match result {
-                Ok(ReserveActiveInputResult::RouteUnavailable) => {
-                    // A newly deployed Runner can reach an API version from before the
-                    // reserve route during the Runner/API rollout and rollback window
-                    // (up to two hours). Remove this legacy selection after that window
-                    // closes and production drain evidence satisfies #26061.
-                    source.mode = ApiActiveInputMode::Legacy;
-                    read_legacy_api_active_input(source).await
-                }
-                Ok(ReserveActiveInputResult::Response(response)) => {
-                    source.mode = ApiActiveInputMode::Reserve;
-                    Ok(ActiveInputBatch::ApiReserve(response))
-                }
-                Err(error) => {
-                    source.mode = ApiActiveInputMode::Reserve;
-                    Err(error)
-                }
-            }
-        }
-        ApiActiveInputMode::Reserve => match source
-            .api
-            .reserve_active_inputs(source.run_id, &source.sandbox_token)
-            .await?
-        {
-            ReserveActiveInputResult::Response(response) => {
-                Ok(ActiveInputBatch::ApiReserve(response))
-            }
-            ReserveActiveInputResult::RouteUnavailable => Err(RunnerError::Api(
-                "reserve active inputs returned 404 after reserve support was selected".to_string(),
-            )),
-        },
-    }
-}
-
-async fn read_legacy_api_active_input(
-    source: &ApiActiveInputSource,
-) -> RunnerResult<ActiveInputBatch> {
-    let event_ids = source
+async fn read_api_active_input(source: &ApiActiveInputSource) -> RunnerResult<ActiveInputBatch> {
+    let response = source
         .api
-        .list_active_input_event_ids(source.run_id, &source.sandbox_token)
+        .reserve_active_inputs(source.run_id, &source.sandbox_token)
         .await?;
-    let Some(event_id) = event_ids.first() else {
-        return Ok(ActiveInputBatch::ApiLegacy {
-            prompt: None,
-            has_more: false,
-        });
-    };
-    let prompt = source
-        .api
-        .claim_active_inputs(
-            source.run_id,
-            &source.sandbox_token,
-            std::slice::from_ref(event_id),
-        )
-        .await?;
-    Ok(ActiveInputBatch::ApiLegacy {
-        prompt: Some(prompt),
-        has_more: event_ids.len() > 1,
-    })
+    Ok(ActiveInputBatch::Api(response))
 }
 
 #[cfg(test)]
@@ -345,13 +269,11 @@ mod tests {
         let delivery_id = Uuid::new_v4().hyphenated().to_string();
 
         for text in texts {
-            for candidate_delivery_id in [None, Some(delivery_id.as_str())] {
-                let counted = active_input_payload_len(candidate_delivery_id, &text).unwrap();
-                let serialized = ActiveInputPayload::new(candidate_delivery_id, &text)
-                    .to_vec()
-                    .unwrap();
-                assert_eq!(counted, serialized.len(), "text len={}", text.len());
-            }
+            let counted = active_input_payload_len(&delivery_id, &text).unwrap();
+            let serialized = ActiveInputPayload::new(&delivery_id, &text)
+                .to_vec()
+                .unwrap();
+            assert_eq!(counted, serialized.len(), "text len={}", text.len());
         }
     }
 }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -75,9 +75,8 @@ impl ActiveInputForwarder {
 
 #[derive(Clone, Copy)]
 enum DeliveryMode {
-    DurableApi,
+    Api,
     Local,
-    Legacy,
 }
 
 enum ForwardDisposition {
@@ -95,7 +94,6 @@ async fn run_forwarder(
     stop: CancellationToken,
 ) {
     let mut next_local_sequence = FIRST_ACTIVE_INPUT_SEQUENCE;
-    let mut legacy_delivery_sequence = 0_u64;
     let mut suppressed_api_delivery_id: Option<String> = None;
     let mut warned_source_read_failure = false;
     let mut warned_payload_too_large = false;
@@ -106,7 +104,7 @@ async fn run_forwarder(
             () = job_cancel.cancelled() => return,
             batch = source.read(next_local_sequence) => batch,
         };
-        let (retry_after_read_error, recheck_immediately) = match batch {
+        let retry_after_read_error = match batch {
             Ok(ActiveInputBatch::Local(entries)) => {
                 for entry in entries {
                     if entry.sequence < next_local_sequence {
@@ -118,7 +116,7 @@ async fn run_forwarder(
                     let delivery_id = local_active_input_delivery_id(run_id, entry.sequence);
                     let disposition = forward_with_retry(
                         run_id,
-                        Some(&delivery_id),
+                        &delivery_id,
                         &entry.text,
                         DeliveryMode::Local,
                         &control,
@@ -135,32 +133,9 @@ async fn run_forwarder(
                         | ForwardDisposition::Stop => return,
                     }
                 }
-                (false, false)
+                false
             }
-            Ok(ActiveInputBatch::ApiLegacy { prompt, has_more }) => {
-                let forwarded = if let Some(prompt) = prompt {
-                    legacy_delivery_sequence = legacy_delivery_sequence.saturating_add(1);
-                    let correlation_id =
-                        format!("active-input:{run_id}:{legacy_delivery_sequence}");
-                    matches!(
-                        forward_once(
-                            run_id,
-                            None,
-                            &correlation_id,
-                            &prompt,
-                            DeliveryMode::Legacy,
-                            &control,
-                            true,
-                        )
-                        .await,
-                        ForwardDisposition::Accepted
-                    )
-                } else {
-                    false
-                };
-                (false, has_more && forwarded)
-            }
-            Ok(ActiveInputBatch::ApiReserve(response)) => match response {
+            Ok(ActiveInputBatch::Api(response)) => match response {
                 ActiveInputReserveResponse::Reserved {
                     delivery_id,
                     event_ids: _,
@@ -168,13 +143,13 @@ async fn run_forwarder(
                 } => {
                     warned_payload_too_large = false;
                     if suppressed_api_delivery_id.as_deref() == Some(&delivery_id) {
-                        (false, false)
+                        false
                     } else {
                         let disposition = forward_with_retry(
                             run_id,
-                            Some(&delivery_id),
+                            &delivery_id,
                             &prompt,
-                            DeliveryMode::DurableApi,
+                            DeliveryMode::Api,
                             &control,
                             &job_cancel,
                             &stop,
@@ -183,7 +158,7 @@ async fn run_forwarder(
                         match disposition {
                             ForwardDisposition::Accepted | ForwardDisposition::Suppress => {
                                 suppressed_api_delivery_id = Some(delivery_id);
-                                (false, false)
+                                false
                             }
                             ForwardDisposition::Retry | ForwardDisposition::Stop => return,
                         }
@@ -192,7 +167,7 @@ async fn run_forwarder(
                 ActiveInputReserveResponse::Empty => {
                     suppressed_api_delivery_id = None;
                     warned_payload_too_large = false;
-                    (false, false)
+                    false
                 }
                 ActiveInputReserveResponse::Terminal => return,
                 ActiveInputReserveResponse::Held {
@@ -210,7 +185,7 @@ async fn run_forwarder(
                             );
                             warned_payload_too_large = true;
                         }
-                        (false, false)
+                        false
                     }
                     ResponseRejectedReason::RunNotRunning => return,
                 },
@@ -220,7 +195,7 @@ async fn run_forwarder(
                     warn!(run_id = %run_id, error = %error, "active-input source read failed; retrying");
                     warned_source_read_failure = true;
                 }
-                (true, false)
+                true
             }
         };
         if !retry_after_read_error {
@@ -232,9 +207,6 @@ async fn run_forwarder(
             () = stop.cancelled() => return,
             () = job_cancel.cancelled() => return,
             () = async {
-                if recheck_immediately {
-                    return;
-                }
                 if retry_after_read_error {
                     tokio::time::sleep(ACTIVE_INPUT_READ_RETRY_INTERVAL).await;
                 } else {
@@ -247,22 +219,18 @@ async fn run_forwarder(
 
 async fn forward_with_retry(
     run_id: RunId,
-    delivery_id: Option<&str>,
+    delivery_id: &str,
     text: &str,
     mode: DeliveryMode,
     control: &GuestProcessControlHandle,
     job_cancel: &CancellationToken,
     stop: &CancellationToken,
 ) -> ForwardDisposition {
-    let correlation_id = delivery_id
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| format!("active-input:{run_id}:legacy"));
     let mut warn_retryable_failure = true;
     loop {
         let disposition = forward_once(
             run_id,
             delivery_id,
-            &correlation_id,
             text,
             mode,
             control,
@@ -284,8 +252,7 @@ async fn forward_with_retry(
 
 async fn forward_once(
     run_id: RunId,
-    delivery_id: Option<&str>,
-    correlation_id: &str,
+    delivery_id: &str,
     text: &str,
     mode: DeliveryMode,
     control: &GuestProcessControlHandle,
@@ -312,11 +279,7 @@ async fn forward_once(
         }
     };
     let outcome = control
-        .control_owned_outcome(
-            correlation_id.to_owned(),
-            bytes,
-            ACTIVE_INPUT_CONTROL_TIMEOUT,
-        )
+        .control_owned_outcome(delivery_id.to_owned(), bytes, ACTIVE_INPUT_CONTROL_TIMEOUT)
         .await;
     classify_control_outcome(run_id, mode, outcome, warn_retryable_failure)
 }
@@ -339,7 +302,7 @@ fn classify_control_outcome(
                         "active-input control will retry"
                     );
                 }
-                identified_or_legacy(mode, ForwardDisposition::Retry)
+                ForwardDisposition::Retry
             }
             ProcessControlGuestStatus::SinkTimeout | ProcessControlGuestStatus::SinkError => {
                 if warn_retryable_failure {
@@ -408,7 +371,7 @@ fn classify_control_outcome(
             }
             match (kind, write_state) {
                 (ProcessControlFailureKind::Operation, ProcessControlWriteState::NotWritten) => {
-                    identified_or_legacy(mode, ForwardDisposition::Retry)
+                    ForwardDisposition::Retry
                 }
                 (
                     ProcessControlFailureKind::Operation,
@@ -417,10 +380,7 @@ fn classify_control_outcome(
                 (ProcessControlFailureKind::BackendCrashed, _) => {
                     if matches!(
                         (mode, write_state),
-                        (
-                            DeliveryMode::DurableApi,
-                            ProcessControlWriteState::PossiblyWritten
-                        )
+                        (DeliveryMode::Api, ProcessControlWriteState::PossiblyWritten)
                     ) {
                         ForwardDisposition::Suppress
                     } else {
@@ -432,19 +392,10 @@ fn classify_control_outcome(
     }
 }
 
-fn identified_or_legacy(mode: DeliveryMode, identified: ForwardDisposition) -> ForwardDisposition {
-    if matches!(mode, DeliveryMode::Legacy) {
-        ForwardDisposition::Accepted
-    } else {
-        identified
-    }
-}
-
 fn uncertain_disposition(mode: DeliveryMode) -> ForwardDisposition {
     match mode {
-        DeliveryMode::DurableApi => ForwardDisposition::Suppress,
+        DeliveryMode::Api => ForwardDisposition::Suppress,
         DeliveryMode::Local => ForwardDisposition::Retry,
-        DeliveryMode::Legacy => ForwardDisposition::Accepted,
     }
 }
 

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -59,13 +59,6 @@ fn http_response(status: &str, body: &str) -> String {
     )
 }
 
-fn http_request_body(request: &str) -> &str {
-    request
-        .split_once("\r\n\r\n")
-        .expect("HTTP request should contain a header boundary")
-        .1
-}
-
 enum HttpServerAction {
     Respond(String),
     Disconnect,
@@ -234,110 +227,6 @@ async fn run_in_sandbox_forwards_local_active_inputs_in_order() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_forwards_legacy_api_active_inputs_as_separate_messages() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let wait_gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        Arc::clone(&wait_gate),
-    ));
-    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
-    let ctx = minimal_context();
-    let run_id = ctx.run_id;
-    let active_input_path = format!("/api/runners/runs/{run_id}/active-inputs");
-    let claim_path = format!("{active_input_path}/claim");
-
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("404 Not Found", r#"{"error":"not found"}"#),
-        http_response("200 OK", r#"{"eventIds":["event-1","event-2"]}"#),
-        http_response("200 OK", r#"{"prompt":"first message"}"#),
-        http_response("200 OK", r#"{"eventIds":["event-2"]}"#),
-        http_response("200 OK", r#"{"prompt":"second message"}"#),
-    ])
-    .await;
-
-    let notifications = ActiveInputNotifications::new();
-    let source = ActiveInputSource::api(
-        ApiClient::new(
-            HttpClient::new(HttpClientConfig {
-                api_url,
-                vercel_bypass: None,
-                client_session_id: "active-input-boundary-test".to_string(),
-            })
-            .unwrap(),
-            "runner-token".to_string(),
-        ),
-        run_id,
-        "sandbox-token".to_string(),
-        notifications.subscribe(run_id),
-    );
-    let cancel = tokio_util::sync::CancellationToken::new();
-    let mut telemetry = test_telemetry(&config, &ctx);
-    let run_task = tokio::spawn(async move {
-        run_in_sandbox(
-            &*sandbox,
-            &ctx,
-            &config,
-            RunStart {
-                restore_guest_state: false,
-                reuse_result: SandboxReuseResult::PoolMiss,
-                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
-                prev_storage: None,
-            },
-            &mut telemetry,
-            RunControls::new(cancel, Some(source)),
-        )
-        .await
-    });
-
-    assert!(
-        overrides
-            .wait_for_process_control_calls(2, RUN_IN_SANDBOX_TEST_TIMEOUT)
-            .await,
-        "pending API inputs should be forwarded without waiting for another notification"
-    );
-    wait_gate.notify_one();
-    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
-        .await
-        .unwrap()
-        .unwrap()
-        .unwrap();
-    assert!(result.failure.is_none());
-
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .expect("active-input server should finish")
-        .unwrap();
-    let mut requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        requests.push(request);
-    }
-    assert_eq!(requests.len(), 5);
-    assert!(requests[0].starts_with(&format!("POST {active_input_path}/reserve ")));
-    assert!(requests[1].starts_with(&format!("GET {active_input_path} ")));
-    assert!(requests[2].starts_with(&format!("POST {claim_path} ")));
-    assert_eq!(
-        serde_json::from_str::<serde_json::Value>(http_request_body(&requests[2])).unwrap(),
-        serde_json::json!({ "eventIds": ["event-1"] })
-    );
-    assert!(requests[3].starts_with(&format!("GET {active_input_path} ")));
-    assert!(requests[4].starts_with(&format!("POST {claim_path} ")));
-    assert_eq!(
-        serde_json::from_str::<serde_json::Value>(http_request_body(&requests[4])).unwrap(),
-        serde_json::json!({ "eventIds": ["event-2"] })
-    );
-
-    let calls = overrides.process_control_calls();
-    assert_eq!(calls.len(), 2);
-    let payloads = calls
-        .iter()
-        .map(|call| serde_json::from_slice::<serde_json::Value>(&call.payload).unwrap())
-        .collect::<Vec<_>>();
-    assert_eq!(payloads[0]["text"], "first message");
-    assert_eq!(payloads[1]["text"], "second message");
-}
-
-#[tokio::test]
 async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -443,19 +332,15 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
         http_response(
             "200 OK",
             &format!(
-                r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"fallback delivered"}}"#,
+                r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"recheck delivered"}}"#,
             ),
         ),
     ])
     .await;
 
     let notifications = ActiveInputNotifications::new();
-    let source = api_active_input_source(
-        api_url,
-        run_id,
-        &notifications,
-        "active-input-fallback-test",
-    );
+    let source =
+        api_active_input_source(api_url, run_id, &notifications, "active-input-recheck-test");
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
     let run_task = tokio::spawn(async move {
@@ -516,7 +401,7 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
     assert_eq!(calls[0].message_id, DELIVERY_ID);
     assert_eq!(
         serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap()["text"],
-        "fallback delivered"
+        "recheck delivered"
     );
 }
 
@@ -599,7 +484,7 @@ async fn run_in_sandbox_retries_local_active_input_with_same_id_after_uncertain_
 }
 
 #[tokio::test]
-async fn run_in_sandbox_falls_back_when_first_reserve_request_is_unavailable() {
+async fn run_in_sandbox_retries_reserve_when_first_request_is_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let wait_gate = Arc::new(tokio::sync::Notify::new());
@@ -609,13 +494,15 @@ async fn run_in_sandbox_falls_back_when_first_reserve_request_is_unavailable() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let active_input_path = format!("/api/runners/runs/{run_id}/active-inputs");
-    let reserve_path = format!("{active_input_path}/reserve");
-    let claim_path = format!("{active_input_path}/claim");
+    let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
     let (api_url, mut request_rx, server) = spawn_http_server(vec![
         http_response("404 Not Found", r#"{"error":"not found"}"#),
-        http_response("200 OK", &format!(r#"{{"eventIds":["{EVENT_ID}"]}}"#)),
-        http_response("200 OK", r#"{"prompt":"legacy delivered"}"#),
+        http_response(
+            "200 OK",
+            &format!(
+                r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"reserve delivered"}}"#,
+            ),
+        ),
     ])
     .await;
     let notifications = ActiveInputNotifications::new();
@@ -623,7 +510,7 @@ async fn run_in_sandbox_falls_back_when_first_reserve_request_is_unavailable() {
         api_url,
         run_id,
         &notifications,
-        "active-input-legacy-fallback-test",
+        "active-input-first-not-found-test",
     );
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -666,16 +553,18 @@ async fn run_in_sandbox_falls_back_when_first_reserve_request_is_unavailable() {
     while let Some(request) = request_rx.recv().await {
         requests.push(request);
     }
-    assert_eq!(requests.len(), 3);
-    assert!(requests[0].starts_with(&format!("POST {reserve_path} ")));
-    assert!(requests[1].starts_with(&format!("GET {active_input_path} ")));
-    assert!(requests[2].starts_with(&format!("POST {claim_path} ")));
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.starts_with(&format!("POST {reserve_path} ")))
+    );
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].message_id, format!("active-input:{run_id}:1"));
+    assert_eq!(calls[0].message_id, DELIVERY_ID);
     let payload = serde_json::from_slice::<serde_json::Value>(&calls[0].payload).unwrap();
-    assert!(payload.get("deliveryId").is_none());
-    assert_eq!(payload["text"], "legacy delivered");
+    assert_eq!(payload["deliveryId"], DELIVERY_ID);
+    assert_eq!(payload["text"], "reserve delivered");
 }
 
 #[tokio::test]
@@ -758,7 +647,7 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_does_not_fall_back_after_ambiguous_reserve_failure() {
+async fn run_in_sandbox_keeps_using_reserve_after_ambiguous_failure() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let wait_gate = Arc::new(tokio::sync::Notify::new());
@@ -779,7 +668,7 @@ async fn run_in_sandbox_does_not_fall_back_after_ambiguous_reserve_failure() {
         api_url,
         run_id,
         &notifications,
-        "active-input-no-unsafe-fallback-test",
+        "active-input-reserve-only-test",
     );
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -977,11 +977,6 @@ pub(crate) struct ApiClient {
     token: String,
 }
 
-pub(crate) enum ReserveActiveInputResult {
-    RouteUnavailable,
-    Response(ActiveInputReserveResponse),
-}
-
 #[derive(Serialize)]
 struct EmptyRequest {}
 
@@ -990,40 +985,11 @@ impl ApiClient {
         Self { http, token }
     }
 
-    pub(crate) async fn list_active_input_event_ids(
-        &self,
-        run_id: RunId,
-        sandbox_token: &str,
-    ) -> RunnerResult<Vec<String>> {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct ListResponse {
-            event_ids: Vec<String>,
-        }
-
-        let run_id = run_id.to_string();
-        let resp = send_api(
-            self.http.request_resolved_route(
-                routes::runners::runs::by_run_id::active_inputs::route(
-                    routes::runners::runs::by_run_id::active_inputs::Params {
-                        run_id: run_id.as_str(),
-                    },
-                ),
-                sandbox_token,
-            ),
-            "list active inputs",
-        )
-        .await?;
-        let resp = check_api_status(resp, "list active inputs").await?;
-        let body: ListResponse = decode_api_json(resp, "list active inputs").await?;
-        Ok(body.event_ids)
-    }
-
     pub(crate) async fn reserve_active_inputs(
         &self,
         run_id: RunId,
         sandbox_token: &str,
-    ) -> RunnerResult<ReserveActiveInputResult> {
+    ) -> RunnerResult<ActiveInputReserveResponse> {
         let run_id = run_id.to_string();
         let resp = send_api(
             self.http
@@ -1039,12 +1005,8 @@ impl ApiClient {
             "reserve active inputs",
         )
         .await?;
-        if resp.status() == StatusCode::NOT_FOUND {
-            return Ok(ReserveActiveInputResult::RouteUnavailable);
-        }
         let resp = check_api_status(resp, "reserve active inputs").await?;
-        let body = decode_api_json(resp, "reserve active inputs").await?;
-        Ok(ReserveActiveInputResult::Response(body))
+        decode_api_json(resp, "reserve active inputs").await
     }
 
     pub(crate) async fn record_active_input_delivery(
@@ -1071,42 +1033,6 @@ impl ApiClient {
         .await?;
         let resp = check_api_status(resp, "record active input delivery").await?;
         decode_api_json(resp, "record active input delivery").await
-    }
-
-    pub(crate) async fn claim_active_inputs(
-        &self,
-        run_id: RunId,
-        sandbox_token: &str,
-        event_ids: &[String],
-    ) -> RunnerResult<String> {
-        #[derive(Serialize)]
-        #[serde(rename_all = "camelCase")]
-        struct ClaimRequest<'a> {
-            event_ids: &'a [String],
-        }
-        #[derive(Deserialize)]
-        struct ClaimResponse {
-            prompt: String,
-        }
-
-        let run_id = run_id.to_string();
-        let resp = send_api(
-            self.http
-                .request_resolved_route(
-                    routes::runners::runs::by_run_id::active_inputs::claim::route(
-                        routes::runners::runs::by_run_id::active_inputs::claim::Params {
-                            run_id: run_id.as_str(),
-                        },
-                    ),
-                    sandbox_token,
-                )
-                .json(&ClaimRequest { event_ids }),
-            "claim active inputs",
-        )
-        .await?;
-        let resp = check_api_status(resp, "claim active inputs").await?;
-        let body: ClaimResponse = decode_api_json(resp, "claim active inputs").await?;
-        Ok(body.prompt)
     }
 
     /// Poll for a pending job. The response contains `job: None` when no work is available.

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -14,7 +14,7 @@ mod local;
 #[cfg(test)]
 pub mod mock;
 
-pub(crate) use api::{ApiClient, ReserveActiveInputResult};
+pub(crate) use api::ApiClient;
 pub use api::{ApiProvider, ApiProviderConfig, BuiltinFirewallCatalogCachePaths};
 pub(crate) use connector_runtime_sync::{
     ConnectorRuntimeSyncHandle, ConnectorRuntimeSyncRegistration,

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -23,8 +23,8 @@ statuses retry the same identity.
 
 The delivery becomes settled through one of two proof-bearing paths:
 
-- A direct receipt confirms that the Guest accepted the batch. Each source is
-  replaced by a run-attributed event and every item becomes `delivered`.
+- A direct receipt confirms that the Guest accepted the input. Its source is
+  replaced by a run-attributed event and the item becomes `delivered`.
 - `/api/webhooks/agent/complete` proves that the Guest has quiesced, or that the
   Runner observed process exit, stopped forwarding, and recovered the receipt
   journal. Completion may overlap sandbox finalization after that boundary.
@@ -78,40 +78,25 @@ thread without replaying the run's ordinary terminal callbacks or billing work.
 ## Compatibility
 
 `activeInputDeliveryIds` is optional, contains at most 1,024 unique canonical
-UUIDs, and carries no prompt content. Older callers can continue to omit it.
-Runs without durable delivery rows retain the legacy completion behavior; no
-protocol version or feature discriminator is persisted.
+UUIDs, and carries no prompt content. A Guest or Runner omits it when the run
+accepted no active input. The API normalizes omission to an empty set, so the
+immediately preceding Runner remains compatible during an adjacent deployment.
+No protocol version or feature discriminator is persisted.
 
-On its first active-input read, a Runner probes the reserve route. Only an
-immediate route-level `404` selects the legacy list/claim protocol for that run.
-Any response or ambiguous failure selects durable reserve mode permanently, so
-a committed reservation can never later fall through to destructive legacy
-claim. Legacy payloads omit the delivery UUID; durable API and local Runner
-payloads include a stable UUID. Older Runners continue to use the retained
-legacy routes against a newer API.
+The Runner always calls the reserve endpoint. A `404` or transport failure is
+an ordinary retryable API error and cannot select another delivery path. Both
+API and local Runner inputs send a stable `deliveryId`; the Guest rejects a
+payload without a canonical delivery ID before queue admission.
 
-The cutover Runner must run with a receipt-capable Guest from #26058. A legacy
-Guest treats process-control acceptance as queue admission and has no durable
-receipt, so it is not a compatible execution peer for a Runner that reserves a
-delivery. Deploy the Guest capability and drain any sandboxes that can still
-start that legacy Guest before enabling the cutover Runner. This is a rollout
-gate rather than a permanent protocol-negotiation branch.
+Runner and Guest ship in the same artifact, so their internal control payload
+does not require cross-version negotiation. Independently deployed API and
+Runner versions remain compatible through the stable reserve response shape:
+`eventIds` is a one-element array, and empty completion receipts may be omitted.
 
 The browser remains event-oriented: optimistic input is reconciled by its chat
 event ID, and receipt/completion replacements use the existing realtime chat
 event projection. Delivery IDs remain internal to API, Runner, and Guest, so
 activation does not introduce a frontend protocol or deployment dependency.
-
-Durable delivery is active as of
-[#26060](https://github.com/vm0-ai/vm0/issues/26060). The legacy compatibility
-routes and optional Guest payload shape remain until the post-deployment
-contraction in [#26061](https://github.com/vm0-ai/vm0/issues/26061).
-
-During rollout, the legacy list/claim endpoint still accepts multiple event IDs
-for old Runners. Current Runners claim only the oldest listed event and
-immediately recheck when more are pending. The legacy batch shape can be removed
-under [#26061](https://github.com/vm0-ai/vm0/issues/26061) after old Runners and
-their claimed runs drain.
 
 Deleting a thread or run cascades its delivery state, so an abandoned delivery
 cannot block an unrelated thread.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -96,7 +96,6 @@ import {
   completeRunWithoutCallbacksFixture,
   deleteAgentRunFixture,
   holdCheckpointReadsFixture,
-  holdChatEventFixture,
   holdChatEventQueueItemFixture,
   holdChatThreadRowLockFixture,
   holdOrgAdmissionLockFixture,
@@ -104,7 +103,6 @@ import {
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
   readCanonicalChatEventStorageFixture,
-  readChatEventContextFixture,
   releaseBddVm0ApiKey,
   replayPendingChatInputQueueEventFixture,
   replaceThreadSessionBindingFixture,
@@ -1556,208 +1554,6 @@ describe("CHAT-02: interrupting active chat runs", () => {
 });
 
 describe("CHAT-02: queueing and recalling messages", () => {
-  it("lets a running runner claim pending input prompts for steer", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-
-    const active = await sendChatRun(actor, {
-      agentId,
-      prompt: "anchor active input run",
-    });
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(active.runId);
-
-    const firstPendingEventId = randomUUID();
-    const secondPendingEventId = randomUUID();
-    const activeFileId = randomUUID();
-    chat.mockCompletedUploadObject(actor, activeFileId, "steer-notes.txt", 17);
-    context.mocks.ably.publish.mockClear();
-    const firstPending = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: active.threadId,
-        prompt: "first steer message",
-        clientEventId: firstPendingEventId,
-      },
-      [201],
-    );
-    const secondPending = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: active.threadId,
-        prompt: "second steer message",
-        clientEventId: secondPendingEventId,
-        userMessage: {
-          version: 1,
-          parts: [
-            {
-              type: "file",
-              fileId: activeFileId,
-              filenameSnapshot: "steer-notes.txt",
-              contentType: "text/plain",
-            },
-            { type: "text", text: "second steer message" },
-          ],
-        },
-      },
-      [201],
-    );
-    if (firstPending.status !== 201 || secondPending.status !== 201) {
-      throw new Error("Expected both pending sends to be accepted");
-    }
-    expect(firstPending.body.runId).toBeNull();
-    expect(secondPending.body.runId).toBeNull();
-    await expect(
-      readChatEventContextFixture(firstPendingEventId),
-    ).resolves.toMatchObject({
-      contextType: "web",
-      contextId: null,
-    });
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith("active-input", {
-      runId: active.runId,
-    });
-
-    await expect(
-      api.listRunnerActiveInputs(claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([firstPendingEventId, secondPendingEventId]);
-    await expect(
-      api.claimRunnerActiveInputs(claim.sandboxToken, active.runId, [
-        secondPendingEventId,
-        firstPendingEventId,
-      ]),
-    ).resolves.toBe(
-      [
-        "first steer message",
-        `[Web file] steer-notes.txt (text/plain)\n   [ID] ${activeFileId}`,
-        "second steer message",
-      ].join("\n\n"),
-    );
-    await expect(
-      api.listRunnerActiveInputs(claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([]);
-
-    const events = await chat.listThreadEvents(actor, active.threadId);
-    const firstClaimed = userMessages(events.events).find((message) => {
-      return message.revokesEventId === firstPendingEventId;
-    });
-    if (!firstClaimed) {
-      throw new Error("Expected the first web message replacement");
-    }
-    await expect(
-      readChatEventContextFixture(firstClaimed.id),
-    ).resolves.toMatchObject({
-      contextType: "web",
-      contextId: null,
-    });
-    for (const pendingEventId of [firstPendingEventId, secondPendingEventId]) {
-      const claimedEvent = events.events.find((event) => {
-        return (
-          event.eventType === "input.prompt" &&
-          event.runId === active.runId &&
-          event.revokesEventId === pendingEventId
-        );
-      });
-      if (!claimedEvent || claimedEvent.eventType !== "input.prompt") {
-        throw new Error("Expected the pending active input to be claimed");
-      }
-      expect(
-        claimedEvent.userMessage.parts.some((part) => {
-          return part.type === "model";
-        }),
-      ).toBeFalsy();
-    }
-
-    const emptyControlPayloadBytes = Buffer.byteLength(
-      JSON.stringify({ type: "active-input", text: "" }),
-      "utf8",
-    );
-    const exactLimitPendingEventId = randomUUID();
-    const exactLimitPending = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: active.threadId,
-        prompt: "x".repeat(
-          ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES - emptyControlPayloadBytes,
-        ),
-        clientEventId: exactLimitPendingEventId,
-      },
-      [201],
-    );
-    if (exactLimitPending.status !== 201) {
-      throw new Error("Expected the exact-limit pending send to be accepted");
-    }
-    expect(exactLimitPending.body.runId).toBeNull();
-    const exactLimitPrompt = await api.claimRunnerActiveInputs(
-      claim.sandboxToken,
-      active.runId,
-      [exactLimitPendingEventId],
-    );
-    expect(
-      Buffer.byteLength(
-        JSON.stringify({ type: "active-input", text: exactLimitPrompt }),
-        "utf8",
-      ),
-    ).toBe(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES);
-
-    const oversizedPendingEventId = randomUUID();
-    const oversizedPending = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: active.threadId,
-        prompt: "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES),
-        clientEventId: oversizedPendingEventId,
-      },
-      [201],
-    );
-    if (oversizedPending.status !== 201) {
-      throw new Error("Expected the oversized pending send to be accepted");
-    }
-    expect(oversizedPending.body.runId).toBeNull();
-    const oversizedConflict = await api.claimRunnerActiveInputsConflict(
-      claim.sandboxToken,
-      active.runId,
-      [oversizedPendingEventId],
-    );
-    expectApiError(oversizedConflict);
-    expect(oversizedConflict.error.message).toBe(
-      "Active input batch exceeds runner control payload limit",
-    );
-    await expect(
-      api.listRunnerActiveInputs(claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([oversizedPendingEventId]);
-
-    const afterOversizedClaim = await chat.listThreadEvents(
-      actor,
-      active.threadId,
-    );
-    expect(
-      userMessages(afterOversizedClaim.events).some((event) => {
-        return event.revokesEventId === oversizedPendingEventId;
-      }),
-    ).toBeFalsy();
-    expect(userMessages(afterOversizedClaim.events)).toContainEqual(
-      expect.objectContaining({
-        runId: active.runId,
-        revokesEventId: exactLimitPendingEventId,
-      }),
-    );
-    await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: active.threadId,
-        revokesEventId: oversizedPendingEventId,
-      },
-      [201],
-    );
-
-    await cancelChatRun(actor, active.runId);
-  }, 90_000);
-
   it("reserves rich inputs one at a time and settles concurrent receipts once", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -1867,9 +1663,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
       }),
     ).toHaveLength(1);
 
-    await expect(
-      api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([secondEventId]);
     const secondReservation = await api.reserveRunnerActiveInputs(
       claimed.claim.sandboxToken,
       active.runId,
@@ -1898,8 +1691,8 @@ describe("CHAT-02: queueing and recalling messages", () => {
       }),
     ).toHaveLength(2);
     await expect(
-      api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([]);
+      api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
+    ).resolves.toStrictEqual({ outcome: "empty" });
     const events = await chat.listThreadEvents(actor, active.threadId);
     const replacements = events.events.filter((event) => {
       return (
@@ -2082,7 +1875,7 @@ describe("CHAT-02: queueing and recalling messages", () => {
 
     const active = await sendChatRun(actor, {
       agentId,
-      prompt: "leave a legacy terminal delivery open",
+      prompt: "leave a terminal delivery open",
     });
     const claimed = await claimChatRun(runnerGroup, active.runId);
     const pendingEventId = randomUUID();
@@ -2161,17 +1954,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
     );
     await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
     await runSteerRunTimeBudgetCron();
-    const pendingEventIds = await api.listRunnerActiveInputs(
-      claimed.claim.sandboxToken,
-      active.runId,
-    );
-    expect(pendingEventIds).toHaveLength(2);
-    const budgetEventId = pendingEventIds.find((eventId) => {
-      return eventId !== releasedEventId;
-    });
-    if (!budgetEventId) {
-      throw new Error("Expected a pending budget input");
-    }
     const reserved = await api.reserveRunnerActiveInputs(
       claimed.claim.sandboxToken,
       active.runId,
@@ -2229,8 +2011,8 @@ describe("CHAT-02: queueing and recalling messages", () => {
       messages.events.filter((event) => {
         return (
           event.eventType === "control.revoke" &&
-          event.revokesEventId === budgetEventId &&
-          event.runId === active.runId
+          event.runId === active.runId &&
+          event.revokesEventId !== releasedEventId
         );
       }),
     ).toHaveLength(1);
@@ -2241,12 +2023,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
     ).toHaveLength(0);
 
     const successorClaim = await claimChatRun(runnerGroup, promoted.runId);
-    await expect(
-      api.listRunnerActiveInputs(
-        successorClaim.claim.sandboxToken,
-        promoted.runId,
-      ),
-    ).resolves.toStrictEqual([laterEventId]);
     await chat.requestSendEvent(
       actor,
       {
@@ -2454,9 +2230,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
       }),
     ).toHaveLength(0);
     const successorClaim = await claimChatRun(runnerGroup, successor);
-    await expect(
-      api.listRunnerActiveInputs(successorClaim.claim.sandboxToken, successor),
-    ).resolves.toStrictEqual([laterEventId]);
     await chat.requestSendEvent(
       actor,
       {
@@ -2504,6 +2277,7 @@ describe("CHAT-02: queueing and recalling messages", () => {
       [403],
     );
     expectApiError(missingDelivery.body);
+    expect(missingDelivery.body.error.code).toBe("FORBIDDEN");
     await failChatRun(
       active.runId,
       claimed.sandboxHeaders,
@@ -2703,9 +2477,6 @@ describe("CHAT-02: queueing and recalling messages", () => {
       outcome: "rejected",
       reason: "payload_too_large",
     });
-    await expect(
-      api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([oversizedEventId]);
     await chat.requestSendEvent(
       actor,
       {
@@ -2746,8 +2517,8 @@ describe("CHAT-02: queueing and recalling messages", () => {
       ),
     ).resolves.toStrictEqual({ outcome: "delivered" });
     await expect(
-      api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([]);
+      api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
+    ).resolves.toStrictEqual({ outcome: "empty" });
     const events = await chat.listThreadEvents(actor, active.threadId);
     expect(events.events).toContainEqual(
       expect.objectContaining({
@@ -2772,23 +2543,27 @@ describe("CHAT-02: queueing and recalling messages", () => {
     await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS - 60_000);
     await runSteerRunTimeBudgetCron();
     await expect(
-      api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([]);
+      api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
+    ).resolves.toStrictEqual({ outcome: "empty" });
 
     await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
     await runSteerRunTimeBudgetCron();
-    const budgetEventIds = await api.listRunnerActiveInputs(
+    const budgetReservation = await api.reserveRunnerActiveInputs(
       claimed.claim.sandboxToken,
       active.runId,
     );
-    expect(budgetEventIds).toHaveLength(1);
+    if (budgetReservation.outcome !== "reserved") {
+      throw new Error("Expected the run time budget input to be reserved");
+    }
+    expect(budgetReservation.eventIds).toHaveLength(1);
+    expect(budgetReservation.prompt).toBe(RUN_TIME_BUDGET_MESSAGE);
     await expect(
-      api.claimRunnerActiveInputs(
+      api.recordRunnerActiveInputDelivery(
         claimed.claim.sandboxToken,
         active.runId,
-        budgetEventIds,
+        budgetReservation.deliveryId,
       ),
-    ).resolves.toBe(RUN_TIME_BUDGET_MESSAGE);
+    ).resolves.toStrictEqual({ outcome: "delivered" });
 
     const publicEvents = await chat.listThreadEvents(actor, active.threadId);
     const budgetEvent = publicEvents.events.find((event) => {
@@ -2809,13 +2584,13 @@ describe("CHAT-02: queueing and recalling messages", () => {
 
     await runSteerRunTimeBudgetCron();
     await expect(
-      api.listRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([]);
+      api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
+    ).resolves.toStrictEqual({ outcome: "empty" });
 
     await cancelChatRun(actor, active.runId);
   }, 90_000);
 
-  it("does not carry an unclaimed time budget input into a later run", async () => {
+  it("does not carry an undelivered time budget input into a later run", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -2826,9 +2601,14 @@ describe("CHAT-02: queueing and recalling messages", () => {
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
     await ageClaimedRun(first.runId, RUN_TIME_BUDGET_STEER_AT_MS);
     await runSteerRunTimeBudgetCron();
-    await expect(
-      api.listRunnerActiveInputs(firstClaim.claim.sandboxToken, first.runId),
-    ).resolves.toHaveLength(1);
+    const firstBudget = await api.reserveRunnerActiveInputs(
+      firstClaim.claim.sandboxToken,
+      first.runId,
+    );
+    expect(firstBudget).toMatchObject({
+      outcome: "reserved",
+      prompt: RUN_TIME_BUDGET_MESSAGE,
+    });
 
     await cancelChatRun(actor, first.runId, firstClaim.sandboxHeaders);
     const second = await sendChatRun(actor, {
@@ -2838,8 +2618,11 @@ describe("CHAT-02: queueing and recalling messages", () => {
     });
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
     await expect(
-      api.listRunnerActiveInputs(secondClaim.claim.sandboxToken, second.runId),
-    ).resolves.toStrictEqual([]);
+      api.reserveRunnerActiveInputs(
+        secondClaim.claim.sandboxToken,
+        second.runId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "empty" });
     await cancelChatRun(actor, second.runId, secondClaim.sandboxHeaders);
   }, 90_000);
 
@@ -6796,16 +6579,22 @@ describe("CHAT-02: prior rounds and thread titles", () => {
       throw new Error("Expected the recommended follow-up to succeed");
     }
     expect(followup.body.runId).toBeNull();
+    const reservation = await api.reserveRunnerActiveInputs(
+      activeClaim.claim.sandboxToken,
+      active.runId,
+    );
+    if (reservation.outcome !== "reserved") {
+      throw new Error("Expected the recommended follow-up to be reserved");
+    }
+    expect(reservation.eventIds).toStrictEqual([eventId]);
+    expect(reservation.prompt).toBe("steer the recommended follow-up");
     await expect(
-      api.listRunnerActiveInputs(activeClaim.claim.sandboxToken, active.runId),
-    ).resolves.toStrictEqual([eventId]);
-    await expect(
-      api.claimRunnerActiveInputs(
+      api.recordRunnerActiveInputDelivery(
         activeClaim.claim.sandboxToken,
         active.runId,
-        [eventId],
+        reservation.deliveryId,
       ),
-    ).resolves.toBe("steer the recommended follow-up");
+    ).resolves.toStrictEqual({ outcome: "delivered" });
 
     const afterFollowup = await waitForThreadMessages(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -496,49 +496,6 @@ export function createRunsApi(context: TestContext) {
       return response.body;
     },
 
-    async listRunnerActiveInputs(sandboxToken: string, runId: string) {
-      const response = await accept(
-        runApp(context)(runnersActiveInputsContract).list({
-          headers: { authorization: `Bearer ${sandboxToken}` },
-          params: { runId },
-        }),
-        [200],
-      );
-      return response.body.eventIds;
-    },
-
-    async claimRunnerActiveInputs(
-      sandboxToken: string,
-      runId: string,
-      eventIds: string[],
-    ) {
-      const response = await accept(
-        runApp(context)(runnersActiveInputsContract).claim({
-          headers: { authorization: `Bearer ${sandboxToken}` },
-          params: { runId },
-          body: { eventIds },
-        }),
-        [200],
-      );
-      return response.body.prompt;
-    },
-
-    async claimRunnerActiveInputsConflict(
-      sandboxToken: string,
-      runId: string,
-      eventIds: string[],
-    ) {
-      const response = await accept(
-        runApp(context)(runnersActiveInputsContract).claim({
-          headers: { authorization: `Bearer ${sandboxToken}` },
-          params: { runId },
-          body: { eventIds },
-        }),
-        [409],
-      );
-      return response.body;
-    },
-
     async requestReserveRunnerActiveInputsAs<
       TStatus extends RunnerActiveInputDeliveryStatus,
     >(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -32,7 +32,6 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { blobs } from "@vm0/db/schema/blob";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   runnerState,
   type RunnerHeldSandboxState as PersistedRunnerHeldSandboxState,
@@ -59,7 +58,7 @@ import { runnerAuth$, type RunnerAuthContext } from "../auth/runner-auth";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
-import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import { db$, writeDb$, type Db } from "../external/db";
 import {
   generatePresignedGetUrl,
   publicS3DownloadSource,
@@ -73,7 +72,7 @@ import {
 import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { now, nowDate } from "../../lib/time";
 import { env } from "../../lib/env";
-import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { badRequestMessage, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { executeRawRows } from "../../lib/db-raw-rows";
 import {
@@ -86,16 +85,9 @@ import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
 import { historyGenerationRunIdForStoredExecutionContext } from "../services/agent-run-queue-payload.service";
 import {
-  activeInputPromptFitsControlPayload,
-  materializePendingActiveInputPrompts,
-  pendingActiveInputRows,
-} from "../services/active-input-prompt.service";
-import {
   recordActiveInputDeliveryReceipt,
-  replacePendingActiveInputEvent,
   reserveActiveInputDelivery,
 } from "../services/active-input-delivery.service";
-import { lockChatQueueThread } from "../services/chat-event-queue.service";
 import { notifyRunningChatRunOfPendingInput } from "../services/chat-thread-queue-drain.service";
 import { loadConnectorRuntimeSnapshot } from "../services/connector-catalog-runtime.service";
 import { loadConnectorRunnerFirewallCatalog } from "../services/connector-runner-firewall-catalog.service";
@@ -2780,175 +2772,11 @@ const builtinFirewallsResolveInner$ = command(
   },
 );
 
-async function loadRunningActiveInputRun(
-  db: ReadonlyDb,
-  args: {
-    readonly runId: string;
-    readonly userId: string;
-    readonly orgId: string;
-  },
-) {
-  const [run] = await db
-    .select({ chatThreadId: zeroRuns.chatThreadId })
-    .from(agentRuns)
-    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-    .where(
-      and(
-        eq(agentRuns.id, args.runId),
-        eq(agentRuns.userId, args.userId),
-        eq(agentRuns.orgId, args.orgId),
-        eq(agentRuns.status, "running"),
-      ),
-    )
-    .limit(1);
-  if (!run?.chatThreadId) {
-    return null;
-  }
-  return { chatThreadId: run.chatThreadId };
-}
-
-const activeInputClaimBody$ = bodyResultOf(runnersActiveInputsContract.claim);
 const activeInputReserveBody$ = bodyResultOf(
   runnersActiveInputsContract.reserve,
 );
 const activeInputReceiptBody$ = bodyResultOf(
   runnersActiveInputsContract.receipt,
-);
-
-const listActiveInputsInner$ = command(async ({ get }, signal: AbortSignal) => {
-  const auth = get(authContext$);
-  const { runId } = get(pathParamsOf(runnersActiveInputsContract.list));
-  if (auth.tokenType !== "sandbox" || auth.runId !== runId) {
-    return notFound("Run not found");
-  }
-  const db = get(db$);
-  const run = await loadRunningActiveInputRun(db, {
-    runId,
-    userId: auth.userId,
-    orgId: auth.orgId,
-  });
-  signal.throwIfAborted();
-  if (!run) {
-    return notFound("Run not found");
-  }
-  const rows = await pendingActiveInputRows(db, run.chatThreadId, runId);
-  signal.throwIfAborted();
-  return {
-    status: 200 as const,
-    body: {
-      eventIds: rows.map((row) => {
-        return row.id;
-      }),
-    },
-  };
-});
-
-const claimActiveInputsInner$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const auth = get(authContext$);
-    const { runId } = get(pathParamsOf(runnersActiveInputsContract.claim));
-    if (auth.tokenType !== "sandbox" || auth.runId !== runId) {
-      return notFound("Run not found");
-    }
-    const body = await get(activeInputClaimBody$);
-    signal.throwIfAborted();
-    if (!body.ok) {
-      return body.response;
-    }
-    const uniqueEventIds = [...new Set(body.data.eventIds)];
-    if (uniqueEventIds.length !== body.data.eventIds.length) {
-      return badRequestMessage("Active input event IDs must be unique");
-    }
-
-    const db = set(writeDb$);
-    const run = await loadRunningActiveInputRun(db, {
-      runId,
-      userId: auth.userId,
-      orgId: auth.orgId,
-    });
-    signal.throwIfAborted();
-    if (!run) {
-      return notFound("Run not found");
-    }
-    const candidates = await pendingActiveInputRows(
-      db,
-      run.chatThreadId,
-      runId,
-      uniqueEventIds,
-    );
-    signal.throwIfAborted();
-    if (candidates.length !== uniqueEventIds.length) {
-      return conflict("One or more active inputs are no longer pending");
-    }
-    const materializedPrompts = await materializePendingActiveInputPrompts(
-      db,
-      candidates,
-      auth,
-      signal,
-    );
-    if (!materializedPrompts) {
-      return conflict("One or more active inputs cannot be materialized");
-    }
-    const promptParts: string[] = [];
-    for (const candidate of candidates) {
-      const prompt = materializedPrompts.get(candidate.id);
-      if (prompt === undefined) {
-        throw new Error("Active input prompt materialization is missing");
-      }
-      promptParts.push(prompt);
-    }
-    const materializedPrompt = promptParts.join("\n\n");
-    if (!activeInputPromptFitsControlPayload(materializedPrompt)) {
-      return conflict(
-        "Active input batch exceeds runner control payload limit",
-      );
-    }
-
-    const result = await db.transaction(async (tx) => {
-      if (!(await lockChatQueueThread(tx, run.chatThreadId))) {
-        return null;
-      }
-      const [lockedRun] = await tx
-        .select({ id: agentRuns.id })
-        .from(agentRuns)
-        .where(
-          and(
-            eq(agentRuns.id, runId),
-            eq(agentRuns.userId, auth.userId),
-            eq(agentRuns.orgId, auth.orgId),
-            eq(agentRuns.status, "running"),
-          ),
-        )
-        .for("update")
-        .limit(1);
-      if (!lockedRun) {
-        return null;
-      }
-      const events = await pendingActiveInputRows(
-        tx,
-        run.chatThreadId,
-        runId,
-        uniqueEventIds,
-      );
-      if (events.length !== uniqueEventIds.length) {
-        return null;
-      }
-      for (const event of events) {
-        await replacePendingActiveInputEvent(tx, event, runId);
-      }
-      return true;
-    });
-    signal.throwIfAborted();
-    if (!result) {
-      return conflict("One or more active inputs are no longer pending");
-    }
-    await publishChatThreadMessageCreatedSafely(auth.userId, run.chatThreadId);
-    signal.throwIfAborted();
-    return {
-      status: 200 as const,
-      body: { prompt: materializedPrompt },
-    };
-  },
 );
 
 const reserveActiveInputsInner$ = command(
@@ -2981,7 +2809,7 @@ const reserveActiveInputsInner$ = command(
         body: {
           outcome: result.outcome,
           deliveryId: result.deliveryId,
-          eventIds: [...result.eventIds],
+          eventIds: [result.sourceEventId],
           prompt: result.prompt,
         },
       };
@@ -2992,7 +2820,7 @@ const reserveActiveInputsInner$ = command(
         body: {
           outcome: result.outcome,
           deliveryId: result.deliveryId,
-          eventIds: [...result.eventIds],
+          eventIds: [result.sourceEventId],
         },
       };
     }
@@ -3055,20 +2883,6 @@ export const runnersRoutes: readonly RouteEntry[] = [
   {
     route: runnersJobClaimContract.claim,
     handler: claimInner$,
-  },
-  {
-    route: runnersActiveInputsContract.list,
-    handler: authRoute(
-      { accept: ["sandbox"], acceptAnySandboxCapability: true },
-      listActiveInputsInner$,
-    ),
-  },
-  {
-    route: runnersActiveInputsContract.claim,
-    handler: authRoute(
-      { accept: ["sandbox"], acceptAnySandboxCapability: true },
-      claimActiveInputsInner$,
-    ),
   },
   {
     route: runnersActiveInputsContract.reserve,

--- a/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
@@ -36,7 +36,12 @@ interface ActiveInputDeliveryScope {
 
 interface ActiveInputDeliveryReference {
   readonly deliveryId: string;
-  readonly eventIds: readonly string[];
+  readonly sourceEventId: string;
+}
+
+interface LockedOpenActiveInputDelivery {
+  readonly deliveryId: string;
+  readonly items: LockedActiveInputDeliveryReceipt["items"];
 }
 
 interface ActiveInputDeliveryIdentity {
@@ -82,7 +87,7 @@ type PreparedReservation =
   | {
       readonly kind: "ready";
       readonly deliveryId: string;
-      readonly eventIds: readonly string[];
+      readonly sourceEventId: string;
       readonly prompt: string;
     };
 
@@ -144,19 +149,15 @@ async function loadActiveInputDeliveryScope(
   };
 }
 
-function combinedPrompt(
-  rows: readonly PendingActiveInputRow[],
+function materializedPrompt(
+  row: PendingActiveInputRow,
   prompts: ReadonlyMap<string, string>,
 ): string {
-  return rows
-    .map((row) => {
-      const prompt = prompts.get(row.id);
-      if (prompt === undefined) {
-        throw new Error("Active input prompt materialization is missing");
-      }
-      return prompt;
-    })
-    .join("\n\n");
+  const prompt = prompts.get(row.id);
+  if (prompt === undefined) {
+    throw new Error("Active input prompt materialization is missing");
+  }
+  return prompt;
 }
 
 async function prepareReservation(
@@ -170,7 +171,8 @@ async function prepareReservation(
     scope.runId,
   ).limit(1);
   signal.throwIfAborted();
-  if (rows.length === 0) {
+  const [row] = rows;
+  if (!row) {
     return { kind: "empty" };
   }
   const prompts = await materializePendingActiveInputPrompts(
@@ -182,7 +184,7 @@ async function prepareReservation(
   if (!prompts) {
     throw new Error("Pending active input cannot be materialized");
   }
-  const prompt = combinedPrompt(rows, prompts);
+  const prompt = materializedPrompt(row, prompts);
   const deliveryId = randomUUID();
   if (!activeInputDeliveryPromptFitsControlPayload(deliveryId, prompt)) {
     return { kind: "rejected", reason: "payload_too_large" };
@@ -190,9 +192,7 @@ async function prepareReservation(
   return {
     kind: "ready",
     deliveryId,
-    eventIds: rows.map((row) => {
-      return row.id;
-    }),
+    sourceEventId: row.id,
     prompt,
   };
 }
@@ -200,7 +200,7 @@ async function prepareReservation(
 async function lockOpenDelivery(
   tx: ActiveInputDeliveryTransaction,
   scope: ActiveInputDeliveryIdentity,
-): Promise<ActiveInputDeliveryReference | null> {
+): Promise<LockedOpenActiveInputDelivery | null> {
   const [delivery] = await tx
     .select({
       id: activeInputDeliveries.id,
@@ -240,9 +240,7 @@ async function lockOpenDelivery(
   }
   return {
     deliveryId: delivery.id,
-    eventIds: items.map((item) => {
-      return item.sourceEventId;
-    }),
+    items,
   };
 }
 
@@ -272,9 +270,17 @@ async function transitionReservation(
   const status = runStatusSchema.parse(run.status);
   const openDelivery = await lockOpenDelivery(tx, scope);
   if (openDelivery) {
+    const [item] = openDelivery.items;
+    if (!item || openDelivery.items.length !== 1) {
+      throw new Error("Open active input reservation has invalid cardinality");
+    }
+    const reference = {
+      deliveryId: openDelivery.deliveryId,
+      sourceEventId: item.sourceEventId,
+    };
     return status === "running"
-      ? { outcome: "retrieve", ...openDelivery }
-      : { outcome: "held", ...openDelivery };
+      ? { outcome: "retrieve", ...reference }
+      : { outcome: "held", ...reference };
   }
   if (isTerminalRunStatus(status)) {
     return { outcome: "terminal" };
@@ -292,13 +298,11 @@ async function transitionReservation(
     tx,
     scope.chatThreadId,
     scope.runId,
-    prepared.eventIds,
+    [prepared.sourceEventId],
   );
   if (
-    currentRows.length !== prepared.eventIds.length ||
-    currentRows.some((row, index) => {
-      return row.id !== prepared.eventIds[index];
-    })
+    currentRows.length !== 1 ||
+    currentRows[0]?.id !== prepared.sourceEventId
   ) {
     return { outcome: "retry" };
   }
@@ -308,19 +312,15 @@ async function transitionReservation(
     chatThreadId: scope.chatThreadId,
     status: "open",
   });
-  await tx.insert(activeInputDeliveryItems).values(
-    prepared.eventIds.map((sourceEventId, position) => {
-      return {
-        deliveryId: prepared.deliveryId,
-        sourceEventId,
-        position,
-      };
-    }),
-  );
+  await tx.insert(activeInputDeliveryItems).values({
+    deliveryId: prepared.deliveryId,
+    sourceEventId: prepared.sourceEventId,
+    position: 0,
+  });
   return {
     outcome: "created",
     deliveryId: prepared.deliveryId,
-    eventIds: prepared.eventIds,
+    sourceEventId: prepared.sourceEventId,
     prompt: prepared.prompt,
   };
 }
@@ -331,18 +331,12 @@ async function materializeDelivery(
   delivery: ActiveInputDeliveryReference,
   signal: AbortSignal,
 ): Promise<string> {
-  const rows = await activeInputRowsByIds(
-    db,
-    scope.chatThreadId,
-    delivery.eventIds,
-  );
+  const rows = await activeInputRowsByIds(db, scope.chatThreadId, [
+    delivery.sourceEventId,
+  ]);
   signal.throwIfAborted();
-  if (
-    rows.length !== delivery.eventIds.length ||
-    rows.some((row, index) => {
-      return row.id !== delivery.eventIds[index];
-    })
-  ) {
+  const [row] = rows;
+  if (!row || rows.length !== 1 || row.id !== delivery.sourceEventId) {
     throw new Error("Active input delivery source membership is invalid");
   }
   const prompts = await materializePendingActiveInputPrompts(
@@ -354,7 +348,7 @@ async function materializeDelivery(
   if (!prompts) {
     throw new Error("Active input delivery cannot be rematerialized");
   }
-  const prompt = combinedPrompt(rows, prompts);
+  const prompt = materializedPrompt(row, prompts);
   if (
     !activeInputDeliveryPromptFitsControlPayload(delivery.deliveryId, prompt)
   ) {
@@ -392,7 +386,7 @@ export async function reserveActiveInputDelivery(
       return {
         outcome: "reserved",
         deliveryId: result.deliveryId,
-        eventIds: result.eventIds,
+        sourceEventId: result.sourceEventId,
         prompt: result.prompt,
       };
     }
@@ -400,7 +394,7 @@ export async function reserveActiveInputDelivery(
       return {
         outcome: "reserved",
         deliveryId: result.deliveryId,
-        eventIds: result.eventIds,
+        sourceEventId: result.sourceEventId,
         prompt: await materializeDelivery(db, scope, result, signal),
       };
     }
@@ -408,7 +402,7 @@ export async function reserveActiveInputDelivery(
   }
 }
 
-export async function replacePendingActiveInputEvent(
+async function replacePendingActiveInputEvent(
   tx: ActiveInputDeliveryTransaction,
   event: PendingActiveInputRow,
   runId: string,
@@ -860,15 +854,12 @@ export async function finalizeActiveInputDeliveryForCompletion(
       chatEventsAppended: pendingBudgetExpired,
     };
   }
-  const items = delivery.eventIds.map((sourceEventId) => {
-    return { sourceEventId, disposition: null };
-  });
   if (!args.deliveredDeliveryIds.has(delivery.deliveryId)) {
     const finalization = await settleOpenActiveInputDeliveryAsUndelivered(
       tx,
       args,
       delivery.deliveryId,
-      items,
+      delivery.items,
     );
     return {
       ...finalization,
@@ -880,7 +871,7 @@ export async function finalizeActiveInputDeliveryForCompletion(
     tx,
     args,
     delivery.deliveryId,
-    items,
+    delivery.items,
   );
   if (!settlement) {
     throw new Error("Delivered active input source is no longer valid");

--- a/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
@@ -51,10 +51,6 @@ const CONTEXT_BACKED_CONTEXT_TYPES: readonly ContextBackedContextType[] = [
   "agentphone",
 ];
 
-export function activeInputPromptFitsControlPayload(prompt: string): boolean {
-  return activeInputControlPayloadFits({ type: "active-input", text: prompt });
-}
-
 export function activeInputDeliveryPromptFitsControlPayload(
   deliveryId: string,
   prompt: string,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -1840,66 +1840,6 @@ export async function holdChatEventQueueItemFixture(args: {
 }
 
 /**
- * Holds one existing ChatEvent row so thread deletion can pause after it
- * owns the parent thread lock. This timing-only boundary does not create or
- * mutate product data and cannot block messages outside the selected thread.
- */
-export async function holdChatEventFixture(args: {
-  readonly threadId: string;
-  readonly eventId: string;
-  readonly signal: AbortSignal;
-}): Promise<{
-  readonly release: () => void;
-  readonly done: Promise<void>;
-  readonly blockedWaiterCount: () => Promise<number>;
-}> {
-  const started = createDeferredPromise<number>(args.signal);
-  const released = createDeferredPromise<void>(args.signal);
-  const done = db().transaction(async (tx) => {
-    const rows = await tx
-      .select({ id: chatEvents.id })
-      .from(chatEvents)
-      .where(
-        and(
-          eq(chatEvents.id, args.eventId),
-          eq(chatEvents.chatThreadId, args.threadId),
-        ),
-      )
-      .for("update")
-      .limit(1);
-    if (!rows[0]) {
-      throw new Error("Expected the chat message row");
-    }
-    const pidRows = await executeRawRows(
-      tx,
-      sql`
-        SELECT pg_backend_pid() AS "pid"
-      `,
-      databasePidRowSchema,
-    );
-    const holderPid = pidRows[0]?.pid;
-    if (!holderPid) {
-      throw new Error("Expected the chat-message lock holder pid");
-    }
-    started.resolve(holderPid);
-    await released.promise;
-  });
-  const holderPid = await started.promise;
-
-  return {
-    release: () => {
-      if (!released.settled()) {
-        released.resolve(undefined);
-      }
-    },
-    done,
-    blockedWaiterCount: async () => {
-      return await transitiveBlockedWaiterCount(holderPid);
-    },
-  };
-}
-
-/**
  * Inserts one event through the production sequence writer, then holds its
  * transaction open. No product endpoint can pause between INSERT and COMMIT,
  * so this fixture is the narrow timing boundary for sequence serialization.

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import {
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
+  activeInputDeliveryReserveResponseSchema,
   compatibleStoredExecutionContextSchema,
   CONNECTOR_RUNTIME_SYNC_TARGETS_MAX,
   connectorRuntimeSyncResultSchema,
@@ -31,6 +32,39 @@ import {
   storedExecutionContextSchema,
   storedResumeSessionSchema,
 } from "../runners";
+
+describe("active-input reservation contract", () => {
+  const deliveryId = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
+  const eventId = "223f8797-a456-4eea-98f7-f7ab88c43c00";
+  const secondEventId = "b5490696-d307-42f7-927c-9b5ca037cb46";
+
+  it("keeps the deployed eventIds array with exactly one source event", () => {
+    expect(
+      activeInputDeliveryReserveResponseSchema.parse({
+        outcome: "reserved",
+        deliveryId,
+        eventIds: [eventId],
+        prompt: "follow-up",
+      }),
+    ).toStrictEqual({
+      outcome: "reserved",
+      deliveryId,
+      eventIds: [eventId],
+      prompt: "follow-up",
+    });
+
+    for (const eventIds of [[], [eventId, secondEventId]]) {
+      expect(
+        activeInputDeliveryReserveResponseSchema.safeParse({
+          outcome: "reserved",
+          deliveryId,
+          eventIds,
+          prompt: "follow-up",
+        }).success,
+      ).toBe(false);
+    }
+  });
+});
 
 describe("cancellation recovery timing contract", () => {
   it("keeps the API stale fallback beyond the runner recovery deadline", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -1013,7 +1013,7 @@ export const runnersJobClaimContract = c.router({
 
 const activeInputDeliveryReferenceSchema = z.object({
   deliveryId: z.uuid(),
-  eventIds: z.array(z.uuid()).min(1),
+  eventIds: z.array(z.uuid()).length(1),
 });
 
 export const activeInputDeliveryReserveResponseSchema = z.discriminatedUnion(
@@ -1044,53 +1044,6 @@ export const activeInputDeliveryReceiptResponseSchema = z.discriminatedUnion(
 );
 
 export const runnersActiveInputsContract = c.router({
-  list: {
-    method: "GET",
-    path: "/api/runners/runs/:runId/active-inputs",
-    headers: authHeadersSchema,
-    pathParams: z.object({
-      runId: z.uuid(),
-    }),
-    responses: {
-      200: z.object({
-        eventIds: z.array(z.uuid()),
-      }),
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-      404: apiErrorSchema,
-      500: apiErrorSchema,
-    },
-    summary: "List pending input prompts for a running agent run",
-  },
-  claim: {
-    method: "POST",
-    path: "/api/runners/runs/:runId/active-inputs/claim",
-    headers: authHeadersSchema,
-    pathParams: z.object({
-      runId: z.uuid(),
-    }),
-    body: z.object({
-      eventIds: z.array(z.uuid()).min(1),
-    }),
-    responses: {
-      200: z.object({
-        prompt: z.string().min(1),
-      }),
-      400: apiErrorSchema,
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-      404: apiErrorSchema,
-      409: apiErrorSchema,
-      500: apiErrorSchema,
-    },
-    summary: "Claim pending input prompts for a running agent run",
-  },
-  /**
-   * This additive route intentionally has no 404 response. During the rollout,
-   * Runner uses route-level 404 exclusively to identify an API that predates
-   * reservation support; every response from an API that implements the route
-   * must preserve its actual lifecycle or error classification.
-   */
   reserve: {
     method: "POST",
     path: "/api/runners/runs/:runId/active-inputs/reserve",

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
@@ -15,18 +15,6 @@ const expectedBindings = [
     rustConstName: "CLAIM",
   },
   {
-    method: "GET",
-    path: "/api/runners/runs/:runId/active-inputs",
-    rustModulePath: ["runners", "runs", "by_run_id", "active_inputs"],
-    rustConstName: "LIST",
-  },
-  {
-    method: "POST",
-    path: "/api/runners/runs/:runId/active-inputs/claim",
-    rustModulePath: ["runners", "runs", "by_run_id", "active_inputs", "claim"],
-    rustConstName: "CLAIM",
-  },
-  {
     method: "POST",
     path: "/api/runners/runs/:runId/active-inputs/reserve",
     rustModulePath: [

--- a/turbo/packages/api-contracts/src/rust-bindings/routes.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/routes.ts
@@ -43,16 +43,6 @@ export const rustRouteBindings = [
     rustConstName: "CLAIM",
   },
   {
-    route: runnersActiveInputsContract.list,
-    rustModulePath: ["runners", "runs", "by_run_id", "active_inputs"],
-    rustConstName: "LIST",
-  },
-  {
-    route: runnersActiveInputsContract.claim,
-    rustModulePath: ["runners", "runs", "by_run_id", "active_inputs", "claim"],
-    rustConstName: "CLAIM",
-  },
-  {
     route: runnersActiveInputsContract.reserve,
     rustModulePath: [
       "runners",


### PR DESCRIPTION
## Summary

- remove the legacy active-input list/claim API and its generated bindings
- make Runner use reserve-only delivery and Guest require canonical delivery IDs with receipts
- preserve the stable reserve/completion wire shapes and historical settlement paths without a database migration

## Compatibility

- the reserve request remains an `eventIds` array containing exactly one event
- empty completion event IDs remain optional, preserving compatibility with the preceding Runner release from #26060
- Runner and Guest are shipped together, so the required delivery ID does not create a supported mixed-version pair
- existing delivery and delivery-item records remain readable and settleable; no persisted data is rewritten

## Merge gates

- confirm authoritative telemetry shows no legacy list/claim requests or unidentified active-input payloads throughout the drain window
- run the planned read-only production audit for open, orphaned, or multi-item active-input deliveries

## Validation

- full pre-commit hook: Prettier, Knip, all Turbo type checks, Cargo fmt/doc/clippy, and file-size validation
- API contracts lint, type checks, generated-binding checks, and 535 contract tests
- API lint, type checks, and 85 active-input BDD tests
- `cargo test -p api-contracts`
- Runner active-input tests and the full Runner suite: 3,121 passed, 20 ignored
- Guest active-input tests and the full Guest Agent suite

Closes #26061

Parent: #26034
