### PR TITLE
test(api): isolate cron skill synchronization storage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
@@ -14,38 +14,30 @@ import {
   DEFAULT_SKILLS_OWNER,
   DEFAULT_SKILLS_REPO,
 } from "@vm0/core/github-url";
-import { getSkillStorageName, SYSTEM_ORG_ID } from "@vm0/core/storage-names";
+import { getSkillStorageName } from "@vm0/core/storage-names";
 import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import { cronSyncSkillsContract } from "@vm0/api-contracts/contracts/cron";
 import { http, HttpResponse } from "msw";
 import { create as createTar } from "tar";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
-import { createBddApi } from "./helpers/api-bdd";
 import {
-  createRunsApi,
-  expectCanonicalStorageManifest,
-} from "./helpers/api-bdd-runs";
-import {
-  cleanupOfficialTestSkillsState,
+  cleanupOwnedSkillsState,
   findSkillByUrlState,
   findSystemStorageByNameState,
   seedCurrentSkillVersionsState,
-  setAllSkillsCommitShaState,
+  setOwnedSkillsCommitShaState,
+  syncOwnedSkillsState,
 } from "./helpers/cron-sync-skills-state";
 import { cronSyncSkillsRoutes } from "../cron-sync-skills";
 
 const context = testContext();
 const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storages";
-const TEST_SKILL_PREFIX = "api-test-skill";
-// The service validates SEED_SKILLS; alpha and beta cover arbitrary repository
-// entries without coupling these route tests to the connector registry size.
-const REQUIRED_SEED_SKILL_NAMES = SEED_SKILLS;
 const STALE_PRESEEDED_COMMIT_SHA = "0".repeat(40);
 
 interface MockSkillEntry {
@@ -62,8 +54,6 @@ interface MockSkillVersion {
   readonly fullPath: string;
   readonly storageName: string;
   readonly versionHash: string;
-  readonly s3Prefix: string;
-  readonly s3Key: string;
   readonly size: number;
   readonly archiveSize: number;
   readonly fileCount: number;
@@ -73,83 +63,151 @@ interface MockSkillVersion {
   };
 }
 
-const EXTRA_SKILLS = {
-  alphaSkill: {
-    name: `${TEST_SKILL_PREFIX}-alpha`,
-    files: [
-      {
-        path: "SKILL.md",
-        content: [
-          "---",
-          `name: ${TEST_SKILL_PREFIX}-alpha`,
-          "description: Alpha integration skill",
-          "---",
-          "",
-          "# Alpha Skill",
-          "Send messages to Alpha.",
-        ].join("\n"),
-      },
-      { path: "index.ts", content: 'console.log("alpha");' },
-    ],
-  },
-  betaSkill: {
-    name: `${TEST_SKILL_PREFIX}-beta`,
-    files: [
-      {
-        path: "SKILL.md",
-        content: [
-          "---",
-          `name: ${TEST_SKILL_PREFIX}-beta`,
-          "description: Beta integration",
-          "---",
-          "",
-          "# Beta Skill",
-        ].join("\n"),
-      },
-    ],
-  },
-} satisfies Record<string, MockSkillEntry>;
-
-function officialTestSkillUrlPrefix(): string {
-  return `https://github.com/vm0-ai/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${TEST_SKILL_PREFIX}-`;
+interface CronSyncSkillsFixture {
+  readonly skillNamePrefix: string;
+  readonly requiredSeedSkillNames: readonly string[];
+  readonly existingSkillName: string;
+  readonly sentinelSkillName: string;
+  readonly alphaSkill: MockSkillEntry;
+  readonly betaSkill: MockSkillEntry;
+  readonly skillUrls: Set<string>;
+  readonly storageNames: Set<string>;
 }
 
-async function cleanupOfficialTestSkills(): Promise<void> {
-  await cleanupOfficialTestSkillsState(context, officialTestSkillUrlPrefix());
-}
-
-async function setAllSkillsCommitSha(commitSha: string): Promise<void> {
-  const skillName = `${TEST_SKILL_PREFIX}-existing`;
-  await setAllSkillsCommitShaState(context, {
-    skillName,
-    url: testSkillUrl(skillName),
-    fullPath: `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`,
-    commitSha,
-    frontmatter: {
-      name: skillName,
-      description: `${skillName} skill`,
+function createCronSyncSkillsFixture(): CronSyncSkillsFixture {
+  const fixtureId = randomUUID().replaceAll("-", "");
+  const skillNamePrefix = `api-test-skill-${fixtureId}-`;
+  const alphaName = `${skillNamePrefix}alpha`;
+  const betaName = `${skillNamePrefix}beta`;
+  return {
+    skillNamePrefix,
+    requiredSeedSkillNames: SEED_SKILLS.map((name) => {
+      return `${skillNamePrefix}${name}`;
+    }),
+    existingSkillName: `${skillNamePrefix}existing`,
+    sentinelSkillName: `api-test-sentinel-${fixtureId}-existing`,
+    alphaSkill: {
+      name: alphaName,
+      files: [
+        {
+          path: "SKILL.md",
+          content: [
+            "---",
+            `name: ${alphaName}`,
+            "description: Alpha integration skill",
+            "---",
+            "",
+            "# Alpha Skill",
+            "Send messages to Alpha.",
+          ].join("\n"),
+        },
+        { path: "index.ts", content: 'console.log("alpha");' },
+      ],
     },
+    betaSkill: {
+      name: betaName,
+      files: [
+        {
+          path: "SKILL.md",
+          content: [
+            "---",
+            `name: ${betaName}`,
+            "description: Beta integration",
+            "---",
+            "",
+            "# Beta Skill",
+          ].join("\n"),
+        },
+      ],
+    },
+    skillUrls: new Set(),
+    storageNames: new Set(),
+  };
+}
+
+function registerOwnedSkill(
+  fixture: CronSyncSkillsFixture,
+  name: string,
+  ownsStorage: boolean,
+): {
+  readonly name: string;
+  readonly url: string;
+  readonly fullPath: string;
+  readonly frontmatter: { readonly name: string; readonly description: string };
+} {
+  const url = testSkillUrl(name);
+  const fullPath = `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${name}`;
+  fixture.skillUrls.add(url);
+  if (ownsStorage) {
+    fixture.storageNames.add(getSkillStorageName(fullPath));
+  }
+  return {
+    name,
+    url,
+    fullPath,
+    frontmatter: { name, description: `${name} skill` },
+  };
+}
+
+function registerOwnedEntries(
+  fixture: CronSyncSkillsFixture,
+  entries: readonly MockSkillEntry[],
+): void {
+  for (const entry of entries) {
+    registerOwnedSkill(fixture, entry.name, true);
+  }
+}
+
+async function cleanupOwnedSkills(
+  fixture: CronSyncSkillsFixture,
+): Promise<void> {
+  if (fixture.skillUrls.size === 0 && fixture.storageNames.size === 0) {
+    return;
+  }
+  await cleanupOwnedSkillsState(context, {
+    skillUrls: [...fixture.skillUrls],
+    storageNames: [...fixture.storageNames],
+  });
+}
+
+async function setOwnedSkillsCommitSha(
+  fixture: CronSyncSkillsFixture,
+  commitSha: string,
+  skillNames: readonly string[] = [fixture.existingSkillName],
+): Promise<void> {
+  await setOwnedSkillsCommitShaState(context, {
+    skills: skillNames.map((name) => {
+      return registerOwnedSkill(fixture, name, false);
+    }),
+    commitSha,
+  });
+}
+
+async function syncOwnedSkills(fixture: CronSyncSkillsFixture) {
+  return await syncOwnedSkillsState(context, {
+    skillNamePrefix: fixture.skillNamePrefix,
+    requiredSkillNames: fixture.requiredSeedSkillNames,
   });
 }
 
 async function seedCurrentSkillVersions(
+  fixture: CronSyncSkillsFixture,
   entries: readonly MockSkillEntry[],
 ): Promise<void> {
   if (entries.length === 0) {
     return;
   }
+  registerOwnedEntries(fixture, entries);
   await seedCurrentSkillVersionsState(context, {
     staleCommitSha: STALE_PRESEEDED_COMMIT_SHA,
     versions: entries.map((entry) => {
-      const version = buildMockSkillVersion(entry);
+      const version = buildMockSkillVersion(fixture, entry);
       return {
         name: version.name,
         url: version.url,
         full_path: version.fullPath,
         storage_name: version.storageName,
         version_hash: version.versionHash,
-        s3_prefix: version.s3Prefix,
-        s3_key: version.s3Key,
         size: version.size,
         archive_size: version.archiveSize,
         file_count: version.fileCount,
@@ -224,10 +282,18 @@ function memoizedTarballBuilder(): (
   };
 }
 
-const createMockTarball = memoizedTarballBuilder();
+const buildMemoizedMockTarball = memoizedTarballBuilder();
 
-function seedSkillEntries(): MockSkillEntry[] {
-  return REQUIRED_SEED_SKILL_NAMES.map((name) => {
+function createMockTarball(
+  fixture: CronSyncSkillsFixture,
+  mockSkills: readonly MockSkillEntry[],
+): Buffer {
+  registerOwnedEntries(fixture, mockSkills);
+  return buildMemoizedMockTarball(mockSkills);
+}
+
+function seedSkillEntries(fixture: CronSyncSkillsFixture): MockSkillEntry[] {
+  return fixture.requiredSeedSkillNames.map((name) => {
     return {
       name,
       files: [
@@ -240,28 +306,30 @@ function seedSkillEntries(): MockSkillEntry[] {
   });
 }
 
-function createFullTarball(extras: readonly MockSkillEntry[]): Buffer {
-  return createMockTarball([...seedSkillEntries(), ...extras]);
+function createFullTarball(
+  fixture: CronSyncSkillsFixture,
+  extras: readonly MockSkillEntry[],
+): Buffer {
+  return createMockTarball(fixture, [...seedSkillEntries(fixture), ...extras]);
 }
 
-function buildMockSkillVersion(skill: MockSkillEntry): MockSkillVersion {
+function buildMockSkillVersion(
+  fixture: CronSyncSkillsFixture,
+  skill: MockSkillEntry,
+): MockSkillVersion {
   const fullPath = `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skill.name}`;
   const storageName = getSkillStorageName(fullPath);
   const versionHash = computeMockSkillVersionHash(skill);
-  const s3Prefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
-  const s3Key = `${s3Prefix}/${versionHash}`;
   return {
     name: skill.name,
     url: testSkillUrl(skill.name),
     fullPath,
     storageName,
     versionHash,
-    s3Prefix,
-    s3Key,
     size: skill.files.reduce((sum, file) => {
       return sum + Buffer.byteLength(file.content);
     }, 0),
-    archiveSize: createMockTarball([skill]).length,
+    archiveSize: createMockTarball(fixture, [skill]).length,
     fileCount: skill.files.length,
     frontmatter: {
       name: skill.name,
@@ -284,8 +352,18 @@ function computeMockSkillVersionHash(skill: MockSkillEntry): string {
     .digest("hex");
 }
 
-async function seedCurrentSeedSkillVersions(): Promise<void> {
-  await seedCurrentSkillVersions(seedSkillEntries());
+async function seedCurrentSeedSkillVersions(
+  fixture: CronSyncSkillsFixture,
+): Promise<void> {
+  await seedCurrentSkillVersions(fixture, seedSkillEntries(fixture));
+}
+
+function useCronSyncSkillsFixture(): CronSyncSkillsFixture {
+  const fixture = createCronSyncSkillsFixture();
+  onTestFinished(async () => {
+    await cleanupOwnedSkills(fixture);
+  });
+  return fixture;
 }
 
 function setupGitRefsHandler(commitSha: string): void {
@@ -359,6 +437,7 @@ function testSkillUrl(name: string): string {
 }
 
 async function findSkillByUrl(url: string): Promise<{
+  readonly name: string;
   readonly fullPath: string;
   readonly commitSha: string | null;
   readonly versionHash: string | null;
@@ -370,6 +449,7 @@ async function findSkillByUrl(url: string): Promise<{
 
 async function findSystemStorageByName(name: string): Promise<{
   readonly headVersionId: string | null;
+  readonly s3Prefix: string;
   readonly size: number;
   readonly versionSize: number | null;
   readonly archiveSize: number | null;
@@ -383,10 +463,6 @@ describe("GET /api/cron/sync-skills", () => {
     mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
     context.mocks.s3.send.mockReset();
     context.mocks.s3.send.mockResolvedValue({});
-  });
-
-  afterEach(async () => {
-    await cleanupOfficialTestSkills();
   });
 
   it("rejects requests with an invalid cron secret", async () => {
@@ -409,16 +485,18 @@ describe("GET /api/cron/sync-skills", () => {
   });
 
   it("skips sync when the stored commit SHA is unchanged", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const commitSha = newCommitSha();
-    await setAllSkillsCommitSha(commitSha);
+    const sentinelCommitSha = newCommitSha();
+    await setOwnedSkillsCommitSha(fixture, sentinelCommitSha, [
+      fixture.sentinelSkillName,
+    ]);
+    await setOwnedSkillsCommitSha(fixture, commitSha);
     setupGitRefsHandler(commitSha);
 
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders() }),
-      [200],
-    );
+    const response = await syncOwnedSkills(fixture);
 
-    expect(response.body).toStrictEqual({
+    expect(response).toStrictEqual({
       success: true,
       commitSha,
       synced: 0,
@@ -427,52 +505,62 @@ describe("GET /api/cron/sync-skills", () => {
       removed: 0,
       total: 0,
     });
+    await expect(
+      findSkillByUrl(testSkillUrl(fixture.sentinelSkillName)),
+    ).resolves.toMatchObject({ commitSha: sentinelCommitSha });
   });
 
   it("syncs new skills from the repository tarball", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const commitSha = newCommitSha();
-    await seedCurrentSeedSkillVersions();
+    await seedCurrentSeedSkillVersions(fixture);
     setupMswHandlers(
       commitSha,
-      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+      createFullTarball(fixture, [fixture.alphaSkill, fixture.betaSkill]),
     );
 
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders() }),
-      [200],
-    );
+    const response = await syncOwnedSkills(fixture);
 
-    expect(response.body.success).toBeTruthy();
-    expect(response.body.commitSha).toBe(commitSha);
-    expect(response.body.synced + response.body.skipped).toBeGreaterThan(0);
+    expect(response).toStrictEqual({
+      success: true,
+      commitSha,
+      synced: 2,
+      skipped: fixture.requiredSeedSkillNames.length,
+      failed: 0,
+      removed: 0,
+      total: fixture.requiredSeedSkillNames.length + 2,
+    });
 
     const alphaSkill = await findSkillByUrl(
-      testSkillUrl(EXTRA_SKILLS.alphaSkill.name),
+      testSkillUrl(fixture.alphaSkill.name),
     );
     expect(alphaSkill).toMatchObject({
-      fullPath: `vm0-ai/vm0-skills/tree/main/${EXTRA_SKILLS.alphaSkill.name}`,
+      name: fixture.alphaSkill.name,
+      fullPath: `vm0-ai/vm0-skills/tree/main/${fixture.alphaSkill.name}`,
       commitSha,
       fileCount: 2,
       frontmatter: {
-        name: EXTRA_SKILLS.alphaSkill.name,
+        name: fixture.alphaSkill.name,
         description: "Alpha integration skill",
       },
     });
-    expect(alphaSkill?.versionHash).toBeTruthy();
+    expect(alphaSkill?.versionHash).toBe(
+      buildMockSkillVersion(fixture, fixture.alphaSkill).versionHash,
+    );
 
     const alphaStorage = await findSystemStorageByName(
       getSkillStorageName(
-        `vm0-ai/vm0-skills/tree/main/${EXTRA_SKILLS.alphaSkill.name}`,
+        `vm0-ai/vm0-skills/tree/main/${fixture.alphaSkill.name}`,
       ),
     );
-    const alphaVersion = buildMockSkillVersion(EXTRA_SKILLS.alphaSkill);
+    if (!alphaStorage) {
+      throw new Error("Expected the alpha skill storage");
+    }
+    const alphaVersion = buildMockSkillVersion(fixture, fixture.alphaSkill);
+    const alphaArchiveKey = `${alphaStorage.s3Prefix}/${alphaVersion.versionHash}/archive.tar.gz`;
     const alphaArchivePut = s3CallsByName("PutObjectCommand").find(
       (command) => {
-        const key = commandInput(command).Key;
-        return (
-          typeof key === "string" &&
-          key.endsWith(`/${alphaVersion.versionHash}/archive.tar.gz`)
-        );
+        return commandInput(command).Key === alphaArchiveKey;
       },
     );
     const alphaArchiveBody = commandInput(alphaArchivePut).Body;
@@ -480,99 +568,116 @@ describe("GET /api/cron/sync-skills", () => {
       throw new Error("Expected the alpha skill archive upload body");
     }
     expect(alphaStorage).toMatchObject({
-      headVersionId: expect.any(String),
+      headVersionId: alphaVersion.versionHash,
       size: alphaVersion.size,
       versionSize: alphaVersion.size,
       archiveSize: alphaArchiveBody.length,
     });
+    expect(
+      s3CallsByName("PutObjectCommand").map((command) => {
+        return commandInput(command).Key;
+      }),
+    ).toContain(
+      `${alphaStorage.s3Prefix}/${alphaVersion.versionHash}/manifest.json`,
+    );
     expect(s3CallsByName("PutObjectCommand")).toHaveLength(4);
   });
 
-  it("mounts only the current default seed skills in claimed runs", async () => {
+  it("syncs isolated counterparts for the current default seed skills", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const commitSha = newCommitSha();
-    setupMswHandlers(commitSha, createFullTarball([]));
-    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+    setupMswHandlers(commitSha, createFullTarball(fixture, []));
+    const response = await syncOwnedSkills(fixture);
 
-    const bdd = createBddApi(context);
-    const runs = createRunsApi(context);
-    const actor = bdd.user();
-    bdd.acceptAgentStorageWrites();
-    runs.acceptStorageDownloads();
-    runs.acceptTelemetryIngest();
-    const runnerGroup = runs.configureRunnerGroup();
-    await runs.grantProEntitlement(actor);
-    await runs.ensureOrgModelProvider(actor);
-    const agent = await bdd.createAgent(actor, {
-      displayName: "Seed Skill Mount Agent",
-      visibility: "private",
+    expect(response).toStrictEqual({
+      success: true,
+      commitSha,
+      synced: fixture.requiredSeedSkillNames.length,
+      skipped: 0,
+      failed: 0,
+      removed: 0,
+      total: fixture.requiredSeedSkillNames.length,
     });
-
-    const run = await runs.createRun(actor, {
-      agentId: agent.agentId,
-      prompt: "inspect default seed skill mounts",
-      modelProvider: "anthropic-api-key",
-    });
-    await runs.heartbeatRunner(runnerGroup);
-    const claim = await runs.claimRunnerJob(run.runId);
-    const skillMountPaths =
-      expectCanonicalStorageManifest(claim.storageManifest)
-        ?.storageMounts.map((storage) => {
-          return storage.mountPath;
-        })
-        .filter((mountPath) => {
-          return mountPath.startsWith("/home/user/.claude/skills/");
-        })
-        .sort() ?? [];
-
-    expect(skillMountPaths).toStrictEqual([
-      "/home/user/.claude/skills/computer-use",
-      "/home/user/.claude/skills/gen",
-      "/home/user/.claude/skills/workflow-setup",
-    ]);
-    expect(skillMountPaths).not.toContain(
-      "/home/user/.claude/skills/deep-dive",
+    const syncedSkills = await Promise.all(
+      fixture.requiredSeedSkillNames.map((name) => {
+        return findSkillByUrl(testSkillUrl(name));
+      }),
     );
+    expect(
+      syncedSkills.map((skill) => {
+        return skill?.name;
+      }),
+    ).toStrictEqual(fixture.requiredSeedSkillNames);
+    expect(
+      new Set(
+        syncedSkills.map((skill) => {
+          return skill?.versionHash;
+        }),
+      ).size,
+    ).toBe(fixture.requiredSeedSkillNames.length);
 
-    await runs.requestCancelRun(actor, run.runId, [200]);
+    const storages = await Promise.all(
+      fixture.requiredSeedSkillNames.map((name) => {
+        const fullPath = `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${name}`;
+        return findSystemStorageByName(getSkillStorageName(fullPath));
+      }),
+    );
+    const objectPrefixes = storages.map((storage) => {
+      if (!storage) {
+        throw new Error("Expected an isolated seed skill storage");
+      }
+      return storage.s3Prefix;
+    });
+    expect(new Set(objectPrefixes).size).toBe(
+      fixture.requiredSeedSkillNames.length,
+    );
   });
 
   it("excludes repository directories without a SKILL.md file", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const commitSha = newCommitSha();
     const nonSkillDirectory = {
-      name: `${TEST_SKILL_PREFIX}-no-skill-md`,
+      name: `${fixture.skillNamePrefix}no-skill-md`,
       files: [{ path: "README.md", content: "Not a skill." }],
     };
-    await seedCurrentSeedSkillVersions();
+    await seedCurrentSeedSkillVersions(fixture);
     setupMswHandlers(
       commitSha,
-      createFullTarball([
-        EXTRA_SKILLS.alphaSkill,
-        EXTRA_SKILLS.betaSkill,
+      createFullTarball(fixture, [
+        fixture.alphaSkill,
+        fixture.betaSkill,
         nonSkillDirectory,
       ]),
     );
 
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders() }),
-      [200],
-    );
+    const response = await syncOwnedSkills(fixture);
 
-    expect(response.body.total).toBe(REQUIRED_SEED_SKILL_NAMES.length + 2);
+    expect(response).toStrictEqual({
+      success: true,
+      commitSha,
+      synced: 2,
+      skipped: fixture.requiredSeedSkillNames.length,
+      failed: 0,
+      removed: 0,
+      total: fixture.requiredSeedSkillNames.length + 2,
+    });
     await expect(
       findSkillByUrl(testSkillUrl(nonSkillDirectory.name)),
     ).resolves.toBeNull();
   });
 
   it("skips malformed skill frontmatter and syncs other skills", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const commitSha = newCommitSha();
+    const badSkillName = `${fixture.skillNamePrefix}bad-yaml`;
     const badSkill = {
-      name: `${TEST_SKILL_PREFIX}-bad-yaml`,
+      name: badSkillName,
       files: [
         {
           path: "SKILL.md",
           content: [
             "---",
-            `name: ${TEST_SKILL_PREFIX}-bad-yaml`,
+            `name: ${badSkillName}`,
             "description:",
             "  - not_a_string",
             "- BAD_LINE",
@@ -583,20 +688,25 @@ describe("GET /api/cron/sync-skills", () => {
         },
       ],
     };
-    await seedCurrentSeedSkillVersions();
+    await seedCurrentSeedSkillVersions(fixture);
     setupMswHandlers(
       commitSha,
-      createFullTarball([EXTRA_SKILLS.alphaSkill, badSkill]),
+      createFullTarball(fixture, [fixture.alphaSkill, badSkill]),
     );
 
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders() }),
-      [200],
-    );
+    const response = await syncOwnedSkills(fixture);
 
-    expect(response.body.failed).toBe(1);
+    expect(response).toStrictEqual({
+      success: true,
+      commitSha,
+      synced: 1,
+      skipped: fixture.requiredSeedSkillNames.length,
+      failed: 1,
+      removed: 0,
+      total: fixture.requiredSeedSkillNames.length + 2,
+    });
     await expect(
-      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.alphaSkill.name)),
+      findSkillByUrl(testSkillUrl(fixture.alphaSkill.name)),
     ).resolves.not.toBeNull();
     await expect(
       findSkillByUrl(testSkillUrl(badSkill.name)),
@@ -604,24 +714,25 @@ describe("GET /api/cron/sync-skills", () => {
   });
 
   it("only uploads changed skills during incremental sync", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const firstCommitSha = newCommitSha();
-    await seedCurrentSeedSkillVersions();
+    await seedCurrentSeedSkillVersions(fixture);
     setupMswHandlers(
       firstCommitSha,
-      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+      createFullTarball(fixture, [fixture.alphaSkill, fixture.betaSkill]),
     );
-    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+    await syncOwnedSkills(fixture);
 
     context.mocks.s3.send.mockClear();
     const nextCommitSha = newCommitSha();
     const modifiedAlpha = {
-      name: EXTRA_SKILLS.alphaSkill.name,
+      name: fixture.alphaSkill.name,
       files: [
         {
           path: "SKILL.md",
           content: [
             "---",
-            `name: ${EXTRA_SKILLS.alphaSkill.name}`,
+            `name: ${fixture.alphaSkill.name}`,
             "description: Updated alpha skill",
             "---",
             "",
@@ -633,79 +744,104 @@ describe("GET /api/cron/sync-skills", () => {
     };
     setupMswHandlers(
       nextCommitSha,
-      createFullTarball([modifiedAlpha, EXTRA_SKILLS.betaSkill]),
+      createFullTarball(fixture, [modifiedAlpha, fixture.betaSkill]),
     );
 
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders() }),
-      [200],
-    );
+    const response = await syncOwnedSkills(fixture);
 
-    expect(response.body.commitSha).toBe(nextCommitSha);
-    expect(response.body.synced).toBe(1);
-    expect(response.body.skipped).toBeGreaterThanOrEqual(1);
+    expect(response).toStrictEqual({
+      success: true,
+      commitSha: nextCommitSha,
+      synced: 1,
+      skipped: fixture.requiredSeedSkillNames.length + 1,
+      failed: 0,
+      removed: 0,
+      total: fixture.requiredSeedSkillNames.length + 2,
+    });
     expect(s3CallsByName("PutObjectCommand")).toHaveLength(2);
 
     await expect(
-      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.alphaSkill.name)),
+      findSkillByUrl(testSkillUrl(fixture.alphaSkill.name)),
     ).resolves.toMatchObject({
       commitSha: nextCommitSha,
       frontmatter: {
-        name: EXTRA_SKILLS.alphaSkill.name,
+        name: fixture.alphaSkill.name,
         description: "Updated alpha skill",
       },
     });
   });
 
   it("removes skills deleted from the source repository and cleans S3 objects", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const firstCommitSha = newCommitSha();
-    await seedCurrentSeedSkillVersions();
+    await seedCurrentSeedSkillVersions(fixture);
     setupMswHandlers(
       firstCommitSha,
-      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+      createFullTarball(fixture, [fixture.alphaSkill, fixture.betaSkill]),
     );
-    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+    await syncOwnedSkills(fixture);
 
-    setupS3ListObjects(["mock/archive.tar.gz", "mock/manifest.json"]);
+    const betaVersion = buildMockSkillVersion(fixture, fixture.betaSkill);
+    const betaStorage = await findSystemStorageByName(betaVersion.storageName);
+    if (!betaStorage) {
+      throw new Error("Expected the beta skill storage");
+    }
+    const betaObjectKeys = [
+      `${betaStorage.s3Prefix}/${betaVersion.versionHash}/archive.tar.gz`,
+      `${betaStorage.s3Prefix}/${betaVersion.versionHash}/manifest.json`,
+    ];
+    setupS3ListObjects(betaObjectKeys);
+    const sentinelCommitSha = newCommitSha();
+    await setOwnedSkillsCommitSha(fixture, sentinelCommitSha, [
+      fixture.sentinelSkillName,
+    ]);
     const nextCommitSha = newCommitSha();
     setupMswHandlers(
       nextCommitSha,
-      createFullTarball([EXTRA_SKILLS.alphaSkill]),
+      createFullTarball(fixture, [fixture.alphaSkill]),
     );
 
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders() }),
-      [200],
-    );
+    const response = await syncOwnedSkills(fixture);
 
-    expect(response.body.removed).toBe(1);
+    expect(response).toStrictEqual({
+      success: true,
+      commitSha: nextCommitSha,
+      synced: 0,
+      skipped: fixture.requiredSeedSkillNames.length + 1,
+      failed: 0,
+      removed: 1,
+      total: fixture.requiredSeedSkillNames.length + 1,
+    });
     await expect(
-      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.betaSkill.name)),
+      findSkillByUrl(testSkillUrl(fixture.betaSkill.name)),
     ).resolves.toBeNull();
     await expect(
-      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.alphaSkill.name)),
+      findSkillByUrl(testSkillUrl(fixture.alphaSkill.name)),
     ).resolves.not.toBeNull();
+    await expect(
+      findSkillByUrl(testSkillUrl(fixture.sentinelSkillName)),
+    ).resolves.toMatchObject({ commitSha: sentinelCommitSha });
 
     const deleteCommand = s3CallsByName("DeleteObjectsCommand")[0];
     expect(commandInput(deleteCommand)).toMatchObject({
       Bucket: BUCKET,
       Delete: {
-        Objects: [
-          { Key: "mock/archive.tar.gz" },
-          { Key: "mock/manifest.json" },
-        ],
+        Objects: betaObjectKeys.map((key) => {
+          return { Key: key };
+        }),
       },
     });
   });
 
   it("keeps DB orphan removal when S3 cleanup fails", async () => {
+    const fixture = useCronSyncSkillsFixture();
     const firstCommitSha = newCommitSha();
-    await seedCurrentSeedSkillVersions();
+    await seedCurrentSeedSkillVersions(fixture);
     setupMswHandlers(
       firstCommitSha,
-      createFullTarball([EXTRA_SKILLS.alphaSkill, EXTRA_SKILLS.betaSkill]),
+      createFullTarball(fixture, [fixture.alphaSkill, fixture.betaSkill]),
     );
-    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+    await syncOwnedSkills(fixture);
 
     context.mocks.s3.send.mockImplementation((command: unknown) => {
       if (commandName(command) === "ListObjectsV2Command") {
@@ -716,32 +852,43 @@ describe("GET /api/cron/sync-skills", () => {
     const nextCommitSha = newCommitSha();
     setupMswHandlers(
       nextCommitSha,
-      createFullTarball([EXTRA_SKILLS.alphaSkill]),
+      createFullTarball(fixture, [fixture.alphaSkill]),
     );
 
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders() }),
-      [200],
-    );
+    const response = await syncOwnedSkills(fixture);
 
-    expect(response.body.removed).toBe(1);
+    expect(response).toStrictEqual({
+      success: true,
+      commitSha: nextCommitSha,
+      synced: 0,
+      skipped: fixture.requiredSeedSkillNames.length + 1,
+      failed: 0,
+      removed: 1,
+      total: fixture.requiredSeedSkillNames.length + 1,
+    });
     await expect(
-      findSkillByUrl(testSkillUrl(EXTRA_SKILLS.betaSkill.name)),
+      findSkillByUrl(testSkillUrl(fixture.betaSkill.name)),
     ).resolves.toBeNull();
   });
 
-  it("logs when seed skills are missing from the source repository", async () => {
+  it("logs missing required skills and restores them after a source rollback", async () => {
+    const fixture = useCronSyncSkillsFixture();
     mockEnv("AXIOM_TOKEN_TELEMETRY", "test-token");
     mockEnv("AXIOM_DATASET_SUFFIX", "dev");
-    const omittedSkills = SEED_SKILLS.slice(0, 2);
+    const omittedSkills = fixture.requiredSeedSkillNames.slice(0, 2);
     const omittedSkillSet = new Set(omittedSkills);
-    const keptSkills = REQUIRED_SEED_SKILL_NAMES.filter((name) => {
+    const keptSkills = fixture.requiredSeedSkillNames.filter((name) => {
       return !omittedSkillSet.has(name);
     });
-    const commitSha = newCommitSha();
+    const initialCommitSha = newCommitSha();
+    setupMswHandlers(initialCommitSha, createFullTarball(fixture, []));
+    await syncOwnedSkills(fixture);
+
+    const removalCommitSha = newCommitSha();
     setupMswHandlers(
-      commitSha,
+      removalCommitSha,
       createMockTarball(
+        fixture,
         keptSkills.map((name) => {
           return {
             name,
@@ -756,20 +903,51 @@ describe("GET /api/cron/sync-skills", () => {
       ),
     );
 
-    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+    const removalResponse = await syncOwnedSkills(fixture);
+
+    expect(removalResponse).toStrictEqual({
+      success: true,
+      commitSha: removalCommitSha,
+      synced: 0,
+      skipped: keptSkills.length,
+      failed: 0,
+      removed: omittedSkills.length,
+      total: keptSkills.length,
+    });
+    await Promise.all(
+      omittedSkills.map(async (name) => {
+        await expect(findSkillByUrl(testSkillUrl(name))).resolves.toBeNull();
+      }),
+    );
 
     expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
       expect.stringContaining("SEED_SKILLS references skills not found"),
       expect.objectContaining({
         context: "skills:sync",
-        missingSkills: expect.arrayContaining([
-          expect.stringContaining("vm0-ai/vm0-skills"),
-        ]),
+        missingSkills: omittedSkills.map((name) => {
+          return testSkillUrl(name);
+        }),
       }),
     );
 
-    const restoreCommitSha = newCommitSha();
-    setupMswHandlers(restoreCommitSha, createFullTarball([]));
-    await accept(apiClient().sync({ headers: cronHeaders() }), [200]);
+    setupMswHandlers(initialCommitSha, createFullTarball(fixture, []));
+    const rollbackResponse = await syncOwnedSkills(fixture);
+
+    expect(rollbackResponse).toStrictEqual({
+      success: true,
+      commitSha: initialCommitSha,
+      synced: omittedSkills.length,
+      skipped: keptSkills.length,
+      failed: 0,
+      removed: 0,
+      total: fixture.requiredSeedSkillNames.length,
+    });
+    await Promise.all(
+      omittedSkills.map(async (name) => {
+        await expect(findSkillByUrl(testSkillUrl(name))).resolves.toMatchObject(
+          { commitSha: initialCommitSha },
+        );
+      }),
+    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/cron-sync-skills-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/cron-sync-skills-state.ts
@@ -2,6 +2,7 @@ import type {
   TestCronSyncSkillsStateActionBody,
   TestCronSyncSkillsStateActionResponse,
   TestCronSyncSkillsStateSkillVersionSeed,
+  TestCronSyncSkillsStateSyncResponse,
 } from "@vm0/api-contracts/contracts/test-cron-sync-skills-state";
 
 import { createAppWithRoutes } from "../../../../app-factory-core";
@@ -11,6 +12,7 @@ import { testCronSyncSkillsStateRoutes } from "../../test-cron-sync-skills-state
 const CRON_SYNC_SKILLS_STATE_ROUTE = "/api/test/cron-sync-skills-state";
 
 interface CronSyncSkillRow {
+  readonly name: string;
   readonly fullPath: string;
   readonly commitSha: string | null;
   readonly versionHash: string | null;
@@ -20,6 +22,7 @@ interface CronSyncSkillRow {
 
 interface CronSyncStorageRow {
   readonly headVersionId: string | null;
+  readonly s3Prefix: string;
   readonly size: number;
   readonly versionSize: number | null;
   readonly archiveSize: number | null;
@@ -65,34 +68,67 @@ async function postAction(
   return await readJson<TestCronSyncSkillsStateActionResponse>(response);
 }
 
-export async function cleanupOfficialTestSkillsState(
-  context: TestContext,
-  urlPrefix: string,
-): Promise<void> {
-  await postAction(context, {
-    action: "cleanup-official-test-skills",
-    url_prefix: urlPrefix,
-  });
-}
-
-export async function setAllSkillsCommitShaState(
+export async function cleanupOwnedSkillsState(
   context: TestContext,
   input: {
-    readonly skillName: string;
-    readonly url: string;
-    readonly fullPath: string;
-    readonly commitSha: string;
-    readonly frontmatter: unknown;
+    readonly skillUrls: readonly string[];
+    readonly storageNames: readonly string[];
   },
 ): Promise<void> {
   await postAction(context, {
-    action: "set-all-skills-commit-sha",
-    skill_name: input.skillName,
-    url: input.url,
-    full_path: input.fullPath,
-    commit_sha: input.commitSha,
-    frontmatter: input.frontmatter,
+    action: "cleanup-owned-skills",
+    skill_urls: [...input.skillUrls],
+    storage_names: [...input.storageNames],
   });
+}
+
+export async function setOwnedSkillsCommitShaState(
+  context: TestContext,
+  input: {
+    readonly skills: readonly {
+      readonly name: string;
+      readonly url: string;
+      readonly fullPath: string;
+      readonly frontmatter: unknown;
+    }[];
+    readonly commitSha: string;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "set-owned-skills-commit-sha",
+    skills: input.skills.map((skill) => {
+      return {
+        name: skill.name,
+        url: skill.url,
+        full_path: skill.fullPath,
+        frontmatter: skill.frontmatter,
+      };
+    }),
+    commit_sha: input.commitSha,
+  });
+}
+
+export async function syncOwnedSkillsState(
+  context: TestContext,
+  input: {
+    readonly skillNamePrefix: string;
+    readonly requiredSkillNames: readonly string[];
+  },
+): Promise<TestCronSyncSkillsStateSyncResponse> {
+  const response = await requestCronSyncSkillsState(
+    context,
+    `${CRON_SYNC_SKILLS_STATE_ROUTE}/sync`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        skill_name_prefix: input.skillNamePrefix,
+        required_skill_names: input.requiredSkillNames,
+      }),
+    },
+  );
+  expectOk(response, "cron sync skills scoped sync");
+  return await readJson<TestCronSyncSkillsStateSyncResponse>(response);
 }
 
 export async function seedCurrentSkillVersionsState(
@@ -119,6 +155,7 @@ export async function findSkillByUrlState(
   });
   return response.skill
     ? {
+        name: response.skill.name,
         fullPath: response.skill.full_path,
         commitSha: response.skill.commit_sha,
         versionHash: response.skill.version_hash,
@@ -139,6 +176,7 @@ export async function findSystemStorageByNameState(
   return response.storage
     ? {
         headVersionId: response.storage.head_version_id,
+        s3Prefix: response.storage.s3_prefix,
         size: response.storage.size,
         versionSize: response.storage.version_size,
         archiveSize: response.storage.archive_size,

--- a/turbo/apps/api/src/signals/routes/test-cron-sync-skills-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-sync-skills-state.ts
@@ -7,18 +7,21 @@ import {
 import { SYSTEM_ORG_ID, VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { skills } from "@vm0/db/schema/skill";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
-import { eq, inArray, like, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
+import { syncSkillsForScope$ } from "../services/cron-sync-skills.service";
+import { newStorageS3Location } from "../services/storage-s3-prefix.utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
 } from "./test-endpoint-helpers";
 
 const actionBody$ = bodyResultOf(testCronSyncSkillsStateContract.action);
+const syncBody$ = bodyResultOf(testCronSyncSkillsStateContract.sync);
 
 type CronSyncSkillsAction<
   TAction extends TestCronSyncSkillsStateActionBody["action"],
@@ -28,59 +31,58 @@ function actionOk(extra: Record<string, unknown> = {}) {
   return { status: 200 as const, body: { ok: true as const, ...extra } };
 }
 
-async function cleanupOfficialTestSkillsForAction(
+async function cleanupOwnedSkillsForAction(
   db: Db,
-  body: CronSyncSkillsAction<"cleanup-official-test-skills">,
+  body: CronSyncSkillsAction<"cleanup-owned-skills">,
   signal: AbortSignal,
 ) {
-  const skillRows = await db
-    .select({ id: skills.id, storageId: skills.storageId })
-    .from(skills)
-    .where(like(skills.url, `${body.url_prefix}%`));
-  signal.throwIfAborted();
-
-  if (skillRows.length === 0) {
-    return actionOk();
+  if (body.skill_urls.length > 0) {
+    await db.delete(skills).where(inArray(skills.url, body.skill_urls));
+    signal.throwIfAborted();
   }
-
-  const skillIds = skillRows.map((row) => {
-    return row.id;
-  });
-  const storageIds = skillRows
-    .map((row) => {
-      return row.storageId;
-    })
-    .filter((id): id is string => {
-      return id !== null;
-    });
-
-  await db.delete(skills).where(inArray(skills.id, skillIds));
-  signal.throwIfAborted();
-  if (storageIds.length > 0) {
-    await db.delete(storages).where(inArray(storages.id, storageIds));
+  if (body.storage_names.length > 0) {
+    await db
+      .delete(storages)
+      .where(
+        and(
+          eq(storages.orgId, SYSTEM_ORG_ID),
+          eq(storages.userId, VOLUME_ORG_USER_ID),
+          inArray(storages.name, body.storage_names),
+        ),
+      );
     signal.throwIfAborted();
   }
   return actionOk();
 }
 
-async function setAllSkillsCommitShaForAction(
+async function setOwnedSkillsCommitShaForAction(
   db: Db,
-  body: CronSyncSkillsAction<"set-all-skills-commit-sha">,
+  body: CronSyncSkillsAction<"set-owned-skills-commit-sha">,
   signal: AbortSignal,
 ) {
-  await db
-    .insert(skills)
-    .values({
-      url: body.url,
-      name: body.skill_name,
-      fullPath: body.full_path,
-      commitSha: body.commit_sha,
-      frontmatter: body.frontmatter,
-    })
-    .onConflictDoNothing();
+  await db.insert(skills).values(
+    body.skills.map((skill) => {
+      return {
+        url: skill.url,
+        name: skill.name,
+        fullPath: skill.full_path,
+        frontmatter: skill.frontmatter,
+      };
+    }),
+  );
   signal.throwIfAborted();
 
-  await db.update(skills).set({ commitSha: body.commit_sha });
+  await db
+    .update(skills)
+    .set({ commitSha: body.commit_sha })
+    .where(
+      inArray(
+        skills.url,
+        body.skills.map((skill) => {
+          return skill.url;
+        }),
+      ),
+    );
   signal.throwIfAborted();
   return actionOk();
 }
@@ -89,33 +91,27 @@ async function seedStorageRows(
   db: Db,
   versions: readonly TestCronSyncSkillsStateSkillVersionSeed[],
 ) {
-  const storageRows = await db
-    .insert(storages)
-    .values(
-      versions.map((version) => {
-        return {
-          orgId: SYSTEM_ORG_ID,
-          userId: VOLUME_ORG_USER_ID,
-          name: version.storage_name,
-          s3Prefix: version.s3_prefix,
-          size: version.size,
-          fileCount: version.file_count,
-        };
-      }),
-    )
-    .onConflictDoUpdate({
-      target: [storages.orgId, storages.userId, storages.name],
-      set: {
-        s3Prefix: sql`excluded.s3_prefix`,
-        size: sql`excluded.size`,
-        fileCount: sql`excluded.file_count`,
-      },
-    })
-    .returning({ id: storages.id, name: storages.name });
+  const storageSeeds = versions.map((version) => {
+    const location = newStorageS3Location(SYSTEM_ORG_ID);
+    return {
+      id: location.storageId,
+      orgId: SYSTEM_ORG_ID,
+      userId: VOLUME_ORG_USER_ID,
+      name: version.storage_name,
+      s3Prefix: location.s3Prefix,
+      size: version.size,
+      fileCount: version.file_count,
+    };
+  });
+  const storageRows = await db.insert(storages).values(storageSeeds).returning({
+    id: storages.id,
+    name: storages.name,
+    s3Prefix: storages.s3Prefix,
+  });
 
   return new Map(
     storageRows.map((row) => {
-      return [row.name, row.id];
+      return [row.name, { id: row.id, s3Prefix: row.s3Prefix }];
     }),
   );
 }
@@ -129,91 +125,63 @@ async function seedCurrentSkillVersionsForAction(
     return actionOk();
   }
 
-  const storageIdsByName = await seedStorageRows(db, body.versions);
+  const storageByName = await seedStorageRows(db, body.versions);
   signal.throwIfAborted();
 
-  await db
-    .insert(storageVersions)
-    .values(
-      body.versions.map((version) => {
-        const storageId = storageIdsByName.get(version.storage_name);
-        if (!storageId) {
-          throw new Error(`Missing storage for ${version.name}`);
-        }
-        return {
-          id: version.version_hash,
-          storageId,
-          s3Key: version.s3_key,
-          size: version.size,
-          archiveSize: version.archive_size,
-          fileCount: version.file_count,
-          message: "Preseeded by cron sync skills route test",
-          createdBy: "system",
-        };
-      }),
-    )
-    .onConflictDoUpdate({
-      target: storageVersions.id,
-      set: {
-        storageId: sql`excluded.storage_id`,
-        s3Key: sql`excluded.s3_key`,
-        size: sql`excluded.size`,
-        archiveSize: sql`excluded.archive_size`,
-        fileCount: sql`excluded.file_count`,
-      },
-    });
+  await db.insert(storageVersions).values(
+    body.versions.map((version) => {
+      const storage = storageByName.get(version.storage_name);
+      if (!storage) {
+        throw new Error(`Missing storage for ${version.name}`);
+      }
+      return {
+        id: version.version_hash,
+        storageId: storage.id,
+        s3Key: `${storage.s3Prefix}/${version.version_hash}`,
+        size: version.size,
+        archiveSize: version.archive_size,
+        fileCount: version.file_count,
+        message: "Preseeded by cron sync skills route test",
+        createdBy: "system",
+      };
+    }),
+  );
   signal.throwIfAborted();
 
   await Promise.all(
     body.versions.map((version) => {
-      const storageId = storageIdsByName.get(version.storage_name);
-      if (!storageId) {
+      const storage = storageByName.get(version.storage_name);
+      if (!storage) {
         throw new Error(`Missing storage for ${version.name}`);
       }
       return db
         .update(storages)
         .set({ headVersionId: version.version_hash })
-        .where(eq(storages.id, storageId));
+        .where(eq(storages.id, storage.id));
     }),
   );
   signal.throwIfAborted();
 
-  await db
-    .insert(skills)
-    .values(
-      body.versions.map((version) => {
-        const storageId = storageIdsByName.get(version.storage_name);
-        if (!storageId) {
-          throw new Error(`Missing storage for ${version.name}`);
-        }
-        return {
-          url: version.url,
-          name: version.name,
-          fullPath: version.full_path,
-          storageId,
-          versionHash: version.version_hash,
-          commitSha: body.stale_commit_sha,
-          frontmatter: version.frontmatter,
-          s3Key: version.s3_key,
-          size: version.size,
-          fileCount: version.file_count,
-        };
-      }),
-    )
-    .onConflictDoUpdate({
-      target: skills.url,
-      set: {
-        name: sql`excluded.name`,
-        fullPath: sql`excluded.full_path`,
-        storageId: sql`excluded.storage_id`,
-        versionHash: sql`excluded.version_hash`,
-        commitSha: sql`excluded.commit_sha`,
-        frontmatter: sql`excluded.frontmatter`,
-        s3Key: sql`excluded.s3_key`,
-        size: sql`excluded.size`,
-        fileCount: sql`excluded.file_count`,
-      },
-    });
+  await db.insert(skills).values(
+    body.versions.map((version) => {
+      const storage = storageByName.get(version.storage_name);
+      if (!storage) {
+        throw new Error(`Missing storage for ${version.name}`);
+      }
+      return {
+        url: version.url,
+        name: version.name,
+        fullPath: version.full_path,
+        storageId: storage.id,
+        versionHash: version.version_hash,
+        commitSha: body.stale_commit_sha,
+        frontmatter: version.frontmatter,
+        s3Key: `${storage.s3Prefix}/${version.version_hash}`,
+        size: version.size,
+        fileCount: version.file_count,
+      };
+    }),
+  );
   signal.throwIfAborted();
   return actionOk();
 }
@@ -225,6 +193,7 @@ async function readSkillByUrlForAction(
 ) {
   const [row] = await db
     .select({
+      name: skills.name,
       fullPath: skills.fullPath,
       commitSha: skills.commitSha,
       versionHash: skills.versionHash,
@@ -238,6 +207,7 @@ async function readSkillByUrlForAction(
   return actionOk({
     skill: row
       ? {
+          name: row.name,
           full_path: row.fullPath,
           commit_sha: row.commitSha,
           version_hash: row.versionHash,
@@ -256,19 +226,27 @@ async function readStorageByNameForAction(
   const [row] = await db
     .select({
       headVersionId: storages.headVersionId,
+      s3Prefix: storages.s3Prefix,
       size: storages.size,
       versionSize: storageVersions.size,
       archiveSize: storageVersions.archiveSize,
     })
     .from(storages)
     .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id))
-    .where(eq(storages.name, body.name))
+    .where(
+      and(
+        eq(storages.orgId, SYSTEM_ORG_ID),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, body.name),
+      ),
+    )
     .limit(1);
   signal.throwIfAborted();
   return actionOk({
     storage: row
       ? {
           head_version_id: row.headVersionId,
+          s3_prefix: row.s3Prefix,
           size: row.size,
           version_size: row.versionSize,
           archive_size: row.archiveSize,
@@ -292,11 +270,11 @@ const mutateCronSyncSkillsState$ = command(
     const db = set(writeDb$);
     const body = bodyResult.data;
     switch (body.action) {
-      case "cleanup-official-test-skills": {
-        return await cleanupOfficialTestSkillsForAction(db, body, signal);
+      case "cleanup-owned-skills": {
+        return await cleanupOwnedSkillsForAction(db, body, signal);
       }
-      case "set-all-skills-commit-sha": {
-        return await setAllSkillsCommitShaForAction(db, body, signal);
+      case "set-owned-skills-commit-sha": {
+        return await setOwnedSkillsCommitShaForAction(db, body, signal);
       }
       case "seed-current-skill-versions": {
         return await seedCurrentSkillVersionsForAction(db, body, signal);
@@ -311,9 +289,40 @@ const mutateCronSyncSkillsState$ = command(
   },
 );
 
+const syncCronSyncSkillsState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(syncBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      syncSkillsForScope$,
+      {
+        skillNamePrefix: bodyResult.data.skill_name_prefix,
+        requiredSkillNames: bodyResult.data.required_skill_names,
+      },
+      signal,
+    );
+    return {
+      status: 200 as const,
+      body: { success: true as const, ...result },
+    };
+  },
+);
+
 export const testCronSyncSkillsStateRoutes: readonly RouteEntry[] = [
   {
     route: testCronSyncSkillsStateContract.action,
     handler: mutateCronSyncSkillsState$,
+  },
+  {
+    route: testCronSyncSkillsStateContract.sync,
+    handler: syncCronSyncSkillsState$,
   },
 ];

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -49,6 +49,11 @@ interface SyncSkillsResult {
   readonly total: number;
 }
 
+interface SyncSkillsScope {
+  readonly skillNamePrefix: string | null;
+  readonly requiredSkillNames: readonly string[];
+}
+
 interface ExtractedFile {
   readonly path: string;
   readonly content: Buffer;
@@ -81,6 +86,7 @@ interface SkillArchiveUpload {
 const log = logger("skills:sync");
 const REPO_REFS_URL = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}.git/info/refs?service=git-upload-pack`;
 const TARBALL_URL = `https://codeload.github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tar.gz/refs/heads/${DEFAULT_SKILLS_BRANCH}`;
+const OFFICIAL_SKILL_URL_ROOT = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/`;
 const SYNC_BATCH_SIZE = 5;
 
 function parseHeadRef(pktLineText: string, branch: string): string {
@@ -596,6 +602,7 @@ function syncSingleSkill(
 function removeOrphanedSkills(
   db: Db,
   extractedSkills: readonly ExtractedSkill[],
+  urlPrefix: string,
   signal: AbortSignal,
 ): Computed<Promise<number>> {
   return computed(async (get): Promise<number> => {
@@ -604,7 +611,6 @@ function removeOrphanedSkills(
         return skillUrl(skill.skillName);
       }),
     );
-    const urlPrefix = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/`;
     const existingSkills = await db
       .select({ id: skills.id, url: skills.url, storageId: skills.storageId })
       .from(skills)
@@ -685,13 +691,16 @@ function removeOrphanedSkills(
   });
 }
 
-function validateSeedSkills(extractedSkills: readonly ExtractedSkill[]): void {
+function validateSeedSkills(
+  extractedSkills: readonly ExtractedSkill[],
+  requiredSkillNames: readonly string[],
+): void {
   const tarballNames = new Set(
     extractedSkills.map((skill) => {
       return skill.skillName;
     }),
   );
-  const missingSkills = SEED_SKILLS.filter((name) => {
+  const missingSkills = requiredSkillNames.filter((name) => {
     return !tarballNames.has(name);
   });
 
@@ -704,16 +713,25 @@ function validateSeedSkills(extractedSkills: readonly ExtractedSkill[]): void {
   }
 }
 
-export const syncSkills$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<SyncSkillsResult> => {
+export const syncSkillsForScope$ = command(
+  async (
+    { get, set },
+    scope: SyncSkillsScope,
+    signal: AbortSignal,
+  ): Promise<SyncSkillsResult> => {
     const db = set(writeDb$);
     const headSha = await fetchHeadCommitSha(signal);
     signal.throwIfAborted();
 
-    const [existing] = await db
-      .select({ commitSha: skills.commitSha })
-      .from(skills)
-      .limit(1);
+    const urlPrefix = `${OFFICIAL_SKILL_URL_ROOT}${scope.skillNamePrefix ?? ""}`;
+    const [existing] =
+      scope.skillNamePrefix === null
+        ? await db.select({ commitSha: skills.commitSha }).from(skills).limit(1)
+        : await db
+            .select({ commitSha: skills.commitSha })
+            .from(skills)
+            .where(like(skills.url, `${urlPrefix}%`))
+            .limit(1);
     signal.throwIfAborted();
 
     if (existing?.commitSha === headSha) {
@@ -727,7 +745,14 @@ export const syncSkills$ = command(
       };
     }
 
-    const extractedSkills = await downloadAndExtractSkills(signal);
+    const extractedSkills = (await downloadAndExtractSkills(signal)).filter(
+      (skill) => {
+        return (
+          scope.skillNamePrefix === null ||
+          skill.skillName.startsWith(scope.skillNamePrefix)
+        );
+      },
+    );
     signal.throwIfAborted();
 
     let synced = 0;
@@ -769,10 +794,10 @@ export const syncSkills$ = command(
     }
 
     const removed = await get(
-      removeOrphanedSkills(db, extractedSkills, signal),
+      removeOrphanedSkills(db, extractedSkills, urlPrefix, signal),
     );
     signal.throwIfAborted();
-    validateSeedSkills(extractedSkills);
+    validateSeedSkills(extractedSkills, scope.requiredSkillNames);
 
     log.debug("Skills sync completed", {
       commitSha: headSha,
@@ -791,5 +816,15 @@ export const syncSkills$ = command(
       removed,
       total: extractedSkills.length,
     };
+  },
+);
+
+export const syncSkills$ = command(
+  async ({ set }, signal: AbortSignal): Promise<SyncSkillsResult> => {
+    return await set(
+      syncSkillsForScope$,
+      { skillNamePrefix: null, requiredSkillNames: SEED_SKILLS },
+      signal,
+    );
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/test-cron-sync-skills-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-sync-skills-state.ts
@@ -14,15 +14,21 @@ const skillVersionSeedSchema = z.object({
   full_path: z.string(),
   storage_name: z.string(),
   version_hash: z.string(),
-  s3_prefix: z.string(),
-  s3_key: z.string(),
   size: z.number(),
   archive_size: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   file_count: z.number(),
   frontmatter: z.unknown(),
 });
 
+const ownedSkillSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  full_path: z.string(),
+  frontmatter: z.unknown(),
+});
+
 const skillRowSchema = z.object({
+  name: z.string(),
   full_path: z.string(),
   commit_sha: z.string().nullable(),
   version_hash: z.string().nullable(),
@@ -32,6 +38,7 @@ const skillRowSchema = z.object({
 
 const storageRowSchema = z.object({
   head_version_id: z.string().nullable(),
+  s3_prefix: z.string(),
   size: z.number(),
   version_size: z.number().nullable(),
   archive_size: z.number().nullable(),
@@ -41,16 +48,14 @@ export const testCronSyncSkillsStateActionBodySchema = z.discriminatedUnion(
   "action",
   [
     z.object({
-      action: z.literal("cleanup-official-test-skills"),
-      url_prefix: z.string(),
+      action: z.literal("cleanup-owned-skills"),
+      skill_urls: z.array(z.string()),
+      storage_names: z.array(z.string()),
     }),
     z.object({
-      action: z.literal("set-all-skills-commit-sha"),
-      skill_name: z.string(),
-      url: z.string(),
-      full_path: z.string(),
+      action: z.literal("set-owned-skills-commit-sha"),
+      skills: z.array(ownedSkillSchema).min(1),
       commit_sha: z.string(),
-      frontmatter: z.unknown(),
     }),
     z.object({
       action: z.literal("seed-current-skill-versions"),
@@ -74,6 +79,21 @@ export const testCronSyncSkillsStateActionResponseSchema = z.object({
   storage: storageRowSchema.nullable().optional(),
 });
 
+const testCronSyncSkillsStateSyncBodySchema = z.object({
+  skill_name_prefix: z.string().regex(/^api-test-skill-[0-9a-f]{32}-$/),
+  required_skill_names: z.array(z.string()).min(1),
+});
+
+const testCronSyncSkillsStateSyncResponseSchema = z.object({
+  success: z.literal(true),
+  commitSha: z.string(),
+  synced: z.number(),
+  skipped: z.number(),
+  failed: z.number(),
+  removed: z.number(),
+  total: z.number(),
+});
+
 export const testCronSyncSkillsStateContract = c.router({
   action: {
     method: "POST",
@@ -86,6 +106,17 @@ export const testCronSyncSkillsStateContract = c.router({
     },
     summary: "Mutate and read cron sync skills API test support state",
   },
+  sync: {
+    method: "POST",
+    path: "/api/test/cron-sync-skills-state/sync",
+    body: testCronSyncSkillsStateSyncBodySchema,
+    responses: {
+      200: testCronSyncSkillsStateSyncResponseSchema,
+      400: testCronSyncSkillsStateErrorSchema,
+      404: z.string(),
+    },
+    summary: "Sync the explicitly scoped skills fixture in API tests",
+  },
 });
 
 export type TestCronSyncSkillsStateContract =
@@ -95,6 +126,9 @@ export type TestCronSyncSkillsStateActionBody = z.infer<
 >;
 export type TestCronSyncSkillsStateActionResponse = z.infer<
   typeof testCronSyncSkillsStateActionResponseSchema
+>;
+export type TestCronSyncSkillsStateSyncResponse = z.infer<
+  typeof testCronSyncSkillsStateSyncResponseSchema
 >;
 export type TestCronSyncSkillsStateSkillVersionSeed = z.infer<
   typeof skillVersionSeedSchema


### PR DESCRIPTION
## Summary

- Give every cron skill-sync test a UUID-scoped repository namespace and register only its own skill and storage cleanup resources.
- Replace shared storage upserts and full-table commit-SHA mutation with generated storage identities, unique object prefixes, plain fixture inserts, and URL-scoped updates.
- Add a validated test-only scoped sync boundary while preserving the public cron path's existing production cutoff and repository selection semantics.
- Keep exact coverage for cutoff, initial and incremental sync, deletion, source rollback, S3 cleanup failure, malformed skills, and missing required skills.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec eslint src/signals/services/cron-sync-skills.service.ts src/signals/routes/__tests__/cron-sync-skills.test.ts --max-warnings 0`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-sync-skills.test.ts` (1 file, 11 tests passed)
- Isolation stress check: two independent focused Vitest processes ran concurrently against the same PostgreSQL database; both passed all 11 tests.

Closes #26598

Part of epic #26569
