### PR TITLE
perf(runner): publish shared workspace cache changes promptly

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -19,7 +19,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde", "now"] }
 clap = { workspace = true, features = ["derive", "env"] }
-nix = { workspace = true, features = ["user", "signal", "fs", "process"] }
+nix = { workspace = true, features = ["user", "signal", "fs", "process", "inotify"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -90,6 +90,7 @@ pub(super) struct HeartbeatController<'a> {
 
 struct HeartbeatRequest {
     force_send: bool,
+    refresh_workspace_cache: bool,
     workspace_cache_change: Option<WorkspaceCacheChange>,
 }
 
@@ -97,6 +98,15 @@ impl HeartbeatRequest {
     fn ordinary() -> Self {
         Self {
             force_send: true,
+            refresh_workspace_cache: true,
+            workspace_cache_change: None,
+        }
+    }
+
+    fn initial_workspace_cache_snapshot() -> Self {
+        Self {
+            force_send: true,
+            refresh_workspace_cache: false,
             workspace_cache_change: None,
         }
     }
@@ -104,12 +114,14 @@ impl HeartbeatRequest {
     fn workspace_cache(change: WorkspaceCacheChange) -> Self {
         Self {
             force_send: false,
+            refresh_workspace_cache: true,
             workspace_cache_change: Some(change),
         }
     }
 
     fn merge(mut self, other: Self) -> Self {
         self.force_send |= other.force_send;
+        self.refresh_workspace_cache |= other.refresh_workspace_cache;
         match (
             self.workspace_cache_change.as_mut(),
             other.workspace_cache_change,
@@ -142,6 +154,13 @@ impl<'a> HeartbeatController<'a> {
         change: WorkspaceCacheChange,
     ) -> RunnerResult<()> {
         self.request_inner(mode, HeartbeatRequest::workspace_cache(change))
+    }
+
+    pub(super) fn request_initial_workspace_cache_snapshot(
+        &mut self,
+        mode: RunnerMode,
+    ) -> RunnerResult<()> {
+        self.request_inner(mode, HeartbeatRequest::initial_workspace_cache_snapshot())
     }
 
     pub(super) fn request_initial_workspace_cache(
@@ -393,6 +412,10 @@ impl WorkspaceCacheStateSnapshot {
         )
     }
 
+    fn loaded_workspace_cache_states(&self) -> Vec<HeldWorkspaceState> {
+        self.lock_inner().workspace_cache_states.clone()
+    }
+
     fn lock_inner(&self) -> MutexGuard<'_, WorkspaceCacheStateSnapshotInner> {
         self.inner
             .lock()
@@ -428,13 +451,20 @@ async fn send_heartbeat(
         hb.workspace_cache_snapshot
             .current_held_workspace_states(hb.active_runs, None)
     });
-    let refresh = refresh_workspace_cache_snapshot_after_change(
-        &hb.workspace_cache_snapshot,
-        hb.workspace_cache.as_ref(),
-        hb.profiles,
-        cache_change,
-    )
-    .await;
+    let refresh = if request.refresh_workspace_cache {
+        refresh_workspace_cache_snapshot_after_change(
+            &hb.workspace_cache_snapshot,
+            hb.workspace_cache.as_ref(),
+            hb.profiles,
+            cache_change,
+        )
+        .await
+    } else {
+        WorkspaceCacheRefreshOutcome {
+            states: hb.workspace_cache_snapshot.loaded_workspace_cache_states(),
+            changed: false,
+        }
+    };
     state.held_sandbox_states =
         filter_current_held_sandbox_states(state.held_sandbox_states, hb.active_runs, None);
     state.held_workspace_states =
@@ -1116,6 +1146,77 @@ mod tests {
         assert_eq!(
             cached_states[0].workspace_caches,
             vec![workspace_cache("vm0/default")]
+        );
+    }
+
+    #[tokio::test]
+    async fn initial_workspace_cache_heartbeat_uses_loaded_snapshot() {
+        let reuse_key = "thread:loaded-initial-snapshot";
+        let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 1,
+        })));
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = WorkspaceImageCache::new(paths.clone());
+        seed_workspace_cache_state(&cache, &paths, reuse_key, "2026-06-01T00:00:00.000Z").await;
+        let profiles = test_profiles();
+        let budget = ResourceBudget::new(8, 32768, 1.0, 4);
+        let active_runs = test_active_runs();
+        let (provider, handle) = MockJobProvider::new(tokio_util::sync::CancellationToken::new());
+        let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
+        refresh_snapshot(
+            &workspace_cache_snapshot,
+            vec![held_workspace_state(
+                reuse_key,
+                "2026-06-01T00:00:00.000Z",
+                &["vm0/default"],
+            )],
+        );
+        let cache_key = crate::paths::scoped_workspace_image_cache_key(
+            "",
+            "vm0/default",
+            reuse_key,
+            CANONICAL_WORKING_DIR,
+            1024 * 1024,
+        );
+        let metadata = paths
+            .workspace_image_cache_dir()
+            .join(cache_key)
+            .join("metadata.json");
+        tokio::fs::remove_file(metadata).await.unwrap();
+        let hb = HeartbeatContext::new(HeartbeatContextInit {
+            idle_pool: &idle_pool,
+            runner_id: "runner-1",
+            name: "test-runner",
+            group: "vm0/test",
+            snapshot_generation: 7,
+            profiles: &profiles,
+            budget: &budget,
+            provider: provider.as_ref(),
+            workspace_cache: Some(cache),
+            active_runs: &active_runs,
+            workspace_cache_snapshot,
+        });
+
+        send_heartbeat(
+            &hb,
+            RunnerMode::Running,
+            42,
+            HeartbeatRequest::initial_workspace_cache_snapshot(),
+        )
+        .await;
+
+        let heartbeats = handle.heartbeats.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(heartbeats.len(), 1);
+        assert_eq!(
+            heartbeats[0].held_workspace_states,
+            vec![held_workspace_state(
+                reuse_key,
+                "2026-06-01T00:00:00.000Z",
+                &["vm0/default"],
+            )]
         );
     }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -90,46 +90,55 @@ pub(super) struct HeartbeatController<'a> {
 
 struct HeartbeatRequest {
     force_send: bool,
-    refresh_workspace_cache: bool,
-    workspace_cache_change: Option<WorkspaceCacheChange>,
+    workspace_cache_refresh: WorkspaceCacheRefresh,
+}
+
+enum WorkspaceCacheRefresh {
+    LoadedSnapshot,
+    FullScan,
+    AfterChange(WorkspaceCacheChange),
+}
+
+impl WorkspaceCacheRefresh {
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::FullScan, _) | (_, Self::FullScan) => Self::FullScan,
+            (Self::LoadedSnapshot, refresh) | (refresh, Self::LoadedSnapshot) => refresh,
+            (Self::AfterChange(mut existing), Self::AfterChange(incoming)) => {
+                existing.merge(incoming);
+                Self::AfterChange(existing)
+            }
+        }
+    }
 }
 
 impl HeartbeatRequest {
     fn ordinary() -> Self {
         Self {
             force_send: true,
-            refresh_workspace_cache: true,
-            workspace_cache_change: None,
+            workspace_cache_refresh: WorkspaceCacheRefresh::FullScan,
         }
     }
 
     fn initial_workspace_cache_snapshot() -> Self {
         Self {
             force_send: true,
-            refresh_workspace_cache: false,
-            workspace_cache_change: None,
+            workspace_cache_refresh: WorkspaceCacheRefresh::LoadedSnapshot,
         }
     }
 
     fn workspace_cache(change: WorkspaceCacheChange) -> Self {
         Self {
             force_send: false,
-            refresh_workspace_cache: true,
-            workspace_cache_change: Some(change),
+            workspace_cache_refresh: WorkspaceCacheRefresh::AfterChange(change),
         }
     }
 
     fn merge(mut self, other: Self) -> Self {
         self.force_send |= other.force_send;
-        self.refresh_workspace_cache |= other.refresh_workspace_cache;
-        match (
-            self.workspace_cache_change.as_mut(),
-            other.workspace_cache_change,
-        ) {
-            (Some(existing), Some(incoming)) => existing.merge(incoming),
-            (None, Some(incoming)) => self.workspace_cache_change = Some(incoming),
-            (Some(_) | None, None) => {}
-        }
+        self.workspace_cache_refresh = self
+            .workspace_cache_refresh
+            .merge(other.workspace_cache_refresh);
         self
     }
 }
@@ -446,23 +455,36 @@ async fn send_heartbeat(
         mode,
     );
     drop(pool);
-    let cache_change = request.workspace_cache_change.as_ref();
+    let cache_change = match &request.workspace_cache_refresh {
+        WorkspaceCacheRefresh::AfterChange(change) => Some(change),
+        WorkspaceCacheRefresh::LoadedSnapshot | WorkspaceCacheRefresh::FullScan => None,
+    };
     let previous_workspace_states = cache_change.map(|_| {
         hb.workspace_cache_snapshot
             .current_held_workspace_states(hb.active_runs, None)
     });
-    let refresh = if request.refresh_workspace_cache {
-        refresh_workspace_cache_snapshot_after_change(
-            &hb.workspace_cache_snapshot,
-            hb.workspace_cache.as_ref(),
-            hb.profiles,
-            cache_change,
-        )
-        .await
-    } else {
-        WorkspaceCacheRefreshOutcome {
+    let refresh = match &request.workspace_cache_refresh {
+        WorkspaceCacheRefresh::LoadedSnapshot => WorkspaceCacheRefreshOutcome {
             states: hb.workspace_cache_snapshot.loaded_workspace_cache_states(),
             changed: false,
+        },
+        WorkspaceCacheRefresh::FullScan => {
+            refresh_workspace_cache_snapshot_after_change(
+                &hb.workspace_cache_snapshot,
+                hb.workspace_cache.as_ref(),
+                hb.profiles,
+                None,
+            )
+            .await
+        }
+        WorkspaceCacheRefresh::AfterChange(change) => {
+            refresh_workspace_cache_snapshot_after_change(
+                &hb.workspace_cache_snapshot,
+                hb.workspace_cache.as_ref(),
+                hb.profiles,
+                Some(change),
+            )
+            .await
         }
     };
     state.held_sandbox_states =
@@ -951,6 +973,33 @@ mod tests {
                     .is_some_and(|actual| actual == message)
             })
             .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
+    }
+
+    fn workspace_cache_change(cache_key: &str) -> WorkspaceCacheChange {
+        WorkspaceCacheChange {
+            observed_at: tokio::time::Instant::now(),
+            committed_cache_keys: BTreeSet::from([cache_key.to_owned()]),
+        }
+    }
+
+    #[test]
+    fn ordinary_heartbeat_dominates_cache_commit_wait_when_coalesced() {
+        let cache_then_ordinary = HeartbeatRequest::workspace_cache(workspace_cache_change("a"))
+            .merge(HeartbeatRequest::ordinary());
+        let ordinary_then_cache = HeartbeatRequest::ordinary().merge(
+            HeartbeatRequest::workspace_cache(workspace_cache_change("b")),
+        );
+
+        assert!(cache_then_ordinary.force_send);
+        assert!(matches!(
+            cache_then_ordinary.workspace_cache_refresh,
+            WorkspaceCacheRefresh::FullScan
+        ));
+        assert!(ordinary_then_cache.force_send);
+        assert!(matches!(
+            ordinary_then_cache.workspace_cache_refresh,
+            WorkspaceCacheRefresh::FullScan
+        ));
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -300,6 +300,7 @@ pub(super) struct WorkspaceCacheRefreshOutcome {
 pub(super) struct InitialWorkspaceCacheRefreshOutcome {
     pub(super) states: Vec<HeldWorkspaceState>,
     pub(super) locked_commit_keys: BTreeSet<String>,
+    pub(super) loaded_cache_keys: BTreeSet<String>,
 }
 
 impl WorkspaceCacheStateSnapshot {
@@ -517,16 +518,18 @@ pub(super) async fn refresh_initial_workspace_cache_snapshot(
         return InitialWorkspaceCacheRefreshOutcome {
             states: outcome.states,
             locked_commit_keys: BTreeSet::new(),
+            loaded_cache_keys: BTreeSet::new(),
         };
     };
     let profile_image_sizes_bytes = profile_image_sizes_bytes(profiles);
-    let (states, locked_commit_keys) = cache
+    let (states, locked_commit_keys, loaded_cache_keys) = cache
         .initial_held_workspace_states_for_profiles(&profile_image_sizes_bytes)
         .await;
     let outcome = snapshot.finish_workspace_cache_refresh(refresh, states);
     InitialWorkspaceCacheRefreshOutcome {
         states: outcome.states,
         locked_commit_keys,
+        loaded_cache_keys,
     }
 }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -90,55 +90,46 @@ pub(super) struct HeartbeatController<'a> {
 
 struct HeartbeatRequest {
     force_send: bool,
-    workspace_cache_refresh: WorkspaceCacheRefresh,
-}
-
-enum WorkspaceCacheRefresh {
-    LoadedSnapshot,
-    FullScan,
-    AfterChange(WorkspaceCacheChange),
-}
-
-impl WorkspaceCacheRefresh {
-    fn merge(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::FullScan, _) | (_, Self::FullScan) => Self::FullScan,
-            (Self::LoadedSnapshot, refresh) | (refresh, Self::LoadedSnapshot) => refresh,
-            (Self::AfterChange(mut existing), Self::AfterChange(incoming)) => {
-                existing.merge(incoming);
-                Self::AfterChange(existing)
-            }
-        }
-    }
+    refresh_workspace_cache: bool,
+    workspace_cache_change: Option<WorkspaceCacheChange>,
 }
 
 impl HeartbeatRequest {
     fn ordinary() -> Self {
         Self {
             force_send: true,
-            workspace_cache_refresh: WorkspaceCacheRefresh::FullScan,
+            refresh_workspace_cache: true,
+            workspace_cache_change: None,
         }
     }
 
     fn initial_workspace_cache_snapshot() -> Self {
         Self {
             force_send: true,
-            workspace_cache_refresh: WorkspaceCacheRefresh::LoadedSnapshot,
+            refresh_workspace_cache: false,
+            workspace_cache_change: None,
         }
     }
 
     fn workspace_cache(change: WorkspaceCacheChange) -> Self {
         Self {
             force_send: false,
-            workspace_cache_refresh: WorkspaceCacheRefresh::AfterChange(change),
+            refresh_workspace_cache: true,
+            workspace_cache_change: Some(change),
         }
     }
 
     fn merge(mut self, other: Self) -> Self {
         self.force_send |= other.force_send;
-        self.workspace_cache_refresh = self
-            .workspace_cache_refresh
-            .merge(other.workspace_cache_refresh);
+        self.refresh_workspace_cache |= other.refresh_workspace_cache;
+        match (
+            self.workspace_cache_change.as_mut(),
+            other.workspace_cache_change,
+        ) {
+            (Some(existing), Some(incoming)) => existing.merge(incoming),
+            (None, Some(incoming)) => self.workspace_cache_change = Some(incoming),
+            (Some(_) | None, None) => {}
+        }
         self
     }
 }
@@ -455,36 +446,23 @@ async fn send_heartbeat(
         mode,
     );
     drop(pool);
-    let cache_change = match &request.workspace_cache_refresh {
-        WorkspaceCacheRefresh::AfterChange(change) => Some(change),
-        WorkspaceCacheRefresh::LoadedSnapshot | WorkspaceCacheRefresh::FullScan => None,
-    };
+    let cache_change = request.workspace_cache_change.as_ref();
     let previous_workspace_states = cache_change.map(|_| {
         hb.workspace_cache_snapshot
             .current_held_workspace_states(hb.active_runs, None)
     });
-    let refresh = match &request.workspace_cache_refresh {
-        WorkspaceCacheRefresh::LoadedSnapshot => WorkspaceCacheRefreshOutcome {
+    let refresh = if request.refresh_workspace_cache {
+        refresh_workspace_cache_snapshot_after_change(
+            &hb.workspace_cache_snapshot,
+            hb.workspace_cache.as_ref(),
+            hb.profiles,
+            cache_change,
+        )
+        .await
+    } else {
+        WorkspaceCacheRefreshOutcome {
             states: hb.workspace_cache_snapshot.loaded_workspace_cache_states(),
             changed: false,
-        },
-        WorkspaceCacheRefresh::FullScan => {
-            refresh_workspace_cache_snapshot_after_change(
-                &hb.workspace_cache_snapshot,
-                hb.workspace_cache.as_ref(),
-                hb.profiles,
-                None,
-            )
-            .await
-        }
-        WorkspaceCacheRefresh::AfterChange(change) => {
-            refresh_workspace_cache_snapshot_after_change(
-                &hb.workspace_cache_snapshot,
-                hb.workspace_cache.as_ref(),
-                hb.profiles,
-                Some(change),
-            )
-            .await
         }
     };
     state.held_sandbox_states =
@@ -983,7 +961,7 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_heartbeat_dominates_cache_commit_wait_when_coalesced() {
+    fn ordinary_heartbeat_forces_send_without_dropping_coalesced_cache_commits() {
         let cache_then_ordinary = HeartbeatRequest::workspace_cache(workspace_cache_change("a"))
             .merge(HeartbeatRequest::ordinary());
         let ordinary_then_cache = HeartbeatRequest::ordinary().merge(
@@ -991,15 +969,23 @@ mod tests {
         );
 
         assert!(cache_then_ordinary.force_send);
-        assert!(matches!(
-            cache_then_ordinary.workspace_cache_refresh,
-            WorkspaceCacheRefresh::FullScan
-        ));
+        assert!(cache_then_ordinary.refresh_workspace_cache);
+        assert_eq!(
+            cache_then_ordinary
+                .workspace_cache_change
+                .unwrap()
+                .committed_cache_keys,
+            BTreeSet::from(["a".to_owned()])
+        );
         assert!(ordinary_then_cache.force_send);
-        assert!(matches!(
-            ordinary_then_cache.workspace_cache_refresh,
-            WorkspaceCacheRefresh::FullScan
-        ));
+        assert!(ordinary_then_cache.refresh_workspace_cache);
+        assert_eq!(
+            ordinary_then_cache
+                .workspace_cache_change
+                .unwrap()
+                .committed_cache_keys,
+            BTreeSet::from(["b".to_owned()])
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -16,11 +16,14 @@ use crate::types::{
     HeartbeatState, HeldSandboxState, HeldWorkspaceState, MAX_HELD_SANDBOX_STATES,
     MAX_WORKSPACE_CACHES_PER_REUSE_KEY,
 };
-use crate::workspace_image_cache::{WorkspaceImageCache, cap_held_workspace_states};
+use crate::workspace_image_cache::{
+    WorkspaceCacheChange, WorkspaceImageCache, cap_held_workspace_states,
+};
 
 /// Period between routine heartbeat ticks sent to the server. First tick is
 /// deferred by one period via `interval_at`.
 pub(super) const HEARTBEAT_PERIOD: Duration = Duration::from_secs(10);
+const WORKSPACE_CACHE_COMMIT_WAIT: Duration = Duration::from_secs(2);
 
 /// References needed to collect and send a heartbeat.
 ///
@@ -81,8 +84,42 @@ impl<'a> HeartbeatContext<'a> {
 pub(super) struct HeartbeatController<'a> {
     context: HeartbeatContext<'a>,
     in_flight: Option<BoxFuture<'a, ()>>,
-    pending: bool,
+    pending: Option<HeartbeatRequest>,
     next_snapshot_sequence: u64,
+}
+
+struct HeartbeatRequest {
+    force_send: bool,
+    workspace_cache_change: Option<WorkspaceCacheChange>,
+}
+
+impl HeartbeatRequest {
+    fn ordinary() -> Self {
+        Self {
+            force_send: true,
+            workspace_cache_change: None,
+        }
+    }
+
+    fn workspace_cache(change: WorkspaceCacheChange) -> Self {
+        Self {
+            force_send: false,
+            workspace_cache_change: Some(change),
+        }
+    }
+
+    fn merge(mut self, other: Self) -> Self {
+        self.force_send |= other.force_send;
+        match (
+            self.workspace_cache_change.as_mut(),
+            other.workspace_cache_change,
+        ) {
+            (Some(existing), Some(incoming)) => existing.merge(incoming),
+            (None, Some(incoming)) => self.workspace_cache_change = Some(incoming),
+            (Some(_) | None, None) => {}
+        }
+        self
+    }
 }
 
 impl<'a> HeartbeatController<'a> {
@@ -90,16 +127,41 @@ impl<'a> HeartbeatController<'a> {
         Self {
             context,
             in_flight: None,
-            pending: false,
+            pending: None,
             next_snapshot_sequence: 1,
         }
     }
 
     pub(super) fn request(&mut self, mode: RunnerMode) -> RunnerResult<()> {
+        self.request_inner(mode, HeartbeatRequest::ordinary())
+    }
+
+    pub(super) fn request_workspace_cache(
+        &mut self,
+        mode: RunnerMode,
+        change: WorkspaceCacheChange,
+    ) -> RunnerResult<()> {
+        self.request_inner(mode, HeartbeatRequest::workspace_cache(change))
+    }
+
+    pub(super) fn request_initial_workspace_cache(
+        &mut self,
+        mode: RunnerMode,
+        change: WorkspaceCacheChange,
+    ) -> RunnerResult<()> {
+        let mut request = HeartbeatRequest::workspace_cache(change);
+        request.force_send = true;
+        self.request_inner(mode, request)
+    }
+
+    fn request_inner(&mut self, mode: RunnerMode, request: HeartbeatRequest) -> RunnerResult<()> {
         if self.in_flight.is_some() {
-            self.pending = true;
+            self.pending = Some(match self.pending.take() {
+                Some(pending) => pending.merge(request),
+                None => request,
+            });
         } else {
-            self.start(mode)?;
+            self.start(mode, request)?;
         }
         Ok(())
     }
@@ -121,8 +183,8 @@ impl<'a> HeartbeatController<'a> {
     pub(super) fn finish_send(&mut self, live_mode: RunnerMode) -> RunnerResult<()> {
         debug_assert!(self.in_flight.is_some());
         self.in_flight = None;
-        if std::mem::take(&mut self.pending) {
-            self.start(live_mode)?;
+        if let Some(request) = self.pending.take() {
+            self.start(live_mode, request)?;
         }
         Ok(())
     }
@@ -136,8 +198,8 @@ impl<'a> HeartbeatController<'a> {
         loop {
             self.wait_for_send().await?;
             self.in_flight = None;
-            if std::mem::take(&mut self.pending) {
-                self.start(mode)?;
+            if let Some(request) = self.pending.take() {
+                self.start(mode, request)?;
             } else {
                 break;
             }
@@ -154,7 +216,7 @@ impl<'a> HeartbeatController<'a> {
         if let Some(send) = self.in_flight.take() {
             send.await;
         }
-        self.pending = false;
+        self.pending = None;
     }
 
     pub(super) fn into_next_snapshot_sequence(self) -> u64 {
@@ -162,7 +224,7 @@ impl<'a> HeartbeatController<'a> {
         self.next_snapshot_sequence
     }
 
-    fn start(&mut self, mode: RunnerMode) -> RunnerResult<()> {
+    fn start(&mut self, mode: RunnerMode, request: HeartbeatRequest) -> RunnerResult<()> {
         debug_assert!(self.in_flight.is_none());
         let snapshot_sequence = self.next_snapshot_sequence;
         let next_snapshot_sequence = snapshot_sequence.checked_add(1).ok_or_else(|| {
@@ -171,7 +233,7 @@ impl<'a> HeartbeatController<'a> {
         self.next_snapshot_sequence = next_snapshot_sequence;
         let context = self.context.clone();
         self.in_flight = Some(Box::pin(async move {
-            send_heartbeat(&context, mode, snapshot_sequence).await;
+            send_heartbeat(&context, mode, snapshot_sequence, request).await;
         }));
         Ok(())
     }
@@ -209,6 +271,16 @@ struct WorkspaceCacheStateSnapshotInner {
 #[derive(Clone, Copy)]
 pub(super) struct WorkspaceCacheSnapshotRefresh {
     revision: u64,
+}
+
+pub(super) struct WorkspaceCacheRefreshOutcome {
+    pub(super) states: Vec<HeldWorkspaceState>,
+    pub(super) changed: bool,
+}
+
+pub(super) struct InitialWorkspaceCacheRefreshOutcome {
+    pub(super) states: Vec<HeldWorkspaceState>,
+    pub(super) locked_commit_keys: BTreeSet<String>,
 }
 
 impl WorkspaceCacheStateSnapshot {
@@ -249,17 +321,22 @@ impl WorkspaceCacheStateSnapshot {
         &self,
         refresh: WorkspaceCacheSnapshotRefresh,
         states: Vec<HeldWorkspaceState>,
-    ) -> Vec<HeldWorkspaceState> {
+    ) -> WorkspaceCacheRefreshOutcome {
         let mut inner = self.lock_inner();
-        inner.workspace_cache_states = if inner.workspace_cache_revision == refresh.revision {
+        let mut next = if inner.workspace_cache_revision == refresh.revision {
             states
         } else {
             merge_workspace_cache_snapshot_states(inner.workspace_cache_states.clone(), states)
         };
-        cap_workspace_cache_snapshot_states(&mut inner.workspace_cache_states);
+        cap_workspace_cache_snapshot_states(&mut next);
+        let changed = inner.workspace_cache_states != next;
+        inner.workspace_cache_states = next;
         inner.workspace_cache_loaded = true;
         inner.workspace_cache_revision = inner.workspace_cache_revision.wrapping_add(1);
-        inner.workspace_cache_states.clone()
+        WorkspaceCacheRefreshOutcome {
+            changed,
+            states: inner.workspace_cache_states.clone(),
+        }
     }
 
     /// Incorporates a successful workspace-cache promotion into the snapshot.
@@ -325,10 +402,11 @@ impl WorkspaceCacheStateSnapshot {
 
 /// Collect current runner state, refresh the local workspace-cache snapshot, and
 /// send a heartbeat to the server.
-pub(super) async fn send_heartbeat(
+async fn send_heartbeat(
     hb: &HeartbeatContext<'_>,
     mode: RunnerMode,
     snapshot_sequence: u64,
+    request: HeartbeatRequest,
 ) {
     let pool = hb.idle_pool.lock().await;
     let mut state = collect_heartbeat_state(
@@ -345,16 +423,36 @@ pub(super) async fn send_heartbeat(
         mode,
     );
     drop(pool);
-    let workspace_cache_states = refresh_workspace_cache_snapshot(
+    let cache_change = request.workspace_cache_change.as_ref();
+    let previous_workspace_states = cache_change.map(|_| {
+        hb.workspace_cache_snapshot
+            .current_held_workspace_states(hb.active_runs, None)
+    });
+    let refresh = refresh_workspace_cache_snapshot_after_change(
         &hb.workspace_cache_snapshot,
         hb.workspace_cache.as_ref(),
         hb.profiles,
+        cache_change,
     )
     .await;
     state.held_sandbox_states =
         filter_current_held_sandbox_states(state.held_sandbox_states, hb.active_runs, None);
     state.held_workspace_states =
-        filter_current_held_workspace_states(workspace_cache_states, hb.active_runs, None);
+        filter_current_held_workspace_states(refresh.states, hb.active_runs, None);
+    if let Some(change) = cache_change
+        && !request.force_send
+        && previous_workspace_states
+            .as_ref()
+            .is_some_and(|previous| *previous == state.held_workspace_states)
+    {
+        info!(
+            changed = false,
+            snapshot_changed = refresh.changed,
+            elapsed_ms = crate::duration::duration_ms(change.observed_at.elapsed()),
+            "workspace cache change reconciled"
+        );
+        return;
+    }
     info!(
         mode = ?mode,
         running = state.running_count,
@@ -363,6 +461,14 @@ pub(super) async fn send_heartbeat(
         "heartbeat"
     );
     hb.provider.heartbeat(&state).await;
+    if let Some(change) = cache_change {
+        info!(
+            changed = true,
+            snapshot_changed = refresh.changed,
+            elapsed_ms = crate::duration::duration_ms(change.observed_at.elapsed()),
+            "workspace cache change heartbeat completed"
+        );
+    }
 }
 
 /// Scans the workspace cache and commits the result to the shared snapshot.
@@ -370,25 +476,81 @@ pub(super) async fn send_heartbeat(
 /// The revision is captured before the asynchronous scan, and no snapshot
 /// mutex is held across the await. The returned value is the committed
 /// snapshot, which may also contain updates merged from concurrent promotions.
-pub(super) async fn refresh_workspace_cache_snapshot(
+pub(super) async fn refresh_initial_workspace_cache_snapshot(
     snapshot: &WorkspaceCacheStateSnapshot,
     workspace_cache: Option<&WorkspaceImageCache>,
     profiles: &BTreeMap<String, ProfileConfig>,
-) -> Vec<HeldWorkspaceState> {
+) -> InitialWorkspaceCacheRefreshOutcome {
     let refresh = snapshot.begin_workspace_cache_refresh();
-    let states = workspace_cache_states(workspace_cache, profiles).await;
+    let Some(cache) = workspace_cache else {
+        let outcome = snapshot.finish_workspace_cache_refresh(refresh, Vec::new());
+        return InitialWorkspaceCacheRefreshOutcome {
+            states: outcome.states,
+            locked_commit_keys: BTreeSet::new(),
+        };
+    };
+    let profile_image_sizes_bytes = profile_image_sizes_bytes(profiles);
+    let (states, locked_commit_keys) = cache
+        .initial_held_workspace_states_for_profiles(&profile_image_sizes_bytes)
+        .await;
+    let outcome = snapshot.finish_workspace_cache_refresh(refresh, states);
+    InitialWorkspaceCacheRefreshOutcome {
+        states: outcome.states,
+        locked_commit_keys,
+    }
+}
+
+async fn refresh_workspace_cache_snapshot_after_change(
+    snapshot: &WorkspaceCacheStateSnapshot,
+    workspace_cache: Option<&WorkspaceImageCache>,
+    profiles: &BTreeMap<String, ProfileConfig>,
+    change: Option<&WorkspaceCacheChange>,
+) -> WorkspaceCacheRefreshOutcome {
+    let refresh = snapshot.begin_workspace_cache_refresh();
+    let states = workspace_cache_states(
+        workspace_cache,
+        profiles,
+        change.map(|change| {
+            (
+                &change.committed_cache_keys,
+                tokio::time::Instant::now() + WORKSPACE_CACHE_COMMIT_WAIT,
+            )
+        }),
+    )
+    .await;
     snapshot.finish_workspace_cache_refresh(refresh, states)
 }
 
 async fn workspace_cache_states(
     workspace_cache: Option<&WorkspaceImageCache>,
     profiles: &BTreeMap<String, ProfileConfig>,
+    commits: Option<(&BTreeSet<String>, tokio::time::Instant)>,
 ) -> Vec<HeldWorkspaceState> {
     let Some(cache) = workspace_cache else {
         return Vec::new();
     };
 
-    let profile_image_sizes_bytes = profiles
+    let profile_image_sizes_bytes = profile_image_sizes_bytes(profiles);
+    match commits {
+        Some((committed_cache_keys, deadline)) if !committed_cache_keys.is_empty() => {
+            cache
+                .held_workspace_states_for_profiles_after_commits(
+                    &profile_image_sizes_bytes,
+                    committed_cache_keys,
+                    deadline,
+                )
+                .await
+        }
+        Some(_) | None => {
+            cache
+                .held_workspace_states_for_profiles(&profile_image_sizes_bytes)
+                .await
+        }
+    }
+}
+
+fn profile_image_sizes_bytes(profiles: &BTreeMap<String, ProfileConfig>) -> BTreeMap<&str, u64> {
+    profiles
         .iter()
         .map(|(name, profile)| {
             (
@@ -396,10 +558,7 @@ async fn workspace_cache_states(
                 u64::from(profile.workspace_disk_mb) * 1024 * 1024,
             )
         })
-        .collect::<BTreeMap<_, _>>();
-    cache
-        .held_workspace_states_for_profiles(&profile_image_sizes_bytes)
-        .await
+        .collect()
 }
 
 fn filter_current_held_sandbox_states(
@@ -918,8 +1077,13 @@ mod tests {
             workspace_cache_snapshot: workspace_cache_snapshot.clone(),
         });
 
-        let ((), events) =
-            capture_heartbeat_events(send_heartbeat(&hb, RunnerMode::Running, 42)).await;
+        let ((), events) = capture_heartbeat_events(send_heartbeat(
+            &hb,
+            RunnerMode::Running,
+            42,
+            HeartbeatRequest::ordinary(),
+        ))
+        .await;
 
         let heartbeat_event = captured_event(&events, "heartbeat");
         assert_eq!(heartbeat_event.level, tracing::Level::INFO);
@@ -966,7 +1130,7 @@ mod tests {
             .await;
         let active_runs = test_active_runs();
         let profiles = test_profiles();
-        let cache_states = workspace_cache_states(Some(&cache), &profiles).await;
+        let cache_states = workspace_cache_states(Some(&cache), &profiles, None).await;
         let states =
             filter_current_held_workspace_states(cache_states, &active_runs, Some("sess-claimed"));
 
@@ -1100,7 +1264,11 @@ mod tests {
             "2026-06-01T00:00:02.000Z",
             &["vm0/default", "vm0/large"],
         );
-        assert_eq!(refreshed, vec![merged.clone()]);
+        assert_eq!(refreshed.states, vec![merged.clone()]);
+        assert!(
+            !refreshed.changed,
+            "the concurrent upsert already installed the merged snapshot before refresh commit"
+        );
 
         let active_runs = test_active_runs();
         let states = snapshot.current_held_workspace_states(&active_runs, None);

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1108,11 +1108,17 @@ impl StartLoopTestObserver {
         .await;
     }
 
-    async fn wait_workspace_cache_change_observed(&self, timeout: Duration) {
-        self.wait_for(timeout, "workspace-cache change", |event| {
-            matches!(event, StartLoopEvent::WorkspaceCacheChangeObserved).then_some(())
-        })
-        .await;
+    async fn wait_workspace_cache_change_observed_after(
+        &self,
+        cursor: StartLoopCursor,
+        timeout: Duration,
+    ) -> StartLoopCursor {
+        let ((), cursor) = self
+            .wait_after(cursor, timeout, "workspace-cache change", |event| {
+                matches!(event, StartLoopEvent::WorkspaceCacheChangeObserved).then_some(())
+            })
+            .await;
+        cursor
     }
 
     async fn wait_idle_cleanup_processed_with_expired_entries(&self, timeout: Duration) -> usize {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -843,6 +843,8 @@ async fn run_start_with_home(
         test_hooks: RunTestHooks {
             outer_job_panic: None,
             test_observer: StartLoopTestObserver::default(),
+            before_initial_workspace_cache_scan: None,
+            after_initial_workspace_cache_scan: None,
         },
     };
 
@@ -942,6 +944,8 @@ struct OrphanReapState {
 struct RunTestHooks {
     outer_job_panic: Option<OuterJobPanicPoint>,
     test_observer: StartLoopTestObserver,
+    before_initial_workspace_cache_scan: Option<StartLoopTestGate>,
+    after_initial_workspace_cache_scan: Option<StartLoopTestGate>,
 }
 
 enum SignalSource {
@@ -970,6 +974,31 @@ enum StartLoopEvent {
 #[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct StartLoopCursor(usize);
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct StartLoopTestGate {
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[cfg(test)]
+impl StartLoopTestGate {
+    async fn enter_and_wait(&self) {
+        self.entered.notify_one();
+        self.release.notified().await;
+    }
+
+    async fn wait_entered(&self, timeout: Duration, context: &str) {
+        tokio::time::timeout(timeout, self.entered.notified())
+            .await
+            .unwrap_or_else(|_| panic!("runner did not reach {context} within {timeout:?}"));
+    }
+
+    fn release(&self) {
+        self.release.notify_one();
+    }
+}
 
 #[cfg(test)]
 #[derive(Clone, Default)]
@@ -1550,7 +1579,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     );
     orphan_reap_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-    let workspace_cache_watcher = match exec_config.workspace_cache.clone() {
+    let mut workspace_cache_watcher = match exec_config.workspace_cache.clone() {
         Some(cache) => match WorkspaceCacheWatcher::new(cache).await {
             Ok(watcher) => Some(watcher),
             Err(error) => {
@@ -1560,7 +1589,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         },
         None => None,
     };
-    let mut workspace_cache_change_fut = workspace_cache_watcher.map(workspace_cache_change_future);
+    #[cfg(test)]
+    if let Some(gate) = &test_hooks.before_initial_workspace_cache_scan {
+        gate.enter_and_wait().await;
+    }
     let hb_ctx = HeartbeatContext::new(HeartbeatContextInit {
         idle_pool: &shared.idle_pool,
         runner_id: &runner.id,
@@ -1580,10 +1612,33 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         &runner.profiles,
     )
     .await;
+    #[cfg(test)]
+    if let Some(gate) = &test_hooks.after_initial_workspace_cache_scan {
+        gate.enter_and_wait().await;
+    }
     debug_assert!(workspace_cache_snapshot.workspace_cache_loaded());
+    let mut initial_relevant_cache_keys = initial_workspace_cache.loaded_cache_keys;
+    initial_relevant_cache_keys.extend(initial_workspace_cache.locked_commit_keys.iter().cloned());
+    let initial_workspace_cache_requires_refresh = match workspace_cache_watcher.as_mut() {
+        Some(watcher) => match watcher
+            .reconcile_initial_relevant_entries(&initial_relevant_cache_keys)
+            .await
+        {
+            Ok(requires_refresh) => requires_refresh,
+            Err(error) => {
+                warn!(error = %error, "workspace cache watcher failed during startup reconciliation; using routine reconciliation");
+                workspace_cache_watcher = None;
+                true
+            }
+        },
+        None => false,
+    };
+    let mut workspace_cache_change_fut = workspace_cache_watcher.map(workspace_cache_change_future);
     let mut heartbeat = HeartbeatController::new(hb_ctx);
     if startup_mode == RunnerMode::Running {
-        if initial_workspace_cache.locked_commit_keys.is_empty() {
+        if initial_workspace_cache.locked_commit_keys.is_empty()
+            && !initial_workspace_cache_requires_refresh
+        {
             if !initial_workspace_cache.states.is_empty() {
                 heartbeat.request_initial_workspace_cache_snapshot(startup_mode)?;
             }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1585,7 +1585,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     if startup_mode == RunnerMode::Running {
         if initial_workspace_cache.locked_commit_keys.is_empty() {
             if !initial_workspace_cache.states.is_empty() {
-                heartbeat.request(startup_mode)?;
+                heartbeat.request_initial_workspace_cache_snapshot(startup_mode)?;
             }
         } else {
             heartbeat.request_initial_workspace_cache(

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -27,6 +27,8 @@
 //!   branches do not restart polling;
 //! - heartbeat work is pinned and single-flight so its I/O does not stall the
 //!   main reactor or overlap a newer snapshot;
+//! - workspace-cache watcher work is pinned across reactor turns so async
+//!   metadata classification cannot lose already-drained kernel events;
 //! - the first routine heartbeat and idle-cleanup ticks are deferred;
 //! - teardown drains heartbeat work and drops discovery before provider
 //!   shutdown.
@@ -37,6 +39,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::Args;
+use futures_util::future::BoxFuture;
 use sandbox::{RuntimeProvider, SandboxRuntime};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
@@ -156,11 +159,29 @@ async fn sleep_until_optional_instant(deadline: Option<Instant>) {
     }
 }
 
+type WorkspaceCacheChangeFuture = BoxFuture<
+    'static,
+    (
+        WorkspaceCacheWatcher,
+        RunnerResult<crate::workspace_image_cache::WorkspaceCacheChange>,
+    ),
+>;
+
+fn workspace_cache_change_future(mut watcher: WorkspaceCacheWatcher) -> WorkspaceCacheChangeFuture {
+    Box::pin(async move {
+        let result = watcher.next_change().await;
+        (watcher, result)
+    })
+}
+
 async fn next_workspace_cache_change(
-    watcher: &mut Option<WorkspaceCacheWatcher>,
-) -> RunnerResult<crate::workspace_image_cache::WorkspaceCacheChange> {
-    match watcher {
-        Some(watcher) => watcher.next_change().await,
+    future: &mut Option<WorkspaceCacheChangeFuture>,
+) -> (
+    WorkspaceCacheWatcher,
+    RunnerResult<crate::workspace_image_cache::WorkspaceCacheChange>,
+) {
+    match future {
+        Some(future) => future.await,
         None => std::future::pending().await,
     }
 }
@@ -938,6 +959,7 @@ enum SignalSource {
 #[derive(Debug, PartialEq, Eq)]
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
+    WorkspaceCacheChangeObserved,
     IdleCleanupProcessed { expired_count: usize },
     ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
@@ -1043,6 +1065,10 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::BudgetExhaustedReactorEntered);
     }
 
+    fn notify_workspace_cache_change_observed(&self) {
+        self.record(StartLoopEvent::WorkspaceCacheChangeObserved);
+    }
+
     fn notify_before_idle_pool_ownership_transfer(&self, run_id: RunId) {
         self.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id });
     }
@@ -1078,6 +1104,13 @@ impl StartLoopTestObserver {
     async fn wait_budget_exhausted_reactor(&self, timeout: Duration) {
         self.wait_for(timeout, "budget-exhausted reactor entry", |event| {
             matches!(event, StartLoopEvent::BudgetExhaustedReactorEntered).then_some(())
+        })
+        .await;
+    }
+
+    async fn wait_workspace_cache_change_observed(&self, timeout: Duration) {
+        self.wait_for(timeout, "workspace-cache change", |event| {
+            matches!(event, StartLoopEvent::WorkspaceCacheChangeObserved).then_some(())
         })
         .await;
     }
@@ -1511,8 +1544,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     );
     orphan_reap_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-    let mut workspace_cache_watcher = match exec_config.workspace_cache.clone() {
-        Some(cache) => match WorkspaceCacheWatcher::new(cache) {
+    let workspace_cache_watcher = match exec_config.workspace_cache.clone() {
+        Some(cache) => match WorkspaceCacheWatcher::new(cache).await {
             Ok(watcher) => Some(watcher),
             Err(error) => {
                 warn!(error = %error, "workspace cache watcher unavailable; using routine reconciliation");
@@ -1521,6 +1554,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         },
         None => None,
     };
+    let mut workspace_cache_change_fut = workspace_cache_watcher.map(workspace_cache_change_future);
     let hb_ctx = HeartbeatContext::new(HeartbeatContextInit {
         idle_pool: &shared.idle_pool,
         runner_id: &runner.id,
@@ -1774,9 +1808,14 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let live_mode = *mode_rx.borrow();
                 heartbeat.finish_send(live_mode)?;
             }
-            result = next_workspace_cache_change(&mut workspace_cache_watcher) => {
+            (watcher, result) = next_workspace_cache_change(&mut workspace_cache_change_fut) => {
                 match result {
                     Ok(change) => {
+                        workspace_cache_change_fut = Some(workspace_cache_change_future(watcher));
+                        #[cfg(test)]
+                        test_hooks
+                            .test_observer
+                            .notify_workspace_cache_change_observed();
                         let live_mode = *mode_rx.borrow();
                         if live_mode == RunnerMode::Running {
                             heartbeat.request_workspace_cache(live_mode, change)?;
@@ -1784,7 +1823,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     }
                     Err(error) => {
                         warn!(error = %error, "workspace cache watcher failed; using routine reconciliation");
-                        workspace_cache_watcher = None;
+                        workspace_cache_change_fut = None;
                     }
                 }
             }
@@ -2002,6 +2041,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // the historical shutdown-deadlock regression covered by mock providers.
     drop(discover_fut);
     teardown.event("drop_discover_fut");
+    drop(workspace_cache_change_fut);
 
     // Drain idle pool first — these VMs hold budget reservations. This
     // also clears `idle_vms` in status.json so the final snapshot is

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -27,7 +27,7 @@
 //!   branches do not restart polling;
 //! - heartbeat work is pinned and single-flight so its I/O does not stall the
 //!   main reactor or overlap a newer snapshot;
-//! - the first heartbeat and idle-cleanup ticks are deferred;
+//! - the first routine heartbeat and idle-cleanup ticks are deferred;
 //! - teardown drains heartbeat work and drops discovery before provider
 //!   shutdown.
 
@@ -72,6 +72,7 @@ use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::status::{StatusTracker, remove_stale_status_file};
+use crate::workspace_image_cache::WorkspaceCacheWatcher;
 use crate::workspace_image_cache::WorkspaceImageCache;
 
 mod active_runs;
@@ -95,7 +96,7 @@ use factory_lifecycle::{shutdown_factory_instances, shutdown_runtime, start_fact
 use heartbeat::{
     HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeartbeatController,
     HeartbeatSnapshotMetadata, WorkspaceCacheStateSnapshot, collect_heartbeat_state,
-    refresh_workspace_cache_snapshot,
+    refresh_initial_workspace_cache_snapshot,
 };
 use identity::{load_or_generate_runner_id, next_heartbeat_generation};
 use idle_lifecycle::{
@@ -151,6 +152,15 @@ fn retain_finalizing_candidate(
 async fn sleep_until_optional_instant(deadline: Option<Instant>) {
     match deadline {
         Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn next_workspace_cache_change(
+    watcher: &mut Option<WorkspaceCacheWatcher>,
+) -> RunnerResult<crate::workspace_image_cache::WorkspaceCacheChange> {
+    match watcher {
+        Some(watcher) => watcher.next_change().await,
         None => std::future::pending().await,
     }
 }
@@ -1501,6 +1511,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     );
     orphan_reap_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    let mut workspace_cache_watcher = match exec_config.workspace_cache.clone() {
+        Some(cache) => match WorkspaceCacheWatcher::new(cache) {
+            Ok(watcher) => Some(watcher),
+            Err(error) => {
+                warn!(error = %error, "workspace cache watcher unavailable; using routine reconciliation");
+                None
+            }
+        },
+        None => None,
+    };
     let hb_ctx = HeartbeatContext::new(HeartbeatContextInit {
         idle_pool: &shared.idle_pool,
         runner_id: &runner.id,
@@ -1514,7 +1534,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         active_runs: &active_runs,
         workspace_cache_snapshot: workspace_cache_snapshot.clone(),
     });
-    refresh_workspace_cache_snapshot(
+    let initial_workspace_cache = refresh_initial_workspace_cache_snapshot(
         &workspace_cache_snapshot,
         exec_config.workspace_cache.as_ref(),
         &runner.profiles,
@@ -1522,6 +1542,21 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     .await;
     debug_assert!(workspace_cache_snapshot.workspace_cache_loaded());
     let mut heartbeat = HeartbeatController::new(hb_ctx);
+    if startup_mode == RunnerMode::Running {
+        if initial_workspace_cache.locked_commit_keys.is_empty() {
+            if !initial_workspace_cache.states.is_empty() {
+                heartbeat.request(startup_mode)?;
+            }
+        } else {
+            heartbeat.request_initial_workspace_cache(
+                startup_mode,
+                crate::workspace_image_cache::WorkspaceCacheChange {
+                    observed_at: tokio::time::Instant::now(),
+                    committed_cache_keys: initial_workspace_cache.locked_commit_keys,
+                },
+            )?;
+        }
+    }
 
     // Pin the discover future so it survives cancellation by other select!
     // branches (heartbeat, idle cleanup, etc.). Without pinning, heartbeat
@@ -1738,6 +1773,20 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 result?;
                 let live_mode = *mode_rx.borrow();
                 heartbeat.finish_send(live_mode)?;
+            }
+            result = next_workspace_cache_change(&mut workspace_cache_watcher) => {
+                match result {
+                    Ok(change) => {
+                        let live_mode = *mode_rx.borrow();
+                        if live_mode == RunnerMode::Running {
+                            heartbeat.request_workspace_cache(live_mode, change)?;
+                        }
+                    }
+                    Err(error) => {
+                        warn!(error = %error, "workspace cache watcher failed; using routine reconciliation");
+                        workspace_cache_watcher = None;
+                    }
+                }
             }
             // Mode changes (signals)
             _ = mode_rx.changed() => {}

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1619,37 +1619,45 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     debug_assert!(workspace_cache_snapshot.workspace_cache_loaded());
     let mut initial_relevant_cache_keys = initial_workspace_cache.loaded_cache_keys;
     initial_relevant_cache_keys.extend(initial_workspace_cache.locked_commit_keys.iter().cloned());
-    let initial_workspace_cache_requires_refresh = match workspace_cache_watcher.as_mut() {
+    let mut initial_workspace_cache_change = match workspace_cache_watcher.as_mut() {
         Some(watcher) => match watcher
             .reconcile_initial_relevant_entries(&initial_relevant_cache_keys)
             .await
         {
-            Ok(requires_refresh) => requires_refresh,
+            Ok(change) => change,
             Err(error) => {
                 warn!(error = %error, "workspace cache watcher failed during startup reconciliation; using routine reconciliation");
                 workspace_cache_watcher = None;
-                true
+                Some(crate::workspace_image_cache::WorkspaceCacheChange {
+                    observed_at: tokio::time::Instant::now(),
+                    committed_cache_keys: std::collections::BTreeSet::new(),
+                })
             }
         },
-        None => false,
+        None => None,
     };
+    if !initial_workspace_cache.locked_commit_keys.is_empty() {
+        let locked_change = crate::workspace_image_cache::WorkspaceCacheChange {
+            observed_at: tokio::time::Instant::now(),
+            committed_cache_keys: initial_workspace_cache.locked_commit_keys,
+        };
+        match initial_workspace_cache_change.as_mut() {
+            Some(change) => change.merge(locked_change),
+            None => initial_workspace_cache_change = Some(locked_change),
+        }
+    }
     let mut workspace_cache_change_fut = workspace_cache_watcher.map(workspace_cache_change_future);
     let mut heartbeat = HeartbeatController::new(hb_ctx);
-    if startup_mode == RunnerMode::Running {
-        if initial_workspace_cache.locked_commit_keys.is_empty()
-            && !initial_workspace_cache_requires_refresh
-        {
-            if !initial_workspace_cache.states.is_empty() {
-                heartbeat.request_initial_workspace_cache_snapshot(startup_mode)?;
+    let initial_heartbeat_mode = lifecycle.current_mode();
+    if initial_heartbeat_mode == RunnerMode::Running {
+        match initial_workspace_cache_change {
+            Some(change) => {
+                heartbeat.request_initial_workspace_cache(initial_heartbeat_mode, change)?;
             }
-        } else {
-            heartbeat.request_initial_workspace_cache(
-                startup_mode,
-                crate::workspace_image_cache::WorkspaceCacheChange {
-                    observed_at: tokio::time::Instant::now(),
-                    committed_cache_keys: initial_workspace_cache.locked_commit_keys,
-                },
-            )?;
+            None if !initial_workspace_cache.states.is_empty() => {
+                heartbeat.request_initial_workspace_cache_snapshot(initial_heartbeat_mode)?;
+            }
+            None => {}
         }
     }
 

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -67,6 +67,21 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     let before_publication = env.handle.heartbeat_count();
 
+    let invalid_cache_key = "d".repeat(64);
+    let invalid_staging = home
+        .workspace_image_cache_dir()
+        .with_file_name("invalid-workspace-cache-staging");
+    tokio::fs::create_dir_all(&invalid_staging).await.unwrap();
+    tokio::fs::write(invalid_staging.join("metadata.json"), b"{}")
+        .await
+        .unwrap();
+    tokio::fs::rename(
+        &invalid_staging,
+        home.workspace_image_cache_dir().join(invalid_cache_key),
+    )
+    .await
+    .unwrap();
+
     let reuse_key = "thread:external-workspace-cache";
     let expected_workspace = WorkspaceCacheCapability {
         profile: "vm0/default".to_string(),
@@ -96,10 +111,13 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
         .await,
         "external publication should be advertised without the routine heartbeat tick",
     );
+    assert_eq!(
+        env.handle.heartbeat_count(),
+        before_publication + 1,
+        "invalid cache events must not create an extra provider heartbeat",
+    );
 
     let before_removal = env.handle.heartbeat_count();
-    let held = publisher_cache.held_workspace_states().await;
-    assert_eq!(held.len(), 1);
     let cache_key = crate::paths::scoped_workspace_image_cache_key(
         &group,
         "vm0/default",
@@ -107,13 +125,21 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
         api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR,
         16 * 1024 * 1024,
     );
-    tokio::fs::remove_file(
-        home.workspace_image_cache_dir()
-            .join(cache_key)
-            .join("metadata.json"),
+    let metadata = home
+        .workspace_image_cache_dir()
+        .join(cache_key)
+        .join("metadata.json");
+    let duplicate_metadata = metadata.with_extension("duplicate");
+    tokio::fs::write(
+        &duplicate_metadata,
+        tokio::fs::read(&metadata).await.unwrap(),
     )
     .await
     .unwrap();
+    tokio::fs::rename(&duplicate_metadata, &metadata)
+        .await
+        .unwrap();
+    tokio::fs::remove_file(&metadata).await.unwrap();
 
     assert!(
         wait_heartbeat_matching_after(
@@ -129,6 +155,11 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
         )
         .await,
         "external removal should promptly withdraw the advertised capability",
+    );
+    assert_eq!(
+        env.handle.heartbeat_count(),
+        before_removal + 1,
+        "duplicate unchanged publication must coalesce with the effective removal",
     );
 
     shutdown(&env, run_handle).await;
@@ -172,24 +203,55 @@ async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tic
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn unavailable_workspace_cache_watcher_does_not_block_discovery() {
-    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
-    let cache_root = config.paths.home.workspace_image_cache_dir();
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
+    let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
+    let home = config.paths.home.clone();
+    let group = config.runner.group.clone();
+    let cache_root = home.workspace_image_cache_dir();
     tokio::fs::write(&cache_root, b"not a directory")
         .await
         .unwrap();
     let workspace_cache = WorkspaceImageCache::shared(
         RunnerPaths::new(config.paths.base_dir.clone()),
-        &config.paths.home,
-        &config.runner.group,
+        &home,
+        &group,
     );
     Arc::get_mut(&mut config.exec_config)
         .unwrap()
-        .workspace_cache = Some(workspace_cache);
+        .workspace_cache = Some(workspace_cache.clone());
 
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    tokio::fs::remove_file(cache_root).await.unwrap();
+    let runner_paths = RunnerPaths::new(env._temp_dir.path().join("fallback-publisher"));
+    tokio::fs::create_dir_all(runner_paths.base_dir())
+        .await
+        .unwrap();
+    let publisher_cache = WorkspaceImageCache::shared(runner_paths.clone(), &home, &group);
+    seed_workspace_cache_state(
+        &publisher_cache,
+        &runner_paths,
+        "thread:routine-fallback",
+        "vm0/default",
+        1024 * 1024,
+    )
+    .await;
+    let before = env.handle.heartbeat_count();
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    assert!(
+        wait_heartbeat_matching_after(&env.handle, before, Duration::from_secs(5), |heartbeat| {
+            heartbeat
+                .held_workspace_states
+                .iter()
+                .any(|state| state.reuse_key == "thread:routine-fallback")
+        })
+        .await,
+        "routine heartbeat must converge after watcher setup failure",
+    );
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -2,8 +2,8 @@ use super::super::super::*;
 use super::super::support::{
     WorkspacePromotionSeedSpec, context_with_session, mock_run_config,
     mock_run_config_with_overrides, push_job, seed_idle_pool_with_overrides,
-    seed_idle_pool_with_workspace_promotion, shutdown, test_profiles, wait_budget_count,
-    wait_discover_entered, wait_idle_pool_reuse_keys,
+    seed_idle_pool_with_workspace_promotion, seed_workspace_cache_state, shutdown, test_profiles,
+    wait_budget_count, wait_discover_entered, wait_idle_pool_reuse_keys,
 };
 
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
@@ -43,6 +43,155 @@ async fn wait_heartbeat_matching_after(
             return false;
         }
     }
+}
+
+#[tokio::test]
+async fn external_workspace_cache_publication_and_removal_trigger_immediate_heartbeats() {
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
+    let home = config.paths.home.clone();
+    let group = config.runner.group.clone();
+    let observer_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let observer_cache = WorkspaceImageCache::shared(observer_paths, &home, &group);
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(observer_cache);
+
+    let publisher_paths = RunnerPaths::new(env._temp_dir.path().join("publisher"));
+    tokio::fs::create_dir_all(publisher_paths.base_dir())
+        .await
+        .unwrap();
+    let publisher_cache = WorkspaceImageCache::shared(publisher_paths.clone(), &home, &group);
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let before_publication = env.handle.heartbeat_count();
+
+    let reuse_key = "thread:external-workspace-cache";
+    let expected_workspace = WorkspaceCacheCapability {
+        profile: "vm0/default".to_string(),
+        workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
+    };
+    seed_workspace_cache_state(
+        &publisher_cache,
+        &publisher_paths,
+        reuse_key,
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+
+    assert!(
+        wait_heartbeat_matching_after(
+            &env.handle,
+            before_publication,
+            Duration::from_secs(5),
+            |heartbeat| {
+                heartbeat.held_workspace_states.iter().any(|state| {
+                    state.reuse_key == reuse_key
+                        && state.workspace_caches.contains(&expected_workspace)
+                })
+            },
+        )
+        .await,
+        "external publication should be advertised without the routine heartbeat tick",
+    );
+
+    let before_removal = env.handle.heartbeat_count();
+    let held = publisher_cache.held_workspace_states().await;
+    assert_eq!(held.len(), 1);
+    let cache_key = crate::paths::scoped_workspace_image_cache_key(
+        &group,
+        "vm0/default",
+        reuse_key,
+        api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR,
+        16 * 1024 * 1024,
+    );
+    tokio::fs::remove_file(
+        home.workspace_image_cache_dir()
+            .join(cache_key)
+            .join("metadata.json"),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        wait_heartbeat_matching_after(
+            &env.handle,
+            before_removal,
+            Duration::from_secs(5),
+            |heartbeat| {
+                heartbeat
+                    .held_workspace_states
+                    .iter()
+                    .all(|state| state.reuse_key != reuse_key)
+            },
+        )
+        .await,
+        "external removal should promptly withdraw the advertised capability",
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tick() {
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = WorkspaceImageCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    seed_workspace_cache_state(
+        &workspace_cache,
+        &runner_paths,
+        "thread:initial-workspace-cache",
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+
+    let run_handle = tokio::spawn(run(config));
+    assert!(
+        wait_heartbeat_matching_after(&env.handle, 0, Duration::from_secs(5), |heartbeat| {
+            heartbeat
+                .held_workspace_states
+                .iter()
+                .any(|state| state.reuse_key == "thread:initial-workspace-cache")
+        })
+        .await,
+        "non-empty initial cache should be published before the deferred routine tick",
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn unavailable_workspace_cache_watcher_does_not_block_discovery() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let cache_root = config.paths.home.workspace_image_cache_dir();
+    tokio::fs::write(&cache_root, b"not a directory")
+        .await
+        .unwrap();
+    let workspace_cache = WorkspaceImageCache::shared(
+        RunnerPaths::new(config.paths.base_dir.clone()),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    shutdown(&env, run_handle).await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -1,6 +1,6 @@
 use super::super::super::*;
 use super::super::support::{
-    WorkspacePromotionSeedSpec, context_with_session, mock_run_config,
+    WorkspacePromotionSeedSpec, assert_run_exits_within, context_with_session, mock_run_config,
     mock_run_config_with_overrides, push_job, seed_idle_pool_with_overrides,
     seed_idle_pool_with_workspace_promotion, seed_workspace_cache_state, shutdown, test_profiles,
     wait_budget_count, wait_discover_entered, wait_idle_pool_reuse_keys,
@@ -251,7 +251,61 @@ async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tic
 }
 
 #[tokio::test]
-async fn startup_cache_invalidated_after_initial_scan_is_not_advertised() {
+async fn drain_during_initial_cache_reconciliation_does_not_send_running_heartbeat() {
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = WorkspaceImageCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    seed_workspace_cache_state(
+        &workspace_cache,
+        &runner_paths,
+        "thread:startup-drain-cache",
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+    let after_scan = StartLoopTestGate::default();
+    config.test_hooks.after_initial_workspace_cache_scan = Some(after_scan.clone());
+
+    let run_handle = tokio::spawn(run(config));
+    after_scan
+        .wait_entered(
+            Duration::from_secs(5),
+            "initial workspace-cache scan before lifecycle refresh",
+        )
+        .await;
+    env.drain();
+    after_scan.release();
+
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "startup cache reconciliation should honor the live draining mode",
+    )
+    .await;
+    let heartbeats = env
+        .handle
+        .heartbeats
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    assert!(
+        heartbeats
+            .iter()
+            .all(|heartbeat| heartbeat.mode != "running"),
+        "draining during startup cache reconciliation must not publish a stale running snapshot: {heartbeats:#?}",
+    );
+}
+
+#[tokio::test]
+async fn startup_unclassified_cache_invalidated_after_scan_is_reconciled() {
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
     let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -72,6 +72,8 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     let before_publication = env.handle.heartbeat_count();
+    env.handle.block_heartbeats();
+    let watcher_cursor = env.start_observer.cursor();
 
     let invalid_cache_key = "d".repeat(64);
     let invalid_staging = home
@@ -103,9 +105,16 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
         16 * 1024 * 1024,
     )
     .await;
-    env.start_observer
-        .wait_workspace_cache_change_observed(Duration::from_secs(5))
+    let watcher_cursor = env
+        .start_observer
+        .wait_workspace_cache_change_observed_after(watcher_cursor, Duration::from_secs(5))
         .await;
+    assert!(
+        env.handle
+            .wait_heartbeat_in_flight(1, Duration::from_secs(5))
+            .await,
+        "the first relevant cache heartbeat should remain blocked",
+    );
 
     let reuse_key = "thread:external-workspace-cache";
     let expected_workspace = WorkspaceCacheCapability {
@@ -120,6 +129,16 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
         16 * 1024 * 1024,
     )
     .await;
+    env.start_observer
+        .wait_workspace_cache_change_observed_after(watcher_cursor, Duration::from_secs(5))
+        .await;
+    assert_eq!(
+        env.handle.heartbeat_count(),
+        before_publication + 1,
+        "the watcher must consume a second event without overlapping the blocked heartbeat",
+    );
+    assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
+    env.handle.unblock_heartbeats();
 
     assert!(
         wait_heartbeat_matching_after(
@@ -141,8 +160,8 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
     );
     assert_eq!(
         env.handle.heartbeat_count(),
-        before_publication + 1,
-        "invalid and foreign cache events must not create extra provider heartbeats",
+        before_publication + 2,
+        "two relevant publications should produce only the active and coalesced heartbeats",
     );
 
     let before_removal = env.handle.heartbeat_count();

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -250,6 +250,86 @@ async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tic
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test]
+async fn startup_cache_invalidated_after_initial_scan_is_not_advertised() {
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let home = config.paths.home.clone();
+    let group = config.runner.group.clone();
+    let workspace_cache = WorkspaceImageCache::shared(runner_paths.clone(), &home, &group);
+    let reuse_key = "thread:startup-cache-invalidation";
+    let cache_key = crate::paths::scoped_workspace_image_cache_key(
+        &group,
+        "vm0/default",
+        reuse_key,
+        api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR,
+        16 * 1024 * 1024,
+    );
+    let cache_entry = home.workspace_image_cache_dir().join(cache_key);
+    tokio::fs::create_dir_all(&cache_entry).await.unwrap();
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache.clone());
+    let before_scan = StartLoopTestGate::default();
+    let after_scan = StartLoopTestGate::default();
+    config.test_hooks.before_initial_workspace_cache_scan = Some(before_scan.clone());
+    config.test_hooks.after_initial_workspace_cache_scan = Some(after_scan.clone());
+
+    let run_handle = tokio::spawn(run(config));
+    before_scan
+        .wait_entered(
+            Duration::from_secs(5),
+            "workspace-cache watcher setup before the initial scan",
+        )
+        .await;
+    seed_workspace_cache_state(
+        &workspace_cache,
+        &runner_paths,
+        reuse_key,
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    before_scan.release();
+
+    after_scan
+        .wait_entered(
+            Duration::from_secs(5),
+            "initial workspace-cache scan before watcher reconciliation",
+        )
+        .await;
+    tokio::fs::remove_file(cache_entry.join("metadata.json"))
+        .await
+        .unwrap();
+    after_scan.release();
+
+    assert!(
+        env.handle
+            .wait_heartbeat_past(0, Duration::from_secs(5))
+            .await,
+        "startup reconciliation should publish the refreshed cache state",
+    );
+    let first_heartbeat = env
+        .handle
+        .heartbeats
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .first()
+        .cloned()
+        .unwrap();
+    assert!(
+        first_heartbeat
+            .held_workspace_states
+            .iter()
+            .all(|state| state.reuse_key != reuse_key),
+        "the first heartbeat must not advertise a cache invalidated after the initial scan",
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn unavailable_workspace_cache_watcher_does_not_block_discovery() {
     let mut profiles = test_profiles();

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -63,6 +63,12 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
         .await
         .unwrap();
     let publisher_cache = WorkspaceImageCache::shared(publisher_paths.clone(), &home, &group);
+    let foreign_publisher_paths = RunnerPaths::new(env._temp_dir.path().join("foreign-publisher"));
+    tokio::fs::create_dir_all(foreign_publisher_paths.base_dir())
+        .await
+        .unwrap();
+    let foreign_publisher_cache =
+        WorkspaceImageCache::shared(foreign_publisher_paths.clone(), &home, "foreign-group");
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     let before_publication = env.handle.heartbeat_count();
@@ -81,6 +87,25 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
     )
     .await
     .unwrap();
+    seed_workspace_cache_state(
+        &foreign_publisher_cache,
+        &foreign_publisher_paths,
+        "thread:foreign-workspace-cache",
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    seed_workspace_cache_state(
+        &publisher_cache,
+        &publisher_paths,
+        "thread:cancel-safe-workspace-cache",
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    env.start_observer
+        .wait_workspace_cache_change_observed(Duration::from_secs(5))
+        .await;
 
     let reuse_key = "thread:external-workspace-cache";
     let expected_workspace = WorkspaceCacheCapability {
@@ -105,6 +130,9 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
                 heartbeat.held_workspace_states.iter().any(|state| {
                     state.reuse_key == reuse_key
                         && state.workspace_caches.contains(&expected_workspace)
+                }) && heartbeat.held_workspace_states.iter().any(|state| {
+                    state.reuse_key == "thread:cancel-safe-workspace-cache"
+                        && state.workspace_caches.contains(&expected_workspace)
                 })
             },
         )
@@ -114,7 +142,7 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
     assert_eq!(
         env.handle.heartbeat_count(),
         before_publication + 1,
-        "invalid cache events must not create an extra provider heartbeat",
+        "invalid and foreign cache events must not create extra provider heartbeats",
     );
 
     let before_removal = env.handle.heartbeat_count();

--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -45,7 +45,7 @@ async fn wait_heartbeat_matching_after(
     }
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn external_workspace_cache_publication_and_removal_trigger_immediate_heartbeats() {
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
@@ -165,7 +165,7 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn non_empty_initial_workspace_cache_is_heartbeated_before_the_routine_tick() {
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -296,6 +296,8 @@ fn build_mock_run_config_with_runtime(
         test_hooks: RunTestHooks {
             outer_job_panic: None,
             test_observer: start_observer.clone(),
+            before_initial_workspace_cache_scan: None,
+            after_initial_workspace_cache_scan: None,
         },
     };
 

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -23,8 +23,8 @@ use super::fs::{
     secure_workspace_cache_publication_file, sparse_copy,
 };
 use super::metadata::{
-    WorkspaceCacheMetadata, WorkspaceCacheState as WorkspaceCacheEntryState,
-    WorkspaceImageFileIdentity, WorkspaceTrust,
+    WorkspaceCacheMetadata, WorkspaceCacheScopeClassification,
+    WorkspaceCacheState as WorkspaceCacheEntryState, WorkspaceImageFileIdentity, WorkspaceTrust,
 };
 use super::path_safety::{
     filter_storage_fingerprints_for_working_dir, is_safe_guest_working_dir,
@@ -719,9 +719,8 @@ impl WorkspaceImageCache {
                 Ok(crate::lock::TryLock::Busy) => {
                     if collect_locked_commits
                         && locked_commit_keys.len() < MAX_HELD_WORKSPACE_STATES
-                        && fs::symlink_metadata(self.workspace_image_cache_metadata(cache_key))
-                            .await
-                            .is_ok()
+                        && self.classify_metadata_scope(cache_key).await
+                            == WorkspaceCacheScopeClassification::Relevant
                     {
                         locked_commit_keys.insert(cache_key.to_owned());
                     }

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1136,6 +1136,7 @@ struct HeldWorkspaceStateScan {
     states: Vec<HeldWorkspaceState>,
     locked_commit_keys: BTreeSet<String>,
 }
+
 impl WorkspaceImageLease {
     #[cfg(test)]
     pub(crate) fn working_dir(&self) -> &str {

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -689,7 +689,7 @@ impl WorkspaceImageCache {
                 };
             }
             Err(e) => {
-                warn!(path = %root.display(), error = %e, "failed to scan workspace image cache");
+                warn!(error = %e, "failed to scan workspace image cache");
                 return HeldWorkspaceStateScan {
                     states: cap_held_workspace_states(states),
                     locked_commit_keys,

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -594,30 +594,108 @@ impl WorkspaceImageCache {
         &self,
         profile_image_sizes_bytes: &BTreeMap<&str, u64>,
     ) -> Vec<HeldWorkspaceState> {
-        self.held_workspace_states_matching_profiles(Some(profile_image_sizes_bytes))
+        self.held_workspace_states_matching_profiles(Some(profile_image_sizes_bytes), None, false)
             .await
+            .states
+    }
+
+    /// Performs the startup scan and returns committed entries skipped for locking.
+    pub(crate) async fn initial_held_workspace_states_for_profiles(
+        &self,
+        profile_image_sizes_bytes: &BTreeMap<&str, u64>,
+    ) -> (Vec<HeldWorkspaceState>, BTreeSet<String>) {
+        let scan = self
+            .held_workspace_states_matching_profiles(Some(profile_image_sizes_bytes), None, true)
+            .await;
+        (scan.states, scan.locked_commit_keys)
+    }
+
+    /// Waits for metadata-commit entry locks before performing the complete scan.
+    ///
+    /// The event-provided keys select locks only. Each hinted entry is validated
+    /// under its acquired guard with the same rules as the complete scan, and
+    /// the validated observation is merged into that scan's bounded result.
+    pub(crate) async fn held_workspace_states_for_profiles_after_commits(
+        &self,
+        profile_image_sizes_bytes: &BTreeMap<&str, u64>,
+        committed_cache_keys: &BTreeSet<String>,
+        deadline: tokio::time::Instant,
+    ) -> Vec<HeldWorkspaceState> {
+        self.held_workspace_states_matching_profiles(
+            Some(profile_image_sizes_bytes),
+            Some((committed_cache_keys, deadline)),
+            false,
+        )
+        .await
+        .states
     }
 
     /// Inspect cache state without a running profile configuration in tests.
     #[cfg(test)]
     pub(crate) async fn held_workspace_states(&self) -> Vec<HeldWorkspaceState> {
-        self.held_workspace_states_matching_profiles(None).await
+        self.held_workspace_states_matching_profiles(None, None, false)
+            .await
+            .states
     }
 
     async fn held_workspace_states_matching_profiles(
         &self,
         profile_image_sizes_bytes: Option<&BTreeMap<&str, u64>>,
-    ) -> Vec<HeldWorkspaceState> {
+        committed_cache_keys: Option<(&BTreeSet<String>, tokio::time::Instant)>,
+        collect_locked_commits: bool,
+    ) -> HeldWorkspaceStateScan {
+        let mut states = Vec::new();
+        let mut validated_cache_keys = BTreeSet::new();
+        if let Some((committed_cache_keys, deadline)) = committed_cache_keys {
+            for cache_key in committed_cache_keys {
+                if !is_cache_key_name(cache_key) {
+                    continue;
+                }
+                let lock = match tokio::time::timeout_at(
+                    deadline,
+                    crate::lock::acquire(self.entry_lock_path(cache_key)),
+                )
+                .await
+                {
+                    Ok(Ok(lock)) => lock,
+                    Ok(Err(_)) => continue,
+                    Err(_) => {
+                        info!(
+                            commit_keys = committed_cache_keys.len(),
+                            "workspace cache commit lock wait timed out"
+                        );
+                        break;
+                    }
+                };
+                if let Some(state) = self
+                    .publishable_held_workspace_state(cache_key, profile_image_sizes_bytes, &lock)
+                    .await
+                {
+                    states.push(state);
+                    validated_cache_keys.insert(cache_key.clone());
+                }
+                drop(lock);
+            }
+        }
+
+        let mut locked_commit_keys = BTreeSet::new();
         let root = self.workspace_image_cache_dir().to_path_buf();
         let mut entries = match fs::read_dir(&root).await {
             Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return HeldWorkspaceStateScan {
+                    states: cap_held_workspace_states(states),
+                    locked_commit_keys,
+                };
+            }
             Err(e) => {
                 warn!(path = %root.display(), error = %e, "failed to scan workspace image cache");
-                return Vec::new();
+                return HeldWorkspaceStateScan {
+                    states: cap_held_workspace_states(states),
+                    locked_commit_keys,
+                };
             }
         };
-        let mut states = Vec::new();
         while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
             let Ok(file_type) = entry.file_type().await else {
@@ -632,33 +710,30 @@ impl WorkspaceImageCache {
             if !is_cache_key_name(cache_key) {
                 continue;
             }
-            let Ok(lock) = crate::lock::try_acquire(self.entry_lock_path(cache_key)).await else {
+            if validated_cache_keys.contains(cache_key) {
                 continue;
-            };
-            let metadata_path = self.workspace_image_cache_metadata(cache_key);
-            let metadata = match self.read_metadata_file(&metadata_path).await {
-                Ok(metadata) => metadata,
-                Err(_) => {
-                    drop(lock);
+            }
+            let lock = match crate::lock::try_acquire_or_busy(self.entry_lock_path(cache_key)).await
+            {
+                Ok(crate::lock::TryLock::Acquired(lock)) => lock,
+                Ok(crate::lock::TryLock::Busy) => {
+                    if collect_locked_commits
+                        && locked_commit_keys.len() < MAX_HELD_WORKSPACE_STATES
+                        && fs::symlink_metadata(self.workspace_image_cache_metadata(cache_key))
+                            .await
+                            .is_ok()
+                    {
+                        locked_commit_keys.insert(cache_key.to_owned());
+                    }
                     continue;
                 }
+                Err(_) => continue,
             };
-            if self
-                .metadata_is_publishable_held_workspace_state(
-                    cache_key,
-                    &metadata,
-                    profile_image_sizes_bytes,
-                )
+            if let Some(state) = self
+                .publishable_held_workspace_state(cache_key, profile_image_sizes_bytes, &lock)
                 .await
             {
-                states.push(HeldWorkspaceState {
-                    reuse_key: metadata.reuse_key,
-                    last_completed_at: metadata.last_completed_at,
-                    workspace_caches: vec![WorkspaceCacheCapability {
-                        profile: metadata.profile_name,
-                        workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
-                    }],
-                });
+                states.push(state);
             }
             drop(lock);
         }
@@ -679,7 +754,36 @@ impl WorkspaceImageCache {
                 "workspace cache state truncated"
             );
         }
-        states
+        HeldWorkspaceStateScan {
+            states,
+            locked_commit_keys,
+        }
+    }
+
+    async fn publishable_held_workspace_state(
+        &self,
+        cache_key: &str,
+        profile_image_sizes_bytes: Option<&BTreeMap<&str, u64>>,
+        _lock: &Flock<std::fs::File>,
+    ) -> Option<HeldWorkspaceState> {
+        let metadata = self
+            .read_metadata_file(&self.workspace_image_cache_metadata(cache_key))
+            .await
+            .ok()?;
+        self.metadata_is_publishable_held_workspace_state(
+            cache_key,
+            &metadata,
+            profile_image_sizes_bytes,
+        )
+        .await
+        .then(|| HeldWorkspaceState {
+            reuse_key: metadata.reuse_key,
+            last_completed_at: metadata.last_completed_at,
+            workspace_caches: vec![WorkspaceCacheCapability {
+                profile: metadata.profile_name,
+                workspace_affinity_version: WORKSPACE_AFFINITY_VERSION,
+            }],
+        })
     }
 
     async fn metadata_is_publishable_held_workspace_state(
@@ -1026,6 +1130,11 @@ impl WorkspaceImageCache {
         }
         Ok(WorkspaceImagePromotionOutcome::Promoted)
     }
+}
+
+struct HeldWorkspaceStateScan {
+    states: Vec<HeldWorkspaceState>,
+    locked_commit_keys: BTreeSet<String>,
 }
 impl WorkspaceImageLease {
     #[cfg(test)]

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -599,15 +599,36 @@ impl WorkspaceImageCache {
             .states
     }
 
-    /// Performs the startup scan and returns committed entries skipped for locking.
+    /// Performs the startup scan and returns the loaded and locked cache keys
+    /// needed to connect subscribe-before-scan watcher state.
     pub(crate) async fn initial_held_workspace_states_for_profiles(
         &self,
         profile_image_sizes_bytes: &BTreeMap<&str, u64>,
-    ) -> (Vec<HeldWorkspaceState>, BTreeSet<String>) {
+    ) -> (Vec<HeldWorkspaceState>, BTreeSet<String>, BTreeSet<String>) {
         let scan = self
             .held_workspace_states_matching_profiles(Some(profile_image_sizes_bytes), None, true)
             .await;
-        (scan.states, scan.locked_commit_keys)
+        // The heartbeat projection omits cache keys, but startup needs the
+        // deterministic keys for the watcher handoff before publishing it.
+        let loaded_cache_keys = scan
+            .states
+            .iter()
+            .flat_map(|state| {
+                state.workspace_caches.iter().filter_map(|workspace| {
+                    profile_image_sizes_bytes
+                        .get(workspace.profile.as_str())
+                        .map(|image_size_bytes| {
+                            self.scoped_cache_key(
+                                &workspace.profile,
+                                &state.reuse_key,
+                                CANONICAL_WORKING_DIR,
+                                *image_size_bytes,
+                            )
+                        })
+                })
+            })
+            .collect();
+        (scan.states, scan.locked_commit_keys, loaded_cache_keys)
     }
 
     /// Waits for metadata-commit entry locks before performing the complete scan.

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -49,6 +49,13 @@ pub(super) struct WorkspaceCacheMetadata {
     pub(super) state: WorkspaceCacheState,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkspaceCacheScopeClassification {
+    Unclassified,
+    Relevant,
+    Foreign,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct WorkspaceImageFileIdentity {
@@ -68,6 +75,32 @@ impl WorkspaceImageFileIdentity {
 }
 
 impl WorkspaceImageCache {
+    /// Classify bounded metadata for advisory routing only.
+    ///
+    /// A matching cache key proves that the scope belongs to the committed
+    /// metadata rather than an unrelated path name. Authoritative cache use
+    /// still validates all fields and the current image while holding the
+    /// entry lock.
+    pub(super) async fn classify_metadata_scope(
+        &self,
+        cache_key: &str,
+    ) -> WorkspaceCacheScopeClassification {
+        let Ok(metadata) = self
+            .read_metadata_file(&self.workspace_image_cache_metadata(cache_key))
+            .await
+        else {
+            return WorkspaceCacheScopeClassification::Unclassified;
+        };
+        if !self.metadata_matches_cache_key(cache_key, &metadata) {
+            return WorkspaceCacheScopeClassification::Unclassified;
+        }
+        if metadata.cache_scope == self.inner.cache_scope {
+            WorkspaceCacheScopeClassification::Relevant
+        } else {
+            WorkspaceCacheScopeClassification::Foreign
+        }
+    }
+
     pub(super) async fn read_valid_metadata(
         &self,
         metadata_path: &Path,

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -49,6 +49,7 @@ mod metadata;
 mod path_safety;
 mod sidecar;
 mod types;
+mod watcher;
 
 #[cfg(test)]
 mod tests;
@@ -70,6 +71,7 @@ pub(crate) use types::{
     WorkspaceSessionHistorySidecar, WorkspaceSessionHistorySidecarPromotionSource,
     WorkspaceSessionHistorySidecarRepresentation,
 };
+pub(crate) use watcher::{WorkspaceCacheChange, WorkspaceCacheWatcher};
 
 const CACHE_FORMAT_VERSION: u32 = 2;
 const WORKSPACE_DRIVE_LAYOUT: &str = "workspace-drive-v1";

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -1,4 +1,5 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::time::Duration;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use tokio::fs;
@@ -280,6 +281,87 @@ async fn held_workspace_states_for_profiles_filters_and_aggregates_current_ident
             .await
             .is_empty()
     );
+}
+
+#[tokio::test]
+async fn commit_reconciliation_waits_for_entry_lock_before_validating() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = WorkspaceImageCache::new(paths);
+    let reuse_key = "thread:commit-lock";
+    let cache_key = write_current_cache_entry_for_profile(
+        &cache,
+        RunId::new_v4(),
+        TEST_PROFILE_NAME,
+        reuse_key,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:01.000Z",
+        "2026-05-01T00:00:01.000Z",
+    )
+    .await;
+    let image_size = format!("image-{reuse_key}").len() as u64;
+    let configured = BTreeMap::from([(TEST_PROFILE_NAME, image_size)]);
+    let committed = BTreeSet::from([cache_key.clone()]);
+    let held_lock = crate::lock::acquire(cache.entry_lock_path(&cache_key))
+        .await
+        .unwrap();
+
+    let cache_for_refresh = cache.clone();
+    let refresh = tokio::spawn(async move {
+        cache_for_refresh
+            .held_workspace_states_for_profiles_after_commits(
+                &configured,
+                &committed,
+                tokio::time::Instant::now() + Duration::from_secs(2),
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !refresh.is_finished(),
+        "commit reconciliation must wait while the publisher owns the entry lock",
+    );
+
+    drop(held_lock);
+    let states = tokio::time::timeout(Duration::from_secs(2), refresh)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(states.len(), 1);
+    assert_eq!(states[0].reuse_key, reuse_key);
+}
+
+#[tokio::test]
+async fn initial_scan_returns_committed_entry_skipped_for_locking() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = WorkspaceImageCache::new(paths);
+    let reuse_key = "thread:initial-commit-lock";
+    let cache_key = write_current_cache_entry_for_profile(
+        &cache,
+        RunId::new_v4(),
+        TEST_PROFILE_NAME,
+        reuse_key,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:01.000Z",
+        "2026-05-01T00:00:01.000Z",
+    )
+    .await;
+    let image_size = format!("image-{reuse_key}").len() as u64;
+    let configured = BTreeMap::from([(TEST_PROFILE_NAME, image_size)]);
+    let held_lock = crate::lock::acquire(cache.entry_lock_path(&cache_key))
+        .await
+        .unwrap();
+
+    let (states, locked_commit_keys) = cache
+        .initial_held_workspace_states_for_profiles(&configured)
+        .await;
+
+    assert!(states.is_empty());
+    assert_eq!(locked_commit_keys, BTreeSet::from([cache_key]));
+    drop(held_lock);
 }
 
 #[test]

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -317,7 +317,7 @@ async fn commit_reconciliation_waits_for_entry_lock_before_validating() {
             )
             .await
     });
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::task::yield_now().await;
     assert!(
         !refresh.is_finished(),
         "commit reconciliation must wait while the publisher owns the entry lock",

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -22,7 +22,9 @@ use super::support::{
     TEST_PROFILE_NAME, local_cache, timestamp_for_index, write_current_cache_entry_for_profile,
 };
 use crate::ids::RunId;
-use crate::paths::{RunnerPaths, scoped_workspace_image_cache_key, workspace_image_cache_key};
+use crate::paths::{
+    HomePaths, RunnerPaths, scoped_workspace_image_cache_key, workspace_image_cache_key,
+};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
     HeldWorkspaceState, MAX_HELD_WORKSPACE_STATES, MAX_WORKSPACE_CACHES_PER_HEARTBEAT,
@@ -361,6 +363,44 @@ async fn initial_scan_returns_committed_entry_skipped_for_locking() {
 
     assert!(states.is_empty());
     assert_eq!(locked_commit_keys, BTreeSet::from([cache_key]));
+    drop(held_lock);
+}
+
+#[tokio::test]
+async fn initial_scan_ignores_locked_foreign_scope_commit() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().join("home"));
+    let observer_paths = RunnerPaths::new(dir.path().join("observer"));
+    let publisher_paths = RunnerPaths::new(dir.path().join("publisher"));
+    fs::create_dir_all(observer_paths.base_dir()).await.unwrap();
+    fs::create_dir_all(publisher_paths.base_dir())
+        .await
+        .unwrap();
+    let observer = WorkspaceImageCache::shared(observer_paths, &home, "group-a");
+    let publisher = WorkspaceImageCache::shared(publisher_paths, &home, "group-b");
+    let reuse_key = "thread:foreign-initial-commit-lock";
+    let cache_key = write_current_cache_entry_for_profile(
+        &publisher,
+        RunId::new_v4(),
+        TEST_PROFILE_NAME,
+        reuse_key,
+        CANONICAL_WORKING_DIR,
+        "2026-05-01T00:00:01.000Z",
+        "2026-05-01T00:00:01.000Z",
+    )
+    .await;
+    let image_size = format!("image-{reuse_key}").len() as u64;
+    let configured = BTreeMap::from([(TEST_PROFILE_NAME, image_size)]);
+    let held_lock = crate::lock::acquire(publisher.entry_lock_path(&cache_key))
+        .await
+        .unwrap();
+
+    let (states, locked_commit_keys) = observer
+        .initial_held_workspace_states_for_profiles(&configured)
+        .await;
+
+    assert!(states.is_empty());
+    assert!(locked_commit_keys.is_empty());
     drop(held_lock);
 }
 

--- a/crates/runner/src/workspace_image_cache/tests/state.rs
+++ b/crates/runner/src/workspace_image_cache/tests/state.rs
@@ -357,7 +357,7 @@ async fn initial_scan_returns_committed_entry_skipped_for_locking() {
         .await
         .unwrap();
 
-    let (states, locked_commit_keys) = cache
+    let (states, locked_commit_keys, _) = cache
         .initial_held_workspace_states_for_profiles(&configured)
         .await;
 
@@ -395,7 +395,7 @@ async fn initial_scan_ignores_locked_foreign_scope_commit() {
         .await
         .unwrap();
 
-    let (states, locked_commit_keys) = observer
+    let (states, locked_commit_keys, _) = observer
         .initial_held_workspace_states_for_profiles(&configured)
         .await;
 

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -125,12 +125,14 @@ impl WorkspaceCacheWatcher {
 
     /// Connects entries accepted by the subscribe-before-scan startup pass to
     /// watcher state before the loaded snapshot can be published. Entries that
-    /// were not already relevant when the watcher subscribed require one more
-    /// authoritative scan after their entry watches are installed.
+    /// were not already relevant when the watcher subscribed return an
+    /// advisory change so matching commits retain the existing lock-aware
+    /// validation path after their entry watches are installed.
     pub(crate) async fn reconcile_initial_relevant_entries(
         &mut self,
         cache_keys: &BTreeSet<String>,
-    ) -> RunnerResult<bool> {
+    ) -> RunnerResult<Option<WorkspaceCacheChange>> {
+        let observed_at = tokio::time::Instant::now();
         let mut committed_cache_keys = BTreeSet::new();
         let mut requires_refresh = false;
         for cache_key in cache_keys {
@@ -148,10 +150,13 @@ impl WorkspaceCacheWatcher {
                 }
             }
         }
-        Ok(requires_refresh
-            || cache_keys.iter().any(|cache_key| {
-                self.entry_watch_state(cache_key) != Some(EntryWatchState::Relevant)
-            }))
+        requires_refresh |= cache_keys
+            .iter()
+            .any(|cache_key| self.entry_watch_state(cache_key) != Some(EntryWatchState::Relevant));
+        Ok(requires_refresh.then_some(WorkspaceCacheChange {
+            observed_at,
+            committed_cache_keys,
+        }))
     }
 
     /// Waits for and coalesces all currently readable relevant mutations.
@@ -595,6 +600,23 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
+        assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_preserves_matching_commit_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(temp.path().join("runner"));
+        let cache = WorkspaceImageCache::new(paths);
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).await.unwrap();
+        let cache_key = commit_entry(&cache, "startup-reconciliation").await;
+
+        let change = watcher
+            .reconcile_initial_relevant_entries(&BTreeSet::from([cache_key.clone()]))
+            .await
+            .unwrap()
+            .expect("newly classified startup entry should require reconciliation");
+
         assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
     }
 

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -115,87 +115,91 @@ impl WorkspaceCacheWatcher {
                 .readable()
                 .await
                 .map_err(|error| watcher_io_error("wait for events", error.kind()))?;
-            ready.clear_ready();
-            drop(ready);
 
             let observed_at = tokio::time::Instant::now();
-            let mut changed = false;
-            let mut reconcile_entry_watches = false;
-            let mut committed_cache_keys = BTreeSet::new();
+            let mut pending_events = Vec::new();
             let mut drained_all_events = false;
             for _ in 0..MAX_EVENT_READ_BATCHES_PER_CHANGE {
-                let events = match self.inotify.get_ref().0.read_events() {
-                    Ok(events) => events,
+                match self.inotify.get_ref().0.read_events() {
+                    Ok(events) => pending_events.extend(events),
                     Err(Errno::EAGAIN) => {
                         drained_all_events = true;
                         break;
                     }
                     Err(error) => return Err(watcher_error("read events", error)),
-                };
-                for event in events {
-                    if event.mask.contains(AddWatchFlags::IN_Q_OVERFLOW) {
-                        changed = true;
-                        reconcile_entry_watches = true;
-                        continue;
-                    }
-                    if event.wd == self.root_watch {
-                        if event.mask.intersects(WATCH_INVALIDATION_FLAGS) {
-                            return Err(RunnerError::Internal(
-                                "workspace cache root watch invalidated".to_string(),
-                            ));
-                        }
-                        let Some(cache_key) = event
-                            .name
-                            .as_deref()
-                            .and_then(OsStr::to_str)
-                            .filter(|name| is_cache_key_name(name))
-                        else {
-                            continue;
-                        };
-                        if event
-                            .mask
-                            .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
-                        {
-                            reconcile_entry_watches = true;
-                        }
-                        if event
-                            .mask
-                            .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
-                        {
-                            changed = true;
-                            reconcile_entry_watches = true;
-                            self.forget_entry_watch(cache_key);
-                        }
-                        continue;
-                    }
+                }
+            }
+            if drained_all_events {
+                ready.clear_ready();
+            }
+            drop(ready);
 
-                    let Some(cache_key) = self.cache_key_by_watch.get(&event.wd).cloned() else {
+            let mut changed = false;
+            let mut reconcile_entry_watches = false;
+            let mut committed_cache_keys = BTreeSet::new();
+            for event in pending_events {
+                if event.mask.contains(AddWatchFlags::IN_Q_OVERFLOW) {
+                    changed = true;
+                    reconcile_entry_watches = true;
+                    continue;
+                }
+                if event.wd == self.root_watch {
+                    if event.mask.intersects(WATCH_INVALIDATION_FLAGS) {
+                        return Err(RunnerError::Internal(
+                            "workspace cache root watch invalidated".to_string(),
+                        ));
+                    }
+                    let Some(cache_key) = event
+                        .name
+                        .as_deref()
+                        .and_then(OsStr::to_str)
+                        .filter(|name| is_cache_key_name(name))
+                    else {
                         continue;
                     };
-                    if event.mask.intersects(WATCH_INVALIDATION_FLAGS) {
-                        self.forget_watch_descriptor(event.wd);
+                    if event
+                        .mask
+                        .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
+                    {
+                        reconcile_entry_watches = true;
+                    }
+                    if event
+                        .mask
+                        .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
+                    {
                         changed = true;
                         reconcile_entry_watches = true;
-                        continue;
+                        self.forget_entry_watch(cache_key);
                     }
-                    let Some(name) = event.name.as_deref() else {
-                        continue;
-                    };
-                    if name == OsStr::new(METADATA_FILE_NAME)
-                        && event.mask.contains(AddWatchFlags::IN_MOVED_TO)
-                    {
-                        changed = true;
-                        if committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {
-                            committed_cache_keys.insert(cache_key);
-                        }
-                    } else if (name == OsStr::new(METADATA_FILE_NAME)
-                        || name == OsStr::new(CURRENT_IMAGE_FILE_NAME))
-                        && event
-                            .mask
-                            .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
-                    {
-                        changed = true;
+                    continue;
+                }
+
+                let Some(cache_key) = self.cache_key_by_watch.get(&event.wd).cloned() else {
+                    continue;
+                };
+                if event.mask.intersects(WATCH_INVALIDATION_FLAGS) {
+                    self.forget_watch_descriptor(event.wd);
+                    changed = true;
+                    reconcile_entry_watches = true;
+                    continue;
+                }
+                let Some(name) = event.name.as_deref() else {
+                    continue;
+                };
+                if name == OsStr::new(METADATA_FILE_NAME)
+                    && event.mask.contains(AddWatchFlags::IN_MOVED_TO)
+                {
+                    changed = true;
+                    if committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {
+                        committed_cache_keys.insert(cache_key);
                     }
+                } else if (name == OsStr::new(METADATA_FILE_NAME)
+                    || name == OsStr::new(CURRENT_IMAGE_FILE_NAME))
+                    && event
+                        .mask
+                        .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
+                {
+                    changed = true;
                 }
             }
             if !drained_all_events {
@@ -365,6 +369,57 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
+    }
+
+    #[tokio::test]
+    async fn bounded_drain_preserves_readiness_for_remaining_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(temp.path().join("runner"));
+        let cache = WorkspaceImageCache::new(paths);
+        let cache_key = "c".repeat(64);
+        cache
+            .ensure_workspace_cache_entry_dir(&cache_key)
+            .await
+            .unwrap();
+        let entry_dir = cache.workspace_image_cache_entry_dir(&cache_key);
+
+        for index in 0..5_000 {
+            tokio::fs::write(entry_dir.join(format!("noise-{index:04}")), b"")
+                .await
+                .unwrap();
+        }
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
+        for index in 0..5_000 {
+            tokio::fs::remove_file(entry_dir.join(format!("noise-{index:04}")))
+                .await
+                .unwrap();
+        }
+        let metadata = cache.workspace_image_cache_metadata(&cache_key);
+        let temporary_metadata = metadata.with_extension("tmp");
+        tokio::fs::write(&temporary_metadata, b"{}").await.unwrap();
+        tokio::fs::rename(&temporary_metadata, &metadata)
+            .await
+            .unwrap();
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(first.committed_cache_keys.is_empty());
+
+        let mut committed_cache_keys = BTreeSet::new();
+        for _ in 0..8 {
+            let change =
+                tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            committed_cache_keys.extend(change.committed_cache_keys);
+            if committed_cache_keys.contains(&cache_key) {
+                break;
+            }
+        }
+        assert_eq!(committed_cache_keys, BTreeSet::from([cache_key]));
     }
 
     #[test]

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -103,7 +103,7 @@ impl WorkspaceCacheWatcher {
             watch_by_cache_key: BTreeMap::new(),
             cache,
         };
-        watcher.reconcile_entry_watches(&mut BTreeSet::new())?;
+        watcher.reconcile_entry_watches(&mut BTreeSet::new(), &BTreeSet::new())?;
         Ok(watcher)
     }
 
@@ -137,6 +137,7 @@ impl WorkspaceCacheWatcher {
             let mut changed = false;
             let mut reconcile_entry_watches = false;
             let mut committed_cache_keys = BTreeSet::new();
+            let mut new_cache_keys = BTreeSet::new();
             for event in pending_events {
                 if event.mask.contains(AddWatchFlags::IN_Q_OVERFLOW) {
                     changed = true;
@@ -162,6 +163,9 @@ impl WorkspaceCacheWatcher {
                         .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
                     {
                         reconcile_entry_watches = true;
+                        if new_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {
+                            new_cache_keys.insert(cache_key.to_owned());
+                        }
                     }
                     if event
                         .mask
@@ -211,7 +215,7 @@ impl WorkspaceCacheWatcher {
             }
 
             if reconcile_entry_watches {
-                self.reconcile_entry_watches(&mut committed_cache_keys)?;
+                self.reconcile_entry_watches(&mut committed_cache_keys, &new_cache_keys)?;
             }
             if changed || !committed_cache_keys.is_empty() {
                 return Ok(WorkspaceCacheChange {
@@ -225,6 +229,7 @@ impl WorkspaceCacheWatcher {
     fn reconcile_entry_watches(
         &mut self,
         committed_cache_keys: &mut BTreeSet<String>,
+        new_cache_keys: &BTreeSet<String>,
     ) -> RunnerResult<()> {
         let stale_cache_keys = self
             .watch_by_cache_key
@@ -241,6 +246,26 @@ impl WorkspaceCacheWatcher {
             .collect::<Vec<_>>();
         for cache_key in stale_cache_keys {
             self.forget_entry_watch(&cache_key);
+        }
+
+        for cache_key in new_cache_keys {
+            if self.watch_by_cache_key.contains_key(cache_key)
+                || !self.entry_is_watchable(cache_key)?
+            {
+                continue;
+            }
+            if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
+                let Some(evicted_cache_key) = self
+                    .watch_by_cache_key
+                    .keys()
+                    .find(|existing| !new_cache_keys.contains(existing.as_str()))
+                    .cloned()
+                else {
+                    break;
+                };
+                self.forget_entry_watch(&evicted_cache_key);
+            }
+            self.add_entry_watch(cache_key.clone(), committed_cache_keys)?;
         }
 
         if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
@@ -269,25 +294,41 @@ impl WorkspaceCacheWatcher {
             if self.watch_by_cache_key.contains_key(&cache_key) {
                 continue;
             }
-            let entry_dir = self.cache.workspace_image_cache_entry_dir(&cache_key);
-            let watch = match self
-                .inotify
-                .get_ref()
-                .0
-                .add_watch(&entry_dir, ENTRY_WATCH_FLAGS)
-            {
-                Ok(watch) => watch,
-                Err(Errno::ENOENT | Errno::ENOTDIR) => continue,
-                Err(error) => return Err(watcher_error("watch entry", error)),
-            };
-            self.cache_key_by_watch.insert(watch, cache_key.clone());
-            self.watch_by_cache_key.insert(cache_key.clone(), watch);
-            if std::fs::symlink_metadata(self.cache.workspace_image_cache_metadata(&cache_key))
-                .is_ok()
-                && committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES
-            {
-                committed_cache_keys.insert(cache_key);
-            }
+            self.add_entry_watch(cache_key, committed_cache_keys)?;
+        }
+        Ok(())
+    }
+
+    fn entry_is_watchable(&self, cache_key: &str) -> RunnerResult<bool> {
+        match std::fs::symlink_metadata(self.cache.workspace_image_cache_entry_dir(cache_key)) {
+            Ok(metadata) => Ok(metadata.is_dir()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(watcher_io_error("inspect entry", error.kind())),
+        }
+    }
+
+    fn add_entry_watch(
+        &mut self,
+        cache_key: String,
+        committed_cache_keys: &mut BTreeSet<String>,
+    ) -> RunnerResult<()> {
+        let entry_dir = self.cache.workspace_image_cache_entry_dir(&cache_key);
+        let watch = match self
+            .inotify
+            .get_ref()
+            .0
+            .add_watch(&entry_dir, ENTRY_WATCH_FLAGS)
+        {
+            Ok(watch) => watch,
+            Err(Errno::ENOENT | Errno::ENOTDIR | Errno::ELOOP) => return Ok(()),
+            Err(error) => return Err(watcher_error("watch entry", error)),
+        };
+        self.cache_key_by_watch.insert(watch, cache_key.clone());
+        self.watch_by_cache_key.insert(cache_key.clone(), watch);
+        if std::fs::symlink_metadata(self.cache.workspace_image_cache_metadata(&cache_key)).is_ok()
+            && committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES
+        {
+            committed_cache_keys.insert(cache_key);
         }
         Ok(())
     }
@@ -420,6 +461,41 @@ mod tests {
             }
         }
         assert_eq!(committed_cache_keys, BTreeSet::from([cache_key]));
+    }
+
+    #[tokio::test]
+    async fn newly_created_entry_replaces_an_existing_watch_at_the_limit() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(temp.path().join("runner"));
+        let cache = WorkspaceImageCache::new(paths);
+        for index in 0..MAX_HELD_WORKSPACE_STATES {
+            cache
+                .ensure_workspace_cache_entry_dir(&format!("{index:064x}"))
+                .await
+                .unwrap();
+        }
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
+        assert_eq!(watcher.watch_by_cache_key.len(), MAX_HELD_WORKSPACE_STATES);
+
+        let cache_key = "f".repeat(64);
+        cache
+            .ensure_workspace_cache_entry_dir(&cache_key)
+            .await
+            .unwrap();
+        tokio::fs::write(cache.workspace_image_cache_metadata(&cache_key), b"{}")
+            .await
+            .unwrap();
+
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            change.committed_cache_keys,
+            BTreeSet::from([cache_key.clone()])
+        );
+        assert_eq!(watcher.watch_by_cache_key.len(), MAX_HELD_WORKSPACE_STATES);
+        assert!(watcher.watch_by_cache_key.contains_key(&cache_key));
     }
 
     #[test]

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -273,16 +273,21 @@ impl WorkspaceCacheWatcher {
         }
         let entries = std::fs::read_dir(self.cache.workspace_image_cache_dir())
             .map_err(|error| watcher_io_error("scan entries", error.kind()))?;
-        for entry in entries {
+        for entry in entries.take(MAX_HELD_WORKSPACE_STATES) {
             if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
                 break;
             }
-            let entry = entry.map_err(|error| watcher_io_error("read entry", error.kind()))?;
-            if !entry
-                .file_type()
-                .map_err(|error| watcher_io_error("read entry type", error.kind()))?
-                .is_dir()
-            {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(watcher_io_error("read entry", error.kind())),
+            };
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(watcher_io_error("read entry type", error.kind())),
+            };
+            if !file_type.is_dir() {
                 continue;
             }
             let Some(cache_key) = entry.file_name().to_str().map(str::to_owned) else {

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -349,6 +349,7 @@ impl WorkspaceCacheWatcher {
         if let Some(cache_key) = self.cache_key_by_watch.remove(&watch) {
             self.watch_by_cache_key.remove(&cache_key);
         }
+        let _ = self.inotify.get_ref().0.rm_watch(watch);
     }
 }
 

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -86,13 +86,15 @@ impl WorkspaceCacheWatcher {
             cache.workspace_image_cache_dir(),
             DirMode::Private,
             "workspace image cache root",
-        )?;
+        )
+        .map_err(|error| watcher_io_error("prepare root", error.kind()))?;
         let inotify = Inotify::init(InitFlags::IN_CLOEXEC | InitFlags::IN_NONBLOCK)
             .map_err(|error| watcher_error("initialize", error))?;
         let root_watch = inotify
             .add_watch(cache.workspace_image_cache_dir(), ROOT_WATCH_FLAGS)
             .map_err(|error| watcher_error("watch root", error))?;
-        let inotify = AsyncFd::new(AsyncInotify(inotify))?;
+        let inotify = AsyncFd::new(AsyncInotify(inotify))
+            .map_err(|error| watcher_io_error("register descriptor", error.kind()))?;
         let mut watcher = Self {
             inotify,
             root_watch,
@@ -107,7 +109,11 @@ impl WorkspaceCacheWatcher {
     /// Waits for and coalesces all currently readable relevant mutations.
     pub(crate) async fn next_change(&mut self) -> RunnerResult<WorkspaceCacheChange> {
         loop {
-            let mut ready = self.inotify.readable().await?;
+            let mut ready = self
+                .inotify
+                .readable()
+                .await
+                .map_err(|error| watcher_io_error("wait for events", error.kind()))?;
             ready.clear_ready();
             drop(ready);
 
@@ -224,12 +230,18 @@ impl WorkspaceCacheWatcher {
         if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
             return Ok(());
         }
-        for entry in std::fs::read_dir(self.cache.workspace_image_cache_dir())? {
+        let entries = std::fs::read_dir(self.cache.workspace_image_cache_dir())
+            .map_err(|error| watcher_io_error("scan entries", error.kind()))?;
+        for entry in entries {
             if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
                 break;
             }
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
+            let entry = entry.map_err(|error| watcher_io_error("read entry", error.kind()))?;
+            if !entry
+                .file_type()
+                .map_err(|error| watcher_io_error("read entry type", error.kind()))?
+                .is_dir()
+            {
                 continue;
             }
             let Some(cache_key) = entry.file_name().to_str().map(str::to_owned) else {
@@ -280,6 +292,10 @@ impl WorkspaceCacheWatcher {
 
 fn watcher_error(action: &str, error: Errno) -> RunnerError {
     RunnerError::Internal(format!("workspace cache watcher {action}: {error}"))
+}
+
+fn watcher_io_error(action: &str, kind: std::io::ErrorKind) -> RunnerError {
+    RunnerError::Internal(format!("workspace cache watcher {action}: {kind:?}"))
 }
 
 #[cfg(test)]
@@ -337,5 +353,24 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
+    }
+
+    #[test]
+    fn setup_error_does_not_expose_cache_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(temp.path().join("runner"));
+        let cache = WorkspaceImageCache::new(paths);
+        let cache_root = cache.workspace_image_cache_dir().to_path_buf();
+        std::fs::create_dir_all(cache_root.parent().unwrap()).unwrap();
+        std::fs::write(&cache_root, b"not a directory").unwrap();
+
+        let error = match WorkspaceCacheWatcher::new(cache) {
+            Ok(_) => panic!("watcher setup should reject a non-directory cache root"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+
+        assert!(message.contains("workspace cache watcher prepare root"));
+        assert!(!message.contains(&cache_root.display().to_string()));
     }
 }

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -1,0 +1,341 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
+use std::os::fd::{AsFd, AsRawFd, RawFd};
+
+use nix::errno::Errno;
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, WatchDescriptor};
+use tokio::io::unix::AsyncFd;
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::host_file::{self, DirMode};
+use crate::types::MAX_HELD_WORKSPACE_STATES;
+
+use super::WorkspaceImageCache;
+use super::entry::is_cache_key_name;
+
+const METADATA_FILE_NAME: &str = "metadata.json";
+const CURRENT_IMAGE_FILE_NAME: &str = "current.ext4";
+
+const ROOT_WATCH_FLAGS: AddWatchFlags = AddWatchFlags::IN_CREATE
+    .union(AddWatchFlags::IN_MOVED_TO)
+    .union(AddWatchFlags::IN_DELETE)
+    .union(AddWatchFlags::IN_MOVED_FROM)
+    .union(AddWatchFlags::IN_DELETE_SELF)
+    .union(AddWatchFlags::IN_MOVE_SELF)
+    .union(AddWatchFlags::IN_UNMOUNT)
+    .union(AddWatchFlags::IN_ONLYDIR)
+    .union(AddWatchFlags::IN_DONT_FOLLOW);
+
+const ENTRY_WATCH_FLAGS: AddWatchFlags = AddWatchFlags::IN_MOVED_TO
+    .union(AddWatchFlags::IN_DELETE)
+    .union(AddWatchFlags::IN_MOVED_FROM)
+    .union(AddWatchFlags::IN_DELETE_SELF)
+    .union(AddWatchFlags::IN_MOVE_SELF)
+    .union(AddWatchFlags::IN_UNMOUNT)
+    .union(AddWatchFlags::IN_ONLYDIR)
+    .union(AddWatchFlags::IN_DONT_FOLLOW);
+
+const WATCH_INVALIDATION_FLAGS: AddWatchFlags = AddWatchFlags::IN_DELETE_SELF
+    .union(AddWatchFlags::IN_MOVE_SELF)
+    .union(AddWatchFlags::IN_UNMOUNT)
+    .union(AddWatchFlags::IN_IGNORED);
+
+/// Advisory cache mutation observed from the host-shared filesystem.
+///
+/// Cache keys identify metadata commits whose existing entry locks should be
+/// awaited before authoritative validation. An empty set still requests a full
+/// reconciliation for removal, invalidation, or queue-overflow events.
+#[derive(Debug)]
+pub(crate) struct WorkspaceCacheChange {
+    pub(crate) observed_at: tokio::time::Instant,
+    pub(crate) committed_cache_keys: BTreeSet<String>,
+}
+
+impl WorkspaceCacheChange {
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.observed_at = self.observed_at.min(other.observed_at);
+        for cache_key in other.committed_cache_keys {
+            if self.committed_cache_keys.len() == MAX_HELD_WORKSPACE_STATES {
+                break;
+            }
+            self.committed_cache_keys.insert(cache_key);
+        }
+    }
+}
+
+/// Non-recursive inotify observer for one host-shared workspace cache.
+pub(crate) struct WorkspaceCacheWatcher {
+    inotify: AsyncFd<AsyncInotify>,
+    root_watch: WatchDescriptor,
+    cache_key_by_watch: BTreeMap<WatchDescriptor, String>,
+    watch_by_cache_key: BTreeMap<String, WatchDescriptor>,
+    cache: WorkspaceImageCache,
+}
+
+struct AsyncInotify(Inotify);
+
+impl AsRawFd for AsyncInotify {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_fd().as_raw_fd()
+    }
+}
+
+impl WorkspaceCacheWatcher {
+    pub(crate) fn new(cache: WorkspaceImageCache) -> RunnerResult<Self> {
+        host_file::ensure_dir(
+            cache.workspace_image_cache_dir(),
+            DirMode::Private,
+            "workspace image cache root",
+        )?;
+        let inotify = Inotify::init(InitFlags::IN_CLOEXEC | InitFlags::IN_NONBLOCK)
+            .map_err(|error| watcher_error("initialize", error))?;
+        let root_watch = inotify
+            .add_watch(cache.workspace_image_cache_dir(), ROOT_WATCH_FLAGS)
+            .map_err(|error| watcher_error("watch root", error))?;
+        let inotify = AsyncFd::new(AsyncInotify(inotify))?;
+        let mut watcher = Self {
+            inotify,
+            root_watch,
+            cache_key_by_watch: BTreeMap::new(),
+            watch_by_cache_key: BTreeMap::new(),
+            cache,
+        };
+        watcher.reconcile_entry_watches(&mut BTreeSet::new())?;
+        Ok(watcher)
+    }
+
+    /// Waits for and coalesces all currently readable relevant mutations.
+    pub(crate) async fn next_change(&mut self) -> RunnerResult<WorkspaceCacheChange> {
+        loop {
+            let mut ready = self.inotify.readable().await?;
+            ready.clear_ready();
+            drop(ready);
+
+            let observed_at = tokio::time::Instant::now();
+            let mut changed = false;
+            let mut reconcile_entry_watches = false;
+            let mut committed_cache_keys = BTreeSet::new();
+            loop {
+                let events = match self.inotify.get_ref().0.read_events() {
+                    Ok(events) => events,
+                    Err(Errno::EAGAIN) => break,
+                    Err(error) => return Err(watcher_error("read events", error)),
+                };
+                for event in events {
+                    if event.mask.contains(AddWatchFlags::IN_Q_OVERFLOW) {
+                        changed = true;
+                        reconcile_entry_watches = true;
+                        continue;
+                    }
+                    if event.wd == self.root_watch {
+                        if event.mask.intersects(WATCH_INVALIDATION_FLAGS) {
+                            return Err(RunnerError::Internal(
+                                "workspace cache root watch invalidated".to_string(),
+                            ));
+                        }
+                        let Some(cache_key) = event
+                            .name
+                            .as_deref()
+                            .and_then(OsStr::to_str)
+                            .filter(|name| is_cache_key_name(name))
+                        else {
+                            continue;
+                        };
+                        if event
+                            .mask
+                            .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
+                        {
+                            reconcile_entry_watches = true;
+                        }
+                        if event
+                            .mask
+                            .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
+                        {
+                            changed = true;
+                            reconcile_entry_watches = true;
+                            self.forget_entry_watch(cache_key);
+                        }
+                        continue;
+                    }
+
+                    let Some(cache_key) = self.cache_key_by_watch.get(&event.wd).cloned() else {
+                        continue;
+                    };
+                    if event.mask.intersects(WATCH_INVALIDATION_FLAGS) {
+                        self.forget_watch_descriptor(event.wd);
+                        changed = true;
+                        reconcile_entry_watches = true;
+                        continue;
+                    }
+                    let Some(name) = event.name.as_deref() else {
+                        continue;
+                    };
+                    if name == OsStr::new(METADATA_FILE_NAME)
+                        && event.mask.contains(AddWatchFlags::IN_MOVED_TO)
+                    {
+                        changed = true;
+                        if committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {
+                            committed_cache_keys.insert(cache_key);
+                        }
+                    } else if (name == OsStr::new(METADATA_FILE_NAME)
+                        || name == OsStr::new(CURRENT_IMAGE_FILE_NAME))
+                        && event
+                            .mask
+                            .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
+                    {
+                        changed = true;
+                    }
+                }
+            }
+
+            if reconcile_entry_watches {
+                self.reconcile_entry_watches(&mut committed_cache_keys)?;
+            }
+            if changed || !committed_cache_keys.is_empty() {
+                return Ok(WorkspaceCacheChange {
+                    observed_at,
+                    committed_cache_keys,
+                });
+            }
+        }
+    }
+
+    fn reconcile_entry_watches(
+        &mut self,
+        committed_cache_keys: &mut BTreeSet<String>,
+    ) -> RunnerResult<()> {
+        let stale_cache_keys = self
+            .watch_by_cache_key
+            .keys()
+            .filter(|cache_key| {
+                match std::fs::symlink_metadata(
+                    self.cache.workspace_image_cache_entry_dir(cache_key),
+                ) {
+                    Ok(metadata) => !metadata.is_dir(),
+                    Err(_) => true,
+                }
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for cache_key in stale_cache_keys {
+            self.forget_entry_watch(&cache_key);
+        }
+
+        if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
+            return Ok(());
+        }
+        for entry in std::fs::read_dir(self.cache.workspace_image_cache_dir())? {
+            if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
+                break;
+            }
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(cache_key) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            if !is_cache_key_name(&cache_key) {
+                continue;
+            }
+            if self.watch_by_cache_key.contains_key(&cache_key) {
+                continue;
+            }
+            let entry_dir = self.cache.workspace_image_cache_entry_dir(&cache_key);
+            let watch = match self
+                .inotify
+                .get_ref()
+                .0
+                .add_watch(&entry_dir, ENTRY_WATCH_FLAGS)
+            {
+                Ok(watch) => watch,
+                Err(Errno::ENOENT | Errno::ENOTDIR) => continue,
+                Err(error) => return Err(watcher_error("watch entry", error)),
+            };
+            self.cache_key_by_watch.insert(watch, cache_key.clone());
+            self.watch_by_cache_key.insert(cache_key.clone(), watch);
+            if std::fs::symlink_metadata(self.cache.workspace_image_cache_metadata(&cache_key))
+                .is_ok()
+                && committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES
+            {
+                committed_cache_keys.insert(cache_key);
+            }
+        }
+        Ok(())
+    }
+
+    fn forget_entry_watch(&mut self, cache_key: &str) {
+        if let Some(watch) = self.watch_by_cache_key.remove(cache_key) {
+            self.cache_key_by_watch.remove(&watch);
+            let _ = self.inotify.get_ref().0.rm_watch(watch);
+        }
+    }
+
+    fn forget_watch_descriptor(&mut self, watch: WatchDescriptor) {
+        if let Some(cache_key) = self.cache_key_by_watch.remove(&watch) {
+            self.watch_by_cache_key.remove(&cache_key);
+        }
+    }
+}
+
+fn watcher_error(action: &str, error: Errno) -> RunnerError {
+    RunnerError::Internal(format!("workspace cache watcher {action}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::RunnerPaths;
+
+    #[tokio::test]
+    async fn reports_metadata_commit_and_removal_from_existing_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(temp.path().join("runner"));
+        let cache = WorkspaceImageCache::new(paths);
+        let cache_key = "a".repeat(64);
+        cache
+            .ensure_workspace_cache_entry_dir(&cache_key)
+            .await
+            .unwrap();
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
+
+        let metadata = cache.workspace_image_cache_metadata(&cache_key);
+        let temporary_metadata = metadata.with_extension("tmp");
+        tokio::fs::write(&temporary_metadata, b"{}").await.unwrap();
+        tokio::fs::rename(&temporary_metadata, &metadata)
+            .await
+            .unwrap();
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
+
+        tokio::fs::remove_file(metadata).await.unwrap();
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(change.committed_cache_keys.is_empty());
+    }
+
+    #[tokio::test]
+    async fn newly_created_entry_with_committed_metadata_is_not_lost() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(temp.path().join("runner"));
+        let cache = WorkspaceImageCache::new(paths);
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
+        let cache_key = "b".repeat(64);
+        let entry_dir = cache.workspace_image_cache_entry_dir(&cache_key);
+        tokio::fs::create_dir_all(&entry_dir).await.unwrap();
+        tokio::fs::write(entry_dir.join(METADATA_FILE_NAME), b"{}")
+            .await
+            .unwrap();
+
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
+    }
+}

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -39,6 +39,7 @@ const WATCH_INVALIDATION_FLAGS: AddWatchFlags = AddWatchFlags::IN_DELETE_SELF
     .union(AddWatchFlags::IN_MOVE_SELF)
     .union(AddWatchFlags::IN_UNMOUNT)
     .union(AddWatchFlags::IN_IGNORED);
+const MAX_EVENT_READ_BATCHES_PER_CHANGE: usize = 16;
 
 /// Advisory cache mutation observed from the host-shared filesystem.
 ///
@@ -121,10 +122,14 @@ impl WorkspaceCacheWatcher {
             let mut changed = false;
             let mut reconcile_entry_watches = false;
             let mut committed_cache_keys = BTreeSet::new();
-            loop {
+            let mut drained_all_events = false;
+            for _ in 0..MAX_EVENT_READ_BATCHES_PER_CHANGE {
                 let events = match self.inotify.get_ref().0.read_events() {
                     Ok(events) => events,
-                    Err(Errno::EAGAIN) => break,
+                    Err(Errno::EAGAIN) => {
+                        drained_all_events = true;
+                        break;
+                    }
                     Err(error) => return Err(watcher_error("read events", error)),
                 };
                 for event in events {
@@ -192,6 +197,13 @@ impl WorkspaceCacheWatcher {
                         changed = true;
                     }
                 }
+            }
+            if !drained_all_events {
+                // Bound one reactor turn even when producers keep the queue
+                // continuously readable. Reconciliation covers events beyond
+                // the batch budget, which remain queued for the next turn.
+                changed = true;
+                reconcile_entry_watches = true;
             }
 
             if reconcile_entry_watches {

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -123,6 +123,37 @@ impl WorkspaceCacheWatcher {
         Ok(watcher)
     }
 
+    /// Connects entries accepted by the subscribe-before-scan startup pass to
+    /// watcher state before the loaded snapshot can be published. Entries that
+    /// were not already relevant when the watcher subscribed require one more
+    /// authoritative scan after their entry watches are installed.
+    pub(crate) async fn reconcile_initial_relevant_entries(
+        &mut self,
+        cache_keys: &BTreeSet<String>,
+    ) -> RunnerResult<bool> {
+        let mut committed_cache_keys = BTreeSet::new();
+        let mut requires_refresh = false;
+        for cache_key in cache_keys {
+            match self.entry_watch_state(cache_key) {
+                Some(EntryWatchState::Relevant) => {}
+                Some(EntryWatchState::Unclassified) => {
+                    requires_refresh = true;
+                    self.classify_metadata_commit(cache_key, &mut committed_cache_keys)
+                        .await;
+                }
+                None => {
+                    requires_refresh = true;
+                    self.add_entry_watch(cache_key.clone(), &mut committed_cache_keys)
+                        .await?;
+                }
+            }
+        }
+        Ok(requires_refresh
+            || cache_keys.iter().any(|cache_key| {
+                self.entry_watch_state(cache_key) != Some(EntryWatchState::Relevant)
+            }))
+    }
+
     /// Waits for and coalesces all currently readable relevant mutations.
     pub(crate) async fn next_change(&mut self) -> RunnerResult<WorkspaceCacheChange> {
         loop {

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -12,6 +12,7 @@ use crate::types::MAX_HELD_WORKSPACE_STATES;
 
 use super::WorkspaceImageCache;
 use super::entry::is_cache_key_name;
+use super::metadata::WorkspaceCacheScopeClassification;
 
 const METADATA_FILE_NAME: &str = "metadata.json";
 const CURRENT_IMAGE_FILE_NAME: &str = "current.ext4";
@@ -43,9 +44,10 @@ const MAX_EVENT_READ_BATCHES_PER_CHANGE: usize = 16;
 
 /// Advisory cache mutation observed from the host-shared filesystem.
 ///
-/// Cache keys identify metadata commits whose existing entry locks should be
-/// awaited before authoritative validation. An empty set still requests a full
-/// reconciliation for removal, invalidation, or queue-overflow events.
+/// Cache keys identify matching-scope metadata commits whose existing entry
+/// locks should be awaited before authoritative validation. An empty set still
+/// requests a full reconciliation for a relevant removal, invalidation, or
+/// queue-overflow event.
 #[derive(Debug)]
 pub(crate) struct WorkspaceCacheChange {
     pub(crate) observed_at: tokio::time::Instant,
@@ -68,9 +70,21 @@ impl WorkspaceCacheChange {
 pub(crate) struct WorkspaceCacheWatcher {
     inotify: AsyncFd<AsyncInotify>,
     root_watch: WatchDescriptor,
-    cache_key_by_watch: BTreeMap<WatchDescriptor, String>,
+    entry_by_watch: BTreeMap<WatchDescriptor, WatchedEntry>,
     watch_by_cache_key: BTreeMap<String, WatchDescriptor>,
     cache: WorkspaceImageCache,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EntryWatchState {
+    Unclassified,
+    Relevant,
+}
+
+#[derive(Clone, Debug)]
+struct WatchedEntry {
+    cache_key: String,
+    state: EntryWatchState,
 }
 
 struct AsyncInotify(Inotify);
@@ -82,7 +96,7 @@ impl AsRawFd for AsyncInotify {
 }
 
 impl WorkspaceCacheWatcher {
-    pub(crate) fn new(cache: WorkspaceImageCache) -> RunnerResult<Self> {
+    pub(crate) async fn new(cache: WorkspaceImageCache) -> RunnerResult<Self> {
         host_file::ensure_dir(
             cache.workspace_image_cache_dir(),
             DirMode::Private,
@@ -99,11 +113,13 @@ impl WorkspaceCacheWatcher {
         let mut watcher = Self {
             inotify,
             root_watch,
-            cache_key_by_watch: BTreeMap::new(),
+            entry_by_watch: BTreeMap::new(),
             watch_by_cache_key: BTreeMap::new(),
             cache,
         };
-        watcher.reconcile_entry_watches(&mut BTreeSet::new(), &BTreeSet::new())?;
+        watcher
+            .reconcile_all_entry_watches(&mut BTreeSet::new())
+            .await?;
         Ok(watcher)
     }
 
@@ -135,13 +151,14 @@ impl WorkspaceCacheWatcher {
             drop(ready);
 
             let mut changed = false;
-            let mut reconcile_entry_watches = false;
+            let mut reconcile_all_entry_watches = false;
             let mut committed_cache_keys = BTreeSet::new();
-            let mut new_cache_keys = BTreeSet::new();
+            let mut metadata_commit_keys = BTreeSet::new();
+            let mut new_cache_keys = Vec::new();
             for event in pending_events {
                 if event.mask.contains(AddWatchFlags::IN_Q_OVERFLOW) {
                     changed = true;
-                    reconcile_entry_watches = true;
+                    reconcile_all_entry_watches = true;
                     continue;
                 }
                 if event.wd == self.root_watch {
@@ -161,30 +178,26 @@ impl WorkspaceCacheWatcher {
                     if event
                         .mask
                         .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
+                        && new_cache_keys.len() < MAX_HELD_WORKSPACE_STATES
                     {
-                        reconcile_entry_watches = true;
-                        if new_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {
-                            new_cache_keys.insert(cache_key.to_owned());
-                        }
+                        new_cache_keys.push(cache_key.to_owned());
                     }
                     if event
                         .mask
                         .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
                     {
-                        changed = true;
-                        reconcile_entry_watches = true;
-                        self.forget_entry_watch(cache_key);
+                        changed |=
+                            self.forget_entry_watch(cache_key) == Some(EntryWatchState::Relevant);
                     }
                     continue;
                 }
 
-                let Some(cache_key) = self.cache_key_by_watch.get(&event.wd).cloned() else {
+                let Some(entry) = self.entry_by_watch.get(&event.wd).cloned() else {
                     continue;
                 };
                 if event.mask.intersects(WATCH_INVALIDATION_FLAGS) {
-                    self.forget_watch_descriptor(event.wd);
-                    changed = true;
-                    reconcile_entry_watches = true;
+                    changed |=
+                        self.forget_watch_descriptor(event.wd) == Some(EntryWatchState::Relevant);
                     continue;
                 }
                 let Some(name) = event.name.as_deref() else {
@@ -193,9 +206,8 @@ impl WorkspaceCacheWatcher {
                 if name == OsStr::new(METADATA_FILE_NAME)
                     && event.mask.contains(AddWatchFlags::IN_MOVED_TO)
                 {
-                    changed = true;
-                    if committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {
-                        committed_cache_keys.insert(cache_key);
+                    if metadata_commit_keys.len() < MAX_HELD_WORKSPACE_STATES {
+                        metadata_commit_keys.insert(entry.cache_key);
                     }
                 } else if (name == OsStr::new(METADATA_FILE_NAME)
                     || name == OsStr::new(CURRENT_IMAGE_FILE_NAME))
@@ -203,19 +215,23 @@ impl WorkspaceCacheWatcher {
                         .mask
                         .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
                 {
-                    changed = true;
+                    changed |= entry.state == EntryWatchState::Relevant;
                 }
             }
-            if !drained_all_events {
-                // Bound one reactor turn even when producers keep the queue
-                // continuously readable. Reconciliation covers events beyond
-                // the batch budget, which remain queued for the next turn.
-                changed = true;
-                reconcile_entry_watches = true;
-            }
 
-            if reconcile_entry_watches {
-                self.reconcile_entry_watches(&mut committed_cache_keys, &new_cache_keys)?;
+            for cache_key in new_cache_keys {
+                changed |= self
+                    .add_entry_watch(cache_key, &mut committed_cache_keys)
+                    .await?;
+            }
+            for cache_key in metadata_commit_keys {
+                changed |= self
+                    .classify_metadata_commit(&cache_key, &mut committed_cache_keys)
+                    .await;
+            }
+            if reconcile_all_entry_watches {
+                self.reconcile_all_entry_watches(&mut committed_cache_keys)
+                    .await?;
             }
             if changed || !committed_cache_keys.is_empty() {
                 return Ok(WorkspaceCacheChange {
@@ -223,13 +239,17 @@ impl WorkspaceCacheWatcher {
                     committed_cache_keys,
                 });
             }
+            if !drained_all_events {
+                // Preserve descriptor readiness for queued events while giving
+                // the reactor a scheduling point between bounded read batches.
+                tokio::task::yield_now().await;
+            }
         }
     }
 
-    fn reconcile_entry_watches(
+    async fn reconcile_all_entry_watches(
         &mut self,
         committed_cache_keys: &mut BTreeSet<String>,
-        new_cache_keys: &BTreeSet<String>,
     ) -> RunnerResult<()> {
         let stale_cache_keys = self
             .watch_by_cache_key
@@ -248,24 +268,10 @@ impl WorkspaceCacheWatcher {
             self.forget_entry_watch(&cache_key);
         }
 
-        for cache_key in new_cache_keys {
-            if self.watch_by_cache_key.contains_key(cache_key)
-                || !self.entry_is_watchable(cache_key)?
-            {
-                continue;
-            }
-            if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
-                let Some(evicted_cache_key) = self
-                    .watch_by_cache_key
-                    .keys()
-                    .find(|existing| !new_cache_keys.contains(existing.as_str()))
-                    .cloned()
-                else {
-                    break;
-                };
-                self.forget_entry_watch(&evicted_cache_key);
-            }
-            self.add_entry_watch(cache_key.clone(), committed_cache_keys)?;
+        let watched_cache_keys = self.watch_by_cache_key.keys().cloned().collect::<Vec<_>>();
+        for cache_key in watched_cache_keys {
+            self.classify_metadata_commit(&cache_key, committed_cache_keys)
+                .await;
         }
 
         if self.watch_by_cache_key.len() == MAX_HELD_WORKSPACE_STATES {
@@ -299,7 +305,8 @@ impl WorkspaceCacheWatcher {
             if self.watch_by_cache_key.contains_key(&cache_key) {
                 continue;
             }
-            self.add_entry_watch(cache_key, committed_cache_keys)?;
+            self.add_entry_watch(cache_key, committed_cache_keys)
+                .await?;
         }
         Ok(())
     }
@@ -312,11 +319,16 @@ impl WorkspaceCacheWatcher {
         }
     }
 
-    fn add_entry_watch(
+    async fn add_entry_watch(
         &mut self,
         cache_key: String,
         committed_cache_keys: &mut BTreeSet<String>,
-    ) -> RunnerResult<()> {
+    ) -> RunnerResult<bool> {
+        if self.watch_by_cache_key.contains_key(&cache_key)
+            || !self.entry_is_watchable(&cache_key)?
+        {
+            return Ok(false);
+        }
         let entry_dir = self.cache.workspace_image_cache_entry_dir(&cache_key);
         let watch = match self
             .inotify
@@ -325,31 +337,114 @@ impl WorkspaceCacheWatcher {
             .add_watch(&entry_dir, ENTRY_WATCH_FLAGS)
         {
             Ok(watch) => watch,
-            Err(Errno::ENOENT | Errno::ENOTDIR | Errno::ELOOP) => return Ok(()),
+            Err(Errno::ENOENT | Errno::ENOTDIR | Errno::ELOOP) => return Ok(false),
             Err(error) => return Err(watcher_error("watch entry", error)),
         };
-        self.cache_key_by_watch.insert(watch, cache_key.clone());
+        self.entry_by_watch.insert(
+            watch,
+            WatchedEntry {
+                cache_key: cache_key.clone(),
+                state: EntryWatchState::Unclassified,
+            },
+        );
         self.watch_by_cache_key.insert(cache_key.clone(), watch);
-        if std::fs::symlink_metadata(self.cache.workspace_image_cache_metadata(&cache_key)).is_ok()
-            && committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES
-        {
-            committed_cache_keys.insert(cache_key);
+        let changed = self
+            .classify_metadata_commit(&cache_key, committed_cache_keys)
+            .await;
+        self.enforce_watch_limit(&cache_key);
+        if !self.watch_by_cache_key.contains_key(&cache_key) {
+            committed_cache_keys.remove(&cache_key);
         }
-        Ok(())
+        Ok(changed && self.watch_by_cache_key.contains_key(&cache_key))
     }
 
-    fn forget_entry_watch(&mut self, cache_key: &str) {
+    async fn classify_metadata_commit(
+        &mut self,
+        cache_key: &str,
+        committed_cache_keys: &mut BTreeSet<String>,
+    ) -> bool {
+        let Some(previous_state) = self.entry_watch_state(cache_key) else {
+            return false;
+        };
+        match self.cache.classify_metadata_scope(cache_key).await {
+            WorkspaceCacheScopeClassification::Relevant => {
+                self.set_entry_watch_state(cache_key, EntryWatchState::Relevant);
+                if committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {
+                    committed_cache_keys.insert(cache_key.to_owned());
+                }
+                true
+            }
+            WorkspaceCacheScopeClassification::Foreign => {
+                self.forget_entry_watch(cache_key);
+                previous_state == EntryWatchState::Relevant
+            }
+            WorkspaceCacheScopeClassification::Unclassified => {
+                self.set_entry_watch_state(cache_key, EntryWatchState::Unclassified);
+                previous_state == EntryWatchState::Relevant
+            }
+        }
+    }
+
+    fn enforce_watch_limit(&mut self, preferred_cache_key: &str) {
+        while self.watch_by_cache_key.len() > MAX_HELD_WORKSPACE_STATES {
+            let preferred_state = self.entry_watch_state(preferred_cache_key);
+            let evicted_cache_key = self
+                .watch_by_cache_key
+                .keys()
+                .find(|cache_key| {
+                    cache_key.as_str() != preferred_cache_key
+                        && self.entry_watch_state(cache_key) == Some(EntryWatchState::Unclassified)
+                })
+                .cloned()
+                .or_else(|| {
+                    (preferred_state == Some(EntryWatchState::Unclassified))
+                        .then(|| preferred_cache_key.to_owned())
+                })
+                .or_else(|| {
+                    self.watch_by_cache_key
+                        .keys()
+                        .find(|cache_key| cache_key.as_str() != preferred_cache_key)
+                        .cloned()
+                });
+            let Some(evicted_cache_key) = evicted_cache_key else {
+                break;
+            };
+            self.forget_entry_watch(&evicted_cache_key);
+        }
+    }
+
+    fn entry_watch_state(&self, cache_key: &str) -> Option<EntryWatchState> {
+        let watch = self.watch_by_cache_key.get(cache_key)?;
+        self.entry_by_watch.get(watch).map(|entry| entry.state)
+    }
+
+    fn set_entry_watch_state(&mut self, cache_key: &str, state: EntryWatchState) {
+        let Some(watch) = self.watch_by_cache_key.get(cache_key) else {
+            return;
+        };
+        if let Some(entry) = self.entry_by_watch.get_mut(watch) {
+            entry.state = state;
+        }
+    }
+
+    fn forget_entry_watch(&mut self, cache_key: &str) -> Option<EntryWatchState> {
         if let Some(watch) = self.watch_by_cache_key.remove(cache_key) {
-            self.cache_key_by_watch.remove(&watch);
+            let state = self.entry_by_watch.remove(&watch).map(|entry| entry.state);
             let _ = self.inotify.get_ref().0.rm_watch(watch);
+            return state;
         }
+        None
     }
 
-    fn forget_watch_descriptor(&mut self, watch: WatchDescriptor) {
-        if let Some(cache_key) = self.cache_key_by_watch.remove(&watch) {
-            self.watch_by_cache_key.remove(&cache_key);
-        }
+    fn forget_watch_descriptor(&mut self, watch: WatchDescriptor) -> Option<EntryWatchState> {
+        let state = if let Some(entry) = self.entry_by_watch.remove(&watch) {
+            self.watch_by_cache_key.remove(&entry.cache_key);
+            Some(entry.state)
+        } else {
+            None
+        };
         let _ = self.inotify.get_ref().0.rm_watch(watch);
+        state
     }
 }
 
@@ -363,34 +458,93 @@ fn watcher_io_error(action: &str, kind: std::io::ErrorKind) -> RunnerError {
 
 #[cfg(test)]
 mod tests {
+    use super::super::fs::allocated_bytes;
+    use super::super::metadata::{
+        WorkspaceCacheMetadata, WorkspaceCacheState, WorkspaceImageFileIdentity, WorkspaceTrust,
+    };
+    use super::super::{
+        CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheTerminalStatus,
+    };
     use super::*;
-    use crate::paths::RunnerPaths;
+    use crate::ids::RunId;
+    use crate::paths::{HomePaths, RunnerPaths};
+    use crate::storage_fingerprints::StorageFingerprints;
+
+    const TEST_PROFILE_NAME: &str = "vm0/default";
+    const TEST_WORKING_DIR: &str = "/workspace";
+
+    async fn commit_entry(cache: &WorkspaceImageCache, reuse_key: &str) -> String {
+        let image = format!("image-{reuse_key}");
+        let cache_key = cache.scoped_cache_key(
+            TEST_PROFILE_NAME,
+            reuse_key,
+            TEST_WORKING_DIR,
+            image.len() as u64,
+        );
+        cache
+            .ensure_workspace_cache_entry_dir(&cache_key)
+            .await
+            .unwrap();
+        let current_image = cache.workspace_image_cache_current_image(&cache_key);
+        tokio::fs::write(&current_image, image).await.unwrap();
+        let current_metadata = tokio::fs::metadata(&current_image).await.unwrap();
+        cache
+            .write_metadata(
+                &cache_key,
+                RunId::new_v4(),
+                WorkspaceCacheMetadata {
+                    format_version: CACHE_FORMAT_VERSION,
+                    cache_scope: cache.inner.cache_scope.clone(),
+                    profile_name: TEST_PROFILE_NAME.into(),
+                    reuse_key: reuse_key.into(),
+                    working_dir: TEST_WORKING_DIR.into(),
+                    last_completed_at: "2026-05-01T00:00:00.000Z".into(),
+                    last_used_at: "2026-05-01T00:00:00.000Z".into(),
+                    last_terminal_status: WorkspaceCacheTerminalStatus::Success,
+                    workspace_trust: WorkspaceTrust::Clean,
+                    logical_image_size_bytes: current_metadata.len(),
+                    allocated_bytes: allocated_bytes(&current_metadata),
+                    current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
+                    drive_layout: WORKSPACE_DRIVE_LAYOUT.into(),
+                    storage_fingerprints: StorageFingerprints::default(),
+                    state: WorkspaceCacheState::Current,
+                },
+            )
+            .await
+            .unwrap();
+        cache_key
+    }
 
     #[tokio::test]
     async fn reports_metadata_commit_and_removal_from_existing_entry() {
         let temp = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(temp.path().join("runner"));
         let cache = WorkspaceImageCache::new(paths);
-        let cache_key = "a".repeat(64);
+        let cache_key = cache.scoped_cache_key(
+            TEST_PROFILE_NAME,
+            "existing-entry",
+            TEST_WORKING_DIR,
+            b"image-existing-entry".len() as u64,
+        );
         cache
             .ensure_workspace_cache_entry_dir(&cache_key)
             .await
             .unwrap();
-        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).await.unwrap();
 
-        let metadata = cache.workspace_image_cache_metadata(&cache_key);
-        let temporary_metadata = metadata.with_extension("tmp");
-        tokio::fs::write(&temporary_metadata, b"{}").await.unwrap();
-        tokio::fs::rename(&temporary_metadata, &metadata)
-            .await
-            .unwrap();
+        assert_eq!(commit_entry(&cache, "existing-entry").await, cache_key);
         let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
+        assert_eq!(
+            change.committed_cache_keys,
+            BTreeSet::from([cache_key.clone()])
+        );
 
-        tokio::fs::remove_file(metadata).await.unwrap();
+        tokio::fs::remove_file(cache.workspace_image_cache_metadata(&cache_key))
+            .await
+            .unwrap();
         let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
             .await
             .unwrap()
@@ -403,13 +557,8 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(temp.path().join("runner"));
         let cache = WorkspaceImageCache::new(paths);
-        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
-        let cache_key = "b".repeat(64);
-        let entry_dir = cache.workspace_image_cache_entry_dir(&cache_key);
-        tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-        tokio::fs::write(entry_dir.join(METADATA_FILE_NAME), b"{}")
-            .await
-            .unwrap();
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).await.unwrap();
+        let cache_key = commit_entry(&cache, "new-entry").await;
 
         let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
             .await
@@ -423,7 +572,12 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(temp.path().join("runner"));
         let cache = WorkspaceImageCache::new(paths);
-        let cache_key = "c".repeat(64);
+        let cache_key = cache.scoped_cache_key(
+            TEST_PROFILE_NAME,
+            "bounded-drain",
+            TEST_WORKING_DIR,
+            b"image-bounded-drain".len() as u64,
+        );
         cache
             .ensure_workspace_cache_entry_dir(&cache_key)
             .await
@@ -435,38 +589,19 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).await.unwrap();
         for index in 0..5_000 {
             tokio::fs::remove_file(entry_dir.join(format!("noise-{index:04}")))
                 .await
                 .unwrap();
         }
-        let metadata = cache.workspace_image_cache_metadata(&cache_key);
-        let temporary_metadata = metadata.with_extension("tmp");
-        tokio::fs::write(&temporary_metadata, b"{}").await.unwrap();
-        tokio::fs::rename(&temporary_metadata, &metadata)
-            .await
-            .unwrap();
+        assert_eq!(commit_entry(&cache, "bounded-drain").await, cache_key);
 
-        let first = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
             .await
             .unwrap()
             .unwrap();
-        assert!(first.committed_cache_keys.is_empty());
-
-        let mut committed_cache_keys = BTreeSet::new();
-        for _ in 0..8 {
-            let change =
-                tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
-                    .await
-                    .unwrap()
-                    .unwrap();
-            committed_cache_keys.extend(change.committed_cache_keys);
-            if committed_cache_keys.contains(&cache_key) {
-                break;
-            }
-        }
-        assert_eq!(committed_cache_keys, BTreeSet::from([cache_key]));
+        assert_eq!(change.committed_cache_keys, BTreeSet::from([cache_key]));
     }
 
     #[tokio::test]
@@ -480,17 +615,10 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).unwrap();
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).await.unwrap();
         assert_eq!(watcher.watch_by_cache_key.len(), MAX_HELD_WORKSPACE_STATES);
 
-        let cache_key = "f".repeat(64);
-        cache
-            .ensure_workspace_cache_entry_dir(&cache_key)
-            .await
-            .unwrap();
-        tokio::fs::write(cache.workspace_image_cache_metadata(&cache_key), b"{}")
-            .await
-            .unwrap();
+        let cache_key = commit_entry(&cache, "preferred-new-entry").await;
 
         let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
             .await
@@ -504,8 +632,119 @@ mod tests {
         assert!(watcher.watch_by_cache_key.contains_key(&cache_key));
     }
 
-    #[test]
-    fn setup_error_does_not_expose_cache_path() {
+    #[tokio::test]
+    async fn create_and_remove_in_one_batch_does_not_leave_a_stale_watch() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(temp.path().join("runner"));
+        let cache = WorkspaceImageCache::new(paths);
+        let mut watcher = WorkspaceCacheWatcher::new(cache.clone()).await.unwrap();
+        let cache_key = "e".repeat(64);
+        let entry_dir = cache.workspace_image_cache_entry_dir(&cache_key);
+
+        tokio::fs::create_dir_all(&entry_dir).await.unwrap();
+        tokio::fs::remove_dir(&entry_dir).await.unwrap();
+        let relevant_cache_key = commit_entry(&cache, "post-create-remove").await;
+
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            change.committed_cache_keys,
+            BTreeSet::from([relevant_cache_key])
+        );
+        assert!(!watcher.watch_by_cache_key.contains_key(&cache_key));
+    }
+
+    #[tokio::test]
+    async fn foreign_scope_commit_and_removal_do_not_report_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(temp.path().join("home"));
+        let observer_paths = RunnerPaths::new(temp.path().join("observer"));
+        let publisher_paths = RunnerPaths::new(temp.path().join("publisher"));
+        tokio::fs::create_dir_all(observer_paths.base_dir())
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(publisher_paths.base_dir())
+            .await
+            .unwrap();
+        let observer = WorkspaceImageCache::shared(observer_paths, &home, "group-a");
+        let publisher = WorkspaceImageCache::shared(publisher_paths, &home, "group-b");
+        let mut watcher = WorkspaceCacheWatcher::new(observer.clone()).await.unwrap();
+
+        let foreign_cache_key = commit_entry(&publisher, "foreign-entry").await;
+        let relevant_cache_key = commit_entry(&observer, "relevant-entry").await;
+
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.next_change())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            change.committed_cache_keys,
+            BTreeSet::from([relevant_cache_key])
+        );
+        assert!(!watcher.watch_by_cache_key.contains_key(&foreign_cache_key));
+
+        tokio::fs::remove_dir_all(publisher.workspace_image_cache_entry_dir(&foreign_cache_key))
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), watcher.next_change())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn foreign_scope_commit_does_not_wake_observer() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(temp.path().join("home"));
+        let observer_paths = RunnerPaths::new(temp.path().join("observer"));
+        let publisher_paths = RunnerPaths::new(temp.path().join("publisher"));
+        tokio::fs::create_dir_all(observer_paths.base_dir())
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(publisher_paths.base_dir())
+            .await
+            .unwrap();
+        let observer = WorkspaceImageCache::shared(observer_paths, &home, "group-a");
+        let publisher = WorkspaceImageCache::shared(publisher_paths, &home, "group-b");
+        let mut watcher = WorkspaceCacheWatcher::new(observer).await.unwrap();
+
+        let foreign_cache_key = commit_entry(&publisher, "foreign-only-entry").await;
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), watcher.next_change())
+                .await
+                .is_err()
+        );
+        assert!(!watcher.watch_by_cache_key.contains_key(&foreign_cache_key));
+    }
+
+    #[tokio::test]
+    async fn existing_foreign_entries_do_not_consume_watch_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(temp.path().join("home"));
+        let observer_paths = RunnerPaths::new(temp.path().join("observer"));
+        let publisher_paths = RunnerPaths::new(temp.path().join("publisher"));
+        tokio::fs::create_dir_all(observer_paths.base_dir())
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(publisher_paths.base_dir())
+            .await
+            .unwrap();
+        let observer = WorkspaceImageCache::shared(observer_paths, &home, "group-a");
+        let publisher = WorkspaceImageCache::shared(publisher_paths, &home, "group-b");
+        let foreign_cache_key = commit_entry(&publisher, "existing-foreign-entry").await;
+
+        let watcher = WorkspaceCacheWatcher::new(observer).await.unwrap();
+
+        assert!(!watcher.watch_by_cache_key.contains_key(&foreign_cache_key));
+        assert!(watcher.watch_by_cache_key.is_empty());
+    }
+
+    #[tokio::test]
+    async fn setup_error_does_not_expose_cache_path() {
         let temp = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(temp.path().join("runner"));
         let cache = WorkspaceImageCache::new(paths);
@@ -513,7 +752,7 @@ mod tests {
         std::fs::create_dir_all(cache_root.parent().unwrap()).unwrap();
         std::fs::write(&cache_root, b"not a directory").unwrap();
 
-        let error = match WorkspaceCacheWatcher::new(cache) {
+        let error = match WorkspaceCacheWatcher::new(cache).await {
             Ok(_) => panic!("watcher setup should reject a non-directory cache root"),
             Err(error) => error,
         };


### PR DESCRIPTION
## Summary

- observe host-shared workspace-cache publications and removals with a bounded, scope-aware inotify watcher
- wait for matching metadata commits at the existing entry-lock boundary, then apply the complete existing cache validation before advertising capability
- preserve single-flight heartbeat coalescing, unchanged cache-only suppression, and the 10-second authoritative fallback
- publish an already validated non-empty startup snapshot without a duplicate cache scan
- reconcile entries that were not classified when the watcher subscribed before the initial publication, preserving matching commit keys for lock-aware validation
- honor the live Runner lifecycle mode after asynchronous startup cache work, so a concurrent drain does not schedule a stale running heartbeat
- keep watcher ownership and queued kernel events stable across main-reactor turns

## Multi-Runner behavior

CI and rollout hosts may run multiple Runner processes with distinct groups against one shared workspace-cache root. Root notifications are necessarily visible to every process, but a size-bounded metadata classification drops foreign-scope commits before they wait for a lock, scan the cache, call the heartbeat API, or consume a persistent entry watch.

Matching-scope commits carry their cache keys through heartbeat coalescing, including when an ordinary lifecycle heartbeat is pending. Reconciliation uses one shared two-second lock deadline, validates each hinted entry while holding its existing entry lock, completes the authoritative cache scan, and sends immediately. Relevant removals reconcile promptly; invalid, ambiguous, overflowed, or missed events remain cold-correct through routine scanning.

The watcher subscribes before the startup scan. Entries already classified as relevant retain their queued inotify events. Entries accepted by the scan while the watcher still has no relevant classification are reclassified after the scan and receive an authoritative refresh before the initial publication; matching commits keep their key so the refresh waits at the existing lock boundary.

## Compatibility

- Runner-only change with no API, database, queue, cache-format, or persisted-state changes
- new Runners observe existing publishers; old Runners retain periodic reconciliation during rollout
- watcher setup, read, classification, lock-wait, or capacity failure degrades to existing periodic behavior
- rollback requires no cleanup or coordinated deployment

## Exclusions

- no publisher protocol or critical-section change
- no successor claim-path wait
- no feature switch or new telemetry transport

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner workspace_image_cache::watcher::tests --all-features` (10 passed)
- `cargo test -p runner cmd::start::tests::idle_reuse::workspace_cache --all-features` (8 passed)
- `cargo test -p runner --all-targets --all-features --quiet -- --test-threads=4` (3120 passed, 20 intentional ignores; guest inventory passed)

Closes #26472

Parent context: #25405
