### PR TITLE
fix: group run models by family with newest-first ordering

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -87,15 +87,15 @@ describe("model-first canonical catalog", () => {
     expect(SUPPORTED_RUN_MODELS).toEqual([
       "claude-fable-5",
       "claude-opus-5",
+      "claude-opus-4-8",
+      "claude-sonnet-5",
+      "claude-sonnet-4-6",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
       "gpt-5.6-luna",
       "gpt-5.5",
-      "claude-opus-4-8",
-      "claude-sonnet-5",
-      "claude-sonnet-4-6",
-      "deepseek-v4-flash",
       "deepseek-v4-pro",
+      "deepseek-v4-flash",
     ]);
   });
 
@@ -300,15 +300,15 @@ describe("model-first canonical catalog", () => {
     expect(SUPPORTED_RUN_MODELS).toEqual([
       "claude-fable-5",
       "claude-opus-5",
+      "claude-opus-4-8",
+      "claude-sonnet-5",
+      "claude-sonnet-4-6",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
       "gpt-5.6-luna",
       "gpt-5.5",
-      "claude-opus-4-8",
-      "claude-sonnet-5",
-      "claude-sonnet-4-6",
-      "deepseek-v4-flash",
       "deepseek-v4-pro",
+      "deepseek-v4-flash",
     ]);
     expect(SUPPORTED_RUN_MODELS).toContain("gpt-5.5");
     expect(SUPPORTED_RUN_MODELS).toContain("claude-sonnet-4-6");

--- a/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
@@ -4,18 +4,21 @@
  * Keep this module lightweight so public UI surfaces can read price tier data
  * without importing the full model provider contract schema.
  */
+// Ordered by model family (claude → gpt → deepseek), and within each family
+// from newest/highest capability to oldest/lowest. This order is load-bearing:
+// it drives the model dropdown and all model-related UI via sortRowsByCatalog.
 export const SUPPORTED_RUN_MODELS = [
   "claude-fable-5",
   "claude-opus-5",
+  "claude-opus-4-8",
+  "claude-sonnet-5",
+  "claude-sonnet-4-6",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
   "gpt-5.5",
-  "claude-opus-4-8",
-  "claude-sonnet-5",
-  "claude-sonnet-4-6",
-  "deepseek-v4-flash",
   "deepseek-v4-pro",
+  "deepseek-v4-flash",
 ] as const;
 
 export type SupportedRunModel = (typeof SUPPORTED_RUN_MODELS)[number];


### PR DESCRIPTION
## Summary

Reorder `SUPPORTED_RUN_MODELS` to group models by family and sort each family newest-first.

## Before

```
claude-fable-5, claude-opus-5,
gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5,
claude-opus-4-8, claude-sonnet-5, claude-sonnet-4-6,
deepseek-v4-flash, deepseek-v4-pro
```

Families were interleaved, so the model dropdown showed a fragmented order.

## After

```
claude-fable-5, claude-opus-5, claude-opus-4-8, claude-sonnet-5, claude-sonnet-4-6,
gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5,
deepseek-v4-pro, deepseek-v4-flash
```

- Family order: claude → gpt → deepseek.
- Within each family: newest/highest capability first.
  - Claude: Fable 5 → Opus 5 → Opus 4.8 → Sonnet 5 → Sonnet 4.6
  - GPT: Sol → Terra → Luna → 5.5
  - DeepSeek: Pro → Flash

This order flows through `sortRowsByCatalog` in the API and drives every model-related UI surface (composer dropdown, org model policies, addable models).

## Files changed

- `turbo/packages/api-contracts/src/contracts/model-price-tiers.ts` — reorder `SUPPORTED_RUN_MODELS`
- `turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts` — update two order assertions