### PR TITLE
refactor(guest): centralize private file replacement

### DIFF
--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use guest_common::telemetry::record_sandbox_op;
+use guest_contracts::runtime_paths::{self, PrivateFileReplacementTarget};
 
 use crate::error::AgentError;
 
@@ -105,9 +106,12 @@ pub(super) fn write_model_catalog(
         return Ok(());
     };
     record_catalog_operation(MODEL_CATALOG_PREPARE_ACTION, || {
-        std::fs::create_dir_all(codex_home)?;
         let path = model_catalog_path(codex_home);
-        write_model_catalog_json_atomic(codex_home, &path, &serde_json::to_vec(model_catalog)?)?;
+        runtime_paths::replace_private_atomic(
+            path,
+            serde_json::to_vec(model_catalog)?,
+            PrivateFileReplacementTarget::ReplaceFinalEntry,
+        )?;
         Ok(())
     })
 }
@@ -120,29 +124,6 @@ fn record_catalog_operation<T>(
     let result = operation();
     record_sandbox_op(action_type, started_at.elapsed(), result.is_ok(), None);
     result
-}
-
-fn write_model_catalog_json_atomic(
-    codex_home: &Path,
-    path: &Path,
-    serialized: &[u8],
-) -> Result<(), AgentError> {
-    use std::io::Write as _;
-
-    let mut temp = tempfile::NamedTempFile::new_in(codex_home)?;
-    temp.as_file_mut().write_all(serialized)?;
-    temp.as_file_mut().flush()?;
-    temp.persist(path).map_err(|error| {
-        AgentError::Io(std::io::Error::new(
-            error.error.kind(),
-            format!(
-                "failed to replace {} atomically: {}",
-                path.display(),
-                error.error
-            ),
-        ))
-    })?;
-    Ok(())
 }
 
 pub(super) fn startup_config_overrides(
@@ -392,6 +373,16 @@ mod tests {
 
         let written = std::fs::read_to_string(model_catalog_path(tmp.path())).unwrap();
         assert_eq!(written, r#"{"models":[{"slug":"deepseek-v4-flash"}]}"#);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = std::fs::metadata(model_catalog_path(tmp.path()))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o7777, 0o600);
+        }
     }
 
     #[cfg(unix)]

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -20,10 +20,10 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Reconcile Codex runtime files using the config captured during bootstrap.
 ///
-/// Auth reconciliation owns `CODEX_HOME` validation and permissions. API-owned
-/// runtime provider metadata writes the model catalog only after that boundary
-/// succeeds, before `codex app-server` can observe startup
-/// config.
+/// Auth reconciliation runs first, and both private writers independently
+/// validate `CODEX_HOME` during publication. API-owned runtime provider
+/// metadata writes the model catalog before `codex app-server` can observe
+/// startup config.
 ///
 /// Three mutually-exclusive states are supported:
 ///

--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -30,6 +30,7 @@ use api_contracts::generated::constants::codex_oauth_token::placeholders::{
 };
 use base64::Engine;
 use chrono::{DateTime, Utc};
+use guest_contracts::runtime_paths::{self, PrivateFileReplacementTarget};
 use serde_json::{Value, json};
 
 use crate::error::AgentError;
@@ -60,6 +61,7 @@ const FAR_FUTURE_EXP_SECS: i64 = 100 * 365 * 24 * 3600;
 /// hostname from inside the sandbox (Epic #11872 risk-mitigation row).
 pub(crate) const REFRESH_TOKEN_NOOP_URL: &str = "http://127.0.0.1:1/blocked";
 const CODEX_HOME_MODE: u32 = 0o700;
+#[cfg(test)]
 const AUTH_JSON_MODE: u32 = 0o600;
 
 pub(crate) enum DesiredCodexAuth<'a> {
@@ -222,29 +224,12 @@ fn remove_auth_json(codex_home: &Path) -> Result<(), AgentError> {
 }
 
 fn write_auth_json_atomic(codex_home: &Path, serialized: &str) -> Result<(), AgentError> {
-    use std::io::Write as _;
-    use std::os::unix::fs::PermissionsExt;
-
     let auth_path = codex_home.join("auth.json");
-    let mut temp = tempfile::NamedTempFile::new_in(codex_home)?;
-
-    {
-        let file = temp.as_file_mut();
-        file.set_permissions(std::fs::Permissions::from_mode(AUTH_JSON_MODE))?;
-        file.write_all(serialized.as_bytes())?;
-        file.flush()?;
-    }
-
-    temp.persist(&auth_path).map_err(|e| {
-        AgentError::Io(std::io::Error::new(
-            e.error.kind(),
-            format!(
-                "failed to replace {} atomically: {}",
-                auth_path.display(),
-                e.error
-            ),
-        ))
-    })?;
+    runtime_paths::replace_private_atomic(
+        auth_path,
+        serialized,
+        PrivateFileReplacementTarget::ReplaceFinalEntry,
+    )?;
     Ok(())
 }
 

--- a/crates/guest-contracts/src/active_input_receipts.rs
+++ b/crates/guest-contracts/src/active_input_receipts.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::runtime_paths;
+use crate::runtime_paths::{self, PrivateFileReplacementTarget};
 
 /// Maximum accepted delivery identities retained for one run.
 pub const MAX_ACTIVE_INPUT_RECEIPT_IDS: usize = 1_024;
@@ -128,7 +128,11 @@ pub fn write_active_input_receipt_journal(
             "receipt journal exceeds {MAX_ACTIVE_INPUT_RECEIPT_JOURNAL_BYTES} bytes"
         )));
     }
-    runtime_paths::replace_private_atomic(path, bytes)
+    runtime_paths::replace_private_atomic(
+        path,
+        bytes,
+        PrivateFileReplacementTarget::PrivateFileOrMissing,
+    )
 }
 
 #[cfg(test)]
@@ -227,6 +231,7 @@ mod tests {
         runtime_paths::replace_private_atomic(
             &path,
             br#"{"runId":"run-123","deliveryIds":[],"extra":true}"#,
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
         )
         .unwrap();
         assert_eq!(
@@ -239,6 +244,7 @@ mod tests {
         runtime_paths::replace_private_atomic(
             &path,
             vec![b'x'; MAX_ACTIVE_INPUT_RECEIPT_JOURNAL_BYTES + 1],
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
         )
         .unwrap();
         assert_eq!(
@@ -292,7 +298,12 @@ mod tests {
         assert_eq!(std::fs::read(&target).unwrap(), b"unchanged");
 
         std::fs::remove_file(&path).unwrap();
-        runtime_paths::replace_private_atomic(&path, b"{}").unwrap();
+        runtime_paths::replace_private_atomic(
+            &path,
+            b"{}",
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
+        )
+        .unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
         assert_eq!(
             read_active_input_receipt_journal(&path, RUN_ID)

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -922,11 +922,15 @@ fn replacement_name() -> OsString {
 }
 
 /// Policy for an existing final entry during private atomic replacement.
+///
+/// These target guarantees apply on Unix. Non-Unix platforms accept the
+/// policy for API consistency without claiming equivalent file-type,
+/// permission, ownership, or symlink validation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrivateFileReplacementTarget {
-    /// Require the target to be missing or an existing private regular file.
+    /// On Unix, require a missing target or an existing private regular file.
     PrivateFileOrMissing,
-    /// Replace the final directory entry without opening or following it.
+    /// On Unix, replace the final entry without opening or following it.
     ReplaceFinalEntry,
 }
 
@@ -1065,7 +1069,8 @@ fn replace_private_atomic_non_unix(
 /// permissions. [`PrivateFileReplacementTarget::ReplaceFinalEntry`] replaces
 /// an existing non-directory final entry without opening or following it.
 /// Existing readers therefore observe either the previous complete file or
-/// the new complete file.
+/// the new complete file. On non-Unix platforms, the target policy adds no
+/// guarantees beyond the platform's rename behavior.
 pub fn replace_private_atomic(
     path: impl AsRef<Path>,
     bytes: impl AsRef<[u8]>,

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -921,6 +921,15 @@ fn replacement_name() -> OsString {
     OsString::from_vec(format!(".vm0-private-replacement-{}", Uuid::new_v4()).into_bytes())
 }
 
+/// Policy for an existing final entry during private atomic replacement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivateFileReplacementTarget {
+    /// Require the target to be missing or an existing private regular file.
+    PrivateFileOrMissing,
+    /// Replace the final directory entry without opening or following it.
+    ReplaceFinalEntry,
+}
+
 #[cfg(unix)]
 fn validate_replace_target(parent: &OwnedFd, name: &OsStr, path: &Path) -> io::Result<()> {
     let name_c = component_cstring(name, path)?;
@@ -952,11 +961,17 @@ fn validate_replace_target(parent: &OwnedFd, name: &OsStr, path: &Path) -> io::R
 }
 
 #[cfg(unix)]
-fn replace_private_atomic_unix(path: &Path, bytes: &[u8]) -> io::Result<()> {
+fn replace_private_atomic_unix(
+    path: &Path,
+    bytes: &[u8],
+    target: PrivateFileReplacementTarget,
+) -> io::Result<()> {
     let name = file_name(path)?;
     let name_c = component_cstring(name, path)?;
     let parent = open_or_create_private_dir(parent_dir(path)?)?;
-    validate_replace_target(&parent, name, path)?;
+    if target == PrivateFileReplacementTarget::PrivateFileOrMissing {
+        validate_replace_target(&parent, name, path)?;
+    }
 
     let temp_name = replacement_name();
     let temp_name_c = component_cstring(&temp_name, path)?;
@@ -1017,7 +1032,11 @@ fn replace_private_atomic_unix(path: &Path, bytes: &[u8]) -> io::Result<()> {
 }
 
 #[cfg(not(unix))]
-fn replace_private_atomic_non_unix(path: &Path, bytes: &[u8]) -> io::Result<()> {
+fn replace_private_atomic_non_unix(
+    path: &Path,
+    bytes: &[u8],
+    _target: PrivateFileReplacementTarget,
+) -> io::Result<()> {
     ensure_parent_dir(path)?;
     let temp_path = path.with_file_name(format!(".vm0-private-replacement-{}", Uuid::new_v4()));
     let mut file = OpenOptions::new()
@@ -1039,18 +1058,26 @@ fn replace_private_atomic_non_unix(path: &Path, bytes: &[u8]) -> io::Result<()> 
 /// Atomically replace a runtime-private file with complete bytes.
 ///
 /// On Unix, the replacement is written to an exclusively created `0600`
-/// sibling, synced, and published with descriptor-relative `renameat`. Parent
-/// and final symlinks, non-regular targets, foreign ownership, and group/other
-/// permissions are rejected. Existing readers therefore observe either the
-/// previous complete file or the new complete file.
-pub fn replace_private_atomic(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Result<()> {
+/// sibling, synced, and published with descriptor-relative `renameat` before
+/// the parent directory is synced. Parent symlinks are always rejected.
+/// [`PrivateFileReplacementTarget::PrivateFileOrMissing`] also rejects final
+/// symlinks, non-regular targets, foreign ownership, and group/other
+/// permissions. [`PrivateFileReplacementTarget::ReplaceFinalEntry`] replaces
+/// an existing non-directory final entry without opening or following it.
+/// Existing readers therefore observe either the previous complete file or
+/// the new complete file.
+pub fn replace_private_atomic(
+    path: impl AsRef<Path>,
+    bytes: impl AsRef<[u8]>,
+    target: PrivateFileReplacementTarget,
+) -> io::Result<()> {
     #[cfg(unix)]
     {
-        replace_private_atomic_unix(path.as_ref(), bytes.as_ref())
+        replace_private_atomic_unix(path.as_ref(), bytes.as_ref(), target)
     }
     #[cfg(not(unix))]
     {
-        replace_private_atomic_non_unix(path.as_ref(), bytes.as_ref())
+        replace_private_atomic_non_unix(path.as_ref(), bytes.as_ref(), target)
     }
 }
 
@@ -1231,6 +1258,155 @@ mod tests {
             Uuid::parse_str(suffix).unwrap().hyphenated().to_string(),
             suffix
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_atomic_replacement_creates_private_paths_and_replaces_private_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("run");
+        let path = parent.join("state.json");
+
+        replace_private_atomic(
+            &path,
+            b"first",
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
+        )
+        .unwrap();
+        replace_private_atomic(
+            &path,
+            b"second",
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"second");
+        assert_eq!(mode(parent), 0o700);
+        assert_eq!(mode(path), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_atomic_replacement_policy_controls_permissive_file_replacement() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("run");
+        std::fs::create_dir(&parent).unwrap();
+        let path = parent.join("state.json");
+        std::fs::write(&path, b"old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let error = replace_private_atomic(
+            &path,
+            b"strict",
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(std::fs::read(&path).unwrap(), b"old");
+
+        replace_private_atomic(
+            &path,
+            b"replacement",
+            PrivateFileReplacementTarget::ReplaceFinalEntry,
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"replacement");
+        assert_eq!(mode(path), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_atomic_replacement_policy_controls_final_symlink_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("run");
+        std::fs::create_dir(&parent).unwrap();
+        let target = temp.path().join("target.json");
+        std::fs::write(&target, b"target").unwrap();
+        let path = parent.join("state.json");
+        symlink(&target, &path).unwrap();
+
+        let error = replace_private_atomic(
+            &path,
+            b"strict",
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"target");
+
+        replace_private_atomic(
+            &path,
+            b"replacement",
+            PrivateFileReplacementTarget::ReplaceFinalEntry,
+        )
+        .unwrap();
+
+        assert!(
+            !std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"replacement");
+        assert_eq!(std::fs::read(&target).unwrap(), b"target");
+        assert_eq!(mode(path), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_atomic_replacement_rejects_symlink_parent_for_both_policies() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let target_parent = temp.path().join("target");
+        std::fs::create_dir(&target_parent).unwrap();
+        let linked_parent = temp.path().join("linked");
+        symlink(&target_parent, &linked_parent).unwrap();
+
+        for target in [
+            PrivateFileReplacementTarget::PrivateFileOrMissing,
+            PrivateFileReplacementTarget::ReplaceFinalEntry,
+        ] {
+            let error = replace_private_atomic(linked_parent.join("state.json"), b"new", target)
+                .unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert!(!target_parent.join("state.json").exists());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_atomic_replacement_cleans_temp_after_directory_publish_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("run");
+        let path = parent.join("state.json");
+        std::fs::create_dir_all(&path).unwrap();
+
+        replace_private_atomic(
+            &path,
+            b"replacement",
+            PrivateFileReplacementTarget::ReplaceFinalEntry,
+        )
+        .unwrap_err();
+
+        assert!(path.is_dir());
+        let entries = std::fs::read_dir(&parent)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![OsString::from("state.json")]);
     }
 
     #[test]

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -973,8 +973,11 @@ fn replace_private_atomic_unix(
     let name = file_name(path)?;
     let name_c = component_cstring(name, path)?;
     let parent = open_or_create_private_dir(parent_dir(path)?)?;
-    if target == PrivateFileReplacementTarget::PrivateFileOrMissing {
-        validate_replace_target(&parent, name, path)?;
+    match target {
+        PrivateFileReplacementTarget::PrivateFileOrMissing => {
+            validate_replace_target(&parent, name, path)?;
+        }
+        PrivateFileReplacementTarget::ReplaceFinalEntry => {}
     }
 
     let temp_name = replacement_name();


### PR DESCRIPTION
## Summary

- centralize private atomic replacement in `guest-contracts` behind an explicit final-target policy
- preserve strict active-input receipt validation while retaining Codex replacement of permissive files and final symlinks without following them
- migrate `auth.json` and `models.json` away from local `NamedTempFile` writers and cover modes, symlinks, publication failures, and cleanup at the shared filesystem boundary

## Exclusions

- no database, API contract, runner protocol, dependency, or rollout migration changes
- no change to Codex startup ordering or no-auth removal behavior

## Validation

- `cd crates && cargo fmt --all`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo test -p guest-contracts`
- `cd crates && cargo test -p guest-agent --lib`
- `cd crates && cargo test -p guest-agent`

Closes #26770
