### PR TITLE
fix(desktop): exit packaged smoke cleanly

### DIFF
--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1427,9 +1427,13 @@ if (!hasSingleInstanceLock) {
         app.exit(1);
         return;
       }
-      console.log(DESKTOP_SMOKE_TEST_READY_MARKER);
-      quitConfirmation.allowQuitWithoutConfirmation();
-      app.quit();
+      await new Promise<void>((resolve) => {
+        process.stdout.write(`${DESKTOP_SMOKE_TEST_READY_MARKER}\n`, () => {
+          resolve();
+        });
+      });
+      app.exit(0);
+      return;
     }
   });
 


### PR DESCRIPTION
## Summary

- flush the packaged Desktop smoke ready marker before exiting
- use `app.exit(0)` for the smoke-only path instead of the normal window-closing quit lifecycle
- prevent auth consume window teardown from turning a successful second packaged launch into `SIGTRAP`

## Production failure evidence

Okou Desktop 0.35.0 was successfully signed and notarized in release workflow run #31595101748. DMG verification and the first installed launch passed. The second launch after replacing the install with the ZIP artifact printed the ready marker, then exited with `SIGTRAP` while the normal `app.quit()` lifecycle rejected the closing auth consume window. Artifact upload and the updater manifest were correctly blocked.

## Validation

- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop exec vitest run src/desktop-smoke-test.test.ts`
- `VM0_DESKTOP_PRODUCT=okou VM0_DESKTOP_PLATFORM_URL=https://app.okou.ai pnpm -F @vm0/desktop package`
- copied the packaged `Okou.app` into a temporary Applications path, ran packaged smoke, replaced the app at the same path, and ran packaged smoke again; both exited successfully and reported ready

Refs #26649
Refs #26364