### PR TITLE
fix: refine fast model toggle interaction

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -197,6 +197,68 @@ async function disableChatEventSnapshotRead(page: Page): Promise<void> {
   });
 }
 
+async function mockSelectedFastModel(page: Page): Promise<void> {
+  const policyId = "00000000-0000-4000-a000-000000000736";
+  await page.route("**/api/okou/feature-switches", async (route) => {
+    const response = await route.fetch();
+    const body: unknown = await response.json();
+    if (!isRecord(body) || !isRecord(body.effectiveSwitches)) {
+      throw new Error("Feature switches returned an unexpected response");
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        effectiveSwitches: {
+          ...body.effectiveSwitches,
+          codexFastMode: true,
+        },
+      },
+    });
+  });
+  await page.route("**/api/okou/model-policies", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        policies: [
+          {
+            id: policyId,
+            model: "gpt-5.6-sol",
+            modelLabel: "GPT 5.6 Sol",
+            isDefault: true,
+            defaultProviderType: "vm0",
+            credentialScope: "org",
+            modelProviderId: null,
+            modelProviderSurfaceId: null,
+            routeStatus: "valid",
+            routeStatusReason: null,
+            createdAt: "2026-08-12T00:00:00.000Z",
+            updatedAt: "2026-08-12T00:00:00.000Z",
+          },
+        ],
+        workspaceDefaultModel: "gpt-5.6-sol",
+        workspaceDefaultPolicyId: policyId,
+      },
+    });
+  });
+  await page.route("**/api/okou/user-model-preference", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        selectedModel: "gpt-5.6-sol",
+        serviceTier: "priority",
+        updatedAt: "2026-08-12T00:00:00.000Z",
+      },
+    });
+  });
+}
+
 interface MockChatThreadOptions {
   readonly agentId: string;
   readonly createdAt: string;
@@ -545,6 +607,24 @@ test("chat page displays tagline after onboarding", async ({ page }) => {
   await expect(page.getByTestId("chat-tagline")).toBeVisible({
     timeout: 20_000,
   });
+});
+
+test("selected Fast model previews deactivation on icon hover", async ({
+  page,
+}) => {
+  await mockSelectedFastModel(page);
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+
+  await page.getByRole("combobox", { name: "GPT 5.6 Sol Fast" }).click();
+  const fastOption = page.getByRole("option", {
+    name: "GPT 5.6 Sol Fast",
+  });
+  const fastIcon = fastOption.locator("svg.lucide-zap");
+  await expect(fastIcon).not.toHaveCSS("fill", "none");
+
+  await fastOption.hover();
+  await expect(fastIcon).toHaveCSS("fill", "none");
 });
 
 test("send a message through the deployed runner", async ({ page }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -667,9 +667,6 @@ describe("chat composer models", () => {
       "fill",
       "currentColor",
     );
-    expect(fastModeIcon(fastModeOption)).toHaveClass(
-      "group-hover/fast-option:fill-none",
-    );
     expect(standardOption.querySelector("svg.lucide-check")).not.toBeNull();
     expect(fastModeOption.querySelector("svg.lucide-check")).toBeNull();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -461,11 +461,7 @@ describe("chat composer models", () => {
         "fill",
         expectedZapIcon ? "none" : "currentColor",
       );
-      await user.click(
-        expectedZapIcon
-          ? fastModeOption
-          : screen.getByRole("option", { name: "GPT 5.6 Sol" }),
-      );
+      await user.click(fastModeOption);
       await expectComposerModel(targetLabel);
       await expect(screen.findByText(notice)).resolves.toBeInTheDocument();
       await user.click(buttonContainingText("Set as default", document.body));
@@ -671,6 +667,9 @@ describe("chat composer models", () => {
       "fill",
       "currentColor",
     );
+    expect(fastModeIcon(fastModeOption)).toHaveClass(
+      "group-hover/fast-option:fill-none",
+    );
     expect(standardOption.querySelector("svg.lucide-check")).not.toBeNull();
     expect(fastModeOption.querySelector("svg.lucide-check")).toBeNull();
 
@@ -694,6 +693,11 @@ describe("chat composer models", () => {
     });
 
     await user.click(standardOption);
+    await expectComposerModel("GPT 5.6 Sol Fast");
+
+    await user.click(await findComposerModel("GPT 5.6 Sol Fast"));
+    fastModeOption = await findFastModeOption("GPT 5.6 Sol");
+    await user.click(fastModeOption);
     await expectComposerModel("GPT 5.6 Sol");
 
     await user.click(await findComposerModel("GPT 5.6 Sol"));

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -442,6 +442,22 @@ function codexFastOptionValue(model: string): string {
   return `${CODEX_FAST_OPTION_PREFIX}${model}`;
 }
 
+function modelFirstSelectionFromInteraction(
+  raw: string,
+  currentSelection: ModelProviderSelection | null,
+  codexFastModeEnabled: boolean,
+): ModelProviderSelection | null | undefined {
+  if (codexFastModeEnabled && currentSelection?.codexServiceTier === "fast") {
+    if (raw === currentSelection.selectedModel) {
+      return undefined;
+    }
+    if (raw === codexFastOptionValue(currentSelection.selectedModel)) {
+      return { selectedModel: currentSelection.selectedModel };
+    }
+  }
+  return modelFirstSelectionFromRaw(raw, codexFastModeEnabled);
+}
+
 function isHiddenModelFirstSelectValue(value: string): boolean {
   return (
     value === INHERIT_SENTINEL || value.startsWith(CODEX_FAST_SELECTED_PREFIX)
@@ -553,8 +569,9 @@ function ModelFirstPolicyRow({
                   size={18}
                   fill={fastSelected ? "currentColor" : "none"}
                   className={cn(
-                    !fastSelected &&
-                      "group-hover/fast-option:fill-current group-data-[highlighted]/fast-option:fill-current",
+                    fastSelected
+                      ? "group-hover/fast-option:fill-none group-data-[highlighted]/fast-option:fill-none"
+                      : "group-hover/fast-option:fill-current group-data-[highlighted]/fast-option:fill-current",
                   )}
                   aria-hidden="true"
                 />
@@ -883,7 +900,14 @@ function SubscribedModelFirstModelPicker({
   };
 
   const handleRawValueChange = (raw: string) => {
-    const selection = modelFirstSelectionFromRaw(raw, codexFastModeEnabled);
+    const selection = modelFirstSelectionFromInteraction(
+      raw,
+      state.selection,
+      codexFastModeEnabled,
+    );
+    if (selection === undefined) {
+      return;
+    }
     if (selection) {
       const policy = state.policies.find((candidate) => {
         return candidate.model === selection.selectedModel;
@@ -1092,14 +1116,19 @@ function EnabledExplicitModelFirstModelPicker(
     fastLabel: props.fastLabel,
   });
   const handleRawValueChange = (raw: string) => {
+    const selection = modelFirstSelectionFromInteraction(
+      raw,
+      state.selection,
+      props.codexFastModeEnabled ?? false,
+    );
+    if (selection === undefined) {
+      return;
+    }
     detach(
       (async () => {
         const result = await resolveSelection(
           {
-            selection: modelFirstSelectionFromRaw(
-              raw,
-              props.codexFastModeEnabled ?? false,
-            ),
+            selection,
           },
           pageSignal,
         );


### PR DESCRIPTION
## Summary

- preview Fast deactivation by rendering the selected lightning icon as an outline on hover
- keep the selected model's standard hit area from disabling Fast, and use the Fast icon to switch back to Standard
- cover both interaction paths in the existing page-level integration test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` (49 passed)
