### PR TITLE
fix: restore block spacing between markdown card slots

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -7,6 +7,10 @@ const composerConnectorSlugs = ["github", "slack", "asana"] as const;
 const responsiveFollowupThreadId = "b0000000-0000-4000-a000-000000000734";
 const modelChangeThreadId = "b0000000-0000-4000-a000-000000000735";
 const imageLayoutThreadId = "b0000000-0000-4000-a000-000000000736";
+const cardSpacingThreadId = "b0000000-0000-4000-a000-000000000737";
+// Card slots carry the same block margins as the paragraphs around them, and
+// adjacent margins collapse into one gap.
+const cardSlotGapPx = 8;
 const responsiveFollowupPrompts = [
   "Draft launch copy",
   "Create a detailed presentation outline with speaker notes",
@@ -608,6 +612,49 @@ async function mockModelChangeThread(
   });
 }
 
+async function mockCardSpacingThread(
+  page: Page,
+  agentId: string,
+): Promise<void> {
+  const createdAt = "2026-08-13T06:00:02Z";
+  const runId = "run-card-spacing";
+  const events = [
+    {
+      id: "msg-card-spacing-assistant",
+      threadId: cardSpacingThreadId,
+      eventType: "output.message",
+      // Each authorization link stands alone in its own paragraph, so the body
+      // parser turns both into card slots the renderer stacks back to back.
+      content: [
+        "Two sessions are waiting for authorization.",
+        new URL("/computer-use/authorize/card-spacing-first", appUrl).href,
+        new URL("/computer-use/authorize/card-spacing-second", appUrl).href,
+      ].join("\n\n"),
+      runId,
+      seqId: 1,
+      createdAt: "2026-08-13T06:00:00Z",
+    },
+    {
+      id: "msg-card-spacing-completed",
+      threadId: cardSpacingThreadId,
+      eventType: "run.completed",
+      content: null,
+      runId,
+      runLifecycleEvent: "completed",
+      seqId: 2,
+      createdAt,
+    },
+  ];
+  await mockChatThread(page, {
+    agentId,
+    createdAt,
+    events,
+    selectedModel: null,
+    threadId: cardSpacingThreadId,
+    title: "Card slot spacing",
+  });
+}
+
 interface DelayedImageRoutes {
   readonly assistantImageRequested: Promise<void>;
   readonly assistantImageUrl: string;
@@ -1087,6 +1134,40 @@ test("model change labels follow the divider at the right edge", async ({
   await expectRightAlignedDivider(
     page.getByText("Next run will use Claude Opus 4.8", { exact: true }),
   );
+});
+
+test("consecutive body cards keep a block gap between them", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  const agentId = new URL(page.url()).pathname.match(
+    /^\/agents\/([^/]+)\/chat\/?$/,
+  )?.[1];
+  if (!agentId) {
+    throw new Error("Could not resolve the active agent from the chat URL");
+  }
+  await mockCardSpacingThread(page, agentId);
+  await navigateToMockChatThread(page, cardSpacingThreadId);
+
+  const cards = page.getByTestId("computer-use-authorization-card");
+  await expect(cards).toHaveCount(2);
+
+  // A card slot enters the markdown tree as a paragraph and leaves it as the
+  // card element, so without the block margin the two borders would touch.
+  await expect
+    .poll(async () => {
+      const [first, second] = await Promise.all([
+        cards.nth(0).boundingBox(),
+        cards.nth(1).boundingBox(),
+      ]);
+      if (!first || !second) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return Math.abs(second.y - (first.y + first.height) - cardSlotGapPx);
+    })
+    .toBeLessThan(2);
 });
 
 test("image preview frames stay fixed while delayed images load", async ({

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -193,8 +193,15 @@ function MediaImageRenderer(props: MarkdownImageProps) {
 function MarkdownDivRenderer(props: MarkdownDivProps) {
   const { children, ...rest } = props;
   const data = props.node?.data;
+  // A card slot enters the tree as a paragraph and leaves it as this div, so it
+  // carries the block spacing the paragraph would have had — without it two
+  // consecutive cards sit border-to-border.
   if (data?.card) {
-    return <MarkdownCardView card={data.card} />;
+    return (
+      <div className="zero-markdown-card">
+        <MarkdownCardView card={data.card} />
+      </div>
+    );
   }
   if (typeof data?.copyCode === "string") {
     return (

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -961,7 +961,8 @@ body {
   max-width: 100%;
 }
 
-.wmde-markdown p {
+.wmde-markdown p,
+.wmde-markdown .zero-markdown-card {
   margin-top: 6px;
   margin-bottom: 6px;
 }
@@ -970,7 +971,9 @@ body {
    Line-height is owned by the bubble container (leading-[1.7]) and inherited
    by the markdown body, mirroring how the bubble owns the font size. */
 .zero-chat-bubble-assistant .wmde-markdown p,
-.zero-chat-bubble-user .wmde-markdown p {
+.zero-chat-bubble-user .wmde-markdown p,
+.zero-chat-bubble-assistant .wmde-markdown .zero-markdown-card,
+.zero-chat-bubble-user .wmde-markdown .zero-markdown-card {
   margin-top: 8px;
   margin-bottom: 8px;
 }


### PR DESCRIPTION
## Problem

Consecutive cards in an assistant message (Gmail draft cards, artifact cards, connector/permission action cards, plan upgrade, browser session) render with **zero vertical gap** — their 1px borders sit directly on top of each other and the 20px rounded corners collide, producing a doubled seam and pinch notches.

Reported by Ming with a screenshot of a 10-draft Gmail list.

## Root cause

A card slot enters the markdown tree as a top-level paragraph:

1. `pipeline.ts:101-118` (`rehypeCards`) replaces that `<p>` with a bare `<div>` carrying `data.card`.
2. `markdown.tsx` (`MarkdownDivRenderer`) drops the `<div>` entirely and returns the card component, so the card's own root element becomes the direct child of `.wmde-markdown`.

Markdown block spacing in `views/css/index.css` is element-name based (`.wmde-markdown p { margin: 6px 0 }`, 8px inside chat bubbles). Once the paragraph became a card element, no spacing rule matched it anymore, and none of the card components carry vertical margin of their own.

## Fix

Render the card slot inside a `zero-markdown-card` wrapper and give that class the same block margins the paragraph had — 6px generally, 8px inside chat bubbles. Adjacent margins collapse to a single 8px gap, matching the paragraph rhythm around it. `.wmde-markdown > :first-child` / `> :last-child` already zero out the edges, so no stray leading or trailing space is added.

Applies to every card kind dispatched by `MarkdownCardView`, not just mail drafts.

## Verification

- `pnpm format`, `pnpm -F @vm0/app check-types`, `pnpm -F @vm0/app lint` — clean
- `vitest run chat-event-action-cards.test.tsx event-body-plan.test.ts` — 46 passed
- Gap rendered and compared at 0 / 8 / 12px; 8px matches the surrounding markdown rhythm

🤖 Generated with [Claude Code](https://claude.com/claude-code)