### PR TITLE
refactor(cli): remove zero migration compatibility

### DIFF
--- a/.github/scripts/audit-okou-cli-cutover.sh
+++ b/.github/scripts/audit-okou-cli-cutover.sh
@@ -45,10 +45,9 @@ if [[ "${argv_status}" -ne 0 ]]; then
   exit "${argv_status}"
 fi
 
-compatibility_count=0
 internal_count=0
 historical_count=0
-fixture_count=0
+unsupported_user_owned_count=0
 unclassified_count=0
 
 while IFS=: read -r file line content; do
@@ -70,24 +69,14 @@ while IFS=: read -r file line content; do
       ;;
   esac
 
-  if [[ -z "${category}" && "${content}" == *"okou-cutover-audit: compatibility-only"* ]]; then
-    category="compatibility-only"
-    compatibility_count=$((compatibility_count + 1))
-  fi
-
-  if [[ -z "${category}" && "${file}" == ".github/scripts/smoke-okou-cli-artifact.sh" && "${content}" == "  zero \\" ]]; then
-    category="compatibility-only"
-    compatibility_count=$((compatibility_count + 1))
-  fi
-
   if [[ -z "${category}" && "${content}" == *"okou-cutover-audit: historical"* ]]; then
     category="historical"
     historical_count=$((historical_count + 1))
   fi
 
-  if [[ -z "${category}" && "${content}" == *"okou-cutover-audit: test-fixture"* ]]; then
-    category="test-fixture"
-    fixture_count=$((fixture_count + 1))
+  if [[ -z "${category}" && "${content}" == *"okou-cutover-audit: unsupported-user-owned"* ]]; then
+    category="unsupported-user-owned"
+    unsupported_user_owned_count=$((unsupported_user_owned_count + 1))
   fi
 
   if [[ -z "${category}" && "${content}" =~ /zero[[:space:]]+model ]]; then
@@ -114,6 +103,71 @@ while IFS= read -r file; do
   unclassified_count=$((unclassified_count + 1))
 done <"${legacy_argv_file}"
 
+report_boundary_failure() {
+  local file="$1"
+  local detail="$2"
+  printf 'unclassified %s:%s\n' "${file}" "${detail}"
+  unclassified_count=$((unclassified_count + 1))
+}
+
+cli_package_path="turbo/apps/cli/package.json"
+if [[ -f "${repo_root}/${cli_package_path}" ]] &&
+  ! jq -e '
+    .bin == {okou: "./dist/okou.js"}
+    and (.scripts.postbuild | type == "string")
+    and ((.scripts.postbuild | contains("zero")) | not)
+  ' "${repo_root}/${cli_package_path}" >/dev/null; then
+  report_boundary_failure "${cli_package_path}" "legacy executable export or packed metadata"
+fi
+
+cli_entrypoint_path="turbo/apps/cli/src/okou.ts"
+if [[ -f "${repo_root}/${cli_entrypoint_path}" ]] &&
+  rg -q 'endsWith\("zero(\.js|\.ts)?"\)' "${repo_root}/${cli_entrypoint_path}"; then
+  report_boundary_failure "${cli_entrypoint_path}" "legacy executable path detection"
+fi
+
+artifact_verifier_path=".github/scripts/verify-okou-cli-artifact.sh"
+if [[ -f "${repo_root}/${artifact_verifier_path}" ]] &&
+  (! rg -q -F 'and ((.bin | keys) == ["okou"])' "${repo_root}/${artifact_verifier_path}" ||
+    ! rg -q -F "grep -Fxq 'package/zero.js'" "${repo_root}/${artifact_verifier_path}"); then
+  report_boundary_failure "${artifact_verifier_path}" "single-bin or no-zero.js invariant missing"
+fi
+
+artifact_smoke_path=".github/scripts/smoke-okou-cli-artifact.sh"
+if [[ -f "${repo_root}/${artifact_smoke_path}" ]] &&
+  (! rg -q -F 'assert_clean_success okou okou-help --help' "${repo_root}/${artifact_smoke_path}" ||
+    ! rg -q -F 'assert_clean_success okou okou-agent-loop-help __agent-loop --help' "${repo_root}/${artifact_smoke_path}" ||
+    ! rg -q -F 'assert_unsupported_entrypoint zero zero-help --help' "${repo_root}/${artifact_smoke_path}" ||
+    rg -q 'assert_clean_success[[:space:]]+zero([[:space:]]|$)' "${repo_root}/${artifact_smoke_path}"); then
+  report_boundary_failure "${artifact_smoke_path}" "canonical success or legacy rejection boundary missing"
+fi
+
+local_deploy_test_path=".github/scripts/tests/deploy-cli-local-test.sh"
+if [[ -f "${repo_root}/${local_deploy_test_path}" ]] &&
+  ! rg -q -F 'and ((.bin | keys) == ["okou"])' "${repo_root}/${local_deploy_test_path}"; then
+  report_boundary_failure "${local_deploy_test_path}" "single-bin package assertion missing"
+fi
+
+turbo_workflow_path=".github/workflows/turbo.yml"
+if [[ -f "${repo_root}/${turbo_workflow_path}" ]] &&
+  (rg -q -F '"$node_prefix/bin/zero"' "${repo_root}/${turbo_workflow_path}" ||
+    ! rg -q -F 'okou __agent-loop --help' "${repo_root}/${turbo_workflow_path}"); then
+  report_boundary_failure "${turbo_workflow_path}" "legacy symlink present or canonical loop smoke missing"
+fi
+
+e2e_setup_path="e2e/helpers/setup.bash"
+if [[ -f "${repo_root}/${e2e_setup_path}" ]] &&
+  rg -q -F 'ZERO_CLI' "${repo_root}/${e2e_setup_path}"; then
+  report_boundary_failure "${e2e_setup_path}" "legacy E2E command wrapper"
+fi
+
+e2e_trace_path="e2e/helpers/trace-cli.sh"
+if [[ -f "${repo_root}/${e2e_trace_path}" ]] &&
+  (! rg -q -F 'CLI_ENTRYPOINT="okou"' "${repo_root}/${e2e_trace_path}" ||
+    rg -q -F '<okou|zero>' "${repo_root}/${e2e_trace_path}"); then
+  report_boundary_failure "${e2e_trace_path}" "legacy entry-point selection"
+fi
+
 guest_agent_path="crates/guest-agent/src/cli/pi_agent_loop.rs"
 if rg -q -F '"zero".to_string()' "${repo_root}/${guest_agent_path}"; then
   echo "unclassified ${guest_agent_path}: guest-agent still invokes zero" >&2
@@ -124,11 +178,10 @@ if ! rg -q -F '"okou".to_string()' "${repo_root}/${guest_agent_path}"; then
   unclassified_count=$((unclassified_count + 1))
 fi
 
-printf 'summary compatibility-only=%s approved-internal-protocol=%s historical=%s test-fixture=%s unclassified=%s\n' \
-  "${compatibility_count}" \
+printf 'summary approved-internal-protocol=%s historical=%s unsupported-user-owned=%s unclassified=%s\n' \
   "${internal_count}" \
   "${historical_count}" \
-  "${fixture_count}" \
+  "${unsupported_user_owned_count}" \
   "${unclassified_count}"
 
 if [[ "${unclassified_count}" -ne 0 ]]; then

--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -16,12 +16,25 @@ package_path="$(cd "$(dirname "$package_path")" && pwd -P)/$(basename "$package_
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
+node_path="$(command -v node)"
+npx_path="$(command -v npx)"
+clean_bin="${tmp_dir}/bin"
+mkdir -p "$clean_bin"
+ln -s "$node_path" "$clean_bin/node"
+clean_path="${clean_bin}:/usr/bin:/bin"
+
+if PATH="$clean_path" command -v zero >/dev/null 2>&1; then
+  echo "Clean CLI smoke environment unexpectedly contains zero" >&2
+  exit 1
+fi
+
 run_cli() {
   local entrypoint="$1"
   local stdout_file="$2"
   local stderr_file="$3"
   shift 3
-  npx --yes --package="$package_path" "$entrypoint" "$@" \
+  PATH="$clean_path" "$node_path" "$npx_path" \
+    --yes --package="$package_path" "$entrypoint" "$@" \
     >"$stdout_file" 2>"$stderr_file"
 }
 
@@ -45,19 +58,37 @@ assert_clean_success() {
   fi
 }
 
+assert_unsupported_entrypoint() {
+  local entrypoint="$1"
+  local output_name="$2"
+  shift 2
+  local status=0
+  run_cli \
+    "$entrypoint" \
+    "$tmp_dir/${output_name}.stdout" \
+    "$tmp_dir/${output_name}.stderr" \
+    "$@" || status=$?
+  if ((status == 0)); then
+    echo "Unsupported CLI entry point unexpectedly succeeded: $entrypoint $*" >&2
+    exit 1
+  fi
+  if grep -Fq "Usage: okou" \
+    "$tmp_dir/${output_name}.stdout" \
+    "$tmp_dir/${output_name}.stderr"; then
+    echo "Unsupported CLI entry point reached the Okou implementation: $entrypoint $*" >&2
+    exit 1
+  fi
+}
+
 assert_clean_success okou okou-help --help
-assert_clean_success zero zero-help --help # okou-cutover-audit: compatibility-only
-cmp "$tmp_dir/okou-help.stdout" "$tmp_dir/zero-help.stdout"
 grep -Fq "Usage: okou" "$tmp_dir/okou-help.stdout"
 grep -Fq "Okou CLI" "$tmp_dir/okou-help.stdout"
 
 assert_clean_success okou okou-version --version
-assert_clean_success zero zero-version --version # okou-cutover-audit: compatibility-only
-cmp "$tmp_dir/okou-version.stdout" "$tmp_dir/zero-version.stdout"
 grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+' "$tmp_dir/okou-version.stdout"
 
-assert_clean_success zero zero-agent-loop-help __agent-loop --help # okou-cutover-audit: compatibility-only
-grep -Fq -- "--standby" "$tmp_dir/zero-agent-loop-help.stdout"
+assert_clean_success okou okou-agent-loop-help __agent-loop --help
+grep -Fq -- "--standby" "$tmp_dir/okou-agent-loop-help.stdout"
 
 okou_error_status=0
 run_cli \
@@ -65,21 +96,11 @@ run_cli \
   "$tmp_dir/okou-error.stdout" \
   "$tmp_dir/okou-error.stderr" \
   __unsupported-command || okou_error_status=$?
-zero_error_status=0
-run_cli \
-  zero \
-  "$tmp_dir/zero-error.stdout" \
-  "$tmp_dir/zero-error.stderr" \
-  __unsupported-command || zero_error_status=$?
-if ((okou_error_status == 0 || zero_error_status == 0)); then
+if ((okou_error_status == 0)); then
   echo "Unsupported CLI command unexpectedly succeeded" >&2
   exit 1
 fi
-if ((okou_error_status != zero_error_status)); then
-  echo "Okou and Zero alias exit codes differ" >&2
-  exit 1
-fi
-cmp "$tmp_dir/okou-error.stdout" "$tmp_dir/zero-error.stdout"
-cmp "$tmp_dir/okou-error.stderr" "$tmp_dir/zero-error.stderr"
 
-echo "Smoke-tested canonical okou and temporary zero CLI entry points"
+assert_unsupported_entrypoint zero zero-help --help
+
+echo "Smoke-tested the canonical okou CLI and unsupported zero boundary"

--- a/.github/scripts/tests/audit-okou-cli-cutover-test.sh
+++ b/.github/scripts/tests/audit-okou-cli-cutover-test.sh
@@ -30,7 +30,8 @@ git -C "${fixture_root}" init -q
 git -C "${fixture_root}" config user.email "okou-audit@example.com"
 git -C "${fixture_root}" config user.name "Okou audit"
 
-fixture_command="run \`zero workflow list --token DO_NOT_PRINT_THIS\`" # okou-cutover-audit: test-fixture
+legacy_entrypoint="$(printf '%s%s' ze ro)"
+fixture_command="run \`${legacy_entrypoint} workflow list --token DO_NOT_PRINT_THIS\`"
 printf '%s\n' "${fixture_command}" >"${fixture_root}/producer.md"
 printf '%s\n' 'let args = vec!["okou".to_string()];' \
   >"${fixture_root}/crates/guest-agent/src/cli/pi_agent_loop.rs"
@@ -61,9 +62,11 @@ grep -Fq 'okou cutover audit could not scan' "${audit_output}"
 git -C "${fixture_root}" rm --cached -q -f -- missing-input.md
 
 printf '%s\n' \
-  "run \`zero workflow list\` <!-- okou-cutover-audit: test-fixture -->" \
+  "run \`${legacy_entrypoint} workflow list\` <!-- okou-cutover-audit: unsupported-user-owned -->" \
   >"${fixture_root}/producer.md"
-"${audit_script}" "${fixture_root}" >/dev/null
+"${audit_script}" "${fixture_root}" >"${audit_output}"
+grep -Fq 'unsupported-user-owned producer.md:1' "${audit_output}"
+grep -Fq 'unsupported-user-owned=1 unclassified=0' "${audit_output}"
 
 legacy_program="$(printf '  \"%s%s\",' ze ro)"
 printf '%s\n' 'const argv = ["node",' "${legacy_program}" '  "list",' '];' \
@@ -75,5 +78,23 @@ fi
 grep -Fq 'unclassified argv.ts:legacy-node-zero-argv' "${audit_output}"
 rm -f -- "${fixture_root}/argv.ts"
 "${audit_script}" "${fixture_root}" >/dev/null
+
+mkdir -p "${fixture_root}/turbo/apps/cli"
+printf '%s\n' \
+  '{' \
+  '  "bin": {' \
+  '    "okou": "./dist/okou.js",' \
+  "    \"${legacy_entrypoint}\": \"./dist/okou.js\"" \
+  '  },' \
+  '  "scripts": {' \
+  '    "postbuild": "pack both entry points"' \
+  '  }' \
+  '}' >"${fixture_root}/turbo/apps/cli/package.json"
+if "${audit_script}" "${fixture_root}" >"${audit_output}" 2>&1; then
+  echo "audit unexpectedly accepted a legacy package export" >&2
+  exit 1
+fi
+grep -Fq 'unclassified turbo/apps/cli/package.json:legacy executable export or packed metadata' \
+  "${audit_output}"
 
 echo "okou cutover audit tests passed"

--- a/.github/scripts/tests/deploy-cli-local-test.sh
+++ b/.github/scripts/tests/deploy-cli-local-test.sh
@@ -39,7 +39,7 @@ cat >"${test_root}/turbo/apps/cli/dist/package.json" <<'EOF'
   "name": "@vm0/okou-cli",
   "version": "1.0.0",
   "private": true,
-  "bin": { "okou": "okou.js", "zero": "okou.js" },
+  "bin": { "okou": "okou.js" },
   "files": ["*.js"]
 }
 EOF
@@ -117,9 +117,8 @@ package_json="$(tar -xOf "${tmp_dir}/package.tgz" package/package.json)"
 jq -e '
   .name == "@vm0/okou-cli"
   and .private == true
-  and ((.bin | keys | sort) == ["okou", "zero"])
+  and ((.bin | keys) == ["okou"])
   and .bin.okou == "okou.js"
-  and .bin.zero == "okou.js"
 ' <<<"$package_json" >/dev/null
 
 echo "deploy-cli-local tests passed"

--- a/.github/scripts/verify-okou-cli-artifact.sh
+++ b/.github/scripts/verify-okou-cli-artifact.sh
@@ -58,9 +58,8 @@ jq -e '
   .name == "@vm0/okou-cli"
   and .private == true
   and (.bin | type == "object")
-  and ((.bin | keys | sort) == ["okou", "zero"])
+  and ((.bin | keys) == ["okou"])
   and .bin.okou == "okou.js"
-  and .bin.zero == "okou.js"
   and ((.dependencies // {}) | length == 0)
   and ((.optionalDependencies // {}) | length == 0)
   and ((.peerDependencies // {}) | length == 0)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -236,6 +236,7 @@ jobs:
             .github/scripts/run-semgrep.sh \
             .github/scripts/runner-behavior-*.sh \
             .github/scripts/smoke-okou-cli-artifact.sh \
+            .github/scripts/verify-okou-cli-artifact.sh \
             .github/scripts/verify-okou-desktop-artifact.sh \
             .github/scripts/tests/ansible-ssh-control-path-test.sh \
             .github/scripts/tests/audit-okou-cli-cutover-test.sh \
@@ -247,6 +248,7 @@ jobs:
             .github/scripts/tests/cloudflare-ssh-preconnect-test.sh \
             .github/scripts/tests/cloudflare-ssh-proxy-test.sh \
             .github/scripts/tests/deploy-desktop-workflow-test.sh \
+            .github/scripts/tests/deploy-cli-local-test.sh \
             .github/scripts/tests/deploy-okou-pages-test.sh \
             .github/scripts/tests/deploy-okou-pages-workflow-test.sh \
             .github/scripts/tests/fetch-okou-desktop-artifact-test.sh \
@@ -257,6 +259,7 @@ jobs:
             .github/scripts/tests/semgrep-results-test.sh \
             .github/scripts/tests/runner-behavior-balloon-test.sh \
             e2e/helpers/browser.bash \
+            e2e/helpers/trace-cli.sh \
             e2e/tests/02-browser/brw-t01-platform-e2e.bats
           # actionlint assumes Bash when shell is omitted and does not model the
           # sh default used by container jobs.

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2215,10 +2215,8 @@ jobs:
           sudo cp -a "$package_root/package" "$cli_dir"
           sudo chmod +x "$cli_dir/okou.js"
           sudo ln -sf "$cli_dir/okou.js" "$node_prefix/bin/okou"
-          sudo ln -sf "$cli_dir/okou.js" "$node_prefix/bin/zero"
           okou --help
-          zero --help # okou-cutover-audit: compatibility-only
-          zero __agent-loop --help # okou-cutover-audit: compatibility-only
+          okou __agent-loop --help
       - name: Run Serial E2E Tests
         run: |
           echo "=== Running Serial E2E Tests ==="

--- a/crates/guest-agent/tests/pi_standby_okou_command.rs
+++ b/crates/guest-agent/tests/pi_standby_okou_command.rs
@@ -14,7 +14,7 @@ use std::os::unix::fs::PermissionsExt;
 
 #[tokio::test]
 async fn pi_standby_launches_canonical_okou_entrypoint() -> Result<(), Box<dyn std::error::Error>> {
-    const PACKAGE_URL: &str = "https://static.vm0.io/okou-cli/dual-entry-test/package.tgz";
+    const PACKAGE_URL: &str = "https://static.vm0.io/okou-cli/okou-only-test/package.tgz";
     const SYSTEM_PROMPT: &str = "fixed Pi command-boundary prompt";
     const SKILL_DIGEST: &str = "sha256:pi-command-boundary-snapshot";
 

--- a/docs/okou-cli-cutover.md
+++ b/docs/okou-cli-cutover.md
@@ -1,137 +1,111 @@
-# Okou first-party producer cutover
+# Okou CLI current identity
 
-This document is the authoritative source audit and deployment-compatibility
-record for issue #26432. It covers the first-party producer cutover only. The
-temporary `zero` executable remains available until the production drain gate
-for child C is proven.
+This document is the authoritative source, residual, and rollback record for
+the completed Okou CLI identity cutover tracked by issues #26429 and #26431.
 
-## Foundation
+## Supported command boundary
 
-The cutover starts from release commit
-`916a75a6910fb873b17b3c07e7dbb9bdf61ad15e`, which contains Task A merge
-`c41cbe9f9ce38ee1bc9266f3fd1cfa5ac95e26c7`. Production selected the immutable
-dual-entry artifact at
-`https://static.vm0.io/okou-cli/916a75a6910fb873b17b3c07e7dbb9bdf61ad15e/package.tgz`.
-Its manifest SHA-256 is
-`afb3206d491ba9686512af3eb132c2797f8e2cf57ef509967a6885d86dc116c9`.
-Production and independent CDN checks executed `okou`, the temporary `zero`
-alias, and the old `zero __agent-loop` boundary from that artifact. <!-- okou-cutover-audit: compatibility-only -->
+The private commit-addressed package exports only `okou`, mapped to
+`okou.js`. Current artifacts contain no duplicate `zero.js` payload, and the
+retired executable name is unsupported. The artifact smoke test exercises the
+real `okou --help` and `okou __agent-loop` boundaries and separately proves
+that the retired name cannot resolve in a clean command environment.
 
-## Deployment compatibility
+Commander parsing, validation, output, HTTP construction, and exit behavior
+remain covered through the canonical entry point. MSW stays at the production
+HTTP boundary. The guest-agent process-boundary integration test asserts the
+exact `npx`, package URL, `okou`, internal loop, and standby argv.
 
-| API / release artifact                             | Runner or guest-agent | Expected entry point | Evidence                                                                                                                                                                                                               |
-| -------------------------------------------------- | --------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| New API with dual-entry artifact                   | New Runner            | `okou __agent-loop`  | The guest-agent process-boundary integration test puts a fake `npx` on `PATH` and asserts the exact Pi standby launch argv. The Runner E2E separately exercises the canonical user command and real CLI HTTP boundary. |
-| New API with dual-entry artifact                   | Old Runner            | `zero __agent-loop`  | The artifact smoke test and Runner E2E execute the legacy internal boundary. <!-- okou-cutover-audit: compatibility-only -->                                                                                           |
-| Old API selecting the recorded dual-entry artifact | New Runner            | `okou __agent-loop`  | Safe because both entry points are present in the immutable artifact.                                                                                                                                                  |
-| Old API selecting a pre-Okou artifact              | New Runner            | unsupported          | Never deploy this pairing. Roll API and Runner back together to an old/old pairing instead.                                                                                                                            |
+## Final removal gate
 
-Old queued and active execution contexts keep their immutable historical
-artifact URL. They are not rewritten and continue with the Runner and artifact
-pairing admitted for that execution.
+The final removal gate passed in the
+[#26431 authorization record](https://github.com/vm0-ai/vm0/issues/26431#issuecomment-5264650228).
+The owner explicitly superseded only the remaining elapsed-time wait; the live
+production, source, durable-content, artifact, health, and rollback checks all
+passed before implementation was authorized.
 
-The command-boundary suites execute Commander parsing, validation, output,
-request construction, and exit behavior. MSW stays at the production HTTP
-boundary. No command arguments are added to Runner E2E trace output.
+The recorded delivery and production evidence is:
 
-## Supported producer audit
+- child A PR #26436 and release #26446 completed;
+- child B PR #26491 and initial release #26506 completed;
+- the latest fully released dual-entry rollback baseline is release #26540 at
+  commit `a08e28cc84dc44a8f28db7571282aad2fd3c8d26`;
+- production contained no Runner version that invoked the retired executable,
+  and pre-cutoff pending, queued, running, finalizing, agent-run queue, and
+  Runner-job queue state was zero;
+- the complete finalization audit matched 184 starts to 184 successful terminal
+  outcomes with no failed or cancelled finalization;
+- the bounded production health audit exceeded the agreed success threshold
+  for both agent and CLI execution and found no systemic Okou failure; and
+- the supported durable source audit was clean at vm0-skills commit
+  `68f64b677e935de2c5195e1df4683edbd2bdd18b`.
 
-The following repository-controlled sources now emit `okou`:
+## Supported caller decision
 
-- guest-agent and Pi standby bootstrap;
-- API-authored system prompts, templates, run guidance, callback examples,
-  recovery hints, and plan-upgrade guidance;
-- CLI help, examples, generated commands, authoring instructions, recovery
-  guidance, service identity, and MCP client identity;
-- in-repository seed metadata, resource indexes, fixtures, platform mocks,
-  E2E operations, development tooling, and current operational documentation.
+All repository-controlled prompts, errors, skills, templates, workflows,
+instructions, tests, operational commands, and Runner bootstrap paths use
+Okou. The supported vm0-skills command tree also uses Okou; retired unsupported
+command trees were removed in their owning repository.
 
-The executable audit is
-`.github/scripts/audit-okou-cli-cutover.sh`. It scans the current command tree
-and retired command spellings across tracked and
-untracked non-ignored files, checks the guest-agent
-bootstrap directly, prints only category plus file and line number, and fails
-on an unclassified reference. It never prints command arguments, secrets,
-identifiers, or content. Its shell test proves both the failure boundary and
-the output-redaction property. Security CI runs the audit explicitly after
-installing `ripgrep`; the hot Turbo toolchain job does not install network
-dependencies for it.
+Arbitrary user-owned persisted workflows, instructions, and templates are not
+rewritten. A legacy executable string in that content is explicitly
+unsupported until its owner deliberately migrates it. Historical execution
+contexts retain their immutable commit-addressed artifact and are not rewritten.
 
-The external first-party durable source `vm0-ai/vm0-skills` was audited at
-commit `8efee9aaeedbcd5a372401679beac740daad9101`. Sixteen files contained 149
-executable legacy references:
+## Preserved protocol identities
 
-- current command-tree references: `agentphone/SKILL.md`,
-  `computer-use/SKILL.md`, `finicity/SKILL.md`, `gen/SKILL.md`,
-  `github-copilot/SKILL.md`, `goal/SKILL.md`, `google-slides/SKILL.md`,
-  `illustration-template/cozy-parlor/SPEC.md`, `lovart/SKILL.md`,
-  `nano-banana/SKILL.md`, `seedance/SKILL.md`, `workflow-setup/SKILL.md`, and
-  `workflow-setup/references/trigger-setup.md`;
-- unsupported retired npm command trees: `local-agent/SKILL.md` and
-  `local-browser/SKILL.md`, plus the `local-agent` marketplace registration.
-
-The 13 current command-tree files contained 115 references. The companion
-owning-repository change
-[`vm0-ai/vm0-skills#323`](https://github.com/vm0-ai/vm0-skills/pull/323)
-migrates every one to `okou`. The two retired npm
-command trees and marketplace registration contained the other 34 references.
-Because neither command is registered by the current CLI and npm publication
-remains retired, the companion change removes both obsolete skills and the
-registration rather than presenting them as Okou commands. No supported
-first-party executable legacy reference remains in that audited source.
-
-Repository-controlled seed metadata has been updated. Arbitrary user-owned
-workflow bodies, instructions, and templates are not rewritten: their meaning
-cannot be established from an embedded string alone. A user-owned legacy
-command is unsupported content until its owner deliberately migrates it. Old
-execution contexts are historical immutable content, not migration targets.
+The executable cleanup does not rename internal protocol or product identities.
+Keep the `OKOU_TOKEN` preference with `ZERO_TOKEN` fallback, both token scopes,
+`OKOU_AGENT_ID` and `ZERO_AGENT_ID`, paired deployment environment injection,
+canonical `OKOU_*` names and `/api/okou/**`, `commands/zero`,
+`decodeZeroTokenPayload`, other `ZERO_*` names and `/api/zero/**`, database and
+backend identifiers, the Slack `/zero model` interaction, and the separate
+Desktop identity. These are not executable CLI producers.
 
 ## Exact residual classification
 
-- **Compatibility-only:** the packed `zero` alias, artifact/workflow smoke
-  checks, serial CLI alias tests, old-Runner `zero __agent-loop` coverage, and <!-- okou-cutover-audit: compatibility-only -->
-  compatibility documentation.
-- **Approved internal protocol:** canonical `OKOU_*` environment variables,
-  Okou token scope, and `/api/okou/**`; compatibility-only `ZERO_*`, Zero token
-  scope, and `/api/zero/**`; plus `commands/zero`, database and backend domain
-  identifiers, and the Slack `/zero model` interaction. The separate Zero
-  Computer Use Desktop product identity is also outside this CLI cutover.
-  These are not executable CLI producers.
-- **Historical:** changelogs, migration notes, retired `zero secret`, <!-- okou-cutover-audit: historical -->
-  `zero variable`, `zero schedule`, and `zero automation` documentation, plus <!-- okou-cutover-audit: historical -->
-  immutable old execution contexts.
-- **Unsupported user-owned content:** arbitrary persisted text that still names
-  the legacy entry point. It is not rewritten automatically.
-- **External first-party durable content:** the 13 supported `vm0-skills`
-  sources listed above are migrated by the companion change; the two retired
-  npm command-tree skills are removed. They are not treated as user-owned text
-  and leave no external first-party executable residual.
+`.github/scripts/audit-okou-cli-cutover.sh` scans tracked and untracked
+non-ignored current source, checks the guest-agent argv, and rejects indirect
+binary exports, executable-path selection, artifact-verifier drift, legacy
+success smoke coverage, workflow symlinks, and E2E wrapper selection. It prints
+only category, file, and line or boundary name; it never prints arguments,
+secrets, identifiers, or user content.
 
-The in-repository audit must report zero unclassified references before merge.
+The final current-source result is:
 
-## Production evidence required before child C
+`approved-internal-protocol=33 historical=241 unsupported-user-owned=0 unclassified=0`
 
-After this child merges and releases, record all of the following on the issue:
+The only allowed residual classes are:
 
-1. The child B merge commit, release commit, exact Turbo run, and exact
-   release-please run with terminal conclusions.
-2. The production API deployment and exact immutable CLI artifact URL and
-   manifest digest it selects.
-3. Deployed Runner versions and a command-boundary production proof that newly
-   admitted work uses an Okou-invoking guest-agent. The evidence may record the
-   entry-point category and bounded counts, but must not record arguments,
-   secrets, identifiers, or user content.
-4. API and Runner cutover timestamps, queue state, active execution state, and
-   finalization state. Derive and cite the conservative maximum lifetime from
-   the then-current queue, execution, and finalization source; elapsed time by
-   itself is not drain proof.
-5. A rerun of both repository audits, confirmation that the companion
-   `vm0-skills` migration is deployed to the durable-content source, and the
-   remaining production legacy-entry evidence.
-6. Proof that no old Runner can claim new work and that all work admitted under
-   an old pairing is terminal before removing the alias.
+- **Approved internal protocol:** the preserved identities listed above. They
+  are not executable command producers.
+- **Historical evidence:** changelogs, archived implementation notes, and
+  immutable historical records and artifacts.
+- **Explicitly unsupported user-owned content:** persisted user-authored text
+  outside the tracked current source. It is not migrated automatically.
 
-Rollback to the last known-good dual-entry release
-`916a75a6910fb873b17b3c07e7dbb9bdf61ad15e`. Never pair an Okou-invoking new
-Runner with a pre-Okou artifact. A rollback past the dual-entry foundation must
-roll both API and Runner back to a compatible old/old pair.
+There is no compatibility-only or tracked executable test-fixture residual
+class. Synthetic legacy commands are assembled only at audit-test runtime so
+detection and redaction remain covered without storing an executable legacy
+command in current source.
+
+## Artifacts and rollback
+
+Historical R2 artifacts are immutable and must not be changed or deleted. The
+last known-good dual-entry rollback artifact is:
+
+`https://static.vm0.io/okou-cli/a08e28cc84dc44a8f28db7571282aad2fd3c8d26/package.tgz`
+
+Its package SHA-256 is
+`2e822e4eda86a34f3794d79318369f2f0e43aa33d1b64fa07f2d72c866b7f67b`,
+and its manifest SHA-256 is
+`a43201ed1d9d86cb656ef5be9444af60dc4cbe9e4501123610f1d0ff7d515a9f`.
+
+Rollback after an Okou-only release must restore that artifact selection
+together with compatible post-B API, Runner, and guest-agent versions. Never
+pair an Okou-invoking Runner with a pre-Okou artifact. Do not mutate or delete
+Run, queue, workflow, audit, or historical artifact state during recovery.
+
+The release owner must attach the final Okou-only production release, artifact,
+and Runner-path evidence to #26431 and #26429 after this cleanup merges. Source
+readiness does not itself claim that the final production release has happened.

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -5,8 +5,8 @@
 Deployed E2E tests exercise the product exactly through supported user-facing
 entry points. The current suite covers:
 
-- the packaged canonical `okou` binary and temporary `zero` alias through
-  unauthenticated command-boundary smoke checks;
+- the packaged canonical `okou` binary through unauthenticated command-boundary
+  smoke checks, including rejection of the retired executable name;
 - Clerk sign-up and sign-in through the hosted form UI;
 - onboarding, chat submission, runner dispatch, and the assistant result through
   the deployed web application;

--- a/docs/testing/cli-testing.md
+++ b/docs/testing/cli-testing.md
@@ -2,9 +2,9 @@
 
 ## Principle
 
-The private CLI package exposes canonical `okou` and a temporary `zero`
-compatibility entry point backed by the same implementation. Command tests are
-integration tests that enter through Commander with `command.parseAsync()`.
+The private CLI package exposes only the canonical `okou` entry point. Command
+tests are integration tests that enter through Commander with
+`command.parseAsync()`.
 
 - Mock the Web API with MSW.
 - Keep command parsing, validation, formatting, and filesystem behavior real.
@@ -31,8 +31,8 @@ src/commands/zero/
 ## Authentication and routing
 
 Product CLI requests prefer `OKOU_TOKEN` and retain `ZERO_TOKEN` as a
-compatibility fallback. Current-command tests should set the canonical name
-explicitly together with the API URL:
+protocol fallback. Tests should set the canonical token explicitly together
+with the API URL unless they are covering that fallback:
 
 ```typescript
 beforeEach(() => {
@@ -47,7 +47,7 @@ afterEach(() => {
 
 Do not create `~/.vm0/config.json`, set `VM0_TOKEN`, or mock the config module.
 Tests for missing authentication should leave both token names unset and assert
-the resulting guidance. Keep focused compatibility coverage that sets only
+the resulting guidance. Keep focused protocol coverage that sets only
 `ZERO_TOKEN` and proves the fallback still reaches the canonical Okou path.
 
 ## Command integration pattern
@@ -114,7 +114,7 @@ HTTP request, and filesystem changes.
 Use the real filesystem under a temporary directory:
 
 ```typescript
-const tempDir = mkdtempSync(path.join(os.tmpdir(), "zero-cli-test-"));
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "okou-cli-test-"));
 const previousCwd = process.cwd();
 process.chdir(tempDir);
 

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -5,6 +5,5 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 load "${TEST_ROOT}/test/libs/bats-support/load"
 load "${TEST_ROOT}/test/libs/bats-assert/load"
 
-# Supported CLI entry points. The wrapper records invocations for CI diagnostics.
-export OKOU_CLI="${TEST_ROOT}/helpers/trace-cli.sh okou"
-export ZERO_CLI="${TEST_ROOT}/helpers/trace-cli.sh zero"
+# The wrapper records canonical Okou invocations for CI diagnostics.
+export OKOU_CLI="${TEST_ROOT}/helpers/trace-cli.sh"

--- a/e2e/helpers/trace-cli.sh
+++ b/e2e/helpers/trace-cli.sh
@@ -14,17 +14,7 @@
 DEFAULT_CLI_TIMEOUT=90
 CLI_TIMEOUT_HEADROOM=20
 
-if (( $# < 1 )); then
-  echo "Usage: $0 <okou|zero> [args...]" >&2
-  exit 1
-fi
-
-CLI_ENTRYPOINT="$1"
-shift
-if [[ "$CLI_ENTRYPOINT" != "okou" && "$CLI_ENTRYPOINT" != "zero" ]]; then
-  echo "Unsupported CLI entry point: $CLI_ENTRYPOINT" >&2
-  exit 1
-fi
+CLI_ENTRYPOINT="okou"
 
 default_cli_timeout() {
   local bats_timeout="${BATS_TEST_TIMEOUT:-}"

--- a/e2e/tests/01-serial/ser-t06-okou-cli-smoke.bats
+++ b/e2e/tests/01-serial/ser-t06-okou-cli-smoke.bats
@@ -1,6 +1,5 @@
 #!/usr/bin/env bats
-# Smoke tests for the Okou CLI binary entry points.
-# Verifies canonical okou and the temporary zero alias use the same surface.
+# Smoke tests for the canonical Okou CLI binary entry point.
 
 load '../../helpers/setup'
 
@@ -20,45 +19,23 @@ load '../../helpers/setup'
     refute_output --partial "artifact"
 }
 
-@test "temporary alias help is identical to canonical okou help" {
-    run $OKOU_CLI --help
-    assert_success
-    local okou_output="$output"
-
-    run $ZERO_CLI --help
-    assert_success
-    [[ "$output" == "$okou_output" ]]
-}
-
-@test "okou and zero output the same version" {
+@test "okou outputs a semantic version" {
     run $OKOU_CLI --version
     assert_success
     assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+'
-    local okou_version="$output"
-
-    run $ZERO_CLI --version
-    assert_success
-    [[ "$output" == "$okou_version" ]]
 }
 
-@test "temporary zero can load the internal agent loop" {
-    run $ZERO_CLI __agent-loop --help
+@test "okou can load the internal agent loop" {
+    run $OKOU_CLI __agent-loop --help
     assert_success
     assert_output --partial "--standby"
 }
 
-@test "okou and zero preserve error output and exit behavior" {
-    local command okou_status okou_output
+@test "okou preserves error output and exit behavior" {
+    local command
     for command in automation schedule; do
         run $OKOU_CLI "$command" list
         assert_failure
-        okou_status="$status"
-        okou_output="$output"
-
-        run $ZERO_CLI "$command" list
-        assert_failure
-        [[ "$status" == "$okou_status" ]]
-        [[ "$output" == "$okou_output" ]]
         assert_output --partial "unknown command '$command'"
     done
 }

--- a/e2e/tests/03-runner/run-t13-chat-attachments.bats
+++ b/e2e/tests/03-runner/run-t13-chat-attachments.bats
@@ -15,7 +15,7 @@ teardown() {
     runner_e2e_teardown_test
 }
 
-@test "dual-entry CLI and chat attachments work across continuation" {
+@test "Okou CLI and chat attachments work across continuation" {
     run create_runner_agent "e2e-chat-attachments-${TEST_ID}"
     echo "$output"
     assert_success
@@ -40,13 +40,11 @@ teardown() {
     first_marker="ATTACHMENTS_OK_${TEST_ID}"
     first_prompt=$(cat <<'EOF'
 set -euo pipefail
-# Prove the dual-entry artifact supports the canonical executable and the old
-# guest-agent binary boundary before using Okou for attachment operations.
+# Prove the artifact supports the canonical executable and guest-agent boundary
+# before using Okou for attachment operations.
 okou_help="$(npx --yes --package="${CLI_PKG_URL}" okou --help)"
-zero_help="$(npx --yes --package="${CLI_PKG_URL}" zero --help)" # okou-cutover-audit: compatibility-only
-test "$okou_help" = "$zero_help"
 grep -F 'Usage: okou' <<<"$okou_help"
-npx --yes --package="${CLI_PKG_URL}" zero __agent-loop --help | grep -F -- '--standby' # okou-cutover-audit: compatibility-only
+npx --yes --package="${CLI_PKG_URL}" okou __agent-loop --help | grep -F -- '--standby'
 npx --yes --package="${CLI_PKG_URL}" okou web download-file '__CONTENT_ID__' -o /tmp/runner-content.txt
 npx --yes --package="${CLI_PKG_URL}" okou web download-file '__EMPTY_ID__' -o /tmp/runner-empty.txt
 grep -F '__CONTENT_MARKER__' /tmp/runner-content.txt

--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -10,8 +10,7 @@
   },
   "type": "module",
   "bin": {
-    "okou": "./dist/okou.js",
-    "zero": "./dist/okou.js"
+    "okou": "./dist/okou.js"
   },
   "engines": {
     "node": ">=22.19.0"
@@ -21,7 +20,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/okou-cli\"; delete this.scripts; delete this.devDependencies; this.bin={okou:\"okou.js\",zero:\"okou.js\"}; this.files=[\"*.js\",\"*.js.map\"]'",
+    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/okou-cli\"; delete this.scripts; delete this.devDependencies; this.bin={okou:\"okou.js\"}; this.files=[\"*.js\",\"*.js.map\"]'",
     "dev": "tsup --watch",
     "bench:startup": "pnpm build && ZERO_STARTUP_BENCH=1 vitest run src/__tests__/okou-startup.bench.test.ts",
     "test": "vitest run",

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -634,10 +634,7 @@ export { program };
 if (
   process.argv[1]?.endsWith("okou.js") ||
   process.argv[1]?.endsWith("okou.ts") ||
-  process.argv[1]?.endsWith("okou") ||
-  process.argv[1]?.endsWith("zero.js") ||
-  process.argv[1]?.endsWith("zero.ts") ||
-  process.argv[1]?.endsWith("zero")
+  process.argv[1]?.endsWith("okou")
 ) {
   await configureGlobalProxyFromEnv();
   const requestedCommand = await loadZeroCommand(getRequestedZeroCommandName());


### PR DESCRIPTION
## Summary

- remove the retired `zero` package binary, packed metadata, and executable-path selection while keeping the canonical `okou` command boundary
- require an Okou-only artifact, preserve the no-`zero.js` invariant, and prove real `zero --help` failure in an isolated command environment
- remove compatibility-only workflow symlinks, local deploy fixtures, serial/Runner E2E success coverage, and trace wrapper selection
- replace the migration record with the final gate evidence, preserved protocol/product identities, rollback baseline, and exact three-class residual audit

## Final removal gate

Implementation was authorized by [#26431 comment 5264650228](https://github.com/vm0-ai/vm0/issues/26431#issuecomment-5264650228). That record explicitly supersedes only the remaining elapsed-time wait and records successful production drain, source, durable-content, artifact, health, and rollback checks.

The preserved rollback baseline is release #26540 at `a08e28cc84dc44a8f28db7571282aad2fd3c8d26`. This PR does not merge, enqueue, release, mutate production, or alter immutable historical artifacts.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm -F @vm0/okou-cli lint`
- `pnpm -F @vm0/okou-cli check-types`
- `pnpm -F @vm0/okou-cli test` — 102 files passed, 1 skipped; 982 tests passed, 1 skipped
- targeted API run-lifecycle integrations — 2 passed, 152 skipped, including the commit-addressed Okou package and paired branded run environment
- `pnpm knip --workspace @vm0/okou-cli`
- real CLI build, artifact builder/verifier, and artifact smoke:
  - package bin is exactly `{"okou":"okou.js"}`
  - `okou --help` and `okou __agent-loop --help` succeed
  - `zero --help` fails without reaching the Okou implementation
  - package contains `okou.js` and no `zero.js`
- audit, deploy-local, deploy-workflow, and workflow-shell compatibility tests
- Bash syntax and ShellCheck for the changed shell surfaces
- serial Okou CLI BATS — 4 passed
- Linux guest-agent exact argv integration — 1 passed
- `cargo fmt --all --check`, Prettier after final edits, and `git diff --check`

The Runner E2E requires the PR preview/fleet and is intentionally left to required PR CI; its command boundary now exercises only real `okou --help` and `okou __agent-loop --help`.

## Residual audit

`approved-internal-protocol=33 historical=241 unsupported-user-owned=0 unclassified=0`

Allowed residual classes are approved internal protocol/product identities, historical evidence, and explicitly unsupported user-owned content. There is no compatibility-only or tracked executable test-fixture residual class.

Preserved identities include `OKOU_TOKEN` preference with `ZERO_TOKEN` fallback, both token scopes, `OKOU_AGENT_ID` and `ZERO_AGENT_ID`, paired deployment environment injection, `commands/zero`, `decodeZeroTokenPayload`, `OKOU_*`, `ZERO_*`, `/api/okou/**`, `/api/zero/**`, database/backend/Desktop identities, and historical changelogs/artifacts.

Closes #26431
Part of #26429