### PR TITLE
fix(api): respect canonical model policy order

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
   LIMITED_FREE1_DEFAULT_RUN_MODEL,
+  SUPPORTED_RUN_MODELS,
   type OrgModelPoliciesResponse,
   type UpdateOrgModelPolicy,
   type ModelProviderType,
@@ -534,7 +535,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
     expect(preferenceResponse.body.selectedModel).toBe(keptModel);
   });
 
-  it("allows adding a supported model that was not seeded by default", async () => {
+  it("sorts configured models by canonical catalog order", async () => {
     const fixture = await seedFixture();
     useSession(fixture);
     const client = apiClient();
@@ -545,7 +546,13 @@ describe("GET/PUT /api/zero/model-policies", () => {
     const updates = [
       ...toUpdate(listResponse.body),
       makeVm0Policy("claude-opus-5"),
+      makeVm0Policy("deepseek-v4-pro"),
     ];
+    const configuredModels = new Set(
+      updates.map((policy) => {
+        return policy.model;
+      }),
+    );
 
     const response = await accept(
       client.update({
@@ -559,7 +566,11 @@ describe("GET/PUT /api/zero/model-policies", () => {
       response.body.policies.map((policy) => {
         return policy.model;
       }),
-    ).toStrictEqual([...DEFAULT_ORG_MODEL_POLICY_MODELS, "claude-opus-5"]);
+    ).toStrictEqual(
+      SUPPORTED_RUN_MODELS.filter((model) => {
+        return configuredModels.has(model);
+      }),
+    );
   });
 
   it("rejects restricted policy writes for limited-free-1 workspaces", async () => {

--- a/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
@@ -1,7 +1,6 @@
 import { command } from "ccstate";
 import { and, eq, inArray, notInArray } from "drizzle-orm";
 import {
-  DEFAULT_ORG_MODEL_POLICY_MODELS,
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   LIMITED_FREE1_DEFAULT_RUN_MODEL,
   MODEL_PROVIDER_TYPES,
@@ -208,16 +207,8 @@ function modelProviderAllowedForOrgPlan(
 }
 
 function getSupportedModelRank(model: string): number {
-  const curatedIndex = DEFAULT_ORG_MODEL_POLICY_MODELS.indexOf(
-    model as (typeof DEFAULT_ORG_MODEL_POLICY_MODELS)[number],
-  );
-  if (curatedIndex !== -1) {
-    return curatedIndex;
-  }
   const catalogIndex = SUPPORTED_RUN_MODELS.indexOf(model as SupportedRunModel);
-  return catalogIndex === -1
-    ? DEFAULT_ORG_MODEL_POLICY_MODELS.length + SUPPORTED_RUN_MODELS.length
-    : DEFAULT_ORG_MODEL_POLICY_MODELS.length + catalogIndex;
+  return catalogIndex === -1 ? SUPPORTED_RUN_MODELS.length : catalogIndex;
 }
 
 function sortRowsByCatalog(rows: OrgModelPolicyRow[]): OrgModelPolicyRow[] {


### PR DESCRIPTION
## Summary

- sort configured model policies exclusively by the canonical `SUPPORTED_RUN_MODELS` catalog
- keep the default seeded model set and workspace default unchanged
- add API route coverage for canonical ordering across seeded and added models

## Context

`DEFAULT_ORG_MODEL_POLICY_MODELS` was acting as a higher-priority ranking bucket before the canonical catalog rank. That kept seeded models ahead of models that should appear earlier according to the shared catalog, so the composer did not reflect the order introduced in #26744.

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/zero-model-policy.service.ts apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts`
- `pnpm -F api lint`
- targeted Oxlint and ESLint for both changed files
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-model-policies.test.ts` *(blocked locally before test execution because PostgreSQL was unavailable on port 5432; CI has the required test database)*
