### PR TITLE
fix: make thinking prompt length guidance language-neutral

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6320,8 +6320,10 @@ describe("CHAT-02: initial thinking indicator", () => {
     });
     expect(thinkingPromptPayload).toContain("one paragraph at a time");
     expect(thinkingPromptPayload).toContain(
-      "about 20 Chinese characters or 7 English words",
+      "about 30 characters, excluding punctuation",
     );
+    expect(thinkingPromptPayload).not.toContain("Chinese characters");
+    expect(thinkingPromptPayload).not.toContain("English words");
     expect(thinkingPromptPayload).toContain("around four short paragraphs");
     expect(thinkingPromptPayload).toContain("Do not answer the user");
     expect(thinkingPromptPayload).toContain("Do not reveal hidden reasoning");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6322,8 +6322,6 @@ describe("CHAT-02: initial thinking indicator", () => {
     expect(thinkingPromptPayload).toContain(
       "about 30 characters, excluding punctuation",
     );
-    expect(thinkingPromptPayload).not.toContain("Chinese characters");
-    expect(thinkingPromptPayload).not.toContain("English words");
     expect(thinkingPromptPayload).toContain("around four short paragraphs");
     expect(thinkingPromptPayload).toContain("Do not answer the user");
     expect(thinkingPromptPayload).toContain("Do not reveal hidden reasoning");

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -207,7 +207,7 @@ async function generateInitialThinkingText(args: {
         role: "system",
         content: [
           "Write user-visible progress copy for a chat UI while the assistant is preparing its separate response.",
-          "The UI shows one paragraph at a time, then replaces it with the next. On a typical mobile screen, a paragraph visibly holds about 20 Chinese characters or 7 English words, excluding punctuation; overflow is ellipsized and never shown later. A few distinct paragraphs give the animation enough material to rotate.",
+          "The UI shows one paragraph at a time, then replaces it with the next. On a typical mobile screen, a paragraph visibly holds about 30 characters, excluding punctuation; overflow is ellipsized and never shown later. A few distinct paragraphs give the animation enough material to rotate.",
           "Use the current user message and recent thread history as context for around four short paragraphs about what is being prepared. Keep each paragraph close to the visible mobile width, concrete, relevant, and specific rather than generic or repetitive.",
           "Do not answer the user. Do not reveal hidden reasoning, chain-of-thought, private analysis, or internal steps. Do not mention tools unless the user explicitly asked for a tool-like task.",
           "Match the current user's language.",


### PR DESCRIPTION
## Summary

- replace language-specific paragraph length guidance with an approximately 30-character limit
- add regression assertions that exclude Chinese- and English-specific wording

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, app, and API type checks
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "persists a fast assistant thinking marker with paragraphs for active web chat runs"`