### PR TITLE
refactor(protocol): stop emitting zero runtime credentials

### DIFF
--- a/docs/okou-protocol-migration.md
+++ b/docs/okou-protocol-migration.md
@@ -1,8 +1,8 @@
 # Okou protocol migration
 
 This document records the Phase B protocol contract for issues #26487 and
-#26490. Phase A compatibility is live at release target
-`2eba4f48e1b1bbcce818f4b8a6c8f717c28f7006`.
+#26490 and the new-context writer stop tracked by #26652. Phase B is live at
+release target `d2fddbf6714b35182e1ef4b787adf84724f6ee02`.
 
 ## Canonical and compatibility surfaces
 
@@ -18,35 +18,49 @@ the Zero alias until the corresponding third-party allowlists are migrated in
 a separately verified rollout. Both callback paths reach the same handler.
 
 Current consumers prefer `OKOU_*` variables and fall back to their `ZERO_*`
-aliases. Every new Zero-agent run emits both `OKOU_APP_URL` and `ZERO_APP_URL`,
-both agent and optional chat-thread identifier names, and two independent
-run-token secrets:
+aliases. New first-party Okou-agent and presentation-template execution
+contexts emit only:
 
-- `OKOU_TOKEN` has `scope: "okou"`.
-- `ZERO_TOKEN` has `scope: "zero"`.
+- `OKOU_APP_URL`;
+- `OKOU_AGENT_ID`;
+- optional `OKOU_CHAT_THREAD_ID`; and
+- one `OKOU_TOKEN` with `scope: "okou"`.
 
-The tokens retain the existing sandbox prefix and equivalent identity,
-organization, run, capability, optional Computer Use host, optional browser,
-issued-at, and expiry claims. They are signed separately and therefore have
-different values. Token values remain inside the existing secret boundary and
-must not be logged, rendered into prompts, telemetry, snapshots, or PR text.
+The token retains the existing sandbox prefix, identity, organization, run,
+capability, optional Computer Use host, optional browser, issued-at, and expiry
+claims. New contexts no longer generate, store, or inject `ZERO_TOKEN`, the
+other branded `ZERO_*` aliases, or the retired
+`ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED` marker. Token values remain inside the
+existing secret boundary and must not be logged, rendered into prompts,
+telemetry, snapshots, or PR text.
 
 ## Compose and queued-context compatibility
 
-The API-authored canonical agent compose remains unchanged, so Phase B does not
-change its content-addressed hash. The run builder emits both branded families
-independently of compose templates. Existing compose versions, old APIs after a
-rollback, draining runtimes, and pinned CLI artifacts therefore keep working
-without rewriting persisted compose content.
+New API-authored agent compose versions use canonical `OKOU_AGENT_ID` and
+`OKOU_TOKEN` templates. Existing content-addressed compose versions are not
+rewritten or rehashed. When a new first-party branded context uses a persisted
+version containing legacy `ZERO_*` templates, the run builder omits those
+templates from that new context's runtime projection so unresolved template
+text and legacy environment keys cannot reach the sandbox.
 
-Already-stored queued and active execution contexts are not rewritten. New
-contexts contain both families. This preserves old guest/runtime consumers
-while allowing current runtimes to select the canonical Okou variables.
+Already-stored queued, active, and finalizing execution contexts remain
+byte-for-byte unchanged. Their stored `ZERO_*` environment, Zero-scoped token,
+and historical `CLI_PKG_URL` continue through the normal runner and API
+compatibility readers. The API and CLI still prefer `OKOU_*` with `ZERO_*`
+fallback, both HTTP namespaces remain routed, and both token scopes remain
+accepted.
+
+Removing any fallback reader, `/api/zero/**` route, Zero token-scope verifier,
+historical artifact, callback, Desktop identity, or persisted object requires a
+separate drain gate. Production verification of the writer stop must inspect
+new context names and token scope without exposing values; declining Zero
+request volume alone is not proof that all legacy contexts have drained.
 
 ## Rollback
 
-Roll Phase B clients and emitters back to the Phase A release target above.
-Leave both namespace routes, both environment readers, both token-scope
-verifiers, the Zero CLI alias, both Desktop identities, stored callbacks, and
-immutable historical artifacts in place. Release and production verification
-are separate from this implementation change.
+Roll the writer stop back to the Phase B release target above to restore dual
+emission. Leave both namespace routes, both environment readers, both
+token-scope verifiers, the Zero CLI alias, both Desktop identities, stored
+callbacks, queued contexts, and immutable historical artifacts in place.
+Release and production verification remain separate from this implementation
+change.

--- a/e2e/tests/03-runner/run-t14-runner-context.bats
+++ b/e2e/tests/03-runner/run-t14-runner-context.bats
@@ -61,22 +61,23 @@ set -euo pipefail
 grep -F '__INSTRUCTION_MARKER__' "$HOME/.codex/AGENTS.md"
 grep -F '__WORKFLOW_MARKER__' "$HOME/.codex/skills/__WORKFLOW_NAME__/context.txt"
 test ! -s "$HOME/.codex/skills/__WORKFLOW_NAME__/empty.txt"
-test "$OKOU_APP_URL" = "$ZERO_APP_URL"
-test "$OKOU_AGENT_ID" = "$ZERO_AGENT_ID"
-test "$OKOU_CHAT_THREAD_ID" = "$ZERO_CHAT_THREAD_ID"
+test -n "$OKOU_APP_URL"
+test -n "$OKOU_AGENT_ID"
+test -n "$OKOU_CHAT_THREAD_ID"
 test -n "$OKOU_TOKEN"
-test -n "$ZERO_TOKEN"
-test "$OKOU_TOKEN" != "$ZERO_TOKEN"
+test -z "${ZERO_APP_URL:-}"
+test -z "${ZERO_AGENT_ID:-}"
+test -z "${ZERO_CHAT_THREAD_ID:-}"
+test -z "${ZERO_TOKEN:-}"
+test -z "${ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED:-}"
 node -e '
-const claims = (name) => {
-  const token = process.env[name];
-  if (!token?.startsWith("vm0_sandbox_")) throw new Error(`${name} is not a sandbox token`);
-  return JSON.parse(Buffer.from(token.slice("vm0_sandbox_".length).split(".")[1], "base64url"));
-};
-const okou = claims("OKOU_TOKEN");
-const zero = claims("ZERO_TOKEN");
-if (okou.scope !== "okou" || zero.scope !== "zero") throw new Error("unexpected branded token scope");
-if (JSON.stringify({...okou, scope: "zero"}) !== JSON.stringify(zero)) throw new Error("branded token claims differ");
+const token = process.env.OKOU_TOKEN;
+if (!token?.startsWith("vm0_sandbox_")) throw new Error("OKOU_TOKEN is not a sandbox token");
+const claims = JSON.parse(Buffer.from(token.slice("vm0_sandbox_".length).split(".")[1], "base64url"));
+if (claims.scope !== "okou") throw new Error("unexpected OKOU_TOKEN scope");
+if (!claims.userId || !claims.orgId || !claims.runId) throw new Error("OKOU_TOKEN is missing identity claims");
+if (!Array.isArray(claims.capabilities)) throw new Error("OKOU_TOKEN is missing capabilities");
+if (!Number.isFinite(claims.iat) || !Number.isFinite(claims.exp) || claims.exp <= claims.iat) throw new Error("OKOU_TOKEN has invalid lifetime claims");
 '
 printf '__OUTPUT_MARKER__\n'
 EOF

--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import {
-  generateBrandedRunTokens,
   generateZeroToken,
   isPatToken,
   isSandboxToken,
@@ -127,28 +126,47 @@ describe("auth tokens", () => {
     });
   });
 
-  it("generates distinct scope-specific tokens with equivalent run claims", () => {
-    const { okouToken, zeroToken } = generateBrandedRunTokens(
+  it("generates one Okou-scoped run token with the complete run claims", () => {
+    const computerUseHostId = "00000000-0000-4000-8000-000000000001";
+    const okouToken = generateZeroToken(
       "user_shared",
       "run_shared",
       "org_shared",
       { [FeatureSwitchKey.Banking]: true },
       {
-        computerUseHostId: "00000000-0000-4000-8000-000000000001",
+        scope: "okou",
+        computerUseHostId,
         cloudBrowserEnabled: true,
         imageRecognitionAvailable: true,
       },
     );
 
-    expect(okouToken.localeCompare(zeroToken)).not.toBe(0);
     const okouPayload = decodeZeroTokenPayloadForTest(okouToken);
-    const zeroPayload = decodeZeroTokenPayloadForTest(zeroToken);
-    expect(okouPayload).toMatchObject({ scope: "okou" });
-    expect(zeroPayload).toMatchObject({ scope: "zero" });
-    expect({ ...okouPayload, scope: "zero" }).toStrictEqual(zeroPayload);
-    expect(verifyZeroToken(okouToken)).toStrictEqual(
-      verifyZeroToken(zeroToken),
-    );
+    expect(okouPayload).toMatchObject({
+      scope: "okou",
+      userId: "user_shared",
+      runId: "run_shared",
+      orgId: "org_shared",
+      computerUseHostId,
+      cloudBrowserEnabled: true,
+      capabilities: expect.arrayContaining([
+        "banking:read",
+        "browser:read",
+        "browser:write",
+        "computer-use:write",
+        "image-recognition:write",
+      ]),
+      iat: expect.any(Number),
+      exp: expect.any(Number),
+    });
+    expect(okouPayload.exp).toBe(Number(okouPayload.iat) + 2 * 60 * 60);
+    expect(verifyZeroToken(okouToken)).toMatchObject({
+      userId: "user_shared",
+      runId: "run_shared",
+      orgId: "org_shared",
+      computerUseHostId,
+      cloudBrowserEnabled: true,
+    });
   });
 
   it("ignores unknown zero capabilities while preserving known capabilities", () => {

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -328,20 +328,6 @@ export function generateZeroToken(
   );
 }
 
-export function generateBrandedRunTokens(
-  userId: string,
-  runId: string,
-  orgId: string,
-  overrides?: Partial<Record<FeatureSwitchKey, boolean>>,
-  options?: Omit<ZeroTokenOptions, "scope">,
-): { readonly okouToken: string; readonly zeroToken: string } {
-  const claims = buildZeroTokenClaims(userId, runId, orgId, overrides, options);
-  return {
-    okouToken: signZeroToken("okou", claims),
-    zeroToken: signZeroToken("zero", claims),
-  };
-}
-
 function buildZeroTokenClaims(
   userId: string,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -100,7 +100,7 @@ async function claimDispatchedRun(runnerGroup: string): Promise<{
   readonly sandboxToken: string;
   readonly prompt: string;
   readonly appendSystemPrompt: string;
-  readonly zeroToken: string | undefined;
+  readonly okouToken: string | undefined;
 }> {
   const runs = createRunsApi(context);
   await runs.heartbeatRunner(runnerGroup);
@@ -121,7 +121,7 @@ async function claimDispatchedRun(runnerGroup: string): Promise<{
     sandboxToken: claim.sandboxToken,
     prompt: claim.prompt,
     appendSystemPrompt: claim.appendSystemPrompt ?? "",
-    zeroToken: claim.environment?.ZERO_TOKEN,
+    okouToken: claim.environment?.OKOU_TOKEN,
   };
 }
 
@@ -1214,13 +1214,13 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     });
     await runs.heartbeatRunner(runnerGroup);
     const claim = await runs.claimRunnerJob(run.runId);
-    const zeroToken = claim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
-      throw new Error("Expected the claimed run to expose ZERO_TOKEN");
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the claimed run to expose OKOU_TOKEN");
     }
 
     const init = await ap.requestPhoneUploadInitWithToken(
-      zeroToken,
+      okouToken,
       { filename: "screen shot.png", contentType: "image/png", length: 123 },
       [200],
     );
@@ -1239,7 +1239,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       size: 456,
     });
     const completed = await ap.requestPhoneUploadCompleteWithToken(
-      zeroToken,
+      okouToken,
       {
         uploadId: init.body.uploadId,
         toNumber: phone,
@@ -1270,7 +1270,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       }),
     );
     const downloaded = await ap.downloadPhoneFileRaw(
-      zeroToken,
+      okouToken,
       completed.body.messageId,
     );
     expect(downloaded.status).toBe(200);

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
@@ -113,10 +113,10 @@ async function claimChatRun(
   };
 }
 
-function zeroTokenFromClaim(claim: RunnerClaim): string {
-  const token = claim.environment?.ZERO_TOKEN;
+function okouTokenFromClaim(claim: RunnerClaim): string {
+  const token = claim.environment?.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry a ZERO_TOKEN");
+    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
   }
   return token;
 }
@@ -297,7 +297,7 @@ async function uploadFile(args: {
     args.owner.runnerGroup,
     run.runId,
   );
-  const bearer = `Bearer ${zeroTokenFromClaim(claim)}`;
+  const bearer = `Bearer ${okouTokenFromClaim(claim)}`;
   const fileId = args.fileId ?? randomUUID();
   stageUploadObject(
     `artifacts/${args.owner.actor.userId}/${fileId}/${args.filename}`,
@@ -363,7 +363,7 @@ async function publishHostedSite(args: {
   const bearer =
     claimed === null
       ? `Bearer ${scopedZeroToken(args.owner, run.runId, ["host:write"])}`
-      : `Bearer ${zeroTokenFromClaim(claimed.claim)}`;
+      : `Bearer ${okouTokenFromClaim(claimed.claim)}`;
   const body = {
     site: args.site,
     artifactKind: args.artifactKind ?? ("hosted-site" as const),
@@ -412,8 +412,8 @@ async function publishHostedSiteFromDirectRun(args: {
         prompt: `publish ${args.site}`,
         modelProviderType: "anthropic-api-key",
         triggerSource: "automation-schedule",
-        vars: { ZERO_AGENT_ID: args.owner.agentId },
-        secrets: { ZERO_TOKEN: "bdd-artifact-catalog-token" },
+        vars: { OKOU_AGENT_ID: args.owner.agentId },
+        secrets: { OKOU_TOKEN: "bdd-artifact-catalog-token" },
       })
     ).runId;
   const bearer = `Bearer ${scopedZeroToken(args.owner, runId, ["host:write"])}`;
@@ -1016,8 +1016,8 @@ describe("GET /api/zero/artifacts/catalog", () => {
       prompt: "create a workflow artifact",
       modelProviderType: "anthropic-api-key",
       triggerSource: "automation-schedule",
-      vars: { ZERO_AGENT_ID: owner.agentId },
-      secrets: { ZERO_TOKEN: "bdd-artifact-catalog-token" },
+      vars: { OKOU_AGENT_ID: owner.agentId },
+      secrets: { OKOU_TOKEN: "bdd-artifact-catalog-token" },
     });
     const fileId = randomUUID();
     stageUploadObject(

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -161,10 +161,10 @@ async function claimChatRun(
   };
 }
 
-function zeroTokenFromClaim(claim: RunnerClaim): string {
-  const token = claim.environment?.ZERO_TOKEN;
+function okouTokenFromClaim(claim: RunnerClaim): string {
+  const token = claim.environment?.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry a ZERO_TOKEN");
+    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
   }
   return token;
 }
@@ -230,7 +230,7 @@ async function createHostedArtifact(args: {
     args.runnerGroup,
     run.runId,
   );
-  const bearer = `Bearer ${zeroTokenFromClaim(claim)}`;
+  const bearer = `Bearer ${okouTokenFromClaim(claim)}`;
   const prepared = await chat.prepareHostedSiteWithBearer(bearer, {
     site: args.site,
     artifactKind: args.artifactKind ?? "hosted-site",
@@ -265,7 +265,7 @@ async function createRunUploadedFile(args: {
     args.owner.runnerGroup,
     run.runId,
   );
-  const bearer = `Bearer ${zeroTokenFromClaim(claim)}`;
+  const bearer = `Bearer ${okouTokenFromClaim(claim)}`;
   const fileId = randomUUID();
   args.owner.objectStore.addObject({
     bucket: "test-user-artifacts",
@@ -404,8 +404,8 @@ describe("artifact upload provenance", () => {
         prompt: `create ${triggerSource} artifact`,
         modelProviderType: "anthropic-api-key",
         triggerSource,
-        vars: { ZERO_AGENT_ID: owner.agentId },
-        secrets: { ZERO_TOKEN: "bdd-artifact-zero-token" },
+        vars: { OKOU_AGENT_ID: owner.agentId },
+        secrets: { OKOU_TOKEN: "bdd-artifact-okou-token" },
       });
       const fileId = randomUUID();
       owner.objectStore.addObject({
@@ -439,7 +439,7 @@ describe("GET /api/zero/chat-threads/:threadId/artifacts", () => {
       prompt: "publish two hosted-site versions",
     });
     const { claim } = await claimChatRun(owner.runnerGroup, run.runId);
-    const bearer = `Bearer ${zeroTokenFromClaim(claim)}`;
+    const bearer = `Bearer ${okouTokenFromClaim(claim)}`;
     host.captureHostedSitesS3();
 
     const site = `artifact-versions-${randomUUID().slice(0, 8)}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -629,11 +629,11 @@ function expectApiDispatchTimingEventsNotToLeak(
   }
 }
 
-/** Sandbox-scoped zero token issued to the run, exposed via the claim env. */
-function zeroTokenFromClaim(claim: RunnerClaim): string {
-  const token = claimEnvironment(claim).ZERO_TOKEN;
+/** Sandbox-scoped Okou token issued to the run, exposed via the claim env. */
+function okouTokenFromClaim(claim: RunnerClaim): string {
+  const token = claimEnvironment(claim).OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry a ZERO_TOKEN");
+    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
   }
   return token;
 }
@@ -3366,7 +3366,7 @@ describe("CHAT-02: Zero Mail link delivery", () => {
       setupApp({ context, routes: zeroMailRoutes })(zeroMailContract).linkDraft(
         {
           headers: {
-            authorization: `Bearer ${zeroTokenFromClaim(claim)}`,
+            authorization: `Bearer ${okouTokenFromClaim(claim)}`,
           },
           body: {
             threadId: run.threadId,
@@ -8069,7 +8069,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
       prompt: "no computer use selected",
     });
     const plainClaim = await claimChatRun(runnerGroup, plain.runId);
-    const plainToken = zeroTokenFromClaim(plainClaim.claim);
+    const plainToken = okouTokenFromClaim(plainClaim.claim);
     const deniedCommand = await cu.requestCreateComputerUseWriteCommand(
       { bearer: plainToken },
       [403],
@@ -8119,7 +8119,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     const grantedClaim = await claimChatRun(runnerGroup, granted.runId);
     await cu.heartbeatComputerUseHost(hostToken);
     await cu.requestCreateComputerUseWriteCommand(
-      { bearer: zeroTokenFromClaim(grantedClaim.claim) },
+      { bearer: okouTokenFromClaim(grantedClaim.claim) },
       [200],
     );
     await cancelChatRun(actor, granted.runId, grantedClaim.sandboxHeaders);
@@ -8133,7 +8133,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     const stickyClaim = await claimChatRun(runnerGroup, sticky.runId);
     await cu.heartbeatComputerUseHost(hostToken);
     await cu.requestCreateComputerUseWriteCommand(
-      { bearer: zeroTokenFromClaim(stickyClaim.claim) },
+      { bearer: okouTokenFromClaim(stickyClaim.claim) },
       [200],
     );
     await cancelChatRun(actor, sticky.runId, stickyClaim.sandboxHeaders);
@@ -8149,7 +8149,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     const clearedClaim = await claimChatRun(runnerGroup, cleared.runId);
     await cu.heartbeatComputerUseHost(hostToken);
     await cu.requestCreateComputerUseWriteCommand(
-      { bearer: zeroTokenFromClaim(clearedClaim.claim) },
+      { bearer: okouTokenFromClaim(clearedClaim.claim) },
       [403],
     );
     await cancelChatRun(actor, cleared.runId, clearedClaim.sandboxHeaders);
@@ -8169,7 +8169,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     const staleClaim = await claimChatRun(runnerGroup, staleGranted.runId);
     await cu.heartbeatComputerUseHost(hostToken);
     await cu.requestCreateComputerUseWriteCommand(
-      { bearer: zeroTokenFromClaim(staleClaim.claim) },
+      { bearer: okouTokenFromClaim(staleClaim.claim) },
       [200],
     );
     await cancelChatRun(actor, staleGranted.runId);
@@ -8553,7 +8553,7 @@ describe("CHAT-02: shared user message queue", () => {
     });
     const { claim: sourceClaim, sandboxHeaders: sourceSandboxHeaders } =
       await claimChatRun(runnerGroup, source.runId);
-    const sourceToken = zeroTokenFromClaim(sourceClaim);
+    const sourceToken = okouTokenFromClaim(sourceClaim);
 
     const firstEventId = randomUUID();
     const firstSend = await requestSendEventWithBearer(
@@ -8787,7 +8787,7 @@ describe("CHAT-02: shared user message queue", () => {
     });
     const { claim: sourceClaim, sandboxHeaders: sourceSandboxHeaders } =
       await claimChatRun(runnerGroup, source.runId);
-    const sourceToken = zeroTokenFromClaim(sourceClaim);
+    const sourceToken = okouTokenFromClaim(sourceClaim);
 
     const rotatedAnchorPrompt = "prior Web round before an agent rotation";
     const rotatedAnchor = await sendChatRun(actor, {
@@ -9003,7 +9003,7 @@ describe("CHAT-02: shared user message queue", () => {
     await setRunAutonomyBudgetFixture(context, root.runId, 1);
 
     const delegated = await requestSendEventWithBearer(
-      zeroTokenFromClaim(rootClaim.claim),
+      okouTokenFromClaim(rootClaim.claim),
       {
         agentId,
         clientEventId: randomUUID(),
@@ -9028,7 +9028,7 @@ describe("CHAT-02: shared user message queue", () => {
 
     const blockedEventId = randomUUID();
     const blocked = await requestSendEventWithBearer(
-      zeroTokenFromClaim(delegatedClaim.claim),
+      okouTokenFromClaim(delegatedClaim.claim),
       {
         agentId,
         clientEventId: blockedEventId,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -239,11 +239,11 @@ async function claimChatRun(
   };
 }
 
-/** Sandbox-scoped zero token issued to the run, exposed via the claim env. */
-function zeroTokenFromClaim(claim: RunnerClaim): string {
-  const token = claim.environment?.ZERO_TOKEN;
+/** Sandbox-scoped Okou token issued to the run, exposed via the claim env. */
+function okouTokenFromClaim(claim: RunnerClaim): string {
+  const token = claim.environment?.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry a ZERO_TOKEN");
+    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
   }
   return token;
 }
@@ -3200,7 +3200,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       runnerGroup,
       run.runId,
     );
-    const runBearer = `Bearer ${zeroTokenFromClaim(claim)}`;
+    const runBearer = `Bearer ${okouTokenFromClaim(claim)}`;
 
     const unauthenticated = await chat.requestListThreadArtifacts(
       null,
@@ -3388,7 +3388,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       prompt: "first artifact run",
     });
     const claim1 = await claimChatRun(runnerGroup, run1.runId);
-    const bearer1 = `Bearer ${zeroTokenFromClaim(claim1.claim)}`;
+    const bearer1 = `Bearer ${okouTokenFromClaim(claim1.claim)}`;
     const ownId = randomUUID();
     const sharedId = randomUUID();
     objectStore.addObject({
@@ -3417,7 +3417,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       prompt: "second artifact run",
     });
     const claim2 = await claimChatRun(runnerGroup, run2.runId);
-    const bearer2 = `Bearer ${zeroTokenFromClaim(claim2.claim)}`;
+    const bearer2 = `Bearer ${okouTokenFromClaim(claim2.claim)}`;
     await chat.completeUploadWithBearer(bearer2, { id: sharedId }, [200]);
 
     let artifacts = await chat.listThreadArtifacts(actor, run1.threadId);

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -20,13 +20,13 @@ legacy zero-host.test.ts and zero-maps.test.ts route tests:
 - Hosted-site/deployment/artifact DB-row asserts are replaced by the files GET
   and complete response bodies; maps org-credit row asserts are
   replaced by billing-status deltas.
-- The run-artifact chain uses the run's real zero token from the runner claim
-  (`claim.environment.ZERO_TOKEN`) instead of seeding runs and rewriting
+- The run-artifact chain uses the run's real Okou token from the runner claim
+  (`claim.environment.OKOU_TOKEN`) instead of seeding runs and rewriting
   deployment rows.
 - Maps gates (NOT_CONFIGURED / 402 / invalid location) stay owned by
   billing-usage-media.bdd.test.ts BILL-02; the slug-suffix reuse and
   missing-index validations stay owned by chat-files.bdd.test.ts FILE-01.
-- "zero token without maps:read -> 403" is dropped: every production zero
+- "run token without maps:read -> 403" is dropped: every production Okou
   token carries maps:read unconditionally (generateZeroToken), so the case is
   not API-constructible.
 */
@@ -835,21 +835,21 @@ describe("CHAIN-BILLING-MEDIA/FILE-01: run-scoped zero-token attribution", () =>
     expect(poll.body.job?.runId).toBe(created.runId);
     const claim = await runs.claimRunnerJob(created.runId);
 
-    // The default zero-agent compose maps ZERO_TOKEN from the run secrets, so
-    // the claimed execution context exposes the real run-scoped zero token.
-    const zeroToken = claim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
+    // The default agent compose maps OKOU_TOKEN from the run secrets, so the
+    // claimed execution context exposes the real run-scoped Okou token.
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
       throw new Error(
-        "Expected claim.environment.ZERO_TOKEN to carry the run-scoped zero token",
+        "Expected claim.environment.OKOU_TOKEN to carry the run-scoped Okou token",
       );
     }
-    expect(zeroToken).toMatch(/^vm0_sandbox_/);
-    expect(claim.secretValues ?? []).toContain(zeroToken);
+    expect(okouToken).toMatch(/^vm0_sandbox_/);
+    expect(claim.secretValues ?? []).toContain(okouToken);
 
     const before = await billing.readBillingStatus(actor);
 
     const geocode = await api.requestMapsGeocodeWithBearer(
-      zeroToken,
+      okouToken,
       { address: "1 Infinite Loop, Cupertino" },
       [200],
     );
@@ -860,7 +860,7 @@ describe("CHAIN-BILLING-MEDIA/FILE-01: run-scoped zero-token attribution", () =>
     });
     expect(geocodeRequests).toHaveLength(1);
 
-    const bearer = { bearerToken: zeroToken };
+    const bearer = { bearerToken: okouToken };
     const site = `bdd-run-artifact-${randomUUID().slice(0, 8)}`;
     const prepared = await api.prepareHostedSite(bearer, {
       site,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4149,13 +4149,13 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const fastClaim = await runs.claimRunnerJob(fastRunId);
     expect(fastClaim.cliAgentType).toBe("codex");
     expect(fastClaim.environment?.VM0_CODEX_SERVICE_TIER).toBe("fast");
-    const fastZeroToken = fastClaim.environment?.ZERO_TOKEN;
-    if (!fastZeroToken) {
-      throw new Error("Expected the Slack Fast run to expose ZERO_TOKEN");
+    const fastOkouToken = fastClaim.environment?.OKOU_TOKEN;
+    if (!fastOkouToken) {
+      throw new Error("Expected the Slack Fast run to expose OKOU_TOKEN");
     }
 
     const agentSend = await integrations.requestSendSlackMessageAsRun(
-      fastZeroToken,
+      fastOkouToken,
       {
         channel: channelId,
         text: "agent-initiated fast message",
@@ -5162,13 +5162,13 @@ describe("INT-02: Telegram integration", () => {
     const claim = await runs.claimRunnerJob(runId);
     expect(claim.cliAgentType).toBe("codex");
     expect(claim.environment?.VM0_CODEX_SERVICE_TIER).toBe("fast");
-    const zeroToken = claim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
-      throw new Error("Expected the Telegram Fast run to expose ZERO_TOKEN");
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the Telegram Fast run to expose OKOU_TOKEN");
     }
 
     const agentSend = await integrations.requestSendTelegramMessageAsRun(
-      zeroToken,
+      okouToken,
       {
         botId,
         chatId: String(dmChatId),

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -889,24 +889,24 @@ describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
 
     const created = await runs.createRun(admin, {
       agentId: agent.agentId,
-      prompt: "exercise org reads with the run zero token",
+      prompt: "exercise org reads with the run Okou token",
       modelProvider: "anthropic-api-key",
     });
     await runs.heartbeatRunner(runnerGroup);
     const poll = await runs.pollRunner(runnerGroup);
     expect(poll.body.job?.runId).toBe(created.runId);
     const claim = await runs.claimRunnerJob(created.runId);
-    const zeroToken = claim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
       throw new Error(
-        "Expected claim.environment.ZERO_TOKEN to carry the run-scoped zero token",
+        "Expected claim.environment.OKOU_TOKEN to carry the run-scoped Okou token",
       );
     }
-    expect(zeroToken).toMatch(/^vm0_sandbox_/);
+    expect(okouToken).toMatch(/^vm0_sandbox_/);
 
     const orgSlug = slug("bdd-r5-token");
     api.mockClerkOrg(admin, { slug: orgSlug, name: "BDD Token Org" });
-    const orgRead = await api.requestReadOrgWithBearer(zeroToken, [200]);
+    const orgRead = await api.requestReadOrgWithBearer(okouToken, [200]);
     expect(orgRead.body).toMatchObject({
       id: admin.orgId,
       role: "admin",
@@ -915,7 +915,7 @@ describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
     // Member listing is deliberately not an agent surface (#25011): the route
     // declares no capability, so a sandbox token is rejected like the writes.
     const membersRejected = await api.requestListMembersWithBearer(
-      zeroToken,
+      okouToken,
       [403],
     );
     expect(membersRejected.body).toStrictEqual({
@@ -928,7 +928,7 @@ describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
     // Representative sandbox-token write rejections (the remaining org
     // routes share the same authRoute statement).
     const updateRejected = await api.requestUpdateOrgWithBearer(
-      zeroToken,
+      okouToken,
       { name: "Token Rename" },
       [403],
     );
@@ -939,7 +939,7 @@ describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
       },
     });
     const logoRejected = await api.requestUploadOrgLogo(
-      { bearerToken: zeroToken },
+      { bearerToken: okouToken },
       logoForm(pngLogoFile()),
       [403],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -37,7 +37,7 @@ import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
-import { verifyZeroToken } from "../../auth/tokens";
+import { generateZeroToken, verifyZeroToken } from "../../auth/tokens";
 import {
   deleteUsagePricingRows,
   seedOrgMetadata,
@@ -724,35 +724,64 @@ function sandboxTokenPayload(token: string): Record<string, unknown> {
   return parsed;
 }
 
-function expectBrandedRunEnvironment(args: {
+function expectCanonicalOkouRunEnvironment(args: {
   readonly environment: Readonly<Record<string, string>> | null | undefined;
   readonly secretValues: readonly string[] | null | undefined;
   readonly appUrl: string;
   readonly agentId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly runId: string;
+  readonly chatThreadId?: string;
 }): void {
   expect(args.environment?.OKOU_APP_URL).toBe(args.appUrl);
-  expect(args.environment?.ZERO_APP_URL).toBe(args.appUrl);
   expect(args.environment?.OKOU_AGENT_ID).toBe(args.agentId);
-  expect(args.environment?.ZERO_AGENT_ID).toBe(args.agentId);
+  if (args.chatThreadId) {
+    expect(args.environment?.OKOU_CHAT_THREAD_ID).toBe(args.chatThreadId);
+  }
+  expect(
+    Object.keys(args.environment ?? {}).filter((key) => {
+      return key.startsWith("ZERO_");
+    }),
+  ).toStrictEqual([]);
   const okouToken = args.environment?.OKOU_TOKEN;
-  const zeroToken = args.environment?.ZERO_TOKEN;
-  if (!okouToken || !zeroToken) {
-    throw new Error("Expected the claim to expose both branded run tokens");
+  if (!okouToken) {
+    throw new Error(
+      "Expected the claim to expose the canonical Okou run token",
+    );
   }
   expect(okouToken.startsWith("vm0_sandbox_")).toBeTruthy();
-  expect(zeroToken.startsWith("vm0_sandbox_")).toBeTruthy();
-  expect(okouToken.localeCompare(zeroToken)).not.toBe(0);
   expect(args.secretValues?.includes(okouToken) ?? false).toBeTruthy();
-  expect(args.secretValues?.includes(zeroToken) ?? false).toBeTruthy();
   const okouClaims = sandboxTokenPayload(okouToken);
-  const zeroClaims = sandboxTokenPayload(zeroToken);
-  expect(okouClaims).toMatchObject({ scope: "okou" });
-  expect(zeroClaims).toMatchObject({ scope: "zero" });
-  expect({ ...okouClaims, scope: "zero" }).toStrictEqual(zeroClaims);
+  expect(okouClaims).toMatchObject({
+    scope: "okou",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: args.runId,
+    capabilities: expect.any(Array),
+    iat: expect.any(Number),
+    exp: expect.any(Number),
+  });
+  expect(Number(okouClaims.exp)).toBeGreaterThan(Number(okouClaims.iat));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function runContextSnapshotForRun(runId: string): Record<string, unknown> {
+  for (const [dataset, events] of context.mocks.axiom.ingest.mock.calls) {
+    if (dataset !== "run-context" || !Array.isArray(events)) {
+      continue;
+    }
+    const snapshot = events.find((event) => {
+      return isRecord(event) && event.runId === runId;
+    });
+    if (isRecord(snapshot)) {
+      return snapshot;
+    }
+  }
+  throw new Error(`Expected a run-context snapshot for ${runId}`);
 }
 
 function sandboxOperationEventsForRun(
@@ -1220,8 +1249,8 @@ function zeroBackedDirectRunBody(args: {
       : { agentComposeId: args.agentId }),
     prompt: args.prompt,
     modelProviderType: "anthropic-api-key" as const,
-    vars: { ZERO_AGENT_ID: args.agentId },
-    secrets: { ZERO_TOKEN: "bdd-zero-direct-token" },
+    vars: { OKOU_AGENT_ID: args.agentId },
+    secrets: { OKOU_TOKEN: "bdd-okou-direct-token" },
   };
 }
 
@@ -1283,6 +1312,12 @@ async function setupSameThreadReuseScenario(sourceRunnerIdentity?: {
     first.runId,
     sourceRunnerIdentity ? { runnerIdentity: sourceRunnerIdentity } : {},
   );
+  expect(firstClaim.environment?.OKOU_CHAT_THREAD_ID).toBe(first.threadId);
+  expect(
+    Object.keys(firstClaim.environment ?? {}).filter((key) => {
+      return key.startsWith("ZERO_");
+    }),
+  ).toStrictEqual([]);
   const cliAgentSessionId = `bdd-reuse-cli-${first.runId}`;
   const reuseKey = `thread:${first.threadId}`;
   const reuseRunnerId = randomUUID();
@@ -5394,11 +5429,12 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.heartbeatRunner(runnerGroup);
     const thirdClaim = await api.claimRunnerJob(third.runId);
     expect(thirdClaim.prompt).toBe("queued run three");
-    const zeroToken = thirdClaim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
-      throw new Error("Expected the promoted claim to expose the zero token");
+    const okouToken = thirdClaim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the promoted claim to expose the Okou token");
     }
-    expect(thirdClaim.secretValues).toContain(zeroToken);
+    expect(thirdClaim.secretValues).toContain(okouToken);
+    expect(thirdClaim.environment ?? {}).not.toHaveProperty("ZERO_TOKEN");
     expect(thirdClaim).not.toHaveProperty("secretValueEnvironmentKeys");
     expect(thirdClaim).not.toHaveProperty("runContextStorage");
     expectClaimNetworkPolicyRefreshPath(third.runId, "baseline_empty");
@@ -6242,10 +6278,10 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     }
 
     const unsupported = await claimModel(unsupportedModel);
-    const unsupportedToken = unsupported.claim.environment?.ZERO_TOKEN;
+    const unsupportedToken = unsupported.claim.environment?.OKOU_TOKEN;
     if (!unsupportedToken) {
       throw new Error(
-        "Expected the unsupported-model run to expose ZERO_TOKEN",
+        "Expected the unsupported-model run to expose OKOU_TOKEN",
       );
     }
     expect(unsupported.claim.appendSystemPrompt ?? "").toContain(
@@ -6257,9 +6293,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, unsupported.runId, [200]);
 
     const supported = await claimModel(supportedModel);
-    const supportedToken = supported.claim.environment?.ZERO_TOKEN;
+    const supportedToken = supported.claim.environment?.OKOU_TOKEN;
     if (!supportedToken) {
-      throw new Error("Expected the supported-model run to expose ZERO_TOKEN");
+      throw new Error("Expected the supported-model run to expose OKOU_TOKEN");
     }
     expect(supported.claim.appendSystemPrompt ?? "").not.toContain(
       "okou recognize",
@@ -6270,9 +6306,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, supported.runId, [200]);
 
     const unknown = await claimModel(unknownModel);
-    const unknownToken = unknown.claim.environment?.ZERO_TOKEN;
+    const unknownToken = unknown.claim.environment?.OKOU_TOKEN;
     if (!unknownToken) {
-      throw new Error("Expected the unknown-model run to expose ZERO_TOKEN");
+      throw new Error("Expected the unknown-model run to expose OKOU_TOKEN");
     }
     expect(unknown.claim.appendSystemPrompt ?? "").not.toContain(
       "okou recognize",
@@ -6415,8 +6451,8 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       prompt: "generate an image from slack",
       modelProviderType: "codex-oauth-token",
       triggerSource: "slack",
-      vars: { ZERO_AGENT_ID: agentId },
-      secrets: { ZERO_TOKEN: "bdd-zero-direct-token" },
+      vars: { OKOU_AGENT_ID: agentId },
+      secrets: { OKOU_TOKEN: "bdd-okou-direct-token" },
     });
     await api.heartbeatRunner(runnerGroup);
     const codexSlackClaim = await api.claimRunnerJob(codexSlackRun.runId);
@@ -7733,7 +7769,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         prompt: "use google ads with explicit developer token",
       }),
       secrets: {
-        ZERO_TOKEN: "bdd-zero-direct-token",
+        OKOU_TOKEN: "bdd-okou-direct-token",
         GOOGLE_ADS_DEVELOPER_TOKEN: "body-developer-token",
       },
     });
@@ -12008,6 +12044,106 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     await api.requestCancelRun(actor, r2Run.runId, [200]);
   });
 
+  it("projects immutable legacy compose templates only for new Okou contexts", async () => {
+    const appUrl = "https://app.writer-stop.example.test";
+    mockEnv("APP_URL", appUrl);
+    const api = createRunsApi(context);
+    const composes = createComposesBddApi(context);
+    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
+    if (!actor.orgId) {
+      throw new Error("The legacy compose fixture requires an organization");
+    }
+
+    const canonicalCompose = await composes.requestReadComposeById(
+      actor,
+      agentId,
+      [200],
+    );
+    const canonicalAgent = Object.values(
+      canonicalCompose.body.content?.agents ?? {},
+    )[0];
+    expect(canonicalAgent?.environment).toStrictEqual({
+      OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
+      OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
+    });
+
+    const legacyEnvironment = {
+      ZERO_AGENT_ID: `\${{ vars.ZERO_AGENT_ID }}`,
+      ZERO_TOKEN: `\${{ secrets.ZERO_TOKEN }}`,
+    };
+    const legacyCompose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [canonicalCompose.body.name]: {
+          framework: "claude-code",
+          environment: legacyEnvironment,
+        },
+      },
+    });
+    expect(legacyCompose.composeId).toBe(agentId);
+
+    const historicalZeroToken = generateZeroToken(
+      actor.userId,
+      "historical-context-fixture",
+      actor.orgId,
+    );
+    const historical = await api.createDirectRun(actor, {
+      agentComposeVersionId: legacyCompose.versionId,
+      prompt: "consume an immutable legacy Zero context",
+      modelProviderType: "anthropic-api-key",
+      vars: { ZERO_AGENT_ID: agentId },
+      secrets: { ZERO_TOKEN: historicalZeroToken },
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const historicalClaim = await api.claimRunnerJob(historical.runId);
+    expect(historicalClaim.agentComposeVersionId).toBe(legacyCompose.versionId);
+    expect(historicalClaim.environment).toMatchObject({
+      ZERO_AGENT_ID: agentId,
+      ZERO_TOKEN: historicalZeroToken,
+    });
+    expect(historicalClaim.environment ?? {}).not.toHaveProperty("OKOU_TOKEN");
+    expect(sandboxTokenPayload(historicalZeroToken)).toMatchObject({
+      scope: "zero",
+    });
+    expect(historicalClaim.secretValues).toContain(historicalZeroToken);
+    await api.requestCancelRun(actor, historical.runId, [200]);
+
+    const current = await api.createRun(actor, {
+      agentId,
+      prompt: "build a canonical context from a legacy compose version",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const currentClaim = await api.claimRunnerJob(current.runId);
+    expect(currentClaim.agentComposeVersionId).toBe(legacyCompose.versionId);
+    expectCanonicalOkouRunEnvironment({
+      environment: currentClaim.environment,
+      secretValues: currentClaim.secretValues,
+      appUrl,
+      agentId,
+      userId: actor.userId,
+      orgId: actor.orgId,
+      runId: current.runId,
+    });
+    expect(
+      Object.values(currentClaim.environment ?? {}).some((value) => {
+        return value.includes("${{");
+      }),
+    ).toBeFalsy();
+    await api.requestCancelRun(actor, current.runId, [200]);
+
+    const unchangedCompose = await composes.requestReadComposeById(
+      actor,
+      agentId,
+      [200],
+    );
+    expect(unchangedCompose.body.headVersionId).toBe(legacyCompose.versionId);
+    expect(
+      Object.values(unchangedCompose.body.content?.agents ?? {})[0]
+        ?.environment,
+    ).toStrictEqual(legacyEnvironment);
+  });
+
   it("injects agent identity, tool hints, and user info into the runner context", async () => {
     const appUrl = "https://app.example.test";
     mockEnv("APP_URL", appUrl);
@@ -12255,18 +12391,26 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       EXPECTED_ZERO_RUN_DISALLOWED_TOOLS,
     );
     expect(claim.disallowedTools).not.toContain("WebFetch");
-    expectBrandedRunEnvironment({
+    expectCanonicalOkouRunEnvironment({
       environment: claim.environment,
       secretValues: claim.secretValues,
       appUrl,
       agentId: agent.agentId,
+      userId: actor.userId,
+      orgId: actor.orgId,
+      runId: run.runId,
     });
+    const runContextSnapshot = runContextSnapshotForRun(run.runId);
+    expect(runContextSnapshot.secretNames).toContain("OKOU_TOKEN");
+    expect(runContextSnapshot.secretNames).not.toContain("ZERO_TOKEN");
     expect(claim.environment?.CLI_PKG_URL).toBe(
       "https://static.vm0.io/okou-cli/test-commit/package.tgz",
     );
     expect(claim.environment?.VM0_APP_URL).toBeUndefined();
     expect(claim.environment?.APP_URL).toBeUndefined();
-    expect(claim.environment?.ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED).toBe("1");
+    expect(claim.environment ?? {}).not.toHaveProperty(
+      "ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED",
+    );
     expect(findFirewallEntry(claim.firewalls, "slack")).toStrictEqual({
       kind: "builtin",
       name: "slack",
@@ -12496,15 +12640,15 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     });
     expect(claim.apiStartTime).toBe(promotedAt);
 
-    // A run-scoped zero token issued without a host binding cannot reach
+    // A run-scoped Okou token issued without a host binding cannot reach
     // computer-use write routes.
-    const zeroToken = claim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
-      throw new Error("Expected the promoted claim to expose the zero token");
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the promoted claim to expose the Okou token");
     }
     const writeRejected =
       await computerUse.requestCreateComputerUseWriteCommand(
-        { bearer: zeroToken },
+        { bearer: okouToken },
         [403],
       );
     expectApiError(writeRejected.body);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -3689,19 +3689,19 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       error: "bdd failure",
     });
 
-    // A claimed run's real zero token reads the log surfaces by capability.
+    // A claimed run's real Okou token reads the log surfaces by capability.
     const tokenRun = await api.createRun(actor, {
       agentId: agentOne.agentId,
       prompt: "zero token run",
       modelProvider: "anthropic-api-key",
     });
     const tokenClaim = await api.claimRunnerJob(tokenRun.runId);
-    const zeroToken = tokenClaim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
-      throw new Error("Expected the claimed run to expose a ZERO_TOKEN");
+    const okouToken = tokenClaim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the claimed run to expose an OKOU_TOKEN");
     }
     const tokenList = await reads.requestListLogsAs(
-      `Bearer ${zeroToken}`,
+      `Bearer ${okouToken}`,
       {},
       [200],
     );
@@ -3712,7 +3712,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       }),
     ).toContain(webRun.runId);
     const tokenDetail = await reads.requestReadLogByIdAs(
-      `Bearer ${zeroToken}`,
+      `Bearer ${okouToken}`,
       webRun.runId,
       [200],
     );
@@ -3810,8 +3810,8 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     const sharedRun = await api.createDirectRun(actor, {
       agentComposeId: currentCompose.composeId,
       prompt: "shared compose version log",
-      vars: { ZERO_AGENT_ID: currentCompose.composeId },
-      secrets: { ZERO_TOKEN: "bdd-zero-token" },
+      vars: { OKOU_AGENT_ID: currentCompose.composeId },
+      secrets: { OKOU_TOKEN: "bdd-okou-token" },
     });
 
     const listed = await reads.requestListLogs(actor, {}, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -785,11 +785,11 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     });
     expect(chatEventDisplayText(claimedEvent)).toBe(displayPrompt);
     const claim = await runsApi.claimRunnerJob(runId);
-    const zeroToken = claim.environment?.ZERO_TOKEN;
-    if (!zeroToken) {
-      throw new Error("Expected the automation event run to expose ZERO_TOKEN");
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the automation event run to expose OKOU_TOKEN");
     }
-    expect(verifyZeroToken(zeroToken)?.capabilities).toContain(
+    expect(verifyZeroToken(okouToken)?.capabilities).toContain(
       "goal:user-control:write",
     );
     expect(claim.prompt).toBe(displayPrompt);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
@@ -115,8 +115,8 @@ async function seedBankingFixture(
         prompt: "banking automation precondition",
         modelProviderType: "anthropic-api-key",
         triggerSource: args.triggerSource,
-        vars: { ZERO_AGENT_ID: agent.agentId },
-        secrets: { ZERO_TOKEN: "bdd-banking-zero-token" },
+        vars: { OKOU_AGENT_ID: agent.agentId },
+        secrets: { OKOU_TOKEN: "bdd-banking-okou-token" },
       })
     : await api.createRun(actor, {
         agentId: agent.agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -197,9 +197,9 @@ async function claimChatRun(
 ) {
   await flushWaitUntilForTest();
   const claim = await runs.claimRunnerJob(runId);
-  const zeroToken = claim.environment?.ZERO_TOKEN;
-  if (!zeroToken) {
-    throw new Error("Expected the runner claim to include ZERO_TOKEN");
+  const okouToken = claim.environment?.OKOU_TOKEN;
+  if (!okouToken) {
+    throw new Error("Expected the runner claim to include OKOU_TOKEN");
   }
   const browserToken = runs.zeroTokenForRunWithCapabilities(actor, runId, [
     "browser:read",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -3210,7 +3210,8 @@ describe("Feishu integration", () => {
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.id);
     expect(claim.prompt).toBe("do the Feishu task");
-    expect(claim.environment?.ZERO_AGENT_ID).toBe(alternateAgentId);
+    expect(claim.environment?.OKOU_AGENT_ID).toBe(alternateAgentId);
+    expect(claim.environment ?? {}).not.toHaveProperty("ZERO_AGENT_ID");
     expect(claim.appendSystemPrompt).toContain(
       "You are currently running inside: Feishu",
     );
@@ -3473,8 +3474,11 @@ describe("Feishu integration", () => {
     const switchedAgentClaim = await runsApi.claimRunnerJob(
       switchedAgentRun.id,
     );
-    expect(switchedAgentClaim.environment?.ZERO_AGENT_ID).toBe(
+    expect(switchedAgentClaim.environment?.OKOU_AGENT_ID).toBe(
       alternateAgentId,
+    );
+    expect(switchedAgentClaim.environment ?? {}).not.toHaveProperty(
+      "ZERO_AGENT_ID",
     );
     expect(switchedAgentClaim.resumeSession).toBeNull();
     await runsApi.requestCancelRun(actor, switchedAgentRun.id, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-mcp-connectors.test.ts
@@ -72,8 +72,8 @@ async function createRunForAgent(actor: ApiTestUser, agentId: string) {
     agentComposeId: agentId,
     prompt: "Discover MCP connectors",
     modelProviderType: "anthropic-api-key",
-    vars: { ZERO_AGENT_ID: agentId },
-    secrets: { ZERO_TOKEN: "mcp-discovery-zero-token" },
+    vars: { OKOU_AGENT_ID: agentId },
+    secrets: { OKOU_TOKEN: "mcp-discovery-okou-token" },
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-presentation-templates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-presentation-templates.test.ts
@@ -38,6 +38,26 @@ const STORAGE_BUCKET = "test-user-storages";
 const PPTX_CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.presentationml.presentation";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function runTokenPayload(token: string): Record<string, unknown> {
+  const payload = token.slice("vm0_sandbox_".length).split(".")[1];
+  if (!payload) {
+    throw new Error("Expected the presentation run token to contain a payload");
+  }
+  const parsed: unknown = JSON.parse(
+    Buffer.from(payload, "base64url").toString(),
+  );
+  if (!isRecord(parsed)) {
+    throw new Error(
+      "Expected the presentation run token payload to be an object",
+    );
+  }
+  return parsed;
+}
+
 interface StoredObject {
   readonly body: Buffer;
   readonly contentType: string | undefined;
@@ -620,8 +640,8 @@ describe("presentation template imports", () => {
       agentComposeId: ownerAgentId,
       prompt: "Unrelated owner run",
       triggerSource: "test",
-      vars: { ZERO_AGENT_ID: ownerAgentId },
-      secrets: { ZERO_TOKEN: "unrelated-test-token" },
+      vars: { OKOU_AGENT_ID: ownerAgentId },
+      secrets: { OKOU_TOKEN: "unrelated-test-token" },
     });
 
     const wrongRunHeaders = [
@@ -680,7 +700,9 @@ describe("presentation template imports", () => {
 
   it("creates, compiles, renames, reads, and deletes an owned template", async () => {
     const actor = bdd.user();
-    await prepareImportActor(actor);
+    const appUrl = "https://app.presentation-writer-stop.example.test";
+    mockEnv("APP_URL", appUrl);
+    const defaultAgentId = await prepareImportActor(actor);
 
     const fixture = installS3Fixture();
     const source = await prepareSource(fixture, {
@@ -709,6 +731,34 @@ describe("presentation template imports", () => {
     });
 
     const runId = await importRunId(actor, created.body.id);
+    await runs.heartbeatRunner();
+    const claim = await runs.claimRunnerJob(runId);
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error("Expected the presentation import to expose OKOU_TOKEN");
+    }
+    expect(claim.environment).toMatchObject({
+      OKOU_APP_URL: appUrl,
+      OKOU_AGENT_ID: defaultAgentId,
+      OKOU_TOKEN: okouToken,
+    });
+    expect(
+      Object.keys(claim.environment ?? {}).filter((key) => {
+        return key.startsWith("ZERO_");
+      }),
+    ).toStrictEqual([]);
+    expect(
+      Object.values(claim.environment ?? {}).some((value) => {
+        return value.includes("${{");
+      }),
+    ).toBeFalsy();
+    expect(claim.secretValues).toContain(okouToken);
+    expect(runTokenPayload(okouToken)).toMatchObject({
+      scope: "okou",
+      userId: actor.userId,
+      orgId: actor.orgId,
+      runId,
+    });
     const runHeaders = sandboxHeaders(actor, runId);
     const sourceDownload = await accept(
       client.source({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -2873,12 +2873,12 @@ describe("POST /api/zero/teams/bot", () => {
     const firstRunId = await runIdForPrompt(actor, "authorize the browser");
     await runsApi.heartbeatRunner(runnerGroup);
     const firstClaim = await runsApi.claimRunnerJob(firstRunId);
-    const firstZeroToken = firstClaim.environment?.ZERO_TOKEN;
-    if (!firstZeroToken) {
-      throw new Error("Claimed Teams runner job did not include ZERO_TOKEN");
+    const firstOkouToken = firstClaim.environment?.OKOU_TOKEN;
+    if (!firstOkouToken) {
+      throw new Error("Claimed Teams runner job did not include OKOU_TOKEN");
     }
     const created = await computerUseApi.createComputerUseAuthorizationRequest({
-      bearer: firstZeroToken,
+      bearer: firstOkouToken,
     });
     const requestToken = requestTokenFromUrl(created.authorizationUrl);
     await computerUseApi.applyComputerUseAuthorizationRequest(
@@ -2905,13 +2905,13 @@ describe("POST /api/zero/teams/bot", () => {
     const secondRunId = await runIdForPrompt(actor, "use the browser");
     await runsApi.heartbeatRunner(runnerGroup);
     const secondClaim = await runsApi.claimRunnerJob(secondRunId);
-    const secondZeroToken = secondClaim.environment?.ZERO_TOKEN;
-    if (!secondZeroToken) {
-      throw new Error("Claimed Teams runner job did not include ZERO_TOKEN");
+    const secondOkouToken = secondClaim.environment?.OKOU_TOKEN;
+    if (!secondOkouToken) {
+      throw new Error("Claimed Teams runner job did not include OKOU_TOKEN");
     }
-    const zeroAuth = verifyZeroToken(secondZeroToken);
-    expect(zeroAuth).toMatchObject({ computerUseHostId: host.hostId });
-    expect(zeroAuth?.capabilities).toContain("computer-use:write");
+    const okouAuth = verifyZeroToken(secondOkouToken);
+    expect(okouAuth).toMatchObject({ computerUseHostId: host.hostId });
+    expect(okouAuth?.capabilities).toContain("computer-use:write");
 
     await runsApi.requestCancelRun(actor, secondRunId, [200]);
     await computerUseApi.stopComputerUseHost(host.hostToken);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -89,12 +89,12 @@ function expectOk(response: Response, operation: string): void {
   throw new Error(`${operation} failed with ${response.status}`);
 }
 
-function zeroTokenFromClaim(
+function okouTokenFromClaim(
   claim: Awaited<ReturnType<typeof runsApi.claimRunnerJob>>,
 ): string {
-  const token = claim.environment?.ZERO_TOKEN;
+  const token = claim.environment?.OKOU_TOKEN;
   if (!token || !token.startsWith("vm0_sandbox_")) {
-    throw new Error("Expected the claim environment to carry a ZERO_TOKEN");
+    throw new Error("Expected the claim environment to carry an OKOU_TOKEN");
   }
   return token;
 }
@@ -335,7 +335,7 @@ describe("okou workflow automation scheduler", () => {
     await runsApi.heartbeatRunner(scenario.runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.runId);
     await computerUseApi.requestCreateComputerUseWriteCommand(
-      { bearer: zeroTokenFromClaim(claim) },
+      { bearer: okouTokenFromClaim(claim) },
       [200],
     );
     const createdRun = await runsApi.readRun(scenario.actor, run.runId);
@@ -355,7 +355,7 @@ describe("okou workflow automation scheduler", () => {
     await runsApi.heartbeatRunner(scenario.runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.runId);
     const denied = await computerUseApi.requestCreateComputerUseWriteCommand(
-      { bearer: zeroTokenFromClaim(claim) },
+      { bearer: okouTokenFromClaim(claim) },
       [403],
     );
     expect(denied.body).toMatchObject({

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -26,8 +26,8 @@ function buildZeroAgentComposeContent(
   agentName: string,
 ): Record<string, unknown> {
   const environment: Record<string, string> = {
-    ZERO_AGENT_ID: `\${{ vars.ZERO_AGENT_ID }}`,
-    ZERO_TOKEN: `\${{ secrets.ZERO_TOKEN }}`,
+    OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
+    OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
   };
 
   const agentDef: Record<string, unknown> = {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -169,7 +169,7 @@ import { previewAutomationBypass$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import { getDatasetName, ingestToAxiom } from "../external/axiom";
 import { now, nowDate } from "../../lib/time";
-import { generateBrandedRunTokens } from "../auth/tokens";
+import { generateZeroToken } from "../auth/tokens";
 import { onRejection, safeSync, settle, tapError } from "../utils";
 import {
   environmentRecordToEntries,
@@ -394,27 +394,21 @@ function buildMcpConnectorPrompt(
   ].join("\n");
 }
 
-function withZeroTokenSecret(
+function withOkouTokenSecret(
   body: CreateRunBody,
-  zeroToken: string,
   okouToken: string,
 ): CreateRunBody {
   return {
     ...body,
     secrets: {
-      ...body.secrets,
+      ...withoutLegacyZeroEntries(body.secrets),
       OKOU_TOKEN: okouToken,
-      ZERO_TOKEN: zeroToken,
     },
   };
 }
 
 function withPendingZeroTokenSecret(body: CreateRunBody): CreateRunBody {
-  return withZeroTokenSecret(
-    body,
-    "__pending_zero_token__",
-    "__pending_okou_token__",
-  );
+  return withOkouTokenSecret(body, "__pending_okou_token__");
 }
 
 function withFinalRunAppendSystemPrompt(args: {
@@ -1186,6 +1180,58 @@ function firstAgent(content: AgentComposeContent): AgentConfig | undefined {
   }
   const firstKey = Object.keys(content.agents)[0];
   return firstKey ? content.agents[firstKey] : undefined;
+}
+
+function canonicalOkouAgentConfig(config: AgentConfig): AgentConfig {
+  if (
+    !config.environment ||
+    !Object.keys(config.environment).some((key) => {
+      return key.startsWith("ZERO_");
+    })
+  ) {
+    return config;
+  }
+  const environment = withoutLegacyZeroEntries(config.environment);
+  if (environment) {
+    return { ...config, environment };
+  }
+  const { environment: _legacyEnvironment, ...configWithoutEnvironment } =
+    config;
+  return configWithoutEnvironment;
+}
+
+function canonicalOkouComposeContent(
+  content: AgentComposeContent,
+): AgentComposeContent {
+  if (content.agent) {
+    return { ...content, agent: canonicalOkouAgentConfig(content.agent) };
+  }
+  if (!content.agents) {
+    return content;
+  }
+  const firstKey = Object.keys(content.agents)[0];
+  const agent = firstKey ? content.agents[firstKey] : undefined;
+  if (!firstKey || !agent) {
+    return content;
+  }
+  return {
+    ...content,
+    agents: {
+      ...content.agents,
+      [firstKey]: canonicalOkouAgentConfig(agent),
+    },
+  };
+}
+
+// Content-addressed compose versions remain persisted unchanged. New branded
+// contexts interpret legacy versions through this runtime-only projection.
+function runtimeResolvedCompose(
+  resolved: ResolvedCompose,
+  canonicalOkouRuntime: boolean,
+): ResolvedCompose {
+  return canonicalOkouRuntime
+    ? { ...resolved, content: canonicalOkouComposeContent(resolved.content) }
+    : resolved;
 }
 
 function resolveFramework(
@@ -2797,6 +2843,21 @@ function mergeRecords<T>(
     }
   }
   return compactRecord(merged);
+}
+
+function withoutLegacyZeroEntries<T>(
+  values: Readonly<Record<string, T>> | undefined,
+): Record<string, T> | undefined {
+  if (!values) {
+    return undefined;
+  }
+  const canonical: Record<string, T> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (!key.startsWith("ZERO_")) {
+      canonical[key] = value;
+    }
+  }
+  return compactRecord(canonical);
 }
 
 function filterSecretConnectorMap(args: {
@@ -5842,6 +5903,7 @@ async function buildStoredExecutionContextDraft(args: {
   readonly extraEnvironment: Record<string, string> | undefined;
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
+  readonly includeZeroTokenSecret: boolean | undefined;
 }): Promise<BuiltStoredExecutionContextDraft> {
   const permissions = args.permissionManifest;
   const executionSecrets = buildStoredExecutionSecrets({
@@ -5860,7 +5922,7 @@ async function buildStoredExecutionContextDraft(args: {
     permissionManifest: permissions,
     customTargets: args.customConnectorContext.targets,
   });
-  const environment = {
+  const expandedEnvironment = {
     ...expandEnvironment({
       content: args.resolved.content,
       vars: args.body.vars,
@@ -5873,6 +5935,9 @@ async function buildStoredExecutionContextDraft(args: {
     ...args.extraEnvironment,
     CLI_PKG_URL: env("CLI_PKG_URL"),
   };
+  const environment = args.includeZeroTokenSecret
+    ? (withoutLegacyZeroEntries(expandedEnvironment) ?? {})
+    : expandedEnvironment;
   const environmentKeyByValue = new Map<string, string>();
   for (const [key, value] of Object.entries(environment)) {
     if (!environmentKeyByValue.has(value)) {
@@ -6456,12 +6521,13 @@ function preparedRunnerJobBody(
   if (!args.includeZeroTokenSecret) {
     return args.body;
   }
-  const { okouToken, zeroToken } = generateBrandedRunTokens(
+  const okouToken = generateZeroToken(
     args.userId,
     args.run.id,
     args.orgId,
     args.featureSwitchContext.overrides,
     {
+      scope: "okou",
       ...(args.zeroTokenComputerUseHostId
         ? { computerUseHostId: args.zeroTokenComputerUseHostId }
         : {}),
@@ -6469,16 +6535,15 @@ function preparedRunnerJobBody(
       imageRecognitionAvailable: args.imageRecognitionAvailable,
     },
   );
-  return withZeroTokenSecret(args.body, zeroToken, okouToken);
+  return withOkouTokenSecret(args.body, okouToken);
 }
 
 function zeroTokenEnvironment(body: CreateRunBody): Record<string, string> {
   const okouToken = body.secrets?.OKOU_TOKEN;
-  const zeroToken = body.secrets?.ZERO_TOKEN;
-  if (!okouToken || !zeroToken) {
-    throw new Error("Branded run tokens are missing from the run context");
+  if (!okouToken) {
+    throw new Error("The Okou run token is missing from the run context");
   }
-  return { OKOU_TOKEN: okouToken, ZERO_TOKEN: zeroToken };
+  return { OKOU_TOKEN: okouToken };
 }
 
 function piEdgeUsageConfig(
@@ -7858,6 +7923,7 @@ async function buildResolvedRunBody(
     readonly resolved: ResolvedCompose;
     readonly persistedEnvironment: PersistedRunEnvironmentSnapshot;
     readonly featureSwitchContext: FeatureSwitchContext;
+    readonly canonicalOkouRuntime: boolean;
   },
   signal: AbortSignal,
 ): Promise<CreateRunBody> {
@@ -7869,11 +7935,14 @@ async function buildResolvedRunBody(
     persistedEnvironment: args.persistedEnvironment,
     runVars,
   });
+  const vars = args.canonicalOkouRuntime
+    ? withoutLegacyZeroEntries(mergedVars)
+    : mergedVars;
   signal.throwIfAborted();
 
   const body: CreateRunBody = {
     ...args.initialBody,
-    vars: mergedVars,
+    vars,
     volumeVersions:
       args.initialBody.volumeVersions !== undefined
         ? args.initialBody.volumeVersions
@@ -7887,7 +7956,12 @@ async function buildResolvedRunBody(
   });
   signal.throwIfAborted();
 
-  return { ...body, secrets: mergedSecrets };
+  return {
+    ...body,
+    secrets: args.canonicalOkouRuntime
+      ? withoutLegacyZeroEntries(mergedSecrets)
+      : mergedSecrets,
+  };
 }
 
 function validateRunEnvironmentReferences(args: {
@@ -8100,6 +8174,34 @@ async function resolveEffectiveConnectorScope(
   };
 }
 
+async function loadPreparedRunFeatureSwitchContext(
+  args: {
+    readonly get: PrepareRunContextGet;
+    readonly createArgs: CreateAgentRunArgs;
+    readonly preloaded: FeatureSwitchContext | undefined;
+    readonly timing: ApiDispatchTimingCollector;
+  },
+  signal: AbortSignal,
+): Promise<FeatureSwitchContext> {
+  return await args.timing.measure(
+    "api_dispatch_prepare_context_feature_switches",
+    "nested",
+    async () => {
+      if (args.preloaded !== undefined) {
+        signal.throwIfAborted();
+        return args.preloaded;
+      }
+      return await args.get(
+        loadRunFeatureSwitchContext(args.createArgs, signal),
+      );
+    },
+    {
+      feature_switch_context_source:
+        args.preloaded === undefined ? "database" : "preloaded",
+    },
+  );
+}
+
 async function prepareRunBodyContext(
   args: {
     readonly get: PrepareRunContextGet;
@@ -8111,26 +8213,16 @@ async function prepareRunBodyContext(
   },
   signal: AbortSignal,
 ): Promise<PreparedRunBodyContext | CreateRunErrorResult> {
-  const featureSwitchContext = await args.timing.measure(
-    "api_dispatch_prepare_context_feature_switches",
-    "nested",
-    async () => {
-      if (args.preloadedFeatureSwitchContext !== undefined) {
-        signal.throwIfAborted();
-        return args.preloadedFeatureSwitchContext;
-      }
-      return await args.get(
-        loadRunFeatureSwitchContext(args.createArgs, signal),
-      );
-    },
+  const featureSwitchContext = await loadPreparedRunFeatureSwitchContext(
     {
-      feature_switch_context_source:
-        args.preloadedFeatureSwitchContext === undefined
-          ? "database"
-          : "preloaded",
+      get: args.get,
+      createArgs: args.createArgs,
+      preloaded: args.preloadedFeatureSwitchContext,
+      timing: args.timing,
     },
+    signal,
   );
-  const resolved = await args.timing.measure(
+  const persistedResolved = await args.timing.measure(
     "api_dispatch_prepare_context_resolve_compose",
     "nested",
     async () => {
@@ -8146,13 +8238,17 @@ async function prepareRunBodyContext(
     },
   );
   signal.throwIfAborted();
-  if (isRouteError(resolved)) {
-    return resolved;
+  if (isRouteError(persistedResolved)) {
+    return persistedResolved;
   }
+  const canonicalOkouRuntime = args.createArgs.includeZeroTokenSecret === true;
+  const resolved = runtimeResolvedCompose(
+    persistedResolved,
+    canonicalOkouRuntime,
+  );
   if (resolved.orgId !== args.createArgs.orgId) {
     return notFound("Resource not found");
   }
-
   const connectorScope = await args.timing.measure(
     "api_dispatch_prepare_context_resolve_connector_scope",
     "nested",
@@ -8171,7 +8267,6 @@ async function prepareRunBodyContext(
   if (isRouteError(connectorScope)) {
     return connectorScope;
   }
-
   const persistedEnvironment = await args.timing.measure(
     "api_dispatch_prepare_context_load_persisted_environment",
     "nested",
@@ -8194,6 +8289,7 @@ async function prepareRunBodyContext(
           resolved,
           persistedEnvironment,
           featureSwitchContext,
+          canonicalOkouRuntime,
         },
         signal,
       );

--- a/turbo/apps/api/src/signals/services/presentation-template-create.service.ts
+++ b/turbo/apps/api/src/signals/services/presentation-template-create.service.ts
@@ -4,6 +4,7 @@ import { presentationTemplates } from "@vm0/db/schema/presentation-template";
 import { eq } from "drizzle-orm";
 
 import { conflict, badRequestMessage, notFound } from "../../lib/error";
+import { env } from "../../lib/env";
 import { isUniqueViolation } from "../../lib/pg-errors";
 import { templateImportPrompt } from "../../lib/template-import-prompt";
 import { now, nowDate } from "../../lib/time";
@@ -185,7 +186,10 @@ export const createPresentationTemplate$ = command(
             agentComposeId: metadata.defaultAgentId,
             prompt: templateImportPrompt(inserted.row.id),
             triggerSource: "template-import",
-            vars: { PRESENTATION_TEMPLATE_ID: inserted.row.id },
+            vars: {
+              PRESENTATION_TEMPLATE_ID: inserted.row.id,
+              OKOU_AGENT_ID: metadata.defaultAgentId,
+            },
           },
           apiStartTime: now(),
           callbacks: [
@@ -196,6 +200,10 @@ export const createPresentationTemplate$ = command(
           ],
           dispatchFailedCallbacks: dispatchFailedRunCallbacks,
           includeZeroTokenSecret: true,
+          extraEnvironment: {
+            OKOU_APP_URL: env("APP_URL"),
+            OKOU_AGENT_ID: metadata.defaultAgentId,
+          },
           connectorScope: {
             allowedConnectorSlugs: [],
             allowedCustomConnectorIds: [],

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -517,19 +517,13 @@ function buildZeroRunExtraEnvironment(args: {
 }): Record<string, string> {
   return {
     OKOU_APP_URL: env("APP_URL"),
-    ZERO_APP_URL: env("APP_URL"),
     OKOU_AGENT_ID: args.agentId,
-    ZERO_AGENT_ID: args.agentId,
-    // Keep the retired rollout marker for older guest CLIs until the CLI
-    // released with this cleanup is the oldest supported guest CLI version.
-    ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED: "1",
     // Chat-mode automation (and web) runs carry their thread id so the
     // in-sandbox CLI can bind a newly created automation to it (the create
     // flow reads $OKOU_CHAT_THREAD_ID when no thread is given).
     ...(args.chatThreadId
       ? {
           OKOU_CHAT_THREAD_ID: args.chatThreadId,
-          ZERO_CHAT_THREAD_ID: args.chatThreadId,
         }
       : {}),
     ...(args.codexServiceTier
@@ -650,7 +644,6 @@ function createRunBody(args: {
     disallowedTools: [...DISALLOWED_TOOLS],
     vars: {
       OKOU_AGENT_ID: args.agent.id,
-      ZERO_AGENT_ID: args.agent.id,
     },
   };
 }

--- a/turbo/apps/cli/src/commands/zero/goal/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/goal/__tests__/index.test.ts
@@ -21,7 +21,12 @@ describe("okou goal command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-okou-token");
+    vi.stubEnv("ZERO_TOKEN", undefined);
+    vi.stubEnv("ZERO_APP_URL", undefined);
+    vi.stubEnv("ZERO_AGENT_ID", undefined);
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED", undefined);
   });
 
   afterEach(() => {
@@ -34,6 +39,9 @@ describe("okou goal command", () => {
   it("creates a goal and prints the JSON response", async () => {
     server.use(
       http.post("http://localhost:3000/api/okou/goal", async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer test-okou-token",
+        );
         await expect(request.json()).resolves.toStrictEqual({
           objective: "ship goal workflows",
         });
@@ -43,7 +51,7 @@ describe("okou goal command", () => {
 
     await zeroGoalCommand.parseAsync([
       "node",
-      "cli",
+      "okou",
       "create",
       "--objective",
       "ship goal workflows",
@@ -71,7 +79,7 @@ describe("okou goal command", () => {
 
     await zeroGoalCommand.parseAsync([
       "node",
-      "cli",
+      "okou",
       "edit",
       "--objective",
       "ship goal workflows v2",
@@ -89,7 +97,7 @@ describe("okou goal command", () => {
       }),
     );
 
-    await zeroGoalCommand.parseAsync(["node", "cli", "get"]);
+    await zeroGoalCommand.parseAsync(["node", "okou", "get"]);
 
     expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
       ACTIVE_GOAL,
@@ -114,7 +122,7 @@ describe("okou goal command", () => {
         }),
       );
 
-      await zeroGoalCommand.parseAsync(["node", "cli", command]);
+      await zeroGoalCommand.parseAsync(["node", "okou", command]);
 
       expect(
         JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0])),
@@ -129,7 +137,7 @@ describe("okou goal command", () => {
       }),
     );
 
-    await zeroGoalCommand.parseAsync(["node", "cli", "clear"]);
+    await zeroGoalCommand.parseAsync(["node", "okou", "clear"]);
 
     expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
       { cleared: true },


### PR DESCRIPTION
## Summary

- emit only `OKOU_APP_URL`, `OKOU_AGENT_ID`, optional `OKOU_CHAT_THREAD_ID`, and one Okou-scoped `OKOU_TOKEN` for newly created first-party branded execution contexts
- stop writing new `ZERO_TOKEN`, branded `ZERO_*` aliases, and the retired callback marker across ordinary agent and presentation-template runs
- author new compose versions with canonical templates while projecting immutable legacy compose versions at runtime without rewriting hashes or stored history
- preserve legacy routes, fallback readers, both token-scope verifiers, callbacks, persisted contexts, artifacts, Desktop identity, and database/internal identifiers
- update run/claim, presentation, Runner payload, and real Commander/MSW CLI-boundary coverage plus the protocol migration guide

## Validation

- `pnpm -F api run check-types`
- `pnpm -F api run lint`
- `pnpm -F @vm0/okou-cli run check-types`
- `pnpm -F @vm0/okou-cli run lint`
- `pnpm exec knip -W api -W @vm0/okou-cli --no-config-hints`
- focused API writer-stop suite: 187 passed
- additional affected API suites: 352 passed
- full API suite: 2938 passed; one shared-object-store GC count assertion observed an extra concurrent orphan, then its complete file passed 6/6 in isolation
- full Okou CLI suite: 982 passed, 1 existing skip; focused real command boundary: 8 passed
- `pnpm format` and final targeted Prettier checks
- ShellCheck and vendored Bats parse/count for `run-t14-runner-context.bats`
- `turbo-playwright-runner-workflow-test.sh`
- `app-preview-ingress-workflow-test.sh`

The focused Runner compatibility test was attempted locally but the current macOS build stops before the Runner crate in unchanged `guest-contracts/src/runtime_paths.rs`: Rust rejects passing `PRIVATE_FILE_MODE` as `u16` to two variadic calls and requests a `c_uint` cast. CI's Linux Runner coverage remains the authoritative check.

## Rollout

Release separately through the normal production workflow. Verify only new context key names and token scope without exposing values. Continue accepting historical Zero traffic and roll back to Phase B release target `d2fddbf6714b35182e1ef4b787adf84724f6ee02` if canonical-only context creation regresses.

Closes #26652
