### PR TITLE
fix(chat): render initial events before mark read completes

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts
@@ -206,7 +206,6 @@ describe("chat event snapshot read", () => {
         parts: [{ type: "text", text: "snapshot prompt" }],
       });
       expect(prompt).not.toHaveProperty("contextType");
-      expect(context.store.get(signals.initialEventsReady$)).toBeTruthy();
       expect(rowRequests).toStrictEqual([3]);
 
       await expect(
@@ -263,7 +262,6 @@ describe("chat event snapshot read", () => {
         { id: assistantEventRow.id, seqId: 2 },
       ]);
       expect(rowRequests).toStrictEqual([0]);
-      expect(context.store.get(signals.initialEventsReady$)).toBeTruthy();
       await expect(
         appDb.get(CHAT_EVENT_ROWS_STORE, assistantEventRow.id),
       ).resolves.toStrictEqual(assistantEventRow);

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-signals.ts
@@ -1,4 +1,4 @@
-import { command, computed, type Command, type Computed } from "ccstate";
+import { command, type Command, type Computed } from "ccstate";
 import type {
   ChatRunOptionsRequest,
   UserMessageInputDocument,
@@ -393,7 +393,6 @@ export interface ChatEventSignals {
   readonly threadId: string;
   readonly chatEvents$: Computed<ChatEvent[]>;
   readonly hasOptimisticUserMessage$: Computed<boolean>;
-  readonly initialEventsReady$: Computed<boolean>;
   readonly setup$: Command<Promise<void>, [AbortSignal]>;
   readonly catchUp$: Command<Promise<void>, [AbortSignal]>;
   readonly sendEvent$: Command<
@@ -422,14 +421,10 @@ export function createChatEventSignals(threadId: string): ChatEventSignals {
     mergePersistentEvents$: events.mergePersistentEvents$,
     syncRemoteEvents$: events.syncRemoteEvents$,
   });
-  const initialEventsReady$ = computed((get): boolean => {
-    return get(events.initialEventsReady$);
-  });
   return {
     threadId,
     chatEvents$: events.chatEvents$,
     hasOptimisticUserMessage$: events.hasOptimisticUserMessage$,
-    initialEventsReady$,
     ...setup,
     sendEvent$,
   };

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-storage-signals.ts
@@ -168,7 +168,6 @@ interface RemoteSyncDependencies {
   readonly threadId: string;
   readonly persistentEvents$: PersistentChatEvents$;
   readonly hasReachedOldestEvent$: Computed<boolean>;
-  readonly initialEventsReady$: State<boolean>;
   readonly mergePersistentEvents$: Command<
     Promise<void>,
     [PersistedChatEvent[], AbortSignal]
@@ -180,7 +179,6 @@ function createSyncRemoteEventsCommand({
   threadId,
   persistentEvents$,
   hasReachedOldestEvent$,
-  initialEventsReady$,
   mergePersistentEvents$,
   dataSource,
 }: RemoteSyncDependencies): Command<Promise<void>, [AbortSignal]> {
@@ -198,7 +196,6 @@ function createSyncRemoteEventsCommand({
     async function syncEventsAfter(): Promise<void> {
       const requestedSinceSeqId = sinceSeqId;
       const isInitialPage = requestedSinceSeqId === undefined;
-      const resolvesInitialEvents = !get(initialEventsReady$);
       const events = await set(
         dataSource.listEventsAfter$,
         { threadId, sinceSeqId: requestedSinceSeqId },
@@ -211,9 +208,6 @@ function createSyncRemoteEventsCommand({
         count: events.length,
       });
       if (events.length === 0) {
-        if (resolvesInitialEvents) {
-          set(initialEventsReady$, true);
-        }
         return;
       }
       await set(writeIndexedDbChatEvents$, threadId, events, signal);
@@ -222,9 +216,6 @@ function createSyncRemoteEventsCommand({
         initialPageOldestEvent = events[0]!;
         await mergeEvents(events);
         signal.throwIfAborted();
-        if (resolvesInitialEvents) {
-          set(initialEventsReady$, true);
-        }
       } else {
         accumulatedEvents.push(...events);
       }
@@ -295,7 +286,6 @@ function createSyncRemoteEventsCommand({
 interface RowSyncDependencies {
   readonly threadId: string;
   readonly persistentEvents$: PersistentChatEvents$;
-  readonly initialEventsReady$: State<boolean>;
   readonly mergePersistentEvents$: Command<
     Promise<void>,
     [PersistedChatEvent[], AbortSignal]
@@ -311,7 +301,6 @@ interface RowSyncDependencies {
 function createSyncRemoteRowsCommand({
   threadId,
   persistentEvents$,
-  initialEventsReady$,
   mergePersistentEvents$,
 }: RowSyncDependencies): Command<Promise<void>, [AbortSignal]> {
   return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
@@ -342,9 +331,6 @@ function createSyncRemoteRowsCommand({
         signal,
       );
       if (!snapshot.ok) {
-        // The skeleton must resolve even when the snapshot request fails; the
-        // error surfaces through the normal toast path.
-        set(initialEventsReady$, true);
         throw snapshot.error;
       }
       if (snapshot.value === null) {
@@ -353,7 +339,6 @@ function createSyncRemoteRowsCommand({
       await set(writeIndexedDbChatEventRows$, snapshot.value.rows, signal);
       signal.throwIfAborted();
       await mergeRows(snapshot.value.rows);
-      set(initialEventsReady$, true);
       return snapshot.value.lastSeqId;
     };
 
@@ -377,7 +362,6 @@ function createSyncRemoteRowsCommand({
       signal.throwIfAborted();
       if (page.kind === "expired") {
         if (cursorFromServer) {
-          set(initialEventsReady$, true);
           throw new Error(
             "chat event rows cursor expired right after a cold start",
           );
@@ -393,7 +377,6 @@ function createSyncRemoteRowsCommand({
       signal.throwIfAborted();
       await mergeRows(page.rows);
       signal.throwIfAborted();
-      set(initialEventsReady$, true);
       const lastRow = page.rows.at(-1);
       if (lastRow !== undefined) {
         sinceSeqId = lastRow.seqId;
@@ -451,9 +434,6 @@ export function createChatEventStorageSignals({
     persistentEvents$: persistentChatEvents$,
     optimisticEvents$,
   });
-  // This is presentation readiness, not network readiness. Event-backed
-  // paths set it only after the durable cache and event projections finish.
-  const initialEventsReady$ = state(false);
   const appendOptimisticEvent$: AppendOptimisticEventCommand = command(
     async (
       { set },
@@ -463,7 +443,6 @@ export function createChatEventStorageSignals({
       set(appendOptimisticChatEvent$, createOptimisticChatEventEntry(input));
       await set(notifyChatEventsChanged$, chatEvents$, signal);
       signal.throwIfAborted();
-      set(initialEventsReady$, true);
     },
   );
   const indexedDbEventCache = createIndexedDbEventCacheSignals(
@@ -498,14 +477,12 @@ export function createChatEventStorageSignals({
     threadId,
     persistentEvents$: persistentChatEvents$,
     hasReachedOldestEvent$,
-    initialEventsReady$,
     mergePersistentEvents$,
     dataSource,
   });
   const syncRemoteRows$ = createSyncRemoteRowsCommand({
     threadId,
     persistentEvents$: persistentChatEvents$,
-    initialEventsReady$,
     mergePersistentEvents$,
   });
   const syncRemoteEvents$ = command(
@@ -529,14 +506,12 @@ export function createChatEventStorageSignals({
             ),
         signal,
       );
-      await set(notifyChatEventsChanged$, chatEvents$, signal);
-      signal.throwIfAborted();
       if (!result.ok) {
-        set(initialEventsReady$, true);
         throw result.error;
       }
       if (get(chatEvents$).length > 0) {
-        set(initialEventsReady$, true);
+        await set(notifyChatEventsChanged$, chatEvents$, signal);
+        signal.throwIfAborted();
       }
     },
   );
@@ -544,7 +519,6 @@ export function createChatEventStorageSignals({
   return {
     chatEvents$,
     hasOptimisticUserMessage$,
-    initialEventsReady$,
     initializeIndexedDbEvents$,
     mergePersistentEvents$,
     appendOptimisticEvent$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -55,6 +55,7 @@ export interface EventImageGroupProjection {
  */
 export interface MessageListSignals {
   readonly setup$: Command<Promise<void>, [AbortSignal]>;
+  readonly catchUp$: Command<Promise<void>, [AbortSignal]>;
   readonly scroll: ReturnType<typeof createChatThreadScrollSignals>;
   readonly sidebar: ThreadSidebarSignals;
   readonly latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -11,7 +11,7 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import { IN_VITEST } from "../../env.ts";
 import { i18n } from "../../i18n/index.ts";
-import { onRef, onRejection, resetSignal, setLoop } from "../utils.ts";
+import { onRef, onRejection, resetSignal, setLoop, settle } from "../utils.ts";
 import { createHeaderAutomationSignals } from "./header-automation-menu.ts";
 import { createThreadSidebarSignals } from "./thread-sidebar.ts";
 import {
@@ -2002,6 +2002,7 @@ function createEventChangeEffects(
     projections,
     scroll,
     syncVisibleEventTrees$,
+    initialEventsReady$,
   }: {
     readonly threadId: string;
     readonly chatEvents: ChatEventSignals;
@@ -2011,6 +2012,7 @@ function createEventChangeEffects(
     >;
     readonly scroll: ChatThreadScrollSignals;
     readonly syncVisibleEventTrees$: Command<Promise<void>, [AbortSignal]>;
+    readonly initialEventsReady$: State<boolean>;
   },
   ownerSignal: AbortSignal,
 ) {
@@ -2048,6 +2050,21 @@ function createEventChangeEffects(
       set(sidebar.open$, { type: "browser" });
     },
   );
+  const updateEventPresentation$ = command(
+    async (
+      { set },
+      scrollPosition: ThreadScrollPosition | null,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await Promise.all([
+        set(syncVisibleEventTrees$, signal),
+        set(autoOpenSidebar$, signal),
+      ]);
+      signal.throwIfAborted();
+      set(initialEventsReady$, true);
+      await set(scroll.autoScroll$, scrollPosition, signal);
+    },
+  );
   const afterEventsChange$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const hasOptimisticUserMessage = get(
@@ -2072,15 +2089,55 @@ function createEventChangeEffects(
         ),
       });
       await Promise.all([
-        set(syncVisibleEventTrees$, signal),
-        set(autoOpenSidebar$, signal),
-        set(scroll.autoScroll$, scrollPosition, signal),
+        set(updateEventPresentation$, scrollPosition, signal),
         set(markThreadReadIfNeeded$, signal),
       ]);
       signal.throwIfAborted();
     },
   );
   return { sidebar, afterEventsChange$ };
+}
+
+function createChatEventPresentationLifecycle({
+  chatEvents,
+  afterEventsChange$,
+  syncVisibleEventTrees$,
+  enableSidebarEntryAnimations$,
+  initialEventsReady$,
+}: {
+  readonly chatEvents: ChatEventSignals;
+  readonly afterEventsChange$: Command<Promise<void>, [AbortSignal]>;
+  readonly syncVisibleEventTrees$: Command<Promise<void>, [AbortSignal]>;
+  readonly enableSidebarEntryAnimations$: Command<void, []>;
+  readonly initialEventsReady$: State<boolean>;
+}) {
+  const setup$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      set(
+        registerChatEventChangeHandler$,
+        chatEvents.chatEvents$,
+        afterEventsChange$,
+        signal,
+      );
+      await set(syncVisibleEventTrees$, signal);
+      set(enableSidebarEntryAnimations$);
+      const result = await settle(set(chatEvents.setup$, signal), signal);
+      if (!result.ok) {
+        set(initialEventsReady$, true);
+        throw result.error;
+      }
+    },
+  );
+  const catchUp$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      const result = await settle(set(chatEvents.catchUp$, signal), signal);
+      set(initialEventsReady$, true);
+      if (!result.ok) {
+        throw result.error;
+      }
+    },
+  );
+  return { setup$, catchUp$ };
 }
 
 function createReadyScrollAfterRenderRequest(
@@ -2170,27 +2227,28 @@ function createChatThreadMessagePipeline(
     position,
     renderWindow.ensureVisibleEventTrees$,
   );
+  const initialEventsReady$ = state(false);
   const effects = createEventChangeEffects(
-    { threadId, chatEvents, projections, scroll, syncVisibleEventTrees$ },
+    {
+      threadId,
+      chatEvents,
+      projections,
+      scroll,
+      syncVisibleEventTrees$,
+      initialEventsReady$,
+    },
     ownerSignal,
   );
   const chatSkeletonVisible$ = computed((get): boolean => {
-    return !get(chatEvents.initialEventsReady$);
+    return !get(initialEventsReady$);
   });
-  const setup$ = command(
-    async ({ set }, signal: AbortSignal): Promise<void> => {
-      set(
-        registerChatEventChangeHandler$,
-        chatEvents.chatEvents$,
-        effects.afterEventsChange$,
-        signal,
-      );
-      await set(syncVisibleEventTrees$, signal);
-      set(effects.sidebar.enableEntryAnimations$);
-      await set(chatEvents.setup$, signal);
-      signal.throwIfAborted();
-    },
-  );
+  const lifecycle = createChatEventPresentationLifecycle({
+    chatEvents,
+    afterEventsChange$: effects.afterEventsChange$,
+    syncVisibleEventTrees$,
+    enableSidebarEntryAnimations$: effects.sidebar.enableEntryAnimations$,
+    initialEventsReady$,
+  });
   const assistantErrorRecovery = createAssistantErrorRecoverySignals({
     threadId,
     chatEvents,
@@ -2219,7 +2277,7 @@ function createChatThreadMessagePipeline(
   return {
     scroll,
     sidebar: effects.sidebar,
-    setup$,
+    ...lifecycle,
     chatSkeletonVisible$,
     ...assistantErrorRecovery,
     ...projections,
@@ -3748,7 +3806,7 @@ function createChatPanelSignalsWithDraft(
   const runTracking = createRunTracking({
     threadId,
     setupChatEvents$: messages.setup$,
-    catchUpChatEvents$: chatEvents.catchUp$,
+    catchUpChatEvents$: messages.catchUp$,
     reloadArtifacts$: messages.reloadArtifacts$,
     subscribeBrowserSessions$: messages.subscribeBrowserSessions$,
     automationSignals: threadOwned,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -6,6 +6,7 @@ import {
   chatThreadArtifactsContract,
   chatThreadByIdContract,
   chatThreadEventsContract,
+  chatThreadMarkReadContract,
   chatThreadsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroBrowserContract } from "@vm0/api-contracts/contracts/zero-browser";
@@ -48,6 +49,33 @@ const IDB_ORG_ID = "zero-chat-thread-idb-org";
 const CHAT_VIEWPORT_HEIGHT = 300;
 const CHAT_SCROLL_HEIGHT = 1000;
 const PAGE_LOAD_TIMEOUT_MS = 5000;
+const EMPTY_THREAD_MESSAGE = "Send a message to start the conversation";
+
+function observeEmptyThreadMessage(): {
+  readonly wasShown: () => boolean;
+  readonly disconnect: () => void;
+} {
+  let wasShown = false;
+  const record = () => {
+    if (
+      document.querySelector("[data-chat-skeleton]") === null &&
+      document.body.textContent?.includes(EMPTY_THREAD_MESSAGE)
+    ) {
+      wasShown = true;
+    }
+  };
+  const observer = new MutationObserver(record);
+  observer.observe(document.body, { childList: true, subtree: true });
+  record();
+  return {
+    wasShown: () => {
+      return wasShown;
+    },
+    disconnect: () => {
+      observer.disconnect();
+    },
+  };
+}
 
 function isChatScrollContainer(element: HTMLElement): boolean {
   return Object.hasOwn(element.dataset, "scrollContainer");
@@ -955,6 +983,90 @@ describe("okou chat thread IndexedDB fallback", () => {
     }
   });
 
+  it("renders IndexedDB rows without an empty state while mark-read is blocked", async () => {
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    mockSidebarThread();
+    const runtimeDb = await primeRuntimeChatDb();
+    const runId = "run-cached-mark-read";
+    const cachedMessage = "Cached while mark-read is pending";
+    const cachedRows = [
+      {
+        id: "00000000-0000-4000-8000-000000000151",
+        chatThreadId: THREAD_ID,
+        runId,
+        revokesEventId: null,
+        eventType: "output.message",
+        payload: { content: cachedMessage },
+        contextType: null,
+        contextId: null,
+        runEventSequenceNumber: null,
+        runEventId: null,
+        seqId: 1,
+        createdAt: "2026-03-10T00:00:01Z",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000152",
+        chatThreadId: THREAD_ID,
+        runId,
+        revokesEventId: null,
+        eventType: "run.completed",
+        payload: null,
+        contextType: null,
+        contextId: null,
+        runEventSequenceNumber: null,
+        runEventId: null,
+        seqId: 2,
+        createdAt: "2026-03-10T00:00:02Z",
+      },
+    ] satisfies ChatEventRowV4[];
+    await Promise.all(
+      cachedRows.map((row) => {
+        return runtimeDb.put(CHAT_EVENT_ROWS_STORE, row);
+      }),
+    );
+
+    const markReadStarted = context.mocks.deferred<void>();
+    const releaseMarkRead = context.mocks.deferred<void>();
+    context.mocks.api(
+      chatThreadMarkReadContract.markRead,
+      async ({ respond }) => {
+        markReadStarted.resolve();
+        await releaseMarkRead.promise;
+        return respond(200, {
+          lastReadAt: "2026-03-10T00:00:02Z",
+          unreads: [],
+        });
+      },
+    );
+    context.mocks.api(chatThreadEventsContract.rows, ({ respond }) => {
+      return respond(200, { rows: [] });
+    });
+    context.mocks.api(chatThreadEventsContract.list, () => {
+      throw new Error("projected events endpoint must not be called");
+    });
+    const emptyThread = observeEmptyThreadMessage();
+
+    try {
+      setupChatPage({ [FeatureSwitchKey.ChatEventSnapshotRead]: true });
+      await markReadStarted.promise;
+
+      await expect(
+        screen.findByText(cachedMessage),
+      ).resolves.toBeInTheDocument();
+      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+      expect(screen.queryByText(EMPTY_THREAD_MESSAGE)).not.toBeInTheDocument();
+      expect(emptyThread.wasShown()).toBeFalsy();
+      expect(releaseMarkRead.settled()).toBeFalsy();
+    } finally {
+      emptyThread.disconnect();
+      if (!releaseMarkRead.settled()) {
+        releaseMarkRead.resolve();
+      }
+      runtimeDb.close();
+    }
+  });
+
   it("shows the message skeleton until the initial remote event request resolves", async () => {
     prepareDefaultAgent();
     mockCurrentThreadDetail();
@@ -993,7 +1105,7 @@ describe("okou chat thread IndexedDB fallback", () => {
     }
   });
 
-  it("keeps the skeleton visible through the snapshot render handoff", async () => {
+  it("renders remote rows without an empty state while mark-read is blocked", async () => {
     prepareDefaultAgent();
     mockCurrentThreadDetail();
     mockSidebarThread();
@@ -1002,6 +1114,9 @@ describe("okou chat thread IndexedDB fallback", () => {
       "https://r2.example.com/chat-events/loading-handoff.ndjson.gz";
     const snapshotBodyRequested = context.mocks.deferred<void>();
     const releaseSnapshotBody = context.mocks.deferred<void>();
+    const markReadStarted = context.mocks.deferred<void>();
+    const releaseMarkRead = context.mocks.deferred<void>();
+    const runId = "run-remote-mark-read";
     const snapshotRows = [
       {
         id: "00000000-0000-4000-8000-000000000201",
@@ -1025,7 +1140,7 @@ describe("okou chat thread IndexedDB fallback", () => {
       {
         id: "00000000-0000-4000-8000-000000000202",
         chatThreadId: THREAD_ID,
-        runId: null,
+        runId,
         revokesEventId: null,
         eventType: "output.message",
         payload: { content: ASSISTANT_MESSAGE },
@@ -1036,13 +1151,27 @@ describe("okou chat thread IndexedDB fallback", () => {
         seqId: 2,
         createdAt: "2026-08-12T06:22:01.000Z",
       },
+      {
+        id: "00000000-0000-4000-8000-000000000203",
+        chatThreadId: THREAD_ID,
+        runId,
+        revokesEventId: null,
+        eventType: "run.completed",
+        payload: null,
+        contextType: null,
+        contextId: null,
+        runEventSequenceNumber: null,
+        runEventId: null,
+        seqId: 3,
+        createdAt: "2026-08-12T06:22:02.000Z",
+      },
     ] satisfies ChatEventRowV4[];
 
     context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
       return respond(200, {
         url: snapshotUrl,
         expiresInSeconds: 900,
-        lastSeqId: 2,
+        lastSeqId: 3,
       });
     });
     context.mocks.http.get(snapshotUrl, async () => {
@@ -1062,6 +1191,17 @@ describe("okou chat thread IndexedDB fallback", () => {
     context.mocks.api(chatThreadEventsContract.list, () => {
       throw new Error("projected events endpoint must not be called");
     });
+    context.mocks.api(
+      chatThreadMarkReadContract.markRead,
+      async ({ respond }) => {
+        markReadStarted.resolve();
+        await releaseMarkRead.promise;
+        return respond(200, {
+          lastReadAt: "2026-08-12T06:22:02.000Z",
+          unreads: [],
+        });
+      },
+    );
 
     let uncoveredLoadingGap = false;
     const observer = new MutationObserver(() => {
@@ -1072,6 +1212,7 @@ describe("okou chat thread IndexedDB fallback", () => {
         uncoveredLoadingGap = true;
       }
     });
+    const emptyThread = observeEmptyThreadMessage();
     try {
       setupChatPage({ [FeatureSwitchKey.ChatEventSnapshotRead]: true });
       await snapshotBodyRequested.promise;
@@ -1082,6 +1223,7 @@ describe("okou chat thread IndexedDB fallback", () => {
       observer.observe(document.body, { childList: true, subtree: true });
 
       releaseSnapshotBody.resolve();
+      await markReadStarted.promise;
 
       await expect(
         screen.findByText(USER_MESSAGE),
@@ -1089,11 +1231,19 @@ describe("okou chat thread IndexedDB fallback", () => {
       await expect(
         screen.findByText(ASSISTANT_MESSAGE),
       ).resolves.toBeInTheDocument();
+      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+      expect(screen.queryByText(EMPTY_THREAD_MESSAGE)).not.toBeInTheDocument();
+      expect(emptyThread.wasShown()).toBeFalsy();
       expect(uncoveredLoadingGap).toBeFalsy();
+      expect(releaseMarkRead.settled()).toBeFalsy();
     } finally {
       observer.disconnect();
+      emptyThread.disconnect();
       if (!releaseSnapshotBody.settled()) {
         releaseSnapshotBody.resolve();
+      }
+      if (!releaseMarkRead.settled()) {
+        releaseMarkRead.resolve();
       }
       runtimeDb.close();
     }


### PR DESCRIPTION
## Summary

- move initial event presentation readiness from chat-event storage into the thread message pipeline
- dismiss the skeleton after visible event trees and sidebar state synchronize, then auto-scroll while mark-read runs independently
- avoid exposing an empty thread during IndexedDB or remote snapshot hydration, with blocked mark-read regression coverage for both paths

## Verification

- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx apps/platform/src/signals/chat-page/__tests__/chat-event-snapshot-read.test.ts (23 passed)
- pnpm --filter @vm0/app check-types
- targeted ESLint and Oxlint on changed files
- git diff --check