### PR TITLE
fix(chat): preserve fast mode during thread creation

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -356,6 +356,8 @@ async function createChatThread(
         clientThreadId: args.clientThreadId,
         eventId: args.eventId,
         model: args.modelSelection.selectedModel,
+        serviceTier:
+          args.modelSelection.codexServiceTier === "fast" ? "priority" : null,
         ...(args.title ? { title: args.title } : {}),
       },
       fetchOptions: { signal },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -9,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 import {
   chatThreadsContract,
   type ChatThreadEvent,
+  type ChatThreadServiceTier,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
@@ -594,7 +595,7 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("selects Standard or Fast from one model row and shows the Fast impact", async () => {
+  it("keeps a new Fast thread Fast when its optimistic state reconciles", async () => {
     const user = userEvent.setup({ delay: null });
     let sentBody:
       | {
@@ -604,9 +605,13 @@ describe("chat composer models", () => {
       | undefined;
     let createdBody:
       | {
+          clientThreadId?: string;
+          eventId?: string;
           model?: string;
+          serviceTier?: ChatThreadServiceTier | null;
         }
       | undefined;
+    let modelSelectionUpdateCount = 0;
 
     context.mocks.data.orgModelPolicies([
       buildModelPolicy({
@@ -622,6 +627,9 @@ describe("chat composer models", () => {
     mockChatLifecycle(context, {
       onThreadCreate: (body) => {
         createdBody = body;
+      },
+      onModelSelectionUpdate: () => {
+        modelSelectionUpdateCount++;
       },
       onRunCreate: (body) => {
         sentBody = body;
@@ -710,11 +718,50 @@ describe("chat composer models", () => {
 
     await waitFor(() => {
       expect(createdBody?.model).toBe("gpt-5.6-sol");
+      expect(createdBody?.serviceTier).toBe("priority");
       expect(sentBody?.model).toBeUndefined();
       expect(sentBody?.runOptions).toStrictEqual({
         codexServiceTier: "fast",
       });
+      expect(modelSelectionUpdateCount).toBe(1);
     });
+
+    const reconciledThreadId = createdBody?.clientThreadId;
+    const reconciledCreateEventId = createdBody?.eventId;
+    if (
+      reconciledThreadId === undefined ||
+      reconciledCreateEventId === undefined
+    ) {
+      throw new Error("Expected the created Fast thread identifiers");
+    }
+    const reconciledTitle = "Reconciled Fast thread";
+    const reconciledSelectedModel = createdBody?.model ?? null;
+    const reconciledServiceTier = createdBody?.serviceTier ?? null;
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, {
+        events: [
+          {
+            id: reconciledCreateEventId,
+            seqId: 1,
+            kind: "created",
+            chatThreadId: reconciledThreadId,
+            agentId: AGENT_ID,
+            title: reconciledTitle,
+            selectedModel: reconciledSelectedModel,
+            serviceTier: reconciledServiceTier,
+            computerUseHostId: null,
+            cloudBrowserEnabled: false,
+            createdAt: "2026-08-12T09:00:00Z",
+          },
+        ],
+        hasMore: false,
+      });
+    });
+    triggerAblyEvent("threadListChanged");
+    await waitFor(() => {
+      expect(document.title).toBe(`${reconciledTitle} | VM0`);
+    });
+    await expectComposerModel("GPT 5.6 Sol Fast");
   });
 
   it("localizes model routes, price guidance, and Codex speed controls in Portuguese", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -13,6 +13,7 @@ import {
   chatEventsContract,
   MODEL_FIRST_SELECTION_PROVIDER_ID,
   type ChatRunOptionsRequest,
+  type ChatThreadServiceTier,
   type CodexServiceTier,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -515,6 +516,7 @@ export function mockChatLifecycle(
       eventId?: string;
       model?: string;
       modelSelection: ModelSelectionRequest;
+      serviceTier?: ChatThreadServiceTier | null;
     }) => void;
     onModelSelectionUpdate?: (body: {
       model?: string | null;
@@ -941,11 +943,13 @@ export function mockChatLifecycle(
       throw new Error("Expected chat thread create to include model");
     }
     selectedModel = modelSelection.selectedModel;
+    codexServiceTier = body.serviceTier === "priority" ? "fast" : null;
     options?.onThreadCreate?.({
       clientThreadId: body.clientThreadId,
       eventId: body.eventId,
       model: body.model,
       modelSelection,
+      serviceTier: body.serviceTier,
     });
     return respond(201, {
       id: threadId,


### PR DESCRIPTION
## Summary

- persist the selected Codex Fast service tier in the initial chat-thread create request
- keep the existing model-selection update for user preference persistence without exposing a Standard intermediate state
- cover optimistic-to-persisted thread reconciliation and assert the composer remains on Fast

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` (49 passed)
