### PR TITLE
test(api): isolate browser reconciliation fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -7,7 +7,7 @@ import {
   type ChatEvent,
   type UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { cronBrowserReconcileContract } from "@vm0/api-contracts/contracts/cron";
+import { testBrowserReconcileContract } from "@vm0/api-contracts/contracts/test-browser-reconcile";
 import type { SupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@vm0/api-contracts/contracts/runners";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
@@ -48,7 +48,7 @@ import {
   generateDataKeyOutput,
   useSecretKmsProbe,
 } from "./helpers/secret-kms-probe";
-import { cronBrowserReconcileRoutes } from "../cron-browser-reconcile";
+import { testBrowserReconcileRoutes } from "../test-browser-reconcile";
 import { zeroGoalsRoutes } from "../zero-goals";
 
 /**
@@ -85,8 +85,6 @@ const GOAL_DRAIN_SUCCESS_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_zero_goal_drain_build_run_input",
   "api_dispatch_pre_create_zero_goal_drain_handoff_run",
 ] as const;
-const CANCELLATION_RECOVERY_CRON_SECRET =
-  "bdd-cancellation-recovery-cron-secret";
 const GOAL_CAPABILITIES = [
   "goal:read",
   "goal:agent-result:write",
@@ -523,9 +521,23 @@ async function expectCancellationRecoveryPending(
     .toBe(expected);
 }
 
-function cancellationRecoveryCronClient() {
-  return setupApp({ context, routes: cronBrowserReconcileRoutes })(
-    cronBrowserReconcileContract,
+function cancellationRecoveryReconcileClient() {
+  return setupApp({ context, routes: testBrowserReconcileRoutes })(
+    testBrowserReconcileContract,
+  );
+}
+
+async function reconcileCancellationRecoveryFixtures(
+  chatThreadId: string,
+  ...additionalChatThreadIds: string[]
+): Promise<void> {
+  await accept(
+    cancellationRecoveryReconcileClient().reconcile({
+      body: {
+        chat_thread_ids: [chatThreadId, ...additionalChatThreadIds],
+      },
+    }),
+    [200],
   );
 }
 
@@ -3025,7 +3037,6 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    mockEnv("CRON_SECRET", CANCELLATION_RECOVERY_CRON_SECRET);
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const run = await startChatRun(actor, {
       agentId,
@@ -3054,14 +3065,7 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     ).toHaveLength(0);
 
     mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS - 1);
-    await accept(
-      cancellationRecoveryCronClient().reconcile({
-        headers: {
-          authorization: `Bearer ${CANCELLATION_RECOVERY_CRON_SECRET}`,
-        },
-      }),
-      [200],
-    );
+    await reconcileCancellationRecoveryFixtures(run.threadId);
     const beforeExpiry = await chat.listThreadEvents(actor, run.threadId);
     expect(
       userMessages(beforeExpiry.events).filter((event) => {
@@ -3074,14 +3078,7 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
 
     context.mocks.ably.publish.mockClear();
     mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
-    await accept(
-      cancellationRecoveryCronClient().reconcile({
-        headers: {
-          authorization: `Bearer ${CANCELLATION_RECOVERY_CRON_SECRET}`,
-        },
-      }),
-      [200],
-    );
+    await reconcileCancellationRecoveryFixtures(run.threadId);
     const replacementRunId = await waitForQueuedEventReplacement(
       actor,
       run.threadId,
@@ -3105,7 +3102,6 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    mockEnv("CRON_SECRET", CANCELLATION_RECOVERY_CRON_SECRET);
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const poisonedRun = await startChatRun(actor, {
@@ -3132,13 +3128,9 @@ describe("CHAT-02/RUN-03: cancellation recovery barrier", () => {
     await api.requestCancelRun(actor, healthyRun.runId, [200]);
     await flushWaitUntilForTest();
     mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
-    await accept(
-      cancellationRecoveryCronClient().reconcile({
-        headers: {
-          authorization: `Bearer ${CANCELLATION_RECOVERY_CRON_SECRET}`,
-        },
-      }),
-      [200],
+    await reconcileCancellationRecoveryFixtures(
+      poisonedRun.threadId,
+      healthyRun.threadId,
     );
 
     const replacementRunId = await waitForQueuedEventReplacement(
@@ -3979,7 +3971,6 @@ describe("CHAT-02: drain-time admission failure", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    mockEnv("CRON_SECRET", CANCELLATION_RECOVERY_CRON_SECRET);
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const anchor = await startChatRun(actor, {
@@ -4082,14 +4073,7 @@ describe("CHAT-02: drain-time admission failure", () => {
       null,
     );
     mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
-    await accept(
-      cancellationRecoveryCronClient().reconcile({
-        headers: {
-          authorization: `Bearer ${CANCELLATION_RECOVERY_CRON_SECRET}`,
-        },
-      }),
-      [200],
-    );
+    await reconcileCancellationRecoveryFixtures(anchor.threadId);
     const retried = await chat.requestSendEvent(
       actor,
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { cronBrowserReconcileContract } from "@vm0/api-contracts/contracts/cron";
+import { testBrowserReconcileContract } from "@vm0/api-contracts/contracts/test-browser-reconcile";
 import {
   zeroBrowserAuthorizationRequestsContract,
   zeroBrowserContract,
@@ -36,14 +36,13 @@ import {
   setComputerUseHostAsPreviousApi,
 } from "./helpers/runtime-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { cronBrowserReconcileRoutes } from "../cron-browser-reconcile";
+import { testBrowserReconcileRoutes } from "../test-browser-reconcile";
 import { zeroBrowserRoutes } from "../zero-browser";
 import { zeroBrowserAuthorizationRoutes } from "../zero-browser-authorization";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { zeroChatThreadComputerUseHostRoutes } from "../zero-chat-threads-computer-use-host";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...cronBrowserReconcileRoutes,
   ...zeroBrowserAuthorizationRoutes,
   ...zeroBrowserRoutes,
   ...zeroChatThreadRoutes,
@@ -52,7 +51,6 @@ const TEST_APP_ROUTES = Object.freeze([
 const context = testContext();
 const computerUse = createComputerUseBddApi(context);
 const BROWSER_USE_API_URL = "https://api.browser-use.com/api/v3";
-const CRON_SECRET = "test-browser-reconcile-secret";
 const STARTED_AT_MS = Date.parse("2026-07-24T10:00:00.000Z");
 const MINUTE_MS = 60_000;
 const DAY_MS = 24 * 60 * MINUTE_MS;
@@ -112,9 +110,9 @@ function chatThreadEventsClient() {
   );
 }
 
-function cronClient() {
-  return setupApp({ context, routes: cronBrowserReconcileRoutes })(
-    cronBrowserReconcileContract,
+function browserReconcileClient() {
+  return setupApp({ context, routes: testBrowserReconcileRoutes })(
+    testBrowserReconcileContract,
   );
 }
 
@@ -219,7 +217,6 @@ async function setupBrowserScenario() {
   mockNow(STARTED_AT_MS);
   mockEnv("ZERO_BROWSER_USE_API_KEY", "test-browser-use-key");
   mockEnv("APP_URL", "https://app.vm0.ai");
-  mockEnv("CRON_SECRET", CRON_SECRET);
   server.use(
     http.delete(`${BROWSER_USE_API_URL}/profiles/:id`, () => {
       return new HttpResponse(null, { status: 204 });
@@ -290,10 +287,15 @@ async function createClaimedChatRun(
   };
 }
 
-async function reconcileBrowsers() {
+async function reconcileBrowsers(
+  chatThreadId: string,
+  ...additionalChatThreadIds: string[]
+) {
   return await accept(
-    cronClient().reconcile({
-      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    browserReconcileClient().reconcile({
+      body: {
+        chat_thread_ids: [chatThreadId, ...additionalChatThreadIds],
+      },
     }),
     [200],
   );
@@ -864,15 +866,11 @@ describe("okou browser route", () => {
       }),
     ).toHaveLength(1);
 
-    // Root deletion preserves browser ownership, so the existing
-    // missing-thread reconciler remains the sole durable provider teardown
-    // path. Delete only this test's roots: the production sweep is global and
-    // is covered by the cleanup route integration tests.
+    // Root deletion preserves browser ownership, so the missing-thread
+    // reconciler remains the sole durable provider teardown path.
     await deleteAgentRunRootFixture(first.runId);
     await deleteAgentRunRootFixture(other.runId);
-    // The reconcile route scans every active browser in the shared database,
-    // so this test's own provider instances and profiles carry the assertion.
-    await reconcileBrowsers();
+    await reconcileBrowsers(first.threadId, other.threadId);
     expect(providerStops()).toBe(3);
     expect(
       deletedProfiles.filter((profileId) => {
@@ -884,7 +882,7 @@ describe("okou browser route", () => {
         return profileId === profileIds[1];
       }),
     ).toHaveLength(1);
-    await reconcileBrowsers();
+    await reconcileBrowsers(first.threadId, other.threadId);
     expect(providerStops()).toBe(3);
     expect(
       deletedProfiles.filter((profileId) => {
@@ -1097,7 +1095,11 @@ describe("okou browser route", () => {
       status: "suspended",
       suspensionReason: "reconcile",
     });
-    const healthy = await reconcileBrowsers();
+    const healthy = await reconcileBrowsers(
+      first.threadId,
+      other.threadId,
+      candidate.threadId,
+    );
     expect(healthy.body).toMatchObject({
       checked: 2,
       stopped: 0,
@@ -1119,6 +1121,95 @@ describe("okou browser route", () => {
       providerIds[1],
       providerIds[2],
     ]);
+  }, 120_000);
+
+  it("reconciles only explicitly selected browser fixtures", async () => {
+    const { runs, chat, actor, agent } = await setupBrowserScenario();
+    const target = await createClaimedChatRun(
+      chat,
+      runs,
+      actor,
+      agent.agentId,
+      "Open the selected managed browser",
+    );
+    const sentinel = await createClaimedChatRun(
+      chat,
+      runs,
+      actor,
+      agent.agentId,
+      "Open the untouched managed browser",
+    );
+    const providerIds = [randomUUID(), randomUUID()] as const;
+    acceptBrowserUseCdpSessions(providerIds);
+    let providerCreates = 0;
+    const stoppedProviderIds: string[] = [];
+    server.use(
+      http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
+        const body = z
+          .strictObject({ name: z.string() })
+          .parse(await request.json());
+        return HttpResponse.json(providerProfile(randomUUID(), body.name), {
+          status: 201,
+        });
+      }),
+      http.post(`${BROWSER_USE_API_URL}/browsers`, () => {
+        const providerId = providerIds[providerCreates];
+        providerCreates += 1;
+        if (!providerId) {
+          return HttpResponse.json(
+            { error: "unexpected browser create" },
+            { status: 500 },
+          );
+        }
+        return HttpResponse.json(providerBrowser(providerId), { status: 201 });
+      }),
+      http.get(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+        return HttpResponse.json(providerBrowser(String(params.id)));
+      }),
+      http.patch(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+        const providerId = String(params.id);
+        stoppedProviderIds.push(providerId);
+        return HttpResponse.json(
+          providerBrowser(providerId, { status: "stopped" }),
+        );
+      }),
+    );
+
+    await accept(
+      client().use({ headers: target.claim.browserHeaders, body: {} }),
+      [200],
+    );
+    await accept(
+      client().use({ headers: sentinel.claim.browserHeaders, body: {} }),
+      [200],
+    );
+
+    mockNow(STARTED_AT_MS + 11 * MINUTE_MS);
+    const reconciled = await reconcileBrowsers(target.threadId);
+    expect(reconciled.body).toStrictEqual({
+      checked: 1,
+      stopped: 1,
+      errors: 0,
+      healthy: 0,
+    });
+    await flushWaitUntilForTest();
+    expect(stoppedProviderIds).toStrictEqual([providerIds[0]]);
+
+    const untouched = await accept(
+      client().get({
+        headers: sentinel.claim.browserHeaders,
+        params: { threadId: sentinel.threadId },
+      }),
+      [200],
+    );
+    expect(untouched.body.browser).toMatchObject({
+      threadId: sentinel.threadId,
+      status: "active",
+    });
+
+    await chat.deleteThread(actor, target.threadId);
+    await chat.deleteThread(actor, sentinel.threadId);
+    await flushWaitUntilForTest();
   }, 120_000);
 
   it("keeps the browser live across runs, lets its viewer resume, and reclaims its idle lease without retrying provider stop", async () => {
@@ -1345,7 +1436,7 @@ describe("okou browser route", () => {
 
     // Before the lease expires the reconciler leaves the browser alone.
     mockNow(STARTED_AT_MS + 11 * MINUTE_MS);
-    const healthy = await reconcileBrowsers();
+    const healthy = await reconcileBrowsers(threadId);
     expect(healthy.body).toMatchObject({
       checked: 1,
       stopped: 0,
@@ -1356,7 +1447,7 @@ describe("okou browser route", () => {
 
     mockNow(STARTED_AT_MS + 16 * MINUTE_MS);
     context.mocks.ably.publish.mockClear();
-    const reclaimed = await reconcileBrowsers();
+    const reclaimed = await reconcileBrowsers(threadId);
     expect(reclaimed.body).toMatchObject({
       stopped: 1,
       errors: 0,
@@ -1368,7 +1459,7 @@ describe("okou browser route", () => {
     await flushWaitUntilForTest();
     expect(firstStopFailures).toBe(1);
     expect(providerStops).toBe(0);
-    const afterFailedStop = await reconcileBrowsers();
+    const afterFailedStop = await reconcileBrowsers(threadId);
     expect(afterFailedStop.body).toMatchObject({
       checked: 0,
       stopped: 0,
@@ -1509,7 +1600,7 @@ describe("okou browser route", () => {
     });
 
     mockNow(STARTED_AT_MS + 31 * MINUTE_MS);
-    const reclaimedAgain = await reconcileBrowsers();
+    const reclaimedAgain = await reconcileBrowsers(threadId);
     expect(reclaimedAgain.body).toMatchObject({ stopped: 1, errors: 0 });
     await flushWaitUntilForTest();
     expect(providerStops).toBe(1);
@@ -1546,7 +1637,7 @@ describe("okou browser route", () => {
     await flushWaitUntilForTest();
     expect(providerStops).toBe(2);
 
-    const reconciled = await reconcileBrowsers();
+    const reconciled = await reconcileBrowsers(threadId);
     expect(reconciled.body).toMatchObject({
       checked: 0,
       stopped: 0,
@@ -1682,7 +1773,7 @@ describe("okou browser route", () => {
     );
 
     mockNow(STARTED_AT_MS + MINUTE_MS);
-    await reconcileBrowsers();
+    await reconcileBrowsers(current.threadId);
     await flushWaitUntilForTest();
     const withScreenshot = await accept(
       client().get({
@@ -1698,13 +1789,13 @@ describe("okou browser route", () => {
     const screenshotKey = new URL(screenshotUrl).pathname.slice(1);
 
     mockNow(STARTED_AT_MS + 11 * MINUTE_MS);
-    const stopped = await reconcileBrowsers();
+    const stopped = await reconcileBrowsers(current.threadId);
     expect(stopped.body).toMatchObject({ stopped: 1, errors: 0 });
     await flushWaitUntilForTest();
     expect(providerStops).toBe(1);
 
     mockNow(STARTED_AT_MS + 11 * MINUTE_MS + 7 * DAY_MS - 1);
-    const retained = await reconcileBrowsers();
+    const retained = await reconcileBrowsers(current.threadId);
     expect(retained.body.errors).toBe(0);
     const beforeCutoff = await accept(
       client().get({
@@ -1720,7 +1811,7 @@ describe("okou browser route", () => {
     expect(deletedProfiles).toStrictEqual([]);
 
     mockNow(STARTED_AT_MS + 11 * MINUTE_MS + 7 * DAY_MS);
-    const failedCleanup = await reconcileBrowsers();
+    const failedCleanup = await reconcileBrowsers(current.threadId);
     expect(failedCleanup.body.errors).toBe(1);
     expect(deletedProfiles).toStrictEqual([profileIds[0]]);
     expect(providerStops).toBe(1);
@@ -1743,7 +1834,7 @@ describe("okou browser route", () => {
       }),
     ).toBeTruthy();
 
-    const cleaned = await reconcileBrowsers();
+    const cleaned = await reconcileBrowsers(current.threadId);
     expect(cleaned.body).toMatchObject({ errors: 0 });
     expect(deletedProfiles).toStrictEqual([profileIds[0], profileIds[0]]);
     expect(providerStops).toBe(1);
@@ -1897,7 +1988,7 @@ describe("okou browser route", () => {
     );
     const threadId = opened.body.browser.threadId;
     mockNow(STARTED_AT_MS + 11 * MINUTE_MS);
-    const reclaimed = await reconcileBrowsers();
+    const reclaimed = await reconcileBrowsers(threadId);
     expect(reclaimed.body).toMatchObject({ stopped: 1, errors: 0 });
     await flushWaitUntilForTest();
 
@@ -2088,7 +2179,7 @@ describe("okou browser route", () => {
     );
     expect(afterViewerLease.body.browser.screenshotUrl).toBeNull();
 
-    const firstReconcile = await reconcileBrowsers();
+    const firstReconcile = await reconcileBrowsers(current.threadId);
     expect(firstReconcile.body).toMatchObject({
       errors: 0,
     });
@@ -2122,7 +2213,7 @@ describe("okou browser route", () => {
     await flushWaitUntilForTest();
     expect(captureCount).toBe(1);
 
-    const secondReconcile = await reconcileBrowsers();
+    const secondReconcile = await reconcileBrowsers(current.threadId);
     expect(secondReconcile.body).toMatchObject({
       errors: 0,
     });
@@ -2198,7 +2289,7 @@ describe("okou browser route", () => {
         );
       }),
     ).toHaveLength(1);
-    const retriedCleanup = await reconcileBrowsers();
+    const retriedCleanup = await reconcileBrowsers(current.threadId);
     expect(retriedCleanup.body).toMatchObject({
       errors: 0,
     });
@@ -2246,7 +2337,7 @@ describe("okou browser route", () => {
       }),
     );
 
-    const reconciled = await reconcileBrowsers();
+    const reconciled = await reconcileBrowsers(current.threadId);
     expect(reconciled.body).toMatchObject({
       errors: 0,
     });
@@ -2301,14 +2392,23 @@ describe("okou browser route", () => {
     );
 
     await deleteChatThreadRootFixture(first.threadId);
-    const reclaimed = await reconcileBrowsers();
-    expect(reclaimed.body.errors).toBe(0);
-    expect(reclaimed.body.stopped).toBeGreaterThanOrEqual(1);
+    const reclaimed = await reconcileBrowsers(first.threadId);
+    expect(reclaimed.body).toStrictEqual({
+      checked: 2,
+      stopped: 2,
+      errors: 0,
+      healthy: 0,
+    });
     await flushWaitUntilForTest();
-    expect(providerStops).toBeGreaterThanOrEqual(1);
+    expect(providerStops).toBe(2);
 
-    const retired = await reconcileBrowsers();
-    expect(retired.body).toMatchObject({ checked: 0, stopped: 0, errors: 0 });
+    const retired = await reconcileBrowsers(first.threadId);
+    expect(retired.body).toStrictEqual({
+      checked: 0,
+      stopped: 0,
+      errors: 0,
+      healthy: 0,
+    });
     await deleteAgentRunRootFixture(first.runId);
   }, 120_000);
 
@@ -2393,7 +2493,7 @@ describe("okou browser route", () => {
     );
 
     mockNow(STARTED_AT_MS + 11 * MINUTE_MS);
-    const reclaimed = await reconcileBrowsers();
+    const reclaimed = await reconcileBrowsers(first.threadId);
     expect(reclaimed.body).toMatchObject({
       errors: 0,
     });

--- a/turbo/apps/api/src/signals/routes/test-browser-reconcile.ts
+++ b/turbo/apps/api/src/signals/routes/test-browser-reconcile.ts
@@ -1,0 +1,51 @@
+import { testBrowserReconcileContract } from "@vm0/api-contracts/contracts/test-browser-reconcile";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
+import { drainStaleChatThreadQueues$ } from "../services/chat-thread-queue-drain.service";
+import { reconcileZeroBrowserFixtures$ } from "../services/zero-browser.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const reconcileBody$ = bodyResultOf(testBrowserReconcileContract.reconcile);
+
+const reconcileBrowserFixturesRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(reconcileBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const body = await set(
+      reconcileZeroBrowserFixtures$,
+      bodyResult.data.chat_thread_ids,
+      signal,
+    );
+    signal.throwIfAborted();
+    await set(
+      drainStaleChatThreadQueues$,
+      {
+        dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+        chatThreadIds: bodyResult.data.chat_thread_ids,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return { status: 200 as const, body };
+  },
+);
+
+export const testBrowserReconcileRoutes: readonly RouteEntry[] = [
+  {
+    route: testBrowserReconcileContract.reconcile,
+    handler: reconcileBrowserFixturesRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -8,6 +8,7 @@ import {
   and,
   asc,
   eq,
+  inArray,
   isNull,
   lt,
   notExists,
@@ -224,6 +225,7 @@ export async function staleChatEventQueueThreadIds(
   args: {
     readonly staleBefore: Date;
     readonly limit: number;
+    readonly chatThreadIds?: readonly string[];
   },
 ): Promise<readonly string[]> {
   const rows = await db
@@ -233,6 +235,9 @@ export async function staleChatEventQueueThreadIds(
       and(
         pendingChatQueueEventCondition(db),
         lt(chatEvents.createdAt, args.staleBefore),
+        args.chatThreadIds === undefined
+          ? undefined
+          : inArray(chatEvents.chatThreadId, args.chatThreadIds),
       ),
     )
     .limit(args.limit);

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -218,9 +218,15 @@ export const drainChatThreadQueueForRun$ = command(
 export const drainStaleChatThreadQueues$ = command(
   async (
     { set },
-    input: { readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks },
+    input: {
+      readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
+      readonly chatThreadIds?: readonly string[];
+    },
     signal: AbortSignal,
   ): Promise<number> => {
+    if (input.chatThreadIds?.length === 0) {
+      return 0;
+    }
     const db = set(writeDb$);
     const currentTime = nowDate().getTime();
     const staleBefore = new Date(currentTime - STALE_QUEUE_ITEM_AGE_MS);
@@ -231,10 +237,12 @@ export const drainStaleChatThreadQueues$ = command(
       expiredCancellationRecoveryThreads(db, {
         expiredBefore: recoveryExpiredBefore,
         limit: DRAIN_SWEEP_LIMIT,
+        chatThreadIds: input.chatThreadIds,
       }),
       staleChatThreadQueueThreadIds(db, {
         staleBefore,
         limit: DRAIN_SWEEP_LIMIT,
+        chatThreadIds: input.chatThreadIds,
       }),
     ]);
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -367,6 +367,7 @@ export async function staleChatThreadQueueThreadIds(
   args: {
     readonly staleBefore: Date;
     readonly limit: number;
+    readonly chatThreadIds?: readonly string[];
   },
 ): Promise<readonly string[]> {
   return await staleChatEventQueueThreadIds(db, args);

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -2727,6 +2727,7 @@ export const stopThreadZeroBrowsers$ = command(
 async function releaseStrandedBrowserStarts(
   db: Db,
   limit: number,
+  chatThreadIds: readonly string[] | null,
   signal: AbortSignal,
 ): Promise<number> {
   const stranded = await db
@@ -2744,6 +2745,9 @@ async function releaseStrandedBrowserStarts(
           browserSessions.updatedAt,
           new Date(nowDate().getTime() - STRANDED_START_GRACE_MS),
         ),
+        chatThreadIds === null
+          ? undefined
+          : inArray(browserSessions.chatThreadId, chatThreadIds),
       ),
     )
     .limit(limit);
@@ -2820,6 +2824,9 @@ async function releaseStrandedBrowserStarts(
               ),
             ),
         ),
+        chatThreadIds === null
+          ? undefined
+          : inArray(browserSessions.chatThreadId, chatThreadIds),
       ),
     )
     .returning({ chatThreadId: browserSessions.chatThreadId });
@@ -3077,6 +3084,7 @@ async function reconcileExpiredInactiveBrowsers(
   db: Db,
   limit: number,
   screenshotSchemaReady: boolean,
+  chatThreadIds: readonly string[] | null,
   signal: AbortSignal,
 ): Promise<{
   readonly checked: number;
@@ -3119,6 +3127,9 @@ async function reconcileExpiredInactiveBrowsers(
               ),
             ),
         ),
+        chatThreadIds === null
+          ? undefined
+          : inArray(browserSessions.chatThreadId, chatThreadIds),
       ),
     )
     .orderBy(browserSessions.updatedAt)
@@ -3158,6 +3169,7 @@ async function reconcileExpiredInactiveBrowsers(
 async function purgeExpiredStoppedBrowserInstances(
   db: Db,
   limit: number,
+  chatThreadIds: readonly string[] | null,
   signal: AbortSignal,
 ): Promise<{ readonly checked: number; readonly cleaned: number }> {
   const cutoff = new Date(nowDate().getTime() - INACTIVE_BROWSER_RETENTION_MS);
@@ -3170,6 +3182,9 @@ async function purgeExpiredStoppedBrowserInstances(
       and(
         eq(browserSessionInstances.status, "stopped"),
         lte(browserSessionInstances.finishedAt, cutoff),
+        chatThreadIds === null
+          ? undefined
+          : inArray(browserSessionInstances.chatThreadId, chatThreadIds),
       ),
     )
     .orderBy(browserSessionInstances.finishedAt)
@@ -3184,6 +3199,9 @@ async function purgeExpiredStoppedBrowserInstances(
       and(
         eq(browserSessionInstances.status, "stopped"),
         lte(browserSessionInstances.finishedAt, cutoff),
+        chatThreadIds === null
+          ? undefined
+          : inArray(browserSessionInstances.chatThreadId, chatThreadIds),
         inArray(
           browserSessionInstances.providerSessionId,
           rows.map((row) => {
@@ -3226,6 +3244,7 @@ interface BrowserReconcileOutcome {
 async function reconcileOrphanedBrowserProfiles(
   db: Db,
   limit: number,
+  chatThreadIds: readonly string[] | null,
   signal: AbortSignal,
 ): Promise<{
   readonly checked: number;
@@ -3242,7 +3261,14 @@ async function reconcileOrphanedBrowserProfiles(
       chatThreads,
       eq(chatThreads.id, browserThreadProfiles.chatThreadId),
     )
-    .where(isNull(chatThreads.id))
+    .where(
+      and(
+        isNull(chatThreads.id),
+        chatThreadIds === null
+          ? undefined
+          : inArray(browserThreadProfiles.chatThreadId, chatThreadIds),
+      ),
+    )
     .orderBy(browserThreadProfiles.updatedAt)
     .limit(limit);
   signal.throwIfAborted();
@@ -3272,6 +3298,7 @@ async function reconcileOrphanedBrowserScreenshots(
   db: Db,
   deleteObjects: (keys: readonly string[]) => Promise<void>,
   limit: number,
+  chatThreadIds: readonly string[] | null,
   signal: AbortSignal,
 ): Promise<{
   readonly checked: number;
@@ -3288,7 +3315,14 @@ async function reconcileOrphanedBrowserScreenshots(
       chatThreads,
       eq(chatThreads.id, browserSessionScreenshots.chatThreadId),
     )
-    .where(isNull(chatThreads.id))
+    .where(
+      and(
+        isNull(chatThreads.id),
+        chatThreadIds === null
+          ? undefined
+          : inArray(browserSessionScreenshots.chatThreadId, chatThreadIds),
+      ),
+    )
     .orderBy(browserSessionScreenshots.updatedAt)
     .limit(limit);
   signal.throwIfAborted();
@@ -3332,6 +3366,7 @@ async function reconcileQueuedBrowserScreenshotDeletions(
   db: Db,
   deleteObjects: (keys: readonly string[]) => Promise<void>,
   limit: number,
+  chatThreadIds: readonly string[] | null,
   signal: AbortSignal,
 ): Promise<{
   readonly checked: number;
@@ -3344,6 +3379,14 @@ async function reconcileQueuedBrowserScreenshotDeletions(
       objectKey: browserSessionScreenshotDeletions.objectKey,
     })
     .from(browserSessionScreenshotDeletions)
+    .where(
+      chatThreadIds === null
+        ? undefined
+        : inArray(
+            browserSessionScreenshotDeletions.chatThreadId,
+            chatThreadIds,
+          ),
+    )
     .orderBy(browserSessionScreenshotDeletions.createdAt)
     .limit(limit);
   signal.throwIfAborted();
@@ -3444,11 +3487,15 @@ const reconcileBrowserInstance$ = command(
   },
 );
 
-export const reconcileZeroBrowsers$ = command(
+const reconcileZeroBrowsersWithScope$ = command(
   async (
     { get, set },
+    chatThreadIds: readonly string[] | null,
     signal: AbortSignal,
   ): Promise<BrowserReconcileResult> => {
+    if (chatThreadIds !== null && chatThreadIds.length === 0) {
+      return { checked: 0, stopped: 0, errors: 0, healthy: 0 };
+    }
     const db = set(writeDb$);
     const rows = await db
       .select({
@@ -3465,7 +3512,14 @@ export const reconcileZeroBrowsers$ = command(
         chatThreads,
         eq(chatThreads.id, browserSessionInstances.chatThreadId),
       )
-      .where(eq(browserSessionInstances.status, "active"))
+      .where(
+        and(
+          eq(browserSessionInstances.status, "active"),
+          chatThreadIds === null
+            ? undefined
+            : inArray(browserSessionInstances.chatThreadId, chatThreadIds),
+        ),
+      )
       .orderBy(browserSessionInstances.updatedAt)
       .limit(RECONCILE_BATCH_SIZE);
     signal.throwIfAborted();
@@ -3483,6 +3537,7 @@ export const reconcileZeroBrowsers$ = command(
     const releasedStarts = await releaseStrandedBrowserStarts(
       db,
       RECONCILE_BATCH_SIZE,
+      chatThreadIds,
       signal,
     );
     const screenshotSchemaReady = await browserScreenshotSchemaAvailable(db);
@@ -3491,16 +3546,19 @@ export const reconcileZeroBrowsers$ = command(
       db,
       RECONCILE_BATCH_SIZE,
       screenshotSchemaReady,
+      chatThreadIds,
       signal,
     );
     const expiredInstanceCleanup = await purgeExpiredStoppedBrowserInstances(
       db,
       RECONCILE_BATCH_SIZE,
+      chatThreadIds,
       signal,
     );
     const profileCleanup = await reconcileOrphanedBrowserProfiles(
       db,
       RECONCILE_BATCH_SIZE,
+      chatThreadIds,
       signal,
     );
     const deleteScreenshotObjects = async (keys: readonly string[]) => {
@@ -3511,6 +3569,7 @@ export const reconcileZeroBrowsers$ = command(
           db,
           deleteScreenshotObjects,
           RECONCILE_BATCH_SIZE,
+          chatThreadIds,
           signal,
         )
       : { checked: 0, cleaned: 0, errors: 0 };
@@ -3519,6 +3578,7 @@ export const reconcileZeroBrowsers$ = command(
           db,
           deleteScreenshotObjects,
           RECONCILE_BATCH_SIZE,
+          chatThreadIds,
           signal,
         )
       : { checked: 0, cleaned: 0, errors: 0 };
@@ -3547,5 +3607,22 @@ export const reconcileZeroBrowsers$ = command(
         orphanedScreenshotCleanup.errors,
       healthy,
     };
+  },
+);
+
+export const reconcileZeroBrowsers$ = command(
+  async ({ set }, signal: AbortSignal): Promise<BrowserReconcileResult> => {
+    return await set(reconcileZeroBrowsersWithScope$, null, signal);
+  },
+);
+
+/** Reconcile only browser resources owned by explicit test fixture threads. */
+export const reconcileZeroBrowserFixtures$ = command(
+  async (
+    { set },
+    chatThreadIds: readonly string[],
+    signal: AbortSignal,
+  ): Promise<BrowserReconcileResult> => {
+    return await set(reconcileZeroBrowsersWithScope$, chatThreadIds, signal);
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-chat-active-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-active-run.service.ts
@@ -193,6 +193,7 @@ export async function expiredCancellationRecoveryThreads(
   args: {
     readonly expiredBefore: Date;
     readonly limit: number;
+    readonly chatThreadIds?: readonly string[];
   },
 ): Promise<readonly { chatThreadId: string; userId: string }[]> {
   const rows = await db
@@ -232,6 +233,9 @@ export async function expiredCancellationRecoveryThreads(
               ),
             ),
         ),
+        args.chatThreadIds === undefined
+          ? undefined
+          : inArray(chatEvents.chatThreadId, args.chatThreadIds),
       ),
     )
     .limit(args.limit);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -333,6 +333,12 @@ export {
   type TestComputerUseStatePostResponse,
 } from "./test-computer-use-state";
 export {
+  testBrowserReconcileBodySchema,
+  testBrowserReconcileContract,
+  type TestBrowserReconcileBody,
+  type TestBrowserReconcileContract,
+} from "./test-browser-reconcile";
+export {
   testRuntimeStateActionBodySchema,
   testRuntimeStateActionResponseSchema,
   testRuntimeStateContract,

--- a/turbo/packages/api-contracts/src/contracts/test-browser-reconcile.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-browser-reconcile.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { cronBrowserReconcileResponseSchema } from "./cron";
+
+const c = initContract();
+
+export const testBrowserReconcileBodySchema = z.object({
+  chat_thread_ids: z.array(z.uuid()).min(1).max(20),
+});
+
+export const testBrowserReconcileContract = c.router({
+  reconcile: {
+    method: "POST",
+    path: "/api/test/reconcile-browser-fixtures",
+    body: testBrowserReconcileBodySchema,
+    responses: {
+      200: cronBrowserReconcileResponseSchema,
+      404: z.string(),
+    },
+    summary: "Reconcile explicit managed-browser test fixtures",
+  },
+});
+
+export type TestBrowserReconcileBody = z.infer<
+  typeof testBrowserReconcileBodySchema
+>;
+export type TestBrowserReconcileContract = typeof testBrowserReconcileContract;


### PR DESCRIPTION
## Summary

- add a gated test-only reconciliation route that requires explicit chat-thread fixture IDs
- scope every browser reconciliation phase and the bundled cancellation-recovery queue selection to those IDs while leaving production cron calls global
- migrate the browser and chat-callback suites off the valid production cron, add an untouched browser sentinel, and assert exact scoped outcomes

## Isolation guarantees

- active instances, stranded starts, inactive sessions, stopped instances, orphan profiles, orphan screenshots, queued screenshot deletions, and stale chat-thread queue candidates are filtered before the production batch limit
- empty or implicit fixture ranges cannot invoke the test route; production callers omit the optional scope and retain their existing global batch behavior
- no test serialization, advisory lock, broad mocked-time partition, residue-tolerant assertion, or unrelated cleanup was added

## Validation

- `git -C .. diff --name-only -z origin/main...HEAD -- 'turbo/**/*.ts' | sed -z 's#^turbo/##' | xargs -0 pnpm exec prettier --check`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm exec knip --workspace apps/api --workspace packages/api-contracts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-browser.test.ts --reporter=dot --silent=passed-only` (14 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t 'releases a lost recovery completion|continues the recovery stale sweep|terminalizes a queued Web message' --reporter=dot --silent=passed-only` (3 passed, 44 skipped)

## Coordination

- rebased onto current `main` before opening
- reviewed open overlap in #26545, #26608, and #26624; their edits are in disjoint regions of the shared files
- repository-wide tests remain delegated to the PR pipeline

Closes #26583

Parent epic: #26569
