### PR TITLE
test(api): enforce external behavior test boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -255,6 +255,32 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
     expectedPrompt: ['"merged": true', '"mergeCommitSha"'],
   },
   {
+    name: "pull request labeled",
+    body: {
+      kind: "event",
+      eventType: "github-pull-request",
+      eventConfig: {
+        provider: "github",
+        event: "pull_request",
+        repository: "vm0-ai/vm0",
+        action: "labeled",
+        filters: { labels: ["ready-to-merge"] },
+      },
+    },
+    event: "pull_request",
+    payload: (installationId) => {
+      return githubPullRequestPayload({
+        action: "labeled",
+        installationId,
+        number: 24_481,
+        label: { id: 1002, name: "ready-to-merge" },
+      });
+    },
+    expectedTrigger:
+      'GitHub label "ready-to-merge" was applied to pull request #24481',
+    expectedPrompt: ['"action": "labeled"', '"name": "ready-to-merge"'],
+  },
+  {
     name: "workflow job completed",
     body: {
       kind: "event",

--- a/turbo/apps/api/src/signals/services/__tests__/workflow-automation-context.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/workflow-automation-context.test.ts
@@ -350,22 +350,6 @@ const cases: readonly WorkflowAutomationContextCase[] = [
 ];
 
 describe("workflow automation context lookup contracts", () => {
-  it("renders label actions of the github-pull-request trigger", () => {
-    expect(
-      workflowAutomationTrigger({
-        eventType: "github-pull-request",
-        eventPayload: {
-          deliveryId: "delivery-pr-labeled",
-          action: "labeled",
-          pullRequest: { number: 24_481 },
-          label: { name: "ready-to-merge" },
-        },
-      }),
-    ).toBe(
-      'GitHub label "ready-to-merge" was applied to pull request #24481 (GitHub webhook delivery delivery-pr-labeled).',
-    );
-  });
-
   it("covers every trigger renderer exactly once", () => {
     expect(
       cases


### PR DESCRIPTION
## Scan

- Timestamp: 2026-08-12T21:13:48Z
- Base commit: 1a3b9d96818bd4ec7ba6a5a85158d3a126eec790
- Primary API ESLint scan: 1,073 files, 0 messages, 0 restricted imports
- Secondary scan: one direct service behavior assertion found inside an existing narrow migration exception

## Violation fixed

The GitHub pull-request labeled trigger test manually constructed an internal automation payload and called workflowAutomationTrigger directly, even though the behavior is reachable through production endpoints.

The replacement creates the workflow automation through its production API, posts a signed GitHub pull_request webhook, and verifies the user-visible trigger and event metadata through the runner claim response.

## Files changed

- turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts: adds the labeled pull-request case to the production webhook integration matrix.
- turbo/apps/api/src/signals/services/__tests__/workflow-automation-context.test.ts: removes the equivalent direct service assertion.

## Intentionally remaining exception

workflow-automation-context.test.ts still imports the service for its existing finite legacy-payload reconstruction and renderer-coverage matrix. Production APIs normalize new inputs and cannot construct historical persisted payload shapes or JSONB key ordering, so that migration contract remains the narrow documented exception. This PR adds no exception or lint bypass.

## Verification

- Prettier check on changed files
- git diff --check
- Full API ESLint: 1,073 files, 0 messages
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types
- webhooks-github-workflow.test.ts: 9 passed
- workflow-automation-context.test.ts: 25 passed