### PR TITLE
fix(desktop): isolate smoke test authentication

### DIFF
--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1444,6 +1444,7 @@ if (!hasSingleInstanceLock) {
     queueDesktopAuthCallbackArgv(process.argv);
 
     if (isDesktopSmokeTestEnabled(process.env)) {
+      desktopAuthSession.signOut();
       try {
         await verifyDesktopSmokeBridge();
       } catch (error) {


### PR DESCRIPTION
## Summary

- force the Desktop auth session to signed-out before the packaged smoke loads its renderer
- prevent the smoke-only renderer auth probe from creating a real hidden token-refresh window
- leave production authentication and startup behavior unchanged

## Context

The Desktop 0.37.0 promotion in release run 31617923102 passed signing, notarization, DMG validation, and the first Okou install launch, then failed the second ZIP/update launch when shutdown closed a hidden auth window and produced `Desktop auth consume window closed` / `SIGTRAP`. The updater manifest was safely not published.

Tracks #26370 and #26364.

## Validation

- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop test` (339 tests)
- production Zero package followed by two consecutive packaged-app smoke launches
- production Okou package followed by two consecutive packaged-app smoke launches
- verified packaged Okou `CFBundleName=Okou` and `CFBundleIdentifier=ai.okou.desktop`