### PR TITLE
refactor(rust): centralize guest stdout framing limits

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1353,6 +1353,7 @@ version = "0.7.1"
 dependencies = [
  "chrono",
  "clap",
+ "guest-contracts",
  "libc",
  "serde_json",
  "tempfile",

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -17,6 +17,7 @@ use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
 use guest_common::log_warn;
+use guest_contracts::stdout_framing::CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -35,7 +36,6 @@ use super::{
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
 const NOTIFICATION_QUEUE_MAX_BYTES: usize = 16 * 1024 * 1024;
-const STDOUT_MAX_LINE_BYTES: usize = 64 * 1024 * 1024;
 const SHUTDOWN_SIGKILL_GRACE: Duration = Duration::from_secs(2);
 const STDERR_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
@@ -1091,8 +1091,12 @@ async fn read_stdout_line<R>(
 where
     R: AsyncBufRead + Unpin,
 {
-    match line_reader::read_bounded_utf8_line(stdout_reader, partial_line, STDOUT_MAX_LINE_BYTES)
-        .await
+    match line_reader::read_bounded_utf8_line(
+        stdout_reader,
+        partial_line,
+        CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES,
+    )
+    .await
     {
         Ok(line) => Ok(line),
         Err(line_reader::BoundedLineError::Io(error)) => Err(CodexAppServerError::Io(error)),
@@ -1117,7 +1121,7 @@ where
 
 fn stdout_line_too_large_error() -> CodexAppServerError {
     CodexAppServerError::Protocol(format!(
-        "app-server stdout line exceeded {STDOUT_MAX_LINE_BYTES} bytes"
+        "app-server stdout line exceeded {CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES} bytes"
     ))
 }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -60,6 +60,7 @@ use guest_contracts::diagnostics::{
     CliObservedExitDiagnostic, CliTerminationDiagnostic, EventDeliveryDiagnostic,
     FailureDetailSource, FailureReason,
 };
+use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use process_group::ChildProcessGroup;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -89,10 +90,6 @@ const CODEX_FIXED_STARTUP_CONFIGS: [&str; 4] = [
 const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
     ["features.fast_mode=true", r#"service_tier="fast""#];
 const CODEX_WEB_SEARCH_DISABLED_CONFIG: &str = r#"web_search="disabled""#;
-/// Maximum retained bytes for one Claude Code stdout record before parsing.
-///
-/// LF is excluded. A preceding CR counts before CRLF normalization.
-const STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(serde::Serialize)]
 struct ClaudeUserFrame<'a> {
@@ -1105,7 +1102,7 @@ async fn execute_cli_inner(
             line_result = line_reader::read_bounded_utf8_line(
                 &mut reader,
                 &mut stdout_partial_line,
-                STDOUT_MAX_LINE_BYTES,
+                ORDINARY_CLI_STDOUT_MAX_LINE_BYTES,
             ), if !stdout_closed => {
                 match line_result {
                     Ok(Some(line)) => {
@@ -1271,7 +1268,7 @@ async fn execute_cli_inner(
                             line_reader::BoundedLineError::Io(error) => AgentError::Io(error),
                             line_reader::BoundedLineError::TooLong => AgentError::Execution(
                                 format!(
-                                    "CLI stdout line exceeded {STDOUT_MAX_LINE_BYTES} bytes"
+                                    "CLI stdout line exceeded {ORDINARY_CLI_STDOUT_MAX_LINE_BYTES} bytes"
                                 ),
                             ),
                             line_reader::BoundedLineError::InvalidUtf8 {

--- a/crates/guest-agent/src/cli/pi_agent_loop.rs
+++ b/crates/guest-agent/src/cli/pi_agent_loop.rs
@@ -20,6 +20,7 @@ use crate::masker::SecretMasker;
 use crate::paths::{self, GuestPaths};
 use crate::pi_standby::PiStandbySignal;
 use guest_common::{log_info, log_warn};
+use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -365,7 +366,7 @@ async fn run_protocol(
             line = line_reader::read_bounded_utf8_line(
                 stdout,
                 partial_line,
-                super::STDOUT_MAX_LINE_BYTES,
+                ORDINARY_CLI_STDOUT_MAX_LINE_BYTES,
             ) => line.map_err(|error| {
                 AgentError::Execution(format!("invalid Pi standby stdout: {error:?}"))
             })?,

--- a/crates/guest-agent/tests/cli_stdout_oversized_newline.rs
+++ b/crates/guest-agent/tests/cli_stdout_oversized_newline.rs
@@ -4,6 +4,7 @@
 mod common;
 
 use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use std::time::Duration;
 
 #[tokio::test]
@@ -29,8 +30,12 @@ async fn oversized_newline_terminated_stdout_terminates_promptly()
         .control_error
         .expect("stdout framing failure should be a controlled execution error")
         .to_string();
+    let expected_error = format!(
+        "CLI stdout line exceeded {} bytes",
+        ORDINARY_CLI_STDOUT_MAX_LINE_BYTES
+    );
     assert!(
-        error.contains("CLI stdout line exceeded 16777216 bytes"),
+        error.contains(&expected_error),
         "unexpected stdout limit error: {error}"
     );
     assert_eq!(execution.last_event_sequence, None);

--- a/crates/guest-agent/tests/cli_stdout_oversized_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stdout_oversized_no_newline.rs
@@ -4,6 +4,7 @@
 mod common;
 
 use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use std::time::Duration;
 
 #[tokio::test]
@@ -29,8 +30,12 @@ async fn oversized_newline_free_stdout_terminates_promptly()
         .control_error
         .expect("stdout framing failure should be a controlled execution error")
         .to_string();
+    let expected_error = format!(
+        "CLI stdout line exceeded {} bytes",
+        ORDINARY_CLI_STDOUT_MAX_LINE_BYTES
+    );
     assert!(
-        error.contains("CLI stdout line exceeded 16777216 bytes"),
+        error.contains(&expected_error),
         "unexpected stdout limit error: {error}"
     );
     assert_eq!(execution.last_event_sequence, None);

--- a/crates/guest-agent/tests/cli_stdout_record_boundaries.rs
+++ b/crates/guest-agent/tests/cli_stdout_record_boundaries.rs
@@ -3,6 +3,7 @@
 
 mod common;
 
+use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use std::io::{Read, Seek, SeekFrom};
 use std::time::Duration;
 
@@ -35,7 +36,7 @@ async fn accepted_stdout_record_boundaries_preserve_raw_logging()
 
     let expected_large_line_start = CRLF_RECORD.len() as u64;
     let expected_eof_record_start =
-        expected_large_line_start + common::CLI_STDOUT_MAX_LINE_BYTES as u64 + 1;
+        expected_large_line_start + ORDINARY_CLI_STDOUT_MAX_LINE_BYTES as u64 + 1;
     let expected_log_bytes = expected_eof_record_start + EOF_RECORD.len() as u64;
     let mut log = std::fs::File::open(runtime.paths.agent_log_file())?;
     assert_eq!(log.metadata()?.len(), expected_log_bytes);

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use guest_agent::cli::codex_app_server::{
     CodexAppServerClient, CodexAppServerConfig, CodexAppServerError, InitializeResponse,
 };
+use guest_contracts::stdout_framing::CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -423,7 +424,10 @@ async fn codex_app_server_oversized_stdout_line_is_rejected() -> Result<(), Stri
     let result = wait_result_allow_error(client.initialize(), "initialize").await;
     match result {
         Err(CodexAppServerError::Protocol(message)) => {
-            assert!(message.contains("app-server stdout line exceeded"));
+            let expected_error = format!(
+                "app-server stdout line exceeded {CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES} bytes"
+            );
+            assert!(message.contains(&expected_error));
             assert!(!message.contains("xxx"));
         }
         other => {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -81,9 +81,6 @@ pub const CLI_STDERR_RESULT_MAX_LINES: usize = 200;
 /// Documented maximum byte length for one returned stderr line after CRLF normalization.
 pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 
-/// Integration contract for one accepted Claude Code stdout record.
-pub const CLI_STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
-
 /// Documented replacement for a stderr line that exceeds the diagnostic limit.
 pub const CLI_STDERR_OMITTED_LONG_LINE: &str =
     "[stderr line omitted: exceeded diagnostic size limit]";

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -18,4 +18,5 @@ pub mod reuse_preparation;
 pub mod runtime_paths;
 pub mod session_history;
 pub mod session_history_identity;
+pub mod stdout_framing;
 pub mod storage_manifest;

--- a/crates/guest-contracts/src/stdout_framing.rs
+++ b/crates/guest-contracts/src/stdout_framing.rs
@@ -1,0 +1,17 @@
+//! Maximum retained-record sizes for CLI stdout framing.
+//!
+//! These limits are shared by guest-agent readers, mock producers, and
+//! integration tests so runtime policy and boundary fixtures stay in lockstep.
+
+/// Maximum retained bytes for one ordinary CLI stdout record before parsing.
+///
+/// This policy is shared by the Claude Code execution path and Pi standby.
+/// LF is excluded. A preceding CR counts before CRLF normalization, and an
+/// EOF-terminated final record is measured without an implicit terminator.
+pub const ORDINARY_CLI_STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Maximum retained bytes for one Codex app-server stdout record before parsing.
+///
+/// LF is excluded. A preceding CR counts before CRLF normalization, and an
+/// EOF-terminated final record is measured without an implicit terminator.
+pub const CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES: usize = 64 * 1024 * 1024;

--- a/crates/guest-mock-claude/src/process/fixtures.rs
+++ b/crates/guest-mock-claude/src/process/fixtures.rs
@@ -4,6 +4,7 @@ use crate::transcript::{
     tool_use_event,
 };
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
+use guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES;
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -20,8 +21,6 @@ const POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_re
 const POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
 const POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
 const POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
-// Integration contract with guest-agent's ordinary stdout framing policy.
-const ORDINARY_STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
 const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 
 pub(super) fn run_fail_no_newline(msg: &str) -> ExitCode {
@@ -160,7 +159,7 @@ fn hang_until_reaped() {
 
 fn write_stdout_limit(stdout: &mut impl Write, byte: u8) -> std::io::Result<()> {
     let chunk = [byte; STDOUT_STREAM_CHUNK_BYTES];
-    for _ in 0..ORDINARY_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
+    for _ in 0..ORDINARY_CLI_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
         stdout.write_all(&chunk)?;
     }
     Ok(())

--- a/crates/guest-mock-codex/Cargo.toml
+++ b/crates/guest-mock-codex/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["derive"] }
+guest-contracts.workspace = true
 libc.workspace = true
 serde_json.workspace = true
 uuid = { workspace = true, features = ["v7"] }

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -11,6 +11,7 @@ use super::messages::{
 use super::persistence::{InputEventContext, persist_input_events};
 use super::scenario::Scenario;
 use super::{AppServerState, INVALID_REQUEST, PendingResponse, ServerAction, spawn_stderr_holder};
+use guest_contracts::stdout_framing::CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES;
 use serde_json::{Value, json};
 use std::io::{self, Write};
 use std::os::unix::net::UnixListener;
@@ -25,8 +26,6 @@ const WAIT_ON_TURN_STEER_READY_FILE: &str = ".vm0-mock-codex-turn-steer-ready";
 const WAIT_ON_TURN_STEER_READY_EVENT: &str = "vm0_mock_codex_turn_steer_ready";
 const WAIT_ON_TURN_STEER_RELEASE_SOCKET: &str = ".vm0-mock-codex-turn-steer-release.sock";
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
-// Integration contract with guest-agent's Codex app-server stdout framing policy.
-const APP_SERVER_STDOUT_MAX_LINE_BYTES: usize = 64 * 1024 * 1024;
 const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 const EVENT_DELIVERY_FLOOD_COUNT: usize = 640;
 const EVENT_DELIVERY_LARGE_EVENT_COUNT: usize = 10;
@@ -68,7 +67,7 @@ impl AppServerState {
         }
         if self.scenario == Scenario::OversizedStdout {
             let chunk = [b'x'; STDOUT_STREAM_CHUNK_BYTES];
-            for _ in 0..APP_SERVER_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
+            for _ in 0..CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES / STDOUT_STREAM_CHUNK_BYTES {
                 output.write_all(&chunk)?;
             }
             output.write_all(b"x\n")?;


### PR DESCRIPTION
## Summary

- add canonical ordinary CLI and Codex app-server stdout framing limits to `guest-contracts`
- make Claude, Pi standby, Codex app-server, both mock producers, and integration expectations compile against those shared values
- add the existing workspace `guest-contracts` dependency to `guest-mock-codex`

## Behavior and scope

This preserves the existing 16 MiB ordinary CLI limit shared by Claude Code and Pi standby, the existing 64 MiB Codex app-server limit, and all current LF, CRLF, EOF-final-record, and limit-plus-one behavior. It only centralizes ownership and derives boundary offsets and diagnostics from the canonical values.

Unrelated stderr diagnostic limits, event-delivery byte limits, Codex notification-queue limits, and `execve` budgets remain separate and unchanged.

## Validation

- `cargo test -p guest-agent --test cli_stdout_record_boundaries --test cli_stdout_oversized_newline --test cli_stdout_oversized_no_newline`
- `cargo test -p guest-agent --test codex_app_server_client codex_app_server_oversized_stdout_line_is_rejected -- --exact`
- `cargo test -p guest-contracts -p guest-mock-claude -p guest-mock-codex`
- `cargo test -p guest-agent --lib cli::pi_agent_loop::tests`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`

Closes #26559
