### PR TITLE
test(api): remove threadless cleanup lock

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -7,7 +7,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { HttpResponse, http } from "msw";
-import { describe, expect, test as vitestTest } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
@@ -15,7 +15,6 @@ import {
   findAgentphoneChatEventByPromptFixture,
   readChatEventContextFixture,
 } from "../../../test-fixtures/chat-events";
-import { withThreadlessRunCleanupTestLockFixture } from "../../../test-fixtures/run-deletion";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { settle } from "../../utils";
 import {
@@ -39,24 +38,6 @@ import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 const context = testContext();
-const PHONE_MEDIA_RUN_TOKEN_TEST =
-  "uploads and streams phone media with a real run-scoped zero token";
-
-function it(name: string, test: () => Promise<void>): void {
-  vitestTest(name, async () => {
-    if (name === PHONE_MEDIA_RUN_TOKEN_TEST) {
-      // This case intentionally creates a test-only direct run. Share the
-      // cleanup suite's lock so its global sweep cannot cancel that run.
-      await withThreadlessRunCleanupTestLockFixture({
-        signal: context.signal,
-        run: test,
-      });
-      return;
-    }
-    await test();
-  });
-}
-
 interface LinkedAgentPhoneActor {
   readonly actor: ApiTestUser;
   readonly phone: string;
@@ -1195,7 +1176,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(sends.messages).toHaveLength(sendsBeforeCompletion);
   });
 
-  it(PHONE_MEDIA_RUN_TOKEN_TEST, async () => {
+  it("uploads and streams phone media with a real run-scoped zero token", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsApi(context);
     const integrations = createBddIntegrationApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2,11 +2,11 @@ import { createHash, randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import {
-  cronCleanupSandboxesContract,
   cronCompactChatThreadSnapshotsContract,
   cronProjectChatEventSearchContract,
 } from "@vm0/api-contracts/contracts/cron";
 import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@vm0/api-contracts/contracts/runners";
+import { testCronCleanupSandboxesStateContract } from "@vm0/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import {
   chatThreadsContract,
   type ChatEvent,
@@ -18,7 +18,7 @@ import {
   type SupportedRunModel,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
-import { describe, expect, onTestFinished, test as vitestTest } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { createApp } from "../../../app-factory";
 import { stubTestTimezone } from "../../../__tests__/env-stub";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
@@ -41,10 +41,7 @@ import {
   insertChatThreadEventTransactionFixture,
 } from "../../../test-fixtures/chat-thread-events";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
-import {
-  setAgentRunCreatedAtFixture,
-  withThreadlessRunCleanupTestLockFixture,
-} from "../../../test-fixtures/run-deletion";
+import { setAgentRunCreatedAtFixture } from "../../../test-fixtures/run-deletion";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
@@ -76,14 +73,13 @@ import {
   insertUsageEvent$,
   materializeHourlyUsage$,
 } from "./helpers/usage-state";
-import { cronCleanupSandboxesRoutes } from "../cron-cleanup-sandboxes";
 import { cronCompactChatThreadSnapshotsRoutes } from "../cron-compact-chat-thread-snapshots";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
+import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { zeroGoalsRoutes } from "../zero-goals";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...cronCleanupSandboxesRoutes,
   ...cronCompactChatThreadSnapshotsRoutes,
   ...cronProjectChatEventSearchRoutes,
   ...zeroChatThreadRoutes,
@@ -114,7 +110,6 @@ const connectorsApi = createConnectorBddApi(context);
 const authOrg = createAuthOrgAgentsBddApi(context);
 const store = createStore();
 const CHAT_THREAD_SNAPSHOT_CRON_SECRET = "chat-thread-snapshot-cron-secret";
-const SANDBOX_CLEANUP_CRON_SECRET = "sandbox-cleanup-cron-secret";
 const DAY_MS = 24 * 60 * 60 * 1000;
 const FORWARD_CLEANUP_CUTOFF_MS = Date.parse("2026-08-03T05:40:26.000Z");
 const FORWARD_CLEANUP_TEST_CREATED_AT = "2026-08-03T05:40:26.001Z";
@@ -133,26 +128,6 @@ type UserMessage = Extract<
 >;
 type AssistantMessage = Exclude<ChatEvent, UserMessage>;
 type RunnerClaim = Awaited<ReturnType<typeof api.claimRunnerJob>>;
-
-function it(name: string, test: () => Promise<void>, timeout?: number): void {
-  vitestTest(
-    name,
-    async () => {
-      if (
-        name ===
-        "cancels in-flight runs and cascades schedules when a thread is deleted"
-      ) {
-        await withThreadlessRunCleanupTestLockFixture({
-          signal: context.signal,
-          run: test,
-        });
-        return;
-      }
-      await test();
-    },
-    timeout,
-  );
-}
 
 async function compactChatThreadSnapshots() {
   const client = setupApp({
@@ -1440,27 +1415,31 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       FORWARD_CLEANUP_CUTOFF_MS,
     );
     const cleanupAt = now() + CANCELLATION_RECOVERY_STALE_AFTER_MS;
-    mockEnv("CRON_SECRET", SANDBOX_CLEANUP_CRON_SECRET);
     mockNow(cleanupAt);
     onTestFinished(clearMockNow);
     const cleanup = await accept(
-      setupApp({ context, routes: cronCleanupSandboxesRoutes })(
-        cronCleanupSandboxesContract,
+      setupApp({ context, routes: testCronCleanupSandboxesStateRoutes })(
+        testCronCleanupSandboxesStateContract,
       ).cleanup({
-        headers: {
-          authorization: `Bearer ${SANDBOX_CLEANUP_CRON_SECRET}`,
+        body: {
+          runIds: [main.runId, sibling.runId],
+          orgIds: [],
+          exportJobIds: [],
         },
       }),
       [200],
     );
-    expect(cleanup.body.threadlessRuns.discovered).toBeGreaterThanOrEqual(2);
-    expect(cleanup.body.threadlessRuns.deleted).toBeGreaterThanOrEqual(2);
+    expect(cleanup.body.threadlessRuns.discovered).toBe(2);
+    expect(cleanup.body.threadlessRuns.deleted).toBe(2);
     await expect(
       api.requestReadRun(actor, main.runId, [404]),
     ).resolves.toMatchObject({ status: 404 });
     await expect(
       api.requestReadRun(actor, sibling.runId, [404]),
     ).resolves.toMatchObject({ status: 404 });
+    await expect(api.readRun(actor, other.runId)).resolves.toMatchObject({
+      status: "pending",
+    });
 
     await cancelChatRun(actor, other.runId);
   }, 120_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -5,14 +5,13 @@ import type { ChatEvent } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { createStore } from "ccstate";
-import { describe, expect, test as vitestTest } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
 import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
-import { withThreadlessRunCleanupTestLockFixture } from "../../../test-fixtures/run-deletion";
 import { readChatEventContextFixture } from "../../../test-fixtures/chat-events";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -387,29 +386,6 @@ async function pollSlackRun(runnerGroup: string): Promise<string> {
   return await pollRunnerRun(
     runnerGroup,
     "Expected a Slack-triggered run in the runner queue",
-  );
-}
-
-function it(name: string, test: () => Promise<void>, timeout?: number): void {
-  vitestTest(
-    name,
-    async () => {
-      if (
-        name ===
-        "delivers canonical Slack callbacks for progress, audit footers, failures, and Slack errors"
-      ) {
-        // The cron cleanup suite runs the global canonical-ingress sweep from
-        // another worker. Share its lock so it cannot claim this test's fresh
-        // Slack ingress outside the owning provider-mock lifetime.
-        await withThreadlessRunCleanupTestLockFixture({
-          signal: context.signal,
-          run: test,
-        });
-        return;
-      }
-      await test();
-    },
-    timeout,
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -14,7 +14,6 @@ import { env } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { testContext, accept } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { withThreadlessRunCleanupTestLockFixture } from "../../../test-fixtures/run-deletion";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { modelStatsRoutes } from "../model-stats";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
@@ -88,7 +87,6 @@ interface DeferredS3Put {
 }
 
 const context = testContext();
-const registerExportTest = it;
 const trackDeferredS3Put = createFixtureTracker<DeferredS3Put>((pendingPut) => {
   pendingPut.resolve();
   return Promise.resolve();
@@ -1111,15 +1109,6 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
 });
 
 describe("OPS-01: user data export", () => {
-  function it(name: string, test: () => Promise<void>): void {
-    registerExportTest(name, async () => {
-      await withThreadlessRunCleanupTestLockFixture({
-        signal: context.signal,
-        run: test,
-      });
-    });
-  }
-
   it("rejects unauthenticated and org-less export requests", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);

--- a/turbo/apps/api/src/test-fixtures/run-deletion.ts
+++ b/turbo/apps/api/src/test-fixtures/run-deletion.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
-import { createDeferredPromise, settleIncludingAbort } from "../signals/utils";
+import { createDeferredPromise } from "../signals/utils";
 
 const databasePidRowSchema = z.object({ pid: z.int() });
 const waiterCountRowSchema = z.object({ waiterCount: z.int() });
@@ -27,58 +27,6 @@ interface HeldDatabaseBoundary {
   readonly release: () => void;
   readonly done: Promise<void>;
   readonly blockedWaiterCount: () => Promise<number>;
-}
-
-/** Serializes integration tests that invoke the global threadless-run sweep. */
-async function holdThreadlessRunCleanupTestLockFixture(args: {
-  readonly signal: AbortSignal;
-}): Promise<HeldDatabaseBoundary> {
-  const started = createDeferredPromise<number>(args.signal);
-  const released = createDeferredPromise<void>(args.signal);
-  const done = db().transaction(async (tx) => {
-    const pidRows = await executeRawRows(
-      tx,
-      sql`SELECT pg_backend_pid() AS "pid"`,
-      databasePidRowSchema,
-    );
-    const pid = pidRows[0]?.pid;
-    if (!pid) {
-      throw new Error("Expected the cleanup test lock holder pid");
-    }
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtextextended('threadless-run-cleanup-integration-test', 0))`,
-    );
-    started.resolve(pid);
-    await released.promise;
-  });
-  const pid = await started.promise;
-  return {
-    release: () => {
-      if (!released.settled()) {
-        released.resolve(undefined);
-      }
-    },
-    done,
-    blockedWaiterCount: async () => {
-      return await directBlockedWaiterCount(pid);
-    },
-  };
-}
-
-export async function withThreadlessRunCleanupTestLockFixture<T>(args: {
-  readonly signal: AbortSignal;
-  readonly run: () => Promise<T>;
-}): Promise<T> {
-  const lock = await holdThreadlessRunCleanupTestLockFixture({
-    signal: args.signal,
-  });
-  const result = await settleIncludingAbort(args.run());
-  lock.release();
-  await lock.done;
-  if (!result.ok) {
-    throw result.error;
-  }
-  return result.value;
 }
 
 /** Deletes one run root without invoking a global maintenance sweep. */


### PR DESCRIPTION
## Summary

- replace the chat-thread deletion test's global sandbox sweep with the fixture-scoped cleanup route for exactly its two deleted-thread runs, including exact cleanup counts and an untouched-run sentinel
- remove the threadless cleanup lock from canonical Slack ingress, user-export, and AgentPhone route coverage now that cleanup suites own only their registered resources
- delete the lock fixture and advisory-lock key without changing production code or route behavior

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts apps/api/src/test-fixtures/run-deletion.ts`
- `pnpm -F api lint`
- `pnpm knip --workspace api --no-progress`
- `pnpm -F api check-types`
- affected integration slices together under normal Vitest workers: 4 files passed, 15 tests passed, 89 skipped
- repository-wide search for `withThreadlessRunCleanupTestLockFixture`, `holdThreadlessRunCleanupTestLockFixture`, the deleted lock key, and threadless lock/serialization patterns: no matches

Closes #26574

Epic: https://github.com/vm0-ai/vm0/issues/26569
