### PR TITLE
perf(api): archive chat event snapshots concurrently

### DIFF
--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { gzipSync } from "node:zlib";
+import { promisify } from "node:util";
+import { gzip } from "node:zlib";
 
 import {
   chatEventRowV4Schema,
@@ -90,11 +91,25 @@ const MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION = 4;
 const ARCHIVE_CONTENT_TYPE = "application/x-ndjson";
 const ARCHIVE_CONTENT_ENCODING = "gzip";
 /**
+ * Compression runs off the event loop so a multi-megabyte thread body does not
+ * block the other archives in flight.
+ */
+const gzipAsync = promisify(gzip);
+/**
  * At the 10-minute cron cadence this cap permits 144k changed threads per day.
  * Normal traffic re-archives roughly 700 active threads per day, so the cap
  * leaves ample room for bursts while keeping each invocation bounded.
  */
 const DEFAULT_THREAD_BATCH_SIZE = 1000;
+/**
+ * Threads archived in parallel within one pass. Rebuild cost is dominated by a
+ * thread's event count, and that count is heavily skewed: p50 is under a
+ * hundred events while the tail reaches five figures. A serial pass lets one
+ * long thread stall every thread queued behind it, so a small pool keeps that
+ * head-of-line delay off the short threads without pressuring the connection
+ * pool or R2.
+ */
+const ARCHIVE_CONCURRENCY = 3;
 const EVENT_PAGE_SIZE = 1000;
 const DEFAULT_R2_GC_GRACE_HOURS = 24 * 7;
 const R2_GC_SHARDS_PER_RUN = 16;
@@ -330,7 +345,7 @@ async function archiveThread(
   signal.throwIfAborted();
   // Every generation is rebuilt from canonical Postgres rows. Existing R2
   // objects are never read or transformed in place.
-  const compressed = gzipSync(Buffer.concat(archive.lines));
+  const compressed = await gzipAsync(Buffer.concat(archive.lines));
   const objectKey = chatEventSnapshotObjectKey(
     candidate.chatThreadId,
     archive.lastSeqId,
@@ -360,6 +375,56 @@ async function archiveThread(
     return null;
   }
   return published.value ? archive.count : null;
+}
+
+interface ArchiveBatchStats {
+  readonly snapshots: number;
+  readonly archivedEvents: number;
+}
+
+/**
+ * Archives a pass's candidates through a fixed-size worker pool. Workers pull
+ * from a shared cursor rather than a fixed stride so a long thread only holds
+ * up its own worker; the remaining workers keep draining the queue. Candidate
+ * order is still oldest-first because workers take the next unclaimed index.
+ */
+async function archiveCandidates(
+  get: ComputedGetter,
+  db: Db,
+  bucket: string,
+  candidates: readonly SnapshotCandidate[],
+  signal: AbortSignal,
+): Promise<ArchiveBatchStats> {
+  let cursor = 0;
+  let snapshots = 0;
+  let archivedEvents = 0;
+  const workerCount = Math.min(ARCHIVE_CONCURRENCY, candidates.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      for (;;) {
+        const candidate = candidates[cursor];
+        cursor += 1;
+        if (candidate === undefined) {
+          return;
+        }
+        const archived = await archiveThread(
+          get,
+          db,
+          bucket,
+          candidate,
+          signal,
+        );
+        signal.throwIfAborted();
+        if (archived !== null) {
+          snapshots += 1;
+          archivedEvents += archived;
+        }
+      }
+    }),
+  );
+
+  return { snapshots, archivedEvents };
 }
 
 async function chatEventSnapshotConvergence(
@@ -697,16 +762,13 @@ export const snapshotChatEvents$ = command(
       .limit(chatEventSnapshotThreadBatchSize());
     signal.throwIfAborted();
 
-    let snapshots = 0;
-    let archivedEvents = 0;
-    for (const candidate of candidates) {
-      const archived = await archiveThread(get, db, bucket, candidate, signal);
-      signal.throwIfAborted();
-      if (archived !== null) {
-        snapshots += 1;
-        archivedEvents += archived;
-      }
-    }
+    const { snapshots, archivedEvents } = await archiveCandidates(
+      get,
+      db,
+      bucket,
+      candidates,
+      signal,
+    );
     const retiredSnapshots = await set(
       deleteRetiredSnapshotVersions$,
       db,


### PR DESCRIPTION
## Summary

- archive a pass's candidates through a fixed three-worker pool instead of one serial loop, so a long thread no longer stalls every thread queued behind it
- move gzip off the event loop (`gzipSync` → promisified `zlib.gzip`) so the pool actually overlaps instead of serializing on compression

No archive semantics change: the same bodies are produced, the same content-addressed keys are derived, and head publication still goes through the exact-parent CAS.

## Why

Rebuild cost per thread scales with its event count, and production data shows that count is heavily skewed. Measured on `vm0-prod-ro` (2026-08-12):

- rebuild size across active threads: p50 **74** events, p90 **209**, p99 **3,740**, max **11,815**
- one closed hour (11:00–12:00 UTC) produced **386** snapshots rebuilding **108,588** events, of which a single thread accounted for **11,801** — about 11% of the hour's work inside one sequential step

Throughput is not the constraint. The pass quota is 1,000 threads × 6 ticks = **6,000/hour**, while only **34** threads were awaiting archive at sampling time, and measured archive lag is **max 12.5 min, p90 12.2, p50 11.2** — consistent with the 10-minute cadence. What the serial loop does cost is fairness: a short thread queued behind an 11k-event rebuild waits for it.

Compression had to move off the event loop in the same change. `gzipSync` blocks the main thread, so three workers would still have serialized behind one large body and the pool would have bought nothing.

## Concurrency choice

Three workers, pulling from a shared cursor rather than a fixed stride. A stride would strand the other workers whenever one draws the long thread, which is exactly the skew this change targets. Three keeps at most three connections in `readCanonicalEvents` paging and three concurrent R2 PUTs, which is deliberately conservative.

Candidate order is unchanged (`archive_schema_version ASC → last_message_at ASC → id ASC`) and workers claim the next unclaimed index, so the pass still drains oldest-first.

## Verification

Existing entry-point coverage in `cron-snapshot-chat-events.test.ts` already runs multi-candidate passes (the retired-head test archives two threads per pass) and its assertions are explicitly order-independent, so the pool path is exercised without new tests.

Ran locally:

- `tsc -p tsconfig.gateways.json` — pass
- `tsc -p tsconfig.core.json` — pass
- `oxlint` on the changed file — pass
- `eslint --max-warnings 0` on the changed file — pass
- `prettier --check` — pass

Vitest is left to the PR pipeline.

## Follow-ups (not in this PR)

Incremental append is the real fix for long threads — reuse the parent object and append only the new tail instead of rebuilding from sequence 1. That became format-safe again only after the v3→v4 migration converged (v3 heads reached zero on 2026-08-12). Two findings from validating it up front:

- gzip is a multi-member format, so `gzip(A) || gzip(B)` concatenates without decompressing and round-trips correctly through both `gunzipSync` and `createGunzip`.
- but member granularity is expensive. Against a single-member baseline, splitting the same 2,000-line body costs **+10%** at 100 lines/member, **+70%** at 25, **+183%** at 10, and **+377%** at 5. Pending threads observed in production were 3–25 events behind, so a naive append-per-tick would land in the worst part of that curve. Incremental append therefore needs a compaction policy (full rebuild once member count or size overhead crosses a threshold), not just an append path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
