### PR TITLE
feat: update chat selection toolbar shortcuts

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "Feedback zu {{count}} Teil Ihrer Antwort:",
       "partsHeading_other": "Feedback zu {{count}} Teilen Ihrer Antwort:",
       "placeholder": "Was soll sich daran ändern?",
-      "reference": "Referenz",
+      "quote": "Zitieren",
       "remove": "Feedback entfernen",
       "sentEmailDescription": "eine gesendete E-Mail (Mail-ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", gesendete ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "Feedback zu {{count}} Teil Ihrer Antwort:",
       "partsHeading_other": "Feedback zu {{count}} Teilen Ihrer Antwort:",
       "placeholder": "Was soll sich daran ändern?",
-      "provide": "Geben Sie Feedback",
+      "reference": "Referenz",
       "remove": "Feedback entfernen",
       "sentEmailDescription": "eine gesendete E-Mail (Mail-ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", gesendete ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "Feedback on {{count}} part of your reply:",
       "partsHeading_other": "Feedback on {{count}} parts of your reply:",
       "placeholder": "What should change about this?",
-      "provide": "Provide feedback",
+      "reference": "Reference",
       "remove": "Remove feedback",
       "sentEmailDescription": "a sent email (mail ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", sent ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "Feedback on {{count}} part of your reply:",
       "partsHeading_other": "Feedback on {{count}} parts of your reply:",
       "placeholder": "What should change about this?",
-      "reference": "Reference",
+      "quote": "Quote",
       "remove": "Remove feedback",
       "sentEmailDescription": "a sent email (mail ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", sent ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Comentarios sobre {{count}} partes de tu respuesta:",
       "partsHeading_other": "Comentarios sobre {{count}} partes de tu respuesta:",
       "placeholder": "¿Qué debería cambiar en esto?",
-      "provide": "Enviar comentarios",
+      "reference": "Referencia",
       "remove": "Eliminar comentarios",
       "sentEmailDescription": "un correo enviado (ID de correo: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID enviado: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Comentarios sobre {{count}} partes de tu respuesta:",
       "partsHeading_other": "Comentarios sobre {{count}} partes de tu respuesta:",
       "placeholder": "¿Qué debería cambiar en esto?",
-      "reference": "Referencia",
+      "quote": "Citar",
       "remove": "Eliminar comentarios",
       "sentEmailDescription": "un correo enviado (ID de correo: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID enviado: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Retour sur {{count}} parties de votre réponse :",
       "partsHeading_other": "Retour sur {{count}} parties de votre réponse :",
       "placeholder": "Que devrait-on changer à ce sujet ?",
-      "provide": "Fournir des retours",
+      "reference": "Référence",
       "remove": "Supprimer les retours",
       "sentEmailDescription": "un email envoyé (ID de l'email : {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID envoyé : {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Retour sur {{count}} parties de votre réponse :",
       "partsHeading_other": "Retour sur {{count}} parties de votre réponse :",
       "placeholder": "Que devrait-on changer à ce sujet ?",
-      "reference": "Référence",
+      "quote": "Citer",
       "remove": "Supprimer les retours",
       "sentEmailDescription": "un email envoyé (ID de l'email : {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID envoyé : {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "{{count}} पर प्रतिक्रिया आपके उत्तर का हिस्सा:",
       "partsHeading_other": "आपके उत्तर के {{count}} भागों पर प्रतिक्रिया:",
       "placeholder": "इसमें क्या बदलाव होना चाहिए?",
-      "provide": "प्रतिक्रिया दें",
+      "reference": "संदर्भ",
       "remove": "प्रतिक्रिया हटाएँ",
       "sentEmailDescription": "भेजा गया ईमेल (मेल ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", भेजा गया ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "{{count}} पर प्रतिक्रिया आपके उत्तर का हिस्सा:",
       "partsHeading_other": "आपके उत्तर के {{count}} भागों पर प्रतिक्रिया:",
       "placeholder": "इसमें क्या बदलाव होना चाहिए?",
-      "reference": "संदर्भ",
+      "quote": "उद्धृत करें",
       "remove": "प्रतिक्रिया हटाएँ",
       "sentEmailDescription": "भेजा गया ईमेल (मेल ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", भेजा गया ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "Masukan untuk {{count}} bagian balasan Anda:",
       "partsHeading_other": "Masukan untuk {{count}} bagian balasan Anda:",
       "placeholder": "Apa yang harus diubah dari ini?",
-      "provide": "Berikan masukan",
+      "reference": "Referensi",
       "remove": "Hapus masukan",
       "sentEmailDescription": "email yang telah dikirim (ID mail: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID terkirim: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "Masukan untuk {{count}} bagian balasan Anda:",
       "partsHeading_other": "Masukan untuk {{count}} bagian balasan Anda:",
       "placeholder": "Apa yang harus diubah dari ini?",
-      "reference": "Referensi",
+      "quote": "Kutip",
       "remove": "Hapus masukan",
       "sentEmailDescription": "email yang telah dikirim (ID mail: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID terkirim: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Feedback su {{count}} parti della tua risposta:",
       "partsHeading_other": "Feedback su {{count}} parti della tua risposta:",
       "placeholder": "Cosa dovrebbe cambiare in questo senso?",
-      "provide": "Fornisci feedback",
+      "reference": "Riferimento",
       "remove": "Rimuovi feedback",
       "sentEmailDescription": "un'e-mail inviata (mail ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", inviato ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Feedback su {{count}} parti della tua risposta:",
       "partsHeading_other": "Feedback su {{count}} parti della tua risposta:",
       "placeholder": "Cosa dovrebbe cambiare in questo senso?",
-      "reference": "Riferimento",
+      "quote": "Cita",
       "remove": "Rimuovi feedback",
       "sentEmailDescription": "un'e-mail inviata (mail ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", inviato ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "返信の {{count}} 部分に関するフィードバック:",
       "partsHeading_other": "返信の {{count}} 部分に関するフィードバック:",
       "placeholder": "これについて何を変える必要がありますか?",
-      "provide": "フィードバックを提供する",
+      "reference": "参照",
       "remove": "フィードバックを削除する",
       "sentEmailDescription": "送信されたメール (メール ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": "、送信された ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "返信の {{count}} 部分に関するフィードバック:",
       "partsHeading_other": "返信の {{count}} 部分に関するフィードバック:",
       "placeholder": "これについて何を変える必要がありますか?",
-      "reference": "参照",
+      "quote": "引用",
       "remove": "フィードバックを削除する",
       "sentEmailDescription": "送信されたメール (メール ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": "、送信された ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "답변 {{count}}개 부분에 대한 피드백:",
       "partsHeading_other": "답변 {{count}}개 부분에 대한 피드백:",
       "placeholder": "무엇을 변경해야 하나요?",
-      "reference": "참조",
+      "quote": "인용",
       "remove": "피드백 제거",
       "sentEmailDescription": "발송된 이메일 (메일 ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", 발송 ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1390,7 +1390,7 @@
       "partsHeading_one": "답변 {{count}}개 부분에 대한 피드백:",
       "partsHeading_other": "답변 {{count}}개 부분에 대한 피드백:",
       "placeholder": "무엇을 변경해야 하나요?",
-      "provide": "피드백 제공",
+      "reference": "참조",
       "remove": "피드백 제거",
       "sentEmailDescription": "발송된 이메일 (메일 ID: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", 발송 ID: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Feedback sobre {{count}} partes da resposta:",
       "partsHeading_other": "Feedback sobre {{count}} partes da resposta:",
       "placeholder": "O que deveria mudar aqui?",
-      "reference": "Referência",
+      "quote": "Citar",
       "remove": "Remover feedback",
       "sentEmailDescription": "um e-mail enviado (ID do e-mail: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID de envio: {{sentId}}",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1418,7 +1418,7 @@
       "partsHeading_many": "Feedback sobre {{count}} partes da resposta:",
       "partsHeading_other": "Feedback sobre {{count}} partes da resposta:",
       "placeholder": "O que deveria mudar aqui?",
-      "provide": "Dar feedback",
+      "reference": "Referência",
       "remove": "Remover feedback",
       "sentEmailDescription": "um e-mail enviado (ID do e-mail: {{id}}{{sentIdSuffix}})",
       "sentIdSuffix": ", ID de envio: {{sentId}}",

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -29,7 +29,7 @@ import type {
 } from "./chat-forward.ts";
 
 // Assistant messages and other agent-produced content, such as linked email
-// drafts, opt into the shared Copy / Reference interaction.
+// drafts, opt into the shared Copy / Quote interaction.
 const FEEDBACK_SOURCE_SELECTOR =
   ".zero-chat-bubble-assistant, [data-feedback-source]";
 const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
@@ -439,7 +439,7 @@ function createToolbarRef({
             await set(copy$, signal);
             return;
           }
-          if (matchShortcut("r", event)) {
+          if (matchShortcut("q", event)) {
             event.preventDefault();
             set(start$);
             return;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -7,24 +7,29 @@ import {
   type State,
 } from "ccstate";
 import { delay } from "signal-timers";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { isEditableTarget, matchShortcut } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { i18n } from "../../i18n/index.ts";
+import {
+  featureSwitch$,
+  feedbackLocationApiSupported$,
+} from "../external/feature-switch.ts";
 import type {
   ComposerFeedbackSignals,
   FeedbackRange,
   FeedbackSource,
 } from "../zero-page/chat-feedback.ts";
 import { writeToClipboard } from "../zero-page/clipboard.ts";
+import { setChatListQuery$ } from "../zero-page/zero-sidebar-state.ts";
 import { onDomEventFn, onRef, resetSignal } from "../utils.ts";
 import type {
   ChatForwardComposerState,
   ChatForwardSelection,
 } from "./chat-forward.ts";
-import { feedbackLocationApiSupported$ } from "../external/feature-switch.ts";
 
 // Assistant messages and other agent-produced content, such as linked email
-// drafts, opt into the shared Copy / Provide feedback interaction.
+// drafts, opt into the shared Copy / Reference interaction.
 const FEEDBACK_SOURCE_SELECTOR =
   ".zero-chat-bubble-assistant, [data-feedback-source]";
 const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
@@ -62,7 +67,7 @@ export interface ChatThreadFeedbackSignals {
   readonly copy$: Command<Promise<void>, [AbortSignal]>;
   readonly forwardSelection$: Computed<ChatForwardSelection | null>;
   readonly forwardComposerState$: Computed<ChatForwardComposerState | null>;
-  readonly openForward$: Command<void, [ChatForwardSelection]>;
+  readonly startForward$: Command<boolean, []>;
   readonly setForwardComposerState$: Command<
     void,
     [ChatForwardComposerState | null]
@@ -345,6 +350,7 @@ function createForwardState(closeSelection$: Command<void, []>) {
   });
   const openForward$ = command(
     ({ set }, selection: ChatForwardSelection): void => {
+      set(setChatListQuery$, "");
       set(internalForwardSelection$, selection);
       set(internalForwardComposerState$, null);
       set(closeSelection$);
@@ -356,6 +362,7 @@ function createForwardState(closeSelection$: Command<void, []>) {
     },
   );
   const closeForward$ = command(({ set }): void => {
+    set(setChatListQuery$, "");
     set(internalForwardSelection$, null);
     set(internalForwardComposerState$, null);
   });
@@ -368,16 +375,39 @@ function createForwardState(closeSelection$: Command<void, []>) {
   };
 }
 
+function createStartForward(
+  selection$: State<CapturedFeedbackSelection | null>,
+  openForward$: Command<void, [ChatForwardSelection]>,
+) {
+  return command(({ get, set }): boolean => {
+    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatForward] ?? false)) {
+      return false;
+    }
+    const selection = get(selection$);
+    if (!selection?.threadId || !selection.runId) {
+      return false;
+    }
+    set(openForward$, {
+      text: selection.text,
+      threadId: selection.threadId,
+      runId: selection.runId,
+    });
+    return true;
+  });
+}
+
 function createToolbarRef({
   resetToolbarSignal$,
   close$,
   copy$,
   start$,
+  startForward$,
 }: {
   resetToolbarSignal$: ReturnType<typeof resetSignal>;
   close$: Command<void, []>;
   copy$: Command<Promise<void>, [AbortSignal]>;
   start$: Command<void, []>;
+  startForward$: Command<boolean, []>;
 }) {
   return onRef(
     command(({ set }, el: HTMLElement, signal: AbortSignal) => {
@@ -409,9 +439,13 @@ function createToolbarRef({
             await set(copy$, signal);
             return;
           }
-          if (matchShortcut("f", event)) {
+          if (matchShortcut("r", event)) {
             event.preventDefault();
             set(start$);
+            return;
+          }
+          if (matchShortcut("f", event) && set(startForward$)) {
+            event.preventDefault();
           }
         }),
         { signal: toolbarSignal },
@@ -512,11 +546,16 @@ export function createChatThreadFeedbackSignals(
     selection.close$,
     feedback,
   );
+  const startForward$ = createStartForward(
+    selection.internalSelection$,
+    forward.openForward$,
+  );
   const setToolbarRef$ = createToolbarRef({
     resetToolbarSignal$: selection.resetToolbarSignal$,
     close$: selection.close$,
     copy$: selection.copy$,
     start$,
+    startForward$,
   });
   const setListenersRef$ = createListenersRef({
     selection$: selection.internalSelection$,
@@ -531,7 +570,7 @@ export function createChatThreadFeedbackSignals(
     copy$: selection.copy$,
     forwardSelection$: forward.forwardSelection$,
     forwardComposerState$: forward.forwardComposerState$,
-    openForward$: forward.openForward$,
+    startForward$,
     setForwardComposerState$: forward.setForwardComposerState$,
     closeForward$: forward.closeForward$,
     setListenersRef$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -315,10 +315,10 @@ async function waitForSelectionToolbarButton(
         label === text ||
         label === `${text} C` ||
         label === `${text} F` ||
-        label === `${text} R` ||
+        label === `${text} Q` ||
         label === `${text}C` ||
         label === `${text}F` ||
-        label === `${text}R`
+        label === `${text}Q`
       );
     });
     expect(button).toBeEnabled();
@@ -887,7 +887,7 @@ describe("chat event action cards", () => {
     });
 
     selectMailText(within(messageSection).getByRole("listitem"));
-    await user.click(await waitForSelectionToolbarButton("Reference"));
+    await user.click(await waitForSelectionToolbarButton("Quote"));
     await waitFor(() => {
       const feedbackItem = document.querySelector("[data-feedback-item]");
       expect(feedbackItem).toHaveTextContent("Mail body after");
@@ -1107,7 +1107,7 @@ describe("chat event action cards", () => {
     selectMailText(
       within(sidebar).getByText("Feedback belongs to the right chat."),
     );
-    await user.click(await waitForSelectionToolbarButton("Reference"));
+    await user.click(await waitForSelectionToolbarButton("Quote"));
     const chatThreads = await screen.findAllByLabelText("Chat thread");
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -315,8 +315,10 @@ async function waitForSelectionToolbarButton(
         label === text ||
         label === `${text} C` ||
         label === `${text} F` ||
+        label === `${text} R` ||
         label === `${text}C` ||
-        label === `${text}F`
+        label === `${text}F` ||
+        label === `${text}R`
       );
     });
     expect(button).toBeEnabled();
@@ -885,7 +887,7 @@ describe("chat event action cards", () => {
     });
 
     selectMailText(within(messageSection).getByRole("listitem"));
-    await user.click(await waitForSelectionToolbarButton("Provide feedback"));
+    await user.click(await waitForSelectionToolbarButton("Reference"));
     await waitFor(() => {
       const feedbackItem = document.querySelector("[data-feedback-item]");
       expect(feedbackItem).toHaveTextContent("Mail body after");
@@ -1105,7 +1107,7 @@ describe("chat event action cards", () => {
     selectMailText(
       within(sidebar).getByText("Feedback belongs to the right chat."),
     );
-    await user.click(await waitForSelectionToolbarButton("Provide feedback"));
+    await user.click(await waitForSelectionToolbarButton("Reference"));
     const chatThreads = await screen.findAllByLabelText("Chat thread");
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -173,7 +173,9 @@ function buttonByText(text: string): HTMLElement {
       label === `${text}C` ||
       label === `${text} C` ||
       label === `${text}F` ||
-      label === `${text} F`
+      label === `${text} F` ||
+      label === `${text}R` ||
+      label === `${text} R`
     );
   });
   if (!button) {
@@ -313,7 +315,7 @@ describe("chat inline feedback", () => {
 
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
     await findFeedbackNote();
     await waitForDeferredSelectionCapture();
 
@@ -498,6 +500,50 @@ describe("chat inline feedback", () => {
     successToast.mockRestore();
   });
 
+  it("opens the forward dialog from the keyboard shortcut", async () => {
+    const sourceRunId = "d0000000-0000-4000-a000-000000000705";
+    const selectedContent = "Reference the approved launch checklist.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Forward shortcut source",
+      chatEvents: [
+        {
+          id: "msg-forward-shortcut-user",
+          role: "user",
+          content: "Review launch readiness",
+          runId: sourceRunId,
+          createdAt: "2026-08-12T11:00:00Z",
+        },
+        {
+          id: "msg-forward-shortcut-assistant",
+          role: "assistant",
+          content: selectedContent,
+          runId: sourceRunId,
+          createdAt: "2026-08-12T11:00:01Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatForward]: true },
+    });
+
+    selectTextForInlineFeedback(await screen.findByText(selectedContent));
+    await screen.findByText("Forward");
+    const forwardButton = buttonByText("Forward");
+    expect(forwardButton).toHaveAttribute("aria-keyshortcuts", "f");
+    expect(buttonByText("Reference")).toHaveAttribute("aria-keyshortcuts", "r");
+
+    const event = dispatchDocumentShortcut("f");
+    expect(event.defaultPrevented).toBeTruthy();
+
+    const dialog = await screen.findByRole("dialog", { name: "Forward to" });
+    expect(within(dialog).getByText(selectedContent)).toBeInTheDocument();
+  });
+
   it("inserts a template node inside a feedback note", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The illustration direction is too generic.";
@@ -534,7 +580,7 @@ describe("chat inline feedback", () => {
 
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
     const feedbackNote = await findFeedbackNote();
     await user.click(feedbackNote);
 
@@ -626,23 +672,27 @@ describe("chat inline feedback", () => {
     selectTextForInlineFeedback(assistantReplyElement);
 
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
       expect(screen.queryByText("Forward")).not.toBeInTheDocument();
     });
+
+    const forwardEvent = dispatchDocumentShortcut("f");
+    expect(forwardEvent.defaultPrevented).toBeFalsy();
+    expect(screen.getByText("Reference")).toBeInTheDocument();
 
     await user.click(buttonByText("Copy"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
     });
     expect(successToast).toHaveBeenCalledWith("Copied");
     successToast.mockRestore();
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Provide feedback"));
+    await user.click(buttonByText("Reference"));
 
     const feedbackComment = await findFeedbackNote();
     await expect(findComposerEditor()).resolves.toBe(composerEditor);
@@ -730,7 +780,7 @@ describe("chat inline feedback", () => {
       await screen.findByText(assistantReply),
       selectedRange,
     );
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
     pastePlainText(await findFeedbackNote(), "Name the owner.");
     await user.click(screen.getByLabelText("Send"));
 
@@ -821,7 +871,7 @@ describe("chat inline feedback", () => {
     });
     apiRolledBack = true;
     selectTextForInlineFeedback(assistantReplyElement, selectedRange);
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
     pastePlainText(await findFeedbackNote(), "Assign the owner.");
     await user.click(screen.getByLabelText("Send"));
 
@@ -1022,7 +1072,7 @@ describe("chat inline feedback", () => {
       }
 
       selectTextForInlineFeedback(assistantReplyElement);
-      await user.click(await screen.findByText("Provide feedback"));
+      await user.click(await screen.findByText("Reference"));
       const feedbackNote = await findFeedbackNote();
       pastePlainText(feedbackNote, "Rewrite this paragraph.");
       await user.click(screen.getByLabelText("Send"));
@@ -1108,7 +1158,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
     const feedbackNote = await findFeedbackNote();
     await user.click(feedbackNote);
     await user.keyboard("/");
@@ -1160,7 +1210,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
 
     await findFeedbackNote();
     await user.keyboard("Mention the dates before the risk summary.");
@@ -1236,7 +1286,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
 
     await findFeedbackNote();
     await user.keyboard("Mention the dates before the risk summary.");
@@ -1288,7 +1338,7 @@ describe("chat inline feedback", () => {
 
     const composerEditor = await findComposerEditor();
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
 
     const feedbackComment = await findFeedbackNote();
     await user.keyboard("补充具体日期");
@@ -1343,7 +1393,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Provide feedback"));
+    await user.click(await screen.findByText("Reference"));
 
     const feedbackComment = await findFeedbackNote();
     await user.click(feedbackComment);
@@ -1412,14 +1462,14 @@ describe("chat inline feedback", () => {
     document.dispatchEvent(new Event("selectionchange"));
     await waitForDeferredSelectionCapture();
 
-    expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reference")).not.toBeInTheDocument();
 
     assistantReplyElement.dispatchEvent(
       new MouseEvent("mouseup", { bubbles: true }),
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
   });
 
@@ -1466,7 +1516,7 @@ describe("chat inline feedback", () => {
     document.dispatchEvent(new Event("selectionchange"));
 
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
   });
 
@@ -1504,7 +1554,7 @@ describe("chat inline feedback", () => {
     selectTextForInlineFeedback(assistantReplyElement);
 
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
 
     const composerEditor = await findComposerEditor();
@@ -1512,7 +1562,7 @@ describe("chat inline feedback", () => {
     expect(composerEditor).toHaveFocus();
 
     await waitFor(() => {
-      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
     });
     await waitForDeferredSelectionCapture();
 
@@ -1550,7 +1600,7 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
     expect(window.getSelection()?.toString()).toBe(assistantReply);
 
@@ -1558,14 +1608,14 @@ describe("chat inline feedback", () => {
     expect(event.defaultPrevented).toBeFalsy();
 
     await waitFor(() => {
-      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
     });
     expect(window.getSelection()?.toString()).toBe(assistantReply);
 
     dispatchDocumentShortcut("c", { ctrlKey: true }, "keyup");
     await waitForDeferredSelectionCapture();
 
-    expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reference")).not.toBeInTheDocument();
     expect(window.getSelection()?.toString()).toBe(assistantReply);
   });
 
@@ -1602,10 +1652,13 @@ describe("chat inline feedback", () => {
     selectTextForInlineFeedback(assistantReplyElement);
 
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
 
-    const event = dispatchDocumentShortcut("f");
+    const referenceButton = buttonByText("Reference");
+    expect(referenceButton).toHaveAttribute("aria-keyshortcuts", "r");
+
+    const event = dispatchDocumentShortcut("r");
     expect(event.defaultPrevented).toBeTruthy();
 
     await findFeedbackNote();
@@ -1656,7 +1709,7 @@ describe("chat inline feedback", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
   });
 
@@ -1692,7 +1745,7 @@ describe("chat inline feedback", () => {
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
 
     // A real browser emits selectionchange after the selection collapses.
@@ -1700,7 +1753,7 @@ describe("chat inline feedback", () => {
     document.dispatchEvent(new Event("selectionchange"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
     });
   });
 
@@ -1796,9 +1849,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
-    click(buttonByText("Provide feedback"));
+    click(buttonByText("Reference"));
 
     pastePlainText(
       await findFeedbackNote(),
@@ -1874,9 +1927,9 @@ describe("chat inline feedback", () => {
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Provide feedback"));
+    await user.click(buttonByText("Reference"));
 
     const firstComment = await findFeedbackNote();
     await user.keyboard("Assign each risk to an owner.");
@@ -1886,9 +1939,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Provide feedback"));
+    await user.click(buttonByText("Reference"));
 
     const comments = await findFeedbackNotes(2);
     expect(comments).toHaveLength(2);
@@ -1948,9 +2001,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Provide feedback"));
+    await user.click(buttonByText("Reference"));
 
     const firstComment = await findFeedbackNote();
     await user.keyboard("Add owners.");
@@ -1960,9 +2013,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+      expect(screen.getByText("Reference")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Provide feedback"));
+    await user.click(buttonByText("Reference"));
 
     const comments = await findFeedbackNotes(2);
     await user.keyboard("Add dates.");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -174,8 +174,8 @@ function buttonByText(text: string): HTMLElement {
       label === `${text} C` ||
       label === `${text}F` ||
       label === `${text} F` ||
-      label === `${text}R` ||
-      label === `${text} R`
+      label === `${text}Q` ||
+      label === `${text} Q`
     );
   });
   if (!button) {
@@ -315,7 +315,7 @@ describe("chat inline feedback", () => {
 
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
     await findFeedbackNote();
     await waitForDeferredSelectionCapture();
 
@@ -502,7 +502,7 @@ describe("chat inline feedback", () => {
 
   it("opens the forward dialog from the keyboard shortcut", async () => {
     const sourceRunId = "d0000000-0000-4000-a000-000000000705";
-    const selectedContent = "Reference the approved launch checklist.";
+    const selectedContent = "Quote the approved launch checklist.";
 
     mockChatLifecycle(context, {
       threadId: FEEDBACK_THREAD_ID,
@@ -533,9 +533,20 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(await screen.findByText(selectedContent));
     await screen.findByText("Forward");
+    const copyButton = buttonByText("Copy");
+    const quoteButton = buttonByText("Quote");
     const forwardButton = buttonByText("Forward");
     expect(forwardButton).toHaveAttribute("aria-keyshortcuts", "f");
-    expect(buttonByText("Reference")).toHaveAttribute("aria-keyshortcuts", "r");
+    expect(quoteButton).toHaveAttribute("aria-keyshortcuts", "q");
+    const toolbar = copyButton.parentElement;
+    if (!(toolbar instanceof HTMLElement)) {
+      throw new Error("Selection toolbar is not available");
+    }
+    expect(queryAllByRoleFast("button", toolbar)).toStrictEqual([
+      copyButton,
+      quoteButton,
+      forwardButton,
+    ]);
 
     const event = dispatchDocumentShortcut("f");
     expect(event.defaultPrevented).toBeTruthy();
@@ -580,7 +591,7 @@ describe("chat inline feedback", () => {
 
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
     const feedbackNote = await findFeedbackNote();
     await user.click(feedbackNote);
 
@@ -672,27 +683,27 @@ describe("chat inline feedback", () => {
     selectTextForInlineFeedback(assistantReplyElement);
 
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
       expect(screen.queryByText("Forward")).not.toBeInTheDocument();
     });
 
     const forwardEvent = dispatchDocumentShortcut("f");
     expect(forwardEvent.defaultPrevented).toBeFalsy();
-    expect(screen.getByText("Reference")).toBeInTheDocument();
+    expect(screen.getByText("Quote")).toBeInTheDocument();
 
     await user.click(buttonByText("Copy"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
+      expect(screen.queryByText("Quote")).not.toBeInTheDocument();
     });
     expect(successToast).toHaveBeenCalledWith("Copied");
     successToast.mockRestore();
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Reference"));
+    await user.click(buttonByText("Quote"));
 
     const feedbackComment = await findFeedbackNote();
     await expect(findComposerEditor()).resolves.toBe(composerEditor);
@@ -780,7 +791,7 @@ describe("chat inline feedback", () => {
       await screen.findByText(assistantReply),
       selectedRange,
     );
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
     pastePlainText(await findFeedbackNote(), "Name the owner.");
     await user.click(screen.getByLabelText("Send"));
 
@@ -871,7 +882,7 @@ describe("chat inline feedback", () => {
     });
     apiRolledBack = true;
     selectTextForInlineFeedback(assistantReplyElement, selectedRange);
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
     pastePlainText(await findFeedbackNote(), "Assign the owner.");
     await user.click(screen.getByLabelText("Send"));
 
@@ -1072,7 +1083,7 @@ describe("chat inline feedback", () => {
       }
 
       selectTextForInlineFeedback(assistantReplyElement);
-      await user.click(await screen.findByText("Reference"));
+      await user.click(await screen.findByText("Quote"));
       const feedbackNote = await findFeedbackNote();
       pastePlainText(feedbackNote, "Rewrite this paragraph.");
       await user.click(screen.getByLabelText("Send"));
@@ -1158,7 +1169,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
     const feedbackNote = await findFeedbackNote();
     await user.click(feedbackNote);
     await user.keyboard("/");
@@ -1210,7 +1221,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
 
     await findFeedbackNote();
     await user.keyboard("Mention the dates before the risk summary.");
@@ -1286,7 +1297,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
 
     await findFeedbackNote();
     await user.keyboard("Mention the dates before the risk summary.");
@@ -1338,7 +1349,7 @@ describe("chat inline feedback", () => {
 
     const composerEditor = await findComposerEditor();
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
 
     const feedbackComment = await findFeedbackNote();
     await user.keyboard("补充具体日期");
@@ -1393,7 +1404,7 @@ describe("chat inline feedback", () => {
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
-    await user.click(await screen.findByText("Reference"));
+    await user.click(await screen.findByText("Quote"));
 
     const feedbackComment = await findFeedbackNote();
     await user.click(feedbackComment);
@@ -1462,14 +1473,14 @@ describe("chat inline feedback", () => {
     document.dispatchEvent(new Event("selectionchange"));
     await waitForDeferredSelectionCapture();
 
-    expect(screen.queryByText("Reference")).not.toBeInTheDocument();
+    expect(screen.queryByText("Quote")).not.toBeInTheDocument();
 
     assistantReplyElement.dispatchEvent(
       new MouseEvent("mouseup", { bubbles: true }),
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
   });
 
@@ -1516,7 +1527,7 @@ describe("chat inline feedback", () => {
     document.dispatchEvent(new Event("selectionchange"));
 
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
   });
 
@@ -1554,7 +1565,7 @@ describe("chat inline feedback", () => {
     selectTextForInlineFeedback(assistantReplyElement);
 
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
 
     const composerEditor = await findComposerEditor();
@@ -1562,7 +1573,7 @@ describe("chat inline feedback", () => {
     expect(composerEditor).toHaveFocus();
 
     await waitFor(() => {
-      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
+      expect(screen.queryByText("Quote")).not.toBeInTheDocument();
     });
     await waitForDeferredSelectionCapture();
 
@@ -1600,7 +1611,7 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
     expect(window.getSelection()?.toString()).toBe(assistantReply);
 
@@ -1608,14 +1619,14 @@ describe("chat inline feedback", () => {
     expect(event.defaultPrevented).toBeFalsy();
 
     await waitFor(() => {
-      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
+      expect(screen.queryByText("Quote")).not.toBeInTheDocument();
     });
     expect(window.getSelection()?.toString()).toBe(assistantReply);
 
     dispatchDocumentShortcut("c", { ctrlKey: true }, "keyup");
     await waitForDeferredSelectionCapture();
 
-    expect(screen.queryByText("Reference")).not.toBeInTheDocument();
+    expect(screen.queryByText("Quote")).not.toBeInTheDocument();
     expect(window.getSelection()?.toString()).toBe(assistantReply);
   });
 
@@ -1652,13 +1663,13 @@ describe("chat inline feedback", () => {
     selectTextForInlineFeedback(assistantReplyElement);
 
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
 
-    const referenceButton = buttonByText("Reference");
-    expect(referenceButton).toHaveAttribute("aria-keyshortcuts", "r");
+    const quoteButton = buttonByText("Quote");
+    expect(quoteButton).toHaveAttribute("aria-keyshortcuts", "q");
 
-    const event = dispatchDocumentShortcut("r");
+    const event = dispatchDocumentShortcut("q");
     expect(event.defaultPrevented).toBeTruthy();
 
     await findFeedbackNote();
@@ -1709,7 +1720,7 @@ describe("chat inline feedback", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
   });
 
@@ -1745,7 +1756,7 @@ describe("chat inline feedback", () => {
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
 
     // A real browser emits selectionchange after the selection collapses.
@@ -1753,7 +1764,7 @@ describe("chat inline feedback", () => {
     document.dispatchEvent(new Event("selectionchange"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Reference")).not.toBeInTheDocument();
+      expect(screen.queryByText("Quote")).not.toBeInTheDocument();
     });
   });
 
@@ -1849,9 +1860,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
-    click(buttonByText("Reference"));
+    click(buttonByText("Quote"));
 
     pastePlainText(
       await findFeedbackNote(),
@@ -1927,9 +1938,9 @@ describe("chat inline feedback", () => {
     const assistantReplyElement = await screen.findByText(assistantReply);
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Reference"));
+    await user.click(buttonByText("Quote"));
 
     const firstComment = await findFeedbackNote();
     await user.keyboard("Assign each risk to an owner.");
@@ -1939,9 +1950,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Reference"));
+    await user.click(buttonByText("Quote"));
 
     const comments = await findFeedbackNotes(2);
     expect(comments).toHaveLength(2);
@@ -2001,9 +2012,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Reference"));
+    await user.click(buttonByText("Quote"));
 
     const firstComment = await findFeedbackNote();
     await user.keyboard("Add owners.");
@@ -2013,9 +2024,9 @@ describe("chat inline feedback", () => {
 
     selectTextForInlineFeedback(assistantReplyElement);
     await waitFor(() => {
-      expect(screen.getByText("Reference")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
     });
-    await user.click(buttonByText("Reference"));
+    await user.click(buttonByText("Quote"));
 
     const comments = await findFeedbackNotes(2);
     await user.keyboard("Add dates.");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -83,8 +83,21 @@ function FeedbackToolbar({
           <ShortcutHint shortcut="c" />
         </button>
         <div className="h-4 w-px bg-border" />
+        <button
+          type="button"
+          onClick={onProvideFeedback}
+          aria-keyshortcuts="q"
+          className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
+        >
+          <MessageCircle size={14} />
+          {t(($) => {
+            return $.chat.feedback.quote;
+          })}
+          <ShortcutHint shortcut="q" />
+        </button>
         {onForward ? (
           <>
+            <div className="h-4 w-px bg-border" />
             <button
               type="button"
               onClick={onForward}
@@ -97,28 +110,15 @@ function FeedbackToolbar({
               })}
               <ShortcutHint shortcut="f" />
             </button>
-            <div className="h-4 w-px bg-border" />
           </>
         ) : null}
-        <button
-          type="button"
-          onClick={onProvideFeedback}
-          aria-keyshortcuts="r"
-          className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
-        >
-          <MessageCircle size={14} />
-          {t(($) => {
-            return $.chat.feedback.reference;
-          })}
-          <ShortcutHint shortcut="r" />
-        </button>
       </div>
     </PopoverContent>
   );
 }
 
-// Mounts the selection listeners and the floating Copy / Forward / Reference
-// toolbar anchored to the selected passage. Picking "Reference"
+// Mounts the selection listeners and the floating Copy / Quote / Forward
+// toolbar anchored to the selected passage. Picking "Quote"
 // drops the quoted passage straight into the composer (see ComposerFeedbackRows
 // in zero-chat-composer.tsx) — there is no separate feedback panel.
 export function ChatFeedbackSelection({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -11,7 +11,6 @@ import {
 } from "@vm0/ui";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { setChatListQuery$ } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import type {
   ChatThreadFeedbackSelection,
@@ -89,12 +88,14 @@ function FeedbackToolbar({
             <button
               type="button"
               onClick={onForward}
+              aria-keyshortcuts="f"
               className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
             >
               <Forward size={14} />
               {t(($) => {
                 return $.chat.forward.action;
               })}
+              <ShortcutHint shortcut="f" />
             </button>
             <div className="h-4 w-px bg-border" />
           </>
@@ -102,22 +103,22 @@ function FeedbackToolbar({
         <button
           type="button"
           onClick={onProvideFeedback}
-          aria-keyshortcuts="f"
+          aria-keyshortcuts="r"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
         >
           <MessageCircle size={14} />
           {t(($) => {
-            return $.chat.feedback.provide;
+            return $.chat.feedback.reference;
           })}
-          <ShortcutHint shortcut="f" />
+          <ShortcutHint shortcut="r" />
         </button>
       </div>
     </PopoverContent>
   );
 }
 
-// Mounts the selection listeners and the floating Copy / Forward / Provide
-// toolbar anchored to the selected passage. Picking "Provide feedback"
+// Mounts the selection listeners and the floating Copy / Forward / Reference
+// toolbar anchored to the selected passage. Picking "Reference"
 // drops the quoted passage straight into the composer (see ComposerFeedbackRows
 // in zero-chat-composer.tsx) — there is no separate feedback panel.
 export function ChatFeedbackSelection({
@@ -140,10 +141,9 @@ export function ChatFeedbackSelection({
   const startFeedback = useSet(feedback.start$);
   const closeSelectionToolbar = useSet(feedback.close$);
   const copy = useSet(feedback.copy$);
-  const openForward = useSet(feedback.openForward$);
+  const startForward = useSet(feedback.startForward$);
   const setForwardComposerState = useSet(feedback.setForwardComposerState$);
   const closeForward = useSet(feedback.closeForward$);
-  const setForwardQuery = useSet(setChatListQuery$);
 
   return (
     <>
@@ -168,19 +168,7 @@ export function ChatFeedbackSelection({
             onProvideFeedback={startFeedback}
             onForward={
               forwardEnabled && selection.threadId && selection.runId
-                ? () => {
-                    const threadId = selection.threadId;
-                    const runId = selection.runId;
-                    if (!threadId || !runId) {
-                      return;
-                    }
-                    openForward({
-                      text: selection.text,
-                      threadId,
-                      runId,
-                    });
-                    setForwardQuery("");
-                  }
+                ? startForward
                 : undefined
             }
           />
@@ -195,7 +183,6 @@ export function ChatFeedbackSelection({
           onComposerStateChange={setForwardComposerState}
           onDismiss={() => {
             closeForward();
-            setForwardQuery("");
           }}
         />
       ) : null}


### PR DESCRIPTION
## Summary

- rename the selected-content feedback action to Quote across supported locales
- use Q for Quote and F for the feature-gated Forward action
- order the selection pill actions as Copy | Quote | Forward
- cover the labels, shortcuts, action order, and existing feedback flows in page-level integration tests

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` (26 passed)
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx` (40 passed)

Browser verification was not run because this repository does not allow starting a local dev server unless explicitly requested.
