### PR TITLE
test(desktop): update drain mocks for okou routes

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -722,19 +722,19 @@ describe("ComputerUseHostRuntime", () => {
     const events: string[] = [];
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
         nextCalls += 1;
         events.push("claim");
         return jsonResponse({ status: "command", command });
       }
-      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
         events.push("complete");
         return jsonResponse({ ok: true });
       }
-      if (url.endsWith("/api/zero/computer-use/host/stop")) {
+      if (url.endsWith("/api/okou/computer-use/host/stop")) {
         events.push("stop");
         return jsonResponse({ ok: true });
       }


### PR DESCRIPTION
## Summary

- update the remaining Computer Use drain test mocks to the canonical `/api/okou` namespace
- unblock the Desktop main/release workflow after the Phase B first-party cutover
- retain the `/api/zero` compatibility route in production code

Follow-up for #26490.

## Validation

- `pnpm -F @vm0/desktop test` (333 passed)
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm exec prettier --check apps/desktop/src/computer-use-host.test.ts`