### PR TITLE
perf(python): stagger firewall auth address attempts

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -26,6 +26,9 @@ from aws_sigv4 import AwsSigV4Credentials
 MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES = 256 * 1024
 FIREWALL_AUTH_FETCH_DEADLINE_SECONDS = 10.0
 _MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES = 64 * 1024
+# RFC 8305's default cadence; four slots keep the oldest path eligible for about one second.
+_FIREWALL_AUTH_CONNECTION_ATTEMPT_DELAY_SECONDS = 0.25
+_MAX_CONCURRENT_FIREWALL_AUTH_CONNECTION_ATTEMPTS = 4
 _DEFAULT_HTTP_PORT = 80
 _DEFAULT_HTTPS_PORT = 443
 _IPV6_VERSION = 6
@@ -350,42 +353,128 @@ def _abort_socket(sock: socket.socket) -> None:
         sock.close()
 
 
+async def _connect_socket(address: _ResolvedAddress) -> socket.socket:
+    sock = socket.socket(address.family, socket.SOCK_STREAM)
+    try:
+        sock.setblocking(False)
+        socket_address: tuple[str, int] | tuple[str, int, int, int]
+        if address.family == socket.AF_INET6:
+            socket_address = (address.host, address.port, 0, 0)
+        else:
+            socket_address = (address.host, address.port)
+        await asyncio.get_running_loop().sock_connect(sock, socket_address)
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except OSError as exc:
+            if exc.errno != errno.ENOPROTOOPT:
+                raise
+    except BaseException:
+        _abort_socket(sock)
+        raise
+    return sock
+
+
+async def _abort_connection_attempts(
+    attempts: tuple[asyncio.Task[socket.socket], ...],
+) -> None:
+    for attempt in attempts:
+        attempt.cancel()
+    await asyncio.gather(*attempts, return_exceptions=True)
+    for attempt in attempts:
+        if attempt.cancelled():
+            continue
+        if attempt.exception() is None:
+            _abort_socket(attempt.result())
+
+
 async def _open_connected_stream(
     addresses: tuple[_ResolvedAddress, ...],
 ) -> _ConnectedStream:
+    if not addresses:
+        raise OSError("Firewall auth connection failed")
+
     loop = asyncio.get_running_loop()
-    last_error: OSError | None = None
-    for address in addresses:
-        sock = socket.socket(address.family, socket.SOCK_STREAM)
-        sock.setblocking(False)
-        try:
-            socket_address: tuple[str, int] | tuple[str, int, int, int]
-            if address.family == socket.AF_INET6:
-                socket_address = (address.host, address.port, 0, 0)
-            else:
-                socket_address = (address.host, address.port)
-            await loop.sock_connect(sock, socket_address)
-            try:
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            except OSError as exc:
-                if exc.errno != errno.ENOPROTOOPT:
-                    raise
-            reader, writer = await asyncio.open_connection(
-                sock=sock,
-                limit=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
+    attempts: dict[asyncio.Task[socket.socket], int] = {}
+    unclaimed_sockets: list[socket.socket] = []
+    next_address_index = 0
+    next_attempt_at = loop.time()
+    last_error: tuple[int, OSError] | None = None
+
+    def start_next_attempt() -> None:
+        nonlocal next_address_index
+        nonlocal next_attempt_at
+
+        attempt = asyncio.create_task(_connect_socket(addresses[next_address_index]))
+        attempts[attempt] = next_address_index
+        next_address_index += 1
+        next_attempt_at = loop.time() + _FIREWALL_AUTH_CONNECTION_ATTEMPT_DELAY_SECONDS
+
+    start_next_attempt()
+    try:
+        while attempts:
+            wait_timeout = (
+                max(0.0, next_attempt_at - loop.time())
+                if next_address_index < len(addresses)
+                else None
             )
-        except OSError as exc:
-            last_error = exc
-            _abort_socket(sock)
-            continue
-        except BaseException:
-            _abort_socket(sock)
-            raise
-        return _ConnectedStream(reader, writer, sock)
+            done, _pending = await asyncio.wait(
+                attempts,
+                timeout=wait_timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            successful_attempts: list[tuple[int, socket.socket]] = []
+            for attempt in sorted(done, key=attempts.__getitem__):
+                address_index = attempts.pop(attempt)
+                try:
+                    connected_socket = attempt.result()
+                except OSError as exc:
+                    if last_error is None or address_index > last_error[0]:
+                        last_error = (address_index, exc)
+                else:
+                    unclaimed_sockets.append(connected_socket)
+                    successful_attempts.append((address_index, connected_socket))
+
+            if successful_attempts:
+                winner_socket = successful_attempts[0][1]
+                for connected_socket in unclaimed_sockets:
+                    if connected_socket is not winner_socket:
+                        _abort_socket(connected_socket)
+                unclaimed_sockets[:] = [winner_socket]
+                await _abort_connection_attempts(tuple(attempts))
+                attempts.clear()
+                unclaimed_sockets.clear()
+                try:
+                    reader, writer = await asyncio.open_connection(
+                        sock=winner_socket,
+                        limit=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
+                    )
+                except BaseException:
+                    _abort_socket(winner_socket)
+                    raise
+                return _ConnectedStream(reader, writer, winner_socket)
+
+            if not attempts:
+                if next_address_index >= len(addresses):
+                    break
+                start_next_attempt()
+                continue
+
+            if next_address_index < len(addresses) and loop.time() >= next_attempt_at:
+                if len(attempts) >= _MAX_CONCURRENT_FIREWALL_AUTH_CONNECTION_ATTEMPTS:
+                    oldest_attempt = min(attempts, key=attempts.__getitem__)
+                    attempts.pop(oldest_attempt)
+                    await _abort_connection_attempts((oldest_attempt,))
+                start_next_attempt()
+    finally:
+        for connected_socket in unclaimed_sockets:
+            _abort_socket(connected_socket)
+        if attempts:
+            await _abort_connection_attempts(tuple(attempts))
 
     if last_error is None:
         raise OSError("Firewall auth connection failed")
-    raise last_error
+    raise last_error[1]
 
 
 def _abort_stream(stream: _ConnectedStream) -> None:

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -12,7 +12,7 @@ import urllib.error
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import patch
 
@@ -31,6 +31,16 @@ from tests.auth_state_helpers import auth_cache_key, cached_headers, require_cac
 from tests.firewall_auth_helpers import firewall_auth_request
 
 _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success response"
+_EMPTY_PROXY_ENVIRONMENT = {
+    "http_proxy": "",
+    "HTTP_PROXY": "",
+    "https_proxy": "",
+    "HTTPS_PROXY": "",
+    "all_proxy": "",
+    "ALL_PROXY": "",
+    "no_proxy": "",
+    "NO_PROXY": "",
+}
 
 
 @dataclass(frozen=True)
@@ -44,6 +54,44 @@ class _RawHttpRequest:
 type _TestServerHandler = Callable[
     [asyncio.StreamReader, asyncio.StreamWriter], Coroutine[object, object, None]
 ]
+type _SocketAddress = tuple[str, int] | tuple[str, int, int, int]
+type _SockConnect = Callable[[socket.socket, _SocketAddress], Coroutine[object, object, None]]
+
+
+@dataclass(frozen=True)
+class _OrderedResolver:
+    expected_host: str
+    addresses: tuple[str, ...]
+
+    async def lookup_ip(self, host: str) -> list[str]:
+        assert host == self.expected_host
+        return list(self.addresses)
+
+
+@dataclass
+class _PendingSockConnect:
+    real_connect: _SockConnect
+    attempted_addresses: list[_SocketAddress] = field(default_factory=list)
+    cancelled_addresses: list[_SocketAddress] = field(default_factory=list)
+    sockets: list[socket.socket] = field(default_factory=list)
+    active_count: int = 0
+    max_active_count: int = 0
+
+    async def __call__(self, sock: socket.socket, address: _SocketAddress) -> None:
+        self.attempted_addresses.append(address)
+        self.sockets.append(sock)
+        self.active_count += 1
+        self.max_active_count = max(self.max_active_count, self.active_count)
+        try:
+            if address[0] == "127.0.0.1":
+                await self.real_connect(sock, address)
+            else:
+                await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled_addresses.append(address)
+            raise
+        finally:
+            self.active_count -= 1
 
 
 @asynccontextmanager
@@ -1180,19 +1228,9 @@ class TestFirewallAuthAsyncTransport:
             requests.append(await _read_raw_http_request(reader))
             await _write_success_response(writer)
 
-        proxy_environment = {
-            "http_proxy": "",
-            "HTTP_PROXY": "",
-            "https_proxy": "",
-            "HTTPS_PROXY": "",
-            "all_proxy": "",
-            "ALL_PROXY": "",
-            "no_proxy": "",
-            "NO_PROXY": "",
-        }
         async with _run_test_server(handle_client) as port:
             with (
-                patch.dict(os.environ, proxy_environment),
+                patch.dict(os.environ, _EMPTY_PROXY_ENVIRONMENT),
                 patch.object(auth_client, "_dns_resolver", OrderedResolver()),
                 patch.object(auth_client.socket, "socket", side_effect=create_socket),
                 patch.object(platform_api, "VERCEL_BYPASS", ""),
@@ -1204,6 +1242,123 @@ class TestFirewallAuthAsyncTransport:
         assert len(requests) == 1
         assert len(client_sockets) == 2
         assert client_sockets[0].fileno() == -1
+
+    async def test_connects_to_second_address_while_first_connect_is_pending(self, mitm_ctx):
+        requests: list[_RawHttpRequest] = []
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            requests.append(await _read_raw_http_request(reader))
+            await _write_success_response(writer)
+
+        loop = asyncio.get_running_loop()
+        connect_probe = _PendingSockConnect(loop.sock_connect)
+        resolver = _OrderedResolver(
+            expected_host="firewall-auth.invalid",
+            addresses=("192.0.2.1", "127.0.0.1"),
+        )
+        async with _run_test_server(handle_client) as port:
+            with (
+                patch.dict(os.environ, _EMPTY_PROXY_ENVIRONMENT),
+                patch.object(auth_client, "_dns_resolver", resolver),
+                patch.object(loop, "sock_connect", new=connect_probe),
+                patch.object(
+                    auth_client,
+                    "_FIREWALL_AUTH_CONNECTION_ATTEMPT_DELAY_SECONDS",
+                    0.01,
+                ),
+                patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.2),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                mitm_ctx(api_url=f"http://firewall-auth.invalid:{port}"),
+            ):
+                result = await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert result.payload.headers == {}
+        assert len(requests) == 1
+        assert [address[0] for address in connect_probe.attempted_addresses] == [
+            "192.0.2.1",
+            "127.0.0.1",
+        ]
+        assert connect_probe.cancelled_addresses == [("192.0.2.1", port)]
+        assert connect_probe.max_active_count == 2
+        assert connect_probe.active_count == 0
+        assert all(sock.fileno() == -1 for sock in connect_probe.sockets)
+
+    async def test_bounds_pending_connects_and_reaches_address_beyond_window(self, mitm_ctx):
+        requests: list[_RawHttpRequest] = []
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            requests.append(await _read_raw_http_request(reader))
+            await _write_success_response(writer)
+
+        pending_hosts = tuple(f"192.0.2.{index}" for index in range(1, 6))
+        loop = asyncio.get_running_loop()
+        connect_probe = _PendingSockConnect(loop.sock_connect)
+        resolver = _OrderedResolver(
+            expected_host="firewall-auth.invalid",
+            addresses=(*pending_hosts, "127.0.0.1"),
+        )
+        async with _run_test_server(handle_client) as port:
+            with (
+                patch.dict(os.environ, _EMPTY_PROXY_ENVIRONMENT),
+                patch.object(auth_client, "_dns_resolver", resolver),
+                patch.object(loop, "sock_connect", new=connect_probe),
+                patch.object(
+                    auth_client,
+                    "_FIREWALL_AUTH_CONNECTION_ATTEMPT_DELAY_SECONDS",
+                    0.01,
+                ),
+                patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.5),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                mitm_ctx(api_url=f"http://firewall-auth.invalid:{port}"),
+            ):
+                result = await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert result.payload.headers == {}
+        assert len(requests) == 1
+        assert [address[0] for address in connect_probe.attempted_addresses] == [
+            *pending_hosts,
+            "127.0.0.1",
+        ]
+        assert {address[0] for address in connect_probe.cancelled_addresses} == set(pending_hosts)
+        assert connect_probe.max_active_count == 4
+        assert connect_probe.active_count == 0
+        assert all(sock.fileno() == -1 for sock in connect_probe.sockets)
+
+    async def test_total_deadline_cancels_pending_connection_attempts(self, mitm_ctx):
+        pending_hosts = tuple(f"192.0.2.{index}" for index in range(1, 4))
+        loop = asyncio.get_running_loop()
+        connect_probe = _PendingSockConnect(loop.sock_connect)
+        resolver = _OrderedResolver(
+            expected_host="firewall-auth.invalid",
+            addresses=pending_hosts,
+        )
+        with (
+            patch.dict(os.environ, _EMPTY_PROXY_ENVIRONMENT),
+            patch.object(auth_client, "_dns_resolver", resolver),
+            patch.object(loop, "sock_connect", new=connect_probe),
+            patch.object(
+                auth_client,
+                "_FIREWALL_AUTH_CONNECTION_ATTEMPT_DELAY_SECONDS",
+                0.01,
+            ),
+            patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.1),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+            mitm_ctx(api_url="http://firewall-auth.invalid"),
+            pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+        ):
+            await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert [address[0] for address in connect_probe.attempted_addresses] == list(pending_hosts)
+        assert {address[0] for address in connect_probe.cancelled_addresses} == set(pending_hosts)
+        assert connect_probe.max_active_count == 3
+        assert connect_probe.active_count == 0
+        assert all(sock.fileno() == -1 for sock in connect_probe.sockets)
 
     async def test_protocol_error_does_not_expose_response_bytes(self, mitm_ctx):
         sensitive_response_bytes = b"sensitive-resolved-auth-value"


### PR DESCRIPTION
## Summary

- stagger trusted multi-address TCP attempts so a stalled address cannot consume the total deadline
- cap each fetch at four live connects and rotate the oldest pending attempt to reach later candidates
- cancel and close losing or timed-out sockets while preserving resolver order, proxy/TLS behavior, the total deadline, and global admission limits

## Tests

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_firewall_auth_client.py` (87 passed)
- `uv run --no-sync python -m pytest tests/ -q` (5353 passed)

## Compatibility

- no API, schema, persisted-state, queue, dependency, generated-artifact, or runner-protocol changes
- old and new runners drain independently against unchanged backend behavior

Closes #26775
