### PR TITLE
fix(cli): create agents as private by default

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -16,12 +16,16 @@ import { server } from "../../../../mocks/server";
 import { createCommand } from "../create";
 import chalk from "chalk";
 
-const mockAgent = {
+const mockAgentWithoutVisibility = {
   agentId: "comp_xyz789",
   displayName: "New Agent",
   description: null,
   sound: null,
   avatarUrl: null,
+};
+
+const mockAgent = {
+  ...mockAgentWithoutVisibility,
   visibility: "private",
 };
 
@@ -123,6 +127,25 @@ describe("okou agent create command", () => {
       expect(capturedBody?.visibility).toBe("public");
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Visibility:   public");
+    });
+
+    it("should handle a create response without visibility", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/okou/agents", () => {
+          return HttpResponse.json(mockAgentWithoutVisibility, { status: 201 });
+        }),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "--display-name",
+        "New Agent",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Agent "comp_xyz789" created');
+      expect(logCalls).not.toContain("Visibility:");
     });
 
     it("should send preset avatar in request body", async () => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -22,6 +22,7 @@ const mockAgent = {
   description: null,
   sound: null,
   avatarUrl: null,
+  visibility: "private",
 };
 
 describe("okou agent create command", () => {
@@ -70,7 +71,7 @@ describe("okou agent create command", () => {
       );
     });
 
-    it("should create agent without workflow attachments in request body", async () => {
+    it("should create a private agent by default", async () => {
       let capturedBody: Record<string, unknown> | undefined;
       server.use(
         http.post(
@@ -90,6 +91,38 @@ describe("okou agent create command", () => {
       ]);
 
       expect(capturedBody?.displayName).toBe("New Agent");
+      expect(capturedBody?.visibility).toBe("private");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Visibility:   private");
+    });
+
+    it("should create a public agent when requested", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/okou/agents",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              { ...mockAgent, visibility: "public" },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "--display-name",
+        "New Agent",
+        "--visibility",
+        "public",
+      ]);
+
+      expect(capturedBody?.visibility).toBe("public");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Visibility:   public");
     });
 
     it("should send preset avatar in request body", async () => {
@@ -190,6 +223,19 @@ describe("okou agent create command", () => {
   });
 
   describe("error handling", () => {
+    it("should reject invalid visibility", async () => {
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "--visibility",
+          "unlisted",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should reject invalid avatar preset", async () => {
       await expect(async () => {
         await createCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -22,6 +22,7 @@ const mockAgent = {
   description: null,
   sound: null,
   avatarUrl: null,
+  visibility: "private",
 };
 
 describe("okou agent edit command", () => {
@@ -66,6 +67,7 @@ describe("okou agent edit command", () => {
       ]);
 
       expect(capturedBody?.displayName).toBe("Updated");
+      expect(capturedBody).not.toHaveProperty("visibility");
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("updated");
     });
@@ -96,6 +98,32 @@ describe("okou agent edit command", () => {
       expect(capturedBody?.description).toBe("Updated role");
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("updated");
+    });
+
+    it("should update visibility", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/okou/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.put(
+          "http://localhost:3000/api/okou/agents/my-agent",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ ...mockAgent, visibility: "public" });
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--visibility",
+        "public",
+      ]);
+
+      expect(capturedBody?.visibility).toBe("public");
     });
 
     it("should update avatar with preset and include it in request body", async () => {
@@ -229,6 +257,20 @@ describe("okou agent edit command", () => {
   });
 
   describe("validation", () => {
+    it("should reject invalid visibility", async () => {
+      await expect(async () => {
+        await editCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--visibility",
+          "unlisted",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should fail when no options provided", async () => {
       await expect(async () => {
         await editCommand.parseAsync(["node", "cli", "my-agent"]);

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
@@ -13,11 +13,15 @@ import { server } from "../../../../mocks/server";
 import { listCommand } from "../list";
 import chalk from "chalk";
 
-const mockAgent = {
+const mockAgentWithoutVisibility = {
   agentId: "my-agent",
   displayName: "My Agent",
   description: null,
   sound: null,
+};
+
+const mockAgent = {
+  ...mockAgentWithoutVisibility,
   visibility: "private",
 };
 
@@ -70,6 +74,21 @@ describe("okou agent list command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No agents found");
+    });
+
+    it("should show a placeholder when visibility is missing", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/okou/agents", () => {
+          return HttpResponse.json([mockAgentWithoutVisibility]);
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const agentRow = mockConsoleLog.mock.calls.flat().find((line) => {
+        return line.includes("my-agent");
+      });
+      expect(agentRow).toMatch(/My Agent\s+-\s*$/);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
@@ -18,6 +18,7 @@ const mockAgent = {
   displayName: "My Agent",
   description: null,
   sound: null,
+  visibility: "private",
 };
 
 describe("okou agent list command", () => {
@@ -54,6 +55,8 @@ describe("okou agent list command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("my-agent");
       expect(logCalls).toContain("My Agent");
+      expect(logCalls).toContain("VISIBILITY");
+      expect(logCalls).toContain("private");
     });
 
     it("should display empty state message when no agents", async () => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -22,6 +22,7 @@ const mockAgent = {
   displayName: "My Agent",
   description: "A test agent",
   sound: "professional",
+  visibility: "private",
 };
 
 const defaultPermissionDetails = [
@@ -137,6 +138,7 @@ describe("okou agent view command", () => {
       expect(logCalls).toContain("comp_abc123");
       expect(logCalls).toContain("A test agent");
       expect(logCalls).toContain("professional");
+      expect(logCalls).toContain("Visibility:   private");
       expect(logCalls).toContain("github (full access)");
     });
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -17,11 +17,15 @@ import {
 import { viewCommand } from "../view";
 import chalk from "chalk";
 
-const mockAgent = {
+const mockAgentWithoutVisibility = {
   agentId: "comp_abc123",
   displayName: "My Agent",
   description: "A test agent",
   sound: "professional",
+};
+
+const mockAgent = {
+  ...mockAgentWithoutVisibility,
   visibility: "private",
 };
 
@@ -166,6 +170,27 @@ describe("okou agent view command", () => {
       expect(logCalls).toContain(
         "preset:2 (medium skin, pink hair, neutral, chill)",
       );
+    });
+
+    it("should handle an agent response without visibility", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/okou/agents/my-agent", () => {
+          return HttpResponse.json(mockAgentWithoutVisibility);
+        }),
+        http.get(
+          "http://localhost:3000/api/okou/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledConnectorSlugs: [] });
+          },
+        ),
+        mockConnectorListHandler(),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Agent ID:     comp_abc123");
+      expect(logCalls).not.toContain("Visibility:");
     });
 
     it("should display custom svg avatar", async () => {

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -111,6 +111,8 @@ Examples:
         if (agent.displayName) {
           console.log(`  Display Name: ${agent.displayName}`);
         }
+        // Commit-addressed CLI/backend responses may omit visibility. Remove
+        // after #26761 verifies producers and queued/active contexts have drained.
         if (agent.visibility) {
           console.log(`  Visibility:   ${agent.visibility}`);
         }

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -1,4 +1,5 @@
-import { Command } from "commander";
+import type { ZeroAgentVisibility } from "@vm0/api-contracts/contracts/zero-agents";
+import { Command, Option } from "commander";
 import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import {
@@ -7,6 +8,7 @@ import {
 } from "../../../lib/api/domains/zero-agents";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { resolveAvatarUrl } from "./avatar";
+import { parseAgentVisibility } from "./visibility";
 
 export const createCommand = new Command()
   .name("create")
@@ -16,6 +18,14 @@ export const createCommand = new Command()
   .option(
     "--sound <tone>",
     "Agent tone: professional, friendly, direct, supportive",
+  )
+  .addOption(
+    new Option(
+      "--visibility <visibility>",
+      "Agent visibility: private or public",
+    )
+      .default("private" satisfies ZeroAgentVisibility)
+      .argParser(parseAgentVisibility),
   )
   .option("--avatar <preset>", "Avatar preset: preset:0 through preset:4")
   .option(
@@ -60,6 +70,7 @@ Avatar:
 
 Examples:
   Minimal:               okou agent create --display-name "My Agent"
+  Public agent:          okou agent create --display-name "My Agent" --visibility public
   Quick preset:          okou agent create --display-name "My Agent" --avatar preset:2
   Custom avatar:         okou agent create --display-name "My Agent" --avatar-skin dark --avatar-hair-color teal --avatar-intensity hyped
   With instructions:     okou agent create --display-name "My Agent" --instructions-file ./instructions.md`,
@@ -70,6 +81,7 @@ Examples:
         displayName?: string;
         description?: string;
         sound?: string;
+        visibility: ZeroAgentVisibility;
         avatar?: string;
         avatarRotation?: string;
         avatarSkin?: string;
@@ -85,6 +97,7 @@ Examples:
           displayName: options.displayName,
           description: options.description,
           sound: options.sound,
+          visibility: options.visibility,
           avatarUrl,
         });
 
@@ -97,6 +110,9 @@ Examples:
         console.log(`  Agent ID:     ${agent.agentId}`);
         if (agent.displayName) {
           console.log(`  Display Name: ${agent.displayName}`);
+        }
+        if (agent.visibility) {
+          console.log(`  Visibility:   ${agent.visibility}`);
         }
 
         console.log();

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -1,4 +1,5 @@
-import { Command } from "commander";
+import type { ZeroAgentVisibility } from "@vm0/api-contracts/contracts/zero-agents";
+import { Command, Option } from "commander";
 import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import {
@@ -8,11 +9,13 @@ import {
 } from "../../../lib/api/domains/zero-agents";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { type AvatarOptions, resolveAvatarUrl } from "./avatar";
+import { parseAgentVisibility } from "./visibility";
 
 interface AgentEditOptions extends AvatarOptions {
   displayName?: string;
   description?: string;
   sound?: string;
+  visibility?: ZeroAgentVisibility;
   instructionsFile?: string;
 }
 
@@ -33,6 +36,7 @@ function hasAgentFieldUpdate(options: AgentEditOptions): boolean {
     options.displayName !== undefined ||
     options.description !== undefined ||
     options.sound !== undefined ||
+    options.visibility !== undefined ||
     hasAvatarUpdate(options)
   );
 }
@@ -63,6 +67,7 @@ async function applyAgentUpdate(
       options.sound !== undefined
         ? options.sound
         : (current.sound ?? undefined),
+    visibility: options.visibility,
     avatarUrl,
   });
 }
@@ -76,6 +81,12 @@ export const editCommand = new Command()
   .option(
     "--sound <tone>",
     "New tone: professional, friendly, direct, supportive",
+  )
+  .addOption(
+    new Option(
+      "--visibility <visibility>",
+      "New visibility: private or public",
+    ).argParser(parseAgentVisibility),
   )
   .option("--avatar <preset>", "Avatar preset: preset:0 through preset:4")
   .option(
@@ -121,6 +132,7 @@ Avatar:
 Examples:
   Update description:      okou agent edit <agent-id> --description "new role"
   Update tone:             okou agent edit <agent-id> --sound friendly
+  Make public:             okou agent edit <agent-id> --visibility public
   Quick preset avatar:     okou agent edit <agent-id> --avatar preset:2
   Custom avatar:           okou agent edit <agent-id> --avatar-skin dark --avatar-hair-color teal --avatar-intensity hyped
   Update instructions:     okou agent edit <agent-id> --instructions-file ./instructions.md
@@ -137,7 +149,7 @@ Notes:
 
       if (!hasAgentUpdate && !options.instructionsFile) {
         throw new Error(
-          "At least one option is required (--display-name, --description, --sound, --avatar, --avatar-*, --instructions-file)",
+          "At least one option is required (--display-name, --description, --sound, --visibility, --avatar, --avatar-*, --instructions-file)",
         );
       }
 

--- a/turbo/apps/cli/src/commands/zero/agent/list.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/list.ts
@@ -42,10 +42,12 @@ Notes:
           return (a.displayName ?? "").length;
         }),
       );
+      const visibilityWidth = "VISIBILITY".length;
 
       const header = [
         "AGENT ID".padEnd(idWidth),
         "DISPLAY NAME".padEnd(displayWidth),
+        "VISIBILITY".padEnd(visibilityWidth),
       ].join("  ");
       console.log(chalk.dim(header));
 
@@ -53,6 +55,7 @@ Notes:
         const row = [
           agent.agentId.padEnd(idWidth),
           (agent.displayName ?? "-").padEnd(displayWidth),
+          (agent.visibility ?? "-").padEnd(visibilityWidth),
         ].join("  ");
         console.log(row);
       }

--- a/turbo/apps/cli/src/commands/zero/agent/list.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/list.ts
@@ -55,6 +55,8 @@ Notes:
         const row = [
           agent.agentId.padEnd(idWidth),
           (agent.displayName ?? "-").padEnd(displayWidth),
+          // Commit-addressed CLI/backend responses may omit visibility. Remove
+          // after #26761 verifies producers and queued/active contexts have drained.
           (agent.visibility ?? "-").padEnd(visibilityWidth),
         ].join("  ");
         console.log(row);

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -119,6 +119,7 @@ Examples:
         if (agent.displayName) console.log(chalk.dim(agent.displayName));
         console.log();
         console.log(`Agent ID:     ${agent.agentId}`);
+        if (agent.visibility) console.log(`Visibility:   ${agent.visibility}`);
 
         const storedPolicies = options.permissions
           ? connectorPermissionGrantsToFirewallPolicies(

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -119,6 +119,8 @@ Examples:
         if (agent.displayName) console.log(chalk.dim(agent.displayName));
         console.log();
         console.log(`Agent ID:     ${agent.agentId}`);
+        // Commit-addressed CLI/backend responses may omit visibility. Remove
+        // after #26761 verifies producers and queued/active contexts have drained.
         if (agent.visibility) console.log(`Visibility:   ${agent.visibility}`);
 
         const storedPolicies = options.permissions

--- a/turbo/apps/cli/src/commands/zero/agent/visibility.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/visibility.ts
@@ -1,0 +1,15 @@
+import {
+  zeroAgentVisibilitySchema,
+  type ZeroAgentVisibility,
+} from "@vm0/api-contracts/contracts/zero-agents";
+import { InvalidArgumentError } from "commander";
+
+export function parseAgentVisibility(value: string): ZeroAgentVisibility {
+  const result = zeroAgentVisibilitySchema.safeParse(value);
+  if (result.success) {
+    return result.data;
+  }
+  throw new InvalidArgumentError(
+    `visibility must be one of: ${zeroAgentVisibilitySchema.options.join(", ")}`,
+  );
+}


### PR DESCRIPTION
## Summary

- default `okou agent create` to `private` while allowing `--visibility public`
- validate visibility values and support changing them through `okou agent edit`
- show visibility in agent create, view, and list output
- keep the API's missing-field fallback unchanged for backward compatibility with existing clients

## Fallbacks

- `createCommand`, `viewCommand`, and `listCommand` tolerate a `ZeroAgentResponse` without `visibility` by omitting the detail or showing `-`. Surface: commit-addressed CLI/backend response. Window: the maximum queue lifetime plus claimed execution and finalization lifetime for pre-change execution contexts. Remove after all supported response producers return `visibility` and those contexts have drained; follow-up #26761.

## Test plan

- `pnpm --filter @vm0/okou-cli exec vitest run src/commands/zero/agent/__tests__/create.test.ts src/commands/zero/agent/__tests__/edit.test.ts src/commands/zero/agent/__tests__/view.test.ts src/commands/zero/agent/__tests__/list.test.ts`
- `pnpm --filter @vm0/okou-cli lint`
- `pnpm --filter @vm0/okou-cli check-types`
