### PR TITLE
test(api): enforce shared-state isolation rules

### DIFF
--- a/docs/testing/api-testing.md
+++ b/docs/testing/api-testing.md
@@ -136,6 +136,43 @@ raise the gap during review.
 For the full reasoning, see
 [Testing External Behavior](./testing-external-behavior.md).
 
+## Shared Persistent State
+
+Teardown cannot establish correctness for shared persistent state. Another
+file or worker can observe, overwrite, or depend on that state before
+`afterEach` or `onTestFinished` runs, and a crashed test may not run teardown at
+all. A test must therefore be correct while other API tests execute
+concurrently, even if its cleanup has not happened yet.
+
+Give every test uniquely owned, explicitly addressable users, organizations,
+providers, storage identities, external entities, cache namespaces, and rows.
+When a production cron scans a global table, keep production behavior global
+but drive correctness through a test-only route whose request names the owned
+IDs. Production-global routes may be mounted only by the focused contract
+harness for fixed missing/wrong-auth assertions. Do not isolate tests with a
+global lock, test ordering, worker serialization, broad clock partitions,
+snapshot/restore of shared rows, or residue-tolerant assertions.
+
+Operator-managed usage-pricing identities and the fixed production staff
+organization are shared production data. Use `createUsagePricingFixture()` to
+map a logical canonical provider to a UUID-owned physical lookup row, and use a
+unique organization fixture for entitlement writes. Fixed production
+identities remain valid in read-only/hash/auth behavior. Raw pricing mutation
+helpers are only for providers already proven UUID-, run-, or fixture-owned.
+
+Cache assertions own their key or namespace. Set and advance mocked time inside
+the test that exercises the TTL; never stagger tests with a module- or
+describe-scoped counter to outlive another test's cache entry. Process-wide
+caches and overrides need an explicit request/test owner and scoped reset
+semantics, such as an `AbortSignal` or async-local boundary.
+
+Cleanup is still useful after ownership establishes correctness. It may remove
+rows and resources created by that test, and it should terminate or release
+test-owned handles, `AbortController`s/signals, MSW handlers, connections,
+sockets/streams, detached work, and temporary files. Such cleanup bounds
+residue and resource lifetime; it must not delete, overwrite, or restore
+pre-existing shared state to make an assertion pass.
+
 ## Commands
 
 Run route-focused tests from `turbo`:

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -326,6 +326,21 @@ export default [
     },
   },
   {
+    files: [
+      "src/**/__tests__/**/*.ts",
+      "src/**/*.test.ts",
+      "src/test-fixtures/**/*.ts",
+      "src/signals/routes/test-*.ts",
+    ],
+    rules: {
+      "api/no-cross-test-time-staggering": "error",
+      "api/no-global-sweep-test-routes": "error",
+      "api/no-legacy-shared-state-markers": "error",
+      "api/no-production-staff-entitlement-mutation": "error",
+      "api/no-unowned-usage-pricing": "error",
+    },
+  },
+  {
     ignores: ["**/dist/**", ".vercel/**"],
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { type CronCleanupSandboxesResponse } from "@vm0/api-contracts/contracts/cron";
+import type { CronCleanupSandboxesResponse } from "@vm0/api-contracts/contracts/cron";
 import {
   triggerSourceSchema,
   type TriggerSource,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -735,7 +735,7 @@ describe("sandbox cleanup", () => {
         threadless: true,
       }),
     );
-    const usageProvider = `cleanup-test-${randomUUID()}`;
+    const usageProvider = `cleanup-test-${fixture.runId}`;
     await seedUsagePricingRows([
       {
         kind: "model",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -1,9 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import {
-  cronCleanupSandboxesContract,
-  type CronCleanupSandboxesResponse,
-} from "@vm0/api-contracts/contracts/cron";
+import { type CronCleanupSandboxesResponse } from "@vm0/api-contracts/contracts/cron";
 import {
   triggerSourceSchema,
   type TriggerSource,
@@ -28,7 +25,6 @@ import {
   onTestFinished,
 } from "vitest";
 
-import { createApp } from "../../../app-factory";
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -49,17 +45,10 @@ import {
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import { cronCleanupSandboxesRoutes } from "../cron-cleanup-sandboxes";
 import { runnersRoutes } from "../runners";
-
-const TEST_APP_ROUTES = Object.freeze([
-  ...cronCleanupSandboxesRoutes,
-  ...runnersRoutes,
-]);
 
 const context = testContext();
 const webhooks = createWebhookCallbackApi(context);
-const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storage-bucket";
 const FIXED_NOW_MS = Date.parse("2000-01-01T00:10:00.000Z");
 const THREADLESS_FORWARD_CUTOFF_MS = Date.parse("2026-08-03T05:40:26.000Z");
@@ -113,26 +102,6 @@ interface RunOwnershipFixture {
 
 interface ChatThreadFixture {
   readonly threadId: string;
-}
-
-function apiClient() {
-  return setupApp({ context, routes: cronCleanupSandboxesRoutes })(
-    cronCleanupSandboxesContract,
-  );
-}
-
-function cronHeaders(secret = CRON_SECRET) {
-  return { authorization: `Bearer ${secret}` };
-}
-
-async function rawCronRequest(
-  headers: Record<string, string> = {},
-): Promise<Response> {
-  const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
-  return await app.request("/api/cron/cleanup-sandboxes", {
-    method: "GET",
-    headers,
-  });
 }
 
 function minutesAgo(minutes: number): Date {
@@ -541,7 +510,6 @@ describe("sandbox cleanup", () => {
     registeredRunIds = [];
     registeredOrgIds = [];
     registeredExportJobIds = [];
-    mockEnv("CRON_SECRET", CRON_SECRET);
     mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
     mockNow(FIXED_NOW_MS);
     context.mocks.s3.send.mockReset();
@@ -550,27 +518,6 @@ describe("sandbox cleanup", () => {
 
   afterEach(() => {
     clearMockNow();
-  });
-
-  it("rejects requests with an invalid cron secret", async () => {
-    const response = await accept(
-      apiClient().cleanup({ headers: cronHeaders("wrong-secret") }),
-      [401],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-    });
-  });
-
-  it("rejects requests with a missing authorization header", async () => {
-    const response = await rawCronRequest();
-    const body = await response.json();
-
-    expect(response.status).toBe(401);
-    expect(body).toStrictEqual({
-      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-    });
   });
 
   it("returns an empty cleanup result for an empty fixture scope", async () => {
@@ -788,7 +735,7 @@ describe("sandbox cleanup", () => {
         threadless: true,
       }),
     );
-    const usageProvider = `cleanup-test-${fixture.runId}`;
+    const usageProvider = `cleanup-test-${randomUUID()}`;
     await seedUsagePricingRows([
       {
         kind: "model",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 
-import { cronConnectorOauthStateCleanupContract } from "@vm0/api-contracts/contracts/cron";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   afterEach,
@@ -22,12 +21,10 @@ import {
   testCronDeleteCleanupsStateContract,
   testCronDeleteCleanupsStateRoutes,
 } from "../test-cron-delete-cleanups-state";
-import { cronConnectorOauthStateCleanupRoutes } from "../cron-connector-oauth-state-cleanup";
 import { zeroConnectorsRoutes } from "../zero-connectors";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
-const CRON_SECRET = "test-connector-oauth-state-cleanup-secret";
 const API_ORIGIN = "https://api.vm0.ai";
 
 function mockAuthenticatedSession(marker: string): void {
@@ -75,7 +72,6 @@ function registerFixtureCleanup(marker: string): void {
 
 describe("connector OAuth state cleanup cron", () => {
   beforeEach(() => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     mockEnv("VM0_API_BACKEND_URL", API_ORIGIN);
     mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
     mockOptionalEnv("GH_OAUTH_CLIENT_ID", "test-client-id");
@@ -84,21 +80,6 @@ describe("connector OAuth state cleanup cron", () => {
 
   afterEach(() => {
     clearMockNow();
-  });
-
-  it("requires the cron secret", async () => {
-    const response = await accept(
-      setupApp({ context, routes: cronConnectorOauthStateCleanupRoutes })(
-        cronConnectorOauthStateCleanupContract,
-      ).cleanup({
-        headers: {},
-      }),
-      [401],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: { code: "UNAUTHORIZED", message: "Invalid cron secret" },
-    });
   });
 
   it("deletes expired states while preserving unexpired states", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-sync-skills.test.ts
@@ -16,13 +16,11 @@ import {
 } from "@vm0/core/github-url";
 import { getSkillStorageName } from "@vm0/core/storage-names";
 import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
-import { cronSyncSkillsContract } from "@vm0/api-contracts/contracts/cron";
 import { http, HttpResponse } from "msw";
 import { create as createTar } from "tar";
 import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 
-import { accept, testContext } from "../../../__tests__/test-context";
-import { setupApp } from "../../../__tests__/test-helpers";
+import { testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import {
@@ -33,10 +31,8 @@ import {
   setOwnedSkillsCommitShaState,
   syncOwnedSkillsState,
 } from "./helpers/cron-sync-skills-state";
-import { cronSyncSkillsRoutes } from "../cron-sync-skills";
 
 const context = testContext();
-const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storages";
 const STALE_PRESEEDED_COMMIT_SHA = "0".repeat(40);
 
@@ -215,16 +211,6 @@ async function seedCurrentSkillVersions(
       };
     }),
   });
-}
-
-function apiClient() {
-  return setupApp({ context, routes: cronSyncSkillsRoutes })(
-    cronSyncSkillsContract,
-  );
-}
-
-function cronHeaders(secret = CRON_SECRET) {
-  return { authorization: `Bearer ${secret}` };
 }
 
 function newCommitSha(): string {
@@ -459,29 +445,9 @@ async function findSystemStorageByName(name: string): Promise<{
 
 describe("GET /api/cron/sync-skills", () => {
   beforeEach(() => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
     context.mocks.s3.send.mockReset();
     context.mocks.s3.send.mockResolvedValue({});
-  });
-
-  it("rejects requests with an invalid cron secret", async () => {
-    const response = await accept(
-      apiClient().sync({ headers: cronHeaders("wrong-secret") }),
-      [401],
-    );
-
-    expect(response.body).toStrictEqual({
-      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-    });
-  });
-
-  it("rejects requests with no authorization header", async () => {
-    const response = await accept(apiClient().sync({ headers: {} }), [401]);
-
-    expect(response.body).toStrictEqual({
-      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-    });
   });
 
   it("skips sync when the stored commit SHA is unchanged", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { mockEnv } from "../../../lib/env";
+import { cronCleanupSandboxesRoutes } from "../cron-cleanup-sandboxes";
+import { cronConnectorOauthStateCleanupRoutes } from "../cron-connector-oauth-state-cleanup";
+import { cronDrainEmailOutboxRoutes } from "../cron-drain-email-outbox";
+import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
+import { modelStatsRoutes } from "../model-stats";
+import { cronReconcileBillingEntitlementsRoutes } from "../cron-reconcile-billing-entitlements";
+import { cronSyncSkillsRoutes } from "../cron-sync-skills";
+import {
+  expectGlobalSweepMissingAuth,
+  expectGlobalSweepRemovedInputRejected,
+  expectGlobalSweepWrongAuth,
+} from "./helpers/global-sweep-contract";
+
+const context = testContext();
+const CRON_SECRET = "test-cron-secret";
+
+describe("production-global sweep route contracts", () => {
+  beforeEach(() => {
+    mockEnv("CRON_SECRET", CRON_SECRET);
+  });
+
+  it("rejects cleanup-sandboxes requests with an invalid cron secret", async () => {
+    await expectGlobalSweepWrongAuth(
+      context,
+      cronCleanupSandboxesRoutes,
+      "/api/cron/cleanup-sandboxes",
+    );
+  });
+
+  it("rejects cleanup-sandboxes requests without authorization", async () => {
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronCleanupSandboxesRoutes,
+      "/api/cron/cleanup-sandboxes",
+    );
+  });
+
+  it("rejects connector OAuth cleanup requests without authorization", async () => {
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronConnectorOauthStateCleanupRoutes,
+      "/api/cron/connector-oauth-state-cleanup",
+    );
+  });
+
+  it("rejects billing reconciliation requests without authorization", async () => {
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronReconcileBillingEntitlementsRoutes,
+      "/api/cron/reconcile-billing-entitlements",
+    );
+  });
+
+  it("rejects email-outbox drain requests without authorization", async () => {
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronDrainEmailOutboxRoutes,
+      "/api/cron/drain-email-outbox",
+    );
+  });
+
+  it("rejects sync-skills requests with an invalid cron secret", async () => {
+    await expectGlobalSweepWrongAuth(
+      context,
+      cronSyncSkillsRoutes,
+      "/api/cron/sync-skills",
+    );
+  });
+
+  it("rejects sync-skills requests without authorization", async () => {
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronSyncSkillsRoutes,
+      "/api/cron/sync-skills",
+    );
+  });
+
+  it("rejects workflow automation sweeps without authorization", async () => {
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronExecuteWorkflowAutomationsRoutes,
+      "/api/cron/execute-workflow-automations",
+    );
+  });
+
+  it("rejects model-stats aggregation with an invalid cron secret", async () => {
+    await expectGlobalSweepWrongAuth(
+      context,
+      modelStatsRoutes,
+      "/api/cron/aggregate-model-stats",
+    );
+  });
+
+  it("rejects the removed model-stats rebuild-window input", async () => {
+    await expectGlobalSweepRemovedInputRejected(
+      context,
+      modelStatsRoutes,
+      "/api/cron/aggregate-model-stats?hours=24",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
@@ -11,7 +11,6 @@ import { cronReconcileBillingEntitlementsRoutes } from "../cron-reconcile-billin
 import { cronSyncSkillsRoutes } from "../cron-sync-skills";
 import {
   expectGlobalSweepMissingAuth,
-  expectGlobalSweepRemovedInputRejected,
   expectGlobalSweepWrongAuth,
 } from "./helpers/global-sweep-contract";
 
@@ -92,14 +91,6 @@ describe("production-global sweep route contracts", () => {
       context,
       modelStatsRoutes,
       "/api/cron/aggregate-model-stats",
-    );
-  });
-
-  it("rejects the removed model-stats rebuild-window input", async () => {
-    await expectGlobalSweepRemovedInputRejected(
-      context,
-      modelStatsRoutes,
-      "/api/cron/aggregate-model-stats?hours=24",
     );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -43,7 +43,7 @@ import {
   mockListStripeInvoices,
   mockStripeClient,
 } from "../../../external/stripe-client";
-import { modelStatsContract, modelStatsRoutes } from "../../model-stats";
+import { modelStatsContract, modelStatsPublicRoutes } from "../../model-stats";
 import { testUsageSettlementRoutes } from "../../test-usage-settlement";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -541,7 +541,7 @@ export function createBillingMediaApi(context: TestContext) {
     },
 
     async readModelRankings() {
-      const client = setupApp({ context, routes: modelStatsRoutes })(
+      const client = setupApp({ context, routes: modelStatsPublicRoutes })(
         modelStatsContract,
       );
       return await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-email.ts
@@ -1,25 +1,18 @@
 import { randomUUID } from "node:crypto";
 
-import { cronDrainEmailOutboxContract } from "@vm0/api-contracts/contracts/cron";
 import type { TestEmailOutboxStateItem } from "@vm0/api-contracts/contracts/test-email-outbox-state";
 import { userExportContract } from "@vm0/api-contracts/contracts/user-export";
 
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { setupApp } from "../../../../__tests__/test-helpers";
 import { flushWaitUntilForTest } from "../../../context/wait-until";
-import { cronDrainEmailOutboxRoutes } from "../../cron-drain-email-outbox";
 import { userExportRoutes } from "../../user-export";
 import type { ApiTestUser } from "./api-bdd";
 import { createEmailOutboxStateApi } from "./email-outbox-state";
 import { createZeroRouteMocks } from "./zero-route-test";
 
-const EMAIL_ROUTES = Object.freeze([
-  ...cronDrainEmailOutboxRoutes,
-  ...userExportRoutes,
-]);
-
 function emailApp(context: TestContext) {
-  return setupApp({ context, routes: EMAIL_ROUTES });
+  return setupApp({ context, routes: userExportRoutes });
 }
 
 function authenticate(context: TestContext, actor: ApiTestUser) {
@@ -99,15 +92,6 @@ export function createEmailApi(context: TestContext) {
 
     async drainEmailOutboxItems(itemIds: readonly string[]): Promise<number> {
       return await outbox.drainItems(itemIds);
-    },
-
-    async requestEmailOutboxCronWithoutAuth() {
-      return await accept(
-        emailApp(context)(cronDrainEmailOutboxContract).drain({
-          headers: {},
-        }),
-        [401],
-      );
     },
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
@@ -1,17 +1,14 @@
-import { cronAggregateModelStatsContract } from "@vm0/api-contracts/contracts/cron";
 import { userExportContract } from "@vm0/api-contracts/contracts/user-export";
 
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { setupApp } from "../../../../__tests__/test-helpers";
 import { createDeferredPromise } from "../../../utils";
-import { modelStatsContract, modelStatsRoutes } from "../../model-stats";
+import { modelStatsContract, modelStatsPublicRoutes } from "../../model-stats";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { userExportRoutes } from "../../user-export";
 
 type AuthHeaders = { readonly authorization?: string };
-
-const CRON_AUTHORIZATION = "Bearer test-cron-secret";
 
 interface ClerkUserProfile {
   readonly id: string;
@@ -59,31 +56,11 @@ function authenticate(
 
 export function createOpsLogsApi(context: TestContext) {
   return {
-    async requestAggregateModelStats<TStatus extends 200 | 401>(
-      auth: "valid" | "invalid",
-      statuses: readonly TStatus[],
-    ) {
-      return await accept(
-        setupApp({ context, routes: modelStatsRoutes })(
-          cronAggregateModelStatsContract,
-        ).aggregate({
-          headers: {
-            authorization:
-              auth === "valid" ? CRON_AUTHORIZATION : "Bearer wrong-secret",
-          },
-          query: {},
-        }),
-        statuses,
-      );
-    },
-
     async readModelRankings(period?: string) {
       return await accept(
-        setupApp({ context, routes: modelStatsRoutes })(
+        setupApp({ context, routes: modelStatsPublicRoutes })(
           modelStatsContract,
-        ).rankings({
-          query: { period },
-        }),
+        ).rankings({ query: { period } }),
         [200],
       );
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -25,7 +25,6 @@ import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zer
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import {
   cronProcessUsageEventsContract,
-  cronReconcileBillingEntitlementsContract,
   cronTelegramCleanupContract,
 } from "@vm0/api-contracts/contracts/cron";
 import { testBillingReconciliationStateContract } from "@vm0/api-contracts/contracts/test-billing-reconciliation-state";
@@ -66,7 +65,6 @@ import {
 import { mockStripeClient } from "../../../external/stripe-client";
 import { cliAuthRoutes } from "../../cli-auth";
 import { cronProcessUsageEventsRoutes } from "../../cron-process-usage-events";
-import { cronReconcileBillingEntitlementsRoutes } from "../../cron-reconcile-billing-entitlements";
 import { cronTelegramCleanupRoutes } from "../../cron-telegram-cleanup";
 import { runnersRoutes } from "../../runners";
 import { webhooksStripeRoutes } from "../../webhooks-stripe";
@@ -154,7 +152,6 @@ const OFFICIAL_RUNNER_AUTHORIZATION =
 const runRoutes = [
   ...cliAuthRoutes,
   ...cronProcessUsageEventsRoutes,
-  ...cronReconcileBillingEntitlementsRoutes,
   ...cronTelegramCleanupRoutes,
   ...runnersRoutes,
   ...webhooksStripeRoutes,
@@ -1266,15 +1263,6 @@ export function createRunsApi(context: TestContext) {
         processUsageEvents,
         telegramCleanup,
       };
-    },
-
-    async requestBillingReconciliationCronWithoutAuth() {
-      return await accept(
-        runApp(context)(cronReconcileBillingEntitlementsContract).reconcile({
-          headers: {},
-        }),
-        [401],
-      );
     },
 
     async reconcileBillingOrganizations(orgIds: readonly string[]) {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/global-sweep-contract.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/global-sweep-contract.ts
@@ -33,14 +33,3 @@ export async function expectGlobalSweepWrongAuth(
   );
   await expectUnauthorized(response);
 }
-
-export async function expectGlobalSweepRemovedInputRejected(
-  context: TestContext,
-  routes: readonly RouteEntry[],
-  path: string,
-): Promise<void> {
-  const response = await createApp({ signal: context.signal, routes }).request(
-    path,
-  );
-  expect(response.status).toBe(400);
-}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/global-sweep-contract.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/global-sweep-contract.ts
@@ -1,0 +1,46 @@
+import { expect } from "vitest";
+
+import { createApp } from "../../../../app-factory";
+import type { TestContext } from "../../../../__tests__/test-context";
+import type { RouteEntry } from "../../../route-entry";
+
+async function expectUnauthorized(response: Response): Promise<void> {
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toStrictEqual({
+    error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
+  });
+}
+
+export async function expectGlobalSweepMissingAuth(
+  context: TestContext,
+  routes: readonly RouteEntry[],
+  path: string,
+): Promise<void> {
+  const response = await createApp({ signal: context.signal, routes }).request(
+    path,
+  );
+  await expectUnauthorized(response);
+}
+
+export async function expectGlobalSweepWrongAuth(
+  context: TestContext,
+  routes: readonly RouteEntry[],
+  path: string,
+): Promise<void> {
+  const response = await createApp({ signal: context.signal, routes }).request(
+    path,
+    { headers: { authorization: "Bearer wrong-secret" } },
+  );
+  await expectUnauthorized(response);
+}
+
+export async function expectGlobalSweepRemovedInputRejected(
+  context: TestContext,
+  routes: readonly RouteEntry[],
+  path: string,
+): Promise<void> {
+  const response = await createApp({ signal: context.signal, routes }).request(
+    path,
+  );
+  expect(response.status).toBe(400);
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -6,16 +6,13 @@ import type {
   GenerationTemplateRequest,
   UserMessageInputDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { cronAggregateModelStatsContract } from "@vm0/api-contracts/contracts/cron";
 import { zeroAgentInstructionsContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
-import { createAppWithRoutes } from "../../../app-factory-core";
 import { env } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { testContext, accept } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { flushWaitUntilForTest } from "../../context/wait-until";
-import { modelStatsRoutes } from "../model-stats";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
@@ -277,30 +274,6 @@ async function waitForUserExportJobStatus(
 }
 
 describe("BILL-02: model usage aggregation and public rankings", () => {
-  it("rejects the model-stats aggregation cron without the cron secret", async () => {
-    const api = createOpsLogsApi(context);
-
-    const rejected = await api.requestAggregateModelStats("invalid", [401]);
-    expect(rejected.body).toStrictEqual({
-      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-    });
-  });
-
-  it("rejects the obsolete model-stats rebuild window", async () => {
-    const aggregateApp = createAppWithRoutes({
-      signal: context.signal,
-      routes: modelStatsRoutes,
-    });
-    const rejected = await aggregateApp.request(
-      cronAggregateModelStatsContract.aggregate.path + "?hours=24",
-      {
-        headers: { authorization: "Bearer test-cron-secret" },
-      },
-    );
-
-    expect(rejected.status).toBe(400);
-  });
-
   it("incrementally projects owned observations into exact rankings", async () => {
     const api = createOpsLogsApi(context);
     const model = "fixture-model-" + randomUUID();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-cron.bdd.test.ts
@@ -429,7 +429,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 
 // Workflow schedule lifecycle and execution coverage lives in
 // zero-workflow-automations.test.ts and zero-workflow-automation-scheduler.test.ts.
-// Shared cron authorization remains covered here.
+// Shared cron authorization is covered in global-sweep-contracts.test.ts.
 
 describe("SCHED-02: cron routes", () => {
   it("rejects invalid cron auth on shared cron routes", async () => {
@@ -445,13 +445,6 @@ describe("SCHED-02: cron routes", () => {
 });
 
 describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
-  it("rejects unauthorized drain requests", async () => {
-    const email = createEmailApi(context);
-
-    const unauthorizedDrain = await email.requestEmailOutboxCronWithoutAuth();
-    expect(unauthorizedDrain.status).toBe(401);
-  });
-
   it("drains a data-export email once at its UTC retry boundary", async () => {
     const email = createEmailApi(context);
     const actor = createBddApi(context).user();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15669,9 +15669,6 @@ describe("BILL-01: billing entitlement reconciliation cron", () => {
         ],
       },
     });
-    const unauthorizedReconcile =
-      await api.requestBillingReconciliationCronWithoutAuth();
-    expect(unauthorizedReconcile.status).toBe(401);
     await api.reconcileBillingOrganizations([billingActorOrgId(actor)]);
 
     const status = await billing.readBillingStatus(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
-import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
 import { mockStripeWebhookEventConstructor } from "../../external/stripe-client";
 import type { ApiTestUser } from "./helpers/api-bdd";
@@ -23,7 +23,6 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
 import { testStripeAutomationEventRoutes } from "../test-stripe-automation-events";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { webhooksStripeAutomationEventsRoutes } from "../webhooks-stripe-automation-events";
@@ -36,12 +35,17 @@ const workflows = createWorkflowsBddApi(context);
 const mocks = createZeroRouteMocks(context);
 
 const AUTOMATION_WEBHOOK_SECRET = "whsec_stripe_automation_events";
-const CRON_SECRET = "stripe-workflow-cron-secret";
 const STRIPE_ACCOUNT_ID = "acct_stripe_workflow_live";
-const cronResultSchema = z.object({
-  executed: z.number().int().nonnegative(),
-  skipped: z.number().int().nonnegative(),
-});
+const EXECUTED_EXECUTION = {
+  success: true,
+  executed: 1,
+  skipped: 0,
+} as const;
+const NO_EXECUTION = {
+  success: true,
+  executed: 0,
+  skipped: 0,
+} as const;
 const TERMINALLY_SKIPPED_EXECUTION = {
   success: true,
   executed: 0,
@@ -259,21 +263,6 @@ async function postStripeAutomationEvent(
   return response;
 }
 
-async function executeCron(): Promise<{
-  readonly executed: number;
-  readonly skipped: number;
-}> {
-  const response = await createApp({
-    signal: context.signal,
-    routes: cronExecuteWorkflowAutomationsRoutes,
-  }).request("/api/cron/execute-workflow-automations", {
-    method: "GET",
-    headers: { authorization: `Bearer ${CRON_SECRET}` },
-  });
-  expect(response.status).toBe(200);
-  return cronResultSchema.parse(await response.json());
-}
-
 async function executeAutomation(scenario: Scenario) {
   return await accept(
     workflowAutomationExecutionClient().execute({
@@ -414,7 +403,6 @@ beforeEach(() => {
     "STRIPE_AUTOMATION_WEBHOOK_SECRET",
     AUTOMATION_WEBHOOK_SECRET,
   );
-  mockEnv("CRON_SECRET", CRON_SECRET);
 });
 
 describe("Stripe automation event webhook", () => {
@@ -523,12 +511,19 @@ describe("Stripe automation event webhook", () => {
       lastDeliveryStatusAt: "2026-08-07T08:00:00.000Z",
       warning: null,
     });
-    const cronResults = await Promise.all([executeCron(), executeCron()]);
+    const executionResults = await Promise.all([
+      executeAutomation(scenario),
+      executeAutomation(scenario),
+    ]);
     expect(
-      cronResults.reduce((total, cron) => {
-        return total + cron.executed;
-      }, 0),
-    ).toBeGreaterThanOrEqual(1);
+      executionResults
+        .map((result) => {
+          return result.body;
+        })
+        .sort((left, right) => {
+          return left.executed - right.executed;
+        }),
+    ).toStrictEqual([NO_EXECUTION, EXECUTED_EXECUTION]);
     expect((await readStripeAutomation(scenario)).health).toMatchObject({
       lastDeliveryStatus: "delivered",
       warning: null,
@@ -756,7 +751,12 @@ describe("Stripe automation event webhook", () => {
     await postStripeAutomationEvent(
       invoicePaidEvent({ eventId: "evt_cross_tenant_seed" }),
     );
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(2);
+    expect((await executeAutomation(first)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
+    expect((await executeAutomation(second)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
     await expect(automationInputEvents(first)).resolves.toHaveLength(1);
     await expect(automationInputEvents(second)).resolves.toHaveLength(1);
 
@@ -775,7 +775,12 @@ describe("Stripe automation event webhook", () => {
 
     await applyDeliveryFixture(second, "clear-forced-failures");
     await postStripeAutomationEvent(retryEvent);
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(2);
+    expect((await executeAutomation(first)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
+    expect((await executeAutomation(second)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
     await expect(automationInputEvents(first)).resolves.toHaveLength(2);
     await expect(automationInputEvents(second)).resolves.toHaveLength(2);
   });
@@ -790,7 +795,9 @@ describe("Stripe automation event webhook", () => {
       "fail-next-queue-admission-for-automation",
     );
 
-    expect((await executeCron()).skipped).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      TERMINALLY_SKIPPED_EXECUTION,
+    );
     await expect(automationInputEvents(scenario)).resolves.toHaveLength(0);
     expect((await readStripeAutomation(scenario)).health).toMatchObject({
       lastDeliveryStatus: "pending",
@@ -799,7 +806,9 @@ describe("Stripe automation event webhook", () => {
 
     await applyDeliveryFixture(scenario, "clear-forced-failures");
     await applyDeliveryFixture(scenario, "make-latest-due");
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
     await expect(automationInputEvents(scenario)).resolves.toHaveLength(1);
     expect((await readStripeAutomation(scenario)).health).toMatchObject({
       lastDeliveryStatus: "delivered",
@@ -820,7 +829,9 @@ describe("Stripe automation event webhook", () => {
     );
     await applyDeliveryFixture(scenario, "hold-latest-claim");
 
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
     await expect(automationInputEvents(scenario)).resolves.toHaveLength(1);
     expect((await readStripeAutomation(scenario)).health).toStrictEqual({
       lastMatchingEventReceivedAt: "2026-08-07T09:01:00.000Z",
@@ -830,7 +841,9 @@ describe("Stripe automation event webhook", () => {
     });
 
     mockNow(firstReceipt + 420_000);
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
     await expect(automationInputEvents(scenario)).resolves.toHaveLength(2);
     expect((await readStripeAutomation(scenario)).health).toMatchObject({
       lastDeliveryStatus: "delivered",
@@ -930,8 +943,9 @@ describe("Stripe automation event webhook", () => {
     await connectors.updateFeatureSwitches(scenario.actor, {
       [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: false,
     });
-    const cron = await executeCron();
-    expect(cron.skipped).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(scenario)).body).toStrictEqual(
+      TERMINALLY_SKIPPED_EXECUTION,
+    );
     expect((await readStripeAutomation(scenario)).health).toMatchObject({
       lastDeliveryStatus: "skipped",
       warning: null,
@@ -1043,7 +1057,9 @@ describe("Stripe automation event webhook", () => {
       enabled: true,
     });
 
-    await executeCron();
+    expect((await executeAutomation(affected)).body).toStrictEqual(
+      TERMINALLY_SKIPPED_EXECUTION,
+    );
     expect((await readStripeAutomation(affected)).health).toMatchObject({
       lastDeliveryStatus: "skipped",
     });
@@ -1057,13 +1073,17 @@ describe("Stripe automation event webhook", () => {
       invoicePaidEvent({ eventId: "evt_recoverable_claim" }),
     );
     await applyDeliveryFixture(recoverable, "hold-latest-claim");
-    await executeCron();
+    expect((await executeAutomation(recoverable)).body).toStrictEqual(
+      NO_EXECUTION,
+    );
     expect((await readStripeAutomation(recoverable)).health).toMatchObject({
       lastDeliveryStatus: "pending",
     });
 
     mockNow(startedAt + 360_000);
-    expect((await executeCron()).executed).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(recoverable)).body).toStrictEqual(
+      EXECUTED_EXECUTION,
+    );
     expect((await readStripeAutomation(recoverable)).health).toMatchObject({
       lastDeliveryStatus: "delivered",
     });
@@ -1078,23 +1098,35 @@ describe("Stripe automation event webhook", () => {
       }),
     );
     await applyDeliveryFixture(exhausted, "corrupt-latest-snapshot");
-    expect((await executeCron()).skipped).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(exhausted)).body).toStrictEqual(
+      TERMINALLY_SKIPPED_EXECUTION,
+    );
     expect((await readStripeAutomation(exhausted)).health).toMatchObject({
       lastDeliveryStatus: "pending",
       warning: null,
     });
 
     mockNow(startedAt + 390_000);
-    expect((await executeCron()).skipped).toBe(0);
+    expect((await executeAutomation(exhausted)).body).toStrictEqual(
+      NO_EXECUTION,
+    );
     mockNow(startedAt + 420_000);
-    expect((await executeCron()).skipped).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(exhausted)).body).toStrictEqual(
+      TERMINALLY_SKIPPED_EXECUTION,
+    );
     mockNow(startedAt + 480_000);
-    expect((await executeCron()).skipped).toBe(0);
+    expect((await executeAutomation(exhausted)).body).toStrictEqual(
+      NO_EXECUTION,
+    );
     mockNow(startedAt + 540_000);
-    expect((await executeCron()).skipped).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(exhausted)).body).toStrictEqual(
+      TERMINALLY_SKIPPED_EXECUTION,
+    );
 
     await applyDeliveryFixture(exhausted, "expire-latest-retry-window");
-    expect((await executeCron()).skipped).toBeGreaterThanOrEqual(1);
+    expect((await executeAutomation(exhausted)).body).toStrictEqual(
+      TERMINALLY_SKIPPED_EXECUTION,
+    );
     expect((await readStripeAutomation(exhausted)).health).toMatchObject({
       lastDeliveryStatus: "failed",
       warning: "delivery_failed",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
@@ -5,7 +5,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { createStore } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { testContext } from "../../../__tests__/test-context";
@@ -14,8 +14,10 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
+  createUsagePricingFixture,
   seedOrgMetadata,
-  seedUsagePricingRows,
+  type UsagePricingFixture,
+  type UsagePricingRow,
 } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
@@ -39,9 +41,19 @@ const JOGGAI_VOICES_URL = "https://api.jogg.ai/v2/voices";
 const JOGGAI_WEBHOOK_SECRET = randomUUID();
 const GENERATED_VIDEO_URL = "https://res.jogg.ai/avatar-video.mp4";
 const VIDEO_BYTES = Buffer.from("generated avatar video");
+const AVATAR_VIDEO_PRICING_ROWS = [
+  {
+    kind: "video",
+    provider: "joggai-talking-avatar",
+    category: "output_video_joggai_credits",
+    unitPrice: 623,
+    unitSize: 1,
+  },
+] as const satisfies readonly UsagePricingRow[];
 
 interface AvatarVideoFixture {
   readonly orgId: string;
+  readonly usagePricingResolution: UsagePricingFixture["resolution"];
   readonly userId: string;
 }
 
@@ -49,7 +61,9 @@ function authHeaders() {
   return { authorization: "Bearer clerk-session" };
 }
 
-function createAvatarVideoTestApp() {
+function createAvatarVideoTestApp(
+  usagePricingResolution?: UsagePricingFixture["resolution"],
+) {
   return createAppWithRoutes({
     signal: context.signal,
     routes: [
@@ -59,6 +73,7 @@ function createAvatarVideoTestApp() {
       ...webhooksBuiltInGenerationRoutes,
       ...zeroBillingStatusRoutes,
     ],
+    usagePricingResolution,
   });
 }
 
@@ -83,8 +98,15 @@ async function seedAvatarVideoFixture(options?: {
   readonly featureEnabled?: boolean;
   readonly withPricing?: boolean;
 }): Promise<AvatarVideoFixture> {
+  const pricing = await createUsagePricingFixture(
+    (options?.withPricing ?? true)
+      ? { configured: AVATAR_VIDEO_PRICING_ROWS }
+      : { missing: AVATAR_VIDEO_PRICING_ROWS },
+  );
+  onTestFinished(pricing.cleanup);
   const fixture = {
     orgId: `org_${randomUUID()}`,
+    usagePricingResolution: pricing.resolution,
     userId: `user_${randomUUID()}`,
   };
   await seedOrgMetadata({
@@ -101,17 +123,6 @@ async function seedAvatarVideoFixture(options?: {
     await updateFeatureSwitchesForUser(context, fixture, {
       [FeatureSwitchKey.JoggAiBuiltIn]: options.featureEnabled,
     });
-  }
-  if (options?.withPricing ?? true) {
-    await seedUsagePricingRows([
-      {
-        kind: "video",
-        provider: "joggai-talking-avatar",
-        category: "output_video_joggai_credits",
-        unitPrice: 623,
-        unitSize: 1,
-      },
-    ]);
   }
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return fixture;
@@ -143,10 +154,9 @@ function readGenerationId(value: unknown, userId: string): string {
 
 async function orgCredits(fixture: AvatarVideoFixture): Promise<number> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
-  const response = await createAvatarVideoTestApp().request(
-    "/api/zero/billing/status",
-    { headers: authHeaders() },
-  );
+  const response = await createAvatarVideoTestApp(
+    fixture.usagePricingResolution,
+  ).request("/api/zero/billing/status", { headers: authHeaders() });
   expect(response.status).toBe(200);
   const body = asRecord(await response.json());
   if (typeof body.credits !== "number") {
@@ -179,18 +189,17 @@ describe("JoggAI built-in avatar video routes", () => {
   it("keeps the built-in capability behind its feature switch", async () => {
     const fixture = await seedAvatarVideoFixture({ featureEnabled: false });
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    const response = await createAvatarVideoTestApp().request(
-      "/api/zero/avatar-video/generate",
-      {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          avatarId: 81,
-          voiceId: "en-US-ChristopherNeural",
-          script: "Hello",
-        }),
-      },
-    );
+    const response = await createAvatarVideoTestApp(
+      fixture.usagePricingResolution,
+    ).request("/api/zero/avatar-video/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        avatarId: 81,
+        voiceId: "en-US-ChristopherNeural",
+        script: "Hello",
+      }),
+    });
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toStrictEqual({
@@ -253,7 +262,7 @@ describe("JoggAI built-in avatar video routes", () => {
       }),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    const app = createAvatarVideoTestApp();
+    const app = createAvatarVideoTestApp(fixture.usagePricingResolution);
 
     const avatars = await app.request(
       "/api/zero/avatar-video/avatars?page=2&pageSize=20&aspectRatio=portrait&style=professional",
@@ -335,7 +344,7 @@ describe("JoggAI built-in avatar video routes", () => {
       }),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    const app = createAvatarVideoTestApp();
+    const app = createAvatarVideoTestApp(fixture.usagePricingResolution);
 
     const avatarResponse = await app.request(
       "/api/zero/avatar-video/avatars?page=2&pageSize=10",
@@ -451,7 +460,7 @@ describe("JoggAI built-in avatar video routes", () => {
       }),
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
-    const app = createAvatarVideoTestApp();
+    const app = createAvatarVideoTestApp(fixture.usagePricingResolution);
     const response = await app.request("/api/zero/avatar-video/generate", {
       method: "POST",
       headers: { authorization: `Bearer ${token}` },
@@ -626,18 +635,17 @@ describe("JoggAI built-in avatar video routes", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const response = await createAvatarVideoTestApp().request(
-      "/api/zero/avatar-video/generate",
-      {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          avatarId: 82,
-          voiceId: "en-US-AvaNeural",
-          audioUrl: "https://example.com/voice.mp3",
-        }),
-      },
-    );
+    const response = await createAvatarVideoTestApp(
+      fixture.usagePricingResolution,
+    ).request("/api/zero/avatar-video/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        avatarId: 82,
+        voiceId: "en-US-AvaNeural",
+        audioUrl: "https://example.com/voice.mp3",
+      }),
+    });
 
     expect(response.status).toBe(202);
     expect(observedBody).toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-share-x.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-share-x.test.ts
@@ -1,13 +1,15 @@
 import { zeroImageShareXContract } from "@vm0/api-contracts/contracts/zero-image-share-x";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import {
+  createUsagePricingFixture,
   seedOrgMetadata,
-  seedUsagePricingRows,
+  type UsagePricingFixture,
+  type UsagePricingRow,
 } from "../../../test-fixtures/system-config-seeds";
 import { seedConnectedXConnector } from "../../../test-fixtures/x-connector";
 import { createBddApi } from "./helpers/api-bdd";
@@ -23,6 +25,15 @@ const IMAGE_BYTES = [137, 80, 78, 71] as const;
 const MAX_X_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 const X_MEDIA_UPLOAD_URL = "https://api.x.com/2/media/upload";
 const X_CREATE_POST_URL = "https://api.x.com/2/tweets";
+const X_IMAGE_SHARE_PRICING_ROWS = [
+  {
+    kind: "connector",
+    provider: "x",
+    category: "content.create",
+    unitPrice: 15,
+    unitSize: 1,
+  },
+] as const satisfies readonly UsagePricingRow[];
 
 class OversizedImageChunk extends Uint8Array {
   override get byteLength(): number {
@@ -45,10 +56,12 @@ function authHeaders() {
   return { authorization: "Bearer clerk-session" };
 }
 
-function client() {
-  return setupApp({ context, routes: zeroImageShareXRoutes })(
-    zeroImageShareXContract,
-  );
+function client(usagePricingResolution?: UsagePricingFixture["resolution"]) {
+  return setupApp({
+    context,
+    routes: zeroImageShareXRoutes,
+    usagePricingResolution,
+  })(zeroImageShareXContract);
 }
 
 function mockXImageShareProvider(options?: {
@@ -118,19 +131,14 @@ describe("POST /api/zero/image-share/x", () => {
     const billing = createBillingMediaApi(context);
     const actor = await setupAuthenticatedXActor();
     await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 1000 });
-    await seedUsagePricingRows([
-      {
-        kind: "connector",
-        provider: "x",
-        category: "content.create",
-        unitPrice: 15,
-        unitSize: 1,
-      },
-    ]);
+    const pricing = await createUsagePricingFixture({
+      configured: X_IMAGE_SHARE_PRICING_ROWS,
+    });
+    onTestFinished(pricing.cleanup);
     const provider = mockXImageShareProvider();
 
     const response = await accept(
-      client().post({
+      client(pricing.resolution).post({
         headers: authHeaders(),
         body: {
           caption: "Edited with Zero",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-seo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-seo.test.ts
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
 import { zeroSeoContract } from "@vm0/api-contracts/contracts/zero-seo";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -11,8 +11,10 @@ import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
+  createUsagePricingFixture,
   seedOrgMetadata,
-  seedUsagePricingRows,
+  type UsagePricingFixture,
+  type UsagePricingRow,
 } from "../../../test-fixtures/system-config-seeds";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
@@ -32,7 +34,20 @@ const SEO_ROUTES = Object.freeze([
 ]);
 const DATAFORSEO_BASE_URL = "https://api.dataforseo.com";
 
-type OrgApiTestUser = ApiTestUser & { readonly orgId: string };
+type OrgApiTestUser = ApiTestUser & {
+  readonly orgId: string;
+  readonly usagePricingResolution: UsagePricingFixture["resolution"];
+};
+
+const SEO_PRICING_ROWS = [
+  {
+    kind: "seo",
+    provider: "dataforseo",
+    category: "provider_cost_usd_micros",
+    unitPrice: 1250,
+    unitSize: 1_000_000,
+  },
+] as const satisfies readonly UsagePricingRow[];
 
 function authenticate(actor: ApiTestUser) {
   createZeroRouteMocks(context).clerk.session(
@@ -43,20 +58,16 @@ function authenticate(actor: ApiTestUser) {
   return { authorization: "Bearer clerk-session" };
 }
 
-function client() {
-  return setupApp({ context, routes: SEO_ROUTES });
+function client(usagePricingResolution?: UsagePricingFixture["resolution"]) {
+  return setupApp({ context, routes: SEO_ROUTES, usagePricingResolution });
 }
 
-async function seedSeoPricing(): Promise<void> {
-  await seedUsagePricingRows([
-    {
-      kind: "seo",
-      provider: "dataforseo",
-      category: "provider_cost_usd_micros",
-      unitPrice: 1250,
-      unitSize: 1_000_000,
-    },
-  ]);
+async function seedSeoPricing(): Promise<UsagePricingFixture> {
+  const pricing = await createUsagePricingFixture({
+    configured: SEO_PRICING_ROWS,
+  });
+  onTestFinished(pricing.cleanup);
+  return pricing;
 }
 
 async function seedActor(): Promise<OrgApiTestUser> {
@@ -66,8 +77,8 @@ async function seedActor(): Promise<OrgApiTestUser> {
   }
   const orgActor = { ...actor, orgId: actor.orgId };
   await createRunsApi(context).grantProEntitlement(orgActor);
-  await seedSeoPricing();
-  return orgActor;
+  const pricing = await seedSeoPricing();
+  return { ...orgActor, usagePricingResolution: pricing.resolution };
 }
 
 async function seedUnfundedActor(): Promise<OrgApiTestUser> {
@@ -79,13 +90,13 @@ async function seedUnfundedActor(): Promise<OrgApiTestUser> {
   const onboarding = await createBddApi(context).completeOnboarding(orgActor);
   expect(onboarding.status).toBe(200);
   await seedOrgMetadata({ orgId: orgActor.orgId, tier: "pro", credits: 0 });
-  await seedSeoPricing();
-  return orgActor;
+  const pricing = await seedSeoPricing();
+  return { ...orgActor, usagePricingResolution: pricing.resolution };
 }
 
-async function credits(actor: ApiTestUser): Promise<number> {
+async function credits(actor: OrgApiTestUser): Promise<number> {
   const response = await accept(
-    client()(zeroBillingStatusContract).get({
+    client(actor.usagePricingResolution)(zeroBillingStatusContract).get({
       headers: authenticate(actor),
     }),
     [200],
@@ -152,7 +163,7 @@ describe("zero SEO routes", () => {
     });
 
     const response = await accept(
-      client()(zeroSeoContract).serp({
+      client(actor.usagePricingResolution)(zeroSeoContract).serp({
         headers: { authorization: `Bearer ${token}` },
         body: {
           query: "technical seo",
@@ -188,7 +199,7 @@ describe("zero SEO routes", () => {
     );
 
     const response = await accept(
-      client()(zeroSeoContract).serp({
+      client(actor.usagePricingResolution)(zeroSeoContract).serp({
         headers: authenticate(actor),
         body: {
           query: "technical seo",
@@ -230,7 +241,7 @@ describe("zero SEO routes", () => {
     );
 
     const response = await accept(
-      client()(zeroSeoContract).serp({
+      client(actor.usagePricingResolution)(zeroSeoContract).serp({
         headers: authenticate(actor),
         body: {
           query: "technical seo",
@@ -294,7 +305,7 @@ describe("zero SEO routes", () => {
     );
 
     const response = await accept(
-      client()(zeroSeoContract).serp({
+      client(actor.usagePricingResolution)(zeroSeoContract).serp({
         headers: authenticate(actor),
         body: {
           query: "technical seo",
@@ -336,7 +347,7 @@ describe("zero SEO routes", () => {
     );
 
     const response = await accept(
-      client()(zeroSeoContract).serp({
+      client(actor.usagePricingResolution)(zeroSeoContract).serp({
         headers: authenticate(actor),
         body: {
           query: "technical seo",
@@ -376,7 +387,7 @@ describe("zero SEO routes", () => {
     );
 
     const response = await accept(
-      client()(zeroSeoContract).serp({
+      client(actor.usagePricingResolution)(zeroSeoContract).serp({
         headers: authenticate(actor),
         body: {
           query: "technical seo",
@@ -432,7 +443,7 @@ describe("zero SEO routes", () => {
     );
 
     const response = await accept(
-      client()(zeroSeoContract).serp({
+      client(actor.usagePricingResolution)(zeroSeoContract).serp({
         headers: authenticate(actor),
         body: {
           query: "coffee shops",
@@ -502,7 +513,7 @@ describe("zero SEO routes", () => {
       ),
     );
     const headers = authenticate(actor);
-    const seoClient = client()(zeroSeoContract);
+    const seoClient = client(actor.usagePricingResolution)(zeroSeoContract);
 
     const serp = await accept(
       seoClient.serp({
@@ -626,7 +637,7 @@ describe("zero SEO routes", () => {
         },
       ),
     );
-    const seoClient = client()(zeroSeoContract);
+    const seoClient = client(actor.usagePricingResolution)(zeroSeoContract);
     const headers = authenticate(actor);
 
     const bing = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -5,13 +5,18 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { zeroMapsContract } from "@vm0/api-contracts/contracts/zero-maps";
 import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
 import { HttpResponse, http } from "msw";
+import { onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
-import { seedUsagePricingRows } from "../../../test-fixtures/system-config-seeds";
+import {
+  createUsagePricingFixture,
+  seedUsagePricingRows,
+  type UsagePricingRow,
+} from "../../../test-fixtures/system-config-seeds";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -45,6 +50,15 @@ const store = createStore();
 const DAY_MS = 86_400_000;
 const GOOGLE_GEOCODING_URL =
   "https://maps.googleapis.com/maps/api/geocode/json";
+const MAPS_GEOCODING_PRICING_ROWS = [
+  {
+    kind: "maps",
+    provider: "google-maps",
+    category: "geocoding",
+    unitPrice: 6,
+    unitSize: 1,
+  },
+] as const satisfies readonly UsagePricingRow[];
 const MODEL_TOKEN_CATEGORIES = {
   input: "tokens.input",
   output: "tokens.output",
@@ -926,15 +940,10 @@ describe("GET /api/zero/usage/record", () => {
   it("uses settlement time consistently for rows, totals, and breakdowns", async () => {
     const fixture = await entitledRecordActor();
     billing.configureMapsProvider();
-    await seedUsagePricingRows([
-      {
-        kind: "maps",
-        provider: "google-maps",
-        category: "geocoding",
-        unitPrice: 6,
-        unitSize: 1,
-      },
-    ]);
+    const pricing = await createUsagePricingFixture({
+      configured: MAPS_GEOCODING_PRICING_ROWS,
+    });
+    onTestFinished(pricing.cleanup);
     server.use(
       http.get(GOOGLE_GEOCODING_URL, () => {
         return HttpResponse.json({
@@ -960,9 +969,11 @@ describe("GET /api/zero/usage/record", () => {
       run.runId,
       ["maps:read"],
     );
-    const maps = setupApp({ context, routes: zeroMapsRoutes })(
-      zeroMapsContract,
-    );
+    const maps = setupApp({
+      context,
+      routes: zeroMapsRoutes,
+      usagePricingResolution: pricing.resolution,
+    })(zeroMapsContract);
     const geocode = await accept(
       maps.geocode({
         headers: { authorization: `Bearer ${mapsToken}` },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-weather.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-weather.test.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import {
   ZERO_AIR_QUALITY_ATTRIBUTION,
@@ -12,8 +12,10 @@ import {
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import {
+  createUsagePricingFixture,
   seedOrgMetadata,
-  seedUsagePricingRows,
+  type UsagePricingFixture,
+  type UsagePricingRow,
 } from "../../../test-fixtures/system-config-seeds";
 import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
@@ -42,58 +44,70 @@ function authenticate(actor: ApiTestUser): { readonly authorization: string } {
   return { authorization: "Bearer clerk-session" };
 }
 
-function client() {
-  return setupApp({ context, routes: zeroWeatherRoutes })(zeroWeatherContract);
+const WEATHER_PRICING_ROWS = [
+  {
+    kind: "weather",
+    provider: "google-weather",
+    category: "current",
+    unitPrice: 0,
+    unitSize: 1,
+  },
+  {
+    kind: "weather",
+    provider: "google-weather",
+    category: "forecast.hourly",
+    unitPrice: 0,
+    unitSize: 1,
+  },
+  {
+    kind: "weather",
+    provider: "google-weather",
+    category: "forecast.daily",
+    unitPrice: 0,
+    unitSize: 1,
+  },
+  {
+    kind: "weather",
+    provider: "google-weather",
+    category: "history.hourly",
+    unitPrice: 0,
+    unitSize: 1,
+  },
+  {
+    kind: "weather",
+    provider: "google-air-quality",
+    category: "current",
+    unitPrice: 0,
+    unitSize: 1,
+  },
+] as const satisfies readonly UsagePricingRow[];
+
+function client(usagePricingResolution?: UsagePricingFixture["resolution"]) {
+  return setupApp({
+    context,
+    routes: zeroWeatherRoutes,
+    usagePricingResolution,
+  })(zeroWeatherContract);
 }
 
 function configureProvider(): void {
   mockEnv("ZERO_WEATHER_GOOGLE_WEATHER_TOKEN", "test-google-weather-key");
 }
 
-async function prepareFreeWeatherActor(actor: ApiTestUser): Promise<void> {
+async function prepareFreeWeatherActor(
+  actor: ApiTestUser,
+): Promise<UsagePricingFixture> {
   if (!actor.orgId) {
     throw new Error("Zero Weather test actor must belong to an organization");
   }
   const completed = await createBddApi(context).completeOnboarding(actor);
   expect(completed.status).toBe(200);
   await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 0 });
-  await seedUsagePricingRows([
-    {
-      kind: "weather",
-      provider: "google-weather",
-      category: "current",
-      unitPrice: 0,
-      unitSize: 1,
-    },
-    {
-      kind: "weather",
-      provider: "google-weather",
-      category: "forecast.hourly",
-      unitPrice: 0,
-      unitSize: 1,
-    },
-    {
-      kind: "weather",
-      provider: "google-weather",
-      category: "forecast.daily",
-      unitPrice: 0,
-      unitSize: 1,
-    },
-    {
-      kind: "weather",
-      provider: "google-weather",
-      category: "history.hourly",
-      unitPrice: 0,
-      unitSize: 1,
-    },
-    {
-      kind: "weather",
-      provider: "google-air-quality",
-      category: "current",
-      unitPrice: 0,
-      unitSize: 1,
-    },
-  ]);
+  const pricing = await createUsagePricingFixture({
+    configured: WEATHER_PRICING_ROWS,
+  });
+  onTestFinished(pricing.cleanup);
+  return pricing;
 }
 
 function expectFreeWeatherResponse(
@@ -147,7 +161,7 @@ describe("okou weather route", () => {
 
   it("records current conditions at zero credits for an empty balance", async () => {
     const actor = createBddApi(context).user();
-    await prepareFreeWeatherActor(actor);
+    const pricing = await prepareFreeWeatherActor(actor);
     mockEnv(
       "OKOU_WEATHER_GOOGLE_WEATHER_TOKEN",
       "test-okou-google-weather-key",
@@ -165,7 +179,7 @@ describe("okou weather route", () => {
     );
 
     const response = await accept(
-      client().current({
+      client(pricing.resolution).current({
         headers: authenticate(actor),
         body: {
           lat: 39.9042,
@@ -194,7 +208,7 @@ describe("okou weather route", () => {
 
   it("forwards one hourly forecast page to Google Weather", async () => {
     const actor = createBddApi(context).user();
-    await prepareFreeWeatherActor(actor);
+    const pricing = await prepareFreeWeatherActor(actor);
     configureProvider();
     let providerUrl: URL | undefined;
     server.use(
@@ -208,7 +222,7 @@ describe("okou weather route", () => {
     );
 
     const response = await accept(
-      client().forecastHourly({
+      client(pricing.resolution).forecastHourly({
         headers: authenticate(actor),
         body: {
           lat: 37.7749,
@@ -231,7 +245,7 @@ describe("okou weather route", () => {
 
   it("forwards one daily forecast page to Google Weather", async () => {
     const actor = createBddApi(context).user();
-    await prepareFreeWeatherActor(actor);
+    const pricing = await prepareFreeWeatherActor(actor);
     configureProvider();
     let providerUrl: URL | undefined;
     server.use(
@@ -242,7 +256,7 @@ describe("okou weather route", () => {
     );
 
     const response = await accept(
-      client().forecastDaily({
+      client(pricing.resolution).forecastDaily({
         headers: authenticate(actor),
         body: {
           lat: 51.5072,
@@ -264,7 +278,7 @@ describe("okou weather route", () => {
 
   it("forwards one hourly history page to Google Weather", async () => {
     const actor = createBddApi(context).user();
-    await prepareFreeWeatherActor(actor);
+    const pricing = await prepareFreeWeatherActor(actor);
     configureProvider();
     let providerUrl: URL | undefined;
     server.use(
@@ -275,7 +289,7 @@ describe("okou weather route", () => {
     );
 
     const response = await accept(
-      client().historyHourly({
+      client(pricing.resolution).historyHourly({
         headers: authenticate(actor),
         body: {
           lat: 35.6762,
@@ -297,7 +311,7 @@ describe("okou weather route", () => {
 
   it("returns compact current air quality at zero credits", async () => {
     const actor = createBddApi(context).user();
-    await prepareFreeWeatherActor(actor);
+    const pricing = await prepareFreeWeatherActor(actor);
     configureProvider();
     let providerUrl: URL | undefined;
     let providerBody: unknown;
@@ -325,7 +339,7 @@ describe("okou weather route", () => {
     );
 
     const response = await accept(
-      client().airQualityCurrent({
+      client(pricing.resolution).airQualityCurrent({
         headers: authenticate(actor),
         body: {
           lat: 39.9042,
@@ -360,7 +374,7 @@ describe("okou weather route", () => {
 
   it("returns Google Air Quality errors without success billing metadata", async () => {
     const actor = createBddApi(context).user();
-    await prepareFreeWeatherActor(actor);
+    const pricing = await prepareFreeWeatherActor(actor);
     configureProvider();
     server.use(
       http.post(GOOGLE_AIR_QUALITY_CURRENT_URL, () => {
@@ -372,7 +386,7 @@ describe("okou weather route", () => {
     );
 
     const response = await accept(
-      client().airQualityCurrent({
+      client(pricing.resolution).airQualityCurrent({
         headers: authenticate(actor),
         body: { lat: 39.9042, lng: 116.4074 },
       }),
@@ -387,7 +401,7 @@ describe("okou weather route", () => {
 
   it("returns Google Weather errors without success billing metadata", async () => {
     const actor = createBddApi(context).user();
-    await prepareFreeWeatherActor(actor);
+    const pricing = await prepareFreeWeatherActor(actor);
     configureProvider();
     server.use(
       http.get(GOOGLE_WEATHER_CURRENT_URL, () => {
@@ -399,7 +413,7 @@ describe("okou weather route", () => {
     );
 
     const response = await accept(
-      client().current({
+      client(pricing.resolution).current({
         headers: authenticate(actor),
         body: { lat: 39.9042, lng: 116.4074, units: "metric" },
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -28,13 +28,11 @@ import { chatEventAutomationPart } from "./helpers/chat-event";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
-import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
 import { zeroAgentsRoutes } from "../zero-agents";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 import { zeroWorkflowsRoutes } from "../zero-workflows";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...cronExecuteWorkflowAutomationsRoutes,
   ...testWorkflowAutomationExecutionRoutes,
   ...zeroAgentsRoutes,
   ...zeroWorkflowAutomationsRoutes,
@@ -52,9 +50,6 @@ const chatFilesApi = createChatFilesBddApi(context);
 const computerUseApi = createComputerUseBddApi(context);
 
 const WORKFLOW_NAME = "scheduler-workflow";
-const CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE =
-  "/api/cron/execute-workflow-automations";
-const CRON_SECRET = "test-cron-secret";
 
 interface Scenario {
   readonly actor: ApiTestUser;
@@ -103,7 +98,6 @@ async function setup(
   options: { readonly timezone?: string } = {},
 ): Promise<Scenario> {
   const runnerGroup = runsApi.configureRunnerGroup();
-  mockEnv("CRON_SECRET", CRON_SECRET);
   const { actor } = await wf.setupWorkflowOrg({ timezone: options.timezone });
   if (!actor.orgId) {
     throw new Error("Expected an org-scoped workflow actor");
@@ -271,20 +265,6 @@ async function deleteWorkflowViaApi(scenario: Scenario): Promise<void> {
 }
 
 describe("okou workflow automation scheduler", () => {
-  it("rejects unauthenticated production cron requests", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
-
-    const response = await createApp({
-      signal: context.signal,
-      routes: TEST_APP_ROUTES,
-    }).request(CRON_EXECUTE_WORKFLOW_AUTOMATIONS_ROUTE);
-
-    expect(response.status).toBe(401);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: { message: "Invalid cron secret", code: "UNAUTHORIZED" },
-    });
-  });
-
   it("does not expose scoped workflow execution in production", async () => {
     mockEnv("ENV", "production");
 

--- a/turbo/apps/api/src/signals/routes/model-stats.ts
+++ b/turbo/apps/api/src/signals/routes/model-stats.ts
@@ -101,13 +101,21 @@ const readPublicModelRankingsRoute$ = command(
   },
 );
 
-export const modelStatsRoutes: readonly RouteEntry[] = [
+const aggregateModelStatsRoutes: readonly RouteEntry[] = [
   {
     route: cronAggregateModelStatsContract.aggregate,
     handler: aggregateModelStatsRoute$,
   },
+];
+
+export const modelStatsPublicRoutes: readonly RouteEntry[] = [
   {
     route: modelStatsContract.rankings,
     handler: readPublicModelRankingsRoute$,
   },
+];
+
+export const modelStatsRoutes: readonly RouteEntry[] = [
+  ...aggregateModelStatsRoutes,
+  ...modelStatsPublicRoutes,
 ];

--- a/turbo/apps/api/src/test-fixtures/usage-pricing.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-pricing.ts
@@ -4,8 +4,9 @@
  * Usage pricing is operator-managed global configuration with no product API
  * (rows are written by ops tooling/migrations in production), so tests cannot
  * construct pricing state through any product endpoint. New route tests use
- * `createUsagePricingFixture` to own unique lookup providers. The raw helpers
- * remain while their existing callers migrate to the scoped model.
+ * `createUsagePricingFixture` to own unique lookup providers. Raw mutation
+ * helpers are reserved for rows whose provider is already proven UUID-, run-,
+ * or fixture-owned; they must never target canonical operator identities.
  */
 import { randomUUID } from "node:crypto";
 

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
@@ -45,6 +45,26 @@ ruleTester.run("no-cross-test-time-staggering", noCrossTestTimeStaggering, {
   ],
   invalid: [
     {
+      name: "canonical namespace mockNow remains rejected",
+      code: `
+        import * as time from "../../../lib/time";
+        let index = 0;
+        beforeEach(() => time.mockNow(1_000 + index++ * 60_000));
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "multi-hop local mockNow aliases remain rejected",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        const first = mockNow;
+        const second = first;
+        let index = 0;
+        beforeEach(() => second(1_000 + index++ * 60_000));
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
       name: "module counter incremented after a beforeEach mock is rejected",
       code: `
         import { mockNow } from "../../../lib/time";

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
@@ -1,0 +1,119 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noCrossTestTimeStaggering } from "../rules/no-cross-test-time-staggering.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-cross-test-time-staggering", noCrossTestTimeStaggering, {
+  valid: [
+    {
+      name: "fixed identical hook time is valid",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        const FIXED_NOW = 1_000;
+        beforeEach(() => mockNow(FIXED_NOW));
+      `,
+    },
+    {
+      name: "TTL progression stays inside its owning test",
+      code: `
+        import { mockNow, withMockNowForTest } from "../../../lib/time";
+        it("expires its cache", async () => {
+          const initialNow = 1_000;
+          await withMockNowForTest(initialNow, async () => {
+            await readManifest();
+            mockNow(initialNow + 59_999);
+            await readManifest();
+            mockNow(initialNow + 60_000);
+            await readManifest();
+          });
+        });
+      `,
+    },
+    {
+      name: "clearMockNow teardown stays valid",
+      code: `
+        import { clearMockNow } from "../../../lib/time";
+        afterEach(() => clearMockNow());
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "module counter incremented after a beforeEach mock is rejected",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        let cacheIndex = 0;
+        beforeEach(() => {
+          mockNow(1_000 + cacheIndex * 60_000);
+          cacheIndex += 1;
+        });
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "describe counter incremented before the hook mock is rejected",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        describe("cache", () => {
+          let sequence = 0;
+          beforeEach(() => {
+            sequence++;
+            mockNow(1_000 + sequence * 60_000);
+          });
+        });
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "aliased hook and mockNow remain rejected",
+      code: `
+        import { beforeEach as setup } from "vitest";
+        import { mockNow as setClock } from "../../../lib/time";
+        let testOrder = 0;
+        setup(() => setClock(1_000 + testOrder++ * 60_000));
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "hook-called wrapper cannot hide shared order",
+      code: `
+        import { beforeEach as setup } from "vitest";
+        import { mockNow as setClock } from "../../../lib/time";
+        let suiteIndex = 0;
+        function setCacheTime(value) { setClock(value); }
+        setup(() => {
+          setCacheTime(1_000 + suiteIndex * 60_000);
+          suiteIndex++;
+        });
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "afterEach staggering remains rejected",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        let index = 0;
+        afterEach(() => mockNow(1_000 + ++index * 60_000));
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "aliased describe scope remains suite-shared",
+      code: `
+        import { describe as suite } from "vitest";
+        import { mockNow } from "../../../lib/time";
+        suite("cache", () => {
+          let index = 0;
+          beforeEach(() => mockNow(1_000 + index++ * 60_000));
+        });
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
@@ -115,5 +115,36 @@ ruleTester.run("no-cross-test-time-staggering", noCrossTestTimeStaggering, {
       `,
       errors: [{ messageId: "sharedTime" }],
     },
+    {
+      name: "module-scoped mutable object member is rejected",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        const clock = { index: 0 };
+        beforeEach(() => mockNow(1_000 + clock.index++ * 60_000));
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "describe-scoped mutable object member is rejected",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        describe("cache", () => {
+          const clock = { index: 0 };
+          beforeEach(() => mockNow(1_000 + clock.index * 60_000));
+          afterEach(() => { clock.index += 1; });
+        });
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
+      name: "local alias of mockNow remains rejected",
+      code: `
+        import { mockNow } from "../../../lib/time";
+        const setClock = mockNow;
+        let index = 0;
+        beforeEach(() => setClock(1_000 + index++ * 60_000));
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-cross-test-time-staggering.test.ts
@@ -45,6 +45,16 @@ ruleTester.run("no-cross-test-time-staggering", noCrossTestTimeStaggering, {
   ],
   invalid: [
     {
+      name: "destructured canonical namespace mockNow remains rejected",
+      code: `
+        import * as time from "../../../lib/time";
+        const { mockNow: setClock } = time;
+        let index = 0;
+        beforeEach(() => setClock(1_000 + index++ * 60_000));
+      `,
+      errors: [{ messageId: "sharedTime" }],
+    },
+    {
       name: "canonical namespace mockNow remains rejected",
       code: `
         import * as time from "../../../lib/time";

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -299,6 +299,49 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
       errors: [{ messageId: "globalSweep" }],
     },
     {
+      name: "explicit undefined activates canonical plain parameter defaults",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount(build = appFactory.createApp) {
+          return build({ routes: ROUTES });
+        }
+        mount(undefined);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "explicit undefined activates canonical object parameter defaults",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount(
+          { createApp: build } = { createApp: appFactory.createApp },
+        ) {
+          return build({ routes: ROUTES });
+        }
+        mount(undefined);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "later undefined spreads activate canonical property defaults",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        const absent = { createApp: undefined };
+        const scopedFactory = (options) => options;
+        function mount({ createApp: build = appFactory.createApp }) {
+          return build({ routes: ROUTES });
+        }
+        mount({ createApp: scopedFactory, ...absent });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "aggregate routes cannot flow through a local member projection",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -327,6 +327,36 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
       errors: [{ messageId: "globalSweep" }],
     },
     {
+      name: "aliased undefined activates canonical plain parameter defaults",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        const absent = undefined;
+        function mount(build = appFactory.createApp) {
+          return build({ routes: ROUTES });
+        }
+        mount(absent);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "aliased void activates canonical object parameter defaults",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        const absent = void 0;
+        function mount(
+          { createApp: build } = { createApp: appFactory.createApp },
+        ) {
+          return build({ routes: ROUTES });
+        }
+        mount(absent);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "later undefined spreads activate canonical property defaults",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -53,19 +53,6 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
       `,
     },
     {
-      name: "removed model-stats input uses a fixed no-auth rejection helper",
-      filename: harness,
-      code: `
-        import { modelStatsRoutes } from "../model-stats";
-        import { expectGlobalSweepRemovedInputRejected } from "./helpers/global-sweep-contract";
-        await expectGlobalSweepRemovedInputRejected(
-          context,
-          modelStatsRoutes,
-          "/api/cron/aggregate-model-stats?hours=24",
-        );
-      `,
-    },
-    {
       name: "automation correctness uses the scoped automation-id executor",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -225,6 +225,38 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
       errors: [{ messageId: "globalSweep" }],
     },
     {
+      name: "canonical factory options cannot flow through plain helper parameters",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount({ createApp: build }) {
+          return build({ routes: ROUTES });
+        }
+        function forward(options) {
+          return mount(options);
+        }
+        forward({ createApp: appFactory.createApp });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "wrapped canonical namespaces cannot flow through object helper parameters",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount(factory) {
+          return factory.createApp({ routes: ROUTES });
+        }
+        function forward({ factory }) {
+          return mount(factory);
+        }
+        forward({ factory: appFactory });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "aggregate routes cannot flow through a local member projection",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -87,8 +87,117 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
         setupApp({ routes: modelStatsPublicRoutes });
       `,
     },
+    {
+      name: "aggregate route member projection may remain metadata only",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        const options = { routes: ROUTES };
+        expect(options.routes).toHaveLength(42);
+      `,
+    },
+    {
+      name: "aggregate route destructuring may remain metadata only",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        const options = { routes: ROUTES };
+        const { routes } = options;
+        expect(routes.map(({ route }) => route.method)).toContain("GET");
+      `,
+    },
+    {
+      name: "a later scoped route property overrides aggregate options",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { createApp } from "../../../app-factory";
+        import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
+        const aggregateOptions = { signal, routes: ROUTES };
+        createApp({
+          ...aggregateOptions,
+          routes: testWorkflowAutomationExecutionRoutes,
+        });
+      `,
+    },
   ],
   invalid: [
+    {
+      name: "defaulted shorthand route destructuring remains rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { createApp } from "../../../app-factory";
+        import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
+        const options = { routes: ROUTES };
+        const { routes = testWorkflowAutomationExecutionRoutes } = options;
+        createApp({ routes });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "defaulted renamed route destructuring remains rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { setupApp } from "../../../__tests__/test-helpers";
+        import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
+        const options = { routes: ROUTES };
+        const { routes: mountedRoutes = testWorkflowAutomationExecutionRoutes } = options;
+        setupApp({ routes: mountedRoutes })(contract);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "destructured helper route parameters remain rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { createApp } from "../../../app-factory";
+        function mount({ routes }) {
+          return createApp({ routes });
+        }
+        mount({ routes: ROUTES });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "defaulted destructured helper parameters remain rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { createApp } from "../../../app-factory";
+        import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
+        function mountWithDefault(
+          { routes } = { routes: testWorkflowAutomationExecutionRoutes },
+        ) {
+          return createApp({ routes });
+        }
+        mountWithDefault({ routes: ROUTES });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "canonical namespace app factory members remain rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        appFactory.createApp({ routes: ROUTES });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "canonical namespace app factory destructuring remains rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        const { createApp: mountFactory } = appFactory;
+        mountFactory({ routes: ROUTES });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
     {
       name: "aggregate routes cannot flow through a local member projection",
       filename: behaviorTest,

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -90,6 +90,29 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
   ],
   invalid: [
     {
+      name: "aggregate routes cannot flow through a local member projection",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { createApp } from "../../../app-factory";
+        const options = { routes: ROUTES };
+        createApp({ signal, routes: options.routes });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "aggregate routes cannot flow through local object destructuring",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { setupApp } from "../../../__tests__/test-helpers";
+        const options = { routes: ROUTES };
+        const { routes } = options;
+        setupApp({ context, routes })(contract);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "aggregate contract binder aliases remain rejected",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -270,6 +270,35 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
       errors: [{ messageId: "globalSweep" }],
     },
     {
+      name: "explicit undefined activates canonical factory property defaults",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount({ createApp: build = appFactory.createApp }) {
+          return build({ routes: ROUTES });
+        }
+        mount({ createApp: undefined });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "canonical namespaces survive nested parameter member projections",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount(factory) {
+          return factory.createApp({ routes: ROUTES });
+        }
+        function forward({ options }) {
+          return mount(options.factory);
+        }
+        forward({ options: { factory: appFactory } });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "aggregate routes cannot flow through a local member projection",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -120,6 +120,19 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
         });
       `,
     },
+    {
+      name: "an explicit scoped factory property overrides a canonical default",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        const buildScopedApp = (options) => options;
+        function mount({ createApp: build = appFactory.createApp }) {
+          return build({ routes: ROUTES });
+        }
+        mount({ createApp: buildScopedApp });
+      `,
+    },
   ],
   invalid: [
     {

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -1,0 +1,225 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noGlobalSweepTestRoutes } from "../rules/no-global-sweep-test-routes.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+const harness =
+  "/app/src/signals/routes/__tests__/global-sweep-contracts.test.ts";
+const behaviorTest =
+  "/app/src/signals/routes/__tests__/stripe-automation-events.test.ts";
+
+const helperImport = `
+  import { expectGlobalSweepMissingAuth } from "./helpers/global-sweep-contract";
+`;
+const routeImport = `
+  import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
+`;
+
+ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
+  valid: [
+    {
+      name: "production bootstrap keeps global behavior",
+      filename: "/app/src/signals/route.ts",
+      code: `${routeImport}
+        export const ROUTES = [...cronExecuteWorkflowAutomationsRoutes];
+      `,
+    },
+    {
+      name: "contract harness passes the route directly to the fixed no-auth helper",
+      filename: harness,
+      code: `${routeImport}${helperImport}
+        await expectGlobalSweepMissingAuth(
+          context,
+          cronExecuteWorkflowAutomationsRoutes,
+          "/api/cron/execute-workflow-automations",
+        );
+      `,
+    },
+    {
+      name: "contract harness admits the fixed wrong-auth helper",
+      filename: harness,
+      code: `${routeImport}
+        import { expectGlobalSweepWrongAuth } from "./helpers/global-sweep-contract";
+        await expectGlobalSweepWrongAuth(
+          context,
+          cronExecuteWorkflowAutomationsRoutes,
+          "/api/cron/execute-workflow-automations",
+        );
+      `,
+    },
+    {
+      name: "removed model-stats input uses a fixed no-auth rejection helper",
+      filename: harness,
+      code: `
+        import { modelStatsRoutes } from "../model-stats";
+        import { expectGlobalSweepRemovedInputRejected } from "./helpers/global-sweep-contract";
+        await expectGlobalSweepRemovedInputRejected(
+          context,
+          modelStatsRoutes,
+          "/api/cron/aggregate-model-stats?hours=24",
+        );
+      `,
+    },
+    {
+      name: "automation correctness uses the scoped automation-id executor",
+      filename: behaviorTest,
+      code: `
+        import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
+        const executeAutomation = (scenario) => setupApp({
+          context,
+          routes: testWorkflowAutomationExecutionRoutes,
+        }).request("/api/test/workflow-automation-execution", {
+          method: "POST",
+          body: JSON.stringify({ automation_id: scenario.automationId }),
+        });
+        expect((await executeAutomation(scenario)).body).toStrictEqual({
+          success: true,
+          executed: 1,
+          skipped: 0,
+        });
+      `,
+    },
+    {
+      name: "scoped route factory from the production module stays valid",
+      filename: behaviorTest,
+      code: `
+        import { cronComputerUseScreenshotCleanupRoutesForTest } from "../cron-computer-use-screenshot-cleanup";
+        setupApp({ routes: cronComputerUseScreenshotCleanupRoutesForTest(commandIds) });
+      `,
+    },
+    {
+      name: "public model rankings do not mount the aggregation sweep",
+      filename: behaviorTest,
+      code: `
+        import { modelStatsPublicRoutes } from "../model-stats";
+        setupApp({ routes: modelStatsPublicRoutes });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "old behavior helper cannot wrap the production-global sweep",
+      filename: behaviorTest,
+      code: `${routeImport}
+        import { createApp } from "../../../app-factory";
+        async function executeCron() {
+          return await createApp({
+            signal,
+            routes: cronExecuteWorkflowAutomationsRoutes,
+          }).request("/api/cron/execute-workflow-automations", {
+            headers: { authorization: "Bearer test-cron-secret" },
+          });
+        }
+        await executeCron();
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot rename a global route import",
+      filename: harness,
+      code: `
+        import { cronExecuteWorkflowAutomationsRoutes as sweep } from "../cron-execute-workflow-automations";
+        ${helperImport}
+        await expectGlobalSweepMissingAuth(context, sweep, "/api/cron/execute-workflow-automations");
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot alias a route locally",
+      filename: harness,
+      code: `${routeImport}${helperImport}
+        const sweep = cronExecuteWorkflowAutomationsRoutes;
+        await expectGlobalSweepMissingAuth(context, sweep, "/api/cron/execute-workflow-automations");
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot put a route in a local array",
+      filename: harness,
+      code: `${routeImport}${helperImport}
+        const routes = [...cronExecuteWorkflowAutomationsRoutes];
+        await expectGlobalSweepMissingAuth(context, routes, "/api/cron/execute-workflow-automations");
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot pass a route through a local wrapper",
+      filename: harness,
+      code: `${routeImport}${helperImport}
+        async function check(routes) {
+          await expectGlobalSweepMissingAuth(context, routes, "/api/cron/execute-workflow-automations");
+        }
+        await check(cronExecuteWorkflowAutomationsRoutes);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot re-export a global route",
+      filename: harness,
+      code: `export { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";`,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot star re-export a global route module",
+      filename: harness,
+      code: `export * from "../cron-execute-workflow-automations";`,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot mount a route with createApp",
+      filename: harness,
+      code: `${routeImport}
+        import { createApp } from "../../../app-factory";
+        await createApp({ signal, routes: cronExecuteWorkflowAutomationsRoutes })
+          .request("/api/cron/execute-workflow-automations");
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot mount a route with setupApp",
+      filename: harness,
+      code: `${routeImport}
+        await setupApp({
+          context,
+          routes: cronExecuteWorkflowAutomationsRoutes,
+        })(cronExecuteWorkflowAutomationsContract).execute({
+          headers: {},
+        });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "approved filename cannot make an authorized behavior call",
+      filename: harness,
+      code: `${routeImport}${helperImport}
+        import { createApp } from "../../../app-factory";
+        const response = await createApp({
+          signal,
+          routes: cronExecuteWorkflowAutomationsRoutes,
+        }).request("/api/cron/execute-workflow-automations", {
+          headers: { authorization: "Bearer test-cron-secret" },
+        });
+        expect(response.status).toBe(200);
+        await expectGlobalSweepMissingAuth(context, cronExecuteWorkflowAutomationsRoutes, "/api/cron/execute-workflow-automations");
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "namespace import cannot hide the sweep",
+      filename: behaviorTest,
+      code: `import * as cron from "../cron-execute-workflow-automations"; cron.cronExecuteWorkflowAutomationsRoutes;`,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "dynamic import cannot hide the sweep",
+      filename: behaviorTest,
+      code: `await import("../cron-execute-workflow-automations");`,
+      errors: [{ messageId: "globalSweep" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -199,6 +199,32 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
       errors: [{ messageId: "globalSweep" }],
     },
     {
+      name: "canonical app factory namespaces cannot flow through helper parameters",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount(factory) {
+          return factory.createApp({ routes: ROUTES });
+        }
+        mount(appFactory);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "destructured canonical app factories cannot flow through helper parameters",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import * as appFactory from "../../../app-factory";
+        function mount({ createApp: build }) {
+          return build({ routes: ROUTES });
+        }
+        mount(appFactory);
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "aggregate routes cannot flow through a local member projection",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -90,6 +90,19 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
   ],
   invalid: [
     {
+      name: "aggregate production routes cannot become a ts-rest behavior client",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { setupApp } from "../../../__tests__/test-helpers";
+        const client = setupApp({ context, routes: ROUTES })(contract);
+        await client.execute({
+          headers: { authorization: "Bearer test-cron-secret" },
+        });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "aggregate production routes cannot become a behavior-test sweep",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -90,6 +90,20 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
   ],
   invalid: [
     {
+      name: "aggregate production routes cannot become a behavior-test sweep",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { createApp } from "../../../app-factory";
+        const aggregateRoutes = ROUTES;
+        const app = createApp({ signal, routes: aggregateRoutes });
+        await app.request("/api/cron/execute-workflow-automations", {
+          headers: { authorization: "Bearer test-cron-secret" },
+        });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "old behavior helper cannot wrap the production-global sweep",
       filename: behaviorTest,
       code: `${routeImport}

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-global-sweep-test-routes.test.ts
@@ -90,6 +90,34 @@ ruleTester.run("no-global-sweep-test-routes", noGlobalSweepTestRoutes, {
   ],
   invalid: [
     {
+      name: "aggregate contract binder aliases remain rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { setupApp } from "../../../__tests__/test-helpers";
+        const bindContract = setupApp({ context, routes: ROUTES });
+        const client = bindContract(contract);
+        await client.execute({
+          headers: { authorization: "Bearer test-cron-secret" },
+        });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
+      name: "aggregate app options aliases remain rejected",
+      filename: behaviorTest,
+      code: `
+        import { ROUTES } from "../../route";
+        import { createApp } from "../../../app-factory";
+        const options = { signal, routes: ROUTES };
+        const app = createApp(options);
+        await app.request("/api/cron/execute-workflow-automations", {
+          headers: { authorization: "Bearer test-cron-secret" },
+        });
+      `,
+      errors: [{ messageId: "globalSweep" }],
+    },
+    {
       name: "aggregate production routes cannot become a ts-rest behavior client",
       filename: behaviorTest,
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-legacy-shared-state-markers.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-legacy-shared-state-markers.test.ts
@@ -1,0 +1,75 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noLegacySharedStateMarkers } from "../rules/no-legacy-shared-state-markers.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-legacy-shared-state-markers", noLegacySharedStateMarkers, {
+  valid: [
+    {
+      name: "owned system-storage actions remain valid",
+      code: `
+        const action = "seed-owned-storage-version";
+        await seedOwnedStorageVersion({ storageId, versionId });
+      `,
+    },
+    {
+      name: "legitimate owned cleanup remains valid",
+      code: `
+        afterEach(() => server.resetHandlers());
+        onTestFinished(async () => {
+          controller.abort();
+          connection.close();
+          await detachedTask;
+          rmSync(tempFile);
+        });
+      `,
+    },
+    {
+      name: "scoped process override remains valid",
+      code: `
+        await withSecretKmsClientForTest(client, async () => decrypt());
+        const cache = teamsBotAuthCacheForSignal(context.signal);
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `const marker = "threadless-run-cleanup-integration-test";`,
+      errors: [{ messageId: "legacyMarker" }],
+    },
+    {
+      code: `await withThreadlessRunCleanupTestLock(run);`,
+      errors: [{ messageId: "legacyMarker" }],
+    },
+    {
+      code: "const action = `restore-storage-state`;",
+      errors: [{ messageId: "legacyMarker" }],
+    },
+    {
+      code: `const action = "seed-storage-version";`,
+      errors: [{ messageId: "legacyMarker" }],
+    },
+    {
+      code: `const action = "delete-storage-version";`,
+      errors: [{ messageId: "legacyMarker" }],
+    },
+    {
+      code: `// SOLE OWNER: this file restores the global row\nrun();`,
+      errors: [{ messageId: "legacyMarker" }],
+    },
+    {
+      code: `resetSecretKmsClientForTests();`,
+      errors: [{ messageId: "legacyMarker" }],
+    },
+    {
+      code: `clearTeamsBotAuthCacheForTest();`,
+      errors: [{ messageId: "legacyMarker" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
@@ -1,0 +1,108 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noProductionStaffEntitlementMutation } from "../rules/no-production-staff-entitlement-mutation.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+const fixtureModule = "../../../test-fixtures/org-plan-entitlement";
+const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+
+ruleTester.run(
+  "no-production-staff-entitlement-mutation",
+  noProductionStaffEntitlementMutation,
+  {
+    valid: [
+      {
+        name: "fixed staff identity remains valid for read and hash behavior",
+        code: `
+          const STAFF_ORG_ID = "${staffOrgId}";
+          expect(hash(STAFF_ORG_ID)).toBe(expectedHash);
+          const actor = user({ orgId: STAFF_ORG_ID });
+          await client.read({ params: { orgId: actor.orgId } });
+        `,
+      },
+      {
+        name: "ordinary unique actor entitlement remains valid",
+        code: `
+          import { randomUUID } from "node:crypto";
+          const actor = user({ orgId: "org_" + randomUUID() });
+          await api.grantProEntitlement(actor);
+        `,
+      },
+      {
+        name: "unique staff fixture mutations remain valid",
+        code: `
+          import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org";
+          import { upsertOrgPlanEntitlementFixture, deleteOrgPlanEntitlementFixture } from "${fixtureModule}";
+          const orgId = createUniqueStaffOrgIdFixture();
+          await upsertOrgPlanEntitlementFixture({ orgId });
+          await deleteOrgPlanEntitlementFixture(orgId);
+        `,
+      },
+      {
+        name: "uncalled defensive fixed-id branch is not a mutation flow",
+        code: `
+          const STAFF_ORG_ID = "${staffOrgId}";
+          async function entitledChatActor(options = {}) {
+            const actor = user(options);
+            await api.grantProEntitlement(actor, options.orgId === STAFF_ORG_ID ? { customerId: "staff" } : {});
+          }
+          await entitledChatActor({ orgId: "org_fixture" });
+        `,
+      },
+    ],
+    invalid: [
+      {
+        name: "direct fixed entitlement upsert is rejected",
+        code: `
+          import { upsertOrgPlanEntitlementFixture } from "${fixtureModule}";
+          await upsertOrgPlanEntitlementFixture({ orgId: "${staffOrgId}" });
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+      {
+        name: "const alias fixed entitlement delete is rejected",
+        code: `
+          import { deleteOrgPlanEntitlementFixture } from "${fixtureModule}";
+          const STAFF_ORG_ID = "${staffOrgId}";
+          await deleteOrgPlanEntitlementFixture(STAFF_ORG_ID);
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+      {
+        name: "fixed staff actor grant is rejected",
+        code: `
+          const STAFF_ORG_ID = "${staffOrgId}";
+          const actor = user({ orgId: STAFF_ORG_ID });
+          await api.grantProEntitlement(actor);
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+      {
+        name: "wrapper parameter propagation is rejected",
+        code: `
+          const STAFF_ORG_ID = "${staffOrgId}";
+          async function grant(actor) {
+            await api.grantProEntitlement(actor);
+          }
+          await grant(user({ orgId: STAFF_ORG_ID }));
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+      {
+        name: "local mutation alias is rejected",
+        code: `
+          import { upsertOrgPlanEntitlementFixture } from "${fixtureModule}";
+          const writeEntitlement = upsertOrgPlanEntitlementFixture;
+          const orgId = "${staffOrgId}";
+          await writeEntitlement({ orgId });
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+    ],
+  },
+);

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
@@ -103,6 +103,18 @@ ruleTester.run(
         `,
         errors: [{ messageId: "productionStaffMutation" }],
       },
+      {
+        name: "options-object wrapper propagation is rejected",
+        code: `
+          import { upsertOrgPlanEntitlementFixture } from "${fixtureModule}";
+          const STAFF_ORG_ID = "${staffOrgId}";
+          async function writeEntitlement(options) {
+            await upsertOrgPlanEntitlementFixture(options);
+          }
+          await writeEntitlement({ orgId: STAFF_ORG_ID });
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
     ],
   },
 );

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
@@ -57,6 +57,16 @@ ruleTester.run(
     ],
     invalid: [
       {
+        name: "destructured namespace fixture mutation is rejected",
+        code: `
+          import * as entitlement from "${fixtureModule}";
+          const STAFF_ORG_ID = "${staffOrgId}";
+          const { upsertOrgPlanEntitlementFixture: writeEntitlement } = entitlement;
+          await writeEntitlement({ orgId: STAFF_ORG_ID });
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+      {
         name: "namespace fixture mutation of fixed staff is rejected",
         code: `
           import * as entitlement from "${fixtureModule}";

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-production-staff-entitlement-mutation.test.ts
@@ -57,6 +57,27 @@ ruleTester.run(
     ],
     invalid: [
       {
+        name: "namespace fixture mutation of fixed staff is rejected",
+        code: `
+          import * as entitlement from "${fixtureModule}";
+          const STAFF_ORG_ID = "${staffOrgId}";
+          await entitlement.upsertOrgPlanEntitlementFixture({ orgId: STAFF_ORG_ID });
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+      {
+        name: "destructured options wrapper propagation is rejected",
+        code: `
+          import { upsertOrgPlanEntitlementFixture } from "${fixtureModule}";
+          const STAFF_ORG_ID = "${staffOrgId}";
+          async function writeEntitlement({ orgId }) {
+            await upsertOrgPlanEntitlementFixture({ orgId });
+          }
+          await writeEntitlement({ orgId: STAFF_ORG_ID });
+        `,
+        errors: [{ messageId: "productionStaffMutation" }],
+      },
+      {
         name: "direct fixed entitlement upsert is rejected",
         code: `
           import { upsertOrgPlanEntitlementFixture } from "${fixtureModule}";

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
@@ -40,10 +40,23 @@ ruleTester.run("no-unowned-usage-pricing", noUnownedUsagePricing, {
       code: `
         import { createUsagePricingFixture, seedUsagePricingRows, deleteUsagePricingRows } from "${fixtureModule}";
         import { createRunsApi } from "../../routes/__tests__/helpers/api-bdd-runs";
+        import { testCronCleanupSandboxesStateRoutes } from "../../routes/test-cron-cleanup-sandboxes-state";
         const api = createRunsApi(context);
         const run = await api.createRun(actor, request);
+        function requestState(body) {
+          return createAppWithRoutes({ routes: testCronCleanupSandboxesStateRoutes }).request("/state", { body: JSON.stringify(body) });
+        }
+        async function postState(body) {
+          return await requestState(body);
+        }
+        async function insertRunFixture() {
+          const response = await postState({ action: "seed-run" });
+          return { runId: stringField(response, "run_id") };
+        }
+        const scopedRun = await trackRun(insertRunFixture());
         const pricing = await createUsagePricingFixture({ configured: [{ kind: "model", provider: "openrouter", category: "input", unitPrice: 1, unitSize: 1 }] });
         await seedUsagePricingRows([{ kind: "model", provider: run.runId, category: "input", unitPrice: 1, unitSize: 1 }]);
+        await seedUsagePricingRows([{ kind: "model", provider: "cleanup-test-" + scopedRun.runId, category: "input", unitPrice: 1, unitSize: 1 }]);
         await deleteUsagePricingRows({ kind: "model", provider: pricing.resolution[0].lookupProvider, categories: ["input"] });
       `,
     },
@@ -169,14 +182,24 @@ ruleTester.run("no-unowned-usage-pricing", noUnownedUsagePricing, {
       errors: [{ messageId: "unownedPricing" }],
     },
     {
-      name: "a fake createRun member cannot manufacture run ownership",
+      name: "fake member and local run factories cannot manufacture ownership",
       code: `
         import { seedUsagePricingRows } from "${fixtureModule}";
+        import { testCronCleanupSandboxesStateRoutes } from "../../routes/test-cron-cleanup-sandboxes-state";
         const fake = { createRun() { return { runId: "google-maps" }; } };
         const run = fake.createRun();
+        function insertRunFixture() {
+          void testCronCleanupSandboxesStateRoutes;
+          return { runId: "google-maps" };
+        }
+        const localRun = insertRunFixture();
         await seedUsagePricingRows([{ kind: "generation", provider: run.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
+        await seedUsagePricingRows([{ kind: "generation", provider: localRun.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
       `,
-      errors: [{ messageId: "unownedPricing" }],
+      errors: [
+        { messageId: "unownedPricing" },
+        { messageId: "unownedPricing" },
+      ],
     },
     {
       name: "an arbitrary imported run factory is not run provenance",

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
@@ -102,6 +102,25 @@ ruleTester.run("no-unowned-usage-pricing", noUnownedUsagePricing, {
   ],
   invalid: [
     {
+      name: "seed-run ownership must match the actual scoped request action",
+      code: `
+        import { createAppWithRoutes } from "../../../app-factory-core";
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        import { testCronCleanupSandboxesStateRoutes } from "../../routes/test-cron-cleanup-sandboxes-state";
+        async function requestState(body) {
+          return await createAppWithRoutes({ routes: testCronCleanupSandboxesStateRoutes })
+            .request("/state", { body: JSON.stringify({ action: "read-state" }) });
+        }
+        async function insertRunFixture() {
+          const response = await requestState({ action: "seed-run" });
+          return { runId: stringField(response, "run_id") };
+        }
+        const run = await insertRunFixture();
+        await seedUsagePricingRows([{ kind: "generation", provider: run.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
       name: "discarded scoped response cannot bless a fixed returned run id",
       code: `
         import { createAppWithRoutes } from "../../../app-factory-core";

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
@@ -221,5 +221,30 @@ ruleTester.run("no-unowned-usage-pricing", noUnownedUsagePricing, {
       `,
       errors: [{ messageId: "unownedPricing" }],
     },
+    {
+      name: "mixed fixture-object wrapper calls are fail-closed",
+      code: `
+        import { createUsagePricingFixture, upsertUsagePricingRows } from "${fixtureModule}";
+        function identity(pricing) { return pricing; }
+        const fixture = await createUsagePricingFixture({ configured: [{ kind: "generation", provider: "google-maps", category: "maps", unitPrice: 1, unitSize: 1 }] });
+        const owned = identity(fixture.resolution[0]);
+        identity({ lookupProvider: "google-maps" });
+        await upsertUsagePricingRows([{ kind: "generation", provider: owned.lookupProvider, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "mixed run-object wrapper calls are fail-closed",
+      code: `
+        import { createDirectRunFixture } from "../../../test-fixtures/agent-runs";
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        function identity(run) { return run; }
+        const fixture = await createDirectRunFixture();
+        const owned = identity(fixture);
+        identity({ runId: "google-maps" });
+        await seedUsagePricingRows([{ kind: "generation", provider: owned.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
   ],
 });

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
@@ -38,6 +38,7 @@ ruleTester.run("no-unowned-usage-pricing", noUnownedUsagePricing, {
     {
       name: "actual run-owned and fixture lookup-provider rows are allowed",
       code: `
+        import { createAppWithRoutes } from "../../../app-factory-core";
         import { createUsagePricingFixture, seedUsagePricingRows, deleteUsagePricingRows } from "${fixtureModule}";
         import { createRunsApi } from "../../routes/__tests__/helpers/api-bdd-runs";
         import { testCronCleanupSandboxesStateRoutes } from "../../routes/test-cron-cleanup-sandboxes-state";
@@ -100,6 +101,26 @@ ruleTester.run("no-unowned-usage-pricing", noUnownedUsagePricing, {
     },
   ],
   invalid: [
+    {
+      name: "discarded scoped response cannot bless a fixed returned run id",
+      code: `
+        import { createAppWithRoutes } from "../../../app-factory-core";
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        import { testCronCleanupSandboxesStateRoutes } from "../../routes/test-cron-cleanup-sandboxes-state";
+        async function requestState(body) {
+          void createAppWithRoutes({ routes: testCronCleanupSandboxesStateRoutes })
+            .request("/state", { body: JSON.stringify(body) });
+          return { run_id: "google-maps" };
+        }
+        async function insertRunFixture() {
+          const response = await requestState({ action: "seed-run" });
+          return { runId: stringField(response, "run_id") };
+        }
+        const run = await insertRunFixture();
+        await seedUsagePricingRows([{ kind: "generation", provider: run.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
     {
       name: "raw canonical overwrite is rejected",
       code: `

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-unowned-usage-pricing.test.ts
@@ -1,0 +1,202 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noUnownedUsagePricing } from "../rules/no-unowned-usage-pricing.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+const fixtureModule = "../../../test-fixtures/system-config-seeds";
+
+ruleTester.run("no-unowned-usage-pricing", noUnownedUsagePricing, {
+  valid: [
+    {
+      name: "canonical logical providers belong in the scoped fixture",
+      code: `
+        import { createUsagePricingFixture } from "${fixtureModule}";
+        const pricing = await createUsagePricingFixture({ configured: [{
+          kind: "generation",
+          provider: "google-weather",
+          category: "air",
+          unitPrice: 1,
+          unitSize: 1,
+        }] });
+        onTestFinished(pricing.cleanup);
+      `,
+    },
+    {
+      name: "raw UUID-owned provider is allowed",
+      code: `
+        import { randomUUID } from "node:crypto";
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        const provider = "fixture-" + randomUUID();
+        await seedUsagePricingRows([{ kind: "model", provider, category: "input", unitPrice: 1, unitSize: 1 }]);
+      `,
+    },
+    {
+      name: "actual run-owned and fixture lookup-provider rows are allowed",
+      code: `
+        import { createUsagePricingFixture, seedUsagePricingRows, deleteUsagePricingRows } from "${fixtureModule}";
+        import { createRunsApi } from "../../routes/__tests__/helpers/api-bdd-runs";
+        const api = createRunsApi(context);
+        const run = await api.createRun(actor, request);
+        const pricing = await createUsagePricingFixture({ configured: [{ kind: "model", provider: "openrouter", category: "input", unitPrice: 1, unitSize: 1 }] });
+        await seedUsagePricingRows([{ kind: "model", provider: run.runId, category: "input", unitPrice: 1, unitSize: 1 }]);
+        await deleteUsagePricingRows({ kind: "model", provider: pricing.resolution[0].lookupProvider, categories: ["input"] });
+      `,
+    },
+    {
+      name: "wrapper parameter is proven UUID-owned at every callsite",
+      code: `
+        import { randomUUID } from "node:crypto";
+        import { upsertUsagePricingRows } from "${fixtureModule}";
+        async function seed(provider) {
+          await upsertUsagePricingRows([{ kind: "model", provider, category: "input", unitPrice: 1, unitSize: 1 }]);
+        }
+        await seed(randomUUID());
+        await seed("fixture-" + randomUUID());
+      `,
+    },
+    {
+      name: "UUID-owned wrapper parameters remain proven through row mapping",
+      code: `
+        import { randomUUID } from "node:crypto";
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        function uniqueProvider(prefix) { return prefix + "-" + randomUUID(); }
+        async function seed(provider) {
+          await seedUsagePricingRows(["input", "output"].map((category) => {
+            return { kind: "model", provider, category, unitPrice: 1, unitSize: 1 };
+          }));
+        }
+        await seed(uniqueProvider("fixture"));
+      `,
+    },
+    {
+      name: "owned handle cleanup is unrelated and remains valid",
+      code: `
+        afterEach(() => server.resetHandlers());
+        onTestFinished(async () => {
+          controller.abort();
+          socket.close();
+          await detachedWork;
+          rmSync(tempFile);
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "raw canonical overwrite is rejected",
+      code: `
+        import { upsertUsagePricingRows } from "${fixtureModule}";
+        await upsertUsagePricingRows([{ kind: "generation", provider: "google-weather", category: "air", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "const alias cannot hide a fixed provider",
+      code: `
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        const PROVIDER = "dataforseo";
+        await seedUsagePricingRows([{ kind: "generation", provider: PROVIDER, category: "seo", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "fixed pricing deletion is rejected",
+      code: `
+        import { deleteUsagePricingRows } from "${fixtureModule}";
+        await deleteUsagePricingRows({ kind: "generation", provider: "joggai", categories: ["avatar-video"] });
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "restore of previously deleted fixed rows is rejected",
+      code: `
+        import { upsertUsagePricingRows } from "${fixtureModule}";
+        const previousRows = [{ kind: "generation", provider: "x", category: "image-share", unitPrice: 1, unitSize: 1 }];
+        await upsertUsagePricingRows(previousRows);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "unproven wrapper parameter is fail-closed",
+      code: `
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        async function seed(provider) {
+          await seedUsagePricingRows([{ kind: "model", provider, category: "input", unitPrice: 1, unitSize: 1 }]);
+        }
+        await seed(process.env.PROVIDER);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "arbitrary lookupProvider property is not ownership",
+      code: `
+        import { upsertUsagePricingRows } from "${fixtureModule}";
+        const fake = { lookupProvider: "google-maps" };
+        await upsertUsagePricingRows([{ kind: "generation", provider: fake.lookupProvider, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "arbitrary runId property is not ownership",
+      code: `
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        const fake = { runId: "google-maps" };
+        await seedUsagePricingRows([{ kind: "generation", provider: fake.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "a local function named randomUUID is not UUID provenance",
+      code: `
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        function randomUUID() { return "google-maps"; }
+        await seedUsagePricingRows([{ kind: "generation", provider: randomUUID(), category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "an arbitrary randomUUID import is not UUID provenance",
+      code: `
+        import { randomUUID } from "arbitrary-uuid-helper";
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        await seedUsagePricingRows([{ kind: "generation", provider: randomUUID(), category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "a fake createRun member cannot manufacture run ownership",
+      code: `
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        const fake = { createRun() { return { runId: "google-maps" }; } };
+        const run = fake.createRun();
+        await seedUsagePricingRows([{ kind: "generation", provider: run.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "an arbitrary imported run factory is not run provenance",
+      code: `
+        import { createDirectRunFixture } from "./fake-run-fixture";
+        import { seedUsagePricingRows } from "${fixtureModule}";
+        const run = await createDirectRunFixture();
+        await seedUsagePricingRows([{ kind: "generation", provider: run.runId, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+    {
+      name: "wrapper returning a fixed lookupProvider remains rejected",
+      code: `
+        import { upsertUsagePricingRows } from "${fixtureModule}";
+        function fakePricing() { return { lookupProvider: "google-maps" }; }
+        const fake = fakePricing();
+        await upsertUsagePricingRows([{ kind: "generation", provider: fake.lookupProvider, category: "maps", unitPrice: 1, unitSize: 1 }]);
+      `,
+      errors: [{ messageId: "unownedPricing" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/api/index.ts
+++ b/turbo/packages/eslint-rules/src/api/index.ts
@@ -1,13 +1,18 @@
 import { gatewayTypecheckBoundary } from "./rules/gateway-typecheck-boundary.ts";
 import { noCatchAbort } from "./rules/no-catch-abort.ts";
+import { noCrossTestTimeStaggering } from "./rules/no-cross-test-time-staggering.ts";
 import { noFnDollarSuffix } from "./rules/no-fn-dollar-suffix.ts";
 import { noGetterSetterParams } from "./rules/no-getter-setter-params.ts";
+import { noGlobalSweepTestRoutes } from "./rules/no-global-sweep-test-routes.ts";
+import { noLegacySharedStateMarkers } from "./rules/no-legacy-shared-state-markers.ts";
 import { noLoggerInfo } from "./rules/no-logger-info.ts";
 import { noNewPromise } from "./rules/no-new-promise.ts";
 import { noPackageVariable } from "./rules/no-package-variable.ts";
+import { noProductionStaffEntitlementMutation } from "./rules/no-production-staff-entitlement-mutation.ts";
 import { noStoreInParams } from "./rules/no-store-in-params.ts";
 import { noSqlRaw } from "./rules/no-sql-raw.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
+import { noUnownedUsagePricing } from "./rules/no-unowned-usage-pricing.ts";
 import { noUnsafeSqlInterpolation } from "./rules/no-unsafe-sql-interpolation.ts";
 import { preferDrizzleApis } from "./rules/prefer-drizzle-apis.ts";
 import { requireExecuteRowSchema } from "./rules/require-execute-row-schema.ts";
@@ -22,14 +27,20 @@ export const apiLintPlugin = {
   rules: {
     "gateway-typecheck-boundary": gatewayTypecheckBoundary,
     "no-catch-abort": noCatchAbort,
+    "no-cross-test-time-staggering": noCrossTestTimeStaggering,
     "no-fn-dollar-suffix": noFnDollarSuffix,
     "no-getter-setter-params": noGetterSetterParams,
+    "no-global-sweep-test-routes": noGlobalSweepTestRoutes,
+    "no-legacy-shared-state-markers": noLegacySharedStateMarkers,
     "no-logger-info": noLoggerInfo,
     "no-new-promise": noNewPromise,
     "no-package-variable": noPackageVariable,
+    "no-production-staff-entitlement-mutation":
+      noProductionStaffEntitlementMutation,
     "no-store-in-params": noStoreInParams,
     "no-sql-raw": noSqlRaw,
     "no-test-vi-mocks": noTestViMocks,
+    "no-unowned-usage-pricing": noUnownedUsagePricing,
     "no-unsafe-sql-interpolation": noUnsafeSqlInterpolation,
     "prefer-drizzle-apis": preferDrizzleApis,
     "require-execute-row-schema": requireExecuteRowSchema,

--- a/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
@@ -100,13 +100,23 @@ function declarationIsSuiteShared(
 }
 
 function isMutationReference(identifier: TSESTree.Identifier): boolean {
-  const parent = identifier.parent;
-  if (parent.type === AST_NODE_TYPES.UpdateExpression) {
+  let target: TSESTree.Node = identifier;
+  while (
+    target.parent.type === AST_NODE_TYPES.MemberExpression &&
+    target.parent.object === target
+  ) {
+    target = target.parent;
+  }
+  const parent = target.parent;
+  if (
+    parent.type === AST_NODE_TYPES.UpdateExpression &&
+    parent.argument === target
+  ) {
     return true;
   }
   return (
     parent.type === AST_NODE_TYPES.AssignmentExpression &&
-    parent.left === identifier
+    parent.left === target
   );
 }
 
@@ -152,7 +162,6 @@ export const noCrossTestTimeStaggering = createRule({
         !variable ||
         definition?.node.type !== AST_NODE_TYPES.VariableDeclarator ||
         definition.node.parent.type !== AST_NODE_TYPES.VariableDeclaration ||
-        definition.node.parent.kind === "const" ||
         !declarationIsSuiteShared(definition.node, context.sourceCode)
       ) {
         return false;
@@ -289,10 +298,29 @@ export const noCrossTestTimeStaggering = createRule({
     function isTimeCall(node: TSESTree.CallExpression): boolean {
       if (node.callee.type === AST_NODE_TYPES.Identifier) {
         const imported = importReference(context.sourceCode, node.callee);
-        return Boolean(
+        if (
           imported &&
           imported.source.endsWith("/lib/time") &&
-          TIME_FUNCTIONS.has(imported.importedName),
+          TIME_FUNCTIONS.has(imported.importedName)
+        ) {
+          return true;
+        }
+        const definition = variableInScope(context.sourceCode, node.callee)
+          ?.defs[0];
+        return Boolean(
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init?.type === AST_NODE_TYPES.Identifier &&
+          (() => {
+            const source = importReference(
+              context.sourceCode,
+              definition.node.init,
+            );
+            return Boolean(
+              source &&
+              source.source.endsWith("/lib/time") &&
+              TIME_FUNCTIONS.has(source.importedName),
+            );
+          })(),
         );
       }
       return (

--- a/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
@@ -3,6 +3,7 @@ import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 import {
   importReference,
   memberName,
+  propertyName,
   unwrapExpression,
   variableInScope,
 } from "../syntax.ts";
@@ -339,6 +340,30 @@ export const noCrossTestTimeStaggering = createRule({
         }
         const definition = variableInScope(context.sourceCode, expression)
           ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          definition.node.id.type === AST_NODE_TYPES.ObjectPattern
+        ) {
+          const destructured = definition.node.id.properties.find((entry) => {
+            return (
+              entry.type === AST_NODE_TYPES.Property &&
+              entry.value.type === AST_NODE_TYPES.Identifier &&
+              entry.value.name === expression.name
+            );
+          });
+          const name =
+            destructured?.type === AST_NODE_TYPES.Property
+              ? propertyName(destructured)
+              : null;
+          if (
+            name &&
+            TIME_FUNCTIONS.has(name) &&
+            isTimeNamespace(definition.node.init)
+          ) {
+            return true;
+          }
+        }
         return Boolean(
           definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
           definition.node.init &&

--- a/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
@@ -1,0 +1,328 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import {
+  importReference,
+  memberName,
+  unwrapExpression,
+  variableInScope,
+} from "../syntax.ts";
+import { createRule } from "../utils.ts";
+
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+
+const TIME_FUNCTIONS = new Set(["mockNow", "withMockNowForTest"]);
+
+function enclosingFunction(node: TSESTree.Node): FunctionNode | null {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      current.type === AST_NODE_TYPES.FunctionDeclaration ||
+      current.type === AST_NODE_TYPES.FunctionExpression
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function functionName(node: FunctionNode): string | null {
+  if (node.type === AST_NODE_TYPES.FunctionDeclaration) {
+    return node.id?.name ?? null;
+  }
+  if (node.id) {
+    return node.id.name;
+  }
+  if (
+    node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+    node.parent.id.type === AST_NODE_TYPES.Identifier
+  ) {
+    return node.parent.id.name;
+  }
+  return null;
+}
+
+function parameterIndex(node: FunctionNode, name: string): number {
+  return node.params.findIndex((parameter) => {
+    return (
+      parameter.type === AST_NODE_TYPES.Identifier && parameter.name === name
+    );
+  });
+}
+
+function isDescribeCallback(
+  node: FunctionNode,
+  sourceCode: Parameters<typeof importReference>[0],
+): boolean {
+  if (node.type === AST_NODE_TYPES.FunctionDeclaration) {
+    return false;
+  }
+  if (
+    node.parent.type !== AST_NODE_TYPES.CallExpression ||
+    !node.parent.arguments.includes(node)
+  ) {
+    return false;
+  }
+  const callee = node.parent.callee;
+  if (callee.type === AST_NODE_TYPES.Identifier) {
+    const imported = importReference(sourceCode, callee);
+    return (
+      callee.name === "describe" ||
+      (imported?.source === "vitest" && imported.importedName === "describe")
+    );
+  }
+  return (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    memberName(callee) === "describe"
+  );
+}
+
+function declarationIsSuiteShared(
+  node: TSESTree.VariableDeclarator,
+  sourceCode: Parameters<typeof importReference>[0],
+): boolean {
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current) {
+    if (
+      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      current.type === AST_NODE_TYPES.FunctionDeclaration ||
+      current.type === AST_NODE_TYPES.FunctionExpression
+    ) {
+      return isDescribeCallback(current, sourceCode);
+    }
+    current = current.parent;
+  }
+  return true;
+}
+
+function isMutationReference(identifier: TSESTree.Identifier): boolean {
+  const parent = identifier.parent;
+  if (parent.type === AST_NODE_TYPES.UpdateExpression) {
+    return true;
+  }
+  return (
+    parent.type === AST_NODE_TYPES.AssignmentExpression &&
+    parent.left === identifier
+  );
+}
+
+export const noCrossTestTimeStaggering = createRule({
+  name: "no-cross-test-time-staggering",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Prevent API cache tests from deriving mocked time from suite-shared mutable order",
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      sharedTime:
+        "Mocked time must not depend on a mutable package/describe-scope counter. Isolate cache state by owned keys and keep TTL advances inside the owning test.",
+    },
+  },
+  create(context) {
+    const calls: TSESTree.CallExpression[] = [];
+    const timeCalls: TSESTree.CallExpression[] = [];
+
+    function callsTo(node: FunctionNode): readonly TSESTree.CallExpression[] {
+      const name = functionName(node);
+      if (!name) {
+        return [];
+      }
+      return calls.filter((call) => {
+        return (
+          call.callee.type === AST_NODE_TYPES.Identifier &&
+          call.callee.name === name
+        );
+      });
+    }
+
+    function identifierIsSharedMutable(
+      identifier: TSESTree.Identifier,
+    ): boolean {
+      const variable = variableInScope(context.sourceCode, identifier);
+      const definition = variable?.defs[0];
+      if (
+        !variable ||
+        definition?.node.type !== AST_NODE_TYPES.VariableDeclarator ||
+        definition.node.parent.type !== AST_NODE_TYPES.VariableDeclaration ||
+        definition.node.parent.kind === "const" ||
+        !declarationIsSuiteShared(definition.node, context.sourceCode)
+      ) {
+        return false;
+      }
+      return variable.references.some((reference) => {
+        return (
+          reference.identifier.type === AST_NODE_TYPES.Identifier &&
+          isMutationReference(reference.identifier)
+        );
+      });
+    }
+
+    function dependsOnSharedMutable(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        if (identifierIsSharedMutable(current)) {
+          return true;
+        }
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return dependsOnSharedMutable(definition.node.init, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          const owner = enclosingFunction(current);
+          if (!owner) {
+            return false;
+          }
+          const index = parameterIndex(owner, current.name);
+          return callsTo(owner).some((call) => {
+            const argument = call.arguments[index];
+            return Boolean(
+              argument &&
+              argument.type !== AST_NODE_TYPES.SpreadElement &&
+              dependsOnSharedMutable(argument, nextSeen),
+            );
+          });
+        }
+        return false;
+      }
+      if (
+        current.type === AST_NODE_TYPES.BinaryExpression ||
+        current.type === AST_NODE_TYPES.LogicalExpression
+      ) {
+        return (
+          (current.left.type !== AST_NODE_TYPES.PrivateIdentifier &&
+            dependsOnSharedMutable(current.left, nextSeen)) ||
+          dependsOnSharedMutable(current.right, nextSeen)
+        );
+      }
+      if (
+        current.type === AST_NODE_TYPES.UnaryExpression ||
+        current.type === AST_NODE_TYPES.UpdateExpression ||
+        current.type === AST_NODE_TYPES.AwaitExpression
+      ) {
+        return dependsOnSharedMutable(current.argument, nextSeen);
+      }
+      if (current.type === AST_NODE_TYPES.ConditionalExpression) {
+        return (
+          dependsOnSharedMutable(current.test, nextSeen) ||
+          dependsOnSharedMutable(current.consequent, nextSeen) ||
+          dependsOnSharedMutable(current.alternate, nextSeen)
+        );
+      }
+      if (current.type === AST_NODE_TYPES.TemplateLiteral) {
+        return current.expressions.some((part) => {
+          return dependsOnSharedMutable(part, nextSeen);
+        });
+      }
+      if (current.type === AST_NODE_TYPES.SequenceExpression) {
+        return current.expressions.some((part) => {
+          return dependsOnSharedMutable(part, nextSeen);
+        });
+      }
+      if (current.type === AST_NODE_TYPES.ArrayExpression) {
+        return current.elements.some((element) => {
+          return Boolean(
+            element &&
+            dependsOnSharedMutable(
+              element.type === AST_NODE_TYPES.SpreadElement
+                ? element.argument
+                : element,
+              nextSeen,
+            ),
+          );
+        });
+      }
+      if (current.type === AST_NODE_TYPES.ObjectExpression) {
+        return current.properties.some((property) => {
+          if (property.type === AST_NODE_TYPES.SpreadElement) {
+            return dependsOnSharedMutable(property.argument, nextSeen);
+          }
+          return (
+            (property.computed &&
+              dependsOnSharedMutable(property.key, nextSeen)) ||
+            (property.value.type !== AST_NODE_TYPES.AssignmentPattern &&
+              dependsOnSharedMutable(
+                property.value as TSESTree.Expression,
+                nextSeen,
+              ))
+          );
+        });
+      }
+      if (current.type === AST_NODE_TYPES.MemberExpression) {
+        return (
+          dependsOnSharedMutable(current.object, nextSeen) ||
+          (current.computed &&
+            dependsOnSharedMutable(current.property, nextSeen))
+        );
+      }
+      if (current.type === AST_NODE_TYPES.CallExpression) {
+        return current.arguments.some((argument) => {
+          return dependsOnSharedMutable(
+            argument.type === AST_NODE_TYPES.SpreadElement
+              ? argument.argument
+              : argument,
+            nextSeen,
+          );
+        });
+      }
+      return false;
+    }
+
+    function isTimeCall(node: TSESTree.CallExpression): boolean {
+      if (node.callee.type === AST_NODE_TYPES.Identifier) {
+        const imported = importReference(context.sourceCode, node.callee);
+        return Boolean(
+          imported &&
+          imported.source.endsWith("/lib/time") &&
+          TIME_FUNCTIONS.has(imported.importedName),
+        );
+      }
+      return (
+        node.callee.type === AST_NODE_TYPES.MemberExpression &&
+        memberName(node.callee) === "setSystemTime"
+      );
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        calls.push(node);
+        if (isTimeCall(node)) {
+          timeCalls.push(node);
+        }
+      },
+      "Program:exit"() {
+        for (const call of timeCalls) {
+          if (
+            call.arguments.some((argument) => {
+              return dependsOnSharedMutable(
+                argument.type === AST_NODE_TYPES.SpreadElement
+                  ? argument.argument
+                  : argument,
+              );
+            })
+          ) {
+            context.report({ node: call, messageId: "sharedTime" });
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-cross-test-time-staggering.ts
@@ -15,6 +15,10 @@ type FunctionNode =
 
 const TIME_FUNCTIONS = new Set(["mockNow", "withMockNowForTest"]);
 
+function isTimeModule(source: string): boolean {
+  return source.endsWith("/lib/time") || source.endsWith("/lib/time.ts");
+}
+
 function enclosingFunction(node: TSESTree.Node): FunctionNode | null {
   let current = node.parent;
   while (current) {
@@ -295,38 +299,71 @@ export const noCrossTestTimeStaggering = createRule({
       return false;
     }
 
-    function isTimeCall(node: TSESTree.CallExpression): boolean {
-      if (node.callee.type === AST_NODE_TYPES.Identifier) {
-        const imported = importReference(context.sourceCode, node.callee);
+    function isTimeNamespace(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current) || current.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      const imported = importReference(context.sourceCode, current);
+      if (imported?.importedName === "*" && isTimeModule(imported.source)) {
+        return true;
+      }
+      const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      return Boolean(
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init &&
+        isTimeNamespace(definition.node.init, nextSeen),
+      );
+    }
+
+    function isTimeFunction(
+      expression: TSESTree.CallExpression["callee"],
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      if (seen.has(expression)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(expression);
+      if (expression.type === AST_NODE_TYPES.Identifier) {
+        const imported = importReference(context.sourceCode, expression);
         if (
           imported &&
-          imported.source.endsWith("/lib/time") &&
+          isTimeModule(imported.source) &&
           TIME_FUNCTIONS.has(imported.importedName)
         ) {
           return true;
         }
-        const definition = variableInScope(context.sourceCode, node.callee)
+        const definition = variableInScope(context.sourceCode, expression)
           ?.defs[0];
         return Boolean(
           definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
-          definition.node.init?.type === AST_NODE_TYPES.Identifier &&
-          (() => {
-            const source = importReference(
-              context.sourceCode,
-              definition.node.init,
-            );
-            return Boolean(
-              source &&
-              source.source.endsWith("/lib/time") &&
-              TIME_FUNCTIONS.has(source.importedName),
-            );
-          })(),
+          definition.node.init &&
+          isTimeFunction(definition.node.init, nextSeen),
         );
       }
-      return (
-        node.callee.type === AST_NODE_TYPES.MemberExpression &&
-        memberName(node.callee) === "setSystemTime"
-      );
+      if (
+        expression.type === AST_NODE_TYPES.MemberExpression &&
+        expression.object.type !== AST_NODE_TYPES.Super
+      ) {
+        const name = memberName(expression);
+        return (
+          name === "setSystemTime" ||
+          Boolean(
+            name &&
+            TIME_FUNCTIONS.has(name) &&
+            isTimeNamespace(expression.object),
+          )
+        );
+      }
+      return false;
+    }
+
+    function isTimeCall(node: TSESTree.CallExpression): boolean {
+      return isTimeFunction(node.callee);
     }
 
     return {

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -9,6 +9,11 @@ import {
 } from "../syntax.ts";
 import { createRule } from "../utils.ts";
 
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+
 interface GlobalSweepBoundary {
   readonly exportName: string;
   readonly moduleName: string;
@@ -217,6 +222,101 @@ export const noGlobalSweepTestRoutes = createRule({
       });
     }
 
+    function localFunctionForCallee(
+      expression: TSESTree.CallExpression["callee"],
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): FunctionNode | null {
+      if (
+        seen.has(expression) ||
+        expression.type !== AST_NODE_TYPES.Identifier
+      ) {
+        return null;
+      }
+      const nextSeen = new Set(seen).add(expression);
+      const definitions =
+        variableInScope(context.sourceCode, expression)?.defs ?? [];
+      for (const definition of definitions) {
+        const node = definition.node;
+        if (
+          node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          node.type === AST_NODE_TYPES.FunctionDeclaration ||
+          node.type === AST_NODE_TYPES.FunctionExpression
+        ) {
+          return node;
+        }
+        if (node.type === AST_NODE_TYPES.VariableDeclarator && node.init) {
+          if (
+            node.init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+            node.init.type === AST_NODE_TYPES.FunctionExpression
+          ) {
+            return node.init;
+          }
+          if (node.init.type === AST_NODE_TYPES.Identifier) {
+            const localFunction = localFunctionForCallee(node.init, nextSeen);
+            if (localFunction) {
+              return localFunction;
+            }
+          }
+        }
+      }
+      return null;
+    }
+
+    function parameterOwner(
+      identifier: TSESTree.Identifier,
+    ): FunctionNode | null {
+      const definition = variableInScope(
+        context.sourceCode,
+        identifier,
+      )?.defs.find((candidate) => {
+        return candidate.type === "Parameter";
+      });
+      const node = definition?.node;
+      if (
+        node?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        node?.type === AST_NODE_TYPES.FunctionDeclaration ||
+        node?.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        return node;
+      }
+      return null;
+    }
+
+    function parameterIndex(node: FunctionNode, name: string): number {
+      return node.params.findIndex((rawParameter) => {
+        const parameter =
+          rawParameter.type === AST_NODE_TYPES.AssignmentPattern
+            ? rawParameter.left
+            : rawParameter;
+        return (
+          parameter.type === AST_NODE_TYPES.Identifier &&
+          parameter.name === name
+        );
+      });
+    }
+
+    function argumentsForParameter(
+      identifier: TSESTree.Identifier,
+    ): readonly TSESTree.Expression[] {
+      const owner = parameterOwner(identifier);
+      if (!owner) {
+        return [];
+      }
+      const index = parameterIndex(owner, identifier.name);
+      if (index < 0) {
+        return [];
+      }
+      return calls.flatMap((call) => {
+        if (localFunctionForCallee(call.callee) !== owner) {
+          return [];
+        }
+        const argument = call.arguments[index];
+        return argument && argument.type !== AST_NODE_TYPES.SpreadElement
+          ? [argument]
+          : [];
+      });
+    }
+
     function isAggregateRoutes(
       expression: TSESTree.Expression,
       seen: ReadonlySet<TSESTree.Node> = new Set(),
@@ -236,6 +336,11 @@ export const noGlobalSweepTestRoutes = createRule({
         }
         const definition = variableInScope(context.sourceCode, current)
           ?.defs[0];
+        if (definition?.type === "Parameter") {
+          return argumentsForParameter(current).some((argument) => {
+            return isAggregateRoutes(argument, nextSeen);
+          });
+        }
         return Boolean(
           definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
           definition.node.init &&
@@ -269,6 +374,62 @@ export const noGlobalSweepTestRoutes = createRule({
       return false;
     }
 
+    function aggregateRoutesOption(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean | null {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return null;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return aggregateRoutesOption(definition.node.init, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          const resolutions = argumentsForParameter(current).map((argument) => {
+            return aggregateRoutesOption(argument, nextSeen);
+          });
+          if (resolutions.some((resolution) => resolution === true)) {
+            return true;
+          }
+          return resolutions.length > 0 &&
+            resolutions.every((resolution) => resolution === false)
+            ? false
+            : null;
+        }
+        return null;
+      }
+      if (current.type !== AST_NODE_TYPES.ObjectExpression) {
+        return null;
+      }
+      for (const property of [...current.properties].reverse()) {
+        if (property.type === AST_NODE_TYPES.SpreadElement) {
+          const spread = aggregateRoutesOption(property.argument, nextSeen);
+          if (spread !== null) {
+            return spread;
+          }
+          continue;
+        }
+        if (
+          propertyName(property) === "routes" &&
+          property.value.type !== AST_NODE_TYPES.AssignmentPattern
+        ) {
+          return isAggregateRoutes(
+            property.value as TSESTree.Expression,
+            nextSeen,
+          );
+        }
+      }
+      return null;
+    }
+
     function isAppFactory(
       expression: TSESTree.CallExpression["callee"],
       seen: ReadonlySet<TSESTree.Node> = new Set(),
@@ -296,78 +457,17 @@ export const noGlobalSweepTestRoutes = createRule({
       );
     }
 
-    function mountedAggregateRoutes(
-      expression: TSESTree.Expression,
-      seen: ReadonlySet<TSESTree.Node> = new Set(),
-    ): boolean {
-      const current = unwrapExpression(expression);
-      if (seen.has(current)) {
-        return false;
-      }
-      const nextSeen = new Set(seen).add(current);
-      if (current.type === AST_NODE_TYPES.Identifier) {
-        const definition = variableInScope(context.sourceCode, current)
-          ?.defs[0];
-        return Boolean(
-          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
-          definition.node.init &&
-          mountedAggregateRoutes(definition.node.init, nextSeen),
-        );
-      }
-      if (current.type !== AST_NODE_TYPES.CallExpression) {
-        return false;
-      }
-      if (isAppFactory(current.callee)) {
-        const options = current.arguments[0];
-        if (!options || options.type !== AST_NODE_TYPES.ObjectExpression) {
-          return false;
-        }
-        return options.properties.some((property) => {
-          return (
-            property.type === AST_NODE_TYPES.Property &&
-            propertyName(property) === "routes" &&
-            property.value.type !== AST_NODE_TYPES.AssignmentPattern &&
-            isAggregateRoutes(property.value as TSESTree.Expression)
-          );
-        });
-      }
-      return (
-        current.callee.type === AST_NODE_TYPES.CallExpression &&
-        mountedAggregateRoutes(current.callee, nextSeen)
-      );
-    }
-
-    function aggregateSweepBoundary(
-      call: TSESTree.CallExpression,
-    ): GlobalSweepBoundary | null {
-      if (
-        call.callee.type !== AST_NODE_TYPES.MemberExpression ||
-        memberName(call.callee) !== "request" ||
-        call.callee.object.type === AST_NODE_TYPES.Super ||
-        !mountedAggregateRoutes(call.callee.object)
-      ) {
-        return null;
-      }
-      const pathArgument = call.arguments[0];
-      if (!pathArgument || pathArgument.type === AST_NODE_TYPES.SpreadElement) {
-        return null;
-      }
-      const path = staticString(pathArgument);
-      return (
-        GLOBAL_SWEEP_BOUNDARIES.find((boundary) => {
-          return (
-            path === boundary.path || path?.startsWith(`${boundary.path}?`)
-          );
-        }) ?? null
-      );
-    }
-
-    function isAggregateContractClientMount(
+    function isAggregateAppFactoryMount(
       call: TSESTree.CallExpression,
     ): boolean {
-      return (
-        call.callee.type === AST_NODE_TYPES.CallExpression &&
-        mountedAggregateRoutes(call.callee)
+      if (!isAppFactory(call.callee)) {
+        return false;
+      }
+      const options = call.arguments[0];
+      return Boolean(
+        options &&
+        options.type !== AST_NODE_TYPES.SpreadElement &&
+        aggregateRoutesOption(options) === true,
       );
     }
 
@@ -451,13 +551,8 @@ export const noGlobalSweepTestRoutes = createRule({
       },
       "Program:exit"() {
         for (const call of calls) {
-          if (isAggregateContractClientMount(call)) {
+          if (isAggregateAppFactoryMount(call)) {
             reportAggregateRoutes(call);
-            continue;
-          }
-          const boundary = aggregateSweepBoundary(call);
-          if (boundary) {
-            report(call, boundary);
           }
         }
         for (const { boundary, specifier } of harnessBindings) {

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -267,6 +267,9 @@ export const noGlobalSweepTestRoutes = createRule({
       const definitions =
         variableInScope(context.sourceCode, expression)?.defs ?? [];
       for (const definition of definitions) {
+        if (definition.type === "Parameter") {
+          continue;
+        }
         const node = definition.node;
         if (
           node.type === AST_NODE_TYPES.ArrowFunctionExpression ||

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -1,0 +1,285 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { importReference } from "../syntax.ts";
+import { createRule } from "../utils.ts";
+
+interface GlobalSweepBoundary {
+  readonly exportName: string;
+  readonly moduleName: string;
+  readonly path: string;
+}
+
+const GLOBAL_SWEEP_BOUNDARIES: readonly GlobalSweepBoundary[] = [
+  {
+    exportName: "cronCleanupSandboxesRoutes",
+    moduleName: "cron-cleanup-sandboxes",
+    path: "/api/cron/cleanup-sandboxes",
+  },
+  {
+    exportName: "cronReconcileBillingEntitlementsRoutes",
+    moduleName: "cron-reconcile-billing-entitlements",
+    path: "/api/cron/reconcile-billing-entitlements",
+  },
+  {
+    exportName: "cronDrainEmailOutboxRoutes",
+    moduleName: "cron-drain-email-outbox",
+    path: "/api/cron/drain-email-outbox",
+  },
+  {
+    exportName: "cronBrowserReconcileRoutes",
+    moduleName: "cron-browser-reconcile",
+    path: "/api/cron/reconcile-browsers",
+  },
+  {
+    exportName: "cronConnectorOauthStateCleanupRoutes",
+    moduleName: "cron-connector-oauth-state-cleanup",
+    path: "/api/cron/connector-oauth-state-cleanup",
+  },
+  {
+    exportName: "cronComputerUseScreenshotCleanupRoutes",
+    moduleName: "cron-computer-use-screenshot-cleanup",
+    path: "/api/cron/computer-use-screenshot-cleanup",
+  },
+  {
+    exportName: "modelStatsRoutes",
+    moduleName: "model-stats",
+    path: "/api/cron/aggregate-model-stats",
+  },
+  {
+    exportName: "cronSyncSkillsRoutes",
+    moduleName: "cron-sync-skills",
+    path: "/api/cron/sync-skills",
+  },
+  {
+    exportName: "cronExecuteWorkflowAutomationsRoutes",
+    moduleName: "cron-execute-workflow-automations",
+    path: "/api/cron/execute-workflow-automations",
+  },
+];
+
+const CONTRACT_HARNESS_SUFFIX =
+  "/src/signals/routes/__tests__/global-sweep-contracts.test.ts";
+const PRODUCTION_ROUTE_SUFFIX = "/src/signals/route.ts";
+const CONTRACT_HELPER_SUFFIX =
+  "/signals/routes/__tests__/helpers/global-sweep-contract";
+const CONTRACT_HELPER_RELATIVE = "./helpers/global-sweep-contract";
+const UNAUTHORIZED_HELPERS = new Set([
+  "expectGlobalSweepMissingAuth",
+  "expectGlobalSweepWrongAuth",
+]);
+const REMOVED_INPUT_HELPER = "expectGlobalSweepRemovedInputRejected";
+const REMOVED_MODEL_STATS_WINDOW_PATH =
+  "/api/cron/aggregate-model-stats?hours=24";
+
+function normalizedFilename(filename: string): string {
+  return filename.replaceAll("\\", "/");
+}
+
+function moduleName(source: string): string {
+  const finalSegment = source.split("/").at(-1) ?? source;
+  return finalSegment.replace(/\.(?:[cm]?[jt]s)$/, "");
+}
+
+function boundaryForImport(
+  source: string,
+  importedName: string,
+): GlobalSweepBoundary | undefined {
+  const importedModule = moduleName(source);
+  return GLOBAL_SWEEP_BOUNDARIES.find((boundary) => {
+    return (
+      boundary.moduleName === importedModule &&
+      boundary.exportName === importedName
+    );
+  });
+}
+
+function boundariesForModule(source: string): readonly GlobalSweepBoundary[] {
+  const importedModule = moduleName(source);
+  return GLOBAL_SWEEP_BOUNDARIES.filter((boundary) => {
+    return boundary.moduleName === importedModule;
+  });
+}
+
+function staticString(
+  expression: TSESTree.CallExpressionArgument,
+): string | null {
+  if (
+    expression.type === AST_NODE_TYPES.Literal &&
+    typeof expression.value === "string"
+  ) {
+    return expression.value;
+  }
+  if (
+    expression.type === AST_NODE_TYPES.TemplateLiteral &&
+    expression.expressions.length === 0
+  ) {
+    return expression.quasis[0]?.value.cooked ?? null;
+  }
+  return null;
+}
+
+function isApprovedHarnessReference(
+  identifier: TSESTree.Identifier,
+  boundary: GlobalSweepBoundary,
+  context: Readonly<{ sourceCode: Parameters<typeof importReference>[0] }>,
+): boolean {
+  const call = identifier.parent;
+  if (
+    call.type !== AST_NODE_TYPES.CallExpression ||
+    call.arguments.length !== 3 ||
+    call.arguments[1] !== identifier ||
+    call.callee.type !== AST_NODE_TYPES.Identifier
+  ) {
+    return false;
+  }
+  const helper = importReference(context.sourceCode, call.callee);
+  if (
+    !helper ||
+    (helper.source !== CONTRACT_HELPER_RELATIVE &&
+      !helper.source.endsWith(CONTRACT_HELPER_SUFFIX)) ||
+    helper.importedName === "default"
+  ) {
+    return false;
+  }
+  const pathArgument = call.arguments[2];
+  if (!pathArgument || pathArgument.type === AST_NODE_TYPES.SpreadElement) {
+    return false;
+  }
+  const path = staticString(pathArgument);
+  if (UNAUTHORIZED_HELPERS.has(helper.importedName)) {
+    return path === boundary.path;
+  }
+  return (
+    helper.importedName === REMOVED_INPUT_HELPER &&
+    boundary.exportName === "modelStatsRoutes" &&
+    path === REMOVED_MODEL_STATS_WINDOW_PATH
+  );
+}
+
+export const noGlobalSweepTestRoutes = createRule({
+  name: "no-global-sweep-test-routes",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Keep API test correctness on fixture-scoped state routes instead of production-global sweeps",
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      globalSweep:
+        "Production-global route '{{ routeName }}' is not an approved correctness boundary. Use a fixture-scoped test route; contract coverage may pass it directly only to the fixed no-auth helper.",
+    },
+  },
+  create(context) {
+    const filename = normalizedFilename(context.filename);
+    const isProductionRoute = filename.endsWith(PRODUCTION_ROUTE_SUFFIX);
+    const isContractHarness = filename.endsWith(CONTRACT_HARNESS_SUFFIX);
+    const harnessBindings: {
+      readonly boundary: GlobalSweepBoundary;
+      readonly specifier: TSESTree.ImportSpecifier;
+    }[] = [];
+
+    function report(node: TSESTree.Node, boundary: GlobalSweepBoundary): void {
+      context.report({
+        node,
+        messageId: "globalSweep",
+        data: { routeName: boundary.exportName },
+      });
+    }
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        if (typeof node.source.value !== "string") {
+          return;
+        }
+        const moduleBoundaries = boundariesForModule(node.source.value);
+        if (moduleBoundaries.length === 0 || isProductionRoute) {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (specifier.type !== AST_NODE_TYPES.ImportSpecifier) {
+            const boundary = moduleBoundaries[0];
+            if (boundary) {
+              report(specifier, boundary);
+            }
+            continue;
+          }
+          const importedName =
+            specifier.imported.type === AST_NODE_TYPES.Identifier
+              ? specifier.imported.name
+              : String(specifier.imported.value);
+          const boundary = boundaryForImport(node.source.value, importedName);
+          if (!boundary) {
+            continue;
+          }
+          if (
+            !isContractHarness ||
+            specifier.local.name !== boundary.exportName
+          ) {
+            report(specifier, boundary);
+            continue;
+          }
+          harnessBindings.push({ boundary, specifier });
+        }
+      },
+      ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration) {
+        if (!node.source || typeof node.source.value !== "string") {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (specifier.type !== AST_NODE_TYPES.ExportSpecifier) {
+            continue;
+          }
+          const localName =
+            specifier.local.type === AST_NODE_TYPES.Identifier
+              ? specifier.local.name
+              : String(specifier.local.value);
+          const boundary = boundaryForImport(node.source.value, localName);
+          if (boundary && !isProductionRoute) {
+            report(specifier, boundary);
+          }
+        }
+      },
+      ExportAllDeclaration(node: TSESTree.ExportAllDeclaration) {
+        if (typeof node.source.value !== "string" || isProductionRoute) {
+          return;
+        }
+        const boundary = boundariesForModule(node.source.value)[0];
+        if (boundary) {
+          report(node, boundary);
+        }
+      },
+      ImportExpression(node: TSESTree.ImportExpression) {
+        if (
+          node.source.type !== AST_NODE_TYPES.Literal ||
+          typeof node.source.value !== "string" ||
+          isProductionRoute
+        ) {
+          return;
+        }
+        const boundary = boundariesForModule(node.source.value)[0];
+        if (boundary) {
+          report(node, boundary);
+        }
+      },
+      "Program:exit"() {
+        for (const { boundary, specifier } of harnessBindings) {
+          const variables = context.sourceCode.getDeclaredVariables(specifier);
+          for (const variable of variables) {
+            for (const reference of variable.references) {
+              const identifier = reference.identifier;
+              if (
+                identifier.type === AST_NODE_TYPES.Identifier &&
+                !isApprovedHarnessReference(identifier, boundary, context)
+              ) {
+                report(identifier, boundary);
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -67,9 +67,6 @@ const UNAUTHORIZED_HELPERS = new Set([
   "expectGlobalSweepMissingAuth",
   "expectGlobalSweepWrongAuth",
 ]);
-const REMOVED_INPUT_HELPER = "expectGlobalSweepRemovedInputRejected";
-const REMOVED_MODEL_STATS_WINDOW_PATH =
-  "/api/cron/aggregate-model-stats?hours=24";
 
 function normalizedFilename(filename: string): string {
   return filename.replaceAll("\\", "/");
@@ -146,13 +143,8 @@ function isApprovedHarnessReference(
     return false;
   }
   const path = staticString(pathArgument);
-  if (UNAUTHORIZED_HELPERS.has(helper.importedName)) {
-    return path === boundary.path;
-  }
   return (
-    helper.importedName === REMOVED_INPUT_HELPER &&
-    boundary.exportName === "modelStatsRoutes" &&
-    path === REMOVED_MODEL_STATS_WINDOW_PATH
+    UNAUTHORIZED_HELPERS.has(helper.importedName) && path === boundary.path
   );
 }
 

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -29,6 +29,12 @@ interface ParameterSource {
   readonly source: TSESTree.Expression;
 }
 
+type FactoryPropertyResolution =
+  | "canonical"
+  | "missing"
+  | "noncanonical"
+  | "unknown";
+
 interface GlobalSweepBoundary {
   readonly exportName: string;
   readonly moduleName: string;
@@ -562,10 +568,86 @@ export const noGlobalSweepTestRoutes = createRule({
         return true;
       }
       const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      if (definition?.type === "Parameter") {
+        const sources = parameterSources(current);
+        return sources.some(({ binding, source }) => {
+          return (
+            binding.property === null && isAppFactoryNamespace(source, nextSeen)
+          );
+        });
+      }
       return Boolean(
         definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
         definition.node.init &&
         isAppFactoryNamespace(definition.node.init, nextSeen),
+      );
+    }
+
+    function appFactoryProperty(
+      expression: TSESTree.Expression,
+      name: string,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): FactoryPropertyResolution {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return "unknown";
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (isAppFactoryNamespace(current, seen)) {
+        return "canonical";
+      }
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return appFactoryProperty(definition.node.init, name, nextSeen);
+        }
+        return importReference(context.sourceCode, current)
+          ? "noncanonical"
+          : "unknown";
+      }
+      if (current.type !== AST_NODE_TYPES.ObjectExpression) {
+        return "unknown";
+      }
+      for (const property of [...current.properties].reverse()) {
+        if (property.type === AST_NODE_TYPES.SpreadElement) {
+          const spread = appFactoryProperty(property.argument, name, nextSeen);
+          if (spread !== "missing") {
+            return spread;
+          }
+          continue;
+        }
+        if (
+          propertyName(property) === name &&
+          property.value.type !== AST_NODE_TYPES.AssignmentPattern
+        ) {
+          return isAppFactory(property.value as TSESTree.Expression, nextSeen)
+            ? "canonical"
+            : "noncanonical";
+        }
+      }
+      return "missing";
+    }
+
+    function isAppFactoryObjectBinding(
+      source: TSESTree.Expression,
+      binding: ObjectBinding,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      if (!binding.property || !APP_FACTORIES.has(binding.property)) {
+        return false;
+      }
+      const resolution = appFactoryProperty(source, binding.property, seen);
+      if (resolution === "canonical") {
+        return true;
+      }
+      return Boolean(
+        resolution === "missing" &&
+        binding.defaultValue &&
+        isAppFactory(binding.defaultValue, seen),
       );
     }
 
@@ -598,6 +680,14 @@ export const noGlobalSweepTestRoutes = createRule({
       }
       const definition = variableInScope(context.sourceCode, expression)
         ?.defs[0];
+      if (definition?.type === "Parameter") {
+        const sources = parameterSources(expression);
+        return sources.some(({ binding, source }) => {
+          return binding.property === null
+            ? isAppFactory(source, nextSeen)
+            : isAppFactoryObjectBinding(source, binding, nextSeen);
+        });
+      }
       if (
         definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
         definition.node.init &&

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -1,6 +1,12 @@
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
-import { importReference } from "../syntax.ts";
+import {
+  importReference,
+  memberName,
+  propertyName,
+  unwrapExpression,
+  variableInScope,
+} from "../syntax.ts";
 import { createRule } from "../utils.ts";
 
 interface GlobalSweepBoundary {
@@ -67,9 +73,30 @@ const UNAUTHORIZED_HELPERS = new Set([
   "expectGlobalSweepMissingAuth",
   "expectGlobalSweepWrongAuth",
 ]);
+const APP_FACTORIES = new Set(["createApp", "createAppWithRoutes", "setupApp"]);
 
 function normalizedFilename(filename: string): string {
   return filename.replaceAll("\\", "/");
+}
+
+function resolvesToProductionRoute(filename: string, source: string): boolean {
+  const normalizedSource = source.replace(/\.(?:[cm]?[jt]s)$/u, "");
+  if (!normalizedSource.startsWith(".")) {
+    return normalizedSource.endsWith("/src/signals/route");
+  }
+  const segments = normalizedFilename(filename).split("/");
+  segments.pop();
+  for (const segment of normalizedSource.split("/")) {
+    if (segment === "." || segment === "") {
+      continue;
+    }
+    if (segment === "..") {
+      segments.pop();
+    } else {
+      segments.push(segment);
+    }
+  }
+  return segments.join("/").endsWith("/src/signals/route");
 }
 
 function moduleName(source: string): string {
@@ -172,6 +199,7 @@ export const noGlobalSweepTestRoutes = createRule({
       readonly boundary: GlobalSweepBoundary;
       readonly specifier: TSESTree.ImportSpecifier;
     }[] = [];
+    const calls: TSESTree.CallExpression[] = [];
 
     function report(node: TSESTree.Node, boundary: GlobalSweepBoundary): void {
       context.report({
@@ -179,6 +207,151 @@ export const noGlobalSweepTestRoutes = createRule({
         messageId: "globalSweep",
         data: { routeName: boundary.exportName },
       });
+    }
+
+    function isAggregateRoutes(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const imported = importReference(context.sourceCode, current);
+        if (
+          imported?.importedName === "ROUTES" &&
+          resolvesToProductionRoute(filename, imported.source)
+        ) {
+          return true;
+        }
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        return Boolean(
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          isAggregateRoutes(definition.node.init, nextSeen),
+        );
+      }
+      if (
+        current.type === AST_NODE_TYPES.MemberExpression &&
+        memberName(current) === "ROUTES" &&
+        current.object.type === AST_NODE_TYPES.Identifier
+      ) {
+        const imported = importReference(context.sourceCode, current.object);
+        return Boolean(
+          imported?.importedName === "*" &&
+          resolvesToProductionRoute(filename, imported.source),
+        );
+      }
+      if (current.type === AST_NODE_TYPES.ArrayExpression) {
+        return current.elements.some((element) => {
+          return Boolean(
+            element &&
+            isAggregateRoutes(
+              element.type === AST_NODE_TYPES.SpreadElement
+                ? element.argument
+                : element,
+              nextSeen,
+            ),
+          );
+        });
+      }
+      return false;
+    }
+
+    function isAppFactory(
+      expression: TSESTree.CallExpression["callee"],
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      if (
+        seen.has(expression) ||
+        expression.type !== AST_NODE_TYPES.Identifier
+      ) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(expression);
+      const imported = importReference(context.sourceCode, expression);
+      if (
+        (imported && APP_FACTORIES.has(imported.importedName)) ||
+        APP_FACTORIES.has(expression.name)
+      ) {
+        return true;
+      }
+      const definition = variableInScope(context.sourceCode, expression)
+        ?.defs[0];
+      return Boolean(
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init &&
+        isAppFactory(definition.node.init, nextSeen),
+      );
+    }
+
+    function mountedAggregateRoutes(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        return Boolean(
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          mountedAggregateRoutes(definition.node.init, nextSeen),
+        );
+      }
+      if (current.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      if (isAppFactory(current.callee)) {
+        const options = current.arguments[0];
+        if (!options || options.type !== AST_NODE_TYPES.ObjectExpression) {
+          return false;
+        }
+        return options.properties.some((property) => {
+          return (
+            property.type === AST_NODE_TYPES.Property &&
+            propertyName(property) === "routes" &&
+            property.value.type !== AST_NODE_TYPES.AssignmentPattern &&
+            isAggregateRoutes(property.value as TSESTree.Expression)
+          );
+        });
+      }
+      return (
+        current.callee.type === AST_NODE_TYPES.CallExpression &&
+        mountedAggregateRoutes(current.callee, nextSeen)
+      );
+    }
+
+    function aggregateSweepBoundary(
+      call: TSESTree.CallExpression,
+    ): GlobalSweepBoundary | null {
+      if (
+        call.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(call.callee) !== "request" ||
+        call.callee.object.type === AST_NODE_TYPES.Super ||
+        !mountedAggregateRoutes(call.callee.object)
+      ) {
+        return null;
+      }
+      const pathArgument = call.arguments[0];
+      if (!pathArgument || pathArgument.type === AST_NODE_TYPES.SpreadElement) {
+        return null;
+      }
+      const path = staticString(pathArgument);
+      return (
+        GLOBAL_SWEEP_BOUNDARIES.find((boundary) => {
+          return (
+            path === boundary.path || path?.startsWith(`${boundary.path}?`)
+          );
+        }) ?? null
+      );
     }
 
     return {
@@ -256,7 +429,16 @@ export const noGlobalSweepTestRoutes = createRule({
           report(node, boundary);
         }
       },
+      CallExpression(node: TSESTree.CallExpression) {
+        calls.push(node);
+      },
       "Program:exit"() {
+        for (const call of calls) {
+          const boundary = aggregateSweepBoundary(call);
+          if (boundary) {
+            report(call, boundary);
+          }
+        }
         for (const { boundary, specifier } of harnessBindings) {
           const variables = context.sourceCode.getDeclaredVariables(specifier);
           for (const variable of variables) {

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -14,6 +14,21 @@ type FunctionNode =
   | TSESTree.FunctionDeclaration
   | TSESTree.FunctionExpression;
 
+interface ObjectBinding {
+  readonly defaultValue: TSESTree.Expression | null;
+  readonly property: string | null;
+}
+
+interface ParameterBinding extends ObjectBinding {
+  readonly index: number;
+  readonly parameterDefault: TSESTree.Expression | null;
+}
+
+interface ParameterSource {
+  readonly binding: ParameterBinding;
+  readonly source: TSESTree.Expression;
+}
+
 interface GlobalSweepBoundary {
   readonly exportName: string;
   readonly moduleName: string;
@@ -79,6 +94,15 @@ const UNAUTHORIZED_HELPERS = new Set([
   "expectGlobalSweepWrongAuth",
 ]);
 const APP_FACTORIES = new Set(["createApp", "createAppWithRoutes", "setupApp"]);
+
+function isCanonicalAppFactoryModule(source: string): boolean {
+  const normalizedSource = source.replace(/\.(?:[cm]?[jt]s)$/u, "");
+  return (
+    normalizedSource.endsWith("/app-factory") ||
+    normalizedSource.endsWith("/app-factory-core") ||
+    normalizedSource.endsWith("/__tests__/test-helpers")
+  );
+}
 
 function normalizedFilename(filename: string): string {
   return filename.replaceAll("\\", "/");
@@ -282,39 +306,103 @@ export const noGlobalSweepTestRoutes = createRule({
       return null;
     }
 
-    function parameterIndex(node: FunctionNode, name: string): number {
-      return node.params.findIndex((rawParameter) => {
+    function objectBinding(
+      pattern: TSESTree.ObjectPattern,
+      name: string,
+    ): ObjectBinding | null {
+      for (const entry of pattern.properties) {
+        if (entry.type !== AST_NODE_TYPES.Property) {
+          continue;
+        }
+        if (
+          entry.value.type === AST_NODE_TYPES.Identifier &&
+          entry.value.name === name
+        ) {
+          return { defaultValue: null, property: propertyName(entry) };
+        }
+        if (
+          entry.value.type === AST_NODE_TYPES.AssignmentPattern &&
+          entry.value.left.type === AST_NODE_TYPES.Identifier &&
+          entry.value.left.name === name
+        ) {
+          return {
+            defaultValue: entry.value.right,
+            property: propertyName(entry),
+          };
+        }
+      }
+      return null;
+    }
+
+    function parameterBinding(
+      node: FunctionNode,
+      name: string,
+    ): ParameterBinding | null {
+      for (const [index, rawParameter] of node.params.entries()) {
         const parameter =
           rawParameter.type === AST_NODE_TYPES.AssignmentPattern
             ? rawParameter.left
             : rawParameter;
-        return (
+        const parameterDefault =
+          rawParameter.type === AST_NODE_TYPES.AssignmentPattern
+            ? rawParameter.right
+            : null;
+        if (
           parameter.type === AST_NODE_TYPES.Identifier &&
           parameter.name === name
-        );
-      });
+        ) {
+          return {
+            defaultValue: null,
+            index,
+            parameterDefault,
+            property: null,
+          };
+        }
+        if (parameter.type !== AST_NODE_TYPES.ObjectPattern) {
+          continue;
+        }
+        const binding = objectBinding(parameter, name);
+        if (binding) {
+          return { ...binding, index, parameterDefault };
+        }
+      }
+      return null;
     }
 
-    function argumentsForParameter(
+    function parameterSources(
       identifier: TSESTree.Identifier,
-    ): readonly TSESTree.Expression[] {
+    ): readonly ParameterSource[] {
       const owner = parameterOwner(identifier);
       if (!owner) {
         return [];
       }
-      const index = parameterIndex(owner, identifier.name);
-      if (index < 0) {
+      const binding = parameterBinding(owner, identifier.name);
+      if (!binding) {
         return [];
       }
       return calls.flatMap((call) => {
         if (localFunctionForCallee(call.callee) !== owner) {
           return [];
         }
-        const argument = call.arguments[index];
-        return argument && argument.type !== AST_NODE_TYPES.SpreadElement
-          ? [argument]
-          : [];
+        const argument = call.arguments[binding.index];
+        const source =
+          argument && argument.type !== AST_NODE_TYPES.SpreadElement
+            ? argument
+            : binding.parameterDefault;
+        return source ? [{ binding, source }] : [];
       });
+    }
+
+    function aggregateObjectBinding(
+      source: TSESTree.Expression,
+      defaultValue: TSESTree.Expression | null,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      const resolution = aggregateRoutesOption(source, seen);
+      if (resolution !== null) {
+        return resolution;
+      }
+      return Boolean(defaultValue && isAggregateRoutes(defaultValue, seen));
     }
 
     function isAggregateRoutes(
@@ -341,25 +429,24 @@ export const noGlobalSweepTestRoutes = createRule({
           definition.node.init &&
           definition.node.id.type === AST_NODE_TYPES.ObjectPattern
         ) {
-          const destructured = definition.node.id.properties.find((entry) => {
-            return (
-              entry.type === AST_NODE_TYPES.Property &&
-              entry.value.type === AST_NODE_TYPES.Identifier &&
-              entry.value.name === current.name
-            );
-          });
-          if (
-            destructured?.type === AST_NODE_TYPES.Property &&
-            propertyName(destructured) === "routes"
-          ) {
-            return (
-              aggregateRoutesOption(definition.node.init, nextSeen) === true
+          const binding = objectBinding(definition.node.id, current.name);
+          if (binding?.property === "routes") {
+            return aggregateObjectBinding(
+              definition.node.init,
+              binding.defaultValue,
+              nextSeen,
             );
           }
         }
         if (definition?.type === "Parameter") {
-          return argumentsForParameter(current).some((argument) => {
-            return isAggregateRoutes(argument, nextSeen);
+          return parameterSources(current).some(({ binding, source }) => {
+            if (binding.property === null) {
+              return isAggregateRoutes(source, nextSeen);
+            }
+            return (
+              binding.property === "routes" &&
+              aggregateObjectBinding(source, binding.defaultValue, nextSeen)
+            );
           });
         }
         return Boolean(
@@ -419,9 +506,11 @@ export const noGlobalSweepTestRoutes = createRule({
           return aggregateRoutesOption(definition.node.init, nextSeen);
         }
         if (definition?.type === "Parameter") {
-          const resolutions = argumentsForParameter(current).map((argument) => {
-            return aggregateRoutesOption(argument, nextSeen);
-          });
+          const resolutions = parameterSources(current)
+            .filter(({ binding }) => binding.property === null)
+            .map(({ source }) => {
+              return aggregateRoutesOption(source, nextSeen);
+            });
           if (resolutions.some((resolution) => resolution === true)) {
             return true;
           }
@@ -456,17 +545,50 @@ export const noGlobalSweepTestRoutes = createRule({
       return null;
     }
 
+    function isAppFactoryNamespace(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current) || current.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      const imported = importReference(context.sourceCode, current);
+      if (
+        imported?.importedName === "*" &&
+        isCanonicalAppFactoryModule(imported.source)
+      ) {
+        return true;
+      }
+      const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      return Boolean(
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init &&
+        isAppFactoryNamespace(definition.node.init, nextSeen),
+      );
+    }
+
     function isAppFactory(
       expression: TSESTree.CallExpression["callee"],
       seen: ReadonlySet<TSESTree.Node> = new Set(),
     ): boolean {
-      if (
-        seen.has(expression) ||
-        expression.type !== AST_NODE_TYPES.Identifier
-      ) {
+      if (seen.has(expression)) {
         return false;
       }
       const nextSeen = new Set(seen).add(expression);
+      if (expression.type === AST_NODE_TYPES.MemberExpression) {
+        const name = memberName(expression);
+        return Boolean(
+          name &&
+          APP_FACTORIES.has(name) &&
+          expression.object.type !== AST_NODE_TYPES.Super &&
+          isAppFactoryNamespace(expression.object, nextSeen),
+        );
+      }
+      if (expression.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
       const imported = importReference(context.sourceCode, expression);
       if (
         (imported && APP_FACTORIES.has(imported.importedName)) ||
@@ -476,6 +598,20 @@ export const noGlobalSweepTestRoutes = createRule({
       }
       const definition = variableInScope(context.sourceCode, expression)
         ?.defs[0];
+      if (
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init &&
+        definition.node.id.type === AST_NODE_TYPES.ObjectPattern
+      ) {
+        const binding = objectBinding(definition.node.id, expression.name);
+        if (
+          binding?.property &&
+          APP_FACTORIES.has(binding.property) &&
+          isAppFactoryNamespace(definition.node.init, nextSeen)
+        ) {
+          return true;
+        }
+      }
       return Boolean(
         definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
         definition.node.init &&

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -34,6 +34,7 @@ type FactoryPropertyResolution =
   | "missing"
   | "noncanonical"
   | "unknown";
+type FactoryValueKind = "factory" | "namespace";
 
 interface GlobalSweepBoundary {
   readonly exportName: string;
@@ -572,7 +573,13 @@ export const noGlobalSweepTestRoutes = createRule({
         const sources = parameterSources(current);
         return sources.some(({ binding, source }) => {
           return (
-            binding.property === null && isAppFactoryNamespace(source, nextSeen)
+            factoryBindingResolution(
+              source,
+              binding,
+              [],
+              "namespace",
+              nextSeen,
+            ) === "canonical"
           );
         });
       }
@@ -583,17 +590,77 @@ export const noGlobalSweepTestRoutes = createRule({
       );
     }
 
-    function appFactoryProperty(
+    function combineFactoryResolutions(
+      resolutions: readonly FactoryPropertyResolution[],
+    ): FactoryPropertyResolution {
+      if (resolutions.some((resolution) => resolution === "canonical")) {
+        return "canonical";
+      }
+      if (
+        resolutions.length > 0 &&
+        resolutions.every((resolution) => resolution === "missing")
+      ) {
+        return "missing";
+      }
+      if (resolutions.some((resolution) => resolution === "unknown")) {
+        return "unknown";
+      }
+      return resolutions.length > 0 ? "noncanonical" : "unknown";
+    }
+
+    function factoryBindingResolution(
+      source: TSESTree.Expression,
+      binding: ObjectBinding,
+      remainingPath: readonly string[],
+      kind: FactoryValueKind,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): FactoryPropertyResolution {
+      if (binding.property === null) {
+        return factoryPathResolution(source, remainingPath, kind, seen);
+      }
+      const resolution = factoryPathResolution(
+        source,
+        [binding.property, ...remainingPath],
+        kind,
+        seen,
+      );
+      if (resolution !== "missing" || !binding.defaultValue) {
+        return resolution;
+      }
+      return factoryPathResolution(
+        binding.defaultValue,
+        remainingPath,
+        kind,
+        seen,
+      );
+    }
+
+    function factoryPathResolution(
       expression: TSESTree.Expression,
-      name: string,
+      path: readonly string[],
+      kind: FactoryValueKind,
       seen: ReadonlySet<TSESTree.Node> = new Set(),
     ): FactoryPropertyResolution {
+      if (path.length === 0) {
+        const isCanonical =
+          kind === "namespace"
+            ? isAppFactoryNamespace(expression, seen)
+            : isAppFactory(expression, seen);
+        return isCanonical ? "canonical" : "noncanonical";
+      }
       const current = unwrapExpression(expression);
       if (seen.has(current)) {
         return "unknown";
       }
       const nextSeen = new Set(seen).add(current);
-      if (isAppFactoryNamespace(current, seen)) {
+      const [name, ...remainingPath] = path;
+      if (
+        name &&
+        remainingPath.length === 0 &&
+        kind === "factory" &&
+        APP_FACTORIES.has(name) &&
+        isAppFactoryNamespace(current, seen)
+      ) {
         return "canonical";
       }
       if (current.type === AST_NODE_TYPES.Identifier) {
@@ -603,7 +670,38 @@ export const noGlobalSweepTestRoutes = createRule({
           definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
           definition.node.init
         ) {
-          return appFactoryProperty(definition.node.init, name, nextSeen);
+          if (definition.node.id.type === AST_NODE_TYPES.ObjectPattern) {
+            const binding = objectBinding(definition.node.id, current.name);
+            return binding
+              ? factoryBindingResolution(
+                  definition.node.init,
+                  binding,
+                  path,
+                  kind,
+                  nextSeen,
+                )
+              : "unknown";
+          }
+          return factoryPathResolution(
+            definition.node.init,
+            path,
+            kind,
+            nextSeen,
+          );
+        }
+        if (definition?.type === "Parameter") {
+          const resolutions = parameterSources(current).map(
+            ({ binding, source }) => {
+              return factoryBindingResolution(
+                source,
+                binding,
+                path,
+                kind,
+                nextSeen,
+              );
+            },
+          );
+          return combineFactoryResolutions(resolutions);
         }
         return importReference(context.sourceCode, current)
           ? "noncanonical"
@@ -614,7 +712,12 @@ export const noGlobalSweepTestRoutes = createRule({
       }
       for (const property of [...current.properties].reverse()) {
         if (property.type === AST_NODE_TYPES.SpreadElement) {
-          const spread = appFactoryProperty(property.argument, name, nextSeen);
+          const spread = factoryPathResolution(
+            property.argument,
+            path,
+            kind,
+            nextSeen,
+          );
           if (spread !== "missing") {
             return spread;
           }
@@ -624,31 +727,15 @@ export const noGlobalSweepTestRoutes = createRule({
           propertyName(property) === name &&
           property.value.type !== AST_NODE_TYPES.AssignmentPattern
         ) {
-          return isAppFactory(property.value as TSESTree.Expression, nextSeen)
-            ? "canonical"
-            : "noncanonical";
+          return factoryPathResolution(
+            property.value as TSESTree.Expression,
+            remainingPath,
+            kind,
+            nextSeen,
+          );
         }
       }
       return "missing";
-    }
-
-    function isAppFactoryObjectBinding(
-      source: TSESTree.Expression,
-      binding: ObjectBinding,
-      seen: ReadonlySet<TSESTree.Node>,
-    ): boolean {
-      if (!binding.property || !APP_FACTORIES.has(binding.property)) {
-        return false;
-      }
-      const resolution = appFactoryProperty(source, binding.property, seen);
-      if (resolution === "canonical") {
-        return true;
-      }
-      return Boolean(
-        resolution === "missing" &&
-        binding.defaultValue &&
-        isAppFactory(binding.defaultValue, seen),
-      );
     }
 
     function isAppFactory(
@@ -683,9 +770,15 @@ export const noGlobalSweepTestRoutes = createRule({
       if (definition?.type === "Parameter") {
         const sources = parameterSources(expression);
         return sources.some(({ binding, source }) => {
-          return binding.property === null
-            ? isAppFactory(source, nextSeen)
-            : isAppFactoryObjectBinding(source, binding, nextSeen);
+          return (
+            factoryBindingResolution(
+              source,
+              binding,
+              [],
+              "factory",
+              nextSeen,
+            ) === "canonical"
+          );
         });
       }
       if (
@@ -695,9 +788,14 @@ export const noGlobalSweepTestRoutes = createRule({
       ) {
         const binding = objectBinding(definition.node.id, expression.name);
         if (
-          binding?.property &&
-          APP_FACTORIES.has(binding.property) &&
-          isAppFactoryNamespace(definition.node.init, nextSeen)
+          binding &&
+          factoryBindingResolution(
+            definition.node.init,
+            binding,
+            [],
+            "factory",
+            nextSeen,
+          ) === "canonical"
         ) {
           return true;
         }

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -611,6 +611,24 @@ export const noGlobalSweepTestRoutes = createRule({
       return resolutions.length > 0 ? "noncanonical" : "unknown";
     }
 
+    function isStaticallyUndefined(expression: TSESTree.Expression): boolean {
+      const current = unwrapExpression(expression);
+      if (
+        current.type === AST_NODE_TYPES.UnaryExpression &&
+        current.operator === "void"
+      ) {
+        return true;
+      }
+      if (
+        current.type !== AST_NODE_TYPES.Identifier ||
+        current.name !== "undefined"
+      ) {
+        return false;
+      }
+      const variable = variableInScope(context.sourceCode, current);
+      return !variable || variable.defs.length === 0;
+    }
+
     function factoryBindingResolution(
       source: TSESTree.Expression,
       binding: ObjectBinding,
@@ -644,18 +662,30 @@ export const noGlobalSweepTestRoutes = createRule({
       kind: FactoryValueKind,
       seen: ReadonlySet<TSESTree.Node> = new Set(),
     ): FactoryPropertyResolution {
-      if (path.length === 0) {
-        const isCanonical =
-          kind === "namespace"
-            ? isAppFactoryNamespace(expression, seen)
-            : isAppFactory(expression, seen);
-        return isCanonical ? "canonical" : "noncanonical";
-      }
       const current = unwrapExpression(expression);
       if (seen.has(current)) {
         return "unknown";
       }
       const nextSeen = new Set(seen).add(current);
+      if (path.length === 0) {
+        if (isStaticallyUndefined(current)) {
+          return "missing";
+        }
+        if (
+          current.type === AST_NODE_TYPES.MemberExpression &&
+          current.object.type !== AST_NODE_TYPES.Super
+        ) {
+          const name = memberName(current);
+          return name
+            ? factoryPathResolution(current.object, [name], kind, nextSeen)
+            : "unknown";
+        }
+        const isCanonical =
+          kind === "namespace"
+            ? isAppFactoryNamespace(current, seen)
+            : isAppFactory(current, seen);
+        return isCanonical ? "canonical" : "noncanonical";
+      }
       const [name, ...remainingPath] = path;
       if (
         name &&

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -4,6 +4,7 @@ import {
   importReference,
   memberName,
   propertyName,
+  resolveLocalExpression,
   unwrapExpression,
   variableInScope,
 } from "../syntax.ts";
@@ -619,7 +620,7 @@ export const noGlobalSweepTestRoutes = createRule({
     }
 
     function isStaticallyUndefined(expression: TSESTree.Expression): boolean {
-      const current = unwrapExpression(expression);
+      const current = resolveLocalExpression(context.sourceCode, expression);
       if (
         current.type === AST_NODE_TYPES.UnaryExpression &&
         current.operator === "void"

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -33,6 +33,7 @@ type FactoryPropertyResolution =
   | "canonical"
   | "missing"
   | "noncanonical"
+  | "undefined"
   | "unknown";
 type FactoryValueKind = "factory" | "namespace";
 
@@ -395,9 +396,15 @@ export const noGlobalSweepTestRoutes = createRule({
           return [];
         }
         const argument = call.arguments[binding.index];
-        const source =
+        const explicitArgument =
           argument && argument.type !== AST_NODE_TYPES.SpreadElement
             ? argument
+            : null;
+        const source =
+          explicitArgument &&
+          (!binding.parameterDefault ||
+            !isStaticallyUndefined(explicitArgument))
+            ? explicitArgument
             : binding.parameterDefault;
         return source ? [{ binding, source }] : [];
       });
@@ -599,10 +606,10 @@ export const noGlobalSweepTestRoutes = createRule({
       if (resolutions.some((resolution) => resolution === "canonical")) {
         return "canonical";
       }
-      if (
-        resolutions.length > 0 &&
-        resolutions.every((resolution) => resolution === "missing")
-      ) {
+      if (resolutions.some((resolution) => resolution === "undefined")) {
+        return "undefined";
+      }
+      if (resolutions.some((resolution) => resolution === "missing")) {
         return "missing";
       }
       if (resolutions.some((resolution) => resolution === "unknown")) {
@@ -645,7 +652,10 @@ export const noGlobalSweepTestRoutes = createRule({
         kind,
         seen,
       );
-      if (resolution !== "missing" || !binding.defaultValue) {
+      if (
+        (resolution !== "missing" && resolution !== "undefined") ||
+        !binding.defaultValue
+      ) {
         return resolution;
       }
       return factoryPathResolution(
@@ -669,7 +679,7 @@ export const noGlobalSweepTestRoutes = createRule({
       const nextSeen = new Set(seen).add(current);
       if (path.length === 0) {
         if (isStaticallyUndefined(current)) {
-          return "missing";
+          return "undefined";
         }
         if (
           current.type === AST_NODE_TYPES.MemberExpression &&

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -209,6 +209,14 @@ export const noGlobalSweepTestRoutes = createRule({
       });
     }
 
+    function reportAggregateRoutes(node: TSESTree.Node): void {
+      context.report({
+        node,
+        messageId: "globalSweep",
+        data: { routeName: "ROUTES" },
+      });
+    }
+
     function isAggregateRoutes(
       expression: TSESTree.Expression,
       seen: ReadonlySet<TSESTree.Node> = new Set(),
@@ -354,6 +362,15 @@ export const noGlobalSweepTestRoutes = createRule({
       );
     }
 
+    function isAggregateContractClientMount(
+      call: TSESTree.CallExpression,
+    ): boolean {
+      return (
+        call.callee.type === AST_NODE_TYPES.CallExpression &&
+        mountedAggregateRoutes(call.callee)
+      );
+    }
+
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
         if (typeof node.source.value !== "string") {
@@ -434,6 +451,10 @@ export const noGlobalSweepTestRoutes = createRule({
       },
       "Program:exit"() {
         for (const call of calls) {
+          if (isAggregateContractClientMount(call)) {
+            reportAggregateRoutes(call);
+            continue;
+          }
           const boundary = aggregateSweepBoundary(call);
           if (boundary) {
             report(call, boundary);

--- a/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-global-sweep-test-routes.ts
@@ -336,6 +336,27 @@ export const noGlobalSweepTestRoutes = createRule({
         }
         const definition = variableInScope(context.sourceCode, current)
           ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          definition.node.id.type === AST_NODE_TYPES.ObjectPattern
+        ) {
+          const destructured = definition.node.id.properties.find((entry) => {
+            return (
+              entry.type === AST_NODE_TYPES.Property &&
+              entry.value.type === AST_NODE_TYPES.Identifier &&
+              entry.value.name === current.name
+            );
+          });
+          if (
+            destructured?.type === AST_NODE_TYPES.Property &&
+            propertyName(destructured) === "routes"
+          ) {
+            return (
+              aggregateRoutesOption(definition.node.init, nextSeen) === true
+            );
+          }
+        }
         if (definition?.type === "Parameter") {
           return argumentsForParameter(current).some((argument) => {
             return isAggregateRoutes(argument, nextSeen);
@@ -347,16 +368,21 @@ export const noGlobalSweepTestRoutes = createRule({
           isAggregateRoutes(definition.node.init, nextSeen),
         );
       }
-      if (
-        current.type === AST_NODE_TYPES.MemberExpression &&
-        memberName(current) === "ROUTES" &&
-        current.object.type === AST_NODE_TYPES.Identifier
-      ) {
-        const imported = importReference(context.sourceCode, current.object);
-        return Boolean(
-          imported?.importedName === "*" &&
-          resolvesToProductionRoute(filename, imported.source),
-        );
+      if (current.type === AST_NODE_TYPES.MemberExpression) {
+        const name = memberName(current);
+        if (
+          name === "ROUTES" &&
+          current.object.type === AST_NODE_TYPES.Identifier
+        ) {
+          const imported = importReference(context.sourceCode, current.object);
+          return Boolean(
+            imported?.importedName === "*" &&
+            resolvesToProductionRoute(filename, imported.source),
+          );
+        }
+        if (name === "routes" && current.object.type !== AST_NODE_TYPES.Super) {
+          return aggregateRoutesOption(current.object, nextSeen) === true;
+        }
       }
       if (current.type === AST_NODE_TYPES.ArrayExpression) {
         return current.elements.some((element) => {

--- a/turbo/packages/eslint-rules/src/api/rules/no-legacy-shared-state-markers.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-legacy-shared-state-markers.ts
@@ -1,0 +1,51 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.ts";
+
+const LEGACY_MARKERS = [
+  "threadless-run-cleanup-integration-test",
+  "threadlessRunCleanupIntegrationTest",
+  "withThreadlessRunCleanupTestLock",
+  "restore-storage-state",
+  "restoreStorageState",
+  "seed-storage-version",
+  "seedStorageVersion",
+  "delete-storage-version",
+  "deleteStorageVersion",
+  "SOLE OWNER",
+  "resetSecretKmsClientForTests",
+  "clearTeamsBotAuthCacheForTest",
+] as const;
+
+export const noLegacySharedStateMarkers = createRule({
+  name: "no-legacy-shared-state-markers",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Prevent deleted API test locks, shared storage restore markers, and process-cache resets from returning",
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      legacyMarker:
+        "Deleted shared-state convention '{{ marker }}' must not return. Use uniquely owned fixture state and scoped overrides instead.",
+    },
+  },
+  create(context) {
+    return {
+      Program(node: TSESTree.Program) {
+        for (const marker of LEGACY_MARKERS) {
+          if (context.sourceCode.text.includes(marker)) {
+            context.report({
+              node,
+              messageId: "legacyMarker",
+              data: { marker },
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
@@ -1,0 +1,359 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import {
+  importReference,
+  memberName,
+  propertyName,
+  unwrapExpression,
+  variableInScope,
+} from "../syntax.ts";
+import { createRule } from "../utils.ts";
+
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+type MutationKind = "delete" | "grant" | "upsert";
+
+const PRODUCTION_STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+
+function enclosingFunction(node: TSESTree.Node): FunctionNode | null {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      current.type === AST_NODE_TYPES.FunctionDeclaration ||
+      current.type === AST_NODE_TYPES.FunctionExpression
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function functionName(node: FunctionNode): string | null {
+  if (node.type === AST_NODE_TYPES.FunctionDeclaration) {
+    return node.id?.name ?? null;
+  }
+  if (node.id) {
+    return node.id.name;
+  }
+  if (
+    node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+    node.parent.id.type === AST_NODE_TYPES.Identifier
+  ) {
+    return node.parent.id.name;
+  }
+  return null;
+}
+
+function parameterIndex(node: FunctionNode, name: string): number {
+  return node.params.findIndex((parameter) => {
+    return (
+      parameter.type === AST_NODE_TYPES.Identifier && parameter.name === name
+    );
+  });
+}
+
+function isEntitlementFixtureModule(source: string): boolean {
+  return (
+    source.endsWith("/test-fixtures/org-plan-entitlement") ||
+    source.endsWith("/test-fixtures/org-plan-entitlement.ts")
+  );
+}
+
+export const noProductionStaffEntitlementMutation = createRule({
+  name: "no-production-staff-entitlement-mutation",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Keep the fixed production staff organization identity read-only in API tests",
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      productionStaffMutation:
+        "Do not mutate entitlements for the fixed production staff organization. Use createUniqueStaffOrgIdFixture() or another test-owned organization.",
+    },
+  },
+  create(context) {
+    const calls: TSESTree.CallExpression[] = [];
+    const functionReturns = new Map<FunctionNode, TSESTree.Expression[]>();
+
+    function callsTo(node: FunctionNode): readonly TSESTree.CallExpression[] {
+      const name = functionName(node);
+      if (!name) {
+        return [];
+      }
+      return calls.filter((call) => {
+        return (
+          call.callee.type === AST_NODE_TYPES.Identifier &&
+          call.callee.name === name
+        );
+      });
+    }
+
+    function expressionProperty(
+      expression: TSESTree.Expression,
+      name: string,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): TSESTree.Expression | null {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return null;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.ObjectExpression) {
+        for (const property of current.properties) {
+          if (
+            property.type === AST_NODE_TYPES.Property &&
+            propertyName(property) === name &&
+            property.value.type !== AST_NODE_TYPES.AssignmentPattern
+          ) {
+            return property.value as TSESTree.Expression;
+          }
+          if (property.type === AST_NODE_TYPES.SpreadElement) {
+            const nested = expressionProperty(
+              property.argument,
+              name,
+              nextSeen,
+            );
+            if (nested) {
+              return nested;
+            }
+          }
+        }
+      }
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return expressionProperty(definition.node.init, name, nextSeen);
+        }
+      }
+      return null;
+    }
+
+    function parameterResolvesToStaff(
+      identifier: TSESTree.Identifier,
+      property: "actor" | "orgId",
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      const owner = enclosingFunction(identifier);
+      if (!owner) {
+        return false;
+      }
+      const index = parameterIndex(owner, identifier.name);
+      if (index < 0) {
+        return false;
+      }
+      return callsTo(owner).some((call) => {
+        const argument = call.arguments[index];
+        if (!argument || argument.type === AST_NODE_TYPES.SpreadElement) {
+          return false;
+        }
+        return property === "actor"
+          ? isStaffActor(argument, seen)
+          : isStaffOrgId(argument, seen);
+      });
+    }
+
+    function isStaffOrgId(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (
+        current.type === AST_NODE_TYPES.Literal &&
+        current.value === PRODUCTION_STAFF_ORG_ID
+      ) {
+        return true;
+      }
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isStaffOrgId(definition.node.init, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          return parameterResolvesToStaff(current, "orgId", nextSeen);
+        }
+        return false;
+      }
+      if (
+        current.type === AST_NODE_TYPES.MemberExpression &&
+        memberName(current) === "orgId"
+      ) {
+        return isStaffActor(current.object, nextSeen);
+      }
+      if (current.type === AST_NODE_TYPES.ConditionalExpression) {
+        return (
+          isStaffOrgId(current.consequent, nextSeen) ||
+          isStaffOrgId(current.alternate, nextSeen)
+        );
+      }
+      return false;
+    }
+
+    function isStaffActor(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.ObjectExpression) {
+        const orgId = expressionProperty(current, "orgId", seen);
+        return orgId ? isStaffOrgId(orgId, nextSeen) : false;
+      }
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isStaffActor(definition.node.init, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          return parameterResolvesToStaff(current, "actor", nextSeen);
+        }
+        return false;
+      }
+      if (current.type === AST_NODE_TYPES.CallExpression) {
+        const calleeName =
+          current.callee.type === AST_NODE_TYPES.Identifier
+            ? current.callee.name
+            : current.callee.type === AST_NODE_TYPES.MemberExpression
+              ? memberName(current.callee)
+              : null;
+        if (calleeName === "user") {
+          const options = current.arguments[0];
+          if (!options || options.type === AST_NODE_TYPES.SpreadElement) {
+            return false;
+          }
+          const orgId = expressionProperty(options, "orgId", nextSeen);
+          return orgId ? isStaffOrgId(orgId, nextSeen) : false;
+        }
+        if (current.callee.type === AST_NODE_TYPES.Identifier) {
+          const calleeName = current.callee.name;
+          const localFunction = [...functionReturns.keys()].find(
+            (candidate) => {
+              return functionName(candidate) === calleeName;
+            },
+          );
+          if (!localFunction) {
+            return false;
+          }
+          return (functionReturns.get(localFunction) ?? []).some((returned) => {
+            return isStaffActor(returned, nextSeen);
+          });
+        }
+      }
+      return false;
+    }
+
+    function mutationKind(
+      callee: TSESTree.CallExpression["callee"],
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): MutationKind | null {
+      if (seen.has(callee)) {
+        return null;
+      }
+      const nextSeen = new Set(seen).add(callee);
+      if (callee.type === AST_NODE_TYPES.MemberExpression) {
+        return memberName(callee) === "grantProEntitlement" ? "grant" : null;
+      }
+      if (callee.type !== AST_NODE_TYPES.Identifier) {
+        return null;
+      }
+      const imported = importReference(context.sourceCode, callee);
+      if (imported && isEntitlementFixtureModule(imported.source)) {
+        if (imported.importedName === "upsertOrgPlanEntitlementFixture") {
+          return "upsert";
+        }
+        if (imported.importedName === "deleteOrgPlanEntitlementFixture") {
+          return "delete";
+        }
+      }
+      const definition = variableInScope(context.sourceCode, callee)?.defs[0];
+      if (
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init
+      ) {
+        return mutationKind(definition.node.init, nextSeen);
+      }
+      return null;
+    }
+
+    function checkMutation(call: TSESTree.CallExpression): void {
+      const kind = mutationKind(call.callee);
+      if (!kind) {
+        return;
+      }
+      const first = call.arguments[0];
+      if (!first || first.type === AST_NODE_TYPES.SpreadElement) {
+        return;
+      }
+      let mutatesStaff = false;
+      if (kind === "upsert") {
+        const orgId = expressionProperty(first, "orgId", new Set());
+        mutatesStaff = orgId ? isStaffOrgId(orgId) : false;
+      } else if (kind === "delete") {
+        mutatesStaff = isStaffOrgId(first);
+      } else {
+        mutatesStaff = isStaffActor(first);
+      }
+      if (mutatesStaff) {
+        context.report({ node: call, messageId: "productionStaffMutation" });
+      }
+    }
+
+    function registerFunction(node: FunctionNode): void {
+      if (!functionReturns.has(node)) {
+        functionReturns.set(node, []);
+      }
+      if (
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+        node.body.type !== AST_NODE_TYPES.BlockStatement
+      ) {
+        functionReturns.get(node)?.push(node.body);
+      }
+    }
+
+    return {
+      ArrowFunctionExpression: registerFunction,
+      FunctionDeclaration: registerFunction,
+      FunctionExpression: registerFunction,
+      ReturnStatement(node: TSESTree.ReturnStatement) {
+        const owner = enclosingFunction(node);
+        if (owner && node.argument) {
+          functionReturns.get(owner)?.push(node.argument);
+        }
+      },
+      CallExpression(node: TSESTree.CallExpression) {
+        calls.push(node);
+      },
+      "Program:exit"() {
+        for (const call of calls) {
+          checkMutation(call);
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
@@ -48,12 +48,40 @@ function functionName(node: FunctionNode): string | null {
   return null;
 }
 
-function parameterIndex(node: FunctionNode, name: string): number {
-  return node.params.findIndex((parameter) => {
-    return (
-      parameter.type === AST_NODE_TYPES.Identifier && parameter.name === name
-    );
-  });
+interface ParameterBinding {
+  readonly index: number;
+  readonly property: string | null;
+}
+
+function parameterBinding(
+  node: FunctionNode,
+  name: string,
+): ParameterBinding | null {
+  for (const [index, rawParameter] of node.params.entries()) {
+    const parameter =
+      rawParameter.type === AST_NODE_TYPES.AssignmentPattern
+        ? rawParameter.left
+        : rawParameter;
+    if (
+      parameter.type === AST_NODE_TYPES.Identifier &&
+      parameter.name === name
+    ) {
+      return { index, property: null };
+    }
+    if (parameter.type !== AST_NODE_TYPES.ObjectPattern) {
+      continue;
+    }
+    for (const entry of parameter.properties) {
+      if (
+        entry.type === AST_NODE_TYPES.Property &&
+        entry.value.type === AST_NODE_TYPES.Identifier &&
+        entry.value.name === name
+      ) {
+        return { index, property: propertyName(entry) };
+      }
+    }
+  }
+  return null;
 }
 
 function isEntitlementFixtureModule(source: string): boolean {
@@ -149,18 +177,24 @@ export const noProductionStaffEntitlementMutation = createRule({
       if (!owner) {
         return false;
       }
-      const index = parameterIndex(owner, identifier.name);
-      if (index < 0) {
+      const binding = parameterBinding(owner, identifier.name);
+      if (!binding) {
         return false;
       }
       return callsTo(owner).some((call) => {
-        const argument = call.arguments[index];
+        const argument = call.arguments[binding.index];
         if (!argument || argument.type === AST_NODE_TYPES.SpreadElement) {
           return false;
         }
+        const value = binding.property
+          ? expressionProperty(argument, binding.property, seen)
+          : argument;
+        if (!value) {
+          return false;
+        }
         return property === "actor"
-          ? isStaffActor(argument, seen)
-          : isStaffOrgId(argument, seen);
+          ? isStaffActor(value, seen)
+          : isStaffOrgId(value, seen);
       });
     }
 
@@ -189,16 +223,20 @@ export const noProductionStaffEntitlementMutation = createRule({
       if (!owner) {
         return false;
       }
-      const index = parameterIndex(owner, current.name);
-      if (index < 0) {
+      const binding = parameterBinding(owner, current.name);
+      if (!binding) {
         return false;
       }
       return callsTo(owner).some((call) => {
-        const argument = call.arguments[index];
+        const argument = call.arguments[binding.index];
+        if (!argument || argument.type === AST_NODE_TYPES.SpreadElement) {
+          return false;
+        }
+        const value = binding.property
+          ? expressionProperty(argument, binding.property, nextSeen)
+          : argument;
         return Boolean(
-          argument &&
-          argument.type !== AST_NODE_TYPES.SpreadElement &&
-          objectPropertyResolvesToStaff(argument, name, nextSeen),
+          value && objectPropertyResolvesToStaff(value, name, nextSeen),
         );
       });
     }
@@ -307,6 +345,30 @@ export const noProductionStaffEntitlementMutation = createRule({
       return false;
     }
 
+    function isEntitlementNamespace(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current) || current.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      const imported = importReference(context.sourceCode, current);
+      if (
+        imported?.importedName === "*" &&
+        isEntitlementFixtureModule(imported.source)
+      ) {
+        return true;
+      }
+      const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      return Boolean(
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init &&
+        isEntitlementNamespace(definition.node.init, nextSeen),
+      );
+    }
+
     function mutationKind(
       callee: TSESTree.CallExpression["callee"],
       seen: ReadonlySet<TSESTree.Node> = new Set(),
@@ -316,7 +378,22 @@ export const noProductionStaffEntitlementMutation = createRule({
       }
       const nextSeen = new Set(seen).add(callee);
       if (callee.type === AST_NODE_TYPES.MemberExpression) {
-        return memberName(callee) === "grantProEntitlement" ? "grant" : null;
+        const name = memberName(callee);
+        if (name === "grantProEntitlement") {
+          return "grant";
+        }
+        if (
+          callee.object.type !== AST_NODE_TYPES.Super &&
+          isEntitlementNamespace(callee.object)
+        ) {
+          if (name === "upsertOrgPlanEntitlementFixture") {
+            return "upsert";
+          }
+          if (name === "deleteOrgPlanEntitlementFixture") {
+            return "delete";
+          }
+        }
+        return null;
       }
       if (callee.type !== AST_NODE_TYPES.Identifier) {
         return null;

--- a/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
@@ -412,6 +412,27 @@ export const noProductionStaffEntitlementMutation = createRule({
         definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
         definition.node.init
       ) {
+        if (definition.node.id.type === AST_NODE_TYPES.ObjectPattern) {
+          const destructured = definition.node.id.properties.find((entry) => {
+            return (
+              entry.type === AST_NODE_TYPES.Property &&
+              entry.value.type === AST_NODE_TYPES.Identifier &&
+              entry.value.name === callee.name
+            );
+          });
+          const name =
+            destructured?.type === AST_NODE_TYPES.Property
+              ? propertyName(destructured)
+              : null;
+          if (isEntitlementNamespace(definition.node.init)) {
+            if (name === "upsertOrgPlanEntitlementFixture") {
+              return "upsert";
+            }
+            if (name === "deleteOrgPlanEntitlementFixture") {
+              return "delete";
+            }
+          }
+        }
         return mutationKind(definition.node.init, nextSeen);
       }
       return null;

--- a/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-production-staff-entitlement-mutation.ts
@@ -164,6 +164,45 @@ export const noProductionStaffEntitlementMutation = createRule({
       });
     }
 
+    function objectPropertyResolvesToStaff(
+      expression: TSESTree.Expression,
+      name: string,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      const property = expressionProperty(current, name, seen);
+      if (property) {
+        return isStaffOrgId(property, nextSeen);
+      }
+      if (current.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      if (definition?.type !== "Parameter") {
+        return false;
+      }
+      const owner = enclosingFunction(current);
+      if (!owner) {
+        return false;
+      }
+      const index = parameterIndex(owner, current.name);
+      if (index < 0) {
+        return false;
+      }
+      return callsTo(owner).some((call) => {
+        const argument = call.arguments[index];
+        return Boolean(
+          argument &&
+          argument.type !== AST_NODE_TYPES.SpreadElement &&
+          objectPropertyResolvesToStaff(argument, name, nextSeen),
+        );
+      });
+    }
+
     function isStaffOrgId(
       expression: TSESTree.Expression,
       seen: ReadonlySet<TSESTree.Node> = new Set(),
@@ -312,8 +351,7 @@ export const noProductionStaffEntitlementMutation = createRule({
       }
       let mutatesStaff = false;
       if (kind === "upsert") {
-        const orgId = expressionProperty(first, "orgId", new Set());
-        mutatesStaff = orgId ? isStaffOrgId(orgId) : false;
+        mutatesStaff = objectPropertyResolvesToStaff(first, "orgId");
       } else if (kind === "delete") {
         mutatesStaff = isStaffOrgId(first);
       } else {

--- a/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
@@ -14,6 +14,12 @@ type FunctionNode =
   | TSESTree.FunctionDeclaration
   | TSESTree.FunctionExpression;
 
+interface CallFrame {
+  readonly call: TSESTree.CallExpression;
+  readonly functionNode: FunctionNode;
+  readonly parent: CallFrame | null;
+}
+
 type MutationName =
   | "deleteUsagePricingRows"
   | "seedUsagePricingRows"
@@ -67,6 +73,28 @@ function isApprovedScopedRunStateRoute(
     exportName === "testCronCleanupSandboxesStateRoutes" &&
     (source.endsWith("/test-cron-cleanup-sandboxes-state") ||
       source.endsWith("/test-cron-cleanup-sandboxes-state.ts"))
+  );
+}
+
+function isApprovedScopedAppFactory(
+  source: string,
+  exportName: string,
+): boolean {
+  if (exportName === "createAppWithRoutes") {
+    return (
+      source.endsWith("/app-factory-core") ||
+      source.endsWith("/app-factory-core.ts")
+    );
+  }
+  if (exportName === "createApp") {
+    return (
+      source.endsWith("/app-factory") || source.endsWith("/app-factory.ts")
+    );
+  }
+  return (
+    exportName === "setupApp" &&
+    (source.endsWith("/__tests__/test-helpers") ||
+      source.endsWith("/__tests__/test-helpers.ts"))
   );
 }
 
@@ -150,7 +178,6 @@ export const noUnownedUsagePricing = createRule({
     const fixtureNamespaces = new Set<string>();
     const calls: TSESTree.CallExpression[] = [];
     const functionReturns = new Map<FunctionNode, TSESTree.Expression[]>();
-    const scopedRunStateRouteFunctions = new Set<FunctionNode>();
 
     function addReturn(
       node: FunctionNode,
@@ -254,28 +281,216 @@ export const noUnownedUsagePricing = createRule({
       });
     }
 
-    function reachesScopedRunStateRoute(
-      node: FunctionNode,
-      seen: ReadonlySet<FunctionNode> = new Set(),
+    function argumentForParameter(
+      identifier: TSESTree.Identifier,
+      frame: CallFrame | null,
+    ): {
+      readonly expression: TSESTree.Expression;
+      readonly frame: CallFrame | null;
+    } | null {
+      const owner = definingParameterFunction(context.sourceCode, identifier);
+      if (!owner) {
+        return null;
+      }
+      let ownerFrame = frame;
+      while (ownerFrame && ownerFrame.functionNode !== owner) {
+        ownerFrame = ownerFrame.parent;
+      }
+      if (!ownerFrame) {
+        return null;
+      }
+      const index = parameterIndex(owner, identifier.name);
+      const argument = ownerFrame.call.arguments[index];
+      if (!argument || argument.type === AST_NODE_TYPES.SpreadElement) {
+        return null;
+      }
+      return { expression: argument, frame: ownerFrame.parent };
+    }
+
+    function isScopedRunStateRoutes(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
     ): boolean {
-      if (seen.has(node)) {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
         return false;
       }
-      if (scopedRunStateRouteFunctions.has(node)) {
+      const nextSeen = new Set(seen).add(current);
+      if (current.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const imported = importReference(context.sourceCode, current);
+      if (
+        imported &&
+        isApprovedScopedRunStateRoute(imported.source, imported.importedName)
+      ) {
         return true;
       }
-      const nextSeen = new Set(seen).add(node);
-      return calls.some((call) => {
+      const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      return Boolean(
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init &&
+        isScopedRunStateRoutes(definition.node.init, nextSeen),
+      );
+    }
+
+    function isScopedAppFactory(
+      expression: TSESTree.CallExpression["callee"],
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      if (
+        seen.has(expression) ||
+        expression.type !== AST_NODE_TYPES.Identifier
+      ) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(expression);
+      const imported = importReference(context.sourceCode, expression);
+      if (
+        imported &&
+        isApprovedScopedAppFactory(imported.source, imported.importedName)
+      ) {
+        return true;
+      }
+      const definition = variableInScope(context.sourceCode, expression)
+        ?.defs[0];
+      return Boolean(
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init &&
+        isScopedAppFactory(definition.node.init, nextSeen),
+      );
+    }
+
+    function isScopedRunStateApp(
+      expression: TSESTree.Expression,
+      frame: CallFrame | null,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isScopedRunStateApp(definition.node.init, frame, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          const argument = argumentForParameter(current, frame);
+          return Boolean(
+            argument &&
+            isScopedRunStateApp(argument.expression, argument.frame, nextSeen),
+          );
+        }
+        return false;
+      }
+      if (current.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      if (!isScopedAppFactory(current.callee)) {
+        return false;
+      }
+      const options = current.arguments[0];
+      if (!options || options.type !== AST_NODE_TYPES.ObjectExpression) {
+        return false;
+      }
+      return options.properties.some((property) => {
         return (
-          enclosingFunction(call) === node &&
-          (() => {
-            const called = localFunctionCalledBy(call);
-            return Boolean(
-              called && reachesScopedRunStateRoute(called, nextSeen),
-            );
-          })()
+          property.type === AST_NODE_TYPES.Property &&
+          propertyName(property) === "routes" &&
+          property.value.type !== AST_NODE_TYPES.AssignmentPattern &&
+          isScopedRunStateRoutes(property.value as TSESTree.Expression)
         );
       });
+    }
+
+    function isScopedRunStateResponse(
+      expression: TSESTree.Expression,
+      frame: CallFrame | null,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isScopedRunStateResponse(
+            definition.node.init,
+            frame,
+            nextSeen,
+          );
+        }
+        if (definition?.type === "Parameter") {
+          const argument = argumentForParameter(current, frame);
+          return Boolean(
+            argument &&
+            isScopedRunStateResponse(
+              argument.expression,
+              argument.frame,
+              nextSeen,
+            ),
+          );
+        }
+        return false;
+      }
+      if (current.type === AST_NODE_TYPES.AwaitExpression) {
+        return isScopedRunStateResponse(current.argument, frame, nextSeen);
+      }
+      if (current.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      if (
+        current.callee.type === AST_NODE_TYPES.MemberExpression &&
+        current.callee.object.type !== AST_NODE_TYPES.Super
+      ) {
+        const name = memberName(current.callee);
+        if (name === "request") {
+          return isScopedRunStateApp(current.callee.object, frame);
+        }
+        if (name === "json") {
+          return isScopedRunStateResponse(
+            current.callee.object,
+            frame,
+            nextSeen,
+          );
+        }
+        if (name === "resolve") {
+          const value = current.arguments[0];
+          return Boolean(
+            value &&
+            value.type !== AST_NODE_TYPES.SpreadElement &&
+            isScopedRunStateResponse(value, frame, nextSeen),
+          );
+        }
+      }
+      const called = localFunctionCalledBy(current);
+      if (!called) {
+        return false;
+      }
+      const returns = functionReturns.get(called) ?? [];
+      const calledFrame: CallFrame = {
+        call: current,
+        functionNode: called,
+        parent: frame,
+      };
+      return (
+        returns.length > 0 &&
+        returns.every((returned) => {
+          return isScopedRunStateResponse(returned, calledFrame, nextSeen);
+        })
+      );
     }
 
     function isScopedSeedRunResult(
@@ -303,10 +518,20 @@ export const noUnownedUsagePricing = createRule({
         return false;
       }
       const called = localFunctionCalledBy(current);
-      return Boolean(
-        called &&
-        callHasSeedRunAction(current) &&
-        reachesScopedRunStateRoute(called),
+      if (!called || !callHasSeedRunAction(current)) {
+        return false;
+      }
+      const returns = functionReturns.get(called) ?? [];
+      const frame: CallFrame = {
+        call: current,
+        functionNode: called,
+        parent: null,
+      };
+      return (
+        returns.length > 0 &&
+        returns.every((returned) => {
+          return isScopedRunStateResponse(returned, frame, nextSeen);
+        })
       );
     }
 
@@ -913,17 +1138,6 @@ export const noUnownedUsagePricing = createRule({
       },
       CallExpression(node: TSESTree.CallExpression) {
         calls.push(node);
-      },
-      Identifier(node: TSESTree.Identifier) {
-        const imported = importReference(context.sourceCode, node);
-        const owner = enclosingFunction(node);
-        if (
-          owner &&
-          imported &&
-          isApprovedScopedRunStateRoute(imported.source, imported.importedName)
-        ) {
-          scopedRunStateRouteFunctions.add(owner);
-        }
       },
       "Program:exit"() {
         for (const call of calls) {

--- a/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
@@ -59,6 +59,17 @@ function isApprovedRunClientFactory(
   );
 }
 
+function isApprovedScopedRunStateRoute(
+  source: string,
+  exportName: string,
+): boolean {
+  return (
+    exportName === "testCronCleanupSandboxesStateRoutes" &&
+    (source.endsWith("/test-cron-cleanup-sandboxes-state") ||
+      source.endsWith("/test-cron-cleanup-sandboxes-state.ts"))
+  );
+}
+
 function enclosingFunction(node: TSESTree.Node): FunctionNode | null {
   let current = node.parent;
   while (current) {
@@ -139,6 +150,7 @@ export const noUnownedUsagePricing = createRule({
     const fixtureNamespaces = new Set<string>();
     const calls: TSESTree.CallExpression[] = [];
     const functionReturns = new Map<FunctionNode, TSESTree.Expression[]>();
+    const scopedRunStateRouteFunctions = new Set<FunctionNode>();
 
     function addReturn(
       node: FunctionNode,
@@ -205,6 +217,152 @@ export const noUnownedUsagePricing = createRule({
           callee.type === AST_NODE_TYPES.Identifier && callee.name === name
         );
       });
+    }
+
+    function localFunctionCalledBy(
+      call: TSESTree.CallExpression,
+    ): FunctionNode | null {
+      if (call.callee.type !== AST_NODE_TYPES.Identifier) {
+        return null;
+      }
+      const definitions =
+        variableInScope(context.sourceCode, call.callee)?.defs ?? [];
+      return (
+        [...functionReturns.keys()].find((candidate) => {
+          return definitions.some((definition) => {
+            return (
+              definition.node === candidate ||
+              (definition.node.type === AST_NODE_TYPES.VariableDeclarator &&
+                definition.node.init === candidate)
+            );
+          });
+        }) ?? null
+      );
+    }
+
+    function callHasSeedRunAction(call: TSESTree.CallExpression): boolean {
+      return call.arguments.some((argument) => {
+        if (argument.type === AST_NODE_TYPES.SpreadElement) {
+          return false;
+        }
+        const action = objectPropertyExpression(argument, "action", new Set());
+        const current = action ? unwrapExpression(action) : null;
+        return (
+          current?.type === AST_NODE_TYPES.Literal &&
+          current.value === "seed-run"
+        );
+      });
+    }
+
+    function reachesScopedRunStateRoute(
+      node: FunctionNode,
+      seen: ReadonlySet<FunctionNode> = new Set(),
+    ): boolean {
+      if (seen.has(node)) {
+        return false;
+      }
+      if (scopedRunStateRouteFunctions.has(node)) {
+        return true;
+      }
+      const nextSeen = new Set(seen).add(node);
+      return calls.some((call) => {
+        return (
+          enclosingFunction(call) === node &&
+          (() => {
+            const called = localFunctionCalledBy(call);
+            return Boolean(
+              called && reachesScopedRunStateRoute(called, nextSeen),
+            );
+          })()
+        );
+      });
+    }
+
+    function isScopedSeedRunResult(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        return Boolean(
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          isScopedSeedRunResult(definition.node.init, nextSeen),
+        );
+      }
+      if (current.type === AST_NODE_TYPES.AwaitExpression) {
+        return isScopedSeedRunResult(current.argument, nextSeen);
+      }
+      if (current.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      const called = localFunctionCalledBy(current);
+      return Boolean(
+        called &&
+        callHasSeedRunAction(current) &&
+        reachesScopedRunStateRoute(called),
+      );
+    }
+
+    function isScopedSeedRunId(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        return Boolean(
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          isScopedSeedRunId(definition.node.init, nextSeen),
+        );
+      }
+      if (current.type === AST_NODE_TYPES.MemberExpression) {
+        return (
+          memberName(current) === "run_id" &&
+          current.object.type !== AST_NODE_TYPES.Super &&
+          isScopedSeedRunResult(current.object, nextSeen)
+        );
+      }
+      if (
+        current.type !== AST_NODE_TYPES.CallExpression ||
+        current.arguments.length < 2
+      ) {
+        return false;
+      }
+      const response = current.arguments[0];
+      const field = current.arguments[1];
+      if (
+        !response ||
+        response.type === AST_NODE_TYPES.SpreadElement ||
+        field?.type !== AST_NODE_TYPES.Literal ||
+        field.value !== "run_id"
+      ) {
+        return false;
+      }
+      return isScopedSeedRunResult(response, nextSeen);
+    }
+
+    function isScopedRunFixtureFactory(node: FunctionNode): boolean {
+      const returns = functionReturns.get(node) ?? [];
+      return (
+        returns.length > 0 &&
+        returns.every((returned) => {
+          const runId = objectPropertyExpression(returned, "runId", new Set());
+          return Boolean(runId && isScopedSeedRunId(runId));
+        })
+      );
     }
 
     function ownedParameterValue(
@@ -392,11 +550,11 @@ export const noUnownedUsagePricing = createRule({
         });
       }
       if (current.callee.type === AST_NODE_TYPES.Identifier) {
-        const calleeName = current.callee.name;
-        const localFunction = [...functionReturns.keys()].find((candidate) => {
-          return functionName(candidate) === calleeName;
-        });
+        const localFunction = localFunctionCalledBy(current);
         if (localFunction) {
+          if (isScopedRunFixtureFactory(localFunction)) {
+            return true;
+          }
           const returns = functionReturns.get(localFunction) ?? [];
           return (
             returns.length > 0 &&
@@ -747,6 +905,17 @@ export const noUnownedUsagePricing = createRule({
       },
       CallExpression(node: TSESTree.CallExpression) {
         calls.push(node);
+      },
+      Identifier(node: TSESTree.Identifier) {
+        const imported = importReference(context.sourceCode, node);
+        const owner = enclosingFunction(node);
+        if (
+          owner &&
+          imported &&
+          isApprovedScopedRunStateRoute(imported.source, imported.importedName)
+        ) {
+          scopedRunStateRouteFunctions.add(owner);
+        }
       },
       "Program:exit"() {
         for (const call of calls) {

--- a/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
@@ -1,0 +1,758 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import {
+  importReference,
+  memberName,
+  propertyName,
+  unwrapExpression,
+  variableInScope,
+} from "../syntax.ts";
+import { createRule } from "../utils.ts";
+
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+
+type MutationName =
+  | "deleteUsagePricingRows"
+  | "seedUsagePricingRows"
+  | "upsertUsagePricingRows";
+
+const RAW_MUTATIONS = new Set<MutationName>([
+  "deleteUsagePricingRows",
+  "seedUsagePricingRows",
+  "upsertUsagePricingRows",
+]);
+const RUN_FACTORY_NAMES = new Set([
+  "createDirectRunFixture",
+  "createRun",
+  "insertRunFixture",
+  "sendChatRun",
+]);
+
+function isPricingFixtureModule(source: string): boolean {
+  return (
+    source.endsWith("/test-fixtures/system-config-seeds") ||
+    source.endsWith("/test-fixtures/system-config-seeds.ts") ||
+    source.endsWith("/test-fixtures/usage-pricing") ||
+    source.endsWith("/test-fixtures/usage-pricing.ts")
+  );
+}
+
+function isApprovedRunFactory(source: string, exportName: string): boolean {
+  return (
+    exportName === "createDirectRunFixture" &&
+    (source.endsWith("/test-fixtures/agent-runs") ||
+      source.endsWith("/test-fixtures/agent-runs.ts"))
+  );
+}
+
+function isApprovedRunClientFactory(
+  source: string,
+  exportName: string,
+): boolean {
+  return (
+    exportName === "createRunsApi" &&
+    (source.endsWith("/helpers/api-bdd-runs") ||
+      source.endsWith("/helpers/api-bdd-runs.ts"))
+  );
+}
+
+function enclosingFunction(node: TSESTree.Node): FunctionNode | null {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      current.type === AST_NODE_TYPES.FunctionDeclaration ||
+      current.type === AST_NODE_TYPES.FunctionExpression
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function functionName(node: FunctionNode): string | null {
+  if (node.type === AST_NODE_TYPES.FunctionDeclaration) {
+    return node.id?.name ?? null;
+  }
+  if (node.id) {
+    return node.id.name;
+  }
+  if (
+    node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+    node.parent.id.type === AST_NODE_TYPES.Identifier
+  ) {
+    return node.parent.id.name;
+  }
+  return null;
+}
+
+function parameterIndex(node: FunctionNode, name: string): number {
+  return node.params.findIndex((parameter) => {
+    return (
+      parameter.type === AST_NODE_TYPES.Identifier && parameter.name === name
+    );
+  });
+}
+
+function definingParameterFunction(
+  sourceCode: Readonly<Parameters<typeof variableInScope>[0]>,
+  identifier: TSESTree.Identifier,
+): FunctionNode | null {
+  const definition = variableInScope(sourceCode, identifier)?.defs.find(
+    (candidate) => {
+      return candidate.type === "Parameter";
+    },
+  );
+  const node = definition?.node;
+  if (
+    node?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+    node?.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node?.type === AST_NODE_TYPES.FunctionExpression
+  ) {
+    return node;
+  }
+  return null;
+}
+
+export const noUnownedUsagePricing = createRule({
+  name: "no-unowned-usage-pricing",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require raw usage-pricing test mutations to prove UUID, run, or fixture ownership",
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      unownedPricing:
+        "Raw usage-pricing mutations require a provider proven unique to this test (randomUUID/runId/lookupProvider). Use createUsagePricingFixture for canonical operator-managed providers.",
+    },
+  },
+  create(context) {
+    const importedMutations = new Map<string, MutationName>();
+    const fixtureNamespaces = new Set<string>();
+    const calls: TSESTree.CallExpression[] = [];
+    const functionReturns = new Map<FunctionNode, TSESTree.Expression[]>();
+
+    function addReturn(
+      node: FunctionNode,
+      expression: TSESTree.Expression,
+    ): void {
+      const returns = functionReturns.get(node) ?? [];
+      returns.push(expression);
+      functionReturns.set(node, returns);
+    }
+
+    function objectPropertyExpression(
+      expression: TSESTree.Expression,
+      name: string,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): TSESTree.Expression | null {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return null;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.ObjectExpression) {
+        for (const property of current.properties) {
+          if (
+            property.type === AST_NODE_TYPES.Property &&
+            propertyName(property) === name &&
+            property.value.type !== AST_NODE_TYPES.AssignmentPattern
+          ) {
+            return property.value as TSESTree.Expression;
+          }
+          if (property.type === AST_NODE_TYPES.SpreadElement) {
+            const spread = objectPropertyExpression(
+              property.argument,
+              name,
+              nextSeen,
+            );
+            if (spread) {
+              return spread;
+            }
+          }
+        }
+        return null;
+      }
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return objectPropertyExpression(definition.node.init, name, nextSeen);
+        }
+      }
+      return null;
+    }
+
+    function callsTo(node: FunctionNode): readonly TSESTree.CallExpression[] {
+      const name = functionName(node);
+      if (!name) {
+        return [];
+      }
+      return calls.filter((call) => {
+        const callee = call.callee;
+        return (
+          callee.type === AST_NODE_TYPES.Identifier && callee.name === name
+        );
+      });
+    }
+
+    function ownedParameterValue(
+      identifier: TSESTree.Identifier,
+      property: string | null,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      const owner = definingParameterFunction(context.sourceCode, identifier);
+      if (!owner) {
+        return false;
+      }
+      const index = parameterIndex(owner, identifier.name);
+      if (index < 0) {
+        return false;
+      }
+      const callSites = callsTo(owner);
+      if (callSites.length === 0) {
+        return false;
+      }
+      return callSites.every((call) => {
+        const argument = call.arguments[index];
+        if (!argument || argument.type === AST_NODE_TYPES.SpreadElement) {
+          return false;
+        }
+        const value = property
+          ? objectPropertyExpression(argument, property, seen)
+          : argument;
+        return value ? isOwnedProvider(value, seen) : false;
+      });
+    }
+
+    function isUsagePricingFixtureSource(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isUsagePricingFixtureSource(definition.node.init, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          const owner = definingParameterFunction(context.sourceCode, current);
+          if (!owner) {
+            return false;
+          }
+          const index = parameterIndex(owner, current.name);
+          return callsTo(owner).some((call) => {
+            const argument = call.arguments[index];
+            return Boolean(
+              argument &&
+              argument.type !== AST_NODE_TYPES.SpreadElement &&
+              isUsagePricingFixtureSource(argument, nextSeen),
+            );
+          });
+        }
+        return false;
+      }
+      if (current.type === AST_NODE_TYPES.AwaitExpression) {
+        return isUsagePricingFixtureSource(current.argument, nextSeen);
+      }
+      if (current.type === AST_NODE_TYPES.MemberExpression) {
+        return (
+          current.object.type !== AST_NODE_TYPES.Super &&
+          isUsagePricingFixtureSource(current.object, nextSeen)
+        );
+      }
+      if (current.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      if (current.callee.type === AST_NODE_TYPES.Identifier) {
+        const calleeName = current.callee.name;
+        const imported = importReference(context.sourceCode, current.callee);
+        if (
+          imported?.importedName === "createUsagePricingFixture" &&
+          isPricingFixtureModule(imported.source)
+        ) {
+          return true;
+        }
+        const localFunction = [...functionReturns.keys()].find((candidate) => {
+          return functionName(candidate) === calleeName;
+        });
+        if (localFunction) {
+          const returns = functionReturns.get(localFunction) ?? [];
+          return (
+            returns.length > 0 &&
+            returns.every((returned) => {
+              return isUsagePricingFixtureSource(returned, nextSeen);
+            })
+          );
+        }
+      }
+      return (
+        current.callee.type === AST_NODE_TYPES.MemberExpression &&
+        current.callee.object.type !== AST_NODE_TYPES.Super &&
+        isUsagePricingFixtureSource(current.callee.object, nextSeen)
+      );
+    }
+
+    function isRunFixtureSource(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isRunFixtureSource(definition.node.init, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          const owner = definingParameterFunction(context.sourceCode, current);
+          if (!owner) {
+            return false;
+          }
+          const index = parameterIndex(owner, current.name);
+          return callsTo(owner).some((call) => {
+            const argument = call.arguments[index];
+            return Boolean(
+              argument &&
+              argument.type !== AST_NODE_TYPES.SpreadElement &&
+              isRunFixtureSource(argument, nextSeen),
+            );
+          });
+        }
+        return false;
+      }
+      if (current.type === AST_NODE_TYPES.AwaitExpression) {
+        return isRunFixtureSource(current.argument, nextSeen);
+      }
+      if (current.type === AST_NODE_TYPES.MemberExpression) {
+        return (
+          current.object.type !== AST_NODE_TYPES.Super &&
+          isRunFixtureSource(current.object, nextSeen)
+        );
+      }
+      if (current.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      const calleeName =
+        current.callee.type === AST_NODE_TYPES.Identifier
+          ? current.callee.name
+          : current.callee.type === AST_NODE_TYPES.MemberExpression
+            ? memberName(current.callee)
+            : null;
+      if (calleeName && RUN_FACTORY_NAMES.has(calleeName)) {
+        if (current.callee.type === AST_NODE_TYPES.Identifier) {
+          const imported = importReference(context.sourceCode, current.callee);
+          if (
+            imported &&
+            imported.importedName === calleeName &&
+            isApprovedRunFactory(imported.source, imported.importedName)
+          ) {
+            return true;
+          }
+        } else if (
+          current.callee.type === AST_NODE_TYPES.MemberExpression &&
+          current.callee.object.type !== AST_NODE_TYPES.Super &&
+          isRunClientSource(current.callee.object, nextSeen)
+        ) {
+          return true;
+        }
+      }
+      if (calleeName === "trackRun") {
+        return current.arguments.some((argument) => {
+          return (
+            argument.type !== AST_NODE_TYPES.SpreadElement &&
+            isRunFixtureSource(argument, nextSeen)
+          );
+        });
+      }
+      if (current.callee.type === AST_NODE_TYPES.Identifier) {
+        const calleeName = current.callee.name;
+        const localFunction = [...functionReturns.keys()].find((candidate) => {
+          return functionName(candidate) === calleeName;
+        });
+        if (localFunction) {
+          const returns = functionReturns.get(localFunction) ?? [];
+          return (
+            returns.length > 0 &&
+            returns.every((returned) => {
+              return isRunFixtureSource(returned, nextSeen);
+            })
+          );
+        }
+      }
+      return false;
+    }
+
+    function isRunClientSource(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node>,
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        return Boolean(
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          isRunClientSource(definition.node.init, nextSeen),
+        );
+      }
+      if (current.type !== AST_NODE_TYPES.CallExpression) {
+        return false;
+      }
+      if (current.callee.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const imported = importReference(context.sourceCode, current.callee);
+      return Boolean(
+        imported &&
+        isApprovedRunClientFactory(imported.source, imported.importedName),
+      );
+    }
+
+    function isOwnedProvider(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isOwnedProvider(definition.node.init, nextSeen);
+        }
+        if (definition?.type === "Parameter") {
+          return ownedParameterValue(current, null, nextSeen);
+        }
+        return false;
+      }
+
+      if (current.type === AST_NODE_TYPES.MemberExpression) {
+        const name = memberName(current);
+        if (current.object.type === AST_NODE_TYPES.Super) {
+          return false;
+        }
+        if (name === "lookupProvider") {
+          return isUsagePricingFixtureSource(current.object, nextSeen);
+        }
+        if (name === "runId") {
+          return isRunFixtureSource(current.object, nextSeen);
+        }
+        if (
+          name &&
+          current.object.type === AST_NODE_TYPES.Identifier &&
+          variableInScope(context.sourceCode, current.object)?.defs[0]?.type ===
+            "Parameter"
+        ) {
+          return ownedParameterValue(current.object, name, nextSeen);
+        }
+        return false;
+      }
+
+      if (current.type === AST_NODE_TYPES.CallExpression) {
+        if (current.callee.type === AST_NODE_TYPES.Identifier) {
+          const calleeName = current.callee.name;
+          const imported = importReference(context.sourceCode, current.callee);
+          if (
+            imported?.source === "node:crypto" &&
+            imported.importedName === "randomUUID"
+          ) {
+            return true;
+          }
+          const localFunction = [...functionReturns.keys()].find(
+            (candidate) => {
+              return functionName(candidate) === calleeName;
+            },
+          );
+          const returns = localFunction
+            ? (functionReturns.get(localFunction) ?? [])
+            : [];
+          if (returns.length > 0) {
+            return returns.every((returned) => {
+              return isOwnedProvider(returned, nextSeen);
+            });
+          }
+        }
+        if (
+          current.callee.type === AST_NODE_TYPES.MemberExpression &&
+          current.callee.object.type !== AST_NODE_TYPES.Super
+        ) {
+          return isOwnedProvider(current.callee.object, nextSeen);
+        }
+        return false;
+      }
+
+      if (current.type === AST_NODE_TYPES.TemplateLiteral) {
+        return current.expressions.some((part) => {
+          return isOwnedProvider(part, nextSeen);
+        });
+      }
+      if (current.type === AST_NODE_TYPES.BinaryExpression) {
+        return (
+          (current.left.type !== AST_NODE_TYPES.PrivateIdentifier &&
+            isOwnedProvider(current.left, nextSeen)) ||
+          isOwnedProvider(current.right, nextSeen)
+        );
+      }
+      if (
+        current.type === AST_NODE_TYPES.ConditionalExpression ||
+        current.type === AST_NODE_TYPES.LogicalExpression
+      ) {
+        return (
+          isOwnedProvider(
+            current.type === AST_NODE_TYPES.ConditionalExpression
+              ? current.consequent
+              : current.left,
+            nextSeen,
+          ) &&
+          isOwnedProvider(
+            current.type === AST_NODE_TYPES.ConditionalExpression
+              ? current.alternate
+              : current.right,
+            nextSeen,
+          )
+        );
+      }
+      if (current.type === AST_NODE_TYPES.SequenceExpression) {
+        const finalExpression = current.expressions.at(-1);
+        return finalExpression
+          ? isOwnedProvider(finalExpression, nextSeen)
+          : false;
+      }
+      if (current.type === AST_NODE_TYPES.AwaitExpression) {
+        return isOwnedProvider(current.argument, nextSeen);
+      }
+      return false;
+    }
+
+    function providerExpressions(
+      expression: TSESTree.Expression,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): readonly TSESTree.Expression[] {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return [];
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.ArrayExpression) {
+        return current.elements.flatMap((element) => {
+          if (!element) {
+            return [];
+          }
+          return providerExpressions(
+            element.type === AST_NODE_TYPES.SpreadElement
+              ? element.argument
+              : element,
+            nextSeen,
+          );
+        });
+      }
+      if (current.type === AST_NODE_TYPES.ObjectExpression) {
+        return current.properties.flatMap((property) => {
+          if (property.type === AST_NODE_TYPES.SpreadElement) {
+            return providerExpressions(property.argument, nextSeen);
+          }
+          if (
+            propertyName(property) === "provider" &&
+            property.value.type !== AST_NODE_TYPES.AssignmentPattern
+          ) {
+            return [property.value as TSESTree.Expression];
+          }
+          return [];
+        });
+      }
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return providerExpressions(definition.node.init, nextSeen);
+        }
+        return [];
+      }
+      if (
+        current.type === AST_NODE_TYPES.CallExpression &&
+        current.callee.type === AST_NODE_TYPES.MemberExpression &&
+        memberName(current.callee) === "map"
+      ) {
+        const callback = current.arguments[0];
+        if (
+          callback?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          callback?.type === AST_NODE_TYPES.FunctionExpression
+        ) {
+          return (functionReturns.get(callback) ?? []).flatMap((returned) => {
+            return providerExpressions(returned, nextSeen);
+          });
+        }
+        return [];
+      }
+      if (current.type === AST_NODE_TYPES.ConditionalExpression) {
+        return [
+          ...providerExpressions(current.consequent, nextSeen),
+          ...providerExpressions(current.alternate, nextSeen),
+        ];
+      }
+      return [];
+    }
+
+    function mutationName(
+      callee: TSESTree.CallExpression["callee"],
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): MutationName | null {
+      if (seen.has(callee)) {
+        return null;
+      }
+      const nextSeen = new Set(seen).add(callee);
+      if (callee.type === AST_NODE_TYPES.Identifier) {
+        const imported = importedMutations.get(callee.name);
+        if (imported) {
+          return imported;
+        }
+        const definition = variableInScope(context.sourceCode, callee)?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init &&
+          (definition.node.init.type === AST_NODE_TYPES.Identifier ||
+            definition.node.init.type === AST_NODE_TYPES.MemberExpression)
+        ) {
+          return mutationName(definition.node.init, nextSeen);
+        }
+        return null;
+      }
+      if (
+        callee.type === AST_NODE_TYPES.MemberExpression &&
+        callee.object.type === AST_NODE_TYPES.Identifier &&
+        fixtureNamespaces.has(callee.object.name)
+      ) {
+        const name = memberName(callee);
+        return name && RAW_MUTATIONS.has(name as MutationName)
+          ? (name as MutationName)
+          : null;
+      }
+      return null;
+    }
+
+    function checkMutation(call: TSESTree.CallExpression): void {
+      const mutation = mutationName(call.callee);
+      if (!mutation) {
+        return;
+      }
+      const argument = call.arguments[0];
+      if (!argument || argument.type === AST_NODE_TYPES.SpreadElement) {
+        context.report({ node: call, messageId: "unownedPricing" });
+        return;
+      }
+      const providers = providerExpressions(argument);
+      if (providers.length === 0) {
+        context.report({ node: argument, messageId: "unownedPricing" });
+        return;
+      }
+      for (const provider of providers) {
+        if (!isOwnedProvider(provider)) {
+          context.report({ node: provider, messageId: "unownedPricing" });
+        }
+      }
+    }
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        if (
+          typeof node.source.value !== "string" ||
+          !isPricingFixtureModule(node.source.value)
+        ) {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+            fixtureNamespaces.add(specifier.local.name);
+            continue;
+          }
+          if (specifier.type !== AST_NODE_TYPES.ImportSpecifier) {
+            continue;
+          }
+          const importedName =
+            specifier.imported.type === AST_NODE_TYPES.Identifier
+              ? specifier.imported.name
+              : String(specifier.imported.value);
+          if (RAW_MUTATIONS.has(importedName as MutationName)) {
+            importedMutations.set(
+              specifier.local.name,
+              importedName as MutationName,
+            );
+          }
+        }
+      },
+      ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression) {
+        if (node.body.type !== AST_NODE_TYPES.BlockStatement) {
+          addReturn(node, node.body);
+        } else if (!functionReturns.has(node)) {
+          functionReturns.set(node, []);
+        }
+      },
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        if (!functionReturns.has(node)) {
+          functionReturns.set(node, []);
+        }
+      },
+      FunctionExpression(node: TSESTree.FunctionExpression) {
+        if (!functionReturns.has(node)) {
+          functionReturns.set(node, []);
+        }
+      },
+      ReturnStatement(node: TSESTree.ReturnStatement) {
+        const owner = enclosingFunction(node);
+        if (owner && node.argument) {
+          addReturn(owner, node.argument);
+        }
+      },
+      CallExpression(node: TSESTree.CallExpression) {
+        calls.push(node);
+      },
+      "Program:exit"() {
+        for (const call of calls) {
+          checkMutation(call);
+        }
+      },
+    };
+  },
+});

--- a/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
@@ -418,14 +418,18 @@ export const noUnownedUsagePricing = createRule({
             return false;
           }
           const index = parameterIndex(owner, current.name);
-          return callsTo(owner).some((call) => {
-            const argument = call.arguments[index];
-            return Boolean(
-              argument &&
-              argument.type !== AST_NODE_TYPES.SpreadElement &&
-              isUsagePricingFixtureSource(argument, nextSeen),
-            );
-          });
+          const callSites = callsTo(owner);
+          return (
+            callSites.length > 0 &&
+            callSites.every((call) => {
+              const argument = call.arguments[index];
+              return Boolean(
+                argument &&
+                argument.type !== AST_NODE_TYPES.SpreadElement &&
+                isUsagePricingFixtureSource(argument, nextSeen),
+              );
+            })
+          );
         }
         return false;
       }
@@ -494,14 +498,18 @@ export const noUnownedUsagePricing = createRule({
             return false;
           }
           const index = parameterIndex(owner, current.name);
-          return callsTo(owner).some((call) => {
-            const argument = call.arguments[index];
-            return Boolean(
-              argument &&
-              argument.type !== AST_NODE_TYPES.SpreadElement &&
-              isRunFixtureSource(argument, nextSeen),
-            );
-          });
+          const callSites = callsTo(owner);
+          return (
+            callSites.length > 0 &&
+            callSites.every((call) => {
+              const argument = call.arguments[index];
+              return Boolean(
+                argument &&
+                argument.type !== AST_NODE_TYPES.SpreadElement &&
+                isRunFixtureSource(argument, nextSeen),
+              );
+            })
+          );
         }
         return false;
       }

--- a/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-unowned-usage-pricing.ts
@@ -20,6 +20,11 @@ interface CallFrame {
   readonly parent: CallFrame | null;
 }
 
+interface FramedExpression {
+  readonly expression: TSESTree.Expression;
+  readonly frame: CallFrame | null;
+}
+
 type MutationName =
   | "deleteUsagePricingRows"
   | "seedUsagePricingRows"
@@ -267,20 +272,6 @@ export const noUnownedUsagePricing = createRule({
       );
     }
 
-    function callHasSeedRunAction(call: TSESTree.CallExpression): boolean {
-      return call.arguments.some((argument) => {
-        if (argument.type === AST_NODE_TYPES.SpreadElement) {
-          return false;
-        }
-        const action = objectPropertyExpression(argument, "action", new Set());
-        const current = action ? unwrapExpression(action) : null;
-        return (
-          current?.type === AST_NODE_TYPES.Literal &&
-          current.value === "seed-run"
-        );
-      });
-    }
-
     function argumentForParameter(
       identifier: TSESTree.Identifier,
       frame: CallFrame | null,
@@ -305,6 +296,174 @@ export const noUnownedUsagePricing = createRule({
         return null;
       }
       return { expression: argument, frame: ownerFrame.parent };
+    }
+
+    function propertyExpressionInFrame(
+      expression: TSESTree.Expression,
+      name: string,
+      frame: CallFrame | null,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): FramedExpression | null {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return null;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.ObjectExpression) {
+        if (
+          current.properties.some((property) => {
+            return property.type === AST_NODE_TYPES.SpreadElement;
+          })
+        ) {
+          return null;
+        }
+        const matches = current.properties.filter((property) => {
+          return (
+            property.type === AST_NODE_TYPES.Property &&
+            propertyName(property) === name &&
+            property.value.type !== AST_NODE_TYPES.AssignmentPattern
+          );
+        });
+        const match = matches.length === 1 ? matches[0] : null;
+        return match?.type === AST_NODE_TYPES.Property
+          ? {
+              expression: match.value as TSESTree.Expression,
+              frame,
+            }
+          : null;
+      }
+      if (current.type !== AST_NODE_TYPES.Identifier) {
+        return null;
+      }
+      const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      if (
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init
+      ) {
+        return propertyExpressionInFrame(
+          definition.node.init,
+          name,
+          frame,
+          nextSeen,
+        );
+      }
+      if (definition?.type !== "Parameter") {
+        return null;
+      }
+      const argument = argumentForParameter(current, frame);
+      return argument
+        ? propertyExpressionInFrame(
+            argument.expression,
+            name,
+            argument.frame,
+            nextSeen,
+          )
+        : null;
+    }
+
+    function isSeedRunAction(
+      expression: TSESTree.Expression,
+      frame: CallFrame | null,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (
+        current.type === AST_NODE_TYPES.Literal &&
+        current.value === "seed-run"
+      ) {
+        return true;
+      }
+      if (current.type !== AST_NODE_TYPES.Identifier) {
+        return false;
+      }
+      const definition = variableInScope(context.sourceCode, current)?.defs[0];
+      if (
+        definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+        definition.node.init
+      ) {
+        return isSeedRunAction(definition.node.init, frame, nextSeen);
+      }
+      if (definition?.type !== "Parameter") {
+        return false;
+      }
+      const argument = argumentForParameter(current, frame);
+      return Boolean(
+        argument &&
+        isSeedRunAction(argument.expression, argument.frame, nextSeen),
+      );
+    }
+
+    function isSeedRunPayload(
+      expression: TSESTree.Expression,
+      frame: CallFrame | null,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const action = propertyExpressionInFrame(
+        expression,
+        "action",
+        frame,
+        seen,
+      );
+      return Boolean(
+        action && isSeedRunAction(action.expression, action.frame, seen),
+      );
+    }
+
+    function isSerializedSeedRunPayload(
+      expression: TSESTree.Expression,
+      frame: CallFrame | null,
+      seen: ReadonlySet<TSESTree.Node> = new Set(),
+    ): boolean {
+      const current = unwrapExpression(expression);
+      if (seen.has(current)) {
+        return false;
+      }
+      const nextSeen = new Set(seen).add(current);
+      if (current.type === AST_NODE_TYPES.Identifier) {
+        const definition = variableInScope(context.sourceCode, current)
+          ?.defs[0];
+        if (
+          definition?.node.type === AST_NODE_TYPES.VariableDeclarator &&
+          definition.node.init
+        ) {
+          return isSerializedSeedRunPayload(
+            definition.node.init,
+            frame,
+            nextSeen,
+          );
+        }
+        if (definition?.type === "Parameter") {
+          const argument = argumentForParameter(current, frame);
+          return Boolean(
+            argument &&
+            isSerializedSeedRunPayload(
+              argument.expression,
+              argument.frame,
+              nextSeen,
+            ),
+          );
+        }
+        return false;
+      }
+      if (
+        current.type !== AST_NODE_TYPES.CallExpression ||
+        current.callee.type !== AST_NODE_TYPES.MemberExpression ||
+        memberName(current.callee) !== "stringify" ||
+        current.callee.object.type !== AST_NODE_TYPES.Identifier ||
+        current.callee.object.name !== "JSON"
+      ) {
+        return false;
+      }
+      const payload = current.arguments[0];
+      return Boolean(
+        payload &&
+        payload.type !== AST_NODE_TYPES.SpreadElement &&
+        isSeedRunPayload(payload, frame, nextSeen),
+      );
     }
 
     function isScopedRunStateRoutes(
@@ -457,7 +616,23 @@ export const noUnownedUsagePricing = createRule({
       ) {
         const name = memberName(current.callee);
         if (name === "request") {
-          return isScopedRunStateApp(current.callee.object, frame);
+          if (!isScopedRunStateApp(current.callee.object, frame)) {
+            return false;
+          }
+          const options = current.arguments[1];
+          if (!options || options.type === AST_NODE_TYPES.SpreadElement) {
+            return false;
+          }
+          const body = propertyExpressionInFrame(
+            options,
+            "body",
+            frame,
+            nextSeen,
+          );
+          return Boolean(
+            body &&
+            isSerializedSeedRunPayload(body.expression, body.frame, nextSeen),
+          );
         }
         if (name === "json") {
           return isScopedRunStateResponse(
@@ -518,7 +693,7 @@ export const noUnownedUsagePricing = createRule({
         return false;
       }
       const called = localFunctionCalledBy(current);
-      if (!called || !callHasSeedRunAction(current)) {
+      if (!called) {
         return false;
       }
       const returns = functionReturns.get(called) ?? [];


### PR DESCRIPTION
## Summary

- document why teardown cannot establish correctness for shared persistent API test state while preserving cleanup of test-owned rows and handles
- consolidate production-global sweep contract/auth coverage behind a fixed helper and move behavior tests to scoped boundaries
- migrate the five fixed usage-pricing callers to UUID-owned physical lookup rows with request-boundary resolution, and scope every remaining Stripe execution sweep by `automation_id`
- add five fail-closed API ESLint rules with 106 focused caller/dataflow tests for global sweeps, pricing ownership, the production staff identity, cross-test clock staggering, and deleted markers

Epic: #26569

Closes #26604

## Exact base and head

- base: `1a3b9d96818bd4ec7ba6a5a85158d3a126eec790`
- head: `1149f034f10fb38d11f73379f2965a79c4538479`
- current main is the same `1a3b9d96818bd4ec7ba6a5a85158d3a126eec790`. It includes merged #26637's Platform isolation guidance and other ccstate rule paths in the same ESLint-rule package; those changes are preserved, and their Platform-only semantics remain separate from these API rules. It also includes #26745's chat-event snapshot/feature-switch removal, whose paths and semantics do not overlap this PR.
- the branch also preserves #26737's DeepSeek V4 Pro changes. Its shared `run-lifecycle.bdd.test.ts` hunk is model admission/claim only, and its `chat-events.bdd.test.ts` changes add fixture-owned model/session scenarios. #26604 removes only the billing-reconciliation global auth probe from `run-lifecycle.bdd.test.ts:15672-15674`.
- the base includes #26739. Its four Feishu group-task scenarios and `removeFeishuInstallation(fixture)` remain unchanged; the helper removes exactly the fixture actor's `fixture.installationId` and is legitimate owned cleanup.
- the required #26730 `authMode: custom.authMode` expressions remain unchanged at `run-lifecycle.bdd.test.ts:8518,9176`.

## Changed-file inventory

- guidance/config: `docs/testing/api-testing.md`, `turbo/apps/api/eslint.config.mjs`
- rule registration and implementations/tests: `turbo/packages/eslint-rules/src/api/index.ts` plus the five `no-{global-sweep-test-routes,unowned-usage-pricing,production-staff-entitlement-mutation,cross-test-time-staggering,legacy-shared-state-markers}` rule/test pairs
- narrow production-global contract boundary: `global-sweep-contracts.test.ts`, `helpers/global-sweep-contract.ts`
- global-caller migrations: `cron-cleanup-sandboxes.test.ts`, `cron-connector-oauth-state-cleanup.test.ts`, `cron-sync-skills.test.ts`, `helpers/api-bdd-billing-media.ts`, `helpers/api-bdd-email.ts`, `helpers/api-bdd-ops-logs.ts`, `helpers/api-bdd-runs.ts`, `ops-logs.bdd.test.ts`, `run-cron.bdd.test.ts`, `run-lifecycle.bdd.test.ts`, `zero-workflow-automation-scheduler.test.ts`, `model-stats.ts`
- fixed-pricing migrations: `zero-weather.test.ts`, `zero-seo.test.ts`, `zero-avatar-video.test.ts`, `zero-image-share-x.test.ts`, `zero-usage-record.test.ts`, `test-fixtures/usage-pricing.ts`
- scoped Stripe execution: `stripe-automation-events.test.ts`

## Production-global route caller audit

All nine production boundaries remain global in `signals/route.ts`; production behavior is unchanged. Tests have only the following direct production-global references on the exact head:

| Boundary | Remaining test reference | Purpose |
| --- | --- | --- |
| cleanup sandboxes | `global-sweep-contracts.test.ts:28,36` | fixed wrong/missing-auth 401 contracts |
| billing entitlement reconciliation | `global-sweep-contracts.test.ts:52` | fixed missing-auth 401 contract |
| email-outbox drain | `global-sweep-contracts.test.ts:60` | fixed missing-auth 401 contract |
| browser reconciliation | none | production bootstrap only; behavior uses `testBrowserReconcileRoutes` |
| connector OAuth cleanup | `global-sweep-contracts.test.ts:44` | fixed missing-auth 401 contract |
| screenshot cleanup | none | production bootstrap only; behavior uses `cronComputerUseScreenshotCleanupRoutesForTest(commandIds)` |
| model-stats aggregation | `global-sweep-contracts.test.ts:92` | fixed wrong-auth 401 contract; rankings use `modelStatsPublicRoutes` |
| skills sync | `global-sweep-contracts.test.ts:68,76` | fixed wrong/missing-auth 401 contracts |
| workflow automation execution | `global-sweep-contracts.test.ts:84` | fixed missing-auth 401 contract; behavior uses `testWorkflowAutomationExecutionRoutes` with `automation_id` |

The consolidated harness performs nine fixed contract operations. Its helper has no valid-auth input and cannot assert 200. Every global route binding must be passed directly as argument 2 to the matching imported helper with the exact path. There is no whole-file exemption. The rule rejects at the resolved aggregate app-factory mount, including direct/aliased factories, local options/spreads, setupApp contract-binder aliases, local `.routes` member projection, defaulted/renamed object-pattern route bindings, destructured/defaulted helper parameters, canonical app-factory namespace members/destructuring, canonical namespaces propagated through plain or destructured local helper parameters, factory-option objects forwarded through plain parameters, and object-wrapped namespaces forwarded through destructured parameters. All use one finite, cycle-safe complete-callsite/property-path resolver. Metadata-only `ROUTES` member projection/destructuring and an explicit later scoped `routes` override remain valid, including existing inspection in `api-namespace-compatibility.test.ts` and `vercel-crons.test.ts`. The obsolete model-stats `hours=24` tombstone, helper, rule exception, and valid fixture are absent.

Behavior callers retain deterministic boundaries: `testCronCleanupSandboxesStateRoutes`, `testBillingReconciliationStateRoutes`, `testEmailOutboxStateRoutes`, `testBrowserReconcileRoutes`, `cronComputerUseScreenshotCleanupRoutesForTest(commandIds)`, `testModelStatsStateRoutes`, `testCronSyncSkillsStateRoutes`, `testCronDeleteCleanupsStateRoutes`, and `testWorkflowAutomationExecutionRoutes`.

Moved auth callers are exactly the three cron test files, four BDD helpers, `ops-logs.bdd.test.ts`, `run-cron.bdd.test.ts`, `run-lifecycle.bdd.test.ts`, and `zero-workflow-automation-scheduler.test.ts` listed above. `model-stats.ts` now exports public rankings separately while preserving the combined production export.

## Usage-pricing ownership audit

The five previously fixed physical identities now enter only as logical fixture inputs:

| Test / fixture line | Logical identity preserved | Owned physical behavior |
| --- | --- | --- |
| `zero-weather.test.ts:106` | `google-weather` and `google-air-quality` categories/assertions | `createUsagePricingFixture().resolution` is injected into each route client |
| `zero-seo.test.ts:66` | `dataforseo` categories and response assertions | fixture resolution is injected at the request boundary |
| `zero-avatar-video.test.ts:101` | `joggai-talking-avatar` billing assertion | configured rows use owned lookup rows; `withPricing: false` uses `missing` rows, so no physical row exists |
| `zero-image-share-x.test.ts:134` | `x` / `content.create` assertions | fixture resolution is injected into the typed client |
| `zero-usage-record.test.ts:943` | `google-maps` / `geocoding` and six-credit assertions | fixture resolution is injected into the maps request |

Each fixture registers only its owned cleanup. Production resolution is unchanged.

Every remaining raw helper caller is classified below; none uses a fixed operator-managed physical identity:

| File / call lines on the exact head | Ownership |
| --- | --- |
| `cron-cleanup-sandboxes.test.ts:739,749` | `cleanup-test-${fixture.runId}`; the scoped `seed-run` boundary creates that unique run ID and `seed-run-ownership` writes the matching `cleanup-test-${runId}` event provider; cleanup deletes the same row |
| `run-lifecycle.bdd.test.ts:14593,14599,14724,14730` | two `randomUUID()`-derived providers with matching owned deletion |
| `chat-threads.bdd.test.ts:2136,2300` | two `randomUUID()`-derived providers |
| `usage-allowance.test.ts:154` | parameter propagated only from `usageProvider()`, which embeds `randomUUID()` |
| `webhooks-callbacks.bdd.test.ts:5230` | `randomUUID()`-derived provider |
| `zero-email.test.ts:122,128` | `randomUUID()`-derived provider with matching owned deletion |
| `test-usage-settlement.test.ts:68,78,180,197,202` | `randomUUID()`-derived providers with matching owned deletion |
| `zero-usage-record.test.ts:205,219,231` | helper parameters whose complete callsites originate in `uniqueProvider()`, which embeds canonical `node:crypto` `randomUUID()` |
| `zero-recognition.test.ts:565` | deliberate deletion of a `createUsagePricingFixture().resolution` lookup row for missing-pricing behavior |
| `zero-translation.test.ts:485` | deliberate deletion of a `createUsagePricingFixture().resolution` lookup row for missing-pricing behavior |

The rule accepts canonical `node:crypto` `randomUUID`, `createRunsApi`/`createDirectRunFixture` provenance from their exact approved modules, the canonical scoped cron `seed-run` response path, and `createUsagePricingFixture().resolution`. The scoped response proof now requires the returned `run_id` to flow from the exact canonical request whose serialized payload resolves through the helper frames to `action: "seed-run"`; a seed-looking outer call paired with an actual `read-state` request is rejected. The rule also rejects local or arbitrarily imported UUID/run-named factories, arbitrary `.runId`/`.lookupProvider` members, fixed delete/upsert/restore rows, unproven wrapper parameters, and mixed real/fixed object-wrapper callsites.

## Stripe execution audit

`stripe-automation-events.test.ts` removes all 18 remaining global `executeCron()` invocations across 17 call lines, plus the helper itself. The scoped replacement preserves:

- concurrent claims for the same owned automation with exact sorted results `[NO_EXECUTION, EXECUTED_EXECUTION]`
- explicit exact executions for both owned tenants during rollback/retry
- queue-admission retry and exact terminal-skip/no-execution transitions
- older/newer health ordering
- owner feature disablement and connector deauthorization
- expired-claim recovery and the 72-hour retry cutoff
- the already-merged #26734 current/legacy snapshot hunk

There are zero `executeCron()` calls and zero production-global workflow sweep imports left in that file.

## Staff, clock, marker, and cleanup audit

- the fixed production staff literal remains in exactly four files: read/hash behavior in `tokens.test.ts:313`; actor/read behavior in `zero-strapi-integration.test.ts:35` and `zero-workflows.test.ts:59`; and the uncalled fixed-ID defensive branch in `chat-events.bdd.test.ts:158`. Whole-API ESLint proves none flows to entitlement upsert/delete, including named aliases, namespaces, namespace destructuring, direct/options-object wrappers, or `grantProEntitlement`.
- `desktop-updates.test.ts` has no module/describe counter. Its only progression is inside one `withMockNowForTest` TTL test at `desktop-updates.test.ts:256,276,286`.
- repository searches are empty outside the guard's own fixtures/implementation for `threadless-run-cleanup-integration-test`, `withThreadlessRunCleanupTestLock`, `restore-storage-state`, `seed-storage-version`, `delete-storage-version`, `SOLE OWNER`, `resetSecretKmsClientForTests`, and `clearTeamsBotAuthCacheForTest`.
- the owned forms `seed-owned-storage-version` / `seedOwnedStorageVersion` remain valid.
- current API source contains 38 legitimate `afterEach(` registrations and 174 legitimate `onTestFinished(` registrations. The five added registrations clean only the five pricing fixtures. AbortController/signal, MSW reset, connection/socket/stream, detached-work, temporary-file, and fixture-installation cleanup remain valid.

## Mechanical guard cases (106/106)

| Rule | Focused cases | Rejected examples | Allowed examples |
| --- | ---: | --- | --- |
| `no-global-sweep-test-routes` | 45 | aggregate production `ROUTES` direct/aliased request mount, local options object, setupApp contract-binder alias, local member projection, plain/defaulted/renamed object destructuring, destructured/defaulted helper parameters, canonical app-factory namespace member/destructuring, canonical namespace plain/destructured helper parameters, forwarded factory-option objects, wrapped/nested namespace parameter projections, explicit-undefined canonical property/plain-parameter/object-parameter defaults, transitive immutable undefined aliases, later undefined spread overwrite, and ts-rest behavior client; old behavior helper, renamed import, local alias, array/spread, wrapper, named/star re-export, authorized 200 call beside an auth probe, namespace/dynamic import | production bootstrap, direct fixed 401 contract helpers, scoped routes and scoped namespace mounts, public rankings, metadata-only member/destructured `ROUTES` inspection, later explicit scoped-route/property override, an explicit scoped factory property overriding a canonical default, omitted/defaulted non-aggregate bindings, mixed canonical/scoped callsites |
| `no-unowned-usage-pricing` | 22 | discarded or mismatched scoped response with a fixed/false-owned `run_id`, fixed overwrite/delete/restore, const alias, unproven parameter, fake lookup/run members, fixed wrapper return, local/arbitrary UUID factory, fake/arbitrary run factory, mixed real/fixed `lookupProvider` and `runId` wrapper calls | logical fixture inputs, canonical UUID, canonical run/returned exact scoped seed-run response, fixture lookup deletion, proven UUID wrapper/mapping, owned-handle cleanup |
| `no-production-staff-entitlement-mutation` | 13 | canonical namespace member/destructured mutation, destructured/options wrapper, direct literal upsert, const-alias delete, `user({orgId})` grant, actor wrapper propagation, mutation alias | read/hash/auth use, unique actor, `createUniqueStaffOrgIdFixture`, unreachable defensive fixed-ID branch |
| `no-cross-test-time-staggering` | 15 | canonical namespace member/destructured `mockNow`, multi-hop local aliases, module/describe counters, mutable `clock.index` members, increments before/after time calls, aliased hooks/describe, hook-called wrapper, `afterEach` staggering | fixed hook time, in-test TTL progression, `clearMockNow` |
| `no-legacy-shared-state-markers` | 11 | every deleted lock/storage/process-reset marker in identifiers, comments, strings, or templates | owned storage actions, owned cleanup, scoped process override |

The six reproductions from review 4919661222 remain explicit invalid cases: aggregate `ROUTES` mounted through a local alias; a discarded scoped response followed by a fixed `run_id`; canonical namespace staff-fixture mutation; destructured staff options propagation; canonical namespace `time.mockNow`; and a two-hop local `mockNow` alias.

The four reproductions from review 4919987870 are also explicit invalid cases: aggregate `ROUTES` mounted by `setupApp` and invoked through a ts-rest contract client; a seed-looking outer call whose canonical scoped request actually serializes `read-state`; destructuring the canonical entitlement namespace into an upsert alias; and destructuring the canonical time namespace into a `mockNow` alias fed by suite-shared order.

The two reproductions from review 4920147651 are explicit invalid cases as well: storing the aggregate `setupApp` contract binder in a local variable before invocation, and passing a local options object containing aggregate `ROUTES` to `createApp`. Both now report exactly once at the resolved aggregate mount.

The two reproductions from review 4920297161 are explicit invalid cases: projecting `options.routes` into a `createApp` mount and destructuring `{ routes }` from local aggregate options before a `setupApp` contract mount. Both now trace to production aggregate `ROUTES` and report exactly once.

The six reproductions from review 4920380072 are explicit invalid cases: defaulted shorthand and renamed object destructuring, destructured and defaulted-destructured helper parameters, a canonical app-factory namespace member, and canonical app-factory namespace destructuring. All six now resolve through the same finite local provenance path and report exactly once. Three companion valid cases prove that metadata-only member projection, metadata-only object destructuring, and `{ ...aggregateOptions, routes: scopedRoutes }` remain allowed.

The two reproductions from review 4920529402 are explicit invalid cases: passing the canonical app-factory namespace through a plain local helper parameter and destructuring its `createApp` member from an object-pattern helper parameter. Both resolve through complete local callsites and report exactly once; computed/member aliases, shorthand/defaulted local factory destructuring, two-hop route helpers, omitted defaults, scoped overrides, and scoped namespace mounts remain valid.

The two reproductions from review 4920620189 are explicit invalid cases: forwarding a canonical factory-method options object through a plain helper parameter, and forwarding an object-wrapped canonical namespace through a destructured helper parameter. Both now resolve through the same cycle-safe binding/property-path graph and report exactly once; two-hop canonical namespaces, canonical defaults, mixed canonical/scoped callsites, scoped namespaces, and explicit scoped property overrides remain valid.

The valid reproduction from review 4920712563 is explicit: `{ createApp: buildScopedApp }` overrides the canonical `build = appFactory.createApp` default and produces no report. Parameter bindings are excluded from local function-callee resolution, so invoking `build({ routes: ROUTES })` can no longer masquerade as another callsite of its containing `mount` function. Defaults activate only when the actual property is absent.

The two reproductions from review 4920787918 are explicit invalid cases: a statically explicit `undefined` factory property activates the canonical destructuring default, and a canonical namespace survives a nested `options.factory` member projection rooted in a complete destructured-parameter callsite. Both report exactly once. The resolver treats only provably global `undefined`/`void` as absent and translates member projections into the same finite property path; forwarded scoped overrides, scoped parameter defaults, all-scoped callsites, both spread precedence directions, missing canonical defaults, two-hop namespaces, and mixed canonical/scoped callsites remain valid.

The three reproductions from review 4920839213 are explicit invalid cases: a statically explicit `undefined` argument activates a canonical plain parameter default; the same argument activates a whole-object parameter default before object binding; and a later spread that explicitly writes `undefined` over a scoped factory activates the canonical property default. The finite resolver now distinguishes an absent property from a present-but-default-triggering value across complete parameter, property, and spread paths. Shadowed `undefined`, scoped nested projections, later scoped spread overrides, `void` defaults, and computed nested canonical projections retain their runtime semantics.


The two reproductions from review 4920973917 are explicit invalid cases: a local immutable alias of global `undefined` activates the canonical plain parameter default, and a local immutable alias of `void 0` activates the canonical whole-object parameter default. `isStaticallyUndefined` now resolves local declarator aliases through the existing finite, cycle-safe immutable-expression graph, which rejects reassigned aliases and preserves a shadowed `undefined` binding as a real value. The prior 104 cases and all eight bounded default-neighborhood controls remain valid.

## Validation

Passed on replacement head `1149f034f10fb38d11f73379f2965a79c4538479` rebased onto `1a3b9d96818bd4ec7ba6a5a85158d3a126eec790`:

- the five focused RuleTester files run individually with `pnpm -F @vm0/eslint-rules exec vitest run <file>` — 106/106 tests (45 + 22 + 13 + 15 + 11)
- `pnpm -F @vm0/eslint-rules lint`
- `pnpm -F @vm0/eslint-rules check-types`
- `pnpm -F api exec eslint . --max-warnings 0` — all five guards pass over the complete rebased API tree
- `pnpm -F api run check-types:tests`
- `git diff --name-only --diff-filter=ACMRT origin/main -z | xargs -0 turbo/node_modules/.bin/prettier --check --ignore-unknown`
- `git diff --check`

PostgreSQL-backed focused integration commands were **NOT RUN locally** on this replacement head. The earlier focused command `pnpm -F api exec vitest run src/signals/routes/__tests__/global-sweep-contracts.test.ts` failed during setup before test execution with `connect ECONNREFUSED ::1:5432` and `connect ECONNREFUSED 127.0.0.1:5432`. Docker remains unavailable (`docker: command not found`), and no dev server was started. The exact-head PR pipeline must supply the real-PostgreSQL behavior evidence for the nine-operation contract harness, cleanup-sandbox owned pricing, all five migrated pricing tests, and the scoped Stripe execution paths.

## Live overlap status

The complete paginated `--limit 100` scan on base `1a3b9d96818bd4ec7ba6a5a85158d3a126eec790` covered 21 open PRs (20 other heads). No other open PR references or closes #26604. Exact changed-path overlaps are:

- #26726 at `a375b161a4a0b780a340c571a81b4ece92de1d93`: `run-lifecycle.bdd.test.ts`, custom/builtin firewall auth sections; semantically distinct.
- #26393 at `6bf55fe9cca006f2e315797d87a0285ee417d5c6`: `helpers/api-bdd-runs.ts`, Stripe subscription-price fixture fields; this PR removes only the global billing cron auth method from that helper.
- #25722 at exact head `96cda73649902b4df67881f213d9016c477e38a6` (draft/open): `cron-sync-skills.test.ts`. Its current hunk owns the Git-tree/archive/Worker bounded-sync rewrite and does not own the production-global auth-probe removal; a future merge/rebase must preserve both semantics.

#26743 advanced to `c95d3f330b1a2ec0b165a26b36abb544e2701099` and changes runner workspace-cache paths only. #26742 remains at `175c78dc5659834089d315fd6af3f591b9ba2728` and removes connector secret-placeholder compatibility. Both are non-overlapping and neither references #26604.

#26744 is merged in the exact base. Its two `api-contracts` model-family/model-price-tier test paths remain non-overlapping.

#26745 is merged in the exact base at `1a3b9d96818bd4ec7ba6a5a85158d3a126eec790`. Its chat-event snapshot-read feature-switch removal shares none of this PR's 34 paths and introduces none of the five forbidden classes/deleted markers.

#26746 at `9ac7920d1cd870c33aa7ce08250736cda5f3ae56` is the open release-main PR. Its release metadata/version/changelog changes share none of this PR's 34 paths and have no #26604 semantic overlap.

Adjacent documentation/rule work:

- #26637 is an ancestor of the exact base at `f7ac054e4b749db68b77b941410615284738ae2b`. Its Platform clock guidance and Platform-only `no-test-after-each` rule are preserved and remain separate from this API-specific file/rule set.
- #25722's adjacent API config change remains confined to `.oxlintrc.json`; this PR changes `eslint.config.mjs` and does not overwrite its Worker/instrument restrictions.
