### PR TITLE
fix(cli): use okou branding in user-visible copy

### DIFF
--- a/turbo/apps/cli/src/__tests__/okou.test.ts
+++ b/turbo/apps/cli/src/__tests__/okou.test.ts
@@ -17,6 +17,16 @@ describe("Okou CLI program", () => {
     );
   });
 
+  it("should use Okou branding for the generate entry-point description", () => {
+    const generateCommand = program.commands.find((command) => {
+      return command.name() === "generate";
+    });
+
+    expect(generateCommand?.description()).toBe(
+      "Generate assets via Okou's built-in pipelines or get connector skill-invocation guidance",
+    );
+  });
+
   it("should register all expected Okou commands", () => {
     const expectedCommands = [
       "model",

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/avatar-video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/avatar-video.test.ts
@@ -84,7 +84,8 @@ describe("okou generate avatar-video command", () => {
 
     avatarVideoCommand.outputHelp();
 
-    expect(helpOutput).toContain("Built-in workflow (vm0 credits):");
+    expect(helpOutput).toContain("Provider: 'built-in' to use Okou credits");
+    expect(helpOutput).toContain("Built-in workflow (Okou credits):");
     expect(helpOutput).toContain(
       "okou generate avatar-video --provider built-in --list-avatars",
     );
@@ -95,6 +96,10 @@ describe("okou generate avatar-video command", () => {
     expect(helpOutput).toContain("okou connector status joggai");
     expect(helpOutput).toContain(
       "okou generate avatar-video --provider joggai",
+    );
+    expect(helpOutput).toContain('--script "Welcome to Okou"');
+    expect(helpOutput).toContain(
+      "Built-in generation uses Okou-managed JoggAI credentials",
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
@@ -564,6 +564,7 @@ describe("okou generate image command", () => {
     expect(helpOutput).not.toContain("--styled ");
     expect(helpOutput).toContain("provider");
     expect(helpOutput).toContain("default");
+    expect(helpOutput).toContain("Provider: 'built-in' to run Okou's pipeline");
     expect(helpOutput).toContain("not support transparent");
     expect(helpOutput).toContain("backgrounds");
     expect(helpOutput).toContain("Image-to-image");

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -199,6 +199,24 @@ describe("okou generate lister", () => {
     return mockConsoleLog.mock.calls.flat().join("\n");
   }
 
+  it("uses Okou branding in generate help", () => {
+    let helpOutput = "";
+    generateCommand.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    generateCommand.outputHelp();
+
+    expect(helpOutput).toContain(
+      "Generate assets via Okou's built-in pipelines",
+    );
+    expect(helpOutput).toContain(
+      "--provider for Okou or connector execution guidance",
+    );
+  });
+
   it("lists ready image generation connectors for the current agent", async () => {
     server.use(
       stubConnectors([
@@ -222,7 +240,7 @@ describe("okou generate lister", () => {
     expect(text).toContain("OpenAI");
     expect(text).not.toContain("replicate-user");
     expect(text).toContain("Built-in command:");
-    expect(text).toContain("vm0");
+    expect(text).toContain("Okou  Built-in image generation");
     expect(text).toContain("Built-in image generation");
     expect(text).toContain(
       "Models: fal.ai: gpt-image-1 (default), gpt-image-2, gpt-image-1.5, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4, nano-banana-2",
@@ -571,6 +589,34 @@ describe("okou generate lister", () => {
     expect(text).toContain("ElevenLabs");
     expect(text).toContain("@elevenlabs-user");
     expect(text).not.toContain("Built-in command:");
+  });
+
+  it("uses Okou branding when a subtype has no built-in pipeline", async () => {
+    const musicCommand = generateCommand.commands.find((command) => {
+      return command.name() === "music";
+    });
+    let helpOutput = "";
+    musicCommand?.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    musicCommand?.outputHelp();
+    expect(helpOutput).toContain(
+      "Okou does not provide a built-in music pipeline.",
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "music",
+      "--provider",
+      "built-in",
+    ]);
+    expect(output()).toContain(
+      "Okou has no built-in music generation pipeline.",
+    );
   });
 
   it("rejects unknown generation types via Commander", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -339,6 +339,7 @@ describe("okou generate video command", () => {
     expect(helpOutput).toContain("--first-frame-image-url");
     expect(helpOutput).toContain("--last-frame-image-url");
     expect(helpOutput).toContain("--json");
+    expect(helpOutput).toContain("Provider: 'built-in' to run Okou's pipeline");
   });
 
   it("should surface API errors", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/voice.test.ts
@@ -12,6 +12,7 @@ import { http, HttpResponse } from "msw";
 import chalk from "chalk";
 import { server } from "../../../../mocks/server";
 import { generateCommand } from "../index";
+import { voiceCommand } from "../voice";
 
 const SPEECH_URL = "http://localhost:3000/api/okou/voice-io/speech";
 const VOICE_RESULT = {
@@ -44,6 +45,20 @@ describe("okou generate voice command", () => {
   afterEach(() => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
+  });
+
+  it("should use Okou branding in voice help", () => {
+    let helpOutput = "";
+    voiceCommand.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    voiceCommand.outputHelp();
+
+    expect(helpOutput).toContain('--prompt "Hello from Okou"');
+    expect(helpOutput).toContain("Provider: 'built-in' to run Okou's pipeline");
   });
 
   it("should generate speech and print the /f file URL", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -66,14 +66,14 @@ describe("okou generate website command", () => {
       "run its exact `source.pull.command`, then use `source.pull.resolvedPath`.",
     );
     expect(stdout).toContain(
-      "The Website index includes vm0 built-in R2 template packages as template entries with `source.archive`.",
+      "The Website index includes Okou built-in R2 template packages as template entries with `source.archive`.",
     );
     expect(stdout).toContain(
       "Each built-in Website template entry includes the exact pull command and extracted package path in `source.pull`.",
     );
     expect(stdout).toContain("observability launch site");
     expect(stdout).toContain(
-      "For landing, marketing, official brand or product, and launch pages, select a vm0 built-in website template.",
+      "For landing, marketing, official brand or product, and launch pages, select an Okou built-in website template.",
     );
     expect(stdout).toContain(
       "For other HTML or website requests, select an Open Design template based on intent; when ambiguous, prefer Open Design.",
@@ -146,7 +146,7 @@ describe("okou generate website command", () => {
     );
     expect(stdout).toContain("Use the explicitly selected template.");
     expect(stdout).not.toContain(
-      "For landing, marketing, official brand or product, and launch pages, select a vm0 built-in website template.",
+      "For landing, marketing, official brand or product, and launch pages, select an Okou built-in website template.",
     );
     expect(stdout).not.toContain(
       "Selected template package: okou resource pull template:web-prototype",

--- a/turbo/apps/cli/src/commands/zero/generate/avatar-video.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/avatar-video.ts
@@ -460,7 +460,7 @@ export const avatarVideoCommand = new Command()
   .option("--voice-use-case <use-case>", "Voice use-case filter")
   .option(
     "--provider <name>",
-    "Provider: 'built-in' to use vm0 credits, or a connector name for skill guidance",
+    "Provider: 'built-in' to use Okou credits, or a connector name for skill guidance",
   )
   .option(
     "--all",
@@ -475,10 +475,10 @@ Examples:
   Generate from audio:   okou generate avatar-video --provider built-in --avatar-id 81 --voice-id en-US-ChristopherNeural --audio-url https://example.com/voice.mp3
   Pipe a script:         cat script.txt | okou generate avatar-video --provider built-in --avatar-id 81 --voice-id en-US-ChristopherNeural
 
-Built-in workflow (vm0 credits):
+Built-in workflow (Okou credits):
   1. okou generate avatar-video --provider built-in --list-avatars
   2. okou generate avatar-video --provider built-in --list-voices --voice-language english
-  3. okou generate avatar-video --provider built-in --avatar-id 81 --voice-id en-US-ChristopherNeural --script "Welcome to vm0"
+  3. okou generate avatar-video --provider built-in --avatar-id 81 --voice-id en-US-ChristopherNeural --script "Welcome to Okou"
 
 JoggAI connector workflow (BYOK):
   1. okou connector status joggai
@@ -493,7 +493,7 @@ Notes:
   - Run the command with no script/audio to reflect built-in and connector choices.
   - Use exactly one of --script (or piped stdin) and --audio-url.
   - Public avatar and voice IDs are discoverable with the list flags.
-  - Built-in generation uses vm0-managed JoggAI credentials and charges org credits.
+  - Built-in generation uses Okou-managed JoggAI credentials and charges org credits.
   - Connector generation uses the connected JoggAI account and provider credits.
   - Authenticates via OKOU_TOKEN and requires file:write capability.`,
   )

--- a/turbo/apps/cli/src/commands/zero/generate/index.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/index.ts
@@ -59,14 +59,14 @@ function buildGenerateHelpText(): string {
   ];
 
   return `\nExamples:\n${examples.join("\n")}\n\nNotes:\n  - Run "okou generate <type>" with no --prompt to list generation choices for that type.
-  - Media and connector-backed generation types may expose --provider for vm0 or connector execution guidance.
+  - Media and connector-backed generation types may expose --provider for Okou or connector execution guidance.
   - HTML artifact types use registry-backed --design-system and --template selection.`;
 }
 
 export const generateCommand = new Command()
   .name("generate")
   .description(
-    "Generate assets via vm0's built-in pipelines or get connector skill-invocation guidance",
+    "Generate assets via Okou's built-in pipelines or get connector skill-invocation guidance",
   )
   .addCommand(imageCommand)
   .addCommand(presentationCommand)

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -511,7 +511,7 @@ function renderBuiltInProvider(params: {
   if (command) {
     console.log("");
     console.log("Built-in command:");
-    console.log(`  vm0  ${command.label}`);
+    console.log(`  Okou  ${command.label}`);
     console.log(`  Models: ${command.models}`);
     if (generationType === "video" || generationType === "avatar-video") {
       if (videoGenerationAllowed === false) {
@@ -543,7 +543,7 @@ function renderBuiltInProvider(params: {
     providers.length === 1 ? "Built-in provider:" : "Built-in providers:",
   );
   for (const provider of providers) {
-    console.log(`  vm0  ${provider.label}  Model: ${provider.model}`);
+    console.log(`  Okou  ${provider.label}  Model: ${provider.model}`);
     console.log(`  Use: ${provider.command}`);
   }
 }

--- a/turbo/apps/cli/src/commands/zero/generate/lister-only.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lister-only.ts
@@ -15,7 +15,7 @@ interface ListerOnlyConfig {
 }
 
 /**
- * Build a generate subcommand for a type that has no vm0 built-in pipeline.
+ * Build a generate subcommand for a type that has no Okou built-in pipeline.
  * The command lists available connector providers and prints skill-invocation
  * guidance when a --provider is named, but cannot execute on its own.
  */
@@ -32,7 +32,7 @@ export function createListerOnlyCommand(config: ListerOnlyConfig): Command {
       "after",
       `
 Notes:
-  - vm0 does not provide a built-in ${config.generationType} pipeline.
+  - Okou does not provide a built-in ${config.generationType} pipeline.
   - Use --provider <connector-name> to get skill-invocation guidance for a
     specific connector, or run with no flags to see every available provider.`,
     )
@@ -45,7 +45,7 @@ Notes:
         }
         if (provider === "built-in") {
           console.log(
-            `vm0 has no built-in ${config.generationType} generation pipeline.`,
+            `Okou has no built-in ${config.generationType} generation pipeline.`,
           );
           console.log("");
           console.log(

--- a/turbo/apps/cli/src/commands/zero/generate/voice.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/voice.ts
@@ -4,7 +4,7 @@ export const voiceCommand = createVoiceGenerateCommand({
   name: "voice",
   generationType: "voice",
   usageCommand: "okou generate voice",
-  examples: `  Generate speech:       okou generate voice --prompt "Hello from vm0"
+  examples: `  Generate speech:       okou generate voice --prompt "Hello from Okou"
   Pipe prompt:           cat script.txt | okou generate voice
   Pick a voice:          okou generate voice --prompt "Ship it" --voice cedar
   List providers:        okou generate voice

--- a/turbo/apps/cli/src/commands/zero/generate/website.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/website.ts
@@ -157,7 +157,7 @@ ${formatRegistryListing(templates, "website templates")}`;
       const templateSelectionRules = resolvedTemplate
         ? ["Use the explicitly selected template."]
         : [
-            "For landing, marketing, official brand or product, and launch pages, select a vm0 built-in website template.",
+            "For landing, marketing, official brand or product, and launch pages, select an Okou built-in website template.",
             "For other HTML or website requests, select an Open Design template based on intent; when ambiguous, prefer Open Design.",
             "Built-in website candidates have `source.archive`; candidates without it are Open Design templates.",
           ];

--- a/turbo/apps/cli/src/commands/zero/github/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/github/__tests__/upload-file.test.ts
@@ -42,6 +42,20 @@ describe("okou github upload-file command", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("uses Okou branding in upload help while preserving repository examples", () => {
+    let helpOutput = "";
+    uploadFileCommand.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    uploadFileCommand.outputHelp();
+
+    expect(helpOutput).toContain("Uploads through Okou storage first");
+    expect(helpOutput).toContain("vm0-ai/vm0");
+  });
+
   it("uploads a file to R2 and posts a GitHub file comment", async () => {
     let putReceivedContentType: string | null = null;
     let completeBody: Record<string, unknown> | undefined;

--- a/turbo/apps/cli/src/commands/zero/github/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/github/upload-file.ts
@@ -61,7 +61,7 @@ Output:
 
 Notes:
   - Uses the GitHub App installation on the server side
-  - Uploads through VM0 storage first, then posts a GitHub comment containing the file URL`,
+  - Uploads through Okou storage first, then posts a GitHub comment containing the file URL`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/commands/zero/recognize/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/recognize/__tests__/index.test.ts
@@ -226,4 +226,17 @@ describe("okou recognize command", () => {
     });
     expect(optionNames).toStrictEqual(["file", "prompt"]);
   });
+
+  it("uses Okou branding in recognition help", () => {
+    let helpOutput = "";
+    zeroRecognizeCommand.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    zeroRecognizeCommand.outputHelp();
+
+    expect(helpOutput).toContain("Uses a fixed Okou-managed recognition model");
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/recognize/index.ts
+++ b/turbo/apps/cli/src/commands/zero/recognize/index.ts
@@ -102,5 +102,5 @@ Example:
 Notes:
   - Available only in runs whose selected model does not support image input
   - Accepts one PNG, JPEG, or WebP image up to 20 MB
-  - Uses a fixed vm0-managed recognition model and prints only recognized text`,
+  - Uses a fixed Okou-managed recognition model and prints only recognized text`,
   );

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -150,7 +150,7 @@ export function createHtmlArtifactAuthoringPacket(
     ...(options.kind === "website"
       ? [
           "- For a selected entry with `source.archive`, run its exact `source.pull.command`, then use `source.pull.resolvedPath`. Do not construct or guess a direct R2 URL.",
-          "- The Website index includes vm0 built-in R2 template packages as template entries with `source.archive`.",
+          "- The Website index includes Okou built-in R2 template packages as template entries with `source.archive`.",
           "- Each built-in Website template entry includes the exact pull command and extracted package path in `source.pull`.",
         ]
       : []),

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -200,7 +200,7 @@ export function createImageGenerateCommand(
     )
     .option(
       "--provider <name>",
-      "Provider: 'built-in' to run vm0's pipeline, or a connector name to get its skill-invocation guidance",
+      "Provider: 'built-in' to run Okou's pipeline, or a connector name to get its skill-invocation guidance",
     )
     .option(
       "--all",

--- a/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
@@ -385,7 +385,7 @@ export function createVideoGenerateCommand(
     .option("--prompt <text>", "Video prompt; can also be piped via stdin")
     .option(
       "--provider <name>",
-      "Provider: 'built-in' to run vm0's pipeline, or a connector name to get its skill-invocation guidance",
+      "Provider: 'built-in' to run Okou's pipeline, or a connector name to get its skill-invocation guidance",
     )
     .option("--template <id>", "Registered video template id")
     .option(

--- a/turbo/apps/cli/src/commands/zero/shared/voice-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/voice-generate.ts
@@ -32,7 +32,7 @@ export function createVoiceGenerateCommand(
     .addOption(new Option("--text <text>", "Alias for --prompt").hideHelp())
     .option(
       "--provider <name>",
-      "Provider: 'built-in' to run vm0's pipeline, or a connector name (heygen, elevenlabs, ...) to get its skill-invocation guidance",
+      "Provider: 'built-in' to run Okou's pipeline, or a connector name (heygen, elevenlabs, ...) to get its skill-invocation guidance",
     )
     .option(
       "--all",

--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
@@ -59,6 +59,21 @@ describe("okou slack upload-file command", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("uses Okou branding in upload help", () => {
+    let helpOutput = "";
+    uploadFileCommand.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    uploadFileCommand.outputHelp();
+
+    expect(helpOutput).toContain(
+      "Run-scoped calls publish to Okou storage before Slack delivery",
+    );
+  });
+
   describe("successful upload", () => {
     it("should upload a file and return file_id and permalink", async () => {
       server.use(

--- a/turbo/apps/cli/src/commands/zero/slack/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/upload-file.ts
@@ -262,7 +262,7 @@ Examples:
 
 Notes:
   - Uses the bot token (not user SLACK_TOKEN), so no files:write permission is needed
-  - Run-scoped calls publish to VM0 storage before Slack delivery
+  - Run-scoped calls publish to Okou storage before Slack delivery
   - Returns canonical asset details and Slack delivery status`,
   )
   .action(withErrorHandler(uploadFile));

--- a/turbo/apps/cli/src/commands/zero/teams/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/teams/__tests__/upload-file.test.ts
@@ -44,6 +44,19 @@ describe("okou teams upload-file command", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("uses Okou branding in upload help", () => {
+    let helpOutput = "";
+    uploadFileCommand.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    uploadFileCommand.outputHelp();
+
+    expect(helpOutput).toContain("Uploads through Okou storage first");
+  });
+
   it("uploads a file to R2 and completes Teams delivery", async () => {
     let putReceivedContentType: string | null = null;
     let completeBody: Record<string, unknown> | undefined;

--- a/turbo/apps/cli/src/commands/zero/teams/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/teams/upload-file.ts
@@ -52,7 +52,7 @@ Output:
     {"activityId":"...","conversationId":"19:...","filename":"report.pdf","mimetype":"application/pdf","size":12345,"url":"https://..."}
 
 Notes:
-  - Uploads through VM0 storage first, then sends the Teams message with the file URL
+  - Uploads through Okou storage first, then sends the Teams message with the file URL
   - Use the Conversation ID and Activity ID from the current Teams run prompt`,
   )
   .action(

--- a/turbo/apps/cli/src/commands/zero/telegram/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/__tests__/upload-file.test.ts
@@ -46,6 +46,22 @@ describe("okou telegram upload-file command", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("uses Okou branding in upload help", () => {
+    let helpOutput = "";
+    uploadFileCommand.configureOutput({
+      writeOut: (text: string) => {
+        helpOutput += text;
+      },
+    });
+
+    uploadFileCommand.outputHelp();
+
+    expect(helpOutput).toContain("Uploads through Okou storage first");
+    expect(helpOutput).toContain(
+      "Okou does not apply file type or size restrictions",
+    );
+  });
+
   it("uploads a file to R2 and completes Telegram sendDocument", async () => {
     let putReceivedContentType: string | null = null;
     let completeBody: Record<string, unknown> | undefined;

--- a/turbo/apps/cli/src/commands/zero/telegram/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/telegram/upload-file.ts
@@ -61,8 +61,8 @@ Output:
 
 Notes:
   - Uses the Telegram bot token on the server side
-  - Uploads through VM0 storage first, then asks Telegram to fetch the file URL
-  - VM0 does not apply file type or size restrictions before calling Telegram`,
+  - Uploads through Okou storage first, then asks Telegram to fetch the file URL
+  - Okou does not apply file type or size restrictions before calling Telegram`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -275,7 +275,7 @@ const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
   {
     name: "generate",
     description:
-      "Generate assets via vm0's built-in pipelines or get connector skill-invocation guidance",
+      "Generate assets via Okou's built-in pipelines or get connector skill-invocation guidance",
     load: async () => {
       return (await import("./commands/zero/generate")).generateCommand;
     },


### PR DESCRIPTION
## Summary

- replace vm0 product copy with Okou branding in Generate and Recognize help/output
- label built-in generation choices as Okou while preserving provider commands and protocol identities
- update GitHub, Slack, Teams, and Telegram upload-file help to describe Okou storage
- add entry-point and integration coverage for every changed help/output surface

## Boundaries

- keep the root CLI description about interacting with vm0 unchanged
- keep vm0-ai/vm0 repository examples, @vm0 package scopes, static.vm0.io URLs, and zero/vm0 protocol identifiers unchanged
- Search has no vm0 product copy in its current help/output, so it requires no source change

## Validation

- pnpm exec prettier --check apps/cli
- pnpm -F @vm0/okou-cli lint
- pnpm -F @vm0/okou-cli check-types
- pnpm knip --workspace @vm0/okou-cli
- pnpm -F @vm0/okou-cli test (98 passed files, 1 skipped; 924 passed tests, 1 skipped)
- pnpm -F @vm0/okou-cli build
- built dist/okou.js help smoke checks for top-level Generate, Generate subcommands, Recognize, and four upload-file commands