### PR TITLE
refactor(connectors): canonicalize legacy secret placeholders

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -12,6 +12,7 @@ import { randomInt, randomUUID } from "node:crypto";
 
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
+  CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS,
   zeroCustomConnectorsContract,
   type CreateCustomConnectorBody,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
@@ -2664,6 +2665,199 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expectNoVisibleSecret(listed, "must-not-be-stored");
 
     await connectorsApi.deleteCustomConnector(admin, original.id);
+  });
+
+  it("canonicalizes legacy manual secret placeholders on create and update", async () => {
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+    const fields = [
+      {
+        key: "secret",
+        label: "Legacy secret",
+        kind: "secret" as const,
+        required: true,
+      },
+      {
+        key: "api_key",
+        label: "API key",
+        kind: "secret" as const,
+        required: true,
+      },
+      {
+        key: "region",
+        label: "Region",
+        kind: "variable" as const,
+        required: true,
+      },
+    ];
+    const created = await connectorsApi.createCustomConnector(admin, {
+      displayName: "BDD Legacy Placeholder Create",
+      prefixTemplates: [`https://${rand}.legacy-create.test/v1/`],
+      fields,
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secret}}/{{secret}}/{{secrets.api_key}}",
+        },
+      ],
+      queryInjections: [
+        {
+          name: "token",
+          valueTemplate: "{{secret}}:{{variables.region}}",
+        },
+      ],
+      authMode: "manual",
+    });
+    const createdInjections = {
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate:
+            "Bearer {{secrets.secret}}/{{secrets.secret}}/{{secrets.api_key}}",
+        },
+      ],
+      queryInjections: [
+        {
+          name: "token",
+          valueTemplate: "{{secrets.secret}}:{{variables.region}}",
+        },
+      ],
+    };
+    expect(created).toMatchObject(createdInjections);
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject(createdInjections);
+
+    const updated = await connectorsApi.updateCustomConnector(
+      admin,
+      created.id,
+      {
+        displayName: "BDD Legacy Placeholder Update",
+        prefixTemplates: created.prefixTemplates,
+        fields,
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Token {{secret}}/{{secrets.api_key}}",
+          },
+        ],
+        queryInjections: [
+          {
+            name: "token",
+            valueTemplate: "{{secret}}:{{secrets.secret}}",
+          },
+        ],
+        authMode: "manual",
+      },
+    );
+    const updatedInjections = {
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Token {{secrets.secret}}/{{secrets.api_key}}",
+        },
+      ],
+      queryInjections: [
+        {
+          name: "token",
+          valueTemplate: "{{secrets.secret}}:{{secrets.secret}}",
+        },
+      ],
+    };
+    expect(updated.storageVersion).toBe(created.storageVersion);
+    expect(updated).toMatchObject(updatedInjections);
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject(updatedInjections);
+
+    await connectorsApi.deleteCustomConnector(admin, created.id);
+  });
+
+  it("rejects invalid legacy manual secret placeholder writes before persistence", async () => {
+    const admin = createBddApi(context).user({ orgRole: "org:admin" });
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+    const undeclaredDisplayName = "BDD Undeclared Legacy Placeholder";
+    const undeclared = await connectorsApi.requestCreateCustomConnector(
+      admin,
+      {
+        displayName: undeclaredDisplayName,
+        prefixTemplates: [`https://${rand}.undeclared-legacy.test/v1/`],
+        fields: [
+          {
+            key: "api_key",
+            label: "API key",
+            kind: "secret",
+            required: true,
+          },
+        ],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{secret}}",
+          },
+        ],
+        queryInjections: [],
+        authMode: "manual",
+      },
+      [400],
+    );
+    expectApiError(undeclared.body);
+    expect(undeclared.body.error.message).toContain(
+      "unsupported {{secret}} placeholder",
+    );
+
+    const legacyPlaceholder = "{{secret}}";
+    const expandedTemplate = `${"x".repeat(
+      CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS - legacyPlaceholder.length,
+    )}${legacyPlaceholder}`;
+    const rejectedDisplayNames: string[] = [undeclaredDisplayName];
+    for (const injectionKind of ["header", "query"] as const) {
+      const displayName = `BDD Expanded Legacy ${injectionKind}`;
+      rejectedDisplayNames.push(displayName);
+      const rejected = await connectorsApi.requestCreateCustomConnector(
+        admin,
+        {
+          displayName,
+          prefixTemplates: [
+            `https://${rand}.${injectionKind}-legacy-limit.test/v1/`,
+          ],
+          fields: [
+            {
+              key: "secret",
+              label: "Legacy secret",
+              kind: "secret",
+              required: true,
+            },
+          ],
+          headerInjections:
+            injectionKind === "header"
+              ? [{ name: "Authorization", valueTemplate: expandedTemplate }]
+              : [
+                  {
+                    name: "Authorization",
+                    valueTemplate: "Bearer {{secrets.secret}}",
+                  },
+                ],
+          queryInjections:
+            injectionKind === "query"
+              ? [{ name: "token", valueTemplate: expandedTemplate }]
+              : [],
+          authMode: "manual",
+        },
+        [400],
+      );
+      expectApiError(rejected.body);
+      expect(rejected.body.error.message).toContain(
+        `${CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS} characters after canonicalization`,
+      );
+    }
+
+    const listed = await connectorsApi.listCustomConnectors(admin);
+    expect(
+      listed.some((connector) => {
+        return rejectedDisplayNames.includes(connector.displayName);
+      }),
+    ).toBeFalsy();
   });
 
   it("creates, patches, secrets, enables for an agent, rejects cross-org ids, and deletes through APIs", async () => {

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -2,24 +2,25 @@ import { command, computed, type Computed } from "ccstate";
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { and, eq, gte, inArray, lt, sql } from "drizzle-orm";
-import type {
-  CreateCustomConnectorBody,
-  CustomConnectorAuthMode,
-  CustomConnectorField,
-  CustomConnectorFieldKind,
-  CustomConnectorHeaderInjection,
-  CustomConnectorHttpResponse,
-  CustomConnectorMcpResponse,
-  CustomConnectorMcpTransport,
-  CustomConnectorOAuthConfig,
-  CustomConnectorOAuthConfigInput,
-  CustomConnectorPermissionBundleRef,
-  CustomConnectorPermissionBundleResponse,
-  CustomConnectorProposal,
-  CustomConnectorQueryInjection,
-  CustomConnectorResponse,
-  CustomConnectorValueInput,
-  UpdateCustomConnectorBody,
+import {
+  CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS,
+  type CreateCustomConnectorBody,
+  type CustomConnectorAuthMode,
+  type CustomConnectorField,
+  type CustomConnectorFieldKind,
+  type CustomConnectorHeaderInjection,
+  type CustomConnectorHttpResponse,
+  type CustomConnectorMcpResponse,
+  type CustomConnectorMcpTransport,
+  type CustomConnectorOAuthConfig,
+  type CustomConnectorOAuthConfigInput,
+  type CustomConnectorPermissionBundleRef,
+  type CustomConnectorPermissionBundleResponse,
+  type CustomConnectorProposal,
+  type CustomConnectorQueryInjection,
+  type CustomConnectorResponse,
+  type CustomConnectorValueInput,
+  type UpdateCustomConnectorBody,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   canonicalizeFirewallBaseUrl,
@@ -959,6 +960,22 @@ function validateTemplateReferences(args: {
   return null;
 }
 
+function canonicalizeInjectionTemplate(
+  template: string,
+  context: string,
+): string | BadRequestResponse {
+  const canonical = template.replaceAll(
+    LEGACY_SECRET_PLACEHOLDER,
+    `{{secrets.${LEGACY_SECRET_KEY}}}`,
+  );
+  if (canonical.length > CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS) {
+    return badRequestMessage(
+      `${context} value template must not exceed ${CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS} characters after canonicalization`,
+    );
+  }
+  return canonical;
+}
+
 function templateWithPlaceholders(template: string): string {
   return template.replaceAll(
     TEMPLATE_REFERENCE_REGEX,
@@ -1159,7 +1176,14 @@ function validateHeaderInjections(args: {
     if (templateError) {
       return templateError;
     }
-    headers.push({ name, valueTemplate: injection.valueTemplate });
+    const valueTemplate = canonicalizeInjectionTemplate(
+      injection.valueTemplate,
+      `Header ${name}`,
+    );
+    if (isBadRequest(valueTemplate)) {
+      return valueTemplate;
+    }
+    headers.push({ name, valueTemplate });
   }
   return headers;
 }
@@ -1191,7 +1215,14 @@ function validateQueryInjections(args: {
     if (templateError) {
       return templateError;
     }
-    queries.push({ name, valueTemplate: injection.valueTemplate });
+    const valueTemplate = canonicalizeInjectionTemplate(
+      injection.valueTemplate,
+      `Query ${name}`,
+    );
+    if (isBadRequest(valueTemplate)) {
+      return valueTemplate;
+    }
+    queries.push({ name, valueTemplate });
   }
   return queries;
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -5,6 +5,8 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+export const CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS = 2_048;
+
 export const customConnectorSlugSchema = z
   .string()
   .regex(/^_[a-z0-9][a-z0-9-]{0,60}[a-z0-9]$/u);
@@ -26,7 +28,10 @@ export type CustomConnectorField = z.infer<typeof customConnectorFieldSchema>;
 
 export const customConnectorHeaderInjectionSchema = z.object({
   name: z.string().min(1).max(128),
-  valueTemplate: z.string().min(1).max(2048),
+  valueTemplate: z
+    .string()
+    .min(1)
+    .max(CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS),
 });
 export type CustomConnectorHeaderInjection = z.infer<
   typeof customConnectorHeaderInjectionSchema
@@ -34,7 +39,10 @@ export type CustomConnectorHeaderInjection = z.infer<
 
 export const customConnectorQueryInjectionSchema = z.object({
   name: z.string().min(1).max(128),
-  valueTemplate: z.string().min(1).max(2048),
+  valueTemplate: z
+    .string()
+    .min(1)
+    .max(CUSTOM_CONNECTOR_INJECTION_TEMPLATE_MAX_CHARS),
 });
 export type CustomConnectorQueryInjection = z.infer<
   typeof customConnectorQueryInjectionSchema


### PR DESCRIPTION
## Summary

- canonicalize exact legacy `{{secret}}` references to `{{secrets.secret}}` after existing manual-field validation
- reject canonicalized header or query templates that would exceed the shared 2,048-character API limit before persistence
- cover create, update, persisted reads, declaration validation, both injection locations, and expansion overflow through API integration tests

## Compatibility

- existing persisted legacy templates remain readable and executable
- canonicalization does not change credential storage versions
- no database schema, credential value, runner protocol, firewall payload, or active-run behavior changes
- production legacy-row counting and the eventual migration/runtime compatibility removal remain gated in #26669

## Validation

- `pnpm exec prettier --check packages/api-contracts/src/contracts/zero-custom-connectors.ts apps/api/src/signals/services/zero-custom-connector.service.ts apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts`
- focused Oxlint and ESLint for all changed files
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts --silent=passed-only` (66 tests on the rebased head)
- `pnpm exec knip --workspace api --workspace @vm0/api-contracts`
- pre-commit full `pnpm knip` and `pnpm check-types`

Closes #26664

Parent: #25312
