### PR TITLE
test(api): isolate agentphone recent history timeout

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -618,10 +618,22 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(sends.messages).toHaveLength(sendsBeforeWebCompletion);
     await waitForRunSessionId(actor, webRun.runId, sharedSession);
 
+    // Provider history changes prompt context without rotating the canonical
+    // session shared by the phone and web surfaces.
     await ap.postAgentPhoneInboundMessage({
       channel: "sms",
       from: phone,
       body: "finish back on my phone",
+      recentHistory: [
+        {
+          messageId: "rh-shared-session",
+          content: "provider history before returning to the phone",
+          direction: "inbound",
+          channel: "sms",
+          from: phone,
+          at: "2026-06-01T08:00:00.000Z",
+        },
+      ],
     });
     const phoneRun2 = await claimDispatchedRun(runnerGroup);
     await completeSandboxRun(phoneRun2.sandboxToken, phoneRun2.runId, 0);
@@ -754,20 +766,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
   });
 
-  it("renders provider recent history and reuses the linked session", async () => {
+  it("renders provider recent history", async () => {
     const ap = createAgentPhoneBddApi(context);
-    const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
-
-    await ap.postAgentPhoneInboundMessage({
-      channel: "sms",
-      from: phone,
-      body: "establish history session",
-    });
-    const run1 = await claimDispatchedRun(runnerGroup);
-    const beforeRun1Completion = sends.messages.length;
-    await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
-    await waitForSendCount(sends, beforeRun1Completion + 1);
-    const historySession = await waitForRunSessionIdPresent(actor, run1.runId);
+    const { phone, runnerGroup } = await entitledLinkedActor();
 
     // Provider-sent recent history wins over stored context: full entries
     // keep channel and timestamp lines, media-only entries become file
@@ -789,25 +790,19 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
         { direction: "inbound" },
       ],
     });
-    const run2 = await claimDispatchedRun(runnerGroup);
-    expect(run2.appendSystemPrompt).toContain("# AgentPhone Message Context");
-    expect(run2.appendSystemPrompt).toContain("MSG_ID: rh-full");
-    expect(run2.appendSystemPrompt).toContain("prior context from provider");
-    expect(run2.appendSystemPrompt).toContain("CHANNEL: sms");
-    expect(run2.appendSystemPrompt).toContain("AT: 2026-06-01T08:00:00.000Z");
-    expect(run2.appendSystemPrompt).toContain(
+    const run = await claimDispatchedRun(runnerGroup);
+    expect(run.appendSystemPrompt).toContain("# AgentPhone Message Context");
+    expect(run.appendSystemPrompt).toContain("MSG_ID: rh-full");
+    expect(run.appendSystemPrompt).toContain("prior context from provider");
+    expect(run.appendSystemPrompt).toContain("CHANNEL: sms");
+    expect(run.appendSystemPrompt).toContain("AT: 2026-06-01T08:00:00.000Z");
+    expect(run.appendSystemPrompt).toContain(
       "[AgentPhone file] https://media.agentphone.test/history-photo.png",
     );
     expect(
-      run2.appendSystemPrompt.match(/- RELATIVE_INDEX:/gu) ?? [],
+      run.appendSystemPrompt.match(/- RELATIVE_INDEX:/gu) ?? [],
     ).toHaveLength(2);
-
-    // Session continuity: the second DM reuses the session saved by the
-    // first completion.
-    const beforeRun2Completion = sends.messages.length;
-    await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
-    await waitForSendCount(sends, beforeRun2Completion + 1);
-    await waitForRunSessionId(actor, run2.runId, historySession);
+    await completeSandboxRun(run.sandboxToken, run.runId, 0);
   });
 
   it("restarts linked sessions when the model route changes", async () => {


### PR DESCRIPTION
## Summary

- keep provider recent-history rendering coverage in a single AgentPhone run lifecycle
- exercise provider history without session rotation in the existing phone/web/phone canonical-session test
- remove the redundant seed lifecycle from the compound timeout case without changing timeouts, adding retries, or weakening its formatting assertions

## Root cause

This was a test time-budget flake caused by shared CI execution latency in a compound integration scenario, rather than a deterministic AgentPhone product regression.

- In the failing `test-api (4)` job, the target reached the 5,000 ms limit at 5,005 ms and the AgentPhone file took 27.855 s. Several neighboring cases in the same file were also roughly 3–5x slower than the control.
- In the successful merge-group run for the exact same SHA, the target completed in 643 ms and the file took 8.141 s.
- The failing log reached the target's first completion-side warning only after approximately the full test budget had elapsed; it never entered the second recent-history lifecycle. The first causal nondeterminism is therefore before recent-history parsing and linked-session comparison.
- The exact failed-SHA test, route, callback, and `waitUntil`/deferred ownership paths were unchanged on the then-latest `main`. The paths await tracked work, and the failure had no abort, unhandled-rejection, detached-cleanup, or teardown signal.
- `OPENROUTER_API_KEY` summary warnings occurred in both the failed and successful controls. Other schema, Browser Use, foreign-key, and bigint errors belonged to intentional negative tests; cancelled Codecov and `ci-gate-turbo` were downstream noise.

The test redundantly paid for two full webhook → dispatch → sandbox completion → callback/delivery lifecycles to prove two independent invariants. Session reuse is already covered by the canonical SMS → web → SMS scenario. That scenario now includes provider history on the final SMS and still verifies the same canonical session, while this test retains the exact provider-history prompt assertions with one lifecycle.

## Evidence

- Trigger run: https://github.com/vm0-ai/vm0/actions/runs/31612320680
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/31612320680/job/94166621255
- Same-SHA successful control: https://github.com/vm0-ai/vm0/actions/runs/31611708237
- Same-SHA successful job: https://github.com/vm0-ai/vm0/actions/runs/31611708237/job/94164487521
- Later unchanged-main successful control: https://github.com/vm0-ai/vm0/actions/runs/31612598480
- Later unchanged-main job: https://github.com/vm0-ai/vm0/actions/runs/31612598480/job/94168791766

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types` (also repeated after rebasing onto current `main`)
- `git diff --check`

The focused Vitest case was not run locally because this environment has no test database and the repair contract prohibits starting local app/API/database services. Turbo CI provides the required database-backed execution. Preview verification is not applicable because this is test-only and changes no deployed runtime or UI behavior.
