### PR TITLE
refactor(python): centralize model json usage protocol dispatch

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1793,23 +1793,11 @@ def _finish_response_handling(
         and response_streaming.uses_model_json_fallback(flow)
     ):
         model_protocol = response_streaming.model_usage_protocol(flow)
-        if model_protocol == "openai_responses":
-            json_usage, json_error = usage.extract_openai_responses_usage_with_error_from_json(
-                bytes(stream_buf),
-                flow.response.headers if flow.response else None,
-            )
-        elif model_protocol == "openai_chat_completions":
-            json_usage, json_error = (
-                usage.extract_openai_chat_completions_usage_with_error_from_json(
-                    bytes(stream_buf),
-                    flow.response.headers if flow.response else None,
-                )
-            )
-        else:
-            json_usage, json_error = usage.extract_anthropic_messages_usage_with_error_from_json(
-                bytes(stream_buf),
-                flow.response.headers if flow.response else None,
-            )
+        json_usage, json_error = usage.extract_model_usage_with_error_from_json(
+            model_protocol,
+            bytes(stream_buf),
+            flow.response.headers if flow.response else None,
+        )
         if json_usage:
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = json_usage
         elif json_error is not None:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -20,7 +20,7 @@ Lifecycle:
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal, NamedTuple
+from typing import NamedTuple
 
 from mitmproxy import http
 from wsproto.utilities import generate_accept_token
@@ -58,12 +58,6 @@ _OPENAI_RESPONSES_SSE_PROTOCOL = "openai_responses_sse"
 _ANTHROPIC_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
 _ANTHROPIC_MESSAGE_STOP_EVENT = "message_stop"
 
-ModelUsageProtocol = Literal[
-    "anthropic_messages",
-    "openai_chat_completions",
-    "openai_responses",
-]
-
 _ResponseChunkParser = Callable[[bytes], None]
 _SseUsageParseErrorLogger = Callable[[str, str], None]
 _AnthropicLifecycleObserver = Callable[[str, str | None], None]
@@ -100,7 +94,7 @@ class _OpenAIResponsesPrewarmState:
     diagnostic_emitted: bool = False
 
 
-def model_usage_protocol(flow: http.HTTPFlow) -> ModelUsageProtocol:
+def model_usage_protocol(flow: http.HTTPFlow) -> usage.ModelUsageProtocol:
     """Classify model usage from the observed request and CLI fallback."""
     request_target = flow_metadata.original_url(flow.metadata) or flow.request.path
     request_path = runtime_url_parsing.strip_url_query_and_fragment(request_target).rstrip("/")
@@ -275,7 +269,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
         return _ResponseUsageStreamSetup(None, False)
     if not _response_can_have_body(flow, response):
         return _ResponseUsageStreamSetup(None, False)
-    if is_observable_model_provider:
+    if model_protocol is not None:
         if _response_has_event_stream_media_type(response):
             lifecycle_observer: _AnthropicLifecycleObserver | None = None
             anthropic_accounting_events: set[str] = set()
@@ -359,12 +353,7 @@ def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStrea
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = finish_sse_usage
             return _ResponseUsageStreamSetup(decode_session.feed, False)
 
-        if model_protocol == "openai_responses":
-            extractor = usage.create_openai_responses_json_usage_extractor()
-        elif model_protocol == "openai_chat_completions":
-            extractor = usage.create_openai_chat_completions_json_usage_extractor()
-        else:
-            extractor = usage.create_anthropic_messages_json_usage_extractor()
+        extractor = usage.create_model_json_usage_extractor(model_protocol)
         decode_session = _make_response_decode_session(
             extractor.feed,
             response.headers,

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -7,6 +7,7 @@ The stable facade covers:
   per-response source identity for WebSocket reporting, and buffer results for
   aggregate platform webhook upload to billing and/or observation endpoints
   through a background thread pool — see :mod:`usage.providers.model_provider`.
+  Cross-provider non-streaming JSON dispatch is owned by :mod:`usage.model_json`.
 - Billable connector responses (flagged by the web layer via
   ``billableFirewalls`` → ``metadata_keys.FIREWALL_BILLABLE``): compute
   per-permission billable resource counts and buffer them for aggregate
@@ -54,6 +55,11 @@ from .counters import (
     set_pending_path,
     write_pending_snapshot,
 )
+from .model_json import (
+    ModelUsageProtocol,
+    create_model_json_usage_extractor,
+    extract_model_usage_with_error_from_json,
+)
 from .openai_chat_completions import (
     create_openai_chat_completions_json_usage_extractor,
     create_openai_chat_completions_sse_usage_extractor,
@@ -91,6 +97,7 @@ from .providers.model_provider import (
 __all__ = [
     "DEFAULT_FLUSH_INTERVAL_SECONDS",
     "BufferedReportLease",
+    "ModelUsageProtocol",
     "OpenAIResponsesClientEvent",
     "OpenAIResponsesEvent",
     "admit_buffered_report",
@@ -102,6 +109,7 @@ __all__ = [
     "create_anthropic_messages_json_usage_extractor",
     "create_anthropic_messages_sse_usage_extractor",
     "create_connector_response_parser",
+    "create_model_json_usage_extractor",
     "create_openai_chat_completions_json_usage_extractor",
     "create_openai_chat_completions_sse_usage_extractor",
     "create_openai_responses_json_usage_extractor",
@@ -110,6 +118,7 @@ __all__ = [
     "decrement_in_flight_flows",
     "drain_usage_events_after_executor_shutdown",
     "extract_anthropic_messages_usage_with_error_from_json",
+    "extract_model_usage_with_error_from_json",
     "extract_openai_chat_completions_usage_with_error_from_json",
     "extract_openai_responses_usage_from_event",
     "extract_openai_responses_usage_with_error_from_json",

--- a/crates/runner/mitm-addon/src/usage/model_json.py
+++ b/crates/runner/mitm-addon/src/usage/model_json.py
@@ -1,0 +1,93 @@
+"""Typed cross-provider dispatch for model JSON usage extraction.
+
+Each supported protocol owns one paired registration containing its incremental
+extractor factory and bounded complete-body extractor. Cross-provider callers
+must dispatch through this module so the two JSON paths cannot drift.
+"""
+
+from collections.abc import Callable
+from typing import Literal, NamedTuple, Protocol, assert_never
+
+from mitmproxy import http
+
+from . import anthropic_messages, openai_chat_completions, openai_responses
+
+ModelUsageProtocol = Literal[
+    "anthropic_messages",
+    "openai_chat_completions",
+    "openai_responses",
+]
+
+ModelJsonUsageResult = tuple[dict | None, str | None]
+
+
+class ModelJsonUsageExtractor(Protocol):
+    """Incremental parser lifecycle shared by model JSON protocols."""
+
+    def feed(self, chunk: bytes) -> None: ...
+
+    def accepts_more_input(self) -> bool: ...
+
+    def finish(self) -> ModelJsonUsageResult: ...
+
+
+_ModelJsonUsageExtractorFactory = Callable[[], ModelJsonUsageExtractor]
+_ModelJsonUsageCompleteBodyExtractor = Callable[
+    [bytes, http.Headers | None],
+    ModelJsonUsageResult,
+]
+
+
+class _ModelJsonUsageRegistration(NamedTuple):
+    create_extractor: _ModelJsonUsageExtractorFactory
+    extract_from_complete_body: _ModelJsonUsageCompleteBodyExtractor
+
+
+_ANTHROPIC_MESSAGES_REGISTRATION = _ModelJsonUsageRegistration(
+    create_extractor=anthropic_messages.create_anthropic_messages_json_usage_extractor,
+    extract_from_complete_body=(
+        anthropic_messages.extract_anthropic_messages_usage_with_error_from_json
+    ),
+)
+_OPENAI_CHAT_COMPLETIONS_REGISTRATION = _ModelJsonUsageRegistration(
+    create_extractor=(openai_chat_completions.create_openai_chat_completions_json_usage_extractor),
+    extract_from_complete_body=(
+        openai_chat_completions.extract_openai_chat_completions_usage_with_error_from_json
+    ),
+)
+_OPENAI_RESPONSES_REGISTRATION = _ModelJsonUsageRegistration(
+    create_extractor=openai_responses.create_openai_responses_json_usage_extractor,
+    extract_from_complete_body=(
+        openai_responses.extract_openai_responses_usage_with_error_from_json
+    ),
+)
+
+
+def _model_json_usage_registration(
+    protocol: ModelUsageProtocol,
+) -> _ModelJsonUsageRegistration:
+    if protocol == "anthropic_messages":
+        return _ANTHROPIC_MESSAGES_REGISTRATION
+    if protocol == "openai_chat_completions":
+        return _OPENAI_CHAT_COMPLETIONS_REGISTRATION
+    if protocol == "openai_responses":
+        return _OPENAI_RESPONSES_REGISTRATION
+    assert_never(protocol)
+
+
+def create_model_json_usage_extractor(
+    protocol: ModelUsageProtocol,
+) -> ModelJsonUsageExtractor:
+    """Create the incremental JSON usage extractor for ``protocol``."""
+
+    return _model_json_usage_registration(protocol).create_extractor()
+
+
+def extract_model_usage_with_error_from_json(
+    protocol: ModelUsageProtocol,
+    body: bytes,
+    headers: http.Headers | None,
+) -> ModelJsonUsageResult:
+    """Extract usage from one complete, optionally encoded model JSON body."""
+
+    return _model_json_usage_registration(protocol).extract_from_complete_body(body, headers)

--- a/crates/runner/mitm-addon/src/usage/model_json.py
+++ b/crates/runner/mitm-addon/src/usage/model_json.py
@@ -24,11 +24,14 @@ ModelJsonUsageResult = tuple[dict | None, str | None]
 class ModelJsonUsageExtractor(Protocol):
     """Incremental parser lifecycle shared by model JSON protocols."""
 
-    def feed(self, chunk: bytes) -> None: ...
+    def feed(self, chunk: bytes) -> None:
+        raise NotImplementedError
 
-    def accepts_more_input(self) -> bool: ...
+    def accepts_more_input(self) -> bool:
+        raise NotImplementedError
 
-    def finish(self) -> ModelJsonUsageResult: ...
+    def finish(self) -> ModelJsonUsageResult:
+        raise NotImplementedError
 
 
 _ModelJsonUsageExtractorFactory = Callable[[], ModelJsonUsageExtractor]
@@ -72,7 +75,7 @@ def _model_json_usage_registration(
         return _OPENAI_CHAT_COMPLETIONS_REGISTRATION
     if protocol == "openai_responses":
         return _OPENAI_RESPONSES_REGISTRATION
-    assert_never(protocol)
+    return assert_never(protocol)
 
 
 def create_model_json_usage_extractor(

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -1,6 +1,7 @@
 """Model-provider response parser setup integration tests."""
 
 import gzip
+from typing import cast
 
 import pytest
 from mitmproxy.test import tutils
@@ -8,9 +9,26 @@ from mitmproxy.test import tutils
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_streaming
+import usage
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import jsonl_exists_after_flush
 from tests.x_flow_helpers import make_x_response_flow
+
+
+class TestModelJsonUsageProtocolDispatch:
+    """Tests for the public typed model JSON dispatch owner."""
+
+    def test_unsupported_protocol_fails_explicitly(self):
+        unsupported_protocol = cast(usage.ModelUsageProtocol, "unsupported")
+
+        with pytest.raises(AssertionError, match="Expected code to be unreachable"):
+            usage.create_model_json_usage_extractor(unsupported_protocol)
+        with pytest.raises(AssertionError, match="Expected code to be unreachable"):
+            usage.extract_model_usage_with_error_from_json(
+                unsupported_protocol,
+                b"{}",
+                None,
+            )
 
 
 class TestResponseHeadersModelJsonParser:

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 
+import brotli
 import pytest
 from mitmproxy import http
 from mitmproxy.test import tutils
@@ -353,6 +354,35 @@ class TestOpenAIChatCompletionsUsage:
 
         assert webhook.usage_events() == []
         assert compact_observation_quantities(webhook.model_usage_observation_events()) == {
+            "tokens.input": 30,
+            "tokens.output": 5,
+        }
+
+    def test_brotli_json_uses_buffered_fallback(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="application/json",
+        )
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json", "content-encoding": "br"}),
+        )
+        body = _chat_payload(usage_payload={"prompt_tokens": 30, "completion_tokens": 5})
+        compressed = brotli.compress(body)
+
+        mitm_addon.responseheaders(flow)
+        assert "model_json_usage_finish" not in flow.metadata
+        assert response_stream(flow)(compressed) == compressed
+        assert flow.metadata[metadata_keys.STREAM_BUFFER] == bytearray(compressed)
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
             "tokens.input": 30,
             "tokens.output": 5,
         }


### PR DESCRIPTION
## Summary

- add one typed model JSON protocol owner that pairs incremental and complete-body extractors
- route response streaming setup and buffered terminal fallback through the shared owner
- cover explicit unknown-protocol failure and Chat Completions Brotli fallback

## Testing

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_response_parser_setup.py tests/test_model_provider_json_streaming.py tests/test_model_provider_json_fallback.py tests/test_openai_chat_completions_usage.py`
- `uv run --no-sync python -m pytest tests/` (`5340 passed`)

## Explicit exclusions

- no SSE or WebSocket parser dispatch changes
- no provider parsing, decompression, billing, observation, or log schema changes
- no API, database, migration, or rollout changes

Closes #26557
