### PR TITLE
fix: refresh concurrency limit after billing changes

### DIFF
--- a/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
@@ -1,11 +1,20 @@
-import { computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import { zeroRunsQueueContract } from "@vm0/api-contracts/contracts/zero-runs";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 
+const queueDataReload$ = state(0);
+
 /** Async computed — auto-fetches queue data when subscribed. */
 export const queueData$ = computed(async (get) => {
+  get(queueDataReload$);
   const client = get(zeroClient$)(zeroRunsQueueContract);
   const result = await accept(client.getQueue(), [200]);
   return result.body;
+});
+
+export const reloadQueueData$ = command(({ set }) => {
+  set(queueDataReload$, (value) => {
+    return value + 1;
+  });
 });

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -25,6 +25,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
 import { replaceSearchParams$, searchParams$ } from "../route.ts";
 import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
+import { reloadQueueData$ } from "../queue-page/queue-signals.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { tapError } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
@@ -481,6 +482,7 @@ export const handleBillingRedirect$ = command(({ get, set }) => {
 
 const reloadBillingStatusFromRealtime$ = command(({ set }) => {
   set(reloadBillingStatus$);
+  set(reloadQueueData$);
   set(reloadUsagePackManagement$);
   set(reloadUsageRecords$);
   return false;

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -331,6 +331,42 @@ describe("queue drawer", () => {
     expect(screen.getByText("Buy $100/month")).toBeInTheDocument();
   });
 
+  it("refreshes the concurrency limit when billing changes in realtime", async () => {
+    let concurrencyLimit = 5;
+    mockConcurrencyCapability(true);
+    context.mocks.api(zeroRunsQueueContract.getQueue, ({ respond }) => {
+      return respond(
+        200,
+        queueResponse({
+          concurrency: {
+            tier: "team",
+            limit: concurrencyLimit,
+            active: 3,
+            available: concurrencyLimit - 3,
+            memberUsage: [],
+          },
+        }),
+      );
+    });
+
+    await openDrawer();
+
+    await waitFor(() => {
+      expect(screen.getByText(/3 of 5 slots/)).toBeInTheDocument();
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+    });
+
+    concurrencyLimit = 6;
+    context.mocks.ably.trigger("billing:changed");
+
+    await waitFor(() => {
+      expect(screen.getByText(/3 of 6 slots/)).toBeInTheDocument();
+      expect(screen.getByText("3 slots available")).toBeInTheDocument();
+    });
+  });
+
   it("shows additional concurrency checkout for Custom admins without plan upgrade", async () => {
     mockConcurrencyCapability(true);
     context.mocks.api(zeroRunsQueueContract.getQueue, ({ respond }) => {


### PR DESCRIPTION
## Summary

- add an explicit reload signal for queue drawer data
- invalidate the queue data when Ably delivers billing:changed
- cover the realtime concurrency-limit refresh in the queue drawer test

## Validation

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged TypeScript checks for shared packages, platform, and API
- pnpm --filter @vm0/app exec vitest run src/views/queue-page/__tests__/queue-drawer.test.tsx (13 passed)