### PR TITLE
fix: align okou cli root description

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@vm0/okou-cli",
   "version": "9.279.4",
   "private": true,
-  "description": "Okou command-line interface for vm0",
+  "description": "Okou command-line interface",
   "repository": {
     "type": "git",
     "url": "https://github.com/vm0-ai/vm0",

--- a/turbo/apps/cli/src/__tests__/okou.test.ts
+++ b/turbo/apps/cli/src/__tests__/okou.test.ts
@@ -12,7 +12,9 @@ describe("Okou CLI program", () => {
 
   it("should use the canonical Okou product identity", () => {
     expect(program.name()).toBe("okou");
-    expect(program.description()).toContain("Okou CLI");
+    expect(program.description()).toBe(
+      "Okou CLI — interact with Okou from inside the sandbox",
+    );
   });
 
   it("should register all expected Okou commands", () => {

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -606,7 +606,7 @@ declare const __CLI_VERSION__: string;
 
 program
   .name("okou")
-  .description("Okou CLI — interact with vm0 from inside the sandbox")
+  .description("Okou CLI — interact with Okou from inside the sandbox")
   .version(__CLI_VERSION__)
   .addHelpText("after", () => {
     return buildZeroHelpText();


### PR DESCRIPTION
## Summary

- update the root Okou CLI description to refer to Okou instead of vm0
- align the package description and strengthen the root program identity assertion

## Validation

- pnpm exec prettier --write apps/cli/package.json apps/cli/src/okou.ts apps/cli/src/__tests__/okou.test.ts
- pnpm -F @vm0/okou-cli lint
- pnpm -F @vm0/okou-cli check-types
- pnpm knip --workspace @vm0/okou-cli
- pnpm -F @vm0/okou-cli test (98 passed files, 915 passed tests; 1 skipped file and test)
- pnpm -F @vm0/okou-cli build
- packed tarball install and okou --help smoke check