### PR TITLE
test(api): scope stripe snapshot execution

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -665,7 +665,8 @@ describe("Stripe automation event webhook", () => {
         },
       }),
     );
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(2);
+    expect((await executeAutomation(current)).body.executed).toBe(1);
+    expect((await executeAutomation(legacy)).body.executed).toBe(1);
 
     const currentClaim = await claimScenarioRun(current);
     const legacyClaim = await claimScenarioRun(legacy);


### PR DESCRIPTION
## Summary

- replace the snapshot fan-out test's global cron scan with scoped execution of its current and legacy Stripe automations
- assert that each fixture automation executes exactly once while preserving all embedded-line, relationship-identity, and no-enrichment assertions
- keep unrelated shared-database automation backlog out of this test's 5-second budget

## Root cause

The failing push run [31613550704](https://github.com/vm0-ai/vm0/actions/runs/31613550704) timed out this test after 5007 ms in [test-api (8)](https://github.com/vm0-ai/vm0/actions/runs/31613550704/job/94170751173). The same test on the exact same SHA passed in 1644 ms in merge-group run [31613114483](https://github.com/vm0-ai/vm0/actions/runs/31613114483), [test-api (8)](https://github.com/vm0-ai/vm0/actions/runs/31613114483/job/94169272251).

This test called the global workflow-automation cron route. That route sequentially scans every due schedule, Notion, Strapi, and Stripe automation in the shared test database, while `testContext()` does not roll back persisted database state. CI scheduling therefore changed how much unrelated backlog this test owned before reaching its two Stripe fixtures. The `PROVIDER_UNAVAILABLE` workflow-queue logs occurred in both the failing and successful runs; they expose unrelated global-scan work but are not the timeout's cause.

The existing test-only scoped executor avoids that shared ownership and is already the isolation mechanism used by the other Stripe automation tests.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (passes; existing repository warnings only)
- `pnpm knip` (exit 0; existing configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check origin/main...HEAD`

The focused Vitest could not be run locally because PostgreSQL is not running in this checkout, and the repair contract prohibits starting local services or loading project secrets. The PR's `test-api (8)` check is the runtime verification.

Preview/browser verification is not applicable: this changes only test code and introduces no deployable or user-visible behavior.
