### PR TITLE
fix(app): allow crawlers to observe noindex

### DIFF
--- a/.github/scripts/tests/prepare-okou-pages-dist-test.sh
+++ b/.github/scripts/tests/prepare-okou-pages-dist-test.sh
@@ -15,6 +15,8 @@ printf '%s\n' \
   '<head>' \
   '  <meta name="vm0-api-origin" content="" />' \
   '</head>' > "${canonical_dist}/index.html"
+cp "${repo_root}/turbo/apps/platform/public/robots.txt" \
+  "${canonical_dist}/robots.txt"
 printf 'console.log("app");\n' > "${canonical_dist}/assets/app-123.js"
 printf '{"version":3}\n' > "${canonical_dist}/assets/app-123.js.map"
 printf '{"version":1}\n' > "${canonical_dist}/manifest.json"
@@ -28,6 +30,7 @@ test -f "${pages_dist}/assets/app-123.js"
 test -f "${pages_dist}/assets/404.html"
 test -f "${pages_dist}/_headers"
 test -f "${pages_dist}/_worker.js"
+test -f "${pages_dist}/robots.txt"
 test ! -e "${pages_dist}/404.html"
 test ! -e "${pages_dist}/assets/app-123.js.map"
 test ! -e "${pages_dist}/manifest.json"
@@ -39,6 +42,8 @@ grep -Fq 'Cache-Control: public, max-age=31536000, immutable' \
 grep -Fq '<title>Not Found</title>' "${pages_dist}/assets/404.html"
 grep -Fq '<meta name="vm0-api-origin" content="" />' \
   "${pages_dist}/index.html"
+grep -Fxq 'Allow: /' "${pages_dist}/robots.txt"
+! grep -Fq 'Disallow:' "${pages_dist}/robots.txt"
 
 preview_pages_dist="${tmp_dir}/preview-pages"
 mkdir -p "$preview_pages_dist"

--- a/turbo/apps/platform/public/robots.txt
+++ b/turbo/apps/platform/public/robots.txt
@@ -1,2 +1,3 @@
+# Crawlers must fetch HTML to observe the worker's noindex header and meta tag.
 User-agent: *
-Disallow: /
+Allow: /


### PR DESCRIPTION
## Summary

- allow search crawlers to fetch app HTML so the Pages worker's `noindex` response header and meta tag can take effect
- keep the app-owned robots policy compatible with Cloudflare Managed Robots
- verify the prepared Pages artifact includes `robots.txt` with `Allow: /` and no `Disallow` rule

## Verification

- `bash -n .github/scripts/tests/prepare-okou-pages-dist-test.sh`
- `bash .github/scripts/tests/prepare-okou-pages-dist-test.sh`
- `bash .github/scripts/tests/okou-app-worker-test.sh`
- `git diff --check`
