### PR TITLE
refactor(cli): use canonical okou host and runtime context

### DIFF
--- a/docs/okou-protocol-migration.md
+++ b/docs/okou-protocol-migration.md
@@ -1,8 +1,9 @@
 # Okou protocol migration
 
 This document records the Phase B protocol contract for issues #26487 and
-#26490 and the new-context writer stop tracked by #26652. Phase B is live at
-release target `d2fddbf6714b35182e1ef4b787adf84724f6ee02`.
+#26490, the new-context writer stop tracked by #26652, and the current-artifact
+CLI canonicalization tracked by #26711. Phase B is live at release target
+`d2fddbf6714b35182e1ef4b787adf84724f6ee02`.
 
 ## Canonical and compatibility surfaces
 
@@ -17,9 +18,12 @@ Slack, Teams, Feishu, and GitHub `redirect_uri` values deliberately remain on
 the Zero alias until the corresponding third-party allowlists are migrated in
 a separately verified rollout. Both callback paths reach the same handler.
 
-Current consumers prefer `OKOU_*` variables and fall back to their `ZERO_*`
-aliases. New first-party Okou-agent and presentation-template execution
-contexts emit only:
+Current API and Desktop consumers prefer `OKOU_*` variables and retain their
+`ZERO_*` fallback readers. The current private CLI source reads only canonical
+Okou runtime context and accepts only Okou-scope run tokens. Historical
+commit-addressed CLI artifacts retain their compatibility readers for the
+execution contexts that selected them. New first-party Okou-agent and
+presentation-template execution contexts emit only:
 
 - `OKOU_APP_URL`;
 - `OKOU_AGENT_ID`;
@@ -45,22 +49,32 @@ text and legacy environment keys cannot reach the sandbox.
 
 Already-stored queued, active, and finalizing execution contexts remain
 byte-for-byte unchanged. Their stored `ZERO_*` environment, Zero-scoped token,
-and historical `CLI_PKG_URL` continue through the normal runner and API
-compatibility readers. The API and CLI still prefer `OKOU_*` with `ZERO_*`
-fallback, both HTTP namespaces remain routed, and both token scopes remain
-accepted.
+and historical `CLI_PKG_URL` continue through the historical CLI artifact and
+normal runner and API compatibility readers. Both HTTP namespaces remain
+routed, and the API continues to accept both token scopes.
 
-Removing any fallback reader, `/api/zero/**` route, Zero token-scope verifier,
-historical artifact, callback, Desktop identity, or persisted object requires a
-separate drain gate. Production verification of the writer stop must inspect
-new context names and token scope without exposing values; declining Zero
-request volume alone is not proof that all legacy contexts have drained.
+The current CLI defaults to `https://api.okou.ai` and sends branded requests
+through `/api/okou/**`. Merging that host change requires the custom domain to
+have valid TLS and to reach the production API boundary; static App HTML,
+redirects, and an unreachable hostname do not pass the gate. The existing
+`VM0_API_BACKEND_URL` override remains available for development, previews,
+and operational rollback.
+
+Removing any other fallback reader, `/api/zero/**` route, server-side Zero
+token-scope verifier, historical artifact, callback, Desktop identity, or
+persisted object requires a separate drain gate. The focused current-CLI slice
+is safe only because old contexts keep their stored commit-addressed artifact
+while the released writer stop makes new contexts canonical-only. Production
+verification must inspect names and token scope without exposing values;
+declining Zero request volume alone is not proof that all legacy contexts have
+drained.
 
 ## Rollback
 
 Roll the writer stop back to the Phase B release target above to restore dual
-emission. Leave both namespace routes, both environment readers, both
-token-scope verifiers, the Zero CLI alias, both Desktop identities, stored
-callbacks, queued contexts, and immutable historical artifacts in place.
-Release and production verification remain separate from this implementation
-change.
+emission. Roll the current CLI source back by selecting the last verified
+dual-reader commit-addressed artifact and restoring the previous API origin.
+Leave both namespace routes, server-side environment readers and token-scope
+verifiers, both Desktop identities, stored callbacks, queued contexts, and
+immutable historical artifacts in place. Release and production verification
+remain separate from implementation changes.

--- a/turbo/apps/cli/src/__tests__/okou-startup.bench.test.ts
+++ b/turbo/apps/cli/src/__tests__/okou-startup.bench.test.ts
@@ -22,7 +22,7 @@ function benchmarkEnv(): NodeJS.ProcessEnv {
     CI: "1",
     NO_COLOR: "1",
     SENTRY_DSN: "",
-    ZERO_TOKEN: "",
+    OKOU_TOKEN: "",
   };
 
   for (const key of [

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -91,7 +91,7 @@ describe("decodeZeroTokenPayload", () => {
       userId: "user-1",
       runId: "run-1",
       orgId: "org-1",
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read", "connector:read"],
       iat: 1000,
       exp: 2000,
@@ -101,7 +101,7 @@ describe("decodeZeroTokenPayload", () => {
       userId: "user-1",
       runId: "run-1",
       orgId: "org-1",
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read", "connector:read"],
       iat: 1000,
       exp: 2000,
@@ -144,7 +144,7 @@ describe("decodeZeroTokenPayload", () => {
 
   it("should return undefined when capabilities is not an array", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: "not-an-array",
     });
     expect(decodeZeroTokenPayload(token)).toBeUndefined();
@@ -162,8 +162,8 @@ describe("registerZeroCommands", () => {
     vi.unstubAllEnvs();
   });
 
-  it("should register globally enabled commands when ZERO_TOKEN is absent", () => {
-    vi.stubEnv("ZERO_TOKEN", undefined);
+  it("should register globally enabled commands when OKOU_TOKEN is absent", () => {
+    vi.stubEnv("OKOU_TOKEN", undefined);
 
     const prog = buildProgram();
     expect(hiddenCommandNames(prog)).toEqual([
@@ -178,10 +178,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide unmapped commands and show capable ones with valid token", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -233,7 +233,7 @@ describe("registerZeroCommands", () => {
     );
     vi.stubEnv(
       "ZERO_TOKEN",
-      buildZeroToken({ scope: "zero", capabilities: ["connector:read"] }),
+      buildZeroToken({ scope: "okou", capabilities: ["connector:read"] }),
     );
 
     const prog = buildProgram();
@@ -243,7 +243,7 @@ describe("registerZeroCommands", () => {
   });
 
   it("should hide run-only commands and keep global commands visible with malformed token", () => {
-    vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
+    vi.stubEnv("OKOU_TOKEN", "not-a-valid-token");
 
     const prog = buildProgram();
 
@@ -262,7 +262,7 @@ describe("registerZeroCommands", () => {
       scope: "sandbox",
       capabilities: ["agent:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -278,10 +278,10 @@ describe("registerZeroCommands", () => {
 
   it("should show globally enabled commands when capabilities array is empty", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: [],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -299,10 +299,10 @@ describe("registerZeroCommands", () => {
 
   it("should show scrape when scrape:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["scrape:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -311,10 +311,10 @@ describe("registerZeroCommands", () => {
 
   it("should show web-search when web-search:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["web-search:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -323,10 +323,10 @@ describe("registerZeroCommands", () => {
 
   it("should show finance when finance:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["finance:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -335,10 +335,10 @@ describe("registerZeroCommands", () => {
 
   it("should show seo when seo:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["seo:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -347,27 +347,27 @@ describe("registerZeroCommands", () => {
 
   it("should show people-search only with people-search:read capability", () => {
     const hiddenToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["web-search:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", hiddenToken);
+    vi.stubEnv("OKOU_TOKEN", hiddenToken);
     expect(hiddenCommandNames(buildProgram())).toContain("people-search");
 
     const visibleToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["people-search:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", visibleToken);
+    vi.stubEnv("OKOU_TOKEN", visibleToken);
     expect(visibleCommandNames(buildProgram())).toContain("people-search");
   });
 
   it("should show credit with either billing read or billing write capability", () => {
     for (const capability of ["billing:read", "billing:write"]) {
       const token = buildZeroToken({
-        scope: "zero",
+        scope: "okou",
         capabilities: [capability],
       });
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_TOKEN", token);
 
       const prog = buildProgram();
 
@@ -377,10 +377,10 @@ describe("registerZeroCommands", () => {
 
   it("should show model commands even without model-provider capabilities", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: [],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -390,10 +390,10 @@ describe("registerZeroCommands", () => {
 
   it("should show slack when slack:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["slack:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -403,10 +403,10 @@ describe("registerZeroCommands", () => {
 
   it("should show feishu when feishu:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["feishu:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
     expect(visibleCommandNames(prog)).toContain("feishu");
@@ -415,10 +415,10 @@ describe("registerZeroCommands", () => {
 
   it("should show github when github:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["github:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -428,10 +428,10 @@ describe("registerZeroCommands", () => {
 
   it("should show github when github:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["github:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -441,10 +441,10 @@ describe("registerZeroCommands", () => {
 
   it("should show chat when chat-thread:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["chat-thread:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -454,10 +454,10 @@ describe("registerZeroCommands", () => {
 
   it("should show chat when chat-thread:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["chat-thread:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -467,10 +467,10 @@ describe("registerZeroCommands", () => {
 
   it("should show chat when chat-event:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["chat-event:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -480,10 +480,10 @@ describe("registerZeroCommands", () => {
 
   it("should show chat when chat-event:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["chat-event:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -493,10 +493,10 @@ describe("registerZeroCommands", () => {
 
   it("should show telegram when telegram:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["telegram:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -506,10 +506,10 @@ describe("registerZeroCommands", () => {
 
   it("should show telegram when telegram:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["telegram:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -519,10 +519,10 @@ describe("registerZeroCommands", () => {
 
   it("should show phone when phone:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["phone:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -532,10 +532,10 @@ describe("registerZeroCommands", () => {
 
   it("should show phone when phone:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["phone:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -545,10 +545,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide telegram when only file:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -558,10 +558,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide telegram when only file:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -571,10 +571,10 @@ describe("registerZeroCommands", () => {
 
   it("should show generate when file:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -584,10 +584,10 @@ describe("registerZeroCommands", () => {
 
   it("should show host when host:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["host:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -597,10 +597,10 @@ describe("registerZeroCommands", () => {
 
   it("should show host when host:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["host:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -610,10 +610,10 @@ describe("registerZeroCommands", () => {
 
   it("should show generate when file capabilities are missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: [],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -623,10 +623,10 @@ describe("registerZeroCommands", () => {
 
   it("should show maps when maps:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["maps:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -636,10 +636,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide maps when maps:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -648,10 +648,10 @@ describe("registerZeroCommands", () => {
 
   it("should show weather when weather:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["weather:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -661,10 +661,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide weather when weather:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -673,10 +673,10 @@ describe("registerZeroCommands", () => {
 
   it("should show banking when banking:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["banking:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -686,10 +686,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide banking when banking:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -698,14 +698,14 @@ describe("registerZeroCommands", () => {
 
   it("should show goal when goal capabilities are present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: [
         "goal:read",
         "goal:agent-result:write",
         "goal:user-control:write",
       ],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -715,10 +715,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide goal when goal capabilities are missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -727,10 +727,10 @@ describe("registerZeroCommands", () => {
 
   it("should show credit when billing:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["billing:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -740,10 +740,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide credit but keep globally enabled upgrade guidance when billing capabilities are missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -752,7 +752,7 @@ describe("registerZeroCommands", () => {
   });
 
   it("should show upgrade guidance", () => {
-    vi.stubEnv("ZERO_TOKEN", undefined);
+    vi.stubEnv("OKOU_TOKEN", undefined);
 
     const prog = buildProgram();
 
@@ -762,38 +762,38 @@ describe("registerZeroCommands", () => {
 
   it("should expose browser when its capability is enabled", () => {
     const enabledToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       userId: "user-1",
       orgId: "org-1",
       capabilities: ["browser:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", enabledToken);
+    vi.stubEnv("OKOU_TOKEN", enabledToken);
 
     expect(visibleCommandNames(buildProgram())).toContain("browser");
   });
 
   it("should expose recognition only to eligible Zero runs", () => {
-    vi.stubEnv("ZERO_TOKEN", undefined);
+    vi.stubEnv("OKOU_TOKEN", undefined);
     const noTokenProgram = buildProgram();
     expect(registeredCommandNames(noTokenProgram)).toContain("recognize");
     expect(hiddenCommandNames(noTokenProgram)).toContain("recognize");
 
     const missingCapabilityToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       userId: "user-1",
       orgId: "org-1",
       capabilities: [],
     });
-    vi.stubEnv("ZERO_TOKEN", missingCapabilityToken);
+    vi.stubEnv("OKOU_TOKEN", missingCapabilityToken);
     expect(hiddenCommandNames(buildProgram())).toContain("recognize");
 
     const eligibleToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       userId: "user-1",
       orgId: "org-1",
       capabilities: ["image-recognition:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", eligibleToken);
+    vi.stubEnv("OKOU_TOKEN", eligibleToken);
     expect(visibleCommandNames(buildProgram())).toContain("recognize");
     expect(buildZeroHelpText(decodeZeroTokenPayload(eligibleToken))).toContain(
       "Recognize an image?",
@@ -801,27 +801,27 @@ describe("registerZeroCommands", () => {
   });
 
   it("should expose translation only to capable Zero runs", () => {
-    vi.stubEnv("ZERO_TOKEN", undefined);
+    vi.stubEnv("OKOU_TOKEN", undefined);
     const noTokenProgram = buildProgram();
     expect(registeredCommandNames(noTokenProgram)).toContain("translate");
     expect(hiddenCommandNames(noTokenProgram)).toContain("translate");
 
     const missingCapabilityToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       userId: "user-1",
       orgId: "org-1",
       capabilities: [],
     });
-    vi.stubEnv("ZERO_TOKEN", missingCapabilityToken);
+    vi.stubEnv("OKOU_TOKEN", missingCapabilityToken);
     expect(hiddenCommandNames(buildProgram())).toContain("translate");
 
     const capableToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       userId: "user-1",
       orgId: "org-1",
       capabilities: ["translation:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", capableToken);
+    vi.stubEnv("OKOU_TOKEN", capableToken);
     expect(visibleCommandNames(buildProgram())).toContain("translate");
     expect(buildZeroHelpText(decodeZeroTokenPayload(capableToken))).toContain(
       "Translate text?",
@@ -830,7 +830,7 @@ describe("registerZeroCommands", () => {
 
   it("should show billing help examples only for billing capabilities", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["billing:read", "billing:write"],
     });
     const help = buildZeroHelpText(decodeZeroTokenPayload(token));
@@ -841,7 +841,7 @@ describe("registerZeroCommands", () => {
 
   it("should show only credit status help for billing read capability", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["billing:read"],
     });
     const help = buildZeroHelpText(decodeZeroTokenPayload(token));
@@ -854,7 +854,7 @@ describe("registerZeroCommands", () => {
 
   it("should show only credit purchase help for billing write capability", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["billing:write"],
     });
     const help = buildZeroHelpText(decodeZeroTokenPayload(token));
@@ -865,7 +865,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide billing help examples when billing capabilities are missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read"],
     });
     const help = buildZeroHelpText(decodeZeroTokenPayload(token));
@@ -876,7 +876,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the maps help example when maps:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["maps:read"],
     });
 
@@ -887,7 +887,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide the maps help example when maps:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -898,7 +898,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the weather help example when weather:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["weather:read"],
     });
 
@@ -909,7 +909,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide the weather help example when weather:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -920,7 +920,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the scrape help example when scrape:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["scrape:read"],
     });
 
@@ -931,7 +931,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide the scrape help example when scrape:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -942,7 +942,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the finance help example when finance:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["finance:read"],
     });
 
@@ -953,7 +953,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide the finance help example when finance:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -964,11 +964,11 @@ describe("registerZeroCommands", () => {
 
   it("should gate the SEO help example on seo:read", () => {
     const visibleToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["seo:read"],
     });
     const hiddenToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -982,7 +982,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the people-search help example when people-search:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["people-search:read"],
     });
 
@@ -993,7 +993,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide the people-search help example when people-search:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -1004,7 +1004,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the banking help example when banking:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["banking:read"],
     });
 
@@ -1015,7 +1015,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide the banking help example when banking:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -1026,7 +1026,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the host help example when host:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["host:write"],
     });
 
@@ -1037,7 +1037,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the hosted site clone help example when host:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["host:read"],
     });
 
@@ -1051,7 +1051,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the website help example", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: [],
     });
 
@@ -1062,10 +1062,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide host when host:write capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1074,7 +1074,7 @@ describe("registerZeroCommands", () => {
 
   it("should hide the host help example when host:write capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["file:write"],
     });
 
@@ -1088,7 +1088,7 @@ describe("registerZeroCommands", () => {
 
   it("should show the model help example in sandbox help", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: [],
     });
 
@@ -1102,10 +1102,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide telegram when file read and telegram write capabilities are missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1116,10 +1116,10 @@ describe("registerZeroCommands", () => {
 
   it("should show teams when teams:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["teams:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1134,10 +1134,10 @@ describe("registerZeroCommands", () => {
 
   it("should show logs when agent-run:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent-run:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1147,10 +1147,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide logs when agent-run:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1159,10 +1159,10 @@ describe("registerZeroCommands", () => {
 
   it("should hide agent when agent:read capability is missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["connector:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1183,10 +1183,10 @@ describe("registerZeroCommands", () => {
 
   it("should show connector when connector:read capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["connector:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1196,39 +1196,39 @@ describe("registerZeroCommands", () => {
 
   it("should show run-only mcp only with connector:read capability", () => {
     const readToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["connector:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", readToken);
+    vi.stubEnv("OKOU_TOKEN", readToken);
     expect(visibleCommandNames(buildProgram())).toContain("mcp");
 
     const writeToken = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["connector:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", writeToken);
+    vi.stubEnv("OKOU_TOKEN", writeToken);
     expect(hiddenCommandNames(buildProgram())).toContain("mcp");
 
-    vi.stubEnv("ZERO_TOKEN", undefined);
+    vi.stubEnv("OKOU_TOKEN", undefined);
     expect(hiddenCommandNames(buildProgram())).toContain("mcp");
   });
 
   it("should show connector when connector:write capability is present", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["connector:write"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     expect(visibleCommandNames(buildProgram())).toContain("connector");
   });
 
   it("should hide connector when connector capabilities are missing", () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read"],
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = buildProgram();
 
@@ -1244,14 +1244,14 @@ describe("okou generate command visibility", () => {
 
   async function importGenerateCommand(token: string) {
     vi.resetModules();
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
     const { generateCommand } = await import("../commands/zero/generate");
     return generateCommand as Command;
   }
 
   it("should show website generation", async () => {
     const token = buildZeroToken({
-      scope: "zero",
+      scope: "okou",
       capabilities: [],
     });
 
@@ -1264,7 +1264,7 @@ describe("okou generate command visibility", () => {
     const token = buildZeroToken({
       userId: "user-non-staff",
       orgId: "org-non-staff",
-      scope: "zero",
+      scope: "okou",
       capabilities: ["host:write"],
     });
 

--- a/turbo/apps/cli/src/commands/zero/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/credit.test.ts
@@ -13,7 +13,7 @@ function buildZeroToken(capabilities: readonly string[]): string {
       userId: "user-credit",
       runId: "run-credit",
       orgId: "org-credit",
-      scope: "zero",
+      scope: "okou",
       capabilities,
       iat: 1000,
       exp: 2000,
@@ -64,7 +64,7 @@ describe("okou credit command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubBillingStatus());
   });
 
@@ -231,7 +231,7 @@ describe("okou credit command", () => {
     const mockConsoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    vi.stubEnv("ZERO_TOKEN", buildZeroToken(["billing:write"]));
+    vi.stubEnv("OKOU_TOKEN", buildZeroToken(["billing:write"]));
 
     try {
       await zeroCreditCommand.parseAsync(["node", "cli"]);
@@ -254,7 +254,7 @@ describe("okou credit command", () => {
     const mockConsoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    vi.stubEnv("ZERO_TOKEN", buildZeroToken(["billing:read"]));
+    vi.stubEnv("OKOU_TOKEN", buildZeroToken(["billing:read"]));
 
     try {
       await zeroCreditCommand.parseAsync(["node", "cli", "20000"]);

--- a/turbo/apps/cli/src/commands/zero/__tests__/developer-support.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/developer-support.test.ts
@@ -27,7 +27,7 @@ describe("okou developer-support command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -18,7 +18,7 @@ function buildJwt(payload: Record<string, unknown>, prefix: string): string {
 }
 
 /**
- * Build a valid ZERO_TOKEN for testing.
+ * Build a valid OKOU_TOKEN for testing.
  * Format: vm0_sandbox_<header>.<payload>.<signature>
  */
 function buildZeroToken(payload: Record<string, unknown>): string {
@@ -99,19 +99,19 @@ describe("okou whoami command", () => {
     await zeroWhoamiCommand.parseAsync(["node", "cli", ...args]);
   }
 
-  describe("sandbox mode (ZERO_AGENT_ID set)", () => {
+  describe("sandbox mode (OKOU_AGENT_ID set)", () => {
     it("should show agent ID, run context, and capabilities with full JWT", async () => {
       const token = buildZeroToken({
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "agent:write"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
 
       await runWhoami();
 
@@ -159,14 +159,14 @@ describe("okou whoami command", () => {
     });
 
     it("should show the workspace name and tier", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv(
-        "ZERO_TOKEN",
+        "OKOU_TOKEN",
         buildZeroToken({
           userId: "user-1",
           runId: "run-abc",
           orgId: "org-xyz",
-          scope: "zero",
+          scope: "okou",
           capabilities: ["agent:read"],
           iat: 1000,
           exp: 2000,
@@ -190,14 +190,14 @@ describe("okou whoami command", () => {
     });
 
     it("should still print identity when the org lookup fails", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
       vi.stubEnv(
-        "ZERO_TOKEN",
+        "OKOU_TOKEN",
         buildZeroToken({
           userId: "user-1",
           runId: "run-abc",
           orgId: "org-xyz",
-          scope: "zero",
+          scope: "okou",
           capabilities: ["agent:read"],
           iat: 1000,
           exp: 2000,
@@ -233,8 +233,8 @@ describe("okou whoami command", () => {
       ).toBe(true);
     });
 
-    it("should show unavailable when ZERO_TOKEN is missing", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", "agent-no-token");
+    it("should show unavailable when OKOU_TOKEN is missing", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", "agent-no-token");
 
       await runWhoami();
 
@@ -266,9 +266,9 @@ describe("okou whoami command", () => {
       ).toBe(false);
     });
 
-    it("should show unavailable when ZERO_TOKEN is malformed", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", "agent-bad-token");
-      vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
+    it("should show unavailable when OKOU_TOKEN is malformed", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", "agent-bad-token");
+      vi.stubEnv("OKOU_TOKEN", "not-a-valid-token");
 
       await runWhoami();
 
@@ -290,13 +290,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -363,13 +363,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -411,13 +411,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -454,13 +454,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -492,13 +492,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -556,13 +556,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -635,13 +635,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       const serverOnlyDetail = catalogPermissionDetail({
@@ -716,13 +716,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -774,13 +774,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -851,13 +851,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -923,13 +923,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -997,13 +997,13 @@ describe("okou whoami command", () => {
         userId: "user-1",
         runId: "run-abc",
         orgId: "org-xyz",
-        scope: "zero",
+        scope: "okou",
         capabilities: ["agent:read", "connector:read"],
         iat: 1000,
         exp: 2000,
       });
-      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
-      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv("OKOU_TOKEN", token);
       vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
 
       server.use(
@@ -1061,16 +1061,16 @@ describe("okou whoami command", () => {
     });
   });
 
-  describe("local mode (no ZERO_AGENT_ID)", () => {
+  describe("local mode (no OKOU_AGENT_ID)", () => {
     beforeEach(() => {
-      vi.stubEnv("ZERO_AGENT_ID", "");
+      vi.stubEnv("OKOU_AGENT_ID", "");
     });
 
-    it("should show authenticated via ZERO_TOKEN env var", async () => {
+    it("should show authenticated via OKOU_TOKEN env var", async () => {
       vi.stubEnv(
-        "ZERO_TOKEN",
+        "OKOU_TOKEN",
         buildZeroToken({
-          scope: "zero",
+          scope: "okou",
           orgId: "test-org",
           userId: "user-1",
           runId: "run-1",
@@ -1105,19 +1105,19 @@ describe("okou whoami command", () => {
       ).toBe(true);
     });
 
-    it("should identify an invalid ZERO_TOKEN", async () => {
-      vi.stubEnv("ZERO_TOKEN", "not-a-zero-token");
+    it("should identify an invalid OKOU_TOKEN", async () => {
+      vi.stubEnv("OKOU_TOKEN", "not-a-zero-token");
 
       await runWhoami();
 
       expect(getAllOutput()).toContain("  Status:     Invalid OKOU_TOKEN");
     });
 
-    it("should identify an expired ZERO_TOKEN", async () => {
+    it("should identify an expired OKOU_TOKEN", async () => {
       vi.stubEnv(
-        "ZERO_TOKEN",
+        "OKOU_TOKEN",
         buildZeroToken({
-          scope: "zero",
+          scope: "okou",
           orgId: "test-org",
           userId: "user-1",
           runId: "run-1",
@@ -1131,16 +1131,16 @@ describe("okou whoami command", () => {
       expect(getAllOutput()).toContain("  Status:     Expired OKOU_TOKEN");
     });
 
-    it("should display active org from ZERO_TOKEN", async () => {
+    it("should display active org from OKOU_TOKEN", async () => {
       const zeroToken = buildZeroToken({
-        scope: "zero",
+        scope: "okou",
         orgId: "test-org-slug",
         userId: "user-1",
         runId: "run-1",
         capabilities: [],
         exp: Math.floor(Date.now() / 1000) + 3600,
       });
-      vi.stubEnv("ZERO_TOKEN", zeroToken);
+      vi.stubEnv("OKOU_TOKEN", zeroToken);
 
       await runWhoami();
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -38,7 +38,7 @@ describe("okou agent create command", () => {
     mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   describe("successful create", () => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/delete.test.ts
@@ -33,7 +33,7 @@ describe("okou agent delete command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -38,7 +38,7 @@ describe("okou agent edit command", () => {
     mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   describe("successful edit", () => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
@@ -32,7 +32,7 @@ describe("okou agent list command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -105,7 +105,7 @@ describe("okou agent view command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(mockUserPermissionGrantsHandler());
     server.use(stubConnectorCatalogPermissions(defaultPermissionDetails));
   });

--- a/turbo/apps/cli/src/commands/zero/banking/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/banking/__tests__/index.test.ts
@@ -33,7 +33,7 @@ describe("okou banking command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 
   afterEach(async () => {
@@ -133,7 +133,7 @@ describe("okou banking command", () => {
   });
 
   it("shows auth guidance when no token is available", async () => {
-    vi.stubEnv("ZERO_TOKEN", undefined);
+    vi.stubEnv("OKOU_TOKEN", undefined);
 
     await expect(
       zeroBankingCommand.parseAsync(["node", "cli", "accounts"]),

--- a/turbo/apps/cli/src/commands/zero/browser/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/browser/__tests__/index.test.ts
@@ -71,8 +71,8 @@ describe("okou browser command", () => {
       force: true,
     });
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     spawnSyncMock.mockReturnValue({ status: 0 });
   });
 

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/cancel.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/cancel.test.ts
@@ -24,8 +24,8 @@ describe("okou chat cancel command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     server.use(
       http.get(METADATA_URL, () => {
         return HttpResponse.json({

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/create.test.ts
@@ -27,8 +27,8 @@ describe("okou chat create command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", CURRENT_THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", CURRENT_THREAD_ID);
   });
 
   afterEach(() => {
@@ -178,7 +178,7 @@ describe("okou chat create command", () => {
   });
 
   it("requires an agent when it runs outside a web chat thread", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
       await zeroChatCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/get.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/get.test.ts
@@ -32,8 +32,8 @@ describe("okou chat get command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
   afterEach(() => {
@@ -112,7 +112,7 @@ describe("okou chat get command", () => {
   });
 
   it("loads another chat thread passed with --thread-id", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     server.use(
       http.get(OTHER_GET_URL, () => {
         return HttpResponse.json({
@@ -138,7 +138,7 @@ describe("okou chat get command", () => {
   });
 
   it("requires a thread ID from the flag or the current web chat", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
       await zeroChatCommand.parseAsync(["node", "cli", "get"]);

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/list.test.ts
@@ -31,7 +31,7 @@ function zeroToken(): string {
       userId: "user_test",
       runId: "00000000-0000-4000-8000-000000000401",
       orgId: "org_test",
-      scope: "zero",
+      scope: "okou",
       capabilities: ["chat-thread:read"],
       iat: 1,
       exp: 4_102_444_800,
@@ -85,8 +85,8 @@ describe("okou chat list command", () => {
     chalk.level = 0;
     cacheDirectory = await mkdtemp(join(tmpdir(), "zero-chat-list-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", zeroToken());
-    vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_TOKEN", zeroToken());
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("XDG_CACHE_HOME", cacheDirectory);
   });
 
@@ -98,7 +98,7 @@ describe("okou chat list command", () => {
     await rm(cacheDirectory, { recursive: true, force: true });
   });
 
-  it("replays incremental events from the cache and defaults to ZERO_AGENT_ID", async () => {
+  it("replays incremental events from the cache and defaults to OKOU_AGENT_ID", async () => {
     let snapshotRequests = 0;
     let eventRequests = 0;
     server.use(
@@ -263,7 +263,7 @@ describe("okou chat list command", () => {
     expect(eventRequests).toBe(3);
   });
 
-  it("lets --agent override ZERO_AGENT_ID", async () => {
+  it("lets --agent override OKOU_AGENT_ID", async () => {
     server.use(
       http.get(SNAPSHOT_URL, () => {
         return HttpResponse.json({
@@ -315,8 +315,8 @@ describe("okou chat list command", () => {
     );
   });
 
-  it("requires an agent id from --agent or ZERO_AGENT_ID", async () => {
-    vi.stubEnv("ZERO_AGENT_ID", "");
+  it("requires an agent id from --agent or OKOU_AGENT_ID", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "");
 
     await expect(async () => {
       await zeroChatCommand.parseAsync(["node", "cli", "list"]);

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
@@ -223,8 +223,8 @@ describe("okou chat messages command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     server.use(
       http.get(FEATURE_SWITCHES_URL, () => {
         return HttpResponse.json(featureSwitches(false));
@@ -282,7 +282,7 @@ describe("okou chat messages command", () => {
   });
 
   it("reads a source thread passed with --thread-id and prints JSON", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     server.use(
       http.get(SOURCE_EVENTS_URL, () => {
         return HttpResponse.json({
@@ -881,7 +881,7 @@ describe("okou chat messages command", () => {
   });
 
   it("requires a thread ID from the flag or the current web chat", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
       await zeroChatCommand.parseAsync(["node", "cli", "messages"]);

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/model.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/model.test.ts
@@ -67,8 +67,8 @@ describe("okou chat model command", () => {
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
   afterEach(() => {
@@ -79,7 +79,7 @@ describe("okou chat model command", () => {
   });
 
   it("shows dynamic help with switchable models", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     server.use(
       http.get(MODEL_POLICIES_URL, () => {
         return HttpResponse.json(MODEL_POLICIES_RESPONSE);
@@ -125,7 +125,7 @@ describe("okou chat model command", () => {
   });
 
   it("shows the model for --thread outside a web chat environment", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     server.use(
       http.get(OTHER_GET_URL, () => {
         return HttpResponse.json({
@@ -153,7 +153,7 @@ describe("okou chat model command", () => {
   });
 
   it("switches the model for --thread outside a web chat environment", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     server.use(
       http.get(MODEL_POLICIES_URL, () => {
         return HttpResponse.json(MODEL_POLICIES_RESPONSE);

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/queued.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/queued.test.ts
@@ -47,8 +47,8 @@ describe("okou chat queued command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     server.use(
       http.get(FEATURE_SWITCHES_URL, () => {
         return HttpResponse.json(featureSwitches(false));

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/rename.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/rename.test.ts
@@ -31,8 +31,8 @@ describe("okou chat rename command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
   afterEach(() => {
@@ -97,7 +97,7 @@ describe("okou chat rename command", () => {
   });
 
   it("renames --thread instead of the current chat thread", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     server.use(
       http.post(OTHER_RENAME_URL, async ({ request }) => {
         await expect(request.json()).resolves.toStrictEqual({
@@ -137,8 +137,8 @@ describe("okou chat rename command", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
-  it("requires ZERO_CHAT_THREAD_ID from the current web chat", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+  it("requires OKOU_CHAT_THREAD_ID from the current web chat", async () => {
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
       await zeroChatCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/send.test.ts
@@ -40,8 +40,8 @@ describe("okou chat send command", () => {
     chalk.level = 0;
     tempDir = mkdtempSync(path.join(tmpdir(), "zero-chat-send-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
   afterEach(() => {
@@ -119,7 +119,7 @@ describe("okou chat send command", () => {
   });
 
   it("reports a message that remains queued and honors --thread-id", async () => {
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     server.use(
       http.get(metadataUrl(OTHER_THREAD_ID), () => {
         return HttpResponse.json({

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -89,7 +89,7 @@ describe("computer-use command visibility", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.stubEnv("ZERO_TOKEN", "");
+    vi.stubEnv("OKOU_TOKEN", "");
   });
 
   afterEach(async () => {
@@ -97,7 +97,7 @@ describe("computer-use command visibility", () => {
     await rm(testOutputDir, { recursive: true, force: true });
   });
 
-  it("should be visible when no ZERO_TOKEN is set", () => {
+  it("should be visible when no OKOU_TOKEN is set", () => {
     const prog = new Command();
     registerZeroCommands(prog);
 
@@ -107,17 +107,17 @@ describe("computer-use command visibility", () => {
     expect(cmd).toBeDefined();
   });
 
-  it("should be visible when ZERO_TOKEN includes computer-use:write", () => {
+  it("should be visible when OKOU_TOKEN includes computer-use:write", () => {
     const token = buildZeroToken({
       userId: "u1",
       runId: "r1",
       orgId: "o1",
-      scope: "zero",
+      scope: "okou",
       capabilities: ["computer-use:write"],
       iat: 1000,
       exp: 2000,
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = new Command();
     registerZeroCommands(prog);
@@ -125,17 +125,17 @@ describe("computer-use command visibility", () => {
     expect(visibleCommandNames(prog)).toContain("computer-use");
   });
 
-  it("should be hidden when ZERO_TOKEN lacks computer-use:write", () => {
+  it("should be hidden when OKOU_TOKEN lacks computer-use:write", () => {
     const token = buildZeroToken({
       userId: "u1",
       runId: "r1",
       orgId: "o1",
-      scope: "zero",
+      scope: "okou",
       capabilities: ["agent:read"],
       iat: 1000,
       exp: 2000,
     });
-    vi.stubEnv("ZERO_TOKEN", token);
+    vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = new Command();
     registerZeroCommands(prog);
@@ -212,7 +212,7 @@ describe("computer-use command visibility", () => {
 
   it("should guide missing computer-use capability errors to delegated authorization", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "zero-run-token-without-computer-use");
+    vi.stubEnv("OKOU_TOKEN", "zero-run-token-without-computer-use");
 
     server.use(
       http.post("http://localhost:3000/api/okou/computer-use/commands", () => {
@@ -248,7 +248,7 @@ describe("computer-use command visibility", () => {
 
   it("should poll pending command results every 500ms", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     let pollCount = 0;
     server.use(
@@ -309,6 +309,39 @@ describe("computer-use command visibility", () => {
     } finally {
       setTimeoutSpy.mockRestore();
     }
+  });
+
+  it("should route production commands through api.okou.ai", async () => {
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+
+    server.use(
+      http.post("https://api.okou.ai/api/okou/computer-use/commands", () => {
+        return HttpResponse.json({
+          commandId: "cmd_okou_origin",
+          status: "queued",
+        });
+      }),
+      http.get(
+        "https://api.okou.ai/api/okou/computer-use/commands/cmd_okou_origin",
+        () => {
+          return HttpResponse.json({
+            id: "cmd_okou_origin",
+            kind: "apps.list",
+            status: "succeeded",
+            hostId: "host_1",
+            hostName: "Desktop",
+            payload: {},
+            result: { apps: [] },
+            timeoutMs: 15_000,
+            createdAt: "2026-08-12T14:00:00.000Z",
+            claimedAt: "2026-08-12T14:00:00.100Z",
+            completedAt: "2026-08-12T14:00:00.200Z",
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync(["node", "cli", "list-apps"]);
   });
 
   it("should write screenshot and app state data to local files in command result console output", async () => {
@@ -381,7 +414,7 @@ describe("computer-use command visibility", () => {
 
   it("should print screenshot and app state file paths for get-app-state", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     const screenshotBytes = Buffer.from("test-png-data");
     const screenshotBase64 = screenshotBytes.toString("base64");
@@ -455,7 +488,7 @@ describe("computer-use command visibility", () => {
 
   it("should send click snapshot coordinates and mouse options", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
       http.post(
@@ -532,7 +565,7 @@ describe("computer-use command visibility", () => {
 
   it("should send click element indexes", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     const screenshotBytes = Buffer.from("test-png-data");
     const screenshotBase64 = screenshotBytes.toString("base64");
@@ -616,7 +649,7 @@ describe("computer-use command visibility", () => {
 
   it("should send press-key snapshot id and key", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
       http.post(
@@ -678,7 +711,7 @@ describe("computer-use command visibility", () => {
 
   it("should send type-text snapshot id and text", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
       http.post(
@@ -737,7 +770,7 @@ describe("computer-use command visibility", () => {
 
   it("should call an mcp plugin tool with json arguments", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     let createBody: unknown;
     server.use(
@@ -802,7 +835,7 @@ describe("computer-use command visibility", () => {
 
   it("should list a server's mcp tools via the reserved tools/list call", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     let createBody: unknown;
     server.use(
@@ -863,7 +896,7 @@ describe("computer-use command visibility", () => {
 
   it("should list mcp servers reported by linked hosts", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
       http.get("http://localhost:3000/api/okou/computer-use/hosts", () => {
@@ -904,7 +937,7 @@ describe("computer-use command visibility", () => {
 
   it("should download pointer-backed screenshots through the API proxy", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     const screenshotBytes = Buffer.from("proxy-png-bytes");
     server.use(
@@ -970,7 +1003,7 @@ describe("computer-use command visibility", () => {
 
   it("should mark expired pointer screenshots in command output", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
       http.post("http://localhost:3000/api/okou/computer-use/commands", () => {

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/check.test.ts
@@ -42,7 +42,7 @@ function buildZeroToken(
     userId: "user-1",
     runId: "run-abc-123",
     orgId: "org-1",
-    scope: "zero",
+    scope: "okou",
     capabilities: ["connector:read", "agent-run:read"],
     iat: Math.floor(Date.now() / 1000),
     exp: Math.floor(Date.now() / 1000) + 3600,
@@ -240,9 +240,9 @@ describe("okou connector check command", () => {
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", API_BASE_URL);
-    vi.stubEnv("ZERO_TOKEN", buildZeroToken());
-    vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", "");
+    vi.stubEnv("OKOU_TOKEN", buildZeroToken());
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
     vi.stubEnv("GH_TOKEN", "");
     vi.stubEnv("GITHUB_TOKEN", "");
   });
@@ -376,8 +376,8 @@ describe("okou connector check command", () => {
     });
 
     it("requires a URL diagnostic before printing a callback permission command", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
-      vi.stubEnv("ZERO_CHAT_THREAD_ID", "thread-abc-123");
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+      vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-abc-123");
       stubDiagnostic(
         resolvedEnvironment({
           permission: { outcome: "ask", basis: "ask-list" },

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
@@ -46,7 +46,7 @@ describe("okou connector connect command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -127,7 +127,7 @@ describe("okou connector list command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
@@ -245,8 +245,8 @@ describe("okou connector list command", () => {
       expect(logCalls).toContain("✓");
     });
 
-    it("renders AUTHORIZED FOR column when $ZERO_AGENT_ID is set", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
+    it("renders AUTHORIZED FOR column when $OKOU_AGENT_ID is set", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
       server.use(
         stubConnectors([connectedGithub]),
         stubAgent(AGENT_UUID, "maya"),
@@ -260,8 +260,8 @@ describe("okou connector list command", () => {
       expect(logCalls).toContain("✓");
     });
 
-    it("--agent overrides $ZERO_AGENT_ID", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
+    it("--agent overrides $OKOU_AGENT_ID", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
       server.use(
         stubConnectors([connectedGithub]),
         stubAgent(AGENT_UUID, "maya"),

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
@@ -101,8 +101,8 @@ describe("okou connector permission-request command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.stubEnv("ZERO_TOKEN", "test-token");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", "");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
     const result = resolvedUrlDiagnostic();
     stubDiagnostic(result, "https://app.vm0.ai");
@@ -119,7 +119,7 @@ describe("okou connector permission-request command", () => {
 
   it("outputs an allow grant link without choosing the user's duration", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     let diagnosticRequest:
       | ReturnType<typeof connectorCheckRequestSchema.parse>
       | undefined;
@@ -162,7 +162,7 @@ describe("okou connector permission-request command", () => {
 
   it("uses the agent permission page inside an automated run", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     vi.stubEnv("ZERO_WORKFLOW_ID", "wf-789");
 
     await permissionRequestCommand.parseAsync([
@@ -189,8 +189,8 @@ describe("okou connector permission-request command", () => {
 
   it("includes the current thread and callback prompt in the grant URL", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", "thread-abc-123");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-abc-123");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -217,8 +217,8 @@ describe("okou connector permission-request command", () => {
 
   it("rejects callback prompts outside the current web chat", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", "");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
 
     await expect(async () => {
       await permissionRequestCommand.parseAsync([
@@ -242,8 +242,8 @@ describe("okou connector permission-request command", () => {
   });
 
   it("rejects callback prompts for a different agent", async () => {
-    vi.stubEnv("ZERO_AGENT_ID", "agent-current");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", "thread-abc-123");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-current");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-abc-123");
 
     await expect(async () => {
       await permissionRequestCommand.parseAsync([
@@ -270,7 +270,7 @@ describe("okou connector permission-request command", () => {
 
   it("outputs an allow grant link for unknown endpoints", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     const unknownUrl = "https://api.cloudflare.com/client/v4/example";
     stubDiagnostic(
       resolvedUrlDiagnostic({
@@ -306,9 +306,9 @@ describe("okou connector permission-request command", () => {
     expect(logCalls).not.toContain("expiresIn=");
   });
 
-  it("uses the agents landing page when ZERO_AGENT_ID is not set", async () => {
+  it("uses the agents landing page when OKOU_AGENT_ID is not set", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "");
+    vi.stubEnv("OKOU_AGENT_ID", "");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -325,9 +325,9 @@ describe("okou connector permission-request command", () => {
     expect(logCalls).not.toContain("/agents/permissions");
   });
 
-  it("uses --agent when ZERO_AGENT_ID is not set", async () => {
+  it("uses --agent when OKOU_AGENT_ID is not set", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "");
+    vi.stubEnv("OKOU_AGENT_ID", "");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -347,9 +347,9 @@ describe("okou connector permission-request command", () => {
     expect(logCalls).toContain("action=allow");
   });
 
-  it("--agent overrides ZERO_AGENT_ID", async () => {
+  it("--agent overrides OKOU_AGENT_ID", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "env-agent-123");
+    vi.stubEnv("OKOU_AGENT_ID", "env-agent-123");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -370,7 +370,7 @@ describe("okou connector permission-request command", () => {
 
   it("transforms www.vm0.ai to app.vm0.ai", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://www.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-1");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-1");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -390,7 +390,7 @@ describe("okou connector permission-request command", () => {
 
   it("prints sensitive Slack user-token guidance for chat:write enable", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     const url = "https://slack.com/api/chat.postMessage";
     stubDiagnostic(
       resolvedUrlDiagnostic({
@@ -428,7 +428,7 @@ describe("okou connector permission-request command", () => {
 
   it("prints sensitive Gmail sending guidance for messages.send enable", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
     const url = "https://gmail.googleapis.com/gmail/v1/users/me/messages/send";
     stubDiagnostic(
       resolvedUrlDiagnostic({
@@ -524,7 +524,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("exits with authentication guidance when no token is available", async () => {
-    vi.stubEnv("ZERO_TOKEN", "");
+    vi.stubEnv("OKOU_TOKEN", "");
     vi.stubEnv("VM0_API_BACKEND_URL", "https://app.vm0.ai");
 
     await expect(async () => {
@@ -653,7 +653,7 @@ describe("okou connector permission-request command", () => {
   );
 
   it("explains selected-host token grants for computer-use permission changes", async () => {
-    vi.stubEnv("ZERO_TOKEN", "");
+    vi.stubEnv("OKOU_TOKEN", "");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -676,7 +676,7 @@ describe("okou connector permission-request command", () => {
 
   it("outputs a delegated authorization link for computer-use enable when authenticated", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "zero-run-token");
+    vi.stubEnv("OKOU_TOKEN", "zero-run-token");
 
     server.use(
       http.post(
@@ -718,7 +718,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("recognizes computer-use:write even when the connector slug is wrong", async () => {
-    vi.stubEnv("ZERO_TOKEN", "");
+    vi.stubEnv("OKOU_TOKEN", "");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -736,7 +736,7 @@ describe("okou connector permission-request command", () => {
   });
 
   it("explains thread access for cloud browser permission changes", async () => {
-    vi.stubEnv("ZERO_TOKEN", "");
+    vi.stubEnv("OKOU_TOKEN", "");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -758,7 +758,7 @@ describe("okou connector permission-request command", () => {
 
   it("outputs a delegated authorization link for cloud browser enable", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "zero-run-token");
+    vi.stubEnv("OKOU_TOKEN", "zero-run-token");
 
     server.use(
       http.post(

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -150,7 +150,7 @@ describe("okou connector search command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
@@ -350,8 +350,8 @@ describe("okou connector search command", () => {
       expect(githubRow).toMatch(/✓/);
     });
 
-    it("adds AUTHORIZED FOR column when ZERO_AGENT_ID is set", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
+    it("adds AUTHORIZED FOR column when OKOU_AGENT_ID is set", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
       server.use(
         stubAgent(AGENT_UUID, "maya"),
         stubUserConnectors(AGENT_UUID, []),
@@ -386,8 +386,8 @@ describe("okou connector search command", () => {
       expect(output).toContain(`AUTHORIZED FOR ${AGENT_UUID}`);
     });
 
-    it("--agent overrides ZERO_AGENT_ID", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
+    it("--agent overrides OKOU_AGENT_ID", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
       server.use(
         stubAgent(AGENT_UUID, "from-flag"),
         stubUserConnectors(AGENT_UUID, ["github"]),

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -124,11 +124,11 @@ describe("okou connector status command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    vi.stubEnv("ZERO_APP_URL", "");
+    vi.stubEnv("OKOU_APP_URL", "");
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
-    vi.stubEnv("ZERO_AGENT_ID", "");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", "");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_AGENT_ID", "");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
   });
 
   afterEach(() => {
@@ -260,8 +260,8 @@ describe("okou connector status command", () => {
     });
 
     it("prints a callback URL example in the current web chat", async () => {
-      vi.stubEnv("ZERO_CHAT_THREAD_ID", "thread-abc-123");
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
+      vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-abc-123");
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
       server.use(
         stubConnector(connectedGithub),
         stubAgent(AGENT_UUID, "maya"),
@@ -313,6 +313,21 @@ describe("okou connector status command", () => {
       expect(logCalls).not.toContain("zero-app.example.test");
     });
 
+    it("ignores legacy Zero runtime context without canonical values", async () => {
+      vi.stubEnv("ZERO_APP_URL", "https://zero-app.example.test");
+      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
+      vi.stubEnv("ZERO_CHAT_THREAD_ID", "zero-thread-456");
+      server.use(stubConnector(connectedGithub));
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain("Authorized:");
+      expect(logCalls).not.toContain(ALT_AGENT_UUID);
+      expect(logCalls).not.toContain("zero-thread-456");
+      expect(logCalls).not.toContain("zero-app.example.test");
+    });
+
     it("uses the production app origin in authorization links", async () => {
       const apiOrigin = "https://api.vm0.ai";
       vi.stubEnv("APP_URL", "https://unrelated.example.test");
@@ -340,11 +355,11 @@ describe("okou connector status command", () => {
       );
     });
 
-    it("prefers ZERO_APP_URL in authorization links", async () => {
+    it("prefers OKOU_APP_URL in authorization links", async () => {
       const apiOrigin = "https://api.example.test";
       const appOrigin = "https://app.example.test";
       vi.stubEnv("VM0_API_BACKEND_URL", apiOrigin);
-      vi.stubEnv("ZERO_APP_URL", `${appOrigin}/ignored-path`);
+      vi.stubEnv("OKOU_APP_URL", `${appOrigin}/ignored-path`);
       server.use(
         stubConnectorCatalogStatus(
           [statusItemFromConnector(connectedGithub)],
@@ -458,8 +473,8 @@ describe("okou connector status command", () => {
       expect(logCalls).not.toContain("okou connector check");
     });
 
-    it("uses $ZERO_AGENT_ID when --agent flag is not provided", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_UUID);
+    it("uses $OKOU_AGENT_ID when --agent flag is not provided", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
       server.use(
         stubConnector(connectedGithub),
         stubAgent(AGENT_UUID, "maya"),
@@ -474,8 +489,8 @@ describe("okou connector status command", () => {
       );
     });
 
-    it("--agent overrides $ZERO_AGENT_ID", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
+    it("--agent overrides $OKOU_AGENT_ID", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
       server.use(
         stubConnector(connectedGithub),
         stubAgent(AGENT_UUID, "maya"),

--- a/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/create.test.ts
@@ -23,7 +23,7 @@ function buildZeroToken(capabilities: readonly string[]): string {
       userId: "user-1",
       runId: "run-1",
       orgId: "org-1",
-      scope: "zero",
+      scope: "okou",
       capabilities,
       iat: 1,
       exp: 2,
@@ -116,8 +116,8 @@ describe("okou connector custom create", () => {
     chalk.level = 0;
     tempDir = mkdtempSync(join(tmpdir(), "zero-custom-connector-create-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", buildZeroToken(["connector:write"]));
-    vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_TOKEN", buildZeroToken(["connector:write"]));
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
   });
 
   afterEach(() => {
@@ -382,7 +382,7 @@ describe("okou connector custom create", () => {
     const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       return undefined as never;
     });
-    vi.stubEnv("ZERO_TOKEN", buildZeroToken(["connector:read"]));
+    vi.stubEnv("OKOU_TOKEN", buildZeroToken(["connector:read"]));
 
     try {
       await customConnectorCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/index.test.ts
@@ -20,7 +20,7 @@ describe("okou connector custom readers", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/update.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/update.test.ts
@@ -21,7 +21,7 @@ function buildZeroToken(): string {
       userId: "user-1",
       runId: "run-1",
       orgId: "org-1",
-      scope: "zero",
+      scope: "okou",
       capabilities: ["connector:write"],
       iat: 1,
       exp: 2,
@@ -114,7 +114,7 @@ describe("okou connector custom update", () => {
     chalk.level = 0;
     tempDir = mkdtempSync(join(tmpdir(), "zero-custom-connector-update-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+    vi.stubEnv("OKOU_TOKEN", buildZeroToken());
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/credit.test.ts
@@ -50,8 +50,8 @@ describe("okou doctor credit command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_APP_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_APP_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubOrg(), stubBillingStatus());
   });
 

--- a/turbo/apps/cli/src/commands/zero/feishu/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/feishu/__tests__/download-file.test.ts
@@ -23,7 +23,7 @@ describe("okou feishu download-file command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = mkdtempSync(join(tmpdir(), "feishu-download-file-"));
   });
 

--- a/turbo/apps/cli/src/commands/zero/feishu/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/feishu/__tests__/send.test.ts
@@ -20,7 +20,7 @@ describe("okou feishu message send command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   it("documents the Feishu targeting modes", () => {

--- a/turbo/apps/cli/src/commands/zero/feishu/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/feishu/__tests__/upload-file.test.ts
@@ -29,7 +29,7 @@ describe("okou feishu upload-file command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = mkdtempSync(join(tmpdir(), "feishu-upload-file-"));
     filePath = join(tempDir, "report.pdf");
     writeFileSync(filePath, FILE_CONTENT);

--- a/turbo/apps/cli/src/commands/zero/finance/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/finance/__tests__/index.test.ts
@@ -58,7 +58,7 @@ describe("okou finance command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     for (const command of zeroFinanceCommand.commands) {
       command.setOptionValue("json", undefined);
       if (command.name() === "chart") {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/avatar-video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/avatar-video.test.ts
@@ -65,7 +65,7 @@ describe("okou generate avatar-video command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubBillingStatus());
   });
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
@@ -45,7 +45,7 @@ describe("okou generate image command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -183,8 +183,8 @@ describe("okou generate lister", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
-    vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     server.use(stubBillingStatus(true));
   });
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -21,7 +21,7 @@ describe("okou generate presentation command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/sprite.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/sprite.test.ts
@@ -24,7 +24,7 @@ describe("okou generate sprite command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -96,7 +96,7 @@ describe("okou generate video command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(stubBillingStatus(true));
   });
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
@@ -38,7 +38,7 @@ describe("okou generate voice command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/github/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/github/__tests__/download-file.test.ts
@@ -25,7 +25,7 @@ describe("okou github download-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `github-download-file-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/github/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/github/__tests__/upload-file.test.ts
@@ -28,7 +28,7 @@ describe("okou github upload-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `github-upload-file-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/goal/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/goal/__tests__/index.test.ts
@@ -23,9 +23,9 @@ describe("okou goal command", () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-okou-token");
     vi.stubEnv("ZERO_TOKEN", undefined);
-    vi.stubEnv("ZERO_APP_URL", undefined);
-    vi.stubEnv("ZERO_AGENT_ID", undefined);
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+    vi.stubEnv("OKOU_APP_URL", undefined);
+    vi.stubEnv("OKOU_AGENT_ID", undefined);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
     vi.stubEnv("ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED", undefined);
   });
 

--- a/turbo/apps/cli/src/commands/zero/host/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/zero/host/__tests__/clone.test.ts
@@ -41,7 +41,7 @@ describe("okou host clone command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = join(tmpdir(), `zero-host-clone-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });
   });

--- a/turbo/apps/cli/src/commands/zero/host/__tests__/publish.test.ts
+++ b/turbo/apps/cli/src/commands/zero/host/__tests__/publish.test.ts
@@ -45,7 +45,7 @@ describe("okou host publish command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = join(tmpdir(), `zero-host-publish-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });
   });

--- a/turbo/apps/cli/src/commands/zero/host/__tests__/versions.test.ts
+++ b/turbo/apps/cli/src/commands/zero/host/__tests__/versions.test.ts
@@ -15,7 +15,7 @@ describe("okou host versions command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -46,7 +46,7 @@ describe("okou logs list command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -103,7 +103,7 @@ describe("okou logs search command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -47,7 +47,7 @@ describe("okou logs view command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mail/__tests__/index.test.ts
@@ -66,9 +66,9 @@ describe("okou mail", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
-    vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/maps/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/maps/__tests__/index.test.ts
@@ -32,7 +32,7 @@ describe("okou maps command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 
   afterEach(async () => {
@@ -406,7 +406,7 @@ describe("okou maps command", () => {
   });
 
   it("shows auth guidance when no token is available", async () => {
-    vi.stubEnv("ZERO_TOKEN", undefined);
+    vi.stubEnv("OKOU_TOKEN", undefined);
 
     await expect(
       zeroMapsCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/mcp/__tests__/index.test.ts
@@ -221,7 +221,7 @@ describe("okou mcp command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/model-provider/__tests__/index.test.ts
@@ -60,7 +60,7 @@ describe("okou model-provider command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
   });
 

--- a/turbo/apps/cli/src/commands/zero/model-provider/index.ts
+++ b/turbo/apps/cli/src/commands/zero/model-provider/index.ts
@@ -11,7 +11,7 @@ import {
 export const MODEL_PROVIDER_SET_GUIDANCE = [
   "Model provider routing is configured in the web app.",
   "",
-  "Organization admins: open https://app.vm0.ai, use the top-left organization menu, choose Manage, then add, delete, or adjust model providers.",
+  "Organization admins: open https://app.okou.ai, use the top-left organization menu, choose Manage, then add, delete, or adjust model providers.",
   "",
   "If an organization admin sets a model provider to subscription, members must use the bottom-left user menu, choose Preferences / Personal Models, and connect their personal subscription.",
 ].join("\n");

--- a/turbo/apps/cli/src/commands/zero/model/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/model/__tests__/index.test.ts
@@ -47,7 +47,7 @@ describe("okou model command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
   });
 
@@ -113,9 +113,9 @@ describe("okou model command", () => {
     );
   });
 
-  it("should point other environments at app.vm0.ai", () => {
+  it("should point other environments at app.okou.ai", () => {
     expect(getModelSwitchGuidance("schedule")).toContain(
-      "Open https://app.vm0.ai",
+      "Open https://app.okou.ai",
     );
   });
 });

--- a/turbo/apps/cli/src/commands/zero/model/index.ts
+++ b/turbo/apps/cli/src/commands/zero/model/index.ts
@@ -34,7 +34,7 @@ export function getModelSwitchGuidance(integration = getCurrentIntegration()) {
     return "Use /model in Telegram to switch models.";
   }
 
-  return "Open https://app.vm0.ai and switch models from the model selector next to the input box.";
+  return "Open https://app.okou.ai and switch models from the model selector next to the input box.";
 }
 
 const listCommand = new Command()

--- a/turbo/apps/cli/src/commands/zero/people-search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/people-search/__tests__/index.test.ts
@@ -73,7 +73,7 @@ describe("okou people-search command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     zeroPeopleSearchCommand.setOptionValue("limit", 5);
     zeroPeopleSearchCommand.setOptionValue("json", undefined);
   });

--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/commands.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/commands.test.ts
@@ -32,7 +32,7 @@ describe("okou phone commands", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     tmpDir = join(tmpdir(), `phone-command-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/zero/presentation-template/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/presentation-template/__tests__/index.test.ts
@@ -52,7 +52,7 @@ describe("okou presentation-template command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = mkdtempSync(join(tmpdir(), "zero-presentation-template-"));
   });
 

--- a/turbo/apps/cli/src/commands/zero/recognize/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/recognize/__tests__/index.test.ts
@@ -70,7 +70,7 @@ describe("okou recognize command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     tempDir = join(tmpdir(), `zero-recognize-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
   });

--- a/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
@@ -170,7 +170,7 @@ describe("okou resource pull command", () => {
   beforeEach(async () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     outputDir = await mkdtemp(path.join(tmpdir(), "zero-resource-pull-test-"));
     mockExit.mockClear();
     mockConsoleLog.mockClear();

--- a/turbo/apps/cli/src/commands/zero/scrape/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/scrape/__tests__/index.test.ts
@@ -47,7 +47,7 @@ describe("okou scrape command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 
   afterEach(async () => {

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -42,7 +42,7 @@ describe("okou search --source chat", () => {
     // see calls made by the current case.
     vi.clearAllMocks();
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     // Commander retains collector state across parseAsync calls on the
     // same command instance. Reset before each case.
     zeroSearchCommand.setOptionValue("source", []);

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/index.test.ts
@@ -79,7 +79,7 @@ describe("okou search command (scaffold)", () => {
 
   it("routes --source logs to the logs-search backend", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     let called = false;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -69,7 +69,7 @@ describe("okou search --source logs parity with okou logs search", () => {
     mockExit.mockClear();
     mockConsoleError.mockClear();
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     zeroSearchCommand.setOptionValue("source", []);
   });
 

--- a/turbo/apps/cli/src/commands/zero/seo/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/seo/__tests__/index.test.ts
@@ -59,7 +59,7 @@ describe("okou seo command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     for (const command of zeroSeoCommand.commands) {
       command.setOptionValue("json", undefined);
       if (command.name() === "serp") {

--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/download-file.test.ts
@@ -33,7 +33,7 @@ describe("okou slack download-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `download-file-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/send.test.ts
@@ -28,7 +28,7 @@ describe("okou slack message send command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
@@ -43,7 +43,7 @@ describe("okou slack upload-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     // Create temp file for tests
     tmpDir = join(tmpdir(), `upload-file-test-${Date.now()}`);

--- a/turbo/apps/cli/src/commands/zero/teams/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/teams/__tests__/download-file.test.ts
@@ -30,7 +30,7 @@ describe("okou teams download-file command", () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `teams-download-file-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/teams/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/teams/__tests__/send.test.ts
@@ -25,7 +25,7 @@ describe("okou teams message send command", () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   it("sends a message with conversation and activity IDs", async () => {

--- a/turbo/apps/cli/src/commands/zero/teams/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/teams/__tests__/upload-file.test.ts
@@ -32,7 +32,7 @@ describe("okou teams upload-file command", () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `teams-upload-file-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/telegram/__tests__/bot-list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/__tests__/bot-list.test.ts
@@ -23,7 +23,7 @@ describe("okou telegram bot list command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
   });

--- a/turbo/apps/cli/src/commands/zero/telegram/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/__tests__/download-file.test.ts
@@ -28,7 +28,7 @@ describe("okou telegram download-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `telegram-download-file-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/telegram/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/__tests__/send.test.ts
@@ -23,7 +23,7 @@ describe("okou telegram message send command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
   });

--- a/turbo/apps/cli/src/commands/zero/telegram/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/__tests__/upload-file.test.ts
@@ -32,7 +32,7 @@ describe("okou telegram upload-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `telegram-upload-file-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/translate/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/translate/__tests__/index.test.ts
@@ -21,7 +21,7 @@ describe("okou translate command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/frames.test.ts
@@ -54,7 +54,7 @@ function readStdout(): string {
 describe("okou video frames command", () => {
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     mockStdoutWrite.mockClear();
   });
 

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -55,7 +55,7 @@ function readStdout(): string {
 describe("okou video transcribe command", () => {
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     mockStdoutWrite.mockClear();
   });
 

--- a/turbo/apps/cli/src/commands/zero/weather/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/weather/__tests__/index.test.ts
@@ -36,7 +36,7 @@ describe("okou weather command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
   });
 
   afterEach(async () => {

--- a/turbo/apps/cli/src/commands/zero/web-search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web-search/__tests__/index.test.ts
@@ -66,7 +66,7 @@ describe("okou web-search command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
     zeroWebSearchCommand.setOptionValue("limit", 5);
     zeroWebSearchCommand.setOptionValue("recency", undefined);
     zeroWebSearchCommand.setOptionValue("domain", []);

--- a/turbo/apps/cli/src/commands/zero/web/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/download-file.test.ts
@@ -32,7 +32,7 @@ describe("okou web download-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `web-download-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/web/__tests__/upload-file.test.ts
@@ -50,7 +50,7 @@ describe("okou web upload-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     tmpDir = join(tmpdir(), `web-upload-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/copy.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/copy.test.ts
@@ -67,7 +67,7 @@ describe("okou workflow copy command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/create.test.ts
@@ -47,9 +47,9 @@ describe("okou workflow create command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
-    vi.stubEnv("ZERO_AGENT_ID", "");
-    vi.stubEnv("ZERO_CHAT_THREAD_ID", "");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_AGENT_ID", "");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
 
     workflowDir = join(tmpdir(), `test-workflow-${Date.now()}`);
     mkdirSync(workflowDir, { recursive: true });
@@ -118,8 +118,8 @@ describe("okou workflow create command", () => {
       expect(logCalls).toContain("1 file(s)");
     });
 
-    it("should resolve agent from ZERO_AGENT_ID env var", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+    it("should resolve agent from OKOU_AGENT_ID env var", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
 
       let capturedBody: Record<string, unknown> | undefined;
       server.use(
@@ -143,9 +143,9 @@ describe("okou workflow create command", () => {
       expect(capturedBody?.agentId).toBe(AGENT_ID);
     });
 
-    it("should forward ZERO_CHAT_THREAD_ID when creating from a chat thread", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
-      vi.stubEnv("ZERO_CHAT_THREAD_ID", CHAT_THREAD_ID);
+    it("should forward OKOU_CHAT_THREAD_ID when creating from a chat thread", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+      vi.stubEnv("OKOU_CHAT_THREAD_ID", CHAT_THREAD_ID);
 
       let capturedBody: Record<string, unknown> | undefined;
       server.use(

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/delete.test.ts
@@ -68,7 +68,7 @@ describe("okou workflow delete command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/edit.test.ts
@@ -73,7 +73,7 @@ describe("okou workflow edit command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
 
     workflowDir = join(tmpdir(), `test-workflow-edit-${Date.now()}`);
     mkdirSync(workflowDir, { recursive: true });

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/list.test.ts
@@ -27,7 +27,7 @@ describe("okou workflow list command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/view.test.ts
@@ -47,8 +47,8 @@ describe("okou workflow view command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
-    vi.stubEnv("ZERO_AGENT_ID", undefined);
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_AGENT_ID", undefined);
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/automation/__tests__/automation.test.ts
@@ -36,7 +36,7 @@ function zeroToken(orgId: string): string {
       userId: "user-123",
       runId: "run-123",
       orgId,
-      scope: "zero",
+      scope: "okou",
       capabilities: [],
       iat: 1,
       exp: 4_102_444_800,
@@ -360,7 +360,7 @@ describe("okou workflow automation commands", () => {
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     server.use(
       http.get(THREAD_METADATA_URL, () => {
         return HttpResponse.json({
@@ -409,7 +409,7 @@ describe("okou workflow automation commands", () => {
   }
 
   async function runStripeEnabledAdd(...args: string[]): Promise<void> {
-    vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+    vi.stubEnv("OKOU_TOKEN", zeroToken("org-stripe-enabled"));
     await createAutomationAddCommand({
       featureSwitchOverrides: {
         [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
@@ -553,8 +553,8 @@ describe("okou workflow automation commands", () => {
       },
     );
 
-    it("should resolve a workflow name under ZERO_AGENT_ID", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+    it("should resolve a workflow name under OKOU_AGENT_ID", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
       const workflows = mockWorkflowList();
       const captured = captureCreateAutomation(loopAutomation);
 
@@ -726,7 +726,7 @@ describe("okou workflow automation commands", () => {
     });
 
     it("should add a GitHub pull request automation for the staff workspace", async () => {
-      vi.stubEnv("ZERO_TOKEN", zeroToken(STAFF_ORG_ID));
+      vi.stubEnv("OKOU_TOKEN", zeroToken(STAFF_ORG_ID));
       const captured = captureCreateAutomation(githubPullRequestAutomation);
 
       await automationCommand.parseAsync([
@@ -767,7 +767,7 @@ describe("okou workflow automation commands", () => {
     });
 
     it("should reject --merged for non-closed GitHub pull request actions", async () => {
-      vi.stubEnv("ZERO_TOKEN", zeroToken(STAFF_ORG_ID));
+      vi.stubEnv("OKOU_TOKEN", zeroToken(STAFF_ORG_ID));
       await expect(async () => {
         await automationCommand.parseAsync([
           "node",
@@ -852,7 +852,7 @@ describe("okou workflow automation commands", () => {
     });
 
     it("should add a GitHub issue comment automation for the staff workspace", async () => {
-      vi.stubEnv("ZERO_TOKEN", zeroToken(STAFF_ORG_ID));
+      vi.stubEnv("OKOU_TOKEN", zeroToken(STAFF_ORG_ID));
       const response = {
         ...automationBase,
         kind: "event",
@@ -929,7 +929,7 @@ describe("okou workflow automation commands", () => {
     });
 
     it("should add a Strapi entry-published automation for the staff workspace", async () => {
-      vi.stubEnv("ZERO_TOKEN", zeroToken(STAFF_ORG_ID));
+      vi.stubEnv("OKOU_TOKEN", zeroToken(STAFF_ORG_ID));
       const captured = captureCreateAutomation(strapiAutomation);
 
       await automationCommand.parseAsync([
@@ -1212,7 +1212,7 @@ describe("okou workflow automation commands", () => {
     });
 
     it("should show Stripe creation in help when the feature is enabled", async () => {
-      vi.stubEnv("ZERO_TOKEN", zeroToken("org-stripe-enabled"));
+      vi.stubEnv("OKOU_TOKEN", zeroToken("org-stripe-enabled"));
       const addCommand = createAutomationAddCommand({
         featureSwitchOverrides: {
           [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,

--- a/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
@@ -10,20 +10,20 @@ function buildFakeZeroJwt(payload: Record<string, unknown>): string {
   return `vm0_sandbox_${header}.${body}.${signature}`;
 }
 
-describe("Zero configuration", () => {
+describe("Okou configuration", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("falls back to ZERO_TOKEN as the run authentication source", async () => {
-    vi.stubEnv("ZERO_TOKEN", "zero-token-value");
+  it("uses OKOU_TOKEN as the run authentication source", async () => {
+    vi.stubEnv("OKOU_TOKEN", "okou-token-value");
     vi.stubEnv("VM0_TOKEN", "legacy-token-value");
 
-    await expect(getToken()).resolves.toBe("zero-token-value");
-    await expect(getActiveToken()).resolves.toBe("zero-token-value");
+    await expect(getToken()).resolves.toBe("okou-token-value");
+    await expect(getActiveToken()).resolves.toBe("okou-token-value");
   });
 
-  it("prefers a non-empty OKOU_TOKEN", async () => {
+  it("ignores ZERO_TOKEN when OKOU_TOKEN is present", async () => {
     vi.stubEnv("OKOU_TOKEN", "okou-token-value");
     vi.stubEnv("ZERO_TOKEN", "zero-token-value");
 
@@ -31,11 +31,12 @@ describe("Zero configuration", () => {
     await expect(getActiveToken()).resolves.toBe("okou-token-value");
   });
 
-  it("falls back to ZERO_TOKEN when OKOU_TOKEN is empty", async () => {
+  it("does not fall back to ZERO_TOKEN when OKOU_TOKEN is empty", async () => {
     vi.stubEnv("OKOU_TOKEN", "");
     vi.stubEnv("ZERO_TOKEN", "zero-token-value");
 
-    await expect(getToken()).resolves.toBe("zero-token-value");
+    await expect(getToken()).resolves.toBeUndefined();
+    await expect(getActiveToken()).resolves.toBeUndefined();
   });
 
   it("does not fall back to VM0_TOKEN", async () => {
@@ -45,9 +46,9 @@ describe("Zero configuration", () => {
     await expect(getActiveToken()).resolves.toBeUndefined();
   });
 
-  it("reads the active organization from a run-scoped ZERO_TOKEN", async () => {
+  it("rejects a zero-scoped OKOU_TOKEN", async () => {
     vi.stubEnv(
-      "ZERO_TOKEN",
+      "OKOU_TOKEN",
       buildFakeZeroJwt({
         scope: "zero",
         orgId: "org-from-zero-token",
@@ -55,7 +56,7 @@ describe("Zero configuration", () => {
       }),
     );
 
-    await expect(getActiveOrg()).resolves.toBe("org-from-zero-token");
+    await expect(getActiveOrg()).resolves.toBeUndefined();
   });
 
   it("reads the active organization from an okou-scoped OKOU_TOKEN", async () => {
@@ -72,7 +73,7 @@ describe("Zero configuration", () => {
   });
 
   it("does not derive an organization from a CLI PAT", async () => {
-    vi.stubEnv("ZERO_TOKEN", "vm0_pat_header.payload.signature");
+    vi.stubEnv("OKOU_TOKEN", "vm0_pat_header.payload.signature");
 
     await expect(getActiveOrg()).resolves.toBeUndefined();
   });
@@ -84,6 +85,6 @@ describe("Zero configuration", () => {
   });
 
   it("defaults routing to the production API", async () => {
-    await expect(getApiUrl()).resolves.toBe("https://api.vm0.ai");
+    await expect(getApiUrl()).resolves.toBe("https://api.okou.ai");
   });
 });

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -7,7 +7,7 @@ export async function getToken(): Promise<string | undefined> {
 
 /**
  * Get the active token for API requests.
- * Agent runs use OKOU_TOKEN with ZERO_TOKEN as a compatibility fallback.
+ * Agent runs use OKOU_TOKEN.
  */
 export async function getActiveToken(): Promise<string | undefined> {
   return getToken();
@@ -19,7 +19,7 @@ export async function getApiUrl(): Promise<string> {
     // Add protocol if missing
     return apiUrl.startsWith("http") ? apiUrl : `https://${apiUrl}`;
   }
-  return "https://api.vm0.ai";
+  return "https://api.okou.ai";
 }
 
 export { decodeZeroTokenPayload };

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -37,7 +37,9 @@ function resolveComputerUseApiBaseUrl(baseUrl: string): string {
   }
 
   const url = new URL(baseUrl);
-  if (url.hostname === "www.vm0.ai" || url.hostname === "app.vm0.ai") {
+  if (url.hostname === "www.okou.ai" || url.hostname === "app.okou.ai") {
+    url.hostname = "api.okou.ai";
+  } else if (url.hostname === "www.vm0.ai" || url.hostname === "app.vm0.ai") {
     url.hostname = "api.vm0.ai";
   }
   return url.toString().replace(/\/$/, "");

--- a/turbo/apps/cli/src/lib/api/zero-token.ts
+++ b/turbo/apps/cli/src/lib/api/zero-token.ts
@@ -4,16 +4,16 @@ export interface ZeroTokenPayload {
   userId: string;
   runId: string;
   orgId: string;
-  scope: "zero" | "okou";
+  scope: "okou";
   capabilities: string[];
   iat: number;
   exp: number;
 }
 
 /**
- * Decode an OKOU_TOKEN or ZERO_TOKEN JWT payload.
+ * Decode an OKOU_TOKEN JWT payload.
  * Only decodes — does NOT verify signature (server does that).
- * If no token is provided, reads OKOU_TOKEN with ZERO_TOKEN as a fallback.
+ * If no token is provided, reads OKOU_TOKEN.
  * Returns undefined if the token is missing, malformed, or has an unsupported scope.
  */
 export function decodeZeroTokenPayload(
@@ -33,10 +33,7 @@ export function decodeZeroTokenPayload(
     const payload = JSON.parse(
       Buffer.from(parts[1]!, "base64url").toString(),
     ) as ZeroTokenPayload;
-    if (
-      (payload.scope === "zero" || payload.scope === "okou") &&
-      Array.isArray(payload.capabilities)
-    ) {
+    if (payload.scope === "okou" && Array.isArray(payload.capabilities)) {
       return payload;
     }
   } catch {

--- a/turbo/apps/cli/src/lib/command/__tests__/with-error-handler.test.ts
+++ b/turbo/apps/cli/src/lib/command/__tests__/with-error-handler.test.ts
@@ -26,7 +26,7 @@ describe("withErrorHandler", () => {
     vi.unstubAllEnvs();
   });
 
-  it("should show ZERO_TOKEN setup guidance when it is missing", async () => {
+  it("should show OKOU_TOKEN setup guidance when it is missing", async () => {
     const handler = withErrorHandler(async () => {
       throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
     });
@@ -43,8 +43,8 @@ describe("withErrorHandler", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
-  it("should show ZERO_TOKEN guidance for UNAUTHORIZED with ZERO_TOKEN set", async () => {
-    vi.stubEnv("ZERO_TOKEN", "some-token");
+  it("should show OKOU_TOKEN guidance for UNAUTHORIZED with OKOU_TOKEN set", async () => {
+    vi.stubEnv("OKOU_TOKEN", "some-token");
 
     const handler = withErrorHandler(async () => {
       throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);

--- a/turbo/apps/cli/src/lib/okou-env.ts
+++ b/turbo/apps/cli/src/lib/okou-env.ts
@@ -3,9 +3,7 @@ function environmentValue(name: string): string | undefined {
 }
 
 function okouEnvironmentValue(suffix: string): string | undefined {
-  return (
-    environmentValue(`OKOU_${suffix}`) ?? environmentValue(`ZERO_${suffix}`)
-  );
+  return environmentValue(`OKOU_${suffix}`);
 }
 
 export function getOkouToken(): string | undefined {


### PR DESCRIPTION
## Summary

- default the private CLI to `https://api.okou.ai` while preserving `VM0_API_BACKEND_URL` overrides
- read only canonical `OKOU_*` runtime context and accept only Okou-scope run tokens in the current CLI artifact
- migrate every current CLI command-boundary fixture to the canonical environment and scope contract
- keep explicit negative coverage for ignored legacy environment names and Zero-scope tokens
- point Okou CLI web guidance at `app.okou.ai`

## Compatibility boundary

This changes only the newly selected commit-addressed CLI artifact. Existing queued and active contexts keep the historical `CLI_PKG_URL` recorded when their execution context was created, so their historical CLI artifact retains dual-reader behavior. The API, Runner, Desktop, provider callbacks, `/api/zero/**` aliases, server-side Zero-scope verification, and historical artifacts are unchanged.

Writer-stop release #26694 completed successfully before implementation. In the bounded post-release production window, `agent_execute` and `cli_execution` each recorded 39 successful operations, CLI `/api/okou/**` traffic recorded no 5xx response, and the queries were non-partial and warning-free.

## Merge gate

Passed on 2026-08-12. `api.okou.ai` is assigned to the production `vm0-api` project with valid TLS. An unauthenticated `/api/okou/org` request returns the expected `401 application/json` API response on both advertised Vercel edge IPs. `api.vm0.ai` remains independently configured and returns the same expected API response. The issue records the DNS and boundary evidence.

## Validation

- `pnpm -F @vm0/okou-cli test` (993 passed, 1 skipped)
- `pnpm -F @vm0/okou-cli lint`
- `pnpm -F @vm0/okou-cli check-types`
- `pnpm -F @vm0/okou-cli build`
- `pnpm knip --workspace @vm0/okou-cli`
- focused default-origin Computer Use command-boundary coverage
- exact residual search confirms production CLI source no longer reads the four legacy runtime environment names or accepts Zero-scope tokens

Closes #26711
