### PR TITLE
test(api): isolate feishu group task scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-feishu-integration.test.ts
@@ -997,6 +997,26 @@ describe("Feishu integration", () => {
     );
   }
 
+  async function removeFeishuInstallation(
+    fixture: FeishuRunFixture,
+  ): Promise<void> {
+    mocks.clerk.session(
+      fixture.actor.userId,
+      fixture.actor.orgId,
+      fixture.actor.orgRole,
+    );
+    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+      zeroFeishuConnectContract,
+    );
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId: fixture.installationId },
+      }),
+      [200],
+    );
+  }
+
   async function startFeishuDmSession(fixture: FeishuRunFixture): Promise<{
     readonly firstMessageId: string;
     readonly mainSessionId: string;
@@ -4184,9 +4204,9 @@ describe("Feishu integration", () => {
     );
   });
 
-  it("runs mentioned group tasks with thread history, dedupe, and session resume", async () => {
+  it("ignores unmentioned and app-authored group messages", async () => {
     const fixture = await setupFeishuRunFixture();
-    const { actor, runnerGroup, appId, callbackUrl } = fixture;
+    const { actor, appId, callbackUrl } = fixture;
     await connectFixtureUser(fixture);
     await postEvent(
       callbackUrl,
@@ -4217,7 +4237,13 @@ describe("Feishu integration", () => {
       }),
     ).toBeFalsy();
 
-    const groupThreadId = `omt_${randomUUID()}`;
+    await removeFeishuInstallation(fixture);
+  });
+
+  it("runs mentioned group tasks with thread history and dedupe", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const { actor, runnerGroup, appId, callbackUrl } = fixture;
+    await connectFixtureUser(fixture);
     const groupMessageId = `om_${randomUUID()}`;
     historyMessages = [
       {
@@ -4305,10 +4331,36 @@ describe("Feishu integration", () => {
       "Reply to",
     );
 
+    await removeFeishuInstallation(fixture);
+  });
+
+  it("attributes mentioned group replies to the triggering user", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const { actor, runnerGroup, appId, callbackUrl } = fixture;
+    await connectFixtureUser(fixture);
+    const groupMessageId = `om_${randomUUID()}`;
+    const groupThreadId = `omt_${randomUUID()}`;
+    await postEvent(
+      callbackUrl,
+      groupMessage(appId, "establish group reply attribution", {
+        messageId: groupMessageId,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const initialGroupRun = await findRun(
+      actor,
+      "establish group reply attribution",
+    );
+    await runsApi.heartbeatRunner(runnerGroup);
+    await runsApi.claimRunnerJob(initialGroupRun.id);
+    await runsApi.requestCancelRun(actor, initialGroupRun.id, [200]);
+    await flushWaitUntilForTest();
+
     const secondOpenId = "ou_feishu_second_user";
     const secondActor = authOrgApi.user({
       userId: `user_${randomUUID()}`,
-      orgId: actor.orgId,
+      orgId: fixture.actor.orgId,
       orgRole: "org:member",
     });
     await enableFeishuIntegration(secondActor, {
@@ -4348,6 +4400,33 @@ describe("Feishu integration", () => {
       `Reply to <at id=${secondOpenId}></at>`,
     );
 
+    await removeFeishuInstallation(fixture);
+  });
+
+  it("resumes mentioned group tasks in the same thread session", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const { actor, runnerGroup, appId, callbackUrl } = fixture;
+    await connectFixtureUser(fixture);
+    const groupMessageId = `om_${randomUUID()}`;
+    const groupThreadId = `omt_${randomUUID()}`;
+    await postEvent(
+      callbackUrl,
+      groupMessage(appId, "handle this group task", {
+        messageId: groupMessageId,
+      }),
+      { encrypted: true },
+    );
+    await flushWaitUntilForTest();
+    const groupRun = await findRun(actor, "handle this group task");
+    await runsApi.heartbeatRunner(runnerGroup);
+    const groupClaim = await runsApi.claimRunnerJob(groupRun.id);
+    const groupCliSessionId = `bdd-feishu-group-cli-${groupRun.id}`;
+    await completeRunSession({
+      runId: groupRun.id,
+      sandboxToken: groupClaim.sandboxToken,
+      sessionId: groupCliSessionId,
+      history: `bdd feishu group history ${groupRun.id}`,
+    });
     await postEvent(
       callbackUrl,
       groupMessage(appId, "continue this group task", {
@@ -4363,15 +4442,7 @@ describe("Feishu integration", () => {
     expect(groupFollowUpClaim.resumeSession?.sessionId).toBe(groupCliSessionId);
     await runsApi.requestCancelRun(actor, groupFollowUp.id, [200]);
     await flushWaitUntilForTest();
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
-      zeroFeishuConnectContract,
-    );
-    await accept(
-      client.removeInstallation({
-        headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: fixture.installationId },
-      }),
-      [200],
-    );
+
+    await removeFeishuInstallation(fixture);
   });
 });


### PR DESCRIPTION
## Summary

- split the compound Feishu mentioned-group test into four independently owned scenarios with fresh fixtures
- preserve the filtering, thread-history, dedupe, triggering-user attribution, reply delivery, and session-resume invariants
- clean up every installation through the production remove-installation route

TURBO_FLAKY_KEY: `test-api-zero-feishu-integration-mentioned-group-thread-history-dedupe-session-resume-5000ms-timeout`

## Root cause

The original test serialized four independent group-message contracts and three sandbox run lifecycles under one fixed 5-second test-body budget. In the failing shard, the trace completed the first two run boundaries and reached the third follow-up/session-resume boundary only after about 4.5 seconds; the test then timed out at 5,130 ms before that boundary completed. The shard as a whole also slowed from roughly 83–85 seconds in the passing controls to 138 seconds.

This is cumulative test-body ownership under shard contention, not teardown, gate, or cancellation behavior. The represented PR #26734 changed only an unrelated Stripe test. The nearby `AbortError` belonged to another test, and the run-summary warnings also occur in passing controls.

Evidence:

- failing merge-group job: https://github.com/vm0-ai/vm0/actions/runs/31617026590/job/94182369518 — target 5,130 ms; Feishu file 46,099 ms; shard 138.03 s
- exact-main-baseline control: https://github.com/vm0-ai/vm0/actions/runs/31616780258/job/94181541576 — target 1,160 ms; Feishu file 14,860 ms; shard 85.43 s
- represented PR-head control: https://github.com/vm0-ai/vm0/actions/runs/31616337652/job/94180036789 — target about 1,165 ms; Feishu file 14,680 ms; shard 83.05 s

## Fix

Each independently observable contract now owns its own fixture and default test budget:

1. unmentioned and app-authored group messages are ignored
2. mentioned group tasks retain history, dedupe, and reply-delivery behavior
3. replies are attributed to the triggering group member using a real established thread
4. follow-ups in the same group thread resume the existing session

No retry, sleep, timeout increase, skip, quarantine, detached cleanup, swallowed rejection, or product-code change is included.

## Validation

- target file passed in five consecutive fresh Vitest processes: 29/29 each; test totals 8.83 s, 8.97 s, 8.83 s, 8.65 s, and 8.42 s
- final target-file regression after static checks: 29/29; test total 8.75 s
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`

## Preview

Not applicable: this PR changes only API test isolation and has no deployable product behavior to validate in a browser preview.
