### PR TITLE
test(api): isolate staff entitlement fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -59,6 +59,7 @@ import {
   deleteOrgPlanEntitlementFixture,
   upsertOrgPlanEntitlementFixture,
 } from "../../../test-fixtures/org-plan-entitlement";
+import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org";
 import { createDeferredPromise, settle } from "../../utils";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { assertPublicConnectorCatalogHasNoPrivateFields } from "./helpers/connector-catalog-public-leak";
@@ -136,7 +137,6 @@ const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
 const SLACK_REVOKE_URL = "https://slack.com/api/auth.revoke";
-const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const STEAM_TEST_ID = "76561198000000000";
 
 type JsonRecord = Record<string, unknown>;
@@ -3935,7 +3935,8 @@ describe("connector catalog valid lifecycle", () => {
       ),
     );
 
-    const actor = bdd.user({ orgId: STAFF_ORG_ID });
+    const orgId = createUniqueStaffOrgIdFixture();
+    const actor = bdd.user({ orgId });
     const created: { agentId?: string; workflowId?: string } = {};
     const cleanupConnector = createConnectorCleanup(actor, "gmail");
     onTestFinished(async () => {
@@ -3947,10 +3948,10 @@ describe("connector catalog valid lifecycle", () => {
       if (created.agentId) {
         await bdd.deleteAgent(actor, created.agentId);
       }
-      await deleteOrgPlanEntitlementFixture(STAFF_ORG_ID);
+      await deleteOrgPlanEntitlementFixture(orgId);
     });
     await upsertOrgPlanEntitlementFixture({
-      orgId: STAFF_ORG_ID,
+      orgId,
       status: "active",
       supportByok: true,
       restrictedVm0Models: false,
@@ -4150,7 +4151,8 @@ describe("connector catalog valid lifecycle", () => {
       }),
     );
 
-    const actor = bdd.user({ orgId: STAFF_ORG_ID });
+    const orgId = createUniqueStaffOrgIdFixture();
+    const actor = bdd.user({ orgId });
     const created: { agentId?: string; workflowId?: string } = {};
     const refreshResume = deferredGate();
     const cleanupConnector = createConnectorCleanup(actor, "gmail");
@@ -4164,10 +4166,10 @@ describe("connector catalog valid lifecycle", () => {
       if (created.agentId) {
         await bdd.deleteAgent(actor, created.agentId);
       }
-      await deleteOrgPlanEntitlementFixture(STAFF_ORG_ID);
+      await deleteOrgPlanEntitlementFixture(orgId);
     });
     await upsertOrgPlanEntitlementFixture({
-      orgId: STAFF_ORG_ID,
+      orgId,
       status: "active",
       supportByok: true,
       restrictedVm0Models: false,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -48,6 +48,7 @@ import {
   readOrgPlanEntitlementFixture,
   upsertOrgPlanEntitlementFixture,
 } from "../../../test-fixtures/org-plan-entitlement";
+import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org";
 import {
   API_TEST_CONNECTOR_FIREWALL_CONFIGS,
   apiTestConnectorCatalogValidationAuthority,
@@ -137,7 +138,6 @@ import { testCustomConnectorSkillVersionAssociationRoutes } from "../test-custom
 const context = testContext();
 const callbackStore = createStore();
 const fixtureStore = createStore();
-const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const ASSISTANT_EVENT_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
@@ -5766,9 +5766,10 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
   it("enforces staff entitlement status at final run admission", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
-    const actor = bdd.user({ orgId: STAFF_ORG_ID });
+    const orgId = createUniqueStaffOrgIdFixture();
+    const actor = bdd.user({ orgId });
     onTestFinished(async () => {
-      await deleteOrgPlanEntitlementFixture(STAFF_ORG_ID);
+      await deleteOrgPlanEntitlementFixture(orgId);
     });
     bdd.acceptAgentStorageWrites();
     api.acceptStorageDownloads();
@@ -5776,7 +5777,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     const runnerGroup = api.configureRunnerGroup();
 
     await upsertOrgPlanEntitlementFixture({
-      orgId: STAFF_ORG_ID,
+      orgId,
       status: "active",
       supportByok: true,
       restrictedVm0Models: false,
@@ -5784,7 +5785,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     const completed = await bdd.completeOnboarding(actor);
     expect(completed.status).toBe(200);
     await upsertOrgPlanEntitlementFixture({
-      orgId: STAFF_ORG_ID,
+      orgId,
       status: "active",
       supportByok: true,
       restrictedVm0Models: false,
@@ -5795,14 +5796,14 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       visibility: "private",
     });
     await seedOrgMetadata({
-      orgId: STAFF_ORG_ID,
+      orgId,
       tier: "limited-free-1",
       credits: 20_000,
     });
     // The metadata fixture keeps the production tier/entitlement invariant.
     // Restore the deliberate staff-only divergence exercised by this test.
     await upsertOrgPlanEntitlementFixture({
-      orgId: STAFF_ORG_ID,
+      orgId,
       status: "active",
       supportByok: true,
       restrictedVm0Models: false,
@@ -5825,7 +5826,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
 
     await upsertOrgPlanEntitlementFixture({
-      orgId: STAFF_ORG_ID,
+      orgId,
       status: "suspended",
       supportByok: true,
       restrictedVm0Models: false,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts
@@ -13,6 +13,7 @@ import {
   deleteOrgPlanEntitlementFixture,
   upsertOrgPlanEntitlementFixture,
 } from "../../../test-fixtures/org-plan-entitlement";
+import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { createBddApi } from "./helpers/api-bdd";
@@ -31,7 +32,6 @@ const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
 const bdd = createBddApi(context);
-const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 
 beforeEach(() => {
   mocks.s3.listObjects([]);
@@ -323,22 +323,26 @@ describe("POST /api/zero/uploads/prepare", () => {
 
   it("normalizes staff entitlement lifecycle statuses for suspension checks", async () => {
     const userId = `user_${randomUUID()}`;
+    const orgId = createUniqueStaffOrgIdFixture();
+    context.mocks.s3.getSignedUrl.mockResolvedValue(
+      "https://r2.example.com/upload?sig=staff-entitlement",
+    );
     const client = setupApp({ context, routes: zeroUploadsTestRoutes })(
       zeroUploadsContract,
     );
-    mocks.clerk.session(userId, STAFF_ORG_ID);
+    mocks.clerk.session(userId, orgId);
     onTestFinished(async () => {
-      await deleteOrgPlanEntitlementFixture(STAFF_ORG_ID);
+      await deleteOrgPlanEntitlementFixture(orgId);
     });
 
     await seedOrgMetadata({
-      orgId: STAFF_ORG_ID,
+      orgId,
       tier: "pro-suspend",
       credits: 0,
     });
     for (const status of ["trialing", "past_due"] as const) {
       await upsertOrgPlanEntitlementFixture({
-        orgId: STAFF_ORG_ID,
+        orgId,
         status,
       });
       await accept(
@@ -351,12 +355,12 @@ describe("POST /api/zero/uploads/prepare", () => {
     }
 
     await seedOrgMetadata({
-      orgId: STAFF_ORG_ID,
+      orgId,
       tier: "pro",
       credits: 1000,
     });
     await upsertOrgPlanEntitlementFixture({
-      orgId: STAFF_ORG_ID,
+      orgId,
       status: "canceled",
     });
     const response = await accept(

--- a/turbo/apps/api/src/test-fixtures/staff-org.ts
+++ b/turbo/apps/api/src/test-fixtures/staff-org.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+
+import { STAFF_ORG_ID_HASHES, fnv1a } from "@vm0/core/identity-hash";
+
+const FNV_PRIME = 16_777_619;
+// Multiplicative inverse of FNV_PRIME modulo 2^32.
+const FNV_PRIME_INVERSE = 899_433_627;
+const COLLISION_ALPHABET =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+function advanceFnv1a(hash: number, character: string): number {
+  return Math.imul(hash ^ character.charCodeAt(0), FNV_PRIME) >>> 0;
+}
+
+function reverseFnv1a(hash: number, character: string): number {
+  return (Math.imul(hash, FNV_PRIME_INVERSE) ^ character.charCodeAt(0)) >>> 0;
+}
+
+function staffCollisionSuffix(
+  prefix: string,
+  targetHash: number,
+): string | null {
+  // Meet in the middle over two three-character halves instead of scanning
+  // all 62^6 suffixes. FNV-1a is reversible one character at a time.
+  const prefixHash = Number.parseInt(fnv1a(prefix), 16);
+  const firstHalves = new Map<number, string>();
+  for (const first of COLLISION_ALPHABET) {
+    for (const second of COLLISION_ALPHABET) {
+      for (const third of COLLISION_ALPHABET) {
+        const hash = advanceFnv1a(
+          advanceFnv1a(advanceFnv1a(prefixHash, first), second),
+          third,
+        );
+        firstHalves.set(hash, `${first}${second}${third}`);
+      }
+    }
+  }
+
+  for (const fourth of COLLISION_ALPHABET) {
+    for (const fifth of COLLISION_ALPHABET) {
+      for (const sixth of COLLISION_ALPHABET) {
+        const precedingHash = reverseFnv1a(
+          reverseFnv1a(reverseFnv1a(targetHash, sixth), fifth),
+          fourth,
+        );
+        const firstHalf = firstHalves.get(precedingHash);
+        if (firstHalf) {
+          return `${firstHalf}${fourth}${fifth}${sixth}`;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Creates a unique organization that exercises the production staff hash gate
+ * without using a production organization identity.
+ */
+export function createUniqueStaffOrgIdFixture(): string {
+  const targetHashHex = STAFF_ORG_ID_HASHES[0];
+  if (!targetHashHex) {
+    throw new Error("Expected at least one configured staff organization hash");
+  }
+  const targetHash = Number.parseInt(targetHashHex, 16);
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const prefix = `org_${randomUUID()}_`;
+    const suffix = staffCollisionSuffix(prefix, targetHash);
+    if (suffix) {
+      return `${prefix}${suffix}`;
+    }
+  }
+  throw new Error("Failed to generate a unique staff organization fixture");
+}


### PR DESCRIPTION
## Summary

- add a focused test fixture that gives every affected example a UUID-owned organization whose FNV-1a hash is accepted by the production staff allow-list
- move upload, final run admission, and connector-readiness entitlement writes from the fixed production staff organization to those unique organizations
- keep staff suspension, BYOK, upload preparation, and connector readiness/race behavior at the route/integration boundary with the real database fixture boundary
- make the affected upload example self-contained by installing its own external S3 signing stub

## Isolation invariants

- the production `org_3ANttyrbWYJk6JKRSTRLEsbsDLe` identity is never passed to an entitlement writer, deleter, snapshot, or restore path by these tests
- each affected `it` creates a fresh UUID-prefixed organization and entitlement row; the generated ID matches `STAFF_ORG_ID_HASHES`, so the production staff-only decision remains under test
- cleanup addresses only the example-owned organization; correctness does not rely on cleanup completion, order, locks, time partitions, serialization, shared identities, or residue-tolerant assertions
- no mocked database or internal unit-test replacement was introduced

## Caller and overlap evidence

- repository-wide searches traced the fixed staff identity, `STAFF_ORG_ID_HASHES`, entitlement fixture callers, `seedOrgMetadata -> upsertOrgMetadataFixture -> upsertOrgPlanEntitlement`, and the feature-switch/staff hash consumers
- no fixed staff identity remains in the three issue-owned test files, and manual dataflow review found no remaining test path from a fixed staff identity to an entitlement mutation
- `createUniqueStaffOrgIdFixture` has exactly four call sites, all in the three issue-owned test files; no pre-existing shared helper was changed
- PR #26549 is merged as `8b1670c218fc1a1f326f720368eaa3a65b137ffa` and is an ancestor of this branch
- every file of every open PR was scanned through the paginated GitHub API: #26635 has a distant session-history hunk in `run-lifecycle.bdd.test.ts`, while draft #25722 has distant checksum/log-redaction hunks in the upload and connector-catalog files; neither overlaps entitlement lines, the new fixture, or this issue's ownership, and no open PR references #26597

## Validation

- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-uploads-prepare.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts -t 'normalizes staff entitlement lifecycle statuses for suspension checks|enforces staff entitlement status at final run admission|uses one external release for readiness status and connector metadata|does not persist an in-flight refresh after the connector is replaced'` — 3 files passed, 4 tests passed, 272 skipped
- `pnpm --filter api run check-types`
- `pnpm exec prettier --check apps/api/src/test-fixtures/staff-org.ts apps/api/src/signals/routes/__tests__/zero-uploads-prepare.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts`
- `pnpm --filter api exec eslint src/test-fixtures/staff-org.ts src/signals/routes/__tests__/zero-uploads-prepare.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/cron-connector-catalog.test.ts --max-warnings 0`
- `pnpm knip --workspace api`
- generated eight fixture IDs and verified that they were unique, different from the production identity, and accepted by both `isStaffOrg` and `STAFF_ORG_ID_HASHES`
- after the combined route test run, the test database contained zero entitlement rows for the production staff identity
- `git diff --check`

Closes #26597

Part of #26569
