### PR TITLE
test(api): isolate web-search pricing scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-web-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-web-search.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import {
   ZERO_WEB_SEARCH_MAX_SNIPPET_CHARS,
@@ -17,9 +17,10 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { setupAppWithRoutes } from "../../../__tests__/test-app";
 import {
-  deleteUsagePricingRows,
+  createUsagePricingFixture,
   seedOrgMetadata,
-  seedUsagePricingRows,
+  type UsagePricingFixture,
+  type UsagePricingKey,
 } from "../../../test-fixtures/system-config-seeds";
 import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
@@ -58,6 +59,7 @@ interface AuthHeaders {
 interface RawRequestOptions {
   readonly instanceSignal?: AbortSignal;
   readonly requestSignal?: AbortSignal;
+  readonly usagePricingResolution?: UsagePricingFixture["resolution"];
 }
 
 function authHeaders(actor: ApiTestUser | null): AuthHeaders {
@@ -80,8 +82,12 @@ function authenticate(actor: ApiTestUser | null): AuthHeaders {
   return authHeaders(actor);
 }
 
-function client() {
-  return setupAppWithRoutes({ context, routes: webSearchRoutes });
+function client(usagePricingResolution?: UsagePricingFixture["resolution"]) {
+  return setupAppWithRoutes({
+    context,
+    routes: webSearchRoutes,
+    usagePricingResolution,
+  });
 }
 
 async function rawWebSearchRequest(
@@ -92,6 +98,7 @@ async function rawWebSearchRequest(
   const app = createAppWithRoutes({
     signal: options.instanceSignal ?? context.signal,
     routes: webSearchRoutes,
+    usagePricingResolution: options.usagePricingResolution,
   });
   const request = new Request("http://api.test/api/zero/web-search", {
     method: "POST",
@@ -141,16 +148,38 @@ function configureProvider(): void {
   mockEnv("ZERO_WEB_SEARCH_PERPLEXITY_TOKEN", "test-perplexity-token");
 }
 
-async function seedWebSearchPricing(): Promise<void> {
-  await seedUsagePricingRows([
-    {
-      kind: "web-search",
-      provider: "perplexity",
-      category: "request",
-      unitPrice: 5,
-      unitSize: 1,
-    },
-  ]);
+function webSearchPricingKey(): UsagePricingKey {
+  return {
+    kind: "web-search",
+    provider: "perplexity",
+    category: "request",
+  };
+}
+
+async function setupConfiguredWebSearchPricing(): Promise<UsagePricingFixture> {
+  const fixture = await createUsagePricingFixture({
+    configured: [
+      {
+        ...webSearchPricingKey(),
+        unitPrice: 5,
+        unitSize: 1,
+      },
+    ],
+  });
+  onTestFinished(async () => {
+    await fixture.cleanup();
+  });
+  return fixture;
+}
+
+async function setupMissingWebSearchPricing(): Promise<UsagePricingFixture> {
+  const fixture = await createUsagePricingFixture({
+    missing: [webSearchPricingKey()],
+  });
+  onTestFinished(async () => {
+    await fixture.cleanup();
+  });
+  return fixture;
 }
 
 function defaultRequest(
@@ -227,7 +256,7 @@ describe("okou web-search route", () => {
     api.acceptTelemetryIngest();
     await api.grantProEntitlement(actor);
     await fundActor(actor);
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     configureProvider();
     const name = `web-search-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
@@ -254,7 +283,7 @@ describe("okou web-search route", () => {
     context.mocks.ably.publish.mockClear();
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: { authorization: `Bearer ${token}` },
         body: defaultRequest(),
       }),
@@ -342,11 +371,7 @@ describe("okou web-search route", () => {
     let providerRequests = 0;
     configureProvider();
     await fundActor(actor);
-    await deleteUsagePricingRows({
-      kind: "web-search",
-      provider: "perplexity",
-      categories: ["request"],
-    });
+    const pricing = await setupMissingWebSearchPricing();
     server.use(
       http.post(PERPLEXITY_SEARCH_URL, () => {
         providerRequests += 1;
@@ -355,7 +380,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -371,7 +396,7 @@ describe("okou web-search route", () => {
     const actor = createBddApi(context).user();
     let providerRequests = 0;
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await bootstrapOnboarding(actor);
     await setActorCredits(actor, 0);
     server.use(
@@ -382,7 +407,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -402,7 +427,7 @@ describe("okou web-search route", () => {
       );
     }
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await bootstrapOnboarding(actor);
     await setActorCredits(actor, 0);
     const effectiveAt = nowDate();
@@ -425,7 +450,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -454,7 +479,7 @@ describe("okou web-search route", () => {
     let requestBody: unknown;
     let authorization: string | null = null;
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -466,7 +491,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest({
           limit: 3,
@@ -513,7 +538,7 @@ describe("okou web-search route", () => {
   it("bills valid empty results", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -523,7 +548,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -539,7 +564,7 @@ describe("okou web-search route", () => {
   it("truncates valid text under field and total output bounds", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const longTitle = `${"t".repeat(ZERO_WEB_SEARCH_MAX_TITLE_CHARS - 1)}😀`;
     server.use(
@@ -557,7 +582,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -583,7 +608,7 @@ describe("okou web-search route", () => {
   it("neutralizes provider control characters in returned text", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     server.use(
       http.post(PERPLEXITY_SEARCH_URL, () => {
@@ -601,7 +626,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -662,7 +687,7 @@ describe("okou web-search route", () => {
   ])("rejects %s without recording usage", async (_name, body, code) => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -672,7 +697,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -688,7 +713,7 @@ describe("okou web-search route", () => {
   it("maps and bounds provider errors without recording usage", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -701,7 +726,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -721,7 +746,7 @@ describe("okou web-search route", () => {
   it("maps provider rate limiting without recording usage", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -731,7 +756,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -747,7 +772,7 @@ describe("okou web-search route", () => {
   it("maps provider transport timeouts without recording usage", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -762,7 +787,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -778,7 +803,7 @@ describe("okou web-search route", () => {
   it("rejects an empty successful provider body without recording usage", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -788,7 +813,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -804,7 +829,7 @@ describe("okou web-search route", () => {
   it("rejects declared oversized responses before reading or billing", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -818,7 +843,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -834,7 +859,7 @@ describe("okou web-search route", () => {
   it("rejects streamed oversized responses with dishonest lengths", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -855,7 +880,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -871,7 +896,7 @@ describe("okou web-search route", () => {
   it("accepts a streamed response without a declared length and bills it", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     const payload = JSON.stringify(providerResponse());
@@ -888,7 +913,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -903,7 +928,7 @@ describe("okou web-search route", () => {
   it("accepts an exact-size streamed response and bills it", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     const json = JSON.stringify({ results: [] });
@@ -928,7 +953,7 @@ describe("okou web-search route", () => {
     );
 
     const response = await accept(
-      client()(zeroWebSearchContract).search({
+      client(pricing.resolution)(zeroWebSearchContract).search({
         headers: authenticate(actor),
         body: defaultRequest(),
       }),
@@ -949,7 +974,7 @@ describe("okou web-search route", () => {
     const providerRelease = createDeferredPromise<void>(context.signal);
     let providerSignalAborted = false;
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -964,6 +989,7 @@ describe("okou web-search route", () => {
 
     const responsePromise = rawWebSearchRequest(actor, defaultRequest(), {
       requestSignal: controller.signal,
+      usagePricingResolution: pricing.resolution,
     });
     await providerStarted.promise;
     providerRelease.resolve(undefined);
@@ -981,7 +1007,7 @@ describe("okou web-search route", () => {
     const abortError = new Error("client disconnected after provider success");
     abortError.name = "AbortError";
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -1009,6 +1035,7 @@ describe("okou web-search route", () => {
 
     const response = await rawWebSearchRequest(actor, defaultRequest(), {
       requestSignal: controller.signal,
+      usagePricingResolution: pricing.resolution,
     });
     const afterCredits = await credits(actor);
 
@@ -1021,7 +1048,7 @@ describe("okou web-search route", () => {
     const actor = createBddApi(context).user();
     let providerRequests = 0;
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
@@ -1030,7 +1057,7 @@ describe("okou web-search route", () => {
         return HttpResponse.json(providerResponse());
       }),
     );
-    const searchClient = client();
+    const searchClient = client(pricing.resolution);
 
     const [first, second] = await Promise.all([
       accept(
@@ -1059,21 +1086,19 @@ describe("okou web-search route", () => {
   it("does not return success when usage processing fails", async () => {
     const actor = createBddApi(context).user();
     configureProvider();
-    await seedWebSearchPricing();
+    const pricing = await setupConfiguredWebSearchPricing();
     await fundActor(actor);
     const beforeCredits = await credits(actor);
     server.use(
       http.post(PERPLEXITY_SEARCH_URL, async () => {
-        await deleteUsagePricingRows({
-          kind: "web-search",
-          provider: "perplexity",
-          categories: ["request"],
-        });
+        await pricing.cleanup();
         return HttpResponse.json(providerResponse());
       }),
     );
 
-    const response = await rawWebSearchRequest(actor, defaultRequest());
+    const response = await rawWebSearchRequest(actor, defaultRequest(), {
+      usagePricingResolution: pricing.resolution,
+    });
     const afterCredits = await credits(actor);
 
     expect(response.status).toBe(500);


### PR DESCRIPTION
## Summary

- Replace fixed Perplexity web-search pricing seeding and deletion with UUID-owned scoped pricing fixtures.
- Pass each fixture resolution through typed and raw Hono test requests, including no-credit, missing-pricing, concurrent-charge, and settlement-error scenarios.
- Preserve every exact provider request count and credit assertion while limiting cleanup to rows created by each test.

## Isolation invariants

- The repository-fixed Perplexity pricing row is never inserted, updated, deleted, or restored.
- Every pricing-dependent test owns a unique lookup provider and registers cleanup only for that fixture.
- The settlement-error case removes only its own scoped row after provider success.
- Production routing and pricing behavior are unchanged; this PR modifies only the web-search route test suite.

## Foundation

- Reuses the non-destructive request-scoped pricing fixture foundation merged in #26621.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/zero-web-search.test.ts` — unchanged.
- `pnpm -F api lint` — passed; emitted only repository-existing Oxlint warnings.
- `pnpm -F api check-types` — passed all dependency, boundary, gateway, core, bootstrap, test, and bootstrap-wiring partitions.
- `pnpm knip` — passed with existing configuration hints.
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/zero-web-search.test.ts` — 1 file passed, 28 tests passed.
- `git diff --check` — passed.

Closes #26594
Epic: #26569