### PR TITLE
feat(platform): gate the credit balance split behind usage pack plans

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1041,6 +1041,7 @@
         "hour": "{{value}}h",
         "left": "{{value}} übrig",
         "minute": "{{value}}m",
+        "remaining": "{{remaining}} / {{total}} Credits",
         "remainingAria": "Verbleibendes Nutzungskontingent für {{label}}",
         "resets": "Wird am {{date}} zurückgesetzt",
         "resetsRaw": "Wird in {{value}} zurückgesetzt",
@@ -4022,6 +4023,7 @@
         "usage": {
           "balanceDescription": "Was deinem Team noch zum Ausgeben bleibt.",
           "balanceTitle": "Credit-Guthaben",
+          "balanceUsageDescription": "Guthaben und Verbrauch deines Teams.",
           "usageDescription": "Ihre Credit-Nutzung über Chats, Automatisierungen und Kanäle hinweg.",
           "usageTitle": "Credit-Nutzung"
         }

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1041,6 +1041,7 @@
         "hour": "{{value}}h",
         "left": "{{value}} left",
         "minute": "{{value}}m",
+        "remaining": "{{remaining}} / {{total}} credits",
         "remainingAria": "Usage allowance {{label}} remaining",
         "resets": "Resets {{date}}",
         "resetsRaw": "Resets {{value}}",
@@ -4022,6 +4023,7 @@
         "usage": {
           "balanceDescription": "What your team has left to spend.",
           "balanceTitle": "Credit balance",
+          "balanceUsageDescription": "Your team's credit balance and usage.",
           "usageDescription": "Your credit usage across chats, automations, and channels.",
           "usageTitle": "Credit usage"
         }

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1062,6 +1062,7 @@
         "hour": "{{value}}h",
         "left": "{{value}} restantes",
         "minute": "{{value}}m",
+        "remaining": "{{remaining}} / {{total}} créditos",
         "remainingAria": "Límite de uso {{label}} restante",
         "resets": "Se restablece el {{date}}",
         "resetsRaw": "Se restablece {{value}}",
@@ -4072,6 +4073,7 @@
         "usage": {
           "balanceDescription": "Lo que le queda a tu equipo para gastar.",
           "balanceTitle": "Saldo de créditos",
+          "balanceUsageDescription": "El saldo de créditos y el uso de tu equipo.",
           "usageDescription": "Tu consumo de créditos en conversaciones, automatizaciones y canales.",
           "usageTitle": "Consumo de créditos"
         }

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1062,6 +1062,7 @@
         "hour": "{{value}}h",
         "left": "{{value}} restants",
         "minute": "{{value}}m",
+        "remaining": "{{remaining}} / {{total}} crédits",
         "remainingAria": "Allocation d'utilisation {{label}} restante",
         "resets": "Réinitialise {{date}}",
         "resetsRaw": "Réinitialise {{value}}",
@@ -4072,6 +4073,7 @@
         "usage": {
           "balanceDescription": "Ce qu'il reste à dépenser à votre équipe.",
           "balanceTitle": "Solde de crédits",
+          "balanceUsageDescription": "Le solde de crédits et la consommation de votre équipe.",
           "usageDescription": "Votre utilisation des crédits dans les conversations, automatisations et canaux.",
           "usageTitle": "Utilisation des crédits"
         }

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1041,6 +1041,7 @@
         "hour": "{{value}}h",
         "left": "{{value}} शेष",
         "minute": "{{value}}m",
+        "remaining": "{{remaining}} / {{total}} क्रेडिट",
         "remainingAria": "उपयोग भत्ता {{label}} शेष है",
         "resets": "{{date}} रीसेट करता है",
         "resetsRaw": "{{value}} रीसेट करता है",
@@ -4022,6 +4023,7 @@
         "usage": {
           "balanceDescription": "आपकी टीम के पास खर्च करने के लिए कितना बचा है।",
           "balanceTitle": "क्रेडिट शेष",
+          "balanceUsageDescription": "आपकी टीम का क्रेडिट बैलेंस और उपयोग।",
           "usageDescription": "चैट, ऑटोमेशन और चैनलों पर आपका क्रेडिट उपयोग।",
           "usageTitle": "क्रेडिट उपयोग"
         }

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1041,6 +1041,7 @@
         "hour": "{{value}} jam",
         "left": "sisa {{value}}",
         "minute": "{{value}} m",
+        "remaining": "{{remaining}} / {{total}} kredit",
         "remainingAria": "Sisa jatah penggunaan {{label}}",
         "resets": "Diatur ulang {{date}}",
         "resetsRaw": "Diatur ulang {{value}}",
@@ -4021,6 +4022,7 @@
         "usage": {
           "balanceDescription": "Sisa yang bisa dibelanjakan tim Anda.",
           "balanceTitle": "Saldo kredit",
+          "balanceUsageDescription": "Saldo kredit dan penggunaan tim Anda.",
           "usageDescription": "Penggunaan kredit Anda di seluruh chat, otomatisasi, dan channel.",
           "usageTitle": "Penggunaan kredit"
         }

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1062,6 +1062,7 @@
         "hour": "{{value}}h",
         "left": "{{value}} rimanenti",
         "minute": "{{value}}m",
+        "remaining": "{{remaining}} / {{total}} crediti",
         "remainingAria": "Limite di utilizzo {{label}} rimanente",
         "resets": "Ripristina {{date}}",
         "resetsRaw": "Ripristina {{value}}",
@@ -4072,6 +4073,7 @@
         "usage": {
           "balanceDescription": "Quanto resta da spendere al tuo team.",
           "balanceTitle": "Saldo del credito",
+          "balanceUsageDescription": "Il saldo dei crediti e l'utilizzo del tuo team.",
           "usageDescription": "Il tuo utilizzo del credito attraverso chat, automazioni e canali.",
           "usageTitle": "Utilizzo del credito"
         }

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1041,6 +1041,7 @@
         "hour": "{{value}}時間",
         "left": "残り {{value}}",
         "minute": "{{value}}分",
+        "remaining": "{{remaining}} / {{total}} クレジット",
         "remainingAria": "使用許容量 {{label}} が残っています",
         "resets": "{{date}}にリセット",
         "resetsRaw": "リセット: {{value}}",
@@ -4021,6 +4022,7 @@
         "usage": {
           "balanceDescription": "チームが使える残高です。",
           "balanceTitle": "クレジット残高",
+          "balanceUsageDescription": "チームのクレジット残高と使用量。",
           "usageDescription": "チャット、オートメーション、チャネル全体でのクレジットの使用状況。",
           "usageTitle": "クレジット使用量"
         }

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1041,6 +1041,7 @@
         "hour": "{{value}}시간",
         "left": "{{value}} 남음",
         "minute": "{{value}}분",
+        "remaining": "{{remaining}} / {{total}} 크레딧",
         "remainingAria": "사용 한도 {{label}} 남음",
         "resets": "{{date}}에 초기화됨",
         "resetsRaw": "{{value}}에 초기화됨",
@@ -4021,6 +4022,7 @@
         "usage": {
           "balanceDescription": "팀이 사용할 수 있는 잔액입니다.",
           "balanceTitle": "크레딧 잔액",
+          "balanceUsageDescription": "팀의 크레딧 잔액 및 사용량입니다.",
           "usageDescription": "채팅, 자동화, 채널에서의 크레딧 사용량입니다.",
           "usageTitle": "크레딧 사용량"
         }

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1062,6 +1062,7 @@
         "hour": "{{value}}h",
         "left": "{{value}} restantes",
         "minute": "{{value}}min",
+        "remaining": "{{remaining}} / {{total}} créditos",
         "remainingAria": "Saldo restante da franquia de uso de {{label}}",
         "resets": "Reinicia em {{date}}",
         "resetsRaw": "Reinicia em {{value}}",
@@ -4072,6 +4073,7 @@
         "usage": {
           "balanceDescription": "O que resta para a sua equipe gastar.",
           "balanceTitle": "Saldo de créditos",
+          "balanceUsageDescription": "O saldo de créditos e o uso da sua equipe.",
           "usageDescription": "Seu uso de créditos em conversas, automações e canais.",
           "usageTitle": "Uso de créditos"
         }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -5,6 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-billing";
 import { zeroOrgMembersContract } from "@vm0/api-contracts/contracts/zero-org-members";
 import { zeroUsageMembersContract } from "@vm0/api-contracts/contracts/zero-usage";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -173,8 +174,14 @@ function mockUsageStory(): void {
   });
 }
 
+const NEW_PRICING = { [FeatureSwitchKey.UsagePackPlans]: true } as const;
+
 async function openCreditBalance(): Promise<void> {
-  detachedSetupPage({ context, path: "/?settings=usage" });
+  detachedSetupPage({
+    context,
+    path: "/?settings=usage",
+    featureSwitches: NEW_PRICING,
+  });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getAllByText("Credit balance")[0]).toBeInTheDocument();
@@ -182,7 +189,11 @@ async function openCreditBalance(): Promise<void> {
 }
 
 async function openCreditUsage(): Promise<void> {
-  detachedSetupPage({ context, path: "/?settings=usage-records" });
+  detachedSetupPage({
+    context,
+    path: "/?settings=usage-records",
+    featureSwitches: NEW_PRICING,
+  });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getAllByText("Credit usage")[0]).toBeInTheDocument();
@@ -301,6 +312,30 @@ describe("organization usage settings", () => {
     });
   });
 
+  it("keeps the usage records inside credit balance without the new pricing", async () => {
+    mockUsageStory();
+    detachedSetupPage({ context, path: "/?settings=usage" });
+
+    await waitFor(() => {
+      expect(screen.getByText("3,750 / 5,000 credits")).toBeInTheDocument();
+    });
+    // The previous single-section layout: collapsed additions, the Mine/Team
+    // tabs, and no separate records section to navigate to.
+    expect(screen.getByTestId("credit-grants-toggle")).toBeInTheDocument();
+    expect(screen.queryByTestId("credit-balance-see-usage")).toBeNull();
+    expect(screen.queryByTestId("credit-balance-buy-credits")).toBeNull();
+    expect(
+      queryAllByRoleFast("tab").some((element) => {
+        return element.textContent === "Team usage";
+      }),
+    ).toBeTruthy();
+    expect(
+      queryAllByRoleFast("button").some((element) => {
+        return element.textContent === "Credit usage";
+      }),
+    ).toBeFalsy();
+  });
+
   it("shows workspace member usage in the credit usage section", async () => {
     mockUsageStory();
     await openCreditUsage();
@@ -327,6 +362,7 @@ describe("organization usage settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=usage",
+      featureSwitches: NEW_PRICING,
     });
 
     await waitFor(() => {
@@ -347,6 +383,7 @@ describe("organization usage settings", () => {
     detachedSetupPage({
       context,
       path: "/?settings=usage-records",
+      featureSwitches: NEW_PRICING,
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -281,6 +281,26 @@ describe("organization usage settings", () => {
     expect(screen.queryByTestId("credit-balance-buy-credits")).toBeNull();
   });
 
+  it("draws the composition bar even when one category holds the balance", async () => {
+    mockUsageStory();
+    mockBillingStatus({
+      creditBreakdown: [
+        {
+          category: "payAsYouGo",
+          label: "Purchased credits",
+          credits: 12_000,
+        },
+      ],
+    });
+    await openCreditBalance();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("credit-balance-segment-payAsYouGo"),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("shows workspace member usage in the credit usage section", async () => {
     mockUsageStory();
     await openCreditUsage();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -312,6 +312,28 @@ describe("organization usage settings", () => {
     });
   });
 
+  it("labels far-future credit grant expiries as never expiring", async () => {
+    mockUsageStory();
+    mockBillingStatus({
+      creditGrants: [
+        {
+          id: "grant-custom",
+          source: "atom_custom_credits",
+          label: "Custom credits",
+          amount: 12_000,
+          remaining: 12_000,
+          createdAt: "2026-03-01T00:00:00Z",
+          expiresAt: "2999-12-31T23:59:59Z",
+        },
+      ],
+    });
+    await openCreditBalance();
+
+    const neverExpires = await screen.findByText("Never expires");
+    expect(neverExpires).toBeInTheDocument();
+    expect(screen.queryByText("Dec 31, 2999")).toBeNull();
+  });
+
   it("keeps the usage records inside credit balance without the new pricing", async () => {
     mockUsageStory();
     detachedSetupPage({ context, path: "/?settings=usage" });
@@ -329,6 +351,19 @@ describe("organization usage settings", () => {
         return element.textContent === "Team usage";
       }),
     ).toBeTruthy();
+    expect(
+      queryAllByRoleFast("button").some((element) => {
+        return element.textContent === "Credit usage";
+      }),
+    ).toBeFalsy();
+  });
+
+  it("falls back from the usage records deep link without the new pricing", async () => {
+    mockUsageStory();
+    detachedSetupPage({ context, path: "/?settings=usage-records" });
+
+    const heading = await screen.findByRole("heading", { name: "Preference" });
+    expect(heading).toBeInTheDocument();
     expect(
       queryAllByRoleFast("button").some((element) => {
         return element.textContent === "Credit usage";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -276,8 +276,8 @@ describe("personal usage settings", () => {
     );
 
     await openUsageSettings(false);
-    // Without a usage pack a member has no organization balance to read, but
-    // their own usage records stay available in their own section.
+    // Without the new pricing a member has neither an organization balance nor
+    // a records section to open.
     expect(
       queryAllByRoleFast("button").some((button) => {
         return button.textContent === "Credit balance";
@@ -287,7 +287,7 @@ describe("personal usage settings", () => {
       queryAllByRoleFast("button").some((button) => {
         return button.textContent === "Credit usage";
       }),
-    ).toBeTruthy();
+    ).toBeFalsy();
     expect(screen.queryByTestId("usage-pack-credit-card")).toBeNull();
     expect(usagePackCreditRequests).toBe(0);
   });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -651,10 +651,11 @@ function CreditBalanceChart({
         </div>
       ) : null}
 
-      {total > 0 && segments.length > 1 && (
+      {total > 0 && segments.length > 0 && (
         // Gapped segments so the composition never reads as the filled progress
-        // meter the usage allowance rows use right above it. A lone segment is
-        // always the whole balance, so it would only add that confusion back.
+        // meter the usage allowance rows use right above it. A single category
+        // still draws its bar: the card keeps one shape no matter how the
+        // balance is made up.
         <TooltipProvider delayDuration={100}>
           <div className="mt-4 flex h-2 w-full gap-[3px]">
             {segments.map((s) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -143,8 +143,21 @@ export function formatCreditDate(value: string): string {
   }).format(new Date(value));
 }
 
-function expiresLabel(grant: CreditAddition): string {
+// Grants that never expire are stored with a sentinel far-future date, and not
+// every source flags them. Anything a century out is a sentinel, not a date a
+// reader needs.
+const NEVER_EXPIRES_AFTER_MS = 100 * 365 * 24 * 60 * 60 * 1000;
+
+function neverExpires(grant: CreditAddition): boolean {
   if (grant.neverExpires) {
+    return true;
+  }
+  const expiresAt = new Date(grant.expiresAt).getTime();
+  return !Number.isNaN(expiresAt) && expiresAt - now() > NEVER_EXPIRES_AFTER_MS;
+}
+
+function expiresLabel(grant: CreditAddition): string {
+  if (neverExpires(grant)) {
     return i18n.t(($) => {
       return $.billing.usage.neverExpires;
     });
@@ -227,7 +240,10 @@ function formatAllowanceWindowLabel(window: UsageAllowanceWindow): string {
   return window.kind;
 }
 
-function formatAllowanceReset(window: UsageAllowanceWindow): string {
+function formatAllowanceReset(
+  window: UsageAllowanceWindow,
+  shortReset: boolean,
+): string {
   const text = window.expiresAt?.trim();
   if (!text) {
     return "";
@@ -247,9 +263,18 @@ function formatAllowanceReset(window: UsageAllowanceWindow): string {
   const resetsToday = date.toDateString() === new Date(now()).toDateString();
   const formatted = new Intl.DateTimeFormat(
     currentLocale(),
-    resetsToday
-      ? { hour: "numeric", minute: "2-digit" }
-      : { month: "short", day: "numeric" },
+    shortReset
+      ? resetsToday
+        ? { hour: "numeric", minute: "2-digit" }
+        : { month: "short", day: "numeric" }
+      : {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+          timeZoneName: "short",
+        },
   ).format(date);
   return i18n.t(
     ($) => {
@@ -259,7 +284,13 @@ function formatAllowanceReset(window: UsageAllowanceWindow): string {
   );
 }
 
-function UsageAllowanceWindowRow({ window }: { window: UsageAllowanceWindow }) {
+function UsageAllowanceWindowRow({
+  splitLayout,
+  window,
+}: {
+  splitLayout: boolean;
+  window: UsageAllowanceWindow;
+}) {
   const { t } = useTranslation();
   const remainingPercent = allowanceRemainingPercent(window);
   const tone = usageTone(remainingPercent);
@@ -272,16 +303,32 @@ function UsageAllowanceWindowRow({ window }: { window: UsageAllowanceWindow }) {
         <div className="min-w-0">
           <div className="text-sm font-medium text-foreground">{label}</div>
           <div className="mt-0.5 truncate text-xs text-muted-foreground">
-            {formatAllowanceReset(window)}
+            {formatAllowanceReset(window, splitLayout)}
           </div>
         </div>
-        <div className="shrink-0 text-right text-sm tabular-nums text-foreground">
-          {t(
-            ($) => {
-              return $.billing.usage.allowance.left;
-            },
-            { value: formatLocalizedNumber(window.remainingUnits) },
-          )}
+        <div
+          className={
+            splitLayout
+              ? "shrink-0 text-right text-sm tabular-nums text-foreground"
+              : "shrink-0 text-right text-xs font-medium tabular-nums text-muted-foreground"
+          }
+        >
+          {splitLayout
+            ? t(
+                ($) => {
+                  return $.billing.usage.allowance.left;
+                },
+                { value: formatLocalizedNumber(window.remainingUnits) },
+              )
+            : t(
+                ($) => {
+                  return $.billing.usage.allowance.remaining;
+                },
+                {
+                  remaining: formatLocalizedNumber(window.remainingUnits),
+                  total: formatLocalizedNumber(window.unitLimit),
+                },
+              )}
         </div>
       </div>
       <div
@@ -295,7 +342,7 @@ function UsageAllowanceWindowRow({ window }: { window: UsageAllowanceWindow }) {
         aria-valuemin={0}
         aria-valuemax={window.unitLimit}
         aria-valuenow={window.remainingUnits}
-        className={`h-2 overflow-hidden rounded-full ${tone.trackClassName}`}
+        className={`${splitLayout ? "h-2" : "h-2.5"} overflow-hidden rounded-full ${tone.trackClassName}`}
       >
         <span
           className={`block h-full rounded-full transition-[width] ${tone.barClassName}`}
@@ -308,8 +355,10 @@ function UsageAllowanceWindowRow({ window }: { window: UsageAllowanceWindow }) {
 
 function UsageAllowanceCard({
   allowance,
+  splitLayout,
 }: {
   allowance: UsageAllowance | null | undefined;
+  splitLayout: boolean;
 }) {
   const { t } = useTranslation();
   const windows = allowance?.windows.filter((window) => {
@@ -331,7 +380,13 @@ function UsageAllowanceCard({
       </p>
       <div className="mt-3 flex flex-col gap-4">
         {windows.map((window) => {
-          return <UsageAllowanceWindowRow key={window.kind} window={window} />;
+          return (
+            <UsageAllowanceWindowRow
+              key={window.kind}
+              splitLayout={splitLayout}
+              window={window}
+            />
+          );
         })}
       </div>
     </div>
@@ -562,7 +617,7 @@ function CreditAdditionTable({
               {formatCreditDate(grant.createdAt)}
             </span>
             <span className="hidden truncate text-xs text-muted-foreground sm:block">
-              {grant.neverExpires
+              {neverExpires(grant)
                 ? t(($) => {
                     return $.billing.usage.neverExpires;
                   })
@@ -581,19 +636,119 @@ function CreditAdditionTable({
   );
 }
 
-function OrgCreditHeader({ total }: { total: number }) {
+function OrgCreditHeader({
+  splitLayout,
+  total,
+}: {
+  splitLayout: boolean;
+  total: number;
+}) {
   const { t } = useTranslation();
   return (
-    <div className="flex items-baseline justify-between gap-3">
+    <div
+      className={`flex justify-between gap-3 ${splitLayout ? "items-baseline" : "items-center"}`}
+    >
       <p className="text-sm font-medium text-foreground">
         {t(($) => {
           return $.billing.usage.orgCredits;
         })}
       </p>
-      <p className="text-xl font-semibold tabular-nums text-foreground">
+      <p
+        className={
+          splitLayout
+            ? "text-xl font-semibold tabular-nums text-foreground"
+            : "text-sm font-medium tabular-nums text-foreground"
+        }
+      >
         {formatLocalizedNumber(total)}
       </p>
     </div>
+  );
+}
+
+/**
+ * The composition of the balance. The split layout gaps the segments so it
+ * cannot be mistaken for the filled allowance meter above it; the previous
+ * layout keeps the joined track and spells the numbers out in a legend.
+ */
+function CreditBreakdownBar({
+  segments,
+  splitLayout,
+  tier,
+  total,
+}: {
+  segments: readonly CreditSegment[];
+  splitLayout: boolean;
+  tier: string;
+  total: number;
+}) {
+  if (total <= 0 || segments.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      <TooltipProvider delayDuration={100}>
+        <div
+          className={
+            splitLayout
+              ? "mt-4 flex h-2 w-full gap-[3px]"
+              : "mt-3 flex h-2.5 w-full rounded-full bg-muted/40"
+          }
+        >
+          {segments.map((s) => {
+            const color = colorForSegment(s);
+            const desc = descriptionForSegment(s, tier);
+            return (
+              <Tooltip key={segmentKey(s)}>
+                <TooltipTrigger asChild>
+                  <div
+                    data-testid={`credit-balance-segment-${segmentKey(s)}`}
+                    className={`${splitLayout ? "h-2 rounded-[2px]" : "h-2.5 first:rounded-l-full last:rounded-r-full"} ${color} cursor-default ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
+                    style={{
+                      width: `${(s.credits / total) * 100}%`,
+                    }}
+                  />
+                </TooltipTrigger>
+                <TooltipContent
+                  side="top"
+                  sideOffset={8}
+                  style={{
+                    backgroundColor: "hsl(var(--popover))",
+                    color: "hsl(var(--popover-foreground))",
+                  }}
+                  className="border shadow-md"
+                >
+                  <div className="font-medium text-foreground">
+                    {labelForSegment(s)} — {formatLocalizedNumber(s.credits)}
+                  </div>
+                  <div className="text-muted-foreground mt-0.5">{desc}</div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+      </TooltipProvider>
+      {!splitLayout && (
+        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+          {segments.map((s) => {
+            return (
+              <div
+                key={segmentKey(s)}
+                className="flex items-center gap-1.5 text-xs text-muted-foreground"
+              >
+                <span
+                  className={`inline-block h-2 w-2 shrink-0 rounded-full ${colorForSegment(s)}`}
+                />
+                <span>{labelForSegment(s)}</span>
+                <span className="tabular-nums">
+                  {formatLocalizedNumber(s.credits)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
   );
 }
 
@@ -601,10 +756,12 @@ function CreditBalanceChart({
   billing,
   onBuyCredits,
   onComparePlans,
+  splitLayout,
 }: {
   billing: BillingStatusResponse;
   onBuyCredits: () => void;
   onComparePlans: () => void;
+  splitLayout: boolean;
 }) {
   const { t } = useTranslation();
   const segments = billing.creditBreakdown.filter((s) => {
@@ -616,9 +773,15 @@ function CreditBalanceChart({
       billing.tier === "limited-free-1" ||
       billing.tier === "pro-suspend") &&
     total <= 0;
+  const grants = billing.creditGrants.map((grant: CreditGrant) => {
+    return {
+      ...grant,
+      neverExpires: grant.source === "auto_recharge",
+    };
+  });
   return (
     <div className="px-5 py-4" data-testid="credit-balance-info">
-      <OrgCreditHeader total={total} />
+      <OrgCreditHeader splitLayout={splitLayout} total={total} />
 
       {showFreeEmptyPrompt ? (
         <div
@@ -651,56 +814,20 @@ function CreditBalanceChart({
         </div>
       ) : null}
 
-      {total > 0 && segments.length > 0 && (
-        // Gapped segments so the composition never reads as the filled progress
-        // meter the usage allowance rows use right above it. A single category
-        // still draws its bar: the card keeps one shape no matter how the
-        // balance is made up.
-        <TooltipProvider delayDuration={100}>
-          <div className="mt-4 flex h-2 w-full gap-[3px]">
-            {segments.map((s) => {
-              const color = colorForSegment(s);
-              const desc = descriptionForSegment(s, billing.tier);
-              return (
-                <Tooltip key={segmentKey(s)}>
-                  <TooltipTrigger asChild>
-                    <div
-                      data-testid={`credit-balance-segment-${segmentKey(s)}`}
-                      className={`h-2 rounded-[2px] ${color} cursor-default ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
-                      style={{
-                        width: `${(s.credits / total) * 100}%`,
-                      }}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="top"
-                    sideOffset={8}
-                    style={{
-                      backgroundColor: "hsl(var(--popover))",
-                      color: "hsl(var(--popover-foreground))",
-                    }}
-                    className="border shadow-md"
-                  >
-                    <div className="font-medium text-foreground">
-                      {labelForSegment(s)} — {formatLocalizedNumber(s.credits)}
-                    </div>
-                    <div className="text-muted-foreground mt-0.5">{desc}</div>
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
-          </div>
-        </TooltipProvider>
-      )}
-      <CreditAdditionTable
-        grants={billing.creditGrants.map((grant: CreditGrant) => {
-          return {
-            ...grant,
-            neverExpires: grant.source === "auto_recharge",
-          };
-        })}
+      <CreditBreakdownBar
+        segments={segments}
+        splitLayout={splitLayout}
+        tier={billing.tier}
+        total={total}
       />
-      <CreditBalanceActions billing={billing} onBuyCredits={onBuyCredits} />
+      {splitLayout ? (
+        <>
+          <CreditAdditionTable grants={grants} />
+          <CreditBalanceActions billing={billing} onBuyCredits={onBuyCredits} />
+        </>
+      ) : (
+        <CreditAdditionList grants={grants} />
+      )}
     </div>
   );
 }
@@ -759,9 +886,11 @@ function CreditBalanceActions({
 export function CreditBalanceCard({
   onBuyCredits,
   onComparePlans,
+  splitLayout,
 }: {
   onBuyCredits: () => void;
   onComparePlans: () => void;
+  splitLayout: boolean;
 }) {
   const { t } = useTranslation();
   const billingLoadable = useLoadable(billingStatusAsync$);
@@ -770,9 +899,12 @@ export function CreditBalanceCard({
   const billingLoading = billingLoadable.state === "loading";
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className={`flex flex-col ${splitLayout ? "gap-4" : "gap-3"}`}>
       {billing ? (
-        <UsageAllowanceCard allowance={billing.usageAllowance} />
+        <UsageAllowanceCard
+          allowance={billing.usageAllowance}
+          splitLayout={splitLayout}
+        />
       ) : null}
       <div className="overflow-hidden rounded-xl bg-card zero-border">
         {billingLoading && !billing ? (
@@ -785,6 +917,7 @@ export function CreditBalanceCard({
             billing={billing}
             onBuyCredits={onBuyCredits}
             onComparePlans={onComparePlans}
+            splitLayout={splitLayout}
           />
         ) : (
           <div className="px-5 py-4">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
@@ -18,6 +18,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  Tabs,
+  TabsList,
+  TabsTrigger,
 } from "@vm0/ui";
 import {
   Tooltip,
@@ -31,6 +34,11 @@ import {
   formatCreditDate,
   type CreditAddition,
 } from "../../org-manage/org-usage-tab.tsx";
+import {
+  PersonalUsageRecord,
+  TeamUsageRecord,
+  UsageRangeSelect,
+} from "../../preferences/personal-usage-record.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
 import { featureSwitch$ } from "../../../../../signals/external/feature-switch.ts";
 import { orgMembers$ } from "../../../../../signals/external/org-members.ts";
@@ -41,8 +49,15 @@ import {
   setBillingSubPage$,
 } from "../../../../../signals/zero-page/settings/workspace-settings-state.ts";
 import {
+  creditBalanceTab$,
+  myUsageRange$,
+  setCreditBalanceTab$,
+  setMyUsageRange$,
+  setTeamUsageRange$,
   setUsagePackMembersDialogOpen$,
+  teamUsageRange$,
   toggleUsagePackMemberAdditions$,
+  type CreditBalanceTab,
   usagePackMemberAdditionsExpandedMemberId$,
   usagePackMembersDialogOpen$,
 } from "../../../../../signals/zero-page/settings/personal-usage-record.ts";
@@ -686,6 +701,12 @@ export function CreditBalanceSection() {
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+  const tab = useGet(creditBalanceTab$);
+  const setTab = useSet(setCreditBalanceTab$);
+  const myRange = useGet(myUsageRange$);
+  const teamRange = useGet(teamUsageRange$);
+  const setMyRange = useSet(setMyUsageRange$);
+  const setTeamRange = useSet(setTeamUsageRange$);
   const features = useLastResolved(featureSwitch$);
   const usagePackPlansEnabled =
     features?.[FeatureSwitchKey.UsagePackPlans] ?? false;
@@ -704,19 +725,66 @@ export function CreditBalanceSection() {
     <UsagePackCreditCard isAdmin={isAdmin} />
   ) : null;
 
+  const creditCard = (
+    <CreditBalanceCard
+      onBuyCredits={goToBuyCredits}
+      onComparePlans={goToComparePlans}
+      splitLayout={usagePackPlansEnabled}
+    />
+  );
+
   // Members only see credits assigned by their usage pack. Organization
   // balances remain available to organization admins.
   if (!isAdmin) {
     return <div>{usagePackCreditCard}</div>;
   }
 
+  // Without the new pricing, the section still owns the usage records and the
+  // Mine/Team tabs that go with them.
+  if (!usagePackPlansEnabled) {
+    const activeRange = tab === "team" ? teamRange : myRange;
+    const setActiveRange = tab === "team" ? setTeamRange : setMyRange;
+    return (
+      <div className="flex flex-col gap-6">
+        {creditCard}
+        <div className="flex flex-col gap-4">
+          {/* One compact header row: tabs on the left, range filter on the right. */}
+          <div className="flex items-center justify-between gap-3">
+            <Tabs
+              value={tab}
+              onValueChange={(value) => {
+                setTab(value as CreditBalanceTab);
+              }}
+            >
+              <TabsList>
+                <TabsTrigger value="mine">
+                  {t(($) => {
+                    return $.usage.records.myUsage;
+                  })}
+                </TabsTrigger>
+                <TabsTrigger value="team">
+                  {t(($) => {
+                    return $.usage.records.teamUsage;
+                  })}
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <UsageRangeSelect value={activeRange} onChange={setActiveRange} />
+          </div>
+          {tab === "mine" ? (
+            <PersonalUsageRecord range={myRange} />
+          ) : (
+            <TeamUsageRecord range={teamRange} />
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-4">
       {usagePackCreditCard}
-      <CreditBalanceCard
-        onBuyCredits={goToBuyCredits}
-        onComparePlans={goToComparePlans}
-      />
+      {creditCard}
       <button
         type="button"
         data-testid="credit-balance-see-usage"

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -107,8 +107,9 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
   const showDebug = features[FeatureSwitchKey.ZeroDebug] ?? false;
-  const showUsage =
-    isAdmin || (features[FeatureSwitchKey.UsagePackPlans] ?? false);
+  const usagePackPlansEnabled =
+    features[FeatureSwitchKey.UsagePackPlans] ?? false;
+  const showUsage = isAdmin || usagePackPlansEnabled;
   const sectionMeta = {
     preference: {
       title: t(($) => {
@@ -232,11 +233,15 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
             },
           ]
         : []),
-      {
-        id: "usage-records" as const,
-        label: sectionMeta["usage-records"].title,
-        icon: History,
-      },
+      ...(usagePackPlansEnabled
+        ? [
+            {
+              id: "usage-records" as const,
+              label: sectionMeta["usage-records"].title,
+              icon: History,
+            },
+          ]
+        : []),
       ...(isAdmin
         ? [
             {
@@ -264,10 +269,19 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const resolvedSection: SettingsSection =
     (!showDebug && activeSection === "debug") ||
     (!showUsage && activeSection === "usage") ||
+    (!usagePackPlansEnabled && activeSection === "usage-records") ||
     (!isAdmin && isAdminOnlySettingsSection(activeSection))
       ? "preference"
       : activeSection;
-  const meta = sectionMeta[resolvedSection];
+  const meta =
+    resolvedSection === "usage" && !usagePackPlansEnabled
+      ? {
+          title: sectionMeta.usage.title,
+          description: t(($) => {
+            return $.settings.dialog.sections.usage.balanceUsageDescription;
+          }),
+        }
+      : sectionMeta[resolvedSection];
 
   const handleSectionChange = (section: SettingsSection) => {
     setActiveSection(section);


### PR DESCRIPTION
## Why

Two things came out of looking at the shipped split (#26699) in production:

1. The org credit composition bar disappeared for the most common paid setup. #26699 skipped it when `creditBreakdown` had a single segment, so an org whose balance is entirely `Pay as you go` saw the number, a bare divider, then the additions table.
2. The whole redesign was live for everyone. It belongs with the new pricing rollout, behind `FeatureSwitchKey.UsagePackPlans`.

A third, visible in the same screen: grants that never expire but are not sourced from auto-recharge printed their sentinel date, e.g. `Dec 31, 2999`.

## What changed

**Gated behind `UsagePackPlans`** — with the switch off, settings render exactly what shipped before #26699:

| Surface | Switch off | Switch on |
| --- | --- | --- |
| Sections | one `Credit balance` holding the Mine/Team usage records | `Credit balance` + `Credit usage`, cross-linked |
| Allowance row | `3,750 / 5,000 credits`, full reset timestamp | `3,750 left`, clock today / day later |
| Balance card | breakdown legend + collapsed `Credit additions` | gapped composition bar + always-visible additions table |
| Actions | none | auto-recharge state + `Buy credits` |

`?settings=usage-records` resolves back to Preference when the switch is off, so the deep link cannot reach a hidden section.

**Fixes**
- Draw the composition bar whenever there is a balance, single category included.
- Treat an expiry more than a century out as `Never expires` in both layouts, instead of trusting `source === "auto_recharge"` alone.

## Tests

- `org-usage-tab.test.tsx`: the split cases now enable the switch; a new case asserts the pre-split layout (collapsed additions, Mine/Team tabs, no records nav item, no buy-credits action) with the switch off, and another asserts a single-category breakdown still renders its segment.
- `personal-usage-tab.test.tsx`: a member without the new pricing sees neither `Credit balance` nor `Credit usage`.

`pnpm -F @vm0/app check-types`, `lint`, `pnpm format` clean; org + personal usage suites pass (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
