### PR TITLE
fix: redirect auth fallbacks to the app

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -581,20 +581,26 @@ describe("createApp", () => {
   });
 
   describe("not found", () => {
-    it("redirects root auth pages to the configured web origin", async () => {
+    it.each([
+      [
+        "/sign-in?redirect_url=https%3A%2F%2Fwww.vm0.ai%2Fconnect",
+        "https://pr-123-app.vm6.ai/sign-in?redirect_url=https%3A%2F%2Fwww.vm0.ai%2Fconnect",
+      ],
+      [
+        "/sign-up/verify?redirect_url=https%3A%2F%2Fwww.vm0.ai%2Fconnect",
+        "https://pr-123-app.vm6.ai/sign-up/verify?redirect_url=https%3A%2F%2Fwww.vm0.ai%2Fconnect",
+      ],
+    ])("redirects %s to the configured app origin", async (path, expected) => {
+      mockEnv("APP_URL", "https://pr-123-app.vm6.ai");
       mockEnv("VM0_WEB_URL", "https://pr-123-www.omby.ai");
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
       });
-      const response = await app.request(
-        "https://pr-123-api.vm6.ai/sign-up?redirect_url=https%3A%2F%2Fstaging-www.omby.ai%2Fconnector%2Fsuccess%3Fdomain%3Dpr-123-api.vm6.ai",
-      );
+      const response = await app.request(`https://pr-123-api.vm6.ai${path}`);
 
       expect(response.status).toBe(302);
-      expect(response.headers.get("location")).toBe(
-        "https://pr-123-www.omby.ai/sign-up?redirect_url=https%3A%2F%2Fstaging-www.omby.ai%2Fconnector%2Fsuccess%3Fdomain%3Dpr-123-api.vm6.ai",
-      );
+      expect(response.headers.get("location")).toBe(expected);
     });
 
     it("returns a 404 JSON response for unmatched routes", async () => {

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -53,7 +53,7 @@ import {
 
 const L = logger("App");
 
-const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
+const AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
 const PREVIEW_AUTOMATION_BYPASS_ERROR = "Preview automation bypass required";
 const BYPASS_FINGERPRINT_LENGTH = 12;
 const UNHANDLED_REQUEST_ERROR_TYPE = "unhandled_request_error" as const;
@@ -104,11 +104,11 @@ function captureError(error: unknown): void {
   }
 }
 
-function redirectToWeb(context: Context): Response {
+function redirectToApp(context: Context): Response {
   const incoming = new URL(context.req.url);
   const target = new URL(
     `${incoming.pathname}${incoming.search}`,
-    env("VM0_WEB_URL"),
+    env("APP_URL"),
   );
   return context.redirect(target.toString());
 }
@@ -597,9 +597,9 @@ export function createAppWithRoutes({
 
   app.use("*", webClientCompatibilityMiddleware);
 
-  for (const path of WEB_AUTH_PATHS) {
-    app.get(path, redirectToWeb);
-    app.get(`${path}/*`, redirectToWeb);
+  for (const path of AUTH_PATHS) {
+    app.get(path, redirectToApp);
+    app.get(`${path}/*`, redirectToApp);
   }
 
   for (const { route, handler } of withApiNamespaceAliases(routes)) {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -5357,6 +5357,8 @@ describe("INT-02: Telegram integration", () => {
 
 describe("INT-03: GitHub and AgentPhone integrations", () => {
   it("keeps GitHub OAuth install and connect-start errors visible through redirects", async () => {
+    mockEnv("APP_URL", "https://app.vm0.test");
+    mockEnv("VM0_WEB_URL", "https://www.vm0.test");
     integrations.clearGithubAppProvider();
     await installApiTestConnectorCatalog();
 
@@ -5407,8 +5409,20 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
       {},
       [307],
     );
-    expect(unauthenticatedConnect.headers.get("location") ?? "").toContain(
-      "/sign-in?redirect_url=",
+    const unauthenticatedLocation =
+      unauthenticatedConnect.headers.get("location");
+    if (!unauthenticatedLocation) {
+      throw new Error("Expected app sign-in redirect");
+    }
+    const unauthenticatedUrl = new URL(unauthenticatedLocation);
+    expect(unauthenticatedUrl.origin).toBe("https://app.vm0.test");
+    expect(unauthenticatedUrl.pathname).toBe("/sign-in");
+    const redirectUrl = unauthenticatedUrl.searchParams.get("redirect_url");
+    if (!redirectUrl) {
+      throw new Error("Expected redirect_url query parameter");
+    }
+    expect(new URL(redirectUrl).pathname).toBe(
+      "/api/okou/github/oauth/connect",
     );
 
     const actor = integrations.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
@@ -176,13 +176,16 @@ describe("GET /api/zero/teams/connect", () => {
     setupTeamsConnectTestEnv(APP_ORIGIN);
   });
 
-  it("redirects unauthenticated users to sign-in with redirect_url", async () => {
+  it("redirects unauthenticated users to app sign-in with redirect_url", async () => {
     const response = await requestConnect(CONNECT_PATH, {});
 
     expect(response.status).toBe(307);
     const location = response.headers.get("location");
-    expect(location).not.toBeNull();
-    const url = new URL(location!);
+    if (!location) {
+      throw new Error("Expected app sign-in redirect");
+    }
+    const url = new URL(location);
+    expect(url.origin).toBe(APP_ORIGIN);
     expect(url.pathname).toBe("/sign-in");
     expect(url.searchParams.get("redirect_url")).toBe(CONNECT_PATH);
   });

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -644,7 +644,7 @@ function invalidGithubConnectLinkRedirect(): Response {
 }
 
 function signInRedirect(requestUrl: string): Response {
-  const signInUrl = new URL("/sign-in", requestUrl);
+  const signInUrl = new URL("/sign-in", env("APP_URL"));
   signInUrl.searchParams.set("redirect_url", requestUrl);
   return redirectResponse(signInUrl.toString());
 }

--- a/turbo/apps/api/src/signals/routes/zero-teams-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-browser-connect.ts
@@ -135,7 +135,7 @@ function connectSuccess(
 }
 
 function signInRedirect(requestUrl: string): Response {
-  const signInUrl = new URL("/sign-in", requestUrl);
+  const signInUrl = new URL("/sign-in", env("APP_URL"));
   signInUrl.searchParams.set("redirect_url", requestUrl);
   return redirectResponse(signInUrl.toString());
 }


### PR DESCRIPTION
## Summary

- redirect API `/sign-in` and `/sign-up` compatibility routes to the configured product app origin
- send unauthenticated GitHub OAuth and legacy Teams connect requests to app `/sign-in` while preserving `redirect_url`
- assert the product-app origin across the affected route integration tests

## Validation

- `pnpm exec prettier --write <changed files>`
- changed-file Oxlint, type-aware Oxlint, and ESLint with zero errors
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/__tests__/app-factory.test.ts` (48 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-teams-browser-connect.test.ts` (8 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t "keeps GitHub OAuth install and connect-start errors visible through redirects"` (1 passed, 39 skipped)

## Merge order

Merge this before vm0-ai/vm0-marketing#441 removes the marketing-owned auth routes. Related to vm0-ai/vm0-marketing#437.