### PR TITLE
feat(desktop): add staged zero migration controls

### DIFF
--- a/.github/scripts/tests/validate-desktop-migration-policy-test.sh
+++ b/.github/scripts/tests/validate-desktop-migration-policy-test.sh
@@ -11,15 +11,21 @@ expect_failure() {
   fi
 }
 
-bash "$VALIDATOR" off false ""
-bash "$VALIDATOR" soft false ""
-expect_failure invalid false ""
-expect_failure hard false ""
-expect_failure hard true ""
-expect_failure hard true "https://github.com/vm0-ai/vm0/issues/26370"
+bash "$VALIDATOR" off false "" refs/heads/main
+bash "$VALIDATOR" soft false "" refs/heads/main
+expect_failure soft false "" refs/heads/feature
+expect_failure invalid false "" refs/heads/main
+expect_failure hard false "" refs/heads/main
+expect_failure hard true "" refs/heads/main
+expect_failure \
+  hard \
+  true \
+  "https://github.com/vm0-ai/vm0/issues/26370" \
+  refs/heads/main
 bash "$VALIDATOR" \
   hard \
   true \
-  "https://github.com/vm0-ai/vm0/issues/26370#issuecomment-123456789"
+  "https://github.com/vm0-ai/vm0/issues/26370#issuecomment-123456789" \
+  refs/heads/main
 
 echo "validate-desktop-migration-policy-test: ok"

--- a/.github/scripts/tests/validate-desktop-migration-policy-test.sh
+++ b/.github/scripts/tests/validate-desktop-migration-policy-test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+VALIDATOR="${REPO_ROOT}/.github/scripts/validate-desktop-migration-policy.sh"
+
+expect_failure() {
+  if bash "$VALIDATOR" "$@" >/dev/null 2>&1; then
+    echo "expected validation failure: $*" >&2
+    exit 1
+  fi
+}
+
+bash "$VALIDATOR" off false ""
+bash "$VALIDATOR" soft false ""
+expect_failure invalid false ""
+expect_failure hard false ""
+expect_failure hard true ""
+expect_failure hard true "https://github.com/vm0-ai/vm0/issues/26370"
+bash "$VALIDATOR" \
+  hard \
+  true \
+  "https://github.com/vm0-ai/vm0/issues/26370#issuecomment-123456789"
+
+echo "validate-desktop-migration-policy-test: ok"

--- a/.github/scripts/validate-desktop-migration-policy.sh
+++ b/.github/scripts/validate-desktop-migration-policy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+confirmed_hard_stop="${2:-false}"
+approval_url="${3:-}"
+
+case "$mode" in
+  off | soft)
+    exit 0
+    ;;
+  hard)
+    if [[ "$confirmed_hard_stop" != "true" ]]; then
+      echo "Hard stop requires confirmed_hard_stop=true" >&2
+      exit 1
+    fi
+    if [[ "$approval_url" != https://github.com/vm0-ai/vm0/issues/26370#issuecomment-* ]]; then
+      echo "Hard stop requires an explicit #26370 approval comment URL" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Mode must be off, soft, or hard" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/validate-desktop-migration-policy.sh
+++ b/.github/scripts/validate-desktop-migration-policy.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 mode="${1:-}"
 confirmed_hard_stop="${2:-false}"
 approval_url="${3:-}"
+git_ref="${4:-}"
+
+if [[ "$git_ref" != "refs/heads/main" ]]; then
+  echo "Desktop migration policy publishing requires refs/heads/main" >&2
+  exit 1
+fi
 
 case "$mode" in
   off | soft)

--- a/.github/workflows/desktop-migration-policy.yml
+++ b/.github/workflows/desktop-migration-policy.yml
@@ -1,0 +1,92 @@
+name: Publish Zero Desktop Migration Policy
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Zero Desktop rollout mode"
+        required: true
+        type: choice
+        options:
+          - off
+          - soft
+          - hard
+        default: soft
+      confirmed_hard_stop:
+        description: "I confirm the #26370 hard-stop go/no-go checklist is approved"
+        required: true
+        type: boolean
+        default: false
+      hard_stop_approval_url:
+        description: "Required for hard: URL of the explicit approval comment on #26370"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-migration-policy-production
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Gate hard-stop activation
+        env:
+          APPROVAL_URL: ${{ inputs.hard_stop_approval_url }}
+          CONFIRMED_HARD_STOP: ${{ inputs.confirmed_hard_stop }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/validate-desktop-migration-policy.sh \
+            "$MODE" \
+            "$CONFIRMED_HARD_STOP" \
+            "$APPROVAL_URL"
+
+      - name: Publish policy asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: ${{ inputs.mode }}
+          POLICY_TAG: desktop-migration-policy
+        run: |
+          set -euo pipefail
+          policy_dir="$(mktemp -d)"
+          policy_file="${policy_dir}/desktop-migration-policy.json"
+          jq -n --arg mode "$MODE" '{schemaVersion: 1, mode: $mode}' > "$policy_file"
+
+          if ! gh release view "$POLICY_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$POLICY_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "Zero Desktop migration policy" \
+              --notes "Mutable production policy for the staged Zero-to-Okou migration. Managed by this workflow only." \
+              --latest=false
+          fi
+          gh release upload "$POLICY_TAG" "$policy_file" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Verify published policy
+        env:
+          EXPECTED_MODE: ${{ inputs.mode }}
+          GH_TOKEN: ${{ github.token }}
+          POLICY_TAG: desktop-migration-policy
+        run: |
+          set -euo pipefail
+          download_dir="$(mktemp -d)"
+          gh release download "$POLICY_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern desktop-migration-policy.json \
+            --dir "$download_dir" \
+            --clobber
+          jq -e \
+            --arg mode "$EXPECTED_MODE" \
+            '.schemaVersion == 1 and .mode == $mode' \
+            "${download_dir}/desktop-migration-policy.json"
+          echo "### Zero Desktop migration policy" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published mode: \`$EXPECTED_MODE\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop-migration-policy.yml
+++ b/.github/workflows/desktop-migration-policy.yml
@@ -40,13 +40,15 @@ jobs:
         env:
           APPROVAL_URL: ${{ inputs.hard_stop_approval_url }}
           CONFIRMED_HARD_STOP: ${{ inputs.confirmed_hard_stop }}
+          GIT_REF: ${{ github.ref }}
           MODE: ${{ inputs.mode }}
         run: |
           set -euo pipefail
           bash .github/scripts/validate-desktop-migration-policy.sh \
             "$MODE" \
             "$CONFIRMED_HARD_STOP" \
-            "$APPROVAL_URL"
+            "$APPROVAL_URL" \
+            "$GIT_REF"
 
       - name: Publish policy asset
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -236,6 +236,7 @@ jobs:
             .github/scripts/run-semgrep.sh \
             .github/scripts/runner-behavior-*.sh \
             .github/scripts/smoke-okou-cli-artifact.sh \
+            .github/scripts/validate-desktop-migration-policy.sh \
             .github/scripts/verify-okou-cli-artifact.sh \
             .github/scripts/verify-okou-desktop-artifact.sh \
             .github/scripts/tests/ansible-ssh-control-path-test.sh \
@@ -258,6 +259,7 @@ jobs:
             .github/scripts/tests/run-semgrep-test.sh \
             .github/scripts/tests/semgrep-results-test.sh \
             .github/scripts/tests/runner-behavior-balloon-test.sh \
+            .github/scripts/tests/validate-desktop-migration-policy-test.sh \
             e2e/helpers/browser.bash \
             e2e/helpers/trace-cli.sh \
             e2e/tests/02-browser/brw-t01-platform-e2e.bats

--- a/docs/zero-desktop-migration-rollout.md
+++ b/docs/zero-desktop-migration-rollout.md
@@ -1,0 +1,137 @@
+# Zero Desktop migration rollout
+
+This runbook controls the final Zero-to-Okou Desktop migration tracked by
+[#26370](https://github.com/vm0-ai/vm0/issues/26370). Shipping the control code
+does not authorize or activate a hard stop.
+
+## Ownership
+
+- The Desktop release owner owns the policy-capable Zero release and verifies
+  that it reached the intended population.
+- The API production owner owns the public policy endpoint and the policy
+  publishing workflow.
+- The support owner must be named in the approval comment before a hard stop.
+- The person who publishes `hard` is also the rollback operator until the
+  observation window ends.
+
+Record the named people, evidence, decision, and rollback operator in a comment
+on #26370. A production environment reviewer is the final deployment gate.
+
+## Policy contract
+
+The `Publish Zero Desktop Migration Policy` workflow publishes
+`desktop-migration-policy.json` as a mutable asset on the
+`desktop-migration-policy` GitHub release. The API exposes the validated policy
+at `GET /api/desktop/migration-policy` with `Cache-Control: no-store`.
+
+| Mode   | Desktop behavior                                                                           |
+| ------ | ------------------------------------------------------------------------------------------ |
+| `off`  | Keep Zero available and hide reminders.                                                    |
+| `soft` | Keep Zero available and show the nonblocking Okou reminder.                                |
+| `hard` | Finish the current command, stop the Zero host, and offer only Download Okou or Quit Zero. |
+
+Eligible Zero builds refresh the policy every five minutes. The API and the
+Desktop both independently fall back to `soft` when the policy is missing,
+unavailable, timed out, or invalid. Okou ignores this policy. Zero versions
+older than the minimum bridge version remain unaffected.
+
+## Publishing a mode
+
+Run the workflow from `main`:
+
+```bash
+gh workflow run desktop-migration-policy.yml \
+  --ref main \
+  -f mode=soft \
+  -f confirmed_hard_stop=false
+```
+
+Then wait for the workflow to succeed and verify the live API response:
+
+```bash
+curl -fsSL https://api.vm0.ai/api/desktop/migration-policy | jq
+```
+
+Publishing `off` or `soft` does not require a Desktop or API release. Publishing
+`hard` additionally requires `confirmed_hard_stop=true`, the URL of the explicit
+approval comment on #26370, and production environment approval.
+
+## Product-aware evidence
+
+Use a bounded Axiom request-log query to distinguish active Desktop products and
+versions. Start with 15 minutes, then expand to at most the three-day retention
+window when assessing adoption:
+
+```apl
+where x_client_type == "Desktop"
+| summarize requests=count(), sessions=dcount(x_client_session_id)
+  by x_client_product, x_client_version
+| sort by requests desc
+```
+
+Check policy delivery and errors separately:
+
+```apl
+where path_template == "/api/desktop/migration-policy"
+| summarize requests=count(), failures=countif(status >= 500)
+  by x_client_product, x_client_version, status
+| sort by requests desc
+```
+
+Use MaskDB aggregates over `computer_use_hosts` to review recent host versions
+and status without retrieving names or tokens:
+
+```json
+{
+  "table": "computer_use_hosts",
+  "where": {
+    "col": "last_seen_at",
+    "op": "gte",
+    "value": "<UTC start of review window>"
+  },
+  "group_by": ["client_product", "app_version", "status"],
+  "metrics": [{ "op": "count", "as": "hosts" }],
+  "order_by": [{ "col": "hosts", "dir": "desc" }],
+  "limit": 100
+}
+```
+
+The MaskDB policy must expose `client_product` as a filterable group field before
+the hard-stop review. If it does not, refreshing that read-only allowlist is a
+go/no-go blocker; do not replace the masked-data review with raw production SQL.
+
+## Hard-stop go/no-go checklist
+
+All items must be recorded as satisfied on #26370 before publishing `hard`:
+
+- [ ] Okou install, login, permissions, Computer Use, updater, and stable
+      download flows remain production-verified.
+- [ ] The policy-capable Zero stable release has been available for at least 72
+      hours and represents at least 95% of active Zero Desktop sessions in the
+      review window.
+- [ ] Remaining external Zero users and versions have been reviewed from
+      bounded Axiom and masked MaskDB evidence; impact is explicitly accepted.
+- [ ] Okou adoption and error rates are healthy, with no unresolved migration,
+      authentication, updater, or Computer Use regression.
+- [ ] The support owner has current download, reinstall, permissions, and login
+      guidance ready.
+- [ ] The rollback operator is available for the activation and observation
+      window.
+- [ ] The approver has posted an explicit `hard` approval comment on #26370.
+
+If any item is unknown or false, the decision is no-go and the policy stays
+`soft`.
+
+## Activation and rollback
+
+Activate only during staffed hours. Publish `hard`, verify the live endpoint,
+and observe policy requests, Zero/Okou active sessions, API failures, and support
+reports for at least 30 minutes. Desktop clients can take up to five minutes to
+apply a new policy.
+
+For any unexpected impact, publish `soft` immediately with the same workflow and
+verify the live endpoint. Running Zero clients poll back to coexistence and may
+restart their host within five minutes. Use `off` instead when the reminder must
+also disappear. Users who already quit Zero must reopen it to receive the
+rollback policy. Record the rollback time, reason, and verification evidence on
+#26370.

--- a/docs/zero-desktop-migration-rollout.md
+++ b/docs/zero-desktop-migration-rollout.md
@@ -46,6 +46,8 @@ gh workflow run desktop-migration-policy.yml \
   -f confirmed_hard_stop=false
 ```
 
+The workflow rejects dispatches from any ref other than `main`.
+
 Then wait for the workflow to succeed and verify the live API response:
 
 ```bash

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -18,6 +18,8 @@ const DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
 const OKOU_DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/ai-okou-desktop-updates/ai-okou-desktop-update-manifest.json";
+const DESKTOP_ZERO_MIGRATION_POLICY_URL =
+  "https://github.com/vm0-ai/vm0/releases/download/desktop-migration-policy/desktop-migration-policy.json";
 
 interface DesktopUpdateRelease {
   readonly version: string;
@@ -122,6 +124,52 @@ describe("desktop update routes", () => {
   beforeEach(async () => {
     await accept(manifestStateClient().reset({ body: {} }), [200]);
   });
+
+  it.each(["off", "soft", "hard"] as const)(
+    "serves the no-store %s Zero migration policy",
+    async (mode) => {
+      server.use(
+        http.get(DESKTOP_ZERO_MIGRATION_POLICY_URL, () => {
+          return HttpResponse.json({ schemaVersion: 1, mode });
+        }),
+      );
+
+      const response = await appRequest(
+        "http://api.test/api/desktop/migration-policy",
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+      await expect(response.json()).resolves.toStrictEqual({
+        schemaVersion: 1,
+        mode,
+      });
+    },
+  );
+
+  it.each([
+    HttpResponse.json({ schemaVersion: 2, mode: "hard" }),
+    new HttpResponse(null, { status: 503 }),
+  ])(
+    "defaults to soft coexistence for an unavailable policy",
+    async (mockResponse) => {
+      server.use(
+        http.get(DESKTOP_ZERO_MIGRATION_POLICY_URL, () => {
+          return mockResponse;
+        }),
+      );
+
+      const response = await appRequest(
+        "http://api.test/api/desktop/migration-policy",
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual({
+        schemaVersion: 1,
+        mode: "soft",
+      });
+    },
+  );
 
   it("redirects the release page route to the current stable desktop release", async () => {
     mockDesktopUpdateManifest(

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -4,14 +4,17 @@ import {
   DESKTOP_UPDATE_LINE_OKOU,
   DESKTOP_UPDATE_LINE_ZERO,
   desktopUpdatesContract,
+  desktopZeroMigrationPolicySchema,
+  type DesktopZeroMigrationPolicy,
   type DesktopUpdateLine,
 } from "@vm0/api-contracts/contracts/desktop-updates";
 import { command } from "ccstate";
 
 import { notFound } from "../../lib/error";
-import { request$ } from "../context/hono";
+import { request$, setResHeader$ } from "../context/hono";
 import { pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
+import { readBoundedResponseText, safeJsonParse, settle } from "../utils";
 import {
   loadDesktopDmgDownloadUrl,
   loadDesktopReleasePageUrl,
@@ -27,6 +30,52 @@ const productReleasePageParams$ = pathParamsOf(
 );
 const productDmgDownloadParams$ = pathParamsOf(
   desktopUpdatesContract.productDmgDownload,
+);
+const DESKTOP_ZERO_MIGRATION_POLICY_URL =
+  "https://github.com/vm0-ai/vm0/releases/download/desktop-migration-policy/desktop-migration-policy.json";
+const SAFE_DESKTOP_ZERO_MIGRATION_POLICY = {
+  schemaVersion: 1,
+  mode: "soft",
+} as const satisfies DesktopZeroMigrationPolicy;
+const DESKTOP_ZERO_MIGRATION_POLICY_MAX_BYTES = 1024;
+
+async function fetchDesktopZeroMigrationPolicy(
+  signal: AbortSignal,
+): Promise<DesktopZeroMigrationPolicy> {
+  const fetched = await settle(
+    fetch(DESKTOP_ZERO_MIGRATION_POLICY_URL, {
+      headers: { Accept: "application/json" },
+      signal,
+    }),
+    signal,
+  );
+  if (!fetched.ok || !fetched.value.ok) {
+    return SAFE_DESKTOP_ZERO_MIGRATION_POLICY;
+  }
+  const body = await settle(
+    readBoundedResponseText(
+      fetched.value,
+      DESKTOP_ZERO_MIGRATION_POLICY_MAX_BYTES,
+    ),
+    signal,
+  );
+  if (!body.ok || body.value.kind !== "text") {
+    return SAFE_DESKTOP_ZERO_MIGRATION_POLICY;
+  }
+  const parsed = desktopZeroMigrationPolicySchema.safeParse(
+    safeJsonParse(body.value.text),
+  );
+  return parsed.success ? parsed.data : SAFE_DESKTOP_ZERO_MIGRATION_POLICY;
+}
+
+const getDesktopMigrationPolicy$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(setResHeader$, "Cache-Control", "no-store");
+    return {
+      status: 200 as const,
+      body: await fetchDesktopZeroMigrationPolicy(signal),
+    };
+  },
 );
 
 function desktopUpdateLineFromRequestUrl(
@@ -176,6 +225,10 @@ const getProductDesktopDmgDownload$ = command(
 );
 
 export const desktopUpdateRoutes: readonly RouteEntry[] = [
+  {
+    route: desktopUpdatesContract.migrationPolicy,
+    handler: getDesktopMigrationPolicy$,
+  },
   {
     route: desktopUpdatesContract.releasePage,
     handler: getDesktopReleasePage$,

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -99,6 +99,7 @@ export interface DesktopZeroMigrationApi {
   readonly remindLater: () => Promise<DesktopZeroMigrationState>;
   readonly beginMigration: () => Promise<DesktopZeroMigrationState>;
   readonly resumeZero: () => Promise<DesktopZeroMigrationState>;
+  readonly quitZero: () => Promise<DesktopZeroMigrationState>;
   readonly subscribe: (callback: () => void) => () => void;
 }
 

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -292,6 +292,7 @@ describe("Desktop IPC boundary", () => {
       DESKTOP_ZERO_MIGRATION_CHANNELS.remindLater,
       DESKTOP_ZERO_MIGRATION_CHANNELS.beginMigration,
       DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero,
+      DESKTOP_ZERO_MIGRATION_CHANNELS.quitZero,
     ]) {
       await expect(invokeIpc(channel, blockedAppUrl)).rejects.toThrow(
         "Zero migration is unavailable on this page",
@@ -302,6 +303,7 @@ describe("Desktop IPC boundary", () => {
     expect(api.remindLater).not.toHaveBeenCalled();
     expect(api.beginMigration).not.toHaveBeenCalled();
     expect(api.resumeZero).not.toHaveBeenCalled();
+    expect(api.quitZero).not.toHaveBeenCalled();
   });
 
   it("notifies only live windows when computer use state changes", async () => {
@@ -491,6 +493,7 @@ function createDesktopZeroMigrationApi(): {
   readonly resumeZero: ReturnType<
     typeof vi.fn<() => Promise<DesktopZeroMigrationState>>
   >;
+  readonly quitZero: ReturnType<typeof vi.fn<() => DesktopZeroMigrationState>>;
 } {
   const state: DesktopZeroMigrationState = {
     mode: "soft_reminder",
@@ -502,6 +505,7 @@ function createDesktopZeroMigrationApi(): {
     remindLater: vi.fn(() => state),
     beginMigration: vi.fn(async () => state),
     resumeZero: vi.fn(async () => state),
+    quitZero: vi.fn(() => state),
   };
 }
 

--- a/turbo/apps/desktop/src/desktop-zero-migration-config.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-config.ts
@@ -1,5 +1,8 @@
 export const ZERO_MIGRATION_BRIDGE_CONFIG = {
   minimumVersion: "0.34.0",
+  policyPath: "/api/desktop/migration-policy",
+  policyRefreshIntervalMs: 5 * 60 * 1_000,
+  policyRequestTimeoutMs: 5 * 1_000,
   downloadUrl:
     "https://api.vm0.ai/api/okou/desktop/updates/stable/darwin/arm64/dmg",
   reminderDelayMs: 7 * 24 * 60 * 60 * 1_000,
@@ -10,6 +13,9 @@ export const ZERO_MIGRATION_BRIDGE_CONFIG = {
     pausedTitle: "Zero is paused while you set up Okou",
     pausedDetail:
       "Finish installing and setting up Okou. If that does not work, you can resume Zero and try again later.",
+    hardStopTitle: "Zero has moved to Okou",
+    hardStopDetail:
+      "Zero is now offline. Download Okou to continue using Computer Use.",
   },
 } as const;
 

--- a/turbo/apps/desktop/src/desktop-zero-migration-electron.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-electron.ts
@@ -9,6 +9,7 @@ interface DesktopZeroMigrationNativeApi {
   readonly remindLater: () => DesktopZeroMigrationState;
   readonly beginMigration: () => Promise<DesktopZeroMigrationState>;
   readonly resumeZero: () => Promise<DesktopZeroMigrationState>;
+  readonly quitZero: () => DesktopZeroMigrationState;
 }
 
 export function notifyDesktopZeroMigrationChanged(): void {
@@ -49,5 +50,9 @@ export function installDesktopZeroMigrationIpc(
   ipcMain.handle(DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero, (event) => {
     assertComputerUsePage(event);
     return api.resumeZero();
+  });
+  ipcMain.handle(DESKTOP_ZERO_MIGRATION_CHANNELS.quitZero, (event) => {
+    assertComputerUsePage(event);
+    return api.quitZero();
   });
 }

--- a/turbo/apps/desktop/src/desktop-zero-migration-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-ipc-channels.ts
@@ -3,5 +3,6 @@ export const DESKTOP_ZERO_MIGRATION_CHANNELS = {
   remindLater: "desktop-zero-migration:remind-later",
   beginMigration: "desktop-zero-migration:begin-migration",
   resumeZero: "desktop-zero-migration:resume-zero",
+  quitZero: "desktop-zero-migration:quit-zero",
   changed: "desktop-zero-migration:changed",
 } as const;

--- a/turbo/apps/desktop/src/desktop-zero-migration-types.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration-types.ts
@@ -3,7 +3,9 @@ export type DesktopZeroMigrationMode =
   | "soft_reminder"
   | "waiting_for_command"
   | "paused"
-  | "download_failed";
+  | "download_failed"
+  | "hard_stop_waiting"
+  | "hard_stop";
 
 export interface DesktopZeroMigrationState {
   readonly mode: DesktopZeroMigrationMode;

--- a/turbo/apps/desktop/src/desktop-zero-migration.test.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration.test.ts
@@ -22,7 +22,11 @@ function createController(options: {
   readonly drainAndStopZero?: () => Promise<void>;
   readonly startZero?: () => Promise<void>;
   readonly openDownload?: (url: string) => Promise<void>;
+  readonly fetchPolicy?: (signal: AbortSignal) => Promise<Response>;
+  readonly quitZero?: () => void;
   readonly onChange?: () => void;
+  readonly onAttention?: () => void;
+  readonly logPolicyError?: (error: unknown) => void;
 }) {
   return new DesktopZeroMigrationController({
     enabled: options.enabled ?? true,
@@ -32,7 +36,15 @@ function createController(options: {
     drainAndStopZero: options.drainAndStopZero ?? vi.fn(async () => {}),
     startZero: options.startZero ?? vi.fn(async () => {}),
     openDownload: options.openDownload ?? vi.fn(async () => {}),
+    fetchPolicy:
+      options.fetchPolicy ??
+      vi.fn(async () => {
+        return Response.json({ schemaVersion: 1, mode: "soft" });
+      }),
+    quitZero: options.quitZero ?? vi.fn(),
     onChange: options.onChange,
+    onAttention: options.onAttention,
+    logPolicyError: options.logPolicyError,
     now: options.now,
   });
 }
@@ -161,5 +173,105 @@ describe("DesktopZeroMigrationController", () => {
       unknown
     >;
     expect(persisted.zeroMigration).toBeUndefined();
+  });
+
+  it("applies a hard stop only after draining the current command", async () => {
+    const filePath = await preferencesPath();
+    let finishDrain!: () => void;
+    const drainAndStopZero = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        finishDrain = resolve;
+      });
+    });
+    const onAttention = vi.fn();
+    const quitZero = vi.fn();
+    const controller = createController({
+      filePath,
+      drainAndStopZero,
+      onAttention,
+      quitZero,
+      fetchPolicy: vi.fn(async () => {
+        return Response.json({ schemaVersion: 1, mode: "hard" });
+      }),
+    });
+
+    const refresh = controller.refreshPolicy();
+    await vi.waitFor(() => {
+      expect(controller.getState().mode).toBe("hard_stop_waiting");
+    });
+    expect(controller.shouldSuppressAutoStart()).toBe(true);
+    expect(controller.allowUserInitiatedStart()).toBe(false);
+    expect(onAttention).toHaveBeenCalledOnce();
+
+    finishDrain();
+    await refresh;
+    expect(controller.getState().mode).toBe("hard_stop");
+    expect(controller.remindLater().mode).toBe("hard_stop");
+    expect((await controller.resumeZero()).mode).toBe("hard_stop");
+
+    controller.quitZero();
+    expect(quitZero).toHaveBeenCalledOnce();
+  });
+
+  it("opens the Okou download without offering Zero recovery in hard mode", async () => {
+    const filePath = await preferencesPath();
+    const drainAndStopZero = vi.fn(async () => {});
+    const openDownload = vi.fn(async () => {});
+    const controller = createController({
+      filePath,
+      drainAndStopZero,
+      openDownload,
+      fetchPolicy: vi.fn(async () => {
+        return Response.json({ schemaVersion: 1, mode: "hard" });
+      }),
+    });
+    await controller.refreshPolicy();
+
+    const state = await controller.beginMigration();
+
+    expect(state.mode).toBe("hard_stop");
+    expect(openDownload).toHaveBeenCalledWith(
+      ZERO_MIGRATION_BRIDGE_CONFIG.downloadUrl,
+    );
+    expect(drainAndStopZero).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to soft coexistence and restarts Zero when policy refresh fails", async () => {
+    const filePath = await preferencesPath();
+    const fetchPolicy = vi
+      .fn<(signal: AbortSignal) => Promise<Response>>()
+      .mockResolvedValueOnce(Response.json({ schemaVersion: 1, mode: "hard" }))
+      .mockRejectedValueOnce(new Error("Policy unavailable"));
+    const startZero = vi.fn(async () => {});
+    const logPolicyError = vi.fn();
+    const controller = createController({
+      filePath,
+      fetchPolicy,
+      startZero,
+      logPolicyError,
+    });
+    await controller.refreshPolicy();
+
+    await controller.refreshPolicy();
+
+    expect(controller.getState().mode).toBe("soft_reminder");
+    expect(controller.shouldSuppressAutoStart()).toBe(false);
+    expect(startZero).toHaveBeenCalledOnce();
+    expect(logPolicyError).toHaveBeenCalledOnce();
+  });
+
+  it("hides the reminder when the remote policy is off", async () => {
+    const filePath = await preferencesPath();
+    const controller = createController({
+      filePath,
+      fetchPolicy: vi.fn(async () => {
+        return Response.json({ schemaVersion: 1, mode: "off" });
+      }),
+    });
+
+    await controller.refreshPolicy();
+
+    expect(controller.getState().mode).toBe("hidden");
+    expect(controller.shouldSuppressAutoStart()).toBe(false);
   });
 });

--- a/turbo/apps/desktop/src/desktop-zero-migration.ts
+++ b/turbo/apps/desktop/src/desktop-zero-migration.ts
@@ -1,4 +1,8 @@
 import {
+  desktopZeroMigrationPolicySchema,
+  type DesktopZeroMigrationRolloutMode,
+} from "@vm0/api-contracts/contracts/desktop-updates";
+import {
   readDesktopPreferenceRecord,
   writeDesktopPreferenceRecord,
 } from "./desktop-preferences";
@@ -23,7 +27,11 @@ interface DesktopZeroMigrationControllerOptions {
   readonly drainAndStopZero: () => Promise<void>;
   readonly startZero: () => Promise<void>;
   readonly openDownload: (url: string) => Promise<void>;
+  readonly fetchPolicy: (signal: AbortSignal) => Promise<Response>;
+  readonly quitZero: () => void;
   readonly onChange?: () => void;
+  readonly onAttention?: () => void;
+  readonly logPolicyError?: (error: unknown) => void;
   readonly now?: () => number;
 }
 
@@ -57,6 +65,12 @@ function migrationErrorMessage(error: unknown): string {
     : "Unable to open the Okou download.";
 }
 
+function hardStopErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? `Unable to stop Zero safely: ${error.message}`
+    : "Unable to stop Zero safely.";
+}
+
 export class DesktopZeroMigrationController {
   private readonly enabled: boolean;
   private readonly product: "zero" | "okou";
@@ -65,9 +79,17 @@ export class DesktopZeroMigrationController {
   private readonly drainAndStopZero: () => Promise<void>;
   private readonly startZero: () => Promise<void>;
   private readonly openDownload: (url: string) => Promise<void>;
+  private readonly fetchPolicy: (signal: AbortSignal) => Promise<Response>;
+  private readonly quitZeroApp: () => void;
   private readonly onChange: () => void;
+  private readonly onAttention: () => void;
+  private readonly logPolicyError: (error: unknown) => void;
   private readonly now: () => number;
   private waitingForCommand = false;
+  private hardStopWaiting = false;
+  private hardStopError: string | null = null;
+  private rolloutMode: DesktopZeroMigrationRolloutMode = "soft";
+  private policyRefresh: Promise<DesktopZeroMigrationRolloutMode> | null = null;
 
   constructor(options: DesktopZeroMigrationControllerOptions) {
     this.enabled = options.enabled;
@@ -77,13 +99,24 @@ export class DesktopZeroMigrationController {
     this.drainAndStopZero = options.drainAndStopZero;
     this.startZero = options.startZero;
     this.openDownload = options.openDownload;
+    this.fetchPolicy = options.fetchPolicy;
+    this.quitZeroApp = options.quitZero;
     this.onChange = options.onChange ?? (() => {});
+    this.onAttention = options.onAttention ?? (() => {});
+    this.logPolicyError = options.logPolicyError ?? (() => {});
     this.now = options.now ?? Date.now;
   }
 
   getState(): DesktopZeroMigrationState {
     if (!this.isEligible()) {
       return { mode: "hidden", nextReminderAt: null, errorMessage: null };
+    }
+    if (this.rolloutMode === "hard") {
+      return {
+        mode: this.hardStopWaiting ? "hard_stop_waiting" : "hard_stop",
+        nextReminderAt: null,
+        errorMessage: this.hardStopError,
+      };
     }
     const preferences = readZeroMigrationPreferences(this.preferencesPath);
     if (this.waitingForCommand) {
@@ -99,6 +132,9 @@ export class DesktopZeroMigrationController {
         nextReminderAt: null,
         errorMessage: preferences.lastError,
       };
+    }
+    if (this.rolloutMode === "off") {
+      return { mode: "hidden", nextReminderAt: null, errorMessage: null };
     }
     if (
       preferences.deferredUntil &&
@@ -120,8 +156,13 @@ export class DesktopZeroMigrationController {
   shouldSuppressAutoStart(): boolean {
     return (
       this.product === "zero" &&
-      readZeroMigrationPreferences(this.preferencesPath).startedAt !== null
+      (this.rolloutMode === "hard" ||
+        readZeroMigrationPreferences(this.preferencesPath).startedAt !== null)
     );
+  }
+
+  allowUserInitiatedStart(): boolean {
+    return this.rolloutMode !== "hard";
   }
 
   shouldOpenWindowOnLaunch(): boolean {
@@ -129,7 +170,7 @@ export class DesktopZeroMigrationController {
   }
 
   remindLater(): DesktopZeroMigrationState {
-    if (!this.isEligible()) {
+    if (!this.isEligible() || this.rolloutMode !== "soft") {
       return this.getState();
     }
     this.writePreferences({
@@ -144,7 +185,27 @@ export class DesktopZeroMigrationController {
   }
 
   async beginMigration(): Promise<DesktopZeroMigrationState> {
-    if (!this.isEligible() || this.waitingForCommand) {
+    if (
+      !this.isEligible() ||
+      this.rolloutMode === "off" ||
+      this.waitingForCommand ||
+      this.hardStopWaiting
+    ) {
+      return this.getState();
+    }
+    if (this.rolloutMode === "hard") {
+      this.hardStopWaiting = true;
+      this.hardStopError = null;
+      this.onChange();
+      try {
+        await this.drainAndStopZero();
+        await this.openDownload(ZERO_MIGRATION_BRIDGE_CONFIG.downloadUrl);
+      } catch (error) {
+        this.hardStopError = migrationErrorMessage(error);
+      } finally {
+        this.hardStopWaiting = false;
+        this.onChange();
+      }
       return this.getState();
     }
     const existing = readZeroMigrationPreferences(this.preferencesPath);
@@ -174,6 +235,9 @@ export class DesktopZeroMigrationController {
   }
 
   async resumeZero(): Promise<DesktopZeroMigrationState> {
+    if (this.rolloutMode === "hard") {
+      return this.getState();
+    }
     this.clearPreferences();
     this.onChange();
     await this.startZero();
@@ -186,6 +250,93 @@ export class DesktopZeroMigrationController {
     }
     this.clearPreferences();
     this.onChange();
+  }
+
+  quitZero(): DesktopZeroMigrationState {
+    if (this.isEligible() && this.rolloutMode === "hard") {
+      this.quitZeroApp();
+    }
+    return this.getState();
+  }
+
+  refreshPolicy(): Promise<DesktopZeroMigrationRolloutMode> {
+    if (!this.isEligible()) {
+      return Promise.resolve(this.rolloutMode);
+    }
+    this.policyRefresh ??= this.fetchAndApplyPolicy().finally(() => {
+      this.policyRefresh = null;
+    });
+    return this.policyRefresh;
+  }
+
+  private async fetchAndApplyPolicy(): Promise<DesktopZeroMigrationRolloutMode> {
+    const abortController = new AbortController();
+    const timeout = setTimeout(() => {
+      abortController.abort();
+    }, ZERO_MIGRATION_BRIDGE_CONFIG.policyRequestTimeoutMs);
+    let mode: DesktopZeroMigrationRolloutMode = "soft";
+    try {
+      const response = await this.fetchPolicy(abortController.signal);
+      if (!response.ok) {
+        throw new Error(`Migration policy returned HTTP ${response.status}`);
+      }
+      const parsed = desktopZeroMigrationPolicySchema.safeParse(
+        await response.json(),
+      );
+      if (!parsed.success) {
+        throw new Error("Migration policy response is invalid");
+      }
+      mode = parsed.data.mode;
+    } catch (error) {
+      this.logPolicyError(error);
+    } finally {
+      clearTimeout(timeout);
+    }
+    await this.applyRolloutMode(mode);
+    return mode;
+  }
+
+  private async applyRolloutMode(
+    mode: DesktopZeroMigrationRolloutMode,
+  ): Promise<void> {
+    const previousMode = this.rolloutMode;
+    const shouldDrainHardStop =
+      previousMode !== "hard" || this.hardStopError !== null;
+    this.rolloutMode = mode;
+    this.hardStopError = null;
+
+    if (mode === "hard") {
+      if (!shouldDrainHardStop) {
+        return;
+      }
+      this.hardStopWaiting = true;
+      if (previousMode !== "hard") {
+        this.onAttention();
+      }
+      this.onChange();
+      try {
+        await this.drainAndStopZero();
+      } catch (error) {
+        this.hardStopError = hardStopErrorMessage(error);
+      } finally {
+        this.hardStopWaiting = false;
+        this.onChange();
+      }
+      return;
+    }
+
+    this.hardStopWaiting = false;
+    this.onChange();
+    if (
+      previousMode === "hard" &&
+      readZeroMigrationPreferences(this.preferencesPath).startedAt === null
+    ) {
+      try {
+        await this.startZero();
+      } catch (error) {
+        this.logPolicyError(error);
+      }
+    }
   }
 
   private isEligible(): boolean {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1443,6 +1443,18 @@ if (!hasSingleInstanceLock) {
     installTray();
     queueDesktopAuthCallbackArgv(process.argv);
 
+    if (isDesktopSmokeTestEnabled(process.env)) {
+      try {
+        await verifyDesktopSmokeBridge();
+      } catch (error) {
+        console.error("[smoke-test] desktop renderer bridge failed", error);
+        app.exit(1);
+        return;
+      }
+      writeSync(1, `${DESKTOP_SMOKE_TEST_READY_MARKER}\n`);
+      process.exit(0);
+    }
+
     startDesktopLaunchComputerUse({
       pendingCallback: desktopAuthSession.takePendingCallback(),
       consumeAuthCallback: (callback) =>
@@ -1465,18 +1477,6 @@ if (!hasSingleInstanceLock) {
     app.on("activate", () => {
       void createMainWindow();
     });
-
-    if (isDesktopSmokeTestEnabled(process.env)) {
-      try {
-        await verifyDesktopSmokeBridge();
-      } catch (error) {
-        console.error("[smoke-test] desktop renderer bridge failed", error);
-        app.exit(1);
-        return;
-      }
-      writeSync(1, `${DESKTOP_SMOKE_TEST_READY_MARKER}\n`);
-      process.exit(0);
-    }
   });
 
   app.on("window-all-closed", () => {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -117,6 +117,7 @@ import {
 } from "./desktop-renderer-url";
 import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
 import { DesktopZeroMigrationController } from "./desktop-zero-migration";
+import { ZERO_MIGRATION_BRIDGE_CONFIG } from "./desktop-zero-migration-config";
 import {
   installDesktopZeroMigrationIpc,
   notifyDesktopZeroMigrationChanged,
@@ -158,6 +159,7 @@ let computerUseNativeBackendDisposed = false;
 let desktopTray: DesktopTrayController | null = null;
 let keepAwakeController: DesktopKeepAwakeController | null = null;
 let zeroMigrationController: DesktopZeroMigrationController | null = null;
+let zeroMigrationPolicyTimer: ReturnType<typeof setInterval> | null = null;
 
 const desktopIdentity: DesktopIdentityInfo = {
   product: config.identity.product,
@@ -534,6 +536,9 @@ function createComputerUseHostRuntime(): ComputerUseHostRuntime {
 async function startComputerUseRuntime(
   options: { readonly userInitiated?: boolean } = {},
 ): Promise<DesktopComputerUseState> {
+  if (zeroMigrationController?.allowUserInitiatedStart() === false) {
+    return getComputerUseBridgeState();
+  }
   if (zeroMigrationController?.shouldSuppressAutoStart()) {
     if (options.userInitiated !== true) {
       return getComputerUseBridgeState();
@@ -677,7 +682,25 @@ function installZeroMigration(): void {
     openDownload: async (url) => {
       await shell.openExternal(url);
     },
+    fetchPolicy: (signal) => {
+      const headers = new Headers();
+      addDesktopClientHeaders(headers);
+      return fetch(
+        new URL(ZERO_MIGRATION_BRIDGE_CONFIG.policyPath, desktopApiBaseUrl),
+        { headers, signal },
+      );
+    },
+    quitZero: () => {
+      quitConfirmation.allowQuitWithoutConfirmation();
+      app.quit();
+    },
     onChange: notifyDesktopZeroMigrationChanged,
+    onAttention: () => {
+      void createMainWindow();
+    },
+    logPolicyError: (error) => {
+      console.warn("Unable to refresh Zero migration policy", error);
+    },
   });
   const controller = zeroMigrationController;
   installDesktopZeroMigrationIpc(
@@ -686,9 +709,29 @@ function installZeroMigration(): void {
       remindLater: () => controller.remindLater(),
       beginMigration: () => controller.beginMigration(),
       resumeZero: () => controller.resumeZero(),
+      quitZero: () => controller.quitZero(),
     },
     { rendererUrl: localRendererUrl },
   );
+}
+
+function startZeroMigrationPolicyRefresh(): void {
+  const controller = zeroMigrationController;
+  if (!controller || zeroMigrationPolicyTimer) {
+    return;
+  }
+  zeroMigrationPolicyTimer = setInterval(() => {
+    void controller.refreshPolicy();
+  }, ZERO_MIGRATION_BRIDGE_CONFIG.policyRefreshIntervalMs);
+  zeroMigrationPolicyTimer.unref();
+}
+
+function stopZeroMigrationPolicyRefresh(): void {
+  if (!zeroMigrationPolicyTimer) {
+    return;
+  }
+  clearInterval(zeroMigrationPolicyTimer);
+  zeroMigrationPolicyTimer = null;
 }
 
 function refreshComputerUsePermissionsForState(): void {
@@ -1367,6 +1410,7 @@ if (!hasSingleInstanceLock) {
       return;
     }
 
+    stopZeroMigrationPolicyRefresh();
     appIsQuitting = true;
     releaseKeepAwake();
     if (!computerUseController.quitStopRequired()) {
@@ -1390,9 +1434,11 @@ if (!hasSingleInstanceLock) {
     installComputerUse();
     installDesktopDeveloperTools();
     installZeroMigration();
-    refreshComputerUsePermissionsForState();
     const desktopAuthSession = getAuthSession();
     installDesktopAuth();
+    await zeroMigrationController?.refreshPolicy();
+    startZeroMigrationPolicyRefresh();
+    refreshComputerUsePermissionsForState();
     developerTools.requestRefresh();
     installTray();
     queueDesktopAuthCallbackArgv(process.argv);

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -206,12 +206,14 @@ describe("Desktop preload bridge", () => {
     await zeroMigration.remindLater();
     await zeroMigration.beginMigration();
     await zeroMigration.resumeZero();
+    await zeroMigration.quitZero();
 
     expect(electronMock.ipcRenderer.invoke.mock.calls).toStrictEqual([
       [DESKTOP_ZERO_MIGRATION_CHANNELS.getState],
       [DESKTOP_ZERO_MIGRATION_CHANNELS.remindLater],
       [DESKTOP_ZERO_MIGRATION_CHANNELS.beginMigration],
       [DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero],
+      [DESKTOP_ZERO_MIGRATION_CHANNELS.quitZero],
     ]);
   });
 

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -174,6 +174,9 @@ const desktopZeroMigrationApi: DesktopZeroMigrationApi = {
   resumeZero() {
     return ipcRenderer.invoke(DESKTOP_ZERO_MIGRATION_CHANNELS.resumeZero);
   },
+  quitZero() {
+    return ipcRenderer.invoke(DESKTOP_ZERO_MIGRATION_CHANNELS.quitZero);
+  },
   subscribe(callback: () => void): () => void {
     const listener = (): void => {
       callback();

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -392,6 +392,9 @@ function createZeroMigrationBridge(initialState: DesktopZeroMigrationState): {
   readonly resumeZero: ReturnType<
     typeof vi.fn<DesktopZeroMigrationApi["resumeZero"]>
   >;
+  readonly quitZero: ReturnType<
+    typeof vi.fn<DesktopZeroMigrationApi["quitZero"]>
+  >;
 } {
   let currentState = initialState;
   const subscribers = new Set<() => void>();
@@ -422,6 +425,9 @@ function createZeroMigrationBridge(initialState: DesktopZeroMigrationState): {
     };
     return currentState;
   });
+  const quitZero = vi.fn<DesktopZeroMigrationApi["quitZero"]>(async () => {
+    return currentState;
+  });
   const subscribe = vi.fn<DesktopZeroMigrationApi["subscribe"]>((callback) => {
     subscribers.add(callback);
     return () => {
@@ -435,11 +441,13 @@ function createZeroMigrationBridge(initialState: DesktopZeroMigrationState): {
       remindLater,
       beginMigration,
       resumeZero,
+      quitZero,
       subscribe,
     },
     beginMigration,
     remindLater,
     resumeZero,
+    quitZero,
   };
 }
 
@@ -553,6 +561,27 @@ describe("Desktop renderer bridge integration", () => {
 
     await waitFor(() => {
       expect(zeroMigration.resumeZero).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("shows only download and quit actions after a remote hard stop", async () => {
+    const { zeroMigration } = installDesktopBridges({
+      zeroMigrationState: {
+        mode: "hard_stop",
+        nextReminderAt: null,
+        errorMessage: null,
+      },
+    });
+
+    renderDesktopApp();
+
+    expect(await screen.findByText("Zero has moved to Okou")).toBeTruthy();
+    expect(screen.queryByText("Remind Me Later")).toBeNull();
+    expect(screen.queryByText("Resume Zero")).toBeNull();
+    fireEvent.click(buttonForText("Quit Zero"));
+
+    await waitFor(() => {
+      expect(zeroMigration.quitZero).toHaveBeenCalledOnce();
     });
   });
 

--- a/turbo/apps/desktop/src/renderer/zero-migration-notice.tsx
+++ b/turbo/apps/desktop/src/renderer/zero-migration-notice.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { Clock3, Download, LoaderCircle, RotateCcw } from "lucide-react";
+import {
+  Clock3,
+  Download,
+  LoaderCircle,
+  LogOut,
+  RotateCcw,
+} from "lucide-react";
 import type { DesktopZeroMigrationState } from "../desktop-zero-migration-types";
 import { ZERO_MIGRATION_BRIDGE_CONFIG } from "../desktop-zero-migration-config";
 import { IconButton } from "./components";
@@ -44,7 +50,10 @@ export function ZeroMigrationNotice() {
     return null;
   }
 
-  const waiting = state.mode === "waiting_for_command";
+  const hardStop =
+    state.mode === "hard_stop" || state.mode === "hard_stop_waiting";
+  const waiting =
+    state.mode === "waiting_for_command" || state.mode === "hard_stop_waiting";
   const paused = state.mode === "paused" || state.mode === "download_failed";
   const runAction = (
     action: () => Promise<DesktopZeroMigrationState>,
@@ -63,16 +72,22 @@ export function ZeroMigrationNotice() {
     <section className="zero-migration-notice" aria-live="polite">
       <div className="zero-migration-copy">
         <strong>
-          {paused
-            ? ZERO_MIGRATION_BRIDGE_CONFIG.copy.pausedTitle
-            : ZERO_MIGRATION_BRIDGE_CONFIG.copy.title}
+          {hardStop
+            ? ZERO_MIGRATION_BRIDGE_CONFIG.copy.hardStopTitle
+            : paused
+              ? ZERO_MIGRATION_BRIDGE_CONFIG.copy.pausedTitle
+              : ZERO_MIGRATION_BRIDGE_CONFIG.copy.title}
         </strong>
         <span>
-          {paused
-            ? ZERO_MIGRATION_BRIDGE_CONFIG.copy.pausedDetail
-            : waiting
-              ? "Waiting for the current Computer Use command to finish. Zero will stop before the Okou download opens."
-              : ZERO_MIGRATION_BRIDGE_CONFIG.copy.detail}
+          {hardStop
+            ? waiting
+              ? "Waiting for the current Computer Use command to finish. Zero will stay offline after it stops."
+              : ZERO_MIGRATION_BRIDGE_CONFIG.copy.hardStopDetail
+            : paused
+              ? ZERO_MIGRATION_BRIDGE_CONFIG.copy.pausedDetail
+              : waiting
+                ? "Waiting for the current Computer Use command to finish. Zero will stop before the Okou download opens."
+                : ZERO_MIGRATION_BRIDGE_CONFIG.copy.detail}
         </span>
         {(state.errorMessage || actionError) && (
           <span className="zero-migration-error">
@@ -101,7 +116,17 @@ export function ZeroMigrationNotice() {
               ? "Try Download Again"
               : "Download Okou"}
         </IconButton>
-        {paused ? (
+        {hardStop ? (
+          <IconButton
+            icon={<LogOut size={15} />}
+            disabled={waiting}
+            onClick={() => {
+              runAction(() => api.quitZero());
+            }}
+          >
+            Quit Zero
+          </IconButton>
+        ) : paused ? (
           <IconButton
             icon={<RotateCcw size={15} />}
             disabled={waiting}

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -13,6 +13,15 @@ const desktopUpdateChannelSchema = z.enum(["stable"]);
 const desktopUpdatePlatformSchema = z.enum(["darwin"]);
 const desktopUpdateArchitectureSchema = z.enum(["arm64"]);
 const desktopUpdateLineSchema = z.enum(DESKTOP_UPDATE_LINES);
+export const desktopZeroMigrationRolloutModeSchema = z.enum([
+  "off",
+  "soft",
+  "hard",
+]);
+export const desktopZeroMigrationPolicySchema = z.object({
+  schemaVersion: z.literal(1),
+  mode: desktopZeroMigrationRolloutModeSchema,
+});
 
 export type DesktopUpdateChannel = z.infer<typeof desktopUpdateChannelSchema>;
 export type DesktopUpdatePlatform = z.infer<typeof desktopUpdatePlatformSchema>;
@@ -20,6 +29,12 @@ export type DesktopUpdateArchitecture = z.infer<
   typeof desktopUpdateArchitectureSchema
 >;
 export type DesktopUpdateLine = z.infer<typeof desktopUpdateLineSchema>;
+export type DesktopZeroMigrationRolloutMode = z.infer<
+  typeof desktopZeroMigrationRolloutModeSchema
+>;
+export type DesktopZeroMigrationPolicy = z.infer<
+  typeof desktopZeroMigrationPolicySchema
+>;
 
 const squirrelMacReleaseSchema = z.object({
   version: z.string(),
@@ -40,6 +55,14 @@ const squirrelMacReleasesSchema = z.object({
 export type SquirrelMacReleases = z.infer<typeof squirrelMacReleasesSchema>;
 
 export const desktopUpdatesContract = c.router({
+  migrationPolicy: {
+    method: "GET",
+    path: "/api/desktop/migration-policy",
+    responses: {
+      200: desktopZeroMigrationPolicySchema,
+    },
+    summary: "Get the remotely controlled Zero Desktop migration policy",
+  },
   releasePage: {
     method: "GET",
     path: "/api/okou/desktop/updates/:channel/:platform/:arch/release",


### PR DESCRIPTION
## Summary

- add a public, no-store Zero Desktop migration policy endpoint backed by a mutable GitHub Release asset, with independent API and Desktop fallback to `soft`
- make policy-capable Zero builds poll `off | soft | hard`, gate by the existing minimum bridge version, and finish the current Computer Use command before a hard stop
- block automatic and manual host starts in hard mode while preserving only the trusted Okou download and a safe Quit Zero action
- add a production-gated policy publishing workflow; `hard` additionally requires an explicit #26370 approval comment and manual confirmation
- document product-aware Axiom/MaskDB evidence, named operational ownership, go/no-go criteria, and fast rollback

## Safety

This PR does not activate a hard stop. Missing, invalid, failed, or timed-out policy reads resolve to `soft` coexistence. Current bounded production evidence is still a hard-stop no-go (185 active Zero Desktop sessions in the last 24-hour sample), and the MaskDB allowlist must expose `computer_use_hosts.client_product` before the masked-data gate can pass.

Tracks #26370 and #26364.

## Validation

- `pnpm -F @vm0/desktop test` (339 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/desktop-updates.test.ts` (20 tests)
- Desktop, API, and API-contract type checks
- Desktop, API, and API-contract lint for affected files/workspaces
- Electron main/preload and renderer production builds
- policy validator shell tests, workflow shell compatibility tests, checkout-depth test, and actionlint
- scoped Knip completed; only pre-existing baseline findings were reported
