### PR TITLE
test(api): isolate email outbox drain callers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -2,10 +2,8 @@ import { createHash, randomUUID } from "node:crypto";
 import { Readable } from "node:stream";
 import { HttpResponse, http } from "msw";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
-import {
-  cronDrainEmailOutboxContract,
-  cronExecuteMorningBriefsContract,
-} from "@vm0/api-contracts/contracts/cron";
+import { cronExecuteMorningBriefsContract } from "@vm0/api-contracts/contracts/cron";
+import type { TestEmailOutboxStateItem } from "@vm0/api-contracts/contracts/test-email-outbox-state";
 import {
   chatThreadEventsContract,
   chatThreadsContract,
@@ -33,6 +31,7 @@ import {
   mockGmailConnectorOAuth,
 } from "./helpers/api-bdd-connectors";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
+import { createEmailOutboxStateApi } from "./helpers/email-outbox-state";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { chatEventDisplayText } from "./helpers/chat-event";
@@ -51,7 +50,6 @@ import {
   setMorningBriefTriggeredAtFixture,
 } from "../../../test-fixtures/morning-brief";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
-import { cronDrainEmailOutboxRoutes } from "../cron-drain-email-outbox";
 import { cronExecuteMorningBriefsRoutes } from "../cron-execute-morning-briefs";
 import { emailMorningBriefUnsubscribeRoutes } from "../email-morning-brief-unsubscribe";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
@@ -60,7 +58,6 @@ import { zeroMorningBriefRoutes } from "../zero-morning-brief";
 import { zeroUserPreferencesRoutes } from "../zero-user-preferences";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...cronDrainEmailOutboxRoutes,
   ...cronExecuteMorningBriefsRoutes,
   ...emailMorningBriefUnsubscribeRoutes,
   ...zeroChatThreadRoutes,
@@ -86,6 +83,7 @@ const chat = createChatFilesBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const connectors = createConnectorBddApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
+const outbox = createEmailOutboxStateApi(context);
 const routeMocks = createZeroRouteMocks(context);
 const callbackStore = createStore();
 const CRON_SECRET = "test-morning-brief-cron-secret";
@@ -103,14 +101,18 @@ const BRIEF_DATE = new Intl.DateTimeFormat("en-CA", {
   day: "2-digit",
   timeZone: TIMEZONE,
 }).format(SEVEN_LOCAL);
-const BRIEF_DATE_LABEL = new Intl.DateTimeFormat("en-US", {
-  weekday: "long",
-  year: "numeric",
-  month: "long",
-  day: "numeric",
-  timeZone: TIMEZONE,
-}).format(SEVEN_LOCAL);
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function morningBriefSubject(timestampMs: number = SEVEN_LOCAL): string {
+  const dateLabel = new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: TIMEZONE,
+  }).format(timestampMs);
+  return `Morning Briefing - ${dateLabel}`;
+}
 
 function mockTimedMorningBriefSignedUrls(): void {
   context.mocks.s3.getSignedUrl.mockImplementation(
@@ -225,12 +227,6 @@ function actorHeaders() {
 function morningBriefCronClient() {
   return setupApp({ context, routes: cronExecuteMorningBriefsRoutes })(
     cronExecuteMorningBriefsContract,
-  );
-}
-
-function drainOutboxClient() {
-  return setupApp({ context, routes: cronDrainEmailOutboxRoutes })(
-    cronDrainEmailOutboxContract,
   );
 }
 
@@ -685,8 +681,27 @@ async function primeMorningBriefThread(scenario: Scenario): Promise<void> {
   await completeMorningBriefRun(scenario, previous.body.runId, 1);
 }
 
-async function drainOutbox(): Promise<void> {
-  await accept(drainOutboxClient().drain({ headers: cronHeaders() }), [200]);
+async function morningBriefOutboxItems(
+  scenario: Scenario,
+  timestampMs: number = SEVEN_LOCAL,
+): Promise<readonly TestEmailOutboxStateItem[]> {
+  return await outbox.findItems({
+    toAddress: scenario.actor.email,
+    subject: morningBriefSubject(timestampMs),
+  });
+}
+
+async function drainMorningBriefOutbox(
+  scenario: Scenario,
+  timestampMs: number = SEVEN_LOCAL,
+): Promise<void> {
+  const item = await outbox.findItem({
+    toAddress: scenario.actor.email,
+    subject: morningBriefSubject(timestampMs),
+  });
+  const sendsBeforeDrain = context.mocks.resend.send.mock.calls.length;
+  await expect(outbox.drainItems([item.id])).resolves.toBe(1);
+  expect(context.mocks.resend.send).toHaveBeenCalledTimes(sendsBeforeDrain + 1);
 }
 
 function sentMorningBriefEmails(): readonly {
@@ -852,7 +867,7 @@ describe("cron execute morning briefs", () => {
       runId,
       0,
     );
-    await drainOutbox();
+    await drainMorningBriefOutbox(scenario);
 
     expect(appendSystemPrompt).toContain("Begin exactly with `Good morning.`");
 
@@ -876,7 +891,7 @@ describe("cron execute morning briefs", () => {
       throw new Error("Expected a morning brief email");
     }
     expect(email.from).toBe("Zero <zero@vm0.bot>");
-    expect(email.subject).toBe(`Morning Briefing - ${BRIEF_DATE_LABEL}`);
+    expect(email.subject).toBe(morningBriefSubject());
     // Generic preheader only; specifics stay inside the body.
     expect(email.html).toContain(
       "Your schedule, action items, and updates for today.",
@@ -934,7 +949,9 @@ describe("cron execute morning briefs", () => {
     // The next day nothing fires for the unsubscribed member.
     mockNow(AFTER_SEVEN_LOCAL + DAY_MS);
     await executeMorningBriefsCron();
-    await drainOutbox();
+    await expect(
+      morningBriefOutboxItems(scenario, AFTER_SEVEN_LOCAL + DAY_MS),
+    ).resolves.toHaveLength(0);
     expect(sentMorningBriefEmails()).toHaveLength(1);
     clearMockNow();
   });
@@ -981,7 +998,7 @@ describe("cron execute morning briefs", () => {
       }),
     );
     await completeMorningBriefRun(scenario, runId, 0);
-    await drainOutbox();
+    await drainMorningBriefOutbox(scenario);
 
     const emails = sentMorningBriefEmails();
     expect(emails).toHaveLength(1);
@@ -1135,7 +1152,7 @@ describe("cron execute morning briefs", () => {
 
     mockUploadedBriefOutput(VALID_OUTPUT);
     await completeMorningBriefRun(scenario, triggeredRunId, 0, null);
-    await drainOutbox();
+    await drainMorningBriefOutbox(scenario);
     expect(sentMorningBriefEmails()).toHaveLength(1);
 
     // Repeat triggers on the same local date return the admitted delivery
@@ -1149,7 +1166,7 @@ describe("cron execute morning briefs", () => {
       [200],
     );
     await flushWaitUntilForTest();
-    await drainOutbox();
+    await expect(morningBriefOutboxItems(scenario)).resolves.toHaveLength(1);
     expect(second.body).toStrictEqual({
       runId: triggeredRunId,
       briefDate: BRIEF_DATE,
@@ -1663,7 +1680,7 @@ describe("cron execute morning briefs", () => {
 
     mockUploadedBriefOutput(VALID_OUTPUT);
     await completeMorningBriefRun(scenario, briefRunId, 0);
-    await drainOutbox();
+    await drainMorningBriefOutbox(scenario);
 
     let userRunId: string | null = null;
     await expect
@@ -1713,7 +1730,7 @@ describe("cron execute morning briefs", () => {
     const { runId } = await findMorningBriefThread(scenario);
     mockUploadedBriefOutput('{"version": 999, "nonsense": true}');
     await completeMorningBriefRun(scenario, runId, 0);
-    await drainOutbox();
+    await expect(morningBriefOutboxItems(scenario)).resolves.toHaveLength(0);
 
     expect(sentMorningBriefEmails()).toHaveLength(0);
     clearMockNow();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { cronDrainEmailOutboxContract } from "@vm0/api-contracts/contracts/cron";
+import type { TestEmailOutboxStateItem } from "@vm0/api-contracts/contracts/test-email-outbox-state";
 import { userExportContract } from "@vm0/api-contracts/contracts/user-export";
 
 import { accept, type TestContext } from "../../../../__tests__/test-context";
@@ -9,9 +10,9 @@ import { flushWaitUntilForTest } from "../../../context/wait-until";
 import { cronDrainEmailOutboxRoutes } from "../../cron-drain-email-outbox";
 import { userExportRoutes } from "../../user-export";
 import type { ApiTestUser } from "./api-bdd";
+import { createEmailOutboxStateApi } from "./email-outbox-state";
 import { createZeroRouteMocks } from "./zero-route-test";
 
-const CRON_AUTHORIZATION = "Bearer test-cron-secret";
 const EMAIL_ROUTES = Object.freeze([
   ...cronDrainEmailOutboxRoutes,
   ...userExportRoutes,
@@ -43,6 +44,8 @@ function authenticate(context: TestContext, actor: ApiTestUser) {
 }
 
 export function createEmailApi(context: TestContext) {
+  const outbox = createEmailOutboxStateApi(context);
+
   return {
     async enqueueDataExportEmail(
       actor: ApiTestUser,
@@ -70,15 +73,40 @@ export function createEmailApi(context: TestContext) {
       ) {
         throw new Error("Expected the data export email job to complete");
       }
-      return { to: actor.email, subject: "Your data export is ready" };
+      const subject = "Your data export is ready";
+      return { to: actor.email, subject };
     },
 
-    async drainEmailOutboxCron(validAuth: boolean) {
+    async findEmailOutboxItems(options: {
+      readonly to: string;
+      readonly subject: string;
+    }): Promise<readonly TestEmailOutboxStateItem[]> {
+      return await outbox.findItems({
+        toAddress: options.to,
+        subject: options.subject,
+      });
+    },
+
+    async findEmailOutboxItem(options: {
+      readonly to: string;
+      readonly subject: string;
+    }): Promise<TestEmailOutboxStateItem> {
+      return await outbox.findItem({
+        toAddress: options.to,
+        subject: options.subject,
+      });
+    },
+
+    async drainEmailOutboxItems(itemIds: readonly string[]): Promise<number> {
+      return await outbox.drainItems(itemIds);
+    },
+
+    async requestEmailOutboxCronWithoutAuth() {
       return await accept(
         emailApp(context)(cronDrainEmailOutboxContract).drain({
-          headers: validAuth ? { authorization: CRON_AUTHORIZATION } : {},
+          headers: {},
         }),
-        [200, 401],
+        [401],
       );
     },
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/email-outbox-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/email-outbox-state.ts
@@ -16,6 +16,11 @@ interface SeedEmailOutboxItemOptions {
   readonly createdAt: Date;
 }
 
+interface FindEmailOutboxItemsOptions {
+  readonly toAddress: string;
+  readonly subject: string;
+}
+
 function stateClient(context: TestContext) {
   return setupAppWithRoutes({
     context,
@@ -32,6 +37,20 @@ async function postAction(
 }
 
 export function createEmailOutboxStateApi(context: TestContext) {
+  async function findItems(
+    options: FindEmailOutboxItemsOptions,
+  ): Promise<readonly TestEmailOutboxStateItem[]> {
+    const response = await postAction(context, {
+      action: "find-item",
+      to_address: options.toAddress,
+      subject: options.subject,
+    });
+    if (response.action !== "find-item") {
+      throw new Error("Expected the email outbox find response");
+    }
+    return response.items;
+  }
+
   return {
     async seedItem(
       options: SeedEmailOutboxItemOptions,
@@ -49,23 +68,18 @@ export function createEmailOutboxStateApi(context: TestContext) {
       return response.item;
     },
 
-    async findItem(options: {
-      readonly toAddress: string;
-      readonly subject: string;
-    }): Promise<TestEmailOutboxStateItem> {
-      const response = await postAction(context, {
-        action: "find-item",
-        to_address: options.toAddress,
-        subject: options.subject,
-      });
-      if (response.action !== "find-item" || response.items.length !== 1) {
+    findItems,
+
+    async findItem(
+      options: FindEmailOutboxItemsOptions,
+    ): Promise<TestEmailOutboxStateItem> {
+      const items = await findItems(options);
+      if (items.length !== 1) {
         throw new Error(
-          `Expected one email outbox item, found ${
-            response.action === "find-item" ? response.items.length : 0
-          }`,
+          `Expected one email outbox item, found ${items.length}`,
         );
       }
-      const item = response.items[0];
+      const item = items[0];
       if (!item) {
         throw new Error("Expected the uniquely matched email outbox item");
       }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
@@ -429,7 +429,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 
 // Workflow schedule lifecycle and execution coverage lives in
 // zero-workflow-automations.test.ts and zero-workflow-automation-scheduler.test.ts.
-// This file retains shared cron authorization and email outbox boundaries.
+// Shared cron authorization remains covered here.
 
 describe("SCHED-02: cron routes", () => {
   it("rejects invalid cron auth on shared cron routes", async () => {
@@ -448,7 +448,7 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
   it("rejects unauthorized drain requests", async () => {
     const email = createEmailApi(context);
 
-    const unauthorizedDrain = await email.drainEmailOutboxCron(false);
+    const unauthorizedDrain = await email.requestEmailOutboxCronWithoutAuth();
     expect(unauthorizedDrain.status).toBe(401);
   });
 
@@ -462,6 +462,7 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
     });
 
     const { to, subject } = await email.enqueueDataExportEmail(actor);
+    const item = await email.findEmailOutboxItem({ to, subject });
     expect(resendSendCallsTo(to)).toBe(0);
 
     context.mocks.resend.send.mockResolvedValue({
@@ -469,10 +470,9 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
       error: { message: "data export drain down" },
     });
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
-    const failedDrain = await email.drainEmailOutboxCron(true);
-    if (failedDrain.status !== 200) {
-      throw new Error("Expected failed email outbox drain to return success");
-    }
+    const failedDrain = await email.drainEmailOutboxItems([item.id]);
+    expect(failedDrain).toBe(1);
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(resendSendCallsTo(to)).toBe(1);
 
     context.mocks.resend.send.mockReset();
@@ -480,20 +480,14 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
       data: { id: "resend-bdd-1" },
     });
 
-    const beforeRetry = await email.drainEmailOutboxCron(true);
-    if (beforeRetry.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(beforeRetry.body.success).toBeTruthy();
+    const beforeRetry = await email.drainEmailOutboxItems([item.id]);
+    expect(beforeRetry).toBe(0);
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(0);
     expect(resendSendCallsTo(to)).toBe(0);
 
     mockNow(baseTime + 1000);
-    const drain = await email.drainEmailOutboxCron(true);
-    if (drain.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(drain.body.success).toBeTruthy();
-    expect(drain.body.drained).toBeGreaterThanOrEqual(1);
+    const drain = await email.drainEmailOutboxItems([item.id]);
+    expect(drain).toBe(1);
     expect(context.mocks.resend.send).toHaveBeenCalledWith(
       expect.objectContaining({
         from: "Zero <vm0@mail.example.com>",
@@ -502,19 +496,20 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
         html: expect.stringContaining("Your data export is ready"),
       }),
     );
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(resendSendCallsTo(to)).toBe(1);
 
-    const second = await email.drainEmailOutboxCron(true);
-    if (second.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
+    const second = await email.drainEmailOutboxItems([item.id]);
+    expect(second).toBe(0);
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(resendSendCallsTo(to)).toBe(1);
   });
 
   it("skips an outbox row locked by the inline drain", async () => {
     const email = createEmailApi(context);
     const actor = createBddApi(context).user();
-    const { to } = await email.enqueueDataExportEmail(actor);
+    const { to, subject } = await email.enqueueDataExportEmail(actor);
+    const item = await email.findEmailOutboxItem({ to, subject });
     const sendStarted = createDeferredPromise<void>(context.signal);
     const releaseSend = createDeferredPromise<void>(context.signal);
     onTestFinished(async () => {
@@ -539,26 +534,25 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
     });
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
 
-    const firstDrain = email.drainEmailOutboxCron(true);
+    const firstDrain = email.drainEmailOutboxItems([item.id]);
     await sendStarted.promise;
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(resendSendCallsTo(to)).toBe(1);
 
-    const concurrentDrain = await email.drainEmailOutboxCron(true);
-    if (concurrentDrain.status !== 200) {
-      throw new Error("Expected concurrent email outbox drain to succeed");
-    }
-    expect(concurrentDrain.body.success).toBeTruthy();
+    const concurrentDrain = await email.drainEmailOutboxItems([item.id]);
+    expect(concurrentDrain).toBe(0);
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(resendSendCallsTo(to)).toBe(1);
 
     releaseSend.resolve(undefined);
-    await firstDrain;
+    await expect(firstDrain).resolves.toBe(1);
     await flushWaitUntilForTest();
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(resendSendCallsTo(to)).toBe(1);
 
-    const afterRelease = await email.drainEmailOutboxCron(true);
-    if (afterRelease.status !== 200) {
-      throw new Error("Expected final email outbox drain to succeed");
-    }
+    const afterRelease = await email.drainEmailOutboxItems([item.id]);
+    expect(afterRelease).toBe(0);
+    expect(context.mocks.resend.send).toHaveBeenCalledTimes(1);
     expect(resendSendCallsTo(to)).toBe(1);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
@@ -96,27 +96,13 @@ async function postInbound(event: WebhookEvent) {
   );
 }
 
-function sendCallsTo(recipient: string): number {
-  return resendMocks.send.mock.calls.filter((call) => {
-    const [payload] = call;
-    if (typeof payload !== "object" || payload === null || !("to" in payload)) {
-      return false;
-    }
-    const to = payload.to;
-    return typeof to === "string"
-      ? to === recipient
-      : Array.isArray(to) && to.includes(recipient);
-  }).length;
-}
-
 beforeEach(() => {
   resendMocks.send.mockReset();
   resendMocks.send.mockResolvedValue({ data: { id: "resend-test-id" } });
   mockEnv("RESEND_API_KEY", "test-resend-key");
   mockEnv("RESEND_WEBHOOK_SECRET", INBOUND_SECRET);
   mockEnv("RESEND_FROM_DOMAIN", "mail.example.com");
-  // This route drains a cross-file outbox; Resend pacing is not part of these
-  // transactional delivery assertions.
+  // Resend pacing is not part of these transactional delivery assertions.
   mockOptionalEnv("EMAIL_OUTBOX_DRAIN_DELAY_MS", "0");
 });
 
@@ -187,9 +173,14 @@ describe("low-credit email delivery", () => {
     // the organization's admin recipients.
     await billing.readBillingStatus(actor);
     await billing.processOrgUsageEvents(actor);
-    const drain = await email.drainEmailOutboxCron(true);
+    const item = await email.findEmailOutboxItem({
+      to: actor.email,
+      subject: "Your credit balance is running low",
+    });
+    const drained = await email.drainEmailOutboxItems([item.id]);
 
-    expect(drain.status).toBe(200);
+    expect(drained).toBe(1);
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
     expect(context.mocks.resend.send).toHaveBeenCalledWith(
       expect.objectContaining({
         from: "VM0 Team <support@vm0.ai>",
@@ -228,10 +219,15 @@ describe("POST /api/zero/email/inbound", () => {
   it("sends data-export email to eligible recipients", async () => {
     const controlActor = bdd.user();
 
-    await email.enqueueDataExportEmail(controlActor);
-    const drain = await email.drainEmailOutboxCron(true);
-    expect(drain.status).toBe(200);
-    expect(sendCallsTo(controlActor.email)).toBe(1);
+    const locator = await email.enqueueDataExportEmail(controlActor);
+    const item = await email.findEmailOutboxItem(locator);
+    const drained = await email.drainEmailOutboxItems([item.id]);
+
+    expect(drained).toBe(1);
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
+    expect(resendMocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: controlActor.email }),
+    );
   });
 
   it("keeps bounced recipients out of transactional sends", async () => {
@@ -245,10 +241,12 @@ describe("POST /api/zero/email/inbound", () => {
       },
     });
 
-    await email.enqueueDataExportEmail(bouncedActor);
-    const drain = await email.drainEmailOutboxCron(true);
-    expect(drain.status).toBe(200);
-    expect(sendCallsTo(bouncedActor.email)).toBe(0);
+    const locator = await email.enqueueDataExportEmail(bouncedActor);
+    const item = await email.findEmailOutboxItem(locator);
+    const drained = await email.drainEmailOutboxItems([item.id]);
+
+    expect(drained).toBe(1);
+    expect(resendMocks.send).toHaveBeenCalledTimes(0);
   });
 
   it("keeps complained recipients out of transactional sends", async () => {
@@ -265,10 +263,11 @@ describe("POST /api/zero/email/inbound", () => {
       },
     });
 
-    await email.enqueueDataExportEmail(complainedActor);
-    const drain = await email.drainEmailOutboxCron(true);
-    expect(drain.status).toBe(200);
-    expect(sendCallsTo(complainedActor.email)).toBe(0);
+    const locator = await email.enqueueDataExportEmail(complainedActor);
+    const items = await email.findEmailOutboxItems(locator);
+
+    expect(items).toHaveLength(0);
+    expect(resendMocks.send).toHaveBeenCalledTimes(0);
   });
 
   it("acknowledges new and reply-address email without creating Agent runs", async () => {


### PR DESCRIPTION
## Summary

- scope every valid test email-outbox drain to IDs created by the current test
- assert exact drain and send counts across retry, suppression, data-export, and morning-brief delivery cases
- preserve production cron authorization coverage and the two-drain row-lock claim-once proof

## Validation

- focused Prettier, Oxlint, and ESLint checks for the five changed files
- `pnpm knip --workspace api`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts src/signals/routes/__tests__/run-cron.bdd.test.ts src/signals/routes/__tests__/zero-email.test.ts src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts` (4 files, 30 tests)

Closes #26582

Parent epic: #26569
