### PR TITLE
feat(desktop): finalize okou application identity

### DIFF
--- a/.github/scripts/build-okou-desktop-artifact.sh
+++ b/.github/scripts/build-okou-desktop-artifact.sh
@@ -25,8 +25,8 @@ if [[ ! -d "$app_dir" || "$(basename "$app_dir")" != "Zero Computer Use.app" ]];
   echo "Desktop artifact requires a Zero Computer Use.app directory: $app_dir" >&2
   exit 1
 fi
-if [[ -n "$okou_app_dir" && (! -d "$okou_app_dir" || "$(basename "$okou_app_dir")" != "Okou Computer Use.app") ]]; then
-  echo "Desktop artifact requires an Okou Computer Use.app directory: $okou_app_dir" >&2
+if [[ -n "$okou_app_dir" && (! -d "$okou_app_dir" || "$(basename "$okou_app_dir")" != "Okou.app") ]]; then
+  echo "Desktop artifact requires an Okou.app directory: $okou_app_dir" >&2
   exit 1
 fi
 
@@ -75,7 +75,7 @@ jq -n \
     }
   }
   | if $okou_archive_sha256 == "" then . else . + {
-      okouAppName: "Okou Computer Use.app",
+      okouAppName: "Okou.app",
       okouArchive: {
         path: "okou-app.tar.gz",
         sha256: $okou_archive_sha256,

--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -35,7 +35,7 @@ ruby -e '
   raise "Okou CI build must package runtime product identity" unless okou_build.fetch("run").include?("product: process.env.VM0_DESKTOP_PRODUCT")
 
   okou_verify = build.fetch("steps").find { |step| step["name"] == "Verify Okou production artifact" }.fetch("run")
-  raise "Okou artifact must verify its bundle ID" unless okou_verify.include?("ai.okou.computer-use")
+  raise "Okou artifact must verify its bundle ID" unless okou_verify.include?("ai.okou.desktop")
   raise "Okou artifact must verify side-by-side installation" unless okou_verify.include?("Zero and Okou should remain installable side by side")
 
   artifact_step = deploy.fetch("steps").find { |step| step["id"] == "artifact" }
@@ -44,11 +44,11 @@ ruby -e '
 
   build_step = deploy.fetch("steps").find { |step| step["name"] == "Build canonical unsigned Desktop app" }
   raise "canonical Desktop build must skip signing" unless build_step.fetch("env").fetch("VM0_DESKTOP_SKIP_SIGNING") == "true"
-  raise "canonical Desktop build must package Okou" unless build_step.fetch("run").include?("Okou Computer Use.app")
+  raise "canonical Desktop build must package Okou" unless build_step.fetch("run").include?("Okou.app")
   raise "canonical Okou build must target app.okou.ai" unless build_step.fetch("run").include?("VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai")
 
   artifact_build = deploy.fetch("steps").find { |step| step["name"] == "Create canonical Desktop artifact" }.fetch("run")
-  raise "canonical artifact must contain the Okou app" unless artifact_build.include?("Okou Computer Use-darwin-arm64/Okou Computer Use.app")
+  raise "canonical artifact must contain the Okou app" unless artifact_build.include?("Okou-darwin-arm64/Okou.app")
 
   artifact_upload = deploy.fetch("steps").find { |step| step["name"] == "Upload canonical Desktop artifact" }.fetch("run")
   raise "canonical artifact must upload the Okou archive" unless artifact_upload.include?("okou-app.tar.gz")
@@ -77,8 +77,8 @@ ruby -e '
   raise "Desktop manifest must wait for promotion" unless Array(publish.fetch("needs")).include?("promote-desktop-release")
   publish_text = publish.fetch("steps").find { |step| step["name"] == "Publish Desktop update manifest" }.fetch("run")
   raise "Desktop manifests must preserve the Zero feed" unless publish_text.include?("desktop-update-manifest.json")
-  raise "Desktop manifests must publish the Okou feed" unless publish_text.include?("okou-desktop-update-manifest.json")
-  raise "Desktop manifests must publish under the Okou mutable tag" unless publish_text.include?("okou-desktop-updates")
+  raise "Desktop manifests must publish the Okou feed" unless publish_text.include?("ai-okou-desktop-update-manifest.json")
+  raise "Desktop manifests must publish under the Okou mutable tag" unless publish_text.include?("ai-okou-desktop-updates")
 ' \
   "$desktop_workflow" \
   "$release_workflow" \

--- a/.github/scripts/tests/okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/okou-desktop-artifact-test.sh
@@ -10,16 +10,16 @@ trap 'rm -rf "$tmp_dir"' EXIT
 commit_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 desktop_version="1.2.3"
 app_dir="${tmp_dir}/package/Zero Computer Use.app"
-okou_app_dir="${tmp_dir}/package/Okou Computer Use.app"
+okou_app_dir="${tmp_dir}/package/Okou.app"
 artifact_dir="${tmp_dir}/artifact"
 mkdir -p \
   "$app_dir/Contents/MacOS" \
   "$app_dir/Contents/Frameworks/Example.framework/Versions/A" \
   "$okou_app_dir/Contents/MacOS"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$app_dir/Contents/MacOS/Zero Computer Use"
-printf '#!/usr/bin/env bash\nexit 0\n' > "$okou_app_dir/Contents/MacOS/Okou Computer Use"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$okou_app_dir/Contents/MacOS/Okou"
 chmod +x "$app_dir/Contents/MacOS/Zero Computer Use"
-chmod +x "$okou_app_dir/Contents/MacOS/Okou Computer Use"
+chmod +x "$okou_app_dir/Contents/MacOS/Okou"
 ln -s A "$app_dir/Contents/Frameworks/Example.framework/Versions/Current"
 
 bash "$build_script" \
@@ -34,7 +34,7 @@ jq -e \
   --arg desktop_version "$desktop_version" \
   '.commitSha == $commit_sha
     and .desktopVersion == $desktop_version
-    and .okouAppName == "Okou Computer Use.app"
+    and .okouAppName == "Okou.app"
     and .okouArchive.path == "okou-app.tar.gz"' \
   "$artifact_dir/manifest.json" >/dev/null
 
@@ -43,7 +43,7 @@ mkdir -p "$extracted_dir"
 tar -xzf "$artifact_dir/app.tar.gz" -C "$extracted_dir"
 tar -xzf "$artifact_dir/okou-app.tar.gz" -C "$extracted_dir"
 test -x "$extracted_dir/Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
-test -x "$extracted_dir/Okou Computer Use.app/Contents/MacOS/Okou Computer Use"
+test -x "$extracted_dir/Okou.app/Contents/MacOS/Okou"
 test -L "$extracted_dir/Zero Computer Use.app/Contents/Frameworks/Example.framework/Versions/Current"
 
 legacy_artifact_dir="${tmp_dir}/legacy-artifact"
@@ -150,28 +150,28 @@ const { packagedAppPaths } = require(path.join(
   "turbo/apps/desktop/scripts/packaged-app-paths.js",
 ));
 
-if (forgeConfig.packagerConfig.name !== "Okou Computer Use") {
+if (forgeConfig.packagerConfig.name !== "Okou") {
   throw new Error("Okou build must use the Okou display name");
 }
-if (forgeConfig.packagerConfig.appBundleId !== "ai.okou.computer-use") {
+if (forgeConfig.packagerConfig.appBundleId !== "ai.okou.desktop") {
   throw new Error("Okou build must use the Okou production bundle ID");
 }
 if (
   forgeConfig.packagerConfig.protocols[0].schemes[0] !==
-  "ai.okou.computer-use"
+  "ai.okou.desktop"
 ) {
   throw new Error("Okou build must register the Okou auth scheme");
 }
 if (
   !packagedAppPaths().appBundlePath.endsWith(
-    `Okou Computer Use-${process.platform}-${process.arch}/Okou Computer Use.app`,
+    `Okou-${process.platform}-${process.arch}/Okou.app`,
   )
 ) {
   throw new Error("Okou packaged app path must be product scoped");
 }
 if (
-  packagedAppPaths({ appBundlePath: "/tmp/Okou Computer Use.app" })
-    .appBundlePath !== "/tmp/Okou Computer Use.app"
+  packagedAppPaths({ appBundlePath: "/tmp/Okou.app" })
+    .appBundlePath !== "/tmp/Okou.app"
 ) {
   throw new Error("Desktop smoke tests must support an installed app path");
 }

--- a/.github/scripts/verify-okou-desktop-artifact.sh
+++ b/.github/scripts/verify-okou-desktop-artifact.sh
@@ -100,14 +100,14 @@ verify_archive \
 has_okou_archive="$(jq -r 'has("okouAppName") or has("okouArchive")' "$manifest_path")"
 if [[ "$has_okou_archive" == "true" ]]; then
   jq -e \
-    '.okouAppName == "Okou Computer Use.app"
+    '.okouAppName == "Okou.app"
       and .okouArchive.path == "okou-app.tar.gz"
       and (.okouArchive.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
       and (.okouArchive.size | type == "number" and . > 0)' \
     "$manifest_path" >/dev/null
   verify_archive \
     "$artifact_dir/okou-app.tar.gz" \
-    "Okou Computer Use.app" \
+    "Okou.app" \
     '.okouArchive'
 elif [[ "$require_okou" == "--require-okou" ]]; then
   echo "Desktop artifact does not contain the required Okou app archive" >&2

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -285,7 +285,7 @@ jobs:
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Okou Computer Use-darwin-arm64-$version.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Okou-darwin-arm64-$version.zip"
           artifact_path="apps/desktop/out/Okou-darwin-arm64.zip"
 
           if [ ! -f "$forge_zip" ]; then
@@ -300,7 +300,7 @@ jobs:
       - name: Verify Okou production artifact
         run: |
           artifact_path="apps/desktop/out/Okou-darwin-arm64.zip"
-          app_dir="apps/desktop/out/Okou Computer Use-darwin-arm64/Okou Computer Use.app"
+          app_dir="apps/desktop/out/Okou-darwin-arm64/Okou.app"
           zero_app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
           plist="$app_dir/Contents/Info.plist"
           runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
@@ -343,14 +343,14 @@ jobs:
             echo "::error::Expected LSMinimumSystemVersion 14.0, found ${minimum_system_version:-missing}"
             exit 1
           fi
-          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Okou Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Okou Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Okou Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.okou.computer-use"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Okou"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Okou"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Okou"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.okou.desktop"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Okou Computer Use Auth"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.okou.computer-use"
-          file "$app_dir/Contents/MacOS/Okou Computer Use" | grep -q "arm64"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Okou Auth"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.okou.desktop"
+          file "$app_dir/Contents/MacOS/Okou" | grep -q "arm64"
           file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
@@ -362,13 +362,13 @@ jobs:
             exit 1
           fi
 
-          unzip -l "$artifact_path" | grep -q "Okou Computer Use.app/Contents/MacOS/Okou Computer Use"
-          unzip -l "$artifact_path" | grep -q "Okou Computer Use.app/Contents/Resources/icon.icns"
-          unzip -l "$artifact_path" | grep -q "Okou Computer Use.app/Contents/Resources/native/computer-use-helper"
-          unzip -l "$artifact_path" | grep -q "Okou Computer Use.app/Contents/Resources/app/dist/main.js"
-          unzip -l "$artifact_path" | grep -q "Okou Computer Use.app/Contents/Resources/app/dist/bootstrap.js"
-          unzip -l "$artifact_path" | grep -q "Okou Computer Use.app/Contents/Resources/app/assets/icon.png"
-          unzip -l "$artifact_path" | grep -q "Okou Computer Use.app/Contents/Resources/app/desktop-runtime-config.json"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/MacOS/Okou"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/native/computer-use-helper"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/app/dist/main.js"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/app/dist/bootstrap.js"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/app/assets/icon.png"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/app/desktop-runtime-config.json"
 
       - name: Smoke test Okou production artifact launch
         env:
@@ -706,7 +706,7 @@ jobs:
             --platform darwin \
             --arch arm64
 
-          okou_app_dir="$PWD/apps/desktop/out/Okou Computer Use-darwin-arm64/Okou Computer Use.app"
+          okou_app_dir="$PWD/apps/desktop/out/Okou-darwin-arm64/Okou.app"
           if [ ! -d "$okou_app_dir" ]; then
             echo "No packaged Okou app found: $okou_app_dir"
             find apps/desktop/out -maxdepth 4 -type d -print || true
@@ -734,7 +734,7 @@ jobs:
             "$DESKTOP_VERSION" \
             "turbo/apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app" \
             /tmp/okou-desktop-artifact \
-            "turbo/apps/desktop/out/Okou Computer Use-darwin-arm64/Okou Computer Use.app"
+            "turbo/apps/desktop/out/Okou-darwin-arm64/Okou.app"
 
       - name: Upload canonical Desktop artifact
         if: steps.existing.outputs.exists != 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -290,7 +290,7 @@ jobs:
           ready_key="okou-desktop/${ARTIFACT_SHA}/ready.json"
           artifact_dir="$(mktemp -d)"
           zero_package_dir="$PWD/apps/desktop/out/Zero Computer Use-darwin-arm64"
-          okou_package_dir="$PWD/apps/desktop/out/Okou Computer Use-darwin-arm64"
+          okou_package_dir="$PWD/apps/desktop/out/Okou-darwin-arm64"
           error_log="$(mktemp)"
 
           for attempt in $(seq 1 60); do
@@ -333,13 +333,13 @@ jobs:
           tar -xzf "$artifact_dir/app.tar.gz" -C "$zero_package_dir"
           tar -xzf "$artifact_dir/okou-app.tar.gz" -C "$okou_package_dir"
           zero_app_dir="$zero_package_dir/Zero Computer Use.app"
-          okou_app_dir="$okou_package_dir/Okou Computer Use.app"
+          okou_app_dir="$okou_package_dir/Okou.app"
           if [ ! -d "$zero_app_dir" ]; then
             echo "Canonical Desktop artifact did not contain Zero Computer Use.app" >&2
             exit 1
           fi
           if [ ! -d "$okou_app_dir" ]; then
-            echo "Canonical Desktop artifact did not contain Okou Computer Use.app" >&2
+            echo "Canonical Desktop artifact did not contain Okou.app" >&2
             exit 1
           fi
           {
@@ -455,7 +455,7 @@ jobs:
             okou \
             "${{ steps.desktop-app.outputs.okou_app_dir }}" \
             Okou \
-            "Okou Computer Use" \
+            "Okou" \
             apps/desktop/assets/dmg-background-okou.svg
 
           {
@@ -573,7 +573,7 @@ jobs:
 
               if [ "$product" = "okou" ]; then
                 install_dir="$RUNNER_TEMP/okou-install-smoke/Applications"
-                installed_app="$install_dir/Okou Computer Use.app"
+                installed_app="$install_dir/Okou.app"
                 update_dir="$RUNNER_TEMP/okou-update-smoke"
                 rm -rf "$install_dir" "$update_dir"
                 mkdir -p "$install_dir" "$update_dir"
@@ -586,7 +586,7 @@ jobs:
 
                 unzip -q "$zip_artifact_path" -d "$update_dir"
                 rm -rf "$installed_app"
-                ditto "$update_dir/Okou Computer Use.app" "$installed_app"
+                ditto "$update_dir/Okou.app" "$installed_app"
                 VM0_DESKTOP_PRODUCT=okou \
                 VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
                 VM0_DESKTOP_SMOKE_APP_PATH="$installed_app" \
@@ -603,10 +603,10 @@ jobs:
             ai.vm0.zero.desktop
           verify_product_artifacts \
             okou \
-            "Okou Computer Use" \
+            "Okou" \
             Okou \
-            ai.okou.computer-use \
-            ai.okou.computer-use
+            ai.okou.desktop \
+            ai.okou.desktop
 
           zero_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${{ steps.desktop-app.outputs.zero_app_dir }}/Contents/Info.plist")
           okou_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${{ steps.desktop-app.outputs.okou_app_dir }}/Contents/Info.plist")
@@ -632,8 +632,8 @@ jobs:
             gh release create "$OKOU_RELEASE_TAG" \
               --repo "${{ github.repository }}" \
               --target "$RELEASE_TARGET" \
-              --title "Okou Computer Use $DESKTOP_VERSION" \
-              --notes "Signed and notarized Okou Computer Use release for Apple silicon Macs." \
+              --title "Okou $DESKTOP_VERSION" \
+              --notes "Signed and notarized Okou release for Apple silicon Macs." \
               --latest=false
           fi
 
@@ -774,7 +774,7 @@ jobs:
               gh release create "$manifest_tag" \
                 --repo "${{ github.repository }}" \
                 --title "$manifest_title" \
-                --notes "Mutable manifest used by the $artifact_name Computer Use auto-update feed." \
+                --notes "Mutable manifest used by the $artifact_name desktop auto-update feed." \
                 --latest=false
             fi
 
@@ -804,8 +804,8 @@ jobs:
             okou \
             Okou \
             "$OKOU_RELEASE_TAG" \
-            okou-desktop-updates \
-            okou-desktop-update-manifest.json \
+            ai-okou-desktop-updates \
+            ai-okou-desktop-update-manifest.json \
             "Okou Desktop Updates"
 
   detect-host-worker-deploy-inputs:

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
@@ -195,7 +195,7 @@ describe("AUTH-02: desktop auth handoff", () => {
 
     const handoff = await authDevice.requestDesktopHandoff(
       bdd.user(),
-      { callbackScheme: "ai.okou.computer-use" },
+      { callbackScheme: "ai.okou.desktop" },
       [200],
     );
     if (handoff.status !== 200) {
@@ -205,7 +205,7 @@ describe("AUTH-02: desktop auth handoff", () => {
     }
 
     const callbackUrl = new URL(handoff.body.callbackUrl);
-    expect(callbackUrl.protocol).toBe("ai.okou.computer-use:");
+    expect(callbackUrl.protocol).toBe("ai.okou.desktop:");
     expect(callbackUrl.hostname).toBe("auth");
     expect(callbackUrl.pathname).toBe("/callback");
 

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -265,7 +265,7 @@ describe("desktop update routes", () => {
     const response = await accept(
       client().productFeed({
         params: {
-          line: "ai-okou-desktop",
+          product: "ai-okou-desktop",
           channel: "stable",
           platform: "darwin",
           arch: "arm64",
@@ -384,7 +384,7 @@ describe("desktop update routes", () => {
     const response = await accept(
       client().productFeed({
         params: {
-          line: "ai-okou-desktop",
+          product: "ai-okou-desktop",
           channel: "stable",
           platform: "darwin",
           arch: "arm64",

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -16,8 +16,10 @@ const TEST_APP_ROUTES = Object.freeze([...desktopUpdateRoutes]);
 const context = testContext();
 const DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
-const OKOU_DESKTOP_UPDATE_MANIFEST_URL =
+const LEGACY_OKOU_DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json";
+const OKOU_DESKTOP_UPDATE_MANIFEST_URL =
+  "https://github.com/vm0-ai/vm0/releases/download/ai-okou-desktop-updates/ai-okou-desktop-update-manifest.json";
 
 interface DesktopUpdateRelease {
   readonly version: string;
@@ -90,7 +92,10 @@ function darwinArm64Release(
 ) {
   return {
     version,
-    name: `${productName} Computer Use ${version}`,
+    name:
+      productName === "Okou"
+        ? `Okou ${version}`
+        : `Zero Computer Use ${version}`,
     notes: `Release ${version}`,
     pubDate: "2026-06-08T00:00:00.000Z",
     platforms: {
@@ -260,7 +265,7 @@ describe("desktop update routes", () => {
     const response = await accept(
       client().productFeed({
         params: {
-          product: "okou",
+          line: "ai-okou-desktop",
           channel: "stable",
           platform: "darwin",
           arch: "arm64",
@@ -275,7 +280,7 @@ describe("desktop update routes", () => {
         {
           version: "1.2.3",
           updateTo: {
-            name: "Okou Computer Use 1.2.3",
+            name: "Okou 1.2.3",
             version: "1.2.3",
             pub_date: "2026-06-08T00:00:00.000Z",
             url: zipUrl,
@@ -286,7 +291,7 @@ describe("desktop update routes", () => {
     });
   });
 
-  it("redirects Okou product routes to Okou release assets", async () => {
+  it("redirects the final Okou line to final-identity release assets", async () => {
     const zipUrl =
       "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
     mockDesktopUpdateManifest(
@@ -297,6 +302,36 @@ describe("desktop update routes", () => {
         product: "okou",
       },
       OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+    );
+
+    const releaseResponse = await appRequest(
+      "http://api.test/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/release",
+    );
+    expect(releaseResponse.status).toBe(302);
+    expect(releaseResponse.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
+    );
+
+    const dmgResponse = await appRequest(
+      "http://api.test/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/dmg",
+    );
+    expect(dmgResponse.status).toBe(302);
+    expect(dmgResponse.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
+    );
+  });
+
+  it("keeps branded Okou routes on the pre-adoption line before cutover", async () => {
+    const zipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
+    mockDesktopUpdateManifest(
+      {
+        ...stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", zipUrl, "Okou"),
+        }),
+        product: "okou",
+      },
+      LEGACY_OKOU_DESKTOP_UPDATE_MANIFEST_URL,
     );
 
     const releaseResponse = await appRequest(
@@ -332,7 +367,7 @@ describe("desktop update routes", () => {
     );
   });
 
-  it("does not serve a Zero artifact from the Okou feed", async () => {
+  it("does not serve a Zero artifact from the final Okou feed", async () => {
     mockDesktopUpdateManifest(
       {
         ...stableManifest("1.2.3", {
@@ -349,7 +384,7 @@ describe("desktop update routes", () => {
     const response = await accept(
       client().productFeed({
         params: {
-          product: "okou",
+          line: "ai-okou-desktop",
           channel: "stable",
           platform: "darwin",
           arch: "arm64",

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -101,8 +101,9 @@ const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
 
 const getProductDesktopReleasePage$ = command(
   async ({ get }, signal: AbortSignal) => {
+    const { product, ...params } = get(productReleasePageParams$);
     const url = await loadDesktopReleasePageUrl(
-      get(productReleasePageParams$),
+      { line: product, ...params },
       signal,
     );
     signal.throwIfAborted();
@@ -123,7 +124,11 @@ const getProductDesktopReleasePage$ = command(
 
 const getProductDesktopUpdateFeed$ = command(
   async ({ get }, signal: AbortSignal) => {
-    const feed = await loadDesktopUpdateFeed(get(productFeedParams$), signal);
+    const { product, ...params } = get(productFeedParams$);
+    const feed = await loadDesktopUpdateFeed(
+      { line: product, ...params },
+      signal,
+    );
     signal.throwIfAborted();
 
     if (!feed) {
@@ -139,8 +144,9 @@ const getProductDesktopUpdateFeed$ = command(
 
 const getProductDesktopDmgDownload$ = command(
   async ({ get }, signal: AbortSignal) => {
+    const { product, ...params } = get(productDmgDownloadParams$);
     const url = await loadDesktopDmgDownloadUrl(
-      get(productDmgDownloadParams$),
+      { line: product, ...params },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -1,10 +1,10 @@
-import { desktopUpdatesContract } from "@vm0/api-contracts/contracts/desktop-updates";
 import { brandedApiNamespace } from "@vm0/api-contracts/contracts/api-namespaces";
 import {
-  DESKTOP_PRODUCT_OKOU,
-  DESKTOP_PRODUCT_ZERO,
-  type DesktopProduct,
-} from "@vm0/api-contracts/contracts/client-headers";
+  DESKTOP_UPDATE_LINE_LEGACY_OKOU,
+  DESKTOP_UPDATE_LINE_ZERO,
+  desktopUpdatesContract,
+  type DesktopUpdateLine,
+} from "@vm0/api-contracts/contracts/desktop-updates";
 import { command } from "ccstate";
 
 import { notFound } from "../../lib/error";
@@ -28,16 +28,18 @@ const productDmgDownloadParams$ = pathParamsOf(
   desktopUpdatesContract.productDmgDownload,
 );
 
-function desktopProductFromRequestUrl(requestUrl: string): DesktopProduct {
+function desktopUpdateLineFromRequestUrl(
+  requestUrl: string,
+): DesktopUpdateLine {
   return brandedApiNamespace(new URL(requestUrl).pathname) === "okou"
-    ? DESKTOP_PRODUCT_OKOU
-    : DESKTOP_PRODUCT_ZERO;
+    ? DESKTOP_UPDATE_LINE_LEGACY_OKOU
+    : DESKTOP_UPDATE_LINE_ZERO;
 }
 
 const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
   const url = await loadDesktopReleasePageUrl(
     {
-      product: desktopProductFromRequestUrl(get(request$).url),
+      line: desktopUpdateLineFromRequestUrl(get(request$).url),
       ...get(releasePageParams$),
     },
     signal,
@@ -59,7 +61,7 @@ const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
 
 const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
   const feed = await loadDesktopUpdateFeed(
-    { product: DESKTOP_PRODUCT_ZERO, ...get(feedParams$) },
+    { line: DESKTOP_UPDATE_LINE_ZERO, ...get(feedParams$) },
     signal,
   );
   signal.throwIfAborted();
@@ -77,7 +79,7 @@ const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
 const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
   const url = await loadDesktopDmgDownloadUrl(
     {
-      product: desktopProductFromRequestUrl(get(request$).url),
+      line: desktopUpdateLineFromRequestUrl(get(request$).url),
       ...get(dmgDownloadParams$),
     },
     signal,

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -1,8 +1,12 @@
-import type {
-  DesktopUpdateArchitecture,
-  DesktopUpdateChannel,
-  DesktopUpdatePlatform,
-  SquirrelMacReleases,
+import {
+  DESKTOP_UPDATE_LINE_LEGACY_OKOU,
+  DESKTOP_UPDATE_LINE_OKOU,
+  DESKTOP_UPDATE_LINE_ZERO,
+  type DesktopUpdateArchitecture,
+  type DesktopUpdateChannel,
+  type DesktopUpdateLine,
+  type DesktopUpdatePlatform,
+  type SquirrelMacReleases,
 } from "@vm0/api-contracts/contracts/desktop-updates";
 import {
   DESKTOP_PRODUCTS,
@@ -23,10 +27,23 @@ const MIN_DESKTOP_DMG_VERSION = "0.12.0";
 
 const DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS = 60_000;
 
-function desktopUpdateManifestUrl(product: DesktopProduct): string {
-  return product === DESKTOP_PRODUCT_OKOU
-    ? "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json"
-    : "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
+function desktopUpdateManifestUrl(line: DesktopUpdateLine): string {
+  if (line === DESKTOP_UPDATE_LINE_ZERO) {
+    return "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
+  }
+  if (line === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
+    return "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json";
+  }
+  if (line === DESKTOP_UPDATE_LINE_OKOU) {
+    return "https://github.com/vm0-ai/vm0/releases/download/ai-okou-desktop-updates/ai-okou-desktop-update-manifest.json";
+  }
+  return line satisfies never;
+}
+
+function desktopProductForUpdateLine(line: DesktopUpdateLine): DesktopProduct {
+  return line === DESKTOP_UPDATE_LINE_ZERO
+    ? DESKTOP_PRODUCT_ZERO
+    : DESKTOP_PRODUCT_OKOU;
 }
 
 function desktopProductArtifactName(product: DesktopProduct): string {
@@ -67,7 +84,7 @@ const desktopUpdateManifestSchema = z.object({
 type DesktopUpdateManifest = z.infer<typeof desktopUpdateManifestSchema>;
 
 interface DesktopUpdateFeedRequest {
-  readonly product: DesktopProduct;
+  readonly line: DesktopUpdateLine;
   readonly channel: DesktopUpdateChannel;
   readonly platform: DesktopUpdatePlatform;
   readonly arch: DesktopUpdateArchitecture;
@@ -79,13 +96,13 @@ interface DesktopUpdateManifestCacheEntry {
 }
 
 const desktopUpdateManifestCache = testOverride<
-  Partial<Record<DesktopProduct, DesktopUpdateManifestCacheEntry>>
+  Partial<Record<DesktopUpdateLine, DesktopUpdateManifestCacheEntry>>
 >(() => {
   return {};
 });
 
 const desktopUpdateManifestOverride = testOverride<
-  Partial<Record<DesktopProduct, DesktopUpdateManifest>>
+  Partial<Record<DesktopUpdateLine, DesktopUpdateManifest>>
 >(() => {
   return {};
 });
@@ -122,7 +139,8 @@ function assetForRelease(
     return null;
   }
 
-  const expectedAssetName = `${desktopProductArtifactName(request.product)}-${request.platform}-${request.arch}-${release.version}.zip`;
+  const product = desktopProductForUpdateLine(request.line);
+  const expectedAssetName = `${desktopProductArtifactName(product)}-${request.platform}-${request.arch}-${release.version}.zip`;
   const actualAssetName = decodeURIComponent(
     new URL(asset.url).pathname.split("/").at(-1) ?? "",
   );
@@ -160,8 +178,9 @@ function desktopDmgDownloadUrl(
   release: DesktopUpdateManifest["releases"][string],
   request: DesktopUpdateFeedRequest,
 ): string {
-  const tagName = `${desktopProductReleaseTagPrefix(request.product)}${release.version}`;
-  const assetName = `${desktopProductArtifactName(request.product)}-${request.platform}-${request.arch}-${release.version}.dmg`;
+  const product = desktopProductForUpdateLine(request.line);
+  const tagName = `${desktopProductReleaseTagPrefix(product)}${release.version}`;
+  const assetName = `${desktopProductArtifactName(product)}-${request.platform}-${request.arch}-${release.version}.dmg`;
   return `${DESKTOP_RELEASE_DOWNLOAD_URL_PREFIX}/${encodeURIComponent(
     tagName,
   )}/${encodeURIComponent(assetName)}`;
@@ -220,21 +239,25 @@ function buildDesktopUpdateFeed(
   return {
     currentRelease: selected.release.version,
     releases: [
-      squirrelRelease(selected.release, selected.asset, request.product),
+      squirrelRelease(
+        selected.release,
+        selected.asset,
+        desktopProductForUpdateLine(request.line),
+      ),
     ],
   };
 }
 
 async function fetchDesktopUpdateManifest(
-  product: DesktopProduct,
+  line: DesktopUpdateLine,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
-  const override = desktopUpdateManifestOverride.get()[product];
+  const override = desktopUpdateManifestOverride.get()[line];
   if (override) {
     return override;
   }
 
-  const response = await fetch(desktopUpdateManifestUrl(product), {
+  const response = await fetch(desktopUpdateManifestUrl(line), {
     headers: { accept: "application/json" },
     signal,
   });
@@ -246,29 +269,30 @@ async function fetchDesktopUpdateManifest(
 
   const manifest = desktopUpdateManifestSchema.parse(await response.json());
   const manifestProduct = manifest.product ?? DESKTOP_PRODUCT_ZERO;
-  if (manifestProduct !== product) {
+  const expectedProduct = desktopProductForUpdateLine(line);
+  if (manifestProduct !== expectedProduct) {
     throw new Error(
-      `Desktop update manifest product mismatch: expected ${product}, received ${manifestProduct}`,
+      `Desktop update manifest product mismatch: expected ${expectedProduct}, received ${manifestProduct}`,
     );
   }
   return manifest;
 }
 
 async function loadDesktopUpdateManifest(
-  product: DesktopProduct,
+  line: DesktopUpdateLine,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
   const cache = desktopUpdateManifestCache.get();
-  const cacheEntry = cache[product];
+  const cacheEntry = cache[line];
   const nowMs = now();
   if (cacheEntry && cacheEntry.expiresAt > nowMs) {
     return cacheEntry.manifest;
   }
 
-  const manifest = await fetchDesktopUpdateManifest(product, signal);
+  const manifest = await fetchDesktopUpdateManifest(line, signal);
   desktopUpdateManifestCache.set({
     ...cache,
-    [product]: {
+    [line]: {
       expiresAt: nowMs + DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS,
       manifest,
     },
@@ -280,7 +304,7 @@ export async function loadDesktopUpdateFeed(
   request: DesktopUpdateFeedRequest,
   signal: AbortSignal,
 ): Promise<SquirrelMacReleases | null> {
-  const manifest = await loadDesktopUpdateManifest(request.product, signal);
+  const manifest = await loadDesktopUpdateManifest(request.line, signal);
   return buildDesktopUpdateFeed(manifest, request);
 }
 
@@ -288,10 +312,13 @@ export async function loadDesktopReleasePageUrl(
   request: DesktopUpdateFeedRequest,
   signal: AbortSignal,
 ): Promise<string | null> {
-  const manifest = await loadDesktopUpdateManifest(request.product, signal);
+  const manifest = await loadDesktopUpdateManifest(request.line, signal);
   const selected = selectDesktopRelease(manifest, request);
   return selected
-    ? desktopReleasePageUrl(selected.release, request.product)
+    ? desktopReleasePageUrl(
+        selected.release,
+        desktopProductForUpdateLine(request.line),
+      )
     : null;
 }
 
@@ -299,7 +326,7 @@ export async function loadDesktopDmgDownloadUrl(
   request: DesktopUpdateFeedRequest,
   signal: AbortSignal,
 ): Promise<string | null> {
-  const manifest = await loadDesktopUpdateManifest(request.product, signal);
+  const manifest = await loadDesktopUpdateManifest(request.line, signal);
   const selected = selectDesktopRelease(manifest, request);
   if (
     !selected ||

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -1,13 +1,13 @@
 # Computer Use Desktop
 
-Electron shell for the Zero and Okou Computer Use products.
+Electron shell for the Zero and Okou products.
 
 This pass is macOS-only. Windows packaging, native push, tray behavior, and
 auto-update are intentionally out of scope. Computer Use setup lives in the
 hosted Platform UI, while this app exposes the Desktop bridge and native macOS
 host runtime that page uses.
 
-Zero Computer Use and Okou Computer Use support macOS 14+ (macOS 14 or newer). Packaged app
+Zero Computer Use and Okou support macOS 14+ (macOS 14 or newer). Packaged app
 metadata, native helper builds, and release verification all use the same
 minimum for Apple silicon artifacts. Intel Macs are not supported.
 
@@ -39,7 +39,7 @@ pnpm desktop:dev
 ```
 
 This packages and runs `Zero CU Dev.app` with `VM0_DESKTOP_PLATFORM_URL` set to
-the local proxy. Set `VM0_DESKTOP_PRODUCT=okou` to package `Okou CU Dev.app`
+the local proxy. Set `VM0_DESKTOP_PRODUCT=okou` to package `Okou Dev.app`
 instead. Use packaged development apps for sign-in callback, URL scheme, and
 permission testing.
 Non-CI packaged desktop builds require the `Developer ID Application: Max &
@@ -70,9 +70,9 @@ VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai \
 pnpm -F @vm0/desktop make
 ```
 
-That build creates `Okou Computer Use.app` with bundle ID and callback scheme
-`ai.okou.computer-use`. Development Okou builds use
-`ai.okou.computer-use.dev`.
+That build creates `Okou.app` with bundle ID and callback scheme
+`ai.okou.desktop`. Development Okou builds use
+`ai.okou.desktop.dev`.
 Local notarized builds use the `notarytool` Keychain profile
 `vm0-desktop-notary` by default. Set `VM0_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE` to
 override the profile and `VM0_DESKTOP_NOTARIZE_KEYCHAIN` to override the
@@ -108,7 +108,7 @@ silicon artifact:
 The downloaded GitHub artifact contains `Zero-darwin-arm64.zip`. Unzip both
 layers, then open `Zero Computer Use.app`.
 The Okou artifact contains `Okou-darwin-arm64.zip` and
-`Okou Computer Use.app`.
+`Okou.app`.
 
 These artifacts are ad-hoc signed, not Developer ID signed, and not notarized.
 macOS Gatekeeper may require right-clicking the app and choosing Open, or
@@ -127,7 +127,7 @@ Desktop releases are versioned by release-please. Changes under
 
 When a release-please merge group changes the Desktop package version, the
 `deploy-desktop` job builds the unsigned production `Zero Computer Use.app` and
-`Okou Computer Use.app` for Apple silicon Macs and publishes both to R2 under
+`Okou.app` for Apple silicon Macs and publishes both to R2 under
 `okou-desktop/<commit-sha>/`. The matching release run resolves the same commit
 as `release_target`, downloads and verifies those immutable app artifacts,
 signs them with the Developer ID Application certificate, notarizes them for
@@ -150,16 +150,19 @@ replace it from the Okou update ZIP, and launch it again.
 Zero and Okou desktop releases are independent products during the rename
 rollout. Existing Zero installations keep using
 `/api/desktop/updates/stable/darwin/arm64` and the `desktop-updates` manifest.
-Okou installations use
-`/api/desktop/updates/okou/stable/darwin/arm64` and the separate
-`okou-desktop-updates` manifest. Each manifest identifies its product, and the
-API rejects ZIP assets whose product filename does not match the requested
-feed. A Zero feed must never publish an Okou artifact, or vice versa.
+Final `ai.okou.desktop` installations use
+`/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64` and the separate
+`ai-okou-desktop-updates` manifest. The pre-adoption Okou feed remains frozen
+until the signed/notarized final identity passes release acceptance, then it is
+retired without receiving a final-identity artifact. Each manifest identifies
+its product, and the API rejects ZIP assets whose product filename does not
+match the requested feed. A Zero feed must never publish an Okou artifact, and
+the pre-adoption Okou feed must never publish a final-identity archive.
 
 The release systems may deploy independently. The API therefore preserves the
 legacy Zero routes and accepts both Zero callback schemes
 (`ai.vm0.zero.desktop` and `ai.vm0.zero.desktop.dev`) while also accepting the
-Okou schemes (`ai.okou.computer-use` and `ai.okou.computer-use.dev`). Desktop
+Okou schemes (`ai.okou.desktop` and `ai.okou.desktop.dev`). Desktop
 builds select exactly one product feed and one callback scheme from their
 packaged identity; they do not discover or switch products at runtime.
 
@@ -170,9 +173,10 @@ the current `api.vm0.ai` and `www.vm0.ai` services until the separate
 `api.okou.ai` readiness gate passes.
 
 Okou is a separate macOS application identity. It can be installed beside
-Zero, gets its own Electron `userData` root and installation ID, and does not
-copy Zero's Chromium profile. Users sign in again and grant Accessibility,
-Screen Recording, and browser Automation permissions again because macOS TCC
+Zero, stores Electron data under its explicit `Okou` data directory, and gets a
+new installation ID. It does not read or migrate the pre-adoption Okou profile
+or Zero's Chromium profile. Users sign in again and grant Accessibility, Screen
+Recording, and browser Automation permissions again because macOS TCC
 associates those permissions with the application identity. The current
 release promotion signs and notarizes both product lines while publishing them
 under independent release tags and update manifests.

--- a/turbo/apps/desktop/assets/dmg-background-okou.svg
+++ b/turbo/apps/desktop/assets/dmg-background-okou.svg
@@ -30,7 +30,7 @@
     <path d="M72 0V400M100 0V400M128 0V400M156 0V400M184 0V400M212 0V400M240 0V400M268 0V400M296 0V400M324 0V400M352 0V400M380 0V400M408 0V400M436 0V400M464 0V400M492 0V400M520 0V400M548 0V400M576 0V400" stroke="#d7dde6" stroke-width="1"/>
   </g>
 
-  <text x="330" y="52" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="25" font-weight="700" fill="#22252a">Okou Computer Use</text>
+  <text x="330" y="52" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="25" font-weight="700" fill="#22252a">Okou</text>
   <text x="330" y="78" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="13" font-weight="500" fill="#6f737a">Drag the app into Applications to install</text>
 
   <g filter="url(#softShadow)">
@@ -39,5 +39,5 @@
   </g>
 
   <text x="330" y="252" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="13" font-weight="700" fill="#4f555d">Drag to install</text>
-  <text x="330" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="12" fill="#7d828a">Open Okou Computer Use from Applications after copying.</text>
+  <text x="330" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="12" fill="#7d828a">Open Okou from Applications after copying.</text>
 </svg>

--- a/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
+++ b/turbo/apps/desktop/scripts/update-desktop-release-manifest.mjs
@@ -6,6 +6,10 @@ const DESKTOP_PRODUCT_ARTIFACT_NAMES = {
   zero: "Zero",
   okou: "Okou",
 };
+const DESKTOP_PRODUCT_RELEASE_NAMES = {
+  zero: "Zero Computer Use",
+  okou: "Okou",
+};
 
 function parseArgs(argv) {
   const args = new Map();
@@ -107,7 +111,7 @@ manifest.releases[version] = {
   version,
   name:
     currentRelease.name ??
-    `${DESKTOP_PRODUCT_ARTIFACT_NAMES[product]} Computer Use ${version}`,
+    `${DESKTOP_PRODUCT_RELEASE_NAMES[product]} ${version}`,
   notes: currentRelease.notes ?? "",
   pubDate,
   platforms,

--- a/turbo/apps/desktop/src/bootstrap-degraded.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.test.ts
@@ -70,6 +70,8 @@ function productionConfig(): DesktopConfig {
       product: "zero",
       brandName: "Zero",
       displayName: "Zero Computer Use",
+      userDataDirectoryName: "Zero Computer Use",
+      updateLine: "zero",
       bundleId: "ai.vm0.desktop",
       authProtocolName: "Zero Desktop",
       authScheme: "vm0-desktop",

--- a/turbo/apps/desktop/src/bootstrap.test.ts
+++ b/turbo/apps/desktop/src/bootstrap.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  return {
+    app: {
+      name: "Electron",
+      getPath: vi.fn<(name: string) => string>(
+        () => "/Users/test/Library/Application Support",
+      ),
+      setName: vi.fn<(name: string) => void>(),
+      setPath: vi.fn<(name: string, path: string) => void>(),
+      whenReady: vi.fn<() => Promise<void>>(() => new Promise(() => {})),
+    },
+    enterDegradedDesktopMode: vi.fn(),
+  };
+});
+
+vi.mock("electron", () => ({ app: mocks.app }));
+
+vi.mock("./config", () => ({
+  resolveDesktopConfig: () => ({
+    platformUrl: new URL("https://app.okou.ai"),
+    webUrl: new URL("https://www.vm0.ai"),
+    environment: "production",
+    identity: {
+      product: "okou",
+      brandName: "Okou",
+      displayName: "Okou",
+      userDataDirectoryName: "Okou",
+      updateLine: "ai-okou-desktop",
+      bundleId: "ai.okou.desktop",
+      authProtocolName: "Okou Auth",
+      authScheme: "ai.okou.desktop",
+    },
+    sessionPartition: "persist:vm0-desktop-production",
+    allowedAppOrigins: new Set(["https://app.okou.ai"]),
+  }),
+}));
+
+vi.mock("./bootstrap-degraded", () => ({
+  enterDegradedDesktopMode: mocks.enterDegradedDesktopMode,
+}));
+
+vi.mock("./desktop-api-base-url", () => ({
+  resolveComputerUseApiBaseUrl: () => "https://api.vm0.ai",
+}));
+
+vi.mock("./desktop-auto-updates", () => ({
+  installDesktopAutoUpdates: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.app.name = "Electron";
+  mocks.app.getPath.mockClear();
+  mocks.app.setName.mockClear();
+  mocks.app.setPath.mockClear();
+  mocks.enterDegradedDesktopMode.mockClear();
+});
+
+describe("desktop bootstrap identity", () => {
+  it("selects the final Okou name and a fresh data directory before startup", async () => {
+    await import("./bootstrap");
+
+    expect(mocks.app.setName).toHaveBeenCalledExactlyOnceWith("Okou");
+    expect(mocks.app.name).toBe("Okou");
+    expect(mocks.app.getPath).toHaveBeenCalledExactlyOnceWith("appData");
+    expect(mocks.app.setPath).toHaveBeenCalledExactlyOnceWith(
+      "userData",
+      "/Users/test/Library/Application Support/Okou",
+    );
+    expect(mocks.enterDegradedDesktopMode).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/desktop/src/bootstrap.ts
+++ b/turbo/apps/desktop/src/bootstrap.ts
@@ -1,4 +1,5 @@
 import { app } from "electron";
+import { join } from "node:path";
 
 import { enterDegradedDesktopMode } from "./bootstrap-degraded";
 import { resolveDesktopConfig } from "./config";
@@ -16,6 +17,10 @@ const config = resolveDesktopConfig();
 const apiBaseUrl = resolveComputerUseApiBaseUrl(config.platformUrl);
 app.setName(config.identity.displayName);
 app.name = config.identity.displayName;
+app.setPath(
+  "userData",
+  join(app.getPath("appData"), config.identity.userDataDirectoryName),
+);
 
 type DesktopMainLoadResult =
   | { readonly ok: true; readonly main: DesktopMainModule }

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { DesktopProduct } from "@vm0/api-contracts/contracts/client-headers";
+import type { DesktopUpdateLine } from "@vm0/api-contracts/contracts/desktop-updates";
 import desktopIdentities from "./desktop-identities.json";
 import { rewriteDesktopServiceHostname } from "./desktop-api-base-url";
 
@@ -13,6 +14,8 @@ export interface DesktopIdentity {
   readonly product: DesktopProduct;
   readonly brandName: "Zero" | "Okou";
   readonly displayName: string;
+  readonly userDataDirectoryName: string;
+  readonly updateLine: DesktopUpdateLine;
   readonly bundleId: string;
   readonly authProtocolName: string;
   readonly authScheme: string;
@@ -46,6 +49,13 @@ function desktopBrandName(value: string): "Zero" | "Okou" {
   throw new Error(`Unsupported desktop brand: ${value}`);
 }
 
+function desktopUpdateLine(value: string): DesktopUpdateLine {
+  if (value === "zero" || value === "okou" || value === "ai-okou-desktop") {
+    return value;
+  }
+  throw new Error(`Unsupported desktop update line: ${value}`);
+}
+
 function desktopIdentity(
   product: DesktopProduct,
   kind: DesktopIdentityKind,
@@ -55,6 +65,7 @@ function desktopIdentity(
     ...identity,
     product: desktopProduct(identity.product),
     brandName: desktopBrandName(identity.brandName),
+    updateLine: desktopUpdateLine(identity.updateLine),
   };
 }
 

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -81,6 +81,8 @@ const productionConfig: DesktopConfig = {
     product: "zero",
     brandName: "Zero",
     displayName: "Zero Computer Use",
+    userDataDirectoryName: "Zero Computer Use",
+    updateLine: "zero",
     bundleId: "ai.vm0.desktop",
     authProtocolName: "Zero Computer Use",
     authScheme: "vm0",
@@ -214,10 +216,12 @@ describe("desktop auto-updates", () => {
       identity: {
         product: "okou",
         brandName: "Okou",
-        displayName: "Okou Computer Use",
-        bundleId: "ai.okou.computer-use",
+        displayName: "Okou",
+        userDataDirectoryName: "Okou",
+        updateLine: "ai-okou-desktop",
+        bundleId: "ai.okou.desktop",
         authProtocolName: "Okou Desktop Auth",
-        authScheme: "ai.okou.computer-use",
+        authScheme: "ai.okou.desktop",
       },
     };
 
@@ -233,7 +237,7 @@ describe("desktop auto-updates", () => {
       expect.objectContaining({
         updateSource: expect.objectContaining({
           baseUrl:
-            "https://api.okou.ai/api/desktop/updates/okou/stable/darwin/arm64",
+            "https://api.okou.ai/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64",
         }),
       }),
     );

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -75,7 +75,7 @@ export function installDesktopAutoUpdates(
 
   const baseUrl = desktopUpdateFeedBaseUrl(
     options.apiBaseUrl,
-    options.config.identity.product,
+    options.config.identity.updateLine,
   );
   if (new URL(baseUrl).protocol !== "https:") {
     console.warn("Desktop auto-updates require an HTTPS feed URL");

--- a/turbo/apps/desktop/src/desktop-identities.json
+++ b/turbo/apps/desktop/src/desktop-identities.json
@@ -5,6 +5,8 @@
       "product": "zero",
       "brandName": "Zero",
       "displayName": "Zero Computer Use",
+      "userDataDirectoryName": "Zero Computer Use",
+      "updateLine": "zero",
       "bundleId": "ai.vm0.zero.desktop",
       "authProtocolName": "Zero Desktop Auth",
       "authScheme": "ai.vm0.zero.desktop"
@@ -13,6 +15,8 @@
       "product": "zero",
       "brandName": "Zero",
       "displayName": "Zero CU Dev",
+      "userDataDirectoryName": "Zero CU Dev",
+      "updateLine": "zero",
       "bundleId": "ai.vm0.zero.desktop.dev",
       "authProtocolName": "Zero CU Dev Desktop Auth",
       "authScheme": "ai.vm0.zero.desktop.dev"
@@ -23,18 +27,22 @@
     "production": {
       "product": "okou",
       "brandName": "Okou",
-      "displayName": "Okou Computer Use",
-      "bundleId": "ai.okou.computer-use",
-      "authProtocolName": "Okou Computer Use Auth",
-      "authScheme": "ai.okou.computer-use"
+      "displayName": "Okou",
+      "userDataDirectoryName": "Okou",
+      "updateLine": "ai-okou-desktop",
+      "bundleId": "ai.okou.desktop",
+      "authProtocolName": "Okou Auth",
+      "authScheme": "ai.okou.desktop"
     },
     "development": {
       "product": "okou",
       "brandName": "Okou",
-      "displayName": "Okou CU Dev",
-      "bundleId": "ai.okou.computer-use.dev",
-      "authProtocolName": "Okou CU Dev Auth",
-      "authScheme": "ai.okou.computer-use.dev"
+      "displayName": "Okou Dev",
+      "userDataDirectoryName": "Okou Dev",
+      "updateLine": "ai-okou-desktop",
+      "bundleId": "ai.okou.desktop.dev",
+      "authProtocolName": "Okou Dev Auth",
+      "authScheme": "ai.okou.desktop.dev"
     }
   }
 }

--- a/turbo/apps/desktop/src/desktop-update-feed.test.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.test.ts
@@ -62,8 +62,10 @@ describe("desktop update feed", () => {
     expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai", "zero")).toBe(
       "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
     );
-    expect(desktopUpdateFeedBaseUrl("https://api.okou.ai", "okou")).toBe(
-      "https://api.okou.ai/api/desktop/updates/okou/stable/darwin/arm64",
+    expect(
+      desktopUpdateFeedBaseUrl("https://api.okou.ai", "ai-okou-desktop"),
+    ).toBe(
+      "https://api.okou.ai/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64",
     );
   });
 });

--- a/turbo/apps/desktop/src/desktop-update-feed.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.ts
@@ -24,12 +24,12 @@ export function shouldInstallDesktopAutoUpdates(
 
 export function desktopUpdateFeedBaseUrl(
   apiBaseUrl: string,
-  product: DesktopConfig["identity"]["product"],
+  updateLine: DesktopConfig["identity"]["updateLine"],
 ): string {
   const url = new URL(apiBaseUrl);
-  const productPath =
-    product === "zero" ? "" : `/${encodeURIComponent(product)}`;
-  url.pathname = `/api/desktop/updates${productPath}/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
+  const updateLinePath =
+    updateLine === "zero" ? "" : `/${encodeURIComponent(updateLine)}`;
+  url.pathname = `/api/desktop/updates${updateLinePath}/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
   url.search = "";
   url.hash = "";
   return url.toString().replace(/\/$/, "");

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -560,7 +560,7 @@ describe("Desktop renderer bridge integration", () => {
     window.vm0DesktopIdentity = {
       product: "okou",
       brandName: "Okou",
-      displayName: "Okou Computer Use",
+      displayName: "Okou",
     };
     installDesktopBridges({
       authState: { status: "signed_out", user: null, organization: null },
@@ -571,7 +571,7 @@ describe("Desktop renderer bridge integration", () => {
 
     renderDesktopApp();
 
-    expect(await screen.findByText("Okou Computer Use")).toBeTruthy();
+    expect(await screen.findByText("Okou")).toBeTruthy();
     expect(await screen.findByText("Sign in to Okou")).toBeTruthy();
   });
 

--- a/turbo/apps/desktop/src/update-desktop-release-manifest.test.ts
+++ b/turbo/apps/desktop/src/update-desktop-release-manifest.test.ts
@@ -58,7 +58,7 @@ describe("update desktop release manifest", () => {
     {
       product: "okou" as const,
       artifactName: "Okou-darwin-arm64-1.2.3.zip",
-      releaseName: "Okou Computer Use 1.2.3",
+      releaseName: "Okou 1.2.3",
     },
   ])("publishes an isolated $product manifest", (testCase) => {
     const manifestPath = temporaryManifestPath();

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -194,6 +194,8 @@ describe("resolveDesktopConfig", () => {
       product: "zero",
       brandName: "Zero",
       displayName: "Zero Computer Use",
+      userDataDirectoryName: "Zero Computer Use",
+      updateLine: "zero",
       bundleId: "ai.vm0.zero.desktop",
       authScheme: "ai.vm0.zero.desktop",
     });
@@ -214,6 +216,8 @@ describe("resolveDesktopConfig", () => {
       product: "zero",
       brandName: "Zero",
       displayName: "Zero CU Dev",
+      userDataDirectoryName: "Zero CU Dev",
+      updateLine: "zero",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
     });
@@ -238,6 +242,8 @@ describe("resolveDesktopConfig", () => {
       product: "zero",
       brandName: "Zero",
       displayName: "Zero CU Dev",
+      userDataDirectoryName: "Zero CU Dev",
+      updateLine: "zero",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
     });
@@ -256,6 +262,8 @@ describe("resolveDesktopConfig", () => {
       product: "zero",
       brandName: "Zero",
       displayName: "Zero CU Dev",
+      userDataDirectoryName: "Zero CU Dev",
+      updateLine: "zero",
       bundleId: "ai.vm0.zero.desktop.dev",
       authScheme: "ai.vm0.zero.desktop.dev",
     });
@@ -275,9 +283,11 @@ describe("resolveDesktopConfig", () => {
     expect(config.identity).toMatchObject({
       product: "okou",
       brandName: "Okou",
-      displayName: "Okou Computer Use",
-      bundleId: "ai.okou.computer-use",
-      authScheme: "ai.okou.computer-use",
+      displayName: "Okou",
+      userDataDirectoryName: "Okou",
+      updateLine: "ai-okou-desktop",
+      bundleId: "ai.okou.desktop",
+      authScheme: "ai.okou.desktop",
     });
     expect(config.sessionPartition).toBe("persist:vm0-desktop-production");
     expect([...config.allowedAppOrigins].sort()).toStrictEqual([
@@ -293,9 +303,11 @@ describe("resolveDesktopConfig", () => {
     expect(config.identity).toMatchObject({
       product: "okou",
       brandName: "Okou",
-      displayName: "Okou CU Dev",
-      bundleId: "ai.okou.computer-use.dev",
-      authScheme: "ai.okou.computer-use.dev",
+      displayName: "Okou Dev",
+      userDataDirectoryName: "Okou Dev",
+      updateLine: "ai-okou-desktop",
+      bundleId: "ai.okou.desktop.dev",
+      authScheme: "ai.okou.desktop.dev",
     });
   });
 
@@ -435,10 +447,10 @@ describe("desktop auth", () => {
     expect(
       buildDesktopAuthStartUrl(
         new URL("https://www.okou.ai"),
-        "ai.okou.computer-use",
+        "ai.okou.desktop",
       ),
     ).toBe(
-      "https://www.okou.ai/desktop-auth/start?callbackScheme=ai.okou.computer-use",
+      "https://www.okou.ai/desktop-auth/start?callbackScheme=ai.okou.desktop",
     );
   });
 
@@ -503,14 +515,14 @@ describe("desktop auth", () => {
     ).toStrictEqual({ code, handoffId: null });
     expect(
       parseDesktopAuthCallback(
-        `ai.okou.computer-use://auth/callback?code=${code}`,
-        "ai.okou.computer-use",
+        `ai.okou.desktop://auth/callback?code=${code}`,
+        "ai.okou.desktop",
       ),
     ).toStrictEqual({ code, handoffId: null });
     expect(
       parseDesktopAuthCallback(
-        `ai.okou.computer-use.dev://auth/callback?code=${code}`,
-        "ai.okou.computer-use.dev",
+        `ai.okou.desktop.dev://auth/callback?code=${code}`,
+        "ai.okou.desktop.dev",
       ),
     ).toStrictEqual({ code, handoffId: null });
     expect(

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -711,7 +711,7 @@
       "lastSeen": "Zuletzt gesehen {{date}}",
       "linkExpires": "Link läuft am {{date}} ab.",
       "macRequirement": "Erfordert einen Apple Silicon Mac mit macOS 14 oder neuer. Intel-Macs werden nicht unterstützt.",
-      "noHostsDescription": "Öffnen Sie {{desktopProductName}} Computer Use auf Ihrem Mac und aktualisieren Sie diese Seite, wenn sie online ist.",
+      "noHostsDescription": "Öffnen Sie {{desktopApplicationName}} auf Ihrem Mac und aktualisieren Sie diese Seite, wenn sie online ist.",
       "noHostsTitle": "Keine Online-Computer",
       "sources": {
         "chat": "dieser Chat-Thread",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -711,7 +711,7 @@
       "lastSeen": "Last seen {{date}}",
       "linkExpires": "Link expires {{date}}.",
       "macRequirement": "Requires an Apple silicon Mac with macOS 14 or newer. Intel Macs aren't supported.",
-      "noHostsDescription": "Open {{desktopProductName}} Computer Use on your Mac and refresh this page when it comes online.",
+      "noHostsDescription": "Open {{desktopApplicationName}} on your Mac and refresh this page when it comes online.",
       "noHostsTitle": "No online computers",
       "sources": {
         "chat": "this chat thread",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -728,7 +728,7 @@
       "lastSeen": "Última vez que se vio {{date}}",
       "linkExpires": "El enlace caduca {{date}}.",
       "macRequirement": "Requiere un Mac Apple Silicon con macOS 14 o más reciente. No se soportan Macs Intel.",
-      "noHostsDescription": "Abre {{desktopProductName}} Uso del ordenador en tu Mac y actualiza esta página cuando esté en línea.",
+      "noHostsDescription": "Abre {{desktopApplicationName}} en tu Mac y actualiza esta página cuando esté en línea.",
       "noHostsTitle": "No hay ordenadores en línea",
       "sources": {
         "chat": "Este hilo de chat",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -728,7 +728,7 @@
       "lastSeen": "Vu pour la dernière fois le {{date}}",
       "linkExpires": "Le lien expire le {{date}}.",
       "macRequirement": "Nécessite un Mac avec puce Apple et macOS 14 ou version ultérieure. Les Mac Intel ne sont pas pris en charge.",
-      "noHostsDescription": "Ouvrez Open {{desktopProductName}} Computer Use sur votre Mac et actualisez cette page lorsqu'il sera en ligne.",
+      "noHostsDescription": "Ouvrez {{desktopApplicationName}} sur votre Mac et actualisez cette page lorsqu'il sera en ligne.",
       "noHostsTitle": "Aucun ordinateur en ligne",
       "sources": {
         "chat": "ce fil de discussion chat",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -711,7 +711,7 @@
       "lastSeen": "अंतिम बार {{date}} देखा गया",
       "linkExpires": "लिंक {{date}} समाप्त हो रहा है।",
       "macRequirement": "macOS 14 या नए संस्करण वाला Apple सिलिकॉन Mac आवश्यक है। Intel Mac समर्थित नहीं हैं.",
-      "noHostsDescription": "अपने मैक पर {{desktopProductName}} कंप्यूटर उपयोग खोलें और ऑनलाइन आने पर इस पेज को रीफ्रेश करें।",
+      "noHostsDescription": "अपने मैक पर {{desktopApplicationName}} खोलें और ऑनलाइन आने पर इस पेज को रीफ्रेश करें।",
       "noHostsTitle": "कोई ऑनलाइन कंप्यूटर नहीं",
       "sources": {
         "chat": "यह चैट थ्रेड",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -711,7 +711,7 @@
       "lastSeen": "Terakhir terlihat {{date}}",
       "linkExpires": "Tautan kedaluwarsa pada {{date}}.",
       "macRequirement": "Memerlukan Mac Apple silicon dengan macOS 14 atau yang lebih baru. Mac Intel tidak didukung.",
-      "noHostsDescription": "Buka {{desktopProductName}} Computer Use di Mac Anda dan muat ulang halaman ini saat sudah online.",
+      "noHostsDescription": "Buka {{desktopApplicationName}} di Mac Anda dan muat ulang halaman ini saat sudah online.",
       "noHostsTitle": "Tidak ada komputer online",
       "sources": {
         "chat": "thread chat ini",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -728,7 +728,7 @@
       "lastSeen": "Visto l'ultima volta {{date}}",
       "linkExpires": "Il collegamento scade {{date}}.",
       "macRequirement": "Richiede un Mac Apple Silicon con macOS 14 o successivo. I Mac Intel non sono supportati.",
-      "noHostsDescription": "Apri {{desktopProductName}} Computer Use sul tuo Mac e aggiorna questa pagina quando è online.",
+      "noHostsDescription": "Apri {{desktopApplicationName}} sul tuo Mac e aggiorna questa pagina quando è online.",
       "noHostsTitle": "Nessun computer online",
       "sources": {
         "chat": "questo thread di chat",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -711,7 +711,7 @@
       "lastSeen": "最後に表示されたのは {{date}}",
       "linkExpires": "リンクの有効期限が切れます {{date}}。",
       "macRequirement": "macOS 14 以降を搭載した Apple Silicon Mac が必要です。 Intel Mac はサポートされていません。",
-      "noHostsDescription": "Mac で {{desktopProductName}} Computer Use を開き、オンラインになったらこのページを更新します。",
+      "noHostsDescription": "Mac で {{desktopApplicationName}} を開き、オンラインになったらこのページを更新します。",
       "noHostsTitle": "オンラインコンピュータはありません",
       "sources": {
         "chat": "このチャットスレッド",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -711,7 +711,7 @@
       "lastSeen": "마지막 접속 {{date}}",
       "linkExpires": "링크는 {{date}}에 만료됩니다.",
       "macRequirement": "Apple 실리콘 Mac과 macOS 14 이상 필요합니다. Intel Mac은 지원되지 않습니다.",
-      "noHostsDescription": "Mac에서 {{desktopProductName}} 컴퓨터 사용을 열고 온라인 상태가 되면 이 페이지를 새로고침하세요.",
+      "noHostsDescription": "Mac에서 {{desktopApplicationName}}을 열고 온라인 상태가 되면 이 페이지를 새로고침하세요.",
       "noHostsTitle": "온라인 컴퓨터 없음",
       "sources": {
         "chat": "이 채팅 스레드",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -728,7 +728,7 @@
       "lastSeen": "Visto pela última vez em {{date}}",
       "linkExpires": "O link expira em {{date}}.",
       "macRequirement": "Requer um Mac com Apple silicon e macOS 14 ou mais recente. Macs com Intel não são compatíveis.",
-      "noHostsDescription": "Abra o {{desktopProductName}} Computer Use no Mac e atualize esta página quando ele ficar online.",
+      "noHostsDescription": "Abra o {{desktopApplicationName}} no Mac e atualize esta página quando ele ficar online.",
       "noHostsTitle": "Nenhum computador online",
       "sources": {
         "chat": "nesta conversa",

--- a/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
@@ -306,7 +306,7 @@ describe("computer use authorization page", () => {
 
     await expect(
       screen.findByText(
-        "Open Okou Computer Use on your Mac and refresh this page when it comes online.",
+        "Open Okou on your Mac and refresh this page when it comes online.",
       ),
     ).resolves.toBeInTheDocument();
     const downloadLink = await waitFor(() => {

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -119,6 +119,8 @@ function HostOption({
 function EmptyHosts() {
   const { t } = useTranslation();
   const computerUseProductName = useGet(computerUseProductName$);
+  const desktopApplicationName =
+    computerUseProductName === "Okou" ? "Okou" : "Zero Computer Use";
   const downloadSupportLoadable = useLoadable(desktopDownloadSupportStatus$);
   const downloadSupportStatus =
     downloadSupportLoadable.state === "hasData"
@@ -145,7 +147,7 @@ function EmptyHosts() {
             ($) => {
               return $.authorization.computerUse.noHostsDescription;
             },
-            { desktopProductName: computerUseProductName },
+            { desktopApplicationName },
           )}
         </p>
         <p className="text-sm leading-5 text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -500,7 +500,7 @@ describe("chat lifecycle", () => {
     );
   });
 
-  it("uses Okou Computer Use copy on an Okou host", async () => {
+  it("uses Okou copy on an Okou host", async () => {
     const previousUrl = window.location.href;
     window.location.href = "https://app.okou.ai/";
     context.signal.addEventListener(

--- a/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
@@ -7,8 +7,8 @@ const c = initContract();
 export const desktopAuthCallbackSchemes = [
   "ai.vm0.zero.desktop",
   "ai.vm0.zero.desktop.dev",
-  "ai.okou.computer-use",
-  "ai.okou.computer-use.dev",
+  "ai.okou.desktop",
+  "ai.okou.desktop.dev",
 ] as const;
 export const defaultDesktopAuthCallbackScheme = desktopAuthCallbackSchemes[0];
 export const desktopAuthCallbackSchemeSchema = z.enum(

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -85,9 +85,9 @@ export const desktopUpdatesContract = c.router({
   },
   productReleasePage: {
     method: "GET",
-    path: "/api/desktop/updates/:line/:channel/:platform/:arch/release",
+    path: "/api/desktop/updates/:product/:channel/:platform/:arch/release",
     pathParams: z.object({
-      line: desktopUpdateLineSchema,
+      product: desktopUpdateLineSchema,
       channel: desktopUpdateChannelSchema,
       platform: desktopUpdatePlatformSchema,
       arch: desktopUpdateArchitectureSchema,
@@ -100,9 +100,9 @@ export const desktopUpdatesContract = c.router({
   },
   productDmgDownload: {
     method: "GET",
-    path: "/api/desktop/updates/:line/:channel/:platform/:arch/dmg",
+    path: "/api/desktop/updates/:product/:channel/:platform/:arch/dmg",
     pathParams: z.object({
-      line: desktopUpdateLineSchema,
+      product: desktopUpdateLineSchema,
       channel: desktopUpdateChannelSchema,
       platform: desktopUpdatePlatformSchema,
       arch: desktopUpdateArchitectureSchema,
@@ -115,9 +115,9 @@ export const desktopUpdatesContract = c.router({
   },
   productFeed: {
     method: "GET",
-    path: "/api/desktop/updates/:line/:channel/:platform/:arch/RELEASES.json",
+    path: "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
     pathParams: z.object({
-      line: desktopUpdateLineSchema,
+      product: desktopUpdateLineSchema,
       channel: desktopUpdateChannelSchema,
       platform: desktopUpdatePlatformSchema,
       arch: desktopUpdateArchitectureSchema,

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -1,20 +1,25 @@
 import { z } from "zod";
 import { initContract } from "./base";
-import { DESKTOP_PRODUCTS } from "./client-headers";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+const DESKTOP_UPDATE_LINES = ["zero", "okou", "ai-okou-desktop"] as const;
+export const DESKTOP_UPDATE_LINE_ZERO = DESKTOP_UPDATE_LINES[0];
+export const DESKTOP_UPDATE_LINE_LEGACY_OKOU = DESKTOP_UPDATE_LINES[1];
+export const DESKTOP_UPDATE_LINE_OKOU = DESKTOP_UPDATE_LINES[2];
+
 const desktopUpdateChannelSchema = z.enum(["stable"]);
 const desktopUpdatePlatformSchema = z.enum(["darwin"]);
 const desktopUpdateArchitectureSchema = z.enum(["arm64"]);
-const desktopUpdateProductSchema = z.enum(DESKTOP_PRODUCTS);
+const desktopUpdateLineSchema = z.enum(DESKTOP_UPDATE_LINES);
 
 export type DesktopUpdateChannel = z.infer<typeof desktopUpdateChannelSchema>;
 export type DesktopUpdatePlatform = z.infer<typeof desktopUpdatePlatformSchema>;
 export type DesktopUpdateArchitecture = z.infer<
   typeof desktopUpdateArchitectureSchema
 >;
+export type DesktopUpdateLine = z.infer<typeof desktopUpdateLineSchema>;
 
 const squirrelMacReleaseSchema = z.object({
   version: z.string(),
@@ -80,9 +85,9 @@ export const desktopUpdatesContract = c.router({
   },
   productReleasePage: {
     method: "GET",
-    path: "/api/desktop/updates/:product/:channel/:platform/:arch/release",
+    path: "/api/desktop/updates/:line/:channel/:platform/:arch/release",
     pathParams: z.object({
-      product: desktopUpdateProductSchema,
+      line: desktopUpdateLineSchema,
       channel: desktopUpdateChannelSchema,
       platform: desktopUpdatePlatformSchema,
       arch: desktopUpdateArchitectureSchema,
@@ -91,13 +96,13 @@ export const desktopUpdatesContract = c.router({
       302: c.noBody(),
       404: apiErrorSchema,
     },
-    summary: "Redirect to a product-specific desktop release page",
+    summary: "Redirect to an identity-specific desktop release page",
   },
   productDmgDownload: {
     method: "GET",
-    path: "/api/desktop/updates/:product/:channel/:platform/:arch/dmg",
+    path: "/api/desktop/updates/:line/:channel/:platform/:arch/dmg",
     pathParams: z.object({
-      product: desktopUpdateProductSchema,
+      line: desktopUpdateLineSchema,
       channel: desktopUpdateChannelSchema,
       platform: desktopUpdatePlatformSchema,
       arch: desktopUpdateArchitectureSchema,
@@ -106,13 +111,13 @@ export const desktopUpdatesContract = c.router({
       302: c.noBody(),
       404: apiErrorSchema,
     },
-    summary: "Redirect to a product-specific desktop DMG download",
+    summary: "Redirect to an identity-specific desktop DMG download",
   },
   productFeed: {
     method: "GET",
-    path: "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+    path: "/api/desktop/updates/:line/:channel/:platform/:arch/RELEASES.json",
     pathParams: z.object({
-      product: desktopUpdateProductSchema,
+      line: desktopUpdateLineSchema,
       channel: desktopUpdateChannelSchema,
       platform: desktopUpdatePlatformSchema,
       arch: desktopUpdateArchitectureSchema,
@@ -122,6 +127,6 @@ export const desktopUpdatesContract = c.router({
       400: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Get a product-specific desktop auto-update feed",
+    summary: "Get an identity-specific desktop auto-update feed",
   },
 });


### PR DESCRIPTION
## Summary

- package the final app as `Okou.app` with production identity and auth scheme `ai.okou.desktop` and development identity `ai.okou.desktop.dev`
- select an explicit fresh `Application Support/Okou` data root and remove the pre-adoption Okou auth schemes
- publish final Okou updates only through the new `ai-okou-desktop` line and `ai-okou-desktop-updates` manifest while leaving the pre-adoption manifest frozen
- update app paths, executable names, DMG copy, release checks, localized Web guidance, docs, and artifact tests to the `Okou` name

## Release gate

This PR intentionally does **not** switch the branded stable/new-user DMG route. It remains on the frozen pre-adoption line until the first real `Okou.app` release passes signed/notarized download, clean-install, launch, auth, permissions, host, Computer Use, and updater acceptance. A follow-up cutover PR will then switch the branded route and retire the old `/okou` updater line.

The old mutable manifest is no longer written by the release workflow, so it cannot receive an `ai.okou.desktop` archive.

## Validation

- affected Desktop/API/App/API-contract TypeScript checks
- Desktop: 100 focused tests
- API: 30 focused tests
- App: 34 focused tests
- affected workspace lint
- Desktop production build and bootstrap bundle guard
- local arm64 `Okou.app` packaging, Info.plist identity inspection, and packaged launch smoke test
- Okou artifact script test
- Desktop deploy/release workflow script test

Refs #26649
Refs #26364