### PR TITLE
feat: add history-backed video settings to chat

### DIFF
--- a/turbo/apps/api/src/lib/generation-template-prompt.ts
+++ b/turbo/apps/api/src/lib/generation-template-prompt.ts
@@ -378,6 +378,39 @@ function selectedVideoParameters(
   return parameters;
 }
 
+export function buildVideoGenerationSettingsPrompt(
+  options: VideoGenerationOptions | undefined,
+): string {
+  const parameters = selectedVideoParameters(options);
+  if (parameters.length === 0) {
+    return "";
+  }
+  const flags = parameters
+    .map((parameter) => {
+      return parameter.flag;
+    })
+    .filter((flag) => {
+      return flag.length > 0;
+    })
+    .join(" ");
+  return [
+    "# Video generation settings",
+    "",
+    "The user configured these defaults for video generation in this message:",
+    ...parameters.map((parameter) => {
+      return `- ${parameter.label}`;
+    }),
+    "",
+    "- These settings do not request a video by themselves; follow the user's prompt.",
+    "- An explicit value on an inline video template overrides the corresponding default above for that template.",
+    ...(flags.length > 0
+      ? [
+          `- For direct video generation without an inline template, pass \`${flags}\` verbatim.`,
+        ]
+      : []),
+  ].join("\n");
+}
+
 function buildVideoGenerationTemplatePrompt(
   generationTemplate: VideoGenerationTemplateInput,
 ): GenerationTemplatePromptResult {

--- a/turbo/apps/api/src/lib/thread-generation-template.ts
+++ b/turbo/apps/api/src/lib/thread-generation-template.ts
@@ -1,8 +1,37 @@
-import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+import type {
+  GenerationTemplateRequest,
+  VideoGenerationOptions,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { parseAvatarTemplateStylePresetId } from "@vm0/core/avatar-template";
 import {
   buildGenerationTemplatePrompt,
   buildGenerationTemplatesPrompt,
+  buildVideoGenerationSettingsPrompt,
 } from "./generation-template-prompt";
+
+function withVideoSettingsDefaults(
+  template: GenerationTemplateRequest,
+  videoOptions: VideoGenerationOptions | undefined,
+): GenerationTemplateRequest {
+  if (
+    template.type !== "video" ||
+    videoOptions === undefined ||
+    parseAvatarTemplateStylePresetId(template.selection.stylePresetId) !==
+      undefined
+  ) {
+    return template;
+  }
+  return {
+    ...template,
+    selection: {
+      ...template.selection,
+      videoOptions: {
+        ...videoOptions,
+        ...template.selection.videoOptions,
+      },
+    },
+  };
+}
 
 /**
  * Resolve the generation-template system prompt for a chat run.
@@ -14,14 +43,27 @@ import {
 export function resolveThreadGenerationTemplatePrompt(args: {
   readonly explicit: GenerationTemplateRequest | null | undefined;
   readonly explicitTemplates?: readonly GenerationTemplateRequest[];
+  readonly videoOptions?: VideoGenerationOptions;
 }): string {
+  const videoSettingsPrompt = buildVideoGenerationSettingsPrompt(
+    args.videoOptions,
+  );
+  let templatePrompt = "";
   if (args.explicitTemplates && args.explicitTemplates.length > 0) {
-    const built = buildGenerationTemplatesPrompt(args.explicitTemplates);
-    return built.status === "resolved" ? built.prompt : "";
+    const templates = args.explicitTemplates.map((template) => {
+      return withVideoSettingsDefaults(template, args.videoOptions);
+    });
+    const built = buildGenerationTemplatesPrompt(templates);
+    templatePrompt = built.status === "resolved" ? built.prompt : "";
+  } else if (args.explicit) {
+    const built = buildGenerationTemplatePrompt(
+      withVideoSettingsDefaults(args.explicit, args.videoOptions),
+    );
+    templatePrompt = built.status === "resolved" ? built.prompt : "";
   }
-  if (!args.explicit) {
-    return "";
-  }
-  const built = buildGenerationTemplatePrompt(args.explicit);
-  return built.status === "resolved" ? built.prompt : "";
+  return [videoSettingsPrompt, templatePrompt]
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .join("\n\n");
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7166,6 +7166,54 @@ describe("CHAT-02: generation templates and attachments", () => {
     await cancelChatRun(actor, sent.runId);
   }, 90_000);
 
+  it("keeps message-scoped video settings hidden from the visible prompt", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const prompt = "make a vertical product video";
+    const sent = await sendChatRun(actor, {
+      agentId,
+      prompt,
+      userMessage: {
+        version: 1,
+        videoOptions: {
+          model: "fal-ai/veo3.1/fast",
+          aspectRatio: "9:16",
+          duration: "8s",
+          resolution: "1080p",
+        },
+        parts: [{ type: "text", text: prompt }],
+      },
+    });
+
+    const run = await api.readRun(actor, sent.runId);
+    expect(run.prompt).toBe(prompt);
+    const systemPrompt = run.appendSystemPrompt ?? "";
+    expect(systemPrompt).toContain("# Video generation settings");
+    expect(systemPrompt).toContain("- Model: veo3.1-fast");
+    expect(systemPrompt).toContain("- Aspect ratio: 9:16");
+    expect(systemPrompt).toContain("- Duration: 8s");
+    expect(systemPrompt).toContain("- Resolution: 1080p");
+    expect(systemPrompt).toContain(
+      "`--model veo3.1-fast --aspect-ratio 9:16 --duration 8s --resolution 1080p` verbatim",
+    );
+
+    const messages = await chat.listThreadEvents(actor, sent.threadId);
+    const message = userMessages(messages.events).find((event) => {
+      return event.eventType === "input.prompt" && event.runId === sent.runId;
+    });
+    expect(message).toMatchObject({
+      userMessage: {
+        videoOptions: {
+          model: "fal-ai/veo3.1/fast",
+          aspectRatio: "9:16",
+          duration: "8s",
+          resolution: "1080p",
+        },
+      },
+    });
+    await cancelChatRun(actor, sent.runId);
+  }, 90_000);
+
   it("renders generation template guidance into the run system prompt", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
@@ -275,6 +275,7 @@ async function materializeActiveInputPrompt(
   const generationTemplatePrompt = resolveThreadGenerationTemplatePrompt({
     explicit: projection.primaryTemplate,
     explicitTemplates: projection.templates,
+    videoOptions: projection.videoOptions,
   });
   const prompt = integration?.prompt ?? projection.agentPrompt;
   const parts = [

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -3031,6 +3031,7 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
       return resolveThreadGenerationTemplatePrompt({
         explicit: args.userMessageProjection?.primaryTemplate,
         explicitTemplates: args.userMessageProjection?.templates,
+        videoOptions: args.userMessageProjection?.videoOptions,
       });
     },
   );

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -9,6 +9,7 @@ import {
   type CodexServiceTier,
   type GenerationTemplateRequest,
   type UserMessageDocument,
+  type VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { SupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -420,6 +421,7 @@ interface RuntimeNormalSendBody extends Omit<
   readonly agentPrompt: string;
   readonly primaryTemplate: GenerationTemplateRequest | undefined;
   readonly templates: readonly GenerationTemplateRequest[];
+  readonly videoOptions: VideoGenerationOptions | undefined;
   readonly hasTextContent: boolean;
 }
 
@@ -723,6 +725,7 @@ function resolveRuntimeNormalSendBody(
     userMessage: body.userMessage,
     primaryTemplate: projection.primaryTemplate,
     templates: projection.templates,
+    videoOptions: projection.videoOptions,
     agentPrompt: projection.agentPrompt,
     hasTextContent: projection.hasTextContent,
   };
@@ -2326,6 +2329,7 @@ const prepareNormalSend$ = command(
     const generationTemplatePrompt = resolveThreadGenerationTemplatePrompt({
       explicit: runtimeBody.primaryTemplate,
       explicitTemplates: runtimeBody.templates,
+      videoOptions: runtimeBody.videoOptions,
     });
     const persistedExplicitSelection =
       await maybePersistTimedExplicitModelFirstSelection(

--- a/turbo/apps/api/src/signals/services/zero-chat-user-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-user-message.service.ts
@@ -6,6 +6,7 @@ import type {
   UserMessageInputDocument,
   UserMessageInputPart,
   UserMessagePart,
+  VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   isChatUserMessageEventType,
@@ -18,6 +19,7 @@ interface UserMessageProjection {
   readonly displayText: string;
   readonly primaryTemplate: GenerationTemplateRequest | undefined;
   readonly templates: readonly GenerationTemplateRequest[];
+  readonly videoOptions: VideoGenerationOptions | undefined;
   readonly hasTextContent: boolean;
 }
 
@@ -104,7 +106,7 @@ export function withAgentRunSourceAnnotation(
     );
   });
   return {
-    version: 1,
+    ...document,
     parts: [
       ...contentParts,
       {
@@ -127,7 +129,7 @@ export function withRunModelAnnotation(
   serviceTier?: ChatThreadServiceTier,
 ): UserMessageDocument {
   return {
-    version: 1,
+    ...document,
     parts: [
       ...document.parts.filter((part) => {
         return part.type !== "model";
@@ -326,6 +328,8 @@ export function projectUserMessage(
   let feedbackParts: Extract<UserMessagePart, { type: "feedback" }>[] = [];
   let primaryTemplate: GenerationTemplateRequest | undefined;
   const templates: GenerationTemplateRequest[] = [];
+  const videoOptions: VideoGenerationOptions | undefined =
+    document.videoOptions;
   let hasTextContent = false;
 
   const registerInlineTemplate = (part: {
@@ -415,6 +419,7 @@ export function projectUserMessage(
     displayText: displayBlocks.join("\n\n"),
     primaryTemplate,
     templates,
+    videoOptions,
     hasTextContent,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -6,6 +6,7 @@ import type {
   ChatThreadArtifactRun,
   ChatThreadDraft,
   UserMessageDocument,
+  VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ChatClipboardPayload } from "../zero-page/clipboard.ts";
 import type { ChatEventGroup } from "./chat-event.ts";
@@ -102,6 +103,7 @@ export interface SendMessageOptions {
   readonly computerUseHostId?: string | null;
   readonly cloudBrowserEnabled?: boolean;
   readonly generationTemplate?: GenerationTemplateRequest;
+  readonly videoOptions?: VideoGenerationOptions;
   readonly editorDocument?: EditorDocumentSnapshot;
   readonly forward?: ChatForwardContext;
   readonly onOptimisticSend?: () => void;
@@ -111,6 +113,7 @@ export interface QueueMessageOptions {
   readonly computerUseHostId: string | null | undefined;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly videoOptions: VideoGenerationOptions | undefined;
   readonly editorDocument: EditorDocumentSnapshot;
   readonly forward?: ChatForwardContext;
   readonly onOptimisticSend?: () => void;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -60,6 +60,7 @@ import {
   type UserMessageDocument,
   type UserMessageInputDocument,
   type UserMessagePart,
+  type VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   chatEventCompatibilityRole,
@@ -83,6 +84,7 @@ import {
   writeChatMessageToClipboard,
   type ChatClipboardPayload,
 } from "../zero-page/clipboard.ts";
+import { withVideoSettingsMetadata } from "../zero-page/video-draft-settings.ts";
 import type {
   EnrichedChatEvent,
   ChatEventGroup,
@@ -818,6 +820,7 @@ function createDraftSync(threadId: string, draft: DraftSignals) {
         input: get(draft.input$),
         editorDocument: set(draft.readEditorDocument$),
         generationTemplate: get(draft.generationTemplate$),
+        videoOptions: get(draft.videoOptions$),
         attachments: persisted,
       });
 
@@ -2684,12 +2687,14 @@ function userMessageForSend({
   prompt,
   editorDocument,
   generationTemplate,
+  videoOptions,
   attachments,
   forward,
 }: {
   readonly prompt: string;
   readonly editorDocument: SendMessageOptions["editorDocument"];
   readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly videoOptions: VideoGenerationOptions | undefined;
   readonly attachments: ResolvedAttachFile[] | undefined;
   readonly forward: ChatForwardContext | undefined;
 }): UserMessageInputDocument {
@@ -2705,7 +2710,7 @@ function userMessageForSend({
   if (!userMessage) {
     throw new Error("Failed to serialize user message");
   }
-  return userMessage;
+  return withVideoSettingsMetadata(userMessage, videoOptions);
 }
 
 function queueUserMessage(
@@ -2716,6 +2721,7 @@ function queueUserMessage(
     prompt: result.prompt,
     editorDocument: options.editorDocument,
     generationTemplate: options.generationTemplate,
+    videoOptions: options.videoOptions,
     attachments: result.attachments,
     forward: options.forward,
   });
@@ -2831,6 +2837,15 @@ function sendInputForRequest(args: {
   };
 }
 
+function videoOptionsForSend(
+  requestOptions: SendMessageOptions | undefined,
+  draftVideoOptions: VideoGenerationOptions | undefined,
+): VideoGenerationOptions | undefined {
+  return requestOptions?.editorDocument
+    ? requestOptions.videoOptions
+    : draftVideoOptions;
+}
+
 function createPerformSendMessage(deps: SendMessageDeps) {
   const { threadId, draft, cancelDraftSync$, flushDraftClear$, sendEvent$ } =
     deps;
@@ -2843,6 +2858,10 @@ function createPerformSendMessage(deps: SendMessageDeps) {
       const generationTemplate = generationTemplateForSend(
         request,
         get(draft.generationTemplate$),
+      );
+      const videoOptions = videoOptionsForSend(
+        request.options,
+        get(draft.videoOptions$),
       );
       const submissionPrompt = submissionPromptForSend(request);
       const result = await prepareSendMessageResult(
@@ -2873,6 +2892,7 @@ function createPerformSendMessage(deps: SendMessageDeps) {
         prompt: userMessagePromptForSend(request, result.prompt),
         editorDocument: request.options?.editorDocument,
         generationTemplate,
+        videoOptions,
         attachments: result.attachments,
         forward: request.options?.forward,
       });
@@ -3707,6 +3727,7 @@ function createThreadSubmitMessageSignal(
                 computerUseHostId: explicit ? computerUseHostId : undefined,
                 cloudBrowserEnabled: explicit ? cloudBrowserEnabled : undefined,
                 generationTemplate: submission.generationTemplate,
+                videoOptions: submission.videoOptions,
                 editorDocument: submission.editorDocument,
                 ...(options.forward ? { forward: options.forward } : {}),
                 ...(options.onOptimisticSend
@@ -3722,6 +3743,7 @@ function createThreadSubmitMessageSignal(
                 ...(explicit ? { computerUseHostId } : {}),
                 ...(explicit ? { cloudBrowserEnabled } : {}),
                 generationTemplate: submission.generationTemplate,
+                videoOptions: submission.videoOptions,
                 editorDocument: submission.editorDocument,
                 ...(options.forward ? { forward: options.forward } : {}),
                 ...(options.onOptimisticSend

--- a/turbo/apps/platform/src/signals/chat-page/model-selection-request.ts
+++ b/turbo/apps/platform/src/signals/chat-page/model-selection-request.ts
@@ -21,7 +21,7 @@ export function withSelectedModelAnnotation(
     return document;
   }
   return {
-    version: 1,
+    ...document,
     parts: [
       ...document.parts,
       {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedAttachFile,
   type UserMessageDocument,
   type UserMessageInputDocument,
+  type VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { OrgModelPoliciesResponse } from "@vm0/api-contracts/contracts/model-providers";
 import type { UserModelPreferenceResponse } from "@vm0/api-contracts/contracts/zero-user-model-preference";
@@ -61,6 +62,7 @@ import {
   type ChatForwardContext,
 } from "./chat-forward.ts";
 import { withOptimisticAgentRunSource } from "./chat-event-signals.ts";
+import { withVideoSettingsMetadata } from "../zero-page/video-draft-settings.ts";
 
 export type NewChatThreadPane = "main" | "sidebar";
 
@@ -77,6 +79,7 @@ interface SendNewThreadMessageRequest {
   draft?: DraftSignals;
   prompt: string;
   generationTemplate: GenerationTemplateRequest | undefined;
+  videoOptions?: VideoGenerationOptions;
   generationTemplateTitleSnapshot?: string;
   editorDocument?: EditorDocumentSnapshot;
   computerUseHostId?: string | null;
@@ -130,7 +133,7 @@ function userMessageForNewThread(
   if (!userMessage) {
     throw new Error("Failed to serialize user message");
   }
-  return userMessage;
+  return withVideoSettingsMetadata(userMessage, request.videoOptions);
 }
 
 function createNewThreadOptimisticEventEntry({

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -137,6 +137,7 @@ function createAgentComposerSignalsWithDraft(
           draft: agentDraft.draft,
           prompt: submission.prompt,
           generationTemplate: submission.generationTemplate,
+          videoOptions: submission.videoOptions,
           editorDocument: submission.editorDocument,
           ...(access.kind === "computerUse"
             ? { computerUseHostId: hostId }

--- a/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
@@ -135,6 +135,7 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
         input: get(draft.input$),
         editorDocument: set(draft.readEditorDocument$),
         generationTemplate: get(draft.generationTemplate$),
+        videoOptions: get(draft.videoOptions$),
         attachments,
       });
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -19,11 +19,13 @@ import type {
   GenerationTemplateRequest,
   PersistedAttachment,
   UserMessageDocument,
+  VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
 import { i18n } from "../../i18n/index.ts";
+import { videoSettingsFromMessage } from "./video-draft-settings.ts";
 
 // ---------------------------------------------------------------------------
 // Attachment types (moved from zero-chat.ts)
@@ -391,6 +393,8 @@ export interface DraftSignals {
     void,
     [GenerationTemplateRequest | undefined]
   >;
+  videoOptions$: Computed<VideoGenerationOptions | undefined>;
+  setVideoOptions$: Command<void, [VideoGenerationOptions | undefined]>;
   attachments$: Computed<ZeroChatAttachment[]>;
   attachmentUploadsReady$: Computed<boolean>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
@@ -537,12 +541,14 @@ function createDraftLifecycleSignals({
   draftInput,
   draftDocument,
   internalGenerationTemplate$,
+  internalVideoOptions$,
   internalAttachments$,
   internalDragOver$,
 }: {
   draftInput: ReturnType<typeof createDraftInputSignals>;
   draftDocument: ReturnType<typeof createDraftDocumentSignals>;
   internalGenerationTemplate$: State<GenerationTemplateRequest | undefined>;
+  internalVideoOptions$: State<VideoGenerationOptions | undefined>;
   internalAttachments$: State<ZeroChatAttachment[]>;
   internalDragOver$: State<boolean>;
 }) {
@@ -551,6 +557,7 @@ function createDraftLifecycleSignals({
     set(draftDocument.setRestoredUserMessage$, null);
     set(draftDocument.setEditorDocument$, null);
     set(internalGenerationTemplate$, undefined);
+    set(internalVideoOptions$, undefined);
     const attachments = get(internalAttachments$);
     for (const attachment of attachments) {
       set(attachment.cancel$);
@@ -565,6 +572,7 @@ function createDraftLifecycleSignals({
     set(draftDocument.setEditorDocument$, null);
     set(draftDocument.setRestoredUserMessage$, value.userMessage);
     set(internalGenerationTemplate$, value.generationTemplate);
+    set(internalVideoOptions$, videoSettingsFromMessage(value.userMessage));
     set(internalAttachments$, value.attachments);
     set(draftInput.setInput$, value.content);
     if (
@@ -584,6 +592,9 @@ export function createDraftSignals(): DraftSignals {
   const internalGenerationTemplate$ = state<
     GenerationTemplateRequest | undefined
   >(undefined);
+  const internalVideoOptions$ = state<VideoGenerationOptions | undefined>(
+    undefined,
+  );
   const internalAttachments$ = state<ZeroChatAttachment[]>([]);
   const internalDragOver$ = state(false);
 
@@ -593,6 +604,14 @@ export function createDraftSignals(): DraftSignals {
   const setGenerationTemplate$ = command(
     ({ set }, value: GenerationTemplateRequest | undefined) => {
       set(internalGenerationTemplate$, value);
+    },
+  );
+  const videoOptions$ = computed((get) => {
+    return get(internalVideoOptions$);
+  });
+  const setVideoOptions$ = command(
+    ({ set }, value: VideoGenerationOptions | undefined) => {
+      set(internalVideoOptions$, value);
     },
   );
 
@@ -666,6 +685,7 @@ export function createDraftSignals(): DraftSignals {
     draftInput,
     draftDocument,
     internalGenerationTemplate$,
+    internalVideoOptions$,
     internalAttachments$,
     internalDragOver$,
   });
@@ -677,6 +697,8 @@ export function createDraftSignals(): DraftSignals {
     setEditorDocument$: draftDocument.setEditorDocument$,
     generationTemplate$,
     setGenerationTemplate$,
+    videoOptions$,
+    setVideoOptions$,
     attachments$,
     attachmentUploadsReady$,
     uploadAttachment$,

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -1,9 +1,11 @@
 import type {
   GenerationTemplateRequest,
   PersistedAttachment,
+  VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { foldActiveChatGoalObjective } from "@vm0/api-contracts/contracts/chat-events";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
+import { DEFAULT_VIDEO_MODEL } from "@vm0/core/video-model-catalog";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { onRef, withCleanup } from "../utils.ts";
 import {
@@ -47,6 +49,11 @@ import {
   replaceWorkflowPromptDraftTarget$,
   setReplaceWorkflowPromptDraftTarget$,
 } from "../chat-page/workflow-prompt-action.ts";
+import {
+  draftMentionsVideo,
+  latestVideoSettingsFromChatEvents,
+  messageVideoTemplateContext,
+} from "./video-draft-settings.ts";
 
 type ComposerEditorSignals = Pick<
   WorkflowComposerSignals,
@@ -84,6 +91,7 @@ type ComposerTemplateEditorSignals = Pick<
   WorkflowComposerSignals,
   | "templatePreview"
   | "hasTemplateAttachment$"
+  | "hasInlineVideoTemplate$"
   | "insertTemplate$"
   | "updateTemplateAt$"
   | "readSelectedTemplate$"
@@ -97,6 +105,7 @@ type ComposerTemplateUiSignals = ComposerUiSignalGroups["template"];
 export interface ComposerSubmission {
   readonly prompt: string;
   readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly videoOptions: VideoGenerationOptions | undefined;
   readonly editorDocument: WorkflowComposerSubmissionSnapshot["editorDocument"];
 }
 
@@ -212,6 +221,12 @@ interface ComposerTemplateSignals
   >;
 }
 
+interface ComposerVideoSignals {
+  readonly intentDetected$: Computed<boolean>;
+  readonly effectiveOptions$: Computed<VideoGenerationOptions | undefined>;
+  readonly setOptions$: Command<void, [VideoGenerationOptions | undefined]>;
+}
+
 export interface ComposerSignals {
   readonly agentId: string;
   readonly editor: ComposerEditorSignals;
@@ -226,6 +241,7 @@ export interface ComposerSignals {
   readonly queue: ComposerQueueSignals;
   readonly goal: ComposerGoalSignals;
   readonly template: ComposerTemplateSignals;
+  readonly video: ComposerVideoSignals;
 }
 
 interface CreateComposerSignalsOptions {
@@ -323,6 +339,7 @@ function composerTemplateSignals(
   return {
     templatePreview: composer.templatePreview,
     hasTemplateAttachment$: composer.hasTemplateAttachment$,
+    hasInlineVideoTemplate$: composer.hasInlineVideoTemplate$,
     insertTemplate$: composer.insertTemplate$,
     updateTemplateAt$: composer.updateTemplateAt$,
     readSelectedTemplate$: composer.readSelectedTemplate$,
@@ -439,6 +456,45 @@ function createRemoveQueuedMessage(
   );
 }
 
+function createComposerVideoSignals(
+  draft: DraftSignals,
+  eventSignals: ReturnType<typeof createComposerChatEventSignals>,
+): ComposerVideoSignals {
+  const intentDetected$ = computed((get): boolean => {
+    return draftMentionsVideo(get(draft.input$));
+  });
+  const effectiveOptions$ = computed((get) => {
+    const explicit = get(draft.videoOptions$);
+    const inherited = get(eventSignals.latestVideoOptions$);
+    return explicit || inherited ? { ...inherited, ...explicit } : undefined;
+  });
+  return {
+    intentDetected$,
+    effectiveOptions$,
+    setOptions$: draft.setVideoOptions$,
+  };
+}
+
+function videoOptionsForSubmission(args: {
+  readonly intentDetected: boolean;
+  readonly hasTextToVideoTemplate: boolean;
+  readonly hasAvatarTemplate: boolean;
+  readonly explicit: VideoGenerationOptions | undefined;
+  readonly inherited: VideoGenerationOptions | undefined;
+}): VideoGenerationOptions | undefined {
+  if (
+    (args.hasAvatarTemplate && !args.hasTextToVideoTemplate) ||
+    (!args.intentDetected && !args.hasTextToVideoTemplate)
+  ) {
+    return undefined;
+  }
+  return {
+    ...args.inherited,
+    ...args.explicit,
+    model: args.explicit?.model ?? args.inherited?.model ?? DEFAULT_VIDEO_MODEL,
+  };
+}
+
 export function createComposerSignals(
   options: CreateComposerSignalsOptions,
 ): ComposerSignals {
@@ -474,6 +530,7 @@ export function createComposerSignals(
     workflowComposer,
   );
   const ui = createComposerUiSignals();
+  const video = createComposerVideoSignals(draft, eventSignals);
 
   return {
     agentId: options.agentId,
@@ -538,6 +595,7 @@ export function createComposerSignals(
       generationTemplate$: draft.generationTemplate$,
       setGenerationTemplate$: draft.setGenerationTemplate$,
     },
+    video,
   };
 }
 
@@ -565,6 +623,9 @@ function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
       );
     },
   );
+  const latestVideoOptions$ = computed((get) => {
+    return latestVideoSettingsFromChatEvents(get(chatEvents$));
+  });
   const sending$ = computed((get): Promise<boolean> => {
     const running = get(runIndicatorState$) !== null;
     const lastAssistantCancelled = lastAssistantCancelledFromGroups(
@@ -616,10 +677,47 @@ function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
     actionsLoading$,
     sending$,
     runningModelSelection$,
+    latestVideoOptions$,
     pendingEvents$,
     activeGoalObjective$,
     hasEvents$,
   };
+}
+
+function createComposerPrimaryActionSignal(
+  options: CreateComposerSignalsOptions,
+  eventSignals: ReturnType<typeof createComposerChatEventSignals>,
+  draft: DraftSignals,
+  hasInput$: WorkflowComposerSignals["hasInput$"],
+  submissionPending$: Computed<boolean>,
+) {
+  return computed(async (get): Promise<ComposerPrimaryAction> => {
+    if (await get(eventSignals.actionsLoading$)) {
+      return "disabled";
+    }
+
+    const uploadsReady = get(draft.attachmentUploadsReady$);
+    const attachments = get(draft.attachments$);
+    let hasContent = options.implicitContent === true || get(hasInput$);
+    if (!hasContent && attachments.length > 0) {
+      const modelSelection = await get(options.modelSelection$);
+      const imageRecognitionEnabled = get(imageRecognitionAvailable$);
+      hasContent = hasVisibleAttachment(
+        modelSelection,
+        attachments,
+        imageRecognitionEnabled,
+      );
+    }
+    const canSend = uploadsReady && hasContent;
+    const sending = await get(eventSignals.sending$);
+    if (sending && !canSend) {
+      return "stop";
+    }
+    if (get(submissionPending$) || !canSend) {
+      return "disabled";
+    }
+    return sending ? "queue" : "send";
+  });
 }
 
 function createComposerSubmissionSignals(
@@ -632,41 +730,12 @@ function createComposerSubmissionSignals(
   const submissionPending$ = computed((get): boolean => {
     return get(internalSubmissionPending$);
   });
-  const primaryAction$ = computed(
-    async (get): Promise<ComposerPrimaryAction> => {
-      if (await get(eventSignals.actionsLoading$)) {
-        return "disabled";
-      }
-
-      const uploadsReady = get(draft.attachmentUploadsReady$);
-      const attachments = get(draft.attachments$);
-      let hasContent =
-        options.implicitContent === true || get(workflowComposer.hasInput$);
-      if (!hasContent && attachments.length > 0) {
-        const modelSelection = await get(options.modelSelection$);
-        const imageRecognitionEnabled = get(imageRecognitionAvailable$);
-        hasContent = hasVisibleAttachment(
-          modelSelection,
-          attachments,
-          imageRecognitionEnabled,
-        );
-      }
-      const canSend = uploadsReady && hasContent;
-      const sending = await get(eventSignals.sending$);
-      if (sending && !canSend) {
-        return "stop";
-      }
-      if (get(submissionPending$)) {
-        return "disabled";
-      }
-      if (!canSend) {
-        return "disabled";
-      }
-      if (!sending) {
-        return "send";
-      }
-      return "queue";
-    },
+  const primaryAction$ = createComposerPrimaryActionSignal(
+    options,
+    eventSignals,
+    draft,
+    workflowComposer.hasInput$,
+    submissionPending$,
   );
   const submitCurrentInput$ = command(
     async (
@@ -715,12 +784,27 @@ function createComposerSubmissionSignals(
           if (!get(draft.attachmentUploadsReady$)) {
             return false;
           }
+          const generationTemplate = get(draft.generationTemplate$);
+          const videoOptionsEnabled =
+            get(featureSwitch$)[FeatureSwitchKey.VideoTemplateOptions] ?? false;
+          const videoOptions = videoOptionsEnabled
+            ? videoOptionsForSubmission({
+                intentDetected: draftMentionsVideo(get(draft.input$)),
+                ...messageVideoTemplateContext(
+                  submission.editorDocument,
+                  generationTemplate,
+                ),
+                explicit: get(draft.videoOptions$),
+                inherited: get(eventSignals.latestVideoOptions$),
+              })
+            : undefined;
           return await set(
             options.submitMessage$,
             action,
             {
               prompt,
-              generationTemplate: get(draft.generationTemplate$),
+              generationTemplate,
+              videoOptions,
               editorDocument: submission.editorDocument,
             },
             signal,

--- a/turbo/apps/platform/src/signals/zero-page/draft-persistence.ts
+++ b/turbo/apps/platform/src/signals/zero-page/draft-persistence.ts
@@ -2,11 +2,13 @@ import type {
   GenerationTemplateRequest,
   PersistedAttachment,
   UserMessageInputDocument,
+  VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   textToMessageDocument,
   type EditorDocumentSnapshot,
 } from "./user-message-document-codec.ts";
+import { withVideoSettingsMetadata } from "./video-draft-settings.ts";
 
 export interface DraftPersistencePayload {
   readonly userMessage: UserMessageInputDocument | null;
@@ -17,6 +19,7 @@ interface DraftPersistenceSource {
   readonly input: string;
   readonly editorDocument: EditorDocumentSnapshot | null;
   readonly generationTemplate: GenerationTemplateRequest | undefined;
+  readonly videoOptions: VideoGenerationOptions | undefined;
   readonly attachments: readonly PersistedAttachment[];
 }
 
@@ -42,6 +45,7 @@ export function buildDraftPersistencePayload(
     if (!userMessage) {
       throw new Error("Failed to serialize user-message draft");
     }
+    userMessage = withVideoSettingsMetadata(userMessage, source.videoOptions);
   }
 
   return { userMessage, attachments };

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -189,6 +189,7 @@ export interface WorkflowComposerSignals {
   readonly focus$: Command<void, []>;
   readonly hasInput$: Computed<boolean>;
   readonly hasTemplateAttachment$: Computed<boolean>;
+  readonly hasInlineVideoTemplate$: Computed<boolean>;
   readonly activeSlashRange$: Computed<SlashWorkflowRange | null>;
   readonly activeChatThreadSuggestionRange$: Computed<ChatThreadSuggestionRange | null>;
   readonly chatThreadSuggestions$: Computed<
@@ -1988,6 +1989,7 @@ interface MountEditorOptions {
   caretIndex$: State<number>;
   editorFocusedState$: State<boolean>;
   selectedSuggestionIndexState$: State<number>;
+  inlineVideoTemplateState$: State<boolean>;
   feedback: ComposerFeedbackModel;
   compositionGate: CompositionGate;
   syncWorkflowNames$: WorkflowNamesSyncCommand;
@@ -1999,6 +2001,23 @@ interface MountEditorOptions {
 interface WorkflowComposerMountOptions {
   readonly autoFocus?: boolean;
   readonly singleLineOnMobile?: boolean;
+}
+
+function hasInlineVideoTemplate(editor: Editor): boolean {
+  let found = false;
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== INLINE_TEMPLATE_NODE_NAME) {
+      return true;
+    }
+    const template = generationTemplateRequestSchema.safeParse(
+      node.attrs.template,
+    );
+    if (template.success && template.data.type === "video") {
+      found = true;
+    }
+    return false;
+  });
+  return found;
 }
 
 function focusMountedEditorAtEnd(editor: Editor): void {
@@ -2016,6 +2035,7 @@ function createMountEditorCommand({
   caretIndex$,
   editorFocusedState$,
   selectedSuggestionIndexState$,
+  inlineVideoTemplateState$,
   feedback,
   compositionGate,
   syncWorkflowNames$,
@@ -2035,6 +2055,7 @@ function createMountEditorCommand({
           createEditorDocumentSnapshot(updatedEditor.state.doc),
         );
         set(selectedSuggestionIndexState$, 0);
+        set(inlineVideoTemplateState$, hasInlineVideoTemplate(updatedEditor));
         set(caretIndex$, updatedEditor.state.selection.head);
         compositionGate.notifySettled();
         // Forward TipTap updates through the React-owned DOM boundary.
@@ -2069,6 +2090,7 @@ function createMountEditorCommand({
         draft.setEditorDocument$,
         createEditorDocumentSnapshot(editor.state.doc),
       );
+      set(inlineVideoTemplateState$, hasInlineVideoTemplate(editor));
       editor.mount(element);
       mountLocalizationListener(editor, runtime, signal);
       mountCompositionListeners(editor, compositionGate, signal);
@@ -2089,6 +2111,7 @@ function createMountEditorCommand({
               draft.setEditorDocument$,
               createEditorDocumentSnapshot(editor.state.doc),
             );
+            set(inlineVideoTemplateState$, hasInlineVideoTemplate(editor));
           }
         },
         syncUserMessage(value) {
@@ -2109,6 +2132,7 @@ function createMountEditorCommand({
             draft.setEditorDocument$,
             createEditorDocumentSnapshot(editor.state.doc),
           );
+          set(inlineVideoTemplateState$, hasInlineVideoTemplate(editor));
         },
       });
       // Keep workflow decoration sync scoped to real editor mounts.
@@ -2126,6 +2150,7 @@ function createMountEditorCommand({
         resetMountedWorkflowRuntime(runtime);
         set(draft.setInputSyncTarget$, null);
         set(editorFocusedState$, false);
+        set(inlineVideoTemplateState$, false);
         editor.unmount();
       });
       await Promise.all([
@@ -2595,6 +2620,7 @@ export function createWorkflowComposerSignals<
   const caretIndex$ = state(-1);
   const editorFocusedState$ = state(false);
   const selectedSuggestionIndexState$ = state(0);
+  const inlineVideoTemplateState$ = state(false);
   const runtime = createWorkflowComposerRuntime();
   const agentMentionAvatarRuntime = createAgentMentionAvatarRuntime();
   const templatePreview = createTemplatePreviewRuntime();
@@ -2658,6 +2684,7 @@ export function createWorkflowComposerSignals<
     caretIndex$,
     editorFocusedState$,
     selectedSuggestionIndexState$,
+    inlineVideoTemplateState$,
     feedback,
     compositionGate,
     syncWorkflowNames$,
@@ -2680,6 +2707,9 @@ export function createWorkflowComposerSignals<
   const hasInput$ = computed((get) => {
     return get(draft.hasInput$) || get(feedback.active$);
   });
+  const hasInlineVideoTemplate$ = computed((get) => {
+    return get(inlineVideoTemplateState$);
+  });
 
   return {
     editor,
@@ -2688,6 +2718,7 @@ export function createWorkflowComposerSignals<
     focus$,
     hasInput$,
     hasTemplateAttachment$: templateAttachment.active$,
+    hasInlineVideoTemplate$,
     activeSlashRange$,
     activeChatThreadSuggestionRange$,
     chatThreadSuggestions$,

--- a/turbo/apps/platform/src/signals/zero-page/video-draft-settings.ts
+++ b/turbo/apps/platform/src/signals/zero-page/video-draft-settings.ts
@@ -1,0 +1,90 @@
+import type {
+  GenerationTemplateRequest,
+  UserMessageDocument,
+  UserMessageInputDocument,
+  VideoGenerationOptions,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { revokedChatEventIds } from "@vm0/api-contracts/contracts/chat-events";
+import { parseAvatarTemplateStylePresetId } from "@vm0/core/avatar-template";
+import type { ChatEvent } from "../chat-page/chat-event-types.ts";
+import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
+
+const VIDEO_DRAFT_PATTERN = /(?:\bvideos?\b|视频|影片|短片)/iu;
+
+/** Conservative lexical hint used only to reveal the video settings control. */
+export function draftMentionsVideo(input: string): boolean {
+  return VIDEO_DRAFT_PATTERN.test(input);
+}
+
+export function videoSettingsFromMessage(
+  document: UserMessageDocument | UserMessageInputDocument | null | undefined,
+): VideoGenerationOptions | undefined {
+  return document?.videoOptions;
+}
+
+/** Replace the draft-owned metadata while preserving every visible part. */
+export function withVideoSettingsMetadata(
+  document: UserMessageInputDocument,
+  videoOptions: VideoGenerationOptions | undefined,
+): UserMessageInputDocument {
+  return {
+    version: 1,
+    parts: document.parts,
+    ...(videoOptions ? { videoOptions } : {}),
+  };
+}
+
+/** Latest authored model acts as the lightweight thread-level fallback. */
+export function latestVideoSettingsFromChatEvents(
+  events: readonly ChatEvent[],
+): VideoGenerationOptions | undefined {
+  const revoked = revokedChatEventIds(events);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (
+      event?.eventType !== "input.prompt" ||
+      revoked.has(event.id) ||
+      event.userMessage === null
+    ) {
+      continue;
+    }
+    const options = videoSettingsFromMessage(event.userMessage);
+    if (options?.model !== undefined) {
+      return { model: options.model };
+    }
+  }
+  return undefined;
+}
+
+export function messageVideoTemplateContext(
+  editorDocument: EditorDocumentSnapshot,
+  selectedTemplate: GenerationTemplateRequest | undefined,
+): {
+  readonly hasTextToVideoTemplate: boolean;
+  readonly hasAvatarTemplate: boolean;
+} {
+  const document = editorDocument.toMessageDocument();
+  let hasTextToVideoTemplate = false;
+  let hasAvatarTemplate = false;
+  const register = (template: GenerationTemplateRequest | undefined): void => {
+    if (template?.type !== "video") {
+      return;
+    }
+    if (
+      parseAvatarTemplateStylePresetId(template.selection.stylePresetId) ===
+      undefined
+    ) {
+      hasTextToVideoTemplate = true;
+    } else {
+      hasAvatarTemplate = true;
+    }
+  };
+  register(selectedTemplate);
+  for (const part of document?.parts ?? []) {
+    if (part.type !== "template") {
+      continue;
+    }
+    register(part.template);
+  }
+  return { hasTextToVideoTemplate, hasAvatarTemplate };
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -12,6 +12,7 @@ import {
 import type {
   GenerationTemplateRequest,
   UserMessageDocument,
+  VideoGenerationOptions,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   zeroAvatarVideoContract,
@@ -19,6 +20,7 @@ import {
   type ZeroAvatarVideoVoicesQuery,
 } from "@vm0/api-contracts/contracts/zero-avatar-video";
 import { avatarTemplateStylePresetId } from "@vm0/core/avatar-template";
+import { DEFAULT_VIDEO_MODEL } from "@vm0/core/video-model-catalog";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
@@ -60,6 +62,12 @@ function sentInlineTemplate(
     }
   }
   return undefined;
+}
+
+function sentVideoSettings(
+  userMessage: UserMessageDocument | undefined,
+): VideoGenerationOptions | undefined {
+  return userMessage?.videoOptions;
 }
 
 function createAvatarFirstPage() {
@@ -228,10 +236,14 @@ function mockVoiceCatalog({
 
 async function openAvatarPicker(
   user: ReturnType<typeof userEvent.setup>,
+  videoOptionsEnabled = false,
 ): Promise<HTMLElement> {
   detachedSetupPage({
     context,
-    featureSwitches: { [FeatureSwitchKey.JoggAiBuiltIn]: true },
+    featureSwitches: {
+      [FeatureSwitchKey.JoggAiBuiltIn]: true,
+      [FeatureSwitchKey.VideoTemplateOptions]: videoOptionsEnabled,
+    },
     path: `/chats/${THREAD_ID}`,
   });
 
@@ -369,6 +381,137 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("reveals the inherited video model only after video intent is detected", async () => {
+    const user = userEvent.setup({ delay: null });
+    let submittedUserMessage: UserMessageDocument | undefined;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "prior-video-message",
+          threadId: THREAD_ID,
+          role: "user",
+          content: "Create the first video",
+          userMessage: {
+            version: 1,
+            videoOptions: {
+              model: "fal-ai/veo3.1/fast",
+              aspectRatio: "9:16",
+            },
+            parts: [{ type: "text", text: "Create the first video" }],
+          },
+          createdAt: "2026-08-11T00:00:00.000Z",
+        },
+      ],
+      onRunCreate(body) {
+        submittedUserMessage = body.userMessage;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.VideoTemplateOptions]: true,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    expect(screen.queryByLabelText(/Video options:/)).not.toBeInTheDocument();
+    await fill(await findComposerEditor(), "Create another video");
+
+    const videoSettings = await screen.findByLabelText(/Video options:/);
+    expect(videoSettings).toHaveAttribute(
+      "aria-label",
+      "Video options: Veo 3.1 fast",
+    );
+    await user.click(videoSettings);
+    expect(screen.getByRole("combobox", { name: "Ratio" })).toHaveTextContent(
+      "16:9",
+    );
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Seedance 2.0" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Video options: Seedance 2.0"),
+      ).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Send"));
+    await waitFor(() => {
+      expect(sentVideoSettings(submittedUserMessage)).toStrictEqual({
+        model: "dreamina-seedance-2-0-260128",
+      });
+    });
+  });
+
+  it("snapshots the default model on the first video prompt", async () => {
+    const user = userEvent.setup({ delay: null });
+    let submittedUserMessage: UserMessageDocument | undefined;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      onRunCreate(body) {
+        submittedUserMessage = body.userMessage;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.VideoTemplateOptions]: true,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await fill(await findComposerEditor(), "生成一个产品视频");
+    await expect(
+      screen.findByLabelText("Video options: Seedance 2.0 fast"),
+    ).resolves.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(sentVideoSettings(submittedUserMessage)).toStrictEqual({
+        model: DEFAULT_VIDEO_MODEL,
+      });
+    });
+  });
+
+  it("drops video settings when video intent is removed", async () => {
+    const user = userEvent.setup({ delay: null });
+    let submittedUserMessage: UserMessageDocument | undefined;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      onRunCreate(body) {
+        submittedUserMessage = body.userMessage;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.VideoTemplateOptions]: true,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const editor = await findComposerEditor();
+    await fill(editor, "Create a product video");
+    await user.click(await screen.findByLabelText(/Video options:/));
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Seedance 2.0" }),
+    );
+
+    await fill(editor, "Write launch copy");
+    expect(screen.queryByLabelText(/Video options:/)).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(submittedUserMessage?.videoOptions).toBeUndefined();
+    });
+  });
+
   it("edits video parameters from the second half of an inline chip", async () => {
     const user = userEvent.setup({ delay: null });
     const template = VIDEO_TEMPLATE_ITEMS[0]!;
@@ -406,6 +549,7 @@ describe("chat composer templates", () => {
     const spec = await screen.findByLabelText(
       "Video options Seedance 2.0 fast \u00b7 16:9 \u00b7 8s \u00b7 720p \u00b7 Audio",
     );
+    expect(screen.queryByLabelText(/Video options:/)).not.toBeInTheDocument();
     const chip = document.querySelector("[data-composer-inline-template]");
     expect(chip?.querySelectorAll("button")).toHaveLength(2);
 
@@ -1123,14 +1267,16 @@ describe("chat composer templates", () => {
     });
     mockVoiceCatalog();
     let submittedTemplate: GenerationTemplateRequest | undefined;
+    let submittedUserMessage: UserMessageDocument | undefined;
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
       onRunCreate(body) {
         submittedTemplate = sentInlineTemplate(body.userMessage);
+        submittedUserMessage = body.userMessage;
       },
     });
 
-    const dialog = await openAvatarPicker(user);
+    const dialog = await openAvatarPicker(user, true);
     await within(dialog).findByLabelText("Select template Ada");
     await user.click(within(dialog).getByLabelText("Aspect ratio: 16:9"));
     await waitFor(() => {
@@ -1147,7 +1293,7 @@ describe("chat composer templates", () => {
     );
 
     await expectInlineTemplateInComposer("Ada");
-    await appendAndSend(user, "Introduce our new product");
+    await appendAndSend(user, "Introduce our new product in an avatar video");
 
     await waitFor(() => {
       expect(submittedTemplate).toStrictEqual({
@@ -1162,6 +1308,7 @@ describe("chat composer templates", () => {
           },
         },
       });
+      expect(submittedUserMessage?.videoOptions).toBeUndefined();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/video-generation-options-form.tsx
+++ b/turbo/apps/platform/src/views/zero-page/video-generation-options-form.tsx
@@ -1,0 +1,213 @@
+import type { VideoGenerationOptions } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  DEFAULT_VIDEO_MODEL,
+  VIDEO_MODEL_CONFIGS,
+  VIDEO_MODELS,
+  resolveVideoGenerationOptions,
+  type ResolvedVideoGenerationOptions,
+  type VideoModel,
+  type VideoModelConfig,
+} from "@vm0/core/video-model-catalog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import { Switch } from "@vm0/ui/components/ui/switch";
+import { useTranslation } from "react-i18next";
+
+/** Keep model-relative defaults sparse; generic message settings pin a model. */
+function toVideoOptionsPatch(
+  next: ResolvedVideoGenerationOptions,
+  modelDefaults: ResolvedVideoGenerationOptions,
+  persistModel: boolean,
+): VideoGenerationOptions {
+  return {
+    ...(persistModel || next.model !== DEFAULT_VIDEO_MODEL
+      ? { model: next.model }
+      : {}),
+    ...(next.aspectRatio === modelDefaults.aspectRatio
+      ? {}
+      : { aspectRatio: next.aspectRatio }),
+    ...(next.duration === modelDefaults.duration
+      ? {}
+      : { duration: next.duration }),
+    ...(next.resolution === modelDefaults.resolution
+      ? {}
+      : { resolution: next.resolution }),
+    ...(next.generateAudio === modelDefaults.generateAudio
+      ? {}
+      : { generateAudio: next.generateAudio }),
+  };
+}
+
+function pickValue<T extends string>(
+  values: readonly T[],
+  next: string,
+): T | undefined {
+  return values.find((value) => {
+    return value === next;
+  });
+}
+
+function VideoOptionRow({
+  label,
+  value,
+  values,
+  onChange,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly values: readonly string[];
+  readonly onChange: (next: string) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="h-8 w-[9.5rem]" aria-label={label}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {values.map((option) => {
+            return (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function VideoModelRow({
+  label,
+  model,
+  onChange,
+}: {
+  readonly label: string;
+  readonly model: VideoModel;
+  readonly onChange: (next: string) => void;
+}) {
+  const models = VIDEO_MODELS.filter((candidate) => {
+    return VIDEO_MODEL_CONFIGS[candidate].public;
+  });
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <Select value={model} onValueChange={onChange}>
+        <SelectTrigger className="h-8 w-[9.5rem]" aria-label={label}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {models.map((candidate) => {
+            return (
+              <SelectItem key={candidate} value={candidate}>
+                {VIDEO_MODEL_CONFIGS[candidate].label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export function VideoGenerationOptionsForm({
+  value,
+  persistModel = false,
+  onChange,
+}: {
+  readonly value: VideoGenerationOptions | undefined;
+  readonly persistModel?: boolean;
+  readonly onChange: (next: VideoGenerationOptions) => void;
+}) {
+  const { t } = useTranslation();
+  const resolved = resolveVideoGenerationOptions(value);
+  const config: VideoModelConfig = VIDEO_MODEL_CONFIGS[resolved.model];
+  const apply = (next: ResolvedVideoGenerationOptions): void => {
+    const settled = resolveVideoGenerationOptions(next);
+    const modelDefaults = resolveVideoGenerationOptions({
+      model: settled.model,
+    });
+    onChange(toVideoOptionsPatch(settled, modelDefaults, persistModel));
+  };
+
+  return (
+    <div className="flex flex-col">
+      <VideoModelRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsModel;
+        })}
+        model={resolved.model}
+        onChange={(next) => {
+          const model = pickValue(VIDEO_MODELS, next);
+          if (model !== undefined) {
+            apply({ ...resolved, model });
+          }
+        }}
+      />
+      <VideoOptionRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsRatio;
+        })}
+        value={resolved.aspectRatio}
+        values={config.aspectRatios}
+        onChange={(next) => {
+          const aspectRatio = pickValue(config.aspectRatios, next);
+          if (aspectRatio !== undefined) {
+            apply({ ...resolved, aspectRatio });
+          }
+        }}
+      />
+      <VideoOptionRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsDuration;
+        })}
+        value={resolved.duration}
+        values={config.durations}
+        onChange={(next) => {
+          const duration = pickValue(config.durations, next);
+          if (duration !== undefined) {
+            apply({ ...resolved, duration });
+          }
+        }}
+      />
+      <VideoOptionRow
+        label={t(($) => {
+          return $.chat.templates.videoOptionsResolution;
+        })}
+        value={resolved.resolution}
+        values={config.resolutions}
+        onChange={(next) => {
+          const resolution = pickValue(config.resolutions, next);
+          if (resolution !== undefined) {
+            apply({ ...resolved, resolution });
+          }
+        }}
+      />
+      {config.supportsGenerateAudio && (
+        <div className="flex items-center justify-between gap-3 py-1.5">
+          <span className="text-sm text-muted-foreground">
+            {t(($) => {
+              return $.chat.templates.videoOptionsAudio;
+            })}
+          </span>
+          <Switch
+            checked={resolved.generateAudio}
+            aria-label={t(($) => {
+              return $.chat.templates.videoOptionsAudio;
+            })}
+            onCheckedChange={(checked) => {
+              apply({ ...resolved, generateAudio: checked });
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/video-template-options-popover.tsx
+++ b/turbo/apps/platform/src/views/zero-page/video-template-options-popover.tsx
@@ -4,129 +4,10 @@ import {
   PopoverAnchor,
   PopoverContent,
 } from "@vm0/ui/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@vm0/ui/components/ui/select";
-import { Switch } from "@vm0/ui/components/ui/switch";
-import type {
-  GenerationTemplateRequest,
-  VideoGenerationOptions,
-} from "@vm0/api-contracts/contracts/chat-threads";
-import {
-  DEFAULT_VIDEO_MODEL,
-  VIDEO_MODEL_CONFIGS,
-  VIDEO_MODELS,
-  resolveVideoGenerationOptions,
-  type ResolvedVideoGenerationOptions,
-  type VideoModel,
-  type VideoModelConfig,
-} from "@vm0/core/video-model-catalog";
+import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import { useTranslation } from "react-i18next";
 import type { ComposerSignals } from "../../signals/zero-page/composer-signals.ts";
-
-/**
- * Only the values the user actually chose are persisted, so a template written
- * today follows a later change of default instead of pinning the current one.
- */
-function toVideoOptionsPatch(
-  next: ResolvedVideoGenerationOptions,
-  modelDefaults: ResolvedVideoGenerationOptions,
-): VideoGenerationOptions {
-  return {
-    ...(next.model === DEFAULT_VIDEO_MODEL ? {} : { model: next.model }),
-    ...(next.aspectRatio === modelDefaults.aspectRatio
-      ? {}
-      : { aspectRatio: next.aspectRatio }),
-    ...(next.duration === modelDefaults.duration
-      ? {}
-      : { duration: next.duration }),
-    ...(next.resolution === modelDefaults.resolution
-      ? {}
-      : { resolution: next.resolution }),
-    ...(next.generateAudio === modelDefaults.generateAudio
-      ? {}
-      : { generateAudio: next.generateAudio }),
-  };
-}
-
-/** Narrows a Select's string payload back to the catalog's literal union. */
-function pickValue<T extends string>(
-  values: readonly T[],
-  next: string,
-): T | undefined {
-  return values.find((value) => {
-    return value === next;
-  });
-}
-
-function VideoOptionRow({
-  label,
-  value,
-  values,
-  onChange,
-}: {
-  readonly label: string;
-  readonly value: string;
-  readonly values: readonly string[];
-  readonly onChange: (next: string) => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-3 py-1.5">
-      <span className="text-sm text-muted-foreground">{label}</span>
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="h-8 w-[9.5rem]" aria-label={label}>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {values.map((option) => {
-            return (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
-
-function VideoModelRow({
-  label,
-  model,
-  onChange,
-}: {
-  readonly label: string;
-  readonly model: VideoModel;
-  readonly onChange: (next: string) => void;
-}) {
-  const models = VIDEO_MODELS.filter((candidate) => {
-    return VIDEO_MODEL_CONFIGS[candidate].public;
-  });
-  return (
-    <div className="flex items-center justify-between gap-3 py-1.5">
-      <span className="text-sm text-muted-foreground">{label}</span>
-      <Select value={model} onValueChange={onChange}>
-        <SelectTrigger className="h-8 w-[9.5rem]" aria-label={label}>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {models.map((candidate) => {
-            return (
-              <SelectItem key={candidate} value={candidate}>
-                {VIDEO_MODEL_CONFIGS[candidate].label}
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
+import { VideoGenerationOptionsForm } from "./video-generation-options-form.tsx";
 
 function VideoTemplateOptionsForm({
   value,
@@ -135,100 +16,27 @@ function VideoTemplateOptionsForm({
   readonly value: GenerationTemplateRequest;
   readonly onChange: (next: GenerationTemplateRequest) => void;
 }) {
-  const { t } = useTranslation();
   if (value.type !== "video") {
     return null;
   }
-  const resolved = resolveVideoGenerationOptions(value.selection.videoOptions);
-  const config: VideoModelConfig = VIDEO_MODEL_CONFIGS[resolved.model];
-  const apply = (next: ResolvedVideoGenerationOptions): void => {
-    // Re-resolve so a value the newly chosen model rejects falls back the same
-    // way the generation service would.
-    const settled = resolveVideoGenerationOptions(next);
-    const modelDefaults = resolveVideoGenerationOptions({
-      model: settled.model,
-    });
+  const apply = (
+    videoOptions: NonNullable<typeof value.selection.videoOptions>,
+  ) => {
     onChange({
       ...value,
       selection: {
         ...value.selection,
-        videoOptions: toVideoOptionsPatch(settled, modelDefaults),
+        videoOptions,
       },
     });
   };
 
   return (
-    <div className="flex flex-col">
-      <VideoModelRow
-        label={t(($) => {
-          return $.chat.templates.videoOptionsModel;
-        })}
-        model={resolved.model}
-        onChange={(next) => {
-          const model = pickValue(VIDEO_MODELS, next);
-          if (model !== undefined) {
-            apply({ ...resolved, model });
-          }
-        }}
-      />
-      <VideoOptionRow
-        label={t(($) => {
-          return $.chat.templates.videoOptionsRatio;
-        })}
-        value={resolved.aspectRatio}
-        values={config.aspectRatios}
-        onChange={(next) => {
-          const aspectRatio = pickValue(config.aspectRatios, next);
-          if (aspectRatio !== undefined) {
-            apply({ ...resolved, aspectRatio });
-          }
-        }}
-      />
-      <VideoOptionRow
-        label={t(($) => {
-          return $.chat.templates.videoOptionsDuration;
-        })}
-        value={resolved.duration}
-        values={config.durations}
-        onChange={(next) => {
-          const duration = pickValue(config.durations, next);
-          if (duration !== undefined) {
-            apply({ ...resolved, duration });
-          }
-        }}
-      />
-      <VideoOptionRow
-        label={t(($) => {
-          return $.chat.templates.videoOptionsResolution;
-        })}
-        value={resolved.resolution}
-        values={config.resolutions}
-        onChange={(next) => {
-          const resolution = pickValue(config.resolutions, next);
-          if (resolution !== undefined) {
-            apply({ ...resolved, resolution });
-          }
-        }}
-      />
-      {config.supportsGenerateAudio && (
-        <div className="flex items-center justify-between gap-3 py-1.5">
-          <span className="text-sm text-muted-foreground">
-            {t(($) => {
-              return $.chat.templates.videoOptionsAudio;
-            })}
-          </span>
-          <Switch
-            checked={resolved.generateAudio}
-            aria-label={t(($) => {
-              return $.chat.templates.videoOptionsAudio;
-            })}
-            onCheckedChange={(checked) => {
-              apply({ ...resolved, generateAudio: checked });
-            }}
-          />
-        </div>
-      )}
-    </div>
+    <VideoGenerationOptionsForm
+      value={value.selection.videoOptions}
+      persistModel
+      onChange={apply}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -145,6 +145,10 @@ import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-
 import type { AgentCustomConnectorGrant } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
 import {
+  VIDEO_MODEL_CONFIGS,
+  resolveVideoGenerationOptions,
+} from "@vm0/core/video-model-catalog";
+import {
   ModelProviderPicker,
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
@@ -183,6 +187,7 @@ import {
   customConnectorMcpEnabled$,
   avatarTemplatesEnabled$,
   imageRecognitionAvailable$,
+  videoTemplateOptionsEnabled$,
 } from "../../signals/external/feature-switch.ts";
 import {
   computerUseHosts$,
@@ -227,6 +232,7 @@ import {
   AvatarTemplatePickerToolbar,
 } from "./avatar-template-picker.tsx";
 import { VideoTemplateOptionsPopover } from "./video-template-options-popover.tsx";
+import { VideoGenerationOptionsForm } from "./video-generation-options-form.tsx";
 import {
   avatarTemplateSelection,
   toAvatarGenerationTemplate,
@@ -7388,6 +7394,76 @@ function ModelConfigurationWarning({
   );
 }
 
+function ComposerVideoSettingsSlot({ signals }: { signals: ComposerSignals }) {
+  const { t } = useTranslation();
+  const enabled = useGet(videoTemplateOptionsEnabled$);
+  const intentDetected = useGet(signals.video.intentDetected$);
+  const effectiveOptions = useGet(signals.video.effectiveOptions$);
+  const hasInlineVideoTemplate = useGet(
+    signals.template.hasInlineVideoTemplate$,
+  );
+  const generationTemplate = useGet(signals.template.generationTemplate$);
+  const setOptions = useSet(signals.video.setOptions$);
+  const notifyDraftChanged = useComposerDraftChange(signals);
+  if (
+    !enabled ||
+    !intentDetected ||
+    hasInlineVideoTemplate ||
+    generationTemplate?.type === "video"
+  ) {
+    return null;
+  }
+
+  const resolved = resolveVideoGenerationOptions(effectiveOptions);
+  const modelLabel = VIDEO_MODEL_CONFIGS[resolved.model].label;
+  const videoLabel = t(($) => {
+    return $.chat.templates.categories.video;
+  });
+  const optionsLabel = t(($) => {
+    return $.chat.templates.videoOptions;
+  });
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="quiet"
+          size="sm"
+          className={cn(
+            "h-8 max-w-[13rem] shrink-0 gap-1.5 px-2 text-xs font-medium text-muted-foreground",
+            "hover:bg-state-hover hover:text-foreground data-popup-open:bg-state-hover data-popup-open:text-foreground",
+            COMPOSER_CONTROL_FOCUS_CLASS,
+          )}
+          aria-label={`${optionsLabel}: ${modelLabel}`}
+        >
+          <Video size={16} aria-hidden="true" />
+          <span className="hidden min-w-0 truncate sm:inline">
+            {videoLabel} · {modelLabel}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="top"
+        sideOffset={8}
+        className="w-[19rem] rounded-xl p-3"
+        aria-label={optionsLabel}
+      >
+        <p className="mb-1.5 text-sm font-medium">{optionsLabel}</p>
+        <VideoGenerationOptionsForm
+          value={effectiveOptions}
+          persistModel
+          onChange={(next) => {
+            setOptions(next);
+            notifyDraftChanged();
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   const { t } = useTranslation();
   const codexFastModeEnabled = useGet(codexFastModeEnabled$);
@@ -8197,6 +8273,7 @@ function ComposerCard({ signals }: { signals: ComposerSignals }) {
               <ComposerConnectorsSlot signals={signals} />
             </div>
             <div className="flex items-center gap-1 sm:gap-2">
+              <ComposerVideoSettingsSlot signals={signals} />
               <ComposerModelPickerSlot signals={signals} />
               <MicButton signals={signals} />
               <ComposerSendControl signals={signals} />

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -363,6 +363,32 @@ describe("chat thread generation template contract", () => {
     ).toMatchObject({ success: false });
   });
 
+  it("accepts non-empty video settings metadata", () => {
+    const userMessage = {
+      version: 1,
+      videoOptions: {
+        model: "fal-ai/veo3.1/fast",
+        aspectRatio: "9:16",
+        duration: "8s",
+      },
+      parts: [{ type: "text", text: "Make a vertical product video" }],
+    };
+
+    expect(userMessageInputDocumentSchema.safeParse(userMessage)).toMatchObject(
+      { success: true },
+    );
+    expect(userMessageDocumentSchema.safeParse(userMessage)).toMatchObject({
+      success: true,
+    });
+    expect(
+      userMessageInputDocumentSchema.safeParse({
+        version: 1,
+        videoOptions: {},
+        parts: [{ type: "text", text: "Make a video" }],
+      }),
+    ).toMatchObject({ success: false });
+  });
+
   it("accepts template parts inside feedback notes", () => {
     const parsed = userMessageDocumentSchema.safeParse({
       version: 1,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -238,6 +238,15 @@ const videoGenerationOptionsSchema = z
   })
   .partial();
 
+const userMessageVideoOptionsSchema = videoGenerationOptionsSchema.refine(
+  (options) => {
+    return Object.values(options).some((value) => {
+      return value !== undefined;
+    });
+  },
+  { message: "Video settings must include at least one option" },
+);
+
 /**
  * Talking-avatar parameters. Unrelated to text-to-video despite sharing the
  * "video" envelope, which older bundles rely on to parse newer messages.
@@ -448,6 +457,7 @@ const userMessagePartSchema = z.discriminatedUnion("type", [
 const userMessageDocumentSchema = z
   .object({
     version: z.literal(1),
+    videoOptions: userMessageVideoOptionsSchema.optional(),
     parts: z
       .array(userMessagePartSchema)
       .min(1)
@@ -482,6 +492,7 @@ const userMessageDocumentSchema = z
 const userMessageInputDocumentSchema = z
   .object({
     version: z.literal(1),
+    videoOptions: userMessageVideoOptionsSchema.optional(),
     parts: z
       .array(userMessageInputPartSchema)
       .min(1)


### PR DESCRIPTION
## Summary

- reveal a compact video settings control only when a draft mentions video intent
- inherit the latest committed video model from chat message history without adding database state
- preserve message-scoped settings through drafts, send, queue, and run prompt construction
- keep inline video templates authoritative and avatar templates independent

## Behavior

- Video settings are gated by the existing `VideoTemplateOptions` feature switch.
- Explicit draft selection takes precedence over the latest model stored in a non-revoked user message, then falls back to the default video model.
- Only the model carries forward across the chat thread; ratio, duration, resolution, and audio remain message-scoped.
- The root-level `videoOptions` metadata is excluded from visible transcript text and validated before it is added to run guidance.

## Verification

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F api check-types`
- targeted API contract test for video settings metadata
- targeted platform tests for keyword detection, inheritance, overrides, removal, inline templates, and avatar templates
- targeted regression test for forwarded assistant content
- scoped Knip validation for the affected workspaces

API BDD coverage is included. Its local execution requires PostgreSQL and was left to PR CI because no local database was available (`ECONNREFUSED :5432`).

Closes #26610
