### PR TITLE
test(api): isolate workflow queue cleanup coverage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1422,6 +1422,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         testCronCleanupSandboxesStateContract,
       ).cleanup({
         body: {
+          chatThreadIds: [],
           runIds: [main.runId, sibling.runId],
           orgIds: [],
           exportJobIds: [],

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -529,6 +529,7 @@ describe("sandbox cleanup", () => {
   }> {
     return {
       body: await cleanupScopedSandboxes({
+        chatThreadIds: [],
         runIds: [...registeredRunIds],
         orgIds: [...registeredOrgIds],
         exportJobIds: [...registeredExportJobIds],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -4,6 +4,7 @@ import {
   chatEventsContract,
   chatThreadEventsContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { testCronCleanupSandboxesStateContract } from "@vm0/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import { testWorkflowAutomationExecutionContract } from "@vm0/api-contracts/contracts/test-workflow-automation-execution";
 import { zeroModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { zeroWorkflowAutomationsContract } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -51,11 +52,10 @@ import { zeroChatEventsRoutes } from "../zero-chat-events";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { zeroModelProvidersRoutes } from "../zero-model-providers";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
-import { cronCleanupSandboxesRoutes } from "../cron-cleanup-sandboxes";
+import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automations";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...cronCleanupSandboxesRoutes,
   ...testWorkflowAutomationExecutionRoutes,
   ...webhooksWorkflowAutomationsRoutes,
   ...zeroChatEventsRoutes,
@@ -72,8 +72,6 @@ const webhooksApi = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-workflow";
-const CRON_CLEANUP_SANDBOXES_ROUTE = "/api/cron/cleanup-sandboxes";
-const CRON_SECRET = "test-cron-secret";
 
 function it(name: string, test: () => Promise<void>, timeout?: number): void {
   vitestTest(
@@ -100,6 +98,13 @@ function workflowAutomationExecutionClient() {
     context,
     routes: testWorkflowAutomationExecutionRoutes,
   })(testWorkflowAutomationExecutionContract);
+}
+
+function cleanupSandboxesClient() {
+  return setupApp({
+    context,
+    routes: testCronCleanupSandboxesStateRoutes,
+  })(testCronCleanupSandboxesStateContract);
 }
 
 function chatEventsClient() {
@@ -131,7 +136,6 @@ interface Scenario {
 
 async function setup(): Promise<Scenario> {
   const runnerGroup = runsApi.configureRunnerGroup();
-  mockEnv("CRON_SECRET", CRON_SECRET);
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   const { actor } = await wf.setupWorkflowOrg({ tier: "team" });
   if (!actor.orgId) {
@@ -454,25 +458,34 @@ async function executeDueWorkflowAutomations(
   expect(response.body.success).toBeTruthy();
 }
 
-async function cleanupSandboxes(): Promise<void> {
-  const response = await createApp({
-    signal: context.signal,
-    routes: TEST_APP_ROUTES,
-  }).request(CRON_CLEANUP_SANDBOXES_ROUTE, {
-    headers: { authorization: `Bearer ${CRON_SECRET}` },
-  });
-  expect(response.status).toBe(200);
+async function cleanupWorkflowQueueFixtures(args: {
+  readonly threadId: string;
+  readonly orgId: string;
+  readonly runIds: readonly string[];
+}): Promise<void> {
+  await accept(
+    cleanupSandboxesClient().cleanup({
+      body: {
+        chatThreadIds: [args.threadId],
+        runIds: [...args.runIds],
+        orgIds: [args.orgId],
+        exportJobIds: [],
+      },
+    }),
+    [200],
+  );
 }
 
 /**
  * Product-visible proof that the stale sweep admitted nothing on this thread
  * while a request is still blocked on the org admission lock.
  *
- * The sweep runs inline in the cron request, so `cleanupSandboxes()` returning
- * at all already shows it never reached that lock — any attempt would block on
- * the hold this test owns. This asserts the outcome half through the queue API:
- * the pending events are exactly the ones queued before the sweep, and no
- * queued item was drained into a run.
+ * The sweep runs inline in the fixture-scoped cleanup request, so
+ * `cleanupWorkflowQueueFixtures()` returning at all already shows it never
+ * reached that lock — any attempt would block on the hold this test owns. This
+ * asserts the outcome half through the queue API: the pending events are
+ * exactly the ones queued before the sweep, and no queued item was drained into
+ * a run.
  *
  * Deliberately not asserted through `admissionLock.waiterCount()`: that counter
  * is a cluster-wide `pg_locks` observation of one `hashtext(orgId)` key shared
@@ -673,7 +686,11 @@ describe("workflow queue", () => {
 
     // The business assertion: the stale sweep must not race the freshly
     // admitted event that is still blocked on org admission.
-    await cleanupSandboxes();
+    await cleanupWorkflowQueueFixtures({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      runIds: [],
+    });
     await expectSweepLeftQueueUntouched(automation.threadId, [event.id]);
 
     admissionLock.release();
@@ -739,7 +756,11 @@ describe("workflow queue", () => {
     // The business assertion: the stale sweep must leave the fresh user message
     // queued and must not drain it ahead of the stale automation event that is
     // still blocked on org admission.
-    await cleanupSandboxes();
+    await cleanupWorkflowQueueFixtures({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      runIds: [],
+    });
     await expectSweepLeftQueueUntouched(automation.threadId, [event.id]);
 
     admissionLock.release();
@@ -776,7 +797,11 @@ describe("workflow queue", () => {
     await runsApi.claimRunnerJob(firstRunId);
     await completeRunWithoutCallbacksFixture({ runId: firstRunId });
 
-    await cleanupSandboxes();
+    await cleanupWorkflowQueueFixtures({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      runIds: [firstRunId],
+    });
 
     await expect(
       pendingAutomationEvents(automation.threadId),
@@ -820,7 +845,11 @@ describe("workflow queue", () => {
     await runsApi.claimRunnerJob(firstRunId);
     await completeRunWithoutCallbacksFixture({ runId: firstRunId });
 
-    await cleanupSandboxes();
+    await cleanupWorkflowQueueFixtures({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      runIds: [firstRunId],
+    });
 
     const messages = await wf.readThreadEvents(automation.threadId);
     expect(messages).toContainEqual(

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -62,6 +62,7 @@ type CleanupSandboxesScope =
   | { readonly kind: "global" }
   | {
       readonly kind: "fixtures";
+      readonly chatThreadIds: readonly string[];
       readonly runIds: readonly string[];
       readonly orgIds: readonly string[];
       readonly exportJobIds: readonly string[];
@@ -475,6 +476,23 @@ const cleanupGlobalIngress$ = command(
   },
 );
 
+const cleanupFixtureChatThreadQueues$ = command(
+  async (
+    { set },
+    chatThreadIds: readonly string[],
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await set(
+      drainStaleChatThreadQueues$,
+      {
+        dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+        chatThreadIds,
+      },
+      signal,
+    );
+  },
+);
+
 export const cleanupSandboxes$ = command(
   async (
     { set },
@@ -554,8 +572,10 @@ export const cleanupSandboxes$ = command(
     signal.throwIfAborted();
     if (scope.kind === "global") {
       await set(cleanupGlobalIngress$, signal);
-      signal.throwIfAborted();
+    } else {
+      await set(cleanupFixtureChatThreadQueues$, scope.chatThreadIds, signal);
     }
+    signal.throwIfAborted();
     const queuedTerminalRuns = [
       ...expiredQueueResult.timedOutRuns,
       ...queuedOrphanResult.timedOutRuns,

--- a/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
@@ -40,6 +40,7 @@ export const testCronCleanupSandboxesStateErrorSchema = z.object({
 });
 
 export const testCronCleanupSandboxesScopeSchema = z.object({
+  chatThreadIds: z.array(z.string().uuid()),
   runIds: z.array(z.string().uuid()),
   orgIds: z.array(z.string().min(1)),
   exportJobIds: z.array(z.string().uuid()),


### PR DESCRIPTION
## Summary

- extend the guarded sandbox-cleanup fixture scope with explicit chat thread IDs
- migrate all four workflow-queue recovery scenarios away from the production-global cleanup route
- keep the merged chat-thread deletion fixture scoped to its owned threadless runs with `chatThreadIds: []`
- preserve exact route-level fresh/stale behavior and the production-global cleanup path

## Validation

- `pnpm exec prettier --check` on the five changed files
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm knip --workspace api --workspace @vm0/api-contracts --no-progress`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts` (28 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts` (44 passed)

Closes #26573

Parent epic: [#26569](https://github.com/vm0-ai/vm0/issues/26569)
