### PR TITLE
refactor(connectors): require tagged custom responses

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/__tests__/index.test.ts
@@ -28,12 +28,12 @@ describe("okou connector custom readers", () => {
     vi.unstubAllEnvs();
   });
 
-  it("normalizes an older kind-less HTTP list response", async () => {
+  it("renders tagged HTTP connectors in list output", async () => {
     const connector = customConnector();
     server.use(
       http.get("http://localhost:3000/api/okou/custom-connectors", () => {
         return HttpResponse.json({
-          connectors: [{ ...connector, kind: undefined }],
+          connectors: [connector],
         });
       }),
     );
@@ -86,13 +86,13 @@ describe("okou connector custom readers", () => {
     expect(connectorRow).toMatch(/✓$/u);
   });
 
-  it("keeps HTTP routing details in status for an older kind-less response", async () => {
+  it("shows tagged HTTP routing details in status", async () => {
     const connector = customConnector();
     server.use(
       http.get(
         `http://localhost:3000/api/okou/custom-connectors/${CONNECTOR_ID}`,
         () => {
-          return HttpResponse.json({ ...connector, kind: undefined });
+          return HttpResponse.json(connector);
         },
       ),
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -348,13 +348,6 @@ function mcpCustomConnector(
   };
 }
 
-function previousApiCustomConnector(
-  connector: CustomConnectorHttpResponse,
-): Omit<CustomConnectorHttpResponse, "kind"> {
-  const { kind: _kind, ...previousApiConnector } = connector;
-  return previousApiConnector;
-}
-
 function publicCustomConnectorOAuthConfig(
   config: NonNullable<CreateCustomConnectorBody["oauthConfig"]>,
 ) {
@@ -4109,28 +4102,6 @@ describe("connectors page", () => {
       expect(dialog).toBeInTheDocument();
     },
   );
-
-  it("connects a kind-less HTTP definition returned by a previous API", async () => {
-    const connector = previousApiCustomConnector(
-      customConnector({ displayName: "Previous API HTTP" }),
-    );
-    context.mocks.data.org({
-      id: "org_1",
-      name: "Test Org",
-      role: "admin",
-    });
-    context.mocks.data.team([]);
-    context.mocks.http.get("*/api/okou/custom-connectors", () => {
-      return HttpResponse.json({ connectors: [connector] });
-    });
-
-    detachedSetupPage({ context, path: "/connectors?tab=custom" });
-
-    click(await screen.findByLabelText("Connect Previous API HTTP"));
-    await expect(
-      screen.findByRole("dialog", { name: "Connect Previous API HTTP" }),
-    ).resolves.toBeInTheDocument();
-  });
 
   it("manages a manual MCP custom connector through the settings lifecycle", async () => {
     const researchAgentId = "c0000000-0000-4000-a000-000000000061";

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -238,35 +238,18 @@ describe("connector client response contracts", () => {
 });
 
 describe("custom connector response contracts", () => {
-  it("normalizes kind-less HTTP responses to the canonical shape", () => {
-    const previousWirePayload = {
-      ...customHttpConnectorPayload,
-      prefixes: ["https://api.example.test"],
-      headerName: "Authorization",
-      headerTemplate: "Bearer {{token}}",
-    };
-    const currentWirePayload = {
-      ...customHttpConnectorPayload,
-    };
-
-    const previous = customConnectorResponseSchema.parse(previousWirePayload);
-    const current = customConnectorResponseSchema.parse(currentWirePayload);
-    const future = customConnectorResponseSchema.parse(
-      customHttpConnectorPayload,
-    );
-    const kindless = customConnectorResponseSchema.parse(
-      customHttpConnectorPayloadBase,
-    );
-
-    expect(previous).toStrictEqual(customHttpConnectorPayload);
-    expect(current).toStrictEqual(customHttpConnectorPayload);
-    expect(future).toStrictEqual(customHttpConnectorPayload);
-    expect(kindless).toStrictEqual(customHttpConnectorPayload);
+  it("requires tagged HTTP responses", () => {
+    expect(
+      customConnectorResponseSchema.parse(customHttpConnectorPayload),
+    ).toStrictEqual(customHttpConnectorPayload);
     expect(
       customConnectorListResponseSchema.parse({
-        connectors: [previousWirePayload],
+        connectors: [customHttpConnectorPayload],
       }),
     ).toStrictEqual({ connectors: [customHttpConnectorPayload] });
+    expect(() => {
+      customConnectorResponseSchema.parse(customHttpConnectorPayloadBase);
+    }).toThrow();
   });
 
   it("parses canonical MCP responses", () => {
@@ -291,16 +274,6 @@ describe("custom connector response contracts", () => {
       transport: "streamable-http",
       prefixTemplates: [],
     } as const;
-    const previousWirePayload = {
-      ...payload,
-      prefixes: [],
-      headerName: "",
-      headerTemplate: "",
-    } as const;
-
-    expect(
-      customConnectorResponseSchema.parse(previousWirePayload),
-    ).toStrictEqual(payload);
     expect(customConnectorResponseSchema.parse(payload)).toStrictEqual(payload);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -157,28 +157,10 @@ export type CustomConnectorMcpResponse = z.infer<
   typeof customConnectorMcpResponseSchema
 >;
 
-const taggedCustomConnectorResponseSchema = z.discriminatedUnion("kind", [
+export const customConnectorResponseSchema = z.discriminatedUnion("kind", [
   customConnectorHttpResponseSchema,
   customConnectorMcpResponseSchema,
 ]);
-
-function normalizeCustomConnectorResponseKind(value: unknown): unknown {
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    !("kind" in value) &&
-    !("endpoint" in value) &&
-    !("transport" in value)
-  ) {
-    return { ...value, kind: "http" };
-  }
-  return value;
-}
-
-export const customConnectorResponseSchema = z.preprocess(
-  normalizeCustomConnectorResponseKind,
-  taggedCustomConnectorResponseSchema,
-);
 export type CustomConnectorResponse = z.infer<
   typeof customConnectorResponseSchema
 >;


### PR DESCRIPTION
## Summary

- require every Custom Connector response to carry an explicit `kind` discriminator
- parse canonical HTTP and MCP responses directly with the tagged response union
- remove retired kind-less compatibility fixtures and normalization coverage

## Compatibility

The API has emitted explicit response kinds since `api-v1.413.0`, and the current Platform minimum version already postdates that rollout. Existing queued CLI artifacts that contain the former permissive parser continue to accept the canonical API response. This PR changes only client-side response validation; it does not change requests, API serialization, persistence, runner protocols, or connector authentication behavior.

## Validation

- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/connector-client-contract.test.ts`
- `pnpm -F @vm0/okou-cli exec vitest run src/commands/zero/connector/custom/__tests__/index.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- affected-workspace formatting, lint, type checking, and Knip
- pre-commit full-repository Knip and TypeScript checks

Closes #26665

Parent: #25031
