### PR TITLE
test(api): isolate connector catalog system storage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -860,7 +860,7 @@ function datadogPrivateAuthMethod(scopes: readonly string[]): JsonRecord {
 
 function buildBundledSkill(
   connectorSlug: string,
-  versionId = "a".repeat(64),
+  versionId = createHash("sha256").update(randomUUID()).digest("hex"),
   metadata: {
     readonly size: number;
     readonly archiveSize: number;
@@ -870,7 +870,7 @@ function buildBundledSkill(
     archiveSize: 321,
     fileCount: 1,
   },
-  storageName = `connector-skill@${connectorSlug}`,
+  storageName = `connector-skill@${connectorSlug}-${randomUUID().replaceAll("-", "")}`,
 ): JsonRecord {
   const prefix = `__system__/volume/${storageName}/${versionId}`;
   return {
@@ -884,10 +884,33 @@ function buildBundledSkill(
   };
 }
 
-interface BundledSkillFixture {
-  readonly descriptor: JsonRecord;
+interface OwnedVolumeStorageFixture {
+  readonly storageId: string;
   readonly storageName: string;
   readonly s3Prefix: string;
+}
+
+function createOwnedVolumeStorageFixture(
+  storageName: string,
+  s3Prefix = `${SYSTEM_ORG_ID}/volume/${storageName}`,
+): OwnedVolumeStorageFixture {
+  return {
+    storageId: randomUUID(),
+    storageName,
+    s3Prefix,
+  };
+}
+
+function createBundledSkillStorageFixture(
+  connectorSlug: string,
+): OwnedVolumeStorageFixture {
+  return createOwnedVolumeStorageFixture(
+    `connector-skill@${connectorSlug}-${randomUUID().replaceAll("-", "")}`,
+  );
+}
+
+interface BundledSkillFixture extends OwnedVolumeStorageFixture {
+  readonly descriptor: JsonRecord;
   readonly versionId: string;
   readonly contentSize: number;
   readonly archiveSize: number;
@@ -897,14 +920,13 @@ interface BundledSkillFixture {
 
 function buildBundledSkillFixture(
   connectorSlug: string,
-  versionId = "a".repeat(64),
-  storageName = `connector-skill@${connectorSlug}`,
+  versionId = createHash("sha256").update(randomUUID()).digest("hex"),
+  storage = createBundledSkillStorageFixture(connectorSlug),
 ): BundledSkillFixture {
   const contentSize = Buffer.byteLength(`# ${connectorSlug}\n`);
   const archiveSize = 321;
   const fileCount = 1;
-  const s3Prefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
-  const versionPrefix = `${s3Prefix}/${versionId}`;
+  const versionPrefix = `${storage.s3Prefix}/${versionId}`;
   const manifestKey = `${versionPrefix}/manifest.json`;
   const archiveKey = `${versionPrefix}/archive.tar.gz`;
   return {
@@ -916,10 +938,9 @@ function buildBundledSkillFixture(
         archiveSize,
         fileCount,
       },
-      storageName,
+      storage.storageName,
     ),
-    storageName,
-    s3Prefix,
+    ...storage,
     versionId,
     contentSize,
     archiveSize,
@@ -1415,37 +1436,79 @@ async function readVolumeStorageState(args: {
   return response.body.storage_state ?? null;
 }
 
-async function restoreVolumeStorageState(args: {
+async function readOwnedVolumeStorageState(
+  storageId: string,
+): Promise<VolumeStorageState | null> {
+  const response = await systemStorageStateAction({
+    action: "read-owned-storage-state",
+    storage_id: storageId,
+  });
+  return response.body.storage_state ?? null;
+}
+
+interface OwnedVolumeStorageClaim extends OwnedVolumeStorageFixture {
   readonly orgId: string;
-  readonly storageName: string;
-  readonly previous: VolumeStorageState | null;
-}): Promise<void> {
+}
+
+async function claimOwnedVolumeStorages(
+  claims: readonly OwnedVolumeStorageClaim[],
+): Promise<void> {
   await systemStorageStateAction({
-    action: "restore-storage-state",
-    org_id: args.orgId,
-    user_id: VOLUME_ORG_USER_ID,
-    storage_name: args.storageName,
-    previous: args.previous,
+    action: "claim-owned-storages",
+    storages: claims.map((claim) => {
+      return {
+        storage_id: claim.storageId,
+        org_id: claim.orgId,
+        user_id: VOLUME_ORG_USER_ID,
+        storage_name: claim.storageName,
+        s3_prefix: claim.s3Prefix,
+      };
+    }),
   });
 }
 
-async function seedVolumeStorageVersion(args: {
-  readonly orgId: string;
-  readonly storageName: string;
+async function claimOwnedVolumeStorage(
+  claim: OwnedVolumeStorageClaim,
+): Promise<void> {
+  await claimOwnedVolumeStorages([claim]);
+}
+
+async function cleanupOwnedVolumeStorages(
+  storageIds: readonly string[],
+): Promise<void> {
+  await systemStorageStateAction({
+    action: "cleanup-owned-storages",
+    storage_ids: [...storageIds],
+  });
+}
+
+async function seedOwnedVolumeStorageVersion(args: {
+  readonly storageId: string;
   readonly versionId: string;
-  readonly s3Prefix: string;
   readonly s3Key: string;
 }): Promise<void> {
   await systemStorageStateAction({
-    action: "seed-storage-version",
+    action: "seed-owned-storage-version",
+    storage_id: args.storageId,
+    version_id: args.versionId,
+    s3_key: args.s3Key,
+    archive_size: 321,
+  });
+}
+
+async function readVolumeStorageVersion(args: {
+  readonly orgId: string;
+  readonly storageName: string;
+  readonly versionId: string;
+}) {
+  const response = await systemStorageStateAction({
+    action: "read-storage-version",
     org_id: args.orgId,
     user_id: VOLUME_ORG_USER_ID,
     storage_name: args.storageName,
     version_id: args.versionId,
-    s3_prefix: args.s3Prefix,
-    s3_key: args.s3Key,
-    archive_size: 321,
   });
+  return response.body.storage_version ?? null;
 }
 
 async function syncCatalog() {
@@ -3030,7 +3093,7 @@ describe("connector catalog valid lifecycle", () => {
   });
 
   it("loads 17 exact connector skill versions in one bounded storage preload", async () => {
-    const fixtureSuffix = randomUUID().slice(0, 8);
+    const fixtureSuffix = randomUUID().replaceAll("-", "");
     const skills = Array.from({ length: 17 }, (_, index) => {
       const sequence = String(index + 1).padStart(2, "0");
       const connectorSlug = `batch-skill-${fixtureSuffix}-${sequence}`;
@@ -3048,15 +3111,11 @@ describe("connector catalog valid lifecycle", () => {
       };
     });
     configureSource();
-    const previousSystemStates: (VolumeStorageState | null)[] = [];
-    for (const skill of skills) {
-      previousSystemStates.push(
-        await readVolumeStorageState({
-          orgId: SYSTEM_ORG_ID,
-          storageName: skill.skill.storageName,
-        }),
-      );
-    }
+    await claimOwnedVolumeStorages(
+      skills.map((skill) => {
+        return { orgId: SYSTEM_ORG_ID, ...skill.skill };
+      }),
+    );
 
     const firstSkill = skills[0];
     if (!firstSkill) {
@@ -3142,18 +3201,18 @@ describe("connector catalog valid lifecycle", () => {
       for (const runId of activeRunIds) {
         await runs.requestCancelRun(actor, runId, [200, 404]);
       }
-      for (const [index, skill] of skills.entries()) {
+      for (const skill of skills) {
         await systemStorageStateAction({
           action: "cleanup",
           object_key_prefix: skill.skill.s3Prefix,
         });
-        await restoreVolumeStorageState({
-          orgId: SYSTEM_ORG_ID,
-          storageName: skill.skill.storageName,
-          previous: previousSystemStates[index] ?? null,
-        });
         await createConnectorCleanup(actor, skill.connectorSlug)();
       }
+      await cleanupOwnedVolumeStorages(
+        skills.map((skill) => {
+          return skill.skill.storageId;
+        }),
+      );
       await bdd.deleteAgent(actor, agent.agentId);
     });
 
@@ -3222,11 +3281,9 @@ describe("connector catalog valid lifecycle", () => {
     activeRunIds.delete(headRun.run.runId);
 
     for (const skill of skills) {
-      await seedVolumeStorageVersion({
-        orgId: SYSTEM_ORG_ID,
-        storageName: skill.skill.storageName,
+      await seedOwnedVolumeStorageVersion({
+        storageId: skill.skill.storageId,
         versionId: skill.newerVersionId,
-        s3Prefix: skill.skill.s3Prefix,
         s3Key: `${skill.skill.s3Prefix}/${skill.newerVersionId}`,
       });
     }
@@ -3253,10 +3310,7 @@ describe("connector catalog valid lifecycle", () => {
     const skill = buildBundledSkillFixture(connectorSlug, selectedVersionId);
     const { storageName, s3Prefix: canonicalPrefix } = skill;
     configureSource();
-    const previousSystemState = await readVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
-    });
+    await claimOwnedVolumeStorage({ orgId: SYSTEM_ORG_ID, ...skill });
     const release = buildRelease({
       version: "2026-07-15.external-exact-skill",
       connectorSlug,
@@ -3274,10 +3328,10 @@ describe("connector catalog valid lifecycle", () => {
       throw new Error("Expected an organization-scoped test actor");
     }
     const runtimeOrgId = actor.orgId;
-    const previousRuntimeState = await readVolumeStorageState({
-      orgId: runtimeOrgId,
+    const runtimeStorage = createOwnedVolumeStorageFixture(
       storageName,
-    });
+      canonicalPrefix,
+    );
     bdd.acceptAgentStorageWrites();
     runs.acceptStorageDownloads();
     runs.acceptTelemetryIngest();
@@ -3299,16 +3353,10 @@ describe("connector catalog valid lifecycle", () => {
         action: "cleanup",
         object_key_prefix: canonicalPrefix,
       });
-      await restoreVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName,
-        previous: previousSystemState,
-      });
-      await restoreVolumeStorageState({
-        orgId: runtimeOrgId,
-        storageName,
-        previous: previousRuntimeState,
-      });
+      await cleanupOwnedVolumeStorages([
+        skill.storageId,
+        runtimeStorage.storageId,
+      ]);
       await cleanupConnector();
       await bdd.deleteAgent(actor, agent.agentId);
     });
@@ -3335,11 +3383,9 @@ describe("connector catalog valid lifecycle", () => {
       });
     };
 
-    await seedVolumeStorageVersion({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
+    await seedOwnedVolumeStorageVersion({
+      storageId: skill.storageId,
       versionId: newerVersionId,
-      s3Prefix: canonicalPrefix,
       s3Key: `${canonicalPrefix}/${newerVersionId}`,
     });
 
@@ -3375,49 +3421,47 @@ describe("connector catalog valid lifecycle", () => {
     await runs.requestCancelRun(actor, run.runId, [200]);
     successfulRunId = undefined;
 
-    await restoreVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
-      previous: previousSystemState,
-    });
-    await seedVolumeStorageVersion({
+    await cleanupOwnedVolumeStorages([skill.storageId]);
+    await claimOwnedVolumeStorage({
       orgId: runtimeOrgId,
-      storageName,
+      ...runtimeStorage,
+    });
+    await seedOwnedVolumeStorageVersion({
+      storageId: runtimeStorage.storageId,
       versionId: selectedVersionId,
-      s3Prefix: canonicalPrefix,
       s3Key: `${canonicalPrefix}/${selectedVersionId}`,
     });
     await expectRegistrationFailure();
-    await restoreVolumeStorageState({
-      orgId: runtimeOrgId,
-      storageName,
-      previous: previousRuntimeState,
-    });
+    await cleanupOwnedVolumeStorages([runtimeStorage.storageId]);
 
-    await seedVolumeStorageVersion({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
+    await claimOwnedVolumeStorage({ orgId: SYSTEM_ORG_ID, ...skill });
+    await seedOwnedVolumeStorageVersion({
+      storageId: skill.storageId,
       versionId: otherVersionId,
-      s3Prefix: canonicalPrefix,
       s3Key: `${canonicalPrefix}/${otherVersionId}`,
     });
     await expectRegistrationFailure();
 
     const wrongPrefix = `${SYSTEM_ORG_ID}/volume/wrong-${storageName}`;
-    await seedVolumeStorageVersion({
+    await cleanupOwnedVolumeStorages([skill.storageId]);
+    await claimOwnedVolumeStorage({
       orgId: SYSTEM_ORG_ID,
+      storageId: skill.storageId,
       storageName,
-      versionId: selectedVersionId,
       s3Prefix: wrongPrefix,
+    });
+    await seedOwnedVolumeStorageVersion({
+      storageId: skill.storageId,
+      versionId: selectedVersionId,
       s3Key: `${wrongPrefix}/${selectedVersionId}`,
     });
     await expectRegistrationFailure();
 
-    await seedVolumeStorageVersion({
-      orgId: SYSTEM_ORG_ID,
-      storageName,
+    await cleanupOwnedVolumeStorages([skill.storageId]);
+    await claimOwnedVolumeStorage({ orgId: SYSTEM_ORG_ID, ...skill });
+    await seedOwnedVolumeStorageVersion({
+      storageId: skill.storageId,
       versionId: selectedVersionId,
-      s3Prefix: canonicalPrefix,
       s3Key: `${canonicalPrefix}/wrong-${selectedVersionId}`,
     });
     await expectRegistrationFailure();
@@ -4557,22 +4601,16 @@ describe("connector catalog valid lifecycle", () => {
 
   it("accepts a complete bundled skill descriptor", async () => {
     configureSource();
-    const resolvedStorageName = `connector-skill@resolved-${randomUUID().slice(0, 8)}`;
+    const resolvedStorageName = `connector-skill@resolved-${randomUUID().replaceAll("-", "")}`;
+    const storage = createOwnedVolumeStorageFixture(resolvedStorageName);
     const skill = buildBundledSkillFixture(
       "external-test",
       createHash("sha256").update(randomUUID()).digest("hex"),
-      resolvedStorageName,
+      storage,
     );
-    const previous = await readVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName: skill.storageName,
-    });
+    await claimOwnedVolumeStorage({ orgId: SYSTEM_ORG_ID, ...skill });
     onTestFinished(async () => {
-      await restoreVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: skill.storageName,
-        previous,
-      });
+      await cleanupOwnedVolumeStorages([skill.storageId]);
     });
     const release = buildRelease({
       version: "2026-07-15.bundled-skill",
@@ -4589,10 +4627,7 @@ describe("connector catalog valid lifecycle", () => {
       active: { catalogVersion: release.version },
     });
     await expect(
-      readVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: skill.storageName,
-      }),
+      readOwnedVolumeStorageState(skill.storageId),
     ).resolves.toStrictEqual({
       s3_prefix: skill.s3Prefix,
       size: skill.contentSize,
@@ -4635,17 +4670,6 @@ describe("connector catalog valid lifecycle", () => {
           .update(`${testCase.label}:${randomUUID()}`)
           .digest("hex"),
       );
-      const previous = await readVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: skill.storageName,
-      });
-      onTestFinished(async () => {
-        await restoreVolumeStorageState({
-          orgId: SYSTEM_ORG_ID,
-          storageName: skill.storageName,
-          previous,
-        });
-      });
       const release = buildRelease({
         version: `2026-07-22.skill-${testCase.label}-${randomUUID().slice(0, 8)}`,
         connectorSlug,
@@ -4680,24 +4704,20 @@ describe("connector catalog valid lifecycle", () => {
   it("reuses immutable skill versions without regressing HEAD", async () => {
     configureSource();
     const connectorSlug = `skill-cache-${randomUUID().slice(0, 8)}`;
+    const storage = createBundledSkillStorageFixture(connectorSlug);
     const firstSkill = buildBundledSkillFixture(
       connectorSlug,
       createHash("sha256").update(`first:${randomUUID()}`).digest("hex"),
+      storage,
     );
     const secondSkill = buildBundledSkillFixture(
       connectorSlug,
       createHash("sha256").update(`second:${randomUUID()}`).digest("hex"),
+      storage,
     );
-    const previous = await readVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName: firstSkill.storageName,
-    });
+    await claimOwnedVolumeStorage({ orgId: SYSTEM_ORG_ID, ...storage });
     onTestFinished(async () => {
-      await restoreVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: firstSkill.storageName,
-        previous,
-      });
+      await cleanupOwnedVolumeStorages([storage.storageId]);
     });
     const firstRelease = buildRelease({
       version: `2026-07-22.skill-cache-first-${randomUUID().slice(0, 8)}`,
@@ -4745,10 +4765,7 @@ describe("connector catalog valid lifecycle", () => {
     expect(requestedKeys).not.toContain(firstSkill.manifestKey);
     expect(requestedKeys).not.toContain(firstSkill.archiveKey);
     await expect(
-      readVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: firstSkill.storageName,
-      }),
+      readOwnedVolumeStorageState(storage.storageId),
     ).resolves.toMatchObject({
       head_version_id: secondSkill.versionId,
     });
@@ -4767,35 +4784,27 @@ describe("connector catalog valid lifecycle", () => {
       conflictingConnectorSlug,
       createHash("sha256").update(`conflict:${randomUUID()}`).digest("hex"),
     );
-    const previousFirst = await readVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName: firstSkill.storageName,
-    });
-    const previousConflicting = await readVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName: conflictingSkill.storageName,
-    });
-    onTestFinished(async () => {
-      await restoreVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: firstSkill.storageName,
-        previous: previousFirst,
-      });
-      await restoreVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: conflictingSkill.storageName,
-        previous: previousConflicting,
-      });
-    });
     const wrongPrefix = `${SYSTEM_ORG_ID}/volume/wrong-${conflictingSkill.storageName}`;
+    await claimOwnedVolumeStorages([
+      { orgId: SYSTEM_ORG_ID, ...firstSkill },
+      {
+        orgId: SYSTEM_ORG_ID,
+        ...conflictingSkill,
+        s3Prefix: wrongPrefix,
+      },
+    ]);
+    onTestFinished(async () => {
+      await cleanupOwnedVolumeStorages([
+        firstSkill.storageId,
+        conflictingSkill.storageId,
+      ]);
+    });
     const existingVersionId = createHash("sha256")
       .update(`existing:${randomUUID()}`)
       .digest("hex");
-    await seedVolumeStorageVersion({
-      orgId: SYSTEM_ORG_ID,
-      storageName: conflictingSkill.storageName,
+    await seedOwnedVolumeStorageVersion({
+      storageId: conflictingSkill.storageId,
       versionId: existingVersionId,
-      s3Prefix: wrongPrefix,
       s3Key: `${wrongPrefix}/${existingVersionId}`,
     });
     const conflictingIconBytes = Buffer.from(
@@ -4851,16 +4860,22 @@ describe("connector catalog valid lifecycle", () => {
       lastAttempt: { failureCode: "invalid-reference" },
     });
     await expect(
-      readVolumeStorageState({
+      readOwnedVolumeStorageState(firstSkill.storageId),
+    ).resolves.toStrictEqual({
+      s3_prefix: firstSkill.s3Prefix,
+      size: 0,
+      file_count: 0,
+      head_version_id: null,
+    });
+    await expect(
+      readVolumeStorageVersion({
         orgId: SYSTEM_ORG_ID,
         storageName: firstSkill.storageName,
+        versionId: firstSkill.versionId,
       }),
     ).resolves.toBeNull();
     await expect(
-      readVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: conflictingSkill.storageName,
-      }),
+      readOwnedVolumeStorageState(conflictingSkill.storageId),
     ).resolves.toStrictEqual({
       s3_prefix: wrongPrefix,
       size: 1,
@@ -4868,10 +4883,10 @@ describe("connector catalog valid lifecycle", () => {
       head_version_id: existingVersionId,
     });
 
-    await restoreVolumeStorageState({
+    await cleanupOwnedVolumeStorages([conflictingSkill.storageId]);
+    await claimOwnedVolumeStorage({
       orgId: SYSTEM_ORG_ID,
-      storageName: conflictingSkill.storageName,
-      previous: previousConflicting,
+      ...conflictingSkill,
     });
     serveObjects(objects);
     expect((await syncCatalog()).body).toMatchObject({
@@ -4880,10 +4895,7 @@ describe("connector catalog valid lifecycle", () => {
     });
     for (const skill of [firstSkill, conflictingSkill]) {
       await expect(
-        readVolumeStorageState({
-          orgId: SYSTEM_ORG_ID,
-          storageName: skill.storageName,
-        }),
+        readOwnedVolumeStorageState(skill.storageId),
       ).resolves.toMatchObject({
         s3_prefix: skill.s3Prefix,
         head_version_id: skill.versionId,
@@ -4898,33 +4910,22 @@ describe("connector catalog valid lifecycle", () => {
       connectorSlug,
       createHash("sha256").update(`shared:${randomUUID()}`).digest("hex"),
     );
-    const ownerStorageName = `connector-skill@owner-${randomUUID().slice(0, 8)}`;
+    const ownerStorageName = `connector-skill@owner-${randomUUID().replaceAll("-", "")}`;
     const ownerPrefix = `${SYSTEM_ORG_ID}/volume/${ownerStorageName}`;
-    const previousOwner = await readVolumeStorageState({
+    const ownerStorage = createOwnedVolumeStorageFixture(
+      ownerStorageName,
+      ownerPrefix,
+    );
+    await claimOwnedVolumeStorage({
       orgId: SYSTEM_ORG_ID,
-      storageName: ownerStorageName,
-    });
-    const previousCandidate = await readVolumeStorageState({
-      orgId: SYSTEM_ORG_ID,
-      storageName: skill.storageName,
+      ...ownerStorage,
     });
     onTestFinished(async () => {
-      await restoreVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: ownerStorageName,
-        previous: previousOwner,
-      });
-      await restoreVolumeStorageState({
-        orgId: SYSTEM_ORG_ID,
-        storageName: skill.storageName,
-        previous: previousCandidate,
-      });
+      await cleanupOwnedVolumeStorages([ownerStorage.storageId]);
     });
-    await seedVolumeStorageVersion({
-      orgId: SYSTEM_ORG_ID,
-      storageName: ownerStorageName,
+    await seedOwnedVolumeStorageVersion({
+      storageId: ownerStorage.storageId,
       versionId: skill.versionId,
-      s3Prefix: ownerPrefix,
       s3Key: `${ownerPrefix}/${skill.versionId}`,
     });
     const release = buildRelease({
@@ -6474,7 +6475,8 @@ describe("connector catalog rejection and latest-valid retention", () => {
             const connector = firstRecord(artifact.connectors, "connectors");
             const skill = buildBundledSkill("wrong");
             skill.storageVersionPrefix =
-              "__system__/volume/connector-skill@other/" + "a".repeat(64);
+              `__system__/volume/connector-skill@other-${randomUUID().replaceAll("-", "")}/` +
+              createHash("sha256").update(randomUUID()).digest("hex");
             connector.skill = skill;
           },
         });

--- a/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-system-storage-presigned-url-cache-state.ts
@@ -5,7 +5,7 @@ import {
 import { systemStoragePresignedUrlCache } from "@vm0/db/schema/system-storage-presigned-url-cache";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { command } from "ccstate";
-import { and, eq, like, sql } from "drizzle-orm";
+import { and, eq, inArray, like, sql } from "drizzle-orm";
 
 import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
@@ -67,6 +67,99 @@ async function cleanupForAction(
     .delete(systemStoragePresignedUrlCache)
     .where(objectKeyPrefixCondition(body.object_key_prefix));
   signal.throwIfAborted();
+  return actionOk();
+}
+
+async function claimOwnedStoragesForAction(
+  db: Db,
+  body: CacheStateAction<"claim-owned-storages">,
+  signal: AbortSignal,
+) {
+  await db.insert(storages).values(
+    body.storages.map((storage) => {
+      return {
+        id: storage.storage_id,
+        orgId: storage.org_id,
+        userId: storage.user_id,
+        name: storage.storage_name,
+        s3Prefix: storage.s3_prefix,
+        size: 0,
+        fileCount: 0,
+      };
+    }),
+  );
+  signal.throwIfAborted();
+  return actionOk();
+}
+
+async function cleanupOwnedStoragesForAction(
+  db: Db,
+  body: CacheStateAction<"cleanup-owned-storages">,
+  signal: AbortSignal,
+) {
+  await db.delete(storages).where(inArray(storages.id, body.storage_ids));
+  signal.throwIfAborted();
+  return actionOk();
+}
+
+async function readOwnedStorageStateForAction(
+  db: Db,
+  body: CacheStateAction<"read-owned-storage-state">,
+  signal: AbortSignal,
+) {
+  const [storage] = await db
+    .select({
+      s3Prefix: storages.s3Prefix,
+      size: storages.size,
+      fileCount: storages.fileCount,
+      headVersionId: storages.headVersionId,
+    })
+    .from(storages)
+    .where(eq(storages.id, body.storage_id))
+    .limit(1);
+  signal.throwIfAborted();
+  return actionOk({
+    storage_state: storage
+      ? {
+          s3_prefix: storage.s3Prefix,
+          size: storage.size,
+          file_count: storage.fileCount,
+          head_version_id: storage.headVersionId,
+        }
+      : null,
+  });
+}
+
+async function seedOwnedStorageVersionForAction(
+  db: Db,
+  body: CacheStateAction<"seed-owned-storage-version">,
+  signal: AbortSignal,
+) {
+  await db.insert(storageVersions).values({
+    id: body.version_id,
+    storageId: body.storage_id,
+    s3Key: body.s3_key,
+    size: 1,
+    archiveSize: body.archive_size,
+    fileCount: 1,
+    message: "Seeded by owned system storage route test fixture",
+    createdBy: "test",
+  });
+  signal.throwIfAborted();
+
+  const updated = await db
+    .update(storages)
+    .set({
+      size: 1,
+      fileCount: 1,
+      headVersionId: body.version_id,
+    })
+    .where(eq(storages.id, body.storage_id))
+    .returning({ id: storages.id });
+  signal.throwIfAborted();
+  if (updated.length !== 1) {
+    throw new Error("Owned storage is unavailable");
+  }
   return actionOk();
 }
 
@@ -400,6 +493,18 @@ const mutateSystemStoragePresignedUrlCacheState$ = command(
     switch (body.action) {
       case "cleanup": {
         return await cleanupForAction(db, body, signal);
+      }
+      case "claim-owned-storages": {
+        return await claimOwnedStoragesForAction(db, body, signal);
+      }
+      case "cleanup-owned-storages": {
+        return await cleanupOwnedStoragesForAction(db, body, signal);
+      }
+      case "read-owned-storage-state": {
+        return await readOwnedStorageStateForAction(db, body, signal);
+      }
+      case "seed-owned-storage-version": {
+        return await seedOwnedStorageVersionForAction(db, body, signal);
       }
       case "read-storage-state": {
         return await readStorageStateForAction(db, body, signal);

--- a/turbo/packages/api-contracts/src/contracts/test-system-storage-presigned-url-cache-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-system-storage-presigned-url-cache-state.ts
@@ -38,11 +38,38 @@ const storageVersionStateSchema = z.object({
   created_by: z.string(),
 });
 
+const ownedStorageSeedSchema = z.object({
+  storage_id: z.string().uuid(),
+  org_id: z.string(),
+  user_id: z.string(),
+  storage_name: z.string(),
+  s3_prefix: z.string(),
+});
+
 export const testSystemStoragePresignedUrlCacheStateActionBodySchema =
   z.discriminatedUnion("action", [
     z.object({
       action: z.literal("cleanup"),
       object_key_prefix: z.string(),
+    }),
+    z.object({
+      action: z.literal("claim-owned-storages"),
+      storages: z.array(ownedStorageSeedSchema).min(1),
+    }),
+    z.object({
+      action: z.literal("cleanup-owned-storages"),
+      storage_ids: z.array(z.string().uuid()).min(1),
+    }),
+    z.object({
+      action: z.literal("read-owned-storage-state"),
+      storage_id: z.string().uuid(),
+    }),
+    z.object({
+      action: z.literal("seed-owned-storage-version"),
+      storage_id: z.string().uuid(),
+      version_id: z.string(),
+      s3_key: z.string(),
+      archive_size: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
     }),
     z.object({
       action: z.literal("read-storage-state"),


### PR DESCRIPTION
## Summary

- give every bundled connector-skill scenario a UUID-owned storage identity, version identity, and object prefix
- add insert-only test-state actions that claim storage rows and seed versions without updating pre-existing rows or versions
- replace storage snapshot/restore teardown with storage-ID cleanup while preserving exact-version mount, batch preload, immutable-version, rollback, conflict, and ownership coverage

## Isolation invariants

- bundled-skill correctness no longer depends on `restoreVolumeStorageState` or teardown completion
- accepted scenarios claim their storage UUID and unique name before production synchronization, so any identity collision fails instead of replacing an existing system storage row or head
- test version seeds are plain inserts and update only the explicitly claimed storage UUID
- retained storage cleanup deletes only explicitly owned storage UUIDs; cache cleanup remains bounded to each fixture's unique object prefix
- invalid metadata and cross-connector identity cases use unique fixture identities and reject before storage mutation

## Caller and overlap evidence

- scanned every caller of the shared system-storage test contract and route; the new actions are additive and are called only by `cron-connector-catalog.test.ts`
- rescanned all 33 open pull requests and 759 changed-file entries: draft #25722 has only a distant logging-redaction hunk in this test near line 7117, while #26555 changes the separate `test-fixtures/storage.ts` helper
- #26650 is merged on the branch base; its staff-entitlement hunks remain unchanged
- rebased onto current `origin/main` at `d0a353cfd`

## Validation

- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts -t 'accepts a complete bundled skill descriptor|rejects incomplete or out-of-range bundled skill metadata|reuses immutable skill versions|rolls back all skill registrations|rejects a connector skill version owned by another storage|rejects bundled skills sharing one'` — 1 file passed, 7 tests passed
- the two runner-claim scenarios reached their existing 10-second local poll timeout; the exact-version timeout reproduced unchanged on current `origin/main`, so the PR pipeline remains authoritative for them
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/api-contracts run check-types`
- targeted ESLint and Oxlint for all three changed files
- `pnpm exec prettier --check` for all three changed files
- `pnpm knip --workspace api`
- `git diff --check origin/main...HEAD`

Closes #26599
Epic: #26569
