### PR TITLE
test(api): scope secret kms overrides to each test

### DIFF
--- a/turbo/apps/api/src/__tests__/setup.ts
+++ b/turbo/apps/api/src/__tests__/setup.ts
@@ -1,13 +1,12 @@
 import { resetApiTestMocks } from "./mocks";
-import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+import { afterAll, afterEach, aroundEach, beforeAll, beforeEach } from "vitest";
 
 import { clearMockedEnv, mockEnv } from "../lib/env";
 import {
-  resetSecretKmsClientForTests,
-  setSecretKmsClientForTests,
   type SecretKmsClient,
   type SecretKmsDataKey,
   type SecretKmsGenerateDataKeyRequest,
+  withSecretKmsClientForTest,
 } from "../lib/secret-kms-client";
 import { clearMockNow } from "../lib/time";
 import { server } from "../mocks/server";
@@ -39,6 +38,10 @@ function createApiTestKmsClient(): SecretKmsClient {
   };
 }
 
+aroundEach(async (runTest) => {
+  await withSecretKmsClientForTest(createApiTestKmsClient(), runTest);
+});
+
 beforeAll(async () => {
   mockApiTestConnectorProviderConfiguration();
   await installApiTestConnectorCatalog();
@@ -48,13 +51,11 @@ beforeAll(async () => {
 beforeEach(() => {
   mockApiTestConnectorProviderConfiguration();
   mockEnv("SECRETS_KMS_KEY_ID", "alias/vm0-secrets-test");
-  setSecretKmsClientForTests(createApiTestKmsClient());
 });
 
 afterEach(async () => {
   await clearAllDetached();
   clearMockNow();
-  resetSecretKmsClientForTests();
   clearMockedEnv();
   resetApiTestMocks();
   server.resetHandlers();

--- a/turbo/apps/api/src/lib/__tests__/secret-kms-client.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/secret-kms-client.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSecretKmsClient,
+  setSecretKmsClientForTests,
+  type SecretKmsClient,
+  withSecretKmsClientForTest,
+} from "../secret-kms-client";
+
+function testClient(): SecretKmsClient {
+  return {
+    generateDataKey: () => {
+      return Promise.reject(new Error("unused generateDataKey"));
+    },
+    decrypt: () => {
+      return Promise.reject(new Error("unused decrypt"));
+    },
+  };
+}
+
+describe("secret KMS client", () => {
+  it("isolates overrides across concurrent test scopes", async () => {
+    const outerClient = getSecretKmsClient();
+    const firstClient = testClient();
+    const updatedFirstClient = testClient();
+    const secondClient = testClient();
+
+    const [firstResult, secondResult] = await Promise.all([
+      withSecretKmsClientForTest(firstClient, async () => {
+        expect(getSecretKmsClient()).toBe(firstClient);
+        await Promise.resolve();
+        setSecretKmsClientForTests(updatedFirstClient);
+        await Promise.resolve();
+        return getSecretKmsClient();
+      }),
+      withSecretKmsClientForTest(secondClient, async () => {
+        expect(getSecretKmsClient()).toBe(secondClient);
+        await Promise.resolve();
+        expect(getSecretKmsClient()).toBe(secondClient);
+        return getSecretKmsClient();
+      }),
+    ]);
+
+    expect(firstResult).toBe(updatedFirstClient);
+    expect(secondResult).toBe(secondClient);
+    expect(getSecretKmsClient()).toBe(outerClient);
+  });
+});

--- a/turbo/apps/api/src/lib/secret-kms-client.ts
+++ b/turbo/apps/api/src/lib/secret-kms-client.ts
@@ -1,10 +1,12 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import {
   DecryptCommand,
   GenerateDataKeyCommand,
   KMSClient,
 } from "@aws-sdk/client-kms";
 
-import { singleton, testOverride } from "./singleton";
+import { singleton } from "./singleton";
 
 export interface SecretKmsGenerateDataKeyRequest {
   readonly keyId: string;
@@ -33,6 +35,10 @@ export interface SecretKmsClient {
     request: SecretKmsGenerateDataKeyRequest,
   ): Promise<SecretKmsDataKey>;
   decrypt(request: SecretKmsDecryptRequest): Promise<Uint8Array>;
+}
+
+interface ScopedSecretKmsClient {
+  client: SecretKmsClient;
 }
 
 const secretKmsClient = singleton((): SecretKmsClient => {
@@ -84,23 +90,29 @@ const secretKmsClient = singleton((): SecretKmsClient => {
   };
 });
 
-const {
-  get: getSecretKmsClientOverride,
-  set: setSecretKmsClientOverride,
-  clear: clearSecretKmsClientOverride,
-} = testOverride<SecretKmsClient | null>(() => {
-  return null;
+const scopedSecretKmsClient = singleton(() => {
+  return new AsyncLocalStorage<ScopedSecretKmsClient>();
 });
 
-export function getSecretKmsClient(): SecretKmsClient {
-  return getSecretKmsClientOverride() ?? secretKmsClient();
+function currentScopedSecretKmsClient(): ScopedSecretKmsClient | undefined {
+  return scopedSecretKmsClient.peek()?.getStore();
 }
 
-export function resetSecretKmsClientForTests(): void {
-  clearSecretKmsClientOverride();
-  secretKmsClient.reset();
+export function getSecretKmsClient(): SecretKmsClient {
+  return currentScopedSecretKmsClient()?.client ?? secretKmsClient();
 }
 
 export function setSecretKmsClientForTests(client: SecretKmsClient): void {
-  setSecretKmsClientOverride(client);
+  const scoped = currentScopedSecretKmsClient();
+  if (!scoped) {
+    throw new Error("Secret KMS test client requires an active test scope");
+  }
+  scoped.client = client;
+}
+
+export async function withSecretKmsClientForTest<T>(
+  client: SecretKmsClient,
+  work: () => Promise<T>,
+): Promise<T> {
+  return await scopedSecretKmsClient().run({ client }, work);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -107,21 +107,6 @@ export async function seedVm0ManagedModelKey(
   return vm0ManagedModelKeyFixture(context, fixtureId, response.selected_model);
 }
 
-export async function enableFakeKms(context: TestContext): Promise<void> {
-  await postAction(context, { action: "enable-fake-kms" });
-}
-
-export async function resetFakeKms(context: TestContext): Promise<void> {
-  await postAction(context, { action: "reset-fake-kms" });
-}
-
-export async function readFakeKmsDecryptCallCount(
-  context: TestContext,
-): Promise<number> {
-  const response = await postAction(context, { action: "read-fake-kms-state" });
-  return response.decrypt_call_count ?? 0;
-}
-
 export async function readBrowserScreenshotSchemaAvailable(
   context: TestContext,
 ): Promise<boolean> {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -101,24 +101,22 @@ import {
 } from "./helpers/connector-credential-storage-state";
 import {
   clearRunApiStart,
-  enableFakeKms,
   holdOrgAdmissionLock,
   mutateRunnerJobConnectorPermissionBaseline,
   mutateRunnerJobSecretValueEnvironmentKeys,
   removeRunCanonicalStorageState,
-  readFakeKmsDecryptCallCount,
   readOrgAdmissionLockState,
   readRunApiStart,
   readRunClaimOwner,
   readRunnerJobStorageState,
   readStoragePersistenceState,
   releaseOrgAdmissionLock,
-  resetFakeKms,
   seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState,
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
   setCustomConnectorAuthTemplateFixture,
   setRunnerJobContextProfileAsPreviousApi,
 } from "./helpers/runtime-state";
+import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import {
   setSecretKmsClientForTests,
   type SecretKmsClient,
@@ -5335,10 +5333,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
   it("queues runs over the concurrency limit and promotes them after cancellation", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
 
     const first = await api.createRun(actor, {
       agentId,
@@ -5390,7 +5385,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
         },
       }),
     );
-    const decryptCountBeforeClaim = await readFakeKmsDecryptCallCount(context);
+    const decryptCountBeforeClaim = kms.decryptCalls;
     await api.heartbeatRunner(runnerGroup);
     const thirdClaim = await api.claimRunnerJob(third.runId);
     expect(thirdClaim.prompt).toBe("queued run three");
@@ -5453,9 +5448,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
         "api_to_claim_request",
       )[0],
     ).not.toHaveProperty("history_generation_run_id");
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(
-      decryptCountBeforeClaim,
-    );
+    expect(kms.decryptCalls).toBe(decryptCountBeforeClaim);
 
     await api.requestCancelRun(actor, second.runId, [200]);
     await api.requestCancelRun(actor, third.runId, [200]);
@@ -7101,17 +7094,14 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       },
     });
 
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
 
     const run = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "use overridden x connector secret",
       secrets: { X_TOKEN: "body-x-token" },
     });
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(0);
+    expect(kms.decryptCalls).toBe(0);
 
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
@@ -7206,16 +7196,13 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       },
     });
 
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
 
     const run = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "use compose-overridden gitlab token",
     });
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(0);
+    expect(kms.decryptCalls).toBe(0);
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectNoApiDispatchActions(timingEvents, [
       "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
@@ -7509,17 +7496,14 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     });
     await api.enableAgentConnectors(actor, agentId, ["x", "gitlab", "figma"]);
 
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
 
     const run = await api.createRun(actor, {
       agentId,
       prompt: "use lazy connector auth credentials",
       modelProvider: "anthropic-api-key",
     });
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(0);
+    expect(kms.decryptCalls).toBe(0);
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -7826,10 +7810,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     api.acceptTelemetryIngest();
     api.configureRunnerGroup();
     await api.grantProEntitlement(actor);
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
     const composeName = `bdd-secret-refs-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
       version: "1",
@@ -7855,7 +7836,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         UNUSED_TOKEN: "unused-secret-value",
       },
     });
-    const decryptCountBeforeClaim = await readFakeKmsDecryptCallCount(context);
+    const decryptCountBeforeClaim = kms.decryptCalls;
     const claim = await api.claimRunnerJob(run.runId);
     expect(claim.environment?.FIRST_TOKEN).toBe("first-secret-value");
     expect(claim.environment?.SECOND_TOKEN).toBe("second-secret-value");
@@ -7864,9 +7845,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       "second-secret-value",
       "first-secret-value",
     ]);
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(
-      decryptCountBeforeClaim,
-    );
+    expect(kms.decryptCalls).toBe(decryptCountBeforeClaim);
     expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
     const claimActionTypes = new Set(
       claimRouteTimingEventsForRun(run.runId).map((event) => {
@@ -7894,10 +7873,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     api.configureRunnerGroup();
     await api.grantProEntitlement(actor);
 
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
     const composeName = `bdd-secret-fallback-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
       version: "1",
@@ -7926,8 +7902,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       missingRun.runId,
       "remove",
     );
-    const decryptCountBeforeMissingClaim =
-      await readFakeKmsDecryptCallCount(context);
+    const decryptCountBeforeMissingClaim = kms.decryptCalls;
 
     const missingClaim = await api.requestClaimRunnerJob(
       true,
@@ -7938,9 +7913,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(missingClaim.body.error.message).toBe(
       "Job missing execution context",
     );
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(
-      decryptCountBeforeMissingClaim,
-    );
+    expect(kms.decryptCalls).toBe(decryptCountBeforeMissingClaim);
     const failedMissingRun = await api.readRun(actor, missingRun.runId);
     expect(failedMissingRun.status).toBe("failed");
     expect(failedMissingRun.error).toBe(
@@ -7959,8 +7932,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       invalidRun.runId,
       "invalid",
     );
-    const decryptCountBeforeInvalidClaim =
-      await readFakeKmsDecryptCallCount(context);
+    const decryptCountBeforeInvalidClaim = kms.decryptCalls;
 
     const claim = await api.claimRunnerJob(invalidRun.runId);
 
@@ -7968,9 +7940,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       "first-fallback-secret",
       "second-fallback-secret",
     ]);
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(
-      decryptCountBeforeInvalidClaim + 1,
-    );
+    expect(kms.decryptCalls).toBe(decryptCountBeforeInvalidClaim + 1);
     expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
     const materializationEvent = singleSandboxOperationEvent(
       claimRouteTimingEventsForRun(invalidRun.runId),
@@ -10099,17 +10069,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       ],
       agentId,
     });
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
 
     const run = await api.createRun(actor, {
       agentId,
       prompt: "use the proposed custom connector",
       modelProvider: "anthropic-api-key",
     });
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(0);
+    expect(kms.decryptCalls).toBe(0);
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
       timingEvents,
@@ -10184,7 +10151,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       tenant: "münich",
       scope: "initial-scope",
     });
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(1);
+    expect(kms.decryptCalls).toBe(1);
 
     context.mocks.ably.publish.mockClear();
     await connectors.setCustomConnectorValues(actor, saved.connector.id, [
@@ -13185,10 +13152,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     api.acceptTelemetryIngest();
     api.configureRunnerGroup();
     await api.grantProEntitlement(actor);
-    await enableFakeKms(context);
-    onTestFinished(async () => {
-      await resetFakeKms(context);
-    });
+    const kms = useSecretKmsProbe();
 
     // A plain compose carries inline environment values but no body, model
     // provider, or connector secrets, so no encrypted secrets map is stored
@@ -13210,15 +13174,12 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     });
     expect(run.status).toBe("pending");
 
-    const decryptCountBeforeNullClaim =
-      await readFakeKmsDecryptCallCount(context);
+    const decryptCountBeforeNullClaim = kms.decryptCalls;
     const claim = await api.claimRunnerJob(run.runId);
     expect(claim.secretValues).toBeNull();
     expect(claim.prompt).toBe("claim without stored secrets");
     expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(
-      decryptCountBeforeNullClaim,
-    );
+    expect(kms.decryptCalls).toBe(decryptCountBeforeNullClaim);
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -13229,14 +13190,11 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       prompt: "claim without matching environment secrets",
       secrets: { UNUSED_TOKEN: "unused-secret-value" },
     });
-    const decryptCountBeforeEmptyClaim =
-      await readFakeKmsDecryptCallCount(context);
+    const decryptCountBeforeEmptyClaim = kms.decryptCalls;
     const emptyClaim = await api.claimRunnerJob(emptyRun.runId);
     expect(emptyClaim.secretValues).toStrictEqual([]);
     expect(emptyClaim).not.toHaveProperty("secretValueEnvironmentKeys");
-    await expect(readFakeKmsDecryptCallCount(context)).resolves.toBe(
-      decryptCountBeforeEmptyClaim,
-    );
+    expect(kms.decryptCalls).toBe(decryptCountBeforeEmptyClaim);
     await api.requestCancelRun(actor, emptyRun.runId, [200]);
 
     // A compose pinned to a non-vm0 runner group fails dispatch at creation.

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -32,13 +32,6 @@ import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
-import {
-  resetSecretKmsClientForTests,
-  setSecretKmsClientForTests,
-  type SecretKmsClient,
-  type SecretKmsDataKey,
-  type SecretKmsGenerateDataKeyRequest,
-} from "../../lib/secret-kms-client";
 import { testOverride } from "../../lib/singleton";
 import type { RouteEntry } from "../route-entry";
 import {
@@ -61,11 +54,7 @@ import {
 // Test-only support actions for generic infrastructure fixtures.
 
 const actionBody$ = bodyResultOf(testRuntimeStateContract.action);
-const fakeKmsDataKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 const VM0_MANAGED_MODEL_KEY_FIXTURE_PREFIX = "vm0-key-runtime-fixture-";
-const fakeKmsDecryptCallCount = testOverride<number>(() => {
-  return 0;
-});
 
 interface OrgAdmissionLockGate {
   holderPid: number | null;
@@ -182,27 +171,6 @@ async function readOrgAdmissionLockState(
     throw new Error("Failed to read org admission lock state");
   }
   return state;
-}
-
-function fakeSecretKmsClient(): SecretKmsClient {
-  return {
-    generateDataKey(
-      request: SecretKmsGenerateDataKeyRequest,
-    ): Promise<SecretKmsDataKey> {
-      return Promise.resolve({
-        keyId: request.keyId,
-        plaintext: fakeKmsDataKey,
-        encryptedDataKey: Buffer.from(
-          `encrypted-data-key:${request.keyId}`,
-          "utf8",
-        ),
-      });
-    },
-    decrypt(): Promise<Uint8Array> {
-      fakeKmsDecryptCallCount.set(fakeKmsDecryptCallCount.get() + 1);
-      return Promise.resolve(fakeKmsDataKey);
-    },
-  };
 }
 
 async function seedVm0ManagedDefaultModelKey(
@@ -1454,25 +1422,6 @@ const postRuntimeStateAction$ = command(
       );
     }
     switch (body.action) {
-      case "enable-fake-kms": {
-        fakeKmsDecryptCallCount.set(0);
-        setSecretKmsClientForTests(fakeSecretKmsClient());
-        return { status: 200 as const, body: { ok: true as const } };
-      }
-      case "reset-fake-kms": {
-        resetSecretKmsClientForTests();
-        fakeKmsDecryptCallCount.set(0);
-        return { status: 200 as const, body: { ok: true as const } };
-      }
-      case "read-fake-kms-state": {
-        return {
-          status: 200 as const,
-          body: {
-            ok: true as const,
-            decrypt_call_count: fakeKmsDecryptCallCount.get(),
-          },
-        };
-      }
       case "mutate-runner-job-secret-value-environment-keys": {
         await mutateRunnerJobSecretValueEnvironmentKeys(
           db,

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -23,15 +23,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     fixture_id: z.uuid(),
   }),
   z.object({
-    action: z.literal("enable-fake-kms"),
-  }),
-  z.object({
-    action: z.literal("reset-fake-kms"),
-  }),
-  z.object({
-    action: z.literal("read-fake-kms-state"),
-  }),
-  z.object({
     action: z.literal("read-browser-screenshot-schema-state"),
   }),
   z.object({
@@ -194,7 +185,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
 export const testRuntimeStateActionResponseSchema = z.object({
   ok: z.literal(true),
   selected_model: z.string().optional(),
-  decrypt_call_count: z.number().optional(),
   browser_screenshot_schema_available: z.boolean().optional(),
   usage_pack_invitation_schema_available: z.boolean().optional(),
   autonomy_budget: z.int().min(0).max(10).nullable().optional(),


### PR DESCRIPTION
## Summary

- scope secret KMS test overrides to the current Vitest test with async context isolation
- replace run-lifecycle KMS enable/reset routes with per-test probes and direct decrypt counters
- preserve the production singleton fallback and all existing failure, timing, and default fake-client scenarios

## Validation

- Prettier check on all changed files
- targeted Oxlint and ESLint on changed API files
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- secret KMS concurrency isolation test (1 passed)
- affected run-lifecycle KMS scenarios (10 passed)
- targeted KMS probe caller scenarios in chat callbacks, connectors, firewall auth, goals, and workflow queue tests (8 passed)

Closes #26602
Epic: #26569
