### PR TITLE
test(api): isolate model stats aggregation fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/model-stats-state.ts
@@ -14,13 +14,57 @@ interface ModelStatsObservationState {
   readonly aggregatedAt: string | null;
 }
 
+export interface ModelStatsStatKey {
+  readonly hourStart: Date;
+  readonly model: string;
+}
+
+export interface ModelStatsFixtureScope {
+  readonly observationIdempotencyKeys: readonly string[];
+  readonly statKeys: readonly ModelStatsStatKey[];
+}
+
+export interface ModelStatsObservationFixture {
+  readonly idempotencyKey: string;
+  readonly model: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadInputTokens: number;
+  readonly cacheCreationInputTokens: number;
+  readonly observedAt: Date;
+  readonly aggregatedAt: Date | null;
+}
+
+interface ModelStatsAggregationResult {
+  readonly cutoff: string;
+  readonly processedHours: number;
+  readonly processedObservations: number;
+  readonly updatedStats: number;
+  readonly deletedObservations: number;
+}
+
+interface ModelStatsRankingResult {
+  readonly period: "today" | "week" | "month";
+  readonly totalTokens: number;
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly rows: readonly {
+    readonly model: string;
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly totalTokens: number;
+    readonly previousTotalTokens: number;
+  }[];
+}
+
 function requestModelStatsState(
   context: TestContext,
   path: string,
   init?: RequestInit,
+  signal: AbortSignal = context.signal,
 ): Promise<Response> {
   const app = createAppWithRoutes({
-    signal: context.signal,
+    signal,
     routes: testModelStatsStateRoutes,
   });
   return Promise.resolve(app.request(path, init));
@@ -40,6 +84,7 @@ function expectOk(response: Response, operation: string): void {
 async function postAction(
   context: TestContext,
   body: TestModelStatsStateActionBody,
+  signal: AbortSignal = context.signal,
 ): Promise<TestModelStatsStateActionResponse> {
   const response = await requestModelStatsState(
     context,
@@ -49,9 +94,98 @@ async function postAction(
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
     },
+    signal,
   );
   await expectOk(response, `model stats state action ${body.action}`);
   return await readJson<TestModelStatsStateActionResponse>(response);
+}
+
+function wireStatKeys(statKeys: readonly ModelStatsStatKey[]) {
+  return statKeys.map((statKey) => {
+    return {
+      hour_start: statKey.hourStart.toISOString(),
+      model: statKey.model,
+    };
+  });
+}
+
+function aggregateFixtureBody(
+  args: ModelStatsFixtureScope & { readonly processedAt: Date },
+): TestModelStatsStateActionBody {
+  return {
+    action: "aggregate-fixture",
+    processed_at: args.processedAt.toISOString(),
+    observation_idempotency_keys: [...args.observationIdempotencyKeys],
+    stat_keys: wireStatKeys(args.statKeys),
+  };
+}
+
+export function requestAggregateModelStatsFixture(
+  context: TestContext,
+  args: ModelStatsFixtureScope & { readonly processedAt: Date },
+  signal: AbortSignal = context.signal,
+): Promise<Response> {
+  return requestModelStatsState(
+    context,
+    `${MODEL_STATS_STATE_ROUTE}/action`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(aggregateFixtureBody(args)),
+    },
+    signal,
+  );
+}
+
+export async function aggregateModelStatsFixture(
+  context: TestContext,
+  args: ModelStatsFixtureScope & { readonly processedAt: Date },
+): Promise<ModelStatsAggregationResult> {
+  const response = await postAction(context, aggregateFixtureBody(args));
+  if (!response.aggregation) {
+    throw new Error("Model stats aggregation response is incomplete");
+  }
+  return {
+    cutoff: response.aggregation.cutoff,
+    processedHours: response.aggregation.processed_hours,
+    processedObservations: response.aggregation.processed_observations,
+    updatedStats: response.aggregation.updated_stats,
+    deletedObservations: response.aggregation.deleted_observations,
+  };
+}
+
+export async function readModelStatsFixtureRankings(
+  context: TestContext,
+  args: {
+    readonly period?: string;
+    readonly now: Date;
+    readonly statKeys: readonly ModelStatsStatKey[];
+  },
+): Promise<ModelStatsRankingResult> {
+  const response = await postAction(context, {
+    action: "read-fixture-rankings",
+    ...(args.period === undefined ? {} : { period: args.period }),
+    now: args.now.toISOString(),
+    stat_keys: wireStatKeys(args.statKeys),
+  });
+  if (!response.ranking) {
+    throw new Error("Model stats ranking response is incomplete");
+  }
+  return {
+    period: response.ranking.period,
+    totalTokens: response.ranking.total_tokens,
+    windowStart: response.ranking.window_start,
+    windowEnd: response.ranking.window_end,
+    rows: response.ranking.rows.map((row) => {
+      return {
+        model: row.model,
+        inputTokens: row.input_tokens,
+        outputTokens: row.output_tokens,
+        totalTokens: row.total_tokens,
+        previousTotalTokens: row.previous_total_tokens,
+      };
+    }),
+  };
 }
 
 export async function holdModelStatsAggregationLock(
@@ -133,19 +267,24 @@ export async function readModelStatsObservations(
   });
 }
 
-export async function insertZeroTokenModelStatsObservation(
+export async function insertModelStatsObservations(
   context: TestContext,
-  args: {
-    readonly idempotencyKey: string;
-    readonly model: string;
-    readonly observedAt: Date;
-  },
+  observations: readonly ModelStatsObservationFixture[],
 ): Promise<void> {
   await postAction(context, {
-    action: "insert-zero-token-observation",
-    idempotency_key: args.idempotencyKey,
-    model: args.model,
-    observed_at: args.observedAt.toISOString(),
+    action: "insert-observations",
+    observations: observations.map((observation) => {
+      return {
+        idempotency_key: observation.idempotencyKey,
+        model: observation.model,
+        input_tokens: observation.inputTokens,
+        output_tokens: observation.outputTokens,
+        cache_read_input_tokens: observation.cacheReadInputTokens,
+        cache_creation_input_tokens: observation.cacheCreationInputTokens,
+        observed_at: observation.observedAt.toISOString(),
+        aggregated_at: observation.aggregatedAt?.toISOString() ?? null,
+      };
+    }),
   });
 }
 
@@ -181,16 +320,12 @@ export async function deleteModelStatsFixture(
   context: TestContext,
   args: {
     readonly idempotencyKeys: readonly string[];
-    readonly models: readonly string[];
-    readonly windowStart: Date;
-    readonly windowEnd: Date;
+    readonly statKeys: readonly ModelStatsStatKey[];
   },
 ): Promise<void> {
   await postAction(context, {
     action: "delete-fixture",
     idempotency_keys: [...args.idempotencyKeys],
-    models: [...args.models],
-    window_start: args.windowStart.toISOString(),
-    window_end: args.windowEnd.toISOString(),
+    stat_keys: wireStatKeys(args.statKeys),
   });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -24,39 +24,64 @@ import { createOpsLogsApi } from "./helpers/api-bdd-ops-logs";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
+  aggregateModelStatsFixture,
   deleteModelStatsFixture,
   deleteModelStatsObservations,
   holdModelStatsAggregationLock,
   holdModelStatsObservationLock,
   insertAppliedModelStatsObservations,
-  insertZeroTokenModelStatsObservation,
+  insertModelStatsObservations,
+  readModelStatsFixtureRankings,
   readModelStatsAggregationLockState,
   readModelStatsObservationLockState,
   readModelStatsObservations,
   releaseModelStatsAggregationLock,
   releaseModelStatsObservationLock,
+  requestAggregateModelStatsFixture,
+  type ModelStatsFixtureScope,
+  type ModelStatsObservationFixture,
+  type ModelStatsStatKey,
 } from "./helpers/model-stats-state";
 import { commitMemoryVersion } from "./helpers/zero-memory";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 import { zeroAgentInstructionsRoutes } from "../zero-agent-instructions";
 
-/*
- * BILL-02 model stats and OPS-01 user export.
- *
- * This file is the SOLE OWNER of GET /api/cron/aggregate-model-stats:
- * the cron is a global projection sweep over model_stat, so calling it from
- * any other test file would race this file's far-past observation windows on
- * the shared database — the same single-file-ownership rule as the email
- * drain / billing reconcile / screenshot cleanup crons (see the shared cron
- * auth helper in helpers/api-bdd-runs.ts).
- *
- * Shared-DB time design: the model-stats chain derives a random far-past UTC
- * day (2003-2009) per run and asserts rankings as baseline+delta, so leftovers
- * from interrupted past runs in a colliding window cannot flake assertions.
- */
+/* BILL-02 model stats and OPS-01 user export. */
 
 const HOUR_MS = 60 * 60_000;
 const DAY_MS = 24 * HOUR_MS;
+
+function modelStatsObservation(args: {
+  readonly idempotencyKey: string;
+  readonly model: string;
+  readonly observedAt: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadInputTokens?: number;
+  readonly cacheCreationInputTokens?: number;
+  readonly aggregatedAt?: number | null;
+}): ModelStatsObservationFixture {
+  return {
+    idempotencyKey: args.idempotencyKey,
+    model: args.model,
+    inputTokens: args.inputTokens ?? 0,
+    outputTokens: args.outputTokens ?? 0,
+    cacheReadInputTokens: args.cacheReadInputTokens ?? 0,
+    cacheCreationInputTokens: args.cacheCreationInputTokens ?? 0,
+    observedAt: new Date(args.observedAt),
+    aggregatedAt:
+      args.aggregatedAt === undefined || args.aggregatedAt === null
+        ? null
+        : new Date(args.aggregatedAt),
+  };
+}
+
+function modelStatsStatKey(
+  model: string,
+  hourStart: number,
+): ModelStatsStatKey {
+  return { model, hourStart: new Date(hourStart) };
+}
 
 interface DeferredS3Put {
   readonly resolve: () => void;
@@ -269,7 +294,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       routes: modelStatsRoutes,
     });
     const rejected = await aggregateApp.request(
-      `${cronAggregateModelStatsContract.aggregate.path}?hours=24`,
+      cronAggregateModelStatsContract.aggregate.path + "?hours=24",
       {
         headers: { authorization: "Bearer test-cron-secret" },
       },
@@ -278,30 +303,39 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     expect(rejected.status).toBe(400);
   });
 
-  it("incrementally projects model observations into public rankings", async () => {
+  it("incrementally projects owned observations into exact rankings", async () => {
     const api = createOpsLogsApi(context);
-    const runs = createRunsApi(context);
-    const webhooks = createWebhookCallbackApi(context);
-    const model = "claude-sonnet-5";
-
-    // Random far-past UTC day (2003-2009): isolated from real-now ranking
-    // windows and unlikely to collide with another interrupted test fixture.
-    const seed = Number.parseInt(randomUUID().slice(0, 8), 16);
-    const dayYear = 2003 + (seed % 7);
-    const dayMonth = Math.floor(seed / 7) % 12;
-    const dayStart = Date.UTC(
-      dayYear,
-      dayMonth,
-      2 + (Math.floor(seed / 84) % 26),
-    );
+    const model = "fixture-model-" + randomUUID();
+    const dayStart = Date.UTC(2026, 0, 2);
     const aggregateAt = dayStart + 4 * HOUR_MS;
     const mainObservedAt = dayStart + 3 * HOUR_MS + 10 * 60_000;
     const previousObservedAt = dayStart - DAY_MS + 22 * HOUR_MS + 30 * 60_000;
+    const oldPendingAt = aggregateAt - 769 * HOUR_MS + 10 * 60_000;
+    const laterAggregateAt = dayStart + 33 * DAY_MS + 4 * HOUR_MS;
     const windowEndIso = new Date(aggregateAt).toISOString();
     const todayStartIso = new Date(dayStart).toISOString();
     const fixtureObservationKeys: string[] = [];
+    const excludedObservationKey = randomUUID();
+    const fixtureStatKeys = [
+      modelStatsStatKey(
+        model,
+        Math.floor(previousObservedAt / HOUR_MS) * HOUR_MS,
+      ),
+      modelStatsStatKey(model, dayStart + 3 * HOUR_MS),
+      modelStatsStatKey(model, dayStart + 4 * HOUR_MS),
+      modelStatsStatKey(model, Math.floor(oldPendingAt / HOUR_MS) * HOUR_MS),
+      modelStatsStatKey(model, dayStart - 5 * HOUR_MS),
+      modelStatsStatKey(model, dayStart - 4 * HOUR_MS),
+    ];
     let aggregationLockRequest: Promise<void> | null = null;
     let observationLockRequest: Promise<void> | null = null;
+
+    function fixtureScope(): ModelStatsFixtureScope {
+      return {
+        observationIdempotencyKeys: [...fixtureObservationKeys],
+        statKeys: fixtureStatKeys,
+      };
+    }
 
     onTestFinished(async () => {
       await releaseModelStatsAggregationLock(context);
@@ -314,190 +348,80 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       }
       if (fixtureObservationKeys.length > 0) {
         await deleteModelStatsFixture(context, {
-          idempotencyKeys: fixtureObservationKeys,
-          models: [model],
-          windowStart: new Date(dayStart - 40 * DAY_MS),
-          windowEnd: new Date(dayStart + DAY_MS),
+          idempotencyKeys: [...fixtureObservationKeys, excludedObservationKey],
+          statKeys: fixtureStatKeys,
         });
       }
     });
 
-    // Given: the run and its sandbox token are created at the real wall
-    // clock, then terminal-ized before any mocked-time ingestion.
-    const { actor, agentId } = await entitledRunActor();
-    const created = await runs.createRun(actor, {
-      agentId,
-      prompt: "observe model usage",
-      modelProvider: "anthropic-api-key",
-    });
-    const sandboxHeaders = {
-      authorization: `Bearer ${runs.sandboxTokenForRun(actor, created.runId)}`,
-    };
-    await runs.requestCancelRun(actor, created.runId, [200]);
-
     mockNow(aggregateAt);
-    const baselineAggregate = await api.requestAggregateModelStats(
-      "valid",
-      [200],
-    );
-    expect(baselineAggregate.body).toMatchObject({
-      success: true,
-      cutoff: windowEndIso,
-    });
-    expect(baselineAggregate.body.processedHours).toBeGreaterThanOrEqual(0);
-    expect(baselineAggregate.body.processedObservations).toBeGreaterThanOrEqual(
-      0,
-    );
-    expect(baselineAggregate.body.updatedStats).toBeGreaterThanOrEqual(0);
-    expect(baselineAggregate.body.deletedObservations).toBeGreaterThanOrEqual(
-      0,
-    );
-
-    const baseline = await api.readModelRankings("today");
-    expect(baseline.headers.get("cache-control")).toBe(
+    const publicRankings = await api.readModelRankings("today");
+    expect(publicRankings.headers.get("cache-control")).toBe(
       "public, s-maxage=300, stale-while-revalidate=600",
     );
-    expect(baseline.body.period).toBe("today");
-    expect(baseline.body.windowStart).toBe(todayStartIso);
-    expect(baseline.body.windowEnd).toBe(windowEndIso);
-    const baseRow = baseline.body.rows.find((row) => {
-      return row.model === model;
-    }) ?? {
-      model,
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-      previousTotalTokens: 0,
-    };
-    const baseTotal = baseline.body.totalTokens;
+    expect(publicRankings.body.period).toBe("today");
+    expect(publicRankings.body.windowStart).toBe(todayStartIso);
+    expect(publicRankings.body.windowEnd).toBe(windowEndIso);
+    const fallback = await api.readModelRankings("unsupported");
+    expect(fallback.body.period).toBe("week");
+    clearMockNow();
 
-    mockNow(mainObservedAt);
     const compactIdempotencyKey = randomUUID();
-    fixtureObservationKeys.push(compactIdempotencyKey);
-    const compactBody = {
-      runId: created.runId,
-      events: [
-        {
-          idempotencyKey: compactIdempotencyKey,
-          model,
-          inputTokens: 300,
-          outputTokens: 200,
-          cacheReadInputTokens: 40,
-          cacheCreationInputTokens: 10,
-        },
-      ],
-    };
-    const duplicateWithinRequest =
-      await webhooks.requestAgentModelUsageObservationV2Unchecked(
-        {
-          runId: created.runId,
-          events: [compactBody.events[0], compactBody.events[0]],
-        },
-        sandboxHeaders,
-        [400],
-      );
-    expect(duplicateWithinRequest.body).toMatchObject({
-      error: { code: "BAD_REQUEST" },
-    });
-
-    const ingested = await webhooks.requestAgentModelUsageObservationV2(
-      compactBody,
-      sandboxHeaders,
-      [200],
+    const previousIdempotencyKey = randomUUID();
+    const zeroTokenIdempotencyKey = randomUUID();
+    const currentHourIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(
+      compactIdempotencyKey,
+      previousIdempotencyKey,
+      zeroTokenIdempotencyKey,
+      currentHourIdempotencyKey,
     );
-    expect(ingested.body).toStrictEqual({ success: true });
-    await webhooks.requestAgentModelUsageObservationV2(
-      compactBody,
-      sandboxHeaders,
-      [200],
-    );
-    await Promise.all([
-      webhooks.requestAgentModelUsageObservationV2(
-        compactBody,
-        sandboxHeaders,
-        [200],
-      ),
-      webhooks.requestAgentModelUsageObservationV2(
-        compactBody,
-        sandboxHeaders,
-        [200],
-      ),
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: compactIdempotencyKey,
+        model,
+        observedAt: mainObservedAt,
+        inputTokens: 300,
+        outputTokens: 200,
+        cacheReadInputTokens: 40,
+        cacheCreationInputTokens: 10,
+      }),
+      modelStatsObservation({
+        idempotencyKey: previousIdempotencyKey,
+        model,
+        observedAt: previousObservedAt,
+        inputTokens: 80,
+      }),
+      modelStatsObservation({
+        idempotencyKey: zeroTokenIdempotencyKey,
+        model,
+        observedAt: mainObservedAt,
+      }),
+      modelStatsObservation({
+        idempotencyKey: currentHourIdempotencyKey,
+        model,
+        observedAt: aggregateAt + 10 * 60_000,
+        inputTokens: 7,
+      }),
+      modelStatsObservation({
+        idempotencyKey: excludedObservationKey,
+        model,
+        observedAt: mainObservedAt,
+        inputTokens: 999,
+      }),
     ]);
 
-    mockNow(previousObservedAt);
-    const previousIdempotencyKey = randomUUID();
-    fixtureObservationKeys.push(previousIdempotencyKey);
-    await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: created.runId,
-        events: [
-          {
-            idempotencyKey: previousIdempotencyKey,
-            model,
-            inputTokens: 80,
-            outputTokens: 0,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-
-    mockNow(mainObservedAt);
-    const zeroTokenIdempotencyKey = randomUUID();
-    fixtureObservationKeys.push(zeroTokenIdempotencyKey);
-    await insertZeroTokenModelStatsObservation(context, {
-      idempotencyKey: zeroTokenIdempotencyKey,
-      model,
-      observedAt: new Date(mainObservedAt),
+    const aggregated = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(aggregateAt),
     });
-
-    mockNow(aggregateAt + 10 * 60_000);
-    const currentHourIdempotencyKey = randomUUID();
-    fixtureObservationKeys.push(currentHourIdempotencyKey);
-    await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: created.runId,
-        events: [
-          {
-            idempotencyKey: currentHourIdempotencyKey,
-            model,
-            inputTokens: 7,
-            outputTokens: 0,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-
-    mockNow(aggregateAt);
-    const aggregated = await api.requestAggregateModelStats("valid", [200]);
-    expect(aggregated.body).toMatchObject({
-      success: true,
+    expect(aggregated).toStrictEqual({
       cutoff: windowEndIso,
+      processedHours: 2,
+      processedObservations: 3,
+      updatedStats: 2,
+      deletedObservations: 1,
     });
-    expect(aggregated.body.processedHours).toBeGreaterThanOrEqual(2);
-    expect(aggregated.body.processedObservations).toBeGreaterThanOrEqual(3);
-    expect(aggregated.body.updatedStats).toBeGreaterThanOrEqual(2);
-
-    const afterIngest = await api.readModelRankings("today");
-    expect(
-      afterIngest.body.rows.find((row) => {
-        return row.model === model;
-      }),
-    ).toStrictEqual({
-      model,
-      inputTokens: baseRow.inputTokens + 350,
-      outputTokens: baseRow.outputTokens + 200,
-      totalTokens: baseRow.totalTokens + 550,
-      previousTotalTokens: baseRow.previousTotalTokens + 80,
-    });
-    expect(afterIngest.body.totalTokens).toBe(baseTotal + 550);
 
     const initialObservationStates = await readModelStatsObservations(context, [
       compactIdempotencyKey,
@@ -505,6 +429,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       zeroTokenIdempotencyKey,
       currentHourIdempotencyKey,
     ]);
+    expect(initialObservationStates).toHaveLength(3);
     expect(initialObservationStates).toStrictEqual(
       expect.arrayContaining([
         {
@@ -521,114 +446,133 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
         },
       ]),
     );
-    expect(
-      initialObservationStates.some((observation) => {
-        return observation.idempotencyKey === previousIdempotencyKey;
-      }),
-    ).toBeFalsy();
+    await expect(
+      readModelStatsObservations(context, [excludedObservationKey]),
+    ).resolves.toStrictEqual([
+      {
+        idempotencyKey: excludedObservationKey,
+        aggregatedAt: null,
+      },
+    ]);
 
-    // A delayed delivery in an already-processed hour remains pending and is
-    // added exactly once by the next cron request.
-    mockNow(mainObservedAt);
+    const afterIngest = await readModelStatsFixtureRankings(context, {
+      period: "today",
+      now: new Date(aggregateAt),
+      statKeys: fixtureStatKeys,
+    });
+    expect(afterIngest).toStrictEqual({
+      period: "today",
+      totalTokens: 550,
+      windowStart: todayStartIso,
+      windowEnd: windowEndIso,
+      rows: [
+        {
+          model,
+          inputTokens: 350,
+          outputTokens: 200,
+          totalTokens: 550,
+          previousTotalTokens: 80,
+        },
+      ],
+    });
+
     const lateIdempotencyKey = randomUUID();
     fixtureObservationKeys.push(lateIdempotencyKey);
-    await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: created.runId,
-        events: [
-          {
-            idempotencyKey: lateIdempotencyKey,
-            model,
-            inputTokens: 0,
-            outputTokens: 50,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-    mockNow(aggregateAt);
-    const lateProcessing = await api.requestAggregateModelStats("valid", [200]);
-    expect(lateProcessing.body).toMatchObject({
-      success: true,
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: lateIdempotencyKey,
+        model,
+        observedAt: mainObservedAt,
+        outputTokens: 50,
+      }),
+    ]);
+    const lateProcessing = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(aggregateAt),
+    });
+    expect(lateProcessing).toStrictEqual({
       cutoff: windowEndIso,
       processedHours: 1,
       processedObservations: 1,
       updatedStats: 1,
+      deletedObservations: 0,
     });
-    const reprocessed = await api.readModelRankings("today");
-    expect(
-      reprocessed.body.rows.find((row) => {
-        return row.model === model;
-      }),
-    ).toStrictEqual({
-      model,
-      inputTokens: baseRow.inputTokens + 350,
-      outputTokens: baseRow.outputTokens + 250,
-      totalTokens: baseRow.totalTokens + 600,
-      previousTotalTokens: baseRow.previousTotalTokens + 80,
+    const reprocessed = await readModelStatsFixtureRankings(context, {
+      period: "today",
+      now: new Date(aggregateAt),
+      statKeys: fixtureStatKeys,
     });
-    expect(reprocessed.body.totalTokens).toBe(baseTotal + 600);
-
-    // Month-period rankings: window asserts only — the month window can
-    // contain leftovers accumulated by colliding past runs.
-    const monthly = await api.readModelRankings("month");
-    expect(monthly.body.period).toBe("month");
-    expect(monthly.body.windowStart).toBe(
-      new Date(Date.UTC(dayYear, dayMonth, 1)).toISOString(),
-    );
-    expect(monthly.body.windowEnd).toBe(windowEndIso);
-    const monthlyRow = monthly.body.rows.find((row) => {
-      return row.model === model;
+    expect(reprocessed).toStrictEqual({
+      period: "today",
+      totalTokens: 600,
+      windowStart: todayStartIso,
+      windowEnd: windowEndIso,
+      rows: [
+        {
+          model,
+          inputTokens: 350,
+          outputTokens: 250,
+          totalTokens: 600,
+          previousTotalTokens: 80,
+        },
+      ],
     });
-    expect(monthlyRow?.totalTokens).toBeGreaterThanOrEqual(600);
 
-    const fallback = await api.readModelRankings("unsupported");
-    expect(fallback.body.period).toBe("week");
+    const monthly = await readModelStatsFixtureRankings(context, {
+      period: "month",
+      now: new Date(aggregateAt),
+      statKeys: fixtureStatKeys,
+    });
+    expect(monthly).toStrictEqual({
+      period: "month",
+      totalTokens: 680,
+      windowStart: new Date(Date.UTC(2026, 0, 1)).toISOString(),
+      windowEnd: windowEndIso,
+      rows: [
+        {
+          model,
+          inputTokens: 430,
+          outputTokens: 250,
+          totalTokens: 680,
+          previousTotalTokens: 0,
+        },
+      ],
+    });
 
-    // Pending work is recovered by lifecycle state regardless of age.
-    const oldPendingAt = aggregateAt - 769 * HOUR_MS + 10 * 60_000;
-    mockNow(oldPendingAt);
     const oldPendingIdempotencyKey = randomUUID();
     fixtureObservationKeys.push(oldPendingIdempotencyKey);
-    await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: created.runId,
-        events: [
-          {
-            idempotencyKey: oldPendingIdempotencyKey,
-            model,
-            inputTokens: 17,
-            outputTokens: 0,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-    mockNow(aggregateAt);
-    const extended = await api.requestAggregateModelStats("valid", [200]);
-    expect(extended.body).toMatchObject({
-      success: true,
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: oldPendingIdempotencyKey,
+        model,
+        observedAt: oldPendingAt,
+        inputTokens: 17,
+      }),
+    ]);
+    const extended = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(aggregateAt),
+    });
+    expect(extended).toStrictEqual({
       cutoff: windowEndIso,
       processedHours: 1,
       processedObservations: 1,
       updatedStats: 1,
+      deletedObservations: 1,
     });
     await expect(
       readModelStatsObservations(context, [oldPendingIdempotencyKey]),
     ).resolves.toStrictEqual([]);
-    await expect(api.readModelRankings("today")).resolves.toMatchObject({
-      body: reprocessed.body,
-    });
+    await expect(
+      readModelStatsFixtureRankings(context, {
+        period: "today",
+        now: new Date(aggregateAt),
+        statKeys: fixtureStatKeys,
+      }),
+    ).resolves.toStrictEqual(reprocessed);
 
-    // Both cron requests begin before this observation is committed. The
-    // transaction lock gives each processing statement a post-lock snapshot,
-    // and the two callers must claim the delivery only once.
+    const concurrentIdempotencyKey = randomUUID();
+    fixtureObservationKeys.push(concurrentIdempotencyKey);
     aggregationLockRequest = holdModelStatsAggregationLock(context);
     await expect
       .poll(
@@ -638,9 +582,16 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
         { timeout: 5000, interval: 20 },
       )
       .toMatchObject({ held: true });
+    const concurrentScope = fixtureScope();
     const concurrentAggregations = [
-      api.requestAggregateModelStats("valid", [200]),
-      api.requestAggregateModelStats("valid", [200]),
+      aggregateModelStatsFixture(context, {
+        ...concurrentScope,
+        processedAt: new Date(aggregateAt),
+      }),
+      aggregateModelStatsFixture(context, {
+        ...concurrentScope,
+        processedAt: new Date(aggregateAt),
+      }),
     ];
     await expect
       .poll(
@@ -652,67 +603,58 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       )
       .toBe(2);
 
-    mockNow(mainObservedAt);
-    const concurrentIdempotencyKey = randomUUID();
-    fixtureObservationKeys.push(concurrentIdempotencyKey);
-    await webhooks.requestAgentModelUsageObservationV2(
-      {
-        runId: created.runId,
-        events: [
-          {
-            idempotencyKey: concurrentIdempotencyKey,
-            model,
-            inputTokens: 0,
-            outputTokens: 25,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-          },
-        ],
-      },
-      sandboxHeaders,
-      [200],
-    );
-
-    mockNow(aggregateAt);
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: concurrentIdempotencyKey,
+        model,
+        observedAt: mainObservedAt,
+        outputTokens: 25,
+      }),
+    ]);
     await releaseModelStatsAggregationLock(context);
     await aggregationLockRequest;
     aggregationLockRequest = null;
     const concurrentResults = await Promise.all(concurrentAggregations);
     for (const result of concurrentResults) {
-      expect(result.body).toMatchObject({
-        success: true,
-        cutoff: windowEndIso,
-      });
+      expect(result.cutoff).toBe(windowEndIso);
+      expect(result.deletedObservations).toBe(0);
     }
     expect(
       concurrentResults.reduce((total, result) => {
-        return total + result.body.processedHours;
+        return total + result.processedHours;
       }, 0),
     ).toBe(1);
     expect(
       concurrentResults.reduce((total, result) => {
-        return total + result.body.processedObservations;
+        return total + result.processedObservations;
       }, 0),
     ).toBe(1);
     expect(
       concurrentResults.reduce((total, result) => {
-        return total + result.body.updatedStats;
+        return total + result.updatedStats;
       }, 0),
     ).toBe(1);
 
-    const afterConcurrent = await api.readModelRankings("today");
-    expect(
-      afterConcurrent.body.rows.find((row) => {
-        return row.model === model;
-      }),
-    ).toStrictEqual({
-      model,
-      inputTokens: baseRow.inputTokens + 350,
-      outputTokens: baseRow.outputTokens + 275,
-      totalTokens: baseRow.totalTokens + 625,
-      previousTotalTokens: baseRow.previousTotalTokens + 80,
+    const afterConcurrent = await readModelStatsFixtureRankings(context, {
+      period: "today",
+      now: new Date(aggregateAt),
+      statKeys: fixtureStatKeys,
     });
-    expect(afterConcurrent.body.totalTokens).toBe(baseTotal + 625);
+    expect(afterConcurrent).toStrictEqual({
+      period: "today",
+      totalTokens: 625,
+      windowStart: todayStartIso,
+      windowEnd: windowEndIso,
+      rows: [
+        {
+          model,
+          inputTokens: 350,
+          outputTokens: 275,
+          totalTokens: 625,
+          previousTotalTokens: 80,
+        },
+      ],
+    });
     await expect(
       readModelStatsObservations(context, [concurrentIdempotencyKey]),
     ).resolves.toStrictEqual([
@@ -722,24 +664,24 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       },
     ]);
 
-    // Cancellation after one committed hour must preserve that progress and
-    // roll the later in-flight hour back for the next request.
     const firstCancellationIdempotencyKey = randomUUID();
     const secondCancellationIdempotencyKey = randomUUID();
     fixtureObservationKeys.push(
       firstCancellationIdempotencyKey,
       secondCancellationIdempotencyKey,
     );
-    await insertZeroTokenModelStatsObservation(context, {
-      idempotencyKey: firstCancellationIdempotencyKey,
-      model,
-      observedAt: new Date(dayStart - 5 * HOUR_MS + 10 * 60_000),
-    });
-    await insertZeroTokenModelStatsObservation(context, {
-      idempotencyKey: secondCancellationIdempotencyKey,
-      model,
-      observedAt: new Date(dayStart - 4 * HOUR_MS + 10 * 60_000),
-    });
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: firstCancellationIdempotencyKey,
+        model,
+        observedAt: dayStart - 5 * HOUR_MS + 10 * 60_000,
+      }),
+      modelStatsObservation({
+        idempotencyKey: secondCancellationIdempotencyKey,
+        model,
+        observedAt: dayStart - 4 * HOUR_MS + 10 * 60_000,
+      }),
+    ]);
 
     observationLockRequest = holdModelStatsObservationLock(
       context,
@@ -755,15 +697,13 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       .toStrictEqual({ held: true });
 
     const cancellationController = new AbortController();
-    const cancelledAggregateApp = createAppWithRoutes({
-      signal: cancellationController.signal,
-      routes: modelStatsRoutes,
-    });
-    const cancelledAggregation = cancelledAggregateApp.request(
-      cronAggregateModelStatsContract.aggregate.path,
+    const cancelledAggregation = requestAggregateModelStatsFixture(
+      context,
       {
-        headers: { authorization: "Bearer test-cron-secret" },
+        ...fixtureScope(),
+        processedAt: new Date(aggregateAt),
       },
+      cancellationController.signal,
     );
     await expect
       .poll(
@@ -819,68 +759,54 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       ]),
     );
 
-    const resumed = await api.requestAggregateModelStats("valid", [200]);
-    expect(resumed.body).toMatchObject({
-      success: true,
+    const resumed = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(aggregateAt),
+    });
+    expect(resumed).toStrictEqual({
       cutoff: windowEndIso,
       processedHours: 1,
       processedObservations: 1,
       updatedStats: 0,
+      deletedObservations: 2,
     });
-    expect(resumed.body.deletedObservations).toBeGreaterThanOrEqual(2);
-    const resumedStates = await readModelStatsObservations(context, [
-      firstCancellationIdempotencyKey,
-      secondCancellationIdempotencyKey,
-    ]);
-    expect(resumedStates).toStrictEqual([]);
+    await expect(
+      readModelStatsObservations(context, [
+        firstCancellationIdempotencyKey,
+        secondCancellationIdempotencyKey,
+      ]),
+    ).resolves.toStrictEqual([]);
 
-    // A failed increment must roll back every statistic mutation. 1,024 maximum
-    // safe integers still fit in PostgreSQL bigint; the 1,025th overflows SUM.
-    // The observation markers must roll back with the additive upsert.
-    mockNow(mainObservedAt);
     const overflowEvents = Array.from({ length: 1025 }, () => {
-      return {
+      return modelStatsObservation({
         idempotencyKey: randomUUID(),
         model,
+        observedAt: mainObservedAt,
         inputTokens: Number.MAX_SAFE_INTEGER,
-        outputTokens: 0,
-        cacheReadInputTokens: 0,
-        cacheCreationInputTokens: 0,
-      };
+      });
     });
     fixtureObservationKeys.push(
       ...overflowEvents.map((event) => {
         return event.idempotencyKey;
       }),
     );
-    for (let offset = 0; offset < overflowEvents.length; offset += 100) {
-      await webhooks.requestAgentModelUsageObservationV2(
-        {
-          runId: created.runId,
-          events: overflowEvents.slice(offset, offset + 100),
-        },
-        sandboxHeaders,
-        [200],
-      );
-    }
+    await insertModelStatsObservations(context, overflowEvents);
 
-    mockNow(aggregateAt);
-    const aggregateApp = createAppWithRoutes({
-      signal: context.signal,
-      routes: modelStatsRoutes,
+    const failedAggregate = await requestAggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(aggregateAt),
     });
-    const failedAggregate = await aggregateApp.request(
-      cronAggregateModelStatsContract.aggregate.path,
-      {
-        headers: { authorization: "Bearer test-cron-secret" },
-      },
-    );
     expect(failedAggregate.status).toBe(500);
     await expect(failedAggregate.json()).resolves.toStrictEqual({
       error: "Internal server error",
     });
-    const afterFailedIncrement = await api.readModelRankings("today");
-    expect(afterFailedIncrement.body).toStrictEqual(afterConcurrent.body);
+    await expect(
+      readModelStatsFixtureRankings(context, {
+        period: "today",
+        now: new Date(aggregateAt),
+        statKeys: fixtureStatKeys,
+      }),
+    ).resolves.toStrictEqual(afterConcurrent);
     const firstOverflowEvent = overflowEvents[0];
     const lastOverflowEvent = overflowEvents.at(-1);
     if (!firstOverflowEvent || !lastOverflowEvent) {
@@ -890,12 +816,20 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       firstOverflowEvent.idempotencyKey,
       lastOverflowEvent.idempotencyKey,
     ]);
-    expect(overflowStates).toHaveLength(2);
-    expect(
-      overflowStates.every((observation) => {
-        return observation.aggregatedAt === null;
+    expect(overflowStates).toStrictEqual(
+      [
+        {
+          idempotencyKey: firstOverflowEvent.idempotencyKey,
+          aggregatedAt: null,
+        },
+        {
+          idempotencyKey: lastOverflowEvent.idempotencyKey,
+          aggregatedAt: null,
+        },
+      ].sort((left, right) => {
+        return left.idempotencyKey.localeCompare(right.idempotencyKey);
       }),
-    ).toBeTruthy();
+    );
     await deleteModelStatsObservations(
       context,
       overflowEvents.map((event) => {
@@ -903,24 +837,17 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       }),
     );
 
-    // A later run processes the formerly current hour before cleaning every
-    // applied observation whose receipt-time retry lifetime has expired.
-    const laterAggregateAt = dayStart + 33 * DAY_MS + 4 * HOUR_MS;
-    mockNow(laterAggregateAt);
-    const laterProcessing = await api.requestAggregateModelStats(
-      "valid",
-      [200],
-    );
-    expect(laterProcessing.body).toMatchObject({
-      success: true,
-      cutoff: new Date(laterAggregateAt).toISOString(),
+    const laterProcessing = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(laterAggregateAt),
     });
-    expect(laterProcessing.body.processedHours).toBeGreaterThanOrEqual(1);
-    expect(laterProcessing.body.processedObservations).toBeGreaterThanOrEqual(
-      1,
-    );
-    expect(laterProcessing.body.updatedStats).toBeGreaterThanOrEqual(1);
-    expect(laterProcessing.body.deletedObservations).toBeGreaterThanOrEqual(5);
+    expect(laterProcessing).toStrictEqual({
+      cutoff: new Date(laterAggregateAt).toISOString(),
+      processedHours: 1,
+      processedObservations: 1,
+      updatedStats: 1,
+      deletedObservations: 5,
+    });
     const cleanedStates = await readModelStatsObservations(context, [
       compactIdempotencyKey,
       previousIdempotencyKey,
@@ -934,31 +861,29 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     ]);
     expect(cleanedStates).toStrictEqual([]);
 
-    mockNow(aggregateAt);
-    const noOp = await api.requestAggregateModelStats("valid", [200]);
-    expect(noOp.body).toStrictEqual({
-      success: true,
+    const noOp = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(aggregateAt),
+    });
+    expect(noOp).toStrictEqual({
       cutoff: windowEndIso,
       processedHours: 0,
       processedObservations: 0,
       updatedStats: 0,
       deletedObservations: 0,
     });
-    const unchanged = await api.readModelRankings("today");
-    expect(unchanged.body).toStrictEqual(afterConcurrent.body);
+    await expect(
+      readModelStatsFixtureRankings(context, {
+        period: "today",
+        now: new Date(aggregateAt),
+        statKeys: fixtureStatKeys,
+      }),
+    ).resolves.toStrictEqual(afterConcurrent);
   });
 
-  it("cleans expired applied observations in bounded batches", async () => {
-    const api = createOpsLogsApi(context);
-    const runs = createRunsApi(context);
-    const webhooks = createWebhookCallbackApi(context);
-    const model = "claude-sonnet-5";
-    const seed = Number.parseInt(randomUUID().slice(0, 8), 16);
-    const dayStart = Date.UTC(
-      1970 + (seed % 7),
-      Math.floor(seed / 7) % 12,
-      2 + (Math.floor(seed / 84) % 26),
-    );
+  it("cleans owned applied observations in bounded batches", async () => {
+    const model = "fixture-model-" + randomUUID();
+    const dayStart = Date.UTC(2026, 1, 2);
     const exactBoundaryObservedAt = dayStart + 3 * HOUR_MS + 15 * 60_000;
     const overBoundaryObservedAt = exactBoundaryObservedAt - 1;
     const underBoundaryObservedAt = exactBoundaryObservedAt + 1;
@@ -966,54 +891,32 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     const cleanupAt = exactBoundaryObservedAt + HOUR_MS;
     const oldPendingAt = cleanupAt - 769 * HOUR_MS;
     const fixtureObservationKeys: string[] = [];
+    const excludedAppliedObservationKey = randomUUID();
+    const fixtureStatKeys = [
+      modelStatsStatKey(model, dayStart + 2 * HOUR_MS),
+      modelStatsStatKey(model, dayStart + 3 * HOUR_MS),
+      modelStatsStatKey(model, dayStart + 4 * HOUR_MS),
+      modelStatsStatKey(model, Math.floor(oldPendingAt / HOUR_MS) * HOUR_MS),
+    ];
+
+    function fixtureScope(): ModelStatsFixtureScope {
+      return {
+        observationIdempotencyKeys: [...fixtureObservationKeys],
+        statKeys: fixtureStatKeys,
+      };
+    }
 
     onTestFinished(async () => {
       if (fixtureObservationKeys.length > 0) {
         await deleteModelStatsFixture(context, {
-          idempotencyKeys: fixtureObservationKeys,
-          models: [model],
-          windowStart: new Date(oldPendingAt - HOUR_MS),
-          windowEnd: new Date(dayStart + DAY_MS),
+          idempotencyKeys: [
+            ...fixtureObservationKeys,
+            excludedAppliedObservationKey,
+          ],
+          statKeys: fixtureStatKeys,
         });
       }
     });
-
-    const { actor, agentId } = await entitledRunActor();
-    const created = await runs.createRun(actor, {
-      agentId,
-      prompt: "clean model usage observations",
-      modelProvider: "anthropic-api-key",
-    });
-    const sandboxHeaders = {
-      authorization: `Bearer ${runs.sandboxTokenForRun(actor, created.runId)}`,
-    };
-    await runs.requestCancelRun(actor, created.runId, [200]);
-
-    async function sendObservation(
-      idempotencyKey: string,
-      inputTokens: number,
-    ): Promise<void> {
-      await webhooks.requestAgentModelUsageObservationV2(
-        {
-          runId: created.runId,
-          events: [
-            {
-              idempotencyKey,
-              model,
-              inputTokens,
-              outputTokens: 0,
-              cacheReadInputTokens: 0,
-              cacheCreationInputTokens: 0,
-            },
-          ],
-        },
-        sandboxHeaders,
-        [200],
-      );
-    }
-
-    mockNow(projectionAt);
-    await api.requestAggregateModelStats("valid", [200]);
 
     const overBoundaryIdempotencyKey = randomUUID();
     const exactBoundaryIdempotencyKey = randomUUID();
@@ -1023,29 +926,64 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       exactBoundaryIdempotencyKey,
       underBoundaryIdempotencyKey,
     );
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: overBoundaryIdempotencyKey,
+        model,
+        observedAt: overBoundaryObservedAt,
+        inputTokens: 11,
+      }),
+      modelStatsObservation({
+        idempotencyKey: exactBoundaryIdempotencyKey,
+        model,
+        observedAt: exactBoundaryObservedAt,
+        inputTokens: 13,
+      }),
+      modelStatsObservation({
+        idempotencyKey: underBoundaryIdempotencyKey,
+        model,
+        observedAt: underBoundaryObservedAt,
+        inputTokens: 17,
+      }),
+      modelStatsObservation({
+        idempotencyKey: excludedAppliedObservationKey,
+        model,
+        observedAt: dayStart + 2 * HOUR_MS,
+        aggregatedAt: projectionAt,
+      }),
+    ]);
 
-    mockNow(overBoundaryObservedAt);
-    await sendObservation(overBoundaryIdempotencyKey, 11);
-    mockNow(exactBoundaryObservedAt);
-    await sendObservation(exactBoundaryIdempotencyKey, 13);
-    mockNow(underBoundaryObservedAt);
-    await sendObservation(underBoundaryIdempotencyKey, 17);
-
-    mockNow(projectionAt);
-    const projected = await api.requestAggregateModelStats("valid", [200]);
-    expect(projected.body).toMatchObject({
-      success: true,
+    const projected = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(projectionAt),
+    });
+    expect(projected).toStrictEqual({
       cutoff: new Date(projectionAt).toISOString(),
       processedHours: 1,
       processedObservations: 3,
       updatedStats: 1,
       deletedObservations: 0,
     });
-    const rankingBeforeCleanup = await api.readModelRankings("today");
-
-    // A retry after projection but within one hour still finds the original
-    // UUID ledger row and cannot create new pending work.
-    await sendObservation(exactBoundaryIdempotencyKey, 13);
+    const rankingBeforeCleanup = await readModelStatsFixtureRankings(context, {
+      period: "today",
+      now: new Date(projectionAt),
+      statKeys: fixtureStatKeys,
+    });
+    expect(rankingBeforeCleanup).toStrictEqual({
+      period: "today",
+      totalTokens: 41,
+      windowStart: new Date(dayStart).toISOString(),
+      windowEnd: new Date(projectionAt).toISOString(),
+      rows: [
+        {
+          model,
+          inputTokens: 41,
+          outputTokens: 0,
+          totalTokens: 41,
+          previousTotalTokens: 0,
+        },
+      ],
+    });
     await expect(
       readModelStatsObservations(context, [exactBoundaryIdempotencyKey]),
     ).resolves.toStrictEqual([
@@ -1057,13 +995,20 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
 
     const oldPendingIdempotencyKey = randomUUID();
     fixtureObservationKeys.push(oldPendingIdempotencyKey);
-    mockNow(oldPendingAt);
-    await sendObservation(oldPendingIdempotencyKey, 19);
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: oldPendingIdempotencyKey,
+        model,
+        observedAt: oldPendingAt,
+        inputTokens: 19,
+      }),
+    ]);
 
-    mockNow(cleanupAt);
-    const cleaned = await api.requestAggregateModelStats("valid", [200]);
-    expect(cleaned.body).toStrictEqual({
-      success: true,
+    const cleaned = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(cleanupAt),
+    });
+    expect(cleaned).toStrictEqual({
       cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),
       processedHours: 1,
       processedObservations: 1,
@@ -1089,12 +1034,22 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
         },
       ]),
     );
-    const rankingAfterCleanup = await api.readModelRankings("today");
-    expect(rankingAfterCleanup.body).toStrictEqual(rankingBeforeCleanup.body);
+    await expect(
+      readModelStatsFixtureRankings(context, {
+        period: "today",
+        now: new Date(projectionAt),
+        statKeys: fixtureStatKeys,
+      }),
+    ).resolves.toStrictEqual(rankingBeforeCleanup);
 
-    // Once the one-hour guarantee has expired and cleanup removed the ledger
-    // row, the same UUID is accepted as a new current-hour observation.
-    await sendObservation(overBoundaryIdempotencyKey, 11);
+    await insertModelStatsObservations(context, [
+      modelStatsObservation({
+        idempotencyKey: overBoundaryIdempotencyKey,
+        model,
+        observedAt: cleanupAt,
+        inputTokens: 11,
+      }),
+    ]);
     await expect(
       readModelStatsObservations(context, [overBoundaryIdempotencyKey]),
     ).resolves.toStrictEqual([
@@ -1115,9 +1070,11 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       aggregatedAt: new Date(projectionAt),
     });
 
-    const firstBatch = await api.requestAggregateModelStats("valid", [200]);
-    expect(firstBatch.body).toStrictEqual({
-      success: true,
+    const firstBatch = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(cleanupAt),
+    });
+    expect(firstBatch).toStrictEqual({
       cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),
       processedHours: 0,
       processedObservations: 0,
@@ -1128,9 +1085,11 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
       readModelStatsObservations(context, cleanupBatchIdempotencyKeys),
     ).resolves.toHaveLength(1);
 
-    const finalBatch = await api.requestAggregateModelStats("valid", [200]);
-    expect(finalBatch.body).toStrictEqual({
-      success: true,
+    const finalBatch = await aggregateModelStatsFixture(context, {
+      ...fixtureScope(),
+      processedAt: new Date(cleanupAt),
+    });
+    expect(finalBatch).toStrictEqual({
       cutoff: new Date(dayStart + 4 * HOUR_MS).toISOString(),
       processedHours: 0,
       processedObservations: 0,
@@ -1140,6 +1099,14 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
     await expect(
       readModelStatsObservations(context, cleanupBatchIdempotencyKeys),
     ).resolves.toStrictEqual([]);
+    await expect(
+      readModelStatsObservations(context, [excludedAppliedObservationKey]),
+    ).resolves.toStrictEqual([
+      {
+        idempotencyKey: excludedAppliedObservationKey,
+        aggregatedAt: new Date(projectionAt).toISOString(),
+      },
+    ]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-model-stats-state.ts
@@ -5,7 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/test-model-stats-state";
 import { modelStat } from "@vm0/db/schema/model-stat";
 import { modelUsageObservation } from "@vm0/db/schema/model-usage-observation";
-import { and, asc, count, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, asc, count, eq, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
@@ -15,6 +15,12 @@ import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import { lockModelStatsAggregation } from "../services/model-stats-aggregation-lock.service";
+import {
+  aggregateModelStats,
+  readModelRankings,
+  type ModelStatKey,
+  type ModelStatsAggregationScope,
+} from "../services/model-stats.service";
 import { createDeferredPromise, onRejection } from "../utils";
 import {
   isTestEndpointAllowed,
@@ -231,24 +237,40 @@ async function deleteObservations(
   signal.throwIfAborted();
 }
 
-async function insertZeroTokenObservation(
+async function insertObservations(
   db: Db,
   body: Extract<
     TestModelStatsStateActionBody,
-    { action: "insert-zero-token-observation" }
+    { action: "insert-observations" }
   >,
   signal: AbortSignal,
 ): Promise<void> {
-  await db.insert(modelUsageObservation).values({
-    idempotencyKey: body.idempotency_key,
-    model: body.model,
-    inputTokens: 0,
-    outputTokens: 0,
-    cacheReadInputTokens: 0,
-    cacheCreationInputTokens: 0,
-    observedAt: new Date(body.observed_at),
-  });
-  signal.throwIfAborted();
+  for (
+    let offset = 0;
+    offset < body.observations.length;
+    offset += OBSERVATION_FIXTURE_INSERT_BATCH_SIZE
+  ) {
+    await db.insert(modelUsageObservation).values(
+      body.observations
+        .slice(offset, offset + OBSERVATION_FIXTURE_INSERT_BATCH_SIZE)
+        .map((observation) => {
+          return {
+            idempotencyKey: observation.idempotency_key,
+            model: observation.model,
+            inputTokens: observation.input_tokens,
+            outputTokens: observation.output_tokens,
+            cacheReadInputTokens: observation.cache_read_input_tokens,
+            cacheCreationInputTokens: observation.cache_creation_input_tokens,
+            observedAt: new Date(observation.observed_at),
+            aggregatedAt:
+              observation.aggregated_at === null
+                ? null
+                : new Date(observation.aggregated_at),
+          };
+        }),
+    );
+    signal.throwIfAborted();
+  }
 }
 
 async function insertAppliedObservations(
@@ -294,6 +316,18 @@ async function deleteFixture(
   body: Extract<TestModelStatsStateActionBody, { action: "delete-fixture" }>,
   signal: AbortSignal,
 ): Promise<void> {
+  const statKeyPredicate = or(
+    ...body.stat_keys.map((statKey) => {
+      return and(
+        eq(modelStat.hourStart, new Date(statKey.hour_start)),
+        eq(modelStat.model, statKey.model),
+      );
+    }),
+  );
+  if (!statKeyPredicate) {
+    throw new Error("Model stats fixture requires at least one stat key");
+  }
+
   await db.transaction(async (tx) => {
     await tx
       .delete(modelUsageObservation)
@@ -301,17 +335,29 @@ async function deleteFixture(
         inArray(modelUsageObservation.idempotencyKey, body.idempotency_keys),
       );
     signal.throwIfAborted();
-    await tx
-      .delete(modelStat)
-      .where(
-        and(
-          gte(modelStat.hourStart, new Date(body.window_start)),
-          lt(modelStat.hourStart, new Date(body.window_end)),
-          inArray(modelStat.model, body.models),
-        ),
-      );
+    await tx.delete(modelStat).where(statKeyPredicate);
     signal.throwIfAborted();
   });
+}
+
+function modelStatKeys(
+  statKeys: readonly { readonly hour_start: string; readonly model: string }[],
+): readonly ModelStatKey[] {
+  return statKeys.map((statKey) => {
+    return {
+      hourStart: new Date(statKey.hour_start),
+      model: statKey.model,
+    };
+  });
+}
+
+function aggregationScope(
+  body: Extract<TestModelStatsStateActionBody, { action: "aggregate-fixture" }>,
+): ModelStatsAggregationScope {
+  return {
+    observationIdempotencyKeys: body.observation_idempotency_keys,
+    statKeys: modelStatKeys(body.stat_keys),
+  };
 }
 
 async function mutateModelStatsState(
@@ -371,8 +417,54 @@ async function mutateModelStatsState(
         },
       };
     }
-    case "insert-zero-token-observation": {
-      await insertZeroTokenObservation(db, body, signal);
+    case "aggregate-fixture": {
+      const result = await aggregateModelStats(db, signal, {
+        processedAt: new Date(body.processed_at),
+        scope: aggregationScope(body),
+      });
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          aggregation: {
+            cutoff: result.cutoff.toISOString(),
+            processed_hours: result.processedHours,
+            processed_observations: result.processedObservations,
+            updated_stats: result.updatedStats,
+            deleted_observations: result.deletedObservations,
+          },
+        },
+      };
+    }
+    case "read-fixture-rankings": {
+      const result = await readModelRankings(db, body.period, signal, {
+        now: new Date(body.now),
+        statKeys: modelStatKeys(body.stat_keys),
+      });
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          ranking: {
+            period: result.period,
+            total_tokens: result.totalTokens,
+            window_start: result.windowStart.toISOString(),
+            window_end: result.windowEnd.toISOString(),
+            rows: result.rows.map((row) => {
+              return {
+                model: row.model,
+                input_tokens: row.inputTokens,
+                output_tokens: row.outputTokens,
+                total_tokens: row.totalTokens,
+                previous_total_tokens: row.previousTotalTokens,
+              };
+            }),
+          },
+        },
+      };
+    }
+    case "insert-observations": {
+      await insertObservations(db, body, signal);
       return { status: 200 as const, body: { ok: true as const } };
     }
     case "insert-applied-observations": {

--- a/turbo/apps/api/src/signals/services/model-stats.service.ts
+++ b/turbo/apps/api/src/signals/services/model-stats.service.ts
@@ -80,6 +80,26 @@ interface ModelStatsProcessingResult {
   readonly deletedObservations: number;
 }
 
+export interface ModelStatKey {
+  readonly hourStart: Date;
+  readonly model: string;
+}
+
+export interface ModelStatsAggregationScope {
+  readonly observationIdempotencyKeys: readonly string[];
+  readonly statKeys: readonly ModelStatKey[];
+}
+
+interface ModelStatsAggregationOptions {
+  readonly processedAt: Date;
+  readonly scope: ModelStatsAggregationScope;
+}
+
+interface ModelStatsRankingOptions {
+  readonly now: Date;
+  readonly statKeys: readonly ModelStatKey[];
+}
+
 interface ModelStatsHourProcessingResult {
   readonly hourStart: Date | null;
   readonly processedObservations: number;
@@ -138,6 +158,25 @@ function utcTimestampParam(date: Date): string {
   return date.toISOString().replace("T", " ").replace("Z", "");
 }
 
+function modelStatKeysPredicate(
+  hourStart: SQLWrapper,
+  model: SQLWrapper,
+  statKeys: readonly ModelStatKey[],
+): SQL {
+  const predicate = or(
+    ...statKeys.map((statKey) => {
+      return and(
+        eq(hourStart, sql`${utcTimestampParam(statKey.hourStart)}::timestamp`),
+        eq(model, statKey.model),
+      );
+    }),
+  );
+  if (!predicate) {
+    throw new Error("Model stats scope requires at least one stat key");
+  }
+  return predicate;
+}
+
 function parseModelRankingPeriod(
   value: string | undefined,
 ): ModelRankingPeriod {
@@ -189,6 +228,7 @@ interface ModelStatsHourProcessingSqlArgs {
   readonly observationModelExpr: SQLWrapper;
   readonly processedAt: string;
   readonly cutoff: string;
+  readonly scope: ModelStatsAggregationScope | undefined;
 }
 
 function modelStatsHourClaimCtes(args: ModelStatsHourProcessingSqlArgs): SQL {
@@ -203,6 +243,11 @@ function modelStatsHourClaimCtes(args: ModelStatsHourProcessingSqlArgs): SQL {
         WHERE ${and(
           isNull(modelUsageObservation.aggregatedAt),
           lt(modelUsageObservation.observedAt, sql`${args.cutoff}::timestamp`),
+          args.scope
+            ? inArray(modelUsageObservation.idempotencyKey, [
+                ...args.scope.observationIdempotencyKeys,
+              ])
+            : undefined,
         )}
         ORDER BY ${modelUsageObservation.observedAt}
         LIMIT 1
@@ -221,6 +266,11 @@ function modelStatsHourClaimCtes(args: ModelStatsHourProcessingSqlArgs): SQL {
             modelUsageObservation.observedAt,
             sql`oldest_pending_hour.hour_start + INTERVAL '1 hour'`,
           ),
+          args.scope
+            ? inArray(modelUsageObservation.idempotencyKey, [
+                ...args.scope.observationIdempotencyKeys,
+              ])
+            : undefined,
         )}
         RETURNING
           ${args.observationModelExpr} AS model,
@@ -237,6 +287,14 @@ function modelStatsHourClaimCtes(args: ModelStatsHourProcessingSqlArgs): SQL {
 function modelStatsHourProjectionCtes(
   args: ModelStatsHourProcessingSqlArgs,
 ): SQL {
+  const statKeyPredicate = args.scope
+    ? modelStatKeysPredicate(
+        sql`oldest_pending_hour.hour_start`,
+        sql`claimed_observations.model`,
+        args.scope.statKeys,
+      )
+    : inArray(sql`claimed_observations.model`, args.modelStatsModelIds);
+
   return sql`
     aggregated AS MATERIALIZED (
         SELECT
@@ -269,7 +327,7 @@ function modelStatsHourProjectionCtes(
         FROM claimed_observations
         CROSS JOIN oldest_pending_hour
         WHERE ${and(
-          inArray(sql`claimed_observations.model`, args.modelStatsModelIds),
+          statKeyPredicate,
           or(
             gt(sql`claimed_observations.input_tokens`, sql`0`),
             gt(sql`claimed_observations.output_tokens`, sql`0`),
@@ -347,12 +405,14 @@ async function processOldestPendingModelStatsHour(
   cutoff: Date,
   processedAt: Date,
   signal: AbortSignal,
+  scope: ModelStatsAggregationScope | undefined,
 ): Promise<ModelStatsHourProcessingResult> {
   const query = modelStatsHourProcessingSql({
     modelStatsModelIds: getModelStatsModelIds(),
     observationModelExpr: modelUsageObservationModelExpression(),
     processedAt: utcTimestampParam(processedAt),
     cutoff: utcTimestampParam(cutoff),
+    scope,
   });
 
   const result = await db.transaction(async (tx) => {
@@ -381,6 +441,7 @@ async function cleanupAppliedModelUsageObservations(
   db: Db,
   cutoff: Date,
   signal: AbortSignal,
+  observationIdempotencyKeys: readonly string[] | undefined,
 ): Promise<number> {
   let deletedObservations = 0;
 
@@ -399,6 +460,11 @@ async function cleanupAppliedModelUsageObservations(
         and(
           isNotNull(modelUsageObservation.aggregatedAt),
           lt(modelUsageObservation.observedAt, cutoff),
+          observationIdempotencyKeys
+            ? inArray(modelUsageObservation.idempotencyKey, [
+                ...observationIdempotencyKeys,
+              ])
+            : undefined,
         ),
       )
       .orderBy(
@@ -425,8 +491,10 @@ async function cleanupAppliedModelUsageObservations(
 async function selectModelRankings(
   db: Db,
   period: ModelRankingPeriod,
+  now: Date,
+  statKeys: readonly ModelStatKey[] | undefined,
 ): Promise<ModelRankingResult> {
-  const window = currentWindow(period, nowDate());
+  const window = currentWindow(period, now);
   const duration = Math.max(window.end.getTime() - window.start.getTime(), 0);
   const previousEnd = window.start;
   const previousStart = new Date(previousEnd.getTime() - duration);
@@ -452,7 +520,13 @@ async function selectModelRankings(
       and(
         gte(modelStat.hourStart, sql`${previousStartParam}::timestamp`),
         lt(modelStat.hourStart, sql`${windowEndParam}::timestamp`),
-        inArray(modelStat.model, modelStatsModelIds),
+        statKeys
+          ? modelStatKeysPredicate(
+              modelStat.hourStart,
+              modelStat.model,
+              statKeys,
+            )
+          : inArray(modelStat.model, modelStatsModelIds),
       ),
     )
     .as("normalized_model_stats");
@@ -515,73 +589,103 @@ async function selectModelRankings(
   };
 }
 
-export const aggregateModelStats$ = command(
-  async ({ set }, signal: AbortSignal): Promise<ModelStatsProcessingResult> => {
-    const db = set(writeDb$);
-    const startedAt = performance.now();
-    const processedAt = nowDate();
-    const cutoff = utcHourStart(processedAt);
-    const cleanupCutoff = new Date(processedAt.getTime() - HOUR_MS);
-    let processedHours = 0;
-    let processedObservations = 0;
-    let updatedStats = 0;
-    let firstProcessedHour: Date | null = null;
-    let lastProcessedHour: Date | null = null;
+export async function aggregateModelStats(
+  db: Db,
+  signal: AbortSignal,
+  options?: ModelStatsAggregationOptions,
+): Promise<ModelStatsProcessingResult> {
+  const startedAt = performance.now();
+  const processedAt = options?.processedAt ?? nowDate();
+  const scope = options?.scope;
+  const cutoff = utcHourStart(processedAt);
+  const cleanupCutoff = new Date(processedAt.getTime() - HOUR_MS);
+  let processedHours = 0;
+  let processedObservations = 0;
+  let updatedStats = 0;
+  let firstProcessedHour: Date | null = null;
+  let lastProcessedHour: Date | null = null;
 
-    while (true) {
-      signal.throwIfAborted();
-      const result = await processOldestPendingModelStatsHour(
-        db,
-        cutoff,
-        processedAt,
-        signal,
-      );
-      signal.throwIfAborted();
-      if (!result.hourStart) {
-        break;
-      }
-
-      firstProcessedHour ??= result.hourStart;
-      lastProcessedHour = result.hourStart;
-      processedHours++;
-      processedObservations += result.processedObservations;
-      updatedStats += result.updatedStats;
-    }
-
-    const deletedObservations = await cleanupAppliedModelUsageObservations(
+  while (true) {
+    signal.throwIfAborted();
+    const result = await processOldestPendingModelStatsHour(
       db,
-      cleanupCutoff,
+      cutoff,
+      processedAt,
       signal,
+      scope,
     );
     signal.throwIfAborted();
+    if (!result.hourStart) {
+      break;
+    }
 
-    const durationMs = Math.round(performance.now() - startedAt);
-    L.debug("model stats processing completed", {
-      cutoff: cutoff.toISOString(),
-      cleanupCutoff: cleanupCutoff.toISOString(),
-      firstProcessedHour: firstProcessedHour?.toISOString() ?? null,
-      lastProcessedHour: lastProcessedHour?.toISOString() ?? null,
-      oldestCompleteBacklogAgeHours:
-        firstProcessedHour === null
-          ? 0
-          : (cutoff.getTime() - firstProcessedHour.getTime()) / HOUR_MS,
-      processedHours,
-      processedObservations,
-      updatedStats,
-      deletedObservations,
-      remainingCompletePendingObservations: 0,
-      durationMs,
-    });
+    firstProcessedHour ??= result.hourStart;
+    lastProcessedHour = result.hourStart;
+    processedHours++;
+    processedObservations += result.processedObservations;
+    updatedStats += result.updatedStats;
+  }
 
-    return {
-      cutoff,
-      processedHours,
-      processedObservations,
-      updatedStats,
-      deletedObservations,
-    };
+  const deletedObservations = await cleanupAppliedModelUsageObservations(
+    db,
+    cleanupCutoff,
+    signal,
+    scope?.observationIdempotencyKeys,
+  );
+  signal.throwIfAborted();
+
+  const durationMs = Math.round(performance.now() - startedAt);
+  L.debug("model stats processing completed", {
+    cutoff: cutoff.toISOString(),
+    cleanupCutoff: cleanupCutoff.toISOString(),
+    firstProcessedHour: firstProcessedHour?.toISOString() ?? null,
+    lastProcessedHour: lastProcessedHour?.toISOString() ?? null,
+    oldestCompleteBacklogAgeHours:
+      firstProcessedHour === null
+        ? 0
+        : (cutoff.getTime() - firstProcessedHour.getTime()) / HOUR_MS,
+    processedHours,
+    processedObservations,
+    updatedStats,
+    deletedObservations,
+    remainingCompletePendingObservations: 0,
+    durationMs,
+  });
+
+  return {
+    cutoff,
+    processedHours,
+    processedObservations,
+    updatedStats,
+    deletedObservations,
+  };
+}
+
+export const aggregateModelStats$ = command(
+  async ({ set }, signal: AbortSignal): Promise<ModelStatsProcessingResult> => {
+    return await aggregateModelStats(set(writeDb$), signal);
   },
 );
+
+export async function readModelRankings(
+  db: Db,
+  periodValue: string | undefined,
+  signal: AbortSignal,
+  options?: ModelStatsRankingOptions,
+): Promise<ModelRankingResult> {
+  const period = parseModelRankingPeriod(periodValue);
+
+  signal.throwIfAborted();
+  const result = await selectModelRankings(
+    db,
+    period,
+    options?.now ?? nowDate(),
+    options?.statKeys,
+  );
+  signal.throwIfAborted();
+
+  return result;
+}
 
 export const readPublicModelRankings$ = command(
   async (
@@ -590,12 +694,6 @@ export const readPublicModelRankings$ = command(
     signal: AbortSignal,
   ): Promise<ModelRankingResult> => {
     const db = set(writeDb$);
-    const period = parseModelRankingPeriod(periodValue);
-
-    signal.throwIfAborted();
-    const result = await selectModelRankings(db, period);
-    signal.throwIfAborted();
-
-    return result;
+    return await readModelRankings(db, periodValue, signal);
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-model-stats-state.ts
@@ -5,6 +5,29 @@ import { initContract } from "./base";
 const c = initContract();
 
 const idempotencyKeysSchema = z.array(z.uuid()).min(1);
+const modelStatKeysSchema = z
+  .array(
+    z.object({
+      hour_start: z.iso.datetime(),
+      model: z.string(),
+    }),
+  )
+  .min(1);
+
+const modelStatsObservationFixtureSchema = z.object({
+  idempotency_key: z.uuid(),
+  model: z.string(),
+  input_tokens: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  output_tokens: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  cache_read_input_tokens: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  cache_creation_input_tokens: z
+    .number()
+    .int()
+    .min(0)
+    .max(Number.MAX_SAFE_INTEGER),
+  observed_at: z.iso.datetime(),
+  aggregated_at: z.iso.datetime().nullable(),
+});
 
 export const testModelStatsStateActionBodySchema = z.discriminatedUnion(
   "action",
@@ -33,10 +56,20 @@ export const testModelStatsStateActionBodySchema = z.discriminatedUnion(
       idempotency_keys: idempotencyKeysSchema,
     }),
     z.object({
-      action: z.literal("insert-zero-token-observation"),
-      idempotency_key: z.uuid(),
-      model: z.string(),
-      observed_at: z.iso.datetime(),
+      action: z.literal("aggregate-fixture"),
+      processed_at: z.iso.datetime(),
+      observation_idempotency_keys: idempotencyKeysSchema,
+      stat_keys: modelStatKeysSchema,
+    }),
+    z.object({
+      action: z.literal("read-fixture-rankings"),
+      period: z.string().optional(),
+      now: z.iso.datetime(),
+      stat_keys: modelStatKeysSchema,
+    }),
+    z.object({
+      action: z.literal("insert-observations"),
+      observations: z.array(modelStatsObservationFixtureSchema).min(1),
     }),
     z.object({
       action: z.literal("insert-applied-observations"),
@@ -52,9 +85,7 @@ export const testModelStatsStateActionBodySchema = z.discriminatedUnion(
     z.object({
       action: z.literal("delete-fixture"),
       idempotency_keys: idempotencyKeysSchema,
-      models: z.array(z.string()).min(1),
-      window_start: z.iso.datetime(),
-      window_end: z.iso.datetime(),
+      stat_keys: modelStatKeysSchema,
     }),
   ],
 );
@@ -64,12 +95,38 @@ const testModelStatsObservationSchema = z.object({
   aggregated_at: z.iso.datetime().nullable(),
 });
 
+const modelStatsAggregationResultSchema = z.object({
+  cutoff: z.iso.datetime(),
+  processed_hours: z.number().int().nonnegative(),
+  processed_observations: z.number().int().nonnegative(),
+  updated_stats: z.number().int().nonnegative(),
+  deleted_observations: z.number().int().nonnegative(),
+});
+
+const modelStatsRankingResultSchema = z.object({
+  period: z.enum(["today", "week", "month"]),
+  total_tokens: z.number().int().nonnegative(),
+  window_start: z.iso.datetime(),
+  window_end: z.iso.datetime(),
+  rows: z.array(
+    z.object({
+      model: z.string(),
+      input_tokens: z.number().int().nonnegative(),
+      output_tokens: z.number().int().nonnegative(),
+      total_tokens: z.number().int().nonnegative(),
+      previous_total_tokens: z.number().int().nonnegative(),
+    }),
+  ),
+});
+
 export const testModelStatsStateActionResponseSchema = z.object({
   ok: z.literal(true),
   aggregation_lock_held: z.boolean().optional(),
   aggregation_lock_waiter_count: z.number().int().nonnegative().optional(),
   observation_lock_held: z.boolean().optional(),
   observations: z.array(testModelStatsObservationSchema).optional(),
+  aggregation: modelStatsAggregationResultSchema.optional(),
+  ranking: modelStatsRankingResultSchema.optional(),
 });
 
 export const testModelStatsStateContract = c.router({


### PR DESCRIPTION
## Summary

- add an explicit test-only aggregation scope over owned observation idempotency keys and exact model-stat keys
- migrate BILL-02 aggregation, resumption, concurrency, overflow rollback, and cleanup coverage away from the global cron sweep to uniquely owned fixtures
- assert exact aggregation and ranking results, including sentinels proving non-owned pending and applied observations remain untouched
- preserve the normal production aggregation/ranking callers and existing aggregation lock semantics by leaving their scope unset

## Scope

The focused test boundary now filters each claim, projection, ranking read, and cleanup to the fixture's explicit identifiers. Fixture teardown deletes only those identifiers and exact stat keys. This change does not add test serialization, new locks, broad mocked-time partitions, residue-tolerant assertions, or unrelated cleanup.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed; existing warnings only, zero errors)
- `pnpm knip` (passed; existing configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'` (12/12 tasks passed)
- `pnpm --filter @vm0/app run check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts -t 'BILL-02' --silent=passed-only` (1 file passed; 4 passed, 11 skipped)
- rebased onto current main `d2fddbf671`; checked all 37 open PR file sets, including paginated file lists, with no overlap

Closes #26585

Part of #26569
