### PR TITLE
refactor(connectors): require auth mode in responses

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9166,7 +9166,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       fields: custom.fields,
       headerInjections: custom.headerInjections,
       queryInjections: custom.queryInjections,
-      authMode: custom.authMode ?? "manual",
+      authMode: custom.authMode,
       permissionBundleRef: custom.permissionBundleRef,
       skillMarkdown: "Use the updated Slack-compatible operations only.",
       storageVersion: custom.storageVersion,

--- a/turbo/apps/cli/src/commands/zero/connector/custom/create.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/create.ts
@@ -43,7 +43,7 @@ async function printCreateResult(
   );
   console.log(chalk.dim(`  ID:             ${connector.id}`));
   console.log(chalk.dim(`  Slug:           ${connector.slug}`));
-  console.log(chalk.dim(`  Authentication: ${connector.authMode ?? "manual"}`));
+  console.log(chalk.dim(`  Authentication: ${connector.authMode}`));
   console.log(chalk.dim("  Status:         awaiting connection"));
   console.log();
   const agentId = getOkouAgentId()?.trim() || undefined;

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -247,6 +247,7 @@ function createCustomConnector(): CustomConnectorHttpResponse {
       },
     ],
     queryInjections: [],
+    authMode: "manual",
     connected: true,
     missingRequiredFields: [],
     configuredFieldKeys: ["secret"],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -107,6 +107,7 @@ function customConnector(
       },
     ],
     queryInjections: [],
+    authMode: "manual",
     connected: false,
     missingRequiredFields: ["secret"],
     configuredFieldKeys: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -300,6 +300,7 @@ function customConnector(
       },
     ],
     queryInjections: [],
+    authMode: "manual",
     storageVersion: 1,
     connected: false,
     missingRequiredFields: ["secret"],
@@ -4148,7 +4149,7 @@ describe("connectors page", () => {
           fields: body.fields,
           headerInjections: body.headerInjections,
           queryInjections: body.queryInjections,
-          authMode: body.authMode,
+          authMode: body.authMode ?? "manual",
           storageVersion: body.storageVersion ?? 1,
           connected: false,
           missingRequiredFields: ["secret"],
@@ -4171,7 +4172,7 @@ describe("connectors page", () => {
           fields: body.fields,
           headerInjections: body.headerInjections,
           queryInjections: body.queryInjections,
-          authMode: body.authMode,
+          authMode: body.authMode ?? connector.authMode,
           storageVersion: body.storageVersion ?? connector.storageVersion,
         };
         return respond(200, connector);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/custom-connector-create-dialog.tsx
@@ -698,7 +698,7 @@ function connectorHasSimpleApiDefinition(
   const field = connector.fields[0];
   const injection = connector.headerInjections[0];
   return (
-    (connector.authMode ?? "manual") === "manual" &&
+    connector.authMode === "manual" &&
     connector.fields.length === 1 &&
     field?.key === "secret" &&
     field.kind === "secret" &&
@@ -721,7 +721,7 @@ function manualDefinitionFromForm(
 ): CustomConnectorDefinitionParts {
   const preserveAdvancedDefinition =
     connector !== undefined &&
-    (connector.authMode ?? "manual") === "manual" &&
+    connector.authMode === "manual" &&
     !connectorHasSimpleApiDefinition(connector);
   if (preserveAdvancedDefinition) {
     return {
@@ -891,7 +891,7 @@ function updateChangesCredentialContract(
   connector: CustomConnectorResponse,
   body: UpdateCustomConnectorBody,
 ): boolean {
-  const currentAuthMode = connector.authMode ?? "manual";
+  const currentAuthMode = connector.authMode;
   const nextAuthMode = body.authMode ?? "manual";
   if (
     currentAuthMode !== nextAuthMode ||
@@ -1002,7 +1002,7 @@ function formCanSubmit(
   }
   const advancedApiDefinition =
     connector !== undefined &&
-    (connector.authMode ?? "manual") === "manual" &&
+    connector.authMode === "manual" &&
     !connectorHasSimpleApiDefinition(connector);
   if (
     form.authMethodTypes.includes("api") &&
@@ -1230,7 +1230,7 @@ export function CustomConnectorCreateDialog({
   const canSubmit = !submitting && formCanSubmit(form, connector, mcpEnabled);
   const advancedApiDefinition =
     connector !== undefined &&
-    (connector.authMode ?? "manual") === "manual" &&
+    connector.authMode === "manual" &&
     !connectorHasSimpleApiDefinition(connector);
 
   const close = () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -252,6 +252,33 @@ describe("custom connector response contracts", () => {
     }).toThrow();
   });
 
+  it("parses canonical OAuth HTTP responses", () => {
+    const payload = {
+      ...customHttpConnectorPayload,
+      authMode: "oauth",
+      oauthConfig: {
+        providerAdapter: "standard",
+        clientId: "oauth-client-id",
+        authorizationUrl: "https://example.test/oauth/authorize",
+        tokenUrl: "https://example.test/oauth/token",
+        tokenEndpointAuthMethod: "client_secret_post",
+        pkceMethod: "S256",
+        scopes: ["read"],
+        authorizationParams: {},
+      },
+    } as const;
+
+    expect(customConnectorResponseSchema.parse(payload)).toStrictEqual(payload);
+  });
+
+  it("rejects responses without an auth mode", () => {
+    const { authMode: _authMode, ...payload } = customHttpConnectorPayload;
+
+    expect(() => {
+      return customConnectorResponseSchema.parse(payload);
+    }).toThrow();
+  });
+
   it("parses canonical MCP responses", () => {
     const payload = {
       id: "00000000-0000-4000-a000-000000000006",

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -122,7 +122,7 @@ const customConnectorResponseBaseSchema = z.object({
   fields: z.array(customConnectorFieldSchema),
   headerInjections: z.array(customConnectorHeaderInjectionSchema),
   queryInjections: z.array(customConnectorQueryInjectionSchema),
-  authMode: customConnectorAuthModeSchema.optional(),
+  authMode: customConnectorAuthModeSchema,
   oauthConfig: customConnectorOAuthConfigSchema.optional(),
   permissionBundleRef: customConnectorPermissionBundleRefSchema
     .nullable()


### PR DESCRIPTION
## Summary

- require `authMode` on custom connector API responses
- remove response-side manual-mode fallbacks from CLI and Platform consumers
- keep create and update request defaults backward compatible
- cover manual, OAuth, MCP, and malformed response contracts

## Testing

- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/connector-client-contract.test.ts`
- `pnpm -F @vm0/okou-cli exec vitest run src/commands/zero/connector/custom/__tests__/create.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "keeps a granted custom skill independent from runtime admission"`
- affected workspace lint and type checks
- `pnpm knip`

Closes #26666
Parent: #25312
