### PR TITLE
test(app): split fast thread reconciliation scenario

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -141,6 +141,20 @@ function fastModeIcon(option: HTMLElement): SVGElement {
   return icon;
 }
 
+function mockBuiltInFastModel(): void {
+  context.mocks.data.orgModelPolicies([
+    buildModelPolicy({
+      id: "00000000-0000-4000-a000-000000000911",
+      model: "gpt-5.6-sol",
+      modelLabel: "GPT 5.6 Sol",
+      isDefault: true,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+    }),
+  ]);
+  mockAgent();
+}
+
 describe("chat composer models", () => {
   it("keeps model resources cached across Clerk profile events", async () => {
     const policy = buildModelPolicy({
@@ -591,46 +605,10 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps a new Fast thread Fast when its optimistic state reconciles", async () => {
+  it("shows Fast details only while the Fast option is hovered", async () => {
     const user = userEvent.setup({ delay: null });
-    let sentBody:
-      | {
-          model?: string;
-          runOptions?: { codexServiceTier?: "fast" };
-        }
-      | undefined;
-    let createdBody:
-      | {
-          clientThreadId?: string;
-          eventId?: string;
-          model?: string;
-          serviceTier?: ChatThreadServiceTier | null;
-        }
-      | undefined;
-    let modelSelectionUpdateCount = 0;
 
-    context.mocks.data.orgModelPolicies([
-      buildModelPolicy({
-        id: "00000000-0000-4000-a000-000000000911",
-        model: "gpt-5.6-sol",
-        modelLabel: "GPT 5.6 Sol",
-        isDefault: true,
-        defaultProviderType: "vm0",
-        credentialScope: "org",
-      }),
-    ]);
-    mockAgent();
-    mockChatLifecycle(context, {
-      onThreadCreate: (body) => {
-        createdBody = body;
-      },
-      onModelSelectionUpdate: () => {
-        modelSelectionUpdateCount++;
-      },
-      onRunCreate: (body) => {
-        sentBody = body;
-      },
-    });
+    mockBuiltInFastModel();
 
     detachedSetupPage({
       context,
@@ -639,7 +617,7 @@ describe("chat composer models", () => {
     });
 
     await user.click(await findComposerModel("GPT 5.6 Sol"));
-    let fastModeOption = await findFastModeOption("GPT 5.6 Sol");
+    const fastModeOption = await findFastModeOption("GPT 5.6 Sol");
     expect(fastModeIcon(fastModeOption)).toHaveAttribute("fill", "none");
     await user.hover(fastModeOption);
     fireEvent.mouseMove(fastModeOption);
@@ -665,6 +643,23 @@ describe("chat composer models", () => {
     expect(
       screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows active Fast state and preserves exact model row selection", async () => {
+    const user = userEvent.setup({ delay: null });
+
+    mockBuiltInFastModel();
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.CodexFastMode]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findComposerModel("GPT 5.6 Sol"));
+    let fastModeOption = await findFastModeOption("GPT 5.6 Sol");
+    await user.click(fastModeOption);
+    await expectComposerModel("GPT 5.6 Sol Fast");
 
     await user.click(await findComposerModel("GPT 5.6 Sol Fast"));
     fastModeOption = await findFastModeOption("GPT 5.6 Sol");
@@ -709,6 +704,48 @@ describe("chat composer models", () => {
     fastModeOption = await findFastModeOption("GPT 5.6 Sol");
     expect(fastModeIcon(fastModeOption)).toHaveAttribute("fill", "none");
     await user.click(fastModeOption);
+    await expectComposerModel("GPT 5.6 Sol Fast");
+  });
+
+  it("keeps a new Fast thread Fast when its optimistic state reconciles", async () => {
+    const user = userEvent.setup({ delay: null });
+    let sentBody:
+      | {
+          model?: string;
+          runOptions?: { codexServiceTier?: "fast" };
+        }
+      | undefined;
+    let createdBody:
+      | {
+          clientThreadId?: string;
+          eventId?: string;
+          model?: string;
+          serviceTier?: ChatThreadServiceTier | null;
+        }
+      | undefined;
+    let modelSelectionUpdateCount = 0;
+
+    mockBuiltInFastModel();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdBody = body;
+      },
+      onModelSelectionUpdate: () => {
+        modelSelectionUpdateCount++;
+      },
+      onRunCreate: (body) => {
+        sentBody = body;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.CodexFastMode]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findComposerModel("GPT 5.6 Sol"));
+    await user.click(await findFastModeOption("GPT 5.6 Sol"));
     await expectComposerModel("GPT 5.6 Sol Fast");
 
     await sendMessageInUI(


### PR DESCRIPTION
## Summary

- split the oversized Fast picker and reconciliation test into independent page-level scenarios for tooltip visibility, active row selection, and optimistic thread reconciliation
- keep the original Fast send, service-tier persistence, model-selection update count, reconciled title, and final picker assertions unchanged
- restore per-test timeout headroom without retries, sleeps, timeout changes, skipped coverage, or production code changes

## Flake evidence

- Triggering run: [Turbo 31600433251](https://github.com/vm0-ai/vm0/actions/runs/31600433251), substantive job: [test-app (2)](https://github.com/vm0-ai/vm0/actions/runs/31600433251/job/94126271675)
- The only substantive failure was `keeps a new Fast thread Fast when its optimistic state reconciles`, which timed out at 5000 ms with a reported duration of 5172 ms while the other 155 tests passed.
- The same SHA passed in [merge-group run 31599890764](https://github.com/vm0-ai/vm0/actions/runs/31599890764/job/94124445302) at 4888 ms. Nearby passing runs reported 4727, 5027, 5113, and 5114 ms for the same test, establishing scheduling-sensitive budget exhaustion rather than a deterministic product failure.
- The mocked Ably catch-up HTTP 500 warning appears in both the failing run and same-SHA passing run, so it is non-causal. `test-app (4)`, `(5)`, and `(7)` were fail-fast cancellations, and `ci-gate-turbo` only aggregated the substantive failure.

## Verification

- pre-change full-file baseline: 49/49 passed; reconciliation scenario 3137 ms locally
- six consecutive post-change full-file runs: 51/51 passed each; split scenario ranges were 1361-1537 ms, 1731-1921 ms, and 898-1232 ms
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

## Preview validation

Not applicable: this PR changes only Vitest scenario boundaries and contains no production or deployment code.
