### PR TITLE
test(rust): make tracing capture deterministic

### DIFF
--- a/crates/tracing-test-support/src/lib.rs
+++ b/crates/tracing-test-support/src/lib.rs
@@ -32,7 +32,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use tracing::field::{Field, Visit};
-use tracing::{Event, Level, Subscriber};
+use tracing::{Dispatch, Event, Level, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 /// A structured tracing event captured by [`CapturedEvents`].
@@ -57,9 +57,22 @@ pub struct CapturedEvent {
 /// installed from any clone are therefore visible from every clone.
 ///
 /// [`Layer`]: tracing_subscriber::layer::Layer
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct CapturedEvents {
     events: Arc<Mutex<Vec<CapturedEvent>>>,
+    // Keep a second dispatch registered while a capture is active. Without it, tracing-core's
+    // single-dispatch fast path can cache Interest::Never when another thread first executes a
+    // callsite. See https://github.com/tokio-rs/tracing/issues/2874.
+    _callsite_interest_guard: Dispatch,
+}
+
+impl Default for CapturedEvents {
+    fn default() -> Self {
+        Self {
+            events: Arc::default(),
+            _callsite_interest_guard: Dispatch::new(tracing::subscriber::NoSubscriber::default()),
+        }
+    }
 }
 
 impl CapturedEvents {

--- a/crates/tracing-test-support/tests/callsite_interest.rs
+++ b/crates/tracing-test-support/tests/callsite_interest.rs
@@ -1,0 +1,40 @@
+use tracing::Dispatch;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
+
+fn emit_shared_callsite(marker: &'static str) {
+    tracing::warn!(marker, "shared callsite");
+}
+
+fn captured_markers(captured: &CapturedEvents) -> Vec<Option<String>> {
+    captured
+        .entries()
+        .into_iter()
+        .map(|event| event.fields.get("marker").cloned())
+        .collect()
+}
+
+#[test]
+fn captures_callsite_first_registered_on_uncaptured_thread() {
+    let first_capture = CapturedEvents::default();
+    let first_dispatch = Dispatch::new(tracing_subscriber::registry().with(first_capture.clone()));
+
+    std::thread::spawn(|| emit_shared_callsite("uncaptured"))
+        .join()
+        .expect("uncaptured event thread should finish");
+    tracing::dispatcher::with_default(&first_dispatch, || emit_shared_callsite("first"));
+
+    let second_capture = CapturedEvents::default();
+    let second_dispatch =
+        Dispatch::new(tracing_subscriber::registry().with(second_capture.clone()));
+    tracing::dispatcher::with_default(&second_dispatch, || emit_shared_callsite("second"));
+
+    assert_eq!(
+        captured_markers(&first_capture),
+        vec![Some("first".to_string())]
+    );
+    assert_eq!(
+        captured_markers(&second_capture),
+        vec![Some("second".to_string())]
+    );
+}


### PR DESCRIPTION
## Summary

- keep a no-op tracing dispatch alive for each `CapturedEvents` instance so callsites use per-dispatch interest instead of caching a global `never` interest
- add a deterministic integration regression test for a callsite first registered on an uncaptured thread
- keep the change confined to the shared Rust test-support crate; production runner behavior is unchanged

The workaround addresses the upstream tracing-core single-dispatch interest-cache behavior tracked in https://github.com/tokio-rs/tracing/issues/2874.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p tracing-test-support --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::connector_runtime_sync::tests -- --test-threads 4`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --workspace --no-deps --all-features`
- `cargo test --manifest-path crates/Cargo.toml --workspace --all-targets --all-features`

Closes #26532
