### PR TITLE
fix(connectors): align custom runtime credential recovery

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9329,13 +9329,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
   });
 
-  it("admits an unrefreshable custom OAuth token only until it expires", async () => {
+  it("fails expired custom OAuth without a refresh token at matched auth", async () => {
     const provider = mockCustomConnectorOAuth2Provider(context, {
       initialExpiresIn: 30,
       initialRefreshToken: null,
     });
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const connectedAt = now();
     mockNow(connectedAt);
@@ -9408,18 +9409,39 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     const expiredRun = await api.createRun(actor, {
       agentId,
-      prompt: "do not use the expired unrefreshable custom connector",
+      prompt: "try the expired unrefreshable custom connector",
       modelProvider: "anthropic-api-key",
     });
     const expiredClaim = await api.claimRunnerJob(expiredRun.runId);
-    expect(expiredClaim.connectorRuntimeTargets).not.toContainEqual(target);
+    expect(expiredClaim.connectorRuntimeTargets).toContainEqual(target);
+    const [runtimeResult] = await api.syncConnectorRuntime(expiredRun.runId, {
+      targets: [{ kind: "custom", customConnectorId: custom.id }],
+    });
+    const runtime = availableCustomConnectorRuntime(runtimeResult);
+    const { body: authBody } = customConnectorRuntimeAuthBody(
+      runtime,
+      fw.encryptedSecretsBody({}),
+    );
+    const reconnectRequired = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${expiredClaim.sandboxToken}` },
+      authBody,
+      [502],
+    );
+    if (reconnectRequired.status !== 502) {
+      throw new Error("Expected missing custom OAuth refresh token");
+    }
+    expect(reconnectRequired.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: [custom.id],
+      failureReason: "reconnect_required",
+    });
     expect(provider.tokenBodies).toHaveLength(1);
 
     await api.requestCancelRun(actor, expiredRun.runId, [200]);
     await connectors.deleteCustomConnector(actor, custom.id);
   });
 
-  it("serializes and injects custom connector OAuth 2.0 refreshes", async () => {
+  it("serializes reconnect-marked custom OAuth recovery", async () => {
     const provider = mockCustomConnectorOAuth2Provider(context, {
       initialExpiresIn: 3600,
       refreshResponse: (attempt) => {
@@ -9485,6 +9507,23 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       state,
     });
     await connectors.updateAgentCustomConnectors(actor, agentId, [custom.id]);
+    if (!actor.orgId) {
+      throw new Error("Expected a custom connector actor with an organization");
+    }
+    await setCustomConnectorCredentialStorageState(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: custom.id,
+      authMethod: "oauth",
+      storageVersion: 1,
+      needsReconnect: true,
+    });
+    await expect(
+      connectors.readCustomConnector(actor, custom.id),
+    ).resolves.toMatchObject({
+      connected: false,
+      missingRequiredFields: ["oauth"],
+    });
 
     const run = await api.createRun(actor, {
       agentId,
@@ -9574,6 +9613,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       expectedBasicAuthorization,
       expectedBasicAuthorization,
     ]);
+    await expect(
+      connectors.readCustomConnector(actor, custom.id),
+    ).resolves.toMatchObject({
+      connected: true,
+      missingRequiredFields: [],
+    });
 
     const currentResolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
@@ -9590,9 +9635,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     expect(provider.tokenBodies).toHaveLength(2);
 
-    if (!actor.orgId) {
-      throw new Error("Expected a custom connector actor with an organization");
-    }
     await setCustomConnectorCredentialStorageState(context, {
       orgId: actor.orgId,
       userId: actor.userId,
@@ -9666,7 +9708,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("marks a custom OAuth connection for reconnect after invalid_grant", async () => {
+  it("retries reconnect-marked custom OAuth after invalid_grant", async () => {
     const provider = mockCustomConnectorOAuth2Provider(context, {
       initialExpiresIn: 3600,
       refreshResponse: () => {
@@ -9754,19 +9796,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       connectors: [custom.id],
       failureReason: "reconnect_required",
     });
-    const stillReconnectRequired = await fw.requestFirewallAuth(
-      { authorization: `Bearer ${claim.sandboxToken}` },
-      currentAuthBody,
-      [502],
-    );
-    if (stillReconnectRequired.status !== 502) {
-      throw new Error("Expected persisted custom OAuth reconnect requirement");
-    }
-    expect(stillReconnectRequired.body.error).toMatchObject({
-      code: "TOKEN_REFRESH_FAILED",
-      connectors: [custom.id],
-      failureReason: "reconnect_required",
-    });
     const [reconnectRuntimeResult] = await api.syncConnectorRuntime(
       firstRun.runId,
       { targets: [{ kind: "custom", customConnectorId: custom.id }] },
@@ -9794,7 +9823,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     const secondRun = await api.createRun(actor, {
       agentId,
-      prompt: "do not retry the revoked OAuth custom connector",
+      prompt: "retry the revoked OAuth custom connector",
       modelProvider: "anthropic-api-key",
     });
     expect(provider.tokenBodies).toHaveLength(2);
@@ -9802,14 +9831,41 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const internalName = `custom_connector_${custom.id.replaceAll("-", "")}`;
     expect(
       findFirewallEntry(secondClaim.firewalls, internalName),
-    ).toBeUndefined();
-    expect(secondClaim.networkPolicies ?? {}).not.toHaveProperty(internalName);
-    expect(secondClaim.connectorRuntimeTargets).not.toContainEqual(
+    ).toBeDefined();
+    expect(secondClaim.networkPolicies ?? {}).toHaveProperty(internalName);
+    expect(secondClaim.connectorRuntimeTargets).toContainEqual(
       expect.objectContaining({
         kind: "custom",
         customConnectorId: custom.id,
       }),
     );
+    const [secondRuntimeResult] = await api.syncConnectorRuntime(
+      secondRun.runId,
+      { targets: [{ kind: "custom", customConnectorId: custom.id }] },
+    );
+    const secondRuntime = availableCustomConnectorRuntime(secondRuntimeResult);
+    const { body: secondAuthBody } = customConnectorRuntimeAuthBody(
+      secondRuntime,
+      fw.encryptedSecretsBody({}),
+    );
+    const retriedReconnectRequired = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${secondClaim.sandboxToken}` },
+      secondAuthBody,
+      [502],
+    );
+    if (retriedReconnectRequired.status !== 502) {
+      throw new Error("Expected retried custom OAuth reconnect requirement");
+    }
+    expect(retriedReconnectRequired.body.error).toMatchObject({
+      code: "TOKEN_REFRESH_FAILED",
+      connectors: [custom.id],
+      failureReason: "reconnect_required",
+    });
+    expect(
+      provider.tokenBodies.map((body) => {
+        return body.get("grant_type");
+      }),
+    ).toStrictEqual(["authorization_code", "refresh_token", "refresh_token"]);
 
     await api.requestCancelRun(actor, firstRun.runId, [200]);
     await api.requestCancelRun(actor, secondRun.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -2816,11 +2816,8 @@ describe("Feishu integration", () => {
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(run.id);
     expect(claim.prompt).toBe(run.prompt);
-    expect(oauthTokenGrantTypes).toStrictEqual([
-      "authorization_code",
-      "refresh_token",
-    ]);
-    expect(oauthRefreshTokens).toStrictEqual(["feishu-user-refresh-token"]);
+    expect(oauthTokenGrantTypes).toStrictEqual(["authorization_code"]);
+    expect(oauthRefreshTokens).toStrictEqual([]);
     const internalName = `custom_connector_${managedConnector.id.replaceAll(
       "-",
       "",

--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors-create.ts
@@ -48,7 +48,7 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     body: serialiseCustomConnector({
       row: result,
       valueMarkers: [],
-      usableConnection: false,
+      connectedConnection: false,
     }),
   };
 });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -187,7 +187,6 @@ import {
   GATEWAY_RUNTIME_SECRET_NAME,
 } from "./model-provider-gateway-runtime";
 import {
-  CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
   CustomConnectorRuntimePrefixError,
   customConnectorInternalName,
   customConnectorManualAuthReferencesMemberField,
@@ -199,7 +198,6 @@ import {
   renderTemplateForRuntime,
   type StoredValueRow,
 } from "./zero-custom-connector.service";
-import { refreshCustomConnectorOAuth2ValuesIfNeeded } from "./custom-connector-oauth2.service";
 import {
   loadCustomConnectorPermissionBundle,
   type CustomConnectorPermissionBundle,
@@ -4230,22 +4228,10 @@ function customConnectorRuntimeSkill(
   };
 }
 
-function customConnectorRuntimeCredentialsAreComplete(
+function customConnectorRequiredMemberCredentialsAreComplete(
   row: CustomConnectorRuntimeDataRows[number],
 ): boolean {
-  const valueMarkers = new Set(
-    row.values.map((value) => {
-      return customConnectorValueMarkerKey(value);
-    }),
-  );
-  const oauthConnected = valueMarkers.has(
-    customConnectorValueMarkerKey({
-      kind: "secret",
-      key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-    }),
-  );
   return (
-    (row.connector.authMode !== "oauth" || oauthConnected) &&
     customConnectorMissingRequiredFieldKeys({
       fields: row.connector.fields,
       markers: row.values,
@@ -4331,7 +4317,7 @@ async function buildCustomConnectorRuntimeRow(args: {
   };
   const skill = customConnectorRuntimeSkill(args.row);
   const missingRequiredStartedAt = now();
-  const missingRequired = !customConnectorRuntimeCredentialsAreComplete(
+  const missingRequired = !customConnectorRequiredMemberCredentialsAreComplete(
     args.row,
   );
   args.stats.recordPhaseDuration("assembleFirewalls", missingRequiredStartedAt);
@@ -4473,10 +4459,10 @@ async function buildNewRunCustomConnectorRuntimeContext(
     rows: args.rows.filter((row) => {
       return (
         row.credentialAccess.kind === "current" &&
-        row.credentialAccess.usable &&
+        row.credentialAccess.runtimeAvailable &&
         (row.connector.authMode !== "manual" ||
           customConnectorManualAuthReferencesMemberField(row.connector)) &&
-        customConnectorRuntimeCredentialsAreComplete(row)
+        customConnectorRequiredMemberCredentialsAreComplete(row)
       );
     }),
   });
@@ -4610,6 +4596,7 @@ async function loadCustomConnectorContext(
       skills: [],
     };
   }
+  signal.throwIfAborted();
   const newRunRows = rows.filter((row) => {
     return (
       row.connector.kind !== "mcp" ||
@@ -4619,33 +4606,13 @@ async function loadCustomConnectorContext(
       )
     );
   });
-  const refreshedRows: CustomConnectorRuntimeDataRows[number][] = [];
-  for (const row of newRunRows) {
-    refreshedRows.push({
-      connector: row.connector,
-      credentialAccess: row.credentialAccess,
-      values: await refreshCustomConnectorOAuth2ValuesIfNeeded(
-        {
-          db,
-          orgId: args.orgId,
-          userId: args.userId,
-          connector: row.connector,
-          values: row.values,
-          featureContext: args.featureSwitchContext,
-        },
-        signal,
-      ),
-    });
-    signal.throwIfAborted();
-  }
-
   return await measureApiDispatchTiming(
     timing,
     "api_dispatch_prepare_context_build_custom_connector_firewalls",
     "nested",
     async () => {
       return await buildNewRunCustomConnectorRuntimeContext({
-        rows: refreshedRows,
+        rows: newRunRows,
         featureSwitchContext: args.featureSwitchContext,
         connectorCatalogSnapshot: args.connectorCatalogSnapshot,
         grants: args.customConnectorGrants,

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -240,13 +240,10 @@ function customConnectorStoredConnectionIsConnected(
   );
 }
 
-function customConnectorStoredConnectionIsRuntimeAvailable(
+function currentCustomConnectorStoredConnectionIsRuntimeAvailable(
   connection: CustomConnectorStoredConnection,
   now: Date,
 ): boolean {
-  if (!customConnectorStoredConnectionIsCurrent(connection)) {
-    return false;
-  }
   return (
     connectorRuntimeCredentialStatusForAccess({
       storedNeedsReconnect: connection.storedNeedsReconnect,
@@ -286,10 +283,8 @@ function customConnectorCredentialAccesses(
       accesses.set(definition.id, {
         kind: "current",
         memberConnectorId: member.id,
-        runtimeAvailable: customConnectorStoredConnectionIsRuntimeAvailable(
-          member,
-          now,
-        ),
+        runtimeAvailable:
+          currentCustomConnectorStoredConnectionIsRuntimeAvailable(member, now),
       });
     } else {
       accesses.set(definition.id, {

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -15,7 +15,10 @@ import {
 } from "../../lib/db-structured-result";
 import { nowDate } from "../../lib/time";
 import type { ReadonlyDb } from "../external/db";
-import { connectorCredentialStatusForAccess } from "./connector-credential-status.service";
+import {
+  connectorCredentialStatusForAccess,
+  connectorRuntimeCredentialStatusForAccess,
+} from "./connector-credential-status.service";
 
 const OAUTH_ACCESS_TOKEN_SECRET_NAME = "access_token";
 const OAUTH_REFRESH_TOKEN_SECRET_NAME = "refresh_token";
@@ -77,7 +80,7 @@ interface CustomConnectorStoredConnection {
   readonly oauthRefreshTokenId: string | null;
 }
 
-interface UsableCustomConnectorConnection {
+interface ConnectedCustomConnectorConnection {
   readonly authMode: OrgCustomConnectorAuthMode;
   readonly storageVersion: number;
 }
@@ -87,7 +90,7 @@ export type CustomConnectorCredentialAccess =
   | {
       readonly kind: "current";
       readonly memberConnectorId: string;
-      readonly usable: boolean;
+      readonly runtimeAvailable: boolean;
     }
   | {
       readonly kind: "incompatible";
@@ -214,7 +217,7 @@ function customConnectorStoredConnectionIsCurrent(
   );
 }
 
-function customConnectorStoredConnectionIsUsable(
+function customConnectorStoredConnectionIsConnected(
   connection: CustomConnectorStoredConnection,
   now: Date,
 ): boolean {
@@ -234,6 +237,26 @@ function customConnectorStoredConnectionIsUsable(
     credentialStatus === "available" &&
     (connection.definitionAuthMethod === "manual" ||
       connection.oauthAccessTokenId !== null)
+  );
+}
+
+function customConnectorStoredConnectionIsRuntimeAvailable(
+  connection: CustomConnectorStoredConnection,
+  now: Date,
+): boolean {
+  if (!customConnectorStoredConnectionIsCurrent(connection)) {
+    return false;
+  }
+  return (
+    connectorRuntimeCredentialStatusForAccess({
+      storedNeedsReconnect: connection.storedNeedsReconnect,
+      tokenExpiresAt:
+        connection.definitionAuthMethod === "oauth"
+          ? connection.tokenExpiresAt
+          : null,
+      now,
+      isRefreshable: connection.definitionAuthMethod === "oauth",
+    }) === "available"
   );
 }
 
@@ -263,7 +286,10 @@ function customConnectorCredentialAccesses(
       accesses.set(definition.id, {
         kind: "current",
         memberConnectorId: member.id,
-        usable: customConnectorStoredConnectionIsUsable(member, now),
+        runtimeAvailable: customConnectorStoredConnectionIsRuntimeAvailable(
+          member,
+          now,
+        ),
       });
     } else {
       accesses.set(definition.id, {
@@ -541,39 +567,42 @@ export async function loadCurrentCustomConnectorStoredValues(
   return customConnectorRuntimeStorageSnapshot(args.definitions, rows);
 }
 
-export async function loadUsableCustomConnectorConnections(
+export async function loadConnectedCustomConnectorConnections(
   db: Pick<ReadonlyDb, "select">,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly connectorIds?: readonly string[];
   },
-): Promise<ReadonlyMap<string, UsableCustomConnectorConnection>> {
+): Promise<ReadonlyMap<string, ConnectedCustomConnectorConnection>> {
   if (args.connectorIds?.length === 0) {
     return new Map();
   }
   const rows = await loadCustomConnectorStoredConnections(db, args);
   const now = nowDate();
-  const usableConnections = new Map<string, UsableCustomConnectorConnection>();
+  const connectedConnections = new Map<
+    string,
+    ConnectedCustomConnectorConnection
+  >();
   for (const row of rows) {
-    if (customConnectorStoredConnectionIsUsable(row, now)) {
-      usableConnections.set(row.customConnectorId, {
+    if (customConnectorStoredConnectionIsConnected(row, now)) {
+      connectedConnections.set(row.customConnectorId, {
         authMode: row.definitionAuthMethod,
         storageVersion: row.definitionStorageVersion,
       });
     }
   }
-  return usableConnections;
+  return connectedConnections;
 }
 
-export function customConnectorDefinitionHasUsableConnection(args: {
-  readonly usableConnections: ReadonlyMap<
+export function customConnectorDefinitionHasConnectedConnection(args: {
+  readonly connectedConnections: ReadonlyMap<
     string,
-    UsableCustomConnectorConnection
+    ConnectedCustomConnectorConnection
   >;
   readonly definition: CustomConnectorCredentialDefinition;
 }): boolean {
-  const connection = args.usableConnections.get(args.definition.id);
+  const connection = args.connectedConnections.get(args.definition.id);
   return (
     connection?.authMode === args.definition.authMode &&
     connection.storageVersion === args.definition.storageVersion

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -41,7 +41,6 @@ import {
 } from "./crypto.utils";
 import { feishuOAuthAppCallbackUrl } from "./feishu-config";
 import {
-  CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
   CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_SECRET_NAME,
   CUSTOM_CONNECTOR_OAUTH_ID_TOKEN_SECRET_NAME,
   CUSTOM_CONNECTOR_OAUTH_REFRESH_TOKEN_SECRET_NAME,
@@ -49,7 +48,6 @@ import {
   normaliseCustomConnectorRow,
   type CustomConnectorOAuthConfigRow,
   type CustomConnectorRow,
-  type StoredValueRow,
 } from "./zero-custom-connector.service";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import type { StoredCustomConnectorOAuthState } from "./connector-oauth-state.service";
@@ -939,10 +937,9 @@ type CustomConnectorOAuth2AccessTokenResolution =
 
 function storedConnectionAccessToken(
   connection: StoredConnection,
-): CustomConnectorOAuth2AccessTokenResolution {
-  if (connection.needsReconnect) {
-    return { kind: "reconnect-required" };
-  }
+):
+  | AvailableCustomConnectorOAuth2AccessToken
+  | { readonly kind: "unavailable" } {
   if (!connection.encryptedAccessToken) {
     return { kind: "unavailable" };
   }
@@ -959,33 +956,6 @@ export class CustomConnectorOAuth2TokenRefreshError extends Error {
     super("Custom connector OAuth 2.0 token refresh failed", { cause });
     this.name = "CustomConnectorOAuth2TokenRefreshError";
   }
-}
-
-function withoutRuntimeOAuthToken(
-  values: readonly StoredValueRow[],
-): readonly StoredValueRow[] {
-  return values.filter((value) => {
-    return !(
-      value.kind === "secret" &&
-      value.key === CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY
-    );
-  });
-}
-
-function withRuntimeOAuthToken(
-  values: readonly StoredValueRow[],
-  connectorId: string,
-  encryptedValue: string,
-): readonly StoredValueRow[] {
-  return [
-    ...withoutRuntimeOAuthToken(values),
-    {
-      connectorId,
-      kind: "secret",
-      key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
-      encryptedValue,
-    },
-  ];
 }
 
 async function markCustomConnectorNeedsReconnect(
@@ -1028,10 +998,12 @@ async function resolveCustomConnectorOAuth2AccessToken(
     return { kind: "unavailable" };
   }
   const accessToken = storedConnectionAccessToken(connection);
-  if (accessToken.kind !== "available") {
-    return accessToken;
-  }
-  if (!args.forceRefresh && connectionAccessTokenIsCurrent(connection)) {
+  if (
+    !args.forceRefresh &&
+    !connection.needsReconnect &&
+    accessToken.kind === "available" &&
+    connectionAccessTokenIsCurrent(connection)
+  ) {
     return accessToken;
   }
   return await args.db.transaction(async (tx) => {
@@ -1048,19 +1020,16 @@ async function resolveCustomConnectorOAuth2AccessToken(
       return { kind: "unavailable" };
     }
     const lockedAccessToken = storedConnectionAccessToken(lockedConnection);
-    if (lockedAccessToken.kind !== "available") {
-      return lockedAccessToken;
-    }
+    const recoveredSinceInitialRead =
+      connection.needsReconnect ||
+      accessToken.kind !== "available" ||
+      (lockedAccessToken.kind === "available" &&
+        lockedAccessToken.encryptedAccessToken !==
+          accessToken.encryptedAccessToken);
     if (
-      args.forceRefresh &&
-      lockedAccessToken.encryptedAccessToken !==
-        accessToken.encryptedAccessToken &&
-      connectionAccessTokenIsCurrent(lockedConnection)
-    ) {
-      return lockedAccessToken;
-    }
-    if (
-      !args.forceRefresh &&
+      !lockedConnection.needsReconnect &&
+      lockedAccessToken.kind === "available" &&
+      (!args.forceRefresh || recoveredSinceInitialRead) &&
       connectionAccessTokenIsCurrent(lockedConnection)
     ) {
       return lockedAccessToken;
@@ -1130,33 +1099,6 @@ async function resolveCustomConnectorOAuth2AccessToken(
       status: "refreshed",
     };
   });
-}
-
-export async function refreshCustomConnectorOAuth2ValuesIfNeeded(
-  args: {
-    readonly db: Db;
-    readonly orgId: string;
-    readonly userId: string;
-    readonly connector: CustomConnectorRow;
-    readonly values: readonly StoredValueRow[];
-    readonly featureContext: FeatureSwitchContext;
-  },
-  signal: AbortSignal,
-): Promise<readonly StoredValueRow[]> {
-  if (args.connector.authMode !== "oauth") {
-    return args.values;
-  }
-  const accessToken = await resolveCustomConnectorOAuth2AccessToken(
-    args,
-    signal,
-  );
-  return accessToken.kind === "available"
-    ? withRuntimeOAuthToken(
-        args.values,
-        args.connector.id,
-        accessToken.encryptedAccessToken,
-      )
-    : withoutRuntimeOAuthToken(args.values);
 }
 
 async function loadLiveCustomConnector(args: {

--- a/turbo/apps/api/src/signals/services/zero-catalog-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-catalog-data.service.ts
@@ -11,9 +11,9 @@ import {
 } from "./zero-custom-connector.service";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import {
-  customConnectorDefinitionHasUsableConnection,
+  customConnectorDefinitionHasConnectedConnection,
   loadCurrentCustomConnectorValueMarkers,
-  loadUsableCustomConnectorConnections,
+  loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
 
 export function zeroCustomConnectorList(args: {
@@ -22,7 +22,7 @@ export function zeroCustomConnectorList(args: {
 }): Computed<Promise<readonly CustomConnectorResponse[]>> {
   return computed(async (get): Promise<readonly CustomConnectorResponse[]> => {
     const db = get(db$);
-    const [connectorRows, markers, usableConnections] = await Promise.all([
+    const [connectorRows, markers, connectedConnections] = await Promise.all([
       db
         .select({
           connector: customConnectorDefinitionSelection(),
@@ -42,14 +42,14 @@ export function zeroCustomConnectorList(args: {
         .where(eq(orgCustomConnectors.orgId, args.orgId))
         .orderBy(orgCustomConnectors.displayName),
       loadCurrentCustomConnectorValueMarkers(db, args),
-      loadUsableCustomConnectorConnections(db, args),
+      loadConnectedCustomConnectorConnections(db, args),
     ]);
     return connectorRows.map((row) => {
       return serialiseCustomConnector({
         row: normaliseCustomConnectorRow(row.connector, row.oauthConfig),
         valueMarkers: markers,
-        usableConnection: customConnectorDefinitionHasUsableConnection({
-          usableConnections,
+        connectedConnection: customConnectorDefinitionHasConnectedConnection({
+          connectedConnections,
           definition: row.connector,
         }),
       });

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -58,10 +58,10 @@ import {
 } from "./custom-connector-credential-storage.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 import {
-  customConnectorDefinitionHasUsableConnection,
+  customConnectorDefinitionHasConnectedConnection,
   loadCurrentCustomConnectorStoredValues,
   loadCurrentCustomConnectorValueMarkers,
-  loadUsableCustomConnectorConnections,
+  loadConnectedCustomConnectorConnections,
   type CustomConnectorCredentialAccess,
   type CustomConnectorCredentialValueMarker,
   type CustomConnectorStoredValue,
@@ -719,7 +719,7 @@ function effectivePermissionBundleRef(
 export function serialiseCustomConnector(args: {
   readonly row: CustomConnectorRow;
   readonly valueMarkers: readonly CustomConnectorCredentialValueMarker[];
-  readonly usableConnection: boolean;
+  readonly connectedConnection: boolean;
 }): CustomConnectorResponse {
   const connectorMarkers = args.valueMarkers.filter((marker) => {
     return (
@@ -740,12 +740,12 @@ export function serialiseCustomConnector(args: {
     args.row.authMode !== "manual" ||
     customConnectorManualAuthReferencesMemberField(args.row);
   const connected =
-    args.usableConnection &&
+    args.connectedConnection &&
     validManualAuth &&
     missingRequiredFields.length === 0;
   const responseMissingRequiredFields = [
     ...missingRequiredFields,
-    ...(args.row.authMode === "oauth" && !args.usableConnection
+    ...(args.row.authMode === "oauth" && !args.connectedConnection
       ? ["oauth"]
       : []),
   ];
@@ -2443,12 +2443,12 @@ export function getCustomConnectorResponse(args: {
     if (!connector) {
       return null;
     }
-    const [markers, usableConnections] = await Promise.all([
+    const [markers, connectedConnections] = await Promise.all([
       loadCurrentCustomConnectorValueMarkers(db, {
         orgId: args.orgId,
         userId: args.userId,
       }),
-      loadUsableCustomConnectorConnections(db, {
+      loadConnectedCustomConnectorConnections(db, {
         orgId: args.orgId,
         userId: args.userId,
       }),
@@ -2456,8 +2456,8 @@ export function getCustomConnectorResponse(args: {
     return serialiseCustomConnector({
       row: connector,
       valueMarkers: markers,
-      usableConnection: customConnectorDefinitionHasUsableConnection({
-        usableConnections,
+      connectedConnection: customConnectorDefinitionHasConnectedConnection({
+        connectedConnections,
         definition: connector,
       }),
     });
@@ -2733,7 +2733,7 @@ async function persistCustomConnectorValues(
   | {
       readonly connector: CustomConnectorRow;
       readonly runtimeRecovered: boolean;
-      readonly usableConnection: boolean;
+      readonly connectedConnection: boolean;
     }
   | BadRequestResponse
   | NotFoundResponse
@@ -2792,7 +2792,7 @@ async function persistCustomConnectorValues(
   return {
     connector: state.connector,
     runtimeRecovered: state.runtimeRecovered,
-    usableConnection: true,
+    connectedConnection: true,
   };
 }
 
@@ -2896,7 +2896,7 @@ export const setCustomConnectorValues$ = command(
     return serialiseCustomConnector({
       row: writeResult.connector,
       valueMarkers: markers,
-      usableConnection: writeResult.usableConnection,
+      connectedConnection: writeResult.connectedConnection,
     });
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-run-mcp-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-mcp-connectors.service.ts
@@ -11,9 +11,9 @@ import { and, eq } from "drizzle-orm";
 import { db$ } from "../external/db";
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import {
-  customConnectorDefinitionHasUsableConnection,
+  customConnectorDefinitionHasConnectedConnection,
   loadCurrentCustomConnectorValueMarkers,
-  loadUsableCustomConnectorConnections,
+  loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
 import {
   normaliseCustomConnectorRow,
@@ -67,13 +67,13 @@ export function zeroRunMcpConnectorList(args: {
     const connectorIds = rows.map(({ connector }) => {
       return connector.id;
     });
-    const [valueMarkers, usableConnections] = await Promise.all([
+    const [valueMarkers, connectedConnections] = await Promise.all([
       loadCurrentCustomConnectorValueMarkers(db, {
         orgId: args.orgId,
         userId: args.userId,
         connectorIds,
       }),
-      loadUsableCustomConnectorConnections(db, {
+      loadConnectedCustomConnectorConnections(db, {
         orgId: args.orgId,
         userId: args.userId,
         connectorIds,
@@ -84,8 +84,8 @@ export function zeroRunMcpConnectorList(args: {
       const response = serialiseCustomConnector({
         row: normaliseCustomConnectorRow(connector),
         valueMarkers,
-        usableConnection: customConnectorDefinitionHasUsableConnection({
-          usableConnections,
+        connectedConnection: customConnectorDefinitionHasConnectedConnection({
+          connectedConnections,
           definition: connector,
         }),
       });


### PR DESCRIPTION
## Summary

- Separate strict Custom connector public connection status from runtime recoverability by reusing the shared connector runtime credential policy used by Builtin connectors.
- Resolve Custom OAuth access tokens only when matched firewall authentication needs them, using the existing row-locked refresh path for expired, missing, or reconnect-marked credentials.
- Keep Manual connector reconnect behavior strict and preserve live definition, ownership, auth-mode, and storage-version validation.

## Exclusions

- No schema, migration, persisted-state, API contract, runner protocol, or feature-switch changes.
- Public `connected` semantics remain strict; reconnect-marked Custom OAuth connections stay visibly disconnected until runtime recovery succeeds.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (154 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts --silent=passed-only` (89 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feishu-integration.test.ts --silent=passed-only` (26 tests)
- Pre-commit hooks: full Turbo Knip and type checks

Closes #26085

Parent delivery issue: #25312
