### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
@@ -66,7 +66,6 @@ import {
   getUsagePackMigrationState,
   previewUsagePackSubscriptionMigration,
   previewUsagePackSubscriptionMigrationRevision,
-  usagePackSubscriptionMigrationSchemaAvailable,
   type UsagePackMigrationOwner,
 } from "../services/usage-pack-subscription-migration.service";
 import { usagePackInvitationPurchaseSchemaAvailable } from "../services/usage-pack-invitation-purchase.service";
@@ -706,13 +705,11 @@ const usagePackChangeConfirmAuthed$ = command(
 async function usagePackMigrationSchemasAvailable(
   db: Parameters<typeof usagePackSubscriptionSchemaAvailable>[0],
 ): Promise<boolean> {
-  const [subscriptionSchema, invitationSchema, migrationSchema] =
-    await Promise.all([
-      usagePackSubscriptionSchemaAvailable(db),
-      usagePackInvitationPurchaseSchemaAvailable(db),
-      usagePackSubscriptionMigrationSchemaAvailable(db),
-    ]);
-  return subscriptionSchema && invitationSchema && migrationSchema;
+  const [subscriptionSchema, invitationSchema] = await Promise.all([
+    usagePackSubscriptionSchemaAvailable(db),
+    usagePackInvitationPurchaseSchemaAvailable(db),
+  ]);
+  return subscriptionSchema && invitationSchema;
 }
 
 const usagePackMigrationGetAuthed$ = command(

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
@@ -421,24 +421,6 @@ function parseRevisionPreviewToken(
   return result.success ? result.data : null;
 }
 
-export async function usagePackSubscriptionMigrationSchemaAvailable(
-  db: Pick<Db, "select">,
-): Promise<boolean> {
-  // Migration hooks run for ordinary Stripe events, so a new API can briefly
-  // precede migration 0907 during the DB/API rollout window (observed maximum:
-  // ~102 minutes). Remove after 0907 is outside the rollback window; #26388.
-  const [state] = await db
-    .select({
-      available:
-        sql`to_regclass('public.usage_pack_subscription_migrations') IS NOT NULL AND to_regclass('public.usage_pack_subscription_migration_selections') IS NOT NULL`.mapWith(
-          pgBooleanDecoder,
-        ),
-    })
-    .from(sql`(SELECT 1) AS schema_probe`)
-    .limit(1);
-  return state?.available ?? false;
-}
-
 async function loadOpenMigrationForOrg(
   db: Pick<Db, "select">,
   orgId: string,
@@ -2384,9 +2366,6 @@ export async function handleUsagePackMigrationInvoicePaid(
   db: Db,
   invoice: UsagePackInvoiceInput,
 ): Promise<UsagePackMigrationLifecycleOutcome> {
-  if (!(await usagePackSubscriptionMigrationSchemaAvailable(db))) {
-    return { handled: false, orgId: null };
-  }
   const migration = await migrationForInvoice(db, invoice);
   if (!migration) {
     return { handled: false, orgId: null };
@@ -2432,9 +2411,6 @@ export async function handleUsagePackMigrationSubscriptionUpdated(
   db: Db,
   subscription: UsagePackSubscriptionInput,
 ): Promise<UsagePackMigrationLifecycleOutcome> {
-  if (!(await usagePackSubscriptionMigrationSchemaAvailable(db))) {
-    return { handled: false, orgId: null };
-  }
   const usagePackSubscriptionId = usagePackSubscriptionIdFromMetadata(
     subscription.metadata,
   );
@@ -2485,9 +2461,6 @@ export async function reconcileUsagePackSubscriptionMigrations(
   readonly reconciled: number;
   readonly orgIds: readonly string[];
 }> {
-  if (!(await usagePackSubscriptionMigrationSchemaAvailable(db))) {
-    return { reconciled: 0, orgIds: [] };
-  }
   const at = nowDate();
   await db
     .update(usagePackSubscriptionMigrations)

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
@@ -20,7 +20,6 @@ import {
 import { and, desc, eq, inArray, lte, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
-import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";


### PR DESCRIPTION
Daily deployment-compatibility cleanup. One cohort survived evidence collection; everything else is inside its window, gated on a product decision, or owned by an open PR, and is listed at the bottom rather than split into a second PR.

## Cohort — remove the usage-pack subscription migration schema probe (#26388)

**Old → new boundary.** `usagePackSubscriptionMigrationSchemaAvailable` probed `to_regclass` for `usage_pack_subscription_migrations` and `usage_pack_subscription_migration_selections`. Migration hooks run for ordinary Stripe events, so a new API deployed ahead of migration `0907_majestic_sheva_callister` would otherwise have queried tables that did not exist yet. The probe guarded three call sites — `handleUsagePackMigrationInvoicePaid`, `handleUsagePackMigrationSubscriptionUpdated`, and `reconcileUsagePackSubscriptionMigrations` — plus one term of the route-level `usagePackMigrationSchemasAvailable`.

**Window.** DB schema compatibility for the old API. #26388's gate is "0907 deployed successfully and the API version from before that migration outside the production rollback window"; the documented observed maximum exposure is ~102 minutes.

**Rollout evidence.** #25529 carried 0907 and merged 2026-08-11T12:11:21Z (`1caa179590bc`). Production migrations run before API traffic promotion, and `api/production` promoted `a31a32a4d841` at **2026-08-11T12:40:43Z**, verified to contain that commit with `git merge-base --is-ancestor`. At this run that is **32.3 hours**, against a ~102-minute window, and **24 further `api/production` deployments** have landed since, so no rollback target predating 0907 remains.

**Axiom evidence** (`vm0-request-log-prod`, explicit bounds `2026-08-11T12:40:43Z → 2026-08-12T21:30:00Z`, `_time` predicate applied before the path filter):

| path_template | method | status | requests | first seen | last seen |
|---|---|---|---|---|---|
| `/api/zero/billing/usage-pack-migration` | GET | 404 | 5 | 2026-08-12T04:43:11Z | 2026-08-12T10:12:22Z |
| `/api/zero/billing/usage-pack-migration` | OPTIONS | 204 | 3 | 2026-08-12T04:43:11Z | 2026-08-12T10:12:21Z |

This is a positive observation, not an absence argument. In `usagePackMigrationGetAuthed$` the `404` (`notFound("Legacy subscription migration is not available")`) is returned strictly **after** `usagePackMigrationSchemasAvailable(db)` returns true, which is the AND of all three probes. Five production GETs reached that branch, so the migration probe observably returned `true` against the production database. **Zero `503` responses** were recorded on any `usage-pack-migration` path across the whole post-promotion window. The `204`s are CORS preflights and carry no signal.

**MaskDB evidence gap, recorded rather than papered over.** `vm0-prod-ro` lists 112 tables and does **not** include `usage_pack_subscription_migrations` or `usage_pack_subscription_migration_selections`, so the masked branch cannot confirm their existence directly. This cohort was deferred on exactly that gap in the 2026-08-12 run. It is closed here by the Axiom observation above, which measures the probe's real result in production instead of inferring it from deployment ordering.

**Removed.** `usagePackSubscriptionMigrationSchemaAvailable`, its three guards, and its term in `usagePackMigrationSchemasAvailable`. Behavior is unchanged: the probe has been returning `true` in production, so every guard was already a pass-through.

**Deliberately out of scope.** #26388 also asks to remove the migration endpoint's temporary `503` contract variants and their tests. That is not yet possible: `usagePackMigrationSchemasAvailable` still ANDs `usagePackSubscriptionSchemaAvailable` and `usagePackInvitationPurchaseSchemaAvailable`, neither of which carries a removal condition, so the `503` path remains reachable and its contract must stay. #26388 therefore stays open for that half. No test asserts the migration-specific `503`, so no test changes were needed — the only `503` case in `zero-billing-checkout.test.ts` covers a missing `STRIPE_SECRET_KEY`.

## Checks

Run once against the combined diff, with a local PostgreSQL 18 cluster created for this run and set to `UTC`:

- `pnpm format`; `pnpm check-types` (all tasks, no errors); `pnpm turbo run lint --filter=api` (0 errors); `pnpm knip` (exit 0)
- `pnpm -F api exec vitest run zero-billing-checkout.test.ts cron-billing-entitlements.test.ts` → 2 files, **107 passed** (covers the route helper and the reconcile cron)
- `pnpm -F api exec vitest run stripe-automation-events.test.ts stripe-invoice-paid-workflow-automation-readiness.test.ts` → 2 files, **36 passed** (covers the Stripe webhook callers)

Per repo guidance the full local Vitest suite was not run and no dev server was started.

## Open-PR overlap

**None.** No open PR touches either changed file. #26393 touches `__tests__/zero-billing-checkout.test.ts`, but this PR needs no test change there, so there is no contention.

Deferred this run, with the exact blocker:

- **#26152** concurrency billing fallbacks — the window *has* expired (the app build carrying #26116 reached `app/production` as `d68524ebc517` at 2026-08-10T13:15:40Z, ~31.7 h against a ~2-day window). Blocked by **#26393**, which is actively restructuring the same surface and edits every symbol in the cohort: `reduceConcurrencySubscription$`, `canChangeInApp` in the contract, in `queue-drawer.tsx`, and in `org-billing-tab.tsx`, plus `existingSubscriptionId`. This is a live semantic conflict, not file adjacency.
- **#26697** feedback-location compatibility — PR #26644 merged 2026-08-12T14:09:51Z, inside its ~2-day window, and a dedicated `remove-pr-26644-feedback-location-compat` automation owns it.
- **#26735** retired Axiom surface routes — PR #26689 merged today; needs ~2 days of App drain plus the ~2 h 17 m commit-addressed CLI drain.
- **#26672 / #26519** website template archive pins — the gate is a product decision (latency target met, switch enabled for all users), not a time window; the switch is default-off.
- **#26487** route-entry Phase A namespace compatibility — the comment states it may be removed only in a separately authorized change.
- **#25716** residual `paymentMethodManagementAvailable` field — owned by the dedicated `remove-payment-method-capability-flag-25716` automation.
- **#25620** avatar flat-field read fallback — still requires a jsonb backfill of persisted rows first.
- `PersonalModelProviderAccounts` rollout fallbacks — the switch is still `enabled: false` (staff org hashes only), so the "once the switch is GA" gate has not opened.
- `browser_*` identity contraction — unchanged blocker: MaskDB exposes no `browser_*` table, so the persisted-data story still cannot be proven.
