### PR TITLE
fix(cli): use okou desktop in computer use guidance

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -199,6 +199,9 @@ describe("computer-use command visibility", () => {
     zeroComputerUseCommand.outputHelp();
 
     expect(helpOutput).toContain("Workflow:");
+    expect(helpOutput).toContain(
+      "Start the Okou Desktop app and make sure Computer Use is online",
+    );
     expect(helpOutput).toContain("okou computer-use list-apps");
     expect(helpOutput).toContain(
       "okou computer-use get-app-state --app <bundleId>",
@@ -208,6 +211,50 @@ describe("computer-use command visibility", () => {
     expect(helpOutput).toContain("overwrites the same files");
     expect(helpOutput).toContain("shift+semicolon");
     expect(helpOutput).toContain("Control_L+J");
+    expect(helpOutput).not.toContain("Zero Desktop");
+  });
+
+  it("should use Okou Desktop branding in plugin help", () => {
+    const pluginCommand = zeroComputerUseCommand.commands.find((command) => {
+      return command.name() === "plugin";
+    });
+    const filesystemCommand = pluginCommand?.commands.find((command) => {
+      return command.name() === "filesystem";
+    });
+    const mcpCommand = pluginCommand?.commands.find((command) => {
+      return command.name() === "mcp";
+    });
+    expect(filesystemCommand).toBeDefined();
+    expect(mcpCommand).toBeDefined();
+
+    let filesystemHelpOutput = "";
+    filesystemCommand!.configureOutput({
+      writeOut: (text: string) => {
+        filesystemHelpOutput += text;
+      },
+    });
+    filesystemCommand!.outputHelp();
+
+    let mcpHelpOutput = "";
+    mcpCommand!.configureOutput({
+      writeOut: (text: string) => {
+        mcpHelpOutput += text;
+      },
+    });
+    mcpCommand!.outputHelp();
+
+    expect(filesystemHelpOutput).toContain(
+      "Use the Okou Desktop filesystem plugin",
+    );
+    expect(filesystemHelpOutput).toContain(
+      "List directories enabled in Okou Desktop",
+    );
+    expect(mcpHelpOutput).toContain(
+      "Use custom MCP servers configured in the Okou Desktop app",
+    );
+    expect(`${filesystemHelpOutput}\n${mcpHelpOutput}`).not.toContain(
+      "Zero Desktop",
+    );
   });
 
   it("should guide missing computer-use capability errors to delegated authorization", async () => {
@@ -235,6 +282,9 @@ describe("computer-use command visibility", () => {
     const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorOutput).toContain("Computer Use authorization required");
     expect(errorOutput).toContain(
+      "ask the user to select an Okou Desktop host for this chat or Slack thread",
+    );
+    expect(errorOutput).toContain(
       "okou connector permission-request computer-use --permission computer-use:write",
     );
     expect(errorOutput).toContain(
@@ -243,6 +293,7 @@ describe("computer-use command visibility", () => {
     expect(errorOutput).not.toContain(
       "403: Missing required capability: computer-use:write",
     );
+    expect(errorOutput).not.toContain("Zero Desktop");
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
@@ -933,6 +984,31 @@ describe("computer-use command visibility", () => {
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Lancy's Mac (online): notes, figma");
+  });
+
+  it("should guide empty mcp setup to Okou Desktop", async () => {
+    vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+
+    server.use(
+      http.get("http://localhost:3000/api/okou/computer-use/hosts", () => {
+        return HttpResponse.json({ hosts: [] });
+      }),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "plugin",
+      "mcp",
+      "list",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(
+      "Configure and enable them in the Okou Desktop app's Developer Tools section",
+    );
+    expect(output).not.toContain("Zero Desktop");
   });
 
   it("should download pointer-backed screenshots through the API proxy", async () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -132,7 +132,7 @@ const COMPUTER_USE_AUTHORIZATION_REQUIRED_ERROR =
   "COMPUTER_USE_AUTHORIZATION_REQUIRED";
 const COMPUTER_USE_HELP_TEXT = `
 Workflow:
-  1. Start the Zero Desktop app and make sure Computer Use is online.
+  1. Start the Okou Desktop app and make sure Computer Use is online.
   2. Run "okou computer-use list-apps" to find the target app's bundleId.
      --app accepts a bundle id only (e.g. com.google.Chrome); the name is for
      display. Apps listed without a bundleId cannot be targeted.
@@ -894,7 +894,7 @@ const openAppCommand = appOption(
 const filesystemListAllowedDirectoriesCommand = addPluginOptions(
   new Command()
     .name("list_allowed_directories")
-    .description("List directories enabled in Zero Desktop")
+    .description("List directories enabled in Okou Desktop")
     .action(
       withErrorHandler(async (options: ComputerUsePluginOptions) => {
         await runFilesystemPluginCommand(
@@ -1158,7 +1158,7 @@ const filesystemGetFileInfoCommand = addPluginOptions(
 
 const filesystemPluginCommand = new Command()
   .name("filesystem")
-  .description("Use the Zero Desktop filesystem plugin")
+  .description("Use the Okou Desktop filesystem plugin")
   .addCommand(filesystemListAllowedDirectoriesCommand)
   .addCommand(filesystemReadTextFileCommand)
   .addCommand(filesystemReadMediaFileCommand)
@@ -1238,7 +1238,7 @@ async function printMcpServers(): Promise<void> {
   }
   if (lines.length === 0) {
     console.log(
-      "No MCP servers are running on any linked host. Configure and enable them in the Zero Desktop app's Developer Tools section.",
+      "No MCP servers are running on any linked host. Configure and enable them in the Okou Desktop app's Developer Tools section.",
     );
     return;
   }
@@ -1299,7 +1299,7 @@ const mcpCallCommand = new Command()
 
 const mcpPluginCommand = new Command()
   .name("mcp")
-  .description("Use custom MCP servers configured in the Zero Desktop app")
+  .description("Use custom MCP servers configured in the Okou Desktop app")
   .addCommand(mcpListCommand)
   .addCommand(mcpCallCommand);
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/permission-request.test.ts
@@ -667,9 +667,13 @@ describe("okou connector permission-request command", () => {
     expect(logCalls).toContain(
       "Computer Use access is not managed as a connector permission.",
     );
-    expect(logCalls).toContain("selected for the chat or thread");
+    expect(logCalls).toContain(
+      "issued only when an Okou Desktop Computer Use host is selected for the chat or thread",
+    );
+    expect(logCalls).toContain("Open Okou Desktop");
     expect(logCalls).toContain("Existing run tokens cannot be upgraded");
     expect(logCalls).toContain("okou whoami");
+    expect(logCalls).not.toContain("Zero Desktop");
     expect(logCalls).not.toContain("[Manage");
     expect(mockConsoleError).not.toHaveBeenCalled();
   });
@@ -705,8 +709,9 @@ describe("okou connector permission-request command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain(
-      "Computer Use needs a Zero Desktop host selected before a run starts.",
+      "Computer Use needs an Okou Desktop host selected before a run starts.",
     );
+    expect(logCalls).not.toContain("Zero Desktop");
     expect(logCalls).toContain(
       "https://app.vm0.ai/computer-use/authorize/vm0_computer_use_authorization_request_test",
     );

--- a/turbo/apps/cli/src/commands/zero/connector/computer-use-guidance.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/computer-use-guidance.ts
@@ -23,10 +23,10 @@ export function isComputerUsePermissionTarget(
 export function printComputerUsePermissionGuidance(): void {
   console.log("Computer Use access is not managed as a connector permission.");
   console.log(
-    "The current run token needs computer-use:write, which is issued only when a Zero Desktop Computer Use host is selected for the chat or thread before the run starts.",
+    "The current run token needs computer-use:write, which is issued only when an Okou Desktop Computer Use host is selected for the chat or thread before the run starts.",
   );
   console.log(
-    "Open Zero Desktop, make sure Computer Use is online, select the Computer Use host for this chat/thread, then start a new run. Existing run tokens cannot be upgraded in place.",
+    "Open Okou Desktop, make sure Computer Use is online, select the Computer Use host for this chat/thread, then start a new run. Existing run tokens cannot be upgraded in place.",
   );
   console.log(
     "Run `okou whoami` to confirm whether the current OKOU_TOKEN includes computer-use:write.",

--- a/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
@@ -175,7 +175,7 @@ function printComputerUseAuthorizationLink(args: {
   readonly expiresAt: string;
 }): void {
   console.log(
-    "Computer Use needs a Zero Desktop host selected before a run starts.",
+    "Computer Use needs an Okou Desktop host selected before a run starts.",
   );
   console.log(
     "Ask the user to authorize a host for future runs in this chat or Slack thread:",

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -115,7 +115,7 @@ export const RUN_ERROR_GUIDANCE: Record<
   COMPUTER_USE_AUTHORIZATION_REQUIRED: {
     title: "Computer Use authorization required",
     guidance:
-      "Request a delegated Computer Use authorization link, ask the user to select a Zero Desktop host for this chat or Slack thread, then start a new run. Existing run tokens cannot be upgraded in place.",
+      "Request a delegated Computer Use authorization link, ask the user to select an Okou Desktop host for this chat or Slack thread, then start a new run. Existing run tokens cannot be upgraded in place.",
     cliHint:
       "okou connector permission-request computer-use --permission computer-use:write",
   },


### PR DESCRIPTION
## Summary

- replace user-visible Zero Desktop wording in current Okou CLI Computer Use help, plugin descriptions, errors, and connector guidance
- keep internal zero command paths, contracts, routes, environment variables, and Desktop identity unchanged
- add command-entry integration coverage for help, MCP setup recovery, delegated authorization, and shared error guidance

## Validation

- `pnpm exec prettier --write <changed files>`
- `pnpm -F @vm0/okou-cli lint`
- `pnpm -F @vm0/okou-cli check-types`
- `pnpm knip --workspace @vm0/okou-cli`
- `pnpm -F @vm0/okou-cli exec vitest run --maxWorkers=4 --silent=passed-only` (917 passed, 1 skipped)
- `pnpm -F @vm0/okou-cli build`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run --maxWorkers=4 --silent=passed-only` (544 passed)
- built `okou` entry-point smoke checks for Computer Use help, filesystem/MCP help, connector recovery guidance, and centralized error guidance