### PR TITLE
refactor(api): migrate provider OAuth callbacks to Okou

### DIFF
--- a/docs/okou-protocol-migration.md
+++ b/docs/okou-protocol-migration.md
@@ -13,10 +13,13 @@ also use that namespace. The API registration and runtime-schema layers still
 publish the same handlers and schemas through `/api/zero/**` for older clients,
 pinned CLI artifacts, installed Desktop builds, and stored callback URLs.
 
-OAuth start requests use the canonical Okou namespace, while provider-facing
-Slack, Teams, Feishu, and GitHub `redirect_uri` values deliberately remain on
-the Zero alias until the corresponding third-party allowlists are migrated in
-a separately verified rollout. Both callback paths reach the same handler.
+OAuth start requests use the canonical Okou namespace. Canonical Slack and
+Teams starts also send canonical callback URLs after their centrally managed
+provider allowlists were expanded; requests through the Zero compatibility
+alias keep sending the legacy callback URL. Current Feishu Platform flows use
+the neutral app callback, and current GitHub connector flows use the neutral
+connector callback. Their legacy branded callbacks remain available for old
+flows. Both branded callback paths reach the same provider handler.
 
 Current API and Desktop consumers prefer `OKOU_*` variables and retain their
 `ZERO_*` fallback readers. The current private CLI source reads only canonical
@@ -68,6 +71,37 @@ while the released writer stop makes new contexts canonical-only. Production
 verification must inspect names and token scope without exposing values;
 declining Zero request volume alone is not proof that all legacy contexts have
 drained.
+
+## Provider callback inventory
+
+Issue #26720 classifies supported provider callbacks by ownership and storage
+boundary. Production is the only centrally allowlisted environment. Preview
+URLs are job-scoped and are not automatically added to production provider
+applications; development and focused integration tests use provider-boundary
+mocks. “Present” below records configuration or durable-state presence only,
+not callback values, request data, or user content.
+
+| Provider surface                                                         | Classification and route class                                                                                       | Owner                                                            | Presence and migration action                                                                                                                                                                                           |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Slack OAuth install and user connect                                     | Generated callback plus provider-console redirect allowlist; branded callback                                        | VM0 provider operations                                          | Cutover gate: verify the production allowlist contains canonical and legacy entries before merge. Canonical starts emit `/api/okou/slack/oauth/callback`; compatibility starts keep `/api/zero/slack/oauth/callback`.   |
+| Slack events, interactivity, and commands                                | Provider-console stored registrations; branded callbacks                                                             | VM0 provider operations                                          | Existing registrations are present and are not mutated. Both namespace acceptors remain because stored Zero registrations are still active.                                                                             |
+| Microsoft Teams user OAuth                                               | Generated callback plus Microsoft Entra web redirect allowlist; branded callback                                     | VM0 provider operations                                          | Cutover gate: verify the production allowlist contains canonical and legacy entries before merge. Canonical starts emit `/api/okou/teams/oauth/callback`; compatibility starts keep `/api/zero/teams/oauth/callback`.   |
+| Microsoft Teams bot messaging                                            | Provider-console stored registration; branded callback                                                               | VM0 provider operations                                          | Existing registration is retained without mutation; both `/api/okou/teams/bot` and its Zero alias remain accepted.                                                                                                      |
+| Feishu user OAuth                                                        | Generated redirect plus per-installation provider-console allowlist                                                  | Installing organization administrator                            | Current Platform registration uses the neutral `/connectors/feishu/callback`. The legacy branded API redirect remains on the Zero alias for old clients and user-owned allowlists; no stored registration is rewritten. |
+| Feishu events                                                            | Generated operator-setup URL plus per-installation stored registration; branded callback                             | Installing organization administrator                            | New setup output is already canonical at `/api/okou/feishu/events/:installationId`. Existing provider registrations are retained and both namespace acceptors remain.                                                   |
+| GitHub App user authorization                                            | Generated callback plus provider-console allowlist and ephemeral stored OAuth state                                  | VM0 provider operations                                          | Current flows use the neutral `/api/connectors/github/callback`; the stored redirect is consumed unchanged. The legacy branded callback remains on its Zero alias for old in-flight flows.                              |
+| GitHub App setup and webhooks                                            | Provider-console setup URL and stored webhook registration; neutral callbacks                                        | VM0 provider operations                                          | Present on `/api/github/app/setup/callback` and `/api/webhooks/github`; no branded producer exists to migrate.                                                                                                          |
+| Telegram bots                                                            | Code-managed `setWebhook` registration plus durable installation record; neutral callback                            | Installing organization administrator                            | Present on `/api/telegram/webhook/:telegramBotId`; registrations and rollback behavior are unchanged.                                                                                                                   |
+| Strapi                                                                   | Generated operator-setup URL plus provider-side stored registration; branded callback                                | Installing organization administrator                            | New setup output is already canonical at `/api/okou/strapi/events/:integrationId`; existing registrations and the Zero acceptor are retained.                                                                           |
+| Google Workspace, Notion, Stripe, Clerk, email, and generation providers | Provider-console registration, provider subscription, or per-job generated URL; neutral `/api/webhooks/**` callbacks | VM0 provider operations or the owning workflow                   | Present and unbranded; no protocol producer migration is required.                                                                                                                                                      |
+| Built-in and custom connector OAuth                                      | Generated callback plus durable OAuth state; neutral API or app callback                                             | Connector catalog owner or installing organization administrator | Redirect state is persisted and consumed verbatim. Existing states are not rewritten; no Zero callback producer is used by current flows.                                                                               |
+| Workflow and run callbacks                                               | Durable callback records; neutral, internal, or user-configured destination                                          | Workflow or run owner                                            | Durable records are present and deliberately excluded from this producer migration. Historical URLs and delivery records remain unchanged.                                                                              |
+
+Low-frequency safety does not rely on a short absence of requests. The rollout
+keeps provider allowlist entries, stored registrations, durable callback
+records, neutral routes, and both branded acceptors in place. A rollback can
+therefore restore the previous producer while those records remain valid and
+without a database or provider-registration rewrite.
 
 ## Rollback
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-oauth.test.ts
@@ -144,6 +144,16 @@ describe("Slack OAuth API routes", () => {
       expect(response.headers.get("cache-control")).toBe("no-store");
     });
 
+    it("uses the canonical callback for canonical install requests", async () => {
+      const response = await appRequest("/api/okou/slack/oauth/install");
+
+      expect(response.status).toBe(307);
+      const redirectUrl = new URL(response.headers.get("location")!);
+      expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
+        `${WEB_ORIGIN}/api/okou/slack/oauth/callback`,
+      );
+    });
+
     it("includes platform state and truncates prompt by codepoint", async () => {
       const prompt = "\u{1F600}".repeat(600);
       const response = await appRequest(
@@ -333,6 +343,22 @@ describe("Slack OAuth API routes", () => {
       });
     });
 
+    it("uses the canonical callback for canonical connect requests", async () => {
+      const fixture = await track(
+        store.set(seedSlackConnectOrg$, {}, context.signal),
+      );
+
+      const response = await appRequest(
+        `/api/okou/slack/oauth/connect?orgId=${fixture.orgId}&vm0UserId=${fixture.userId}`,
+      );
+
+      expect(response.status).toBe(307);
+      const redirectUrl = new URL(response.headers.get("location")!);
+      expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
+        `${WEB_ORIGIN}/api/okou/slack/oauth/callback`,
+      );
+    });
+
     it("uses the web rewrite origin for connect callback URLs", async () => {
       const fixture = await track(
         store.set(seedSlackConnectOrg$, {}, context.signal),
@@ -483,6 +509,24 @@ describe("Slack OAuth API routes", () => {
   });
 
   describe("GET /api/zero/slack/oauth/callback", () => {
+    it("uses the canonical callback for canonical token exchanges", async () => {
+      context.mocks.slack.oauth.v2.access.mockResolvedValueOnce({
+        ok: false,
+        error: "invalid_code",
+      });
+
+      const response = await appRequest(
+        "/api/okou/slack/oauth/callback?code=valid-code",
+      );
+
+      expect(response.status).toBe(307);
+      expect(context.mocks.slack.oauth.v2.access).toHaveBeenCalledWith(
+        expect.objectContaining({
+          redirect_uri: `${WEB_ORIGIN}/api/okou/slack/oauth/callback`,
+        }),
+      );
+    });
+
     it("creates a platform installation and connection for an admin install", async () => {
       const fixture = await track(
         store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
@@ -62,6 +62,7 @@ function idToken(payload: Readonly<Record<string, unknown>>): string {
 
 function callbackPath(args: {
   readonly code?: string;
+  readonly namespace?: "okou" | "zero";
   readonly state: Readonly<Record<string, unknown>>;
 }): string {
   const params = new URLSearchParams();
@@ -69,7 +70,7 @@ function callbackPath(args: {
     params.set("code", args.code);
   }
   params.set("state", JSON.stringify(args.state));
-  return `/api/zero/teams/oauth/callback?${params.toString()}`;
+  return `/api/${args.namespace ?? "zero"}/teams/oauth/callback?${params.toString()}`;
 }
 
 function teamsInstallUrl(tenantId: string): string {
@@ -183,6 +184,18 @@ describe("Teams OAuth API routes", () => {
     expect(state).toStrictEqual({ orgId: "org_1", vm0UserId: "user_1" });
   });
 
+  it("uses the canonical callback for canonical connect requests", async () => {
+    const response = await appRequest(
+      "/api/okou/teams/oauth/connect?orgId=org_1&vm0UserId=user_1",
+    );
+
+    expect(response.status).toBe(307);
+    const redirectUrl = new URL(response.headers.get("location")!);
+    expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
+      `${API_ORIGIN}/api/okou/teams/oauth/callback`,
+    );
+  });
+
   it("keeps API-host connect requests on the API callback origin", async () => {
     const response = await appRequest(
       "/api/zero/teams/oauth/connect?orgId=org_1&vm0UserId=user_1",
@@ -261,6 +274,31 @@ describe("Teams OAuth API routes", () => {
       connectUrl: null,
       tenantId: fixture.teamsTenantId,
     });
+  });
+
+  it("uses the canonical callback for canonical token exchanges", async () => {
+    const fixture = await uninstalledTeamsFixture(track);
+    await seedMembership(fixture.orgId, fixture.userId, "admin");
+    mockMicrosoftOAuth({
+      tenantId: fixture.teamsTenantId,
+      aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: fixture.teamsUserPrincipalName,
+      expectedRedirectUri: `${API_ORIGIN}/api/okou/teams/oauth/callback`,
+    });
+
+    const response = await appRequest(
+      callbackPath({
+        code: "valid-code",
+        namespace: "okou",
+        state: { orgId: fixture.orgId, vm0UserId: fixture.userId },
+      }),
+      { origin: API_ORIGIN },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      teamsInstallUrl(fixture.teamsTenantId),
+    );
   });
 
   it("connects and binds an unbound Teams installation using Microsoft OAuth", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-slack-oauth.ts
@@ -1,4 +1,5 @@
 import { command, computed } from "ccstate";
+import { brandedApiNamespace } from "@vm0/api-contracts/contracts/api-namespaces";
 import { zeroSlackOauthContract } from "@vm0/api-contracts/contracts/zero-slack-oauth";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
@@ -127,8 +128,11 @@ function parseOAuthState(state: string | undefined): OAuthState {
   };
 }
 
-function callbackRedirectUri(origin: string): string {
-  return `${origin}/api/zero/slack/oauth/callback`;
+/** Keep legacy starts and in-flight callbacks paired with their allowlisted URI. */
+function callbackRedirectUri(request: Request, origin: string): string {
+  const namespace =
+    brandedApiNamespace(new URL(request.url).pathname) ?? "okou";
+  return `${origin}/api/${namespace}/slack/oauth/callback`;
 }
 
 function slackCredentials(): {
@@ -180,7 +184,10 @@ const installOauth$ = computed((get) => {
   const authUrl = new URL(SLACK_OAUTH_URL);
   authUrl.searchParams.set("client_id", clientId);
   authUrl.searchParams.set("scope", SLACK_BOT_SCOPES.join(","));
-  authUrl.searchParams.set("redirect_uri", callbackRedirectUri(origin));
+  authUrl.searchParams.set(
+    "redirect_uri",
+    callbackRedirectUri(request, origin),
+  );
   if (state) {
     authUrl.searchParams.set("state", state);
   }
@@ -237,7 +244,10 @@ const connectOauth$ = command(async ({ get }, signal: AbortSignal) => {
   const authUrl = new URL(SLACK_OAUTH_URL);
   authUrl.searchParams.set("client_id", clientId);
   authUrl.searchParams.set("user_scope", "identity.basic");
-  authUrl.searchParams.set("redirect_uri", callbackRedirectUri(origin));
+  authUrl.searchParams.set(
+    "redirect_uri",
+    callbackRedirectUri(request, origin),
+  );
   authUrl.searchParams.set("state", JSON.stringify(stateObj));
   authUrl.searchParams.set("team", installation.slackWorkspaceId);
 
@@ -364,7 +374,7 @@ const handleInstallCallback$ = command(
         readonly clientId: string;
         readonly clientSecret: string;
       };
-      readonly callbackOrigin: string;
+      readonly redirectUri: string;
     },
     signal: AbortSignal,
   ): Promise<Response> => {
@@ -373,7 +383,7 @@ const handleInstallCallback$ = command(
         args.credentials.clientId,
         args.credentials.clientSecret,
         args.code,
-        callbackRedirectUri(args.callbackOrigin),
+        args.redirectUri,
       ),
       (error) => {
         L.error("Slack OAuth exchange failed", { error });
@@ -497,7 +507,7 @@ const handleConnectCallback$ = command(
         readonly clientId: string;
         readonly clientSecret: string;
       };
-      readonly callbackOrigin: string;
+      readonly redirectUri: string;
     },
     signal: AbortSignal,
   ): Promise<Response> => {
@@ -510,7 +520,7 @@ const handleConnectCallback$ = command(
         args.credentials.clientId,
         args.credentials.clientSecret,
         args.code,
-        callbackRedirectUri(args.callbackOrigin),
+        args.redirectUri,
       ),
       (error) => {
         L.error("Slack OAuth exchange failed (connect flow)", { error });
@@ -607,6 +617,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
     return redirectResponse(canonicalRedirectUrl);
   }
   const origin = getOAuthWebOrigin(request);
+  const redirectUri = callbackRedirectUri(request, origin);
   const credentials = slackCredentials();
   if (!credentials) {
     return jsonErrorResponse("Slack integration is not configured", 503);
@@ -630,7 +641,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
         code: query.code,
         state,
         credentials,
-        callbackOrigin: origin,
+        redirectUri,
       },
       signal,
     );
@@ -642,7 +653,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
       code: query.code,
       state,
       credentials,
-      callbackOrigin: origin,
+      redirectUri,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/routes/zero-teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-oauth.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import { brandedApiNamespace } from "@vm0/api-contracts/contracts/api-namespaces";
 import { zeroTeamsOauthContract } from "@vm0/api-contracts/contracts/zero-teams-oauth";
 import { z } from "zod";
 
@@ -138,8 +139,11 @@ function parseOAuthState(state: string | undefined): OAuthState {
   };
 }
 
-function callbackRedirectUri(origin: string): string {
-  return `${origin}/api/zero/teams/oauth/callback`;
+/** Keep legacy starts and in-flight callbacks paired with their allowlisted URI. */
+function callbackRedirectUri(request: Request, origin: string): string {
+  const namespace =
+    brandedApiNamespace(new URL(request.url).pathname) ?? "okou";
+  return `${origin}/api/${namespace}/teams/oauth/callback`;
 }
 
 function microsoftCredentials(): {
@@ -312,7 +316,10 @@ const connectOauth$ = command(({ get }) => {
 
   const authUrl = new URL(MICROSOFT_AUTHORIZATION_URL);
   authUrl.searchParams.set("client_id", credentials.clientId);
-  authUrl.searchParams.set("redirect_uri", callbackRedirectUri(origin));
+  authUrl.searchParams.set(
+    "redirect_uri",
+    callbackRedirectUri(request, origin),
+  );
   authUrl.searchParams.set("response_type", "code");
   authUrl.searchParams.set("scope", MICROSOFT_TEAMS_CONNECT_SCOPES.join(" "));
   authUrl.searchParams.set("state", JSON.stringify(stateObj));
@@ -356,7 +363,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
         clientId: credentials.clientId,
         clientSecret: credentials.clientSecret,
         code: query.code,
-        redirectUri: callbackRedirectUri(origin),
+        redirectUri: callbackRedirectUri(request, origin),
       },
       signal,
     ),


### PR DESCRIPTION
## Summary

- make canonical Slack install/connect and Microsoft Teams connect flows send `/api/okou/**` callback URLs
- preserve `/api/zero/**` starts, in-flight callback token exchanges, stored registrations, neutral provider callbacks, and rollback behavior
- document the full provider callback inventory, ownership, storage class, and migration disposition without recording sensitive values

## Compatibility

Canonical and compatibility requests derive the provider redirect URI from the request namespace. This keeps old clients and in-flight OAuth exchanges paired with the exact legacy URI while new first-party canonical starts use Okou. No route, provider registration, OAuth state row, durable callback, or historical record is removed or rewritten.

Current Feishu Platform OAuth and GitHub connector OAuth use neutral callbacks; Feishu event and Strapi setup output is already canonical. Existing Slack ingress, Teams bot, Feishu event, GitHub webhook, Telegram, connector, workflow, and run callback registrations remain unchanged.

## External rollout gate

This PR remains draft until VM0 provider operations verifies both canonical and legacy production redirect entries coexist in the Slack App and Microsoft Entra application. No provider-console write is claimed yet; evidence is tracked in #26720.

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-oauth.test.ts src/signals/routes/__tests__/zero-teams-oauth.test.ts` (57 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- focused Prettier formatting and `git diff --check`

Closes #26720