### PR TITLE
feat(core): enable meta ads connector globally

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -13,6 +13,7 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -23,7 +24,6 @@ describe("isFeatureEnabled", () => {
 
   it("should return false for disabled switch without context", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(false);
   });
 
   it("should return false for disabled switch with non-matching userId", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -156,7 +156,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.MetaAdsConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Meta Ads Manager connector",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- enable the Meta Ads connector globally by turning on `metaAdsConnector`
- update core feature-switch coverage for the globally enabled state

## Context

Meta Ads was temporarily disabled in #22262. This restores global availability while retaining the feature switch as a rollback path.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts` (24 tests passed)
- `git diff --check`
