### PR TITLE
fix(python): preserve unbalanced base literal scope

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/patterns.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/patterns.py
@@ -43,6 +43,19 @@ def _is_invalid_greedy_param(
     return pattern_index != last_pattern_index or bool(prefix) or bool(suffix)
 
 
+def _segment_outer_literal_scope(seg: str) -> tuple[str, str]:
+    """Return literals that are structurally outside a segment's brace envelope."""
+    prefix, open_brace, _ = seg.partition("{")
+    if not open_brace or "}" in prefix:
+        prefix = ""
+
+    _, close_brace, suffix = seg.rpartition("}")
+    if not close_brace or "{" in suffix:
+        suffix = ""
+
+    return prefix, suffix
+
+
 def _parse_segment(seg: str) -> ParsedSegment:
     """Parse a single host or path segment into an immutable result."""
     open_count = seg.count("{")
@@ -51,7 +64,12 @@ def _parse_segment(seg: str) -> ParsedSegment:
     if open_count == 0 and close_count == 0:
         return SegmentLiteral(seg)
     if open_count != close_count:
-        return SegmentError(f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}')
+        prefix, suffix = _segment_outer_literal_scope(seg)
+        return SegmentError(
+            f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}',
+            prefix,
+            suffix,
+        )
 
     open1 = seg.find("{")
     close1 = seg.find("}")
@@ -59,10 +77,7 @@ def _parse_segment(seg: str) -> ParsedSegment:
         return SegmentError(f'unbalanced brace in segment "{seg}" — {_SEGMENT_ERROR_HINT}')
 
     if open_count >= _MULTI_PARAM_BRACE_COUNT:
-        prefix = seg[:open1]
-        suffix = seg[seg.rfind("}") + 1 :]
-        if "{" in suffix:
-            suffix = ""
+        prefix, suffix = _segment_outer_literal_scope(seg)
         open2 = seg.find("{", close1 + 1)
         if close1 + 1 == open2:
             return SegmentError(

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_base.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_base.py
@@ -203,9 +203,33 @@ def test_malformed_base_params_fail_closed_after_base_match(base, url):
             "https://api.example.com/us-prod-public/items",
             id="path-suffix",
         ),
+        pytest.param(
+            "https://api-{region}-{env.example.com",
+            "https://api-us-prod.example.com/items",
+            "https://evil.example.com/items",
+            id="unbalanced-open-host-prefix",
+        ),
+        pytest.param(
+            "https://{region}-env}-api.example.com",
+            "https://us-prod-api.example.com/items",
+            "https://us-prod-evil.example.com/items",
+            id="unbalanced-close-host-suffix",
+        ),
+        pytest.param(
+            "https://api.example.com/admin-{region}-{env",
+            "https://api.example.com/admin-us-prod/items",
+            "https://api.example.com/public/items",
+            id="unbalanced-open-path-prefix",
+        ),
+        pytest.param(
+            "https://api.example.com/{region}-env}-admin",
+            "https://api.example.com/us-prod-admin/items",
+            "https://api.example.com/us-prod-public/items",
+            id="unbalanced-close-path-suffix",
+        ),
     ],
 )
-def test_malformed_multi_param_base_respects_outer_literal_scope(
+def test_malformed_base_respects_outer_literal_scope(
     base,
     matched_url,
     unrelated_url,


### PR DESCRIPTION
## Summary

- preserve structurally safe outer prefix and suffix scope when unequal brace counts make a firewall base segment malformed
- reuse the existing `SegmentError` metadata and compiled mixed-segment matcher so in-scope malformed bases still fail closed
- add host and path regressions for excess-opening/excess-closing braces, prefix/suffix scope, unrelated requests, and in-scope requests

## Scope

- keeps the accepted connector grammar, public parser result, TypeScript parity, and other malformed segment categories unchanged
- introduces no API, persisted-state, migration, protocol, rollout, or new compatibility behavior
- keeps request matching on the existing prefix/suffix path with no new runtime matcher type

## Verification

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_compiled_firewall_malformed_base.py tests/test_firewall_semantics_contract.py tests/test_compiled_firewall_base_specificity_precedence.py` (252 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,342 passed)

Closes #26556
