### PR TITLE
fix(platform): limit background sync to ten unread threads

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
@@ -31,13 +31,10 @@ const resetSubscriberSignal$ = resetSignal();
 const THREAD_ID = "b0000000-0000-4000-a000-000000000801";
 const OTHER_THREAD_ID = "b0000000-0000-4000-a000-000000000805";
 const THIRD_THREAD_ID = "b0000000-0000-4000-a000-000000000809";
-const FIRST_THIRTY_UNREAD_THREAD_IDS = Array.from(
-  { length: 30 },
-  (_, index) => {
-    return `c0000000-0000-4000-a000-${String(index + 1).padStart(12, "0")}`;
-  },
-);
-const THIRTY_FIRST_UNREAD_THREAD_ID = "c0000000-0000-4000-a000-000000000031";
+const FIRST_TEN_UNREAD_THREAD_IDS = Array.from({ length: 10 }, (_, index) => {
+  return `c0000000-0000-4000-a000-${String(index + 1).padStart(12, "0")}`;
+});
+const ELEVENTH_UNREAD_THREAD_ID = "c0000000-0000-4000-a000-000000000011";
 const FIRST_CACHED_EVENT_ID = "00000000-0000-4000-8000-000000000802";
 const LAST_CACHED_EVENT_ID = "00000000-0000-4000-8000-000000000803";
 const NEW_EVENT_ID = "00000000-0000-4000-8000-000000000804";
@@ -154,7 +151,7 @@ function mockMissingSnapshots(): void {
 }
 
 describe("chat event background sync", () => {
-  it("prefetches the first 30 unread and all active threads once", async () => {
+  it("prefetches only the first 10 unread threads once", async () => {
     const initialThreadIdsReady = context.mocks.deferred<void>();
     const requestedThreadIds: string[] = [];
     let indicatorRequests = 0;
@@ -165,10 +162,10 @@ describe("chat event background sync", () => {
       return respond(200, {
         agents: {},
         threads: Object.fromEntries([
-          ...FIRST_THIRTY_UNREAD_THREAD_IDS.map((threadId) => {
+          ...FIRST_TEN_UNREAD_THREAD_IDS.map((threadId) => {
             return [threadId, "unread" as const];
           }),
-          [THIRTY_FIRST_UNREAD_THREAD_ID, "unread" as const],
+          [ELEVENTH_UNREAD_THREAD_ID, "unread" as const],
           [OTHER_THREAD_ID, "active" as const],
           [THIRD_THREAD_ID, "active" as const],
         ]),
@@ -190,19 +187,15 @@ describe("chat event background sync", () => {
     initialThreadIdsReady.resolve();
 
     await waitFor(() => {
-      expect(requestedThreadIds).toHaveLength(32);
+      expect(requestedThreadIds).toHaveLength(10);
     });
     expect(indicatorRequests).toBe(1);
     expect(new Set(requestedThreadIds)).toStrictEqual(
-      new Set([
-        ...FIRST_THIRTY_UNREAD_THREAD_IDS,
-        OTHER_THREAD_ID,
-        THIRD_THREAD_ID,
-      ]),
+      new Set(FIRST_TEN_UNREAD_THREAD_IDS),
     );
   });
 
-  it("catches up only the first 30 unread threads after reconnect", async () => {
+  it("catches up only the first 10 unread threads after reconnect", async () => {
     const requestedThreadIds: string[] = [];
     let unreadThreadIds = [THREAD_ID];
     let indicatorRequests = 0;
@@ -228,25 +221,23 @@ describe("chat event background sync", () => {
     await setupAuthenticatedBackgroundSync();
 
     await waitFor(() => {
-      expect(new Set(requestedThreadIds)).toStrictEqual(
-        new Set([THREAD_ID, OTHER_THREAD_ID]),
-      );
+      expect(requestedThreadIds).toStrictEqual([THREAD_ID]);
       expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
     });
     requestedThreadIds.length = 0;
     unreadThreadIds = [
-      ...FIRST_THIRTY_UNREAD_THREAD_IDS,
-      THIRTY_FIRST_UNREAD_THREAD_ID,
+      ...FIRST_TEN_UNREAD_THREAD_IDS,
+      ELEVENTH_UNREAD_THREAD_ID,
     ];
 
     context.mocks.ably.triggerReconnect();
 
     await waitFor(() => {
       expect(indicatorRequests).toBe(2);
-      expect(requestedThreadIds).toHaveLength(30);
+      expect(requestedThreadIds).toHaveLength(10);
     });
     expect(new Set(requestedThreadIds)).toStrictEqual(
-      new Set(FIRST_THIRTY_UNREAD_THREAD_IDS),
+      new Set(FIRST_TEN_UNREAD_THREAD_IDS),
     );
   });
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
@@ -31,6 +31,13 @@ const resetSubscriberSignal$ = resetSignal();
 const THREAD_ID = "b0000000-0000-4000-a000-000000000801";
 const OTHER_THREAD_ID = "b0000000-0000-4000-a000-000000000805";
 const THIRD_THREAD_ID = "b0000000-0000-4000-a000-000000000809";
+const FIRST_THIRTY_UNREAD_THREAD_IDS = Array.from(
+  { length: 30 },
+  (_, index) => {
+    return `c0000000-0000-4000-a000-${String(index + 1).padStart(12, "0")}`;
+  },
+);
+const THIRTY_FIRST_UNREAD_THREAD_ID = "c0000000-0000-4000-a000-000000000031";
 const FIRST_CACHED_EVENT_ID = "00000000-0000-4000-8000-000000000802";
 const LAST_CACHED_EVENT_ID = "00000000-0000-4000-8000-000000000803";
 const NEW_EVENT_ID = "00000000-0000-4000-8000-000000000804";
@@ -147,7 +154,7 @@ function mockMissingSnapshots(): void {
 }
 
 describe("chat event background sync", () => {
-  it("subscribes while prefetching unread and active threads once", async () => {
+  it("prefetches the first 30 unread and all active threads once", async () => {
     const initialThreadIdsReady = context.mocks.deferred<void>();
     const requestedThreadIds: string[] = [];
     let indicatorRequests = 0;
@@ -157,11 +164,14 @@ describe("chat event background sync", () => {
       await initialThreadIdsReady.promise;
       return respond(200, {
         agents: {},
-        threads: {
-          [THREAD_ID]: "unread",
-          [OTHER_THREAD_ID]: "active",
-          [THIRD_THREAD_ID]: "active",
-        },
+        threads: Object.fromEntries([
+          ...FIRST_THIRTY_UNREAD_THREAD_IDS.map((threadId) => {
+            return [threadId, "unread" as const];
+          }),
+          [THIRTY_FIRST_UNREAD_THREAD_ID, "unread" as const],
+          [OTHER_THREAD_ID, "active" as const],
+          [THIRD_THREAD_ID, "active" as const],
+        ]),
       });
     });
     mockMissingSnapshots();
@@ -180,15 +190,19 @@ describe("chat event background sync", () => {
     initialThreadIdsReady.resolve();
 
     await waitFor(() => {
-      expect(requestedThreadIds).toHaveLength(3);
+      expect(requestedThreadIds).toHaveLength(32);
     });
     expect(indicatorRequests).toBe(1);
     expect(new Set(requestedThreadIds)).toStrictEqual(
-      new Set([THREAD_ID, OTHER_THREAD_ID, THIRD_THREAD_ID]),
+      new Set([
+        ...FIRST_THIRTY_UNREAD_THREAD_IDS,
+        OTHER_THREAD_ID,
+        THIRD_THREAD_ID,
+      ]),
     );
   });
 
-  it("catches up only unread threads after reconnect", async () => {
+  it("catches up only the first 30 unread threads after reconnect", async () => {
     const requestedThreadIds: string[] = [];
     let unreadThreadIds = [THREAD_ID];
     let indicatorRequests = 0;
@@ -220,14 +234,20 @@ describe("chat event background sync", () => {
       expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
     });
     requestedThreadIds.length = 0;
-    unreadThreadIds = [THIRD_THREAD_ID];
+    unreadThreadIds = [
+      ...FIRST_THIRTY_UNREAD_THREAD_IDS,
+      THIRTY_FIRST_UNREAD_THREAD_ID,
+    ];
 
     context.mocks.ably.triggerReconnect();
 
     await waitFor(() => {
       expect(indicatorRequests).toBe(2);
-      expect(requestedThreadIds).toStrictEqual([THIRD_THREAD_ID]);
+      expect(requestedThreadIds).toHaveLength(30);
     });
+    expect(new Set(requestedThreadIds)).toStrictEqual(
+      new Set(FIRST_THIRTY_UNREAD_THREAD_IDS),
+    );
   });
 
   it("fills only rows after the cached thread end", async () => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
@@ -15,10 +15,7 @@ import {
   listRowsAfter$,
 } from "./remote-chat-event-row-data-source.ts";
 import { receiveActiveChatEvents$ } from "./chat-event-signal-registry.ts";
-import {
-  allUnreadThreadIds$,
-  sidebarActiveThreadIds$,
-} from "./chat-thread-indicators.ts";
+import { allUnreadThreadIds$ } from "./chat-thread-indicators.ts";
 import {
   chatEventDebugSummaries,
   chatEventTraceTime,
@@ -26,7 +23,7 @@ import {
 
 const L = logger("ChatEventBackgroundSync");
 const CHAT_THREAD_MESSAGE_CREATED_PREFIX = "chatThreadMessageCreated:";
-const BACKGROUND_UNREAD_THREAD_LIMIT = 30;
+const BACKGROUND_UNREAD_THREAD_LIMIT = 10;
 const THREAD_START_SEQ_ID = 0;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -238,20 +235,17 @@ const subscribeChatEventBackgroundSync$ = command(
   },
 );
 
-const syncInitialUnreadAndActiveChatThreadEvents$ = command(
+const syncInitialUnreadChatThreadEvents$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const [unreadThreadIds, activeThreadIds] = await Promise.all([
-      get(allUnreadThreadIds$),
-      get(sidebarActiveThreadIds$),
-    ]);
+    const unreadThreadIds = await get(allUnreadThreadIds$);
     signal.throwIfAborted();
 
-    const threadIds = new Set([
-      ...Array.from(unreadThreadIds).slice(0, BACKGROUND_UNREAD_THREAD_LIMIT),
-      ...activeThreadIds,
-    ]);
+    const threadIds = Array.from(unreadThreadIds).slice(
+      0,
+      BACKGROUND_UNREAD_THREAD_LIMIT,
+    );
     await Promise.all(
-      Array.from(threadIds, (threadId) => {
+      threadIds.map((threadId) => {
         return set(
           handleUserChannelMessage$,
           { name: `${CHAT_THREAD_MESSAGE_CREATED_PREFIX}${threadId}` },
@@ -266,7 +260,7 @@ export const setupChatEventBackgroundSync$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
     await Promise.all([
       set(subscribeChatEventBackgroundSync$, signal),
-      set(syncInitialUnreadAndActiveChatThreadEvents$, signal),
+      set(syncInitialUnreadChatThreadEvents$, signal),
     ]);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-background-sync.ts
@@ -26,6 +26,7 @@ import {
 
 const L = logger("ChatEventBackgroundSync");
 const CHAT_THREAD_MESSAGE_CREATED_PREFIX = "chatThreadMessageCreated:";
+const BACKGROUND_UNREAD_THREAD_LIMIT = 30;
 const THREAD_START_SEQ_ID = 0;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -205,10 +206,13 @@ const catchUpUnreadChatThreadEvents$ = command(
     await foregroundReady.promise;
     signal.throwIfAborted();
 
-    const unreadThreadIds = await get(allUnreadThreadIds$);
+    const unreadThreadIds = Array.from(await get(allUnreadThreadIds$)).slice(
+      0,
+      BACKGROUND_UNREAD_THREAD_LIMIT,
+    );
     signal.throwIfAborted();
     await Promise.all(
-      Array.from(unreadThreadIds, (threadId) => {
+      unreadThreadIds.map((threadId) => {
         return set(
           handleUserChannelMessage$,
           { name: `${CHAT_THREAD_MESSAGE_CREATED_PREFIX}${threadId}` },
@@ -242,7 +246,10 @@ const syncInitialUnreadAndActiveChatThreadEvents$ = command(
     ]);
     signal.throwIfAborted();
 
-    const threadIds = new Set([...unreadThreadIds, ...activeThreadIds]);
+    const threadIds = new Set([
+      ...Array.from(unreadThreadIds).slice(0, BACKGROUND_UNREAD_THREAD_LIMIT),
+      ...activeThreadIds,
+    ]);
     await Promise.all(
       Array.from(threadIds, (threadId) => {
         return set(


### PR DESCRIPTION
## Summary

- limit background catch-up to the first 10 unread chat threads during initial setup and reconnect
- exclude active-only threads from background prefetch while preserving precise Realtime thread sync
- cover both background paths with 11 unread threads and active-only threads to verify overflow and active candidates are skipped

## Verification

- `corepack pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-event-background-sync.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
