### PR TITLE
fix(desktop): make packaged smoke exit atomic

### DIFF
--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import { captureDesktopNativeHelperError } from "./sentry-main";
+import { writeSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1427,11 +1428,7 @@ if (!hasSingleInstanceLock) {
         app.exit(1);
         return;
       }
-      await new Promise<void>((resolve) => {
-        process.stdout.write(`${DESKTOP_SMOKE_TEST_READY_MARKER}\n`, () => {
-          resolve();
-        });
-      });
+      writeSync(1, `${DESKTOP_SMOKE_TEST_READY_MARKER}\n`);
       process.exit(0);
     }
   });


### PR DESCRIPTION
## Summary

- write the packaged-smoke ready marker synchronously to stdout
- exit immediately after the synchronous write
- remove the remaining event-loop race with auth BrowserWindow rejection

## Root cause

The stdout marker could reach the parent process before the asynchronous `process.stdout.write` callback ran. During that gap, an auth consume window rejection could terminate Electron with `SIGTRAP`. A synchronous file-descriptor write followed by `process.exit(0)` makes marker publication and smoke termination atomic.

## Validation

- `pnpm exec prettier --write apps/desktop/src/main.ts`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop exec vitest run src/desktop-smoke-test.test.ts --maxWorkers=4 --silent=passed-only`
- packaged Zero production app: 10 consecutive smoke launches passed
- packaged Okou production app: 10 consecutive smoke launches passed

Fixes the remaining release-smoke race tracked in #26649.