### PR TITLE
fix: discard oversized session history at checkpoint

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -136,6 +136,14 @@ pub mod webhooks {
     pub mod agent {
         /// DTOs for creating recoverable agent checkpoints.
         pub mod checkpoints {
+            /// Reason a checkpoint intentionally omits resumable CLI agent session history.
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            pub enum RequestCliAgentSessionHistoryDisposition {
+                /// The native history was oversized and had no safe bounded generation.
+                #[serde(rename = "discarded_oversized")]
+                DiscardedOversized,
+            }
+
             /// Artifact version captured by an agent checkpoint.
             #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             #[serde(rename_all = "camelCase")]
@@ -171,8 +179,13 @@ pub mod webhooks {
                 pub cli_agent_type: String,
                 /// CLI agent session identifier being checkpointed.
                 pub cli_agent_session_id: String,
-                /// SHA-256 hash of the uploaded CLI agent session history.
-                pub cli_agent_session_history_hash: String,
+                /// Optional SHA-256 hash of the uploaded CLI agent session history.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub cli_agent_session_history_hash: Option<String>,
+                /// Optional reason resumable CLI agent session history was intentionally omitted.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub cli_agent_session_history_disposition:
+                    Option<RequestCliAgentSessionHistoryDisposition>,
                 /// Optional artifact versions captured by the checkpoint.
                 #[serde(default, skip_serializing_if = "Option::is_none")]
                 pub artifact_snapshots: Option<Vec<RequestArtifactSnapshot>>,

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -44,7 +44,8 @@ fn generated_checkpoint_request_omits_absent_snapshots() {
         run_id: "run-1".to_string(),
         cli_agent_type: "claude-code".to_string(),
         cli_agent_session_id: "session-1".to_string(),
-        cli_agent_session_history_hash: history_hash.clone(),
+        cli_agent_session_history_hash: Some(history_hash.clone()),
+        cli_agent_session_history_disposition: None,
         artifact_snapshots: None,
         volume_versions_snapshot: None,
     };
@@ -69,7 +70,8 @@ fn generated_checkpoint_request_round_trips_preserve_parent_snapshot() {
         run_id: "run-1".to_string(),
         cli_agent_type: "codex".to_string(),
         cli_agent_session_id: "session-1".to_string(),
-        cli_agent_session_history_hash: "b".repeat(64),
+        cli_agent_session_history_hash: Some("b".repeat(64)),
+        cli_agent_session_history_disposition: None,
         artifact_snapshots: Some(vec![checkpoints::RequestArtifactSnapshot {
             name: "memory".to_string(),
             version: "version-1".to_string(),
@@ -100,6 +102,31 @@ fn generated_checkpoint_request_round_trips_preserve_parent_snapshot() {
 
     let round_trip: checkpoints::Request = serde_json::from_value(value).unwrap();
     assert_eq!(round_trip, request);
+}
+
+#[test]
+fn generated_checkpoint_request_serializes_discarded_oversized_history() {
+    let request = checkpoints::Request {
+        run_id: "run-1".to_string(),
+        cli_agent_type: "codex".to_string(),
+        cli_agent_session_id: "session-1".to_string(),
+        cli_agent_session_history_hash: None,
+        cli_agent_session_history_disposition: Some(
+            checkpoints::RequestCliAgentSessionHistoryDisposition::DiscardedOversized,
+        ),
+        artifact_snapshots: None,
+        volume_versions_snapshot: None,
+    };
+
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        json!({
+            "runId": "run-1",
+            "cliAgentType": "codex",
+            "cliAgentSessionId": "session-1",
+            "cliAgentSessionHistoryDisposition": "discarded_oversized",
+        })
+    );
 }
 
 #[test]

--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -225,24 +225,39 @@ async fn create_checkpoint_impl(
         artifact::snapshot_artifact_entries(http, inputs.run_id, inputs.artifact_entries),
         session_history::prepare_and_upload_session_history(http, inputs.run_id, history_inputs),
     );
-    let session_history::CheckpointSessionHistory {
-        cli_agent_session_id,
-        history_marker_payload,
-        history_hash,
-        history_size,
-        live_history,
-    } = checkpoint_history?;
+    let checkpoint_history = checkpoint_history?;
     let artifact_snapshots = artifact_snapshots?;
 
-    // Build and send checkpoint payload (session history hash only, content uploaded to S3)
     let cli_agent_type = inputs.framework.agent_type();
-    let payload = checkpoints::Request {
-        run_id: inputs.run_id.to_string(),
-        cli_agent_type: cli_agent_type.to_string(),
-        cli_agent_session_id,
-        cli_agent_session_history_hash: history_hash,
-        artifact_snapshots,
-        volume_versions_snapshot: None,
+    let (payload, uploaded_history) = match checkpoint_history {
+        session_history::CheckpointSessionHistory::Uploaded(history) => {
+            let payload = checkpoints::Request {
+                run_id: inputs.run_id.to_string(),
+                cli_agent_type: cli_agent_type.to_string(),
+                cli_agent_session_id: history.cli_agent_session_id.clone(),
+                cli_agent_session_history_hash: Some(history.history_hash.clone()),
+                cli_agent_session_history_disposition: None,
+                artifact_snapshots,
+                volume_versions_snapshot: None,
+            };
+            (payload, Some(history))
+        }
+        session_history::CheckpointSessionHistory::DiscardedOversized {
+            cli_agent_session_id,
+        } => {
+            let payload = checkpoints::Request {
+                run_id: inputs.run_id.to_string(),
+                cli_agent_type: cli_agent_type.to_string(),
+                cli_agent_session_id,
+                cli_agent_session_history_hash: None,
+                cli_agent_session_history_disposition: Some(
+                    checkpoints::RequestCliAgentSessionHistoryDisposition::DiscardedOversized,
+                ),
+                artifact_snapshots,
+                volume_versions_snapshot: None,
+            };
+            (payload, None)
+        }
     };
 
     log_info!(LOG_TAG, "Calling checkpoint API...");
@@ -266,13 +281,17 @@ async fn create_checkpoint_impl(
         .and_then(|v| v.as_str());
 
     if let Some(id) = checkpoint_id {
-        if session_history::reconcile_live_history_after_checkpoint(live_history) {
+        if let Some(uploaded_history) = uploaded_history
+            && session_history::reconcile_live_history_after_checkpoint(
+                uploaded_history.live_history,
+            )
+        {
             session_history::write_final_session_history_identity(
                 mode,
-                &payload.cli_agent_session_id,
-                &payload.cli_agent_session_history_hash,
-                history_size,
-                &history_marker_payload,
+                &uploaded_history.cli_agent_session_id,
+                &uploaded_history.history_hash,
+                uploaded_history.history_size,
+                &uploaded_history.history_marker_payload,
                 inputs.framework,
                 inputs.final_session_history_identity_file.as_ref(),
             );

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -20,7 +20,8 @@ use guest_common::telemetry::{
 };
 use guest_common::{log_info, log_warn};
 use guest_session_prune::{
-    ClaudeHistorySelection, CodexHistorySelection, select_claude_compact_generation,
+    ClaudeHistoryIneligibleReason, ClaudeHistorySelection, CodexHistoryIneligibleReason,
+    CodexHistorySelection, select_claude_compact_generation,
     select_claude_compact_generation_with_candidate_limit_for_test,
     select_codex_compact_generation, select_codex_compact_generation_with_candidate_limit_for_test,
 };
@@ -158,6 +159,11 @@ struct PreparedSessionHistory {
     raw_size: u64,
     upload_source: PreparedSessionHistoryUploadSource,
     live_history: PreparedLiveHistory,
+}
+
+enum PreparedSessionHistoryOutcome {
+    Upload(PreparedSessionHistory),
+    DiscardedOversized,
 }
 
 pub(super) enum PreparedLiveHistory {
@@ -330,7 +336,7 @@ impl CheckpointSessionHistoryInputs {
     }
 }
 
-pub(super) struct CheckpointSessionHistory {
+pub(super) struct UploadedCheckpointSessionHistory {
     pub(super) cli_agent_session_id: String,
     pub(super) history_marker_payload: String,
     pub(super) history_hash: String,
@@ -338,9 +344,53 @@ pub(super) struct CheckpointSessionHistory {
     pub(super) live_history: PreparedLiveHistory,
 }
 
-struct PreparedCheckpointSessionHistory {
-    checkpoint: CheckpointSessionHistory,
-    upload: SessionHistoryUpload,
+pub(super) enum CheckpointSessionHistory {
+    Uploaded(UploadedCheckpointSessionHistory),
+    DiscardedOversized { cli_agent_session_id: String },
+}
+
+enum PreparedCheckpointSessionHistory {
+    Upload {
+        checkpoint: UploadedCheckpointSessionHistory,
+        upload: SessionHistoryUpload,
+    },
+    DiscardedOversized {
+        cli_agent_session_id: String,
+    },
+}
+
+const fn should_discard_oversized_claude(reason: ClaudeHistoryIneligibleReason) -> bool {
+    match reason {
+        ClaudeHistoryIneligibleReason::NoCompactBoundary => true,
+        ClaudeHistoryIneligibleReason::SourceWithinGuard
+        | ClaudeHistoryIneligibleReason::InvalidRecord
+        | ClaudeHistoryIneligibleReason::RecordTooLarge
+        | ClaudeHistoryIneligibleReason::InvalidCompactBoundary
+        | ClaudeHistoryIneligibleReason::InvalidCompactSummary
+        | ClaudeHistoryIneligibleReason::SessionIdMismatch
+        | ClaudeHistoryIneligibleReason::InvalidUuid
+        | ClaudeHistoryIneligibleReason::BrokenParent
+        | ClaudeHistoryIneligibleReason::BrokenToolPair
+        | ClaudeHistoryIneligibleReason::SourceChanged => false,
+    }
+}
+
+const fn should_discard_oversized_codex(reason: CodexHistoryIneligibleReason) -> bool {
+    match reason {
+        CodexHistoryIneligibleReason::NoCompactBoundary
+        | CodexHistoryIneligibleReason::CandidateTooLarge => true,
+        CodexHistoryIneligibleReason::SourceWithinGuard
+        | CodexHistoryIneligibleReason::InvalidCanonicalMetadata
+        | CodexHistoryIneligibleReason::ThreadIdMismatch
+        | CodexHistoryIneligibleReason::UnsupportedHistoryMode
+        | CodexHistoryIneligibleReason::InvalidRecord
+        | CodexHistoryIneligibleReason::RecordTooLarge
+        | CodexHistoryIneligibleReason::InvalidCompactBoundary
+        | CodexHistoryIneligibleReason::InvalidTurn
+        | CodexHistoryIneligibleReason::MissingTurnContext
+        | CodexHistoryIneligibleReason::RollbackAfterCompact
+        | CodexHistoryIneligibleReason::SourceChanged => false,
+    }
 }
 
 async fn run_session_history_blocking<T>(
@@ -473,7 +523,7 @@ fn prepare_session_history(
     cli_agent_session_id: &str,
     history_marker_payload: &str,
     history_read_start: std::time::Instant,
-) -> Result<PreparedSessionHistory, AgentError> {
+) -> Result<PreparedSessionHistoryOutcome, AgentError> {
     if mode.can_prune_history()
         && framework == env::Framework::ClaudeCode
         && !history::is_codex_marker(history_marker_payload)
@@ -505,7 +555,7 @@ fn prepare_session_history(
                     kind: NativeHistoryKind::ClaudeCode,
                     replacement,
                 };
-                return Ok(prepared);
+                return Ok(PreparedSessionHistoryOutcome::Upload(prepared));
             }
             Ok(ClaudeHistorySelection::Ineligible(reason)) => {
                 log_info!(
@@ -518,6 +568,13 @@ fn prepare_session_history(
                     SessionHistoryPruneOutcome::Ineligible,
                     Some(SessionHistoryPruneReason::Selector(reason.as_str())),
                 );
+                if should_discard_oversized_claude(reason) {
+                    log_info!(
+                        LOG_TAG,
+                        "Discarding oversized Claude session history without a bounded generation"
+                    );
+                    return Ok(PreparedSessionHistoryOutcome::DiscardedOversized);
+                }
             }
             Err(error) => {
                 log_warn!(
@@ -566,7 +623,7 @@ fn prepare_session_history(
                                 kind: NativeHistoryKind::Codex,
                                 replacement,
                             };
-                            return Ok(prepared);
+                            return Ok(PreparedSessionHistoryOutcome::Upload(prepared));
                         }
                         Ok(CodexHistorySelection::Ineligible(reason)) => {
                             log_info!(
@@ -579,6 +636,13 @@ fn prepare_session_history(
                                 SessionHistoryPruneOutcome::Ineligible,
                                 Some(SessionHistoryPruneReason::Selector(reason.as_str())),
                             );
+                            if should_discard_oversized_codex(reason) {
+                                log_info!(
+                                    LOG_TAG,
+                                    "Discarding oversized Codex session history without a bounded generation"
+                                );
+                                return Ok(PreparedSessionHistoryOutcome::DiscardedOversized);
+                            }
                         }
                         Err(error) => {
                             log_warn!(
@@ -645,6 +709,7 @@ fn prepare_session_history(
     match source {
         history::SessionHistoryCheckpointSource::Decoded(history_bytes) => {
             prepare_raw_session_history(mode, history_read_start, history_bytes)
+                .map(PreparedSessionHistoryOutcome::Upload)
         }
         history::SessionHistoryCheckpointSource::CodexZstd { encoded } => {
             prepare_reused_zstd_session_history(
@@ -653,6 +718,7 @@ fn prepare_session_history(
                 encoded,
                 checkpoint_max_bytes,
             )
+            .map(PreparedSessionHistoryOutcome::Upload)
         }
     }
 }
@@ -962,24 +1028,32 @@ fn prepare_checkpoint_session_history(
         &history_marker_payload,
         history_read_start,
     )?;
-    let PreparedSessionHistory {
-        hash: history_hash,
-        raw_size: history_size,
-        upload_source,
-        live_history,
-    } = prepared_history;
-    let upload = upload_source.into_upload(history_size)?;
-
-    Ok(PreparedCheckpointSessionHistory {
-        checkpoint: CheckpointSessionHistory {
-            cli_agent_session_id,
-            history_marker_payload,
-            history_hash,
-            history_size,
-            live_history,
-        },
-        upload,
-    })
+    match prepared_history {
+        PreparedSessionHistoryOutcome::Upload(prepared_history) => {
+            let PreparedSessionHistory {
+                hash: history_hash,
+                raw_size: history_size,
+                upload_source,
+                live_history,
+            } = prepared_history;
+            let upload = upload_source.into_upload(history_size)?;
+            Ok(PreparedCheckpointSessionHistory::Upload {
+                checkpoint: UploadedCheckpointSessionHistory {
+                    cli_agent_session_id,
+                    history_marker_payload,
+                    history_hash,
+                    history_size,
+                    live_history,
+                },
+                upload,
+            })
+        }
+        PreparedSessionHistoryOutcome::DiscardedOversized => {
+            Ok(PreparedCheckpointSessionHistory::DiscardedOversized {
+                cli_agent_session_id,
+            })
+        }
+    }
 }
 
 pub(super) async fn prepare_and_upload_session_history(
@@ -989,9 +1063,17 @@ pub(super) async fn prepare_and_upload_session_history(
 ) -> Result<CheckpointSessionHistory, AgentError> {
     let prepared =
         run_session_history_blocking(move || prepare_checkpoint_session_history(inputs)).await?;
-    let PreparedCheckpointSessionHistory { checkpoint, upload } = prepared;
-    upload_session_history(http, run_id, &checkpoint.history_hash, upload).await?;
-    Ok(checkpoint)
+    match prepared {
+        PreparedCheckpointSessionHistory::Upload { checkpoint, upload } => {
+            upload_session_history(http, run_id, &checkpoint.history_hash, upload).await?;
+            Ok(CheckpointSessionHistory::Uploaded(checkpoint))
+        }
+        PreparedCheckpointSessionHistory::DiscardedOversized {
+            cli_agent_session_id,
+        } => Ok(CheckpointSessionHistory::DiscardedOversized {
+            cli_agent_session_id,
+        }),
+    }
 }
 
 pub(super) fn reconcile_live_history_after_checkpoint(live_history: PreparedLiveHistory) -> bool {

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -204,6 +204,148 @@ async fn success_checkpoint_preserves_small_codex_history() {
 }
 
 #[tokio::test]
+async fn success_checkpoint_discards_oversized_claude_history_without_compact_boundary() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let runtime = runtime_from_process_env().unwrap();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let line =
+        b"{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"ordinary\"}}\n";
+    let mut history = Vec::new();
+    while history.len() <= CHECKPOINT_TEST_CANDIDATE_MAX_BYTES as usize {
+        history.extend_from_slice(line);
+    }
+    let history_dir = write_literal_session_history(session_id, &history).unwrap();
+    let history_path = history_dir.path().join(format!("{session_id}.jsonl"));
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(500);
+    });
+    let expected_session_id = session_id.to_string();
+    let checkpoint_mock = server.mock(move |when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.respond_with(move |request| {
+            let body = serde_json::from_slice::<Value>(request.body_ref()).unwrap();
+            if body["cliAgentSessionId"] == expected_session_id
+                && body["cliAgentSessionHistoryDisposition"] == "discarded_oversized"
+                && body.get("cliAgentSessionHistoryHash").is_none()
+            {
+                json_http_response(200, json!({"checkpointId": "checkpoint-discarded-claude"}))
+            } else {
+                http_status(400)
+            }
+        });
+    });
+
+    create_bounded_checkpoint(&runtime).await.unwrap();
+
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    assert_eq!(std::fs::read(history_path).unwrap(), history);
+    assert_session_history_prune_operation(
+        &runtime,
+        "ineligible",
+        Some("no_compact_boundary"),
+        true,
+    )
+    .unwrap();
+    assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
+}
+
+#[tokio::test]
+async fn success_checkpoint_discards_codex_history_that_jumps_past_hard_limit() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    let (history_dir, history_path, history) =
+        write_codex_history_without_compact(session_id, None, CHECKPOINT_TEST_MAX_BYTES as usize)
+            .unwrap();
+    runtime.config.home_dir = history_dir.path().to_string_lossy().into_owned();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(500);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentType":"codex"}"#)
+            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"discarded_oversized"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-discarded-codex"}));
+    });
+
+    create_bounded_checkpoint(&runtime).await.unwrap();
+
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    assert_eq!(std::fs::read(history_path).unwrap(), history);
+    assert_session_history_prune_operation(
+        &runtime,
+        "ineligible",
+        Some("no_compact_boundary"),
+        true,
+    )
+    .unwrap();
+    assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
+}
+
+#[tokio::test]
+async fn success_checkpoint_discards_codex_history_with_oversized_canonical_candidate() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mut runtime = runtime_from_process_env().unwrap();
+    runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    let (history_dir, history_path, history) = write_codex_history_without_compact(
+        session_id,
+        Some(CHECKPOINT_TEST_CANDIDATE_MAX_BYTES as usize),
+        CHECKPOINT_TEST_CANDIDATE_MAX_BYTES as usize,
+    )
+    .unwrap();
+    runtime.config.home_dir = history_dir.path().to_string_lossy().into_owned();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(500);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionHistoryDisposition":"discarded_oversized"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-discarded-candidate"}));
+    });
+
+    create_bounded_checkpoint(&runtime).await.unwrap();
+
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    assert_eq!(std::fs::read(history_path).unwrap(), history);
+    assert_session_history_prune_operation(
+        &runtime,
+        "ineligible",
+        Some("candidate_too_large"),
+        true,
+    )
+    .unwrap();
+}
+
+#[tokio::test]
 async fn checkpoint_records_codex_prune_resolution_error() {
     let _api = SharedApiMock::new().await;
     let mut runtime = runtime_from_process_env().unwrap();

--- a/crates/guest-agent/tests/integration/checkpoint/support.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/support.rs
@@ -324,6 +324,85 @@ pub(super) fn write_prunable_codex_history(
     Ok((history_dir, history_path, candidate))
 }
 
+pub(super) fn write_codex_history_without_compact(
+    session_id: &str,
+    canonical_target_size: Option<usize>,
+    minimum_source_size: usize,
+) -> Result<(tempfile::TempDir, std::path::PathBuf, Vec<u8>), String> {
+    let history_dir =
+        tempfile::tempdir().map_err(|error| format!("create Codex history dir: {error}"))?;
+    let day_dir = history_dir
+        .path()
+        .join(".codex")
+        .join("sessions")
+        .join("2026")
+        .join("08")
+        .join("12");
+    std::fs::create_dir_all(&day_dir)
+        .map_err(|error| format!("create Codex session directory: {error}"))?;
+    let history_path = day_dir.join(format!("rollout-{session_id}.jsonl"));
+
+    let canonical_record = |padding: &str| -> Result<Vec<u8>, String> {
+        let mut bytes = serde_json::to_vec(&json!({
+            "timestamp": "2026-08-12T00:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "session_id": session_id,
+                "timestamp": "2026-08-12T00:00:00Z",
+                "cwd": guest_agent::paths::CANONICAL_WORKING_DIR,
+                "originator": "codex",
+                "cli_version": "0.144.6",
+                "source": "cli",
+                "history_mode": "legacy",
+                "padding": padding,
+            },
+        }))
+        .map_err(|error| format!("encode Codex canonical record: {error}"))?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    };
+    let empty_canonical = canonical_record("")?;
+    let canonical = if let Some(target_size) = canonical_target_size {
+        let padding_size = target_size
+            .checked_sub(empty_canonical.len())
+            .ok_or_else(|| {
+                format!(
+                    "canonical target {target_size} is below minimum {}",
+                    empty_canonical.len()
+                )
+            })?;
+        let canonical = canonical_record(&"x".repeat(padding_size))?;
+        if canonical.len() != target_size {
+            return Err(format!(
+                "canonical record size mismatch: expected {target_size}, got {}",
+                canonical.len()
+            ));
+        }
+        canonical
+    } else {
+        empty_canonical
+    };
+    let mut filler = serde_json::to_vec(&json!({
+        "timestamp": "2026-08-12T00:00:01Z",
+        "type": "world_state",
+        "payload": {"full": true, "state": {"working_directory": "/workspace"}},
+    }))
+    .map_err(|error| format!("encode Codex filler record: {error}"))?;
+    filler.push(b'\n');
+
+    let mut history = canonical;
+    while history.len() <= minimum_source_size {
+        history.extend_from_slice(&filler);
+    }
+    std::fs::write(&history_path, &history)
+        .map_err(|error| format!("write Codex history: {error}"))?;
+    let (session_id_file, _) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, session_id)
+        .map_err(|error| format!("write Codex session id: {error}"))?;
+    Ok((history_dir, history_path, history))
+}
+
 pub(super) fn zstd_session_history_for_test(history: &[u8]) -> std::io::Result<Vec<u8>> {
     zstd::stream::encode_all(history, 3)
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5780,6 +5780,68 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, second.runId);
   }, 90_000);
 
+  it("rotates a canonical thread after an oversized history is discarded", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const firstPrompt = "finish work before native history becomes oversized";
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: firstPrompt,
+    });
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    const firstAnswer = "completed work preserved outside native history";
+    chatCallbacks.mockChatOutputEvents([assistantEvent(0, firstAnswer)]);
+    const outputEvents = chatCallbacks.consumeMockChatOutputEvents();
+    await webhooks.requestAgentEvents(
+      { runId: first.runId, events: outputEvents },
+      firstClaim.sandboxHeaders,
+      [200],
+    );
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: first.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `discarded-cli-${first.runId}`,
+        cliAgentSessionHistoryDisposition: "discarded_oversized",
+      },
+      firstClaim.sandboxHeaders,
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      {
+        runId: first.runId,
+        exitCode: 0,
+        lastEventSequence: 0,
+      },
+      firstClaim.sandboxHeaders,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    await waitForRunStatus(actor, first.runId, "completed");
+
+    const second = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue in a fresh native session",
+    });
+    expect(sandboxOperationEventsForRun(second.runId)).toContainEqual(
+      expect.objectContaining({
+        op_type: "chat_thread_session_binding_persisted",
+        binding_action: "rotated",
+      }),
+    );
+    const secondRun = await api.readRun(actor, second.runId);
+    const appended = secondRun.appendSystemPrompt ?? "";
+    expect(appended).toContain("# Web Chat Run Context");
+    expect(appended).toContain(firstPrompt);
+    expect(appended).toContain(firstAnswer);
+
+    const secondClaim = await claimChatRun(runnerGroup, second.runId);
+    expect(secondClaim.claim.resumeSession).toBeNull();
+    await cancelChatRun(actor, second.runId, secondClaim.sandboxHeaders);
+  }, 90_000);
+
   it("retries preparation when the canonical conversation snapshot changes", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -612,27 +612,30 @@ export function createWebhookCallbackApi(context: TestContext) {
       headers: SandboxWebhookHeaders,
       statuses: readonly (200 | 400 | 401 | 404 | 500)[],
     ) {
-      const sessionHistoryBlob = registerKnownSessionHistoryBlob(
-        context,
-        body.runId,
-        body.cliAgentSessionHistoryHash,
-      );
-      if (sessionHistoryBlob && statuses.includes(200)) {
-        await accept(
-          setupApp({ context, routes: webhooksAgentCheckpointsRoutes })(
-            webhookCheckpointsPrepareHistoryContract,
-          ).prepare({
-            headers,
-            body: {
-              runId: body.runId,
-              hash: body.cliAgentSessionHistoryHash,
-              rawSize: sessionHistoryBlob.byteLength,
-              encodedSize: sessionHistoryBlob.byteLength,
-              encoding: "identity",
-            },
-          }),
-          [200],
+      const historyHash = body.cliAgentSessionHistoryHash;
+      if (historyHash !== undefined) {
+        const sessionHistoryBlob = registerKnownSessionHistoryBlob(
+          context,
+          body.runId,
+          historyHash,
         );
+        if (sessionHistoryBlob && statuses.includes(200)) {
+          await accept(
+            setupApp({ context, routes: webhooksAgentCheckpointsRoutes })(
+              webhookCheckpointsPrepareHistoryContract,
+            ).prepare({
+              headers,
+              body: {
+                runId: body.runId,
+                hash: historyHash,
+                rawSize: sessionHistoryBlob.byteLength,
+                encodedSize: sessionHistoryBlob.byteLength,
+                encoding: "identity",
+              },
+            }),
+            [200],
+          );
+        }
       }
       return await accept(
         setupApp({ context, routes: webhooksAgentCheckpointsRoutes })(

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -1497,6 +1497,77 @@ describe("OPS-01: user data export", () => {
     ).toBeFalsy();
   });
 
+  it("exports successfully when a session intentionally has no history", async () => {
+    const api = createOpsLogsApi(context);
+    const bdd = createBddApi(context);
+    createMiscRoutesApi(context);
+    const runs = createRunsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const actor = bdd.user();
+    const exportStartAt = Date.UTC(2026, 4, 12, 5, 45);
+    const downloadUrl =
+      "https://r2.example.com/bdd-export-historyless.zip?sig=test";
+
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD Export Historyless Agent",
+      visibility: "private",
+    });
+    const run = await runs.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "checkpoint without resumable history",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await runs.claimRunnerJob(run.runId);
+    const headers = { authorization: `Bearer ${claim.sandboxToken}` };
+
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: run.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-export-historyless-${run.runId}`,
+        cliAgentSessionHistoryDisposition: "discarded_oversized",
+      },
+      headers,
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: run.runId, exitCode: 0 },
+      headers,
+      [200],
+    );
+
+    mockNow(exportStartAt);
+    context.mocks.s3.getSignedUrl.mockResolvedValue(downloadUrl);
+    const started = await api.requestPostUserExport(actor, [202]);
+    const exportKey = `exports/${actor.userId}/${started.body.jobId}.zip`;
+
+    await waitForUserExportJobStatus(
+      api,
+      actor,
+      started.body.jobId,
+      "completed",
+    );
+    const zip = exportZip(exportKey);
+    const names = zipEntryNames(zip);
+    expect(
+      names.some((name) => {
+        return name.endsWith("-history.jsonl");
+      }),
+    ).toBeFalsy();
+
+    const manifest = JSON.parse(zipText(zip, "export-manifest.json")) as {
+      readonly counts: {
+        readonly sessionHistories: number;
+      };
+    };
+    expect(manifest.counts.sessionHistories).toBe(0);
+  });
+
   it("exports gzip-backed session history bytes as a jsonl conversation file", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2527,7 +2527,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, canonicalRun.runId, [200]);
   });
 
-  it("persists canonical mounts across session continuation", async () => {
+  it("persists canonical mounts across historyless session continuation", async () => {
     const api = createRunsApi(context);
     const storages = createStoragesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -2685,15 +2685,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       versionId: preparedMemory.versionId,
       files: [memoryFile],
     });
-    const historyHash = createHash("sha256")
-      .update(`canonical storage history ${initialRun.runId}`)
-      .digest("hex");
     const checkpoint = await webhooks.requestAgentCheckpoint(
       {
         runId: initialRun.runId,
         cliAgentType: "claude-code",
         cliAgentSessionId: `bdd-storage-cli-${initialRun.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
+        cliAgentSessionHistoryDisposition: "discarded_oversized",
         artifactSnapshots: [
           {
             name: initialMemory.name,
@@ -2795,6 +2792,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       prompt: "continue canonical storage session",
     });
     const sessionClaim = await api.claimRunnerJob(sessionRun.runId);
+    expect(sessionClaim.resumeSession).toBeNull();
     const sessionManifest = sessionClaim.storageManifest;
     if (!sessionManifest || !("storageMounts" in sessionManifest)) {
       throw new Error("Expected canonical mounts from session persistence");

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -367,21 +367,32 @@ export const createAgentCheckpoint$ = command(
       runStorageMounts: run.storageMounts,
       artifactSnapshots: input.body.artifactSnapshots,
     });
+    const historyHash = input.body.cliAgentSessionHistoryHash;
 
-    await db
-      .insert(blobs)
-      .values({
-        hash: input.body.cliAgentSessionHistoryHash,
-        rawSize: 0,
-        encoding: SESSION_HISTORY_ENCODING_IDENTITY,
-        encodedSize: 0,
-        refCount: 1,
-      })
-      .onConflictDoUpdate({
-        target: blobs.hash,
-        set: { refCount: sql`${blobs.refCount} + 1` },
-      });
-    signal.throwIfAborted();
+    if (historyHash !== undefined) {
+      await db
+        .insert(blobs)
+        .values({
+          hash: historyHash,
+          rawSize: 0,
+          encoding: SESSION_HISTORY_ENCODING_IDENTITY,
+          encodedSize: 0,
+          refCount: 1,
+        })
+        .onConflictDoUpdate({
+          target: blobs.hash,
+          set: { refCount: sql`${blobs.refCount} + 1` },
+        });
+      signal.throwIfAborted();
+    }
+
+    const historyFields =
+      historyHash === undefined
+        ? {
+            cliAgentSessionHistory: null,
+            cliAgentSessionHistoryHash: null,
+          }
+        : { cliAgentSessionHistoryHash: historyHash };
 
     const [conversation] = await db
       .insert(conversations)
@@ -389,14 +400,14 @@ export const createAgentCheckpoint$ = command(
         runId: input.body.runId,
         cliAgentType: input.body.cliAgentType,
         cliAgentSessionId: input.body.cliAgentSessionId,
-        cliAgentSessionHistoryHash: input.body.cliAgentSessionHistoryHash,
+        ...historyFields,
       })
       .onConflictDoUpdate({
         target: conversations.runId,
         set: {
           cliAgentType: input.body.cliAgentType,
           cliAgentSessionId: input.body.cliAgentSessionId,
-          cliAgentSessionHistoryHash: input.body.cliAgentSessionHistoryHash,
+          ...historyFields,
         },
       })
       .returning({ id: conversations.id });

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -47,6 +47,7 @@ export interface ChatThreadSessionResolution {
 interface HistoricalThreadSession {
   readonly sessionId: string;
   readonly conversationId: string | null;
+  readonly historylessConversation: boolean;
   readonly route: ChatThreadSessionRoute;
   readonly routeRunCreatedAt: Date;
 }
@@ -56,6 +57,18 @@ interface SessionRunRoute {
   readonly modelProvider: string | null;
   readonly modelProviderId: string | null;
   readonly createdAt: Date;
+}
+
+function isHistorylessConversation(snapshot: {
+  readonly conversationId: string | null;
+  readonly cliAgentSessionHistory: string | null;
+  readonly cliAgentSessionHistoryHash: string | null;
+}): boolean {
+  return (
+    snapshot.conversationId !== null &&
+    snapshot.cliAgentSessionHistory === null &&
+    snapshot.cliAgentSessionHistoryHash === null
+  );
 }
 
 function isKnownModelProvider(
@@ -135,6 +148,8 @@ async function latestHistoricalThreadSession(args: {
       modelProvider: zeroRuns.modelProvider,
       modelProviderId: zeroRuns.modelProviderId,
       cliAgentType: conversations.cliAgentType,
+      cliAgentSessionHistory: conversations.cliAgentSessionHistory,
+      cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
       routeRunCreatedAt: agentRuns.createdAt,
     })
     .from(zeroRuns)
@@ -162,6 +177,7 @@ async function latestHistoricalThreadSession(args: {
   return {
     sessionId: row.sessionId,
     conversationId: row.conversationId,
+    historylessConversation: isHistorylessConversation(row),
     route: {
       selectedModel: row.selectedModel,
       modelProvider: row.modelProvider,
@@ -266,10 +282,14 @@ function shouldRotateCanonicalSession(args: {
 async function shouldRotateResolvedSession(args: {
   readonly db: Db | ReadonlyDb;
   readonly orgId: string;
+  readonly historylessConversation: boolean;
   readonly previousRoute: ChatThreadSessionRoute;
   readonly nextRoute: ChatThreadSessionRoute;
   readonly previousRunCreatedAt: Date | null;
 }): Promise<boolean> {
+  if (args.historylessConversation) {
+    return true;
+  }
   const routeConfigurationChanged = await customSurfaceRouteChanged({
     db: args.db,
     orgId: args.orgId,
@@ -305,6 +325,8 @@ export async function resolveChatThreadSession(args: {
       routeRunId: zeroRuns.id,
       routeRunCreatedAt: agentRuns.createdAt,
       cliAgentType: conversations.cliAgentType,
+      cliAgentSessionHistory: conversations.cliAgentSessionHistory,
+      cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
       cloudBrowserEnabled: chatThreads.cloudBrowserEnabled,
     })
     .from(chatThreads)
@@ -355,6 +377,7 @@ export async function resolveChatThreadSession(args: {
     const rotate = await shouldRotateResolvedSession({
       db: args.db,
       orgId: args.orgId,
+      historylessConversation: isHistorylessConversation(thread),
       previousRoute,
       nextRoute: args.route,
       previousRunCreatedAt:
@@ -386,6 +409,7 @@ export async function resolveChatThreadSession(args: {
   const rotate = await shouldRotateResolvedSession({
     db: args.db,
     orgId: args.orgId,
+    historylessConversation: historical.historylessConversation,
     previousRoute: historical.route,
     nextRoute: args.route,
     previousRunCreatedAt: historical.routeRunCreatedAt,

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -15,6 +15,7 @@ import {
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 
+import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { Db, ReadonlyDb } from "../external/db";
 
 export interface ChatThreadSessionRoute {
@@ -59,16 +60,12 @@ interface SessionRunRoute {
   readonly createdAt: Date;
 }
 
-function isHistorylessConversation(snapshot: {
-  readonly conversationId: string | null;
-  readonly cliAgentSessionHistory: string | null;
-  readonly cliAgentSessionHistoryHash: string | null;
-}): boolean {
-  return (
-    snapshot.conversationId !== null &&
-    snapshot.cliAgentSessionHistory === null &&
-    snapshot.cliAgentSessionHistoryHash === null
-  );
+function historylessConversationSql() {
+  return sql`(
+    ${conversations.id} IS NOT NULL
+    AND ${conversations.cliAgentSessionHistory} IS NULL
+    AND ${conversations.cliAgentSessionHistoryHash} IS NULL
+  )`.mapWith(pgBooleanDecoder);
 }
 
 function isKnownModelProvider(
@@ -148,8 +145,7 @@ async function latestHistoricalThreadSession(args: {
       modelProvider: zeroRuns.modelProvider,
       modelProviderId: zeroRuns.modelProviderId,
       cliAgentType: conversations.cliAgentType,
-      cliAgentSessionHistory: conversations.cliAgentSessionHistory,
-      cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
+      historylessConversation: historylessConversationSql(),
       routeRunCreatedAt: agentRuns.createdAt,
     })
     .from(zeroRuns)
@@ -177,7 +173,7 @@ async function latestHistoricalThreadSession(args: {
   return {
     sessionId: row.sessionId,
     conversationId: row.conversationId,
-    historylessConversation: isHistorylessConversation(row),
+    historylessConversation: row.historylessConversation,
     route: {
       selectedModel: row.selectedModel,
       modelProvider: row.modelProvider,
@@ -325,8 +321,7 @@ export async function resolveChatThreadSession(args: {
       routeRunId: zeroRuns.id,
       routeRunCreatedAt: agentRuns.createdAt,
       cliAgentType: conversations.cliAgentType,
-      cliAgentSessionHistory: conversations.cliAgentSessionHistory,
-      cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
+      historylessConversation: historylessConversationSql(),
       cloudBrowserEnabled: chatThreads.cloudBrowserEnabled,
     })
     .from(chatThreads)
@@ -377,7 +372,7 @@ export async function resolveChatThreadSession(args: {
     const rotate = await shouldRotateResolvedSession({
       db: args.db,
       orgId: args.orgId,
-      historylessConversation: isHistorylessConversation(thread),
+      historylessConversation: thread.historylessConversation,
       previousRoute,
       nextRoute: args.route,
       previousRunCreatedAt:

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { ZipArchive } from "archiver";
 import { command, computed, type Computed } from "ccstate";
-import { and, asc, desc, eq, gt, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, or } from "drizzle-orm";
 import { chatEventCompatibilityRole } from "@vm0/api-contracts/contracts/chat-events";
 import type { UserMessageDocument } from "@vm0/api-contracts/contracts/chat-threads";
 import { RESUME_SESSION_HISTORY_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
@@ -822,7 +822,15 @@ async function collectConversationMessages(
       eq(conversations.id, agentSessions.conversationId),
     )
     .leftJoin(blobs, eq(conversations.cliAgentSessionHistoryHash, blobs.hash))
-    .where(eq(agentSessions.userId, userId))
+    .where(
+      and(
+        eq(agentSessions.userId, userId),
+        or(
+          isNotNull(conversations.cliAgentSessionHistory),
+          isNotNull(conversations.cliAgentSessionHistoryHash),
+        ),
+      ),
+    )
     .orderBy(asc(agentSessions.createdAt), asc(agentSessions.id));
   signal.throwIfAborted();
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../storages";
 import {
   ACTIVE_INPUT_DELIVERY_RECEIPT_MAX_IDS,
+  webhookCheckpointsContract,
   webhookCompleteContract,
   webhookStoragesCommitContract,
   webhookStoragesPrepareContract,
@@ -16,6 +17,50 @@ import {
 
 const storageId = "00000000-0000-4000-8000-000000000000";
 const manifestHash = "a".repeat(64);
+
+describe("agent checkpoint session history", () => {
+  const baseBody = {
+    runId: "00000000-0000-4000-8000-000000000000",
+    cliAgentType: "codex",
+    cliAgentSessionId: "00000000-0000-4000-8000-000000000001",
+  };
+
+  it("accepts exactly one uploaded hash or discarded disposition", () => {
+    expect(
+      webhookCheckpointsContract.create.body.safeParse({
+        ...baseBody,
+        cliAgentSessionHistoryHash: manifestHash,
+      }).success,
+    ).toBe(true);
+    expect(
+      webhookCheckpointsContract.create.body.safeParse({
+        ...baseBody,
+        cliAgentSessionHistoryDisposition: "discarded_oversized",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects missing, conflicting, and unknown history dispositions", () => {
+    const invalidBodies = [
+      baseBody,
+      {
+        ...baseBody,
+        cliAgentSessionHistoryHash: manifestHash,
+        cliAgentSessionHistoryDisposition: "discarded_oversized",
+      },
+      {
+        ...baseBody,
+        cliAgentSessionHistoryDisposition: "unknown",
+      },
+    ];
+
+    for (const body of invalidBodies) {
+      expect(
+        webhookCheckpointsContract.create.body.safeParse(body).success,
+      ).toBe(false);
+    }
+  });
+});
 
 function manifestFile(path: string) {
   return { path, hash: manifestHash, size: 0 };

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -720,13 +720,29 @@ export const webhookCheckpointsContract = c.router({
         runId: z.string().min(1, "runId is required"),
         cliAgentType: z.string().min(1, "cliAgentType is required"),
         cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
-        cliAgentSessionHistoryHash: sha256HexSchema,
+        cliAgentSessionHistoryHash: sha256HexSchema.optional(),
+        cliAgentSessionHistoryDisposition: z
+          .enum(["discarded_oversized"])
+          .optional(),
         // Multi-artifact snapshots are folded into canonical checkpoint mounts
         // and projected back into the legacy response shape.
         artifactSnapshots: artifactSnapshotsSchema.optional(),
         volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
       })
-      .strict(),
+      .strict()
+      .superRefine((body, ctx) => {
+        const hasHash = body.cliAgentSessionHistoryHash !== undefined;
+        const hasDisposition =
+          body.cliAgentSessionHistoryDisposition !== undefined;
+        if (hasHash === hasDisposition) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["cliAgentSessionHistoryHash"],
+            message:
+              "Exactly one session history hash or disposition is required",
+          });
+        }
+      }),
     responses: {
       200: z.object({
         checkpointId: z.string(),

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -238,6 +238,9 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain(
       "pub volume_versions_snapshot: Option<RequestVolumeVersionsSnapshot>,",
     );
+    expect(firstRender).toMatch(
+      /pub cli_agent_session_history_disposition:\n\s+Option<RequestCliAgentSessionHistoryDisposition>,/,
+    );
     expect(firstRender).toContain(
       "pub versions: std::collections::BTreeMap<String, String>,",
     );

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -1357,6 +1357,10 @@ function renderStructField(
 
   if (rustType.startsWith("Option<") && rustType.endsWith(">")) {
     const innerType = rustType.slice("Option<".length, -1);
+    const compactOption = `${indent}    Option<${innerType}>,`;
+    if (context.moduleIndentWidth + compactOption.length <= 100) {
+      return [`${indent}${visibility}${rustName}:`, compactOption];
+    }
     return [
       `${indent}${visibility}${rustName}: Option<`,
       `${indent}    ${innerType},`,

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -273,6 +273,17 @@ export const rustTypeBindings = [
         },
       },
       {
+        rustTypeName: "RequestCliAgentSessionHistoryDisposition",
+        rustDoc: [
+          "Reason a checkpoint intentionally omits resumable CLI agent session history.",
+        ],
+        variants: {
+          discarded_oversized: [
+            "The native history was oversized and had no safe bounded generation.",
+          ],
+        },
+      },
+      {
         rustTypeName: "Request",
         rustDoc: ["Request body for creating a recoverable agent checkpoint."],
         fields: {
@@ -282,7 +293,10 @@ export const rustTypeBindings = [
             "CLI agent session identifier being checkpointed.",
           ],
           cliAgentSessionHistoryHash: [
-            "SHA-256 hash of the uploaded CLI agent session history.",
+            "Optional SHA-256 hash of the uploaded CLI agent session history.",
+          ],
+          cliAgentSessionHistoryDisposition: [
+            "Optional reason resumable CLI agent session history was intentionally omitted.",
           ],
           artifactSnapshots: [
             "Optional artifact versions captured by the checkpoint.",

--- a/turbo/packages/db/src/schema/agent-run-session-conversation.ts
+++ b/turbo/packages/db/src/schema/agent-run-session-conversation.ts
@@ -165,7 +165,8 @@ export const agentSessions = pgTable(
  * Stores CLI agent conversation history for checkpoint resumption
  *
  * Session history storage strategy:
- * - New records use cliAgentSessionHistoryHash (R2 blob reference)
+ * - Resumable new records use cliAgentSessionHistoryHash (R2 blob reference)
+ * - Intentionally historyless checkpoints leave both history fields null
  * - Legacy records use cliAgentSessionHistory (TEXT field)
  * - Read logic: use the hash-backed path when present; use TEXT only for
  *   legacy rows that do not have a hash


### PR DESCRIPTION
## Summary

- extend the checkpoint webhook contract so a guest must provide exactly one uploaded history hash or the explicit `discarded_oversized` disposition
- let the guest discard only oversized Claude/Codex histories whose typed selector result proves that no bounded resumable generation is available, while skipping blob preparation/upload and leaving the native history file unchanged
- persist a successful historyless checkpoint with existing nullable conversation fields, preserve artifact/storage snapshots, and rotate later thread continuation into a fresh native session with recent chat context
- omit intentionally historyless sessions from user-data history exports so a valid discarded checkpoint cannot fail the whole export
- keep wrapped optional Rust binding fields generator- and rustfmt-stable so the additive contract remains reproducible in CI

## Deployment compatibility

- deploy the additive API contract before the guest; old guests continue sending the existing hash shape
- a new guest uses the disposition only on the previously failing oversized-history path, so an old API can reject that path during overlap without affecting ordinary checkpoints
- no database schema, migration, backfill, or new persisted field is introduced

## Exclusions

- no change to compact-generation selection or pruning rules
- no suppression of selector integrity, identity, filesystem, upload, artifact, or checkpoint API failures
- no change to small or safely compactable session histories
- no fabricated session-history entry in user exports when no resumable history was persisted

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts generate:python`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run` (28 files, 536 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @vm0/api-contracts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "rotates a canonical thread after an oversized history is discarded"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "persists canonical mounts across historyless session continuation"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/ops-logs.bdd.test.ts` (16 tests)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p api-contracts --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent -p api-contracts --no-deps --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration checkpoint::`
- runtime API schema compatibility check against the current `main` baseline
- repository pre-commit hooks, including full Turbo type checking and Knip

Closes #26465
