### PR TITLE
fix(runner): preserve guest control headroom under workload pressure

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -745,11 +745,15 @@ identity=/tmp/vm0-one-shot-containment.identity
 group_file=/tmp/vm0-one-shot-containment.group
 rm -f "$identity" "$group_file"
 relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
-own_group=${relative##*/}
-case "$own_group" in
-  exec-*) ;;
+case "$relative" in
+  /vm0-exec/exec-*/workload) ;;
   *) echo "unexpected one-shot cgroup: $relative" >&2; exit 1 ;;
 esac
+operation=${relative%/workload}
+own_group=${operation##*/}
+test -f "/sys/fs/cgroup$operation/workload/cpu.max"
+test -f "/sys/fs/cgroup$operation/workload/memory.max"
+test -f "/sys/fs/cgroup$operation/workload/pids.max"
 printf '%s\n' "$own_group" > "$group_file"
 setsid python3 -c 'import os, pathlib, signal, time; p=pathlib.Path("/tmp/vm0-one-shot-containment.identity"); fields=pathlib.Path("/proc/self/stat").read_text().rsplit(")", 1)[1].split(); signal.signal(signal.SIGTERM, signal.SIG_IGN); p.write_text(f"{os.getpid()} {fields[19]}\n"); time.sleep(300)' </dev/null >/dev/null 2>&1 &
 for _ in $(seq 1 100); do
@@ -781,7 +785,12 @@ if current_identity=$(awk '{sub(/^.*\) /, ""); print $1, $20}' "/proc/$pid/stat"
 fi
 base=/sys/fs/cgroup/vm0-exec
 relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
-own_group=${relative##*/}
+case "$relative" in
+  /vm0-exec/exec-*/workload) ;;
+  *) echo "unexpected verification cgroup: $relative" >&2; exit 1 ;;
+esac
+operation=${relative%/workload}
+own_group=${operation##*/}
 test -n "$own_group"
 test -d "$base/$own_group"
 old_group=$(cat "$group_file")

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -548,7 +548,9 @@ import pathlib
 import signal
 import time
 
-pathlib.Path("/tmp/vm0-process-containment/pid-pressure-vm").touch()
+marker = pathlib.Path("/tmp/vm0-process-containment")
+marker.mkdir()
+(marker / "pid-pressure-vm").touch()
 relative = next(
     line.removeprefix("0::").strip()
     for line in pathlib.Path("/proc/self/cgroup").read_text().splitlines()

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -121,8 +121,16 @@ grep -Eq '^[0-9]+$' "$parent/workload/memory.high"
 grep -Eq '^[0-9]+$' "$parent/workload/memory.max"
 grep -Eq '^[0-9]+$' "$parent/workload/pids.max"
 test -z "${VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT:-}"
-control_pid=$(head -n 1 "$parent/control/cgroup.procs")
-test -n "$control_pid"
+control_member_count=$(wc -l < "$parent/control/cgroup.procs")
+if [ "$control_member_count" -ne 1 ]; then
+  echo "control cgroup must contain only Guest Agent; members=$(tr '\n' ' ' < "$parent/control/cgroup.procs")" >&2
+  exit 1
+fi
+control_pid=$(cat "$parent/control/cgroup.procs")
+if [ "$(cat "/proc/$control_pid/comm")" != "guest-agent" ]; then
+  echo "control cgroup member is not Guest Agent: pid=$control_pid comm=$(cat "/proc/$control_pid/comm")" >&2
+  exit 1
+fi
 if ls "/proc/$control_pid/fd" >/dev/null 2>&1; then
   echo "workload can inspect Guest Agent descriptors" >&2
   exit 1
@@ -623,6 +631,14 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
 
 LOGS=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
   || fail "failed to read runner logs"
+MEMORY_FAILURE_LOG=$(printf '%s\n' "$LOGS" \
+  | grep -F "run_id=$MEMORY_RUN_ID" \
+  | grep -F 'job execution failed' \
+  | tail -1) \
+  || fail "missing memory-pressure terminal failure log"
+if ! grep -E 'workload_memory_oom(_kill)?_events=[1-9][0-9]*' <<<"$MEMORY_FAILURE_LOG" >/dev/null; then
+  fail "memory-pressure terminal log omitted structured workload OOM counters"
+fi
 LEAK_LINE=$(printf '%s\n' "$LOGS" \
   | grep -F 'exec process containment cleaned' \
   | grep -F 'descendants_observed=true' \

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -119,7 +119,7 @@ test "$(cat "$parent/control/memory.min")" = "$expected_control_memory_min"
 grep -Eq '^[0-9]+ [0-9]+$' "$parent/workload/cpu.max"
 grep -Eq '^[0-9]+$' "$parent/workload/memory.high"
 grep -Eq '^[0-9]+$' "$parent/workload/memory.max"
-grep -Eq '^[0-9]+$' "$parent/workload/pids.max"
+test "$(cat "$parent/workload/pids.max")" = max
 test -z "${VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT:-}"
 control_member_count=$(wc -l < "$parent/control/cgroup.procs")
 if [ "$control_member_count" -ne 1 ]; then
@@ -568,8 +568,8 @@ relative = next(
     if line.startswith("0::")
 )
 workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
-# The production 2,048-process ceiling was exercised during calibration. A
-# smaller operation-local ceiling keeps this committed kernel-path smoke fast.
+# Production leaves are uncapped until representative workload task counts are
+# calibrated. This operation-local ceiling keeps the enforcement smoke fast.
 (workload / "pids.max").write_text("64")
 children = []
 while True:

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -103,6 +103,10 @@ for controller in cpu memory pids; do
   grep -qw "$controller" "$base/cgroup.subtree_control"
   grep -qw "$controller" "$parent/cgroup.subtree_control"
 done
+expected_control_memory_min=$((384 * 1024 * 1024))
+test "$(cat "$base/memory.min")" = "$expected_control_memory_min"
+test "$(cat "$parent/memory.min")" = "$expected_control_memory_min"
+test "$(cat "$parent/control/memory.min")" = "$expected_control_memory_min"
 grep -Eq '^[0-9]+ [0-9]+$' "$parent/workload/cpu.max"
 grep -Eq '^[0-9]+$' "$parent/workload/memory.high"
 grep -Eq '^[0-9]+$' "$parent/workload/memory.max"

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -89,6 +89,36 @@ rm -rf "$marker"
 mkdir -p "$marker"
 touch "$marker/vm-reuse-marker"
 
+base=/sys/fs/cgroup/vm0-exec
+relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
+case "$relative" in
+  /vm0-exec/exec-*/workload) ;;
+  *) echo "agent CLI is outside workload cgroup: $relative" >&2; exit 1 ;;
+esac
+operation=${relative%/workload}
+parent="/sys/fs/cgroup$operation"
+test -d "$parent/control"
+test -d "$parent/workload"
+for controller in cpu memory pids; do
+  grep -qw "$controller" "$base/cgroup.subtree_control"
+  grep -qw "$controller" "$parent/cgroup.subtree_control"
+done
+grep -Eq '^[0-9]+ [0-9]+$' "$parent/workload/cpu.max"
+grep -Eq '^[0-9]+$' "$parent/workload/memory.high"
+grep -Eq '^[0-9]+$' "$parent/workload/memory.max"
+grep -Eq '^[0-9]+$' "$parent/workload/pids.max"
+test -z "${VM0_WORKLOAD_CGROUP_PROCS_FD:-}"
+control_pid=$(head -n 1 "$parent/control/cgroup.procs")
+test -n "$control_pid"
+if ls "/proc/$control_pid/fd" >/dev/null 2>&1; then
+  echo "workload can inspect Guest Agent descriptors" >&2
+  exit 1
+fi
+if printf 0 > "$parent/control/cgroup.procs" 2>/dev/null; then
+  echo "workload can move itself into the control cgroup" >&2
+  exit 1
+fi
+
 setsid python3 -c 'import os, pathlib, signal, time; p=pathlib.Path("/tmp/vm0-process-containment/user.identity"); fields=pathlib.Path("/proc/self/stat").read_text().rsplit(")", 1)[1].split(); signal.signal(signal.SIGTERM, signal.SIG_IGN); p.write_text(f"{os.getpid()} {fields[19]}\n"); time.sleep(300)' </dev/null >"$marker/user.launch.log" 2>&1 &
 user_launcher_pid=$!
 setsid sudo -n python3 -c 'import os, pathlib, time; p=pathlib.Path("/tmp/vm0-process-containment/root.identity"); fields=pathlib.Path("/proc/self/stat").read_text().rsplit(")", 1)[1].split(); p.write_text(f"{os.getpid()} {fields[19]}\n"); time.sleep(300)' </dev/null >"$marker/root.launch.log" 2>&1 &
@@ -219,12 +249,22 @@ for identity in "$marker/user.identity" "$marker/root.identity"; do
 done
 
 relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
-own_group=${relative##*/}
+case "$relative" in
+  /vm0-exec/exec-*/workload) ;;
+  *) echo "unexpected current cgroup: $relative" >&2; exit 1 ;;
+esac
+operation=${relative%/workload}
+own_group=${operation##*/}
 test -n "$own_group"
 test -d "$base/$own_group"
+test -d "$base/$own_group/control"
+test -d "$base/$own_group/workload"
 test -z "$(find "$base" -mindepth 1 -maxdepth 1 -type d ! -name "$own_group" -print -quit)"
 grep -q '^populated 1$' "$base/cgroup.events"
-test -z "$(cat "$base/cgroup.subtree_control")"
+for controller in cpu memory pids; do
+  grep -qw "$controller" "$base/cgroup.subtree_control"
+  grep -qw "$controller" "$base/$own_group/cgroup.subtree_control"
+done
 echo containment-turn-2
 PROMPT
 )

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -339,18 +339,19 @@ echo "--- Pressure: sustain CPU saturation with live process control ---"
 PRESSURE_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 PRESSURE_SESSION_ID="e2e-process-containment-pressure"
 PRESSURE_SUBMIT_OUTPUT=$(mktemp)
-# Queue one input immediately to keep the mock turn open while this script
-# resolves its sandbox; later inputs exercise control during CPU pressure.
+# Queue one input immediately while this script resolves the sandbox. Keep the
+# final input after the pressure command so the mock turn cannot finish first.
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --timeout 45 \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
-  --prompt '@active-input-smoke:4' \
+  --prompt '@active-input-smoke:5' \
   --active-input 'after=100ms,text=cpu-pressure-ready' \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \
-  --active-input 'after=7s,text=cpu-pressure-three' \
+  --active-input 'after=6s,text=cpu-pressure-three' \
+  --active-input 'after=9s,text=cpu-pressure-finish' \
   >"$PRESSURE_SUBMIT_OUTPUT" 2>&1 &
 PRESSURE_SUBMIT_PID=$!
 
@@ -385,7 +386,7 @@ done
 [ -n "$PRESSURE_SANDBOX_ID" ] \
   || fail "CPU-pressure sandbox did not become ready"
 
-CPU_PRESSURE_SECONDS=8
+CPU_PRESSURE_SECONDS=6
 CPU_PRESSURE_COMMAND=$(cat <<'SCRIPT'
 set -eu
 duration=$1
@@ -447,7 +448,7 @@ SUBMITTED_PRESSURE_RUN_ID=$(jq -r '.run_id // empty' <<<"$PRESSURE_SUBMIT_JSON")
 PRESSURE_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${PRESSURE_RUN_ID}.log"
 PRESSURE_METRICS_LOG="/var/lib/vm0-runner/logs/metrics-${PRESSURE_RUN_ID}.jsonl"
 sudo grep -F -q \
-  'RESULT=cpu-pressure-ready+cpu-pressure-one+cpu-pressure-two+cpu-pressure-three' \
+  'RESULT=cpu-pressure-ready+cpu-pressure-one+cpu-pressure-two+cpu-pressure-three+cpu-pressure-finish' \
   "$PRESSURE_STREAM_LOG" \
   || fail "CPU-pressure active inputs were not all consumed in order"
 

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -494,9 +494,9 @@ relative = next(
     if line.startswith("0::")
 )
 workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
-# Keep the committed smoke fast while exercising the same workload-local OOM
-# boundary and counters as the production-capacity Firecracker calibration.
-(workload / "memory.high").write_text(str(192 * 1024 * 1024))
+# Disable soft-limit throttling for this smoke so reclaim cannot postpone the
+# workload-local OOM. The production memory.high policy is covered above.
+(workload / "memory.high").write_text("max")
 (workload / "memory.max").write_text(str(256 * 1024 * 1024))
 chunk_size = 16 * 1024 * 1024
 chunks = []

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -429,6 +429,9 @@ CPU_PRESSURE_ELAPSED=$SECONDS
 printf '%s\n' "$CPU_PRESSURE_RESULT"
 [ "$CPU_PRESSURE_ELAPSED" -ge "$CPU_PRESSURE_SECONDS" ] \
   || fail "CPU pressure ended early after ${CPU_PRESSURE_ELAPSED}s"
+grep -E -q '^cpu-pressure-complete throttled_periods=[1-9][0-9]*$' \
+  <<<"$CPU_PRESSURE_RESULT" \
+  || fail "CPU pressure did not report throttling"
 
 if wait "$PRESSURE_SUBMIT_PID"; then
   PRESSURE_SUBMIT_STATUS=0
@@ -635,9 +638,6 @@ LEAK_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$LEAK_LINE"
 if grep -F 'process control latency exceeded calibrated bound' <<<"$LOGS" >/dev/null; then
   fail "process control exceeded the calibrated 750ms bound under pressure"
 fi
-grep -F 'exec workload resource pressure observed' <<<"$LOGS" \
-  | grep -E 'cpu_nr_throttled=[1-9][0-9]*' >/dev/null \
-  || fail "CPU-pressure enforcement was not reported"
 PID_CLEANUP_LINE=$(printf '%s\n' "$LOGS" \
   | grep -F 'exec process containment cleaned' \
   | grep -F 'descendants_observed=true' \

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -339,12 +339,15 @@ echo "--- Pressure: sustain CPU saturation with live process control ---"
 PRESSURE_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 PRESSURE_SESSION_ID="e2e-process-containment-pressure"
 PRESSURE_SUBMIT_OUTPUT=$(mktemp)
+# Queue one input immediately to keep the mock turn open while this script
+# resolves its sandbox; later inputs exercise control during CPU pressure.
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --timeout 45 \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
-  --prompt '@active-input-smoke:3' \
+  --prompt '@active-input-smoke:4' \
+  --active-input 'after=100ms,text=cpu-pressure-ready' \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \
   --active-input 'after=7s,text=cpu-pressure-three' \
@@ -444,7 +447,7 @@ SUBMITTED_PRESSURE_RUN_ID=$(jq -r '.run_id // empty' <<<"$PRESSURE_SUBMIT_JSON")
 PRESSURE_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${PRESSURE_RUN_ID}.log"
 PRESSURE_METRICS_LOG="/var/lib/vm0-runner/logs/metrics-${PRESSURE_RUN_ID}.jsonl"
 sudo grep -F -q \
-  'RESULT=cpu-pressure-one+cpu-pressure-two+cpu-pressure-three' \
+  'RESULT=cpu-pressure-ready+cpu-pressure-one+cpu-pressure-two+cpu-pressure-three' \
   "$PRESSURE_STREAM_LOG" \
   || fail "CPU-pressure active inputs were not all consumed in order"
 

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -46,6 +46,8 @@ BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5
 UNIT="vm0-runner-${SVC}.service"
 SESSION_ID="e2e-process-containment-session"
 CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+PRESSURE_SUBMIT_PID=""
+PRESSURE_SUBMIT_OUTPUT=""
 
 fail() { echo "FAIL: $1"; exit 1; }
 
@@ -61,6 +63,13 @@ wait_for_unit_inactive() {
 
 cleanup() {
   echo "--- Cleanup ---"
+  if [ -n "$PRESSURE_SUBMIT_PID" ]; then
+    kill "$PRESSURE_SUBMIT_PID" 2>/dev/null || true
+    wait "$PRESSURE_SUBMIT_PID" 2>/dev/null || true
+  fi
+  if [ -n "$PRESSURE_SUBMIT_OUTPUT" ]; then
+    rm -f "$PRESSURE_SUBMIT_OUTPUT"
+  fi
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   wait_for_unit_inactive
   sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
@@ -111,7 +120,7 @@ grep -Eq '^[0-9]+ [0-9]+$' "$parent/workload/cpu.max"
 grep -Eq '^[0-9]+$' "$parent/workload/memory.high"
 grep -Eq '^[0-9]+$' "$parent/workload/memory.max"
 grep -Eq '^[0-9]+$' "$parent/workload/pids.max"
-test -z "${VM0_WORKLOAD_CGROUP_PROCS_FD:-}"
+test -z "${VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT:-}"
 control_pid=$(head -n 1 "$parent/control/cgroup.procs")
 test -n "$control_pid"
 if ls "/proc/$control_pid/fd" >/dev/null 2>&1; then
@@ -204,6 +213,29 @@ done
   || fixture_fail root 13 "readiness deadline exceeded"
 verify_live_identity user 14
 verify_live_identity root 15
+
+# Persist adversarial login profiles for the next reuse turn. Production
+# Guest Agent bootstrap must use a non-login shell and SCM_RIGHTS, so neither
+# profile can run before the trusted binary or retain a placement capability.
+cat > "$HOME/.profile" <<'PROFILE'
+touch /tmp/vm0-process-containment/profile-executed
+for descriptor in /proc/self/fd/*; do
+  target=$(readlink "$descriptor" 2>/dev/null || true)
+  case "$target" in
+    */workload/cgroup.procs)
+      printf '%s\n' "$target" > /tmp/vm0-process-containment/profile-capability
+      ;;
+  esac
+done
+(sleep 300) &
+PROFILE
+cp "$HOME/.profile" "$HOME/.bash_profile"
+cat > "$HOME/.vm0-bootstrap-env" <<'BASH_ENV'
+touch /tmp/vm0-process-containment/pam-environment-executed
+BASH_ENV
+cat > "$HOME/.pam_environment" <<'PAM_ENV'
+BASH_ENV DEFAULT=/home/user/.vm0-bootstrap-env
+PAM_ENV
 echo containment-turn-1
 PROMPT
 )
@@ -234,6 +266,20 @@ set -eu
 marker=/tmp/vm0-process-containment
 base=/sys/fs/cgroup/vm0-exec
 test -f "$marker/vm-reuse-marker"
+if [ -e "$marker/profile-executed" ]; then
+  echo "sandbox login profile executed before Guest Agent" >&2
+  exit 1
+fi
+if [ -e "$marker/profile-capability" ]; then
+  echo "sandbox login profile observed workload placement capability" >&2
+  exit 1
+fi
+if [ -e "$marker/pam-environment-executed" ]; then
+  echo "sandbox PAM environment executed code before Guest Agent" >&2
+  exit 1
+fi
+rm -f "$HOME/.profile" "$HOME/.bash_profile" \
+  "$HOME/.pam_environment" "$HOME/.vm0-bootstrap-env"
 
 for identity in "$marker/user.identity" "$marker/root.identity"; do
   read -r pid start_time < "$identity"
@@ -289,6 +335,283 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --prompt 'test -f /tmp/vm0-process-containment/vm-reuse-marker' \
   || fail "Turn 3 failed; healthy cleanup did not re-enter reuse"
 
+echo "--- Pressure: sustain CPU saturation with live process control ---"
+PRESSURE_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+PRESSURE_SESSION_ID="e2e-process-containment-pressure"
+PRESSURE_SUBMIT_OUTPUT=$(mktemp)
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --timeout 45 \
+  --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
+  --session-id "$PRESSURE_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt '@active-input-smoke:3' \
+  --active-input 'after=2s,text=cpu-pressure-one' \
+  --active-input 'after=4s,text=cpu-pressure-two' \
+  --active-input 'after=7s,text=cpu-pressure-three' \
+  >"$PRESSURE_SUBMIT_OUTPUT" 2>&1 &
+PRESSURE_SUBMIT_PID=$!
+
+PRESSURE_RUN_ID=""
+PRESSURE_SANDBOX_ID=""
+for _ in $(seq 1 60); do
+  if ! kill -0 "$PRESSURE_SUBMIT_PID" 2>/dev/null; then
+    wait "$PRESSURE_SUBMIT_PID" 2>/dev/null || true
+    PRESSURE_SUBMIT_PID=""
+    cat "$PRESSURE_SUBMIT_OUTPUT"
+    fail "CPU-pressure submit exited before its sandbox became ready"
+  fi
+  mapfile -t CLAIM_FILES < <(
+    sudo find "$GROUP_DIR/claims" -maxdepth 1 -type f -name '*.claim' \
+      -printf '%f\n' 2>/dev/null | sort
+  )
+  [ "${#CLAIM_FILES[@]}" -le 1 ] \
+    || fail "expected one CPU-pressure claim, found ${#CLAIM_FILES[@]}"
+  if [ "${#CLAIM_FILES[@]}" -eq 1 ]; then
+    PRESSURE_RUN_ID=${CLAIM_FILES[0]%.claim}
+    PRESSURE_SANDBOX_ID=$(sudo jq -r --arg run_id "$PRESSURE_RUN_ID" \
+      '.active_runs[]? | select(.run_id == $run_id) | .sandbox_id' \
+      "$RUNNER_DIR/status.json" 2>/dev/null)
+    if [ -n "$PRESSURE_SANDBOX_ID" ] \
+      && [ -S "/run/vm0/sock/$PRESSURE_SANDBOX_ID/control.sock" ]; then
+      break
+    fi
+  fi
+  PRESSURE_SANDBOX_ID=""
+  sleep 1
+done
+[ -n "$PRESSURE_SANDBOX_ID" ] \
+  || fail "CPU-pressure sandbox did not become ready"
+
+CPU_PRESSURE_SECONDS=8
+CPU_PRESSURE_COMMAND=$(cat <<'SCRIPT'
+set -eu
+duration=$1
+relative=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)
+case "$relative" in
+  /vm0-exec/exec-*/workload) ;;
+  *) echo "CPU pressure is outside workload cgroup: $relative" >&2; exit 1 ;;
+esac
+workload="/sys/fs/cgroup$relative"
+before=$(awk '$1 == "nr_throttled" { print $2 }' "$workload/cpu.stat")
+worker_count=$(( $(getconf _NPROCESSORS_ONLN) * 4 ))
+worker_pids=""
+cleanup_workers() {
+  if [ -n "$worker_pids" ]; then
+    kill $worker_pids 2>/dev/null || true
+    wait $worker_pids 2>/dev/null || true
+  fi
+}
+trap cleanup_workers EXIT INT TERM
+worker=0
+while [ "$worker" -lt "$worker_count" ]; do
+  yes >/dev/null &
+  worker_pids="$worker_pids $!"
+  worker=$((worker + 1))
+done
+sleep "$duration"
+after=$(awk '$1 == "nr_throttled" { print $2 }' "$workload/cpu.stat")
+[ "$after" -gt "$before" ] \
+  || { echo "CPU quota did not throttle the workload" >&2; exit 1; }
+echo "cpu-pressure-complete throttled_periods=$((after - before))"
+SCRIPT
+)
+SECONDS=0
+CPU_PRESSURE_RESULT=$(sudo "$BIN_DIR/runner" exec \
+  --timeout 30 \
+  --sandbox "$PRESSURE_SANDBOX_ID" \
+  -- sh -c "$CPU_PRESSURE_COMMAND" sh "$CPU_PRESSURE_SECONDS") \
+  || fail "concurrent ordinary-exec CPU pressure failed"
+CPU_PRESSURE_ELAPSED=$SECONDS
+printf '%s\n' "$CPU_PRESSURE_RESULT"
+[ "$CPU_PRESSURE_ELAPSED" -ge "$CPU_PRESSURE_SECONDS" ] \
+  || fail "CPU pressure ended early after ${CPU_PRESSURE_ELAPSED}s"
+
+if wait "$PRESSURE_SUBMIT_PID"; then
+  PRESSURE_SUBMIT_STATUS=0
+else
+  PRESSURE_SUBMIT_STATUS=$?
+fi
+PRESSURE_SUBMIT_PID=""
+cat "$PRESSURE_SUBMIT_OUTPUT"
+[ "$PRESSURE_SUBMIT_STATUS" -eq 0 ] \
+  || fail "process control did not remain live during CPU pressure"
+PRESSURE_SUBMIT_JSON=$(awk '/^\{/{line=$0} END{print line}' "$PRESSURE_SUBMIT_OUTPUT")
+[ -n "$PRESSURE_SUBMIT_JSON" ] \
+  || fail "CPU-pressure submit did not return a JSON result"
+SUBMITTED_PRESSURE_RUN_ID=$(jq -r '.run_id // empty' <<<"$PRESSURE_SUBMIT_JSON")
+[ "$SUBMITTED_PRESSURE_RUN_ID" = "$PRESSURE_RUN_ID" ] \
+  || fail "CPU-pressure result run ID did not match its claim"
+PRESSURE_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${PRESSURE_RUN_ID}.log"
+PRESSURE_METRICS_LOG="/var/lib/vm0-runner/logs/metrics-${PRESSURE_RUN_ID}.jsonl"
+sudo grep -F -q \
+  'RESULT=cpu-pressure-one+cpu-pressure-two+cpu-pressure-three' \
+  "$PRESSURE_STREAM_LOG" \
+  || fail "CPU-pressure active inputs were not all consumed in order"
+
+METRICS_SUMMARY=$(sudo jq -sr '
+  [
+    .[]
+    | .ts
+    | sub("\\.[0-9]+Z$"; "Z")
+    | fromdateiso8601
+  ] as $samples
+  | if ($samples | length) < 2 then
+      error("insufficient metric samples")
+    else
+      [
+        ($samples | length),
+        ($samples[-1] - $samples[0]),
+        ([range(1; ($samples | length)) as $index
+          | $samples[$index] - $samples[$index - 1]] | max)
+      ]
+      | @tsv
+    end
+' "$PRESSURE_METRICS_LOG") \
+  || fail "failed to summarize CPU-pressure Guest metrics"
+read -r METRICS_COUNT METRICS_SPAN_SECS METRICS_MAX_GAP_SECS <<<"$METRICS_SUMMARY"
+[ "$METRICS_SPAN_SECS" -ge 4 ] \
+  || fail "Guest control metrics did not remain live during CPU pressure: ${METRICS_SPAN_SECS}s"
+[ "$METRICS_MAX_GAP_SECS" -le 15 ] \
+  || fail "Guest control metric cadence exceeded 15s: ${METRICS_MAX_GAP_SECS}s"
+rm -f "$PRESSURE_SUBMIT_OUTPUT"
+PRESSURE_SUBMIT_OUTPUT=""
+
+echo "--- Pressure: exhaust workload memory without killing Guest Agent ---"
+MEMORY_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+MEMORY_SESSION_ID="e2e-process-containment-memory"
+MEMORY_PROMPT=$(cat <<'PROMPT'
+sudo -n python3 - <<'PY'
+import pathlib
+import time
+
+relative = next(
+    line.removeprefix("0::").strip()
+    for line in pathlib.Path("/proc/self/cgroup").read_text().splitlines()
+    if line.startswith("0::")
+)
+workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
+# Keep the committed smoke fast while exercising the same workload-local OOM
+# boundary and counters as the production-capacity Firecracker calibration.
+(workload / "memory.high").write_text(str(192 * 1024 * 1024))
+(workload / "memory.max").write_text(str(256 * 1024 * 1024))
+chunk_size = 16 * 1024 * 1024
+chunks = []
+while True:
+    chunk = bytearray(chunk_size)
+    for offset in range(0, chunk_size, 4096):
+        chunk[offset] = 1
+    chunks.append(chunk)
+    time.sleep(0.1)
+PY
+PROMPT
+)
+SECONDS=0
+if MEMORY_RESULT=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --timeout 30 \
+  --chat-thread-id "$MEMORY_CHAT_THREAD_ID" \
+  --session-id "$MEMORY_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt "$MEMORY_PROMPT" \
+  --active-input 'after=1s,text=memory-pressure-control'); then
+  printf '%s\n' "$MEMORY_RESULT"
+  fail "memory exhaustion unexpectedly completed successfully"
+else
+  MEMORY_SUBMIT_STATUS=$?
+fi
+MEMORY_ELAPSED=$SECONDS
+printf '%s\n' "$MEMORY_RESULT"
+[ "$MEMORY_SUBMIT_STATUS" -ne 0 ] \
+  || fail "memory exhaustion did not fail the workload"
+[ "$MEMORY_ELAPSED" -lt 20 ] \
+  || fail "memory exhaustion was not bounded: ${MEMORY_ELAPSED}s"
+MEMORY_RESULT_JSON=$(awk '/^\{/{line=$0} END{print line}' <<<"$MEMORY_RESULT")
+MEMORY_RUN_ID=$(jq -r '.run_id // empty' <<<"$MEMORY_RESULT_JSON")
+[ -n "$MEMORY_RUN_ID" ] || fail "memory-pressure result omitted run ID"
+MEMORY_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${MEMORY_RUN_ID}.log"
+sudo grep -F -q 'workload resource limit reached' "$MEMORY_STREAM_LOG" \
+  || fail "memory-pressure failure was not classified"
+sudo grep -E -q 'memory_oom(_kill)?=[1-9][0-9]*' "$MEMORY_STREAM_LOG" \
+  || fail "memory-pressure diagnostics omitted the OOM event"
+
+echo "--- Pressure: exhaust workload PID capacity and reclaim descendants ---"
+PID_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
+PID_SESSION_ID="e2e-process-containment-pids"
+PID_PROMPT=$(cat <<'PROMPT'
+sudo -n python3 - <<'PY'
+import errno
+import os
+import pathlib
+import signal
+import time
+
+pathlib.Path("/tmp/vm0-process-containment/pid-pressure-vm").touch()
+relative = next(
+    line.removeprefix("0::").strip()
+    for line in pathlib.Path("/proc/self/cgroup").read_text().splitlines()
+    if line.startswith("0::")
+)
+workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
+# The production 2,048-process ceiling was exercised during calibration. A
+# smaller operation-local ceiling keeps this committed kernel-path smoke fast.
+(workload / "pids.max").write_text("64")
+children = []
+while True:
+    try:
+        pid = os.fork()
+    except OSError as error:
+        if error.errno != errno.EAGAIN:
+            raise
+        break
+    if pid == 0:
+        os.setsid()
+        null = os.open("/dev/null", os.O_RDWR)
+        for descriptor in (0, 1, 2):
+            os.dup2(null, descriptor)
+        if null > 2:
+            os.close(null)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        while True:
+            signal.pause()
+    children.append(pid)
+
+events = {}
+for line in (workload / "pids.events").read_text().splitlines():
+    key, value = line.split()
+    events[key] = int(value)
+if events.get("max", 0) == 0:
+    raise RuntimeError("pids.max did not reject a workload fork")
+print(f"pid-pressure-ready children={len(children)} max={events['max']}", flush=True)
+time.sleep(2)
+print(f"pid-pressure-complete children={len(children)}", flush=True)
+PY
+PROMPT
+)
+PID_RESULT=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --timeout 30 \
+  --chat-thread-id "$PID_CHAT_THREAD_ID" \
+  --session-id "$PID_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt "$PID_PROMPT" \
+  --active-input 'after=1s,text=pid-pressure-control') \
+  || fail "PID-pressure workload did not finalize"
+printf '%s\n' "$PID_RESULT"
+PID_RESULT_JSON=$(awk '/^\{/{line=$0} END{print line}' <<<"$PID_RESULT")
+PID_RUN_ID=$(jq -r '.run_id // empty' <<<"$PID_RESULT_JSON")
+[ -n "$PID_RUN_ID" ] || fail "PID-pressure result omitted run ID"
+PID_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${PID_RUN_ID}.log"
+sudo grep -F -q 'pid-pressure-complete children=' "$PID_STREAM_LOG" \
+  || fail "PID-pressure workload did not reach the cgroup limit"
+sudo grep -E -q 'pids_max=[1-9][0-9]*' "$PID_STREAM_LOG" \
+  || fail "PID-pressure diagnostics omitted the pids.max event"
+
+echo "--- Pressure: prove PID-exhaustion cleanup preserved VM reuse ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --chat-thread-id "$PID_CHAT_THREAD_ID" \
+  --session-id "$PID_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt 'test -f /tmp/vm0-process-containment/pid-pressure-vm' \
+  || fail "PID-pressure cleanup did not preserve safe VM reuse"
+
 LOGS=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
   || fail "failed to read runner logs"
 LEAK_LINE=$(printf '%s\n' "$LOGS" \
@@ -303,8 +626,33 @@ LEAK_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$LEAK_LINE"
 [ "$LEAK_CLEANUP_MS" -le 2000 ] \
   || fail "leaked cleanup exceeded bounded lifecycle: ${LEAK_CLEANUP_MS}ms"
 
+if grep -F 'process control latency exceeded calibrated bound' <<<"$LOGS" >/dev/null; then
+  fail "process control exceeded the calibrated 750ms bound under pressure"
+fi
+grep -F 'exec workload resource pressure observed' <<<"$LOGS" \
+  | grep -E 'cpu_nr_throttled=[1-9][0-9]*' >/dev/null \
+  || fail "CPU-pressure enforcement was not reported"
+PID_CLEANUP_LINE=$(printf '%s\n' "$LOGS" \
+  | grep -F 'exec process containment cleaned' \
+  | grep -F 'descendants_observed=true' \
+  | grep -F 'cgroup_kill_used=true' \
+  | sed -n 's/.*initial_members=\([0-9][0-9]*\).*/\1 &/p' \
+  | sort -nr \
+  | head -1) \
+  || fail "missing forced PID-pressure cleanup"
+PID_INITIAL_MEMBERS=${PID_CLEANUP_LINE%% *}
+[ "$PID_INITIAL_MEMBERS" -ge 50 ] \
+  || fail "PID-pressure cleanup observed only ${PID_INITIAL_MEMBERS} members"
+PID_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$PID_CLEANUP_LINE")
+[ -n "$PID_CLEANUP_MS" ] || fail "PID-pressure cleanup latency was not reported"
+[ "$PID_CLEANUP_MS" -le 5000 ] \
+  || fail "PID-pressure cleanup exceeded 5s: ${PID_CLEANUP_MS}ms"
+
 echo "PASS: detached user/root descendants were reclaimed"
 echo "PASS: leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy cleanup preserved reuse"
+echo "PASS: compressed CPU pressure kept process control and ${METRICS_COUNT} metric samples live"
+echo "PASS: workload OOM was classified in ${MEMORY_ELAPSED}s without killing Guest Agent"
+echo "PASS: pids.max cleanup reclaimed ${PID_INITIAL_MEMBERS} members in ${PID_CLEANUP_MS}ms"
 
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
 wait_for_unit_inactive

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -392,6 +392,10 @@ jobs:
           HOME=/root USER=root LOGNAME=root \
             cargo test -p vsock-guest --release --no-default-features \
               --test production_identity -- \
+              --ignored --exact production_exec_identity_matches_sandbox_user
+          HOME=/root USER=root LOGNAME=root \
+            cargo test -p vsock-guest --release --no-default-features \
+              --test production_identity -- \
               --ignored --exact production_env_script_remains_until_operation_cleanup
 
   coverage:

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -54,6 +54,7 @@ pub struct CodexAppServerConfig {
     config_overrides: Vec<String>,
     current_dir: Option<PathBuf>,
     opt_out_notification_methods: Vec<String>,
+    workload_containment: Option<crate::workload_containment::WorkloadContainment>,
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +79,7 @@ impl CodexAppServerConfig {
             config_overrides: Vec::new(),
             current_dir: None,
             opt_out_notification_methods: Vec::new(),
+            workload_containment: None,
         }
     }
 
@@ -116,6 +118,16 @@ impl CodexAppServerConfig {
     /// directory from Tokio's command builder.
     pub fn with_current_dir(mut self, current_dir: impl Into<PathBuf>) -> Self {
         self.current_dir = Some(current_dir.into());
+        self
+    }
+
+    /// Supply the production cgroup placement capability for this child.
+    #[must_use]
+    pub fn with_workload_containment(
+        mut self,
+        containment: Option<crate::workload_containment::WorkloadContainment>,
+    ) -> Self {
+        self.workload_containment = containment;
         self
     }
 
@@ -368,6 +380,11 @@ impl CodexAppServerClient {
             .kill_on_drop(true);
         if let Some(current_dir) = config.current_dir {
             cmd.current_dir(current_dir);
+        }
+        if let Some(containment) = config.workload_containment.as_ref() {
+            containment
+                .configure_command(&mut cmd)
+                .map_err(CodexAppServerError::Spawn)?;
         }
         let mut child = cmd.spawn().map_err(CodexAppServerError::Spawn)?;
         let stdin = child.stdin.take().ok_or_else(|| {

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -246,14 +246,18 @@ async fn run_codex_app_server(
         mut active_input,
         user_cancellation,
         codex_startup,
+        workload_containment,
     } = controls;
     let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
     let mut ingestor = CliEventIngestor::new(runtime, codex_startup);
     let mut output_timing = CodexOutputTiming::default();
     let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
-    let mut client = CodexAppServerClient::spawn(codex_app_server_config(runtime))
-        .map_err(|error| app_server_error(masker, error))?;
+    let mut client = CodexAppServerClient::spawn(codex_app_server_config(
+        runtime,
+        workload_containment.cloned(),
+    ))
+    .map_err(|error| app_server_error(masker, error))?;
     let mut heartbeat_done = false;
     let active_input_controller = active_input.controller();
 
@@ -534,7 +538,10 @@ async fn run_codex_app_server(
     }
 }
 
-fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConfig {
+fn codex_app_server_config(
+    runtime: &CliRuntimeConfig<'_>,
+    workload_containment: Option<crate::workload_containment::WorkloadContainment>,
+) -> CodexAppServerConfig {
     let binary = if runtime.use_mock_codex {
         log_info!(LOG_TAG, "Using mock-codex app-server for testing");
         PathBuf::from(runtime.mock_codex_path.as_ref())
@@ -552,6 +559,7 @@ fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConf
         )
         .with_config_overrides(config_overrides)
         .with_current_dir(paths::CANONICAL_WORKING_DIR)
+        .with_workload_containment(workload_containment)
         .with_opt_out_notification_methods(IGNORED_NOTIFICATION_METHODS.iter().copied());
     if runtime.use_mock_codex {
         let scenario = std::env::var("MOCK_CODEX_APP_SERVER_SCENARIO")

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -764,6 +764,7 @@ pub struct CliExecutionControls<'a> {
     active_input: ActiveInputWriter,
     user_cancellation: CancellationToken,
     codex_startup: Option<&'a CodexStartupTiming>,
+    workload_containment: Option<&'a crate::workload_containment::WorkloadContainment>,
 }
 
 impl<'a> CliExecutionControls<'a> {
@@ -778,7 +779,17 @@ impl<'a> CliExecutionControls<'a> {
             active_input,
             user_cancellation,
             codex_startup,
+            workload_containment: None,
         }
+    }
+    /// Supply the production workload placement capability for CLI children.
+    #[must_use]
+    pub fn with_workload_containment(
+        mut self,
+        containment: Option<&'a crate::workload_containment::WorkloadContainment>,
+    ) -> Self {
+        self.workload_containment = containment;
+        self
     }
 }
 
@@ -819,6 +830,7 @@ async fn execute_cli_inner(
         active_input,
         user_cancellation,
         codex_startup: _,
+        workload_containment,
     } = controls;
 
     let replay_user_messages =
@@ -891,6 +903,9 @@ async fn execute_cli_inner(
     // Set the child cwd explicitly at spawn time so the CLI observes the
     // current canonical workspace mount instead of relying on inherited cwd.
     set_cli_current_dir(&mut cmd, paths::CANONICAL_WORKING_DIR)?;
+    if let Some(workload_containment) = workload_containment {
+        workload_containment.configure_command(&mut cmd)?;
+    }
 
     // Open the run log before spawning the CLI. If the run-id-scoped path is
     // invalid or unavailable, fail without starting a child process.

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -39,6 +39,7 @@ mod session_metadata;
 pub mod telemetry;
 pub mod timing;
 mod urls;
+pub mod workload_containment;
 
 #[cfg(test)]
 static SYSTEM_LOG_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -41,8 +41,7 @@ fn checkpoint_failure_reason(error: &AgentError) -> Option<FailureReason> {
         .then_some(FailureReason::SessionHistoryLimit)
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     if let Some(exit_code) = helper_exit_code_from_args() {
         std::process::exit(exit_code);
     }
@@ -54,7 +53,20 @@ async fn main() {
             std::process::exit(1);
         }
     };
-    let exit_code = run(runtime).await;
+    let async_runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            log_error!(
+                LOG_TAG,
+                "Fatal: failed to initialize async runtime: {error}"
+            );
+            std::process::exit(1);
+        }
+    };
+    let exit_code = async_runtime.block_on(run(runtime));
     std::process::exit(exit_code);
 }
 
@@ -474,7 +486,8 @@ async fn execute(
         masker,
         heartbeat_monitor,
         http.clone(),
-        cli::CliExecutionControls::new(active_input, cli_cancellation, codex_startup.as_ref()),
+        cli::CliExecutionControls::new(active_input, cli_cancellation, codex_startup.as_ref())
+            .with_workload_containment(runtime.workload_containment.as_ref()),
         config,
         runtime_paths,
         start,
@@ -597,6 +610,31 @@ async fn execute(
             )
         }
     };
+    if let Some(workload_containment) = runtime.workload_containment.as_ref() {
+        match workload_containment.resource_diagnostics() {
+            Ok(diagnostics) => {
+                if let Some(pressure) = diagnostics.pressure {
+                    log_info!(LOG_TAG, "{pressure}");
+                }
+                if let Some(hard_limit) = diagnostics.hard_limit {
+                    log_warn!(LOG_TAG, "{hard_limit}");
+                    if exit_code != 0 {
+                        error_message = if error_message.is_empty() {
+                            hard_limit
+                        } else {
+                            format!("{error_message}; {hard_limit}")
+                        };
+                    }
+                }
+            }
+            Err(error) => {
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to read workload resource diagnostics: {error}"
+                );
+            }
+        }
+    }
     let cli_elapsed = cli_start.elapsed();
     record_sandbox_op(
         "cli_execution",
@@ -1064,6 +1102,7 @@ mod tests {
             config,
             paths: paths::GuestPaths::from_runtime_dir(test_runtime_dir()),
             http,
+            workload_containment: None,
         }
     }
 
@@ -1183,6 +1222,7 @@ mod tests {
             guest_contracts::env::MOCK_CODEX_PATH_ENV,
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             process_control_ipc::BOOTSTRAP_ENV,
+            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV,
             "MOCK_CODEX_APP_SERVER_SCENARIO",
         ] {
             unsafe {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1222,7 +1222,7 @@ mod tests {
             guest_contracts::env::MOCK_CODEX_PATH_ENV,
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             process_control_ipc::BOOTSTRAP_ENV,
-            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV,
+            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
             "MOCK_CODEX_APP_SERVER_SCENARIO",
         ] {
             unsafe {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -22,7 +22,7 @@ use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use guest_contracts::diagnostics::{
     AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationReason, EventDeliveryDiagnostic, FailureClass,
-    FailureDiagnostic, FailureReason,
+    FailureDiagnostic, FailureReason, WorkloadResourceLimitDiagnostic,
 };
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
@@ -617,14 +617,13 @@ async fn execute(
                     log_info!(LOG_TAG, "{pressure}");
                 }
                 if let Some(hard_limit) = diagnostics.hard_limit {
-                    log_warn!(LOG_TAG, "{hard_limit}");
-                    if exit_code != 0 {
-                        error_message = if error_message.is_empty() {
-                            hard_limit
-                        } else {
-                            format!("{error_message}; {hard_limit}")
-                        };
-                    }
+                    let message = apply_workload_resource_limit(
+                        exit_code,
+                        &mut error_message,
+                        &mut failure_diagnostic,
+                        hard_limit,
+                    );
+                    log_warn!(LOG_TAG, "{message}");
                 }
             }
             Err(error) => {
@@ -676,6 +675,36 @@ async fn execute(
         runtime,
     )
     .await
+}
+
+fn apply_workload_resource_limit(
+    exit_code: i32,
+    error_message: &mut String,
+    failure_diagnostic: &mut Option<FailureDiagnostic>,
+    hard_limit: WorkloadResourceLimitDiagnostic,
+) -> String {
+    let message = format!(
+        "workload resource limit reached (memory_max={}, memory_oom={}, memory_oom_kill={}, memory_oom_group_kill={}, pids_max={})",
+        hard_limit.memory_max_events,
+        hard_limit.memory_oom_events,
+        hard_limit.memory_oom_kill_events,
+        hard_limit.memory_oom_group_kill_events,
+        hard_limit.pids_max_events,
+    );
+    if exit_code == 0 {
+        return message;
+    }
+
+    if error_message.is_empty() {
+        error_message.clone_from(&message);
+    } else {
+        error_message.push_str("; ");
+        error_message.push_str(&message);
+    }
+    if let Some(diagnostic) = failure_diagnostic.take() {
+        *failure_diagnostic = Some(diagnostic.with_workload_resource_limit(hard_limit));
+    }
+    message
 }
 
 fn event_delivery_failure_message(diagnostic: &EventDeliveryDiagnostic) -> String {
@@ -1054,6 +1083,7 @@ mod tests {
             None
         );
     }
+
     static COMPLETE_EXECUTION_MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
     static MAIN_TEST_RUNTIME_ROOT: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
         let timestamp_nanos = std::time::SystemTime::now()

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -35,8 +35,9 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 
 use guest_contracts::process_containment::{
-    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX,
-    REQUIRED_CGROUP_CONTROLLERS, WORKLOAD_CGROUP_NAME, WorkloadResourcePolicy,
+    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, CONTROL_MEMORY_RESERVE_BYTES, EXEC_CGROUP_BASE_PATH,
+    EXEC_CGROUP_NAME_PREFIX, REQUIRED_CGROUP_CONTROLLERS, WORKLOAD_CGROUP_NAME,
+    WorkloadResourcePolicy,
 };
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
@@ -55,6 +56,7 @@ const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
 const CPU_MAX_FILE: &str = "cpu.max";
 const MEMORY_HIGH_FILE: &str = "memory.high";
 const MEMORY_MAX_FILE: &str = "memory.max";
+const MEMORY_MIN_FILE: &str = "memory.min";
 const MEMORY_OOM_GROUP_FILE: &str = "memory.oom.group";
 const PIDS_MAX_FILE: &str = "pids.max";
 #[cfg(debug_assertions)]
@@ -273,6 +275,7 @@ fn verify_process_containment() -> io::Result<()> {
         CGROUP_EVENTS_FILE,
         CGROUP_KILL_FILE,
         CGROUP_SUBTREE_CONTROL_FILE,
+        MEMORY_MIN_FILE,
     ] {
         if !std::fs::metadata(paths.base.join(filename))?.is_file() {
             return Err(io::Error::new(
@@ -286,6 +289,14 @@ fn verify_process_containment() -> io::Result<()> {
         &std::fs::read_to_string(paths.base.join(CGROUP_SUBTREE_CONTROL_FILE))?,
         "exec cgroup base",
     )?;
+    if std::fs::read_to_string(paths.base.join(MEMORY_MIN_FILE))?.trim()
+        != CONTROL_MEMORY_RESERVE_BYTES.to_string()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "exec cgroup base does not preserve control memory",
+        ));
+    }
 
     let base_procs = std::fs::read_to_string(paths.base.join(CGROUP_PROCS_FILE))?;
     if !base_procs.trim().is_empty() {

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -7,10 +7,11 @@
 //! Preparation proceeds in this order:
 //!
 //! 1. Validate the current runtime directory and the optional retained runtime directory.
-//! 2. Prove that the helper is contained in the sole live supervised-exec operation. The canonical
-//!    cgroup v2 base must provide the required capability files, have no enabled subtree
-//!    controllers or direct processes, contain no stale operation leaves, and be populated by the
-//!    helper's current leaf.
+//! 2. Prove that the helper is in the `workload` leaf of the sole live
+//!    supervised-exec operation. The canonical cgroup v2 base and empty
+//!    operation parent must distribute the required controllers, expose the
+//!    exact `control`/`workload` shape, contain no stale operation, and be
+//!    recursively populated only by the helper's workload leaf.
 //! 3. Open the runtime parent and every protected runtime directory, require them to share a mount,
 //!    and record their identities before deletion.
 //! 4. Measure rootfs capacity, recursively remove every unprotected direct child of the runtime
@@ -34,7 +35,8 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 
 use guest_contracts::process_containment::{
-    CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX,
+    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX,
+    REQUIRED_CGROUP_CONTROLLERS, WORKLOAD_CGROUP_NAME, WorkloadResourcePolicy,
 };
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
@@ -46,9 +48,15 @@ use crate::nofollow_fs::{Dir, FileIdentity};
 
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
 const CGROUP_EVENTS_FILE: &str = "cgroup.events";
+const CGROUP_CONTROLLERS_FILE: &str = "cgroup.controllers";
 const CGROUP_KILL_FILE: &str = "cgroup.kill";
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
 const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
+const CPU_MAX_FILE: &str = "cpu.max";
+const MEMORY_HIGH_FILE: &str = "memory.high";
+const MEMORY_MAX_FILE: &str = "memory.max";
+const MEMORY_OOM_GROUP_FILE: &str = "memory.oom.group";
+const PIDS_MAX_FILE: &str = "pids.max";
 #[cfg(debug_assertions)]
 const TEST_CONTAINMENT_ROOT_ENV: &str = "VM0_TEST_PROCESS_CONTAINMENT_ROOT";
 #[cfg(debug_assertions)]
@@ -238,7 +246,7 @@ struct ProcessContainmentPaths {
 
 fn verify_process_containment() -> io::Result<()> {
     let paths = process_containment_paths();
-    let current_group = current_process_cgroup_name()?;
+    let current_operation = current_process_cgroup_name()?;
     if paths.require_cgroup2_filesystem && !is_cgroup2_filesystem(&paths.mount)? {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -260,6 +268,7 @@ fn verify_process_containment() -> io::Result<()> {
         ));
     }
     for filename in [
+        CGROUP_CONTROLLERS_FILE,
         CGROUP_PROCS_FILE,
         CGROUP_EVENTS_FILE,
         CGROUP_KILL_FILE,
@@ -273,13 +282,10 @@ fn verify_process_containment() -> io::Result<()> {
         }
     }
 
-    let subtree_control = std::fs::read_to_string(paths.base.join(CGROUP_SUBTREE_CONTROL_FILE))?;
-    if !subtree_control.trim().is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "resource controllers are enabled for the exec cgroup",
-        ));
-    }
+    verify_required_controllers(
+        &std::fs::read_to_string(paths.base.join(CGROUP_SUBTREE_CONTROL_FILE))?,
+        "exec cgroup base",
+    )?;
 
     let base_procs = std::fs::read_to_string(paths.base.join(CGROUP_PROCS_FILE))?;
     if !base_procs.trim().is_empty() {
@@ -292,7 +298,7 @@ fn verify_process_containment() -> io::Result<()> {
     for entry in std::fs::read_dir(&paths.base)? {
         let entry = entry?;
         let file_type = entry.file_type()?;
-        if entry.file_name() == current_group {
+        if entry.file_name() == current_operation {
             if !file_type.is_dir() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -311,6 +317,78 @@ fn verify_process_containment() -> io::Result<()> {
         ));
     }
 
+    let operation_path = paths.base.join(&current_operation);
+    for filename in [
+        CGROUP_CONTROLLERS_FILE,
+        CGROUP_PROCS_FILE,
+        CGROUP_EVENTS_FILE,
+        CGROUP_KILL_FILE,
+        CGROUP_SUBTREE_CONTROL_FILE,
+    ] {
+        if !std::fs::metadata(operation_path.join(filename))?.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("operation cgroup core file is invalid: {filename}"),
+            ));
+        }
+    }
+    verify_required_controllers(
+        &std::fs::read_to_string(operation_path.join(CGROUP_SUBTREE_CONTROL_FILE))?,
+        "operation cgroup",
+    )?;
+    if !std::fs::read_to_string(operation_path.join(CGROUP_PROCS_FILE))?
+        .trim()
+        .is_empty()
+    {
+        return Err(io::Error::other(
+            "operation cgroup contains direct processes",
+        ));
+    }
+
+    let control_path = operation_path.join(CONTROL_CGROUP_NAME);
+    let workload_path = operation_path.join(WORKLOAD_CGROUP_NAME);
+    let mut leaf_names = std::fs::read_dir(&operation_path)?
+        .filter_map(|entry| match entry {
+            Ok(entry) => match entry.file_type() {
+                Ok(file_type) if file_type.is_dir() => Some(Ok(entry.file_name())),
+                Ok(_) => None,
+                Err(error) => Some(Err(error)),
+            },
+            Err(error) => Some(Err(error)),
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    leaf_names.sort();
+    let mut expected_leaf_names = vec![
+        OsString::from(CONTROL_CGROUP_NAME),
+        OsString::from(WORKLOAD_CGROUP_NAME),
+    ];
+    expected_leaf_names.sort();
+    if leaf_names != expected_leaf_names {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "operation cgroup does not contain exactly control and workload leaves",
+        ));
+    }
+    verify_leaf_core_files(&control_path)?;
+    verify_leaf_core_files(&workload_path)?;
+    verify_workload_policy(&workload_path)?;
+    if parse_populated(&std::fs::read_to_string(
+        control_path.join(CGROUP_EVENTS_FILE),
+    )?) != Some(false)
+    {
+        return Err(io::Error::other(
+            "reuse helper operation control leaf is populated",
+        ));
+    }
+    if parse_populated(&std::fs::read_to_string(
+        workload_path.join(CGROUP_EVENTS_FILE),
+    )?) != Some(true)
+    {
+        return Err(io::Error::other(
+            "reuse helper is not contained in its workload leaf",
+        ));
+    }
+
     let events = std::fs::read_to_string(paths.base.join(CGROUP_EVENTS_FILE))?;
     match parse_populated(&events) {
         Some(true) => Ok(()),
@@ -322,6 +400,88 @@ fn verify_process_containment() -> io::Result<()> {
             "cgroup.events is missing valid populated state",
         )),
     }
+}
+
+fn verify_required_controllers(content: &str, location: &str) -> io::Result<()> {
+    let controllers = content.split_ascii_whitespace().collect::<Vec<_>>();
+    let missing = REQUIRED_CGROUP_CONTROLLERS
+        .into_iter()
+        .filter(|controller| !controllers.contains(controller))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "{location} is missing required controllers: {}",
+            missing.join(",")
+        ),
+    ))
+}
+
+fn verify_leaf_core_files(leaf_path: &Path) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(leaf_path)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "operation cgroup leaf is not a directory",
+        ));
+    }
+    for filename in [
+        CGROUP_PROCS_FILE,
+        CGROUP_EVENTS_FILE,
+        CGROUP_KILL_FILE,
+        CGROUP_SUBTREE_CONTROL_FILE,
+    ] {
+        if !std::fs::metadata(leaf_path.join(filename))?.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("operation cgroup leaf file is invalid: {filename}"),
+            ));
+        }
+    }
+    if !std::fs::read_to_string(leaf_path.join(CGROUP_SUBTREE_CONTROL_FILE))?
+        .trim()
+        .is_empty()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "operation cgroup leaf distributes controllers",
+        ));
+    }
+    for entry in std::fs::read_dir(leaf_path)? {
+        if entry?.file_type()?.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "operation cgroup leaf contains a nested cgroup",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_workload_policy(workload_path: &Path) -> io::Result<()> {
+    let policy = WorkloadResourcePolicy::for_current_guest_capacity().map_err(io::Error::other)?;
+    for (filename, expected) in [
+        (
+            CPU_MAX_FILE,
+            format!("{} {}", policy.cpu_quota_us, policy.cpu_period_us),
+        ),
+        (MEMORY_HIGH_FILE, policy.memory_high_bytes.to_string()),
+        (MEMORY_MAX_FILE, policy.memory_max_bytes.to_string()),
+        (MEMORY_OOM_GROUP_FILE, "1".to_string()),
+        (PIDS_MAX_FILE, policy.pids_max.to_string()),
+    ] {
+        let actual = std::fs::read_to_string(workload_path.join(filename))?;
+        if actual.trim() != expected {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("workload cgroup policy mismatch for {filename}"),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn current_process_cgroup_name() -> io::Result<OsString> {
@@ -360,18 +520,19 @@ fn current_group_name_from_path(cgroup_path: &Path) -> io::Result<OsString> {
         )
     })?;
     let mut components = group_path.components();
-    let group = match (components.next(), components.next()) {
-        (Some(Component::Normal(group)), None)
+    let group = match (components.next(), components.next(), components.next()) {
+        (Some(Component::Normal(group)), Some(Component::Normal(leaf)), None)
             if group
                 .as_bytes()
-                .starts_with(EXEC_CGROUP_NAME_PREFIX.as_bytes()) =>
+                .starts_with(EXEC_CGROUP_NAME_PREFIX.as_bytes())
+                && leaf == WORKLOAD_CGROUP_NAME =>
         {
             group.to_os_string()
         }
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "current process is not in an exec operation leaf",
+                "current process is not in an exec operation workload leaf",
             ));
         }
     };

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -3,6 +3,7 @@
 use crate::env::{GuestConfig, GuestConfigRaw};
 use crate::http::HttpClient;
 use crate::paths::GuestPaths;
+use crate::workload_containment::WorkloadContainment;
 
 /// Production runtime services for one guest-agent run.
 #[derive(Clone)]
@@ -10,6 +11,7 @@ pub struct GuestRuntime {
     pub config: GuestConfig,
     pub paths: GuestPaths,
     pub http: HttpClient,
+    pub workload_containment: Option<WorkloadContainment>,
 }
 
 impl GuestRuntime {
@@ -30,6 +32,7 @@ impl GuestRuntime {
     /// process-wide setup and consume runner-owned inputs before returning, so
     /// callers must not retry it in the same process.
     pub fn from_process_env() -> Result<Self, String> {
+        let workload_containment = WorkloadContainment::from_process_env()?;
         let raw = GuestConfigRaw::from_process_env();
         raw.require_run_payload_file()?;
         let paths = paths_from_raw(&raw)?;
@@ -43,6 +46,7 @@ impl GuestRuntime {
             config,
             paths,
             http,
+            workload_containment,
         })
     }
 }

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -15,6 +15,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
+use guest_contracts::diagnostics::WorkloadResourceLimitDiagnostic;
 use guest_contracts::process_containment::{
     CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, EXEC_CGROUP_NAME_PREFIX,
     MATERIAL_CPU_THROTTLED_USEC, WORKLOAD_CGROUP_NAME, WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
@@ -37,8 +38,8 @@ pub struct WorkloadContainment {
 /// Resource enforcement observed for a completed workload.
 #[derive(Debug, Eq, PartialEq)]
 pub struct WorkloadResourceDiagnostics {
-    /// Hard memory or PID limit summary suitable for a failure message.
-    pub hard_limit: Option<String>,
+    /// Hard memory or PID limit counters suitable for structured attribution.
+    pub hard_limit: Option<WorkloadResourceLimitDiagnostic>,
     /// CPU throttling or memory-high summary suitable for an informational log.
     pub pressure: Option<String>,
 }
@@ -121,16 +122,14 @@ impl WorkloadContainment {
         let cpu_throttled_usec = value_or_zero(&cpu, "throttled_usec");
         let memory_high = value_or_zero(&memory, "high");
 
-        let hard_limit = (memory_max > 0
-            || memory_oom > 0
-            || memory_oom_kill > 0
-            || memory_oom_group_kill > 0
-            || pids_max > 0)
-            .then(|| {
-                format!(
-                    "workload resource limit reached (memory_max={memory_max}, memory_oom={memory_oom}, memory_oom_kill={memory_oom_kill}, memory_oom_group_kill={memory_oom_group_kill}, pids_max={pids_max})"
-                )
-            });
+        let hard_limit = WorkloadResourceLimitDiagnostic {
+            memory_max_events: memory_max,
+            memory_oom_events: memory_oom,
+            memory_oom_kill_events: memory_oom_kill,
+            memory_oom_group_kill_events: memory_oom_group_kill,
+            pids_max_events: pids_max,
+        };
+        let hard_limit = hard_limit.has_events().then_some(hard_limit);
         let pressure =
             (cpu_throttled_usec >= MATERIAL_CPU_THROTTLED_USEC || memory_high > 0).then(|| {
             format!(
@@ -184,7 +183,7 @@ fn test_allows_unmanaged_process_control() -> bool {
 fn deny_peer_process_inspection() -> io::Result<()> {
     // SAFETY: PR_SET_DUMPABLE changes only the current single-threaded Guest
     // Agent bootstrap process. Reapplying it here is required because the
-    // preceding `su` and exec transitions may reset the value set by
+    // preceding credential and exec transitions may reset the value set by
     // `vsock-guest` before exec.
     if unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0) } != 0 {
         return Err(io::Error::last_os_error());
@@ -395,10 +394,14 @@ mod tests {
         let diagnostics = containment.resource_diagnostics().unwrap();
 
         assert_eq!(
-            diagnostics.hard_limit.as_deref(),
-            Some(
-                "workload resource limit reached (memory_max=5, memory_oom=1, memory_oom_kill=1, memory_oom_group_kill=1, pids_max=6)"
-            )
+            diagnostics.hard_limit,
+            Some(WorkloadResourceLimitDiagnostic {
+                memory_max_events: 5,
+                memory_oom_events: 1,
+                memory_oom_kill_events: 1,
+                memory_oom_group_kill_events: 1,
+                pids_max_events: 6,
+            })
         );
         assert_eq!(
             diagnostics.pressure.as_deref(),

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -1,0 +1,446 @@
+//! Secure workload-cgroup placement owned by Guest Agent.
+//!
+//! The root guest supervisor places Guest Agent in an operation's `control`
+//! leaf and passes a write-only descriptor for the sibling `workload` leaf.
+//! Guest Agent adopts that descriptor before starting its async runtime, marks
+//! it close-on-exec, and uses a cloned descriptor only in each CLI child's
+//! `pre_exec` hook. The descriptor is never copied into a workload environment.
+
+use std::fs;
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::process::CommandExt;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use guest_contracts::process_containment::{
+    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, EXEC_CGROUP_NAME_PREFIX,
+    MATERIAL_CPU_THROTTLED_USEC, WORKLOAD_CGROUP_NAME, WORKLOAD_CGROUP_PROCS_FD_ENV,
+};
+
+const CGROUP_PROCS_FILE: &str = "cgroup.procs";
+const PROC_SELF_CGROUP: &str = "/proc/self/cgroup";
+const CGROUP2_SUPER_MAGIC: u64 = 0x6367_7270;
+#[cfg(debug_assertions)]
+const TEST_ALLOW_UNMANAGED_PROCESS_CONTROL_ENV: &str = "VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL";
+
+/// Root-opened capability used only to place CLI children in `workload`.
+#[derive(Clone, Debug)]
+pub struct WorkloadContainment {
+    placement: Arc<OwnedFd>,
+    workload_path: Arc<PathBuf>,
+}
+
+/// Resource enforcement observed for a completed workload.
+#[derive(Debug, Eq, PartialEq)]
+pub struct WorkloadResourceDiagnostics {
+    /// Hard memory or PID limit summary suitable for a failure message.
+    pub hard_limit: Option<String>,
+    /// CPU throttling or memory-high summary suitable for an informational log.
+    pub pressure: Option<String>,
+}
+
+impl WorkloadContainment {
+    /// Adopt the production bootstrap descriptor from the process environment.
+    ///
+    /// This must run before any other thread can read or mutate process-global
+    /// environment state. A process-control bootstrap requires a matching
+    /// workload capability in production. Direct local execution is unmanaged
+    /// when neither bootstrap value exists.
+    pub fn from_process_env() -> Result<Option<Self>, String> {
+        let process_control_present = match std::env::var_os(process_control_ipc::BOOTSTRAP_ENV) {
+            None => false,
+            Some(endpoint) if endpoint.is_empty() => false,
+            Some(endpoint) if endpoint.to_str().is_none() => {
+                return Err(format!(
+                    "{} must be valid UTF-8",
+                    process_control_ipc::BOOTSTRAP_ENV
+                ));
+            }
+            Some(_) => true,
+        };
+        let placement_value = std::env::var_os(WORKLOAD_CGROUP_PROCS_FD_ENV);
+
+        match (process_control_present, placement_value) {
+            (false, None) => Ok(None),
+            (true, None) if test_allows_unmanaged_process_control() => Ok(None),
+            (true, None) => Err(format!(
+                "{} is required with {}",
+                WORKLOAD_CGROUP_PROCS_FD_ENV,
+                process_control_ipc::BOOTSTRAP_ENV
+            )),
+            (false, Some(_)) => Err(format!(
+                "{} requires {}",
+                WORKLOAD_CGROUP_PROCS_FD_ENV,
+                process_control_ipc::BOOTSTRAP_ENV
+            )),
+            (true, Some(value)) => {
+                // SAFETY: production calls this before constructing the Tokio
+                // runtime, so no other thread can access the environment.
+                unsafe { std::env::remove_var(WORKLOAD_CGROUP_PROCS_FD_ENV) };
+                let value = value
+                    .into_string()
+                    .map_err(|_| format!("{WORKLOAD_CGROUP_PROCS_FD_ENV} must be valid UTF-8"))?;
+                Self::adopt(&value)
+                    .map(Some)
+                    .map_err(|error| format!("invalid {WORKLOAD_CGROUP_PROCS_FD_ENV}: {error}"))
+            }
+        }
+    }
+
+    /// Install workload placement on a Tokio child command.
+    ///
+    /// The cloned descriptor remains close-on-exec. The pre-exec write moves
+    /// the child before its program starts, and exec then closes the capability.
+    pub fn configure_command(&self, command: &mut tokio::process::Command) -> io::Result<()> {
+        let placement = self.placement.try_clone()?;
+        // SAFETY: the closure performs one async-signal-safe raw write to an
+        // already-open descriptor between fork and exec.
+        unsafe {
+            command
+                .as_std_mut()
+                .pre_exec(move || write_self_to_cgroup(placement.as_raw_fd()));
+        }
+        Ok(())
+    }
+
+    /// Read workload resource counters after CLI execution.
+    pub fn resource_diagnostics(&self) -> io::Result<WorkloadResourceDiagnostics> {
+        let cpu = read_key_values(&self.workload_path.join("cpu.stat"))?;
+        let memory = read_key_values(&self.workload_path.join("memory.events"))?;
+        let pids = read_key_values(&self.workload_path.join("pids.events"))?;
+        let memory_max = value_or_zero(&memory, "max");
+        let memory_oom = value_or_zero(&memory, "oom");
+        let memory_oom_kill = value_or_zero(&memory, "oom_kill");
+        let memory_oom_group_kill = value_or_zero(&memory, "oom_group_kill");
+        let pids_max = value_or_zero(&pids, "max");
+        let cpu_nr_throttled = value_or_zero(&cpu, "nr_throttled");
+        let cpu_throttled_usec = value_or_zero(&cpu, "throttled_usec");
+        let memory_high = value_or_zero(&memory, "high");
+
+        let hard_limit = (memory_max > 0
+            || memory_oom > 0
+            || memory_oom_kill > 0
+            || memory_oom_group_kill > 0
+            || pids_max > 0)
+            .then(|| {
+                format!(
+                    "workload resource limit reached (memory_max={memory_max}, memory_oom={memory_oom}, memory_oom_kill={memory_oom_kill}, memory_oom_group_kill={memory_oom_group_kill}, pids_max={pids_max})"
+                )
+            });
+        let pressure =
+            (cpu_throttled_usec >= MATERIAL_CPU_THROTTLED_USEC || memory_high > 0).then(|| {
+            format!(
+                "workload resource pressure observed (cpu_nr_throttled={cpu_nr_throttled}, cpu_throttled_usec={cpu_throttled_usec}, memory_high={memory_high})"
+            )
+        });
+        Ok(WorkloadResourceDiagnostics {
+            hard_limit,
+            pressure,
+        })
+    }
+
+    fn adopt(value: &str) -> io::Result<Self> {
+        let raw_fd = value.parse::<RawFd>().map_err(|error| {
+            io::Error::new(io::ErrorKind::InvalidInput, format!("invalid fd: {error}"))
+        })?;
+        if raw_fd < 3 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "workload placement fd must be at least 3",
+            ));
+        }
+
+        // SAFETY: F_GETFD only inspects the supplied descriptor.
+        let descriptor_flags = unsafe { libc::fcntl(raw_fd, libc::F_GETFD) };
+        if descriptor_flags < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `raw_fd` was validated above and ownership is transferred
+        // exactly once from the inherited bootstrap descriptor.
+        let placement = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        deny_peer_process_inspection()?;
+        let workload_path = validate_descriptor(&placement)?;
+        set_close_on_exec(placement.as_raw_fd(), descriptor_flags)?;
+
+        Ok(Self {
+            placement: Arc::new(placement),
+            workload_path: Arc::new(workload_path),
+        })
+    }
+}
+
+fn test_allows_unmanaged_process_control() -> bool {
+    #[cfg(debug_assertions)]
+    {
+        matches!(
+            std::env::var(TEST_ALLOW_UNMANAGED_PROCESS_CONTROL_ENV),
+            Ok(value) if value == "true"
+        )
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        false
+    }
+}
+
+fn deny_peer_process_inspection() -> io::Result<()> {
+    // SAFETY: PR_SET_DUMPABLE changes only the current single-threaded Guest
+    // Agent bootstrap process. Reapplying it here is required because the
+    // preceding `su` and exec transitions may reset the value set by
+    // `vsock-guest` before exec.
+    if unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn validate_descriptor(placement: &OwnedFd) -> io::Result<PathBuf> {
+    // SAFETY: F_GETFL only reads flags from a valid owned descriptor.
+    let status_flags = unsafe { libc::fcntl(placement.as_raw_fd(), libc::F_GETFL) };
+    if status_flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if status_flags & libc::O_ACCMODE != libc::O_WRONLY {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "workload placement fd is not write-only",
+        ));
+    }
+
+    let mut stats = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    // SAFETY: `placement` is valid and `stats` points to writable memory.
+    if unsafe { libc::fstatfs(placement.as_raw_fd(), stats.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful fstatfs initialized `stats`.
+    if unsafe { stats.assume_init() }.f_type as u64 != CGROUP2_SUPER_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "workload placement fd is not on cgroup v2",
+        ));
+    }
+
+    let expected = expected_workload_procs_path()?;
+    let actual = fs::read_link(format!("/proc/self/fd/{}", placement.as_raw_fd()))?;
+    if actual != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "workload placement fd targets {}, expected {}",
+                actual.display(),
+                expected.display()
+            ),
+        ));
+    }
+    expected
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| io::Error::other("workload cgroup.procs path has no parent"))
+}
+
+fn read_key_values(path: &Path) -> io::Result<std::collections::HashMap<String, u64>> {
+    fs::read_to_string(path)?
+        .lines()
+        .map(|line| {
+            let mut fields = line.split_ascii_whitespace();
+            let key = fields.next().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "missing cgroup counter name")
+            })?;
+            let value = fields
+                .next()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "missing cgroup counter value")
+                })?
+                .parse::<u64>()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            if fields.next().is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "unexpected cgroup counter field",
+                ));
+            }
+            Ok((key.to_string(), value))
+        })
+        .collect()
+}
+
+fn value_or_zero(values: &std::collections::HashMap<String, u64>, key: &str) -> u64 {
+    values.get(key).copied().unwrap_or(0)
+}
+
+fn expected_workload_procs_path() -> io::Result<PathBuf> {
+    let content = fs::read_to_string(PROC_SELF_CGROUP)?;
+    let relative = content
+        .lines()
+        .find_map(|line| line.strip_prefix("0::"))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "current unified cgroup path is missing",
+            )
+        })?;
+    let path = Path::new(relative);
+    let components = path.components().collect::<Vec<_>>();
+    let [
+        Component::RootDir,
+        Component::Normal(base),
+        Component::Normal(operation),
+        Component::Normal(leaf),
+    ] = components.as_slice()
+    else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Guest Agent is not in a canonical control cgroup",
+        ));
+    };
+    if *base != "vm0-exec"
+        || !operation
+            .as_encoded_bytes()
+            .starts_with(EXEC_CGROUP_NAME_PREFIX.as_bytes())
+        || *leaf != CONTROL_CGROUP_NAME
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Guest Agent is not in a canonical control cgroup",
+        ));
+    }
+
+    Ok(Path::new(CGROUP_V2_MOUNT_PATH)
+        .join(base)
+        .join(operation)
+        .join(WORKLOAD_CGROUP_NAME)
+        .join(CGROUP_PROCS_FILE))
+}
+
+fn set_close_on_exec(fd: RawFd, current_flags: libc::c_int) -> io::Result<()> {
+    // SAFETY: `fd` is valid and this only adds FD_CLOEXEC.
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, current_flags | libc::FD_CLOEXEC) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn write_self_to_cgroup(fd: RawFd) -> io::Result<()> {
+    loop {
+        // SAFETY: `fd` is open for writing and the one-byte buffer is valid.
+        let written = unsafe { libc::write(fd, b"0".as_ptr().cast(), 1) };
+        if written == 1 {
+            return Ok(());
+        }
+        if written < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        return Err(io::Error::from_raw_os_error(libc::EIO));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Seek, SeekFrom};
+    use std::process::Stdio;
+
+    #[test]
+    fn pre_exec_places_child_without_inheriting_descriptor() {
+        let mut placement = tempfile::tempfile().unwrap();
+        let containment = WorkloadContainment {
+            placement: Arc::new(placement.try_clone().unwrap().into()),
+            workload_path: Arc::new(PathBuf::from("/unused")),
+        };
+        let placement_fd = containment.placement.as_raw_fd();
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg(format!("test ! -e /proc/self/fd/{placement_fd}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        containment.configure_command(&mut command).unwrap();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let status = runtime
+            .block_on(async move { command.status().await })
+            .unwrap();
+
+        assert!(status.success());
+        placement.seek(SeekFrom::Start(0)).unwrap();
+        let mut content = String::new();
+        placement.read_to_string(&mut content).unwrap();
+        assert_eq!(content, "0");
+    }
+
+    #[test]
+    fn reports_hard_limits_and_pressure_from_cgroup_counters() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join("cpu.stat"),
+            "usage_usec 10\nnr_throttled 2\nthrottled_usec 3\n",
+        )
+        .unwrap();
+        fs::write(
+            directory.path().join("memory.events"),
+            "low 0\nhigh 4\nmax 5\noom 1\noom_kill 1\noom_group_kill 1\n",
+        )
+        .unwrap();
+        fs::write(directory.path().join("pids.events"), "max 6\n").unwrap();
+        let containment = WorkloadContainment {
+            placement: Arc::new(tempfile::tempfile().unwrap().into()),
+            workload_path: Arc::new(directory.path().to_path_buf()),
+        };
+
+        let diagnostics = containment.resource_diagnostics().unwrap();
+
+        assert_eq!(
+            diagnostics.hard_limit.as_deref(),
+            Some(
+                "workload resource limit reached (memory_max=5, memory_oom=1, memory_oom_kill=1, memory_oom_group_kill=1, pids_max=6)"
+            )
+        );
+        assert_eq!(
+            diagnostics.pressure.as_deref(),
+            Some(
+                "workload resource pressure observed (cpu_nr_throttled=2, cpu_throttled_usec=3, memory_high=4)"
+            )
+        );
+    }
+
+    #[test]
+    fn ignores_immaterial_cpu_throttling() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join("cpu.stat"),
+            format!(
+                "usage_usec 10\nnr_throttled 2\nthrottled_usec {}\n",
+                MATERIAL_CPU_THROTTLED_USEC - 1
+            ),
+        )
+        .unwrap();
+        fs::write(
+            directory.path().join("memory.events"),
+            "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n",
+        )
+        .unwrap();
+        fs::write(directory.path().join("pids.events"), "max 0\n").unwrap();
+        let containment = WorkloadContainment {
+            placement: Arc::new(tempfile::tempfile().unwrap().into()),
+            workload_path: Arc::new(directory.path().to_path_buf()),
+        };
+
+        let diagnostics = containment.resource_diagnostics().unwrap();
+
+        assert_eq!(
+            diagnostics,
+            WorkloadResourceDiagnostics {
+                hard_limit: None,
+                pressure: None,
+            }
+        );
+    }
+}

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -1,26 +1,29 @@
 //! Secure workload-cgroup placement owned by Guest Agent.
 //!
 //! The root guest supervisor places Guest Agent in an operation's `control`
-//! leaf and passes a write-only descriptor for the sibling `workload` leaf.
-//! Guest Agent adopts that descriptor before starting its async runtime, marks
-//! it close-on-exec, and uses a cloned descriptor only in each CLI child's
-//! `pre_exec` hook. The descriptor is never copied into a workload environment.
+//! leaf and transfers a write-only descriptor for the sibling `workload` leaf
+//! over a nonce-authenticated local socket with `SCM_RIGHTS`. Guest Agent adopts
+//! that descriptor before starting its async runtime and uses a cloned
+//! descriptor only in each CLI child's `pre_exec` hook. The descriptor is never
+//! inherited through the sandbox-user launch chain or copied into a workload
+//! environment.
 
 use std::fs;
 use std::io;
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use guest_contracts::process_containment::{
     CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, EXEC_CGROUP_NAME_PREFIX,
-    MATERIAL_CPU_THROTTLED_USEC, WORKLOAD_CGROUP_NAME, WORKLOAD_CGROUP_PROCS_FD_ENV,
+    MATERIAL_CPU_THROTTLED_USEC, WORKLOAD_CGROUP_NAME, WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
 };
 
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
 const PROC_SELF_CGROUP: &str = "/proc/self/cgroup";
 const CGROUP2_SUPER_MAGIC: u64 = 0x6367_7270;
+const WORKLOAD_BOOTSTRAP_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 #[cfg(debug_assertions)]
 const TEST_ALLOW_UNMANAGED_PROCESS_CONTROL_ENV: &str = "VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL";
 
@@ -41,7 +44,7 @@ pub struct WorkloadResourceDiagnostics {
 }
 
 impl WorkloadContainment {
-    /// Adopt the production bootstrap descriptor from the process environment.
+    /// Receive and adopt the production bootstrap descriptor.
     ///
     /// This must run before any other thread can read or mutate process-global
     /// environment state. A process-control bootstrap requires a matching
@@ -59,31 +62,31 @@ impl WorkloadContainment {
             }
             Some(_) => true,
         };
-        let placement_value = std::env::var_os(WORKLOAD_CGROUP_PROCS_FD_ENV);
+        let placement_endpoint = std::env::var_os(WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV);
 
-        match (process_control_present, placement_value) {
+        match (process_control_present, placement_endpoint) {
             (false, None) => Ok(None),
             (true, None) if test_allows_unmanaged_process_control() => Ok(None),
             (true, None) => Err(format!(
                 "{} is required with {}",
-                WORKLOAD_CGROUP_PROCS_FD_ENV,
+                WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 process_control_ipc::BOOTSTRAP_ENV
             )),
             (false, Some(_)) => Err(format!(
                 "{} requires {}",
-                WORKLOAD_CGROUP_PROCS_FD_ENV,
+                WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
                 process_control_ipc::BOOTSTRAP_ENV
             )),
             (true, Some(value)) => {
                 // SAFETY: production calls this before constructing the Tokio
                 // runtime, so no other thread can access the environment.
-                unsafe { std::env::remove_var(WORKLOAD_CGROUP_PROCS_FD_ENV) };
-                let value = value
-                    .into_string()
-                    .map_err(|_| format!("{WORKLOAD_CGROUP_PROCS_FD_ENV} must be valid UTF-8"))?;
-                Self::adopt(&value)
-                    .map(Some)
-                    .map_err(|error| format!("invalid {WORKLOAD_CGROUP_PROCS_FD_ENV}: {error}"))
+                unsafe { std::env::remove_var(WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV) };
+                let value = value.into_string().map_err(|_| {
+                    format!("{WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV} must be valid UTF-8")
+                })?;
+                Self::receive(&value).map(Some).map_err(|error| {
+                    format!("invalid {WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV}: {error}")
+                })
             }
         }
     }
@@ -140,25 +143,19 @@ impl WorkloadContainment {
         })
     }
 
-    fn adopt(value: &str) -> io::Result<Self> {
-        let raw_fd = value.parse::<RawFd>().map_err(|error| {
-            io::Error::new(io::ErrorKind::InvalidInput, format!("invalid fd: {error}"))
-        })?;
-        if raw_fd < 3 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "workload placement fd must be at least 3",
-            ));
-        }
+    fn receive(endpoint: &str) -> io::Result<Self> {
+        let stream = process_control_ipc::connect_abstract(endpoint)?;
+        stream.set_read_timeout(Some(WORKLOAD_BOOTSTRAP_READ_TIMEOUT))?;
+        let placement = process_control_ipc::receive_workload_placement(&stream)?;
+        Self::adopt(placement)
+    }
 
+    fn adopt(placement: OwnedFd) -> io::Result<Self> {
         // SAFETY: F_GETFD only inspects the supplied descriptor.
-        let descriptor_flags = unsafe { libc::fcntl(raw_fd, libc::F_GETFD) };
+        let descriptor_flags = unsafe { libc::fcntl(placement.as_raw_fd(), libc::F_GETFD) };
         if descriptor_flags < 0 {
             return Err(io::Error::last_os_error());
         }
-        // SAFETY: `raw_fd` was validated above and ownership is transferred
-        // exactly once from the inherited bootstrap descriptor.
-        let placement = unsafe { OwnedFd::from_raw_fd(raw_fd) };
         deny_peer_process_inspection()?;
         let workload_path = validate_descriptor(&placement)?;
         set_close_on_exec(placement.as_raw_fd(), descriptor_flags)?;

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -108,6 +108,7 @@ fn test_runtime(
         config,
         paths,
         http,
+        workload_containment: None,
     })
 }
 

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -156,7 +156,8 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!cli_env.contains_key(process_control_ipc::BOOTSTRAP_ENV));
     assert!(!cli_env.contains_key("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL"));
     assert!(
-        !cli_env.contains_key(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV)
+        !cli_env
+            .contains_key(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
     );
 
     Ok(())

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -28,6 +28,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             process_control_ipc::BOOTSTRAP_ENV,
             "runner-control-endpoint",
         );
+        std::env::set_var("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true");
         std::env::set_var("NODE_EXTRA_CA_CERTS", "/rootfs/vm0-proxy-ca.crt");
         std::env::set_var("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt");
         std::env::set_var("REQUESTS_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt");
@@ -153,6 +154,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!cli_env.contains_key(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV));
     assert!(!cli_env.contains_key("CLI_AGENT_TYPE"));
     assert!(!cli_env.contains_key(process_control_ipc::BOOTSTRAP_ENV));
+    assert!(!cli_env.contains_key("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL"));
+    assert!(
+        !cli_env.contains_key(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV)
+    );
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -280,6 +280,7 @@ fn recovery_checkpoint_derives_missing_codex_history_marker() -> TestResult {
         config,
         paths: fixture.paths().clone(),
         http,
+        workload_containment: None,
     };
     runtime.block_on(
         guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&guest_runtime),

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -869,7 +869,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::MOCK_CODEX_PATH_ENV,
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         process_control_ipc::BOOTSTRAP_ENV,
-        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV,
+        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
         "VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL",
         "MOCK_CODEX_APP_SERVER_SCENARIO",
     ] {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -869,6 +869,8 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::MOCK_CODEX_PATH_ENV,
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         process_control_ipc::BOOTSTRAP_ENV,
+        guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV,
+        "VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL",
         "MOCK_CODEX_APP_SERVER_SCENARIO",
     ] {
         unsafe {

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -1236,6 +1236,7 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
         config,
         paths,
         http: http_client!(),
+        workload_containment: None,
     };
 
     unsafe {

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -101,6 +101,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         ("VM0_API_TOKEN", ""),
         ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),
         ("VM0_SANDBOX_REUSE_RESULT", "reused"),
+        ("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true"),
         ("HOME", workdir.as_str()),
     ];
 
@@ -218,6 +219,7 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
         ("VM0_API_TOKEN", ""),
         ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),
         ("VM0_SANDBOX_REUSE_RESULT", "reused"),
+        ("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true"),
         ("HOME", workdir.as_str()),
     ];
 

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -7,9 +7,11 @@
 
 mod common;
 
-use std::io;
-use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::fs::File;
+use std::io::{self, Write};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -25,9 +27,58 @@ const READY_CONTROL_MESSAGE_ID: &str = "process-control-after-cli-ready";
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
 
+struct MockStartGate {
+    writer: File,
+}
+
 struct ConnectionHarness {
     host: Option<vsock_host::VsockHost>,
     guest: Option<thread::JoinHandle<io::Result<()>>>,
+}
+
+impl MockStartGate {
+    fn create(dir: &Path, mock: &Path) -> TestResult<(Self, PathBuf)> {
+        let fifo = dir.join("mock-start.fifo");
+        let c_fifo = std::ffi::CString::new(fifo.as_os_str().as_bytes())?;
+        // SAFETY: c_fifo is a valid NUL-terminated path and the mode is a
+        // normal POSIX permission mask for a test-only FIFO.
+        if unsafe { libc::mkfifo(c_fifo.as_ptr(), 0o600) } != 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+
+        // Keep both FIFO ends open so the wrapper can block on its read even
+        // when the test releases it before the wrapper reaches that read.
+        // SAFETY: c_fifo remains valid for the call and ownership of the
+        // returned descriptor transfers to File below.
+        let fd = unsafe {
+            libc::open(
+                c_fifo.as_ptr(),
+                libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+        // SAFETY: fd is a freshly opened descriptor owned by this function.
+        let writer = unsafe { File::from_raw_fd(fd) };
+
+        let wrapper = dir.join("gated-mock-claude.sh");
+        let script = format!(
+            "#!/bin/sh\nIFS= read -r _ < {}\nexec {} \"$@\"\n",
+            quote_shell_arg(&fifo.to_string_lossy()),
+            quote_shell_arg(&mock.to_string_lossy()),
+        );
+        std::fs::write(&wrapper, script)?;
+        let mut permissions = std::fs::metadata(&wrapper)?.permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&wrapper, permissions)?;
+
+        Ok((Self { writer }, wrapper))
+    }
+
+    fn release(&mut self) -> io::Result<()> {
+        self.writer.write_all(b"start\n")
+    }
 }
 
 impl ConnectionHarness {
@@ -67,6 +118,7 @@ impl Drop for ConnectionHarness {
 async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
+    let (mut mock_start_gate, gated_mock) = MockStartGate::create(tmp.path(), &mock)?;
     let run_id = format!(
         "process-control-channel-{}-{}",
         std::process::id(),
@@ -76,7 +128,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let guest_agent = env!("CARGO_BIN_EXE_guest-agent");
     let prompt = "@active-input-smoke:2";
     let workdir = tmp.path().to_string_lossy().into_owned();
-    let mock_path = mock.to_string_lossy().into_owned();
+    let mock_path = gated_mock.to_string_lossy().into_owned();
     let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), &run_id)?;
     let run_payload_path = common::write_run_payload_file_for_test(
         &runtime_dir,
@@ -143,6 +195,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         )
         .await?;
 
+    mock_start_gate.release()?;
     let mut stdout = collect_stdout_until(
         &mut stdout_rx,
         b"READY_FOR_ACTIVE_INPUT",

--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -6,7 +6,26 @@
 
 mod common;
 
+use std::process::Command;
 use std::time::Duration;
+
+#[test]
+fn process_control_endpoint_without_workload_capability_fails_closed() {
+    let output = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+        .env(process_control_ipc::BOOTSTRAP_ENV, "missing-capability")
+        .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV)
+        .env_remove("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL")
+        .output()
+        .expect("spawn guest-agent");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("is required with"), "stderr: {stderr}");
+}
 
 #[tokio::test]
 async fn process_control_endpoint_is_not_inherited_by_cli_child()
@@ -25,6 +44,7 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child()
             process_control_ipc::BOOTSTRAP_ENV,
             "stale-process-control-endpoint",
         );
+        std::env::set_var("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true");
     }
 
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 fn process_control_endpoint_without_workload_capability_fails_closed() {
     let output = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
         .env(process_control_ipc::BOOTSTRAP_ENV, "missing-capability")
-        .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV)
+        .env_remove(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
         .env_remove("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL")
         .output()
         .expect("spawn guest-agent");
@@ -21,10 +21,52 @@ fn process_control_endpoint_without_workload_capability_fails_closed() {
     assert_eq!(output.status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV),
+        stderr.contains(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV),
         "stderr: {stderr}"
     );
     assert!(stderr.contains("is required with"), "stderr: {stderr}");
+}
+
+#[test]
+fn workload_capability_is_received_over_scm_rights_and_validated() {
+    let nonce = *b"workload-fd-test";
+    let endpoint = format!(
+        "{}-workload-placement",
+        process_control_ipc::endpoint_name(std::process::id(), &nonce)
+    );
+    let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+    let broker = std::thread::spawn(move || {
+        use std::os::fd::AsFd;
+
+        let stream = process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(5))
+            .expect("guest-agent should connect to workload capability broker");
+        let invalid_placement = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/null")
+            .unwrap();
+        process_control_ipc::send_workload_placement(&stream, invalid_placement.as_fd()).unwrap();
+    });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+        .env(
+            process_control_ipc::BOOTSTRAP_ENV,
+            "process-control-present",
+        )
+        .env(
+            guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+            endpoint,
+        )
+        .env_remove("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL")
+        .output()
+        .expect("spawn guest-agent");
+    broker.join().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("workload placement fd is not on cgroup v2"),
+        "stderr: {stderr}"
+    );
 }
 
 #[tokio::test]

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -396,12 +396,12 @@ fn prepare_for_reuse_rejects_nested_workload_cgroup() -> TestResult {
 }
 
 #[test]
-fn prepare_for_reuse_rejects_workload_policy_mismatch() -> TestResult {
+fn prepare_for_reuse_rejects_stale_workload_pid_limit() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
     std::fs::write(
-        containment.base.join("exec-current/workload/cpu.max"),
-        b"max 100000\n",
+        containment.base.join("exec-current/workload/pids.max"),
+        b"2048\n",
     )?;
 
     let output = run_helper_with_containment(&request, &containment)?;

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -333,6 +333,21 @@ fn prepare_for_reuse_rejects_missing_controller() -> TestResult {
 }
 
 #[test]
+fn prepare_for_reuse_rejects_missing_ancestor_memory_protection() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(containment.base.join("memory.min"), b"0\n")?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
 fn prepare_for_reuse_rejects_direct_processes_in_operation_parent() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
@@ -434,6 +449,10 @@ impl ContainmentFixture {
         ] {
             std::fs::write(base.join(filename), content)?;
         }
+        std::fs::write(
+            base.join("memory.min"),
+            guest_contracts::process_containment::CONTROL_MEMORY_RESERVE_BYTES.to_string(),
+        )?;
         let operation = base.join("exec-current");
         std::fs::create_dir(&operation)?;
         for (filename, content) in [

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -258,7 +258,7 @@ fn prepare_for_reuse_rejects_stale_operation_cgroup() -> TestResult {
 fn prepare_for_reuse_rejects_missing_current_operation_cgroup() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
-    std::fs::remove_dir(containment.base.join("exec-current"))?;
+    std::fs::remove_dir_all(containment.base.join("exec-current"))?;
 
     let output = run_helper_with_containment(&request, &containment)?;
 
@@ -304,7 +304,8 @@ fn prepare_for_reuse_rejects_current_process_outside_exec_base() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
 
-    let output = run_helper_with_current_group(&request, &containment, "/outside/exec-current")?;
+    let output =
+        run_helper_with_current_group(&request, &containment, "/outside/exec-current/workload")?;
 
     assert_eq!(
         output.status.code(),
@@ -314,15 +315,96 @@ fn prepare_for_reuse_rejects_current_process_outside_exec_base() -> TestResult {
 }
 
 #[test]
-fn prepare_for_reuse_rejects_enabled_controllers() -> TestResult {
+fn prepare_for_reuse_rejects_missing_controller() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
     std::fs::write(
         containment.base.join("cgroup.subtree_control"),
-        b"+memory\n",
+        b"cpu memory\n",
     )?;
 
     let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_direct_processes_in_operation_parent() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(containment.base.join("exec-current/cgroup.procs"), b"42\n")?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_populated_control_leaf() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(
+        containment.base.join("exec-current/control/cgroup.events"),
+        b"populated 1\n",
+    )?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_nested_workload_cgroup() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::create_dir(containment.base.join("exec-current/workload/unexpected"))?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_workload_policy_mismatch() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(
+        containment.base.join("exec-current/workload/cpu.max"),
+        b"max 100000\n",
+    )?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_helper_in_control_leaf() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+
+    let output =
+        run_helper_with_current_group(&request, &containment, "/vm0-exec/exec-current/control")?;
 
     assert_eq!(
         output.status.code(),
@@ -343,14 +425,59 @@ impl ContainmentFixture {
         let root = directory.path().join("cgroup");
         let base = root.join("vm0-exec");
         std::fs::create_dir_all(&base)?;
-        std::fs::create_dir(base.join("exec-current"))?;
         for (filename, content) in [
+            ("cgroup.controllers", "cpu memory pids\n"),
             ("cgroup.procs", ""),
             ("cgroup.events", "populated 1\nfrozen 0\n"),
             ("cgroup.kill", ""),
-            ("cgroup.subtree_control", ""),
+            ("cgroup.subtree_control", "cpu memory pids\n"),
         ] {
             std::fs::write(base.join(filename), content)?;
+        }
+        let operation = base.join("exec-current");
+        std::fs::create_dir(&operation)?;
+        for (filename, content) in [
+            ("cgroup.controllers", "cpu memory pids\n"),
+            ("cgroup.procs", ""),
+            ("cgroup.events", "populated 1\nfrozen 0\n"),
+            ("cgroup.kill", ""),
+            ("cgroup.subtree_control", "cpu memory pids\n"),
+        ] {
+            std::fs::write(operation.join(filename), content)?;
+        }
+        for (leaf, populated) in [("control", "0"), ("workload", "1")] {
+            let leaf = operation.join(leaf);
+            std::fs::create_dir(&leaf)?;
+            for (filename, content) in [
+                ("cgroup.procs", ""),
+                (
+                    "cgroup.events",
+                    if populated == "1" {
+                        "populated 1\nfrozen 0\n"
+                    } else {
+                        "populated 0\nfrozen 0\n"
+                    },
+                ),
+                ("cgroup.kill", ""),
+                ("cgroup.subtree_control", ""),
+            ] {
+                std::fs::write(leaf.join(filename), content)?;
+            }
+        }
+        let policy = guest_contracts::process_containment::WorkloadResourcePolicy::for_current_guest_capacity()
+            .map_err(std::io::Error::other)?;
+        let workload = operation.join("workload");
+        for (filename, value) in [
+            (
+                "cpu.max",
+                format!("{} {}", policy.cpu_quota_us, policy.cpu_period_us),
+            ),
+            ("memory.high", policy.memory_high_bytes.to_string()),
+            ("memory.max", policy.memory_max_bytes.to_string()),
+            ("memory.oom.group", "1".to_string()),
+            ("pids.max", policy.pids_max.to_string()),
+        ] {
+            std::fs::write(workload.join(filename), value)?;
         }
         Ok(Self {
             _directory: directory,
@@ -382,7 +509,7 @@ fn run_helper_with_containment(
     request: &ReusePreparationRequest,
     containment: &ContainmentFixture,
 ) -> Result<Output, Box<dyn std::error::Error>> {
-    run_helper_with_current_group(request, containment, "/vm0-exec/exec-current")
+    run_helper_with_current_group(request, containment, "/vm0-exec/exec-current/workload")
 }
 
 fn run_helper_with_current_group(
@@ -418,7 +545,7 @@ fn run_helper_with_bind_mount(
         .env("VM0_TEST_PROCESS_CONTAINMENT_ROOT", &containment.root)
         .env(
             "VM0_TEST_PROCESS_CONTAINMENT_CURRENT_GROUP",
-            "/vm0-exec/exec-current",
+            "/vm0-exec/exec-current/workload",
         )
         .env("VM0_MOUNT_SOURCE", mount_source)
         .env("VM0_MOUNT_TARGET", mount_target)

--- a/crates/guest-agent/tests/user_cancellation_recovery.rs
+++ b/crates/guest-agent/tests/user_cancellation_recovery.rs
@@ -212,7 +212,8 @@ async fn run_scenario(scenario: Scenario) -> Result<(), Box<dyn std::error::Erro
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
                 &runtime_dir,
             )
-            .env(process_control_ipc::BOOTSTRAP_ENV, &endpoint),
+            .env(process_control_ipc::BOOTSTRAP_ENV, &endpoint)
+            .env("VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL", "true"),
         Duration::from_secs(20),
         "guest-agent did not finish within its finalization budget",
     )

--- a/crates/guest-agent/tests/zero_web_search_policy.rs
+++ b/crates/guest-agent/tests/zero_web_search_policy.rs
@@ -111,6 +111,7 @@ fn build_runtime(
         config,
         paths,
         http,
+        workload_containment: None,
     })
 }
 

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -50,6 +50,9 @@ pub struct FailureDiagnostic {
     /// Bounded event-delivery failure details, when delivery was terminally incomplete.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub event_delivery: Option<EventDeliveryDiagnostic>,
+    /// Workload-local hard-limit counters observed for the failed CLI process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workload_resource_limit: Option<WorkloadResourceLimitDiagnostic>,
 }
 
 impl FailureDiagnostic {
@@ -75,6 +78,7 @@ impl FailureDiagnostic {
             prompt_bytes: prompt.prompt_bytes,
             first_line_bytes: prompt.first_line_bytes,
             event_delivery: None,
+            workload_resource_limit: None,
         }
     }
 
@@ -138,6 +142,44 @@ impl FailureDiagnostic {
     pub fn with_event_delivery(mut self, event_delivery: EventDeliveryDiagnostic) -> Self {
         self.event_delivery = Some(event_delivery);
         self
+    }
+
+    /// Attach workload-local hard-limit counters.
+    #[must_use]
+    pub fn with_workload_resource_limit(
+        mut self,
+        workload_resource_limit: WorkloadResourceLimitDiagnostic,
+    ) -> Self {
+        self.workload_resource_limit = Some(workload_resource_limit);
+        self
+    }
+}
+
+/// Bounded cgroup-v2 hard-limit counters observed for a failed workload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkloadResourceLimitDiagnostic {
+    /// Number of workload allocations rejected by `memory.max`.
+    pub memory_max_events: u64,
+    /// Number of workload OOM events.
+    pub memory_oom_events: u64,
+    /// Number of workload processes killed by the OOM killer.
+    pub memory_oom_kill_events: u64,
+    /// Number of workload cgroups killed as an OOM group.
+    pub memory_oom_group_kill_events: u64,
+    /// Number of workload forks or clones rejected by `pids.max`.
+    pub pids_max_events: u64,
+}
+
+impl WorkloadResourceLimitDiagnostic {
+    /// Whether at least one hard-limit event was observed.
+    #[must_use]
+    pub const fn has_events(self) -> bool {
+        self.memory_max_events > 0
+            || self.memory_oom_events > 0
+            || self.memory_oom_kill_events > 0
+            || self.memory_oom_group_kill_events > 0
+            || self.pids_max_events > 0
     }
 }
 
@@ -850,6 +892,39 @@ mod tests {
     }
 
     #[test]
+    fn failure_diagnostic_serializes_workload_resource_limit_counters() {
+        let workload_resource_limit = WorkloadResourceLimitDiagnostic {
+            memory_max_events: 5,
+            memory_oom_events: 2,
+            memory_oom_kill_events: 1,
+            memory_oom_group_kill_events: 0,
+            pids_max_events: 3,
+        };
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("exhaust the workload"),
+        )
+        .with_cli_exit_code(137)
+        .with_workload_resource_limit(workload_resource_limit);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(
+            json["workloadResourceLimit"],
+            serde_json::json!({
+                "memoryMaxEvents": 5,
+                "memoryOomEvents": 2,
+                "memoryOomKillEvents": 1,
+                "memoryOomGroupKillEvents": 0,
+                "pidsMaxEvents": 3,
+            })
+        );
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
     fn failure_diagnostic_serializes_cli_termination() {
         let cli_termination = CliTerminationDiagnostic::new(CliTerminationReason::PostResultReap)
             .record_signal(CliTerminationSignal::Sigterm, Some(1401), Some(10_000))
@@ -1433,5 +1508,6 @@ mod tests {
         assert_eq!(diagnostic.failure_reason, None);
         assert_eq!(diagnostic.cli_termination, None);
         assert_eq!(diagnostic.event_delivery, None);
+        assert_eq!(diagnostic.workload_resource_limit, None);
     }
 }

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -1,4 +1,10 @@
-//! Shared guest process-containment paths.
+//! Shared guest process-containment and resource-policy contract.
+//!
+//! Each exec operation owns an empty parent cgroup with `control` and
+//! `workload` leaves. A process-control-enabled Guest Agent runs in `control`;
+//! every agent CLI and ordinary exec runs in `workload`. The parent remains
+//! empty so it can distribute cgroup v2 controllers and act as the recursive
+//! cleanup boundary.
 
 /// Canonical cgroup v2 mount inside the guest.
 pub const CGROUP_V2_MOUNT_PATH: &str = "/sys/fs/cgroup";
@@ -8,3 +14,181 @@ pub const EXEC_CGROUP_BASE_PATH: &str = "/sys/fs/cgroup/vm0-exec";
 
 /// Prefix for each per-operation cgroup directly below the exec cgroup base.
 pub const EXEC_CGROUP_NAME_PREFIX: &str = "exec-";
+
+/// Leaf reserved for the trusted Guest Agent control process.
+pub const CONTROL_CGROUP_NAME: &str = "control";
+
+/// Leaf containing agent CLIs, tools, and ordinary exec processes.
+pub const WORKLOAD_CGROUP_NAME: &str = "workload";
+
+/// Cgroup v2 controllers required for workload resource isolation.
+pub const REQUIRED_CGROUP_CONTROLLERS: [&str; 3] = ["cpu", "memory", "pids"];
+
+/// Value written to `cgroup.subtree_control` to enable required controllers.
+pub const REQUIRED_CGROUP_SUBTREE_CONTROL: &str = "+cpu +memory +pids";
+
+/// Runner-owned bootstrap variable containing an inherited workload
+/// `cgroup.procs` descriptor number.
+///
+/// The root guest supervisor opens the write-only descriptor and passes it only
+/// to a process-control-enabled Guest Agent. Guest Agent consumes the variable,
+/// marks the descriptor close-on-exec, and uses cloned descriptors only from
+/// CLI-child `pre_exec` hooks.
+pub const WORKLOAD_CGROUP_PROCS_FD_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_FD";
+
+/// Smallest Runner profile vCPU count supported by the workload policy.
+pub const MIN_PROFILE_VCPU: u32 = 2;
+
+/// Smallest Runner profile memory size supported by the workload policy.
+pub const MIN_PROFILE_MEMORY_MB: u32 = 4096;
+
+/// CPU bandwidth period used for workload cgroups.
+pub const WORKLOAD_CPU_PERIOD_US: u64 = 100_000;
+
+/// CPU time per period reserved outside each workload leaf for control work.
+pub const CONTROL_CPU_RESERVE_US: u64 = 10_000;
+
+/// Minimum accumulated CPU throttling reported as material pressure.
+pub const MATERIAL_CPU_THROTTLED_USEC: u64 = 1_000_000;
+
+/// Memory kept outside the workload hard limit for Guest control services.
+pub const CONTROL_MEMORY_RESERVE_BYTES: u64 = 384 * 1024 * 1024;
+
+/// Additional distance between workload `memory.high` and `memory.max`.
+pub const WORKLOAD_MEMORY_HIGH_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Minimum useful workload memory after reserving Guest control headroom.
+pub const MIN_WORKLOAD_MEMORY_BYTES: u64 = 384 * 1024 * 1024;
+
+/// Maximum number of processes accepted in one workload leaf.
+pub const WORKLOAD_PIDS_MAX: u64 = 2048;
+
+/// Highest cgroup v2 CPU weight, assigned to a controlled operation and its
+/// Guest Agent leaf so concurrent ordinary execs cannot dominate it.
+pub const CONTROL_CPU_WEIGHT: u64 = 10_000;
+
+/// Calibrated cgroup v2 resource policy for one workload leaf.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WorkloadResourcePolicy {
+    /// Workload CPU quota in microseconds per [`Self::cpu_period_us`].
+    pub cpu_quota_us: u64,
+    /// Workload CPU bandwidth period in microseconds.
+    pub cpu_period_us: u64,
+    /// Workload memory throttling threshold in bytes.
+    pub memory_high_bytes: u64,
+    /// Workload hard memory limit in bytes.
+    pub memory_max_bytes: u64,
+    /// Protected Guest Agent memory in bytes.
+    pub control_memory_min_bytes: u64,
+    /// Workload process limit.
+    pub pids_max: u64,
+}
+
+impl WorkloadResourcePolicy {
+    /// Derive the policy from capacity visible to the current Guest.
+    pub fn for_current_guest_capacity() -> Result<Self, &'static str> {
+        // SAFETY: these sysconf selectors return scalar capacity values.
+        let vcpu = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+        // SAFETY: these sysconf selectors return scalar capacity values.
+        let physical_pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+        // SAFETY: these sysconf selectors return scalar capacity values.
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if vcpu <= 0 || physical_pages <= 0 || page_size <= 0 {
+            return Err("guest capacity query returned a non-positive value");
+        }
+        let vcpu = u32::try_from(vcpu).map_err(|_| "guest vCPU count is out of range")?;
+        let memory_bytes = u64::try_from(physical_pages)
+            .ok()
+            .and_then(|pages| {
+                u64::try_from(page_size)
+                    .ok()
+                    .and_then(|size| pages.checked_mul(size))
+            })
+            .ok_or("guest physical memory size is out of range")?;
+        Self::for_guest_capacity(vcpu, memory_bytes)
+    }
+
+    /// Derive the fixed platform policy from Guest-visible capacity.
+    ///
+    /// `vcpu` is the number of online processors and `memory_bytes` is physical
+    /// memory visible to the Guest. The calculation fails when the Guest cannot
+    /// leave both the calibrated control reserve and a useful workload budget.
+    pub fn for_guest_capacity(vcpu: u32, memory_bytes: u64) -> Result<Self, &'static str> {
+        if vcpu < MIN_PROFILE_VCPU {
+            return Err("guest vCPU capacity is below the workload-containment minimum");
+        }
+
+        let total_cpu_us = u64::from(vcpu)
+            .checked_mul(WORKLOAD_CPU_PERIOD_US)
+            .ok_or("guest vCPU capacity overflows workload policy")?;
+        let cpu_quota_us = total_cpu_us
+            .checked_sub(CONTROL_CPU_RESERVE_US)
+            .filter(|quota| *quota > 0)
+            .ok_or("guest CPU capacity cannot preserve control headroom")?;
+
+        let memory_max_bytes = memory_bytes
+            .checked_sub(CONTROL_MEMORY_RESERVE_BYTES)
+            .filter(|limit| *limit >= MIN_WORKLOAD_MEMORY_BYTES)
+            .ok_or("guest memory capacity cannot preserve control headroom")?;
+        let memory_high_bytes = memory_max_bytes
+            .checked_sub(WORKLOAD_MEMORY_HIGH_HEADROOM_BYTES)
+            .filter(|limit| *limit > 0)
+            .ok_or("guest memory capacity cannot provide a workload high threshold")?;
+
+        Ok(Self {
+            cpu_quota_us,
+            cpu_period_us: WORKLOAD_CPU_PERIOD_US,
+            memory_high_bytes,
+            memory_max_bytes,
+            control_memory_min_bytes: CONTROL_MEMORY_RESERVE_BYTES,
+            pids_max: WORKLOAD_PIDS_MAX,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_default_profile_policy() {
+        let policy =
+            WorkloadResourcePolicy::for_guest_capacity(2, u64::from(4096_u32) * 1024 * 1024)
+                .unwrap();
+
+        assert_eq!(policy.cpu_quota_us, 190_000);
+        assert_eq!(policy.cpu_period_us, 100_000);
+        assert_eq!(policy.memory_max_bytes, 3712 * 1024 * 1024);
+        assert_eq!(policy.memory_high_bytes, 3456 * 1024 * 1024);
+        assert_eq!(policy.control_memory_min_bytes, 384 * 1024 * 1024);
+        assert_eq!(policy.pids_max, 2048);
+    }
+
+    #[test]
+    fn rejects_capacity_without_memory_headroom() {
+        let error = WorkloadResourcePolicy::for_guest_capacity(
+            MIN_PROFILE_VCPU,
+            CONTROL_MEMORY_RESERVE_BYTES + MIN_WORKLOAD_MEMORY_BYTES - 1,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            "guest memory capacity cannot preserve control headroom"
+        );
+    }
+
+    #[test]
+    fn rejects_capacity_below_vcpu_minimum() {
+        let error = WorkloadResourcePolicy::for_guest_capacity(
+            MIN_PROFILE_VCPU - 1,
+            u64::from(MIN_PROFILE_MEMORY_MB) * 1024 * 1024,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            "guest vCPU capacity is below the workload-containment minimum"
+        );
+    }
+}

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -63,8 +63,12 @@ pub const CONTROL_MEMORY_RESERVE_BYTES: u64 = 384 * 1024 * 1024;
 /// Additional distance between workload `memory.high` and `memory.max`.
 pub const WORKLOAD_MEMORY_HIGH_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
 
-/// Maximum number of processes accepted in one workload leaf.
-pub const WORKLOAD_PIDS_MAX: u64 = 2048;
+/// Value written to workload `pids.max` while no production ceiling is calibrated.
+///
+/// The PID controller remains enabled for accounting and operation-local
+/// enforcement tests, but normal workloads are not capped by an arbitrary
+/// task count.
+pub const WORKLOAD_PIDS_MAX: &str = "max";
 
 /// Highest cgroup v2 CPU weight, assigned to a controlled operation and its
 /// Guest Agent leaf so concurrent ordinary execs cannot dominate it.
@@ -83,8 +87,8 @@ pub struct WorkloadResourcePolicy {
     pub memory_max_bytes: u64,
     /// Protected Guest Agent memory in bytes.
     pub control_memory_min_bytes: u64,
-    /// Workload process limit.
-    pub pids_max: u64,
+    /// Value written to the workload `pids.max` cgroup file.
+    pub pids_max: &'static str,
 }
 
 impl WorkloadResourcePolicy {
@@ -160,7 +164,7 @@ mod tests {
         assert_eq!(policy.memory_max_bytes, 3712 * 1024 * 1024);
         assert_eq!(policy.memory_high_bytes, 3456 * 1024 * 1024);
         assert_eq!(policy.control_memory_min_bytes, 384 * 1024 * 1024);
-        assert_eq!(policy.pids_max, 2048);
+        assert_eq!(policy.pids_max, "max");
     }
 
     #[test]

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -52,6 +52,10 @@ pub const CONTROL_CPU_RESERVE_US: u64 = 10_000;
 pub const MATERIAL_CPU_THROTTLED_USEC: u64 = 1_000_000;
 
 /// Memory kept outside the workload hard limit for Guest control services.
+///
+/// Cgroup v2 limits effective `memory.min` protection by every ancestor. The
+/// exec base, controlled operation, and control leaf must therefore all use
+/// this value so concurrent operation siblings cannot reclaim the reservation.
 pub const CONTROL_MEMORY_RESERVE_BYTES: u64 = 384 * 1024 * 1024;
 
 /// Additional distance between workload `memory.high` and `memory.max`.

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -55,9 +55,6 @@ pub const CONTROL_MEMORY_RESERVE_BYTES: u64 = 384 * 1024 * 1024;
 /// Additional distance between workload `memory.high` and `memory.max`.
 pub const WORKLOAD_MEMORY_HIGH_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
 
-/// Minimum useful workload memory after reserving Guest control headroom.
-pub const MIN_WORKLOAD_MEMORY_BYTES: u64 = 384 * 1024 * 1024;
-
 /// Maximum number of processes accepted in one workload leaf.
 pub const WORKLOAD_PIDS_MAX: u64 = 2048;
 
@@ -110,7 +107,7 @@ impl WorkloadResourcePolicy {
     ///
     /// `vcpu` is the number of online processors and `memory_bytes` is physical
     /// memory visible to the Guest. The calculation fails when the Guest cannot
-    /// leave both the calibrated control reserve and a useful workload budget.
+    /// preserve the fixed control reserve and workload high-limit headroom.
     pub fn for_guest_capacity(vcpu: u32, memory_bytes: u64) -> Result<Self, &'static str> {
         let total_cpu_us = u64::from(vcpu)
             .checked_mul(WORKLOAD_CPU_PERIOD_US)
@@ -122,7 +119,7 @@ impl WorkloadResourcePolicy {
 
         let memory_max_bytes = memory_bytes
             .checked_sub(CONTROL_MEMORY_RESERVE_BYTES)
-            .filter(|limit| *limit >= MIN_WORKLOAD_MEMORY_BYTES)
+            .filter(|limit| *limit > 0)
             .ok_or("guest memory capacity cannot preserve control headroom")?;
         let memory_high_bytes = memory_max_bytes
             .checked_sub(WORKLOAD_MEMORY_HIGH_HEADROOM_BYTES)
@@ -159,12 +156,9 @@ mod tests {
     }
 
     #[test]
-    fn rejects_capacity_without_memory_headroom() {
-        let error = WorkloadResourcePolicy::for_guest_capacity(
-            1,
-            CONTROL_MEMORY_RESERVE_BYTES + MIN_WORKLOAD_MEMORY_BYTES - 1,
-        )
-        .unwrap_err();
+    fn rejects_capacity_without_control_memory_headroom() {
+        let error = WorkloadResourcePolicy::for_guest_capacity(1, CONTROL_MEMORY_RESERVE_BYTES)
+            .unwrap_err();
 
         assert_eq!(
             error,
@@ -173,15 +167,13 @@ mod tests {
     }
 
     #[test]
-    fn derives_smallest_profile_policy_from_fixed_reserves() {
-        let policy = WorkloadResourcePolicy::for_guest_capacity(
-            1,
-            CONTROL_MEMORY_RESERVE_BYTES + MIN_WORKLOAD_MEMORY_BYTES,
-        )
-        .unwrap();
+    fn derives_small_profile_policy_from_fixed_reserves() {
+        let policy =
+            WorkloadResourcePolicy::for_guest_capacity(1, u64::from(1024_u32) * 1024 * 1024)
+                .unwrap();
 
         assert_eq!(policy.cpu_quota_us, 90_000);
-        assert_eq!(policy.memory_max_bytes, 384 * 1024 * 1024);
-        assert_eq!(policy.memory_high_bytes, 128 * 1024 * 1024);
+        assert_eq!(policy.memory_max_bytes, 640 * 1024 * 1024);
+        assert_eq!(policy.memory_high_bytes, 384 * 1024 * 1024);
     }
 }

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -36,12 +36,6 @@ pub const REQUIRED_CGROUP_SUBTREE_CONTROL: &str = "+cpu +memory +pids";
 /// variable and uses cloned descriptors only from CLI-child `pre_exec` hooks.
 pub const WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
-/// Smallest Runner profile vCPU count supported by the workload policy.
-pub const MIN_PROFILE_VCPU: u32 = 2;
-
-/// Smallest Runner profile memory size supported by the workload policy.
-pub const MIN_PROFILE_MEMORY_MB: u32 = 4096;
-
 /// CPU bandwidth period used for workload cgroups.
 pub const WORKLOAD_CPU_PERIOD_US: u64 = 100_000;
 
@@ -118,10 +112,6 @@ impl WorkloadResourcePolicy {
     /// memory visible to the Guest. The calculation fails when the Guest cannot
     /// leave both the calibrated control reserve and a useful workload budget.
     pub fn for_guest_capacity(vcpu: u32, memory_bytes: u64) -> Result<Self, &'static str> {
-        if vcpu < MIN_PROFILE_VCPU {
-            return Err("guest vCPU capacity is below the workload-containment minimum");
-        }
-
         let total_cpu_us = u64::from(vcpu)
             .checked_mul(WORKLOAD_CPU_PERIOD_US)
             .ok_or("guest vCPU capacity overflows workload policy")?;
@@ -171,7 +161,7 @@ mod tests {
     #[test]
     fn rejects_capacity_without_memory_headroom() {
         let error = WorkloadResourcePolicy::for_guest_capacity(
-            MIN_PROFILE_VCPU,
+            1,
             CONTROL_MEMORY_RESERVE_BYTES + MIN_WORKLOAD_MEMORY_BYTES - 1,
         )
         .unwrap_err();
@@ -183,16 +173,15 @@ mod tests {
     }
 
     #[test]
-    fn rejects_capacity_below_vcpu_minimum() {
-        let error = WorkloadResourcePolicy::for_guest_capacity(
-            MIN_PROFILE_VCPU - 1,
-            u64::from(MIN_PROFILE_MEMORY_MB) * 1024 * 1024,
+    fn derives_smallest_profile_policy_from_fixed_reserves() {
+        let policy = WorkloadResourcePolicy::for_guest_capacity(
+            1,
+            CONTROL_MEMORY_RESERVE_BYTES + MIN_WORKLOAD_MEMORY_BYTES,
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert_eq!(
-            error,
-            "guest vCPU capacity is below the workload-containment minimum"
-        );
+        assert_eq!(policy.cpu_quota_us, 90_000);
+        assert_eq!(policy.memory_max_bytes, 384 * 1024 * 1024);
+        assert_eq!(policy.memory_high_bytes, 128 * 1024 * 1024);
     }
 }

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -27,14 +27,14 @@ pub const REQUIRED_CGROUP_CONTROLLERS: [&str; 3] = ["cpu", "memory", "pids"];
 /// Value written to `cgroup.subtree_control` to enable required controllers.
 pub const REQUIRED_CGROUP_SUBTREE_CONTROL: &str = "+cpu +memory +pids";
 
-/// Runner-owned bootstrap variable containing an inherited workload
-/// `cgroup.procs` descriptor number.
+/// Runner-owned bootstrap variable containing the nonce-authenticated local
+/// endpoint that transfers a workload `cgroup.procs` descriptor.
 ///
-/// The root guest supervisor opens the write-only descriptor and passes it only
-/// to a process-control-enabled Guest Agent. Guest Agent consumes the variable,
-/// marks the descriptor close-on-exec, and uses cloned descriptors only from
-/// CLI-child `pre_exec` hooks.
-pub const WORKLOAD_CGROUP_PROCS_FD_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_FD";
+/// The root guest supervisor keeps the write-only descriptor out of the user
+/// launch chain and sends it with `SCM_RIGHTS` only after Guest Agent connects
+/// from the matching operation `control` cgroup. Guest Agent consumes this
+/// variable and uses cloned descriptors only from CLI-child `pre_exec` hooks.
+pub const WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
 /// Smallest Runner profile vCPU count supported by the workload policy.
 pub const MIN_PROFILE_VCPU: u32 = 2;

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -36,6 +36,14 @@ pub const REQUIRED_CGROUP_SUBTREE_CONTROL: &str = "+cpu +memory +pids";
 /// variable and uses cloned descriptors only from CLI-child `pre_exec` hooks.
 pub const WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV: &str = "VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT";
 
+/// Smallest Runner profile vCPU count validated for workload containment.
+pub const MIN_PROFILE_VCPU: u32 = 1;
+
+/// Smallest configured Runner profile memory size validated for workload
+/// containment. Guest startup independently derives its policy from the
+/// smaller capacity actually visible inside the VM.
+pub const MIN_PROFILE_MEMORY_MB: u32 = 1024;
+
 /// CPU bandwidth period used for workload cgroups.
 pub const WORKLOAD_CPU_PERIOD_US: u64 = 100_000;
 
@@ -175,5 +183,16 @@ mod tests {
         assert_eq!(policy.cpu_quota_us, 90_000);
         assert_eq!(policy.memory_max_bytes, 640 * 1024 * 1024);
         assert_eq!(policy.memory_high_bytes, 384 * 1024 * 1024);
+    }
+
+    #[test]
+    fn derives_policy_from_calibrated_minimum_guest_capacity() {
+        // A 1-vCPU/1024-MiB Firecracker Guest exposes this physical capacity
+        // after kernel reservations on the production-equivalent test host.
+        let policy = WorkloadResourcePolicy::for_guest_capacity(1, 1_033_928_704).unwrap();
+
+        assert_eq!(policy.cpu_quota_us, 90_000);
+        assert_eq!(policy.memory_max_bytes, 631_275_520);
+        assert_eq!(policy.memory_high_bytes, 362_840_064);
     }
 }

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -17,8 +17,8 @@ use std::io;
 use std::path::Path;
 
 use guest_contracts::process_containment::{
-    CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH, REQUIRED_CGROUP_CONTROLLERS,
-    REQUIRED_CGROUP_SUBTREE_CONTROL,
+    CGROUP_V2_MOUNT_PATH, CONTROL_MEMORY_RESERVE_BYTES, EXEC_CGROUP_BASE_PATH,
+    REQUIRED_CGROUP_CONTROLLERS, REQUIRED_CGROUP_SUBTREE_CONTROL,
 };
 
 const CGROUP_CONTROLLERS_FILE: &str = "cgroup.controllers";
@@ -159,9 +159,11 @@ impl std::error::Error for InitError {}
 /// Mount cgroup v2 and validate the canonical exec process-containment base.
 ///
 /// Cgroup v2 is mounted at `CGROUP_V2_MOUNT_PATH`. The exec base at
-/// `EXEC_CGROUP_BASE_PATH` must be empty and distribute the `cpu`, `memory`,
-/// and `pids` controllers. `vsock-guest` creates an empty operation parent and
-/// two controlled leaves beneath it for each exec operation.
+/// `EXEC_CGROUP_BASE_PATH` must be empty, distribute the `cpu`, `memory`, and
+/// `pids` controllers, and carry the ancestor `memory.min` required for
+/// effective control-process protection. `vsock-guest` creates an empty
+/// operation parent and two controlled leaves beneath it for each exec
+/// operation.
 fn initialize_process_containment() -> Result<(), InitError> {
     create_dir_all(Path::new(CGROUP_V2_MOUNT_PATH))?;
     mount(
@@ -182,6 +184,16 @@ fn initialize_process_containment() -> Result<(), InitError> {
     let base = Path::new(EXEC_CGROUP_BASE_PATH);
     create_dir_all(base)?;
     enable_required_controllers(base)?;
+    let memory_min_path = base.join(MEMORY_MIN_FILE);
+    fs::write(
+        &memory_min_path,
+        CONTROL_MEMORY_RESERVE_BYTES.to_string().as_bytes(),
+    )
+    .map_err(|source| InitError::Filesystem {
+        operation: "configure control memory protection in",
+        path: memory_min_path.display().to_string(),
+        source,
+    })?;
     verify_process_containment_base(base)?;
     eprintln!("[guest-init] Exec process containment initialized");
     Ok(())
@@ -287,6 +299,17 @@ fn verify_process_containment_base(base: &Path) -> Result<(), InitError> {
             "exec cgroup base contains direct processes".into(),
         ));
     }
+    let memory_min =
+        fs::read_to_string(base.join(MEMORY_MIN_FILE)).map_err(|source| InitError::Filesystem {
+            operation: "read",
+            path: base.join(MEMORY_MIN_FILE).display().to_string(),
+            source,
+        })?;
+    if memory_min.trim() != CONTROL_MEMORY_RESERVE_BYTES.to_string() {
+        return Err(InitError::InvalidProcessContainment(format!(
+            "exec cgroup base {MEMORY_MIN_FILE} does not preserve control memory"
+        )));
+    }
     Ok(())
 }
 
@@ -341,11 +364,15 @@ mod tests {
             (CGROUP_KILL_FILE, ""),
             (CGROUP_SUBTREE_CONTROL_FILE, subtree_control),
             (CPU_WEIGHT_FILE, "100\n"),
-            (MEMORY_MIN_FILE, "0\n"),
             (PIDS_MAX_FILE, "max\n"),
         ] {
             fs::write(base.join(filename), content).unwrap();
         }
+        fs::write(
+            base.join(MEMORY_MIN_FILE),
+            CONTROL_MEMORY_RESERVE_BYTES.to_string(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -457,5 +484,16 @@ mod tests {
         let error = verify_process_containment_base(dir.path()).unwrap_err();
 
         assert!(error.to_string().contains("direct processes"));
+    }
+
+    #[test]
+    fn process_containment_base_rejects_missing_ancestor_memory_protection() {
+        let dir = tempfile::tempdir().unwrap();
+        write_cgroup_core_files(dir.path(), "cpu memory pids\n");
+        fs::write(dir.path().join(MEMORY_MIN_FILE), "0\n").unwrap();
+
+        let error = verify_process_containment_base(dir.path()).unwrap_err();
+
+        assert!(error.to_string().contains("preserve control memory"));
     }
 }

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -16,12 +16,19 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use guest_contracts::process_containment::{CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH};
+use guest_contracts::process_containment::{
+    CGROUP_V2_MOUNT_PATH, EXEC_CGROUP_BASE_PATH, REQUIRED_CGROUP_CONTROLLERS,
+    REQUIRED_CGROUP_SUBTREE_CONTROL,
+};
 
+const CGROUP_CONTROLLERS_FILE: &str = "cgroup.controllers";
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
 const CGROUP_EVENTS_FILE: &str = "cgroup.events";
 const CGROUP_KILL_FILE: &str = "cgroup.kill";
 const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
+const CPU_WEIGHT_FILE: &str = "cpu.weight";
+const MEMORY_MIN_FILE: &str = "memory.min";
+const PIDS_MAX_FILE: &str = "pids.max";
 
 /// Initialize guest boot filesystems, exec process containment, and environment.
 ///
@@ -152,11 +159,9 @@ impl std::error::Error for InitError {}
 /// Mount cgroup v2 and validate the canonical exec process-containment base.
 ///
 /// Cgroup v2 is mounted at `CGROUP_V2_MOUNT_PATH`. The exec base at
-/// `EXEC_CGROUP_BASE_PATH` must expose `cgroup.procs`, `cgroup.events`,
-/// `cgroup.kill`, and `cgroup.subtree_control` as files, with no resource
-/// controllers enabled for its subtree. `vsock-guest` depends on this invariant
-/// for per-exec process cleanup and for validating quiescence before sandbox
-/// reuse.
+/// `EXEC_CGROUP_BASE_PATH` must be empty and distribute the `cpu`, `memory`,
+/// and `pids` controllers. `vsock-guest` creates an empty operation parent and
+/// two controlled leaves beneath it for each exec operation.
 fn initialize_process_containment() -> Result<(), InitError> {
     create_dir_all(Path::new(CGROUP_V2_MOUNT_PATH))?;
     mount(
@@ -171,11 +176,60 @@ fn initialize_process_containment() -> Result<(), InitError> {
         source,
     })?;
 
+    let mount = Path::new(CGROUP_V2_MOUNT_PATH);
+    enable_required_controllers(mount)?;
+
     let base = Path::new(EXEC_CGROUP_BASE_PATH);
     create_dir_all(base)?;
+    enable_required_controllers(base)?;
     verify_process_containment_base(base)?;
     eprintln!("[guest-init] Exec process containment initialized");
     Ok(())
+}
+
+fn enable_required_controllers(cgroup: &Path) -> Result<(), InitError> {
+    let controllers_path = cgroup.join(CGROUP_CONTROLLERS_FILE);
+    let controllers =
+        fs::read_to_string(&controllers_path).map_err(|source| InitError::Filesystem {
+            operation: "read",
+            path: controllers_path.display().to_string(),
+            source,
+        })?;
+    verify_required_controllers(&controllers, "available")?;
+
+    let subtree_control_path = cgroup.join(CGROUP_SUBTREE_CONTROL_FILE);
+    fs::write(
+        &subtree_control_path,
+        REQUIRED_CGROUP_SUBTREE_CONTROL.as_bytes(),
+    )
+    .map_err(|source| InitError::Filesystem {
+        operation: "enable required controllers in",
+        path: subtree_control_path.display().to_string(),
+        source,
+    })?;
+
+    let enabled =
+        fs::read_to_string(&subtree_control_path).map_err(|source| InitError::Filesystem {
+            operation: "read",
+            path: subtree_control_path.display().to_string(),
+            source,
+        })?;
+    verify_required_controllers(&enabled, "enabled")
+}
+
+fn verify_required_controllers(content: &str, state: &str) -> Result<(), InitError> {
+    let controllers = content.split_ascii_whitespace().collect::<Vec<_>>();
+    let missing = REQUIRED_CGROUP_CONTROLLERS
+        .into_iter()
+        .filter(|required| !controllers.contains(required))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(InitError::InvalidProcessContainment(format!(
+        "required cgroup controllers are not {state}: {}",
+        missing.join(",")
+    )))
 }
 
 fn create_dir_all(path: &Path) -> Result<(), InitError> {
@@ -188,10 +242,14 @@ fn create_dir_all(path: &Path) -> Result<(), InitError> {
 
 fn verify_process_containment_base(base: &Path) -> Result<(), InitError> {
     for filename in [
+        CGROUP_CONTROLLERS_FILE,
         CGROUP_PROCS_FILE,
         CGROUP_EVENTS_FILE,
         CGROUP_KILL_FILE,
         CGROUP_SUBTREE_CONTROL_FILE,
+        CPU_WEIGHT_FILE,
+        MEMORY_MIN_FILE,
+        PIDS_MAX_FILE,
     ] {
         let path = base.join(filename);
         let metadata = fs::metadata(&path).map_err(|source| InitError::Filesystem {
@@ -207,16 +265,26 @@ fn verify_process_containment_base(base: &Path) -> Result<(), InitError> {
         }
     }
 
-    let subtree_control_path = base.join(CGROUP_SUBTREE_CONTROL_FILE);
     let subtree_control =
-        fs::read_to_string(&subtree_control_path).map_err(|source| InitError::Filesystem {
-            operation: "read",
-            path: subtree_control_path.display().to_string(),
-            source,
+        fs::read_to_string(base.join(CGROUP_SUBTREE_CONTROL_FILE)).map_err(|source| {
+            InitError::Filesystem {
+                operation: "read",
+                path: base.join(CGROUP_SUBTREE_CONTROL_FILE).display().to_string(),
+                source,
+            }
         })?;
-    if !subtree_control.trim().is_empty() {
+    verify_required_controllers(&subtree_control, "enabled")?;
+
+    let direct_processes = fs::read_to_string(base.join(CGROUP_PROCS_FILE)).map_err(|source| {
+        InitError::Filesystem {
+            operation: "read",
+            path: base.join(CGROUP_PROCS_FILE).display().to_string(),
+            source,
+        }
+    })?;
+    if !direct_processes.trim().is_empty() {
         return Err(InitError::InvalidProcessContainment(
-            "resource controllers are enabled for the exec subtree".into(),
+            "exec cgroup base contains direct processes".into(),
         ));
     }
     Ok(())
@@ -267,10 +335,14 @@ mod tests {
     fn write_cgroup_core_files(base: &Path, subtree_control: &str) {
         fs::create_dir_all(base).unwrap();
         for (filename, content) in [
+            (CGROUP_CONTROLLERS_FILE, "cpu memory pids\n"),
             (CGROUP_PROCS_FILE, ""),
             (CGROUP_EVENTS_FILE, "populated 0\nfrozen 0\n"),
             (CGROUP_KILL_FILE, ""),
             (CGROUP_SUBTREE_CONTROL_FILE, subtree_control),
+            (CPU_WEIGHT_FILE, "100\n"),
+            (MEMORY_MIN_FILE, "0\n"),
+            (PIDS_MAX_FILE, "max\n"),
         ] {
             fs::write(base.join(filename), content).unwrap();
         }
@@ -359,20 +431,31 @@ mod tests {
     }
 
     #[test]
-    fn process_containment_base_rejects_enabled_controllers() {
+    fn process_containment_base_rejects_missing_controller() {
         let dir = tempfile::tempdir().unwrap();
-        write_cgroup_core_files(dir.path(), "+memory\n");
+        write_cgroup_core_files(dir.path(), "cpu memory\n");
 
         let error = verify_process_containment_base(dir.path()).unwrap_err();
 
-        assert!(error.to_string().contains("resource controllers"));
+        assert!(error.to_string().contains("pids"));
     }
 
     #[test]
-    fn process_containment_base_accepts_controller_free_core_files() {
+    fn process_containment_base_accepts_required_controllers() {
         let dir = tempfile::tempdir().unwrap();
-        write_cgroup_core_files(dir.path(), "\n");
+        write_cgroup_core_files(dir.path(), "cpu memory pids\n");
 
         verify_process_containment_base(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn process_containment_base_rejects_direct_processes() {
+        let dir = tempfile::tempdir().unwrap();
+        write_cgroup_core_files(dir.path(), "cpu memory pids\n");
+        fs::write(dir.path().join(CGROUP_PROCS_FILE), "123\n").unwrap();
+
+        let error = verify_process_containment_base(dir.path()).unwrap_err();
+
+        assert!(error.to_string().contains("direct processes"));
     }
 }

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -101,9 +101,9 @@ pub fn init_filesystem() -> Result<(), InitError> {
     //
     // /etc/environment is baked into the rootfs by customize-rootfs.sh and
     // contains variables shared by ALL users (LANG, NODE_EXTRA_CA_CERTS, …).
-    // PAM reads it for login shells (`su - user`), but the init process
-    // (root) and its children (vsock-guest → `sh -c`) don't go through PAM,
-    // so we load it explicitly here.
+    // PAM also reads it during sandbox-user transitions, but the init process
+    // (root) and its direct children do not go through PAM, so we load it
+    // explicitly here.
     //
     // SAFETY: We are the init process, no other threads are running yet
     unsafe {
@@ -113,8 +113,8 @@ pub fn init_filesystem() -> Result<(), InitError> {
         std::env::set_var("SHELL", "/bin/bash");
     }
 
-    // 6. Change to root home directory (init runs as root;
-    // `su - user` will cd to /home/user automatically)
+    // 6. Change to root home directory. The command launcher selects the
+    // sandbox user's home explicitly when it transitions users.
     let _ = std::env::set_current_dir("/root");
 
     eprintln!("[guest-init] Filesystem initialization complete");

--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -5,7 +5,10 @@
 //! This crate defines the local, blocking protocol used after `vsock-guest`
 //! exposes an operation-control endpoint and `guest-agent` connects back to it.
 //! The transport is a Linux abstract Unix stream socket. Endpoint names are
-//! abstract-socket names, not filesystem paths.
+//! abstract-socket names, not filesystem paths. A second operation-local
+//! endpoint transfers one root-owned workload-placement descriptor with
+//! `SCM_RIGHTS`; the descriptor is never inherited through the sandbox-user
+//! launch chain.
 //!
 //! The endpoint is bootstrapped through [`BOOTSTRAP_ENV`]. `vsock-guest`
 //! creates the endpoint name with [`endpoint_name`], binds it with
@@ -64,7 +67,10 @@ mod transport;
 pub use codec::{
     read_hello, read_request, read_response, write_hello, write_request, write_response,
 };
-pub use transport::{accept_with_timeout, bind_abstract_listener, connect_abstract, endpoint_name};
+pub use transport::{
+    accept_with_timeout, bind_abstract_listener, connect_abstract, endpoint_name,
+    receive_workload_placement, send_workload_placement,
+};
 
 /// Environment variable carrying the operation-control abstract socket name.
 ///

--- a/crates/process-control-ipc/src/transport.rs
+++ b/crates/process-control-ipc/src/transport.rs
@@ -146,7 +146,7 @@ pub fn send_workload_placement(stream: &UnixStream, placement: BorrowedFd<'_>) -
     message.msg_iov = &mut iov;
     message.msg_iovlen = 1;
     message.msg_control = ancillary.as_mut_ptr().cast();
-    message.msg_controllen = control_len;
+    message.msg_controllen = ancillary_length(control_len)?;
 
     // SAFETY: message owns a suitably aligned ancillary buffer large enough
     // for one cmsghdr plus one RawFd payload.
@@ -161,7 +161,7 @@ pub fn send_workload_placement(stream: &UnixStream, placement: BorrowedFd<'_>) -
     unsafe {
         (*header).cmsg_level = libc::SOL_SOCKET;
         (*header).cmsg_type = libc::SCM_RIGHTS;
-        (*header).cmsg_len = cmsg_len_for_one_fd();
+        (*header).cmsg_len = ancillary_length(cmsg_len_for_one_fd())?;
         std::ptr::write_unaligned(
             libc::CMSG_DATA(header).cast::<libc::c_int>(),
             placement.as_raw_fd(),
@@ -213,7 +213,7 @@ pub fn receive_workload_placement(stream: &UnixStream) -> io::Result<OwnedFd> {
     message.msg_iov = &mut iov;
     message.msg_iovlen = 1;
     message.msg_control = ancillary.as_mut_ptr().cast();
-    message.msg_controllen = std::mem::size_of_val(&ancillary);
+    message.msg_controllen = ancillary_length(std::mem::size_of_val(&ancillary))?;
 
     let received = loop {
         // SAFETY: message references writable marker, iovec, and ancillary
@@ -273,12 +273,12 @@ fn received_rights_descriptors(message: &libc::msghdr) -> Vec<libc::c_int> {
         // SAFETY: header is a valid ancillary header returned by the CMSG
         // traversal helpers.
         let current = unsafe { &*header };
+        let current_len = ancillary_length_usize(current.cmsg_len);
         if current.cmsg_level == libc::SOL_SOCKET
             && current.cmsg_type == libc::SCM_RIGHTS
-            && current.cmsg_len >= cmsg_len_for_one_fd()
+            && current_len >= cmsg_len_for_one_fd()
         {
-            let payload_bytes = current
-                .cmsg_len
+            let payload_bytes = current_len
                 .saturating_sub(cmsg_len_for_one_fd() - std::mem::size_of::<libc::c_int>());
             let count = payload_bytes / std::mem::size_of::<libc::c_int>();
             // SAFETY: CMSG_DATA points at `count` complete RawFd values inside
@@ -301,6 +301,31 @@ fn close_raw_descriptors(descriptors: &[libc::c_int]) {
         // the malformed-bootstrap path.
         unsafe { libc::close(*descriptor) };
     }
+}
+
+#[cfg(target_env = "musl")]
+fn ancillary_length(length: usize) -> io::Result<libc::socklen_t> {
+    libc::socklen_t::try_from(length).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "workload placement ancillary length is out of range",
+        )
+    })
+}
+
+#[cfg(not(target_env = "musl"))]
+fn ancillary_length(length: usize) -> io::Result<usize> {
+    Ok(length)
+}
+
+#[cfg(target_env = "musl")]
+fn ancillary_length_usize(length: libc::socklen_t) -> usize {
+    length as usize
+}
+
+#[cfg(not(target_env = "musl"))]
+fn ancillary_length_usize(length: usize) -> usize {
+    length
 }
 
 /// Accept one stream from an operation-control listener before `timeout` elapses.

--- a/crates/process-control-ipc/src/transport.rs
+++ b/crates/process-control-ipc/src/transport.rs
@@ -1,12 +1,14 @@
 use std::io;
 use std::mem::{MaybeUninit, size_of};
-use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::time::{Duration, Instant};
 
 const ENDPOINT_PREFIX: &str = "vm0-process-control-";
 const MAX_U32_DECIMAL_DIGITS: usize = 10;
 const NONCE_HEX_LEN: usize = 16 * 2;
+const WORKLOAD_PLACEMENT_MARKER: u8 = 0x57;
+const ANCILLARY_BUFFER_WORDS: usize = 8;
 
 /// Build the abstract socket name for an operation-control endpoint.
 ///
@@ -85,11 +87,10 @@ pub fn bind_abstract_listener(name: &str) -> io::Result<UnixListener> {
     Ok(unsafe { UnixListener::from_raw_fd(fd.into_raw_fd()) })
 }
 
-/// Connect to a Linux abstract Unix operation-control endpoint.
+/// Connect to a Linux abstract Unix operation-local endpoint.
 ///
-/// `name` is an abstract socket name, not a filesystem path. A newly connected
-/// guest-agent side stream must send [`crate::write_hello`] before the server
-/// side treats the sink as connected.
+/// `name` is an abstract socket name, not a filesystem path. The caller must
+/// perform the handshake required by the endpoint's protocol after connecting.
 ///
 /// # Errors
 ///
@@ -113,6 +114,193 @@ pub fn connect_abstract(name: &str) -> io::Result<UnixStream> {
     }
     // SAFETY: fd is a valid connected stream and ownership is transferred.
     Ok(unsafe { UnixStream::from_raw_fd(fd.into_raw_fd()) })
+}
+
+/// Send one workload-placement descriptor over a connected control stream.
+///
+/// The descriptor is transferred with `SCM_RIGHTS` alongside a one-byte
+/// bootstrap marker. The sender retains ownership of its descriptor. This is
+/// used on a dedicated authenticated bootstrap connection so the root guest
+/// supervisor never has to make the capability inheritable across a
+/// sandbox-user transition.
+///
+/// # Errors
+///
+/// Socket errors are returned as standard [`io::Error`] values. A short send
+/// is reported as [`io::ErrorKind::WriteZero`].
+pub fn send_workload_placement(stream: &UnixStream, placement: BorrowedFd<'_>) -> io::Result<()> {
+    let marker = [WORKLOAD_PLACEMENT_MARKER];
+    let mut iov = libc::iovec {
+        iov_base: marker.as_ptr().cast_mut().cast(),
+        iov_len: marker.len(),
+    };
+    let mut ancillary = [0_usize; ANCILLARY_BUFFER_WORDS];
+    let control_len = cmsg_space_for_one_fd();
+    if control_len > std::mem::size_of_val(&ancillary) {
+        return Err(io::Error::other(
+            "workload placement ancillary buffer is too small",
+        ));
+    }
+    // SAFETY: a zeroed msghdr is initialized below before sendmsg reads it.
+    let mut message = unsafe { MaybeUninit::<libc::msghdr>::zeroed().assume_init() };
+    message.msg_iov = &mut iov;
+    message.msg_iovlen = 1;
+    message.msg_control = ancillary.as_mut_ptr().cast();
+    message.msg_controllen = control_len;
+
+    // SAFETY: message owns a suitably aligned ancillary buffer large enough
+    // for one cmsghdr plus one RawFd payload.
+    let header = unsafe { libc::CMSG_FIRSTHDR(&message) };
+    if header.is_null() {
+        return Err(io::Error::other(
+            "workload placement ancillary header is unavailable",
+        ));
+    }
+    // SAFETY: header points into the initialized ancillary buffer and its data
+    // region is large enough for one RawFd.
+    unsafe {
+        (*header).cmsg_level = libc::SOL_SOCKET;
+        (*header).cmsg_type = libc::SCM_RIGHTS;
+        (*header).cmsg_len = cmsg_len_for_one_fd();
+        std::ptr::write_unaligned(
+            libc::CMSG_DATA(header).cast::<libc::c_int>(),
+            placement.as_raw_fd(),
+        );
+    }
+
+    loop {
+        // SAFETY: message references live marker, iovec, and ancillary buffers
+        // for the duration of this call.
+        let sent = unsafe { libc::sendmsg(stream.as_raw_fd(), &message, libc::MSG_NOSIGNAL) };
+        if sent == 1 {
+            return Ok(());
+        }
+        if sent < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "workload placement bootstrap marker was not sent",
+        ));
+    }
+}
+
+/// Receive one workload-placement descriptor from a connected control stream.
+///
+/// The returned descriptor has close-on-exec set atomically by
+/// `MSG_CMSG_CLOEXEC`. Exactly one `SCM_RIGHTS` descriptor and the expected
+/// one-byte bootstrap marker are required; malformed ancillary data is rejected
+/// and any received descriptors are closed before returning an error.
+///
+/// # Errors
+///
+/// Socket errors are returned as standard [`io::Error`] values. Missing,
+/// truncated, or malformed descriptor bootstrap data returns
+/// [`io::ErrorKind::InvalidData`].
+pub fn receive_workload_placement(stream: &UnixStream) -> io::Result<OwnedFd> {
+    let mut marker = [0_u8; 1];
+    let mut iov = libc::iovec {
+        iov_base: marker.as_mut_ptr().cast(),
+        iov_len: marker.len(),
+    };
+    let mut ancillary = [0_usize; ANCILLARY_BUFFER_WORDS];
+    // SAFETY: a zeroed msghdr is initialized below before recvmsg writes it.
+    let mut message = unsafe { MaybeUninit::<libc::msghdr>::zeroed().assume_init() };
+    message.msg_iov = &mut iov;
+    message.msg_iovlen = 1;
+    message.msg_control = ancillary.as_mut_ptr().cast();
+    message.msg_controllen = std::mem::size_of_val(&ancillary);
+
+    let received = loop {
+        // SAFETY: message references writable marker, iovec, and ancillary
+        // buffers for the duration of this call.
+        let received =
+            unsafe { libc::recvmsg(stream.as_raw_fd(), &mut message, libc::MSG_CMSG_CLOEXEC) };
+        if received >= 0 {
+            break received;
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    };
+
+    let descriptors = received_rights_descriptors(&message);
+    let valid = received == 1
+        && marker == [WORKLOAD_PLACEMENT_MARKER]
+        && message.msg_flags & (libc::MSG_CTRUNC | libc::MSG_TRUNC) == 0
+        && descriptors.len() == 1;
+    if !valid {
+        close_raw_descriptors(&descriptors);
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid workload placement descriptor bootstrap",
+        ));
+    }
+
+    let descriptor = descriptors.into_iter().next().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "workload placement descriptor bootstrap was empty",
+        )
+    })?;
+    // SAFETY: recvmsg installed this descriptor for the receiving process, it
+    // appears exactly once in the validated rights message, and ownership is
+    // transferred to the returned OwnedFd.
+    Ok(unsafe { OwnedFd::from_raw_fd(descriptor) })
+}
+
+fn cmsg_space_for_one_fd() -> usize {
+    // SAFETY: CMSG_SPACE performs only the platform alignment calculation.
+    unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::c_int>() as _) as usize }
+}
+
+fn cmsg_len_for_one_fd() -> usize {
+    // SAFETY: CMSG_LEN performs only the platform alignment calculation.
+    unsafe { libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as _) as usize }
+}
+
+fn received_rights_descriptors(message: &libc::msghdr) -> Vec<libc::c_int> {
+    let mut descriptors = Vec::new();
+    // SAFETY: message and its ancillary buffer were initialized by recvmsg;
+    // CMSG_FIRSTHDR/CMSG_NXTHDR stay within msg_controllen.
+    let mut header = unsafe { libc::CMSG_FIRSTHDR(message) };
+    while !header.is_null() {
+        // SAFETY: header is a valid ancillary header returned by the CMSG
+        // traversal helpers.
+        let current = unsafe { &*header };
+        if current.cmsg_level == libc::SOL_SOCKET
+            && current.cmsg_type == libc::SCM_RIGHTS
+            && current.cmsg_len >= cmsg_len_for_one_fd()
+        {
+            let payload_bytes = current
+                .cmsg_len
+                .saturating_sub(cmsg_len_for_one_fd() - std::mem::size_of::<libc::c_int>());
+            let count = payload_bytes / std::mem::size_of::<libc::c_int>();
+            // SAFETY: CMSG_DATA points at `count` complete RawFd values inside
+            // the current ancillary record.
+            let data = unsafe { libc::CMSG_DATA(header).cast::<libc::c_int>() };
+            for index in 0..count {
+                // SAFETY: index is bounded by the validated ancillary payload.
+                descriptors.push(unsafe { std::ptr::read_unaligned(data.add(index)) });
+            }
+        }
+        // SAFETY: header belongs to message's ancillary buffer.
+        header = unsafe { libc::CMSG_NXTHDR(message, header) };
+    }
+    descriptors
+}
+
+fn close_raw_descriptors(descriptors: &[libc::c_int]) {
+    for descriptor in descriptors {
+        // SAFETY: each descriptor was installed by recvmsg and is discarded on
+        // the malformed-bootstrap path.
+        unsafe { libc::close(*descriptor) };
+    }
 }
 
 /// Accept one stream from an operation-control listener before `timeout` elapses.
@@ -238,6 +426,8 @@ fn poll_fd(fd: libc::c_int, events: libc::c_short, deadline: Instant) -> io::Res
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::MetadataExt;
 
     fn bind_test_listener(case: &str) -> (String, UnixListener) {
         let name = format!("vm0-test-{case}-{}", std::process::id());
@@ -317,6 +507,39 @@ mod tests {
         let server = accept_with_timeout(&listener, Duration::from_secs(1)).unwrap();
         let _client = client.join().unwrap();
         drop(server);
+    }
+
+    #[test]
+    fn workload_placement_descriptor_round_trips_close_on_exec() {
+        let (sender, receiver) = UnixStream::pair().unwrap();
+        let placement = std::fs::File::open("/dev/null").unwrap();
+        let expected = placement.metadata().unwrap();
+        let send = std::thread::spawn(move || {
+            send_workload_placement(&sender, placement.as_fd()).unwrap();
+        });
+
+        let received = receive_workload_placement(&receiver).unwrap();
+        send.join().unwrap();
+        let received = std::fs::File::from(received);
+        let actual = received.metadata().unwrap();
+        assert_eq!(actual.dev(), expected.dev());
+        assert_eq!(actual.ino(), expected.ino());
+        // SAFETY: F_GETFD only inspects the valid received descriptor.
+        let flags = unsafe { libc::fcntl(received.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0);
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+
+    #[test]
+    fn workload_placement_descriptor_requires_ancillary_rights() {
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        std::thread::spawn(move || {
+            use std::io::Write;
+            sender.write_all(&[WORKLOAD_PLACEMENT_MARKER]).unwrap();
+        });
+
+        let error = receive_workload_placement(&receiver).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -7,6 +7,7 @@
 use guest_contracts::diagnostics::{
     CliObservedExitDiagnostic, CliObservedExitKind, CliTerminationDiagnostic,
     EventDeliveryDiagnostic, FailureClass, FailureDiagnostic, FailureReason,
+    WorkloadResourceLimitDiagnostic,
 };
 use tracing::info;
 
@@ -47,6 +48,9 @@ fn log_job_execution_failed(
     );
     let event_delivery_fields = JobEventDeliveryLogFields::from(
         diagnostic.and_then(|diagnostic| diagnostic.event_delivery.as_ref()),
+    );
+    let workload_resource_fields = JobWorkloadResourceLogFields::from(
+        diagnostic.and_then(|diagnostic| diagnostic.workload_resource_limit.as_ref()),
     );
     let resource_fields = JobResourceLogFields::from(failure.resource_diagnostics);
     let (timeout_ms, elapsed_ms, guest_duration_ms) = match failure.kind {
@@ -151,6 +155,13 @@ fn log_job_execution_failed(
                     event_delivery_fields.drain_active_attempt_elapsed_ms,
                 event_delivery_drain_active_outcome =
                     event_delivery_fields.drain_active_outcome,
+                workload_memory_max_events = workload_resource_fields.memory_max_events,
+                workload_memory_oom_events = workload_resource_fields.memory_oom_events,
+                workload_memory_oom_kill_events =
+                    workload_resource_fields.memory_oom_kill_events,
+                workload_memory_oom_group_kill_events =
+                    workload_resource_fields.memory_oom_group_kill_events,
+                workload_pids_max_events = workload_resource_fields.pids_max_events,
                 resource_failure_kind = resource_fields.resource_failure_kind,
                 guest_root_fs_used_percent = resource_fields.guest_root_fs_used_percent,
                 guest_root_fs_available_kb = resource_fields.guest_root_fs_available_kb,
@@ -188,6 +199,14 @@ struct JobResourceLogFields {
     guest_root_fs_available_inodes: Option<u64>,
     guest_workspace_fs_used_percent: Option<u64>,
     guest_memory_available_mb: Option<u64>,
+}
+
+struct JobWorkloadResourceLogFields {
+    memory_max_events: Option<u64>,
+    memory_oom_events: Option<u64>,
+    memory_oom_kill_events: Option<u64>,
+    memory_oom_group_kill_events: Option<u64>,
+    pids_max_events: Option<u64>,
 }
 
 struct JobCliTerminationLogFields {
@@ -355,6 +374,19 @@ impl From<Option<executor::ResourceFailureDiagnostics>> for JobResourceLogFields
     }
 }
 
+impl From<Option<&WorkloadResourceLimitDiagnostic>> for JobWorkloadResourceLogFields {
+    fn from(diagnostic: Option<&WorkloadResourceLimitDiagnostic>) -> Self {
+        Self {
+            memory_max_events: diagnostic.map(|diagnostic| diagnostic.memory_max_events),
+            memory_oom_events: diagnostic.map(|diagnostic| diagnostic.memory_oom_events),
+            memory_oom_kill_events: diagnostic.map(|diagnostic| diagnostic.memory_oom_kill_events),
+            memory_oom_group_kill_events: diagnostic
+                .map(|diagnostic| diagnostic.memory_oom_group_kill_events),
+            pids_max_events: diagnostic.map(|diagnostic| diagnostic.pids_max_events),
+        }
+    }
+}
+
 fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
     match diagnostic.failure_class {
         FailureClass::CliNonzero => matches!(
@@ -389,7 +421,7 @@ mod tests {
         EventDeliveryActiveBatchDiagnostic, EventDeliveryAttemptFailureKind,
         EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
         EventDeliveryDrainTimeoutDiagnostic, EventDeliveryFailedBatchDiagnostic, FailureClass,
-        FailureDetailSource, PromptMetadata, SessionHistoryStatus,
+        FailureDetailSource, PromptMetadata, SessionHistoryStatus, WorkloadResourceLimitDiagnostic,
     };
     use tracing::Level;
     use tracing_subscriber::prelude::*;
@@ -928,6 +960,32 @@ mod tests {
         assert_field_eq(&event, "guest_root_fs_available_inodes", "42");
         assert_field_eq(&event, "guest_workspace_fs_used_percent", "1");
         assert_field_eq(&event, "guest_memory_available_mb", "624");
+    }
+
+    #[test]
+    fn workload_resource_limit_logs_structured_counters() {
+        let diagnostic = job_failure_diagnostic(None).with_workload_resource_limit(
+            WorkloadResourceLimitDiagnostic {
+                memory_max_events: 5,
+                memory_oom_events: 2,
+                memory_oom_kill_events: 1,
+                memory_oom_group_kill_events: 0,
+                pids_max_events: 3,
+            },
+        );
+        let failure = executor::ExecutionFailure::new(
+            137,
+            "Agent workload reached its memory limit",
+            Some(diagnostic),
+        );
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_field_eq(&event, "workload_memory_max_events", "5");
+        assert_field_eq(&event, "workload_memory_oom_events", "2");
+        assert_field_eq(&event, "workload_memory_oom_kill_events", "1");
+        assert_field_eq(&event, "workload_memory_oom_group_kill_events", "0");
+        assert_field_eq(&event, "workload_pids_max_events", "3");
     }
 
     #[test]

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -47,7 +47,9 @@ use std::path::{Path, PathBuf};
 use nix::fcntl::Flock;
 use serde::{Deserialize, Serialize};
 
-use guest_contracts::process_containment::WorkloadResourcePolicy;
+use guest_contracts::process_containment::{
+    MIN_PROFILE_MEMORY_MB, MIN_PROFILE_VCPU, WorkloadResourcePolicy,
+};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
@@ -543,9 +545,21 @@ async fn validate(
                 profile.vcpu
             )));
         }
+        if profile.vcpu < MIN_PROFILE_VCPU {
+            return Err(RunnerError::Config(format!(
+                "profile {name}: vcpu ({}) is below workload-containment minimum ({MIN_PROFILE_VCPU})",
+                profile.vcpu
+            )));
+        }
         if profile.memory_mb > MAX_MEMORY_MB {
             return Err(RunnerError::Config(format!(
                 "profile {name}: memory_mb ({}) exceeds maximum ({MAX_MEMORY_MB})",
+                profile.memory_mb
+            )));
+        }
+        if profile.memory_mb < MIN_PROFILE_MEMORY_MB {
+            return Err(RunnerError::Config(format!(
+                "profile {name}: memory_mb ({}) is below workload-containment minimum ({MIN_PROFILE_MEMORY_MB})",
                 profile.memory_mb
             )));
         }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -47,7 +47,7 @@ use std::path::{Path, PathBuf};
 use nix::fcntl::Flock;
 use serde::{Deserialize, Serialize};
 
-use guest_contracts::process_containment::{MIN_PROFILE_MEMORY_MB, MIN_PROFILE_VCPU};
+use guest_contracts::process_containment::WorkloadResourcePolicy;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
@@ -543,24 +543,17 @@ async fn validate(
                 profile.vcpu
             )));
         }
-        if profile.vcpu < MIN_PROFILE_VCPU {
-            return Err(RunnerError::Config(format!(
-                "profile {name}: vcpu ({}) is below workload-containment minimum ({MIN_PROFILE_VCPU})",
-                profile.vcpu
-            )));
-        }
         if profile.memory_mb > MAX_MEMORY_MB {
             return Err(RunnerError::Config(format!(
                 "profile {name}: memory_mb ({}) exceeds maximum ({MAX_MEMORY_MB})",
                 profile.memory_mb
             )));
         }
-        if profile.memory_mb < MIN_PROFILE_MEMORY_MB {
-            return Err(RunnerError::Config(format!(
-                "profile {name}: memory_mb ({}) is below workload-containment minimum ({MIN_PROFILE_MEMORY_MB})",
-                profile.memory_mb
-            )));
-        }
+        WorkloadResourcePolicy::for_guest_capacity(
+            profile.vcpu,
+            u64::from(profile.memory_mb) * 1024 * 1024,
+        )
+        .map_err(|error| RunnerError::Config(format!("profile {name}: {error}")))?;
         if profile.rootfs_disk_mb > MAX_DISK_MB {
             return Err(RunnerError::Config(format!(
                 "profile {name}: rootfs_disk_mb ({}) exceeds maximum ({MAX_DISK_MB})",

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -47,6 +47,8 @@ use std::path::{Path, PathBuf};
 use nix::fcntl::Flock;
 use serde::{Deserialize, Serialize};
 
+use guest_contracts::process_containment::{MIN_PROFILE_MEMORY_MB, MIN_PROFILE_VCPU};
+
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
 use crate::paths::{HomePaths, RootfsPaths, SnapshotPaths};
@@ -118,9 +120,9 @@ pub struct ProfileConfig {
     /// Host-local snapshot identity, covering rootfs identity plus VM shape,
     /// workspace disk size, and provider/runtime inputs.
     pub snapshot_hash: String,
-    /// Guest vCPU count. Must be non-zero and ≤ 1024.
+    /// Guest vCPU count. Must support Guest workload containment and be ≤ 1024.
     pub vcpu: u32,
-    /// Guest RAM in MiB. Must be non-zero and ≤ 1 TiB.
+    /// Guest RAM in MiB. Must support Guest workload containment and be ≤ 1 TiB.
     pub memory_mb: u32,
     /// Rootfs disk in MiB. Used to size the bootable rootfs image.
     /// Must be non-zero and ≤ 1 TiB.
@@ -541,9 +543,21 @@ async fn validate(
                 profile.vcpu
             )));
         }
+        if profile.vcpu < MIN_PROFILE_VCPU {
+            return Err(RunnerError::Config(format!(
+                "profile {name}: vcpu ({}) is below workload-containment minimum ({MIN_PROFILE_VCPU})",
+                profile.vcpu
+            )));
+        }
         if profile.memory_mb > MAX_MEMORY_MB {
             return Err(RunnerError::Config(format!(
                 "profile {name}: memory_mb ({}) exceeds maximum ({MAX_MEMORY_MB})",
+                profile.memory_mb
+            )));
+        }
+        if profile.memory_mb < MIN_PROFILE_MEMORY_MB {
+            return Err(RunnerError::Config(format!(
+                "profile {name}: memory_mb ({}) is below workload-containment minimum ({MIN_PROFILE_MEMORY_MB})",
                 profile.memory_mb
             )));
         }

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -522,7 +522,7 @@ async fn load_rejects_zero_memory_mb_in_profile() {
 }
 
 #[tokio::test]
-async fn load_accepts_profile_below_default_calibration() {
+async fn load_accepts_calibrated_minimum_profile() {
     let fixture = ConfigFixture::new().await;
     let yaml = fixture.yaml_with_profile(
         "vm0/default",
@@ -540,12 +540,12 @@ async fn load_accepts_profile_below_default_calibration() {
 }
 
 #[tokio::test]
-async fn load_rejects_memory_without_fixed_containment_headroom() {
+async fn load_rejects_memory_below_calibrated_minimum() {
     let fixture = ConfigFixture::without_image_artifacts().await;
     let yaml = fixture.yaml_with_profile(
         "vm0/default",
         ProfileConfig {
-            memory_mb: 640,
+            memory_mb: 1023,
             ..default_profile_config()
         },
         "",
@@ -554,7 +554,27 @@ async fn load_rejects_memory_without_fixed_containment_headroom() {
     let err = fixture.load_config(&yaml, true).await.unwrap_err();
     assert!(
         err.to_string()
-            .contains("cannot provide a workload high threshold"),
+            .contains("below workload-containment minimum (1024)"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn load_rejects_arithmetic_only_memory_remainder() {
+    let fixture = ConfigFixture::without_image_artifacts().await;
+    let yaml = fixture.yaml_with_profile(
+        "vm0/default",
+        ProfileConfig {
+            memory_mb: 641,
+            ..default_profile_config()
+        },
+        "",
+    );
+
+    let err = fixture.load_config(&yaml, true).await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("below workload-containment minimum (1024)"),
         "got: {err}"
     );
 }

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -522,23 +522,21 @@ async fn load_rejects_zero_memory_mb_in_profile() {
 }
 
 #[tokio::test]
-async fn load_rejects_vcpu_below_workload_containment_minimum() {
-    let fixture = ConfigFixture::without_image_artifacts().await;
+async fn load_accepts_profile_at_workload_containment_boundary() {
+    let fixture = ConfigFixture::new().await;
     let yaml = fixture.yaml_with_profile(
         "vm0/default",
         ProfileConfig {
-            vcpu: MIN_PROFILE_VCPU - 1,
+            vcpu: 1,
+            memory_mb: 768,
             ..default_profile_config()
         },
         "",
     );
 
-    let err = fixture.load_config(&yaml, true).await.unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("below workload-containment minimum"),
-        "got: {err}"
-    );
+    let config = fixture.load_config(&yaml, true).await.unwrap();
+    assert_eq!(config.profiles["vm0/default"].vcpu, 1);
+    assert_eq!(config.profiles["vm0/default"].memory_mb, 768);
 }
 
 #[tokio::test]
@@ -547,7 +545,7 @@ async fn load_rejects_memory_below_workload_containment_minimum() {
     let yaml = fixture.yaml_with_profile(
         "vm0/default",
         ProfileConfig {
-            memory_mb: MIN_PROFILE_MEMORY_MB - 1,
+            memory_mb: 767,
             ..default_profile_config()
         },
         "",
@@ -555,8 +553,7 @@ async fn load_rejects_memory_below_workload_containment_minimum() {
 
     let err = fixture.load_config(&yaml, true).await.unwrap_err();
     assert!(
-        err.to_string()
-            .contains("below workload-containment minimum"),
+        err.to_string().contains("cannot preserve control headroom"),
         "got: {err}"
     );
 }

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -522,6 +522,46 @@ async fn load_rejects_zero_memory_mb_in_profile() {
 }
 
 #[tokio::test]
+async fn load_rejects_vcpu_below_workload_containment_minimum() {
+    let fixture = ConfigFixture::without_image_artifacts().await;
+    let yaml = fixture.yaml_with_profile(
+        "vm0/default",
+        ProfileConfig {
+            vcpu: MIN_PROFILE_VCPU - 1,
+            ..default_profile_config()
+        },
+        "",
+    );
+
+    let err = fixture.load_config(&yaml, true).await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("below workload-containment minimum"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn load_rejects_memory_below_workload_containment_minimum() {
+    let fixture = ConfigFixture::without_image_artifacts().await;
+    let yaml = fixture.yaml_with_profile(
+        "vm0/default",
+        ProfileConfig {
+            memory_mb: MIN_PROFILE_MEMORY_MB - 1,
+            ..default_profile_config()
+        },
+        "",
+    );
+
+    let err = fixture.load_config(&yaml, true).await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("below workload-containment minimum"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
 async fn load_rejects_zero_rootfs_disk_mb_in_profile() {
     let fixture = ConfigFixture::without_image_artifacts().await;
     let yaml = fixture.yaml_with_profile(

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -522,13 +522,13 @@ async fn load_rejects_zero_memory_mb_in_profile() {
 }
 
 #[tokio::test]
-async fn load_accepts_profile_at_workload_containment_boundary() {
+async fn load_accepts_profile_below_default_calibration() {
     let fixture = ConfigFixture::new().await;
     let yaml = fixture.yaml_with_profile(
         "vm0/default",
         ProfileConfig {
             vcpu: 1,
-            memory_mb: 768,
+            memory_mb: 1024,
             ..default_profile_config()
         },
         "",
@@ -536,16 +536,16 @@ async fn load_accepts_profile_at_workload_containment_boundary() {
 
     let config = fixture.load_config(&yaml, true).await.unwrap();
     assert_eq!(config.profiles["vm0/default"].vcpu, 1);
-    assert_eq!(config.profiles["vm0/default"].memory_mb, 768);
+    assert_eq!(config.profiles["vm0/default"].memory_mb, 1024);
 }
 
 #[tokio::test]
-async fn load_rejects_memory_below_workload_containment_minimum() {
+async fn load_rejects_memory_without_fixed_containment_headroom() {
     let fixture = ConfigFixture::without_image_artifacts().await;
     let yaml = fixture.yaml_with_profile(
         "vm0/default",
         ProfileConfig {
-            memory_mb: 767,
+            memory_mb: 640,
             ..default_profile_config()
         },
         "",
@@ -553,7 +553,8 @@ async fn load_rejects_memory_below_workload_containment_minimum() {
 
     let err = fixture.load_config(&yaml, true).await.unwrap_err();
     assert!(
-        err.to_string().contains("cannot preserve control headroom"),
+        err.to_string()
+            .contains("cannot provide a workload high threshold"),
         "got: {err}"
     );
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -30,9 +30,9 @@ use super::diagnostics::{
     AgentBootstrapAbnormalExitLogContext, AgentEnvDiagnostics, AgentStdoutStreamDiagnostics,
     StdoutDrainReport, build_agent_env_diagnostics, build_agent_env_key_diagnostics,
     check_host_oom, collect_agent_abnormal_exit_diagnostics, dmesg_indicates_oom,
-    drain_stdout_to_file, explicit_enospc_evidence, log_agent_abnormal_exit_env_diagnostics,
-    log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,
-    read_guest_error_file, read_guest_failure_diagnostic_file,
+    drain_stdout_to_file, explicit_enospc_evidence, failure_diagnostic_reports_workload_memory_oom,
+    log_agent_abnormal_exit_env_diagnostics, log_agent_bootstrap_abnormal_exit_diagnostics,
+    log_agent_process_exit_summary, read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
     should_collect_unattributed_sigkill_resource_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
@@ -2409,10 +2409,20 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         stdout_stream_diagnostics,
     );
 
+    let failure_diagnostic = if !cancellation_observed && process_failed(&exit) {
+        read_guest_failure_diagnostic_file(sandbox, context.run_id).await
+    } else {
+        None
+    };
+
     // Check for OOM kill when process was terminated by SIGKILL. Skip only
     // after hard fallback, where the SIGKILL exit code is synthetic. A
-    // cooperative guest exit remains real process evidence.
-    if !used_hard_cancellation_fallback && process_exit_oom_candidate(&exit) {
+    // cooperative guest exit remains real process evidence. A guest-authored
+    // workload OOM diagnostic is more specific than VM-wide dmesg output.
+    if !used_hard_cancellation_fallback
+        && process_exit_oom_candidate(&exit)
+        && !failure_diagnostic_reports_workload_memory_oom(failure_diagnostic.as_ref())
+    {
         let dmesg_req = ExecRequest {
             cmd: "dmesg | tail -20 2>/dev/null",
             timeout: Duration::from_secs(5),
@@ -2461,7 +2471,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     } else if process_failed(&exit) {
         let failure_exit_code = process_failure_exit_code(&exit);
         let stderr = process_failure_stderr(&exit);
-        let failure_diagnostic = read_guest_failure_diagnostic_file(sandbox, context.run_id).await;
         let should_read_guest_error = stderr.is_empty()
             || (failure_diagnostic.is_none()
                 && matches!(exit.termination, ExecTermination::Exited { exit_code } if exit_code != 0));

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -37,8 +37,9 @@ pub(super) use environment::{
 };
 pub(super) use exit::{
     AgentBootstrapAbnormalExitLogContext, explicit_enospc_evidence,
-    log_agent_abnormal_exit_env_diagnostics, log_agent_bootstrap_abnormal_exit_diagnostics,
-    log_agent_process_exit_summary, should_collect_agent_abnormal_exit_diagnostics,
+    failure_diagnostic_reports_workload_memory_oom, log_agent_abnormal_exit_env_diagnostics,
+    log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,
+    should_collect_agent_abnormal_exit_diagnostics,
     should_collect_unattributed_sigkill_resource_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };

--- a/crates/runner/src/executor/diagnostics/exit.rs
+++ b/crates/runner/src/executor/diagnostics/exit.rs
@@ -55,6 +55,18 @@ pub(in crate::executor) fn should_collect_unattributed_sigkill_resource_diagnost
             .is_some_and(|diagnostic| unattributed_sigkill_cli_failure(diagnostic, exit_code))
 }
 
+pub(in crate::executor) fn failure_diagnostic_reports_workload_memory_oom(
+    diagnostic: Option<&FailureDiagnostic>,
+) -> bool {
+    diagnostic
+        .and_then(|diagnostic| diagnostic.workload_resource_limit.as_ref())
+        .is_some_and(|limit| {
+            limit.memory_oom_events > 0
+                || limit.memory_oom_kill_events > 0
+                || limit.memory_oom_group_kill_events > 0
+        })
+}
+
 fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic, exit_code: i32) -> bool {
     diagnostic.failure_class == FailureClass::CliNonzero
         && diagnostic.cli_exit_code == Some(exit_code)
@@ -66,6 +78,7 @@ fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic, exit_code: i
             .is_some_and(|observed_exit| {
                 observed_sigkill_matches_exit_code(observed_exit, exit_code)
             })
+        && !failure_diagnostic_reports_workload_memory_oom(Some(diagnostic))
 }
 
 fn observed_sigkill_matches_exit_code(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -3,7 +3,7 @@ use crate::executor::{SandboxReuseDisposition, SandboxReuseRejection, SandboxReu
 use guest_contracts::diagnostics::{
     EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
     EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
-    EventDeliveryFailedBatchDiagnostic,
+    EventDeliveryFailedBatchDiagnostic, WorkloadResourceLimitDiagnostic,
 };
 
 #[tokio::test]
@@ -235,6 +235,60 @@ async fn execute_inner_appends_stream_limit_marker_after_oom_rewrite() {
     let mut expected = b"partial stdout\n".to_vec();
     expected.extend_from_slice(STDOUT_STREAM_LIMIT_MARKER);
     assert_eq!(system_stream_log, expected);
+}
+
+#[tokio::test]
+async fn execute_inner_preserves_workload_oom_diagnostic_before_dmesg_rewrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, EXIT_SIGKILL, Vec::new(), Vec::new()));
+    let workload_resource_limit = WorkloadResourceLimitDiagnostic {
+        memory_max_events: 3,
+        memory_oom_events: 2,
+        memory_oom_kill_events: 1,
+        memory_oom_group_kill_events: 0,
+        pids_max_events: 0,
+    };
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("consume memory"),
+    )
+    .with_cli_exit_code(EXIT_SIGKILL)
+    .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL))
+    .with_failure_detail_source(FailureDetailSource::FallbackExitCode)
+    .with_workload_resource_limit(workload_resource_limit);
+    overrides.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+    let guest_error = "Process killed by signal 9; workload resource limit reached";
+    overrides.push_read_file_result(Ok(Some(guest_error.as_bytes().to_vec())));
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "dmesg".to_string(),
+        exit_code: 0,
+        stdout: b"Out of memory: Killed process 1234".to_vec(),
+        stderr: Vec::new(),
+    });
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+    let outcome = run_new_sandbox_outcome(&factory, &minimal_context(), &config, &default_params())
+        .await
+        .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected workload failure");
+    assert_eq!(failure.exit_code, EXIT_SIGKILL);
+    assert_eq!(failure.error, guest_error);
+    assert_eq!(failure.diagnostic, Some(diagnostic));
+    assert!(failure.resource_diagnostics.is_none());
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit),
+    );
+    assert!(
+        overrides
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("dmesg") && !call.cmd.contains("guest-agent-binary"))
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/src/factory/invariant.rs
+++ b/crates/sandbox-fc/src/factory/invariant.rs
@@ -5,8 +5,8 @@ use crate::network::{GUEST_NETWORK, generate_boot_args};
 /// Shell command executed during snapshot creation to pre-warm guest state.
 /// Changing this invalidates all cached snapshots (included in [`config_hash`]).
 ///
-/// **Note:** Do NOT wrap this in `su - user -c '...'` — the vsock-guest exec
-/// handler already wraps commands with `su - user -c` in release builds.
+/// **Note:** Do NOT wrap this in another user transition — the vsock-guest exec
+/// handler already uses non-login `su` with an explicit `/bin/sh` in release builds.
 /// Double-wrapping creates nested sessions where inner processes escape the
 /// process group, surviving SIGKILL on timeout as orphans frozen into the
 /// snapshot.

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -90,6 +90,75 @@ const GUEST_PARK_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Independent deadline for terminal diagnostics on an already-severe park.
 const GUEST_MEMORY_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Elevated-latency signal below the production-equivalent 750 ms bound.
+const PROCESS_CONTROL_LATENCY_INFO_THRESHOLD: Duration = Duration::from_millis(250);
+/// Firecracker-calibrated upper bound for process-control delivery under load.
+const PROCESS_CONTROL_LATENCY_WARN_THRESHOLD: Duration = Duration::from_millis(750);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProcessControlLatencyLevel {
+    Info,
+    Warn,
+}
+
+fn process_control_latency_level(elapsed: Duration) -> Option<ProcessControlLatencyLevel> {
+    if elapsed >= PROCESS_CONTROL_LATENCY_WARN_THRESHOLD {
+        Some(ProcessControlLatencyLevel::Warn)
+    } else if elapsed >= PROCESS_CONTROL_LATENCY_INFO_THRESHOLD {
+        Some(ProcessControlLatencyLevel::Info)
+    } else {
+        None
+    }
+}
+
+fn process_control_outcome_label(outcome: &ProcessControlOutcome) -> &'static str {
+    match outcome {
+        ProcessControlOutcome::Delivered(_) => "delivered",
+        ProcessControlOutcome::GuestStatus { status, .. } => match status {
+            ProcessControlGuestStatus::Inactive => "guest_inactive",
+            ProcessControlGuestStatus::NonceMismatch => "guest_nonce_mismatch",
+            ProcessControlGuestStatus::Unsupported => "guest_unsupported",
+            ProcessControlGuestStatus::Rejected => "guest_rejected",
+            ProcessControlGuestStatus::SinkUnavailable => "guest_sink_unavailable",
+            ProcessControlGuestStatus::SinkTimeout => "guest_sink_timeout",
+            ProcessControlGuestStatus::QueueFull => "guest_queue_full",
+            ProcessControlGuestStatus::SinkError => "guest_sink_error",
+        },
+        ProcessControlOutcome::GuestError(_) => "guest_error",
+        ProcessControlOutcome::Failed {
+            kind: ProcessControlFailureKind::Operation,
+            ..
+        } => "operation_failed",
+        ProcessControlOutcome::Failed {
+            kind: ProcessControlFailureKind::BackendCrashed,
+            ..
+        } => "backend_crashed",
+    }
+}
+
+fn log_process_control_latency(
+    elapsed: Duration,
+    timeout: Duration,
+    outcome: &ProcessControlOutcome,
+) {
+    let Some(level) = process_control_latency_level(elapsed) else {
+        return;
+    };
+    let elapsed_ms = duration_ms(elapsed);
+    let timeout_ms = duration_ms(timeout);
+    let outcome = process_control_outcome_label(outcome);
+    match level {
+        ProcessControlLatencyLevel::Info => info!(
+            elapsed_ms,
+            timeout_ms, outcome, "process control latency elevated"
+        ),
+        ProcessControlLatencyLevel::Warn => warn!(
+            elapsed_ms,
+            timeout_ms, outcome, "process control latency exceeded calibrated bound"
+        ),
+    }
+}
+
 struct SandboxStartTiming<'a> {
     observer: Option<&'a mut dyn SandboxStartObserver>,
 }
@@ -918,6 +987,7 @@ impl FirecrackerSandbox {
             BackendCrashed,
         }
 
+        let started = Instant::now();
         let operation = SandboxOperation::ProcessControl;
         let write_started = Arc::new(AtomicBool::new(false));
         if let Err(error) =
@@ -928,11 +998,13 @@ impl FirecrackerSandbox {
             } else {
                 ProcessControlFailureKind::Operation
             };
-            return Self::process_control_failure(
+            let outcome = Self::process_control_failure(
                 kind,
                 &write_started,
                 Self::operation_start_io_error(operation, error, Self::current_state_from(&state)),
             );
+            log_process_control_latency(started.elapsed(), timeout, &outcome);
+            return outcome;
         }
 
         let write_observer = FrameWriteObserver::new({
@@ -953,7 +1025,7 @@ impl FirecrackerSandbox {
             () = wait_for_backend_crash(state_rx) => ControlOutcome::BackendCrashed,
         };
 
-        match outcome {
+        let outcome = match outcome {
             ControlOutcome::Returned(Ok(vsock_host::ExecControlOutcome::Delivered(ack))) => {
                 ProcessControlOutcome::Delivered(ProcessControlAck {
                     message_id: ack.message_id,
@@ -977,24 +1049,27 @@ impl FirecrackerSandbox {
             }
             ControlOutcome::Returned(Err(error)) => {
                 if Self::current_state_from(&state) == SandboxState::Crashed {
-                    return Self::process_control_failure(
+                    Self::process_control_failure(
                         ProcessControlFailureKind::BackendCrashed,
                         &write_started,
                         io::Error::other(Self::backend_crashed_error(operation)),
-                    );
+                    )
+                } else {
+                    Self::process_control_failure(
+                        ProcessControlFailureKind::Operation,
+                        &write_started,
+                        error,
+                    )
                 }
-                Self::process_control_failure(
-                    ProcessControlFailureKind::Operation,
-                    &write_started,
-                    error,
-                )
             }
             ControlOutcome::BackendCrashed => Self::process_control_failure(
                 ProcessControlFailureKind::BackendCrashed,
                 &write_started,
                 io::Error::other(Self::backend_crashed_error(operation)),
             ),
-        }
+        };
+        log_process_control_latency(started.elapsed(), timeout, &outcome);
+        outcome
     }
 
     /// Atomically transition between states using CAS. Returns `true` if the

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2712,6 +2712,26 @@ async fn file_operation_entrypoints_preserve_operation_context_for_start_rejecti
         .expect("abort prepare park");
 }
 
+#[test]
+fn process_control_latency_logs_only_material_delays() {
+    assert_eq!(
+        process_control_latency_level(Duration::from_millis(249)),
+        None
+    );
+    assert_eq!(
+        process_control_latency_level(Duration::from_millis(250)),
+        Some(ProcessControlLatencyLevel::Info)
+    );
+    assert_eq!(
+        process_control_latency_level(Duration::from_millis(749)),
+        Some(ProcessControlLatencyLevel::Info)
+    );
+    assert_eq!(
+        process_control_latency_level(Duration::from_millis(750)),
+        Some(ProcessControlLatencyLevel::Warn)
+    );
+}
+
 #[tokio::test]
 async fn process_control_rejects_closed_policy_gate_without_dirtying() {
     let ExecProcessControlFixture {

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -51,6 +51,7 @@ use std::time::{Duration, Instant};
 
 #[cfg(test)]
 use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
+use guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV;
 use vsock_proto::{
     self, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecLifecyclePolicy,
     ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy, MSG_ERROR,
@@ -948,16 +949,6 @@ fn run_exec_operation_worker<S>(
     let stdin_bytes = request.stdin_bytes.take();
     let pipe_stdin = stdin_bytes.is_some();
 
-    let env_refs = env_refs(&request.env);
-    let mut env_with_control;
-    let effective_env = if let Some(endpoint) = request.exec_control_bootstrap_endpoint.as_deref() {
-        env_with_control = Vec::with_capacity(env_refs.len() + 1);
-        env_with_control.extend_from_slice(&env_refs);
-        env_with_control.push((process_control_ipc::BOOTSTRAP_ENV, endpoint));
-        env_with_control.as_slice()
-    } else {
-        env_refs.as_slice()
-    };
     let process_containment = match ExecProcessContainment::create(
         request.seq,
         request.process_containment_mode,
@@ -970,6 +961,44 @@ fn run_exec_operation_worker<S>(
             ));
             return;
         }
+    };
+    let workload_bootstrap =
+        if let Some(endpoint) = request.exec_control_bootstrap_endpoint.as_deref() {
+            let expected_uid = match crate::user::shell_command_uid(request.sudo) {
+                Ok(uid) => uid,
+                Err(error) => {
+                    let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+                    completion.start_failed(&format!(
+                        "Failed to resolve workload placement bootstrap identity: {error}"
+                    ));
+                    return;
+                }
+            };
+            match process_containment.start_workload_placement_bootstrap(endpoint, expected_uid) {
+                Ok(bootstrap) => bootstrap,
+                Err(error) => {
+                    let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+                    completion.start_failed(&format!(
+                        "Failed to initialize workload placement bootstrap: {error}"
+                    ));
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+    let env_refs = env_refs(&request.env);
+    let mut env_with_control;
+    let effective_env = if let Some(endpoint) = request.exec_control_bootstrap_endpoint.as_deref() {
+        env_with_control = Vec::with_capacity(env_refs.len() + 2);
+        env_with_control.extend_from_slice(&env_refs);
+        env_with_control.push((process_control_ipc::BOOTSTRAP_ENV, endpoint));
+        if let Some(bootstrap) = workload_bootstrap.as_ref() {
+            env_with_control.push((WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV, bootstrap.endpoint()));
+        }
+        env_with_control.as_slice()
+    } else {
+        env_refs.as_slice()
     };
     let spawned = match spawn_shell_command_with_pipes(
         &request.command,
@@ -988,6 +1017,7 @@ fn run_exec_operation_worker<S>(
             return;
         }
     };
+    let _workload_bootstrap = workload_bootstrap;
 
     let SpawnedShellCommand {
         child,

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -958,16 +958,19 @@ fn run_exec_operation_worker<S>(
     } else {
         env_refs.as_slice()
     };
-    let process_containment =
-        match ExecProcessContainment::create(request.seq, request.process_containment_mode) {
-            Ok(process_containment) => process_containment,
-            Err(error) => {
-                completion.start_failed(&format!(
-                    "Failed to initialize exec process containment: {error}"
-                ));
-                return;
-            }
-        };
+    let process_containment = match ExecProcessContainment::create(
+        request.seq,
+        request.process_containment_mode,
+        request.exec_control_bootstrap_endpoint.is_some(),
+    ) {
+        Ok(process_containment) => process_containment,
+        Err(error) => {
+            completion.start_failed(&format!(
+                "Failed to initialize exec process containment: {error}"
+            ));
+            return;
+        }
+    };
     let spawned = match spawn_shell_command_with_pipes(
         &request.command,
         effective_env,

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -18,7 +18,7 @@ use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
 use crate::shutdown::handle_shutdown;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
-use crate::user::apply_write_file_identity;
+use crate::user::apply_command_identity;
 use crate::wait::{
     WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
 };
@@ -260,7 +260,7 @@ fn spawn_write_file_command(
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
-    apply_write_file_identity(&mut command, use_sudo)?;
+    apply_command_identity(&mut command, use_sudo)?;
     spawn_in_own_process_group(&mut command)
 }
 
@@ -271,7 +271,7 @@ fn spawn_write_files_command() -> io::Result<Child> {
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
-    apply_write_file_identity(&mut command, false)?;
+    apply_command_identity(&mut command, false)?;
     spawn_in_own_process_group(&mut command)
 }
 

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -1,12 +1,14 @@
 use std::collections::HashSet;
 use std::fs::{self, OpenOptions};
 use std::io;
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use guest_contracts::exec_terminal::{
@@ -14,9 +16,9 @@ use guest_contracts::exec_terminal::{
     EXEC_PROCESS_CONTAINMENT_TERM_GRACE,
 };
 use guest_contracts::process_containment::{
-    CONTROL_CGROUP_NAME, CONTROL_CPU_WEIGHT, EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX,
-    MATERIAL_CPU_THROTTLED_USEC, REQUIRED_CGROUP_CONTROLLERS, REQUIRED_CGROUP_SUBTREE_CONTROL,
-    WORKLOAD_CGROUP_NAME, WorkloadResourcePolicy,
+    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, CONTROL_CPU_WEIGHT, EXEC_CGROUP_BASE_PATH,
+    EXEC_CGROUP_NAME_PREFIX, MATERIAL_CPU_THROTTLED_USEC, REQUIRED_CGROUP_CONTROLLERS,
+    REQUIRED_CGROUP_SUBTREE_CONTROL, WORKLOAD_CGROUP_NAME, WorkloadResourcePolicy,
 };
 
 use crate::log::log;
@@ -36,6 +38,9 @@ const MEMORY_OOM_GROUP_FILE: &str = "memory.oom.group";
 const PIDS_EVENTS_FILE: &str = "pids.events";
 const PIDS_MAX_FILE: &str = "pids.max";
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const WORKLOAD_BOOTSTRAP_ACCEPT_POLL: Duration = Duration::from_millis(100);
+const WORKLOAD_BOOTSTRAP_ENDPOINT_SUFFIX: &str = "-workload-placement";
+const THREAD_WORKLOAD_BOOTSTRAP: &str = "vsock-workload-bootstrap";
 
 static NEXT_CGROUP_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -72,19 +77,39 @@ struct CgroupGuard {
 
 pub(crate) struct PreparedProcessContainmentCommand {
     outer_placement: Option<OwnedFd>,
-    inherited_workload_placement: Option<OwnedFd>,
+    deny_process_inspection: bool,
 }
 
 impl PreparedProcessContainmentCommand {
-    pub(crate) fn inherited_workload_fd(&self) -> Option<RawFd> {
-        self.inherited_workload_placement
-            .as_ref()
-            .map(AsRawFd::as_raw_fd)
-    }
-
     pub(crate) fn configure_command(self, command: &mut Command) {
         if let Some(outer_placement) = self.outer_placement {
-            install_child_placement(command, outer_placement, self.inherited_workload_placement);
+            install_child_placement(command, outer_placement, self.deny_process_inspection);
+        }
+    }
+}
+
+pub(crate) struct WorkloadPlacementBootstrap {
+    endpoint: String,
+    cancel: Arc<AtomicBool>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl WorkloadPlacementBootstrap {
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl Drop for WorkloadPlacementBootstrap {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take()
+            && let Err(error) = worker.join()
+        {
+            log(
+                "WARN",
+                &format!("workload placement bootstrap worker panicked: {error:?}"),
+            );
         }
     }
 }
@@ -137,13 +162,28 @@ impl ExecProcessContainment {
             ContainmentBackend::Cgroup(guard) => guard.prepare_command(),
             ContainmentBackend::TestNoop => Ok(PreparedProcessContainmentCommand {
                 outer_placement: None,
-                inherited_workload_placement: None,
+                deny_process_inspection: false,
             }),
             #[cfg(test)]
             ContainmentBackend::TestDirectory(_) => Ok(PreparedProcessContainmentCommand {
                 outer_placement: None,
-                inherited_workload_placement: None,
+                deny_process_inspection: false,
             }),
+        }
+    }
+
+    pub(crate) fn start_workload_placement_bootstrap(
+        &self,
+        control_endpoint: &str,
+        expected_uid: libc::uid_t,
+    ) -> Result<Option<WorkloadPlacementBootstrap>, ProcessContainmentError> {
+        match &self.backend {
+            ContainmentBackend::Cgroup(guard) => guard
+                .start_workload_placement_bootstrap(control_endpoint, expected_uid)
+                .map(Some),
+            ContainmentBackend::TestNoop => Ok(None),
+            #[cfg(test)]
+            ContainmentBackend::TestDirectory(_) => Ok(None),
         }
     }
 
@@ -298,15 +338,56 @@ impl CgroupGuard {
             .outer_placement
             .try_clone()
             .map_err(|error| ProcessContainmentError::new("clone outer cgroup.procs", error))?;
-        let inherited_workload_placement = self
-            .workload_placement
-            .as_ref()
-            .map(OwnedFd::try_clone)
-            .transpose()
-            .map_err(|error| ProcessContainmentError::new("clone workload cgroup.procs", error))?;
+        let trusted_control = self.workload_placement.is_some();
         Ok(PreparedProcessContainmentCommand {
             outer_placement: Some(outer_placement),
-            inherited_workload_placement,
+            deny_process_inspection: trusted_control,
+        })
+    }
+
+    fn start_workload_placement_bootstrap(
+        &self,
+        control_endpoint: &str,
+        expected_uid: libc::uid_t,
+    ) -> Result<WorkloadPlacementBootstrap, ProcessContainmentError> {
+        let placement = self
+            .workload_placement
+            .as_ref()
+            .ok_or_else(|| {
+                ProcessContainmentError::new(
+                    "prepare workload placement bootstrap",
+                    io::Error::other("trusted control cgroup has no workload placement capability"),
+                )
+            })?
+            .try_clone()
+            .map_err(|error| {
+                ProcessContainmentError::new("clone workload cgroup.procs for bootstrap", error)
+            })?;
+        let endpoint = format!("{control_endpoint}{WORKLOAD_BOOTSTRAP_ENDPOINT_SUFFIX}");
+        let listener = process_control_ipc::bind_abstract_listener(&endpoint).map_err(|error| {
+            ProcessContainmentError::new("bind workload placement bootstrap endpoint", error)
+        })?;
+        let expected_cgroup = self.group_path.join(CONTROL_CGROUP_NAME);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let worker_cancel = Arc::clone(&cancel);
+        let worker = thread::Builder::new()
+            .name(THREAD_WORKLOAD_BOOTSTRAP.to_owned())
+            .spawn(move || {
+                serve_workload_placement(
+                    listener,
+                    placement,
+                    expected_uid,
+                    &expected_cgroup,
+                    &worker_cancel,
+                );
+            })
+            .map_err(|error| {
+                ProcessContainmentError::new("start workload placement bootstrap worker", error)
+            })?;
+        Ok(WorkloadPlacementBootstrap {
+            endpoint,
+            cancel,
+            worker: Some(worker),
         })
     }
 
@@ -671,7 +752,7 @@ fn cleanup_cgroup(
 fn install_child_placement(
     command: &mut Command,
     placement: OwnedFd,
-    inherited_workload_placement: Option<OwnedFd>,
+    deny_process_inspection: bool,
 ) {
     // SAFETY: the closure performs only raw writes and fcntl calls on already
     // open descriptors. These operations are async-signal-safe between fork
@@ -679,32 +760,111 @@ fn install_child_placement(
     unsafe {
         command.pre_exec(move || {
             write_self_to_cgroup(placement.as_raw_fd())?;
-            if let Some(workload_placement) = inherited_workload_placement.as_ref() {
+            if deny_process_inspection {
                 deny_unprivileged_process_inspection()?;
-                clear_close_on_exec(workload_placement.as_raw_fd())?;
             }
             Ok(())
         });
     }
 }
 
+fn serve_workload_placement(
+    listener: std::os::unix::net::UnixListener,
+    placement: OwnedFd,
+    expected_uid: libc::uid_t,
+    expected_cgroup: &Path,
+    cancel: &AtomicBool,
+) {
+    while !cancel.load(Ordering::Acquire) {
+        let stream = match process_control_ipc::accept_with_timeout(
+            &listener,
+            WORKLOAD_BOOTSTRAP_ACCEPT_POLL,
+        ) {
+            Ok(stream) => stream,
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => continue,
+            Err(error) => {
+                log(
+                    "WARN",
+                    &format!("workload placement bootstrap accept failed: {error}"),
+                );
+                return;
+            }
+        };
+
+        match workload_bootstrap_peer_matches(&stream, expected_uid, expected_cgroup) {
+            Ok(true) => {
+                if let Err(error) =
+                    process_control_ipc::send_workload_placement(&stream, placement.as_fd())
+                {
+                    log(
+                        "WARN",
+                        &format!("workload placement descriptor send failed: {error}"),
+                    );
+                }
+                return;
+            }
+            Ok(false) => {
+                log(
+                    "WARN",
+                    "workload placement bootstrap rejected an unexpected peer",
+                );
+            }
+            Err(error) => {
+                log(
+                    "WARN",
+                    &format!("workload placement bootstrap peer validation failed: {error}"),
+                );
+            }
+        }
+    }
+}
+
+fn workload_bootstrap_peer_matches(
+    stream: &std::os::unix::net::UnixStream,
+    expected_uid: libc::uid_t,
+    expected_cgroup: &Path,
+) -> io::Result<bool> {
+    // SAFETY: zeroed ucred is a valid output buffer for SO_PEERCRED.
+    let mut credentials = unsafe { std::mem::zeroed::<libc::ucred>() };
+    let mut credentials_len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: stream is a connected Unix socket and the output pointers refer
+    // to a correctly sized ucred buffer and socklen_t.
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            std::ptr::addr_of_mut!(credentials).cast(),
+            std::ptr::addr_of_mut!(credentials_len),
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if credentials_len as usize != std::mem::size_of::<libc::ucred>()
+        || credentials.pid <= 0
+        || credentials.uid != expected_uid
+    {
+        return Ok(false);
+    }
+
+    let cgroup = fs::read_to_string(format!("/proc/{}/cgroup", credentials.pid));
+    let cgroup = match cgroup {
+        Ok(cgroup) => cgroup,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let relative = cgroup.lines().find_map(|line| line.strip_prefix("0::"));
+    let Some(relative) = relative.and_then(|path| path.strip_prefix('/')) else {
+        return Ok(false);
+    };
+    Ok(Path::new(CGROUP_V2_MOUNT_PATH).join(relative) == expected_cgroup)
+}
+
 fn deny_unprivileged_process_inspection() -> io::Result<()> {
     // SAFETY: PR_SET_DUMPABLE changes only the calling child between fork and
     // exec and does not access shared userspace state.
     if unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0) } != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-fn clear_close_on_exec(fd: RawFd) -> io::Result<()> {
-    // SAFETY: `fd` is an owned descriptor retained by the pre-exec closure.
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
-    if flags < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    // SAFETY: clearing FD_CLOEXEC changes only this valid descriptor's flags.
-    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
         return Err(io::Error::last_os_error());
     }
     Ok(())
@@ -1006,7 +1166,7 @@ mod tests {
         let child_fd: OwnedFd = placement.try_clone().unwrap().into();
         let mut command = Command::new("/bin/true");
         command.stdout(Stdio::null()).stderr(Stdio::null());
-        install_child_placement(&mut command, child_fd, None);
+        install_child_placement(&mut command, child_fd, false);
 
         let status = command.status().unwrap();
 
@@ -1015,6 +1175,26 @@ mod tests {
         let mut content = String::new();
         placement.read_to_string(&mut content).unwrap();
         assert_eq!(content, "0");
+    }
+
+    #[test]
+    fn workload_bootstrap_authenticates_peer_uid_and_cgroup() {
+        let (peer, _server) = std::os::unix::net::UnixStream::pair().unwrap();
+        // SAFETY: geteuid is a simple scalar getter with no preconditions.
+        let uid = unsafe { libc::geteuid() };
+        let current_cgroup = fs::read_to_string("/proc/self/cgroup").unwrap();
+        let relative = current_cgroup
+            .lines()
+            .find_map(|line| line.strip_prefix("0::/"))
+            .unwrap();
+        let expected = Path::new(CGROUP_V2_MOUNT_PATH).join(relative);
+
+        assert!(workload_bootstrap_peer_matches(&peer, uid, &expected).unwrap());
+        assert!(!workload_bootstrap_peer_matches(&peer, uid.wrapping_add(1), &expected).unwrap());
+        assert!(
+            !workload_bootstrap_peer_matches(&peer, uid, &expected.join("not-the-peer-cgroup"))
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -81,9 +81,15 @@ pub(crate) struct PreparedProcessContainmentCommand {
 }
 
 impl PreparedProcessContainmentCommand {
-    pub(crate) fn configure_command(self, command: &mut Command) {
-        if let Some(outer_placement) = self.outer_placement {
-            install_child_placement(command, outer_placement, self.deny_process_inspection);
+    pub(crate) fn configure_placement(&mut self, command: &mut Command) {
+        if let Some(outer_placement) = self.outer_placement.take() {
+            install_child_placement(command, outer_placement);
+        }
+    }
+
+    pub(crate) fn configure_process_inspection(self, command: &mut Command) {
+        if self.deny_process_inspection {
+            install_process_inspection_denial(command);
         }
     }
 }
@@ -749,22 +755,23 @@ fn cleanup_cgroup(
     })
 }
 
-fn install_child_placement(
-    command: &mut Command,
-    placement: OwnedFd,
-    deny_process_inspection: bool,
-) {
+fn install_child_placement(command: &mut Command, placement: OwnedFd) {
     // SAFETY: the closure performs only raw writes and fcntl calls on already
     // open descriptors. These operations are async-signal-safe between fork
     // and exec.
     unsafe {
         command.pre_exec(move || {
             write_self_to_cgroup(placement.as_raw_fd())?;
-            if deny_process_inspection {
-                deny_unprivileged_process_inspection()?;
-            }
             Ok(())
         });
+    }
+}
+
+fn install_process_inspection_denial(command: &mut Command) {
+    // SAFETY: the closure performs one async-signal-safe prctl call in the
+    // child after its credential transition and before exec.
+    unsafe {
+        command.pre_exec(deny_unprivileged_process_inspection);
     }
 }
 
@@ -1024,10 +1031,12 @@ fn wait_until_empty(group_path: &Path, timeout: Duration) -> Result<bool, Proces
     }
 }
 
-fn remove_empty_cgroup(group_path: &Path) -> Result<(), ProcessContainmentError> {
+fn remove_empty_cgroup_until(
+    group_path: &Path,
+    deadline: Instant,
+) -> Result<(), ProcessContainmentError> {
     #[cfg(test)]
     remove_test_cgroup_interface_files(group_path);
-    let deadline = Instant::now() + EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT;
     loop {
         match fs::remove_dir(group_path) {
             Ok(()) => return Ok(()),
@@ -1037,7 +1046,8 @@ fn remove_empty_cgroup(group_path: &Path) -> Result<(), ProcessContainmentError>
                     Some(libc::EBUSY) | Some(libc::ENOTEMPTY)
                 ) && Instant::now() < deadline =>
             {
-                thread::sleep(POLL_INTERVAL);
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                thread::sleep(remaining.min(POLL_INTERVAL));
             }
             Err(error) => {
                 return Err(ProcessContainmentError::new("remove cgroup", error));
@@ -1070,14 +1080,15 @@ fn cgroup_leaf_paths(group_path: &Path) -> [PathBuf; 2] {
 }
 
 fn remove_cgroup_hierarchy(group_path: &Path) -> Result<(), ProcessContainmentError> {
+    let deadline = Instant::now() + EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT;
     for leaf_path in cgroup_leaf_paths(group_path) {
-        match remove_empty_cgroup(&leaf_path) {
+        match remove_empty_cgroup_until(&leaf_path, deadline) {
             Ok(()) => {}
             Err(error) if error.source.kind() == io::ErrorKind::NotFound => {}
             Err(error) => return Err(error),
         }
     }
-    remove_empty_cgroup(group_path)
+    remove_empty_cgroup_until(group_path, deadline)
 }
 
 #[cfg(test)]
@@ -1166,7 +1177,7 @@ mod tests {
         let child_fd: OwnedFd = placement.try_clone().unwrap().into();
         let mut command = Command::new("/bin/true");
         command.stdout(Stdio::null()).stderr(Stdio::null());
-        install_child_placement(&mut command, child_fd, false);
+        install_child_placement(&mut command, child_fd);
 
         let status = command.status().unwrap();
 

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -13,13 +13,28 @@ use guest_contracts::exec_terminal::{
     EXEC_PROCESS_CONTAINMENT_KILL_EMPTY_TIMEOUT, EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT,
     EXEC_PROCESS_CONTAINMENT_TERM_GRACE,
 };
-use guest_contracts::process_containment::{EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX};
+use guest_contracts::process_containment::{
+    CONTROL_CGROUP_NAME, CONTROL_CPU_WEIGHT, EXEC_CGROUP_BASE_PATH, EXEC_CGROUP_NAME_PREFIX,
+    MATERIAL_CPU_THROTTLED_USEC, REQUIRED_CGROUP_CONTROLLERS, REQUIRED_CGROUP_SUBTREE_CONTROL,
+    WORKLOAD_CGROUP_NAME, WorkloadResourcePolicy,
+};
 
 use crate::log::log;
 
 const CGROUP_EVENTS_FILE: &str = "cgroup.events";
 const CGROUP_KILL_FILE: &str = "cgroup.kill";
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
+const CGROUP_SUBTREE_CONTROL_FILE: &str = "cgroup.subtree_control";
+const CPU_MAX_FILE: &str = "cpu.max";
+const CPU_STAT_FILE: &str = "cpu.stat";
+const CPU_WEIGHT_FILE: &str = "cpu.weight";
+const MEMORY_EVENTS_FILE: &str = "memory.events";
+const MEMORY_HIGH_FILE: &str = "memory.high";
+const MEMORY_MAX_FILE: &str = "memory.max";
+const MEMORY_MIN_FILE: &str = "memory.min";
+const MEMORY_OOM_GROUP_FILE: &str = "memory.oom.group";
+const PIDS_EVENTS_FILE: &str = "pids.events";
+const PIDS_MAX_FILE: &str = "pids.max";
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 static NEXT_CGROUP_ID: AtomicU64 = AtomicU64::new(1);
@@ -50,8 +65,28 @@ enum ContainmentBackend {
 struct CgroupGuard {
     group_name: String,
     group_path: PathBuf,
-    placement: OwnedFd,
+    outer_placement: OwnedFd,
+    workload_placement: Option<OwnedFd>,
     create_elapsed: Duration,
+}
+
+pub(crate) struct PreparedProcessContainmentCommand {
+    outer_placement: Option<OwnedFd>,
+    inherited_workload_placement: Option<OwnedFd>,
+}
+
+impl PreparedProcessContainmentCommand {
+    pub(crate) fn inherited_workload_fd(&self) -> Option<RawFd> {
+        self.inherited_workload_placement
+            .as_ref()
+            .map(AsRawFd::as_raw_fd)
+    }
+
+    pub(crate) fn configure_command(self, command: &mut Command) {
+        if let Some(outer_placement) = self.outer_placement {
+            install_child_placement(command, outer_placement, self.inherited_workload_placement);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -82,6 +117,7 @@ impl ExecProcessContainment {
     pub(crate) fn create(
         sequence: u32,
         mode: ProcessContainmentMode,
+        trusted_control: bool,
     ) -> Result<Self, ProcessContainmentError> {
         if use_test_noop_backend(mode) {
             return Ok(Self {
@@ -89,20 +125,25 @@ impl ExecProcessContainment {
             });
         }
 
-        CgroupGuard::create(sequence).map(|guard| Self {
+        CgroupGuard::create(sequence, trusted_control).map(|guard| Self {
             backend: ContainmentBackend::Cgroup(guard),
         })
     }
 
-    pub(crate) fn configure_command(
+    pub(crate) fn prepare_command(
         &self,
-        command: &mut Command,
-    ) -> Result<(), ProcessContainmentError> {
+    ) -> Result<PreparedProcessContainmentCommand, ProcessContainmentError> {
         match &self.backend {
-            ContainmentBackend::Cgroup(guard) => guard.configure_command(command),
-            ContainmentBackend::TestNoop => Ok(()),
+            ContainmentBackend::Cgroup(guard) => guard.prepare_command(),
+            ContainmentBackend::TestNoop => Ok(PreparedProcessContainmentCommand {
+                outer_placement: None,
+                inherited_workload_placement: None,
+            }),
             #[cfg(test)]
-            ContainmentBackend::TestDirectory(_) => Ok(()),
+            ContainmentBackend::TestDirectory(_) => Ok(PreparedProcessContainmentCommand {
+                outer_placement: None,
+                inherited_workload_placement: None,
+            }),
         }
     }
 
@@ -166,11 +207,22 @@ fn verify_exec_process_containment_empty_in(
 }
 
 impl CgroupGuard {
-    fn create(sequence: u32) -> Result<Self, ProcessContainmentError> {
-        Self::create_in(Path::new(EXEC_CGROUP_BASE_PATH), sequence)
+    fn create(sequence: u32, trusted_control: bool) -> Result<Self, ProcessContainmentError> {
+        let policy = workload_resource_policy()?;
+        Self::create_in(
+            Path::new(EXEC_CGROUP_BASE_PATH),
+            sequence,
+            trusted_control,
+            policy,
+        )
     }
 
-    fn create_in(base_path: &Path, sequence: u32) -> Result<Self, ProcessContainmentError> {
+    fn create_in(
+        base_path: &Path,
+        sequence: u32,
+        trusted_control: bool,
+        policy: WorkloadResourcePolicy,
+    ) -> Result<Self, ProcessContainmentError> {
         let started = Instant::now();
         let id = NEXT_CGROUP_ID.fetch_add(1, Ordering::Relaxed);
         let group_name = format!(
@@ -180,14 +232,44 @@ impl CgroupGuard {
         let group_path = base_path.join(&group_name);
         fs::create_dir(&group_path)
             .map_err(|error| ProcessContainmentError::new("create cgroup", error))?;
-        let placement = match OpenOptions::new()
-            .write(true)
-            .open(group_path.join(CGROUP_PROCS_FILE))
-        {
-            Ok(placement) => placement,
-            Err(source) => {
-                let original = ProcessContainmentError::new("open cgroup.procs", source);
-                if let Err(rollback) = remove_empty_cgroup(&group_path) {
+
+        let setup: Result<(OwnedFd, Option<OwnedFd>), ProcessContainmentError> = (|| {
+            enable_required_controllers(&group_path)?;
+            let control_path = group_path.join(CONTROL_CGROUP_NAME);
+            let workload_path = group_path.join(WORKLOAD_CGROUP_NAME);
+            fs::create_dir(&control_path)
+                .map_err(|error| ProcessContainmentError::new("create control cgroup", error))?;
+            fs::create_dir(&workload_path)
+                .map_err(|error| ProcessContainmentError::new("create workload cgroup", error))?;
+            configure_resource_policy(
+                &group_path,
+                &control_path,
+                &workload_path,
+                trusted_control,
+                policy,
+            )?;
+
+            let outer_path = if trusted_control {
+                &control_path
+            } else {
+                &workload_path
+            };
+            let outer_placement = open_placement(outer_path, "open outer cgroup.procs")?;
+            let workload_placement = if trusted_control {
+                Some(open_placement(
+                    &workload_path,
+                    "open workload cgroup.procs",
+                )?)
+            } else {
+                None
+            };
+            Ok((outer_placement, workload_placement))
+        })();
+
+        let (outer_placement, workload_placement) = match setup {
+            Ok(placements) => placements,
+            Err(original) => {
+                if let Err(rollback) = remove_cgroup_hierarchy(&group_path) {
                     log(
                         "ERROR",
                         &format!(
@@ -203,18 +285,29 @@ impl CgroupGuard {
         Ok(Self {
             group_name,
             group_path,
-            placement: placement.into(),
+            outer_placement,
+            workload_placement,
             create_elapsed: started.elapsed(),
         })
     }
 
-    fn configure_command(&self, command: &mut Command) -> Result<(), ProcessContainmentError> {
-        let placement = self
-            .placement
+    fn prepare_command(
+        &self,
+    ) -> Result<PreparedProcessContainmentCommand, ProcessContainmentError> {
+        let outer_placement = self
+            .outer_placement
             .try_clone()
-            .map_err(|error| ProcessContainmentError::new("clone cgroup.procs", error))?;
-        install_child_placement(command, placement);
-        Ok(())
+            .map_err(|error| ProcessContainmentError::new("clone outer cgroup.procs", error))?;
+        let inherited_workload_placement = self
+            .workload_placement
+            .as_ref()
+            .map(OwnedFd::try_clone)
+            .transpose()
+            .map_err(|error| ProcessContainmentError::new("clone workload cgroup.procs", error))?;
+        Ok(PreparedProcessContainmentCommand {
+            outer_placement: Some(outer_placement),
+            inherited_workload_placement,
+        })
     }
 
     fn cleanup(self, mode: ProcessContainmentCleanupMode) -> Result<(), ProcessContainmentError> {
@@ -222,10 +315,14 @@ impl CgroupGuard {
         let CgroupGuard {
             group_name,
             group_path,
-            placement,
+            outer_placement,
+            workload_placement,
             create_elapsed,
         } = self;
-        drop(placement);
+        drop(outer_placement);
+        drop(workload_placement);
+
+        log_resource_events(&group_name, &group_path.join(WORKLOAD_CGROUP_NAME));
 
         let result = cleanup_cgroup(&group_path, mode);
         match result {
@@ -265,6 +362,214 @@ impl CgroupGuard {
     }
 }
 
+fn workload_resource_policy() -> Result<WorkloadResourcePolicy, ProcessContainmentError> {
+    WorkloadResourcePolicy::for_current_guest_capacity().map_err(|message| {
+        ProcessContainmentError::new("derive workload resource policy", io::Error::other(message))
+    })
+}
+
+fn enable_required_controllers(group_path: &Path) -> Result<(), ProcessContainmentError> {
+    fs::write(
+        group_path.join(CGROUP_SUBTREE_CONTROL_FILE),
+        REQUIRED_CGROUP_SUBTREE_CONTROL.as_bytes(),
+    )
+    .map_err(|error| ProcessContainmentError::new("enable cgroup controllers", error))?;
+    let enabled = fs::read_to_string(group_path.join(CGROUP_SUBTREE_CONTROL_FILE))
+        .map_err(|error| ProcessContainmentError::new("read cgroup controllers", error))?;
+    let enabled = enabled
+        .split_ascii_whitespace()
+        .map(|controller| controller.trim_start_matches('+'))
+        .collect::<HashSet<_>>();
+    if REQUIRED_CGROUP_CONTROLLERS
+        .into_iter()
+        .all(|controller| enabled.contains(controller))
+    {
+        return Ok(());
+    }
+    Err(ProcessContainmentError::new(
+        "verify cgroup controllers",
+        io::Error::other("operation cgroup is missing a required controller"),
+    ))
+}
+
+fn configure_resource_policy(
+    group_path: &Path,
+    control_path: &Path,
+    workload_path: &Path,
+    trusted_control: bool,
+    policy: WorkloadResourcePolicy,
+) -> Result<(), ProcessContainmentError> {
+    write_cgroup_value(
+        workload_path,
+        CPU_MAX_FILE,
+        &format!("{} {}", policy.cpu_quota_us, policy.cpu_period_us),
+        "configure workload cpu.max",
+    )?;
+    write_cgroup_value(
+        workload_path,
+        MEMORY_HIGH_FILE,
+        &policy.memory_high_bytes.to_string(),
+        "configure workload memory.high",
+    )?;
+    write_cgroup_value(
+        workload_path,
+        MEMORY_MAX_FILE,
+        &policy.memory_max_bytes.to_string(),
+        "configure workload memory.max",
+    )?;
+    write_cgroup_value(
+        workload_path,
+        MEMORY_OOM_GROUP_FILE,
+        "1",
+        "configure workload memory.oom.group",
+    )?;
+    write_cgroup_value(
+        workload_path,
+        PIDS_MAX_FILE,
+        &policy.pids_max.to_string(),
+        "configure workload pids.max",
+    )?;
+
+    if trusted_control {
+        let weight = CONTROL_CPU_WEIGHT.to_string();
+        write_cgroup_value(
+            group_path,
+            CPU_WEIGHT_FILE,
+            &weight,
+            "prioritize controlled operation CPU",
+        )?;
+        write_cgroup_value(
+            control_path,
+            CPU_WEIGHT_FILE,
+            &weight,
+            "prioritize Guest Agent CPU",
+        )?;
+        write_cgroup_value(
+            group_path,
+            MEMORY_MIN_FILE,
+            &policy.control_memory_min_bytes.to_string(),
+            "protect controlled operation memory",
+        )?;
+        write_cgroup_value(
+            control_path,
+            MEMORY_MIN_FILE,
+            &policy.control_memory_min_bytes.to_string(),
+            "protect Guest Agent memory",
+        )?;
+    }
+    Ok(())
+}
+
+fn write_cgroup_value(
+    group_path: &Path,
+    filename: &str,
+    value: &str,
+    stage: &'static str,
+) -> Result<(), ProcessContainmentError> {
+    fs::write(group_path.join(filename), value.as_bytes())
+        .map_err(|error| ProcessContainmentError::new(stage, error))
+}
+
+fn open_placement(
+    group_path: &Path,
+    stage: &'static str,
+) -> Result<OwnedFd, ProcessContainmentError> {
+    OpenOptions::new()
+        .write(true)
+        .open(group_path.join(CGROUP_PROCS_FILE))
+        .map(Into::into)
+        .map_err(|error| ProcessContainmentError::new(stage, error))
+}
+
+#[derive(Debug, Default)]
+struct ResourceEvents {
+    cpu_nr_throttled: u64,
+    cpu_throttled_usec: u64,
+    memory_high: u64,
+    memory_max: u64,
+    memory_oom: u64,
+    memory_oom_kill: u64,
+    memory_oom_group_kill: u64,
+    pids_max: u64,
+}
+
+fn log_resource_events(group_name: &str, workload_path: &Path) {
+    let events = match read_resource_events(workload_path) {
+        Ok(events) => events,
+        Err(error) => {
+            log(
+                "WARN",
+                &format!(
+                    "exec workload resource diagnostics unavailable group={group_name} error={error}"
+                ),
+            );
+            return;
+        }
+    };
+    if events.memory_max > 0
+        || events.memory_oom > 0
+        || events.memory_oom_kill > 0
+        || events.memory_oom_group_kill > 0
+        || events.pids_max > 0
+    {
+        log(
+            "WARN",
+            &format!(
+                "exec workload hard resource limit reached group={group_name} memory_max={} memory_oom={} memory_oom_kill={} memory_oom_group_kill={} pids_max={}",
+                events.memory_max,
+                events.memory_oom,
+                events.memory_oom_kill,
+                events.memory_oom_group_kill,
+                events.pids_max
+            ),
+        );
+    }
+    if events.cpu_throttled_usec >= MATERIAL_CPU_THROTTLED_USEC || events.memory_high > 0 {
+        log(
+            "INFO",
+            &format!(
+                "exec workload resource pressure observed group={group_name} cpu_nr_throttled={} cpu_throttled_usec={} memory_high={}",
+                events.cpu_nr_throttled, events.cpu_throttled_usec, events.memory_high
+            ),
+        );
+    }
+}
+
+fn read_resource_events(workload_path: &Path) -> io::Result<ResourceEvents> {
+    let cpu = read_key_value_file(&workload_path.join(CPU_STAT_FILE))?;
+    let memory = read_key_value_file(&workload_path.join(MEMORY_EVENTS_FILE))?;
+    let pids = read_key_value_file(&workload_path.join(PIDS_EVENTS_FILE))?;
+    Ok(ResourceEvents {
+        cpu_nr_throttled: value_or_zero(&cpu, "nr_throttled"),
+        cpu_throttled_usec: value_or_zero(&cpu, "throttled_usec"),
+        memory_high: value_or_zero(&memory, "high"),
+        memory_max: value_or_zero(&memory, "max"),
+        memory_oom: value_or_zero(&memory, "oom"),
+        memory_oom_kill: value_or_zero(&memory, "oom_kill"),
+        memory_oom_group_kill: value_or_zero(&memory, "oom_group_kill"),
+        pids_max: value_or_zero(&pids, "max"),
+    })
+}
+
+fn read_key_value_file(path: &Path) -> io::Result<std::collections::HashMap<String, u64>> {
+    fs::read_to_string(path)?
+        .lines()
+        .map(|line| {
+            let (key, value) = line.split_once(' ').ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "invalid cgroup event line")
+            })?;
+            let value = value
+                .parse::<u64>()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            Ok((key.to_string(), value))
+        })
+        .collect()
+}
+
+fn value_or_zero(values: &std::collections::HashMap<String, u64>, key: &str) -> u64 {
+    values.get(key).copied().unwrap_or(0)
+}
+
 #[derive(Debug)]
 struct CleanupReport {
     descendants_observed: bool,
@@ -294,17 +599,22 @@ fn cleanup_cgroup(
     let mut graceful_errors = 0;
 
     if descendants_observed && mode == ProcessContainmentCleanupMode::Graceful {
-        match read_member_pids(group_path) {
-            Ok(pids) => {
-                initial_members = pids.len();
-                graceful_errors = signal_term(group_path, &pids);
-            }
-            Err(error) => {
-                graceful_errors = 1;
-                log(
-                    "WARN",
-                    &format!("exec process containment graceful enumeration failed error={error}"),
-                );
+        for leaf_path in cgroup_leaf_paths(group_path) {
+            match read_member_pids(&leaf_path) {
+                Ok(pids) => {
+                    initial_members += pids.len();
+                    graceful_errors += signal_term(&leaf_path, &pids);
+                }
+                Err(error) => {
+                    graceful_errors += 1;
+                    log(
+                        "WARN",
+                        &format!(
+                            "exec process containment graceful enumeration failed leaf={} error={error}",
+                            leaf_path.display()
+                        ),
+                    );
+                }
             }
         }
 
@@ -349,7 +659,7 @@ fn cleanup_cgroup(
         }
     }
 
-    remove_empty_cgroup(group_path)?;
+    remove_cgroup_hierarchy(group_path)?;
     Ok(CleanupReport {
         descendants_observed,
         cgroup_kill_used,
@@ -358,13 +668,46 @@ fn cleanup_cgroup(
     })
 }
 
-fn install_child_placement(command: &mut Command, placement: OwnedFd) {
-    // SAFETY: the closure performs only a raw write to an already-open file
-    // descriptor. `write` and reading errno are async-signal-safe between
-    // `fork` and `exec`.
+fn install_child_placement(
+    command: &mut Command,
+    placement: OwnedFd,
+    inherited_workload_placement: Option<OwnedFd>,
+) {
+    // SAFETY: the closure performs only raw writes and fcntl calls on already
+    // open descriptors. These operations are async-signal-safe between fork
+    // and exec.
     unsafe {
-        command.pre_exec(move || write_self_to_cgroup(placement.as_raw_fd()));
+        command.pre_exec(move || {
+            write_self_to_cgroup(placement.as_raw_fd())?;
+            if let Some(workload_placement) = inherited_workload_placement.as_ref() {
+                deny_unprivileged_process_inspection()?;
+                clear_close_on_exec(workload_placement.as_raw_fd())?;
+            }
+            Ok(())
+        });
     }
+}
+
+fn deny_unprivileged_process_inspection() -> io::Result<()> {
+    // SAFETY: PR_SET_DUMPABLE changes only the calling child between fork and
+    // exec and does not access shared userspace state.
+    if unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn clear_close_on_exec(fd: RawFd) -> io::Result<()> {
+    // SAFETY: `fd` is an owned descriptor retained by the pre-exec closure.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: clearing FD_CLOEXEC changes only this valid descriptor's flags.
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 fn write_self_to_cgroup(fd: RawFd) -> io::Result<()> {
@@ -522,6 +865,8 @@ fn wait_until_empty(group_path: &Path, timeout: Duration) -> Result<bool, Proces
 }
 
 fn remove_empty_cgroup(group_path: &Path) -> Result<(), ProcessContainmentError> {
+    #[cfg(test)]
+    remove_test_cgroup_interface_files(group_path);
     let deadline = Instant::now() + EXEC_PROCESS_CONTAINMENT_REMOVE_TIMEOUT;
     loop {
         match fs::remove_dir(group_path) {
@@ -539,6 +884,40 @@ fn remove_empty_cgroup(group_path: &Path) -> Result<(), ProcessContainmentError>
             }
         }
     }
+}
+
+#[cfg(test)]
+fn remove_test_cgroup_interface_files(group_path: &Path) {
+    for filename in [
+        CGROUP_SUBTREE_CONTROL_FILE,
+        CPU_MAX_FILE,
+        CPU_WEIGHT_FILE,
+        MEMORY_HIGH_FILE,
+        MEMORY_MAX_FILE,
+        MEMORY_MIN_FILE,
+        MEMORY_OOM_GROUP_FILE,
+        PIDS_MAX_FILE,
+    ] {
+        let _ = fs::remove_file(group_path.join(filename));
+    }
+}
+
+fn cgroup_leaf_paths(group_path: &Path) -> [PathBuf; 2] {
+    [
+        group_path.join(CONTROL_CGROUP_NAME),
+        group_path.join(WORKLOAD_CGROUP_NAME),
+    ]
+}
+
+fn remove_cgroup_hierarchy(group_path: &Path) -> Result<(), ProcessContainmentError> {
+    for leaf_path in cgroup_leaf_paths(group_path) {
+        match remove_empty_cgroup(&leaf_path) {
+            Ok(()) => {}
+            Err(error) if error.source.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    remove_empty_cgroup(group_path)
 }
 
 #[cfg(test)]
@@ -627,7 +1006,7 @@ mod tests {
         let child_fd: OwnedFd = placement.try_clone().unwrap().into();
         let mut command = Command::new("/bin/true");
         command.stdout(Stdio::null()).stderr(Stdio::null());
-        install_child_placement(&mut command, child_fd);
+        install_child_placement(&mut command, child_fd, None);
 
         let status = command.status().unwrap();
 
@@ -642,12 +1021,15 @@ mod tests {
     fn partial_creation_failure_removes_operation_cgroup() {
         let base = tempfile::tempdir().unwrap();
 
-        let result = CgroupGuard::create_in(base.path(), 17);
+        let policy =
+            WorkloadResourcePolicy::for_guest_capacity(2, u64::from(4096_u32) * 1024 * 1024)
+                .unwrap();
+        let result = CgroupGuard::create_in(base.path(), 17, false, policy);
         let Err(error) = result else {
             panic!("placement-file open unexpectedly succeeded");
         };
 
-        assert_eq!(error.stage, "open cgroup.procs");
+        assert_eq!(error.stage, "open outer cgroup.procs");
         assert_eq!(error.source.kind(), io::ErrorKind::NotFound);
         assert!(fs::read_dir(base.path()).unwrap().next().is_none());
     }

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -513,7 +513,7 @@ fn configure_resource_policy(
     write_cgroup_value(
         workload_path,
         PIDS_MAX_FILE,
-        &policy.pids_max.to_string(),
+        policy.pids_max,
         "configure workload pids.max",
     )?;
 

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -68,7 +68,7 @@ const ENV_SCRIPT_SUFFIX: &str = ".sh";
 const ENV_SCRIPT_STALE_AFTER: Duration = Duration::from_secs(60 * 60);
 const CHOWN_UNCHANGED_UID: libc::uid_t = !0;
 
-fn shell_command_user() -> io::Result<Option<(&'static str, PathBuf)>> {
+fn shell_command_user_home() -> io::Result<Option<PathBuf>> {
     #[cfg(any(debug_assertions, feature = "test-support"))]
     {
         Ok(None)
@@ -77,10 +77,7 @@ fn shell_command_user() -> io::Result<Option<(&'static str, PathBuf)>> {
     #[cfg(not(any(debug_assertions, feature = "test-support")))]
     {
         // Default user for command execution (UID 1000)
-        Ok(Some((
-            crate::user::sandbox_user_name(),
-            crate::user::sandbox_user_home()?,
-        )))
+        crate::user::sandbox_user_home().map(Some)
     }
 }
 
@@ -91,8 +88,7 @@ fn shell_escape_value(val: &str) -> String {
 
 /// Build a Command to execute a shell command as the appropriate user.
 ///
-/// When `sudo` is true the command runs as root, bypassing `su` and the PAM
-/// overhead that comes with it.
+/// When `sudo` is true the command runs as root.
 ///
 /// In production-style builds, non-sudo commands run through a non-login
 /// `/bin/sh` selected explicitly rather than the sandbox user's login shell.
@@ -101,19 +97,18 @@ fn shell_escape_value(val: &str) -> String {
 /// persisted sandbox-owned profile files before the trusted command bootstrap.
 /// In debug/test-support builds, local tests run as the current user unless
 /// `sudo` explicitly requests elevation through `sudo sh -c`.
-pub(crate) fn build_shell_command(command: &str, sudo: bool) -> io::Result<Command> {
-    let user = shell_command_user()?;
+fn build_shell_command_program(command: &str, sudo: bool) -> io::Result<Command> {
+    let user_home = shell_command_user_home()?;
     Ok(build_shell_command_for_user(
         command,
         sudo,
-        user.as_ref()
-            .map(|(username, home)| (*username, home.as_path())),
+        user_home.as_deref(),
     ))
 }
 
-fn build_shell_command_for_user(command: &str, sudo: bool, user: Option<(&str, &Path)>) -> Command {
-    match user {
-        Some((user, home)) => {
+fn build_shell_command_for_user(command: &str, sudo: bool, user_home: Option<&Path>) -> Command {
+    match user_home {
+        Some(home) => {
             if sudo {
                 // Release: already root — run directly
                 let mut c = Command::new("sh");
@@ -121,12 +116,8 @@ fn build_shell_command_for_user(command: &str, sudo: bool, user: Option<(&str, &
                 c
             } else {
                 let command = format!(". /etc/profile\n{command}");
-                let mut c = Command::new("su");
-                c.arg("--shell")
-                    .arg("/bin/sh")
-                    .arg("--command")
-                    .arg(command)
-                    .arg(user);
+                let mut c = Command::new("/bin/sh");
+                c.arg("-c").arg(command);
                 c.current_dir(home);
                 c
             }
@@ -497,7 +488,7 @@ fn create_env_script_in_dir(
 
         let result = (|| -> io::Result<()> {
             file.write_all(script.as_bytes())?;
-            if effective_uid() == 0 && !sudo && shell_command_user()?.is_some() {
+            if effective_uid() == 0 && !sudo && shell_command_user_home()?.is_some() {
                 // Keep the per-run directory and script root-owned. The
                 // sandbox user only gets group read/traverse access; if it
                 // owned either path, an existing same-UID process could
@@ -541,7 +532,7 @@ fn script_invocation(path: &Path) -> io::Result<String> {
             "env script path must be valid UTF-8",
         )
     })?;
-    Ok(format!("/bin/bash {}", shell_escape_value(path)))
+    Ok(format!("exec /bin/bash {}", shell_escape_value(path)))
 }
 
 pub(crate) fn build_shell_command_with_env(
@@ -551,7 +542,7 @@ pub(crate) fn build_shell_command_with_env(
 ) -> io::Result<PreparedShellCommand> {
     if env.is_empty() {
         return Ok(PreparedShellCommand {
-            command: build_shell_command(command, sudo)?,
+            command: build_shell_command_program(command, sudo)?,
             env_script: None,
         });
     }
@@ -562,7 +553,7 @@ pub(crate) fn build_shell_command_with_env(
         .ok_or_else(|| io::Error::other("env script path missing"))?;
     let invocation = script_invocation(script_path)?;
     Ok(PreparedShellCommand {
-        command: build_shell_command(&invocation, sudo)?,
+        command: build_shell_command_program(&invocation, sudo)?,
         env_script: Some(env_script),
     })
 }
@@ -590,7 +581,7 @@ pub(crate) fn spawn_shell_command_with_pipes(
     process_containment: ExecProcessContainment,
 ) -> io::Result<SpawnedShellCommand> {
     let spawn_result = (|| -> io::Result<(Child, Option<EnvScriptGuard>)> {
-        let prepared_containment = process_containment.prepare_command().map_err(|error| {
+        let mut prepared_containment = process_containment.prepare_command().map_err(|error| {
             io::Error::other(format!("process containment setup failed: {error}"))
         })?;
         let PreparedShellCommand {
@@ -601,7 +592,12 @@ pub(crate) fn spawn_shell_command_with_pipes(
         if pipe_stdin {
             command.stdin(Stdio::piped());
         }
-        prepared_containment.configure_command(&mut command);
+        // Placement requires the root-opened cgroup descriptor. Drop to the
+        // sandbox identity only after placement, then restore non-dumpable
+        // state because setuid may reset it.
+        prepared_containment.configure_placement(&mut command);
+        crate::user::apply_command_identity(&mut command, sudo)?;
+        prepared_containment.configure_process_inspection(&mut command);
         let child = crate::process::spawn_in_own_process_group(&mut command)?;
         Ok((child, env_script))
     })();
@@ -765,7 +761,7 @@ mod tests {
         let script =
             create_env_script_in_dir(&dir, "echo \"$FOO\"", &[("FOO", secret)], true).unwrap();
         let invocation = script_invocation(script.path().unwrap()).unwrap();
-        let command = build_shell_command(&invocation, true).unwrap();
+        let command = build_shell_command_program(&invocation, true).unwrap();
         let argv = std::iter::once(command.get_program().to_string_lossy().to_string())
             .chain(
                 command
@@ -776,7 +772,7 @@ mod tests {
             .join("\0");
 
         assert!(!argv.contains(secret));
-        assert!(argv.contains("/bin/bash"));
+        assert!(argv.contains("exec /bin/bash"));
         assert!(argv.contains(script.path().unwrap().to_str().unwrap()));
     }
 
@@ -1085,33 +1081,16 @@ mod tests {
 
     #[test]
     fn build_shell_command_for_sandbox_user() {
-        let command = build_shell_command_for_user(
-            "echo hello",
-            false,
-            Some(("sandbox", Path::new("/home/sandbox"))),
-        );
+        let command =
+            build_shell_command_for_user("echo hello", false, Some(Path::new("/home/sandbox")));
         assert_eq!(command.get_current_dir(), Some(Path::new("/home/sandbox")));
-        assert_command(
-            command,
-            "su",
-            &[
-                "--shell",
-                "/bin/sh",
-                "--command",
-                ". /etc/profile\necho hello",
-                "sandbox",
-            ],
-        );
+        assert_command(command, "/bin/sh", &["-c", ". /etc/profile\necho hello"]);
     }
 
     #[test]
     fn build_privileged_shell_command_for_sandbox_user() {
         assert_command(
-            build_shell_command_for_user(
-                "reboot",
-                true,
-                Some(("sandbox", Path::new("/home/sandbox"))),
-            ),
+            build_shell_command_for_user("reboot", true, Some(Path::new("/home/sandbox"))),
             "sh",
             &["-c", "reboot"],
         );

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -10,11 +10,12 @@
 //! treated as secret material by this module.
 //!
 //! The wrapper depends on build mode and `sudo`. Production non-`sudo` commands
-//! run through a non-login `/bin/sh` as the sandbox user, production `sudo`
-//! commands run as root, and debug/test-support builds run as the current user
-//! unless `sudo` requests the local `sudo sh -c` wrapper. The production
-//! wrapper must stay non-login: sandbox-owned profile files may persist across
-//! VM reuse and must never run before the trusted command bootstrap.
+//! run through a non-login `/bin/sh` as the sandbox user after explicitly
+//! loading the root-owned system profile, production `sudo` commands run as
+//! root, and debug/test-support builds run as the current user unless `sudo`
+//! requests the local `sudo sh -c` wrapper. The production wrapper must stay
+//! non-login: sandbox-owned profile files may persist across VM reuse and must
+//! never run before the trusted command bootstrap.
 //!
 //! The env-script path is one security boundary. Env keys must be shell
 //! identifiers, command/env values reject NUL bytes, the parent directory must
@@ -95,8 +96,9 @@ fn shell_escape_value(val: &str) -> String {
 ///
 /// In production-style builds, non-sudo commands run through a non-login
 /// `/bin/sh` selected explicitly rather than the sandbox user's login shell.
-/// This prevents persisted sandbox-owned profile files from executing before
-/// a root-owned env script and from observing inherited bootstrap capabilities.
+/// The command sources only `/etc/profile` so rootfs-provided runtime
+/// environment such as `RUSTUP_HOME` remains available without executing
+/// persisted sandbox-owned profile files before the trusted command bootstrap.
 /// In debug/test-support builds, local tests run as the current user unless
 /// `sudo` explicitly requests elevation through `sudo sh -c`.
 pub(crate) fn build_shell_command(command: &str, sudo: bool) -> io::Result<Command> {
@@ -118,6 +120,7 @@ fn build_shell_command_for_user(command: &str, sudo: bool, user: Option<(&str, &
                 c.arg("-c").arg(command);
                 c
             } else {
+                let command = format!(". /etc/profile\n{command}");
                 let mut c = Command::new("su");
                 c.arg("--shell")
                     .arg("/bin/sh")
@@ -1091,7 +1094,13 @@ mod tests {
         assert_command(
             command,
             "su",
-            &["--shell", "/bin/sh", "--command", "echo hello", "sandbox"],
+            &[
+                "--shell",
+                "/bin/sh",
+                "--command",
+                ". /etc/profile\necho hello",
+                "sandbox",
+            ],
         );
     }
 

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -10,9 +10,11 @@
 //! treated as secret material by this module.
 //!
 //! The wrapper depends on build mode and `sudo`. Production non-`sudo` commands
-//! run through the sandbox user, production `sudo` commands run as root, and
-//! debug/test-support builds run as the current user unless `sudo` requests the
-//! local `sudo sh -c` wrapper.
+//! run through a non-login `/bin/sh` as the sandbox user, production `sudo`
+//! commands run as root, and debug/test-support builds run as the current user
+//! unless `sudo` requests the local `sudo sh -c` wrapper. The production
+//! wrapper must stay non-login: sandbox-owned profile files may persist across
+//! VM reuse and must never run before the trusted command bootstrap.
 //!
 //! The env-script path is one security boundary. Env keys must be shell
 //! identifiers, command/env values reject NUL bytes, the parent directory must
@@ -55,8 +57,6 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsE
 
 use shell_quote::quote_shell_arg;
 
-use guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV;
-
 use crate::process_containment::{ExecProcessContainment, ProcessContainmentCleanupMode};
 
 /// Maximum length for command preview in logs
@@ -67,16 +67,19 @@ const ENV_SCRIPT_SUFFIX: &str = ".sh";
 const ENV_SCRIPT_STALE_AFTER: Duration = Duration::from_secs(60 * 60);
 const CHOWN_UNCHANGED_UID: libc::uid_t = !0;
 
-fn shell_command_user() -> Option<&'static str> {
+fn shell_command_user() -> io::Result<Option<(&'static str, PathBuf)>> {
     #[cfg(any(debug_assertions, feature = "test-support"))]
     {
-        None
+        Ok(None)
     }
 
     #[cfg(not(any(debug_assertions, feature = "test-support")))]
     {
         // Default user for command execution (UID 1000)
-        Some(crate::user::sandbox_user_name())
+        Ok(Some((
+            crate::user::sandbox_user_name(),
+            crate::user::sandbox_user_home()?,
+        )))
     }
 }
 
@@ -87,19 +90,28 @@ fn shell_escape_value(val: &str) -> String {
 
 /// Build a Command to execute a shell command as the appropriate user.
 ///
-/// When `sudo` is true the command runs as root, bypassing `su - user` and
-/// the PAM overhead that comes with it.
+/// When `sudo` is true the command runs as root, bypassing `su` and the PAM
+/// overhead that comes with it.
 ///
-/// In production-style builds, non-sudo commands run through `su - user`.
+/// In production-style builds, non-sudo commands run through a non-login
+/// `/bin/sh` selected explicitly rather than the sandbox user's login shell.
+/// This prevents persisted sandbox-owned profile files from executing before
+/// a root-owned env script and from observing inherited bootstrap capabilities.
 /// In debug/test-support builds, local tests run as the current user unless
 /// `sudo` explicitly requests elevation through `sudo sh -c`.
-pub(crate) fn build_shell_command(command: &str, sudo: bool) -> Command {
-    build_shell_command_for_user(command, sudo, shell_command_user())
+pub(crate) fn build_shell_command(command: &str, sudo: bool) -> io::Result<Command> {
+    let user = shell_command_user()?;
+    Ok(build_shell_command_for_user(
+        command,
+        sudo,
+        user.as_ref()
+            .map(|(username, home)| (*username, home.as_path())),
+    ))
 }
 
-fn build_shell_command_for_user(command: &str, sudo: bool, user: Option<&str>) -> Command {
+fn build_shell_command_for_user(command: &str, sudo: bool, user: Option<(&str, &Path)>) -> Command {
     match user {
-        Some(user) => {
+        Some((user, home)) => {
             if sudo {
                 // Release: already root — run directly
                 let mut c = Command::new("sh");
@@ -107,7 +119,12 @@ fn build_shell_command_for_user(command: &str, sudo: bool, user: Option<&str>) -
                 c
             } else {
                 let mut c = Command::new("su");
-                c.arg("-").arg(user).arg("-c").arg(command);
+                c.arg("--shell")
+                    .arg("/bin/sh")
+                    .arg("--command")
+                    .arg(command)
+                    .arg(user);
+                c.current_dir(home);
                 c
             }
         }
@@ -477,7 +494,7 @@ fn create_env_script_in_dir(
 
         let result = (|| -> io::Result<()> {
             file.write_all(script.as_bytes())?;
-            if effective_uid() == 0 && !sudo && shell_command_user().is_some() {
+            if effective_uid() == 0 && !sudo && shell_command_user()?.is_some() {
                 // Keep the per-run directory and script root-owned. The
                 // sandbox user only gets group read/traverse access; if it
                 // owned either path, an existing same-UID process could
@@ -531,7 +548,7 @@ pub(crate) fn build_shell_command_with_env(
 ) -> io::Result<PreparedShellCommand> {
     if env.is_empty() {
         return Ok(PreparedShellCommand {
-            command: build_shell_command(command, sudo),
+            command: build_shell_command(command, sudo)?,
             env_script: None,
         });
     }
@@ -542,7 +559,7 @@ pub(crate) fn build_shell_command_with_env(
         .ok_or_else(|| io::Error::other("env script path missing"))?;
     let invocation = script_invocation(script_path)?;
     Ok(PreparedShellCommand {
-        command: build_shell_command(&invocation, sudo),
+        command: build_shell_command(&invocation, sudo)?,
         env_script: Some(env_script),
     })
 }
@@ -573,22 +590,10 @@ pub(crate) fn spawn_shell_command_with_pipes(
         let prepared_containment = process_containment.prepare_command().map_err(|error| {
             io::Error::other(format!("process containment setup failed: {error}"))
         })?;
-        let inherited_workload_fd = prepared_containment
-            .inherited_workload_fd()
-            .map(|fd| fd.to_string());
-        let mut env_with_workload_placement;
-        let effective_env = if let Some(fd) = inherited_workload_fd.as_deref() {
-            env_with_workload_placement = Vec::with_capacity(env.len() + 1);
-            env_with_workload_placement.extend_from_slice(env);
-            env_with_workload_placement.push((WORKLOAD_CGROUP_PROCS_FD_ENV, fd));
-            env_with_workload_placement.as_slice()
-        } else {
-            env
-        };
         let PreparedShellCommand {
             mut command,
             env_script,
-        } = build_shell_command_with_env(command, effective_env, sudo)?;
+        } = build_shell_command_with_env(command, env, sudo)?;
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
         if pipe_stdin {
             command.stdin(Stdio::piped());
@@ -757,7 +762,7 @@ mod tests {
         let script =
             create_env_script_in_dir(&dir, "echo \"$FOO\"", &[("FOO", secret)], true).unwrap();
         let invocation = script_invocation(script.path().unwrap()).unwrap();
-        let command = build_shell_command(&invocation, true);
+        let command = build_shell_command(&invocation, true).unwrap();
         let argv = std::iter::once(command.get_program().to_string_lossy().to_string())
             .chain(
                 command
@@ -1077,17 +1082,27 @@ mod tests {
 
     #[test]
     fn build_shell_command_for_sandbox_user() {
+        let command = build_shell_command_for_user(
+            "echo hello",
+            false,
+            Some(("sandbox", Path::new("/home/sandbox"))),
+        );
+        assert_eq!(command.get_current_dir(), Some(Path::new("/home/sandbox")));
         assert_command(
-            build_shell_command_for_user("echo hello", false, Some("sandbox")),
+            command,
             "su",
-            &["-", "sandbox", "-c", "echo hello"],
+            &["--shell", "/bin/sh", "--command", "echo hello", "sandbox"],
         );
     }
 
     #[test]
     fn build_privileged_shell_command_for_sandbox_user() {
         assert_command(
-            build_shell_command_for_user("reboot", true, Some("sandbox")),
+            build_shell_command_for_user(
+                "reboot",
+                true,
+                Some(("sandbox", Path::new("/home/sandbox"))),
+            ),
             "sh",
             &["-c", "reboot"],
         );

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -55,6 +55,8 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsE
 
 use shell_quote::quote_shell_arg;
 
+use guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_FD_ENV;
+
 use crate::process_containment::{ExecProcessContainment, ProcessContainmentCleanupMode};
 
 /// Maximum length for command preview in logs
@@ -568,19 +570,30 @@ pub(crate) fn spawn_shell_command_with_pipes(
     process_containment: ExecProcessContainment,
 ) -> io::Result<SpawnedShellCommand> {
     let spawn_result = (|| -> io::Result<(Child, Option<EnvScriptGuard>)> {
+        let prepared_containment = process_containment.prepare_command().map_err(|error| {
+            io::Error::other(format!("process containment setup failed: {error}"))
+        })?;
+        let inherited_workload_fd = prepared_containment
+            .inherited_workload_fd()
+            .map(|fd| fd.to_string());
+        let mut env_with_workload_placement;
+        let effective_env = if let Some(fd) = inherited_workload_fd.as_deref() {
+            env_with_workload_placement = Vec::with_capacity(env.len() + 1);
+            env_with_workload_placement.extend_from_slice(env);
+            env_with_workload_placement.push((WORKLOAD_CGROUP_PROCS_FD_ENV, fd));
+            env_with_workload_placement.as_slice()
+        } else {
+            env
+        };
         let PreparedShellCommand {
             mut command,
             env_script,
-        } = build_shell_command_with_env(command, env, sudo)?;
+        } = build_shell_command_with_env(command, effective_env, sudo)?;
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
         if pipe_stdin {
             command.stdin(Stdio::piped());
         }
-        process_containment
-            .configure_command(&mut command)
-            .map_err(|error| {
-                io::Error::other(format!("process containment setup failed: {error}"))
-            })?;
+        prepared_containment.configure_command(&mut command);
         let child = crate::process::spawn_in_own_process_group(&mut command)?;
         Ok((child, env_script))
     })();

--- a/crates/vsock-guest/src/user.rs
+++ b/crates/vsock-guest/src/user.rs
@@ -33,6 +33,11 @@ pub(crate) fn sandbox_user_name() -> &'static str {
     SANDBOX_USER
 }
 
+#[cfg(not(any(debug_assertions, feature = "test-support")))]
+pub(crate) fn sandbox_user_home() -> io::Result<PathBuf> {
+    cached_system_user_credentials().map(|credentials| credentials.home.clone())
+}
+
 pub(crate) fn sandbox_user_gid() -> io::Result<libc::gid_t> {
     #[cfg(any(debug_assertions, feature = "test-support"))]
     {
@@ -44,6 +49,24 @@ pub(crate) fn sandbox_user_gid() -> io::Result<libc::gid_t> {
     #[cfg(not(any(debug_assertions, feature = "test-support")))]
     {
         cached_system_user_credentials().map(|credentials| credentials.gid as libc::gid_t)
+    }
+}
+
+pub(crate) fn shell_command_uid(sudo: bool) -> io::Result<libc::uid_t> {
+    if sudo {
+        // SAFETY: geteuid is a simple scalar getter with no preconditions.
+        return Ok(unsafe { libc::geteuid() });
+    }
+
+    #[cfg(any(debug_assertions, feature = "test-support"))]
+    {
+        // SAFETY: geteuid is a simple scalar getter with no preconditions.
+        Ok(unsafe { libc::geteuid() })
+    }
+
+    #[cfg(not(any(debug_assertions, feature = "test-support")))]
+    {
+        cached_system_user_credentials().map(|credentials| credentials.uid as libc::uid_t)
     }
 }
 

--- a/crates/vsock-guest/src/user.rs
+++ b/crates/vsock-guest/src/user.rs
@@ -29,11 +29,6 @@ enum TargetIdentity {
 }
 
 #[cfg(not(any(debug_assertions, feature = "test-support")))]
-pub(crate) fn sandbox_user_name() -> &'static str {
-    SANDBOX_USER
-}
-
-#[cfg(not(any(debug_assertions, feature = "test-support")))]
 pub(crate) fn sandbox_user_home() -> io::Result<PathBuf> {
     cached_system_user_credentials().map(|credentials| credentials.home.clone())
 }
@@ -70,7 +65,7 @@ pub(crate) fn shell_command_uid(sudo: bool) -> io::Result<libc::uid_t> {
     }
 }
 
-pub(crate) fn apply_write_file_identity(command: &mut Command, sudo: bool) -> io::Result<()> {
+pub(crate) fn apply_command_identity(command: &mut Command, sudo: bool) -> io::Result<()> {
     #[cfg(any(debug_assertions, feature = "test-support"))]
     let _ = command;
     match target_identity(sudo)? {
@@ -143,7 +138,7 @@ fn apply_credentials(command: &mut Command, credentials: UserCredentials) -> io:
         let _ = command;
         return Err(io::Error::new(
             io::ErrorKind::Unsupported,
-            "write_file user credential drop requires Unix",
+            "sandbox user credential drop requires Unix",
         ));
     }
 

--- a/crates/vsock-guest/tests/production_identity.rs
+++ b/crates/vsock-guest/tests/production_identity.rs
@@ -11,7 +11,7 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use vsock_proto::{
-    ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
+    ExecCapturedOutput, ExecControlPolicy, ExecLifecyclePolicy, ExecOutputPolicy, ExecOutputStream,
     ExecStartEncodeRequest, ExecTermination, ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_CANCEL,
     MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED, MSG_READY, MSG_WRITE_FILE,
     MSG_WRITE_FILE_RESULT, RawMessage,
@@ -99,6 +99,62 @@ fn production_write_file_identity_matches_sudo_policy() {
     send_write_file(&mut stream, 2, &sudo_report_path, true);
 
     assert_eq!(sudo_report.read_identity(), parent);
+
+    drop(stream);
+    join_guest_connection(handle);
+}
+
+#[test]
+#[ignore = "requires root and a production sandbox account; executed explicitly by Rust CI"]
+fn production_exec_identity_matches_sandbox_user() {
+    require_production_configuration();
+    assert_eq!(current_identity().uid, 0, "test must run as root");
+
+    let (handle, mut stream) = start_guest_connection();
+    let sequence = 2;
+    let command = "printf 'uid=%s\\ngid=%s\\ngroups=%s\\ncwd=%s\\nhome=%s\\nuser=%s\\nlogname=%s\\n' \"$(id -u)\" \"$(id -g)\" \"$(id -G)\" \"$(pwd -P)\" \"${HOME-}\" \"${USER-}\" \"${LOGNAME-}\"";
+    let payload = vsock_proto::encode_exec_start_with_expected_exit_codes(ExecStartEncodeRequest {
+        lifecycle: ExecLifecyclePolicy::OneShot,
+        timeout: ExecTimeoutPolicy::Duration { timeout_ms: 5_000 },
+        command,
+        env: &[],
+        sudo: false,
+        label: "production-exec-identity",
+        stdout: ExecOutputPolicy::Capture { limit_bytes: 1_024 },
+        stderr: ExecOutputPolicy::Capture { limit_bytes: 1_024 },
+        expected_exit_codes: &[],
+        control: ExecControlPolicy::Disabled,
+        stdin_bytes: None,
+    })
+    .expect("encode exec-start payload");
+    let frame = vsock_proto::encode(MSG_EXEC_START, sequence, &payload).expect("frame exec start");
+    stream.write_all(&frame).expect("send exec-start request");
+
+    let response = read_message(&mut stream);
+    assert_eq!(response.msg_type, MSG_EXEC_RESULT);
+    assert_eq!(response.seq, sequence);
+    let result = vsock_proto::decode_exec_result(&response.payload).expect("decode exec result");
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(result.diagnostic, "");
+    let ExecCapturedOutput::Captured {
+        bytes: stdout,
+        truncated: false,
+    } = result.stdout
+    else {
+        panic!("production identity stdout was not fully captured");
+    };
+    assert_eq!(
+        parse_identity_report(std::str::from_utf8(stdout).expect("identity output is UTF-8")),
+        Identity {
+            uid: SANDBOX_UID,
+            gid: SANDBOX_GID,
+            groups: BTreeSet::from([SANDBOX_GID, SANDBOX_SUPPLEMENTARY_GID]),
+            cwd: PathBuf::from(SANDBOX_HOME),
+            home: SANDBOX_HOME.to_string(),
+            user: "user".to_string(),
+            logname: "user".to_string(),
+        }
+    );
 
     drop(stream);
     join_guest_connection(handle);


### PR DESCRIPTION
## Summary

- split each Guest exec operation into an empty cgroup parent with dedicated `control` and `workload` leaves
- reserve CPU and memory headroom for Guest Agent control work while bounding workload CPU and memory
- keep the PID controller available without imposing an uncalibrated production task ceiling
- place Claude, Codex app-server, Pi, ordinary execs, and their descendants in `workload` before exec
- transfer the workload-placement capability over an operation-local authenticated `SCM_RIGHTS` broker instead of inheriting it across the sandbox-user transition
- preserve nested-cgroup cleanup, disconnected execution handling, and same-VM reuse invariants, with one shared terminal cleanup deadline for the complete cgroup hierarchy
- preserve workload hard-limit counters in structured failure diagnostics and Runner terminal logs
- validate Runner profiles against the Firecracker-calibrated 1-vCPU/1024-MiB minimum, then derive workload limits from fixed control reserves

Closes #26479

## Resource policy

The default 2-vCPU Guest uses:

- workload `cpu.max`: `190000 100000`, reserving 0.1 vCPU for control work
- control/operation `cpu.weight`: `10000`
- workload `memory.max`: Guest-visible physical memory minus 384 MiB
- workload `memory.high`: 256 MiB below `memory.max`
- base/operation/control `memory.min`: 384 MiB
- workload `pids.max`: `max`

The PID controller remains enabled for per-operation accounting, diagnostics, and bounded enforcement tests. Production leaves use `pids.max=max` because this PR has no representative Claude, Codex, and Pi `pids.peak` calibration that would justify a fixed task ceiling. The committed behavior test temporarily sets its own operation to `64` to verify fork rejection, structured `pids.events` attribution, cleanup, and reuse without constraining normal workloads.

Runner rejects configured profiles below the Firecracker-calibrated 1 vCPU / 1024 MiB support boundary. Profiles at or above that boundary use the same fixed-reserve calculation inside the Guest. Guest startup recalculates from actual Guest-visible capacity and fails closed if that capacity cannot preserve the reserves.

On `dev-1.aws.vm3.ai`, an exact 1-vCPU/1024-MiB Firecracker snapshot exposed 1,033,928,704 bytes to the Guest after kernel reservations. The resulting workload limits were 0.9 vCPU, 631,275,520-byte `memory.max`, and 362,840,064-byte `memory.high`. The complete short containment scenario passed on that profile. Configurations such as 641 MiB or 1023 MiB are rejected even though a purely arithmetic remainder could be positive.

## Security and lifecycle

- `vsock-guest` keeps the root-opened, write-only workload `cgroup.procs` descriptor out of the sandbox-user launch chain. A dedicated abstract Unix endpoint sends it with `SCM_RIGHTS` only to the expected UID in the exact operation `control` cgroup, verified with `SO_PEERCRED` and `/proc/<pid>/cgroup`.
- The sandbox-user transition directly applies the resolved UID, GID, supplementary groups, home, and trusted environment before executing an explicit non-login `/bin/sh`. Process placement occurs while privileged, and process-inspection denial is restored after the credential transition. Reuse coverage plants adversarial `.profile`, `.bash_profile`, and PAM `BASH_ENV` hooks and proves none execute before Guest Agent.
- Guest Agent consumes the endpoint and receives the descriptor before starting Tokio, validates a write-only cgroup v2 descriptor targeting the exact sibling `workload/cgroup.procs`, remains non-dumpable, and uses close-on-exec clones only in CLI-child `pre_exec` hooks.
- Workload environments contain neither the endpoint nor the descriptor, and workload code cannot inspect Guest Agent descriptors or move itself into `control`. Behavior coverage requires the `control` cgroup to contain exactly the Guest Agent process.
- Graceful termination enumerates both leaves with pidfd identity checks; forced cleanup keeps the operation parent as the recursive `cgroup.kill` boundary. Leaf and parent removal share one bounded terminal-cleanup deadline.
- Reuse validation requires the exact controller topology, ancestor memory protection, workload limits, and quiescence contract before parking a sandbox. A sandbox retaining the former `pids.max=2048` policy is rejected rather than reused under the new policy.

This protects the supported workload boundary from CPU and memory pressure. It does not claim protection from task exhaustion while production `pids.max` is unlimited, or attempt to defend the cgroup hierarchy from malicious Guest root, which is outside this issue's trust model.

## Validation

Current-head local checks:

- `cargo fmt --all --check`
- `cargo clippy -p guest-contracts -p vsock-guest -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p guest-contracts -p vsock-guest -p guest-agent -p runner`
- `cargo test -p guest-contracts --all-targets --all-features`
- `cargo test -p vsock-guest --lib process_containment::tests --all-features`
- `cargo test -p guest-agent --test reuse_preparation_helper --all-features`
- `cargo test -p runner --bin runner --all-features 'config::tests::load_'`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- repository pre-commit Rust formatting, workspace Clippy, rustdoc, commitlint, and file-size checks

Earlier implementation validation also covered targeted Clippy and rustdoc for `process-control-ipc`, `guest-init`, `vsock-guest`, `guest-agent`, and `sandbox-fc`; release checking for `vsock-guest`; unit/integration suites for process-control IPC, Guest workload placement, `vsock-guest`, and `sandbox-fc`; targeted Runner tests for workload-limit attribution, terminal logging, and OOM fallback behavior; and Bash syntax validation for both modified Runner behavior scripts.

The exact 1-vCPU/1024-MiB Firecracker validation on `dev-1.aws.vm3.ai` completed the full short process-containment behavior in 19.5 seconds:

- six seconds of CPU saturation produced 59 throttled periods while all process-control inputs and two five-second metric samples remained live
- workload-local memory OOM was classified in two seconds without killing Guest Agent
- an operation-local PID limit rejected forks and cleanup reclaimed 58 members in 536 ms
- detached user/root descendants were reclaimed, and three-turn plus post-pressure same-VM reuse remained clean

The committed CI regression uses the same short behavior shape: six seconds of CPU pressure, a ninth-second completion input, and temporary operation-local memory/PID limits for bounded kernel-path coverage. It does not add a two-minute active delay.

Production-equivalent validation on `local-1.aws.vm3.ai`, aarch64, 2 vCPU / 4096 MiB, verified the review fixes:

- non-sudo exec ran as UID/GID 1000 with the expected supplementary group and home, while `control` contained exactly `guest-agent` and the workload could not inspect its descriptors
- a bounded 256-MiB workload OOM completed in under four seconds of Guest execution; Runner retained all five structured cgroup counters, did not rewrite the failure as `guest_memory_oom_killed`, and classified the sandbox as `eligible_nonzero_exit`

Earlier production-equivalent resource calibration on the same host established:

- sustained CPU pressure for 141-142 seconds while Guest heartbeats, five-second metrics, and process-control delivery remained live; active-input delivery stayed below 0.73 seconds
- concurrent ordinary-exec CPU pressure while three process-control messages were consumed and heartbeat cadence remained stable
- workload-local memory exhaustion and operation-local PID enforcement while Guest Agent remained available; cancellation was approximately 117 ms in the memory-pressure run and cleanup removed approximately 2,000 descendants
- three same-VM reuse turns without stale operation cgroups or user/root descendants
- the effective base/operation/control `memory.min` protection chain

## Observability

Process-control delivery records structured `elapsed_ms`, `timeout_ms`, and `outcome` fields only for material latency: `INFO` at 250 ms and `WARN` at the calibrated 750 ms bound. Routine fast delivery remains silent.

Workload `memory.max`, OOM, OOM-kill, OOM-group-kill, and any `pids.max` event counters are carried in the version-compatible failure diagnostic and projected into structured Runner terminal fields.

## Performance

On the default profile, CPU-bound OpenSSL throughput changed from 2.122 GB/s on `main` to 2.029 GB/s with the 5% CPU reserve (`-4.35%`). No-pressure startup increased by approximately 31 ms in the sampled runs (about 48 ms to 79 ms); this small absolute measurement was noisy.

## Exclusions

No database schema, API heartbeat, Runner heartbeat, terminal-state, active-input protocol, public API, feature switch, user-configurable resource policy, or uncalibrated production PID ceiling is introduced.
