### PR TITLE
fix(platform): hide composer placeholder after whitespace input

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -31,6 +31,7 @@ import {
   placeCaretAfterText,
   workflowSummary,
 } from "./chat-composer-test-helpers.ts";
+import { PLACEHOLDER } from "./chat-test-helpers.ts";
 
 // The composer editor is mounted on first paint and mounted again once page
 // bootstrap settles, so an element captured too early is detached by the time a
@@ -154,6 +155,29 @@ describe("chat composer models", () => {
 
     const editor = await findComposerEditor();
     expect(editor).toHaveClass("min-h-[68px]", "md:min-h-[96px]");
+  });
+
+  it("hides the placeholder for whitespace without enabling send", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("claude-fable-5");
+    mockAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const editor = await findComposerEditor();
+    expect(screen.getByText(PLACEHOLDER)).toBeInTheDocument();
+    expect(screen.getByLabelText("Send")).toBeDisabled();
+
+    await user.click(editor);
+    await user.keyboard(" ");
+
+    await waitFor(() => {
+      expect(screen.queryByText(PLACEHOLDER)).not.toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Send")).toBeDisabled();
   });
 
   it("selects from the slash workflow menu with a visual viewport offset", async () => {

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -6,6 +6,7 @@ import {
 } from "ccstate-react";
 import type { Editor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { useEditorState } from "@tiptap/react";
 import { Popover, PopoverAnchor, type KeyboardEventLike } from "@vm0/ui";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
@@ -145,10 +146,16 @@ function WorkflowComposerPlaceholder({
 }) {
   useTranslation();
   const hasInput = useGet(composer.editor.hasInput$);
+  const hasEditorText = useEditorState({
+    editor: composer.editor.editor,
+    selector: ({ editor }) => {
+      return editor.state.doc.textContent.length > 0;
+    },
+  });
   const hasTemplateAttachment = useGet(
     composer.template.hasTemplateAttachment$,
   );
-  if (hasInput) {
+  if (hasInput || hasEditorText) {
     return null;
   }
   return (


### PR DESCRIPTION
## Summary

- hide the chat composer placeholder when the TipTap document contains text, including whitespace
- leave draft serialization and message sendability unchanged
- add page-level regression coverage for placeholder and send-button behavior

## Root cause

The placeholder reused `hasInput$`, which intentionally trims whitespace because it represents whether the composer can be submitted. Placeholder visibility has different semantics: any text present in the editor, including a space, should hide it. The component now observes TipTap text content directly while retaining `hasInput$` for non-text composer content.

## Testing

- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-editor-and-suggestions.test.tsx`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`

Closes #26682