### PR TITLE
feat(desktop): cut over okou downloads to final identity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -16,8 +16,6 @@ const TEST_APP_ROUTES = Object.freeze([...desktopUpdateRoutes]);
 const context = testContext();
 const DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
-const LEGACY_OKOU_DESKTOP_UPDATE_MANIFEST_URL =
-  "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json";
 const OKOU_DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/ai-okou-desktop-updates/ai-okou-desktop-update-manifest.json";
 
@@ -321,7 +319,7 @@ describe("desktop update routes", () => {
     );
   });
 
-  it("keeps branded Okou routes on the pre-adoption line before cutover", async () => {
+  it("serves branded Okou routes from the final identity line after cutover", async () => {
     const zipUrl =
       "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
     mockDesktopUpdateManifest(
@@ -331,15 +329,7 @@ describe("desktop update routes", () => {
         }),
         product: "okou",
       },
-      LEGACY_OKOU_DESKTOP_UPDATE_MANIFEST_URL,
-    );
-
-    const releaseResponse = await appRequest(
-      "http://api.test/api/desktop/updates/okou/stable/darwin/arm64/release",
-    );
-    expect(releaseResponse.status).toBe(302);
-    expect(releaseResponse.headers.get("Location")).toBe(
-      "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
+      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
     );
 
     const brandedReleaseResponse = await appRequest(
@@ -350,14 +340,6 @@ describe("desktop update routes", () => {
       "https://github.com/vm0-ai/vm0/releases/tag/okou-desktop-v1.2.3",
     );
 
-    const dmgResponse = await appRequest(
-      "http://api.test/api/desktop/updates/okou/stable/darwin/arm64/dmg",
-    );
-    expect(dmgResponse.status).toBe(302);
-    expect(dmgResponse.headers.get("Location")).toBe(
-      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
-    );
-
     const brandedDmgResponse = await appRequest(
       "http://api.test/api/okou/desktop/updates/stable/darwin/arm64/dmg",
     );
@@ -365,6 +347,18 @@ describe("desktop update routes", () => {
     expect(brandedDmgResponse.headers.get("Location")).toBe(
       "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.dmg",
     );
+  });
+
+  it("returns not found for the retired pre-adoption Okou update line", async () => {
+    for (const path of [
+      "/api/desktop/updates/okou/stable/darwin/arm64/release",
+      "/api/desktop/updates/okou/stable/darwin/arm64/dmg",
+      "/api/desktop/updates/okou/stable/darwin/arm64/RELEASES.json",
+    ]) {
+      const response = await appRequest(`http://api.test${path}`);
+
+      expect(response.status).toBe(404);
+    }
   });
 
   it("does not serve a Zero artifact from the final Okou feed", async () => {

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -1,6 +1,7 @@
 import { brandedApiNamespace } from "@vm0/api-contracts/contracts/api-namespaces";
 import {
   DESKTOP_UPDATE_LINE_LEGACY_OKOU,
+  DESKTOP_UPDATE_LINE_OKOU,
   DESKTOP_UPDATE_LINE_ZERO,
   desktopUpdatesContract,
   type DesktopUpdateLine,
@@ -32,7 +33,7 @@ function desktopUpdateLineFromRequestUrl(
   requestUrl: string,
 ): DesktopUpdateLine {
   return brandedApiNamespace(new URL(requestUrl).pathname) === "okou"
-    ? DESKTOP_UPDATE_LINE_LEGACY_OKOU
+    ? DESKTOP_UPDATE_LINE_OKOU
     : DESKTOP_UPDATE_LINE_ZERO;
 }
 
@@ -102,6 +103,9 @@ const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
 const getProductDesktopReleasePage$ = command(
   async ({ get }, signal: AbortSignal) => {
     const { product, ...params } = get(productReleasePageParams$);
+    if (product === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
+      return notFound("This desktop update line is retired.");
+    }
     const url = await loadDesktopReleasePageUrl(
       { line: product, ...params },
       signal,
@@ -125,6 +129,9 @@ const getProductDesktopReleasePage$ = command(
 const getProductDesktopUpdateFeed$ = command(
   async ({ get }, signal: AbortSignal) => {
     const { product, ...params } = get(productFeedParams$);
+    if (product === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
+      return notFound("This desktop update line is retired.");
+    }
     const feed = await loadDesktopUpdateFeed(
       { line: product, ...params },
       signal,
@@ -145,6 +152,9 @@ const getProductDesktopUpdateFeed$ = command(
 const getProductDesktopDmgDownload$ = command(
   async ({ get }, signal: AbortSignal) => {
     const { product, ...params } = get(productDmgDownloadParams$);
+    if (product === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
+      return notFound("This desktop update line is retired.");
+    }
     const url = await loadDesktopDmgDownloadUrl(
       { line: product, ...params },
       signal,

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -152,12 +152,13 @@ rollout. Existing Zero installations keep using
 `/api/desktop/updates/stable/darwin/arm64` and the `desktop-updates` manifest.
 Final `ai.okou.desktop` installations use
 `/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64` and the separate
-`ai-okou-desktop-updates` manifest. The pre-adoption Okou feed remains frozen
-until the signed/notarized final identity passes release acceptance, then it is
-retired without receiving a final-identity artifact. Each manifest identifies
-its product, and the API rejects ZIP assets whose product filename does not
-match the requested feed. A Zero feed must never publish an Okou artifact, and
-the pre-adoption Okou feed must never publish a final-identity archive.
+`ai-okou-desktop-updates` manifest. The stable branded Okou download route also
+resolves through this final-identity manifest. The pre-adoption Okou manifest
+remains frozen without a final-identity artifact, and its explicit product
+routes return `404`. Each manifest identifies its product, and the API rejects
+ZIP assets whose product filename does not match the requested feed. A Zero
+feed must never publish an Okou artifact, and the pre-adoption Okou feed must
+never publish a final-identity archive.
 
 The release systems may deploy independently. The API therefore preserves the
 legacy Zero routes and accepts both Zero callback schemes


### PR DESCRIPTION
## Summary

- switch the stable branded Okou release and DMG routes from the retired pre-adoption feed to `ai-okou-desktop`
- return `404` from the explicit pre-adoption `okou` product release, DMG, and updater routes
- preserve the legacy Zero routes and feed unchanged
- document the final feed ownership and retirement behavior

## Release gate evidence

The cutover is gated by the accepted public `okou-desktop-v0.35.1` release:

- signed and notarized `Okou.app`, bundle ID and URL scheme `ai.okou.desktop`
- Gatekeeper and stapling validation passed on the downloaded DMG and ZIP app
- clean DMG install and packaged launch passed
- replacing the installed app from the public update ZIP and launching again passed
- the final `ai-okou-desktop` endpoint resolves to `Okou-darwin-arm64-0.35.1.dmg`
- Zero 0.35.1 remains isolated on `desktop-v0.35.1/Zero-*`

Before this change, the branded route still resolves to the frozen 0.34.0 pre-adoption package. After deployment it resolves through the accepted final-identity manifest.

## Rollback

Revert the branded route mapping in `desktop-updates.ts` and redeploy the API. This does not mutate the Zero, retired Okou, or final Okou manifests.

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/desktop-updates.test.ts --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`

Refs #26649
Refs #26364
