### PR TITLE
test(connectors): remove retired definition artifacts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2666,24 +2666,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await connectorsApi.deleteCustomConnector(admin, original.id);
   });
 
-  it("rejects the retired legacy HTTP create body", async () => {
-    const admin = createBddApi(context).user({ orgRole: "org:admin" });
-    const response = await connectorsApi.requestCreateCustomConnectorRaw(
-      admin,
-      {
-        displayName: "BDD Retired Legacy Create",
-        prefixes: ["https://retired-legacy.example.test/v1/"],
-        headerName: "Authorization",
-        headerTemplate: "Bearer {{secret}}",
-      },
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({
-      error: { code: "BAD_REQUEST" },
-    });
-  });
-
   it("creates, patches, secrets, enables for an agent, rejects cross-org ids, and deletes through APIs", async () => {
     const bdd = createBddApi(context);
     bdd.acceptAgentStorageWrites();


### PR DESCRIPTION
## Summary

- remove the compatibility-only API BDD case for the retired Custom HTTP create shape
- simplify Custom connector response contract fixtures to current canonical HTTP and MCP payloads
- retain explicit coverage for the independently supported kind-less HTTP response normalization

## Scope

This is test-only cleanup. It does not change request validation, response parsing, runtime behavior, database schema or data, migrations, generated artifacts, or deployment compatibility.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/connector-client-contract.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm knip --workspace api --workspace @vm0/api-contracts`
- pre-commit hook: repository Prettier, Knip, full Turbo type check, file-size check, and commitlint

Closes #26663

Parent context: #25312
