### PR TITLE
fix(chat): enable snapshot object garbage collection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
@@ -50,6 +50,25 @@ const trackFakeChatEventObject = createFixtureTracker(
 );
 
 const CRON_SECRET = "test-cron-secret";
+const R2_GC_SLOT_MS = 10 * 60 * 1000;
+const R2_GC_SHARD_GROUP_COUNT = 16 ** 2;
+
+function mockR2GcWindowForKey(key: string, after: Date): Date {
+  const prefixStart = "chat-events/".length;
+  const shardGroup = Number.parseInt(
+    key.slice(prefixStart, prefixStart + 2),
+    16,
+  );
+  const firstSlot = Math.ceil(after.getTime() / R2_GC_SLOT_MS);
+  const slotOffset =
+    (shardGroup -
+      (firstSlot % R2_GC_SHARD_GROUP_COUNT) +
+      R2_GC_SHARD_GROUP_COUNT) %
+    R2_GC_SHARD_GROUP_COUNT;
+  const aligned = new Date((firstSlot + slotOffset) * R2_GC_SLOT_MS);
+  mockNow(aligned);
+  return aligned;
+}
 
 function authenticate(actor: ApiTestUser) {
   createZeroRouteMocks(context).clerk.session(
@@ -127,7 +146,6 @@ describe("chat event snapshot read endpoints", () => {
     // assertions about this file's threads never depend on batch ordering.
     mockOptionalEnv("CHAT_EVENT_SNAPSHOT_BATCH_SIZE", "10000");
     mockOptionalEnv("CHAT_EVENT_SEARCH_PROJECTION_BATCH_SIZE", "10000");
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD", "fff");
   });
 
   it("serves a presigned download only for a current-version head", async () => {
@@ -469,9 +487,10 @@ describe("chat event snapshot read endpoints", () => {
     const head = await readChatEventSnapshotHead(context, threadId);
     expect(readFakeChatEventObject(head.object_key)).toBeDefined();
 
-    const future = new Date(now() + 8 * 24 * 60 * 60 * 1000);
-    mockNow(future);
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD", threadId.slice(0, 3));
+    const future = mockR2GcWindowForKey(
+      head.object_key,
+      new Date(now() + 8 * 24 * 60 * 60 * 1000),
+    );
     ageFakeChatEventObject(
       head.object_key,
       new Date(future.getTime() - 8 * 24 * 60 * 60 * 1000),
@@ -487,14 +506,6 @@ describe("chat event snapshot read endpoints", () => {
       orphanKey,
       new Date(future.getTime() - 8 * 24 * 60 * 60 * 1000),
     );
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_DRY_RUN", "true");
-    const orphanDryRun = await runSnapshotCron();
-    expect(orphanDryRun).toMatchObject({
-      r2ObjectsMeasured: 1,
-      r2ObjectsDeleted: 0,
-    });
-    expect(readFakeChatEventObject(orphanKey)).toBeDefined();
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_DRY_RUN", "false");
     const orphanGc = await runSnapshotCron();
     expect(orphanGc).toMatchObject({
       r2ObjectsMeasured: 1,
@@ -527,9 +538,10 @@ describe("chat event snapshot read endpoints", () => {
       writeFakeChatEventObject(key, Buffer.from("orphan"));
       await trackFakeChatEventObject(Promise.resolve(key));
     }
-    mockNow(new Date(now() + 8 * 24 * 60 * 60 * 1000));
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD", shard);
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_GC_DRY_RUN", "false");
+    mockR2GcWindowForKey(
+      `chat-events/${shard}`,
+      new Date(now() + 8 * 24 * 60 * 60 * 1000),
+    );
 
     const result = await runSnapshotCron();
 

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -102,7 +102,7 @@ const gunzipAsync = promisify(gunzip);
  */
 const DEFAULT_THREAD_BATCH_SIZE = 1000;
 const EVENT_PAGE_SIZE = 1000;
-const DEFAULT_R2_GC_GRACE_HOURS = 24 * 7;
+const R2_GC_GRACE_HOURS = 24 * 7;
 const R2_GC_SHARDS_PER_RUN = 16;
 const R2_GC_SHARD_COUNT = 16 ** 3;
 const R2_GC_PAGE_SIZE = 1000;
@@ -142,32 +142,6 @@ function chatEventSnapshotThreadBatchSize(): number {
     );
   }
   return parsed;
-}
-
-function positiveIntegerEnv(name: string, fallback: number): number {
-  const raw = optionalEnv(name);
-  if (raw === undefined) {
-    return fallback;
-  }
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return parsed;
-}
-
-function booleanEnv(name: string, fallback = false): boolean {
-  const raw = optionalEnv(name);
-  if (raw === undefined) {
-    return fallback;
-  }
-  if (raw === "true") {
-    return true;
-  }
-  if (raw === "false") {
-    return false;
-  }
-  throw new Error(`${name} must be true or false`);
 }
 
 function hoursBefore(now: Date, hours: number): Date {
@@ -561,15 +535,6 @@ const deleteRetiredSnapshotVersions$ = command(
 );
 
 function chatEventSnapshotGcPrefixes(now: Date): readonly string[] {
-  const override = optionalEnv("CHAT_EVENT_SNAPSHOT_GC_SHARD");
-  if (override !== undefined) {
-    if (!/^[0-9a-f]{3}$/u.test(override)) {
-      throw new Error(
-        "CHAT_EVENT_SNAPSHOT_GC_SHARD must be three lowercase hex digits",
-      );
-    }
-    return [`chat-events/${override}`];
-  }
   const slot = Math.floor(now.getTime() / R2_GC_SLOT_MS);
   const first = (slot * R2_GC_SHARDS_PER_RUN) % R2_GC_SHARD_COUNT;
   return Array.from({ length: R2_GC_SHARDS_PER_RUN }, (_, offset) => {
@@ -610,14 +575,7 @@ async function collectR2SnapshotGarbage(
   signal: AbortSignal,
 ): Promise<R2GcStats> {
   const now = nowDate();
-  const olderThan = hoursBefore(
-    now,
-    positiveIntegerEnv(
-      "CHAT_EVENT_SNAPSHOT_GC_GRACE_HOURS",
-      DEFAULT_R2_GC_GRACE_HOURS,
-    ),
-  );
-  const dryRun = booleanEnv("CHAT_EVENT_SNAPSHOT_GC_DRY_RUN", true);
+  const olderThan = hoursBefore(now, R2_GC_GRACE_HOURS);
   let scanned = 0;
   let measured = 0;
   let deleted = 0;
@@ -682,7 +640,7 @@ async function collectR2SnapshotGarbage(
       bytesMeasured += garbage.reduce((total, object) => {
         return total + object.size;
       }, 0);
-      if (dryRun || garbage.length === 0) {
+      if (garbage.length === 0) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

- make the bounded chat-event snapshot collector delete eligible R2 objects on every cron pass
- remove the unused dry-run, grace-period, and shard environment overrides
- keep the fixed seven-day grace period, automatic 4,096-shard sweep, 1,000-object quota, current-head protection, and reference recheck
- update route integration coverage to follow the production shard schedule and assert actual deletion

## Rollout evidence

- `CHAT_EVENT_SNAPSHOT_GC_DRY_RUN`, `CHAT_EVENT_SNAPSHOT_GC_GRACE_HOURS`, and `CHAT_EVENT_SNAPSHOT_GC_SHARD` are absent from the production API environment. The default dry-run setting therefore kept generic orphan collection measurement-only.
- The snapshot cron has returned 200 on its steady ten-minute cadence since the August 9 R2 permission fix.
- In the checked production window after the global reader rollout, `/event-rows` returned 30,324 successful responses and `/event-snapshot` returned 746 successful responses, with no 5xx responses for either endpoint.
- #25818 already shipped the bounded mark-and-sweep implementation and its safety coverage. This PR removes only the terminal rollout controls.

## Safety

- Only objects older than seven days are eligible.
- Current heads remain protected, and non-head references are rechecked when their rows are deleted.
- Deletion remains capped at 1,000 objects per cron pass.
- Automatic sharding scans 16 of 4,096 prefixes per ten-minute run, completing a sweep in about 1.8 days.
- R2 deletion remains best-effort; failed object deletions become unreferenced candidates for a later pass.

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/cron-snapshot-chat-events.service.ts apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts` (7 tests passed)

Follow-up to #25813.
