### PR TITLE
fix: mark hosted sites as noindex

### DIFF
--- a/turbo/apps/host-worker/src/index.test.ts
+++ b/turbo/apps/host-worker/src/index.test.ts
@@ -234,6 +234,16 @@ describe("hosted site worker", () => {
     expect(response.headers.get("Vary")).toBe("Origin");
   });
 
+  it("marks hosted site responses as noindex", async () => {
+    const response = await worker.fetch(
+      new Request("https://demo.sites.vm0.io/"),
+      env(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Robots-Tag")).toBe("noindex");
+  });
+
   it("serves default robots.txt when the active deployment omits it", async () => {
     const response = await worker.fetch(
       new Request("https://demo.sites.vm0.io/robots.txt"),

--- a/turbo/apps/host-worker/src/index.ts
+++ b/turbo/apps/host-worker/src/index.ts
@@ -124,6 +124,7 @@ function setCorsHeaders(headers: Headers, request: Request): void {
 function corsResponse(response: Response, request: Request): Response {
   const headers = new Headers(response.headers);
   setCorsHeaders(headers, request);
+  headers.set("X-Robots-Tag", "noindex");
   return new Response(response.body, {
     headers,
     status: response.status,


### PR DESCRIPTION
## Summary

- add `X-Robots-Tag: noindex` to hosted-site Worker responses
- cover the response header with a Host Worker integration test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm exec vitest run apps/host-worker/src/index.test.ts` (10 passed)
- `pnpm --filter @vm0/host-worker exec wrangler deploy --env="" --dry-run`
