### PR TITLE
test(api): isolate teams bot fixtures and auth cache

### DIFF
--- a/turbo/apps/api/src/lib/teams-bot-auth.ts
+++ b/turbo/apps/api/src/lib/teams-bot-auth.ts
@@ -65,9 +65,20 @@ type TeamsBotAuthResult =
       readonly message: string;
     };
 
-const teamsBotAuthCache = singleton(() => {
-  return new TeamsBotAuthCache();
+const teamsBotAuthCaches = singleton(() => {
+  return new WeakMap<AbortSignal, TeamsBotAuthCache>();
 });
+
+function teamsBotAuthCache(owner: AbortSignal): TeamsBotAuthCache {
+  const caches = teamsBotAuthCaches();
+  const existing = caches.get(owner);
+  if (existing) {
+    return existing;
+  }
+  const cache = new TeamsBotAuthCache();
+  caches.set(owner, cache);
+  return cache;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -210,9 +221,11 @@ async function fetchJson(url: string): Promise<unknown> {
   return await response.json();
 }
 
-async function loadBotFrameworkKeys(): Promise<CachedKeys> {
+async function loadBotFrameworkKeys(
+  cacheOwner: AbortSignal,
+): Promise<CachedKeys> {
   const currentTime = now();
-  const cache = teamsBotAuthCache();
+  const cache = teamsBotAuthCache(cacheOwner);
   if (cache.keys && cache.keys.expiresAt > currentTime) {
     return cache.keys;
   }
@@ -346,11 +359,14 @@ function keyEndorsesChannel(key: JwkKey, channelId: string | null): boolean {
   return key.endorsements.includes(channelId);
 }
 
-export async function verifyTeamsBotAuthorization(args: {
-  readonly authorization: string | undefined;
-  readonly serviceUrl: string;
-  readonly channelId: string | null;
-}): Promise<TeamsBotAuthResult> {
+export async function verifyTeamsBotAuthorization(
+  args: {
+    readonly authorization: string | undefined;
+    readonly serviceUrl: string;
+    readonly channelId: string | null;
+  },
+  cacheOwner: AbortSignal,
+): Promise<TeamsBotAuthResult> {
   const botAppId = env("MICROSOFT_TEAMS_BOT_APP_ID");
   if (!botAppId) {
     return {
@@ -380,7 +396,7 @@ export async function verifyTeamsBotAuthorization(args: {
     return { ok: false, status: 401, message: "Invalid Teams bot token" };
   }
 
-  const botFrameworkKeys = await loadBotFrameworkKeys();
+  const botFrameworkKeys = await loadBotFrameworkKeys(cacheOwner);
   if (!botFrameworkKeys.metadata.algorithms.includes(header.alg)) {
     return {
       ok: false,
@@ -430,8 +446,4 @@ export async function verifyTeamsBotAuthorization(args: {
   }
 
   return { ok: true, claims };
-}
-
-export function clearTeamsBotAuthCacheForTest(): void {
-  teamsBotAuthCache.reset();
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-teams-connect.ts
@@ -11,7 +11,6 @@ import { createAppWithRoutes } from "../../../../app-factory-core";
 import { mockEnv } from "../../../../lib/env";
 import { now } from "../../../../lib/time";
 import { server } from "../../../../mocks/server";
-import { clearTeamsBotAuthCacheForTest } from "../../../../lib/teams-bot-auth";
 import { zeroTeamsBotRoutes } from "../../zero-teams-bot";
 
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
@@ -27,14 +26,23 @@ const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const publicJwk = keyPair.publicKey.export({ format: "jwk" });
 
 export interface TeamsConnectFixture {
+  readonly fixtureId: string;
   readonly orgId: string;
   readonly userId: string;
   readonly teamsTenantId: string;
   readonly teamsTenantName: string;
   readonly teamsTeamId: string;
+  readonly teamsTeamAadGroupId: string;
   readonly teamsTeamName: string;
+  readonly teamsChannelId: string;
+  readonly teamsConversationId: string;
+  readonly teamsThreadId: string;
+  readonly teamsActivityId: string;
+  readonly teamsAppId: string;
+  readonly teamsBotId: string;
   readonly teamsUserId: string;
   readonly teamsAadObjectId: string;
+  readonly teamsUserPrincipalName: string;
   readonly serviceUrl: string;
 }
 
@@ -42,7 +50,6 @@ export function setupTeamsConnectTestEnv(
   appUrl = "https://app.vm0.test",
   apiBackendUrl = "https://api.vm0.test",
 ): void {
-  clearTeamsBotAuthCacheForTest();
   mockEnv("MICROSOFT_TEAMS_BOT_APP_ID", BOT_APP_ID);
   mockEnv("MICROSOFT_TEAMS_APP_TENANT_ID", TEAMS_APP_TENANT_ID);
   mockEnv("APP_URL", appUrl);
@@ -53,23 +60,39 @@ export function setupTeamsConnectTestEnv(
 export function teamsConnectFixture(
   overrides: Partial<TeamsConnectFixture> = {},
 ): TeamsConnectFixture {
+  const fixtureId = overrides.fixtureId ?? randomUUID().replace(/-/g, "");
   return {
-    orgId: overrides.orgId ?? `org_${randomUUID()}`,
-    userId: overrides.userId ?? `user_${randomUUID()}`,
-    teamsTenantId:
-      overrides.teamsTenantId ??
-      `tenant_${randomUUID().replace(/-/g, "").slice(0, 10)}`,
+    fixtureId,
+    orgId: overrides.orgId ?? `org_teams_${fixtureId}`,
+    userId: overrides.userId ?? `user_teams_${fixtureId}`,
+    teamsTenantId: overrides.teamsTenantId ?? `tenant_${fixtureId}`,
     teamsTenantName: overrides.teamsTenantName ?? "Test Tenant",
-    teamsTeamId:
-      overrides.teamsTeamId ??
-      `team_${randomUUID().replace(/-/g, "").slice(0, 10)}`,
+    teamsTeamId: overrides.teamsTeamId ?? `team_${fixtureId}`,
+    teamsTeamAadGroupId:
+      overrides.teamsTeamAadGroupId ?? `team-aad-${fixtureId}`,
     teamsTeamName: overrides.teamsTeamName ?? "Test Team",
-    teamsUserId: overrides.teamsUserId ?? `29:user-${randomUUID().slice(0, 8)}`,
-    teamsAadObjectId:
-      overrides.teamsAadObjectId ??
-      `aad_${randomUUID().replace(/-/g, "").slice(0, 10)}`,
+    teamsChannelId:
+      overrides.teamsChannelId ?? `19:channel-${fixtureId}@thread.tacv2`,
+    teamsConversationId:
+      overrides.teamsConversationId ??
+      `19:conversation-${fixtureId}@thread.tacv2`,
+    teamsThreadId: overrides.teamsThreadId ?? `root-${fixtureId}`,
+    teamsActivityId: overrides.teamsActivityId ?? `activity-${fixtureId}`,
+    teamsAppId: overrides.teamsAppId ?? `teams-app-${fixtureId}`,
+    teamsBotId: overrides.teamsBotId ?? `28:bot-${fixtureId}`,
+    teamsUserId: overrides.teamsUserId ?? `29:user-${fixtureId}`,
+    teamsAadObjectId: overrides.teamsAadObjectId ?? `aad-user-${fixtureId}`,
+    teamsUserPrincipalName:
+      overrides.teamsUserPrincipalName ?? `user-${fixtureId}@example.test`,
     serviceUrl: overrides.serviceUrl ?? SERVICE_URL,
   };
+}
+
+export function teamsFixtureExternalId(
+  fixture: TeamsConnectFixture,
+  prefix: string,
+): string {
+  return `${prefix}-${fixture.fixtureId}`;
 }
 
 function botFrameworkHandlers(): void {
@@ -138,36 +161,40 @@ export function teamsMessageActivityForTest(
 ): Record<string, unknown> {
   return {
     type: "message",
-    id: "activity-1",
+    id: fixture.teamsActivityId,
     timestamp: "2026-06-30T09:10:00.000Z",
     serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
-      id: "19:thread@thread.tacv2",
+      id: fixture.teamsConversationId,
       conversationType: "channel",
     },
     channelData: {
       tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
-      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
-      channel: { id: "19:channel@thread.tacv2", name: "General" },
-      teamsAppId: BOT_APP_ID,
+      team: {
+        id: fixture.teamsTeamId,
+        aadGroupId: fixture.teamsTeamAadGroupId,
+        name: fixture.teamsTeamName,
+      },
+      channel: { id: fixture.teamsChannelId, name: "General" },
+      teamsAppId: fixture.teamsAppId,
     },
     from: {
       id: fixture.teamsUserId,
       name: "Ada Lovelace",
       aadObjectId: fixture.teamsAadObjectId,
-      userPrincipalName: "ada@example.com",
+      userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: "28:bot-1", name: "Zero" },
+    recipient: { id: fixture.teamsBotId, name: "Zero" },
     text: "<at>Zero</at> deploy the preview",
     entities: [
       {
         type: "mention",
         text: "<at>Zero</at>",
-        mentioned: { id: "28:bot-1", name: "Zero" },
+        mentioned: { id: fixture.teamsBotId, name: "Zero" },
       },
     ],
-    replyToId: "root-activity",
+    replyToId: fixture.teamsThreadId,
     ...overrides,
   };
 }
@@ -177,22 +204,26 @@ function teamsBotRemovedActivity(
 ): Record<string, unknown> {
   return {
     type: "conversationUpdate",
-    id: "activity-remove-1",
+    id: teamsFixtureExternalId(fixture, "activity-remove"),
     timestamp: "2026-06-30T09:20:00.000Z",
     serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
-      id: "19:thread@thread.tacv2",
+      id: fixture.teamsConversationId,
       conversationType: "channel",
     },
     channelData: {
       tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
-      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
-      channel: { id: "19:channel@thread.tacv2", name: "General" },
-      teamsAppId: BOT_APP_ID,
+      team: {
+        id: fixture.teamsTeamId,
+        aadGroupId: fixture.teamsTeamAadGroupId,
+        name: fixture.teamsTeamName,
+      },
+      channel: { id: fixture.teamsChannelId, name: "General" },
+      teamsAppId: fixture.teamsAppId,
     },
-    recipient: { id: "28:bot-1", name: "Zero" },
-    membersRemoved: [{ id: "28:bot-1", name: "Zero" }],
+    recipient: { id: fixture.teamsBotId, name: "Zero" },
+    membersRemoved: [{ id: fixture.teamsBotId, name: "Zero" }],
   };
 }
 
@@ -200,11 +231,11 @@ export async function postTeamsActivityForTest(args: {
   readonly signal: AbortSignal;
   readonly activity: Record<string, unknown>;
 }): Promise<Response> {
-  clearTeamsBotAuthCacheForTest();
   mockEnv("MICROSOFT_TEAMS_BOT_APP_ID", BOT_APP_ID);
   botFrameworkHandlers();
+  const appSignal = AbortSignal.any([args.signal]);
   const app = createAppWithRoutes({
-    signal: args.signal,
+    signal: appSignal,
     routes: zeroTeamsBotRoutes,
   });
   return await app.request("http://api.test/api/zero/teams/bot", {
@@ -224,7 +255,7 @@ export async function installTeamsForTest(
   const response = await postTeamsActivityForTest({
     signal,
     activity: teamsMessageActivityForTest(fixture, {
-      id: "activity-install-seed",
+      id: teamsFixtureExternalId(fixture, "activity-install-seed"),
       text: "installation seed",
       entities: [],
       replyToId: null,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -39,6 +39,7 @@ import {
   removeTeamsForTest,
   setupTeamsConnectTestEnv,
   teamsConnectFixture,
+  teamsFixtureExternalId,
   teamsMessageActivityForTest,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
@@ -114,7 +115,7 @@ function teamsPostedActivityFromUnknown(value: unknown): TeamsPostedActivity {
 }
 
 function teamsApiMocks(args: {
-  readonly serviceUrl: string;
+  readonly fixture: TeamsConnectFixture;
   readonly activityStatus?: number;
   readonly activityError?: string;
 }): {
@@ -125,7 +126,7 @@ function teamsApiMocks(args: {
   const tokenRequests: URLSearchParams[] = [];
   const postedActivities: TeamsPostedActivity[] = [];
   const reactionRequests: TeamsReactionRequest[] = [];
-  const serviceBaseUrl = teamsServiceBaseUrl(args.serviceUrl);
+  const serviceBaseUrl = teamsServiceBaseUrl(args.fixture.serviceUrl);
 
   server.use(
     http.post(BOT_FRAMEWORK_TOKEN_URL, async ({ request }) => {
@@ -159,7 +160,10 @@ function teamsApiMocks(args: {
           });
         }
         return HttpResponse.json({
-          id: `teams-activity-${postedActivities.length}`,
+          id: teamsFixtureExternalId(
+            args.fixture,
+            `teams-activity-${postedActivities.length}`,
+          ),
         });
       },
     ),
@@ -175,7 +179,10 @@ function teamsApiMocks(args: {
           });
         }
         return HttpResponse.json({
-          id: `teams-activity-${postedActivities.length}`,
+          id: teamsFixtureExternalId(
+            args.fixture,
+            `teams-activity-${postedActivities.length}`,
+          ),
         });
       },
     ),
@@ -239,14 +246,16 @@ function teamsApiMocks(args: {
       "https://graph.microsoft.com/v1.0/teams/:teamId/channels/:channelId/messages/:messageId",
       ({ params }) => {
         const messageId =
-          typeof params.messageId === "string" ? params.messageId : "root";
+          typeof params.messageId === "string"
+            ? params.messageId
+            : args.fixture.teamsThreadId;
         return HttpResponse.json({
           id: messageId,
           createdDateTime: "2026-06-30T09:00:00.000Z",
           messageType: "message",
           from: {
             user: {
-              id: "29:user-1",
+              id: args.fixture.teamsUserId,
               displayName: "Ada Lovelace",
             },
           },
@@ -342,7 +351,8 @@ async function connectTeamsFixture(
         tenantId: fixture.teamsTenantId,
         teamsUserId: fixture.teamsUserId,
         teamsUserDisplayName: options.displayName ?? "Ada Lovelace",
-        teamsUserPrincipalName: options.principalName ?? "ada@example.com",
+        teamsUserPrincipalName:
+          options.principalName ?? fixture.teamsUserPrincipalName,
         teamId: fixture.teamsTeamId,
         teamName: fixture.teamsTeamName,
         serviceUrl: fixture.serviceUrl,
@@ -390,7 +400,7 @@ async function setupConnectedTeamsActor(
       },
     );
   }
-  const setupTeamsApi = teamsApiMocks({ serviceUrl: fixture.serviceUrl });
+  const setupTeamsApi = teamsApiMocks({ fixture });
   await installTeamsForTest(context.signal, fixture);
   await flushWaitUntilForTest();
   await connectTeamsFixture(fixture);
@@ -423,7 +433,8 @@ async function dispatchTeamsRun(args: {
         id: args.fixture.teamsUserId,
         name: args.senderName ?? "Ada Lovelace",
         aadObjectId: args.fixture.teamsAadObjectId,
-        userPrincipalName: args.senderPrincipalName ?? "ada@example.com",
+        userPrincipalName:
+          args.senderPrincipalName ?? args.fixture.teamsUserPrincipalName,
       },
     }),
   });
@@ -462,7 +473,7 @@ async function postTeamsPersonalMessage(args: {
           id: args.fixture.teamsTenantId,
           name: args.fixture.teamsTenantName,
         },
-        teamsAppId: BOT_APP_ID,
+        teamsAppId: args.fixture.teamsAppId,
       },
       text: args.text,
       entities: [],
@@ -512,7 +523,7 @@ async function switchTeamsAgent(args: {
           id: args.fixture.teamsTenantId,
           name: args.fixture.teamsTenantName,
         },
-        teamsAppId: BOT_APP_ID,
+        teamsAppId: args.fixture.teamsAppId,
       },
       text: "",
       entities: [],
@@ -629,10 +640,18 @@ afterEach(async () => {
 describe("Teams chat callbacks", () => {
   it("claims Teams launch material from context", async () => {
     const teams = await setupConnectedTeamsActor();
-    teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    teamsApiMocks({ fixture: teams.fixture });
+    const firstActivityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-queue-params-first",
+    );
+    const queuedActivityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-queue-params-second",
+    );
     const firstRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-queue-params-first",
+      activityId: firstActivityId,
       text: "hold the Teams queue",
     });
     const firstClaim = await claimTeamsRun({
@@ -643,7 +662,7 @@ describe("Teams chat callbacks", () => {
     const queuedPrompt = `claim Teams launch context ${teams.fixture.teamsTenantId}`;
     await postTeamsPersonalMessage({
       fixture: teams.fixture,
-      activityId: "activity-queue-params-second",
+      activityId: queuedActivityId,
       text: queuedPrompt,
     });
     const queuedParams = await findPendingChatEventByPromptFixture({
@@ -665,7 +684,7 @@ describe("Teams chat callbacks", () => {
       teamsChannelId: null,
       teamsConversationId: `a:personal-${teams.fixture.teamsUserId}`,
       teamsConversationType: "personal",
-      teamsActivityId: "activity-queue-params-second",
+      teamsActivityId: queuedActivityId,
       teamsThreadContext: "",
       teamsMessageText: queuedPrompt,
       teamsMessageFiles: [],
@@ -673,10 +692,10 @@ describe("Teams chat callbacks", () => {
       teamsTeamName: null,
       teamsThreadId: `direct-message:${teams.defaultAgentId}:claude-sonnet-5`,
       teamsServiceUrl: teams.fixture.serviceUrl,
-      teamsAppId: BOT_APP_ID,
+      teamsAppId: teams.fixture.teamsAppId,
       teamsSenderUserId: teams.fixture.teamsUserId,
       teamsSenderDisplayName: "Ada Lovelace",
-      teamsSenderPrincipalName: "ada@example.com",
+      teamsSenderPrincipalName: teams.fixture.teamsUserPrincipalName,
       teamsConnectionId: expect.any(String),
     });
     await completeSandboxRun({
@@ -700,7 +719,7 @@ describe("Teams chat callbacks", () => {
       "You are currently running inside: Microsoft Teams",
     );
     expect(queuedClaim.appendSystemPrompt).toContain(
-      "Thread ID: activity-queue-params-second",
+      `Thread ID: ${queuedActivityId}`,
     );
 
     await completeSandboxRun({
@@ -712,12 +731,14 @@ describe("Teams chat callbacks", () => {
 
   it("delivers queued Teams admission failures with launch material", async () => {
     const teams = await setupConnectedTeamsActor();
-    const teamsApi = teamsApiMocks({
-      serviceUrl: teams.fixture.serviceUrl,
-    });
+    const teamsApi = teamsApiMocks({ fixture: teams.fixture });
+    const firstActivityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-admission-first",
+    );
     const firstRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-admission-first",
+      activityId: firstActivityId,
       text: "hold the Teams admission queue",
     });
     const firstClaim = await claimTeamsRun({
@@ -726,7 +747,10 @@ describe("Teams chat callbacks", () => {
     });
 
     const queuedPrompt = `reject this queued Teams message ${teams.fixture.teamsTenantId}`;
-    const queuedActivityId = "activity-admission-queued";
+    const queuedActivityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-admission-queued",
+    );
     await postTeamsPersonalMessage({
       fixture: teams.fixture,
       activityId: queuedActivityId,
@@ -782,10 +806,18 @@ describe("Teams chat callbacks", () => {
 
   it("uses installation bot identity when the activity omits it", async () => {
     const teams = await setupConnectedTeamsActor();
-    teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    teamsApiMocks({ fixture: teams.fixture });
+    const firstActivityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-bot-fallback-first",
+    );
+    const queuedActivityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-bot-fallback-second",
+    );
     const firstRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-bot-fallback-first",
+      activityId: firstActivityId,
       text: "hold the Teams bot fallback queue",
     });
     const firstClaim = await claimTeamsRun({
@@ -796,7 +828,7 @@ describe("Teams chat callbacks", () => {
     const queuedPrompt = `claim without an activity recipient ${teams.fixture.teamsTenantId}`;
     await postTeamsPersonalMessage({
       fixture: teams.fixture,
-      activityId: "activity-bot-fallback-second",
+      activityId: queuedActivityId,
       text: queuedPrompt,
       omitRecipient: true,
     });
@@ -818,17 +850,22 @@ describe("Teams chat callbacks", () => {
       runId: queuedRunId,
     });
     expect(queuedClaim.prompt).toBe(queuedPrompt);
-    expect(queuedClaim.appendSystemPrompt).toContain("Bot ID: 28:bot-1");
+    expect(queuedClaim.appendSystemPrompt).toContain(
+      `Bot ID: ${teams.fixture.teamsBotId}`,
+    );
     expect(queuedClaim.appendSystemPrompt).toContain("Bot name: Zero");
     await runsApi.requestCancelRun(teams.actor, queuedRunId, [200]);
   });
 
   it("keeps personal message sessions scoped to the selected agent", async () => {
     const teams = await setupConnectedTeamsActor();
-    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    const teamsApi = teamsApiMocks({ fixture: teams.fixture });
     const defaultRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-default-agent",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-default-agent",
+      ),
       text: "remember this DM context",
     });
     const defaultClaim = await claimTeamsRun({
@@ -849,12 +886,18 @@ describe("Teams chat callbacks", () => {
     });
     await switchTeamsAgent({
       fixture: teams.fixture,
-      activityId: "activity-personal-switch-alternate",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-switch-alternate",
+      ),
       agentId: alternateAgent.agentId,
     });
     const alternateRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-alternate-agent",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-alternate-agent",
+      ),
       text: "use an alternate Teams DM agent",
     });
     const alternateClaim = await claimTeamsRun({
@@ -870,13 +913,19 @@ describe("Teams chat callbacks", () => {
     });
     await switchTeamsAgent({
       fixture: teams.fixture,
-      activityId: "activity-personal-switch-default",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-switch-default",
+      ),
       agentId: teams.defaultAgentId,
     });
 
     const returnToDefaultRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-default-agent-return",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-default-agent-return",
+      ),
       text: "return to the default Teams DM agent",
     });
     const returnToDefaultClaim = await claimTeamsRun({
@@ -890,8 +939,11 @@ describe("Teams chat callbacks", () => {
 
   it("forks personal message threads without replacing the main session", async () => {
     const teams = await setupConnectedTeamsActor();
-    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
-    const rootActivityId = "activity-personal-main";
+    const teamsApi = teamsApiMocks({ fixture: teams.fixture });
+    const rootActivityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-personal-main",
+    );
     const mainRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
       activityId: rootActivityId,
@@ -911,7 +963,10 @@ describe("Teams chat callbacks", () => {
 
     const threadRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-thread-first",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-thread-first",
+      ),
       threadId: rootActivityId,
       text: "open a personal message thread",
     });
@@ -929,7 +984,10 @@ describe("Teams chat callbacks", () => {
 
     const threadFollowUpRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-thread-follow-up",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-thread-follow-up",
+      ),
       threadId: rootActivityId,
       text: "continue the personal message thread",
     });
@@ -947,7 +1005,10 @@ describe("Teams chat callbacks", () => {
 
     const returnToMainRunId = await dispatchTeamsPersonalRun({
       fixture: teams.fixture,
-      activityId: "activity-personal-main-return",
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-personal-main-return",
+      ),
       text: "return to the main DM",
     });
     const returnToMainClaim = await claimTeamsRun({
@@ -959,13 +1020,18 @@ describe("Teams chat callbacks", () => {
 
   it("posts completed run replies and persists canonical Teams thread sessions", async () => {
     const teams = await setupConnectedTeamsActor({ zeroDebug: true });
-    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    const teamsApi = teamsApiMocks({ fixture: teams.fixture });
     mockOptionalEnv("OPENROUTER_API_KEY", "teams-summary-key");
     const summaryRequests = mockOpenRouterSummary("Teams completed summary");
+    const activityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-completed-1",
+    );
+    const threadId = teamsFixtureExternalId(teams.fixture, "root-completed");
     const runId = await dispatchTeamsRun({
       fixture: teams.fixture,
-      activityId: "activity-completed-1",
-      threadId: "root-completed",
+      activityId,
+      threadId,
       text: "finish the task",
     });
     mocks.clerk.session(teams.fixture.userId, teams.fixture.orgId, "org:admin");
@@ -1007,7 +1073,7 @@ describe("Teams chat callbacks", () => {
               kind: "teams",
               href:
                 "https://teams.microsoft.com/l/message/" +
-                "19%3Achannel%40thread.tacv2/activity-completed-1" +
+                `${encodeURIComponent(teams.fixture.teamsChannelId)}/${activityId}` +
                 `?tenantId=${encodeURIComponent(teams.fixture.teamsTenantId)}`,
             },
           ],
@@ -1046,7 +1112,7 @@ describe("Teams chat callbacks", () => {
     expect(teamsApi.postedActivities[0]).toMatchObject({
       type: "message",
       textFormat: "markdown",
-      replyToId: "activity-completed-1",
+      replyToId: activityId,
       channelData: {
         tenant: { id: teams.fixture.teamsTenantId },
       },
@@ -1061,8 +1127,8 @@ describe("Teams chat callbacks", () => {
     expect(teamsApi.reactionRequests).toStrictEqual([
       {
         method: "DELETE",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-completed-1",
+        conversationId: teams.fixture.teamsConversationId,
+        activityId,
         reactionType: "1f4ad_thoughtballoon",
       },
     ]);
@@ -1102,7 +1168,13 @@ describe("Teams chat callbacks", () => {
           teamsTenantId: teams.fixture.teamsTenantId,
           teamsTenantName: teams.fixture.teamsTenantName,
           teamsTeamId: teams.fixture.teamsTeamId,
+          teamsTeamAadGroupId: teams.fixture.teamsTeamAadGroupId,
           teamsTeamName: teams.fixture.teamsTeamName,
+          teamsChannelId: teams.fixture.teamsChannelId,
+          teamsConversationId: teams.fixture.teamsConversationId,
+          teamsThreadId: threadId,
+          teamsAppId: teams.fixture.teamsAppId,
+          teamsBotId: teams.fixture.teamsBotId,
           serviceUrl: teams.fixture.serviceUrl,
         }),
       ),
@@ -1114,20 +1186,21 @@ describe("Teams chat callbacks", () => {
     });
     const tokenRequestCountBeforeConnect = teamsApi.tokenRequests.length;
     const postedActivityCountBeforeConnect = teamsApi.postedActivities.length;
+    const secondPrincipalName = secondFixture.teamsUserPrincipalName;
     await connectTeamsFixture(secondFixture, {
       displayName: "Grace Hopper",
-      principalName: "grace@example.com",
+      principalName: secondPrincipalName,
     });
     await flushWaitUntilForTest();
     teamsApi.tokenRequests.splice(tokenRequestCountBeforeConnect);
     teamsApi.postedActivities.splice(postedActivityCountBeforeConnect);
     const secondRunId = await dispatchTeamsRun({
       fixture: secondFixture,
-      activityId: "activity-completed-2",
-      threadId: "root-completed",
+      activityId: teamsFixtureExternalId(secondFixture, "activity-completed-2"),
+      threadId,
       text: "finish the follow-up",
       senderName: "Grace Hopper",
-      senderPrincipalName: "grace@example.com",
+      senderPrincipalName: secondPrincipalName,
     });
     const secondClaim = await claimTeamsRun({
       runnerGroup: teams.runnerGroup,
@@ -1150,19 +1223,27 @@ describe("Teams chat callbacks", () => {
     const followUpClaim = await claimFollowUpInThread({
       fixture: teams.fixture,
       runnerGroup: teams.runnerGroup,
-      threadId: "root-completed",
-      activityId: "activity-completed-follow-up",
+      threadId,
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-completed-follow-up",
+      ),
     });
     expect(followUpClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
   });
 
   it("posts readable failed run replies without persisting a thread session", async () => {
     const teams = await setupConnectedTeamsActor();
-    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    const teamsApi = teamsApiMocks({ fixture: teams.fixture });
+    const activityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-failed-1",
+    );
+    const threadId = teamsFixtureExternalId(teams.fixture, "root-failed");
     const runId = await dispatchTeamsRun({
       fixture: teams.fixture,
-      activityId: "activity-failed-1",
-      threadId: "root-failed",
+      activityId,
+      threadId,
       text: "fail this task",
     });
     const claim = await claimTeamsRun({
@@ -1185,8 +1266,8 @@ describe("Teams chat callbacks", () => {
     expect(teamsApi.reactionRequests).toStrictEqual([
       {
         method: "DELETE",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-failed-1",
+        conversationId: teams.fixture.teamsConversationId,
+        activityId,
         reactionType: "1f4ad_thoughtballoon",
       },
     ]);
@@ -1194,19 +1275,30 @@ describe("Teams chat callbacks", () => {
     const followUpClaim = await claimFollowUpInThread({
       fixture: teams.fixture,
       runnerGroup: teams.runnerGroup,
-      threadId: "root-failed",
-      activityId: "activity-failed-follow-up",
+      threadId,
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-failed-follow-up",
+      ),
     });
     expect(followUpClaim.resumeSession).toBeNull();
   });
 
   it("does not post replies when the Teams installation is missing", async () => {
     const teams = await setupConnectedTeamsActor();
-    const teamsApi = teamsApiMocks({ serviceUrl: teams.fixture.serviceUrl });
+    const teamsApi = teamsApiMocks({ fixture: teams.fixture });
+    const activityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-missing-install-1",
+    );
+    const threadId = teamsFixtureExternalId(
+      teams.fixture,
+      "root-missing-install",
+    );
     const runId = await dispatchTeamsRun({
       fixture: teams.fixture,
-      activityId: "activity-missing-install-1",
-      threadId: "root-missing-install",
+      activityId,
+      threadId,
       text: "complete after uninstall",
     });
     const claim = await claimTeamsRun({
@@ -1234,8 +1326,11 @@ describe("Teams chat callbacks", () => {
     const followUpClaim = await claimFollowUpInThread({
       fixture: teams.fixture,
       runnerGroup: teams.runnerGroup,
-      threadId: "root-missing-install",
-      activityId: "activity-missing-install-follow-up",
+      threadId,
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-missing-install-follow-up",
+      ),
     });
     expect(followUpClaim.resumeSession).toBeNull();
   });
@@ -1243,14 +1338,22 @@ describe("Teams chat callbacks", () => {
   it("keeps the canonical thread session when the Teams API rejects the reply", async () => {
     const teams = await setupConnectedTeamsActor();
     const teamsApi = teamsApiMocks({
-      serviceUrl: teams.fixture.serviceUrl,
+      fixture: teams.fixture,
       activityStatus: 500,
       activityError: "upstream exploded",
     });
+    const activityId = teamsFixtureExternalId(
+      teams.fixture,
+      "activity-teams-api-error-1",
+    );
+    const threadId = teamsFixtureExternalId(
+      teams.fixture,
+      "root-teams-api-error",
+    );
     const runId = await dispatchTeamsRun({
       fixture: teams.fixture,
-      activityId: "activity-teams-api-error-1",
-      threadId: "root-teams-api-error",
+      activityId,
+      threadId,
       text: "complete while Teams is down",
     });
     const claim = await claimTeamsRun({
@@ -1273,8 +1376,8 @@ describe("Teams chat callbacks", () => {
     expect(teamsApi.reactionRequests).toStrictEqual([
       {
         method: "DELETE",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-teams-api-error-1",
+        conversationId: teams.fixture.teamsConversationId,
+        activityId,
         reactionType: "1f4ad_thoughtballoon",
       },
     ]);
@@ -1282,8 +1385,11 @@ describe("Teams chat callbacks", () => {
     const followUpClaim = await claimFollowUpInThread({
       fixture: teams.fixture,
       runnerGroup: teams.runnerGroup,
-      threadId: "root-teams-api-error",
-      activityId: "activity-teams-api-error-follow-up",
+      threadId,
+      activityId: teamsFixtureExternalId(
+        teams.fixture,
+        "activity-teams-api-error-follow-up",
+      ),
     });
     expect(followUpClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-teams.test.ts
@@ -22,6 +22,7 @@ import {
   removeTeamsForTest,
   setupTeamsConnectTestEnv,
   teamsConnectFixture,
+  teamsFixtureExternalId,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
 import { zeroIntegrationsTeamsMessageRoutes } from "../zero-integrations-teams-message";
@@ -72,7 +73,18 @@ function teamsFixture(): TeamsConnectFixture {
   });
 }
 
-function mockOutgoingTeams(captured: CapturedTeamsActivity): void {
+function mockOutgoingTeams(
+  fixture: TeamsConnectFixture,
+  captured: CapturedTeamsActivity,
+): {
+  readonly activityId: string;
+  readonly dmConversationId: string;
+} {
+  const activityId = teamsFixtureExternalId(fixture, "teams-activity");
+  const dmConversationId = `a:${teamsFixtureExternalId(
+    fixture,
+    "teams-dm-conversation",
+  )}`;
   server.use(
     http.post(BOT_FRAMEWORK_TOKEN_URL, async ({ request }) => {
       const form = await request.formData();
@@ -87,7 +99,7 @@ function mockOutgoingTeams(captured: CapturedTeamsActivity): void {
           string,
           unknown
         >;
-        return HttpResponse.json({ id: "a:teams-dm-conversation" });
+        return HttpResponse.json({ id: dmConversationId });
       },
     ),
     http.post(
@@ -99,7 +111,7 @@ function mockOutgoingTeams(captured: CapturedTeamsActivity): void {
             ? params.conversationId
             : undefined;
         captured.body = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({ id: "teams-activity-1" });
+        return HttpResponse.json({ id: activityId });
       },
     ),
     http.post(
@@ -111,10 +123,12 @@ function mockOutgoingTeams(captured: CapturedTeamsActivity): void {
             ? params.conversationId
             : undefined;
         captured.body = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({ id: "teams-activity-1" });
+        return HttpResponse.json({ id: activityId });
       },
     ),
   );
+
+  return { activityId, dmConversationId };
 }
 
 async function seedConnectedTeams(fixture: TeamsConnectFixture): Promise<void> {
@@ -136,7 +150,7 @@ async function seedConnectedTeams(fixture: TeamsConnectFixture): Promise<void> {
         tenantId: fixture.teamsTenantId,
         teamsUserId: fixture.teamsUserId,
         teamsUserDisplayName: "Ada Lovelace",
-        teamsUserPrincipalName: "ada@example.com",
+        teamsUserPrincipalName: fixture.teamsUserPrincipalName,
       },
     }),
     [200],
@@ -165,7 +179,7 @@ describe("Microsoft Teams integration CLI routes", () => {
     fixtures.push(fixture);
     await seedConnectedTeams(fixture);
     const captured: CapturedTeamsActivity = {};
-    mockOutgoingTeams(captured);
+    const outgoing = mockOutgoingTeams(fixture, captured);
 
     const client = setupApp({
       context,
@@ -174,8 +188,8 @@ describe("Microsoft Teams integration CLI routes", () => {
     const response = await accept(
       client.sendMessage({
         body: {
-          conversationId: "19:thread@thread.tacv2",
-          activityId: "root-activity",
+          conversationId: fixture.teamsConversationId,
+          activityId: fixture.teamsThreadId,
           text: "Hello from Teams CLI",
         },
         headers: {
@@ -191,15 +205,15 @@ describe("Microsoft Teams integration CLI routes", () => {
 
     expect(response.body).toStrictEqual({
       ok: true,
-      activityId: "teams-activity-1",
-      conversationId: "19:thread@thread.tacv2",
+      activityId: outgoing.activityId,
+      conversationId: fixture.teamsConversationId,
     });
     expect(captured.authorization).toBe("Bearer bot-framework-token");
     expect(captured.body).toMatchObject({
       type: "message",
       text: "Hello from Teams CLI",
       textFormat: "markdown",
-      replyToId: "root-activity",
+      replyToId: fixture.teamsThreadId,
       channelData: { tenant: { id: fixture.teamsTenantId } },
     });
   });
@@ -209,7 +223,7 @@ describe("Microsoft Teams integration CLI routes", () => {
     fixtures.push(fixture);
     await seedConnectedTeams(fixture);
     const captured: CapturedTeamsActivity = {};
-    mockOutgoingTeams(captured);
+    const outgoing = mockOutgoingTeams(fixture, captured);
 
     const client = setupApp({
       context,
@@ -245,16 +259,16 @@ describe("Microsoft Teams integration CLI routes", () => {
 
     expect(response.body).toStrictEqual({
       ok: true,
-      activityId: "teams-activity-1",
-      conversationId: "a:teams-dm-conversation",
+      activityId: outgoing.activityId,
+      conversationId: outgoing.dmConversationId,
     });
     expect(captured.conversationBody).toMatchObject({
-      bot: { id: "28:bot-1", name: "Zero" },
+      bot: { id: fixture.teamsBotId, name: "Zero" },
       members: [{ id: fixture.teamsUserId, name: "Ada Lovelace" }],
       isGroup: false,
       channelData: { tenant: { id: fixture.teamsTenantId } },
     });
-    expect(captured.conversationId).toBe("a:teams-dm-conversation");
+    expect(captured.conversationId).toBe(outgoing.dmConversationId);
     expect(captured.body).toMatchObject({
       type: "message",
       summary: "Pick a workflow",
@@ -276,7 +290,7 @@ describe("Microsoft Teams integration CLI routes", () => {
     fixtures.push(fixture);
     await seedConnectedTeams(fixture);
     const captured: CapturedTeamsActivity = {};
-    mockOutgoingTeams(captured);
+    const outgoing = mockOutgoingTeams(fixture, captured);
 
     const uploadId = randomUUID();
     mocks.s3.listObjects([
@@ -295,8 +309,8 @@ describe("Microsoft Teams integration CLI routes", () => {
       client.complete({
         body: {
           uploadId,
-          conversationId: "19:thread@thread.tacv2",
-          activityId: "root-activity",
+          conversationId: fixture.teamsConversationId,
+          activityId: fixture.teamsThreadId,
           contentType: "application/pdf",
           text: "Daily report",
         },
@@ -306,8 +320,8 @@ describe("Microsoft Teams integration CLI routes", () => {
     );
 
     expect(response.body).toMatchObject({
-      activityId: "teams-activity-1",
-      conversationId: "19:thread@thread.tacv2",
+      activityId: outgoing.activityId,
+      conversationId: fixture.teamsConversationId,
       filename: "report.pdf",
       mimetype: "application/pdf",
       size: 1234,
@@ -317,7 +331,7 @@ describe("Microsoft Teams integration CLI routes", () => {
     expect(captured.body?.text).toContain("[report.pdf]");
     expect(captured.body).toMatchObject({
       type: "message",
-      replyToId: "root-activity",
+      replyToId: fixture.teamsThreadId,
       attachments: [
         {
           contentType: "application/pdf",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -14,15 +14,14 @@ import { zeroTeamsConnectContract } from "@vm0/api-contracts/contracts/zero-team
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { signSandboxJwtForTests, verifyZeroToken } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { clearTeamsBotAuthCacheForTest } from "../../../lib/teams-bot-auth";
-import { now } from "../../../lib/time";
+import { now, withMockNowForTest } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -40,6 +39,7 @@ import {
   removeTeamsForTest,
   setupTeamsConnectTestEnv,
   teamsConnectFixture,
+  teamsFixtureExternalId,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
 import {
@@ -67,7 +67,6 @@ const TEAMS_BOT_PATH = "http://api.test/api/zero/teams/bot";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";
 const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
-const TEAMS_AAD_GROUP_ID = "22222222-2222-2222-2222-222222222222";
 const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
 const APP_ORIGIN = "https://app.vm0.test";
 const KEY_ID = "teams-test-key";
@@ -93,16 +92,14 @@ const publicJwk = keyPair.publicKey.export({ format: "jwk" });
 
 function botFixture(): TeamsConnectFixture {
   return teamsConnectFixture({
-    orgId: "org_teams_bot_test",
-    userId: "user_teams_bot_test",
-    teamsTenantId: "tenant-1",
     teamsTenantName: "Tenant One",
-    teamsTeamId: "team-1",
     teamsTeamName: "Team One",
-    teamsUserId: "29:user-1",
-    teamsAadObjectId: "aad-user-1",
     serviceUrl: SERVICE_URL,
   });
+}
+
+async function trackedBotFixture(): Promise<TeamsConnectFixture> {
+  return await trackTeamsFixture(Promise.resolve(botFixture()));
 }
 
 function teamsInstallUrl(): string {
@@ -119,9 +116,11 @@ function teamsOauthConnectUrl(fixture: TeamsConnectFixture): string {
   return url.toString();
 }
 
-function botFrameworkHandlers(): void {
+function botFrameworkHandlers(): string[] {
+  const requests: string[] = [];
   server.use(
     http.get(BOT_FRAMEWORK_METADATA_URL, () => {
+      requests.push("metadata");
       return HttpResponse.json({
         issuer: "https://api.botframework.com",
         jwks_uri: BOT_FRAMEWORK_KEYS_URL,
@@ -129,6 +128,7 @@ function botFrameworkHandlers(): void {
       });
     }),
     http.get(BOT_FRAMEWORK_KEYS_URL, () => {
+      requests.push("jwks");
       return HttpResponse.json({
         keys: [
           {
@@ -142,6 +142,7 @@ function botFrameworkHandlers(): void {
       });
     }),
   );
+  return requests;
 }
 
 function teamsServiceBaseUrl(serviceUrl: string): string {
@@ -167,6 +168,7 @@ type TeamsOutboundRequests = TeamsOutboundRequest[] & {
 
 function teamsOutboundHandlers(serviceUrl: string): TeamsOutboundRequests {
   const serviceBaseUrl = teamsServiceBaseUrl(serviceUrl);
+  const responseActivityId = `teams-activity-${randomUUID()}`;
   const requests: TeamsOutboundRequests = Object.assign(
     [] as TeamsOutboundRequest[],
     { reactions: [] as TeamsReactionRequest[] },
@@ -194,7 +196,7 @@ function teamsOutboundHandlers(serviceUrl: string): TeamsOutboundRequests {
           activityId: null,
           body: await request.json(),
         });
-        return HttpResponse.json({ id: "teams-activity-1" });
+        return HttpResponse.json({ id: responseActivityId });
       },
     ),
     http.post(
@@ -209,7 +211,7 @@ function teamsOutboundHandlers(serviceUrl: string): TeamsOutboundRequests {
             typeof params.activityId === "string" ? params.activityId : "",
           body: await request.json(),
         });
-        return HttpResponse.json({ id: "teams-activity-1" });
+        return HttpResponse.json({ id: responseActivityId });
       },
     ),
     http.put(
@@ -271,6 +273,7 @@ function graphTokenUrl(tenantId: string): string {
 
 function teamsGraphMessage(
   message: TeamsGraphMessageFixture,
+  defaultSenderId: string,
 ): Record<string, unknown> {
   return {
     id: message.id,
@@ -279,7 +282,7 @@ function teamsGraphMessage(
     messageType: "message",
     from: {
       user: {
-        id: message.senderId ?? "29:user-1",
+        id: message.senderId ?? defaultSenderId,
         displayName: message.senderName ?? "Ada Lovelace",
         ...(message.senderPrincipalName !== undefined
           ? { userPrincipalName: message.senderPrincipalName }
@@ -297,6 +300,7 @@ function teamsGraphMessage(
 
 function teamsGraphUserMap(
   messages: readonly TeamsGraphMessageFixture[],
+  defaultSenderId: string,
 ): ReadonlyMap<
   string,
   {
@@ -312,7 +316,7 @@ function teamsGraphUserMap(
     }
   >();
   for (const message of messages) {
-    const senderId = message.senderId ?? "29:user-1";
+    const senderId = message.senderId ?? defaultSenderId;
     const existing = users.get(senderId);
     const userPrincipalName =
       message.graphUserPrincipalName ?? existing?.userPrincipalName ?? null;
@@ -326,7 +330,7 @@ function teamsGraphUserMap(
 }
 
 function teamsGraphHistoryHandlers(args: {
-  readonly tenantId: string;
+  readonly fixture: TeamsConnectFixture;
   readonly teamsAppId?: string;
   readonly personalChatId?: string;
   readonly chatMessages?: readonly TeamsGraphMessageFixture[];
@@ -338,28 +342,41 @@ function teamsGraphHistoryHandlers(args: {
 }): string[] {
   const requests: string[] = [];
   const personalChatId =
-    args.personalChatId ?? "19:personal-chat@unq.gbl.spaces";
-  const personalInstallationId = "personal-app-installation";
-  const teamsAppId = args.teamsAppId ?? "teams-app-test";
-  const users = teamsGraphUserMap([
-    ...(args.chatMessages ?? []),
-    ...args.channelMessages,
-    ...Object.values(args.threadRoots),
-    ...Object.values(args.threadReplies).flat(),
-  ]);
+    args.personalChatId ??
+    `19:${teamsFixtureExternalId(
+      args.fixture,
+      "personal-chat",
+    )}@unq.gbl.spaces`;
+  const personalInstallationId = teamsFixtureExternalId(
+    args.fixture,
+    "personal-app-installation",
+  );
+  const teamsAppId = args.teamsAppId ?? args.fixture.teamsAppId;
+  const users = teamsGraphUserMap(
+    [
+      ...(args.chatMessages ?? []),
+      ...args.channelMessages,
+      ...Object.values(args.threadRoots),
+      ...Object.values(args.threadReplies).flat(),
+    ],
+    args.fixture.teamsUserId,
+  );
   server.use(
-    http.post(graphTokenUrl(args.tenantId), async ({ request }) => {
-      const form = await request.formData();
-      expect(form.get("client_id")).toBe(BOT_APP_ID);
-      expect(form.get("client_secret")).toBe(BOT_APP_PASSWORD);
-      expect(form.get("scope")).toBe("https://graph.microsoft.com/.default");
-      requests.push("graph-token");
-      return HttpResponse.json({
-        access_token: "teams-graph-token",
-        token_type: "Bearer",
-        expires_in: 3600,
-      });
-    }),
+    http.post(
+      graphTokenUrl(args.fixture.teamsTenantId),
+      async ({ request }) => {
+        const form = await request.formData();
+        expect(form.get("client_id")).toBe(BOT_APP_ID);
+        expect(form.get("client_secret")).toBe(BOT_APP_PASSWORD);
+        expect(form.get("scope")).toBe("https://graph.microsoft.com/.default");
+        requests.push("graph-token");
+        return HttpResponse.json({
+          access_token: "teams-graph-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      },
+    ),
     http.get(
       "https://graph.microsoft.com/v1.0/users/:userId/teamwork/installedApps",
       ({ params, request }) => {
@@ -412,7 +429,9 @@ function teamsGraphHistoryHandlers(args: {
         expect(chatId).toBe(personalChatId);
         requests.push(`chat-messages:${chatId}`);
         return HttpResponse.json({
-          value: (args.chatMessages ?? []).map(teamsGraphMessage),
+          value: (args.chatMessages ?? []).map((message) => {
+            return teamsGraphMessage(message, args.fixture.teamsUserId);
+          }),
         });
       },
     ),
@@ -422,10 +441,12 @@ function teamsGraphHistoryHandlers(args: {
         expect(request.headers.get("authorization")).toBe(
           "Bearer teams-graph-token",
         );
-        expect(params.teamId).toBe(TEAMS_AAD_GROUP_ID);
+        expect(params.teamId).toBe(args.fixture.teamsTeamAadGroupId);
         requests.push("channel-messages");
         return HttpResponse.json({
-          value: args.channelMessages.map(teamsGraphMessage),
+          value: args.channelMessages.map((message) => {
+            return teamsGraphMessage(message, args.fixture.teamsUserId);
+          }),
         });
       },
     ),
@@ -435,12 +456,14 @@ function teamsGraphHistoryHandlers(args: {
         expect(request.headers.get("authorization")).toBe(
           "Bearer teams-graph-token",
         );
-        expect(params.teamId).toBe(TEAMS_AAD_GROUP_ID);
+        expect(params.teamId).toBe(args.fixture.teamsTeamAadGroupId);
         const messageId =
           typeof params.messageId === "string" ? params.messageId : "";
         requests.push(`thread-replies:${messageId}`);
         return HttpResponse.json({
-          value: (args.threadReplies[messageId] ?? []).map(teamsGraphMessage),
+          value: (args.threadReplies[messageId] ?? []).map((message) => {
+            return teamsGraphMessage(message, args.fixture.teamsUserId);
+          }),
         });
       },
     ),
@@ -450,13 +473,13 @@ function teamsGraphHistoryHandlers(args: {
         expect(request.headers.get("authorization")).toBe(
           "Bearer teams-graph-token",
         );
-        expect(params.teamId).toBe(TEAMS_AAD_GROUP_ID);
+        expect(params.teamId).toBe(args.fixture.teamsTeamAadGroupId);
         const messageId =
           typeof params.messageId === "string" ? params.messageId : "";
         requests.push(`thread-root:${messageId}`);
         const root = args.threadRoots[messageId];
         return root
-          ? HttpResponse.json(teamsGraphMessage(root))
+          ? HttpResponse.json(teamsGraphMessage(root, args.fixture.teamsUserId))
           : HttpResponse.json(
               { error: { code: "NotFound", message: "Message not found" } },
               { status: 404 },
@@ -549,139 +572,154 @@ function zeroToken(args: {
 }
 
 function teamsMessageActivity(
-  fixture: TeamsConnectFixture = botFixture(),
+  fixture: TeamsConnectFixture,
   overrides: Readonly<Record<string, unknown>> = {},
 ): Record<string, unknown> {
   return {
     type: "message",
-    id: "activity-1",
+    id: fixture.teamsActivityId,
     timestamp: "2026-06-30T09:10:00.000Z",
     serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
-      id: "19:thread@thread.tacv2",
+      id: fixture.teamsConversationId,
       conversationType: "channel",
     },
     channelData: {
       tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
       team: {
         id: fixture.teamsTeamId,
-        aadGroupId: TEAMS_AAD_GROUP_ID,
+        aadGroupId: fixture.teamsTeamAadGroupId,
         name: fixture.teamsTeamName,
       },
-      channel: { id: "19:channel@thread.tacv2", name: "General" },
-      teamsAppId: "teams-app-test",
+      channel: { id: fixture.teamsChannelId, name: "General" },
+      teamsAppId: fixture.teamsAppId,
     },
     from: {
       id: fixture.teamsUserId,
       name: "Ada Lovelace",
       aadObjectId: fixture.teamsAadObjectId,
-      userPrincipalName: "ada@example.com",
+      userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: "28:bot-1", name: "Zero" },
+    recipient: { id: fixture.teamsBotId, name: "Zero" },
     text: "<at>Zero</at> deploy the preview",
     entities: [
       {
         type: "mention",
         text: "<at>Zero</at>",
-        mentioned: { id: "28:bot-1", name: "Zero" },
+        mentioned: { id: fixture.teamsBotId, name: "Zero" },
       },
     ],
-    replyToId: "root-activity",
+    replyToId: fixture.teamsThreadId,
     ...overrides,
   };
 }
 
 function teamsBotRemovedActivity(
-  fixture: TeamsConnectFixture = botFixture(),
+  fixture: TeamsConnectFixture,
 ): Record<string, unknown> {
   return {
     type: "conversationUpdate",
-    id: "activity-remove-1",
+    id: teamsFixtureExternalId(fixture, "activity-remove"),
     timestamp: "2026-06-30T09:20:00.000Z",
     serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
-      id: "19:thread@thread.tacv2",
+      id: fixture.teamsConversationId,
       conversationType: "channel",
     },
     channelData: {
       tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
-      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
-      channel: { id: "19:channel@thread.tacv2", name: "General" },
-      teamsAppId: "teams-app-test",
+      team: {
+        id: fixture.teamsTeamId,
+        aadGroupId: fixture.teamsTeamAadGroupId,
+        name: fixture.teamsTeamName,
+      },
+      channel: { id: fixture.teamsChannelId, name: "General" },
+      teamsAppId: fixture.teamsAppId,
     },
-    recipient: { id: "28:bot-1", name: "Zero" },
-    membersRemoved: [{ id: "28:bot-1", name: "Zero" }],
+    recipient: { id: fixture.teamsBotId, name: "Zero" },
+    membersRemoved: [{ id: fixture.teamsBotId, name: "Zero" }],
   };
 }
 
 function teamsBotInstalledActivity(
-  fixture: TeamsConnectFixture = botFixture(),
+  fixture: TeamsConnectFixture,
 ): Record<string, unknown> {
   return {
     type: "conversationUpdate",
-    id: "activity-install-1",
+    id: teamsFixtureExternalId(fixture, "activity-install"),
     timestamp: "2026-06-30T09:15:00.000Z",
     serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
-      id: "19:thread@thread.tacv2",
+      id: fixture.teamsConversationId,
       conversationType: "channel",
     },
     channelData: {
       tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
-      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
-      channel: { id: "19:channel@thread.tacv2", name: "General" },
-      teamsAppId: "teams-app-test",
+      team: {
+        id: fixture.teamsTeamId,
+        aadGroupId: fixture.teamsTeamAadGroupId,
+        name: fixture.teamsTeamName,
+      },
+      channel: { id: fixture.teamsChannelId, name: "General" },
+      teamsAppId: fixture.teamsAppId,
     },
     from: {
       id: fixture.teamsUserId,
       name: "Ada Lovelace",
       aadObjectId: fixture.teamsAadObjectId,
-      userPrincipalName: "ada@example.com",
+      userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: "28:bot-1", name: "Zero" },
-    membersAdded: [{ id: "28:bot-1", name: "Zero" }],
+    recipient: { id: fixture.teamsBotId, name: "Zero" },
+    membersAdded: [{ id: fixture.teamsBotId, name: "Zero" }],
   };
 }
 
 function teamsBotInstallationAddedActivity(
-  fixture: TeamsConnectFixture = botFixture(),
+  fixture: TeamsConnectFixture,
 ): Record<string, unknown> {
   return {
     type: "installationUpdate",
     action: "add",
-    id: "activity-installation-add-1",
+    id: teamsFixtureExternalId(fixture, "activity-installation-add"),
     timestamp: "2026-06-30T09:15:00.000Z",
     serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
-      id: "19:thread@thread.tacv2",
+      id: fixture.teamsConversationId,
       conversationType: "channel",
     },
     channelData: {
       tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
-      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
-      channel: { id: "19:channel@thread.tacv2", name: "General" },
-      teamsAppId: "teams-app-test",
+      team: {
+        id: fixture.teamsTeamId,
+        aadGroupId: fixture.teamsTeamAadGroupId,
+        name: fixture.teamsTeamName,
+      },
+      channel: { id: fixture.teamsChannelId, name: "General" },
+      teamsAppId: fixture.teamsAppId,
     },
     from: {
       id: fixture.teamsUserId,
       name: "Ada Lovelace",
       aadObjectId: fixture.teamsAadObjectId,
-      userPrincipalName: "ada@example.com",
+      userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: "28:bot-1", name: "Zero" },
+    recipient: { id: fixture.teamsBotId, name: "Zero" },
   };
 }
 
-async function postTeamsActivity(args: {
-  readonly activity: Record<string, unknown>;
-  readonly token?: string;
-}): Promise<Response> {
+async function postTeamsActivity(
+  args: {
+    readonly activity: Record<string, unknown>;
+    readonly token?: string;
+  },
+  signal: AbortSignal = context.signal,
+): Promise<Response> {
   const app = createAppWithRoutes({
-    signal: context.signal,
+    signal,
     routes: zeroTeamsBotRoutes,
   });
   const headers: Record<string, string> = {
@@ -774,7 +812,7 @@ async function connectTeamsFixture(
         tenantId: fixture.teamsTenantId,
         teamsAadObjectId: fixture.teamsAadObjectId,
         teamsUserDisplayName: "Ada Lovelace",
-        teamsUserPrincipalName: "ada@example.com",
+        teamsUserPrincipalName: fixture.teamsUserPrincipalName,
       },
     }),
     [200],
@@ -798,7 +836,7 @@ function teamsPersonalMessageActivity(args: {
         id: args.fixture.teamsTenantId,
         name: args.fixture.teamsTenantName,
       },
-      teamsAppId: "teams-app-test",
+      teamsAppId: args.fixture.teamsAppId,
     },
     text: args.text,
     entities: [],
@@ -824,7 +862,7 @@ function teamsPersonalThreadMessageActivity(args: {
         id: args.fixture.teamsTenantId,
         name: args.fixture.teamsTenantName,
       },
-      teamsAppId: "teams-app-test",
+      teamsAppId: args.fixture.teamsAppId,
     },
     text: args.text,
     entities: [],
@@ -886,14 +924,10 @@ describe("POST /api/zero/teams/bot", () => {
     teamsOutboundHandlers(SERVICE_URL);
   });
 
-  afterEach(async () => {
-    await flushWaitUntilForTest();
-    await removeTeamsForTest(context.signal, botFixture());
-  });
-
   it("rejects missing Teams authorization", async () => {
+    const fixture = botFixture();
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(),
+      activity: teamsMessageActivity(fixture),
     });
 
     expect(response.status).toBe(401);
@@ -906,8 +940,9 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("rejects a Teams activity without a stable identifier", async () => {
+    const fixture = botFixture();
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
+      activity: teamsMessageActivity(fixture, {
         id: undefined,
         timestamp: undefined,
       }),
@@ -923,8 +958,9 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("rejects a Teams message without an activity id", async () => {
+    const fixture = botFixture();
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), { id: undefined }),
+      activity: teamsMessageActivity(fixture, { id: undefined }),
     });
 
     expect(response.status).toBe(400);
@@ -937,10 +973,11 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("rejects a Teams token for another bot app", async () => {
+    const fixture = botFixture();
     botFrameworkHandlers();
 
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(),
+      activity: teamsMessageActivity(fixture),
       token: teamsToken({
         audience: "00000000-0000-0000-0000-000000000002",
       }),
@@ -956,11 +993,12 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("normalizes a valid Teams message activity", async () => {
+    const fixture = await trackedBotFixture();
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(),
+      activity: teamsMessageActivity(fixture),
       token: teamsToken(),
     });
 
@@ -970,24 +1008,24 @@ describe("POST /api/zero/teams/bot", () => {
       ok: true,
       activity: {
         kind: "message",
-        activityId: "activity-1",
-        tenantId: "tenant-1",
+        activityId: fixture.teamsActivityId,
+        tenantId: fixture.teamsTenantId,
         serviceUrl: SERVICE_URL,
-        conversationId: "19:thread@thread.tacv2",
+        conversationId: fixture.teamsConversationId,
         conversationType: "channel",
-        teamId: "team-1",
-        teamAadGroupId: TEAMS_AAD_GROUP_ID,
+        teamId: fixture.teamsTeamId,
+        teamAadGroupId: fixture.teamsTeamAadGroupId,
         teamName: "Team One",
-        channelId: "19:channel@thread.tacv2",
-        threadId: "root-activity",
+        channelId: fixture.teamsChannelId,
+        threadId: fixture.teamsThreadId,
         sender: {
-          id: "29:user-1",
+          id: fixture.teamsUserId,
           name: "Ada Lovelace",
-          aadObjectId: "aad-user-1",
-          userPrincipalName: "ada@example.com",
+          aadObjectId: fixture.teamsAadObjectId,
+          userPrincipalName: fixture.teamsUserPrincipalName,
         },
         recipient: {
-          id: "28:bot-1",
+          id: fixture.teamsBotId,
           name: "Zero",
           aadObjectId: null,
           userPrincipalName: null,
@@ -995,7 +1033,7 @@ describe("POST /api/zero/teams/bot", () => {
         rawText: "<at>Zero</at> deploy the preview",
         text: "deploy the preview",
         mentionsRecipient: true,
-        idempotencyKey: "19:thread@thread.tacv2:message:activity-1",
+        idempotencyKey: `${fixture.teamsConversationId}:message:${fixture.teamsActivityId}`,
       },
     });
     const { connectUrl: connectUrlValue } = z
@@ -1003,32 +1041,38 @@ describe("POST /api/zero/teams/bot", () => {
       .parse(body);
     expect(connectUrlValue).toContain(`${APP_ORIGIN}/settings/teams`);
     const connectUrl = new URL(connectUrlValue);
-    expect(connectUrl.searchParams.get("tenantId")).toBe("tenant-1");
+    expect(connectUrl.searchParams.get("tenantId")).toBe(fixture.teamsTenantId);
     expect(connectUrl.searchParams.get("tenantName")).toBe("Tenant One");
-    expect(connectUrl.searchParams.get("teamsUserId")).toBe("29:user-1");
-    expect(connectUrl.searchParams.get("teamsAadObjectId")).toBe("aad-user-1");
-    expect(connectUrl.searchParams.get("activityId")).toBe("activity-1");
+    expect(connectUrl.searchParams.get("teamsUserId")).toBe(
+      fixture.teamsUserId,
+    );
+    expect(connectUrl.searchParams.get("teamsAadObjectId")).toBe(
+      fixture.teamsAadObjectId,
+    );
+    expect(connectUrl.searchParams.get("activityId")).toBe(
+      fixture.teamsActivityId,
+    );
     expect(connectUrl.searchParams.get("teamsUserDisplayName")).toBe(
       "Ada Lovelace",
     );
     expect(connectUrl.searchParams.get("teamsUserPrincipalName")).toBe(
-      "ada@example.com",
+      fixture.teamsUserPrincipalName,
     );
     expect(connectUrl.searchParams.get("displayName")).toBeNull();
     expect(connectUrl.searchParams.get("upn")).toBeNull();
-    expect(connectUrl.searchParams.get("teamId")).toBe("team-1");
+    expect(connectUrl.searchParams.get("teamId")).toBe(fixture.teamsTeamId);
     expect(connectUrl.searchParams.get("teamName")).toBe("Team One");
     expect(connectUrl.searchParams.get("conversationType")).toBe("channel");
     expect(body).not.toHaveProperty("dispatch");
     await flushWaitUntilForTest();
     expect(outboundRequests).toHaveLength(1);
     expect(outboundRequests[0]).toMatchObject({
-      conversationId: "19:thread@thread.tacv2",
-      activityId: "activity-1",
+      conversationId: fixture.teamsConversationId,
+      activityId: fixture.teamsActivityId,
       body: {
         type: "message",
         summary: TEAMS_LOGIN_PROMPT_FALLBACK_TEXT,
-        replyToId: "activity-1",
+        replyToId: fixture.teamsActivityId,
         attachments: [
           {
             contentType: "application/vnd.microsoft.card.adaptive",
@@ -1053,17 +1097,13 @@ describe("POST /api/zero/teams/bot", () => {
           },
         ],
         channelData: {
-          tenant: { id: "tenant-1" },
+          tenant: { id: fixture.teamsTenantId },
         },
       },
     });
     expect(outboundRequests[0]?.body).not.toHaveProperty("text");
 
-    mocks.clerk.session(
-      "user_teams_bot_test",
-      "org_teams_bot_test",
-      "org:admin",
-    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
@@ -1071,11 +1111,11 @@ describe("POST /api/zero/teams/bot", () => {
       client.connect({
         headers: { authorization: "Bearer clerk-session" },
         body: {
-          tenantId: "tenant-1",
-          teamsUserId: "29:user-1",
-          teamsAadObjectId: "aad-user-1",
+          tenantId: fixture.teamsTenantId,
+          teamsUserId: fixture.teamsUserId,
+          teamsAadObjectId: fixture.teamsAadObjectId,
           teamsUserDisplayName: "Ada Lovelace",
-          teamsUserPrincipalName: "ada@example.com",
+          teamsUserPrincipalName: fixture.teamsUserPrincipalName,
         },
       }),
       [200],
@@ -1089,19 +1129,92 @@ describe("POST /api/zero/teams/bot", () => {
     expect(status.body).toMatchObject({
       isInstalled: true,
       isConnected: true,
-      tenantId: "tenant-1",
+      tenantId: fixture.teamsTenantId,
       tenantName: "Tenant One",
-      teamId: "team-1",
+      teamId: fixture.teamsTeamId,
       teamName: "Team One",
     });
   });
 
+  it("reuses and refreshes Teams auth metadata within explicit app lifecycles", async () => {
+    const fixture = await trackedBotFixture();
+    const authRequests = botFrameworkHandlers();
+    const firstAppSignal = AbortSignal.any([context.signal]);
+    const nextAppSignal = AbortSignal.any([context.signal]);
+    const initialTime = now();
+
+    for (const activityId of ["auth-cache-first", "auth-cache-reused"]) {
+      const response = await postTeamsActivity(
+        {
+          activity: teamsMessageActivity(fixture, {
+            id: teamsFixtureExternalId(fixture, activityId),
+            entities: [],
+          }),
+          token: teamsToken(),
+        },
+        firstAppSignal,
+      );
+      expect(response.status).toBe(200);
+      await response.json();
+      await flushWaitUntilForTest();
+    }
+    expect(authRequests).toStrictEqual(["metadata", "jwks"]);
+
+    await withMockNowForTest(
+      initialTime + 24 * 60 * 60 * 1000 + 60_000,
+      async () => {
+        const refreshedResponse = await postTeamsActivity(
+          {
+            activity: teamsMessageActivity(fixture, {
+              id: teamsFixtureExternalId(fixture, "auth-cache-refreshed"),
+              entities: [],
+            }),
+            token: teamsToken(),
+          },
+          firstAppSignal,
+        );
+        expect(refreshedResponse.status).toBe(200);
+        await refreshedResponse.json();
+        await flushWaitUntilForTest();
+      },
+    );
+    expect(authRequests).toStrictEqual([
+      "metadata",
+      "jwks",
+      "metadata",
+      "jwks",
+    ]);
+
+    const refreshedResponse = await postTeamsActivity(
+      {
+        activity: teamsMessageActivity(fixture, {
+          id: teamsFixtureExternalId(fixture, "auth-cache-reloaded"),
+          entities: [],
+        }),
+        token: teamsToken(),
+      },
+      nextAppSignal,
+    );
+    expect(refreshedResponse.status).toBe(200);
+    await refreshedResponse.json();
+    await flushWaitUntilForTest();
+    expect(authRequests).toStrictEqual([
+      "metadata",
+      "jwks",
+      "metadata",
+      "jwks",
+      "metadata",
+      "jwks",
+    ]);
+  });
+
   it("ignores Teams channel messages that do not mention the bot", async () => {
+    const fixture = await trackedBotFixture();
     botFrameworkHandlers();
 
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-unmentioned-channel",
+      activity: teamsMessageActivity(fixture, {
+        id: teamsFixtureExternalId(fixture, "activity-unmentioned-channel"),
         text: "hello channel",
         entities: [],
       }),
@@ -1122,15 +1235,16 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("sends one team welcome across installation and members-added events", async () => {
+    const fixture = await trackedBotFixture();
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const installationResponse = await postTeamsActivity({
-      activity: teamsBotInstallationAddedActivity(),
+      activity: teamsBotInstallationAddedActivity(fixture),
       token: teamsToken(),
     });
     const membersAddedResponse = await postTeamsActivity({
-      activity: teamsBotInstalledActivity(),
+      activity: teamsBotInstalledActivity(fixture),
       token: teamsToken(),
     });
 
@@ -1141,7 +1255,7 @@ describe("POST /api/zero/teams/bot", () => {
     await flushWaitUntilForTest();
     expect(outboundRequests).toHaveLength(1);
     expect(outboundRequests[0]).toMatchObject({
-      conversationId: "19:thread@thread.tacv2",
+      conversationId: fixture.teamsConversationId,
       activityId: null,
       body: {
         type: "message",
@@ -1154,13 +1268,13 @@ describe("POST /api/zero/teams/bot", () => {
             type: "mention",
             text: "<at>Ada Lovelace</at>",
             mentioned: {
-              id: "29:user-1",
+              id: fixture.teamsUserId,
               name: "Ada Lovelace",
             },
           },
         ],
         channelData: {
-          tenant: { id: "tenant-1" },
+          tenant: { id: fixture.teamsTenantId },
         },
       },
     });
@@ -1168,20 +1282,29 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("sends a personal welcome message when Teams adds the bot in personal scope", async () => {
+    const fixture = await trackedBotFixture();
+    const activityId = teamsFixtureExternalId(
+      fixture,
+      "activity-install-personal",
+    );
+    const conversationId = `a:personal-${fixture.teamsUserId}`;
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
       activity: {
-        ...teamsBotInstallationAddedActivity(),
-        id: "activity-install-personal",
+        ...teamsBotInstallationAddedActivity(fixture),
+        id: activityId,
         conversation: {
-          id: "a:personal-29:user-1",
+          id: conversationId,
           conversationType: "personal",
         },
         channelData: {
-          tenant: { id: "tenant-1", name: "Tenant One" },
-          teamsAppId: "teams-app-test",
+          tenant: {
+            id: fixture.teamsTenantId,
+            name: fixture.teamsTenantName,
+          },
+          teamsAppId: fixture.teamsAppId,
         },
       },
       token: teamsToken(),
@@ -1192,14 +1315,14 @@ describe("POST /api/zero/teams/bot", () => {
     await flushWaitUntilForTest();
     expect(outboundRequests).toHaveLength(1);
     expect(outboundRequests[0]).toMatchObject({
-      conversationId: "a:personal-29:user-1",
+      conversationId,
       activityId: null,
       body: {
         type: "message",
         text: TEAMS_WELCOME_TEXT,
         textFormat: "markdown",
         channelData: {
-          tenant: { id: "tenant-1" },
+          tenant: { id: fixture.teamsTenantId },
         },
       },
     });
@@ -1208,12 +1331,33 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("responds to Teams validation help and greeting messages without a mention", async () => {
+    const fixture = await trackedBotFixture();
+    const helpActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-validation-help",
+    );
+    const slashHelpActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-validation-slash-help",
+    );
+    const groupHelpActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-validation-group-chat-help",
+    );
+    const greetingActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-validation-hi",
+    );
+    const groupConversationId = `19:${teamsFixtureExternalId(
+      fixture,
+      "group-chat",
+    )}@thread.v2`;
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const helpResponse = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-validation-help",
+      activity: teamsMessageActivity(fixture, {
+        id: helpActivityId,
         text: "help",
         entities: [],
       }),
@@ -1223,8 +1367,8 @@ describe("POST /api/zero/teams/bot", () => {
     expect(helpBody).not.toHaveProperty("dispatch");
 
     const slashHelpResponse = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-validation-slash-help",
+      activity: teamsMessageActivity(fixture, {
+        id: slashHelpActivityId,
         text: "/help",
         entities: [],
       }),
@@ -1234,15 +1378,18 @@ describe("POST /api/zero/teams/bot", () => {
     expect(slashHelpBody).not.toHaveProperty("dispatch");
 
     const groupChatHelpResponse = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-validation-group-chat-help",
+      activity: teamsMessageActivity(fixture, {
+        id: groupHelpActivityId,
         conversation: {
-          id: "19:group-chat@thread.v2",
+          id: groupConversationId,
           conversationType: "groupChat",
         },
         channelData: {
-          tenant: { id: "tenant-1", name: "Tenant One" },
-          teamsAppId: "teams-app-test",
+          tenant: {
+            id: fixture.teamsTenantId,
+            name: fixture.teamsTenantName,
+          },
+          teamsAppId: fixture.teamsAppId,
         },
         text: "help",
         entities: [],
@@ -1256,8 +1403,8 @@ describe("POST /api/zero/teams/bot", () => {
     expect(groupChatHelpBody).not.toHaveProperty("dispatch");
 
     const greetingResponse = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-validation-hi",
+      activity: teamsMessageActivity(fixture, {
+        id: greetingActivityId,
         text: "Hi",
         entities: [],
       }),
@@ -1271,10 +1418,10 @@ describe("POST /api/zero/teams/bot", () => {
         return request.activityId;
       }),
     ).toStrictEqual([
-      "activity-validation-help",
-      "activity-validation-slash-help",
-      "activity-validation-group-chat-help",
-      "activity-validation-hi",
+      helpActivityId,
+      slashHelpActivityId,
+      groupHelpActivityId,
+      greetingActivityId,
     ]);
     expect(outboundRequests[0]?.body).toMatchObject({
       text: expect.stringContaining("Okou Teams Bot Help"),
@@ -1288,12 +1435,14 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("responds to Teams greeting messages with a mention", async () => {
+    const fixture = await trackedBotFixture();
+    const activityId = teamsFixtureExternalId(fixture, "activity-mentioned-hi");
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-mentioned-hi",
+      activity: teamsMessageActivity(fixture, {
+        id: activityId,
         text: "<at>Zero</at> Hi",
       }),
       token: teamsToken(),
@@ -1309,23 +1458,24 @@ describe("POST /api/zero/teams/bot", () => {
     });
     expect(outboundRequests).toHaveLength(1);
     expect(outboundRequests[0]).toMatchObject({
-      conversationId: "19:thread@thread.tacv2",
-      activityId: "activity-mentioned-hi",
+      conversationId: fixture.teamsConversationId,
+      activityId,
       body: {
         type: "message",
         text: TEAMS_WELCOME_TEXT,
-        replyToId: "activity-mentioned-hi",
+        replyToId: activityId,
       },
     });
   });
 
   it("does not run other Teams commands without a mention in channel scope", async () => {
+    const fixture = await trackedBotFixture();
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-unmentioned-disconnect",
+      activity: teamsMessageActivity(fixture, {
+        id: teamsFixtureExternalId(fixture, "activity-unmentioned-disconnect"),
         text: "disconnect",
         entities: [],
       }),
@@ -1347,19 +1497,25 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("handles Teams personal messages without requiring a bot mention", async () => {
+    const fixture = await trackedBotFixture();
+    const activityId = teamsFixtureExternalId(fixture, "activity-personal-dm");
+    const conversationId = `a:personal-${fixture.teamsUserId}`;
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(SERVICE_URL);
 
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-personal-dm",
+      activity: teamsMessageActivity(fixture, {
+        id: activityId,
         conversation: {
-          id: "a:personal-conversation",
+          id: conversationId,
           conversationType: "personal",
         },
         channelData: {
-          tenant: { id: "tenant-1", name: "Tenant One" },
-          teamsAppId: "teams-app-test",
+          tenant: {
+            id: fixture.teamsTenantId,
+            name: fixture.teamsTenantName,
+          },
+          teamsAppId: fixture.teamsAppId,
         },
         text: "hello from dm",
         entities: [],
@@ -1374,7 +1530,7 @@ describe("POST /api/zero/teams/bot", () => {
       activity: {
         kind: "message",
         conversationType: "personal",
-        threadId: "activity-personal-dm",
+        threadId: activityId,
         text: "hello from dm",
         mentionsRecipient: false,
       },
@@ -1383,12 +1539,12 @@ describe("POST /api/zero/teams/bot", () => {
     await flushWaitUntilForTest();
     expect(outboundRequests).toHaveLength(1);
     expect(outboundRequests[0]).toMatchObject({
-      conversationId: "a:personal-conversation",
-      activityId: "activity-personal-dm",
+      conversationId,
+      activityId,
       body: {
         type: "message",
         summary: TEAMS_LOGIN_PROMPT_FALLBACK_TEXT,
-        replyToId: "activity-personal-dm",
+        replyToId: activityId,
         attachments: [
           {
             contentType: "application/vnd.microsoft.card.adaptive",
@@ -1422,6 +1578,8 @@ describe("POST /api/zero/teams/bot", () => {
     const fixture = await trackTeamsFixture(
       Promise.resolve(teamsConnectFixture()),
     );
+    const activityId = teamsFixtureExternalId(fixture, "activity-file-channel");
+    const attachmentId = teamsFixtureExternalId(fixture, "channel-attachment");
     const actor = authOrgApi.user({
       userId: fixture.userId,
       orgId: fixture.orgId,
@@ -1445,11 +1603,10 @@ describe("POST /api/zero/teams/bot", () => {
     await runsApi.ensureOrgModelProvider(actor);
     await installTeamsForTest(context.signal, fixture);
     await connectTeamsFixture(fixture);
-    clearTeamsBotAuthCacheForTest();
     botFrameworkHandlers();
     teamsOutboundHandlers(fixture.serviceUrl);
     teamsGraphHistoryHandlers({
-      tenantId: fixture.teamsTenantId,
+      fixture,
       channelMessages: [],
       threadRoots: {},
       threadReplies: {},
@@ -1458,12 +1615,12 @@ describe("POST /api/zero/teams/bot", () => {
     const contentUrl = "https://contoso.sharepoint.com/sites/docs/spec.png";
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
-        id: "activity-file-channel",
+        id: activityId,
         text: "please inspect this",
         replyToId: null,
         attachments: [
           {
-            id: "channel-attachment-1",
+            id: attachmentId,
             contentType: "reference",
             contentUrl,
             name: "spec.png",
@@ -1546,10 +1703,8 @@ describe("POST /api/zero/teams/bot", () => {
               type: "source",
               kind: "teams",
               href: `https://teams.microsoft.com/l/message/${encodeURIComponent(
-                "19:channel@thread.tacv2",
-              )}/activity-file-channel?tenantId=${encodeURIComponent(
-                fixture.teamsTenantId,
-              )}`,
+                fixture.teamsChannelId,
+              )}/${activityId}?tenantId=${encodeURIComponent(fixture.teamsTenantId)}`,
             },
           ],
         },
@@ -1608,6 +1763,11 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("uses short file ids for Teams personal attachments", async () => {
     const { fixture, actor, runnerGroup } = await setupConnectedTeamsBotActor();
+    const activityId = teamsFixtureExternalId(
+      fixture,
+      "activity-personal-file",
+    );
+    const attachmentId = teamsFixtureExternalId(fixture, "personal-attachment");
     const downloadUrl = new URL(
       "https://contoso.sharepoint.com/_layouts/15/download.aspx",
     );
@@ -1629,12 +1789,12 @@ describe("POST /api/zero/teams/bot", () => {
       activity: {
         ...teamsPersonalMessageActivity({
           fixture,
-          id: "activity-personal-file",
+          id: activityId,
           text: "inspect this personal attachment",
         }),
         attachments: [
           {
-            id: "personal-attachment-1",
+            id: attachmentId,
             contentType: "application/vnd.microsoft.teams.file.download.info",
             content: {
               downloadUrl: downloadUrl.toString(),
@@ -1709,22 +1869,24 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("preserves non-bot Teams mentions in message text", async () => {
+    const fixture = await trackedBotFixture();
+    const mentionedUserId = teamsFixtureExternalId(fixture, "29:user-grace");
     botFrameworkHandlers();
 
     const response = await postTeamsActivity({
-      activity: teamsMessageActivity(botFixture(), {
-        id: "activity-user-mention",
+      activity: teamsMessageActivity(fixture, {
+        id: teamsFixtureExternalId(fixture, "activity-user-mention"),
         text: "<at>Zero</at> ask <at>Grace Hopper</at> to review",
         entities: [
           {
             type: "mention",
             text: "<at>Zero</at>",
-            mentioned: { id: "28:bot-1", name: "Zero" },
+            mentioned: { id: fixture.teamsBotId, name: "Zero" },
           },
           {
             type: "mention",
             text: "<at>Grace Hopper</at>",
-            mentioned: { id: "29:user-2", name: "Grace Hopper" },
+            mentioned: { id: mentionedUserId, name: "Grace Hopper" },
           },
         ],
       }),
@@ -1736,7 +1898,7 @@ describe("POST /api/zero/teams/bot", () => {
     expect(body).toMatchObject({
       activity: {
         kind: "message",
-        text: "ask @Grace Hopper (29:user-2) to review",
+        text: `ask @Grace Hopper (${mentionedUserId}) to review`,
         mentionsRecipient: true,
       },
     });
@@ -1747,6 +1909,28 @@ describe("POST /api/zero/teams/bot", () => {
   it("handles connected Teams bot commands", async () => {
     const { fixture, actor, outboundRequests } =
       await setupConnectedTeamsBotActor();
+    const activityIds = {
+      help: teamsFixtureExternalId(fixture, "activity-command-help"),
+      connect: teamsFixtureExternalId(fixture, "activity-command-connect"),
+      switch: teamsFixtureExternalId(fixture, "activity-command-switch"),
+      model: teamsFixtureExternalId(fixture, "activity-command-model"),
+      switchSubmit: teamsFixtureExternalId(
+        fixture,
+        "activity-command-switch-submit",
+      ),
+      modelSubmit: teamsFixtureExternalId(
+        fixture,
+        "activity-command-model-submit",
+      ),
+      switchedRun: teamsFixtureExternalId(
+        fixture,
+        "activity-command-switch-run",
+      ),
+      disconnect: teamsFixtureExternalId(
+        fixture,
+        "activity-command-disconnect",
+      ),
+    };
     const switchAgent = await authOrgApi.createAgent(actor, {
       displayName: "Teams support agent",
       visibility: "public",
@@ -1756,7 +1940,7 @@ describe("POST /api/zero/teams/bot", () => {
     const helpResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-help",
+        id: activityIds.help,
         text: "/help",
       }),
       token: teamsToken(),
@@ -1768,7 +1952,7 @@ describe("POST /api/zero/teams/bot", () => {
     const connectResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-connect",
+        id: activityIds.connect,
         text: "/connect",
       }),
       token: teamsToken(),
@@ -1780,7 +1964,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-switch",
+        id: activityIds.switch,
         text: "/switch",
       }),
       token: teamsToken(),
@@ -1792,7 +1976,7 @@ describe("POST /api/zero/teams/bot", () => {
     const modelResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-model",
+        id: activityIds.model,
         text: "/model",
       }),
       token: teamsToken(),
@@ -1804,7 +1988,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchSubmitResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-switch-submit",
+        id: activityIds.switchSubmit,
         text: "",
         value: {
           zeroTeamsAction: "switch_agent",
@@ -1828,7 +2012,7 @@ describe("POST /api/zero/teams/bot", () => {
     const modelSubmitResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-model-submit",
+        id: activityIds.modelSubmit,
         text: "",
         value: {
           zeroTeamsAction: "switch_model",
@@ -1861,12 +2045,12 @@ describe("POST /api/zero/teams/bot", () => {
         return request.activityId;
       }),
     ).toStrictEqual([
-      "activity-command-help",
-      "activity-command-connect",
-      "activity-command-switch",
-      "activity-command-model",
-      "activity-command-switch-submit",
-      "activity-command-model-submit",
+      activityIds.help,
+      activityIds.connect,
+      activityIds.switch,
+      activityIds.model,
+      activityIds.switchSubmit,
+      activityIds.modelSubmit,
     ]);
     expect(outboundRequests[0]?.body).toMatchObject({
       type: "message",
@@ -1957,7 +2141,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchedRunResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-switch-run",
+        id: activityIds.switchedRun,
         text: "run after switch",
       }),
       token: teamsToken(),
@@ -1985,7 +2169,7 @@ describe("POST /api/zero/teams/bot", () => {
     const disconnectResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-command-disconnect",
+        id: activityIds.disconnect,
         text: "/disconnect",
       }),
       token: teamsToken(),
@@ -2008,6 +2192,32 @@ describe("POST /api/zero/teams/bot", () => {
 
   it("applies agent and model switches to existing Teams chat threads", async () => {
     const { fixture, actor, runnerGroup } = await setupConnectedTeamsBotActor();
+    const threadId = teamsFixtureExternalId(
+      fixture,
+      "activity-existing-switch-root",
+    );
+    const activityIds = {
+      initial: teamsFixtureExternalId(
+        fixture,
+        "activity-existing-switch-initial",
+      ),
+      switchAgent: teamsFixtureExternalId(
+        fixture,
+        "activity-existing-switch-agent",
+      ),
+      switchedAgentRun: teamsFixtureExternalId(
+        fixture,
+        "activity-existing-switch-agent-run",
+      ),
+      switchModel: teamsFixtureExternalId(
+        fixture,
+        "activity-existing-switch-model",
+      ),
+      switchedModelRun: teamsFixtureExternalId(
+        fixture,
+        "activity-existing-switch-model-run",
+      ),
+    };
     const supportAgent = await authOrgApi.createAgent(actor, {
       displayName: "Teams switched agent",
       visibility: "public",
@@ -2037,18 +2247,17 @@ describe("POST /api/zero/teams/bot", () => {
       },
     ]);
     teamsGraphHistoryHandlers({
-      tenantId: fixture.teamsTenantId,
+      fixture,
       chatMessages: [],
       channelMessages: [],
       threadRoots: {},
       threadReplies: {},
     });
-    const threadId = "activity-existing-switch-root";
 
     const initialResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-existing-switch-initial",
+        id: activityIds.initial,
         threadId,
         text: "run before switching",
       }),
@@ -2065,7 +2274,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchAgentResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-existing-switch-agent",
+        id: activityIds.switchAgent,
         text: "",
         value: {
           zeroTeamsAction: "switch_agent",
@@ -2080,7 +2289,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchedAgentResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-existing-switch-agent-run",
+        id: activityIds.switchedAgentRun,
         threadId,
         text: "run after agent switch",
       }),
@@ -2106,7 +2315,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchModelResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-existing-switch-model",
+        id: activityIds.switchModel,
         text: "",
         value: {
           zeroTeamsAction: "switch_model",
@@ -2121,7 +2330,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchedModelResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-existing-switch-model-run",
+        id: activityIds.switchedModelRun,
         threadId,
         text: "run after model switch",
       }),
@@ -2145,13 +2354,37 @@ describe("POST /api/zero/teams/bot", () => {
   it("replies when a connected Teams run is queued", async () => {
     const { fixture, actor, outboundRequests } =
       await setupConnectedTeamsBotActor();
+    const firstActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-queue-active-1",
+    );
+    const secondActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-queue-active-2",
+    );
+    const queuedActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-queue-third",
+    );
+    const firstThreadId = teamsFixtureExternalId(
+      fixture,
+      "activity-queue-thread-1",
+    );
+    const secondThreadId = teamsFixtureExternalId(
+      fixture,
+      "activity-queue-thread-2",
+    );
+    const queuedThreadId = teamsFixtureExternalId(
+      fixture,
+      "activity-queue-thread-3",
+    );
     outboundRequests.splice(0, outboundRequests.length);
 
     const firstResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-queue-active-1",
-        threadId: "activity-queue-thread-1",
+        id: firstActivityId,
+        threadId: firstThreadId,
         text: "active run one",
       }),
       token: teamsToken(),
@@ -2164,8 +2397,8 @@ describe("POST /api/zero/teams/bot", () => {
     const secondResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-queue-active-2",
-        threadId: "activity-queue-thread-2",
+        id: secondActivityId,
+        threadId: secondThreadId,
         text: "active run two",
       }),
       token: teamsToken(),
@@ -2178,8 +2411,8 @@ describe("POST /api/zero/teams/bot", () => {
     const queuedResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-queue-third",
-        threadId: "activity-queue-thread-3",
+        id: queuedActivityId,
+        threadId: queuedThreadId,
         text: "queued run three",
       }),
       token: teamsToken(),
@@ -2209,7 +2442,7 @@ describe("POST /api/zero/teams/bot", () => {
       },
     ]);
     expect(outboundRequests[3]).toMatchObject({
-      activityId: "activity-queue-third",
+      activityId: queuedActivityId,
       body: {
         type: "message",
         summary: expect.stringContaining("Run queued"),
@@ -2245,6 +2478,14 @@ describe("POST /api/zero/teams/bot", () => {
   it("clears thinking and adds audit/footer text for Teams run admission failures", async () => {
     const fixture = await trackTeamsFixture(
       Promise.resolve(teamsConnectFixture()),
+    );
+    const switchActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-failure-switch-agent",
+    );
+    const failedActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-run-pre-dispatch-failure",
     );
     const actor = authOrgApi.user({
       userId: fixture.userId,
@@ -2301,7 +2542,7 @@ describe("POST /api/zero/teams/bot", () => {
     const switchResponse = await postTeamsActivity({
       activity: teamsPersonalMessageActivity({
         fixture,
-        id: "activity-failure-switch-agent",
+        id: switchActivityId,
         text: "",
         value: {
           zeroTeamsAction: "switch_agent",
@@ -2320,7 +2561,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     outboundRequests.splice(0, outboundRequests.length);
     teamsGraphHistoryHandlers({
-      tenantId: fixture.teamsTenantId,
+      fixture,
       chatMessages: [],
       channelMessages: [],
       threadRoots: {},
@@ -2328,7 +2569,7 @@ describe("POST /api/zero/teams/bot", () => {
     });
     const failedResponse = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
-        id: "activity-run-pre-dispatch-failure",
+        id: failedActivityId,
         text: "<at>Zero</at> run without entitlement",
       }),
       token: teamsToken(),
@@ -2339,7 +2580,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     expect(outboundRequests).toHaveLength(1);
     expect(outboundRequests[0]).toMatchObject({
-      activityId: "activity-run-pre-dispatch-failure",
+      activityId: failedActivityId,
       body: {
         type: "message",
         text: expect.stringContaining(`[Audit](${APP_ORIGIN}/activities)`),
@@ -2352,14 +2593,14 @@ describe("POST /api/zero/teams/bot", () => {
     expect(outboundRequests.reactions).toStrictEqual([
       {
         method: "PUT",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-run-pre-dispatch-failure",
+        conversationId: fixture.teamsConversationId,
+        activityId: failedActivityId,
         reactionType: "1f4ad_thoughtballoon",
       },
       {
         method: "DELETE",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-run-pre-dispatch-failure",
+        conversationId: fixture.teamsConversationId,
+        activityId: failedActivityId,
         reactionType: "1f4ad_thoughtballoon",
       },
     ]);
@@ -2369,7 +2610,7 @@ describe("POST /api/zero/teams/bot", () => {
     const { fixture, actor, outboundRequests } =
       await setupConnectedTeamsBotActor();
     teamsGraphHistoryHandlers({
-      tenantId: fixture.teamsTenantId,
+      fixture,
       chatMessages: [],
       channelMessages: [],
       threadRoots: {},
@@ -2379,7 +2620,7 @@ describe("POST /api/zero/teams/bot", () => {
     outboundRequests.reactions.splice(0, outboundRequests.reactions.length);
     const activity = teamsPersonalMessageActivity({
       fixture,
-      id: "activity-deduplicated",
+      id: teamsFixtureExternalId(fixture, "activity-deduplicated"),
       text: "run this Teams task once",
     });
 
@@ -2418,6 +2659,41 @@ describe("POST /api/zero/teams/bot", () => {
     const fixture = await trackTeamsFixture(
       Promise.resolve(teamsConnectFixture()),
     );
+    const rootDispatchId = teamsFixtureExternalId(fixture, "root-dispatch");
+    const contextActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-context",
+    );
+    const contextFileActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-context-file-only",
+    );
+    const dispatchActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-dispatch",
+    );
+    const channelContextActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-channel-context",
+    );
+    const priorChannelMessageId = teamsFixtureExternalId(
+      fixture,
+      "channel-prior",
+    );
+    const futureChannelMessageId = teamsFixtureExternalId(
+      fixture,
+      "channel-future",
+    );
+    const mentionedUserId = teamsFixtureExternalId(fixture, "29:user-grace");
+    const planAttachmentId = teamsFixtureExternalId(fixture, "teams-file-plan");
+    const checklistAttachmentId = teamsFixtureExternalId(
+      fixture,
+      "teams-file-checklist",
+    );
+    const currentAttachmentId = teamsFixtureExternalId(
+      fixture,
+      "teams-file-current",
+    );
     const actor = authOrgApi.user({
       userId: fixture.userId,
       orgId: fixture.orgId,
@@ -2455,18 +2731,18 @@ describe("POST /api/zero/teams/bot", () => {
 
     const channelMessages: TeamsGraphMessageFixture[] = [];
     const threadRoots: Record<string, TeamsGraphMessageFixture> = {
-      "root-dispatch": {
-        id: "root-dispatch",
+      [rootDispatchId]: {
+        id: rootDispatchId,
         text: "remember the deployment target",
         createdDateTime: "2026-06-30T09:10:00.000Z",
         senderId: fixture.teamsUserId,
-        graphUserPrincipalName: "ada@example.com",
+        graphUserPrincipalName: fixture.teamsUserPrincipalName,
       },
     };
     const threadReplies: Record<string, TeamsGraphMessageFixture[]> = {
-      "root-dispatch": [
+      [rootDispatchId]: [
         {
-          id: "activity-context-1",
+          id: contextActivityId,
           text: 'confirm with <at id="0">Grace Hopper</at> that the target is staging',
           createdDateTime: "2026-06-30T09:11:00.000Z",
           senderId: fixture.teamsUserId,
@@ -2476,7 +2752,7 @@ describe("POST /api/zero/teams/bot", () => {
               mentionText: '<at id="0">Grace Hopper</at>',
               mentioned: {
                 user: {
-                  id: "29:user-grace",
+                  id: mentionedUserId,
                   displayName: "Grace Hopper",
                 },
               },
@@ -2484,7 +2760,7 @@ describe("POST /api/zero/teams/bot", () => {
           ],
           attachments: [
             {
-              id: "teams-file-plan-1",
+              id: planAttachmentId,
               name: "deployment-plan.pdf",
               contentType: "application/vnd.microsoft.teams.file.download.info",
               content: {
@@ -2495,13 +2771,13 @@ describe("POST /api/zero/teams/bot", () => {
           ],
         },
         {
-          id: "activity-context-file-only",
+          id: contextFileActivityId,
           text: "",
           createdDateTime: "2026-06-30T09:11:30.000Z",
           senderId: fixture.teamsUserId,
           attachments: [
             {
-              id: "teams-file-checklist-1",
+              id: checklistAttachmentId,
               name: "release-checklist.txt",
               contentType: "application/vnd.microsoft.teams.file.download.info",
               content: {
@@ -2512,7 +2788,7 @@ describe("POST /api/zero/teams/bot", () => {
           ],
         },
         {
-          id: "activity-dispatch-1",
+          id: dispatchActivityId,
           text: "ship the Teams dispatch",
           createdDateTime: "2026-06-30T09:12:00.000Z",
           senderId: fixture.teamsUserId,
@@ -2520,7 +2796,7 @@ describe("POST /api/zero/teams/bot", () => {
       ],
     };
     const graphRequests = teamsGraphHistoryHandlers({
-      tenantId: fixture.teamsTenantId,
+      fixture,
       channelMessages,
       threadRoots,
       threadReplies,
@@ -2528,19 +2804,19 @@ describe("POST /api/zero/teams/bot", () => {
 
     channelMessages.push(
       {
-        id: "activity-channel-context-1",
+        id: channelContextActivityId,
         text: "start another topic",
         createdDateTime: "2026-06-30T09:12:00.000Z",
         senderId: fixture.teamsUserId,
       },
       {
-        id: "channel-prior-1",
+        id: priorChannelMessageId,
         text: "api channel planning",
         createdDateTime: "2026-06-30T09:09:00.000Z",
         senderId: fixture.teamsUserId,
       },
       {
-        id: "channel-future-1",
+        id: futureChannelMessageId,
         text: "future channel topic",
         createdDateTime: "2026-06-30T09:13:00.000Z",
         senderId: fixture.teamsUserId,
@@ -2549,7 +2825,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     const channelContextResponse = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
-        id: "activity-channel-context-1",
+        id: channelContextActivityId,
         replyToId: null,
         text: "<at>Zero</at> start another topic",
       }),
@@ -2564,8 +2840,8 @@ describe("POST /api/zero/teams/bot", () => {
     expect(outboundRequests.reactions).toStrictEqual([
       {
         method: "PUT",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-channel-context-1",
+        conversationId: fixture.teamsConversationId,
+        activityId: channelContextActivityId,
         reactionType: "1f4ad_thoughtballoon",
       },
     ]);
@@ -2594,13 +2870,13 @@ describe("POST /api/zero/teams/bot", () => {
       0,
       channelMessages.length,
       {
-        id: "root-dispatch",
+        id: rootDispatchId,
         text: "remember the deployment target",
         createdDateTime: "2026-06-30T09:10:00.000Z",
         senderId: fixture.teamsUserId,
       },
       {
-        id: "channel-prior-1",
+        id: priorChannelMessageId,
         text: "api channel planning",
         createdDateTime: "2026-06-30T09:09:00.000Z",
         senderId: fixture.teamsUserId,
@@ -2609,12 +2885,12 @@ describe("POST /api/zero/teams/bot", () => {
 
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
-        id: "activity-dispatch-1",
-        replyToId: "root-dispatch",
+        id: dispatchActivityId,
+        replyToId: rootDispatchId,
         text: "<at>Zero</at> ship the Teams dispatch",
         attachments: [
           {
-            id: "teams-file-current-1",
+            id: currentAttachmentId,
             name: "current-task.txt",
             contentType: "application/vnd.microsoft.teams.file.download.info",
             content: {
@@ -2634,14 +2910,14 @@ describe("POST /api/zero/teams/bot", () => {
     expect(outboundRequests.reactions).toStrictEqual([
       {
         method: "PUT",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-channel-context-1",
+        conversationId: fixture.teamsConversationId,
+        activityId: channelContextActivityId,
         reactionType: "1f4ad_thoughtballoon",
       },
       {
         method: "PUT",
-        conversationId: "19:thread@thread.tacv2",
-        activityId: "activity-dispatch-1",
+        conversationId: fixture.teamsConversationId,
+        activityId: dispatchActivityId,
         reactionType: "1f4ad_thoughtballoon",
       },
     ]);
@@ -2718,9 +2994,9 @@ describe("POST /api/zero/teams/bot", () => {
       `Team ID: ${fixture.teamsTeamId}`,
     );
     expect(currentIntegrationPrompt).toContain(
-      "Conversation ID: 19:thread@thread.tacv2",
+      `Conversation ID: ${fixture.teamsConversationId}`,
     );
-    expect(currentIntegrationPrompt).toContain("Thread ID: root-dispatch");
+    expect(currentIntegrationPrompt).toContain(`Thread ID: ${rootDispatchId}`);
     expect(currentIntegrationPrompt).not.toContain("Teams user ID:");
     expect(currentIntegrationPrompt).not.toContain("Teams display name:");
     expect(currentIntegrationPrompt).not.toContain(
@@ -2735,7 +3011,7 @@ describe("POST /api/zero/teams/bot", () => {
       `Teams user ID: ${fixture.teamsUserId}`,
     );
     expect(currentUserPrompt).toContain(
-      "Teams user principal name: ada@example.com",
+      `Teams user principal name: ${fixture.teamsUserPrincipalName}`,
     );
     expect(currentUserPrompt).toContain("Teams display name: Ada Lovelace");
     expect(teamsThreadContext).toContain(
@@ -2743,59 +3019,72 @@ describe("POST /api/zero/teams/bot", () => {
     );
     expect(teamsThreadContext).toContain("- RELATIVE_INDEX: -1");
     expect(teamsThreadContext).toContain(
-      `- SENDER: {id: ${fixture.teamsUserId}, name: Ada Lovelace, email: ada@example.com}`,
+      `- SENDER: {id: ${fixture.teamsUserId}, name: Ada Lovelace, email: ${fixture.teamsUserPrincipalName}}`,
     );
     expect(teamsThreadContext).toContain("remember the deployment target");
     expect(teamsThreadContext).toContain(
-      "confirm with @Grace Hopper (29:user-grace) that the target is staging",
+      `confirm with @Grace Hopper (${mentionedUserId}) that the target is staging`,
     );
     expect(teamsThreadContext).toContain(
       "[Teams file] deployment-plan.pdf (application/pdf)",
     );
     expect(teamsThreadContext).toContain(
-      "[Teams attachment ID] teams-file-plan-1",
+      `[Teams attachment ID] ${planAttachmentId}`,
     );
     expect(teamsThreadContext).toContain(
       "[Teams file] release-checklist.txt (text/plain)",
     );
     expect(teamsThreadContext).toContain(
-      "[Teams attachment ID] teams-file-checklist-1",
+      `[Teams attachment ID] ${checklistAttachmentId}`,
     );
     expect(teamsThreadContext).not.toContain("ship the Teams dispatch");
-    expect(graphRequests).toContain("thread-root:root-dispatch");
-    expect(graphRequests).toContain("thread-replies:root-dispatch");
+    expect(graphRequests).toContain(`thread-root:${rootDispatchId}`);
+    expect(graphRequests).toContain(`thread-replies:${rootDispatchId}`);
     expect(graphRequests).toContain(`user:${fixture.teamsUserId}`);
   });
 
   it("includes recent Teams personal messages in the run context", async () => {
     const { fixture, actor, runnerGroup, outboundRequests } =
       await setupConnectedTeamsBotActor();
-    const personalChatId = "19:personal-test@unq.gbl.spaces";
+    const personalChatId = `19:${teamsFixtureExternalId(
+      fixture,
+      "personal-test",
+    )}@unq.gbl.spaces`;
+    const currentActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-personal-thread-current",
+    );
     const graphRequests = teamsGraphHistoryHandlers({
-      tenantId: fixture.teamsTenantId,
+      fixture,
       teamsAppId: BOT_APP_ID,
       personalChatId,
       chatMessages: [
         {
-          id: "activity-personal-thread-current",
+          id: currentActivityId,
           text: "continue this private task",
           createdDateTime: "2026-06-30T09:13:00.000Z",
           senderId: fixture.teamsUserId,
         },
         {
-          id: "activity-personal-thread-prior-reply",
+          id: teamsFixtureExternalId(
+            fixture,
+            "activity-personal-thread-prior-reply",
+          ),
           text: "the target is staging",
           createdDateTime: "2026-06-30T09:12:00.000Z",
           senderId: fixture.teamsUserId,
         },
         {
-          id: "activity-unrelated-personal-root",
+          id: teamsFixtureExternalId(
+            fixture,
+            "activity-unrelated-personal-root",
+          ),
           text: "unrelated private task",
           createdDateTime: "2026-06-30T09:11:00.000Z",
           senderId: fixture.teamsUserId,
         },
         {
-          id: "activity-personal-thread-root",
+          id: teamsFixtureExternalId(fixture, "activity-personal-thread-root"),
           text: "remember the private deployment target",
           createdDateTime: "2026-06-30T09:10:00.000Z",
           senderId: fixture.teamsUserId,
@@ -2811,7 +3100,7 @@ describe("POST /api/zero/teams/bot", () => {
       activity: {
         ...teamsPersonalMessageActivity({
           fixture,
-          id: "activity-personal-thread-current",
+          id: currentActivityId,
           text: "continue this private task",
         }),
         channelData: {
@@ -2855,12 +3144,15 @@ describe("POST /api/zero/teams/bot", () => {
     const host = await computerUseApi.startComputerUseHost(actor, {
       hostName: "Teams authorized host",
     });
-    const threadId = "teams-computer-use-thread";
+    const threadId = teamsFixtureExternalId(
+      fixture,
+      "teams-computer-use-thread",
+    );
 
     const firstResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-computer-use-authorize",
+        id: teamsFixtureExternalId(fixture, "activity-computer-use-authorize"),
         threadId,
         text: "authorize the browser",
       }),
@@ -2892,7 +3184,7 @@ describe("POST /api/zero/teams/bot", () => {
     const secondResponse = await postTeamsActivity({
       activity: teamsPersonalThreadMessageActivity({
         fixture,
-        id: "activity-computer-use-resume",
+        id: teamsFixtureExternalId(fixture, "activity-computer-use-resume"),
         threadId,
         text: "use the browser",
       }),
@@ -2921,6 +3213,7 @@ describe("POST /api/zero/teams/bot", () => {
     const fixture = await trackTeamsFixture(
       Promise.resolve(teamsConnectFixture()),
     );
+    const activityId = teamsFixtureExternalId(fixture, "activity-no-default");
     botFrameworkHandlers();
     const outboundRequests = teamsOutboundHandlers(fixture.serviceUrl);
 
@@ -2935,7 +3228,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
-        id: "activity-no-default",
+        id: activityId,
         text: "<at>Zero</at> hello",
       }),
       token: teamsToken(),
@@ -2945,20 +3238,25 @@ describe("POST /api/zero/teams/bot", () => {
     const body = await readTeamsBotResponseAndFlush(response);
     expect(body).not.toHaveProperty("dispatch");
     expect(outboundRequests.at(-1)).toMatchObject({
-      activityId: "activity-no-default",
+      activityId,
       body: {
         type: "message",
         text: expect.stringContaining("No agent is configured"),
-        replyToId: "activity-no-default",
+        replyToId: activityId,
       },
     });
   });
 
   it("normalizes a Teams bot removal activity", async () => {
+    const fixture = botFixture();
+    const removalActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-remove",
+    );
     botFrameworkHandlers();
 
     const response = await postTeamsActivity({
-      activity: teamsBotRemovedActivity(),
+      activity: teamsBotRemovedActivity(fixture),
       token: teamsToken(),
     });
 
@@ -2968,28 +3266,27 @@ describe("POST /api/zero/teams/bot", () => {
       activity: {
         kind: "bot_removed",
         reason: "members_removed",
-        tenantId: "tenant-1",
-        conversationId: "19:thread@thread.tacv2",
-        channelId: "19:channel@thread.tacv2",
+        tenantId: fixture.teamsTenantId,
+        conversationId: fixture.teamsConversationId,
+        channelId: fixture.teamsChannelId,
         membersRemoved: [
           {
-            id: "28:bot-1",
+            id: fixture.teamsBotId,
             name: "Zero",
             aadObjectId: null,
             userPrincipalName: null,
           },
         ],
-        idempotencyKey:
-          "19:thread@thread.tacv2:conversationUpdate:activity-remove-1",
+        idempotencyKey: `${fixture.teamsConversationId}:conversationUpdate:${removalActivityId}`,
       },
     });
   });
 
   it("cleans up installation and dependent connections on Teams bot removal", async () => {
-    const fixture = botFixture();
+    const fixture = await trackedBotFixture();
     botFrameworkHandlers();
     await postTeamsActivity({
-      activity: teamsMessageActivity(),
+      activity: teamsMessageActivity(fixture),
       token: teamsToken(),
     });
     await flushWaitUntilForTest();
@@ -3010,7 +3307,7 @@ describe("POST /api/zero/teams/bot", () => {
     );
 
     const response = await postTeamsActivity({
-      activity: teamsBotRemovedActivity(),
+      activity: teamsBotRemovedActivity(fixture),
       token: teamsToken(),
     });
 
@@ -3031,7 +3328,7 @@ describe("POST /api/zero/teams/bot", () => {
   });
 
   it("publishes Teams status changes when an install activity refreshes a bound installation", async () => {
-    const fixture = botFixture();
+    const fixture = await trackedBotFixture();
     botFrameworkHandlers();
     context.mocks.ably.publish.mockResolvedValue(undefined);
     await installTeamsForTest(context.signal, fixture);
@@ -3047,7 +3344,6 @@ describe("POST /api/zero/teams/bot", () => {
       [200],
     );
     context.mocks.ably.publish.mockClear();
-    clearTeamsBotAuthCacheForTest();
     botFrameworkHandlers();
 
     const response = await postTeamsActivity({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
@@ -14,6 +14,7 @@ import {
   removeTeamsForTest,
   setupTeamsConnectTestEnv,
   teamsConnectFixture,
+  teamsFixtureExternalId,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
 import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
@@ -105,7 +106,7 @@ function connectBody(
     teamsUserId,
     teamsAadObjectId: fixture.teamsAadObjectId,
     teamsUserDisplayName: "Ada Lovelace",
-    teamsUserPrincipalName: "ada@example.com",
+    teamsUserPrincipalName: fixture.teamsUserPrincipalName,
     teamId: fixture.teamsTeamId,
     teamName: fixture.teamsTeamName,
     serviceUrl: fixture.serviceUrl,
@@ -134,7 +135,10 @@ async function bindTeamsInstallation(
   await accept(
     client.connect({
       headers: { authorization: "Bearer clerk-session" },
-      body: connectBody(fixture, "29:admin-user"),
+      body: connectBody(
+        fixture,
+        teamsFixtureExternalId(fixture, "29:admin-user"),
+      ),
     }),
     [200],
   );
@@ -205,6 +209,8 @@ describe("GET /api/zero/teams/connect", () => {
       teamsTenantName: "",
       teamsTeamName: "",
     });
+    const linkedTeamId = teamsFixtureExternalId(fixture, "team-from-link");
+    const linkedActivityId = teamsFixtureExternalId(fixture, "activity-link");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const response = await requestConnect(
@@ -214,11 +220,11 @@ describe("GET /api/zero/teams/connect", () => {
         teamsUserId: fixture.teamsUserId,
         teamsAadObjectId: fixture.teamsAadObjectId,
         teamsUserDisplayName: "Ada Lovelace",
-        teamsUserPrincipalName: "ada@example.com",
-        teamId: "team-from-link",
+        teamsUserPrincipalName: fixture.teamsUserPrincipalName,
+        teamId: linkedTeamId,
         teamName: "Team From Link",
         serviceUrl: fixture.serviceUrl,
-        activityId: "activity-1",
+        activityId: linkedActivityId,
       }),
     );
 
@@ -240,15 +246,15 @@ describe("GET /api/zero/teams/connect", () => {
       "Ada Lovelace",
     );
     expect(redirectUrl.searchParams.get("teamsUserPrincipalName")).toBe(
-      "ada@example.com",
+      fixture.teamsUserPrincipalName,
     );
-    expect(redirectUrl.searchParams.get("teamId")).toBe("team-from-link");
+    expect(redirectUrl.searchParams.get("teamId")).toBe(linkedTeamId);
     expect(redirectUrl.searchParams.get("serviceUrl")).toBe(fixture.serviceUrl);
-    expect(redirectUrl.searchParams.get("activityId")).toBe("activity-1");
+    expect(redirectUrl.searchParams.get("activityId")).toBe(linkedActivityId);
     expect(redirectUrl.searchParams.get("teamName")).toBe("Team From Link");
     await expectTeamsConnected(fixture, {
       tenantName: "Tenant From Link",
-      teamId: "team-from-link",
+      teamId: linkedTeamId,
       teamName: "Team From Link",
     });
   });
@@ -279,7 +285,7 @@ describe("GET /api/zero/teams/connect", () => {
         tenantId: fixture.teamsTenantId,
         teamsAadObjectId: fixture.teamsAadObjectId,
         teamsUserDisplayName: "Ada Lovelace",
-        teamsUserPrincipalName: "ada@example.com",
+        teamsUserPrincipalName: fixture.teamsUserPrincipalName,
       }),
     );
 
@@ -321,7 +327,7 @@ describe("GET /api/zero/teams/connect", () => {
     const response = await requestConnect(
       connectUrl({
         tenantId: fixture.teamsTenantId,
-        teamsUserId: "29:member-user",
+        teamsUserId: teamsFixtureExternalId(fixture, "29:member-user"),
         orgId: fixture.orgId,
       }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
@@ -17,6 +17,7 @@ import {
   removeTeamsForTest,
   setupTeamsConnectTestEnv,
   teamsConnectFixture,
+  teamsFixtureExternalId,
   teamsMessageActivityForTest,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
@@ -71,7 +72,7 @@ function connectBody(
     teamsUserId,
     teamsAadObjectId,
     teamsUserDisplayName: "Ada Lovelace",
-    teamsUserPrincipalName: "ada@example.com",
+    teamsUserPrincipalName: fixture.teamsUserPrincipalName,
     teamId: fixture.teamsTeamId,
     teamName: fixture.teamsTeamName,
     serviceUrl: fixture.serviceUrl,
@@ -87,6 +88,14 @@ function teamsWelcomeHandlers(
 ): TeamsWelcomeRequest[] {
   const requests: TeamsWelcomeRequest[] = [];
   const serviceBaseUrl = teamsServiceBaseUrl(fixture.serviceUrl);
+  const welcomeConversationId = `a:${teamsFixtureExternalId(
+    fixture,
+    "teams-welcome-conversation",
+  )}`;
+  const welcomeActivityId = teamsFixtureExternalId(
+    fixture,
+    "teams-welcome-activity",
+  );
 
   server.use(
     http.post(BOT_FRAMEWORK_TOKEN_URL, async ({ request }) => {
@@ -105,7 +114,7 @@ function teamsWelcomeHandlers(
         kind: "conversation",
         body: await request.json(),
       });
-      return HttpResponse.json({ id: "a:teams-welcome-conversation" });
+      return HttpResponse.json({ id: welcomeConversationId });
     }),
     http.post(
       `${serviceBaseUrl}/v3/conversations/:conversationId/activities`,
@@ -114,7 +123,7 @@ function teamsWelcomeHandlers(
           kind: "activity",
           body: await request.json(),
         });
-        return HttpResponse.json({ id: "teams-welcome-activity" });
+        return HttpResponse.json({ id: welcomeActivityId });
       },
     ),
   );
@@ -128,7 +137,14 @@ async function seedTeamsInstallation(
   ) => Promise<TeamsConnectFixture>,
   values: Partial<TeamsConnectFixture> = {},
 ): Promise<TeamsConnectFixture> {
-  const fixture = await track(Promise.resolve(teamsConnectFixture(values)));
+  const fixture = await track(
+    Promise.resolve(
+      teamsConnectFixture({
+        teamsAppId: BOT_APP_ID,
+        ...values,
+      }),
+    ),
+  );
   await installTeamsForTest(context.signal, fixture);
   return fixture;
 }
@@ -158,7 +174,8 @@ describe("GET /api/zero/integrations/teams/connect", () => {
   });
 
   it("returns uninstalled status when the org has no Teams installation", async () => {
-    mocks.clerk.session("user_empty", "org_empty", "org:admin");
+    const fixture = teamsConnectFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
       zeroTeamsConnectContract,
@@ -177,15 +194,16 @@ describe("GET /api/zero/integrations/teams/connect", () => {
       isAdmin: true,
       installUrl: teamsInstallUrl(),
       connectUrl: teamsOauthConnectUrl({
-        orgId: "org_empty",
-        userId: "user_empty",
+        orgId: fixture.orgId,
+        userId: fixture.userId,
       }),
     });
   });
 
   it("falls back to the web origin when the API backend URL is unset", async () => {
+    const fixture = teamsConnectFixture();
     mockEnv("VM0_API_BACKEND_URL", undefined);
-    mocks.clerk.session("user_empty", "org_empty", "org:admin");
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
       zeroTeamsConnectContract,
@@ -205,8 +223,8 @@ describe("GET /api/zero/integrations/teams/connect", () => {
       installUrl: teamsInstallUrl(),
       connectUrl: teamsOauthConnectUrl(
         {
-          orgId: "org_empty",
-          userId: "user_empty",
+          orgId: fixture.orgId,
+          userId: fixture.userId,
         },
         "https://app.vm0.test",
       ),
@@ -272,7 +290,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     );
 
     const seedActivity = teamsMessageActivityForTest(fixture, {
-      id: "activity-stale-teams-app",
+      id: teamsFixtureExternalId(fixture, "activity-stale-teams-app"),
     });
     const channelData = seedActivity.channelData as Record<string, unknown>;
     const response = await postTeamsActivityForTest({
@@ -281,7 +299,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
         ...seedActivity,
         channelData: {
           ...channelData,
-          teamsAppId: "22222222-2222-2222-2222-222222222222",
+          teamsAppId: teamsFixtureExternalId(fixture, "stale-teams-app"),
         },
       },
     });
@@ -422,6 +440,12 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     const adminUserId = `admin_${fixture.userId}`;
     const memberUserId = `member_${fixture.userId}`;
+    const adminTeamsUserId = teamsFixtureExternalId(fixture, "29:admin-user");
+    const memberTeamsUserId = teamsFixtureExternalId(fixture, "29:member-user");
+    const memberTeamsAadObjectId = teamsFixtureExternalId(
+      fixture,
+      "aad-member-user",
+    );
 
     const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
       zeroTeamsConnectContract,
@@ -430,7 +454,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     await accept(
       client.connect({
         headers: { authorization: "Bearer clerk-session" },
-        body: connectBody(fixture, "29:admin-user"),
+        body: connectBody(fixture, adminTeamsUserId),
       }),
       [200],
     );
@@ -439,7 +463,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     const response = await accept(
       client.connect({
         headers: { authorization: "Bearer clerk-session" },
-        body: connectBody(fixture, "29:member-user", "aad-member-user"),
+        body: connectBody(fixture, memberTeamsUserId, memberTeamsAadObjectId),
       }),
       [200],
     );
@@ -508,6 +532,14 @@ describe("POST /api/zero/integrations/teams/connect", () => {
 
   it("sends a one-time Teams welcome message after connect", async () => {
     const fixture = await seedTeamsInstallation(track);
+    const personalConversationId = `a:${teamsFixtureExternalId(
+      fixture,
+      "personal-conversation",
+    )}`;
+    const connectActivityId = teamsFixtureExternalId(
+      fixture,
+      "activity-connect",
+    );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     mockEnv("MICROSOFT_TEAMS_BOT_APP_PASSWORD", BOT_APP_PASSWORD);
     const welcomeRequests = teamsWelcomeHandlers(fixture);
@@ -517,9 +549,9 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     );
     const body = {
       ...connectBody(fixture),
-      conversationId: "a:personal-conversation",
+      conversationId: personalConversationId,
       conversationType: "personal",
-      activityId: "activity-connect",
+      activityId: connectActivityId,
     };
     await accept(
       client.connect({
@@ -540,7 +572,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     expect(welcomeRequests[0]).toMatchObject({
       kind: "conversation",
       body: {
-        bot: { id: "28:bot-1", name: "Zero" },
+        bot: { id: fixture.teamsBotId, name: "Zero" },
         members: [{ id: fixture.teamsUserId, name: "Ada Lovelace" }],
         isGroup: false,
         channelData: {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
@@ -84,7 +84,7 @@ function mockMicrosoftOAuth(args: {
   readonly tenantId: string;
   readonly aadObjectId: string;
   readonly displayName?: string;
-  readonly userPrincipalName?: string;
+  readonly userPrincipalName: string;
   readonly expectedRedirectUri?: string;
 }): void {
   server.use(
@@ -112,7 +112,7 @@ function mockMicrosoftOAuth(args: {
       return HttpResponse.json({
         id: args.aadObjectId,
         displayName: args.displayName ?? "Ada Lovelace",
-        userPrincipalName: args.userPrincipalName ?? "ada@example.com",
+        userPrincipalName: args.userPrincipalName,
         mail: null,
       });
     }),
@@ -215,6 +215,7 @@ describe("Teams OAuth API routes", () => {
     mockMicrosoftOAuth({
       tenantId: fixture.teamsTenantId,
       aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: fixture.teamsUserPrincipalName,
     });
 
     const response = await appRequest(
@@ -269,6 +270,7 @@ describe("Teams OAuth API routes", () => {
     mockMicrosoftOAuth({
       tenantId: fixture.teamsTenantId,
       aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: fixture.teamsUserPrincipalName,
     });
 
     const response = await appRequest(
@@ -322,8 +324,9 @@ describe("Teams OAuth API routes", () => {
     );
 
     mockMicrosoftOAuth({
-      tenantId: "tenant-other",
+      tenantId: `other-${fixture.teamsTenantId}`,
       aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: fixture.teamsUserPrincipalName,
     });
 
     const response = await appRequest(

--- a/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
@@ -332,11 +332,14 @@ const handleZeroTeamsBot$ = command(
       );
     }
 
-    const auth = await verifyTeamsBotAuthorization({
-      authorization: get(authorization$),
-      serviceUrl,
-      channelId: readTeamsActivityChannelId(body),
-    });
+    const auth = await verifyTeamsBotAuthorization(
+      {
+        authorization: get(authorization$),
+        serviceUrl,
+        channelId: readTeamsActivityChannelId(body),
+      },
+      signal,
+    );
     signal.throwIfAborted();
 
     if (!auth.ok) {


### PR DESCRIPTION
## Summary

- derive Teams persistence fixtures from one unique per-scenario namespace, including org, user, tenant, team, channel, conversation, activity, app, bot, principal, and AAD identities
- complete the migration of every direct `teamsConnectFixture()` / `teamsMessageActivityForTest()` caller while retaining only configured Bot Framework app, tenant, and protocol constants
- make the Bot Framework metadata/JWKS cache explicitly owned by the API app lifecycle and remove test-only global cache resets
- preserve install, connect, message, removal, cache reuse, TTL refresh, and cache-owner isolation coverage through public routes

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed; non-blocking pre-existing Oxlint warnings only)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- full focused caller files: `zero-teams-connect.test.ts` (14/14), `zero-integrations-teams.test.ts` (3/3), `zero-teams-browser-connect.test.ts` (8/8), and `zero-teams-oauth.test.ts` (7/7)
- focused bot lifecycle/cache/message slice: 7/7 passed in `zero-teams-bot.test.ts`
- full local `zero-teams-bot.test.ts` comparison: branch 22 passed / 6 failed versus current-main baseline 21 passed / 6 failed; the same six runner job-claim cases return `404 Job not found in queue` locally, while the added auth-cache coverage passes
- full local `internal-callbacks-teams.test.ts` attempted: all nine cases reach the same local runner job-claim `404 Job not found in queue` before their callback assertions; the PR pipeline covers these runner-dependent cases
- ownership revision for `8f147dec7c7388229dad0a6c36750054d81cc009`: `zero-teams-connect.test.ts` passed 14/14 and the focused cache reuse, TTL refresh, and owner-isolation case passed 1/1 (27 unrelated bot tests skipped)
- PR pipeline for `8f147dec7c7388229dad0a6c36750054d81cc009`: 74 passed / 18 intentionally skipped / 0 failed; API shard 2 passed 24/24 files and 325/325 tests, and the Turbo, security, crates, and pull-request-title gates passed
- positional-signal revision for `b6b76e38216bc8ae51db2743068ffb2eeb25de61`: targeted Prettier, standard/type-aware Oxlint, ESLint, and `pnpm --filter api run check-types` passed; focused default-owner and cache-owner route validation passed 3/3 (25 unrelated tests skipped), preserving reuse, 24-hour TTL refresh, and distinct owner isolation
- exact-head PR pipeline for `b6b76e38216bc8ae51db2743068ffb2eeb25de61`: 74 passed / 18 intentionally skipped / 0 failed; full Turbo attempt 3 recreated the preview lifecycle and passed all eight API shards plus the previously flaky runner attachment shard, with Turbo, security, crates, CodeQL, and pull-request-title gates green

No full local Vitest suite or local dev server was run; repository-wide validation is left to the PR pipeline.

Closes #26603
Epic: #26569
